### PR TITLE
📖 fix: correct ACMM badge rendering in README (#8979)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KubeStellar Console
 
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/clubanderson/b9a9ae8469f1897a22d5a40629bc1e82/raw/coverage-badge.json)
-[![ACMM](https://img.shields.io/endpoint?url=https%3A%2F%2Fconsole.kubestellar.io%2Fapi%2Facmm%2Fbadge%3Frepo%3Dkubestellar%252Fconsole%26v%3D3&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0id2hpdGUiPjxjaXJjbGUgY3g9IjkiIGN5PSIxMSIgcj0iOCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIi8%2BPGVsbGlwc2UgY3g9IjkiIGN5PSIxMSIgcng9IjgiIHJ5PSIzLjUiIGZpbGw9Im5vbmUiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMS42Ii8%2BPGxpbmUgeDE9IjEiIHkxPSIxMSIgeDI9IjE3IiB5Mj0iMTEiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMS42Ii8%2BPGxpbmUgeDE9IjkiIHkxPSIzIiB4Mj0iOSIgeTI9IjE5IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjEuNiIvPjxwb2x5Z29uIHBvaW50cz0iMTYsMSAxNy40LDQuMyAyMSw0LjMgMTguMSw2LjUgMTkuMiw5LjggMTYsNy43IDEyLjgsOS44IDEzLjksNi41IDExLDQuMyAxNC42LDQuMyIvPjwvc3ZnPg%3D%3D)](https://console.kubestellar.io/acmm?repo=kubestellar%2Fconsole)
+[![ACMM](https://img.shields.io/endpoint?url=https%3A%2F%2Fconsole.kubestellar.io%2Fapi%2Facmm%2Fbadge%3Frepo%3Dkubestellar%252Fconsole%26v%3D3)](https://console.kubestellar.io/acmm?repo=kubestellar%2Fconsole)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/kubestellar/console/badge)](https://securityscorecards.dev/viewer/?uri=github.com/kubestellar/console)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12343/badge?v=2)](https://www.bestpractices.dev/projects/12343)
 


### PR DESCRIPTION
Fixes #8979

Fixes the ACMM badge in README.md so it renders correctly.

The badge URL contained a large base64-encoded SVG data URI as a custom logo override (`&logo=data:image/svg+xml;base64,...`). GitHub's Content Security Policy blocks `data:` URIs in image sources, which prevented the badge from rendering.

The badge endpoint already returns `"namedLogo":"github"` in its JSON response, so removing the custom logo parameter is sufficient — shields.io will use the named logo from the response automatically.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>