### PR TITLE
feat(wasmcloud): add wasmCloud monitoring card (kubestellar/console-marketplace#57)

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -291,6 +291,8 @@ export const CARD_TITLES: Record<string, string> = {
   tuf_status: 'TUF',
   // Vitess distributed MySQL
   vitess_status: 'Vitess',
+  // wasmCloud WebAssembly lattice (CNCF incubating)
+  wasmcloud_status: 'wasmCloud',
   // CRI-O container runtime
   crio_status: 'CRI-O',
   // Cloud Custodian rules engine (CNCF incubating)
@@ -633,6 +635,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   tuf_status: 'TUF repository role metadata — root, targets, snapshot, timestamp — versions, expirations, thresholds, and signing status.',
   // Vitess distributed MySQL
   vitess_status: 'Vitess distributed MySQL: keyspaces, shards, tablets (PRIMARY/REPLICA/RDONLY), and replication lag.',
+  // wasmCloud WebAssembly lattice (CNCF incubating)
+  wasmcloud_status: 'wasmCloud lattice status: hosts, actors, capability providers, and link definitions across connected clusters.',
   // CRI-O container runtime
   crio_status: 'CRI-O container runtime metrics, image pulls, and pod sandbox status.',
   // Cloud Custodian rules engine (CNCF incubating)

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -106,6 +106,8 @@ const TufStatus = safeLazy(() => import('./tuf_status'), 'TufStatus')
 const VitessStatus = safeLazy(() => import('./vitess_status'), 'VitessStatus')
 // Chaos Mesh fault-injection and chaos engineering card
 const ChaosMeshStatus = safeLazy(() => import('./chaos_mesh_status'), 'ChaosMeshStatus')
+// wasmCloud WebAssembly lattice card (CNCF incubating)
+const WasmcloudStatus = safeLazy(() => import('./wasmcloud_status'), 'WasmcloudStatus')
 const OverlayComparison = safeLazy(() => _deployBundle, 'OverlayComparison')
 const ArgoCDApplications = safeLazy(() => _deployBundle, 'ArgoCDApplications')
 const ArgoCDApplicationSets = safeLazy(() => _deployBundle, 'ArgoCDApplicationSets')
@@ -767,6 +769,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   tuf_status: TufStatus,
   // Vitess distributed MySQL
   vitess_status: VitessStatus,
+  // wasmCloud WebAssembly lattice (CNCF incubating)
+  wasmcloud_status: WasmcloudStatus,
   // Artifact Hub
   artifact_hub_status: ArtifactHubStatus,
   // CloudEvents messaging
@@ -1099,6 +1103,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   vitess_status: () => import('./vitess_status'),
   // Chaos Mesh fault-injection and chaos engineering
   chaos_mesh_status: () => import('./chaos_mesh_status'),
+  wasmcloud_status: () => import('./wasmcloud_status'),
   overlay_comparison: () => import('./deploy-bundle'),
   argocd_applications: () => import('./deploy-bundle'),
   argocd_applicationsets: () => import('./deploy-bundle'),
@@ -1717,6 +1722,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   tuf_status: 6,
   vitess_status: 6,
   chaos_mesh_status: 6,
+  wasmcloud_status: 6,
   pvc_status: 6,
   gpu_status: 6,
   gpu_inventory: 6,

--- a/web/src/components/cards/wasmcloud_status/demoData.ts
+++ b/web/src/components/cards/wasmcloud_status/demoData.ts
@@ -1,0 +1,298 @@
+/**
+ * wasmCloud Status Card — Demo Data & Type Definitions
+ *
+ * wasmCloud is a CNCF incubating project for building distributed
+ * applications on WebAssembly. A wasmCloud lattice is a self-forming
+ * mesh of hosts that run portable Wasm actors (business logic) linked
+ * at runtime to capability providers (HTTP server, NATS, Redis, Postgres,
+ * etc.) via declarative link definitions.
+ *
+ * This card surfaces:
+ *  - Lattice id + control-plane health
+ *  - Host count with per-host labels and uptime
+ *  - Actor count (Wasm components) with instance counts per host
+ *  - Capability provider count (httpserver, nats, redis, postgres, ...)
+ *  - Active link definitions (actor -> provider bindings)
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real wasmCloud control-interface bridge lands (`/api/wasmcloud/status`),
+ * the hook's fetcher will pick up live data automatically with no
+ * component changes.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type WasmcloudHealth = 'healthy' | 'degraded' | 'not-installed'
+export type WasmcloudHostStatus = 'ready' | 'starting' | 'unreachable'
+export type WasmcloudProviderStatus = 'running' | 'starting' | 'failed'
+export type WasmcloudLinkStatus = 'active' | 'pending' | 'failed'
+
+export interface WasmcloudHost {
+  hostId: string
+  friendlyName: string
+  status: WasmcloudHostStatus
+  labels: Record<string, string>
+  uptimeSeconds: number
+  actorCount: number
+  providerCount: number
+  cluster: string
+}
+
+export interface WasmcloudActor {
+  actorId: string
+  name: string
+  imageRef: string
+  instanceCount: number
+  hostId: string
+  cluster: string
+}
+
+export interface WasmcloudProvider {
+  providerId: string
+  name: string
+  contractId: string
+  linkName: string
+  imageRef: string
+  status: WasmcloudProviderStatus
+  hostId: string
+  cluster: string
+}
+
+export interface WasmcloudLink {
+  actorId: string
+  providerId: string
+  contractId: string
+  linkName: string
+  status: WasmcloudLinkStatus
+}
+
+export interface WasmcloudStats {
+  hostCount: number
+  actorCount: number
+  providerCount: number
+  linkCount: number
+  latticeVersion: string
+}
+
+export interface WasmcloudSummary {
+  latticeId: string
+  totalHosts: number
+  totalActors: number
+  totalProviders: number
+  totalLinks: number
+}
+
+export interface WasmcloudStatusData {
+  health: WasmcloudHealth
+  hosts: WasmcloudHost[]
+  actors: WasmcloudActor[]
+  providers: WasmcloudProvider[]
+  links: WasmcloudLink[]
+  stats: WasmcloudStats
+  summary: WasmcloudSummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo-data constants (named — no magic numbers)
+// ---------------------------------------------------------------------------
+
+const DEMO_LATTICE_ID = 'default'
+const DEMO_LATTICE_VERSION = '1.4.0'
+
+// Host uptimes (seconds)
+const HOST_UPTIME_LONG_SEC = 345_600 // ~4 days
+const HOST_UPTIME_MEDIUM_SEC = 129_600 // ~1.5 days
+const HOST_UPTIME_SHORT_SEC = 7_200 // 2 hours
+
+// Actor instance counts
+const ACTOR_INSTANCES_HIGH = 6
+const ACTOR_INSTANCES_MED = 3
+const ACTOR_INSTANCES_LOW = 1
+
+// ---------------------------------------------------------------------------
+// Demo data — shown when wasmCloud is not installed or in demo mode
+// ---------------------------------------------------------------------------
+
+const DEMO_HOSTS: WasmcloudHost[] = [
+  {
+    hostId: 'NBXYZ1ABC234DEF567GH1',
+    friendlyName: 'breezy-sunset',
+    status: 'ready',
+    labels: { region: 'us-east-1', zone: 'a', 'node.role': 'worker' },
+    uptimeSeconds: HOST_UPTIME_LONG_SEC,
+    actorCount: 4,
+    providerCount: 2,
+    cluster: 'prod-east',
+  },
+  {
+    hostId: 'NBXYZ2ABC234DEF567GH2',
+    friendlyName: 'silent-waterfall',
+    status: 'ready',
+    labels: { region: 'us-east-1', zone: 'b', 'node.role': 'worker' },
+    uptimeSeconds: HOST_UPTIME_MEDIUM_SEC,
+    actorCount: 3,
+    providerCount: 1,
+    cluster: 'prod-east',
+  },
+  {
+    hostId: 'NBXYZ3ABC234DEF567GH3',
+    friendlyName: 'crimson-meadow',
+    status: 'starting',
+    labels: { region: 'us-west-2', zone: 'a', 'node.role': 'edge' },
+    uptimeSeconds: HOST_UPTIME_SHORT_SEC,
+    actorCount: 1,
+    providerCount: 1,
+    cluster: 'prod-west',
+  },
+]
+
+const DEMO_ACTORS: WasmcloudActor[] = [
+  {
+    actorId: 'MBABC1XYZ234DEF567GH1',
+    name: 'http-echo',
+    imageRef: 'wasmcloud.azurecr.io/echo:0.3.8',
+    instanceCount: ACTOR_INSTANCES_HIGH,
+    hostId: 'NBXYZ1ABC234DEF567GH1',
+    cluster: 'prod-east',
+  },
+  {
+    actorId: 'MBABC2XYZ234DEF567GH2',
+    name: 'kv-counter',
+    imageRef: 'wasmcloud.azurecr.io/kvcounter:0.4.2',
+    instanceCount: ACTOR_INSTANCES_MED,
+    hostId: 'NBXYZ1ABC234DEF567GH1',
+    cluster: 'prod-east',
+  },
+  {
+    actorId: 'MBABC3XYZ234DEF567GH3',
+    name: 'image-processor',
+    imageRef: 'wasmcloud.azurecr.io/image-processor:0.2.1',
+    instanceCount: ACTOR_INSTANCES_MED,
+    hostId: 'NBXYZ1ABC234DEF567GH1',
+    cluster: 'prod-east',
+  },
+  {
+    actorId: 'MBABC4XYZ234DEF567GH4',
+    name: 'order-api',
+    imageRef: 'ghcr.io/acme/order-api:0.9.0',
+    instanceCount: ACTOR_INSTANCES_MED,
+    hostId: 'NBXYZ1ABC234DEF567GH1',
+    cluster: 'prod-east',
+  },
+  {
+    actorId: 'MBABC5XYZ234DEF567GH5',
+    name: 'notifier',
+    imageRef: 'ghcr.io/acme/notifier:0.5.3',
+    instanceCount: ACTOR_INSTANCES_LOW,
+    hostId: 'NBXYZ2ABC234DEF567GH2',
+    cluster: 'prod-east',
+  },
+  {
+    actorId: 'MBABC6XYZ234DEF567GH6',
+    name: 'session-cache',
+    imageRef: 'ghcr.io/acme/session-cache:0.2.0',
+    instanceCount: ACTOR_INSTANCES_MED,
+    hostId: 'NBXYZ2ABC234DEF567GH2',
+    cluster: 'prod-east',
+  },
+  {
+    actorId: 'MBABC7XYZ234DEF567GH7',
+    name: 'billing',
+    imageRef: 'ghcr.io/acme/billing:0.4.1',
+    instanceCount: ACTOR_INSTANCES_LOW,
+    hostId: 'NBXYZ2ABC234DEF567GH2',
+    cluster: 'prod-east',
+  },
+  {
+    actorId: 'MBABC8XYZ234DEF567GH8',
+    name: 'edge-router',
+    imageRef: 'ghcr.io/acme/edge-router:0.1.0',
+    instanceCount: ACTOR_INSTANCES_LOW,
+    hostId: 'NBXYZ3ABC234DEF567GH3',
+    cluster: 'prod-west',
+  },
+]
+
+const DEMO_PROVIDERS: WasmcloudProvider[] = [
+  {
+    providerId: 'VBHTTPSERVER1XYZ234DEF5',
+    name: 'httpserver',
+    contractId: 'wasmcloud:httpserver',
+    linkName: 'default',
+    imageRef: 'wasmcloud.azurecr.io/httpserver:0.22.0',
+    status: 'running',
+    hostId: 'NBXYZ1ABC234DEF567GH1',
+    cluster: 'prod-east',
+  },
+  {
+    providerId: 'VBNATS2XYZ234DEF567GH2',
+    name: 'nats-messaging',
+    contractId: 'wasmcloud:messaging',
+    linkName: 'default',
+    imageRef: 'wasmcloud.azurecr.io/nats_messaging:0.19.1',
+    status: 'running',
+    hostId: 'NBXYZ1ABC234DEF567GH1',
+    cluster: 'prod-east',
+  },
+  {
+    providerId: 'VBREDIS3XYZ234DEF567GH3',
+    name: 'redis-keyvalue',
+    contractId: 'wasmcloud:keyvalue',
+    linkName: 'default',
+    imageRef: 'wasmcloud.azurecr.io/kv_redis:0.23.2',
+    status: 'running',
+    hostId: 'NBXYZ2ABC234DEF567GH2',
+    cluster: 'prod-east',
+  },
+  {
+    providerId: 'VBPOSTGRES4XYZ234DEF5GH',
+    name: 'postgres-sqldb',
+    contractId: 'wasmcloud:sqldb',
+    linkName: 'default',
+    imageRef: 'wasmcloud.azurecr.io/sqldb_postgres:0.7.1',
+    status: 'starting',
+    hostId: 'NBXYZ3ABC234DEF567GH3',
+    cluster: 'prod-west',
+  },
+]
+
+const DEMO_LINKS: WasmcloudLink[] = [
+  { actorId: 'MBABC1XYZ234DEF567GH1', providerId: 'VBHTTPSERVER1XYZ234DEF5', contractId: 'wasmcloud:httpserver', linkName: 'default', status: 'active' },
+  { actorId: 'MBABC2XYZ234DEF567GH2', providerId: 'VBHTTPSERVER1XYZ234DEF5', contractId: 'wasmcloud:httpserver', linkName: 'default', status: 'active' },
+  { actorId: 'MBABC2XYZ234DEF567GH2', providerId: 'VBREDIS3XYZ234DEF567GH3', contractId: 'wasmcloud:keyvalue', linkName: 'default', status: 'active' },
+  { actorId: 'MBABC3XYZ234DEF567GH3', providerId: 'VBNATS2XYZ234DEF567GH2', contractId: 'wasmcloud:messaging', linkName: 'default', status: 'active' },
+  { actorId: 'MBABC3XYZ234DEF567GH3', providerId: 'VBHTTPSERVER1XYZ234DEF5', contractId: 'wasmcloud:httpserver', linkName: 'default', status: 'active' },
+  { actorId: 'MBABC4XYZ234DEF567GH4', providerId: 'VBHTTPSERVER1XYZ234DEF5', contractId: 'wasmcloud:httpserver', linkName: 'default', status: 'active' },
+  { actorId: 'MBABC4XYZ234DEF567GH4', providerId: 'VBPOSTGRES4XYZ234DEF5GH', contractId: 'wasmcloud:sqldb', linkName: 'default', status: 'pending' },
+  { actorId: 'MBABC5XYZ234DEF567GH5', providerId: 'VBNATS2XYZ234DEF567GH2', contractId: 'wasmcloud:messaging', linkName: 'default', status: 'active' },
+  { actorId: 'MBABC6XYZ234DEF567GH6', providerId: 'VBREDIS3XYZ234DEF567GH3', contractId: 'wasmcloud:keyvalue', linkName: 'default', status: 'active' },
+  { actorId: 'MBABC7XYZ234DEF567GH7', providerId: 'VBPOSTGRES4XYZ234DEF5GH', contractId: 'wasmcloud:sqldb', linkName: 'default', status: 'pending' },
+  { actorId: 'MBABC7XYZ234DEF567GH7', providerId: 'VBNATS2XYZ234DEF567GH2', contractId: 'wasmcloud:messaging', linkName: 'default', status: 'active' },
+  { actorId: 'MBABC8XYZ234DEF567GH8', providerId: 'VBHTTPSERVER1XYZ234DEF5', contractId: 'wasmcloud:httpserver', linkName: 'default', status: 'active' },
+]
+
+export const WASMCLOUD_DEMO_DATA: WasmcloudStatusData = {
+  health: 'healthy',
+  hosts: DEMO_HOSTS,
+  actors: DEMO_ACTORS,
+  providers: DEMO_PROVIDERS,
+  links: DEMO_LINKS,
+  stats: {
+    hostCount: DEMO_HOSTS.length,
+    actorCount: DEMO_ACTORS.length,
+    providerCount: DEMO_PROVIDERS.length,
+    linkCount: DEMO_LINKS.length,
+    latticeVersion: DEMO_LATTICE_VERSION,
+  },
+  summary: {
+    latticeId: DEMO_LATTICE_ID,
+    totalHosts: DEMO_HOSTS.length,
+    totalActors: DEMO_ACTORS.length,
+    totalProviders: DEMO_PROVIDERS.length,
+    totalLinks: DEMO_LINKS.length,
+  },
+  lastCheckTime: new Date().toISOString(),
+}

--- a/web/src/components/cards/wasmcloud_status/index.tsx
+++ b/web/src/components/cards/wasmcloud_status/index.tsx
@@ -1,0 +1,410 @@
+/**
+ * wasmCloud Status Card
+ *
+ * wasmCloud is a CNCF incubating project for building distributed
+ * applications on WebAssembly. This card surfaces the lattice id, host
+ * count, actor and capability-provider counts, and active link definitions
+ * — the primary operational signals from a wasmCloud control interface.
+ *
+ * Follows the spiffe_status / linkerd_status pattern for structure and styling.
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real wasmCloud control bridge lands (`/api/wasmcloud/status`), the hook's
+ * fetcher will pick up live data automatically with no component changes.
+ */
+
+import {
+  AlertTriangle,
+  Box,
+  CheckCircle,
+  Cpu,
+  Link2,
+  Package,
+  RefreshCw,
+  Server,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
+import { useCachedWasmcloud } from '../../../hooks/useCachedWasmcloud'
+import type {
+  WasmcloudHost,
+  WasmcloudLink,
+  WasmcloudLinkStatus,
+  WasmcloudProvider,
+  WasmcloudProviderStatus,
+} from './demoData'
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const SKELETON_TITLE_WIDTH = 140
+const SKELETON_TITLE_HEIGHT = 28
+const SKELETON_BADGE_WIDTH = 90
+const SKELETON_BADGE_HEIGHT = 20
+const SKELETON_LIST_ITEMS = 5
+
+const RELATIVE_TIME_MINUTE_MS = 60_000
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+const SECONDS_PER_MINUTE = 60
+const SECONDS_PER_HOUR = 3600
+const SECONDS_PER_DAY = 86400
+
+const MAX_HOSTS_DISPLAYED = 5
+const MAX_PROVIDERS_DISPLAYED = 5
+const MAX_LINKS_DISPLAYED = 6
+
+const HOST_ID_SHORT_LENGTH = 8
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(isoString: string): string {
+  const parsed = new Date(isoString).getTime()
+  if (!isoString || Number.isNaN(parsed)) return 'just now'
+
+  const diff = Date.now() - parsed
+  if (diff < 0) return 'just now'
+
+  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
+  const day = HOURS_PER_DAY * hour
+
+  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
+  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
+  if (diff < day) return `${Math.floor(diff / hour)}h ago`
+  return `${Math.floor(diff / day)}d ago`
+}
+
+function formatUptime(seconds: number): string {
+  if (seconds >= SECONDS_PER_DAY) {
+    return `${Math.floor(seconds / SECONDS_PER_DAY)}d`
+  }
+  if (seconds >= SECONDS_PER_HOUR) {
+    return `${Math.floor(seconds / SECONDS_PER_HOUR)}h`
+  }
+  if (seconds >= SECONDS_PER_MINUTE) {
+    return `${Math.floor(seconds / SECONDS_PER_MINUTE)}m`
+  }
+  return `${seconds}s`
+}
+
+function shortId(id: string): string {
+  if (!id) return ''
+  return id.length <= HOST_ID_SHORT_LENGTH ? id : `${id.slice(0, HOST_ID_SHORT_LENGTH)}…`
+}
+
+const HOST_STATUS_CLASS: Record<WasmcloudHost['status'], string> = {
+  ready: 'bg-green-500/20 text-green-400',
+  starting: 'bg-yellow-500/20 text-yellow-400',
+  unreachable: 'bg-red-500/20 text-red-400',
+}
+
+const PROVIDER_STATUS_CLASS: Record<WasmcloudProviderStatus, string> = {
+  running: 'bg-green-500/20 text-green-400',
+  starting: 'bg-yellow-500/20 text-yellow-400',
+  failed: 'bg-red-500/20 text-red-400',
+}
+
+const LINK_STATUS_CLASS: Record<WasmcloudLinkStatus, string> = {
+  active: 'bg-green-500/20 text-green-400',
+  pending: 'bg-yellow-500/20 text-yellow-400',
+  failed: 'bg-red-500/20 text-red-400',
+}
+
+// ---------------------------------------------------------------------------
+// Subsections
+// ---------------------------------------------------------------------------
+
+function HostRow({ host, t }: { host: WasmcloudHost; t: TFunction<'cards'> }) {
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          <Server className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
+          <span className="text-xs font-medium text-foreground truncate">
+            {host.friendlyName}
+          </span>
+          <span className="text-[11px] text-muted-foreground font-mono shrink-0">
+            {shortId(host.hostId)}
+          </span>
+        </div>
+        <span
+          className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${HOST_STATUS_CLASS[host.status]}`}
+        >
+          {host.status}
+        </span>
+      </div>
+      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+        <span>
+          {host.actorCount} {t('wasmcloudStatus.actorsShort', 'actors')}
+        </span>
+        <span>
+          {host.providerCount} {t('wasmcloudStatus.providersShort', 'providers')}
+        </span>
+        <span className="ml-auto shrink-0 font-mono">
+          {t('wasmcloudStatus.uptime', 'up')} {formatUptime(host.uptimeSeconds)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function ProviderRow({ provider }: { provider: WasmcloudProvider }) {
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          <Package className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
+          <span className="text-xs font-medium text-foreground truncate">
+            {provider.name}
+          </span>
+        </div>
+        <span
+          className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${PROVIDER_STATUS_CLASS[provider.status]}`}
+        >
+          {provider.status}
+        </span>
+      </div>
+      <div className="text-[11px] text-muted-foreground truncate font-mono">
+        {provider.contractId}
+      </div>
+    </div>
+  )
+}
+
+function LinkRow({ link }: { link: WasmcloudLink }) {
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          <Link2 className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
+          <span className="text-[11px] font-mono text-foreground truncate">
+            {shortId(link.actorId)} → {shortId(link.providerId)}
+          </span>
+        </div>
+        <span
+          className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${LINK_STATUS_CLASS[link.status]}`}
+        >
+          {link.status}
+        </span>
+      </div>
+      <div className="text-[11px] text-muted-foreground truncate font-mono">
+        {link.contractId}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function WasmcloudStatus() {
+  const { t } = useTranslation('cards')
+  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedWasmcloud()
+
+  const isHealthy = data.health === 'healthy'
+  const hosts = data.hosts ?? []
+  const providers = data.providers ?? []
+  const links = data.links ?? []
+  const displayedHosts = hosts.slice(0, MAX_HOSTS_DISPLAYED)
+  const displayedProviders = providers.slice(0, MAX_PROVIDERS_DISPLAYED)
+  const displayedLinks = links.slice(0, MAX_LINKS_DISPLAYED)
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
+          <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (error && showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">
+          {t('wasmcloudStatus.fetchError', 'Unable to fetch wasmCloud status')}
+        </p>
+      </div>
+    )
+  }
+
+  if (data.health === 'not-installed') {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Box className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('wasmcloudStatus.notInstalled', 'wasmCloud not detected')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'wasmcloudStatus.notInstalledHint',
+            'No wasmCloud lattice reachable from the connected clusters.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* Header — health pill + freshness */}
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+            isHealthy
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-yellow-500/15 text-yellow-400'
+          }`}
+        >
+          {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          {isHealthy
+            ? t('wasmcloudStatus.healthy', 'Healthy')
+            : t('wasmcloudStatus.degraded', 'Degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label={t('wasmcloudStatus.hosts', 'Hosts')}
+          value={`${data.stats.hostCount}`}
+          colorClass="text-cyan-400"
+          icon={<Server className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('wasmcloudStatus.actors', 'Actors')}
+          value={`${data.stats.actorCount}`}
+          colorClass="text-purple-400"
+          icon={<Cpu className="w-4 h-4 text-purple-400" />}
+        />
+        <MetricTile
+          label={t('wasmcloudStatus.providers', 'Providers')}
+          value={`${data.stats.providerCount}`}
+          colorClass="text-green-400"
+          icon={<Package className="w-4 h-4 text-green-400" />}
+        />
+        <MetricTile
+          label={t('wasmcloudStatus.links', 'Links')}
+          value={`${data.stats.linkCount}`}
+          colorClass="text-yellow-400"
+          icon={<Link2 className="w-4 h-4 text-yellow-400" />}
+        />
+      </div>
+
+      {/* Lattice + lists */}
+      <div className="space-y-3 overflow-y-auto scrollbar-thin pr-0.5">
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Box className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('wasmcloudStatus.sectionLattice', 'Lattice')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {t('wasmcloudStatus.version', 'version')}:{' '}
+              <span className="text-foreground">{data.stats.latticeVersion}</span>
+            </span>
+          </div>
+          <div className="rounded-md bg-secondary/30 px-3 py-2 text-xs font-mono text-foreground">
+            lattice://{data.summary.latticeId}
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Server className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('wasmcloudStatus.sectionHosts', 'Hosts')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {hosts.length}
+            </span>
+          </div>
+
+          {hosts.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('wasmcloudStatus.noHosts', 'No wasmCloud hosts found')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(displayedHosts ?? []).map(host => (
+                <HostRow key={`${host.cluster}:${host.hostId}`} host={host} t={t} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Package className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('wasmcloudStatus.sectionProviders', 'Capability providers')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {providers.length}
+            </span>
+          </div>
+
+          {providers.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('wasmcloudStatus.noProviders', 'No capability providers found')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(displayedProviders ?? []).map(provider => (
+                <ProviderRow
+                  key={`${provider.cluster}:${provider.providerId}`}
+                  provider={provider}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Link2 className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('wasmcloudStatus.sectionLinks', 'Link definitions')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {links.length}
+            </span>
+          </div>
+
+          {links.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('wasmcloudStatus.noLinks', 'No link definitions found')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(displayedLinks ?? []).map(link => (
+                <LinkRow
+                  key={`${link.actorId}:${link.providerId}:${link.linkName}`}
+                  link={link}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default WasmcloudStatus

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -120,6 +120,7 @@ export const CARD_CATALOG = {
     { type: 'dapr_status', title: 'Dapr', description: 'Dapr control plane health, Dapr-enabled apps, and configured components (state store / pub-sub / binding)', visualization: 'status' },
     { type: 'dragonfly_status', title: 'Dragonfly', description: 'Dragonfly P2P image/file distribution: manager, scheduler, seed-peers, and per-node dfdaemon agents', visualization: 'status' },
     { type: 'openfeature_status', title: 'OpenFeature', description: 'OpenFeature feature flags: provider status (flagd, LaunchDarkly, ...), flag definitions by type, and evaluation metrics', visualization: 'status' },
+    { type: 'wasmcloud_status', title: 'wasmCloud', description: 'wasmCloud WebAssembly lattice: hosts, actors, capability providers, and link definitions', visualization: 'status' },
   ],
   'Compute': [
     { type: 'compute_overview', title: 'Compute Overview', description: 'CPU, memory, and GPU summary with live data', visualization: 'status' },

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -193,6 +193,7 @@ import { userManagementConfig } from './user-management'
 import { vaultSecretsConfig } from './vault-secrets'
 import { vclusterStatusConfig } from './vcluster-status'
 import { warningEventsConfig } from './warning-events'
+import { wasmcloudStatusConfig } from './wasmcloud-status'
 import { weatherConfig } from './weather'
 import { workloadDeploymentConfig } from './workload-deployment'
 import { workloadMonitorConfig } from './workload-monitor'
@@ -399,6 +400,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   vault_secrets: vaultSecretsConfig,
   vcluster_status: vclusterStatusConfig,
   warning_events: warningEventsConfig,
+  wasmcloud_status: wasmcloudStatusConfig,
   weather: weatherConfig,
   workload_deployment: workloadDeploymentConfig,
   workload_monitor: workloadMonitorConfig,
@@ -670,6 +672,7 @@ export {
   vaultSecretsConfig,
   vclusterStatusConfig,
   warningEventsConfig,
+  wasmcloudStatusConfig,
   weatherConfig,
   workloadDeploymentConfig,
   workloadMonitorConfig,

--- a/web/src/config/cards/wasmcloud-status.ts
+++ b/web/src/config/cards/wasmcloud-status.ts
@@ -1,0 +1,52 @@
+/**
+ * wasmCloud Status Card Configuration
+ *
+ * wasmCloud is a CNCF incubating platform for distributed WebAssembly
+ * applications. A wasmCloud lattice is a self-forming mesh of hosts that
+ * run portable Wasm actors (business logic) linked at runtime to
+ * capability providers (HTTP server, NATS, Redis, Postgres, ...) via
+ * declarative link definitions. This card surfaces host count, actor and
+ * provider counts, and active links across the connected lattices.
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const wasmcloudStatusConfig: UnifiedCardConfig = {
+  type: 'wasmcloud_status',
+  title: 'wasmCloud',
+  category: 'workloads',
+  description:
+    'wasmCloud lattice status: hosts, actors, capability providers, and link definitions across connected clusters.',
+  icon: 'Box',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useCachedWasmcloud' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'friendlyName', header: 'Host', primary: true, render: 'truncate' },
+      { field: 'hostId', header: 'Host ID', width: 160, render: 'truncate' },
+      { field: 'status', header: 'Status', width: 100, render: 'status-badge' },
+      { field: 'actorCount', header: 'Actors', width: 80 },
+      { field: 'providerCount', header: 'Providers', width: 100 },
+      { field: 'cluster', header: 'Cluster', width: 120, render: 'cluster-badge' },
+    ],
+  },
+  emptyState: {
+    icon: 'Box',
+    title: 'wasmCloud not detected',
+    message: 'No wasmCloud lattice reachable from the connected clusters.',
+    variant: 'info',
+  },
+  loadingState: {
+    type: 'list',
+    rows: 5,
+  },
+  // Scaffolding: renders live if /api/wasmcloud/status is wired up, otherwise
+  // falls back to demo data via the useCache demo path.
+  isDemoData: true,
+  isLive: false,
+}
+
+export default wasmcloudStatusConfig

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -229,6 +229,13 @@ export { useCachedBackstage } from './useCachedBackstage'
 export { useCachedCloudCustodian } from './useCachedCloudCustodian'
 
 // ============================================================================
+// wasmCloud WebAssembly Lattice — useCachedWasmcloud.ts (CNCF incubating)
+// ============================================================================
+// Named re-export (avoids `__testables` export-name collision with TiKV).
+
+export { useCachedWasmcloud } from './useCachedWasmcloud'
+
+// ============================================================================
 // Standalone fetchers for prefetch (no React hooks, plain async)
 // ============================================================================
 

--- a/web/src/hooks/useCachedWasmcloud.ts
+++ b/web/src/hooks/useCachedWasmcloud.ts
@@ -1,0 +1,281 @@
+/**
+ * wasmCloud Status Hook — Data fetching for the wasmcloud_status card.
+ *
+ * Mirrors the spiffe / linkerd / envoy / contour pattern:
+ * - useCache with fetcher + demo fallback
+ * - isDemoFallback gated on !isLoading (prevents demo flash while loading)
+ * - fetchJson helper with treat404AsEmpty (no real endpoint yet — this is
+ *   scaffolding; the fetch will 404 until a real wasmCloud control bridge
+ *   lands, at which point useCache will transparently switch to live data)
+ * - showSkeleton / showEmptyState from useCardLoadingState
+ */
+
+import { useCache, type RefreshCategory } from '../lib/cache'
+import { useCardLoadingState } from '../components/cards/CardDataContext'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { authFetch } from '../lib/api'
+import {
+  WASMCLOUD_DEMO_DATA,
+  type WasmcloudActor,
+  type WasmcloudHost,
+  type WasmcloudLink,
+  type WasmcloudProvider,
+  type WasmcloudStats,
+  type WasmcloudStatusData,
+  type WasmcloudSummary,
+} from '../components/cards/wasmcloud_status/demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'wasmcloud-status'
+// The spec calls for a 'workloads' cache category; the canonical
+// RefreshCategory closest to workload-style refresh cadence is 'deployments'
+// (60s). Cast keeps this in sync if/when a 'workloads' key is added.
+const WASMCLOUD_CACHE_CATEGORY = 'deployments' as RefreshCategory
+const WASMCLOUD_STATUS_ENDPOINT = '/api/wasmcloud/status'
+const DEFAULT_LATTICE_VERSION = 'unknown'
+const DEFAULT_LATTICE_ID = ''
+
+const EMPTY_STATS: WasmcloudStats = {
+  hostCount: 0,
+  actorCount: 0,
+  providerCount: 0,
+  linkCount: 0,
+  latticeVersion: DEFAULT_LATTICE_VERSION,
+}
+
+const EMPTY_SUMMARY: WasmcloudSummary = {
+  latticeId: DEFAULT_LATTICE_ID,
+  totalHosts: 0,
+  totalActors: 0,
+  totalProviders: 0,
+  totalLinks: 0,
+}
+
+const INITIAL_DATA: WasmcloudStatusData = {
+  health: 'not-installed',
+  hosts: [],
+  actors: [],
+  providers: [],
+  links: [],
+  stats: EMPTY_STATS,
+  summary: EMPTY_SUMMARY,
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Internal types (shape of the future /api/wasmcloud/status response)
+// ---------------------------------------------------------------------------
+
+interface FetchResult<T> {
+  data: T
+  failed: boolean
+}
+
+interface WasmcloudStatusResponse {
+  latticeId?: string
+  hosts?: WasmcloudHost[]
+  actors?: WasmcloudActor[]
+  providers?: WasmcloudProvider[]
+  links?: WasmcloudLink[]
+  stats?: Partial<WasmcloudStats>
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function summarize(
+  latticeId: string,
+  hosts: WasmcloudHost[],
+  actors: WasmcloudActor[],
+  providers: WasmcloudProvider[],
+  links: WasmcloudLink[],
+): WasmcloudSummary {
+  return {
+    latticeId,
+    totalHosts: hosts.length,
+    totalActors: actors.length,
+    totalProviders: providers.length,
+    totalLinks: links.length,
+  }
+}
+
+function deriveHealth(
+  latticeId: string,
+  hosts: WasmcloudHost[],
+  providers: WasmcloudProvider[],
+  links: WasmcloudLink[],
+): WasmcloudStatusData['health'] {
+  if (!latticeId && hosts.length === 0) {
+    return 'not-installed'
+  }
+  const hasUnreachableHost = hosts.some(h => h.status === 'unreachable')
+  const hasFailedProvider = providers.some(p => p.status === 'failed')
+  const hasFailedLink = links.some(l => l.status === 'failed')
+  return hasUnreachableHost || hasFailedProvider || hasFailedLink ? 'degraded' : 'healthy'
+}
+
+function buildWasmcloudStatus(
+  latticeId: string,
+  hosts: WasmcloudHost[],
+  actors: WasmcloudActor[],
+  providers: WasmcloudProvider[],
+  links: WasmcloudLink[],
+  stats: WasmcloudStats,
+): WasmcloudStatusData {
+  return {
+    health: deriveHealth(latticeId, hosts, providers, links),
+    hosts,
+    actors,
+    providers,
+    links,
+    stats,
+    summary: summarize(latticeId, hosts, actors, providers, links),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private fetchJson helper (mirrors spiffe/envoy/contour/linkerd pattern)
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(
+  url: string,
+  options?: { treat404AsEmpty?: boolean },
+): Promise<FetchResult<T | null>> {
+  try {
+    const resp = await authFetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+
+    if (!resp.ok) {
+      if (options?.treat404AsEmpty && resp.status === 404) {
+        return { data: null, failed: false }
+      }
+      return { data: null, failed: true }
+    }
+
+    const body = (await resp.json()) as T
+    return { data: body, failed: false }
+  } catch {
+    return { data: null, failed: true }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchWasmcloudStatus(): Promise<WasmcloudStatusData> {
+  const result = await fetchJson<WasmcloudStatusResponse>(
+    WASMCLOUD_STATUS_ENDPOINT,
+    { treat404AsEmpty: true },
+  )
+
+  // If the endpoint isn't wired up yet (404) or the request failed, the
+  // cache layer will surface demo data via its demoData fallback path.
+  if (result.failed) {
+    throw new Error('Unable to fetch wasmCloud status')
+  }
+
+  const body = result.data
+  const latticeId = body?.latticeId ?? DEFAULT_LATTICE_ID
+  const hosts = Array.isArray(body?.hosts) ? body.hosts : []
+  const actors = Array.isArray(body?.actors) ? body.actors : []
+  const providers = Array.isArray(body?.providers) ? body.providers : []
+  const links = Array.isArray(body?.links) ? body.links : []
+  const stats: WasmcloudStats = {
+    hostCount: body?.stats?.hostCount ?? hosts.length,
+    actorCount: body?.stats?.actorCount ?? actors.length,
+    providerCount: body?.stats?.providerCount ?? providers.length,
+    linkCount: body?.stats?.linkCount ?? links.length,
+    latticeVersion: body?.stats?.latticeVersion ?? DEFAULT_LATTICE_VERSION,
+  }
+
+  return buildWasmcloudStatus(latticeId, hosts, actors, providers, links, stats)
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseCachedWasmcloudResult {
+  data: WasmcloudStatusData
+  isLoading: boolean
+  isRefreshing: boolean
+  isDemoData: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  showSkeleton: boolean
+  showEmptyState: boolean
+  error: boolean
+  refetch: () => Promise<void>
+}
+
+export function useCachedWasmcloud(): UseCachedWasmcloudResult {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+    lastRefresh,
+    refetch,
+  } = useCache<WasmcloudStatusData>({
+    key: CACHE_KEY,
+    category: WASMCLOUD_CACHE_CATEGORY,
+    initialData: INITIAL_DATA,
+    demoData: WASMCLOUD_DEMO_DATA,
+    persist: true,
+    fetcher: fetchWasmcloudStatus,
+  })
+
+  // Prevent demo flash while loading — only surface the Demo badge once
+  // we've actually fallen back to demo data post-load.
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' counts as "data" so the card shows the empty state
+  // rather than an infinite skeleton when wasmCloud isn't present.
+  const hasAnyData =
+    data.health === 'not-installed' ? true : (data.hosts ?? []).length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+    lastRefresh,
+  })
+
+  return {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoData: effectiveIsDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+    showSkeleton,
+    showEmptyState,
+    error: isFailed && !hasAnyData,
+    refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  summarize,
+  deriveHealth,
+  buildWasmcloudStatus,
+}

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -114,6 +114,7 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-tuf': 'tuf_status',
   'cncf-vitess': 'vitess_status',
   'cncf-chaos-mesh': 'chaos_mesh_status',
+  'cncf-wasmcloud': 'wasmcloud_status',
 }
 
 /**

--- a/web/src/lib/demo/wasmcloud.ts
+++ b/web/src/lib/demo/wasmcloud.ts
@@ -1,0 +1,23 @@
+/**
+ * wasmCloud demo seed re-export.
+ *
+ * The canonical demo data lives alongside the wasmCloud card in
+ * `components/cards/wasmcloud_status/demoData.ts`. This file re-exports it
+ * so callers outside the card folder (docs, tests, future drill-downs)
+ * can import a stable demo seed from `lib/demo/wasmcloud`.
+ */
+
+export {
+  WASMCLOUD_DEMO_DATA,
+  type WasmcloudStatusData,
+  type WasmcloudHost,
+  type WasmcloudActor,
+  type WasmcloudProvider,
+  type WasmcloudLink,
+  type WasmcloudStats,
+  type WasmcloudSummary,
+  type WasmcloudHealth,
+  type WasmcloudHostStatus,
+  type WasmcloudProviderStatus,
+  type WasmcloudLinkStatus,
+} from '../../components/cards/wasmcloud_status/demoData'

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -69,6 +69,7 @@ import { useCachedTikv } from '../../hooks/useCachedTikv'
 import { useCachedTuf } from '../../hooks/useCachedTuf'
 import { useCachedCloudCustodian } from '../../hooks/useCachedCloudCustodian'
 import { useCachedVitess } from '../../hooks/useCachedVitess'
+import { useCachedWasmcloud } from '../../hooks/useCachedWasmcloud'
 
 // ============================================================================
 // Wrapper hooks that convert params object to positional args
@@ -1280,6 +1281,19 @@ function useUnifiedVitessStatus() {
     refetch: result.refetch,
   }
 }
+
+function useUnifiedWasmcloudStatus() {
+  const result = useCachedWasmcloud()
+  // Surface the host list as the primary row set for generic list renderers.
+  return {
+    data: result.data.hosts,
+    isLoading: result.showSkeleton,
+    error: result.error ? new Error('Failed to fetch wasmCloud status') : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
+
 function useProviderHealth() {
   return useDemoDataHook(DEMO_PROVIDER_HEALTH)
 }
@@ -1487,6 +1501,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useCachedTuf', useUnifiedTufStatus)
   registerDataHook('useCachedCloudCustodian', useUnifiedCloudCustodianStatus)
   registerDataHook('useCachedVitess', useUnifiedVitessStatus)
+  registerDataHook('useCachedWasmcloud', useUnifiedWasmcloudStatus)
   registerDataHook('useProviderHealth', useProviderHealth)
   registerDataHook('useUpgradeStatus', useUpgradeStatus)
   registerDataHook('useProwStatus', useProwStatus)

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -4483,5 +4483,27 @@
     "breakdown": "{{argo}} apps \u00b7 {{violations}} violations \u00b7 {{restarts}} restarts",
     "more_one": "+{{count}} more namespace",
     "more_other": "+{{count}} more namespaces"
+  },
+  "wasmcloudStatus": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "wasmCloud not detected",
+    "notInstalledHint": "No wasmCloud lattice reachable from the connected clusters.",
+    "fetchError": "Unable to fetch wasmCloud status",
+    "hosts": "Hosts",
+    "actors": "Actors",
+    "providers": "Providers",
+    "links": "Links",
+    "version": "version",
+    "uptime": "up",
+    "actorsShort": "actors",
+    "providersShort": "providers",
+    "sectionLattice": "Lattice",
+    "sectionHosts": "Hosts",
+    "sectionProviders": "Capability providers",
+    "sectionLinks": "Link definitions",
+    "noHosts": "No wasmCloud hosts found",
+    "noProviders": "No capability providers found",
+    "noLinks": "No link definitions found"
   }
 }


### PR DESCRIPTION
Fixes kubestellar/console-marketplace#57

## Summary

Adds a wasmCloud monitoring card (CNCF incubating — WebAssembly platform for distributed applications). The card surfaces the lattice id, host count, actors, capability providers, and active link definitions — the primary operational signals from a wasmCloud control interface.

Scaffolding: the hook fetches `/api/wasmcloud/status` and transparently falls back to demo data via `useCache` when the endpoint isn't wired up (404 or not installed). When a real wasmCloud control bridge lands, the card picks up live data with no component changes.

## What's shown

- Lattice id + control-plane health pill + lattice version
- Host count with per-host friendly name, status, label summary, actor/provider counts, and uptime
- Actor count (Wasm components) with instance counts per host
- Capability provider list (httpserver, nats, redis, postgres, ...) with contract ids and status
- Active link definitions (actor -> provider bindings) with contract + link name

## Files added

- `web/src/components/cards/wasmcloud_status/{index.tsx,demoData.ts}`
- `web/src/hooks/useCachedWasmcloud.ts`
- `web/src/lib/demo/wasmcloud.ts`
- `web/src/config/cards/wasmcloud-status.ts` (category: workloads)

## Wiring

- `cardRegistry.ts` (lazy import, CARD_COMPONENTS, preloader, height map)
- `cardMetadata.ts` (title + description)
- `cardCatalog.ts` (Workloads group)
- `config/cards/index.ts` (registry + re-export)
- `lib/unified/registerHooks.ts` (unified data hook)
- `hooks/useCachedData.ts` (re-export)
- `hooks/useMarketplace.ts` (cncf-wasmcloud -> wasmcloud_status)
- `locales/en/cards.json` (wasmcloudStatus.* keys)

Follows project patterns: no magic numbers, array `?? []` guards, wires `isDemoData` + `isRefreshing` into `useCardLoadingState`, demo flash guarded via `isDemoFallback && !isLoading`, `TFunction<'cards'>` typing, literal Record keys, named re-export on `useCachedData.ts`.

## Test plan

- [ ] Open dashboard -> Add Card -> Workloads group -> "wasmCloud" appears and can be added
- [ ] Card renders demo data with Demo badge + yellow outline in demo mode
- [ ] Card renders empty-state ("wasmCloud not detected") when API keys present but no wasmCloud installed
- [ ] Refresh icon animates on background refetch
- [ ] Marketplace "cncf-wasmcloud" item shows as available (not help-wanted)