### PR TITLE
🐛 fix(a11y): improve color contrast and remove stale INVENTORY entry

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -155,7 +155,6 @@ The Auto-QA workflow uses this file to verify component consistency.
 | KubeVelaStatus | web/src/components/cards/kubevela_status/index.ts | `kubevela_status` |
 | KarmadaStatus | web/src/components/cards/karmada_status/index.ts | `karmada_status` |
 | ThanosStatus | web/src/components/cards/thanos_status/index.tsx | `thanos_status` |
-| OpenFeatureStatus | web/src/components/cards/openfeature_status/index.ts | `openfeature_status` |
 | CrossplaneManagedResources | web/src/components/cards/crossplane-status/CrossplaneManagedResources.tsx | `crossplane_managed_resources` |
 
 ## Multi-Tenancy Cards

--- a/web/src/components/NotFound.tsx
+++ b/web/src/components/NotFound.tsx
@@ -51,7 +51,7 @@ export default function NotFound() {
           <h1 className="text-3xl font-bold text-zinc-100">
             Page not found
           </h1>
-          <p className="text-zinc-400 text-base leading-relaxed">
+          <p className="text-muted-foreground text-base leading-relaxed">
             <code className="px-2 py-0.5 bg-zinc-800 rounded text-sm text-purple-300">{path}</code>
             {' '}doesn&apos;t exist yet — but it could!
           </p>
@@ -63,7 +63,7 @@ export default function NotFound() {
             <Sparkles className="w-4 h-4" />
             <span className="text-sm font-semibold">Ship it in hours, not months</span>
           </div>
-          <p className="text-zinc-400 text-sm leading-relaxed">
+          <p className="text-muted-foreground text-sm leading-relaxed">
             KubeStellar Console uses AI-powered repo automation to go from feature
             request to production in hours. Open an issue and watch the magic happen.
           </p>
@@ -88,8 +88,8 @@ export default function NotFound() {
                 onClick={() => navigate(to)}
                 className="flex flex-col items-center gap-1.5 p-3 rounded-lg bg-zinc-800/50 hover:bg-zinc-700/50 border border-zinc-700/50 hover:border-zinc-600 transition-colors group"
               >
-                <Icon className="w-4 h-4 text-zinc-400 group-hover:text-purple-400 transition-colors" />
-                <span className="text-xs text-zinc-400 group-hover:text-zinc-200 transition-colors">{label}</span>
+                <Icon className="w-4 h-4 text-muted-foreground group-hover:text-purple-400 transition-colors" />
+                <span className="text-xs text-muted-foreground group-hover:text-zinc-200 transition-colors">{label}</span>
               </button>
             ))}
           </div>
