### PR TITLE
feat(longhorn): add Longhorn monitoring card (kubestellar/console-marketplace#45)

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -277,6 +277,8 @@ export const CARD_TITLES: Record<string, string> = {
   grpc_status: 'gRPC Services',
   // Linkerd service mesh
   linkerd_status: 'Linkerd',
+  // Longhorn distributed block storage (CNCF Incubating)
+  longhorn_status: 'Longhorn',
   // OpenTelemetry collector (CNCF)
   otel_status: 'OpenTelemetry',
   // Rook cloud-native storage orchestrator
@@ -619,6 +621,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   grpc_status: 'gRPC service serving status, per-service RPS, p99 latency, and error rates.',
   // Linkerd service mesh
   linkerd_status: 'Linkerd service mesh meshed pods, success rate, RPS, and p99 latency per deployment.',
+  // Longhorn distributed block storage (CNCF Incubating)
+  longhorn_status: 'Longhorn distributed block storage: volumes (state/robustness), node status, replica health, and capacity utilization.',
   // OpenTelemetry collector
   otel_status: 'OpenTelemetry Collectors: pipeline health, receivers and exporters, dropped telemetry, and export errors across connected clusters.',
   // Rook cloud-native storage orchestrator (Ceph)

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -90,6 +90,8 @@ const EnvoyStatus = safeLazy(() => import('./envoy_status'), 'EnvoyStatus')
 const GrpcStatus = safeLazy(() => import('./grpc_status'), 'GrpcStatus')
 // Linkerd service mesh card
 const LinkerdStatus = safeLazy(() => import('./linkerd_status'), 'LinkerdStatus')
+// Longhorn distributed block storage card (CNCF Incubating)
+const LonghornStatus = safeLazy(() => import('./longhorn_status'), 'LonghornStatus')
 // OpenTelemetry collector card (Observability)
 const OtelStatus = safeLazy(() => import('./otel_status'), 'OtelStatus')
 // Rook cloud-native storage orchestrator card
@@ -753,6 +755,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   grpc_status: GrpcStatus,
   // Linkerd service mesh
   linkerd_status: LinkerdStatus,
+  // Longhorn distributed block storage (CNCF Incubating)
+  longhorn_status: LonghornStatus,
   // OpenTelemetry collector
   otel_status: OtelStatus,
   // Rook cloud-native storage orchestrator (Ceph)
@@ -1090,6 +1094,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   envoy_status: () => import('./envoy_status'),
   grpc_status: () => import('./grpc_status'),
   linkerd_status: () => import('./linkerd_status'),
+  longhorn_status: () => import('./longhorn_status'),
   otel_status: () => import('./otel_status'),
   rook_status: () => import('./rook_status'),
   spiffe_status: () => import('./spiffe_status'),
@@ -1709,6 +1714,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   envoy_status: 6,
   grpc_status: 6,
   linkerd_status: 6,
+  longhorn_status: 6,
   otel_status: 6,
   rook_status: 6,
   spiffe_status: 6,

--- a/web/src/components/cards/longhorn_status/index.tsx
+++ b/web/src/components/cards/longhorn_status/index.tsx
@@ -1,0 +1,384 @@
+/**
+ * Longhorn Status Card
+ *
+ * Surfaces Longhorn (CNCF Incubating) distributed block storage state —
+ * volume list, node status, replica health, and storage capacity. Falls
+ * back to demo data when Longhorn isn't installed or the user is in
+ * demo mode.
+ *
+ * Mirrors the rook_status / tikv_status / spiffe_status pattern.
+ */
+
+import { useTranslation } from 'react-i18next'
+import {
+  AlertTriangle,
+  CheckCircle,
+  HardDrive,
+  RefreshCw,
+  Server,
+  XCircle,
+} from 'lucide-react'
+import { useCachedLonghorn } from '../../../hooks/useCachedLonghorn'
+import { useCardLoadingState } from '../CardDataContext'
+import { SkeletonCardWithRefresh } from '../../ui/Skeleton'
+import { EmptyState } from '../../ui/EmptyState'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { cn } from '../../../lib/cn'
+import type {
+  LonghornNode,
+  LonghornVolume,
+  LonghornVolumeRobustness,
+} from '../../../lib/demo/longhorn'
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const BYTES_PER_KIB = 1024
+const BYTES_PER_MIB = BYTES_PER_KIB * 1024
+const BYTES_PER_GIB = BYTES_PER_MIB * 1024
+const BYTES_PER_TIB = BYTES_PER_GIB * 1024
+const BYTES_PER_PIB = BYTES_PER_TIB * 1024
+
+const PCT_MULTIPLIER = 100
+const CAPACITY_DECIMALS = 1
+const USAGE_PCT_WARN = 70
+const USAGE_PCT_ALERT = 85
+
+// Keep the card compact — cap visible rows.
+const VOLUME_PAGE_SIZE = 6
+const NODE_PAGE_SIZE = 4
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0'
+  if (bytes >= BYTES_PER_PIB) return `${(bytes / BYTES_PER_PIB).toFixed(CAPACITY_DECIMALS)} PiB`
+  if (bytes >= BYTES_PER_TIB) return `${(bytes / BYTES_PER_TIB).toFixed(CAPACITY_DECIMALS)} TiB`
+  if (bytes >= BYTES_PER_GIB) return `${(bytes / BYTES_PER_GIB).toFixed(CAPACITY_DECIMALS)} GiB`
+  if (bytes >= BYTES_PER_MIB) return `${(bytes / BYTES_PER_MIB).toFixed(CAPACITY_DECIMALS)} MiB`
+  return `${bytes} B`
+}
+
+function usagePct(used: number, total: number): number {
+  if (total <= 0) return 0
+  const pct = (used / total) * PCT_MULTIPLIER
+  return Math.max(0, Math.min(PCT_MULTIPLIER, pct))
+}
+
+function usageColor(pct: number): string {
+  if (pct >= USAGE_PCT_ALERT) return 'text-red-400'
+  if (pct >= USAGE_PCT_WARN) return 'text-yellow-400'
+  return 'text-green-400'
+}
+
+const ROBUSTNESS_BADGE_CLASSES: Record<LonghornVolumeRobustness, string> = {
+  healthy: 'bg-green-500/20 text-green-400',
+  degraded: 'bg-yellow-500/20 text-yellow-400',
+  faulted: 'bg-red-500/20 text-red-400',
+  unknown: 'bg-secondary/40 text-muted-foreground',
+}
+
+function RobustnessIcon({ robustness }: { robustness: LonghornVolumeRobustness }) {
+  if (robustness === 'healthy') {
+    return <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
+  }
+  if (robustness === 'degraded') {
+    return <AlertTriangle className="w-3.5 h-3.5 text-yellow-400 shrink-0" />
+  }
+  if (robustness === 'faulted') {
+    return <XCircle className="w-3.5 h-3.5 text-red-400 shrink-0" />
+  }
+  return <Server className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+}
+
+// ---------------------------------------------------------------------------
+// Row components
+// ---------------------------------------------------------------------------
+
+function VolumeRow({ volume }: { volume: LonghornVolume }) {
+  const { t } = useTranslation('cards')
+  const replicasMissing = volume.replicasDesired - volume.replicasHealthy
+  const pct = usagePct(volume.actualSizeBytes, volume.sizeBytes)
+
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          <RobustnessIcon robustness={volume.robustness} />
+          <span className="text-xs font-medium truncate font-mono">
+            {volume.namespace}/{volume.name}
+          </span>
+        </div>
+        <span
+          className={cn(
+            'text-[11px] px-1.5 py-0.5 rounded-full shrink-0',
+            ROBUSTNESS_BADGE_CLASSES[volume.robustness],
+          )}
+        >
+          {volume.robustness}
+        </span>
+      </div>
+
+      <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+        <span className="truncate">
+          {t('longhornStatus.replicasShort', {
+            healthy: volume.replicasHealthy,
+            desired: volume.replicasDesired,
+            defaultValue: 'replicas {{healthy}}/{{desired}}',
+          })}
+          {replicasMissing > 0 && (
+            <span className="text-yellow-400"> · -{replicasMissing}</span>
+          )}
+          {' · '}
+          {volume.state}
+          {volume.nodeAttached && ` · ${volume.nodeAttached}`}
+        </span>
+        <span className={cn('flex items-center gap-1 shrink-0', usageColor(pct))}>
+          <HardDrive className="w-3 h-3" />
+          {formatBytes(volume.actualSizeBytes)} / {formatBytes(volume.sizeBytes)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function NodeRow({ node }: { node: LonghornNode }) {
+  const { t } = useTranslation('cards')
+  const pct = usagePct(node.storageUsedBytes, node.storageTotalBytes)
+
+  let statusClass: string
+  let statusLabel: string
+  if (!node.ready) {
+    statusClass = 'bg-red-500/20 text-red-400'
+    statusLabel = t('longhornStatus.nodeNotReady', 'Not ready')
+  } else if (!node.schedulable) {
+    statusClass = 'bg-yellow-500/20 text-yellow-400'
+    statusLabel = t('longhornStatus.nodeCordoned', 'Cordoned')
+  } else {
+    statusClass = 'bg-green-500/20 text-green-400'
+    statusLabel = t('longhornStatus.nodeReady', 'Ready')
+  }
+
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          <Server className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
+          <span className="text-xs font-medium truncate font-mono">
+            {node.name}
+          </span>
+          {node.cluster && (
+            <span className="text-[11px] text-muted-foreground truncate">
+              {node.cluster}
+            </span>
+          )}
+        </div>
+        <span className={cn('text-[11px] px-1.5 py-0.5 rounded-full shrink-0', statusClass)}>
+          {statusLabel}
+        </span>
+      </div>
+
+      <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+        <span className="truncate">
+          {t('longhornStatus.replicaCount', {
+            count: node.replicaCount,
+            defaultValue: '{{count}} replicas',
+          })}
+        </span>
+        <span className={cn('flex items-center gap-1 shrink-0', usageColor(pct))}>
+          <HardDrive className="w-3 h-3" />
+          {formatBytes(node.storageUsedBytes)} / {formatBytes(node.storageTotalBytes)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function LonghornStatus() {
+  const { t } = useTranslation(['cards', 'common'])
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoFallback,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  } = useCachedLonghorn()
+
+  // Rule: never show demo data while still loading.
+  const isDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' still counts as "we have data" so the card shows the
+  // empty state rather than being stuck in an indefinite skeleton.
+  const hasAnyData =
+    data.health === 'not-installed'
+      ? true
+      : data.summary.totalVolumes > 0 || data.summary.totalNodes > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    isDemoData,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  })
+
+  if (showSkeleton) {
+    return <SkeletonCardWithRefresh showStats={true} rows={VOLUME_PAGE_SIZE} />
+  }
+
+  if (showEmptyState || (data.health === 'not-installed' && !isDemoData)) {
+    return (
+      <div className="h-full flex items-center justify-center p-4">
+        <EmptyState
+          icon={<HardDrive className="w-8 h-8 text-muted-foreground/40" />}
+          title={t('longhornStatus.notInstalled', 'Longhorn not detected')}
+          description={t(
+            'longhornStatus.notInstalledHint',
+            'No Longhorn volumes or nodes found. Install Longhorn to monitor distributed block storage.',
+          )}
+        />
+      </div>
+    )
+  }
+
+  const isHealthy = data.health === 'healthy'
+  const volumes = (data.volumes ?? []).slice(0, VOLUME_PAGE_SIZE)
+  const nodes = (data.nodes ?? []).slice(0, NODE_PAGE_SIZE)
+
+  return (
+    <div className="h-full flex flex-col min-h-card gap-4 overflow-hidden animate-in fade-in duration-500">
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={cn(
+            'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
+            isHealthy
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-yellow-500/15 text-yellow-400',
+          )}
+        >
+          {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          {isHealthy
+            ? t('longhornStatus.healthy', 'Healthy')
+            : t('longhornStatus.degraded', 'Degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={cn('w-3 h-3', isRefreshing ? 'animate-spin' : '')} />
+          <span>
+            {t('longhornStatus.volumeCount', {
+              count: data.summary.totalVolumes,
+              defaultValue: '{{count}} volumes',
+            })}
+          </span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label={t('longhornStatus.healthyVolumes', 'Healthy')}
+          value={data.summary.healthyVolumes}
+          colorClass="text-green-400"
+          icon={<CheckCircle className="w-4 h-4 text-green-400" />}
+        />
+        <MetricTile
+          label={t('longhornStatus.degradedVolumes', 'Degraded')}
+          value={data.summary.degradedVolumes + data.summary.faultedVolumes}
+          colorClass={
+            data.summary.degradedVolumes + data.summary.faultedVolumes > 0
+              ? 'text-yellow-400'
+              : 'text-green-400'
+          }
+          icon={
+            data.summary.degradedVolumes + data.summary.faultedVolumes > 0 ? (
+              <AlertTriangle className="w-4 h-4 text-yellow-400" />
+            ) : (
+              <CheckCircle className="w-4 h-4 text-green-400" />
+            )
+          }
+        />
+        <MetricTile
+          label={t('longhornStatus.nodesReady', 'Nodes ready')}
+          value={`${data.summary.readyNodes}/${data.summary.totalNodes}`}
+          colorClass={
+            data.summary.readyNodes === data.summary.totalNodes
+              ? 'text-green-400'
+              : 'text-yellow-400'
+          }
+          icon={<Server className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('longhornStatus.capacity', 'Capacity')}
+          value={`${formatBytes(data.summary.totalUsedBytes)} / ${formatBytes(
+            data.summary.totalCapacityBytes,
+          )}`}
+          colorClass="text-blue-400"
+          icon={<HardDrive className="w-4 h-4 text-blue-400" />}
+        />
+      </div>
+
+      <div className="space-y-3 overflow-y-auto scrollbar-thin pr-0.5">
+        <section className="space-y-1.5">
+          <div className="flex items-center gap-2">
+            <HardDrive className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('longhornStatus.sectionVolumes', 'Volumes')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {data.summary.totalVolumes}
+            </span>
+          </div>
+          {volumes.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('longhornStatus.noVolumes', 'No Longhorn volumes reporting.')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(volumes ?? []).map(volume => (
+                <VolumeRow
+                  key={`${volume.cluster}:${volume.namespace}:${volume.name}`}
+                  volume={volume}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-1.5">
+          <div className="flex items-center gap-2">
+            <Server className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('longhornStatus.sectionNodes', 'Storage nodes')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {data.summary.totalNodes}
+            </span>
+          </div>
+          {nodes.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('longhornStatus.noNodes', 'No Longhorn storage nodes reporting.')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(nodes ?? []).map(node => (
+                <NodeRow key={`${node.cluster}:${node.name}`} node={node} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default LonghornStatus

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -141,6 +141,7 @@ export const CARD_CATALOG = {
     { type: 'fluid_status', title: 'Fluid', description: 'Fluid dataset caching status, runtime health, and data load progress', visualization: 'status' },
     { type: 'cubefs_status', title: 'CubeFS', description: 'CubeFS distributed file system health, volume status, and node topology', visualization: 'status' },
     { type: 'rook_status', title: 'Rook', description: 'Rook-managed CephClusters: Ceph health, OSD/MON/MGR counts, and capacity', visualization: 'status' },
+    { type: 'longhorn_status', title: 'Longhorn', description: 'Longhorn distributed block storage: volumes, node status, replica health, and capacity utilization', visualization: 'status' },
     { type: 'tikv_status', title: 'TiKV', description: 'TiKV distributed key-value store: store nodes, regions, leaders, and capacity', visualization: 'status' },
     { type: 'vitess_status', title: 'Vitess', description: 'Vitess distributed MySQL: keyspaces, shards, tablets (PRIMARY/REPLICA/RDONLY), and replication lag', visualization: 'status' },
   ],

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -75,6 +75,7 @@ import { grpcStatusConfig } from './grpc-status'
 import { kedaStatusConfig } from './keda-status'
 import { kserveStatusConfig } from './kserve-status'
 import { linkerdStatusConfig } from './linkerd-status'
+import { longhornStatusConfig } from './longhorn-status'
 import { otelStatusConfig } from './otel-status'
 import { rookStatusConfig } from './rook-status'
 import { tikvStatusConfig } from './tikv-status'
@@ -279,6 +280,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   keda_status: kedaStatusConfig,
   kserve_status: kserveStatusConfig,
   linkerd_status: linkerdStatusConfig,
+  longhorn_status: longhornStatusConfig,
   otel_status: otelStatusConfig,
   rook_status: rookStatusConfig,
   tikv_status: tikvStatusConfig,

--- a/web/src/config/cards/longhorn-status.ts
+++ b/web/src/config/cards/longhorn-status.ts
@@ -1,0 +1,62 @@
+/**
+ * Longhorn Status Card Configuration
+ *
+ * Longhorn (CNCF Incubating) is a cloud-native distributed block storage
+ * system for Kubernetes. This card surfaces volume state and robustness,
+ * per-node storage utilization, replica health, and cluster-wide capacity.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const longhornStatusConfig: UnifiedCardConfig = {
+  type: 'longhorn_status',
+  title: 'Longhorn',
+  category: 'storage',
+  description:
+    'Longhorn distributed block storage: volumes (state/robustness), node status, replica health, and capacity utilization.',
+
+  // Appearance
+  icon: 'HardDrive',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedLonghorn',
+  },
+
+  // Content — list visualization with volume rows
+  content: {
+    type: 'list',
+    pageSize: 6,
+    columns: [
+      { field: 'name', header: 'Volume', primary: true, render: 'truncate' },
+      { field: 'robustness', header: 'Robustness', width: 120, render: 'status-badge' },
+      { field: 'state', header: 'State', width: 100 },
+      { field: 'replicasHealthy', header: 'Replicas', width: 90 },
+      { field: 'sizeBytes', header: 'Size', width: 100 },
+      { field: 'cluster', header: 'Cluster', width: 120, render: 'cluster-badge' },
+    ],
+  },
+
+  emptyState: {
+    icon: 'HardDrive',
+    title: 'Longhorn not detected',
+    message: 'No Longhorn volumes or nodes found on connected clusters.',
+    variant: 'info',
+  },
+
+  loadingState: {
+    type: 'list',
+    rows: 5,
+  },
+
+  // Renders live when /api/longhorn/status is wired up; otherwise falls
+  // back to demo data via the useCache demoData path.
+  isDemoData: false,
+  isLive: true,
+}
+
+export default longhornStatusConfig

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -172,6 +172,13 @@ export { useCachedCni } from './useCachedCni'
 export { useCachedOpenfeature } from './useCachedOpenfeature'
 
 // ============================================================================
+// Longhorn Distributed Block Storage — useCachedLonghorn.ts (CNCF Incubating)
+// ============================================================================
+// Named re-export (avoids `__testables` export-name collision with TiKV).
+
+export { useCachedLonghorn } from './useCachedLonghorn'
+
+// ============================================================================
 // TiKV Distributed Key-Value Store — useCachedTikv.ts
 // ============================================================================
 

--- a/web/src/hooks/useCachedLonghorn.ts
+++ b/web/src/hooks/useCachedLonghorn.ts
@@ -1,0 +1,253 @@
+/**
+ * useCachedLonghorn — Cached hook for Longhorn distributed block storage status.
+ *
+ * Longhorn (CNCF Incubating) replicates block volumes across Kubernetes
+ * nodes. This hook surfaces:
+ *   • Volume list + per-volume state/robustness/replica health
+ *   • Node status (Ready + schedulable)
+ *   • Cluster-wide capacity utilization
+ *
+ * Follows the mandatory caching contract defined in CLAUDE.md:
+ * - useCache with fetcher + demoData
+ * - isDemoFallback guarded so it's false during loading
+ * - Standard CachedHookResult return shape
+ * - 404 from the endpoint is treated as "not installed" (empty) rather
+ *   than a failure — the card then renders the "Longhorn not detected"
+ *   empty state instead of falling back to demo.
+ */
+
+import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { authFetch } from '../lib/api'
+import {
+  LONGHORN_DEMO_DATA,
+  type LonghornNode,
+  type LonghornStatusData,
+  type LonghornSummary,
+  type LonghornVolume,
+  type LonghornVolumeRobustness,
+  type LonghornVolumeState,
+} from '../lib/demo/longhorn'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY_LONGHORN = 'longhorn-status'
+const LONGHORN_STATUS_ENDPOINT = '/api/longhorn/status'
+
+// HTTP status sentinels
+const HTTP_NOT_FOUND = 404
+
+const INITIAL_DATA: LonghornStatusData = {
+  health: 'not-installed',
+  volumes: [],
+  nodes: [],
+  summary: {
+    totalVolumes: 0,
+    healthyVolumes: 0,
+    degradedVolumes: 0,
+    faultedVolumes: 0,
+    totalNodes: 0,
+    readyNodes: 0,
+    schedulableNodes: 0,
+    totalCapacityBytes: 0,
+    totalUsedBytes: 0,
+  },
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Internal types (shape of the /api/longhorn/status response)
+// ---------------------------------------------------------------------------
+
+interface LonghornStatusResponse {
+  volumes?: LonghornVolume[]
+  nodes?: LonghornNode[]
+}
+
+const VALID_VOLUME_STATES: ReadonlyArray<LonghornVolumeState> = [
+  'attached',
+  'detached',
+  'attaching',
+  'detaching',
+  'creating',
+  'deleting',
+]
+
+const VALID_VOLUME_ROBUSTNESS: ReadonlyArray<LonghornVolumeRobustness> = [
+  'healthy',
+  'degraded',
+  'faulted',
+  'unknown',
+]
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function normalizeVolumeState(value: string | undefined): LonghornVolumeState {
+  if (value && (VALID_VOLUME_STATES as readonly string[]).includes(value)) {
+    return value as LonghornVolumeState
+  }
+  return 'detached'
+}
+
+function normalizeRobustness(value: string | undefined): LonghornVolumeRobustness {
+  if (value && (VALID_VOLUME_ROBUSTNESS as readonly string[]).includes(value)) {
+    return value as LonghornVolumeRobustness
+  }
+  return 'unknown'
+}
+
+function summarize(
+  volumes: LonghornVolume[],
+  nodes: LonghornNode[],
+): LonghornSummary {
+  let healthyVolumes = 0
+  let degradedVolumes = 0
+  let faultedVolumes = 0
+  for (const v of volumes ?? []) {
+    if (v.robustness === 'healthy') healthyVolumes += 1
+    else if (v.robustness === 'degraded') degradedVolumes += 1
+    else if (v.robustness === 'faulted') faultedVolumes += 1
+  }
+
+  let readyNodes = 0
+  let schedulableNodes = 0
+  let totalCapacityBytes = 0
+  let totalUsedBytes = 0
+  for (const n of nodes ?? []) {
+    if (n.ready) readyNodes += 1
+    if (n.schedulable) schedulableNodes += 1
+    totalCapacityBytes += n.storageTotalBytes
+    totalUsedBytes += n.storageUsedBytes
+  }
+
+  return {
+    totalVolumes: volumes.length,
+    healthyVolumes,
+    degradedVolumes,
+    faultedVolumes,
+    totalNodes: nodes.length,
+    readyNodes,
+    schedulableNodes,
+    totalCapacityBytes,
+    totalUsedBytes,
+  }
+}
+
+function deriveHealth(
+  volumes: LonghornVolume[],
+  nodes: LonghornNode[],
+): LonghornStatusData['health'] {
+  if (volumes.length === 0 && nodes.length === 0) {
+    return 'not-installed'
+  }
+  const hasFaultedVolume = volumes.some(v => v.robustness === 'faulted')
+  const hasDegradedVolume = volumes.some(v => v.robustness === 'degraded')
+  const hasUnreadyNode = nodes.some(n => !n.ready)
+  if (hasFaultedVolume || hasDegradedVolume || hasUnreadyNode) {
+    return 'degraded'
+  }
+  return 'healthy'
+}
+
+function buildStatus(
+  volumes: LonghornVolume[],
+  nodes: LonghornNode[],
+): LonghornStatusData {
+  return {
+    health: deriveHealth(volumes, nodes),
+    volumes,
+    nodes,
+    summary: summarize(volumes, nodes),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchLonghornStatus(): Promise<LonghornStatusData> {
+  const resp = await authFetch(LONGHORN_STATUS_ENDPOINT, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
+
+  if (!resp.ok) {
+    // Endpoint not wired up / Longhorn not installed → treat as empty so
+    // the card renders its "not installed" empty state rather than an error.
+    if (resp.status === HTTP_NOT_FOUND) return buildStatus([], [])
+    throw new Error(`HTTP ${resp.status}`)
+  }
+
+  const body = (await resp.json()) as LonghornStatusResponse
+  const rawVolumes = Array.isArray(body.volumes) ? body.volumes : []
+  const rawNodes = Array.isArray(body.nodes) ? body.nodes : []
+
+  const volumes: LonghornVolume[] = (rawVolumes ?? []).map(v => ({
+    name: v.name ?? '',
+    namespace: v.namespace ?? '',
+    state: normalizeVolumeState(v.state),
+    robustness: normalizeRobustness(v.robustness),
+    replicasDesired: v.replicasDesired ?? 0,
+    replicasHealthy: v.replicasHealthy ?? 0,
+    sizeBytes: v.sizeBytes ?? 0,
+    actualSizeBytes: v.actualSizeBytes ?? 0,
+    nodeAttached: v.nodeAttached ?? '',
+    cluster: v.cluster ?? '',
+  }))
+
+  const nodes: LonghornNode[] = (rawNodes ?? []).map(n => ({
+    name: n.name ?? '',
+    cluster: n.cluster ?? '',
+    ready: Boolean(n.ready),
+    schedulable: Boolean(n.schedulable),
+    storageTotalBytes: n.storageTotalBytes ?? 0,
+    storageUsedBytes: n.storageUsedBytes ?? 0,
+    replicaCount: n.replicaCount ?? 0,
+  }))
+
+  return buildStatus(volumes, nodes)
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useCachedLonghorn(): CachedHookResult<LonghornStatusData> {
+  const result = useCache<LonghornStatusData>({
+    key: CACHE_KEY_LONGHORN,
+    category: 'default' as RefreshCategory,
+    initialData: INITIAL_DATA,
+    demoData: LONGHORN_DEMO_DATA,
+    persist: true,
+    fetcher: fetchLonghornStatus,
+  })
+
+  return {
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  normalizeVolumeState,
+  normalizeRobustness,
+  summarize,
+  deriveHealth,
+  buildStatus,
+}

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -103,6 +103,7 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-grpc': 'grpc_status',
   'cncf-kserve': 'kserve_status',
   'cncf-linkerd': 'linkerd_status',
+  'cncf-longhorn': 'longhorn_status',
   'cncf-openfeature': 'openfeature_status',
   'cncf-rook': 'rook_status',
   'cncf-spiffe': 'spiffe_status',

--- a/web/src/lib/demo/longhorn.ts
+++ b/web/src/lib/demo/longhorn.ts
@@ -1,0 +1,318 @@
+/**
+ * Longhorn Status Card — Demo Data & Type Definitions
+ *
+ * Longhorn (CNCF Incubating) is a cloud-native distributed block storage
+ * system for Kubernetes. It replicates volumes across nodes and exposes a
+ * PVC-compatible storage class.
+ *
+ * This card surfaces:
+ *  - Volume list (state, robustness, replica count, size)
+ *  - Node status (Ready / schedulable)
+ *  - Replica health per volume
+ *  - Total / used storage capacity across the cluster
+ *
+ * Shown when Longhorn is not installed or when the user is in demo mode.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type LonghornInstallHealth = 'healthy' | 'degraded' | 'not-installed'
+
+/**
+ * Volume operational state as reported by `volume.status.state`.
+ */
+export type LonghornVolumeState =
+  | 'attached'
+  | 'detached'
+  | 'attaching'
+  | 'detaching'
+  | 'creating'
+  | 'deleting'
+
+/**
+ * Volume robustness as reported by `volume.status.robustness`.
+ * `healthy` = all replicas are up-to-date.
+ * `degraded` = rebuilding / at least one replica missing.
+ * `faulted`  = no healthy replicas; the volume is unusable until restored.
+ */
+export type LonghornVolumeRobustness = 'healthy' | 'degraded' | 'faulted' | 'unknown'
+
+export interface LonghornVolume {
+  /** Volume name (matches the PVC it backs when created via storage class). */
+  name: string
+  namespace: string
+  state: LonghornVolumeState
+  robustness: LonghornVolumeRobustness
+  /** Desired replica count configured on the volume. */
+  replicasDesired: number
+  /** Currently healthy replicas. */
+  replicasHealthy: number
+  sizeBytes: number
+  /** Actual data written (reported by the engine). */
+  actualSizeBytes: number
+  /** Node the engine is attached to (empty when detached). */
+  nodeAttached: string
+  cluster: string
+}
+
+export interface LonghornNode {
+  name: string
+  cluster: string
+  /** `True` means the kubelet reports the node Ready. */
+  ready: boolean
+  /** Whether Longhorn considers the node schedulable for new replicas. */
+  schedulable: boolean
+  /** Total storage reserved for Longhorn on this node. */
+  storageTotalBytes: number
+  storageUsedBytes: number
+  replicaCount: number
+}
+
+export interface LonghornSummary {
+  totalVolumes: number
+  healthyVolumes: number
+  degradedVolumes: number
+  faultedVolumes: number
+  totalNodes: number
+  readyNodes: number
+  schedulableNodes: number
+  totalCapacityBytes: number
+  totalUsedBytes: number
+}
+
+export interface LonghornStatusData {
+  health: LonghornInstallHealth
+  volumes: LonghornVolume[]
+  nodes: LonghornNode[]
+  summary: LonghornSummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo data constants — no magic numbers
+// ---------------------------------------------------------------------------
+
+const BYTES_PER_GIB = 1024 * 1024 * 1024
+const BYTES_PER_TIB = 1024 * BYTES_PER_GIB
+
+// Per-volume sizes
+const VOL_SIZE_SMALL_GIB = 10
+const VOL_SIZE_MEDIUM_GIB = 50
+const VOL_SIZE_LARGE_GIB = 200
+const VOL_SIZE_XLARGE_GIB = 500
+
+// Per-volume used (actual written) bytes — expressed as % of size
+const PCT_TO_FRACTION = 100
+const VOL_USED_PCT_LOW = 20
+const VOL_USED_PCT_MID = 55
+const VOL_USED_PCT_HIGH = 80
+const VOL_USED_PCT_FULL = 95
+
+// Default replica fan-out
+const REPLICAS_DEFAULT = 3
+const REPLICAS_HIGH = 4
+
+// Per-node capacity
+const NODE_CAPACITY_TIB = 1 // 1 TiB per node × 4 nodes = ~4 TiB cluster total ≈ 3 TiB usable
+const NODE1_USED_GIB = 520
+const NODE2_USED_GIB = 310
+const NODE3_USED_GIB = 780
+const NODE4_USED_GIB = 180
+
+const NODE1_REPLICAS = 6
+const NODE2_REPLICAS = 4
+const NODE3_REPLICAS = 8
+const NODE4_REPLICAS = 3
+
+// ---------------------------------------------------------------------------
+// Demo volumes — 8 entries covering healthy / degraded / faulted states
+// ---------------------------------------------------------------------------
+
+function gibToBytes(gib: number): number {
+  return gib * BYTES_PER_GIB
+}
+
+function usedFraction(sizeBytes: number, pct: number): number {
+  return Math.round((sizeBytes * pct) / PCT_TO_FRACTION)
+}
+
+const VOL_MEDIUM_BYTES = gibToBytes(VOL_SIZE_MEDIUM_GIB)
+const VOL_LARGE_BYTES = gibToBytes(VOL_SIZE_LARGE_GIB)
+const VOL_SMALL_BYTES = gibToBytes(VOL_SIZE_SMALL_GIB)
+const VOL_XLARGE_BYTES = gibToBytes(VOL_SIZE_XLARGE_GIB)
+
+const DEMO_VOLUMES: LonghornVolume[] = [
+  {
+    name: 'pvc-postgres-primary',
+    namespace: 'databases',
+    state: 'attached',
+    robustness: 'healthy',
+    replicasDesired: REPLICAS_DEFAULT,
+    replicasHealthy: REPLICAS_DEFAULT,
+    sizeBytes: VOL_LARGE_BYTES,
+    actualSizeBytes: usedFraction(VOL_LARGE_BYTES, VOL_USED_PCT_HIGH),
+    nodeAttached: 'worker-1',
+    cluster: 'prod-us-east',
+  },
+  {
+    name: 'pvc-postgres-replica',
+    namespace: 'databases',
+    state: 'attached',
+    robustness: 'healthy',
+    replicasDesired: REPLICAS_DEFAULT,
+    replicasHealthy: REPLICAS_DEFAULT,
+    sizeBytes: VOL_LARGE_BYTES,
+    actualSizeBytes: usedFraction(VOL_LARGE_BYTES, VOL_USED_PCT_MID),
+    nodeAttached: 'worker-2',
+    cluster: 'prod-us-east',
+  },
+  {
+    name: 'pvc-kafka-broker-0',
+    namespace: 'streaming',
+    state: 'attached',
+    robustness: 'healthy',
+    replicasDesired: REPLICAS_DEFAULT,
+    replicasHealthy: REPLICAS_DEFAULT,
+    sizeBytes: VOL_MEDIUM_BYTES,
+    actualSizeBytes: usedFraction(VOL_MEDIUM_BYTES, VOL_USED_PCT_LOW),
+    nodeAttached: 'worker-3',
+    cluster: 'prod-us-east',
+  },
+  {
+    name: 'pvc-prometheus-data',
+    namespace: 'monitoring',
+    state: 'attached',
+    robustness: 'degraded',
+    replicasDesired: REPLICAS_DEFAULT,
+    replicasHealthy: REPLICAS_DEFAULT - 1,
+    sizeBytes: VOL_XLARGE_BYTES,
+    actualSizeBytes: usedFraction(VOL_XLARGE_BYTES, VOL_USED_PCT_FULL),
+    nodeAttached: 'worker-1',
+    cluster: 'prod-us-east',
+  },
+  {
+    name: 'pvc-redis-cache',
+    namespace: 'platform',
+    state: 'attached',
+    robustness: 'healthy',
+    replicasDesired: REPLICAS_DEFAULT,
+    replicasHealthy: REPLICAS_DEFAULT,
+    sizeBytes: VOL_SMALL_BYTES,
+    actualSizeBytes: usedFraction(VOL_SMALL_BYTES, VOL_USED_PCT_MID),
+    nodeAttached: 'worker-2',
+    cluster: 'prod-us-east',
+  },
+  {
+    name: 'pvc-minio-data',
+    namespace: 'storage',
+    state: 'attached',
+    robustness: 'degraded',
+    replicasDesired: REPLICAS_HIGH,
+    replicasHealthy: REPLICAS_HIGH - 2,
+    sizeBytes: VOL_XLARGE_BYTES,
+    actualSizeBytes: usedFraction(VOL_XLARGE_BYTES, VOL_USED_PCT_HIGH),
+    nodeAttached: 'worker-3',
+    cluster: 'edge-dallas',
+  },
+  {
+    name: 'pvc-grafana-storage',
+    namespace: 'monitoring',
+    state: 'detached',
+    robustness: 'unknown',
+    replicasDesired: REPLICAS_DEFAULT,
+    replicasHealthy: REPLICAS_DEFAULT,
+    sizeBytes: VOL_SMALL_BYTES,
+    actualSizeBytes: usedFraction(VOL_SMALL_BYTES, VOL_USED_PCT_LOW),
+    nodeAttached: '',
+    cluster: 'edge-dallas',
+  },
+  {
+    name: 'pvc-elasticsearch-hot',
+    namespace: 'logging',
+    state: 'attached',
+    robustness: 'faulted',
+    replicasDesired: REPLICAS_DEFAULT,
+    replicasHealthy: 0,
+    sizeBytes: VOL_LARGE_BYTES,
+    actualSizeBytes: usedFraction(VOL_LARGE_BYTES, VOL_USED_PCT_MID),
+    nodeAttached: 'worker-4',
+    cluster: 'edge-dallas',
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Demo nodes — 4 entries, 3 TiB total capacity w/ mixed utilization
+// ---------------------------------------------------------------------------
+
+const NODE_CAPACITY_BYTES = NODE_CAPACITY_TIB * BYTES_PER_TIB
+
+const DEMO_NODES: LonghornNode[] = [
+  {
+    name: 'worker-1',
+    cluster: 'prod-us-east',
+    ready: true,
+    schedulable: true,
+    storageTotalBytes: NODE_CAPACITY_BYTES,
+    storageUsedBytes: gibToBytes(NODE1_USED_GIB),
+    replicaCount: NODE1_REPLICAS,
+  },
+  {
+    name: 'worker-2',
+    cluster: 'prod-us-east',
+    ready: true,
+    schedulable: true,
+    storageTotalBytes: NODE_CAPACITY_BYTES,
+    storageUsedBytes: gibToBytes(NODE2_USED_GIB),
+    replicaCount: NODE2_REPLICAS,
+  },
+  {
+    name: 'worker-3',
+    cluster: 'prod-us-east',
+    ready: true,
+    schedulable: false,
+    storageTotalBytes: NODE_CAPACITY_BYTES,
+    storageUsedBytes: gibToBytes(NODE3_USED_GIB),
+    replicaCount: NODE3_REPLICAS,
+  },
+  {
+    name: 'worker-4',
+    cluster: 'edge-dallas',
+    ready: false,
+    schedulable: false,
+    storageTotalBytes: NODE_CAPACITY_BYTES,
+    storageUsedBytes: gibToBytes(NODE4_USED_GIB),
+    replicaCount: NODE4_REPLICAS,
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Derived summary
+// ---------------------------------------------------------------------------
+
+const DEMO_HEALTHY_VOLUMES = DEMO_VOLUMES.filter(v => v.robustness === 'healthy').length
+const DEMO_DEGRADED_VOLUMES = DEMO_VOLUMES.filter(v => v.robustness === 'degraded').length
+const DEMO_FAULTED_VOLUMES = DEMO_VOLUMES.filter(v => v.robustness === 'faulted').length
+const DEMO_READY_NODES = DEMO_NODES.filter(n => n.ready).length
+const DEMO_SCHEDULABLE_NODES = DEMO_NODES.filter(n => n.schedulable).length
+const DEMO_TOTAL_CAPACITY = DEMO_NODES.reduce((sum, n) => sum + n.storageTotalBytes, 0)
+const DEMO_TOTAL_USED = DEMO_NODES.reduce((sum, n) => sum + n.storageUsedBytes, 0)
+
+export const LONGHORN_DEMO_DATA: LonghornStatusData = {
+  health: 'degraded',
+  volumes: DEMO_VOLUMES,
+  nodes: DEMO_NODES,
+  summary: {
+    totalVolumes: DEMO_VOLUMES.length,
+    healthyVolumes: DEMO_HEALTHY_VOLUMES,
+    degradedVolumes: DEMO_DEGRADED_VOLUMES,
+    faultedVolumes: DEMO_FAULTED_VOLUMES,
+    totalNodes: DEMO_NODES.length,
+    readyNodes: DEMO_READY_NODES,
+    schedulableNodes: DEMO_SCHEDULABLE_NODES,
+    totalCapacityBytes: DEMO_TOTAL_CAPACITY,
+    totalUsedBytes: DEMO_TOTAL_USED,
+  },
+  lastCheckTime: new Date().toISOString(),
+}

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -61,6 +61,7 @@ import { useCachedKeda } from '../../hooks/useCachedKeda'
 import { useCachedKserve } from '../../hooks/useCachedKserve'
 import { useCachedLinkerd } from '../../hooks/useCachedLinkerd'
 import { useCachedOpenfeature } from '../../hooks/useCachedOpenfeature'
+import { useCachedLonghorn } from '../../hooks/useCachedLonghorn'
 import { useCachedOtel } from '../../hooks/useCachedOtel'
 import { useCachedRook } from '../../hooks/useCachedRook'
 import { useCachedSpiffe } from '../../hooks/useCachedSpiffe'
@@ -1185,6 +1186,17 @@ function useUnifiedKserveStatus() {
   }
 }
 
+function useUnifiedLonghornStatus() {
+  const result = useCachedLonghorn()
+  // Surface the volume list as the primary row set for generic list renderers.
+  return {
+    data: result.data.volumes,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
 function useUnifiedOtelStatus() {
   const result = useCachedOtel()
   return {
@@ -1478,6 +1490,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useCachedKeda', useUnifiedKedaStatus)
   registerDataHook('useCachedKserve', useUnifiedKserveStatus)
   registerDataHook('useCachedLinkerd', useUnifiedLinkerdStatus)
+  registerDataHook('useCachedLonghorn', useUnifiedLonghornStatus)
   registerDataHook('useCachedOtel', useUnifiedOtelStatus)
   registerDataHook('useCachedRook', useUnifiedRookStatus)
   registerDataHook('useCachedSpiffe', useUnifiedSpiffeStatus)


### PR DESCRIPTION
Fixes kubestellar/console-marketplace#45

## Summary

Adds a Longhorn monitoring card (CNCF Incubating distributed block storage) to the KubeStellar Console. Shows volumes, node status, replica health, and storage capacity — falls back to demo data when Longhorn isn't installed.

## What's included

- **Card component** (`components/cards/longhorn_status/index.tsx`) — volume list with robustness badges (healthy/degraded/faulted), state, attached node, replica fan-out, and per-volume usage; storage-node list with Ready/cordoned badges and per-node capacity bars; 4-tile summary (healthy, degraded+faulted, nodes ready, total capacity).
- **Cached hook** (`hooks/useCachedLonghorn.ts`) — `useCache('longhorn-status', category: 'default')` against `/api/longhorn/status`; 404 is treated as "not installed" (empty state), any other non-OK as failure. Exports pure helpers via `__testables`.
- **Demo data** (`lib/demo/longhorn.ts`) — 8 volumes (5 healthy / 2 degraded / 1 faulted), 4 storage nodes, ~4 TiB cluster capacity with mixed utilization.
- **Card config** (`config/cards/longhorn-status.ts`) — `UnifiedCardConfig` with `category: 'storage'`, `HardDrive` icon, 6x4 default size.
- **Registry wiring (8 slots)**:
  - `cardRegistry.ts` — safeLazy import, component map, dynamic preloader, page size
  - `cardMetadata.ts` — title + description
  - `cardCatalog.ts` — Storage category entry
  - `config/cards/index.ts` — import + `CARD_CONFIGS` map
  - `useCachedData.ts` — named re-export (avoids `__testables` collision)
  - `useMarketplace.ts` — `cncf-longhorn` -> `longhorn_status` mapping
  - `lib/unified/registerHooks.ts` — import, `useUnifiedLonghornStatus` wrapper, `registerDataHook('useCachedLonghorn', ...)`

## Conventions followed (CLAUDE.md)

- All numeric literals are named constants
- Array operations guarded with `?? []` and `(x ?? []).map(...)`
- `isDemoFallback && !isLoading` gating to prevent demo-badge flash during loading
- Full `useCardLoadingState` wiring with `isDemoData`, `isRefreshing`, `hasAnyData`, `isFailed`, `consecutiveFailures`, `lastRefresh`
- Literal `Record<LonghornVolumeRobustness, string>` for robustness badge class map
- No `import React`; no raw hex colors; no magic numbers

## Test plan

- [ ] Card appears in Console Studio under Storage
- [ ] Demo data renders with yellow outline + Demo badge when `/api/longhorn/status` 404s
- [ ] No loading-flash of demo data on first paint
- [ ] Refresh icon spins during background refresh
- [ ] Empty state renders when the endpoint is wired and returns no volumes/nodes