### PR TITLE
🐛 fix(tests): update operators tests to match no-token guard behavior

### DIFF
--- a/web/src/hooks/mcp/__tests__/operators.test.ts
+++ b/web/src/hooks/mcp/__tests__/operators.test.ts
@@ -425,7 +425,7 @@ describe('useOperators – phase → status mapping', () => {
 })
 
 describe('useOperators – SSE unavailable when no token', () => {
-  it('falls back to REST when no token in localStorage', async () => {
+  it('skips REST call when no token in localStorage (prevents GA4 auth errors)', async () => {
     localStorage.removeItem('token')
     const fakeOps = [
       { name: 'op1', namespace: 'ns', version: 'v1', status: 'Succeeded', cluster: 'c1' },
@@ -435,10 +435,10 @@ describe('useOperators – SSE unavailable when no token', () => {
     const { result } = renderHook(() => useOperators())
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
-    // SSE should not be attempted; REST should be called
+    // Neither SSE nor REST should be attempted without a token (#9957)
     expect(mockFetchSSE).not.toHaveBeenCalled()
-    expect(mockApiGet).toHaveBeenCalled()
-    expect(result.current.operators.length).toBe(1)
+    expect(mockApiGet).not.toHaveBeenCalled()
+    expect(result.current.operators.length).toBe(0)
   })
 
   it('falls back to REST when token is demo-token', async () => {
@@ -628,7 +628,7 @@ describe('useOperatorSubscriptions – SSE onClusterData progressive rendering',
 })
 
 describe('useOperatorSubscriptions – SSE unavailable when no token', () => {
-  it('falls back to REST when no token in localStorage', async () => {
+  it('skips REST call when no token in localStorage (prevents GA4 auth errors)', async () => {
     localStorage.removeItem('token')
     const fakeSubs = [
       { name: 'sub1', namespace: 'ns', channel: 'stable', source: 'src', installPlanApproval: 'Automatic', currentCSV: 'csv.v1', cluster: 'c1' },
@@ -638,9 +638,10 @@ describe('useOperatorSubscriptions – SSE unavailable when no token', () => {
     const { result } = renderHook(() => useOperatorSubscriptions())
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
+    // Neither SSE nor REST should be attempted without a token (#9957)
     expect(mockFetchSSE).not.toHaveBeenCalled()
-    expect(mockApiGet).toHaveBeenCalled()
-    expect(result.current.subscriptions.length).toBe(1)
+    expect(mockApiGet).not.toHaveBeenCalled()
+    expect(result.current.subscriptions.length).toBe(0)
   })
 })
 


### PR DESCRIPTION
Fixes post-merge test regression introduced by #9962.

PR #9962 added token guards to `useOperators` and `useOperatorSubscriptions` that skip the REST fallback entirely when no token is present (preventing GA4 auth error spikes, #9957).

Two tests in `operators.test.ts` still described the old behavior — "falls back to REST when no token" — and asserted that `mockApiGet` was called and operators/subscriptions were populated. With the guard in place, neither SSE nor REST is attempted, so those assertions fail.

**Change**: Update both tests to assert the new contract:
- `mockFetchSSE` not called ✓ (unchanged)
- `mockApiGet` not called (was: called)
- operators/subscriptions empty (was: populated from mock)

This fixes the `merge-coverage` shard 8 failure on main.