### PR TITLE
feat(spire): add SPIRE monitoring card (kubestellar/console-marketplace#19)

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -285,6 +285,8 @@ export const CARD_TITLES: Record<string, string> = {
   spiffe_status: 'SPIFFE',
   // CNI (Container Network Interface) plugin status
   cni_status: 'CNI',
+  // SPIRE (SPIFFE Runtime Environment) — workload identity
+  spire_status: 'SPIRE',
   // TiKV distributed key-value store
   tikv_status: 'TiKV',
   // TUF (The Update Framework) repository metadata
@@ -627,6 +629,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   spiffe_status: 'SPIFFE/SPIRE workload identity: trust domain, SVID counts (x509/JWT), federated trust domains, and registration entries.',
   // CNI (Container Network Interface) plugin status
   cni_status: 'Container Network Interface plugin status: active plugin, per-node CNI readiness, pod network CIDR, and NetworkPolicy coverage across services.',
+  // SPIRE (SPIFFE Runtime Environment) — workload identity
+  spire_status: 'SPIRE workload identity — server pod health, agent DaemonSet coverage, attested agents, registration entries, and trust bundle age.',
   // TiKV distributed key-value store
   tikv_status: 'TiKV distributed key-value store: store nodes, region counts, leader counts, and capacity utilization across the cluster.',
   // TUF (The Update Framework) repository metadata

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -98,6 +98,8 @@ const RookStatus = safeLazy(() => import('./rook_status'), 'RookStatus')
 const SpiffeStatus = safeLazy(() => import('./spiffe_status'), 'SpiffeStatus')
 // CNI (Container Network Interface) plugin status card
 const CniStatus = safeLazy(() => import('./cni_status'), 'CniStatus')
+// SPIRE (SPIFFE Runtime Environment) workload identity card
+const SpireStatus = safeLazy(() => import('./spire_status'), 'SpireStatus')
 // TiKV distributed key-value store card
 const TikvStatus = safeLazy(() => import('./tikv_status'), 'TikvStatus')
 // TUF (The Update Framework) repository metadata card
@@ -761,6 +763,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   spiffe_status: SpiffeStatus,
   // CNI plugin status (Cilium, Calico, Flannel, etc.)
   cni_status: CniStatus,
+  // SPIRE (SPIFFE Runtime Environment) — workload identity
+  spire_status: SpireStatus,
   // TiKV distributed key-value store
   tikv_status: TikvStatus,
   // TUF (The Update Framework) repository metadata
@@ -1094,6 +1098,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   rook_status: () => import('./rook_status'),
   spiffe_status: () => import('./spiffe_status'),
   cni_status: () => import('./cni_status'),
+  spire_status: () => import('./spire_status'),
   tikv_status: () => import('./tikv_status'),
   tuf_status: () => import('./tuf_status'),
   vitess_status: () => import('./vitess_status'),
@@ -1713,6 +1718,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   rook_status: 6,
   spiffe_status: 6,
   cni_status: 6,
+  spire_status: 6,
   tikv_status: 6,
   tuf_status: 6,
   vitess_status: 6,

--- a/web/src/components/cards/spire_status/index.tsx
+++ b/web/src/components/cards/spire_status/index.tsx
@@ -1,0 +1,324 @@
+/**
+ * SPIRE (SPIFFE Runtime Environment) Status Card
+ *
+ * Displays SPIRE workload identity plane health — server pod readiness,
+ * agent DaemonSet coverage, attested agent count, registration entry
+ * count, and trust bundle age. Follows the tuf_status / linkerd_status
+ * pattern for structure and styling.
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real SPIRE bridge lands (backed by the SPIRE server admin API), the
+ * hook's fetcher will pick up live data automatically with no component
+ * changes.
+ */
+
+import {
+  AlertTriangle,
+  CheckCircle,
+  Clock,
+  RefreshCw,
+  Server,
+  ShieldCheck,
+  ShieldOff,
+  Users,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
+import { useCachedSpire } from '../../../hooks/useCachedSpire'
+import { useCardLoadingState } from '../CardDataContext'
+import { cn } from '../../../lib/cn'
+import type { SpirePodPhase, SpireServerPod } from '../../../lib/demo/spire'
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const SKELETON_TITLE_WIDTH = 140
+const SKELETON_TITLE_HEIGHT = 28
+const SKELETON_BADGE_WIDTH = 90
+const SKELETON_BADGE_HEIGHT = 20
+const SKELETON_LIST_ITEMS = 3
+
+// Trust bundle age thresholds — these mirror typical SPIRE rotation cadence.
+// A healthy rotation is under 24h; over 48h signals the rotation pipeline
+// is stalled.
+const TRUST_BUNDLE_AGE_WARN_HOURS = 24
+const TRUST_BUNDLE_AGE_ALERT_HOURS = 48
+
+// How many server pod rows to show inline — SPIRE is typically deployed
+// as a HA StatefulSet of 1-3 replicas, so 4 rows covers the common case
+// and keeps the card compact.
+const MAX_SERVER_POD_ROWS = 4
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function phaseBadgeClass(phase: SpirePodPhase, ready: boolean): string {
+  if (phase === 'Running' && ready) return 'bg-green-500/20 text-green-400'
+  if (phase === 'Running' && !ready) return 'bg-yellow-500/20 text-yellow-400'
+  if (phase === 'Pending') return 'bg-yellow-500/20 text-yellow-400'
+  if (phase === 'Failed') return 'bg-red-500/20 text-red-400'
+  if (phase === 'Succeeded') return 'bg-blue-500/20 text-blue-400'
+  return 'bg-secondary/40 text-muted-foreground'
+}
+
+function trustBundleColor(hours: number): string {
+  if (hours >= TRUST_BUNDLE_AGE_ALERT_HOURS) return 'text-red-400'
+  if (hours >= TRUST_BUNDLE_AGE_WARN_HOURS) return 'text-yellow-400'
+  return 'text-green-400'
+}
+
+function ServerPodRow({
+  pod,
+  phaseLabel,
+}: {
+  pod: SpireServerPod
+  phaseLabel: string
+}) {
+  const isHealthy = pod.ready && pod.phase === 'Running'
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          {isHealthy ? (
+            <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
+          ) : (
+            <AlertTriangle className="w-3.5 h-3.5 text-yellow-400 shrink-0" />
+          )}
+          <span className="text-xs font-medium font-mono truncate">{pod.name}</span>
+        </div>
+        <span
+          className={cn(
+            'text-[11px] px-1.5 py-0.5 rounded-full shrink-0',
+            phaseBadgeClass(pod.phase, pod.ready),
+          )}
+        >
+          {phaseLabel}
+        </span>
+      </div>
+      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+        <span className="truncate">{pod.node}</span>
+        {pod.restarts > 0 ? (
+          <span className="text-yellow-400 shrink-0">
+            {pod.restarts}×
+          </span>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function SpireStatus() {
+  const { t } = useTranslation('cards')
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoFallback,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  } = useCachedSpire()
+
+  // Rule: never show demo data while still loading
+  const isDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' counts as "we have data" so the card isn't stuck in skeleton
+  const hasAnyData =
+    data.health === 'not-installed' ? true : data.serverPods.length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    isDemoData,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  })
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
+          <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (showEmptyState || (data.health === 'not-installed' && !isDemoData)) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <ShieldOff className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('spireStatus.notInstalled', 'SPIRE not detected')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'spireStatus.notInstalledHint',
+            'No SPIRE server pods reachable. Deploy SPIRE (server + agent DaemonSet) to monitor workload identity issuance across the fleet.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  const isHealthy = data.health === 'healthy'
+  const serverPods = data.serverPods ?? []
+  const agent = data.agentDaemonSet
+
+  const phaseLabels: Record<SpirePodPhase, string> = {
+    Running: t('spireStatus.phaseRunning', 'Running'),
+    Pending: t('spireStatus.phasePending', 'Pending'),
+    Failed: t('spireStatus.phaseFailed', 'Failed'),
+    Succeeded: t('spireStatus.phaseSucceeded', 'Succeeded'),
+    Unknown: t('spireStatus.phaseUnknown', 'Unknown'),
+  }
+
+  const trustBundleAge = data.summary.trustBundleAgeHours
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* Header — health pill + trust domain */}
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={cn(
+            'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
+            isHealthy
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-yellow-500/15 text-yellow-400',
+          )}
+        >
+          {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          {isHealthy
+            ? t('spireStatus.healthy', 'Healthy')
+            : t('spireStatus.degraded', 'Degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={cn('w-3 h-3', isRefreshing ? 'animate-spin' : '')} />
+          <span>
+            {t('spireStatus.version', 'version')}:{' '}
+            <span className="text-foreground font-mono">{data.version}</span>
+          </span>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label={t('spireStatus.serverReplicas', 'Server')}
+          value={`${data.summary.serverReadyReplicas}/${data.summary.serverDesiredReplicas}`}
+          colorClass={
+            data.summary.serverReadyReplicas === data.summary.serverDesiredReplicas
+              ? 'text-green-400'
+              : 'text-yellow-400'
+          }
+          icon={<Server className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('spireStatus.attestedAgents', 'Agents')}
+          value={data.summary.attestedAgents}
+          colorClass="text-cyan-400"
+          icon={<Users className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('spireStatus.registrationEntries', 'Entries')}
+          value={data.summary.registrationEntries}
+          colorClass="text-cyan-400"
+          icon={<ShieldCheck className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('spireStatus.trustBundleAge', 'Bundle age')}
+          value={`${trustBundleAge}h`}
+          colorClass={trustBundleColor(trustBundleAge)}
+          icon={<Clock className={cn('w-4 h-4', trustBundleColor(trustBundleAge))} />}
+        />
+      </div>
+
+      {/* Server pods + agent DS detail */}
+      <div className="space-y-3 overflow-y-auto scrollbar-thin pr-0.5">
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Server className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('spireStatus.sectionServer', 'SPIRE Server')}
+            </h4>
+            {data.trustDomain ? (
+              <span className="text-[11px] text-muted-foreground ml-auto truncate max-w-[50%] font-mono">
+                {data.trustDomain}
+              </span>
+            ) : null}
+          </div>
+
+          {serverPods.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('spireStatus.noServerPods', 'No SPIRE server pods reporting.')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(serverPods ?? [])
+                .slice(0, MAX_SERVER_POD_ROWS)
+                .map(pod => (
+                  <ServerPodRow
+                    key={pod.name}
+                    pod={pod}
+                    phaseLabel={phaseLabels[pod.phase] ?? pod.phase}
+                  />
+                ))}
+            </div>
+          )}
+        </section>
+
+        {agent ? (
+          <section className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Users className="w-4 h-4 text-cyan-400" />
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {t('spireStatus.sectionAgent', 'Agent DaemonSet')}
+              </h4>
+            </div>
+            <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs font-medium font-mono truncate">
+                  {agent.namespace}/{agent.name}
+                </span>
+                <span
+                  className={cn(
+                    'text-[11px] px-1.5 py-0.5 rounded-full shrink-0',
+                    agent.numberReady === agent.desiredNumberScheduled &&
+                      agent.numberMisscheduled === 0
+                      ? 'bg-green-500/20 text-green-400'
+                      : 'bg-yellow-500/20 text-yellow-400',
+                  )}
+                >
+                  {agent.numberReady}/{agent.desiredNumberScheduled}{' '}
+                  {t('spireStatus.nodes', 'nodes')}
+                </span>
+              </div>
+              {agent.numberMisscheduled > 0 ? (
+                <div className="text-[11px] text-yellow-400">
+                  {t('spireStatus.misscheduled', '{{count}} misscheduled', {
+                    count: agent.numberMisscheduled,
+                  })}
+                </div>
+              ) : null}
+            </div>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export default SpireStatus

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -260,6 +260,7 @@ export const CARD_CATALOG = {
     { type: 'intoto_supply_chain', title: 'in-toto Supply Chain', description: 'Monitor supply chain security and verify layout steps across clusters', visualization: 'status' },
     { type: 'tuf_status', title: 'TUF', description: 'TUF repository role metadata — root, targets, snapshot, timestamp — with versions, expirations, and signing status', visualization: 'status' },
     { type: 'cloud_custodian_status', title: 'Cloud Custodian', description: 'Cloud Custodian policy runs — success / fail / dry-run counts, last-run timestamps, top resources acted on, and violations by severity', visualization: 'status' },
+    { type: 'spire_status', title: 'SPIRE', description: 'SPIRE workload identity — server pod health, agent DaemonSet coverage, attested agents, registration entries, and trust bundle age', visualization: 'status' },
     { type: 'falco_alerts', title: 'Falco Alerts', description: 'Runtime security monitoring - syscall anomalies, container escapes, privilege escalation', visualization: 'events' },
     { type: 'trivy_scan', title: 'Trivy Scanner', description: 'Vulnerability scanning for container images, IaC, and secrets', visualization: 'table' },
     { type: 'kubescape_scan', title: 'Kubescape', description: 'Security posture management and NSA/CISA hardening compliance', visualization: 'status' },

--- a/web/src/components/marketplace/MarketplaceThumbnail.tsx
+++ b/web/src/components/marketplace/MarketplaceThumbnail.tsx
@@ -86,6 +86,7 @@ const PROJECT_TO_GITHUB_ORG: Record<string, string> = {
   volcano: 'volcano-sh',
   kubeedge: 'kubeedge',
   spiffe: 'spiffe',
+  spire: 'spiffe',
   notary: 'notaryproject',
 }
 

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -77,6 +77,7 @@ import { kserveStatusConfig } from './kserve-status'
 import { linkerdStatusConfig } from './linkerd-status'
 import { otelStatusConfig } from './otel-status'
 import { rookStatusConfig } from './rook-status'
+import { spireStatusConfig } from './spire-status'
 import { tikvStatusConfig } from './tikv-status'
 import { tufStatusConfig } from './tuf-status'
 import { vitessStatusConfig } from './vitess-status'
@@ -281,6 +282,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   linkerd_status: linkerdStatusConfig,
   otel_status: otelStatusConfig,
   rook_status: rookStatusConfig,
+  spire_status: spireStatusConfig,
   tikv_status: tikvStatusConfig,
   tuf_status: tufStatusConfig,
   vitess_status: vitessStatusConfig,

--- a/web/src/config/cards/spire-status.ts
+++ b/web/src/config/cards/spire-status.ts
@@ -1,0 +1,51 @@
+/**
+ * SPIRE (SPIFFE Runtime Environment) Status Card Configuration
+ *
+ * SPIRE is the reference implementation of SPIFFE — a CNCF graduated
+ * workload identity framework. This card surfaces SPIRE server pod
+ * health, agent DaemonSet coverage, attested agent count, registration
+ * entry count, and trust bundle age so operators can spot identity
+ * plane problems before workloads start failing mTLS.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const spireStatusConfig: UnifiedCardConfig = {
+  type: 'spire_status',
+  title: 'SPIRE',
+  category: 'security',
+  description:
+    'SPIRE workload identity — server pod health, agent DaemonSet coverage, attested agents, registration entries, and trust bundle age.',
+  icon: 'ShieldCheck',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useCachedSpire' },
+  content: {
+    type: 'list',
+    pageSize: 4,
+    columns: [
+      { field: 'name', header: 'Pod', primary: true, width: 200 },
+      { field: 'phase', header: 'Phase', width: 100 },
+      { field: 'ready', header: 'Ready', width: 90 },
+      { field: 'restarts', header: 'Restarts', width: 100 },
+      { field: 'node', header: 'Node', render: 'truncate' },
+    ],
+  },
+  emptyState: {
+    icon: 'ShieldCheck',
+    title: 'SPIRE not detected',
+    message: 'No SPIRE server pods reachable from the connected clusters.',
+    variant: 'info',
+  },
+  loadingState: {
+    type: 'list',
+    rows: 4,
+  },
+  // Scaffolding: renders live if /api/spire/status is wired up, otherwise
+  // falls back to demo data via the useCache demo path.
+  isDemoData: true,
+  isLive: false,
+}
+
+export default spireStatusConfig

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -170,6 +170,11 @@ export { useCachedCni } from './useCachedCni'
 // Named re-export (avoids `__testables` export-name collision with TiKV).
 
 export { useCachedOpenfeature } from './useCachedOpenfeature'
+// SPIRE (SPIFFE Runtime Environment) — useCachedSpire.ts
+// ============================================================================
+// Named re-export (avoids `__testables` export-name collision with other hooks).
+
+export { useCachedSpire } from './useCachedSpire'
 
 // ============================================================================
 // TiKV Distributed Key-Value Store — useCachedTikv.ts

--- a/web/src/hooks/useCachedSpire.ts
+++ b/web/src/hooks/useCachedSpire.ts
@@ -1,0 +1,207 @@
+/**
+ * useCachedSpire — Cached hook for SPIRE (SPIFFE Runtime Environment) status.
+ *
+ * Follows the mandatory caching contract defined in CLAUDE.md:
+ * - useCache with fetcher + demoData
+ * - isDemoFallback guarded so it's false during loading
+ * - Standard CachedHookResult return shape
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real SPIRE bridge lands (for example /api/spire/status backed by the
+ * SPIRE server admin API surfacing server pods, agent DaemonSet, attested
+ * agent count, and registration entry count), the fetcher picks up live
+ * data automatically with no component changes.
+ */
+
+import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { authFetch } from '../lib/api'
+import {
+  SPIRE_DEMO_DATA,
+  type SpireAgentDaemonSet,
+  type SpireHealth,
+  type SpireServerPod,
+  type SpireStatusData,
+  type SpireSummary,
+} from '../lib/demo/spire'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY_SPIRE = 'spire-status'
+const SPIRE_STATUS_ENDPOINT = '/api/spire/status'
+const DEFAULT_VERSION = 'unknown'
+const DEFAULT_TRUST_DOMAIN = ''
+
+const NOT_FOUND_STATUS = 404
+
+const INITIAL_SUMMARY: SpireSummary = {
+  registrationEntries: 0,
+  attestedAgents: 0,
+  trustBundleAgeHours: 0,
+  serverReadyReplicas: 0,
+  serverDesiredReplicas: 0,
+}
+
+const INITIAL_DATA: SpireStatusData = {
+  health: 'not-installed',
+  version: DEFAULT_VERSION,
+  trustDomain: DEFAULT_TRUST_DOMAIN,
+  serverPods: [],
+  agentDaemonSet: null,
+  summary: INITIAL_SUMMARY,
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Internal types (shape of the future /api/spire/status response)
+// ---------------------------------------------------------------------------
+
+interface SpireStatusResponse {
+  version?: string
+  trustDomain?: string
+  serverPods?: SpireServerPod[]
+  agentDaemonSet?: SpireAgentDaemonSet | null
+  summary?: Partial<SpireSummary>
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-testable)
+// ---------------------------------------------------------------------------
+
+function countReadyPods(pods: SpireServerPod[]): number {
+  let ready = 0
+  for (const pod of pods ?? []) {
+    if (pod.ready && pod.phase === 'Running') ready += 1
+  }
+  return ready
+}
+
+function deriveHealth(
+  serverPods: SpireServerPod[],
+  agentDaemonSet: SpireAgentDaemonSet | null,
+  summary: SpireSummary,
+): SpireHealth {
+  const hasServerPods = (serverPods ?? []).length > 0
+  const hasAgent = agentDaemonSet !== null && agentDaemonSet !== undefined
+
+  if (!hasServerPods && !hasAgent) return 'not-installed'
+
+  // Any server pod not ready → degraded
+  const readyPods = countReadyPods(serverPods)
+  const expectedServerReplicas =
+    summary.serverDesiredReplicas > 0
+      ? summary.serverDesiredReplicas
+      : (serverPods ?? []).length
+  if (expectedServerReplicas > 0 && readyPods < expectedServerReplicas) {
+    return 'degraded'
+  }
+
+  // Agent DaemonSet coverage check — any node missing an agent → degraded
+  if (agentDaemonSet) {
+    if (agentDaemonSet.numberReady < agentDaemonSet.desiredNumberScheduled) {
+      return 'degraded'
+    }
+    if (agentDaemonSet.numberMisscheduled > 0) return 'degraded'
+  }
+
+  return 'healthy'
+}
+
+function buildSpireStatus(
+  version: string,
+  trustDomain: string,
+  serverPods: SpireServerPod[],
+  agentDaemonSet: SpireAgentDaemonSet | null,
+  summaryIn: Partial<SpireSummary>,
+): SpireStatusData {
+  const normalizedPods = serverPods ?? []
+  const readyPods = countReadyPods(normalizedPods)
+  const desiredReplicas =
+    typeof summaryIn.serverDesiredReplicas === 'number'
+      ? summaryIn.serverDesiredReplicas
+      : normalizedPods.length
+  const summary: SpireSummary = {
+    registrationEntries: summaryIn.registrationEntries ?? 0,
+    attestedAgents:
+      summaryIn.attestedAgents ?? (agentDaemonSet?.numberReady ?? 0),
+    trustBundleAgeHours: summaryIn.trustBundleAgeHours ?? 0,
+    serverReadyReplicas: summaryIn.serverReadyReplicas ?? readyPods,
+    serverDesiredReplicas: desiredReplicas,
+  }
+  return {
+    health: deriveHealth(normalizedPods, agentDaemonSet ?? null, summary),
+    version,
+    trustDomain,
+    serverPods: normalizedPods,
+    agentDaemonSet: agentDaemonSet ?? null,
+    summary,
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchSpireStatus(): Promise<SpireStatusData> {
+  const resp = await authFetch(SPIRE_STATUS_ENDPOINT, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
+
+  if (!resp.ok) {
+    if (resp.status === NOT_FOUND_STATUS) {
+      // Endpoint not yet wired — surface "not-installed" so the cache layer
+      // will fall back to demo data instead of flagging a hard failure.
+      return buildSpireStatus(DEFAULT_VERSION, DEFAULT_TRUST_DOMAIN, [], null, {})
+    }
+    throw new Error(`HTTP ${resp.status}`)
+  }
+
+  const body = (await resp.json()) as SpireStatusResponse
+  const version = body.version ?? DEFAULT_VERSION
+  const trustDomain = body.trustDomain ?? DEFAULT_TRUST_DOMAIN
+  const serverPods = Array.isArray(body.serverPods) ? body.serverPods : []
+  const agentDaemonSet = body.agentDaemonSet ?? null
+  const summary = body.summary ?? {}
+  return buildSpireStatus(version, trustDomain, serverPods, agentDaemonSet, summary)
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useCachedSpire(): CachedHookResult<SpireStatusData> {
+  const result = useCache<SpireStatusData>({
+    key: CACHE_KEY_SPIRE,
+    category: 'default' as RefreshCategory,
+    initialData: INITIAL_DATA,
+    demoData: SPIRE_DEMO_DATA,
+    persist: true,
+    fetcher: fetchSpireStatus,
+  })
+
+  return {
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  countReadyPods,
+  deriveHealth,
+  buildSpireStatus,
+}

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -107,6 +107,7 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-rook': 'rook_status',
   'cncf-spiffe': 'spiffe_status',
   'cncf-cni': 'cni_status',
+  'cncf-spire': 'spire_status',
   'cncf-strimzi': 'strimzi_status',
   'cncf-thanos': 'thanos_status',
   'cncf-opentelemetry': 'otel_status',

--- a/web/src/lib/demo/spire.ts
+++ b/web/src/lib/demo/spire.ts
@@ -1,0 +1,172 @@
+/**
+ * SPIRE (SPIFFE Runtime Environment) Status Card — Demo Data & Types
+ *
+ * SPIRE is the reference implementation of SPIFFE — a CNCF graduated
+ * workload identity framework. It issues short-lived SVIDs (SPIFFE
+ * Verifiable Identity Documents) to workloads based on admission
+ * attestation performed by agents running on each node.
+ *
+ * Operators care about:
+ *   - SPIRE server pod health (replicas desired/ready/available)
+ *   - Agent DaemonSet coverage across nodes
+ *   - How many agents are currently attested (online + trusted)
+ *   - Registration entry count (workload identities provisioned)
+ *   - Trust bundle age (how long since the last rotation)
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SpireHealth = 'healthy' | 'degraded' | 'not-installed'
+
+export type SpirePodPhase =
+  | 'Running'
+  | 'Pending'
+  | 'Failed'
+  | 'Succeeded'
+  | 'Unknown'
+
+export interface SpireServerPod {
+  name: string
+  phase: SpirePodPhase
+  ready: boolean
+  restarts: number
+  /** ISO timestamp — when the pod started. */
+  startedAt: string
+  /** Node the pod is scheduled onto. */
+  node: string
+}
+
+export interface SpireAgentDaemonSet {
+  name: string
+  namespace: string
+  /** Nodes that the DaemonSet should schedule onto. */
+  desiredNumberScheduled: number
+  /** Nodes that have at least one running agent pod. */
+  numberReady: number
+  /** Nodes where an agent pod is available (ready + min ready seconds). */
+  numberAvailable: number
+  /** Nodes where scheduling is missing an agent pod. */
+  numberMisscheduled: number
+}
+
+export interface SpireSummary {
+  /** Registration entries currently provisioned. */
+  registrationEntries: number
+  /** Agents that have completed node attestation and hold a valid SVID. */
+  attestedAgents: number
+  /** Trust bundle age in hours (since last CA rotation). */
+  trustBundleAgeHours: number
+  /** Count of SPIRE server pods that are ready. */
+  serverReadyReplicas: number
+  /** Desired SPIRE server replicas. */
+  serverDesiredReplicas: number
+}
+
+export interface SpireStatusData {
+  health: SpireHealth
+  /** SPIRE server version string (e.g. "1.10.4"). */
+  version: string
+  /** Trust domain configured on the SPIRE server (e.g. "example.org"). */
+  trustDomain: string
+  serverPods: SpireServerPod[]
+  agentDaemonSet: SpireAgentDaemonSet | null
+  summary: SpireSummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo data — shown when SPIRE is not installed or in demo mode
+// ---------------------------------------------------------------------------
+
+const MS_PER_SECOND = 1000
+const SECONDS_PER_MINUTE = 60
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+const MS_PER_HOUR = MS_PER_SECOND * SECONDS_PER_MINUTE * MINUTES_PER_HOUR
+const MS_PER_DAY = MS_PER_HOUR * HOURS_PER_DAY
+
+// Demo SPIRE server — highly-available 3-replica deployment
+const DEMO_SERVER_REPLICAS_DESIRED = 3
+const DEMO_SERVER_REPLICAS_READY = 3
+
+// Demo agent DaemonSet scheduled on every worker node
+const DEMO_AGENT_DESIRED_NODES = 12
+const DEMO_AGENT_READY_NODES = 11
+const DEMO_AGENT_AVAILABLE_NODES = 11
+const DEMO_AGENT_MISSCHEDULED = 0
+
+// Demo identity counts — realistic for a mid-size cluster
+const DEMO_REGISTRATION_ENTRIES = 147
+const DEMO_ATTESTED_AGENTS = 11
+
+// Trust bundle rotated ~18 hours ago — a healthy cadence is daily.
+const DEMO_TRUST_BUNDLE_AGE_HOURS = 18
+
+const DEMO_VERSION = '1.10.4'
+const DEMO_TRUST_DOMAIN = 'kubestellar.demo'
+
+// Server pod uptime values chosen to look realistic (days / hours).
+const DEMO_POD_0_UPTIME_DAYS = 14
+const DEMO_POD_1_UPTIME_DAYS = 14
+const DEMO_POD_2_UPTIME_HOURS = 6
+
+const DEMO_POD_RESTARTS_NONE = 0
+const DEMO_POD_RESTARTS_ROLLING = 1
+
+const NOW_MS = Date.now()
+
+const DEMO_SERVER_PODS: SpireServerPod[] = [
+  {
+    name: 'spire-server-0',
+    phase: 'Running',
+    ready: true,
+    restarts: DEMO_POD_RESTARTS_NONE,
+    startedAt: new Date(NOW_MS - DEMO_POD_0_UPTIME_DAYS * MS_PER_DAY).toISOString(),
+    node: 'ip-10-0-1-10.ec2.internal',
+  },
+  {
+    name: 'spire-server-1',
+    phase: 'Running',
+    ready: true,
+    restarts: DEMO_POD_RESTARTS_NONE,
+    startedAt: new Date(NOW_MS - DEMO_POD_1_UPTIME_DAYS * MS_PER_DAY).toISOString(),
+    node: 'ip-10-0-1-11.ec2.internal',
+  },
+  {
+    name: 'spire-server-2',
+    phase: 'Running',
+    ready: true,
+    restarts: DEMO_POD_RESTARTS_ROLLING,
+    startedAt: new Date(NOW_MS - DEMO_POD_2_UPTIME_HOURS * MS_PER_HOUR).toISOString(),
+    node: 'ip-10-0-1-12.ec2.internal',
+  },
+]
+
+const DEMO_AGENT_DAEMONSET: SpireAgentDaemonSet = {
+  name: 'spire-agent',
+  namespace: 'spire-system',
+  desiredNumberScheduled: DEMO_AGENT_DESIRED_NODES,
+  numberReady: DEMO_AGENT_READY_NODES,
+  numberAvailable: DEMO_AGENT_AVAILABLE_NODES,
+  numberMisscheduled: DEMO_AGENT_MISSCHEDULED,
+}
+
+export const SPIRE_DEMO_DATA: SpireStatusData = {
+  // One agent pod is not ready (11/12) — show the card in a "degraded" state
+  // so the warning styling is exercised in demo mode.
+  health: 'degraded',
+  version: DEMO_VERSION,
+  trustDomain: DEMO_TRUST_DOMAIN,
+  serverPods: DEMO_SERVER_PODS,
+  agentDaemonSet: DEMO_AGENT_DAEMONSET,
+  summary: {
+    registrationEntries: DEMO_REGISTRATION_ENTRIES,
+    attestedAgents: DEMO_ATTESTED_AGENTS,
+    trustBundleAgeHours: DEMO_TRUST_BUNDLE_AGE_HOURS,
+    serverReadyReplicas: DEMO_SERVER_REPLICAS_READY,
+    serverDesiredReplicas: DEMO_SERVER_REPLICAS_DESIRED,
+  },
+  lastCheckTime: new Date(NOW_MS).toISOString(),
+}

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -65,6 +65,7 @@ import { useCachedOtel } from '../../hooks/useCachedOtel'
 import { useCachedRook } from '../../hooks/useCachedRook'
 import { useCachedSpiffe } from '../../hooks/useCachedSpiffe'
 import { useCachedCni } from '../../hooks/useCachedCni'
+import { useCachedSpire } from '../../hooks/useCachedSpire'
 import { useCachedTikv } from '../../hooks/useCachedTikv'
 import { useCachedTuf } from '../../hooks/useCachedTuf'
 import { useCachedCloudCustodian } from '../../hooks/useCachedCloudCustodian'
@@ -1267,6 +1268,15 @@ function useUnifiedOpenfeatureStatus() {
     isLoading: result.showSkeleton,
     error: result.error ? new Error('Failed to fetch OpenFeature status') : null,
     refetch: () => { result.refetch() },
+function useUnifiedSpireStatus() {
+  const result = useCachedSpire()
+  // Surface the SPIRE server pod list as the primary row set for generic
+  // list renderers.
+  return {
+    data: result.data.serverPods,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
   }
 }
 
@@ -1483,6 +1493,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useCachedSpiffe', useUnifiedSpiffeStatus)
   registerDataHook('useCachedCni', useUnifiedCniStatus)
   registerDataHook('useCachedOpenfeature', useUnifiedOpenfeatureStatus)
+  registerDataHook('useCachedSpire', useUnifiedSpireStatus)
   registerDataHook('useCachedTikv', useUnifiedTikvStatus)
   registerDataHook('useCachedTuf', useUnifiedTufStatus)
   registerDataHook('useCachedCloudCustodian', useUnifiedCloudCustodianStatus)

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -1268,6 +1268,9 @@ function useUnifiedOpenfeatureStatus() {
     isLoading: result.showSkeleton,
     error: result.error ? new Error('Failed to fetch OpenFeature status') : null,
     refetch: () => { result.refetch() },
+  }
+}
+
 function useUnifiedSpireStatus() {
   const result = useCachedSpire()
   // Surface the SPIRE server pod list as the primary row set for generic

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3290,6 +3290,27 @@
     "leaderCount_one": "{{count}} leader",
     "leaderCount_other": "{{count}} leaders"
   },
+  "spireStatus": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "SPIRE not detected",
+    "notInstalledHint": "No SPIRE server pods reachable. Deploy SPIRE (server + agent DaemonSet) to monitor workload identity issuance across the fleet.",
+    "version": "version",
+    "serverReplicas": "Server",
+    "attestedAgents": "Agents",
+    "registrationEntries": "Entries",
+    "trustBundleAge": "Bundle age",
+    "sectionServer": "SPIRE Server",
+    "sectionAgent": "Agent DaemonSet",
+    "noServerPods": "No SPIRE server pods reporting.",
+    "nodes": "nodes",
+    "misscheduled": "{{count}} misscheduled",
+    "phaseRunning": "Running",
+    "phasePending": "Pending",
+    "phaseFailed": "Failed",
+    "phaseSucceeded": "Succeeded",
+    "phaseUnknown": "Unknown"
+  },
   "tufStatus": {
     "healthy": "Healthy",
     "degraded": "Degraded",


### PR DESCRIPTION
Fixes kubestellar/console-marketplace#19

## Summary

Adds a SPIRE (SPIFFE Runtime Environment) monitoring card — CNCF graduated workload identity framework. The card surfaces:

- SPIRE server pod health (replicas desired/ready, phase, restarts, node)
- Agent DaemonSet coverage (ready / desired nodes, misscheduled count)
- Attested agent count
- Registration entry count
- Trust bundle age with yellow/red thresholds at 24h / 48h
- Trust domain + SPIRE server version in the header

Scaffolding hook — `/api/spire/status` is not yet wired, so the card renders from demo data today. When a real SPIRE bridge lands (backed by the SPIRE server admin API) the fetcher picks up live data with no component changes.

Follows the `tuf_status` / `linkerd_status` pattern:

- `isDemoFallback` guarded with `!isLoading`
- `isDemoData` + `isRefreshing` both passed to `useCardLoadingState`
- Named constants everywhere (no magic numbers)
- `?? []` guards on every list iteration
- All user-facing strings via `t()`
- Security category in `cardCatalog` + config

## Test plan

- [ ] Add SPIRE card from the card catalog (Security Posture group)
- [ ] Verify the card renders with demo data (yellow "Demo data" outline + badge)
- [ ] Verify the health pill shows "Degraded" (demo agent DS has 11/12 ready)
- [ ] Verify the four summary tiles render correct values (Server 3/3, Agents 11, Entries 147, Bundle age 18h)
- [ ] Verify the server pod list shows all three `spire-server-0/1/2` rows
- [ ] Verify the agent DaemonSet section shows `spire-system/spire-agent` with 11/12 nodes
- [ ] Marketplace `cncf-spire` item gets promoted from help-wanted to available via `reconcileImplementedCards`