### PR TITLE
🐛 Fix small touch targets for WCAG 2.5.5 compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ web/e2e/user-flows/test-results/
 
 # Storybook
 web/storybook-static/
+web/node_modules

--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -111,7 +111,7 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
   if (error) return (
     <div className="flex flex-col items-center justify-center h-64 gap-3">
       <p className="text-red-400 font-medium">{error}</p>
-      <button onClick={fetchData} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-1"><RefreshCw className="w-4 h-4" /> Retry</button>
+      <button onClick={fetchData} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-1 min-h-11 min-w-11 px-3 py-2"><RefreshCw className="w-4 h-4" /> Retry</button>
     </div>
   )
 

--- a/web/src/components/compliance/DataResidency.tsx
+++ b/web/src/components/compliance/DataResidency.tsx
@@ -146,7 +146,7 @@ export const DataResidencyContent = memo(function DataResidencyContent() {
     return (
       <div className="flex flex-col items-center justify-center h-64 gap-3">
         <p className="text-red-400 font-medium">{error}</p>
-        <button onClick={fetchData} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-1">
+        <button onClick={fetchData} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-1 min-h-11 min-w-11 px-3 py-2">
           <RefreshCw className="w-4 h-4" /> Retry
         </button>
       </div>

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -93,7 +93,7 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
   if (error) return (
     <div className="flex flex-col items-center justify-center h-64 gap-3">
       <p className="text-red-400 font-medium">{error}</p>
-      <button onClick={fetchData} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-1"><RefreshCw className="w-4 h-4" /> Retry</button>
+      <button onClick={fetchData} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-1 min-h-11 min-w-11 px-3 py-2"><RefreshCw className="w-4 h-4" /> Retry</button>
     </div>
   )
 

--- a/web/src/components/drilldown/views/ServiceDrillDown.tsx
+++ b/web/src/components/drilldown/views/ServiceDrillDown.tsx
@@ -477,7 +477,7 @@ function InfoField({ label, value, icon, onCopy, copied }: {
       <div className="flex items-center gap-2">
         <span className="text-sm text-foreground truncate" title={value}>{value}</span>
         {onCopy && (
-          <button onClick={onCopy} className="p-0.5 rounded hover:bg-secondary shrink-0" title="Copy">
+          <button onClick={onCopy} className="p-2 min-h-11 min-w-11 flex items-center justify-center rounded hover:bg-secondary shrink-0" title="Copy">
             {copied ? <Check className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3 text-muted-foreground" />}
           </button>
         )}

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -676,7 +676,7 @@ export function Layout({ children: _children }: LayoutProps) {
                   <div className="w-2 h-2 rounded-full bg-red-400 animate-pulse" />
                   <span>{t('layout.connectionLost')}</span>
                   {restartState === 'restarting' ? (
-                    <button disabled className="ml-1 flex items-center gap-1.5 px-2.5 py-1 bg-muted text-muted-foreground rounded text-xs cursor-wait">
+                    <button disabled className="ml-1 flex items-center gap-1.5 px-2.5 py-2 min-h-11 bg-muted text-muted-foreground rounded text-xs cursor-wait">
                       <Loader2 className="w-3 h-3 animate-spin" />
                       {t('layout.restarting')}
                     </button>


### PR DESCRIPTION
Fixes #9946

## Changes
Add `min-h-11 min-w-11` (44px minimum) to interactive elements flagged by Auto-QA for WCAG 2.5.5 target size compliance:

- **Retry buttons** in compliance components (ChangeControlAudit, SegregationOfDuties, DataResidency) — added `min-h-11 min-w-11 px-3 py-2`
- **Copy button** in ServiceDrillDown — changed `p-0.5` to `p-2 min-h-11 min-w-11 flex items-center justify-center`
- **Disabled restart button** in Layout — changed `py-1` to `py-2 min-h-11`

Other flagged items already have proper touch targets (`min-h-11 min-w-11` already present or are non-interactive elements).

## Testing
- Build passes (`npm run build`)
- Lint unchanged (no new errors)