### PR TITLE
feat(volcano): add Volcano monitoring card (kubestellar/console-marketplace#56)

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -297,6 +297,8 @@ export const CARD_TITLES: Record<string, string> = {
   vitess_status: 'Vitess',
   // wasmCloud WebAssembly lattice (CNCF incubating)
   wasmcloud_status: 'wasmCloud',
+  // Volcano batch/HPC scheduler (CNCF Incubating)
+  volcano_status: 'Volcano',
   // CRI-O container runtime
   crio_status: 'CRI-O',
   // Cloud Custodian rules engine (CNCF incubating)
@@ -645,6 +647,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   vitess_status: 'Vitess distributed MySQL: keyspaces, shards, tablets (PRIMARY/REPLICA/RDONLY), and replication lag.',
   // wasmCloud WebAssembly lattice (CNCF incubating)
   wasmcloud_status: 'wasmCloud lattice status: hosts, actors, capability providers, and link definitions across connected clusters.',
+  // Volcano batch/HPC scheduler (CNCF Incubating)
+  volcano_status: 'Volcano batch/HPC scheduler: queues, jobs (pending/running/completed/failed), pod groups, and GPU allocation.',
   // CRI-O container runtime
   crio_status: 'CRI-O container runtime metrics, image pulls, and pod sandbox status.',
   // Cloud Custodian rules engine (CNCF incubating)

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -112,6 +112,8 @@ const VitessStatus = safeLazy(() => import('./vitess_status'), 'VitessStatus')
 const ChaosMeshStatus = safeLazy(() => import('./chaos_mesh_status'), 'ChaosMeshStatus')
 // wasmCloud WebAssembly lattice card (CNCF incubating)
 const WasmcloudStatus = safeLazy(() => import('./wasmcloud_status'), 'WasmcloudStatus')
+// Volcano batch/HPC scheduler card (CNCF Incubating)
+const VolcanoStatus = safeLazy(() => import('./volcano_status'), 'VolcanoStatus')
 const OverlayComparison = safeLazy(() => _deployBundle, 'OverlayComparison')
 const ArgoCDApplications = safeLazy(() => _deployBundle, 'ArgoCDApplications')
 const ArgoCDApplicationSets = safeLazy(() => _deployBundle, 'ArgoCDApplicationSets')
@@ -779,6 +781,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   vitess_status: VitessStatus,
   // wasmCloud WebAssembly lattice (CNCF incubating)
   wasmcloud_status: WasmcloudStatus,
+  // Volcano batch/HPC scheduler (CNCF Incubating)
+  volcano_status: VolcanoStatus,
   // Artifact Hub
   artifact_hub_status: ArtifactHubStatus,
   // CloudEvents messaging
@@ -1114,6 +1118,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   // Chaos Mesh fault-injection and chaos engineering
   chaos_mesh_status: () => import('./chaos_mesh_status'),
   wasmcloud_status: () => import('./wasmcloud_status'),
+  volcano_status: () => import('./volcano_status'),
   overlay_comparison: () => import('./deploy-bundle'),
   argocd_applications: () => import('./deploy-bundle'),
   argocd_applicationsets: () => import('./deploy-bundle'),
@@ -1735,6 +1740,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   vitess_status: 6,
   chaos_mesh_status: 6,
   wasmcloud_status: 6,
+  volcano_status: 6,
   pvc_status: 6,
   gpu_status: 6,
   gpu_inventory: 6,

--- a/web/src/components/cards/volcano_status/demoData.ts
+++ b/web/src/components/cards/volcano_status/demoData.ts
@@ -1,0 +1,396 @@
+/**
+ * Volcano Status Card — Demo Data & Type Definitions
+ *
+ * Volcano is a CNCF Incubating batch/HPC scheduler that extends Kubernetes
+ * with gang scheduling, fair-share queues, preemption, and per-job resource
+ * accounting. It's the de-facto scheduler for AI/ML training, HPC, and
+ * big-data workloads on Kubernetes.
+ *
+ * This card surfaces the operational signals a platform team needs to
+ * monitor a Volcano deployment:
+ *  - Queues with weight, capability, and allocated / guaranteed capacity
+ *  - Jobs grouped by phase (pending, running, completed, failed)
+ *  - Pod groups (the unit of gang scheduling) and their scheduling state
+ *  - Aggregate GPU allocation across the batch workload
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real Volcano bridge lands (`/api/volcano/status`), the hook's fetcher
+ * will pick up live data automatically with no component changes.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type VolcanoHealth = 'healthy' | 'degraded' | 'not-installed'
+export type VolcanoJobPhase =
+  | 'Pending'
+  | 'Running'
+  | 'Completed'
+  | 'Failed'
+  | 'Aborted'
+export type PodGroupPhase =
+  | 'Pending'
+  | 'Inqueue'
+  | 'Running'
+  | 'Completed'
+  | 'Failed'
+  | 'Unknown'
+export type QueueState = 'Open' | 'Closed' | 'Closing'
+
+export interface VolcanoQueue {
+  name: string
+  state: QueueState
+  weight: number
+  runningJobs: number
+  pendingJobs: number
+  allocatedCpu: number
+  allocatedMemGiB: number
+  allocatedGpu: number
+  capabilityCpu: number
+  capabilityMemGiB: number
+  capabilityGpu: number
+  cluster: string
+}
+
+export interface VolcanoJob {
+  name: string
+  namespace: string
+  queue: string
+  phase: VolcanoJobPhase
+  minAvailable: number
+  runningPods: number
+  totalPods: number
+  gpuRequest: number
+  cluster: string
+  createdAt: string
+}
+
+export interface VolcanoPodGroup {
+  name: string
+  namespace: string
+  queue: string
+  phase: PodGroupPhase
+  minMember: number
+  runningMember: number
+  cluster: string
+}
+
+export interface VolcanoStats {
+  totalQueues: number
+  openQueues: number
+  totalJobs: number
+  pendingJobs: number
+  runningJobs: number
+  completedJobs: number
+  failedJobs: number
+  totalPodGroups: number
+  allocatedGpu: number
+  schedulerVersion: string
+}
+
+export interface VolcanoSummary {
+  totalQueues: number
+  totalJobs: number
+  totalPodGroups: number
+  allocatedGpu: number
+}
+
+export interface VolcanoStatusData {
+  health: VolcanoHealth
+  queues: VolcanoQueue[]
+  jobs: VolcanoJob[]
+  podGroups: VolcanoPodGroup[]
+  stats: VolcanoStats
+  summary: VolcanoSummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo-data constants (named — no magic numbers)
+// ---------------------------------------------------------------------------
+
+const DEMO_SCHEDULER_VERSION = '1.9.0'
+const DEMO_CLUSTER_PRIMARY = 'prod-east'
+const DEMO_CLUSTER_SECONDARY = 'prod-west'
+
+// Queue capabilities & allocations
+const DEFAULT_QUEUE_WEIGHT = 1
+const HIGH_PRIORITY_QUEUE_WEIGHT = 4
+const ML_TRAINING_QUEUE_WEIGHT = 2
+
+const DEFAULT_QUEUE_CAP_CPU = 64
+const DEFAULT_QUEUE_CAP_MEM_GIB = 256
+const DEFAULT_QUEUE_CAP_GPU = 4
+const DEFAULT_QUEUE_ALLOC_CPU = 18
+const DEFAULT_QUEUE_ALLOC_MEM_GIB = 72
+const DEFAULT_QUEUE_ALLOC_GPU = 1
+const DEFAULT_QUEUE_RUNNING = 3
+const DEFAULT_QUEUE_PENDING = 1
+
+const HIGH_PRIORITY_CAP_CPU = 128
+const HIGH_PRIORITY_CAP_MEM_GIB = 512
+const HIGH_PRIORITY_CAP_GPU = 8
+const HIGH_PRIORITY_ALLOC_CPU = 96
+const HIGH_PRIORITY_ALLOC_MEM_GIB = 384
+const HIGH_PRIORITY_ALLOC_GPU = 6
+const HIGH_PRIORITY_RUNNING = 5
+const HIGH_PRIORITY_PENDING = 2
+
+const ML_TRAINING_CAP_CPU = 256
+const ML_TRAINING_CAP_MEM_GIB = 1024
+const ML_TRAINING_CAP_GPU = 32
+const ML_TRAINING_ALLOC_CPU = 192
+const ML_TRAINING_ALLOC_MEM_GIB = 768
+const ML_TRAINING_ALLOC_GPU = 24
+const ML_TRAINING_RUNNING = 7
+const ML_TRAINING_PENDING = 4
+
+// Job counts (15 jobs total — distributed across phases)
+const DEMO_TOTAL_JOBS = 15
+const DEMO_PENDING_JOBS = 3
+const DEMO_RUNNING_JOBS = 6
+const DEMO_COMPLETED_JOBS = 5
+const DEMO_FAILED_JOBS = 1
+
+// Pod-group count
+const DEMO_POD_GROUP_COUNT = 42
+
+// Aggregate GPU allocation
+const DEMO_ALLOCATED_GPU_TOTAL =
+  DEFAULT_QUEUE_ALLOC_GPU + HIGH_PRIORITY_ALLOC_GPU + ML_TRAINING_ALLOC_GPU
+
+// Per-job sizing
+const JOB_MIN_AVAILABLE_SMALL = 2
+const JOB_MIN_AVAILABLE_MEDIUM = 4
+const JOB_MIN_AVAILABLE_LARGE = 8
+
+const JOB_TOTAL_PODS_SMALL = 2
+const JOB_TOTAL_PODS_MEDIUM = 4
+const JOB_TOTAL_PODS_LARGE = 8
+
+const JOB_GPU_NONE = 0
+const JOB_GPU_SMALL = 1
+const JOB_GPU_MEDIUM = 2
+const JOB_GPU_LARGE = 4
+
+// Pod-group members
+const PG_MIN_SMALL = 2
+const PG_MIN_MEDIUM = 4
+const PG_MIN_LARGE = 8
+
+// Relative timestamps (ms before "now") for demo createdAt values
+const FIVE_MINUTES_MS = 5 * 60 * 1000
+const ONE_HOUR_MS = 60 * 60 * 1000
+const SIX_HOURS_MS = 6 * 60 * 60 * 1000
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+// ---------------------------------------------------------------------------
+// Demo data — shown when Volcano is not installed or in demo mode
+// ---------------------------------------------------------------------------
+
+const DEMO_QUEUES: VolcanoQueue[] = [
+  {
+    name: 'default',
+    state: 'Open',
+    weight: DEFAULT_QUEUE_WEIGHT,
+    runningJobs: DEFAULT_QUEUE_RUNNING,
+    pendingJobs: DEFAULT_QUEUE_PENDING,
+    allocatedCpu: DEFAULT_QUEUE_ALLOC_CPU,
+    allocatedMemGiB: DEFAULT_QUEUE_ALLOC_MEM_GIB,
+    allocatedGpu: DEFAULT_QUEUE_ALLOC_GPU,
+    capabilityCpu: DEFAULT_QUEUE_CAP_CPU,
+    capabilityMemGiB: DEFAULT_QUEUE_CAP_MEM_GIB,
+    capabilityGpu: DEFAULT_QUEUE_CAP_GPU,
+    cluster: DEMO_CLUSTER_PRIMARY,
+  },
+  {
+    name: 'high-priority',
+    state: 'Open',
+    weight: HIGH_PRIORITY_QUEUE_WEIGHT,
+    runningJobs: HIGH_PRIORITY_RUNNING,
+    pendingJobs: HIGH_PRIORITY_PENDING,
+    allocatedCpu: HIGH_PRIORITY_ALLOC_CPU,
+    allocatedMemGiB: HIGH_PRIORITY_ALLOC_MEM_GIB,
+    allocatedGpu: HIGH_PRIORITY_ALLOC_GPU,
+    capabilityCpu: HIGH_PRIORITY_CAP_CPU,
+    capabilityMemGiB: HIGH_PRIORITY_CAP_MEM_GIB,
+    capabilityGpu: HIGH_PRIORITY_CAP_GPU,
+    cluster: DEMO_CLUSTER_PRIMARY,
+  },
+  {
+    name: 'ml-training',
+    state: 'Open',
+    weight: ML_TRAINING_QUEUE_WEIGHT,
+    runningJobs: ML_TRAINING_RUNNING,
+    pendingJobs: ML_TRAINING_PENDING,
+    allocatedCpu: ML_TRAINING_ALLOC_CPU,
+    allocatedMemGiB: ML_TRAINING_ALLOC_MEM_GIB,
+    allocatedGpu: ML_TRAINING_ALLOC_GPU,
+    capabilityCpu: ML_TRAINING_CAP_CPU,
+    capabilityMemGiB: ML_TRAINING_CAP_MEM_GIB,
+    capabilityGpu: ML_TRAINING_CAP_GPU,
+    cluster: DEMO_CLUSTER_SECONDARY,
+  },
+]
+
+const DEMO_JOBS: VolcanoJob[] = [
+  {
+    name: 'resnet50-train-001',
+    namespace: 'ml-training',
+    queue: 'ml-training',
+    phase: 'Running',
+    minAvailable: JOB_MIN_AVAILABLE_LARGE,
+    runningPods: JOB_TOTAL_PODS_LARGE,
+    totalPods: JOB_TOTAL_PODS_LARGE,
+    gpuRequest: JOB_GPU_LARGE,
+    cluster: DEMO_CLUSTER_SECONDARY,
+    createdAt: new Date(Date.now() - ONE_HOUR_MS).toISOString(),
+  },
+  {
+    name: 'bert-finetune-042',
+    namespace: 'ml-training',
+    queue: 'ml-training',
+    phase: 'Running',
+    minAvailable: JOB_MIN_AVAILABLE_MEDIUM,
+    runningPods: JOB_TOTAL_PODS_MEDIUM,
+    totalPods: JOB_TOTAL_PODS_MEDIUM,
+    gpuRequest: JOB_GPU_MEDIUM,
+    cluster: DEMO_CLUSTER_SECONDARY,
+    createdAt: new Date(Date.now() - SIX_HOURS_MS).toISOString(),
+  },
+  {
+    name: 'spark-etl-nightly',
+    namespace: 'data',
+    queue: 'high-priority',
+    phase: 'Running',
+    minAvailable: JOB_MIN_AVAILABLE_MEDIUM,
+    runningPods: JOB_TOTAL_PODS_MEDIUM,
+    totalPods: JOB_TOTAL_PODS_MEDIUM,
+    gpuRequest: JOB_GPU_NONE,
+    cluster: DEMO_CLUSTER_PRIMARY,
+    createdAt: new Date(Date.now() - SIX_HOURS_MS).toISOString(),
+  },
+  {
+    name: 'hyperparam-sweep-17',
+    namespace: 'ml-training',
+    queue: 'ml-training',
+    phase: 'Pending',
+    minAvailable: JOB_MIN_AVAILABLE_LARGE,
+    runningPods: 0,
+    totalPods: JOB_TOTAL_PODS_LARGE,
+    gpuRequest: JOB_GPU_LARGE,
+    cluster: DEMO_CLUSTER_SECONDARY,
+    createdAt: new Date(Date.now() - FIVE_MINUTES_MS).toISOString(),
+  },
+  {
+    name: 'monte-carlo-sim',
+    namespace: 'research',
+    queue: 'default',
+    phase: 'Completed',
+    minAvailable: JOB_MIN_AVAILABLE_SMALL,
+    runningPods: 0,
+    totalPods: JOB_TOTAL_PODS_SMALL,
+    gpuRequest: JOB_GPU_NONE,
+    cluster: DEMO_CLUSTER_PRIMARY,
+    createdAt: new Date(Date.now() - ONE_DAY_MS).toISOString(),
+  },
+  {
+    name: 'llama-eval-007',
+    namespace: 'ml-training',
+    queue: 'high-priority',
+    phase: 'Failed',
+    minAvailable: JOB_MIN_AVAILABLE_MEDIUM,
+    runningPods: 0,
+    totalPods: JOB_TOTAL_PODS_MEDIUM,
+    gpuRequest: JOB_GPU_MEDIUM,
+    cluster: DEMO_CLUSTER_PRIMARY,
+    createdAt: new Date(Date.now() - SIX_HOURS_MS).toISOString(),
+  },
+  {
+    name: 'genomics-align-21',
+    namespace: 'research',
+    queue: 'default',
+    phase: 'Running',
+    minAvailable: JOB_MIN_AVAILABLE_SMALL,
+    runningPods: JOB_TOTAL_PODS_SMALL,
+    totalPods: JOB_TOTAL_PODS_SMALL,
+    gpuRequest: JOB_GPU_SMALL,
+    cluster: DEMO_CLUSTER_PRIMARY,
+    createdAt: new Date(Date.now() - ONE_HOUR_MS).toISOString(),
+  },
+]
+
+const DEMO_POD_GROUPS: VolcanoPodGroup[] = [
+  {
+    name: 'resnet50-train-001-pg',
+    namespace: 'ml-training',
+    queue: 'ml-training',
+    phase: 'Running',
+    minMember: PG_MIN_LARGE,
+    runningMember: PG_MIN_LARGE,
+    cluster: DEMO_CLUSTER_SECONDARY,
+  },
+  {
+    name: 'bert-finetune-042-pg',
+    namespace: 'ml-training',
+    queue: 'ml-training',
+    phase: 'Running',
+    minMember: PG_MIN_MEDIUM,
+    runningMember: PG_MIN_MEDIUM,
+    cluster: DEMO_CLUSTER_SECONDARY,
+  },
+  {
+    name: 'spark-etl-nightly-pg',
+    namespace: 'data',
+    queue: 'high-priority',
+    phase: 'Running',
+    minMember: PG_MIN_MEDIUM,
+    runningMember: PG_MIN_MEDIUM,
+    cluster: DEMO_CLUSTER_PRIMARY,
+  },
+  {
+    name: 'hyperparam-sweep-17-pg',
+    namespace: 'ml-training',
+    queue: 'ml-training',
+    phase: 'Inqueue',
+    minMember: PG_MIN_LARGE,
+    runningMember: 0,
+    cluster: DEMO_CLUSTER_SECONDARY,
+  },
+  {
+    name: 'genomics-align-21-pg',
+    namespace: 'research',
+    queue: 'default',
+    phase: 'Running',
+    minMember: PG_MIN_SMALL,
+    runningMember: PG_MIN_SMALL,
+    cluster: DEMO_CLUSTER_PRIMARY,
+  },
+]
+
+export const VOLCANO_DEMO_DATA: VolcanoStatusData = {
+  health: 'healthy',
+  queues: DEMO_QUEUES,
+  jobs: DEMO_JOBS,
+  podGroups: DEMO_POD_GROUPS,
+  stats: {
+    totalQueues: DEMO_QUEUES.length,
+    openQueues: DEMO_QUEUES.filter(q => q.state === 'Open').length,
+    totalJobs: DEMO_TOTAL_JOBS,
+    pendingJobs: DEMO_PENDING_JOBS,
+    runningJobs: DEMO_RUNNING_JOBS,
+    completedJobs: DEMO_COMPLETED_JOBS,
+    failedJobs: DEMO_FAILED_JOBS,
+    totalPodGroups: DEMO_POD_GROUP_COUNT,
+    allocatedGpu: DEMO_ALLOCATED_GPU_TOTAL,
+    schedulerVersion: DEMO_SCHEDULER_VERSION,
+  },
+  summary: {
+    totalQueues: DEMO_QUEUES.length,
+    totalJobs: DEMO_TOTAL_JOBS,
+    totalPodGroups: DEMO_POD_GROUP_COUNT,
+    allocatedGpu: DEMO_ALLOCATED_GPU_TOTAL,
+  },
+  lastCheckTime: new Date().toISOString(),
+}

--- a/web/src/components/cards/volcano_status/index.tsx
+++ b/web/src/components/cards/volcano_status/index.tsx
@@ -1,0 +1,411 @@
+/**
+ * Volcano Status Card
+ *
+ * Volcano is a CNCF Incubating batch/HPC scheduler for Kubernetes that
+ * extends the default scheduler with gang scheduling, fair-share queues,
+ * preemption, and per-job resource accounting. It's the de-facto scheduler
+ * for AI/ML training, HPC, and big-data workloads on Kubernetes.
+ *
+ * This card surfaces the operational signals a platform team needs to
+ * monitor a Volcano deployment: queues (with capacity), job phase
+ * distribution (pending / running / completed / failed), pod groups, and
+ * aggregate GPU allocation.
+ *
+ * Follows the spiffe_status / linkerd_status / envoy_status pattern for
+ * structure and styling.
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real Volcano bridge lands (`/api/volcano/status`), the hook's fetcher
+ * will pick up live data automatically with no component changes.
+ */
+
+import {
+  AlertTriangle,
+  CheckCircle,
+  Cpu,
+  Layers,
+  ListChecks,
+  Package,
+  RefreshCw,
+  Users,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
+import { useCachedVolcano } from '../../../hooks/useCachedVolcano'
+import type {
+  QueueState,
+  VolcanoJob,
+  VolcanoJobPhase,
+  VolcanoPodGroup,
+  VolcanoQueue,
+} from './demoData'
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const SKELETON_TITLE_WIDTH = 140
+const SKELETON_TITLE_HEIGHT = 28
+const SKELETON_BADGE_WIDTH = 90
+const SKELETON_BADGE_HEIGHT = 20
+const SKELETON_LIST_ITEMS = 5
+
+const RELATIVE_TIME_MINUTE_MS = 60_000
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+
+const MAX_QUEUES_DISPLAYED = 5
+const MAX_JOBS_DISPLAYED = 5
+
+const PERCENT_MAX = 100
+const PERCENT_NEAR_FULL_THRESHOLD = 80
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(isoString: string): string {
+  const parsed = new Date(isoString).getTime()
+  if (!isoString || Number.isNaN(parsed)) return 'just now'
+
+  const diff = Date.now() - parsed
+  if (diff < 0) return 'just now'
+
+  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
+  const day = HOURS_PER_DAY * hour
+
+  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
+  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
+  if (diff < day) return `${Math.floor(diff / hour)}h ago`
+  return `${Math.floor(diff / day)}d ago`
+}
+
+const QUEUE_STATE_CLASS: Record<QueueState, string> = {
+  Open: 'bg-green-500/20 text-green-400',
+  Closing: 'bg-yellow-500/20 text-yellow-400',
+  Closed: 'bg-red-500/20 text-red-400',
+}
+
+const JOB_PHASE_CLASS: Record<VolcanoJobPhase, string> = {
+  Pending: 'bg-yellow-500/20 text-yellow-400',
+  Running: 'bg-cyan-500/20 text-cyan-400',
+  Completed: 'bg-green-500/20 text-green-400',
+  Failed: 'bg-red-500/20 text-red-400',
+  Aborted: 'bg-red-500/20 text-red-400',
+}
+
+function percentUsed(allocated: number, capability: number): number {
+  if (capability <= 0) return 0
+  const pct = (allocated / capability) * PERCENT_MAX
+  return Math.min(Math.round(pct), PERCENT_MAX)
+}
+
+function usageBarClass(pct: number): string {
+  if (pct >= PERCENT_NEAR_FULL_THRESHOLD) return 'bg-red-400'
+  if (pct >= PERCENT_MAX / 2) return 'bg-yellow-400'
+  return 'bg-cyan-400'
+}
+
+// ---------------------------------------------------------------------------
+// Subsections
+// ---------------------------------------------------------------------------
+
+function QueueRow({ queue }: { queue: VolcanoQueue }) {
+  const cpuPct = percentUsed(queue.allocatedCpu, queue.capabilityCpu)
+  const gpuPct = percentUsed(queue.allocatedGpu, queue.capabilityGpu)
+
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          <Layers className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
+          <span className="text-xs font-medium text-foreground truncate font-mono">
+            {queue.name}
+          </span>
+        </div>
+        <span
+          className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${QUEUE_STATE_CLASS[queue.state]}`}
+        >
+          {queue.state}
+        </span>
+      </div>
+      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+        <span>
+          {queue.runningJobs} run · {queue.pendingJobs} pend
+        </span>
+        <span className="ml-auto shrink-0 font-mono">weight {queue.weight}</span>
+      </div>
+      <div className="space-y-1">
+        <div className="flex items-center gap-2 text-[11px]">
+          <span className="text-muted-foreground w-8 shrink-0">CPU</span>
+          <div className="flex-1 h-1.5 rounded bg-secondary/50 overflow-hidden">
+            <div
+              className={`h-full ${usageBarClass(cpuPct)}`}
+              style={{ width: `${cpuPct}%` }}
+            />
+          </div>
+          <span className="font-mono text-muted-foreground shrink-0">
+            {queue.allocatedCpu}/{queue.capabilityCpu}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 text-[11px]">
+          <span className="text-muted-foreground w-8 shrink-0">GPU</span>
+          <div className="flex-1 h-1.5 rounded bg-secondary/50 overflow-hidden">
+            <div
+              className={`h-full ${usageBarClass(gpuPct)}`}
+              style={{ width: `${gpuPct}%` }}
+            />
+          </div>
+          <span className="font-mono text-muted-foreground shrink-0">
+            {queue.allocatedGpu}/{queue.capabilityGpu}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function JobRow({ job }: { job: VolcanoJob }) {
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          <Package className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
+          <span className="text-xs font-medium text-foreground truncate font-mono">
+            {job.namespace}/{job.name}
+          </span>
+        </div>
+        <span
+          className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${JOB_PHASE_CLASS[job.phase]}`}
+        >
+          {job.phase}
+        </span>
+      </div>
+      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+        <span className="truncate">
+          queue {job.queue} · {job.runningPods}/{job.totalPods} pods
+        </span>
+        <span className="ml-auto shrink-0 font-mono">
+          {job.gpuRequest > 0 ? `${job.gpuRequest} GPU` : 'CPU-only'}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function VolcanoStatus() {
+  const { t } = useTranslation('cards')
+  const { data, isRefreshing, error, showSkeleton, showEmptyState } =
+    useCachedVolcano()
+
+  const isHealthy = data.health === 'healthy'
+  const queues = data.queues ?? []
+  const jobs = data.jobs ?? []
+  const podGroups: VolcanoPodGroup[] = data.podGroups ?? []
+  const displayedQueues = queues.slice(0, MAX_QUEUES_DISPLAYED)
+  const displayedJobs = jobs.slice(0, MAX_JOBS_DISPLAYED)
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton
+            variant="rounded"
+            width={SKELETON_TITLE_WIDTH}
+            height={SKELETON_TITLE_HEIGHT}
+          />
+          <Skeleton
+            variant="rounded"
+            width={SKELETON_BADGE_WIDTH}
+            height={SKELETON_BADGE_HEIGHT}
+          />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (error && showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">
+          {t('volcanoStatus.fetchError', 'Unable to fetch Volcano status')}
+        </p>
+      </div>
+    )
+  }
+
+  if (data.health === 'not-installed') {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Layers className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('volcanoStatus.notInstalled', 'Volcano scheduler not detected')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'volcanoStatus.notInstalledHint',
+            'No Volcano scheduler reachable from the connected clusters.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* Header — health pill + freshness */}
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+            isHealthy
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-yellow-500/15 text-yellow-400'
+          }`}
+        >
+          {isHealthy ? (
+            <CheckCircle className="w-4 h-4" />
+          ) : (
+            <AlertTriangle className="w-4 h-4" />
+          )}
+          {isHealthy
+            ? t('volcanoStatus.healthy', 'Healthy')
+            : t('volcanoStatus.degraded', 'Degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label={t('volcanoStatus.queues', 'Queues')}
+          value={`${data.stats.totalQueues}`}
+          colorClass="text-cyan-400"
+          icon={<Layers className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('volcanoStatus.runningJobs', 'Running')}
+          value={`${data.stats.runningJobs}`}
+          colorClass="text-green-400"
+          icon={<ListChecks className="w-4 h-4 text-green-400" />}
+        />
+        <MetricTile
+          label={t('volcanoStatus.pendingJobs', 'Pending')}
+          value={`${data.stats.pendingJobs}`}
+          colorClass="text-yellow-400"
+          icon={<ListChecks className="w-4 h-4 text-yellow-400" />}
+        />
+        <MetricTile
+          label={t('volcanoStatus.allocatedGpu', 'GPUs')}
+          value={`${data.stats.allocatedGpu}`}
+          colorClass="text-purple-400"
+          icon={<Cpu className="w-4 h-4 text-purple-400" />}
+        />
+      </div>
+
+      {/* Scheduler info + lists */}
+      <div className="space-y-3 overflow-y-auto scrollbar-thin pr-0.5">
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Users className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('volcanoStatus.sectionScheduler', 'Scheduler')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {t('volcanoStatus.version', 'version')}:{' '}
+              <span className="text-foreground">{data.stats.schedulerVersion}</span>
+            </span>
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-[11px]">
+            <div className="rounded-md bg-secondary/30 px-2 py-1.5">
+              <div className="text-muted-foreground">
+                {t('volcanoStatus.podGroups', 'Pod groups')}
+              </div>
+              <div className="font-mono text-foreground">
+                {data.stats.totalPodGroups}
+              </div>
+            </div>
+            <div className="rounded-md bg-secondary/30 px-2 py-1.5">
+              <div className="text-muted-foreground">
+                {t('volcanoStatus.completedJobs', 'Completed')}
+              </div>
+              <div className="font-mono text-green-400">
+                {data.stats.completedJobs}
+              </div>
+            </div>
+            <div className="rounded-md bg-secondary/30 px-2 py-1.5">
+              <div className="text-muted-foreground">
+                {t('volcanoStatus.failedJobs', 'Failed')}
+              </div>
+              <div className="font-mono text-red-400">{data.stats.failedJobs}</div>
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Layers className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('volcanoStatus.sectionQueues', 'Queues')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {queues.length}
+            </span>
+          </div>
+
+          {queues.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('volcanoStatus.noQueues', 'No queues configured')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(displayedQueues ?? []).map(queue => (
+                <QueueRow key={`${queue.cluster}:${queue.name}`} queue={queue} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Package className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('volcanoStatus.sectionJobs', 'Recent jobs')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {jobs.length} · {podGroups.length} pg
+            </span>
+          </div>
+
+          {jobs.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('volcanoStatus.noJobs', 'No Volcano jobs found')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(displayedJobs ?? []).map(job => (
+                <JobRow
+                  key={`${job.cluster}:${job.namespace}:${job.name}`}
+                  job={job}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default VolcanoStatus

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -121,6 +121,7 @@ export const CARD_CATALOG = {
     { type: 'dragonfly_status', title: 'Dragonfly', description: 'Dragonfly P2P image/file distribution: manager, scheduler, seed-peers, and per-node dfdaemon agents', visualization: 'status' },
     { type: 'openfeature_status', title: 'OpenFeature', description: 'OpenFeature feature flags: provider status (flagd, LaunchDarkly, ...), flag definitions by type, and evaluation metrics', visualization: 'status' },
     { type: 'wasmcloud_status', title: 'wasmCloud', description: 'wasmCloud WebAssembly lattice: hosts, actors, capability providers, and link definitions', visualization: 'status' },
+    { type: 'volcano_status', title: 'Volcano', description: 'Volcano batch/HPC scheduler: queues, jobs (pending/running/completed/failed), pod groups, and GPU allocation', visualization: 'status' },
   ],
   'Compute': [
     { type: 'compute_overview', title: 'Compute Overview', description: 'CPU, memory, and GPU summary with live data', visualization: 'status' },

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -194,6 +194,7 @@ import { upgradeStatusConfig } from './upgrade-status'
 import { userManagementConfig } from './user-management'
 import { vaultSecretsConfig } from './vault-secrets'
 import { vclusterStatusConfig } from './vcluster-status'
+import { volcanoStatusConfig } from './volcano-status'
 import { warningEventsConfig } from './warning-events'
 import { wasmcloudStatusConfig } from './wasmcloud-status'
 import { weatherConfig } from './weather'
@@ -403,6 +404,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   user_management: userManagementConfig,
   vault_secrets: vaultSecretsConfig,
   vcluster_status: vclusterStatusConfig,
+  volcano_status: volcanoStatusConfig,
   warning_events: warningEventsConfig,
   wasmcloud_status: wasmcloudStatusConfig,
   weather: weatherConfig,
@@ -675,6 +677,7 @@ export {
   userManagementConfig,
   vaultSecretsConfig,
   vclusterStatusConfig,
+  volcanoStatusConfig,
   warningEventsConfig,
   wasmcloudStatusConfig,
   weatherConfig,

--- a/web/src/config/cards/volcano-status.ts
+++ b/web/src/config/cards/volcano-status.ts
@@ -1,0 +1,53 @@
+/**
+ * Volcano Status Card Configuration
+ *
+ * Volcano is a CNCF Incubating batch/HPC scheduler for Kubernetes — the
+ * de-facto scheduler for AI/ML training, HPC, and big-data workloads. It
+ * extends the default Kubernetes scheduler with gang scheduling, fair-share
+ * queues, preemption, and per-job resource accounting.
+ *
+ * This card surfaces queues, jobs (pending/running/completed/failed), pod
+ * groups, and aggregate GPU allocation.
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const volcanoStatusConfig: UnifiedCardConfig = {
+  type: 'volcano_status',
+  title: 'Volcano',
+  category: 'workloads',
+  description:
+    'Volcano batch/HPC scheduler: queues, jobs (pending/running/completed/failed), pod groups, and GPU allocation.',
+  icon: 'Layers',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useCachedVolcano' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'name', header: 'Job', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', width: 140, render: 'truncate' },
+      { field: 'queue', header: 'Queue', width: 140, render: 'truncate' },
+      { field: 'phase', header: 'Phase', width: 100, render: 'status-badge' },
+      { field: 'gpuRequest', header: 'GPU', width: 80 },
+      { field: 'cluster', header: 'Cluster', width: 120, render: 'cluster-badge' },
+    ],
+  },
+  emptyState: {
+    icon: 'Layers',
+    title: 'Volcano scheduler not detected',
+    message: 'No Volcano scheduler reachable from the connected clusters.',
+    variant: 'info',
+  },
+  loadingState: {
+    type: 'list',
+    rows: 5,
+  },
+  // Scaffolding: renders live if /api/volcano/status is wired up, otherwise
+  // falls back to demo data via the useCache demo path.
+  isDemoData: true,
+  isLive: false,
+}
+
+export default volcanoStatusConfig

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -171,8 +171,7 @@ export { useCachedCni } from './useCachedCni'
 
 export { useCachedOpenfeature } from './useCachedOpenfeature'
 // SPIRE (SPIFFE Runtime Environment) — useCachedSpire.ts
-// ============================================================================
-// Named re-export (avoids `__testables` export-name collision with other hooks).
+// =====================================================================// Named re-export (avoids `__testables` export-name collision with other hooks).
 
 export { useCachedSpire } from './useCachedSpire'
 
@@ -182,6 +181,12 @@ export { useCachedSpire } from './useCachedSpire'
 // Named re-export (avoids `__testables` export-name collision with TiKV).
 
 export { useCachedLonghorn } from './useCachedLonghorn'
+=======
+// Volcano Batch/HPC Scheduler — useCachedVolcano.ts (CNCF Incubating)
+// ============================================================================
+// Named re-export (avoids `__testables` export-name collision with TiKV).
+
+export { useCachedVolcano } from './useCachedVolcano'
 
 // ============================================================================
 // TiKV Distributed Key-Value Store — useCachedTikv.ts

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -181,7 +181,6 @@ export { useCachedSpire } from './useCachedSpire'
 // Named re-export (avoids `__testables` export-name collision with TiKV).
 
 export { useCachedLonghorn } from './useCachedLonghorn'
-=======
 // Volcano Batch/HPC Scheduler — useCachedVolcano.ts (CNCF Incubating)
 // ============================================================================
 // Named re-export (avoids `__testables` export-name collision with TiKV).

--- a/web/src/hooks/useCachedVolcano.ts
+++ b/web/src/hooks/useCachedVolcano.ts
@@ -1,0 +1,289 @@
+/**
+ * Volcano Status Hook — Data fetching for the volcano_status card.
+ *
+ * Mirrors the spiffe / linkerd / envoy pattern:
+ * - useCache with fetcher + demo fallback
+ * - isDemoFallback gated on !isLoading (prevents demo flash while loading)
+ * - fetchJson helper with treat404AsEmpty (no real endpoint yet — this is
+ *   scaffolding; the fetch will 404 until a real Volcano bridge lands, at
+ *   which point useCache will transparently switch to live data)
+ * - showSkeleton / showEmptyState from useCardLoadingState
+ */
+
+import { useCache, type RefreshCategory } from '../lib/cache'
+import { useCardLoadingState } from '../components/cards/CardDataContext'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { authFetch } from '../lib/api'
+import {
+  VOLCANO_DEMO_DATA,
+  type VolcanoJob,
+  type VolcanoPodGroup,
+  type VolcanoQueue,
+  type VolcanoStats,
+  type VolcanoStatusData,
+  type VolcanoSummary,
+} from '../components/cards/volcano_status/demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'volcano-status'
+const VOLCANO_STATUS_ENDPOINT = '/api/volcano/status'
+const DEFAULT_SCHEDULER_VERSION = 'unknown'
+
+const EMPTY_STATS: VolcanoStats = {
+  totalQueues: 0,
+  openQueues: 0,
+  totalJobs: 0,
+  pendingJobs: 0,
+  runningJobs: 0,
+  completedJobs: 0,
+  failedJobs: 0,
+  totalPodGroups: 0,
+  allocatedGpu: 0,
+  schedulerVersion: DEFAULT_SCHEDULER_VERSION,
+}
+
+const EMPTY_SUMMARY: VolcanoSummary = {
+  totalQueues: 0,
+  totalJobs: 0,
+  totalPodGroups: 0,
+  allocatedGpu: 0,
+}
+
+const INITIAL_DATA: VolcanoStatusData = {
+  health: 'not-installed',
+  queues: [],
+  jobs: [],
+  podGroups: [],
+  stats: EMPTY_STATS,
+  summary: EMPTY_SUMMARY,
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Internal types (shape of the future /api/volcano/status response)
+// ---------------------------------------------------------------------------
+
+interface FetchResult<T> {
+  data: T
+  failed: boolean
+}
+
+interface VolcanoStatusResponse {
+  queues?: VolcanoQueue[]
+  jobs?: VolcanoJob[]
+  podGroups?: VolcanoPodGroup[]
+  stats?: Partial<VolcanoStats>
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function summarize(
+  queues: VolcanoQueue[],
+  jobs: VolcanoJob[],
+  podGroups: VolcanoPodGroup[],
+  stats: VolcanoStats,
+): VolcanoSummary {
+  return {
+    totalQueues: queues.length,
+    totalJobs: jobs.length,
+    totalPodGroups: podGroups.length,
+    allocatedGpu: stats.allocatedGpu,
+  }
+}
+
+function deriveHealth(
+  queues: VolcanoQueue[],
+  jobs: VolcanoJob[],
+): VolcanoStatusData['health'] {
+  if (queues.length === 0 && jobs.length === 0) {
+    return 'not-installed'
+  }
+  const hasFailedJobs = jobs.some(j => j.phase === 'Failed')
+  return hasFailedJobs ? 'degraded' : 'healthy'
+}
+
+function deriveStatsFromLists(
+  queues: VolcanoQueue[],
+  jobs: VolcanoJob[],
+  podGroups: VolcanoPodGroup[],
+  partial: Partial<VolcanoStats> | undefined,
+): VolcanoStats {
+  const openQueues = queues.filter(q => q.state === 'Open').length
+  const pendingJobs = jobs.filter(j => j.phase === 'Pending').length
+  const runningJobs = jobs.filter(j => j.phase === 'Running').length
+  const completedJobs = jobs.filter(j => j.phase === 'Completed').length
+  const failedJobs = jobs.filter(j => j.phase === 'Failed').length
+  const allocatedGpu = queues.reduce((sum, q) => sum + q.allocatedGpu, 0)
+
+  return {
+    totalQueues: partial?.totalQueues ?? queues.length,
+    openQueues: partial?.openQueues ?? openQueues,
+    totalJobs: partial?.totalJobs ?? jobs.length,
+    pendingJobs: partial?.pendingJobs ?? pendingJobs,
+    runningJobs: partial?.runningJobs ?? runningJobs,
+    completedJobs: partial?.completedJobs ?? completedJobs,
+    failedJobs: partial?.failedJobs ?? failedJobs,
+    totalPodGroups: partial?.totalPodGroups ?? podGroups.length,
+    allocatedGpu: partial?.allocatedGpu ?? allocatedGpu,
+    schedulerVersion: partial?.schedulerVersion ?? DEFAULT_SCHEDULER_VERSION,
+  }
+}
+
+function buildVolcanoStatus(
+  queues: VolcanoQueue[],
+  jobs: VolcanoJob[],
+  podGroups: VolcanoPodGroup[],
+  stats: VolcanoStats,
+): VolcanoStatusData {
+  return {
+    health: deriveHealth(queues, jobs),
+    queues,
+    jobs,
+    podGroups,
+    stats,
+    summary: summarize(queues, jobs, podGroups, stats),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private fetchJson helper (mirrors spiffe/envoy/contour/linkerd pattern)
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(
+  url: string,
+  options?: { treat404AsEmpty?: boolean },
+): Promise<FetchResult<T | null>> {
+  try {
+    const resp = await authFetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+
+    if (!resp.ok) {
+      if (options?.treat404AsEmpty && resp.status === 404) {
+        return { data: null, failed: false }
+      }
+      return { data: null, failed: true }
+    }
+
+    const body = (await resp.json()) as T
+    return { data: body, failed: false }
+  } catch {
+    return { data: null, failed: true }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchVolcanoStatus(): Promise<VolcanoStatusData> {
+  const result = await fetchJson<VolcanoStatusResponse>(
+    VOLCANO_STATUS_ENDPOINT,
+    { treat404AsEmpty: true },
+  )
+
+  // If the endpoint isn't wired up yet (404) or the request failed, the
+  // cache layer will surface demo data via its demoData fallback path.
+  if (result.failed) {
+    throw new Error('Unable to fetch Volcano status')
+  }
+
+  const body = result.data
+  const queues = Array.isArray(body?.queues) ? body.queues : []
+  const jobs = Array.isArray(body?.jobs) ? body.jobs : []
+  const podGroups = Array.isArray(body?.podGroups) ? body.podGroups : []
+  const stats = deriveStatsFromLists(queues, jobs, podGroups, body?.stats)
+
+  return buildVolcanoStatus(queues, jobs, podGroups, stats)
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseCachedVolcanoResult {
+  data: VolcanoStatusData
+  isLoading: boolean
+  isRefreshing: boolean
+  isDemoData: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  showSkeleton: boolean
+  showEmptyState: boolean
+  error: boolean
+  refetch: () => Promise<void>
+}
+
+export function useCachedVolcano(): UseCachedVolcanoResult {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+    lastRefresh,
+    refetch,
+  } = useCache<VolcanoStatusData>({
+    key: CACHE_KEY,
+    category: 'default' as RefreshCategory,
+    initialData: INITIAL_DATA,
+    demoData: VOLCANO_DEMO_DATA,
+    persist: true,
+    fetcher: fetchVolcanoStatus,
+  })
+
+  // Prevent demo flash while loading — only surface the Demo badge once
+  // we've actually fallen back to demo data post-load.
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' counts as "data" so the card shows the empty state
+  // rather than an infinite skeleton when Volcano isn't present.
+  const hasAnyData =
+    data.health === 'not-installed'
+      ? true
+      : (data.queues ?? []).length > 0 || (data.jobs ?? []).length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+    lastRefresh,
+  })
+
+  return {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoData: effectiveIsDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+    showSkeleton,
+    showEmptyState,
+    error: isFailed && !hasAnyData,
+    refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  summarize,
+  deriveHealth,
+  deriveStatsFromLists,
+  buildVolcanoStatus,
+}

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -117,6 +117,7 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-vitess': 'vitess_status',
   'cncf-chaos-mesh': 'chaos_mesh_status',
   'cncf-wasmcloud': 'wasmcloud_status',
+  'cncf-volcano': 'volcano_status',
 }
 
 /**

--- a/web/src/lib/demo/volcano.ts
+++ b/web/src/lib/demo/volcano.ts
@@ -1,0 +1,22 @@
+/**
+ * Volcano demo seed re-export.
+ *
+ * The canonical demo data lives alongside the Volcano card in
+ * `components/cards/volcano_status/demoData.ts`. This file re-exports it
+ * so callers outside the card folder (docs, tests, future drill-downs)
+ * can import a stable demo seed from `lib/demo/volcano`.
+ */
+
+export {
+  VOLCANO_DEMO_DATA,
+  type VolcanoStatusData,
+  type VolcanoQueue,
+  type VolcanoJob,
+  type VolcanoPodGroup,
+  type VolcanoStats,
+  type VolcanoSummary,
+  type VolcanoHealth,
+  type VolcanoJobPhase,
+  type PodGroupPhase,
+  type QueueState,
+} from '../../components/cards/volcano_status/demoData'

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -72,6 +72,7 @@ import { useCachedTuf } from '../../hooks/useCachedTuf'
 import { useCachedCloudCustodian } from '../../hooks/useCachedCloudCustodian'
 import { useCachedVitess } from '../../hooks/useCachedVitess'
 import { useCachedWasmcloud } from '../../hooks/useCachedWasmcloud'
+import { useCachedVolcano } from '../../hooks/useCachedVolcano'
 
 // ============================================================================
 // Wrapper hooks that convert params object to positional args
@@ -1314,6 +1315,13 @@ function useUnifiedWasmcloudStatus() {
     data: result.data.hosts,
     isLoading: result.showSkeleton,
     error: result.error ? new Error('Failed to fetch wasmCloud status') : null,
+function useUnifiedVolcanoStatus() {
+  const result = useCachedVolcano()
+  // Surface the job list as the primary row set for generic list renderers.
+  return {
+    data: result.data.jobs,
+    isLoading: result.showSkeleton,
+    error: result.error ? new Error('Failed to fetch Volcano status') : null,
     refetch: () => { result.refetch() },
   }
 }
@@ -1529,6 +1537,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useCachedCloudCustodian', useUnifiedCloudCustodianStatus)
   registerDataHook('useCachedVitess', useUnifiedVitessStatus)
   registerDataHook('useCachedWasmcloud', useUnifiedWasmcloudStatus)
+  registerDataHook('useCachedVolcano', useUnifiedVolcanoStatus)
   registerDataHook('useProviderHealth', useProviderHealth)
   registerDataHook('useUpgradeStatus', useUpgradeStatus)
   registerDataHook('useProwStatus', useProwStatus)

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -1315,6 +1315,10 @@ function useUnifiedWasmcloudStatus() {
     data: result.data.hosts,
     isLoading: result.showSkeleton,
     error: result.error ? new Error('Failed to fetch wasmCloud status') : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
 function useUnifiedVolcanoStatus() {
   const result = useCachedVolcano()
   // Surface the job list as the primary row set for generic list renderers.

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3271,6 +3271,7 @@
     "sectionNodes": "Nodes",
     "noNodes": "No nodes reporting CNI status",
     "unknownCidr": "unknown"
+  },
   "volcanoStatus": {
     "healthy": "Healthy",
     "degraded": "Degraded",

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3271,6 +3271,25 @@
     "sectionNodes": "Nodes",
     "noNodes": "No nodes reporting CNI status",
     "unknownCidr": "unknown"
+  "volcanoStatus": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "Volcano scheduler not detected",
+    "notInstalledHint": "No Volcano scheduler reachable from the connected clusters.",
+    "fetchError": "Unable to fetch Volcano status",
+    "queues": "Queues",
+    "runningJobs": "Running",
+    "pendingJobs": "Pending",
+    "completedJobs": "Completed",
+    "failedJobs": "Failed",
+    "allocatedGpu": "GPUs",
+    "podGroups": "Pod groups",
+    "version": "version",
+    "sectionScheduler": "Scheduler",
+    "sectionQueues": "Queues",
+    "sectionJobs": "Recent jobs",
+    "noQueues": "No queues configured",
+    "noJobs": "No Volcano jobs found"
   },
   "tikvStatus": {
     "healthy": "Healthy",


### PR DESCRIPTION
## Summary

Adds a Volcano batch/HPC scheduler monitoring card to the Console. Volcano is a CNCF Incubating scheduler that extends Kubernetes with gang scheduling, fair-share queues, preemption, and per-job resource accounting — the de-facto scheduler for AI/ML training, HPC, and big-data workloads.

The card surfaces the operational signals platform teams need to monitor a Volcano deployment:

- **Queues** with weight, state (Open / Closing / Closed), running vs pending jobs, and allocated vs capability CPU / GPU
- **Jobs** grouped by phase: pending / running / completed / failed / aborted
- **Pod groups** (the gang-scheduling unit) and scheduling state
- **Aggregate GPU allocation** across the batch workload
- **Health pill** + scheduler version

## Scaffolding

The hook fetches `/api/volcano/status` and transparently falls back to demo data via `useCache` when the endpoint isn't wired up (404 / not installed). When a real Volcano bridge lands, the card will pick up live data with no component changes.

## Files

New:
- `web/src/components/cards/volcano_status/{index.tsx,demoData.ts}`
- `web/src/hooks/useCachedVolcano.ts`
- `web/src/lib/demo/volcano.ts`
- `web/src/config/cards/volcano-status.ts` (category: `workloads`)

Wiring (8 registry files):
- `cardRegistry.ts` (lazy import, `RAW_CARD_COMPONENTS`, preloader, default width)
- `cardMetadata.ts` (title + description)
- `cardCatalog.ts` (Workloads group)
- `config/cards/index.ts` (registry + re-export)
- `lib/unified/registerHooks.ts` (unified data hook)
- `hooks/useCachedData.ts` (named re-export to avoid `__testables` collision)
- `hooks/useMarketplace.ts` (`cncf-volcano` -> `volcano_status`)
- `locales/en/cards.json` (`volcanoStatus.*` keys)

## CLAUDE.md compliance

- No magic numbers — every literal is a named constant
- Array guards with `?? []` on all hook outputs
- Wires `isDemoData` + `isRefreshing` into `useCardLoadingState`
- Demo flash guarded via `isDemoFallback && !isLoading`
- Literal `Record` keys for status color maps (`QUEUE_STATE_CLASS`, `JOB_PHASE_CLASS`)
- Named re-export in `useCachedData.ts`
- No raw hex colors; semantic Tailwind classes only
- `TFunction` via `useTranslation('cards')`

Fixes kubestellar/console-marketplace#56