### PR TITLE
🐛 Fix ksc_error auth spike from 7 marketplace card hooks (#9933)

### DIFF
--- a/web/src/hooks/useCachedDapr.ts
+++ b/web/src/hooks/useCachedDapr.ts
@@ -141,9 +141,14 @@ function buildDaprStatus(
 // Private fetchJson helper (mirrors contour/flux/envoy pattern)
 // ---------------------------------------------------------------------------
 
+/** HTTP statuses that indicate "endpoint not available" — treat as empty, not
+ *  as a hard failure. 401/403 cover unauthenticated/demo visitors hitting
+ *  the JWT-protected /api group; 404/501/503 cover Netlify SPA fallback and
+ *  the MSW catch-all (#9933). */
+const NOT_INSTALLED_STATUSES = new Set<number>([401, 403, 404, 501, 503])
+
 async function fetchJson<T>(
   url: string,
-  options?: { treat404AsEmpty?: boolean },
 ): Promise<FetchResult<T | null>> {
   try {
     const resp = await authFetch(url, {
@@ -152,13 +157,19 @@ async function fetchJson<T>(
     })
 
     if (!resp.ok) {
-      if (options?.treat404AsEmpty && resp.status === 404) {
+      if (NOT_INSTALLED_STATUSES.has(resp.status)) {
         return { data: null, failed: false }
       }
       return { data: null, failed: true }
     }
 
-    const body = (await resp.json()) as T
+    // Defensive JSON parse — Netlify SPA fallback may return text/html (#9933)
+    let body: T
+    try {
+      body = (await resp.json()) as T
+    } catch {
+      return { data: null, failed: false }
+    }
     return { data: body, failed: false }
   } catch {
     return { data: null, failed: true }
@@ -172,7 +183,6 @@ async function fetchJson<T>(
 async function fetchDaprStatus(): Promise<DaprStatusData> {
   const result = await fetchJson<DaprStatusResponse>(
     DAPR_STATUS_ENDPOINT,
-    { treat404AsEmpty: true },
   )
 
   if (result.failed) {

--- a/web/src/hooks/useCachedDragonfly.ts
+++ b/web/src/hooks/useCachedDragonfly.ts
@@ -236,6 +236,10 @@ function buildStatus(pods: PodItem[]): DragonflyStatusData {
 // Fetcher
 // ---------------------------------------------------------------------------
 
+/** HTTP statuses that indicate "endpoint not available" — treat as empty, not
+ *  as a hard failure (#9933). */
+const NOT_INSTALLED_STATUSES = new Set<number>([401, 403, 404, 501, 503])
+
 async function fetchDragonflyStatus(): Promise<DragonflyStatusData> {
   const params = new URLSearchParams({
     group: '',
@@ -249,12 +253,18 @@ async function fetchDragonflyStatus(): Promise<DragonflyStatusData> {
   })
 
   if (!resp.ok) {
-    if (resp.status === 404) return buildStatus([])
+    if (NOT_INSTALLED_STATUSES.has(resp.status)) return buildStatus([])
     throw new Error(`HTTP ${resp.status}`)
   }
 
-  const body = (await resp.json()) as PodListResponse
-  const items = Array.isArray(body.items) ? body.items : []
+  // Defensive JSON parse — Netlify SPA fallback may return text/html (#9933)
+  let body: PodListResponse
+  try {
+    body = (await resp.json()) as PodListResponse
+  } catch {
+    return buildStatus([])
+  }
+  const items = Array.isArray(body?.items) ? body.items : []
   return buildStatus(items)
 }
 

--- a/web/src/hooks/useCachedOtel.ts
+++ b/web/src/hooks/useCachedOtel.ts
@@ -286,6 +286,10 @@ function buildStatus(collectors: OtelCollector[]): OtelStatusData {
 // Fetcher
 // ---------------------------------------------------------------------------
 
+/** HTTP statuses that indicate "endpoint not available" — treat as empty, not
+ *  as a hard failure (#9933). */
+const NOT_INSTALLED_STATUSES = new Set<number>([401, 403, 404, 501, 503])
+
 async function fetchOtelStatus(): Promise<OtelStatusData> {
   const params = new URLSearchParams({
     group: '',
@@ -299,12 +303,18 @@ async function fetchOtelStatus(): Promise<OtelStatusData> {
   })
 
   if (!resp.ok) {
-    if (resp.status === 404) return buildStatus([])
+    if (NOT_INSTALLED_STATUSES.has(resp.status)) return buildStatus([])
     throw new Error(`HTTP ${resp.status}`)
   }
 
-  const body = (await resp.json()) as PodListResponse
-  const items = Array.isArray(body.items) ? body.items : []
+  // Defensive JSON parse — Netlify SPA fallback may return text/html (#9933)
+  let body: PodListResponse
+  try {
+    body = (await resp.json()) as PodListResponse
+  } catch {
+    return buildStatus([])
+  }
+  const items = Array.isArray(body?.items) ? body.items : []
   const otelPods = items.filter(isOtelCollectorPod)
   const collectors = otelPods.map(podToCollector)
   return buildStatus(collectors)

--- a/web/src/hooks/useCachedRook.ts
+++ b/web/src/hooks/useCachedRook.ts
@@ -33,8 +33,9 @@ const CEPH_CLUSTER_GROUP = 'ceph.rook.io'
 const CEPH_CLUSTER_VERSION = 'v1'
 const CEPH_CLUSTER_RESOURCE = 'cephclusters'
 
-// HTTP status sentinels
-const HTTP_NOT_FOUND = 404
+/** HTTP statuses that indicate "endpoint not available" — treat as empty, not
+ *  as a hard failure (#9933). */
+const NOT_INSTALLED_STATUSES = new Set<number>([401, 403, 404, 501, 503])
 
 const INITIAL_DATA: RookStatusData = {
   health: 'not-installed',
@@ -195,13 +196,18 @@ async function fetchRookStatus(): Promise<RookStatusData> {
   })
 
   if (!resp.ok) {
-    // CRD not registered → treat as "not installed" without surfacing an error.
-    if (resp.status === HTTP_NOT_FOUND) return buildStatus([])
+    if (NOT_INSTALLED_STATUSES.has(resp.status)) return buildStatus([])
     throw new Error(`HTTP ${resp.status}`)
   }
 
-  const body = (await resp.json()) as CephClusterListResponse
-  const items = Array.isArray(body.items) ? body.items : []
+  // Defensive JSON parse — Netlify SPA fallback may return text/html (#9933)
+  let body: CephClusterListResponse
+  try {
+    body = (await resp.json()) as CephClusterListResponse
+  } catch {
+    return buildStatus([])
+  }
+  const items = Array.isArray(body?.items) ? body.items : []
   const clusters = (items ?? []).map(itemToCluster)
   return buildStatus(clusters)
 }

--- a/web/src/hooks/useCachedSpiffe.ts
+++ b/web/src/hooks/useCachedSpiffe.ts
@@ -122,9 +122,14 @@ function buildSpiffeStatus(
 // Private fetchJson helper (mirrors envoy/contour/linkerd pattern)
 // ---------------------------------------------------------------------------
 
+/** HTTP statuses that indicate "endpoint not available" — treat as empty, not
+ *  as a hard failure. 401/403 cover unauthenticated/demo visitors hitting
+ *  the JWT-protected /api group; 404/501/503 cover Netlify SPA fallback and
+ *  the MSW catch-all (#9933). */
+const NOT_INSTALLED_STATUSES = new Set<number>([401, 403, 404, 501, 503])
+
 async function fetchJson<T>(
   url: string,
-  options?: { treat404AsEmpty?: boolean },
 ): Promise<FetchResult<T | null>> {
   try {
     const resp = await authFetch(url, {
@@ -133,13 +138,19 @@ async function fetchJson<T>(
     })
 
     if (!resp.ok) {
-      if (options?.treat404AsEmpty && resp.status === 404) {
+      if (NOT_INSTALLED_STATUSES.has(resp.status)) {
         return { data: null, failed: false }
       }
       return { data: null, failed: true }
     }
 
-    const body = (await resp.json()) as T
+    // Defensive JSON parse — Netlify SPA fallback may return text/html (#9933)
+    let body: T
+    try {
+      body = (await resp.json()) as T
+    } catch {
+      return { data: null, failed: false }
+    }
     return { data: body, failed: false }
   } catch {
     return { data: null, failed: true }
@@ -153,7 +164,6 @@ async function fetchJson<T>(
 async function fetchSpiffeStatus(): Promise<SpiffeStatusData> {
   const result = await fetchJson<SpiffeStatusResponse>(
     SPIFFE_STATUS_ENDPOINT,
-    { treat404AsEmpty: true },
   )
 
   // If the endpoint isn't wired up yet (404) or the request failed, the

--- a/web/src/hooks/useCachedTuf.ts
+++ b/web/src/hooks/useCachedTuf.ts
@@ -37,7 +37,11 @@ const DEFAULT_REPOSITORY = ''
 // clear warning before any single role expires.
 const EXPIRING_SOON_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
 
-const NOT_FOUND_STATUS = 404
+/** HTTP statuses that indicate "endpoint not available" — treat as empty, not
+ *  as a hard failure. 401/403 cover unauthenticated/demo visitors hitting
+ *  the JWT-protected /api group; 404/501/503 cover Netlify SPA fallback and
+ *  the MSW catch-all (#9933). */
+const NOT_INSTALLED_STATUSES = new Set<number>([401, 403, 404, 501, 503])
 
 const INITIAL_DATA: TufStatusData = {
   health: 'not-installed',
@@ -137,18 +141,24 @@ async function fetchTufStatus(): Promise<TufStatusData> {
   })
 
   if (!resp.ok) {
-    if (resp.status === NOT_FOUND_STATUS) {
-      // Endpoint not yet wired — surface "not-installed" so the cache layer
-      // will fall back to demo data instead of flagging a hard failure.
+    if (NOT_INSTALLED_STATUSES.has(resp.status)) {
+      // Endpoint not yet wired / auth required / MSW catch-all (#9933) —
+      // surface "not-installed" so the cache layer falls back to demo data.
       return buildTufStatus([], DEFAULT_SPEC_VERSION, DEFAULT_REPOSITORY)
     }
     throw new Error(`HTTP ${resp.status}`)
   }
 
-  const body = (await resp.json()) as TufStatusResponse
-  const roles = Array.isArray(body.roles) ? body.roles : []
-  const specVersion = body.specVersion ?? DEFAULT_SPEC_VERSION
-  const repository = body.repository ?? DEFAULT_REPOSITORY
+  // Defensive JSON parse — Netlify SPA fallback may return text/html (#9933)
+  let body: TufStatusResponse
+  try {
+    body = (await resp.json()) as TufStatusResponse
+  } catch {
+    return buildTufStatus([], DEFAULT_SPEC_VERSION, DEFAULT_REPOSITORY)
+  }
+  const roles = Array.isArray(body?.roles) ? body.roles : []
+  const specVersion = body?.specVersion ?? DEFAULT_SPEC_VERSION
+  const repository = body?.repository ?? DEFAULT_REPOSITORY
   return buildTufStatus(roles, specVersion, repository)
 }
 


### PR DESCRIPTION
Fixes #9933

## Summary

The 7 marketplace card PRs (#9921–#9928) introduced hooks whose fetchers only treated HTTP 404 as "not installed". On Netlify the MSW catch-all returns 503 for unknown `/api/` routes, and the JWT middleware returns 401 for unauthenticated visitors — both caused unhandled errors that surfaced as `ksc_error` events with `error_code: auth`.

## Changes

Apply the same defensive pattern from the TiKV fix (#9923) to all 6 affected hooks:

1. **`NOT_INSTALLED_STATUSES`** — treat 401, 403, 404, 501, 503 as "endpoint unavailable" → return empty/not-installed data instead of throwing
2. **Defensive JSON parse** — wrap `resp.json()` in try/catch so Netlify SPA fallback (`text/html` 200) doesn't produce `Unexpected token '<'` errors
3. **Optional-chaining** on response body fields

### Affected hooks

| Hook | Endpoint | Issue |
|------|----------|-------|
| `useCachedDapr` | `/api/dapr/status` | No backend handler exists |
| `useCachedSpiffe` | `/api/spiffe/status` | No backend handler exists |
| `useCachedTuf` | `/api/tuf/status` | No backend handler exists |
| `useCachedOtel` | `/api/mcp/custom-resources` | Only handled 404 |
| `useCachedRook` | `/api/mcp/custom-resources` | Only handled 404 |
| `useCachedDragonfly` | `/api/mcp/custom-resources` | Only handled 404 |

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (no new warnings)
- [ ] Netlify deploy preview renders cards without `ksc_error` spikes
- [ ] Demo mode shows demo data with yellow outline + Demo badge
- [ ] Live MCP backend still renders live data correctly