### PR TITLE
🐛 fix(security): bump postcss 8.5.8→8.5.10 (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -79,7 +79,7 @@
         "istanbul-reports": "^3.1.7",
         "jsdom": "^29.0.1",
         "msw": "^2.13.2",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.10",
         "rimraf": "^6.1.3",
         "storybook": "^10.3.5",
         "tailwindcss": "^4.2.4",
@@ -2950,6 +2950,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",
@@ -8475,9 +8539,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/web/package.json
+++ b/web/package.json
@@ -118,7 +118,7 @@
     "istanbul-reports": "^3.1.7",
     "jsdom": "^29.0.1",
     "msw": "^2.13.2",
-    "postcss": "^8.5.8",
+    "postcss": "^8.5.10",
     "rimraf": "^6.1.3",
     "storybook": "^10.3.5",
     "tailwindcss": "^4.2.4",


### PR DESCRIPTION
## Summary

Bumps postcss from 8.5.8 to 8.5.10 to resolve a moderate-severity XSS vulnerability detected by Scorecard (code-scanning alert #16).

## Vulnerability

**GHSA-qx2v-qp2m-jg93** — PostCSS XSS via unescaped `</style>` in CSS Stringify Output  
Severity: **moderate** | Affected: postcss < 8.5.10

## Changes

- `web/package.json`: `postcss` `^8.5.8` → `^8.5.10`
- `web/package-lock.json`: updated lock

## Notes on remaining vuln

The other vulnerability in Scorecard alert #16 (**GHSA-w5hq-g745-h8pq**, `uuid < 14`) is in a transitive dependency via `@netlify/blobs@10 → @netlify/dev-utils → uuid`. The only available npm fix would downgrade `@netlify/blobs` from 10.x to 8.x, which is a breaking change. Not addressed in this PR.

## Verification

- ✅ `npm run build` passes
- ✅ postcss GHSA-qx2v-qp2m-jg93 no longer flagged by `npm audit`