@@ -99,14 +99,14 @@ export default function NotFound() {
         <div className="flex items-center justify-center gap-3 pt-2">
           <button
             onClick={() => navigate(-1)}
-            className="inline-flex items-center gap-1.5 px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200 border border-zinc-700 hover:border-zinc-600 rounded-lg transition-colors"
+            className="inline-flex items-center gap-1.5 px-4 py-2 text-sm text-muted-foreground hover:text-zinc-200 border border-zinc-700 hover:border-zinc-600 rounded-lg transition-colors"
           >
             <ArrowLeft className="w-3.5 h-3.5" />
             Go back
           </button>
           <button
             onClick={() => navigate(ROUTES.HOME)}
-            className="inline-flex items-center gap-1.5 px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200 border border-zinc-700 hover:border-zinc-600 rounded-lg transition-colors"
+            className="inline-flex items-center gap-1.5 px-4 py-2 text-sm text-muted-foreground hover:text-zinc-200 border border-zinc-700 hover:border-zinc-600 rounded-lg transition-colors"
           >
             <Home className="w-3.5 h-3.5" />
             Home

--- a/web/src/components/cards/EnterpriseComplianceCards.tsx
+++ b/web/src/components/cards/EnterpriseComplianceCards.tsx
@@ -101,7 +101,7 @@ export function GxPCard() {
             {data.chain_integrity
               ? <CheckCircle2 className="w-4 h-4 text-green-400" />
               : <XCircle className="w-4 h-4 text-red-400" />}
-            <span className="text-sm text-gray-300">Hash Chain {data.chain_integrity ? 'Intact' : 'Broken'}</span>
+            <span className="text-sm text-muted-foreground">Hash Chain {data.chain_integrity ? 'Intact' : 'Broken'}</span>
           </div>
           <div className="grid grid-cols-3 gap-2">
             <MiniStat label="Records" value={Number(data.total_records ?? 0)} />
@@ -143,8 +143,8 @@ export function ComplianceFrameworksCard() {
   return (
     <CardShell title="Compliance Frameworks" icon={Shield} onClick={() => nav('/compliance-frameworks')}>
       <div className="space-y-2">
-        <div className="flex items-center gap-2"><CheckCircle2 className="w-3 h-3 text-green-400" /><span className="text-sm text-gray-300">PCI-DSS 4.0</span></div>
-        <div className="flex items-center gap-2"><CheckCircle2 className="w-3 h-3 text-green-400" /><span className="text-sm text-gray-300">SOC 2 Type II</span></div>
+        <div className="flex items-center gap-2"><CheckCircle2 className="w-3 h-3 text-green-400" /><span className="text-sm text-muted-foreground">PCI-DSS 4.0</span></div>
+        <div className="flex items-center gap-2"><CheckCircle2 className="w-3 h-3 text-green-400" /><span className="text-sm text-muted-foreground">SOC 2 Type II</span></div>
         <p className="text-xs text-gray-500 mt-2">Click to evaluate frameworks</p>
       </div>
     </CardShell>

--- a/web/src/components/compliance/ComplianceFrameworks.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.tsx
@@ -98,7 +98,7 @@ function CheckRow({ check }: { check: ComplianceCheck }) {
           <span className="text-xs font-medium text-zinc-200 truncate">{check.name}</span>
           <SeverityBadge severity={check.severity} />
         </div>
-        {check.message && <p className="text-[11px] text-zinc-400 mt-0.5">{check.message}</p>}
+        {check.message && <p className="text-[11px] text-muted-foreground mt-0.5">{check.message}</p>}
         {check.status !== 'pass' && check.remediation && (
           <p className="text-[11px] text-blue-400 mt-0.5">💡 {check.remediation}</p>
         )}
@@ -120,7 +120,7 @@ function ControlAccordion({ control }: { control: ControlResult }) {
         onClick={() => setOpen(v => !v)}
         type="button"
       >
-        <Icon className="w-4 h-4 text-zinc-400 shrink-0" />
+        <Icon className="w-4 h-4 text-muted-foreground shrink-0" />
         <StatusBadge status={control.status} />
         <span className="text-sm font-medium text-zinc-200 flex-1 truncate">{control.id}: {control.name}</span>
         <span className="text-xs text-zinc-500">{control.checks.length} checks</span>
@@ -151,7 +151,7 @@ function FrameworkCard({ fw, selected, onSelect }: { fw: Framework; selected: bo
         <Shield className="w-4 h-4 text-blue-400" />
         <span className="text-sm font-semibold text-zinc-100">{fw.name}</span>
       </div>
-      <p className="text-xs text-zinc-400 line-clamp-2 mb-2">{fw.description}</p>
+      <p className="text-xs text-muted-foreground line-clamp-2 mb-2">{fw.description}</p>
       <div className="flex gap-3 text-[11px] text-zinc-500">
         <span>{fw.controls} controls</span>
         <span>{fw.checks} checks</span>
@@ -241,7 +241,7 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
 
   if (fwLoading) {
     return (
-      <div className="flex items-center justify-center h-64 text-zinc-400">
+      <div className="flex items-center justify-center h-64 text-muted-foreground">
         <Loader2 className="w-6 h-6 animate-spin mr-2" />
         Loading frameworks…
       </div>
@@ -328,7 +328,7 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
             <ScoreRing score={result.score} />
             <div className="space-y-2">
               <h2 className="text-lg font-bold text-white">{result.framework_name}</h2>
-              <p className="text-sm text-zinc-400">
+              <p className="text-sm text-muted-foreground">
                 Cluster: <span className="text-zinc-200">{result.cluster}</span>
               </p>
               <div className="flex gap-4 text-sm">

--- a/web/src/components/compliance/ComplianceReports.tsx
+++ b/web/src/components/compliance/ComplianceReports.tsx
@@ -110,7 +110,7 @@ export const ComplianceReportsContent = memo(function ComplianceReportsContent()
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           {/* Framework Picker */}
           <div>
-            <label className="block text-sm font-medium text-zinc-400 mb-1.5">Framework</label>
+            <label className="block text-sm font-medium text-muted-foreground mb-1.5">Framework</label>
             <Select
               value={selectedFw}
               onChange={(e) => setSelectedFw(e.target.value)}
@@ -127,7 +127,7 @@ export const ComplianceReportsContent = memo(function ComplianceReportsContent()
 
           {/* Cluster Picker */}
           <div>
-            <label className="block text-sm font-medium text-zinc-400 mb-1.5">Cluster</label>
+            <label className="block text-sm font-medium text-muted-foreground mb-1.5">Cluster</label>
             <Select
               value={selectedCluster}
               onChange={(e) => setSelectedCluster(e.target.value)}
@@ -141,14 +141,14 @@ export const ComplianceReportsContent = memo(function ComplianceReportsContent()
 
           {/* Format Picker */}
           <div>
-            <label className="block text-sm font-medium text-zinc-400 mb-1.5">Format</label>
+            <label className="block text-sm font-medium text-muted-foreground mb-1.5">Format</label>
             <div className="flex gap-2">
               <button
                 onClick={() => setFormat('pdf')}
                 className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
                   format === 'pdf'
                     ? 'border-indigo-500 bg-indigo-500/20 text-indigo-300'
-                    : 'border-zinc-600 bg-zinc-700/50 text-zinc-400 hover:text-zinc-200'
+                    : 'border-zinc-600 bg-zinc-700/50 text-muted-foreground hover:text-zinc-200'
                 }`}
               >
                 📄 PDF
@@ -158,7 +158,7 @@ export const ComplianceReportsContent = memo(function ComplianceReportsContent()
                 className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
                   format === 'json'
                     ? 'border-indigo-500 bg-indigo-500/20 text-indigo-300'
-                    : 'border-zinc-600 bg-zinc-700/50 text-zinc-400 hover:text-zinc-200'
+                    : 'border-zinc-600 bg-zinc-700/50 text-muted-foreground hover:text-zinc-200'
                 }`}
               >
                 {'{ }'} JSON
@@ -175,7 +175,7 @@ export const ComplianceReportsContent = memo(function ComplianceReportsContent()
                 <p className="text-sm font-medium text-zinc-200">{selectedFramework.name}</p>
                 <p className="text-xs text-zinc-500 mt-0.5">{(selectedFramework as Framework & { description?: string }).description || 'Regulatory compliance framework'}</p>
               </div>
-              <div className="flex gap-4 text-xs text-zinc-400">
+              <div className="flex gap-4 text-xs text-muted-foreground">
                 <span>{(selectedFramework as Framework & { controls?: number }).controls ?? '—'} controls</span>
                 <span>{(selectedFramework as Framework & { checks?: number }).checks ?? '—'} checks</span>
               </div>
@@ -218,7 +218,7 @@ export const ComplianceReportsContent = memo(function ComplianceReportsContent()
       {/* Info Section */}
       <div className="rounded-xl border border-zinc-700/50 bg-zinc-800/50 p-6">
         <h2 className="text-lg font-medium text-zinc-200 mb-3">About Compliance Reports</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-zinc-400">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-muted-foreground">
           <div>
             <h3 className="font-medium text-zinc-300 mb-1">PDF Reports</h3>
             <p>Audit-ready documents with cover page, executive summary, per-control findings, evidence, and remediation steps. Suitable for sharing with auditors and compliance teams.</p>

--- a/web/src/components/enterprise/EnterprisePortal.tsx
+++ b/web/src/components/enterprise/EnterprisePortal.tsx
@@ -97,7 +97,7 @@ function VerticalCard({ sectionId, title, items, onNavigate }: {
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
           <div className="p-2 rounded-lg bg-gray-800/50">
-            <Icon className="w-5 h-5 text-gray-300" />
+            <Icon className="w-5 h-5 text-muted-foreground" />
           </div>
           <div>
             <h3 className="text-sm font-semibold text-white">{title}</h3>
@@ -130,7 +130,7 @@ function VerticalCard({ sectionId, title, items, onNavigate }: {
           <button
             key={item.href}
             onClick={() => onNavigate(item.href)}
-            className="w-full flex items-center justify-between px-3 py-1.5 rounded-md text-sm text-gray-300 hover:bg-gray-700/40 hover:text-white transition-colors group"
+            className="w-full flex items-center justify-between px-3 py-1.5 rounded-md text-sm text-muted-foreground hover:bg-gray-700/40 hover:text-white transition-colors group"
           >
             <span>{item.label}</span>
             <ArrowRight className="w-3.5 h-3.5 opacity-0 group-hover:opacity-100 transition-opacity" />


### PR DESCRIPTION
Fixes #9972
Fixes #9973

## Summary

### Issue #9972 — Color contrast (WCAG AA)
Replaced hardcoded `text-zinc-400` / `text-gray-300` with the `text-muted-foreground` semantic token in UI text, labels, and interactive element base states. This ensures correct contrast in both dark and light themes. Hover states (`hover:text-zinc-200`) are preserved as-is. ECharts internal chart colors were not touched.

**Files changed:**
- `web/src/components/cards/EnterpriseComplianceCards.tsx` — card body text
- `web/src/components/NotFound.tsx` — body text, icon labels, nav buttons
- `web/src/components/enterprise/EnterprisePortal.tsx` — nav button text and icon
- `web/src/components/compliance/ComplianceFrameworks.tsx` — check messages, accordion icon, framework description, loading state, cluster label
- `web/src/components/compliance/ComplianceReports.tsx` — form labels, format toggle buttons, framework info row, info section body

### Issue #9973 — INVENTORY.md stale entry
Removed the stale `openfeature_status` entry from `INVENTORY.md` — the referenced file `web/src/components/cards/openfeature_status/index.ts` does not exist in the repo.

## Checklist
- [x] `npm run build` passes
- [x] No new lint errors introduced (pre-existing errors are unrelated to these changes)
- [x] DCO signed-off