### PR TITLE
🐛 fix: eliminate 6 GA4 auth errors on /alerts page (#9957)

### DIFF
--- a/web/src/components/alerts/Alerts.tsx
+++ b/web/src/components/alerts/Alerts.tsx
@@ -3,7 +3,6 @@ import { AlertCircle } from 'lucide-react'
 import { useAlerts, useAlertRules } from '../../hooks/useAlerts'
 import { useClusters } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
 import { StatBlockValue } from '../ui/StatsOverview'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
@@ -21,8 +20,6 @@ export function Alerts() {
   const { rules } = useAlertRules()
   const { isRefreshing: dataRefreshing, refetch, error } = useClusters()
   const { drillToAllAlerts } = useDrillDownActions()
-  const { getStatValue: getUniversalStatValue } = useUniversalStats()
-
   // Local state for last updated time
   const [lastUpdated, setLastUpdated] = useState<Date | undefined>(undefined)
 
@@ -71,7 +68,9 @@ export function Alerts() {
     }
   }
 
-  const getStatValue = (blockId: string) => createMergedStatValueGetter(getDashboardStatValue, getUniversalStatValue)(blockId)
+  // DashboardPage calls useUniversalStats internally and merges with this getter,
+  // so we do not need to call useUniversalStats here to avoid duplicate API calls.
+  const getStatValue = getDashboardStatValue
 
   return (
     <DashboardPage

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -413,6 +413,14 @@ export function useIngresses(cluster?: string, namespace?: string) {
         // Fall through to API
       }
     }
+    // Skip REST fallback when no token to prevent GA4 auth errors (#9957)
+    const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+    if (!token) {
+      setIngresses([])
+      setIsLoading(false)
+      setIsRefreshing(false)
+      return
+    }
     try {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)

--- a/web/src/hooks/mcp/operators.ts
+++ b/web/src/hooks/mcp/operators.ts
@@ -180,7 +180,14 @@ export function useOperators(cluster?: string) {
         }
       }
 
-      // REST fallback
+      // REST fallback — skip entirely if no token to prevent GA4 auth errors (#9957)
+      if (!token) {
+        setIsLoading(false)
+        setIsRefreshing(false)
+        fetchInProgressRef.current = false
+        return
+      }
+
       const url = cluster
         ? `/api/gitops/operators?cluster=${encodeURIComponent(cluster)}`
         : '/api/gitops/operators'
@@ -344,7 +351,14 @@ export function useOperatorSubscriptions(cluster?: string) {
         }
       }
 
-      // REST fallback
+      // REST fallback — skip entirely if no token to prevent GA4 auth errors (#9957)
+      if (!token) {
+        setIsLoading(false)
+        setIsRefreshing(false)
+        fetchInProgressRef.current = false
+        return
+      }
+
       const url = cluster
         ? `/api/gitops/operator-subscriptions?cluster=${encodeURIComponent(cluster)}`
         : '/api/gitops/operator-subscriptions'


### PR DESCRIPTION
Fixes #9957

## Root Cause

Two issues combining to produce 6 `No authentication token available` GA4 errors on `/alerts`.

### Issue 1 — redundant `useUniversalStats()` in `Alerts.tsx`

`DashboardPage` already calls `useUniversalStats()` internally and merges any custom `getStatValue` with it. `Alerts.tsx` was **also** calling `useUniversalStats()` and pre-merging before passing to `DashboardPage`, causing every sub-hook (`useOperators`, `useOperatorSubscriptions`, `useIngresses`, …) to run **twice** and emit double the auth errors (3 hooks × 2 = 6 errors).

**Fix:** remove the redundant call; pass `getDashboardStatValue` directly — `DashboardPage` merges with its own universal stats getter.

### Issue 2 — missing token guards in three hooks

| Hook | Path | Problem |
|------|------|---------|
| `useOperators` | `/api/gitops/operators` | No token → SSE skipped → falls through to `api.get()` which emits GA4 auth event |
| `useOperatorSubscriptions` | `/api/gitops/operator-subscriptions` | Same pattern |
| `useIngresses` | `LOCAL_AGENT_HTTP_URL/ingresses` | No token guard before `api.get()` |

**Fix:** return early when no token is available — hooks show empty/cached state until auth is established, consistent with how `useGPUNodes` already handles this.

## Files Changed

- `web/src/components/alerts/Alerts.tsx` — remove redundant `useUniversalStats()`
- `web/src/hooks/mcp/operators.ts` — token guard in `useOperators` + `useOperatorSubscriptions`
- `web/src/hooks/mcp/networking.ts` — token guard in `useIngresses`

## Testing

- Build: ✅ `npm run build` passes
- No new lint errors introduced (existing lint errors in changed files are pre-existing)