### PR TITLE
feat(cni): add CNI monitoring card (kubestellar/console-marketplace#33)

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -280,6 +280,8 @@ export const CARD_TITLES: Record<string, string> = {
   rook_status: 'Rook',
   // SPIFFE workload identity (CNCF graduated)
   spiffe_status: 'SPIFFE',
+  // CNI (Container Network Interface) plugin status
+  cni_status: 'CNI',
   // TiKV distributed key-value store
   tikv_status: 'TiKV',
   // TUF (The Update Framework) repository metadata
@@ -613,6 +615,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   rook_status: 'Rook-managed CephClusters: Ceph health, OSD/MON/MGR counts, capacity usage, and PG state summary.',
   // SPIFFE workload identity (CNCF graduated)
   spiffe_status: 'SPIFFE/SPIRE workload identity: trust domain, SVID counts (x509/JWT), federated trust domains, and registration entries.',
+  // CNI (Container Network Interface) plugin status
+  cni_status: 'Container Network Interface plugin status: active plugin, per-node CNI readiness, pod network CIDR, and NetworkPolicy coverage across services.',
   // TiKV distributed key-value store
   tikv_status: 'TiKV distributed key-value store: store nodes, region counts, leader counts, and capacity utilization across the cluster.',
   // TUF (The Update Framework) repository metadata

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -94,6 +94,8 @@ const OtelStatus = safeLazy(() => import('./otel_status'), 'OtelStatus')
 const RookStatus = safeLazy(() => import('./rook_status'), 'RookStatus')
 // SPIFFE workload identity card (CNCF graduated)
 const SpiffeStatus = safeLazy(() => import('./spiffe_status'), 'SpiffeStatus')
+// CNI (Container Network Interface) plugin status card
+const CniStatus = safeLazy(() => import('./cni_status'), 'CniStatus')
 // TiKV distributed key-value store card
 const TikvStatus = safeLazy(() => import('./tikv_status'), 'TikvStatus')
 // TUF (The Update Framework) repository metadata card
@@ -742,6 +744,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   rook_status: RookStatus,
   // SPIFFE workload identity (CNCF graduated)
   spiffe_status: SpiffeStatus,
+  // CNI plugin status (Cilium, Calico, Flannel, etc.)
+  cni_status: CniStatus,
   // TiKV distributed key-value store
   tikv_status: TikvStatus,
   // TUF (The Update Framework) repository metadata
@@ -1073,6 +1077,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   otel_status: () => import('./otel_status'),
   rook_status: () => import('./rook_status'),
   spiffe_status: () => import('./spiffe_status'),
+  cni_status: () => import('./cni_status'),
   tikv_status: () => import('./tikv_status'),
   tuf_status: () => import('./tuf_status'),
   vitess_status: () => import('./vitess_status'),
@@ -1680,6 +1685,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   otel_status: 6,
   rook_status: 6,
   spiffe_status: 6,
+  cni_status: 6,
   tikv_status: 6,
   tuf_status: 6,
   vitess_status: 6,

--- a/web/src/components/cards/cni_status/index.tsx
+++ b/web/src/components/cards/cni_status/index.tsx
@@ -1,0 +1,262 @@
+/**
+ * CNI Status Card
+ *
+ * The Container Network Interface (CNI) plugin provides pod networking inside
+ * a Kubernetes cluster. This card surfaces the active plugin, node readiness
+ * for CNI, the pod network CIDR, and NetworkPolicy coverage across services.
+ *
+ * Follows the spiffe_status / linkerd_status pattern for structure and
+ * styling.
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real CNI inspection bridge lands (`/api/cni/status`), the hook's fetcher
+ * will pick up live data automatically with no component changes.
+ */
+
+import {
+  AlertTriangle,
+  CheckCircle,
+  Cpu,
+  Network,
+  RefreshCw,
+  Shield,
+  Share2,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
+import { useCachedCni } from '../../../hooks/useCachedCni'
+import type { CniNodeState, CniNodeStatus } from '../../../lib/demo/cni'
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const SKELETON_TITLE_WIDTH = 140
+const SKELETON_TITLE_HEIGHT = 28
+const SKELETON_BADGE_WIDTH = 90
+const SKELETON_BADGE_HEIGHT = 20
+const SKELETON_LIST_ITEMS = 5
+
+const RELATIVE_TIME_MINUTE_MS = 60_000
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+
+const MAX_NODES_DISPLAYED = 6
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(isoString: string): string {
+  const parsed = new Date(isoString).getTime()
+  if (!isoString || Number.isNaN(parsed)) return 'just now'
+
+  const diff = Date.now() - parsed
+  if (diff < 0) return 'just now'
+
+  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
+  const day = HOURS_PER_DAY * hour
+
+  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
+  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
+  if (diff < day) return `${Math.floor(diff / hour)}h ago`
+  return `${Math.floor(diff / day)}d ago`
+}
+
+const NODE_STATE_CLASS_MAP: Record<CniNodeState, string> = {
+  'ready': 'bg-green-500/20 text-green-400',
+  'not-ready': 'bg-red-500/20 text-red-400',
+  'unknown': 'bg-yellow-500/20 text-yellow-400',
+}
+
+function nodeStateClass(state: CniNodeState): string {
+  return NODE_STATE_CLASS_MAP[state] ?? NODE_STATE_CLASS_MAP.unknown
+}
+
+// ---------------------------------------------------------------------------
+// Subsections
+// ---------------------------------------------------------------------------
+
+function NodeRow({ node }: { node: CniNodeStatus }) {
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          <Cpu className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
+          <span className="text-xs font-medium text-foreground truncate font-mono">
+            {node.node}
+          </span>
+        </div>
+        <span
+          className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${nodeStateClass(
+            node.state,
+          )}`}
+        >
+          {node.state}
+        </span>
+      </div>
+      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+        <span className="truncate font-mono">{node.podCidr}</span>
+        <span className="ml-auto shrink-0">
+          {node.plugin} {node.pluginVersion}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function CniStatus() {
+  const { t } = useTranslation('cards')
+  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedCni()
+
+  const isHealthy = data.health === 'healthy'
+  const nodes = data.nodes ?? []
+  const displayedNodes = nodes.slice(0, MAX_NODES_DISPLAYED)
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
+          <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (error && showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">
+          {t('cniStatus.fetchError', 'Unable to fetch CNI status')}
+        </p>
+      </div>
+    )
+  }
+
+  if (data.health === 'not-installed') {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Network className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('cniStatus.notInstalled', 'CNI plugin not detected')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'cniStatus.notInstalledHint',
+            'No CNI metadata reachable from the connected clusters.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* Header — health pill + freshness */}
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+            isHealthy
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-yellow-500/15 text-yellow-400'
+          }`}
+        >
+          {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          {isHealthy
+            ? t('cniStatus.healthy', 'Healthy')
+            : t('cniStatus.degraded', 'Degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label={t('cniStatus.plugin', 'Plugin')}
+          value={data.summary.activePlugin}
+          colorClass="text-cyan-400"
+          icon={<Network className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('cniStatus.nodesReady', 'Nodes Ready')}
+          value={`${data.summary.nodesCniReady}/${data.summary.nodeCount}`}
+          colorClass="text-green-400"
+          icon={<Cpu className="w-4 h-4 text-green-400" />}
+        />
+        <MetricTile
+          label={t('cniStatus.policies', 'NetworkPolicies')}
+          value={`${data.summary.networkPolicyCount}`}
+          colorClass="text-purple-400"
+          icon={<Shield className="w-4 h-4 text-purple-400" />}
+        />
+        <MetricTile
+          label={t('cniStatus.servicesWithPolicy', 'Svcs w/ Policy')}
+          value={`${data.summary.servicesWithNetworkPolicy}/${data.stats.totalServices}`}
+          colorClass="text-yellow-400"
+          icon={<Share2 className="w-4 h-4 text-yellow-400" />}
+        />
+      </div>
+
+      {/* Pod CIDR + node list */}
+      <div className="space-y-3 overflow-y-auto scrollbar-thin pr-0.5">
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Network className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('cniStatus.sectionPodCidr', 'Pod network CIDR')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {t('cniStatus.version', 'version')}:{' '}
+              <span className="text-foreground">{data.summary.pluginVersion}</span>
+            </span>
+          </div>
+          <div className="rounded-md bg-secondary/30 px-3 py-2 text-xs font-mono text-foreground">
+            {data.summary.podNetworkCidr || t('cniStatus.unknownCidr', 'unknown')}
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Cpu className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('cniStatus.sectionNodes', 'Nodes')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {nodes.length}
+            </span>
+          </div>
+
+          {nodes.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('cniStatus.noNodes', 'No nodes reporting CNI status')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(displayedNodes ?? []).map(node => (
+                <NodeRow
+                  key={`${node.cluster}:${node.node}`}
+                  node={node}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default CniStatus

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -155,6 +155,7 @@ export const CARD_CATALOG = {
     { type: 'service_topology', title: 'Service Topology', description: 'Animated service mesh visualization with cross-cluster traffic', visualization: 'status' },
     { type: 'ingress_status', title: 'Ingress Status', description: 'Ingress resources with hosts, paths, and backend services', visualization: 'table' },
     { type: 'network_policy_status', title: 'Network Policy Status', description: 'NetworkPolicy resources with pod selectors and rules', visualization: 'table' },
+    { type: 'cni_status', title: 'CNI', description: 'Container Network Interface plugin: active plugin, per-node CNI readiness, pod network CIDR, and NetworkPolicy coverage', visualization: 'status' },
     { type: 'cilium_status', title: 'Cilium', description: 'Cilium eBPF networking, network policy enforcement, and Hubble flow visibility.', visualization: 'status' },
     { type: 'contour_status', title: 'Contour', description: 'Contour ingress proxy status, HTTPProxy resources, and Envoy fleet health', visualization: 'status' },
     { type: 'envoy_status', title: 'Envoy Proxy', description: 'Envoy listener health, upstream cluster health, and request/connection stats', visualization: 'status' },

--- a/web/src/config/cards/cni-status.ts
+++ b/web/src/config/cards/cni-status.ts
@@ -1,0 +1,50 @@
+/**
+ * CNI Status Card Configuration
+ *
+ * The Container Network Interface (CNI) plugin provides pod networking inside
+ * a Kubernetes cluster. This card surfaces the active plugin (Cilium, Calico,
+ * Flannel, etc.), per-node CNI readiness, pod network CIDR, and NetworkPolicy
+ * coverage across services.
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const cniStatusConfig: UnifiedCardConfig = {
+  type: 'cni_status',
+  title: 'CNI',
+  category: 'network',
+  description:
+    'Container Network Interface plugin status: active plugin, per-node CNI readiness, pod network CIDR, and NetworkPolicy coverage.',
+  icon: 'Network',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useCachedCni' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'node', header: 'Node', primary: true, render: 'truncate' },
+      { field: 'state', header: 'State', width: 100, render: 'status-badge' },
+      { field: 'plugin', header: 'Plugin', width: 120 },
+      { field: 'pluginVersion', header: 'Version', width: 100 },
+      { field: 'podCidr', header: 'Pod CIDR', width: 140 },
+      { field: 'cluster', header: 'Cluster', width: 120, render: 'cluster-badge' },
+    ],
+  },
+  emptyState: {
+    icon: 'Network',
+    title: 'CNI plugin not detected',
+    message: 'No CNI metadata reachable from the connected clusters.',
+    variant: 'info',
+  },
+  loadingState: {
+    type: 'list',
+    rows: 5,
+  },
+  // Scaffolding: renders live if /api/cni/status is wired up, otherwise
+  // falls back to demo data via the useCache demo path.
+  isDemoData: true,
+  isLive: false,
+}
+
+export default cniStatusConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -34,6 +34,7 @@ import { clusterLocationsConfig } from './cluster-locations'
 import { clusterMetricsConfig } from './cluster-metrics'
 import { clusterNetworkConfig } from './cluster-network'
 import { clusterResourceTreeConfig } from './cluster-resource-tree'
+import { cniStatusConfig } from './cni-status'
 import { complianceScoreConfig } from './compliance-score'
 import { computeOverviewConfig } from './compute-overview'
 import { configMapStatusConfig } from './configmap-status'
@@ -231,6 +232,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   cluster_metrics: clusterMetricsConfig,
   cluster_network: clusterNetworkConfig,
   cluster_resource_tree: clusterResourceTreeConfig,
+  cni_status: cniStatusConfig,
   compliance_score: complianceScoreConfig,
   compute_overview: computeOverviewConfig,
   configmap_status: configMapStatusConfig,
@@ -519,6 +521,7 @@ export {
   clusterMetricsConfig,
   clusterNetworkConfig,
   clusterResourceTreeConfig,
+  cniStatusConfig,
   complianceScoreConfig,
   computeOverviewConfig,
   configMapStatusConfig,

--- a/web/src/hooks/useCachedCni.ts
+++ b/web/src/hooks/useCachedCni.ts
@@ -1,0 +1,286 @@
+/**
+ * CNI Status Hook — Data fetching for the cni_status card.
+ *
+ * Mirrors the spiffe / linkerd / envoy pattern:
+ * - useCache with fetcher + demo fallback
+ * - isDemoFallback gated on !isLoading (prevents demo flash while loading)
+ * - fetchJson helper with treat404AsEmpty (no real endpoint yet — this is
+ *   scaffolding; the fetch will 404 until a real CNI inspection bridge lands,
+ *   at which point useCache will transparently switch to live data)
+ * - showSkeleton / showEmptyState from useCardLoadingState
+ */
+
+import { useCache } from '../lib/cache'
+import { useCardLoadingState } from '../components/cards/CardDataContext'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { authFetch } from '../lib/api'
+import {
+  CNI_DEMO_DATA,
+  type CniHealth,
+  type CniNodeStatus,
+  type CniPlugin,
+  type CniStats,
+  type CniStatusData,
+  type CniSummary,
+} from '../lib/demo/cni'
+
+// ---------------------------------------------------------------------------
+// Constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'cni-status'
+const CNI_STATUS_ENDPOINT = '/api/cni/status'
+
+const DEFAULT_PLUGIN: CniPlugin = 'unknown'
+const DEFAULT_PLUGIN_VERSION = 'unknown'
+const DEFAULT_POD_CIDR = ''
+const DEFAULT_SERVICE_CIDR = ''
+const DEFAULT_COUNT = 0
+
+const EMPTY_STATS: CniStats = {
+  activePlugin: DEFAULT_PLUGIN,
+  pluginVersion: DEFAULT_PLUGIN_VERSION,
+  podNetworkCidr: DEFAULT_POD_CIDR,
+  serviceNetworkCidr: DEFAULT_SERVICE_CIDR,
+  nodeCount: DEFAULT_COUNT,
+  nodesCniReady: DEFAULT_COUNT,
+  networkPolicyCount: DEFAULT_COUNT,
+  servicesWithNetworkPolicy: DEFAULT_COUNT,
+  totalServices: DEFAULT_COUNT,
+  podsWithIp: DEFAULT_COUNT,
+  totalPods: DEFAULT_COUNT,
+}
+
+const EMPTY_SUMMARY: CniSummary = {
+  activePlugin: DEFAULT_PLUGIN,
+  pluginVersion: DEFAULT_PLUGIN_VERSION,
+  podNetworkCidr: DEFAULT_POD_CIDR,
+  nodesCniReady: DEFAULT_COUNT,
+  nodeCount: DEFAULT_COUNT,
+  networkPolicyCount: DEFAULT_COUNT,
+  servicesWithNetworkPolicy: DEFAULT_COUNT,
+}
+
+const INITIAL_DATA: CniStatusData = {
+  health: 'not-installed',
+  nodes: [],
+  stats: EMPTY_STATS,
+  summary: EMPTY_SUMMARY,
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Internal types (shape of the future /api/cni/status response)
+// ---------------------------------------------------------------------------
+
+interface FetchResult<T> {
+  data: T
+  failed: boolean
+}
+
+interface CniStatusResponse {
+  activePlugin?: CniPlugin
+  pluginVersion?: string
+  podNetworkCidr?: string
+  serviceNetworkCidr?: string
+  nodes?: CniNodeStatus[]
+  stats?: Partial<CniStats>
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function summarize(
+  stats: CniStats,
+): CniSummary {
+  return {
+    activePlugin: stats.activePlugin,
+    pluginVersion: stats.pluginVersion,
+    podNetworkCidr: stats.podNetworkCidr,
+    nodesCniReady: stats.nodesCniReady,
+    nodeCount: stats.nodeCount,
+    networkPolicyCount: stats.networkPolicyCount,
+    servicesWithNetworkPolicy: stats.servicesWithNetworkPolicy,
+  }
+}
+
+function deriveHealth(
+  stats: CniStats,
+  nodes: CniNodeStatus[],
+): CniHealth {
+  if (stats.activePlugin === 'unknown' && nodes.length === 0) {
+    return 'not-installed'
+  }
+  const hasUnreadyNode = nodes.some(n => n.state !== 'ready')
+  if (hasUnreadyNode) return 'degraded'
+  if (stats.nodeCount > 0 && stats.nodesCniReady < stats.nodeCount) {
+    return 'degraded'
+  }
+  return 'healthy'
+}
+
+function buildCniStatus(
+  stats: CniStats,
+  nodes: CniNodeStatus[],
+): CniStatusData {
+  return {
+    health: deriveHealth(stats, nodes),
+    nodes,
+    stats,
+    summary: summarize(stats),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private fetchJson helper (mirrors spiffe/envoy/contour/linkerd pattern)
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(
+  url: string,
+  options?: { treat404AsEmpty?: boolean },
+): Promise<FetchResult<T | null>> {
+  try {
+    const resp = await authFetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+
+    if (!resp.ok) {
+      if (options?.treat404AsEmpty && resp.status === 404) {
+        return { data: null, failed: false }
+      }
+      return { data: null, failed: true }
+    }
+
+    const body = (await resp.json()) as T
+    return { data: body, failed: false }
+  } catch {
+    return { data: null, failed: true }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchCniStatus(): Promise<CniStatusData> {
+  const result = await fetchJson<CniStatusResponse>(
+    CNI_STATUS_ENDPOINT,
+    { treat404AsEmpty: true },
+  )
+
+  // If the endpoint isn't wired up yet (404) or the request failed, the
+  // cache layer will surface demo data via its demoData fallback path.
+  if (result.failed) {
+    throw new Error('Unable to fetch CNI status')
+  }
+
+  const body = result.data
+  const nodes = Array.isArray(body?.nodes) ? body.nodes : []
+  const stats: CniStats = {
+    activePlugin: body?.stats?.activePlugin ?? body?.activePlugin ?? DEFAULT_PLUGIN,
+    pluginVersion:
+      body?.stats?.pluginVersion ?? body?.pluginVersion ?? DEFAULT_PLUGIN_VERSION,
+    podNetworkCidr:
+      body?.stats?.podNetworkCidr ?? body?.podNetworkCidr ?? DEFAULT_POD_CIDR,
+    serviceNetworkCidr:
+      body?.stats?.serviceNetworkCidr
+      ?? body?.serviceNetworkCidr
+      ?? DEFAULT_SERVICE_CIDR,
+    nodeCount: body?.stats?.nodeCount ?? nodes.length,
+    nodesCniReady:
+      body?.stats?.nodesCniReady
+      ?? nodes.filter(n => n.state === 'ready').length,
+    networkPolicyCount: body?.stats?.networkPolicyCount ?? DEFAULT_COUNT,
+    servicesWithNetworkPolicy:
+      body?.stats?.servicesWithNetworkPolicy ?? DEFAULT_COUNT,
+    totalServices: body?.stats?.totalServices ?? DEFAULT_COUNT,
+    podsWithIp: body?.stats?.podsWithIp ?? DEFAULT_COUNT,
+    totalPods: body?.stats?.totalPods ?? DEFAULT_COUNT,
+  }
+
+  return buildCniStatus(stats, nodes)
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseCachedCniResult {
+  data: CniStatusData
+  isLoading: boolean
+  isRefreshing: boolean
+  isDemoData: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  showSkeleton: boolean
+  showEmptyState: boolean
+  error: boolean
+  refetch: () => Promise<void>
+}
+
+export function useCachedCni(): UseCachedCniResult {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+    lastRefresh,
+    refetch,
+  } = useCache<CniStatusData>({
+    key: CACHE_KEY,
+    category: 'services',
+    initialData: INITIAL_DATA,
+    demoData: CNI_DEMO_DATA,
+    persist: true,
+    fetcher: fetchCniStatus,
+  })
+
+  // Prevent demo flash while loading — only surface the Demo badge once
+  // we've actually fallen back to demo data post-load.
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' counts as "data" so the card shows the empty state
+  // rather than an infinite skeleton when CNI metadata isn't available.
+  const hasAnyData =
+    data.health === 'not-installed' ? true : (data.nodes ?? []).length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+    lastRefresh,
+  })
+
+  return {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoData: effectiveIsDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+    showSkeleton,
+    showEmptyState,
+    error: isFailed && !hasAnyData,
+    refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  summarize,
+  deriveHealth,
+  buildCniStatus,
+}

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -158,6 +158,13 @@ export { useCachedRook } from './useCachedRook'
 export { useCachedSpiffe } from './useCachedSpiffe'
 
 // ============================================================================
+// CNI (Container Network Interface) — useCachedCni.ts
+// ============================================================================
+// Named re-export (avoids `__testables` export-name collision).
+
+export { useCachedCni } from './useCachedCni'
+
+// ============================================================================
 // TiKV Distributed Key-Value Store — useCachedTikv.ts
 // ============================================================================
 

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -102,6 +102,7 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-openfeature': 'openfeature_status',
   'cncf-rook': 'rook_status',
   'cncf-spiffe': 'spiffe_status',
+  'cncf-cni': 'cni_status',
   'cncf-strimzi': 'strimzi_status',
   'cncf-thanos': 'thanos_status',
   'cncf-opentelemetry': 'otel_status',

--- a/web/src/lib/demo/cni.ts
+++ b/web/src/lib/demo/cni.ts
@@ -1,0 +1,165 @@
+/**
+ * CNI (Container Network Interface) Status — Demo Data & Type Definitions
+ *
+ * The CNI plugin provides pod networking inside a Kubernetes cluster. Common
+ * implementations include Cilium (eBPF), Calico, Flannel, Weave, Antrea, and
+ * Kindnet. This card surfaces:
+ *
+ *  - Active CNI plugin (name + version)
+ *  - Node count with CNI ready / total
+ *  - Pod network CIDR
+ *  - Services using NetworkPolicy (rough adoption indicator)
+ *  - Per-node CNI daemonset health
+ *  - Aggregate metrics (pods with IPs, routable services, policies in effect)
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a real
+ * CNI inspection bridge lands (`/api/cni/status`), the hook's fetcher will
+ * pick up live data automatically with no component changes.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CniHealth = 'healthy' | 'degraded' | 'not-installed'
+export type CniPlugin =
+  | 'cilium'
+  | 'calico'
+  | 'flannel'
+  | 'weave'
+  | 'antrea'
+  | 'kindnet'
+  | 'aws-vpc-cni'
+  | 'azure-cni'
+  | 'unknown'
+export type CniNodeState = 'ready' | 'not-ready' | 'unknown'
+
+export interface CniNodeStatus {
+  node: string
+  cluster: string
+  state: CniNodeState
+  plugin: CniPlugin
+  pluginVersion: string
+  podCidr: string
+  lastHeartbeat: string
+}
+
+export interface CniStats {
+  activePlugin: CniPlugin
+  pluginVersion: string
+  podNetworkCidr: string
+  serviceNetworkCidr: string
+  nodeCount: number
+  nodesCniReady: number
+  networkPolicyCount: number
+  servicesWithNetworkPolicy: number
+  totalServices: number
+  podsWithIp: number
+  totalPods: number
+}
+
+export interface CniSummary {
+  activePlugin: CniPlugin
+  pluginVersion: string
+  podNetworkCidr: string
+  nodesCniReady: number
+  nodeCount: number
+  networkPolicyCount: number
+  servicesWithNetworkPolicy: number
+}
+
+export interface CniStatusData {
+  health: CniHealth
+  nodes: CniNodeStatus[]
+  stats: CniStats
+  summary: CniSummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const DEMO_PLUGIN: CniPlugin = 'cilium'
+const DEMO_PLUGIN_VERSION = '1.15.6'
+const DEMO_POD_CIDR = '10.244.0.0/16'
+const DEMO_SERVICE_CIDR = '10.96.0.0/12'
+const DEMO_NODE_COUNT = 3
+const DEMO_NODES_CNI_READY = 3
+const DEMO_NETWORK_POLICY_COUNT = 5
+const DEMO_SERVICES_WITH_POLICY = 8
+const DEMO_TOTAL_SERVICES = 24
+const DEMO_PODS_WITH_IP = 148
+const DEMO_TOTAL_PODS = 150
+
+// Per-node pod CIDRs (documented example allocations)
+const NODE_1_POD_CIDR = '10.244.0.0/24'
+const NODE_2_POD_CIDR = '10.244.1.0/24'
+const NODE_3_POD_CIDR = '10.244.2.0/24'
+
+// Heartbeat timestamps relative to "now"
+const FIFTEEN_SECONDS_MS = 15 * 1000
+const TWENTY_SECONDS_MS = 20 * 1000
+const TEN_SECONDS_MS = 10 * 1000
+
+// ---------------------------------------------------------------------------
+// Demo data — shown when CNI endpoint is unreachable or in demo mode
+// ---------------------------------------------------------------------------
+
+const DEMO_NODES: CniNodeStatus[] = [
+  {
+    node: 'kind-control-plane',
+    cluster: 'prod-east',
+    state: 'ready',
+    plugin: DEMO_PLUGIN,
+    pluginVersion: DEMO_PLUGIN_VERSION,
+    podCidr: NODE_1_POD_CIDR,
+    lastHeartbeat: new Date(Date.now() - FIFTEEN_SECONDS_MS).toISOString(),
+  },
+  {
+    node: 'kind-worker',
+    cluster: 'prod-east',
+    state: 'ready',
+    plugin: DEMO_PLUGIN,
+    pluginVersion: DEMO_PLUGIN_VERSION,
+    podCidr: NODE_2_POD_CIDR,
+    lastHeartbeat: new Date(Date.now() - TEN_SECONDS_MS).toISOString(),
+  },
+  {
+    node: 'kind-worker2',
+    cluster: 'prod-east',
+    state: 'ready',
+    plugin: DEMO_PLUGIN,
+    pluginVersion: DEMO_PLUGIN_VERSION,
+    podCidr: NODE_3_POD_CIDR,
+    lastHeartbeat: new Date(Date.now() - TWENTY_SECONDS_MS).toISOString(),
+  },
+]
+
+export const CNI_DEMO_DATA: CniStatusData = {
+  health: 'healthy',
+  nodes: DEMO_NODES,
+  stats: {
+    activePlugin: DEMO_PLUGIN,
+    pluginVersion: DEMO_PLUGIN_VERSION,
+    podNetworkCidr: DEMO_POD_CIDR,
+    serviceNetworkCidr: DEMO_SERVICE_CIDR,
+    nodeCount: DEMO_NODE_COUNT,
+    nodesCniReady: DEMO_NODES_CNI_READY,
+    networkPolicyCount: DEMO_NETWORK_POLICY_COUNT,
+    servicesWithNetworkPolicy: DEMO_SERVICES_WITH_POLICY,
+    totalServices: DEMO_TOTAL_SERVICES,
+    podsWithIp: DEMO_PODS_WITH_IP,
+    totalPods: DEMO_TOTAL_PODS,
+  },
+  summary: {
+    activePlugin: DEMO_PLUGIN,
+    pluginVersion: DEMO_PLUGIN_VERSION,
+    podNetworkCidr: DEMO_POD_CIDR,
+    nodesCniReady: DEMO_NODES_CNI_READY,
+    nodeCount: DEMO_NODE_COUNT,
+    networkPolicyCount: DEMO_NETWORK_POLICY_COUNT,
+    servicesWithNetworkPolicy: DEMO_SERVICES_WITH_POLICY,
+  },
+  lastCheckTime: new Date().toISOString(),
+}

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -59,6 +59,7 @@ import { useCachedLinkerd } from '../../hooks/useCachedLinkerd'
 import { useCachedOtel } from '../../hooks/useCachedOtel'
 import { useCachedRook } from '../../hooks/useCachedRook'
 import { useCachedSpiffe } from '../../hooks/useCachedSpiffe'
+import { useCachedCni } from '../../hooks/useCachedCni'
 import { useCachedTikv } from '../../hooks/useCachedTikv'
 import { useCachedTuf } from '../../hooks/useCachedTuf'
 import { useCachedVitess } from '../../hooks/useCachedVitess'
@@ -1186,6 +1187,17 @@ function useUnifiedSpiffeStatus() {
   }
 }
 
+function useUnifiedCniStatus() {
+  const result = useCachedCni()
+  // Surface the node list as the primary row set for generic list renderers.
+  return {
+    data: result.data.nodes,
+    isLoading: result.showSkeleton,
+    error: result.error ? new Error('Failed to fetch CNI status') : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
 function useUnifiedVitessStatus() {
   const result = useCachedVitess()
   // Surface the keyspace list as the primary row set for generic list renderers.
@@ -1394,6 +1406,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useCachedOtel', useUnifiedOtelStatus)
   registerDataHook('useCachedRook', useUnifiedRookStatus)
   registerDataHook('useCachedSpiffe', useUnifiedSpiffeStatus)
+  registerDataHook('useCachedCni', useUnifiedCniStatus)
   registerDataHook('useCachedTikv', useUnifiedTikvStatus)
   registerDataHook('useCachedTuf', useUnifiedTufStatus)
   registerDataHook('useCachedVitess', useUnifiedVitessStatus)

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3195,6 +3195,22 @@
     "noEntries": "No registration entries found",
     "noFederated": "No federated trust domains"
   },
+  "cniStatus": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "CNI plugin not detected",
+    "notInstalledHint": "No CNI metadata reachable from the connected clusters.",
+    "fetchError": "Unable to fetch CNI status",
+    "plugin": "Plugin",
+    "nodesReady": "Nodes Ready",
+    "policies": "NetworkPolicies",
+    "servicesWithPolicy": "Svcs w/ Policy",
+    "version": "version",
+    "sectionPodCidr": "Pod network CIDR",
+    "sectionNodes": "Nodes",
+    "noNodes": "No nodes reporting CNI status",
+    "unknownCidr": "unknown"
+  },
   "tikvStatus": {
     "healthy": "Healthy",
     "degraded": "Degraded",


### PR DESCRIPTION
## Summary

Adds a Container Network Interface (CNI) monitoring card that surfaces:

- **Active CNI plugin** (Cilium, Calico, Flannel, Weave, Antrea, Kindnet, etc.) with version
- **Node count with CNI ready** (e.g. `3/3`)
- **Pod network CIDR** (e.g. `10.244.0.0/16`)
- **NetworkPolicy coverage** — total policies + services with NetworkPolicy / total services
- **Per-node CNI daemonset health** (node, state, pod CIDR, plugin version)

Follows the `spiffe_status` / `linkerd_status` scaffolding pattern — the card renders via demo fallback today, and will transparently switch to live data once `/api/cni/status` is wired up on the Go backend.

## Implementation

- `web/src/components/cards/cni_status/index.tsx` — card UI (health pill, summary tiles, pod CIDR section, node list)
- `web/src/hooks/useCachedCni.ts` — `useCache('cni-status', category: 'services')` with `/api/cni/status` 404→empty fallback, `isDemoFallback && !isLoading` guard, `__testables` export
- `web/src/lib/demo/cni.ts` — types + demo data (Cilium 1.15.6, 3-node kind cluster, 10.244.0.0/16 pod CIDR, 5 NetworkPolicies)
- `web/src/config/cards/cni-status.ts` — `UnifiedCardConfig`, category `'network'`
- Registry wiring: `cardRegistry.ts` (lazy import + `CARD_COMPONENTS` + `CARD_CHUNK_PRELOADERS` + `CARD_DEFAULT_WIDTHS`), `cardMetadata.ts` (title + description), `cardCatalog.ts` (Network section), `config/cards/index.ts` (import + `CARD_CONFIGS` + array), `registerHooks.ts` (`useUnifiedCniStatus` wrapper surfaces `nodes[]`), `useCachedData.ts` (named re-export), `useMarketplace.ts` (`'cncf-cni'` mapping)
- i18n: `cniStatus.*` namespace in `locales/en/cards.json` (all user-facing strings via `t()`)

## CLAUDE.md rules followed

- No magic numbers — every literal is a named const
- `?? []` guards on all array iterations
- No `import React` (new JSX transform)
- `isDemoFallback && !isLoading` in the hook (prevents demo flash)
- `useCardLoadingState({ isLoading: isLoading && !hasAnyData, isRefreshing, isDemoData, hasAnyData, isFailed, consecutiveFailures })` — full wiring for Demo badge / yellow outline
- Named re-export in `useCachedData.ts` (not `export *`) — avoids `__testables` collision
- Literal string keys in `Record<CniNodeState, string>` for the state→class map

## Test plan

- [ ] Card appears in the Network section of the Add Cards drawer
- [ ] Card renders demo data (Cilium 1.15.6, 3/3 nodes ready, 10.244.0.0/16) with yellow Demo badge
- [ ] Loading skeleton shows on first visit (no demo flash)
- [ ] Refresh icon spins while stale-while-revalidate is running
- [ ] `cncf-cni` marketplace item resolves to the implemented card

Fixes kubestellar/console-marketplace#33