### PR TITLE
🐛 fix(test): correct runtime card config assertions for chaosMeshStatus

### DIFF
--- a/web/src/config/cards/__tests__/card-configs-runtime.test.ts
+++ b/web/src/config/cards/__tests__/card-configs-runtime.test.ts
@@ -14,12 +14,14 @@ describe('Runtime card configs', () => {
     expect(config.category).toBe('runtime')
   })
 
-  it.each(runtimeCards)('$name has valid columns array', ({ config }) => {
-    expect(Array.isArray(config.columns)).toBe(true)
-    expect(config.columns?.length).toBeGreaterThan(0)
-    config.columns?.forEach(col => {
-      expect(col.key).toBeTruthy()
-      expect(col.label).toBeTruthy()
+  it.each(runtimeCards)('$name has valid content.items array', ({ config }) => {
+    expect(config.content).toBeTruthy()
+    expect(config.content?.type).toBe('status-grid')
+    expect(Array.isArray(config.content?.items)).toBe(true)
+    expect(config.content?.items?.length).toBeGreaterThan(0)
+    config.content?.items?.forEach((item: { id: string; label: string }) => {
+      expect(item.id).toBeTruthy()
+      expect(item.label).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
Fixes #9958

The `card-configs-runtime.test.ts` was checking `config.columns` at the top-level, but `chaosMeshStatusConfig` uses `content.items` (status-grid pattern) — there is no top-level `columns` property.

## Changes

Updated the `'has valid columns array'` test to:
1. Verify `config.content` exists
2. Verify `config.content.type` is `'status-grid'`
3. Verify `Array.isArray(config.content.items)` is true
4. Verify `config.content.items.length > 0`
5. Verify each item has a truthy `id` and `label`

Also renamed the test description to `'has valid content.items array'` to accurately reflect what is being tested.