### PR TITLE
🌱 ci: raise coverage gate threshold 80%→91%

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -21,7 +21,7 @@ concurrency:
 
 env:
   NODE_VERSION: '22'
-  COVERAGE_THRESHOLD: 80
+  COVERAGE_THRESHOLD: 91
 
 jobs:
   coverage-gate:


### PR DESCRIPTION
Closes scanner-beads-89z8

The Coverage Gate workflow had `COVERAGE_THRESHOLD=80` while reviewer policy sets the floor at **91%**. This created a silent 11-point regression window.

**Change:** `.github/workflows/coverage-gate.yml` line 24: `80` → `91`

No code changes — CI config only.