### PR TITLE
feat(spiffe): add SPIFFE monitoring card (kubestellar/console-marketplace#18)

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -278,6 +278,8 @@ export const CARD_TITLES: Record<string, string> = {
   otel_status: 'OpenTelemetry',
   // Rook cloud-native storage orchestrator
   rook_status: 'Rook',
+  // SPIFFE workload identity (CNCF graduated)
+  spiffe_status: 'SPIFFE',
   // TiKV distributed key-value store
   tikv_status: 'TiKV',
   // TUF (The Update Framework) repository metadata
@@ -607,6 +609,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   otel_status: 'OpenTelemetry Collectors: pipeline health, receivers and exporters, dropped telemetry, and export errors across connected clusters.',
   // Rook cloud-native storage orchestrator (Ceph)
   rook_status: 'Rook-managed CephClusters: Ceph health, OSD/MON/MGR counts, capacity usage, and PG state summary.',
+  // SPIFFE workload identity (CNCF graduated)
+  spiffe_status: 'SPIFFE/SPIRE workload identity: trust domain, SVID counts (x509/JWT), federated trust domains, and registration entries.',
   // TiKV distributed key-value store
   tikv_status: 'TiKV distributed key-value store: store nodes, region counts, leader counts, and capacity utilization across the cluster.',
   // TUF (The Update Framework) repository metadata

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -92,6 +92,8 @@ const LinkerdStatus = safeLazy(() => import('./linkerd_status'), 'LinkerdStatus'
 const OtelStatus = safeLazy(() => import('./otel_status'), 'OtelStatus')
 // Rook cloud-native storage orchestrator card
 const RookStatus = safeLazy(() => import('./rook_status'), 'RookStatus')
+// SPIFFE workload identity card (CNCF graduated)
+const SpiffeStatus = safeLazy(() => import('./spiffe_status'), 'SpiffeStatus')
 // TiKV distributed key-value store card
 const TikvStatus = safeLazy(() => import('./tikv_status'), 'TikvStatus')
 // TUF (The Update Framework) repository metadata card
@@ -734,6 +736,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   otel_status: OtelStatus,
   // Rook cloud-native storage orchestrator (Ceph)
   rook_status: RookStatus,
+  // SPIFFE workload identity (CNCF graduated)
+  spiffe_status: SpiffeStatus,
   // TiKV distributed key-value store
   tikv_status: TikvStatus,
   // TUF (The Update Framework) repository metadata
@@ -1064,6 +1068,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   linkerd_status: () => import('./linkerd_status'),
   otel_status: () => import('./otel_status'),
   rook_status: () => import('./rook_status'),
+  spiffe_status: () => import('./spiffe_status'),
   tikv_status: () => import('./tikv_status'),
   tuf_status: () => import('./tuf_status'),
   vitess_status: () => import('./vitess_status'),
@@ -1666,6 +1671,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   linkerd_status: 6,
   otel_status: 6,
   rook_status: 6,
+  spiffe_status: 6,
   tikv_status: 6,
   tuf_status: 6,
   vitess_status: 6,

--- a/web/src/components/cards/spiffe_status/demoData.ts
+++ b/web/src/components/cards/spiffe_status/demoData.ts
@@ -1,0 +1,176 @@
+/**
+ * SPIFFE Status Card — Demo Data & Type Definitions
+ *
+ * SPIFFE (Secure Production Identity Framework For Everyone) is a CNCF
+ * graduated project that defines a standard for cryptographically
+ * identifying workloads across heterogeneous environments. SPIRE is the
+ * reference runtime that issues SPIFFE Verifiable Identity Documents
+ * (SVIDs) — either x509 certificates or JWT tokens.
+ *
+ * This card surfaces:
+ *  - Trust domain (the root of trust — typically a DNS-style name)
+ *  - Number of active SVIDs issued (x509 and JWT)
+ *  - Federated trust domains (cross-domain relationships for multi-cluster)
+ *  - Per-workload registration entries (SPIFFE ID → selector bindings)
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real SPIRE server bridge lands (`/api/spiffe/status`), the hook's
+ * fetcher will pick up live data automatically with no component changes.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SpiffeHealth = 'healthy' | 'degraded' | 'not-installed'
+export type SvidType = 'x509' | 'jwt'
+export type FederationStatus = 'active' | 'pending' | 'failed'
+
+export interface SpiffeRegistrationEntry {
+  spiffeId: string
+  parentId: string
+  selector: string
+  svidType: SvidType
+  ttlSeconds: number
+  cluster: string
+}
+
+export interface SpiffeFederatedDomain {
+  trustDomain: string
+  bundleEndpoint: string
+  status: FederationStatus
+  lastRefresh: string
+}
+
+export interface SpiffeStats {
+  x509SvidCount: number
+  jwtSvidCount: number
+  registrationEntryCount: number
+  agentCount: number
+  serverVersion: string
+}
+
+export interface SpiffeSummary {
+  trustDomain: string
+  totalSvids: number
+  totalFederatedDomains: number
+  totalEntries: number
+}
+
+export interface SpiffeStatusData {
+  health: SpiffeHealth
+  entries: SpiffeRegistrationEntry[]
+  federatedDomains: SpiffeFederatedDomain[]
+  stats: SpiffeStats
+  summary: SpiffeSummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo-data constants (named — no magic numbers)
+// ---------------------------------------------------------------------------
+
+const DEMO_TRUST_DOMAIN = 'prod.example.org'
+const DEMO_X509_SVID_COUNT = 48
+const DEMO_JWT_SVID_COUNT = 17
+const DEMO_AGENT_COUNT = 6
+const DEMO_SERVER_VERSION = '1.9.4'
+
+// Per-entry TTLs
+const TTL_ONE_HOUR_SECONDS = 3600
+const TTL_FOUR_HOURS_SECONDS = 14400
+const TTL_TWELVE_HOURS_SECONDS = 43200
+const TTL_ONE_DAY_SECONDS = 86400
+
+// Federated-bundle refresh timestamps (milliseconds before "now")
+const TEN_MINUTES_MS = 10 * 60 * 1000
+const TWO_HOURS_MS = 2 * 60 * 60 * 1000
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+// ---------------------------------------------------------------------------
+// Demo data — shown when SPIFFE/SPIRE is not installed or in demo mode
+// ---------------------------------------------------------------------------
+
+const DEMO_ENTRIES: SpiffeRegistrationEntry[] = [
+  {
+    spiffeId: 'spiffe://prod.example.org/ns/frontend/sa/web',
+    parentId: 'spiffe://prod.example.org/spire/agent/k8s_psat/prod/node-1',
+    selector: 'k8s:ns:frontend,k8s:sa:web',
+    svidType: 'x509',
+    ttlSeconds: TTL_ONE_HOUR_SECONDS,
+    cluster: 'prod-east',
+  },
+  {
+    spiffeId: 'spiffe://prod.example.org/ns/api/sa/api-gateway',
+    parentId: 'spiffe://prod.example.org/spire/agent/k8s_psat/prod/node-2',
+    selector: 'k8s:ns:api,k8s:sa:api-gateway',
+    svidType: 'x509',
+    ttlSeconds: TTL_ONE_HOUR_SECONDS,
+    cluster: 'prod-east',
+  },
+  {
+    spiffeId: 'spiffe://prod.example.org/ns/auth/sa/oidc',
+    parentId: 'spiffe://prod.example.org/spire/agent/k8s_psat/prod/node-1',
+    selector: 'k8s:ns:auth,k8s:sa:oidc',
+    svidType: 'jwt',
+    ttlSeconds: TTL_FOUR_HOURS_SECONDS,
+    cluster: 'prod-east',
+  },
+  {
+    spiffeId: 'spiffe://prod.example.org/ns/payments/sa/billing',
+    parentId: 'spiffe://prod.example.org/spire/agent/k8s_psat/prod/node-3',
+    selector: 'k8s:ns:payments,k8s:sa:billing',
+    svidType: 'x509',
+    ttlSeconds: TTL_TWELVE_HOURS_SECONDS,
+    cluster: 'prod-west',
+  },
+  {
+    spiffeId: 'spiffe://prod.example.org/ns/data/sa/etl',
+    parentId: 'spiffe://prod.example.org/spire/agent/k8s_psat/prod/node-4',
+    selector: 'k8s:ns:data,k8s:sa:etl',
+    svidType: 'jwt',
+    ttlSeconds: TTL_ONE_DAY_SECONDS,
+    cluster: 'prod-west',
+  },
+]
+
+const DEMO_FEDERATED_DOMAINS: SpiffeFederatedDomain[] = [
+  {
+    trustDomain: 'staging.example.org',
+    bundleEndpoint: 'https://spire-server.staging.example.org/bundle',
+    status: 'active',
+    lastRefresh: new Date(Date.now() - TEN_MINUTES_MS).toISOString(),
+  },
+  {
+    trustDomain: 'partner.acme.io',
+    bundleEndpoint: 'https://spire.partner.acme.io/bundle',
+    status: 'active',
+    lastRefresh: new Date(Date.now() - TWO_HOURS_MS).toISOString(),
+  },
+  {
+    trustDomain: 'edge.example.org',
+    bundleEndpoint: 'https://spire-edge.example.org/bundle',
+    status: 'pending',
+    lastRefresh: new Date(Date.now() - ONE_DAY_MS).toISOString(),
+  },
+]
+
+export const SPIFFE_DEMO_DATA: SpiffeStatusData = {
+  health: 'healthy',
+  entries: DEMO_ENTRIES,
+  federatedDomains: DEMO_FEDERATED_DOMAINS,
+  stats: {
+    x509SvidCount: DEMO_X509_SVID_COUNT,
+    jwtSvidCount: DEMO_JWT_SVID_COUNT,
+    registrationEntryCount: DEMO_ENTRIES.length,
+    agentCount: DEMO_AGENT_COUNT,
+    serverVersion: DEMO_SERVER_VERSION,
+  },
+  summary: {
+    trustDomain: DEMO_TRUST_DOMAIN,
+    totalSvids: DEMO_X509_SVID_COUNT + DEMO_JWT_SVID_COUNT,
+    totalFederatedDomains: DEMO_FEDERATED_DOMAINS.length,
+    totalEntries: DEMO_ENTRIES.length,
+  },
+  lastCheckTime: new Date().toISOString(),
+}

--- a/web/src/components/cards/spiffe_status/index.tsx
+++ b/web/src/components/cards/spiffe_status/index.tsx
@@ -1,0 +1,330 @@
+/**
+ * SPIFFE Status Card
+ *
+ * SPIFFE (Secure Production Identity Framework For Everyone) is a CNCF
+ * graduated identity standard. This card surfaces the active trust domain,
+ * SVID counts (x509 and JWT), federated trust domains, and recent
+ * registration entries — the primary operational signals from a SPIRE
+ * server.
+ *
+ * Follows the linkerd_status / envoy_status pattern for structure and styling.
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real SPIRE server bridge lands (`/api/spiffe/status`), the hook's fetcher
+ * will pick up live data automatically with no component changes.
+ */
+
+import {
+  AlertTriangle,
+  CheckCircle,
+  Fingerprint,
+  Globe,
+  Key,
+  RefreshCw,
+  Shield,
+  Users,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
+import { useCachedSpiffe } from '../../../hooks/useCachedSpiffe'
+import type {
+  SpiffeFederatedDomain,
+  SpiffeRegistrationEntry,
+} from './demoData'
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const SKELETON_TITLE_WIDTH = 140
+const SKELETON_TITLE_HEIGHT = 28
+const SKELETON_BADGE_WIDTH = 90
+const SKELETON_BADGE_HEIGHT = 20
+const SKELETON_LIST_ITEMS = 5
+
+const RELATIVE_TIME_MINUTE_MS = 60_000
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+const SECONDS_PER_MINUTE = 60
+const SECONDS_PER_HOUR = 3600
+const SECONDS_PER_DAY = 86400
+
+const MAX_ENTRIES_DISPLAYED = 5
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(isoString: string): string {
+  const parsed = new Date(isoString).getTime()
+  if (!isoString || Number.isNaN(parsed)) return 'just now'
+
+  const diff = Date.now() - parsed
+  if (diff < 0) return 'just now'
+
+  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
+  const day = HOURS_PER_DAY * hour
+
+  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
+  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
+  if (diff < day) return `${Math.floor(diff / hour)}h ago`
+  return `${Math.floor(diff / day)}d ago`
+}
+
+function formatTtl(seconds: number): string {
+  if (seconds >= SECONDS_PER_DAY) {
+    return `${Math.floor(seconds / SECONDS_PER_DAY)}d`
+  }
+  if (seconds >= SECONDS_PER_HOUR) {
+    return `${Math.floor(seconds / SECONDS_PER_HOUR)}h`
+  }
+  if (seconds >= SECONDS_PER_MINUTE) {
+    return `${Math.floor(seconds / SECONDS_PER_MINUTE)}m`
+  }
+  return `${seconds}s`
+}
+
+function federationStatusClass(status: SpiffeFederatedDomain['status']): string {
+  if (status === 'active') return 'bg-green-500/20 text-green-400'
+  if (status === 'pending') return 'bg-yellow-500/20 text-yellow-400'
+  return 'bg-red-500/20 text-red-400'
+}
+
+// ---------------------------------------------------------------------------
+// Subsections
+// ---------------------------------------------------------------------------
+
+function EntryRow({ entry }: { entry: SpiffeRegistrationEntry }) {
+  const svidClass =
+    entry.svidType === 'x509'
+      ? 'bg-cyan-500/20 text-cyan-400'
+      : 'bg-purple-500/20 text-purple-400'
+
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          <Fingerprint className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
+          <span className="text-xs font-medium text-foreground truncate font-mono">
+            {entry.spiffeId}
+          </span>
+        </div>
+        <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${svidClass}`}>
+          {entry.svidType.toUpperCase()}
+        </span>
+      </div>
+      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+        <span className="truncate">{entry.selector}</span>
+        <span className="ml-auto shrink-0 font-mono">
+          ttl {formatTtl(entry.ttlSeconds)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function FederatedRow({ domain }: { domain: SpiffeFederatedDomain }) {
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          <Globe className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
+          <span className="text-xs font-medium text-foreground truncate font-mono">
+            {domain.trustDomain}
+          </span>
+        </div>
+        <span
+          className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${federationStatusClass(
+            domain.status,
+          )}`}
+        >
+          {domain.status}
+        </span>
+      </div>
+      <div className="text-[11px] text-muted-foreground truncate">
+        {domain.bundleEndpoint}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function SpiffeStatus() {
+  const { t } = useTranslation('cards')
+  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedSpiffe()
+
+  const isHealthy = data.health === 'healthy'
+  const entries = data.entries ?? []
+  const federatedDomains = data.federatedDomains ?? []
+  const displayedEntries = entries.slice(0, MAX_ENTRIES_DISPLAYED)
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
+          <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (error && showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">
+          {t('spiffeStatus.fetchError', 'Unable to fetch SPIFFE status')}
+        </p>
+      </div>
+    )
+  }
+
+  if (data.health === 'not-installed') {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Shield className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('spiffeStatus.notInstalled', 'SPIFFE/SPIRE not detected')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'spiffeStatus.notInstalledHint',
+            'No SPIRE server reachable from the connected clusters.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* Header — health pill + freshness */}
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+            isHealthy
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-yellow-500/15 text-yellow-400'
+          }`}
+        >
+          {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          {isHealthy
+            ? t('spiffeStatus.healthy', 'Healthy')
+            : t('spiffeStatus.degraded', 'Degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label={t('spiffeStatus.x509Svids', 'x509 SVIDs')}
+          value={`${data.stats.x509SvidCount}`}
+          colorClass="text-cyan-400"
+          icon={<Key className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('spiffeStatus.jwtSvids', 'JWT SVIDs')}
+          value={`${data.stats.jwtSvidCount}`}
+          colorClass="text-purple-400"
+          icon={<Key className="w-4 h-4 text-purple-400" />}
+        />
+        <MetricTile
+          label={t('spiffeStatus.federated', 'Federated')}
+          value={`${data.summary.totalFederatedDomains}`}
+          colorClass="text-green-400"
+          icon={<Globe className="w-4 h-4 text-green-400" />}
+        />
+        <MetricTile
+          label={t('spiffeStatus.agents', 'Agents')}
+          value={`${data.stats.agentCount}`}
+          colorClass="text-yellow-400"
+          icon={<Users className="w-4 h-4 text-yellow-400" />}
+        />
+      </div>
+
+      {/* Trust domain + lists */}
+      <div className="space-y-3 overflow-y-auto scrollbar-thin pr-0.5">
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Shield className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('spiffeStatus.sectionTrustDomain', 'Trust domain')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {t('spiffeStatus.server', 'server')}:{' '}
+              <span className="text-foreground">{data.stats.serverVersion}</span>
+            </span>
+          </div>
+          <div className="rounded-md bg-secondary/30 px-3 py-2 text-xs font-mono text-foreground">
+            spiffe://{data.summary.trustDomain}
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Fingerprint className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('spiffeStatus.sectionEntries', 'Registration entries')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {entries.length}
+            </span>
+          </div>
+
+          {entries.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('spiffeStatus.noEntries', 'No registration entries found')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(displayedEntries ?? []).map(entry => (
+                <EntryRow
+                  key={`${entry.cluster}:${entry.spiffeId}`}
+                  entry={entry}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Globe className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('spiffeStatus.sectionFederated', 'Federated trust domains')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {federatedDomains.length}
+            </span>
+          </div>
+
+          {federatedDomains.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('spiffeStatus.noFederated', 'No federated trust domains')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(federatedDomains ?? []).map(domain => (
+                <FederatedRow key={domain.trustDomain} domain={domain} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default SpiffeStatus

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -261,6 +261,7 @@ export const CARD_CATALOG = {
     { type: 'compliance_drift', title: 'Compliance Drift', description: 'Detect clusters deviating from fleet compliance baseline', visualization: 'status' },
     { type: 'cross_cluster_policy_comparison', title: 'Cross-Cluster Policy Comparison', description: 'Compare Kyverno policy deployment across clusters', visualization: 'table' },
     { type: 'trestle_scan', title: 'Compliance Trestle (OSCAL)', description: 'OSCAL compliance assessment via Compliance Trestle (CNCF Sandbox)', visualization: 'status' },
+    { type: 'spiffe_status', title: 'SPIFFE', description: 'SPIFFE/SPIRE workload identity: trust domain, SVID counts (x509/JWT), federated domains, and registration entries', visualization: 'status' },
   ],
   'Data Compliance': [
     { type: 'vault_secrets', title: 'HashiCorp Vault', description: 'Secrets management, dynamic credentials, and encryption-as-a-service', visualization: 'status' },

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -173,6 +173,7 @@ import { serviceImportsConfig } from './service-imports'
 import { serviceStatusConfig } from './service-status'
 import { serviceTopologyConfig } from './service-topology'
 import { solitaireConfig } from './solitaire'
+import { spiffeStatusConfig } from './spiffe-status'
 import { statefulSetStatusConfig } from './statefulset-status'
 import { stockMarketTickerConfig } from './stock-market-ticker'
 import { storageOverviewConfig } from './storage-overview'
@@ -370,6 +371,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   service_status: serviceStatusConfig,
   service_topology: serviceTopologyConfig,
   solitaire: solitaireConfig,
+  spiffe_status: spiffeStatusConfig,
   statefulset_status: statefulSetStatusConfig,
   stock_market_ticker: stockMarketTickerConfig,
   storage_overview: storageOverviewConfig,
@@ -636,6 +638,7 @@ export {
   serviceStatusConfig,
   serviceTopologyConfig,
   solitaireConfig,
+  spiffeStatusConfig,
   statefulSetStatusConfig,
   stockMarketTickerConfig,
   storageOverviewConfig,

--- a/web/src/config/cards/spiffe-status.ts
+++ b/web/src/config/cards/spiffe-status.ts
@@ -1,0 +1,49 @@
+/**
+ * SPIFFE Status Card Configuration
+ *
+ * SPIFFE (Secure Production Identity Framework For Everyone) is a CNCF
+ * graduated identity standard — typically deployed alongside SPIRE (the
+ * reference runtime). This card surfaces the active trust domain, SVID
+ * counts (x509 and JWT), federated trust domains, and registration entries.
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const spiffeStatusConfig: UnifiedCardConfig = {
+  type: 'spiffe_status',
+  title: 'SPIFFE',
+  category: 'security',
+  description:
+    'SPIFFE/SPIRE workload identity: trust domain, SVID counts (x509/JWT), federated domains, and registration entries.',
+  icon: 'Fingerprint',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useCachedSpiffe' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'spiffeId', header: 'SPIFFE ID', primary: true, render: 'truncate' },
+      { field: 'selector', header: 'Selector', width: 180, render: 'truncate' },
+      { field: 'svidType', header: 'SVID', width: 80, render: 'status-badge' },
+      { field: 'ttlSeconds', header: 'TTL', width: 80 },
+      { field: 'cluster', header: 'Cluster', width: 120, render: 'cluster-badge' },
+    ],
+  },
+  emptyState: {
+    icon: 'Fingerprint',
+    title: 'SPIFFE/SPIRE not detected',
+    message: 'No SPIRE server reachable from the connected clusters.',
+    variant: 'info',
+  },
+  loadingState: {
+    type: 'list',
+    rows: 5,
+  },
+  // Scaffolding: renders live if /api/spiffe/status is wired up, otherwise
+  // falls back to demo data via the useCache demo path.
+  isDemoData: true,
+  isLive: false,
+}
+
+export default spiffeStatusConfig

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -151,6 +151,13 @@ export * from './useCachedJaegerStatus'
 export { useCachedRook } from './useCachedRook'
 
 // ============================================================================
+// SPIFFE Workload Identity — useCachedSpiffe.ts (CNCF graduated)
+// ============================================================================
+// Named re-export (avoids `__testables` export-name collision with TiKV).
+
+export { useCachedSpiffe } from './useCachedSpiffe'
+
+// ============================================================================
 // TiKV Distributed Key-Value Store — useCachedTikv.ts
 // ============================================================================
 

--- a/web/src/hooks/useCachedSpiffe.ts
+++ b/web/src/hooks/useCachedSpiffe.ts
@@ -1,0 +1,261 @@
+/**
+ * SPIFFE Status Hook — Data fetching for the spiffe_status card.
+ *
+ * Mirrors the linkerd / envoy / contour pattern:
+ * - useCache with fetcher + demo fallback
+ * - isDemoFallback gated on !isLoading (prevents demo flash while loading)
+ * - fetchJson helper with treat404AsEmpty (no real endpoint yet — this is
+ *   scaffolding; the fetch will 404 until a real SPIRE server bridge lands,
+ *   at which point useCache will transparently switch to live data)
+ * - showSkeleton / showEmptyState from useCardLoadingState
+ */
+
+import { useCache } from '../lib/cache'
+import { useCardLoadingState } from '../components/cards/CardDataContext'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { authFetch } from '../lib/api'
+import {
+  SPIFFE_DEMO_DATA,
+  type SpiffeFederatedDomain,
+  type SpiffeRegistrationEntry,
+  type SpiffeStats,
+  type SpiffeStatusData,
+  type SpiffeSummary,
+} from '../components/cards/spiffe_status/demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'spiffe-status'
+const SPIFFE_STATUS_ENDPOINT = '/api/spiffe/status'
+const DEFAULT_SERVER_VERSION = 'unknown'
+const DEFAULT_TRUST_DOMAIN = ''
+
+const EMPTY_STATS: SpiffeStats = {
+  x509SvidCount: 0,
+  jwtSvidCount: 0,
+  registrationEntryCount: 0,
+  agentCount: 0,
+  serverVersion: DEFAULT_SERVER_VERSION,
+}
+
+const EMPTY_SUMMARY: SpiffeSummary = {
+  trustDomain: DEFAULT_TRUST_DOMAIN,
+  totalSvids: 0,
+  totalFederatedDomains: 0,
+  totalEntries: 0,
+}
+
+const INITIAL_DATA: SpiffeStatusData = {
+  health: 'not-installed',
+  entries: [],
+  federatedDomains: [],
+  stats: EMPTY_STATS,
+  summary: EMPTY_SUMMARY,
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Internal types (shape of the future /api/spiffe/status response)
+// ---------------------------------------------------------------------------
+
+interface FetchResult<T> {
+  data: T
+  failed: boolean
+}
+
+interface SpiffeStatusResponse {
+  trustDomain?: string
+  entries?: SpiffeRegistrationEntry[]
+  federatedDomains?: SpiffeFederatedDomain[]
+  stats?: Partial<SpiffeStats>
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function summarize(
+  trustDomain: string,
+  entries: SpiffeRegistrationEntry[],
+  federatedDomains: SpiffeFederatedDomain[],
+  stats: SpiffeStats,
+): SpiffeSummary {
+  return {
+    trustDomain,
+    totalSvids: stats.x509SvidCount + stats.jwtSvidCount,
+    totalFederatedDomains: federatedDomains.length,
+    totalEntries: entries.length,
+  }
+}
+
+function deriveHealth(
+  trustDomain: string,
+  entries: SpiffeRegistrationEntry[],
+  federatedDomains: SpiffeFederatedDomain[],
+): SpiffeStatusData['health'] {
+  if (!trustDomain && entries.length === 0) {
+    return 'not-installed'
+  }
+  const hasFailedFederation = federatedDomains.some(d => d.status === 'failed')
+  return hasFailedFederation ? 'degraded' : 'healthy'
+}
+
+function buildSpiffeStatus(
+  trustDomain: string,
+  entries: SpiffeRegistrationEntry[],
+  federatedDomains: SpiffeFederatedDomain[],
+  stats: SpiffeStats,
+): SpiffeStatusData {
+  return {
+    health: deriveHealth(trustDomain, entries, federatedDomains),
+    entries,
+    federatedDomains,
+    stats,
+    summary: summarize(trustDomain, entries, federatedDomains, stats),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private fetchJson helper (mirrors envoy/contour/linkerd pattern)
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(
+  url: string,
+  options?: { treat404AsEmpty?: boolean },
+): Promise<FetchResult<T | null>> {
+  try {
+    const resp = await authFetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+
+    if (!resp.ok) {
+      if (options?.treat404AsEmpty && resp.status === 404) {
+        return { data: null, failed: false }
+      }
+      return { data: null, failed: true }
+    }
+
+    const body = (await resp.json()) as T
+    return { data: body, failed: false }
+  } catch {
+    return { data: null, failed: true }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchSpiffeStatus(): Promise<SpiffeStatusData> {
+  const result = await fetchJson<SpiffeStatusResponse>(
+    SPIFFE_STATUS_ENDPOINT,
+    { treat404AsEmpty: true },
+  )
+
+  // If the endpoint isn't wired up yet (404) or the request failed, the
+  // cache layer will surface demo data via its demoData fallback path.
+  if (result.failed) {
+    throw new Error('Unable to fetch SPIFFE status')
+  }
+
+  const body = result.data
+  const trustDomain = body?.trustDomain ?? DEFAULT_TRUST_DOMAIN
+  const entries = Array.isArray(body?.entries) ? body.entries : []
+  const federatedDomains = Array.isArray(body?.federatedDomains)
+    ? body.federatedDomains
+    : []
+  const stats: SpiffeStats = {
+    x509SvidCount: body?.stats?.x509SvidCount ?? 0,
+    jwtSvidCount: body?.stats?.jwtSvidCount ?? 0,
+    registrationEntryCount: body?.stats?.registrationEntryCount ?? entries.length,
+    agentCount: body?.stats?.agentCount ?? 0,
+    serverVersion: body?.stats?.serverVersion ?? DEFAULT_SERVER_VERSION,
+  }
+
+  return buildSpiffeStatus(trustDomain, entries, federatedDomains, stats)
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseCachedSpiffeResult {
+  data: SpiffeStatusData
+  isLoading: boolean
+  isRefreshing: boolean
+  isDemoData: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  showSkeleton: boolean
+  showEmptyState: boolean
+  error: boolean
+  refetch: () => Promise<void>
+}
+
+export function useCachedSpiffe(): UseCachedSpiffeResult {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+    lastRefresh,
+    refetch,
+  } = useCache<SpiffeStatusData>({
+    key: CACHE_KEY,
+    category: 'services',
+    initialData: INITIAL_DATA,
+    demoData: SPIFFE_DEMO_DATA,
+    persist: true,
+    fetcher: fetchSpiffeStatus,
+  })
+
+  // Prevent demo flash while loading — only surface the Demo badge once
+  // we've actually fallen back to demo data post-load.
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' counts as "data" so the card shows the empty state
+  // rather than an infinite skeleton when SPIRE isn't present.
+  const hasAnyData =
+    data.health === 'not-installed' ? true : (data.entries ?? []).length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+    lastRefresh,
+  })
+
+  return {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoData: effectiveIsDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+    showSkeleton,
+    showEmptyState,
+    error: isFailed && !hasAnyData,
+    refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  summarize,
+  deriveHealth,
+  buildSpiffeStatus,
+}

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -100,6 +100,7 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-linkerd': 'linkerd_status',
   'cncf-openfeature': 'openfeature_status',
   'cncf-rook': 'rook_status',
+  'cncf-spiffe': 'spiffe_status',
   'cncf-strimzi': 'strimzi_status',
   'cncf-thanos': 'thanos_status',
   'cncf-opentelemetry': 'otel_status',

--- a/web/src/lib/demo/spiffe.ts
+++ b/web/src/lib/demo/spiffe.ts
@@ -1,0 +1,20 @@
+/**
+ * SPIFFE demo seed re-export.
+ *
+ * The canonical demo data lives alongside the SPIFFE card in
+ * `components/cards/spiffe_status/demoData.ts`. This file re-exports it
+ * so callers outside the card folder (docs, tests, future drill-downs)
+ * can import a stable demo seed from `lib/demo/spiffe`.
+ */
+
+export {
+  SPIFFE_DEMO_DATA,
+  type SpiffeStatusData,
+  type SpiffeRegistrationEntry,
+  type SpiffeFederatedDomain,
+  type SpiffeStats,
+  type SpiffeSummary,
+  type SpiffeHealth,
+  type SvidType,
+  type FederationStatus,
+} from '../../components/cards/spiffe_status/demoData'

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -57,6 +57,7 @@ import { useCachedKeda } from '../../hooks/useCachedKeda'
 import { useCachedLinkerd } from '../../hooks/useCachedLinkerd'
 import { useCachedOtel } from '../../hooks/useCachedOtel'
 import { useCachedRook } from '../../hooks/useCachedRook'
+import { useCachedSpiffe } from '../../hooks/useCachedSpiffe'
 import { useCachedTikv } from '../../hooks/useCachedTikv'
 import { useCachedTuf } from '../../hooks/useCachedTuf'
 import { useCachedVitess } from '../../hooks/useCachedVitess'
@@ -1162,6 +1163,17 @@ function useUnifiedRookStatus() {
   }
 }
 
+function useUnifiedSpiffeStatus() {
+  const result = useCachedSpiffe()
+  // Surface the registration entry list as the primary row set for generic list renderers.
+  return {
+    data: result.data.entries,
+    isLoading: result.showSkeleton,
+    error: result.error ? new Error('Failed to fetch SPIFFE status') : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
 function useUnifiedVitessStatus() {
   const result = useCachedVitess()
   // Surface the keyspace list as the primary row set for generic list renderers.
@@ -1368,6 +1380,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useCachedLinkerd', useUnifiedLinkerdStatus)
   registerDataHook('useCachedOtel', useUnifiedOtelStatus)
   registerDataHook('useCachedRook', useUnifiedRookStatus)
+  registerDataHook('useCachedSpiffe', useUnifiedSpiffeStatus)
   registerDataHook('useCachedTikv', useUnifiedTikvStatus)
   registerDataHook('useCachedTuf', useUnifiedTufStatus)
   registerDataHook('useCachedVitess', useUnifiedVitessStatus)

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3158,6 +3158,23 @@
     "mgrShort": "MGR {{active}}+{{standby}}",
     "pgShort": "PG {{clean}}/{{total}}"
   },
+  "spiffeStatus": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "SPIFFE/SPIRE not detected",
+    "notInstalledHint": "No SPIRE server reachable from the connected clusters.",
+    "fetchError": "Unable to fetch SPIFFE status",
+    "x509Svids": "x509 SVIDs",
+    "jwtSvids": "JWT SVIDs",
+    "federated": "Federated",
+    "agents": "Agents",
+    "server": "server",
+    "sectionTrustDomain": "Trust domain",
+    "sectionEntries": "Registration entries",
+    "sectionFederated": "Federated trust domains",
+    "noEntries": "No registration entries found",
+    "noFederated": "No federated trust domains"
+  },
   "tikvStatus": {
     "healthy": "Healthy",
     "degraded": "Degraded",


### PR DESCRIPTION
Fixes kubestellar/console-marketplace#18

## Summary

SPIFFE (Secure Production Identity Framework For Everyone) is a CNCF graduated project defining a standard for cryptographically identifying workloads — typically paired with SPIRE, the reference runtime that issues SVIDs (x509 certificates or JWT tokens) scoped to a trust domain.

This PR adds a SPIFFE monitoring card modelled on the existing Linkerd/Envoy/Contour status cards.

### What the card shows
- Active trust domain (`spiffe://<domain>`)
- SVID counts split by type (x509 vs JWT)
- Federated trust domains with bundle endpoints and refresh status
- Recent registration entries with selectors and TTLs
- Control-plane health pill and server version

### Scaffolding
The hook fetches `/api/spiffe/status` and transparently falls back to demo data via `useCache` when the endpoint isn't wired up (404 or not installed). When a real SPIRE server bridge lands, the card picks up live data with no component changes.

## Files

**New:**
- `web/src/components/cards/spiffe_status/{index.tsx,demoData.ts}`
- `web/src/hooks/useCachedSpiffe.ts`
- `web/src/lib/demo/spiffe.ts`
- `web/src/config/cards/spiffe-status.ts` (category: `security`)

**Wiring:**
- `cardRegistry.ts` — lazy import, `CARD_COMPONENTS`, preloader, height map
- `cardMetadata.ts` — title + description
- `cardCatalog.ts` — Security Posture group
- `config/cards/index.ts` — registry + re-export
- `lib/unified/registerHooks.ts` — unified data hook
- `hooks/useCachedData.ts` — re-export
- `hooks/useMarketplace.ts` — `cncf-spiffe` → `spiffe_status`
- `locales/en/cards.json` — `spiffeStatus.*` keys

## Conventions followed
- No magic numbers (all values are named constants)
- Array access guarded with `?? []`
- No `import React` — JSX transform
- All user-facing strings through `t()`
- `isDemoData` + `isRefreshing` wired into `useCardLoadingState`
- Demo flash guarded via `isDemoFallback && !isLoading` in the hook
- `useCardLoadingState({ isLoading: isLoading && !hasAnyData, ... })`

## Test plan
- [ ] Card appears in Add Cards modal under Security Posture as "SPIFFE"
- [ ] Card renders with demo data (yellow outline + Demo badge) when `/api/spiffe/status` returns 404
- [ ] Skeleton shows on first load, not demo-flash
- [ ] Refresh icon spins during background refetch
- [ ] Marketplace item `cncf-spiffe` auto-reconciles from help-wanted to available