### PR TITLE
fix: add DashboardHeader to compliance dashboards and fix enterprise sidebar width

### DIFF
--- a/web/src/components/compliance/LicenseComplianceDashboard.tsx
+++ b/web/src/components/compliance/LicenseComplianceDashboard.tsx
@@ -7,10 +7,12 @@
  */
 import { useState, useEffect } from 'react'
 import {
-  Scale, CheckCircle2, XCircle, AlertTriangle, Loader2,
-  RefreshCw, BookOpen,
+  CheckCircle2, XCircle, AlertTriangle, Loader2,
+  BookOpen,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 /** How often to re-scan license data (ms) */
 const LICENSE_REFRESH_MS = 300_000
@@ -65,6 +67,7 @@ export default function LicenseComplianceDashboard() {
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'violations' | 'inventory' | 'categories'>('violations')
   const [filterRisk, setFilterRisk] = useState<LicenseRisk | null>('denied')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   const fetchData = async () => {
     setLoading(true)
@@ -116,21 +119,16 @@ export default function LicenseComplianceDashboard() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <Scale className="w-7 h-7 text-indigo-400" />
-            License Compliance Scanner
-          </h1>
-          <p className="text-gray-400 mt-1">
-            Open-source license inventory with deny/warn-list violation detection
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="License Compliance Scanner"
+        subtitle="Open-source license inventory with deny/warn-list violation detection"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="license-compliance-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/SigningStatusDashboard.tsx
+++ b/web/src/components/compliance/SigningStatusDashboard.tsx
@@ -8,9 +8,11 @@
 import { useState, useEffect } from 'react'
 import {
   BadgeCheck, XCircle, AlertTriangle, Loader2,
-  RefreshCw, Shield, ShieldAlert, ShieldOff, Server,
+  Shield, ShieldAlert, ShieldOff, Server,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 /** Polling interval for signature status refresh (ms) */
 const REFRESH_INTERVAL_MS = 120_000
@@ -63,6 +65,7 @@ export default function SigningStatusDashboard() {
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'images' | 'policies'>('images')
   const [filterUnsigned, setFilterUnsigned] = useState(false)
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   const fetchData = async () => {
     setLoading(true)
@@ -112,21 +115,16 @@ export default function SigningStatusDashboard() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <BadgeCheck className="w-7 h-7 text-purple-400" />
-            Sigstore / Cosign Verification
-          </h1>
-          <p className="text-gray-400 mt-1">
-            Image signature verification and supply chain attestation across the fleet
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="Sigstore / Cosign Verification"
+        subtitle="Image signature verification and supply chain attestation across the fleet"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="signing-status-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/enterprise/EnterpriseSidebar.tsx
+++ b/web/src/components/enterprise/EnterpriseSidebar.tsx
@@ -27,7 +27,7 @@ const SIDEBAR_FEATURES = {
   addMore: true,
   clusterStatus: true,
   collapsePin: true,
-  resize: true,
+  resize: false,
   activeUsers: true,
 } as const
 


### PR DESCRIPTION
Fixes #9822
Fixes #9823

Re-creation of #9839 which was closed due to merge conflicts.

## Changes
- Add DashboardHeader with Tip/Auto/refresh controls to LicenseComplianceDashboard and SigningStatusDashboard (the only two compliance dashboards that were missing it)
- Remove unused `RefreshCw` and `Scale` icon imports that were only used in the replaced manual headers
- Disable resize on enterprise sidebar to prevent width drift from the locked 256px default — the sidebar already uses `widthOverride={SIDEBAR_DEFAULT_WIDTH_PX}` but the resize handle allowed users to drag it wider, persisting a larger width