### PR TITLE
🌱 refactor: replace magic-number ms offsets with named constants

### DIFF
--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -31,6 +31,8 @@ const TWO_MINUTES_MS = 2 * 60 * 1000
 const THREE_MINUTES_MS = 3 * 60 * 1000
 const FOUR_MINUTES_MS = 4 * 60 * 1000
 const FIVE_MINUTES_MS = 5 * 60 * 1000
+
+interface MissionsProps {
   config?: Record<string, unknown>
 }
 

--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -26,7 +26,11 @@ import { useTranslation } from 'react-i18next'
 import { useMissions } from '../../hooks/useMissions'
 import { useApiKeyCheck, ApiKeyPromptModal } from './console-missions/shared'
 
-interface MissionsProps {
+// Named time-offset constants for demo fixture data (CLAUDE.md: No Magic Numbers)
+const TWO_MINUTES_MS = 2 * 60 * 1000
+const THREE_MINUTES_MS = 3 * 60 * 1000
+const FOUR_MINUTES_MS = 4 * 60 * 1000
+const FIVE_MINUTES_MS = 5 * 60 * 1000
   config?: Record<string, unknown>
 }
 
@@ -43,8 +47,8 @@ const DEMO_MISSIONS: DeployMission[] = [
       { cluster: 'openshift-prod', status: 'running', replicas: 3, readyReplicas: 3 },
       { cluster: 'do-nyc1-prod', status: 'running', replicas: 3, readyReplicas: 3 },
     ],
-    startedAt: Date.now() - 300000,
-    completedAt: Date.now() - 240000 },
+    startedAt: Date.now() - FIVE_MINUTES_MS,
+    completedAt: Date.now() - FOUR_MINUTES_MS },
   {
     id: 'demo-2',
     workload: 'api-gateway',
@@ -57,8 +61,8 @@ const DEMO_MISSIONS: DeployMission[] = [
       { cluster: 'aks-dev-westeu', status: 'running', replicas: 2, readyReplicas: 2 },
       { cluster: 'rancher-mgmt', status: 'running', replicas: 2, readyReplicas: 2 },
     ],
-    startedAt: Date.now() - 180000,
-    completedAt: Date.now() - 120000 },
+    startedAt: Date.now() - THREE_MINUTES_MS,
+    completedAt: Date.now() - TWO_MINUTES_MS },
 ]
 
 const STATUS_CONFIG: Record<DeployMissionStatus, {

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -34,6 +34,8 @@ const TWENTY_MINUTES_MS = 20 * 60 * 1000
 const THIRTY_MINUTES_MS = 30 * 60 * 1000
 const ONE_HOUR_MS = 60 * 60 * 1000
 const TWO_HOURS_MS = 2 * 60 * 60 * 1000
+
+interface GitHubCIMonitorProps {
   config?: Record<string, unknown>
 }
 

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -23,7 +23,17 @@ import { formatTimeAgo, loadRepos, saveRepos } from './gitHubCIUtils'
 import { usePipelineFilter } from '../pipelines/PipelineFilterContext'
 import { RepoSubtitle } from '../pipelines/RepoSubtitle'
 
-interface GitHubCIMonitorProps {
+// Named time-offset constants for demo fixture data (CLAUDE.md: No Magic Numbers)
+const THIRTY_SECONDS_MS = 30 * 1000
+const ONE_MINUTE_MS = 60 * 1000
+const TWO_MINUTES_MS = 2 * 60 * 1000
+const FIVE_MINUTES_MS = 5 * 60 * 1000
+const TEN_MINUTES_MS = 10 * 60 * 1000
+const FIFTEEN_MINUTES_MS = 15 * 60 * 1000
+const TWENTY_MINUTES_MS = 20 * 60 * 1000
+const THIRTY_MINUTES_MS = 30 * 60 * 1000
+const ONE_HOUR_MS = 60 * 60 * 1000
+const TWO_HOURS_MS = 2 * 60 * 60 * 1000
   config?: Record<string, unknown>
 }
 
@@ -86,14 +96,14 @@ const TITLE_DIAGNOSE = 'Diagnose with AI'
 
 // Demo data for when GitHub API is not available
 const DEMO_WORKFLOWS: WorkflowRun[] = [
-  { id: '1', name: 'CI / Build & Test', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'success', branch: 'main', event: 'push', runNumber: 1234, createdAt: new Date(Date.now() - 300000).toISOString(), updatedAt: new Date(Date.now() - 60000).toISOString(), url: '#' },
-  { id: '2', name: 'CI / Lint', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'failure', branch: 'feat/new-feature', event: 'pull_request', runNumber: 1233, createdAt: new Date(Date.now() - 600000).toISOString(), updatedAt: new Date(Date.now() - 300000).toISOString(), url: '#' },
-  { id: '3', name: 'Release / Publish', repo: 'kubestellar/kubestellar', status: 'in_progress', conclusion: null, branch: 'main', event: 'workflow_dispatch', runNumber: 1232, createdAt: new Date(Date.now() - 120000).toISOString(), updatedAt: new Date(Date.now() - 30000).toISOString(), url: '#' },
-  { id: '4', name: 'E2E Tests', repo: 'kubestellar/console', status: 'completed', conclusion: 'success', branch: 'main', event: 'push', runNumber: 567, createdAt: new Date(Date.now() - 900000).toISOString(), updatedAt: new Date(Date.now() - 600000).toISOString(), url: '#' },
-  { id: '5', name: 'CI / Build & Test', repo: 'kubestellar/console', status: 'completed', conclusion: 'success', branch: 'feat/workload-monitor', event: 'pull_request', runNumber: 566, createdAt: new Date(Date.now() - 1200000).toISOString(), updatedAt: new Date(Date.now() - 900000).toISOString(), url: '#' },
-  { id: '6', name: 'Deploy Preview', repo: 'kubestellar/console', status: 'queued', conclusion: null, branch: 'feat/card-factory', event: 'pull_request', runNumber: 565, createdAt: new Date(Date.now() - 60000).toISOString(), updatedAt: new Date(Date.now() - 30000).toISOString(), url: '#' },
-  { id: '7', name: 'Security Scan', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'timed_out', branch: 'main', event: 'schedule', runNumber: 1231, createdAt: new Date(Date.now() - 3600000).toISOString(), updatedAt: new Date(Date.now() - 1800000).toISOString(), url: '#' },
-  { id: '8', name: 'Dependabot', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'success', branch: 'dependabot/npm/react-19', event: 'pull_request', runNumber: 1230, createdAt: new Date(Date.now() - 7200000).toISOString(), updatedAt: new Date(Date.now() - 3600000).toISOString(), url: '#' },
+  { id: '1', name: 'CI / Build & Test', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'success', branch: 'main', event: 'push', runNumber: 1234, createdAt: new Date(Date.now() - FIVE_MINUTES_MS).toISOString(), updatedAt: new Date(Date.now() - ONE_MINUTE_MS).toISOString(), url: '#' },
+  { id: '2', name: 'CI / Lint', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'failure', branch: 'feat/new-feature', event: 'pull_request', runNumber: 1233, createdAt: new Date(Date.now() - TEN_MINUTES_MS).toISOString(), updatedAt: new Date(Date.now() - FIVE_MINUTES_MS).toISOString(), url: '#' },
+  { id: '3', name: 'Release / Publish', repo: 'kubestellar/kubestellar', status: 'in_progress', conclusion: null, branch: 'main', event: 'workflow_dispatch', runNumber: 1232, createdAt: new Date(Date.now() - TWO_MINUTES_MS).toISOString(), updatedAt: new Date(Date.now() - THIRTY_SECONDS_MS).toISOString(), url: '#' },
+  { id: '4', name: 'E2E Tests', repo: 'kubestellar/console', status: 'completed', conclusion: 'success', branch: 'main', event: 'push', runNumber: 567, createdAt: new Date(Date.now() - FIFTEEN_MINUTES_MS).toISOString(), updatedAt: new Date(Date.now() - TEN_MINUTES_MS).toISOString(), url: '#' },
+  { id: '5', name: 'CI / Build & Test', repo: 'kubestellar/console', status: 'completed', conclusion: 'success', branch: 'feat/workload-monitor', event: 'pull_request', runNumber: 566, createdAt: new Date(Date.now() - TWENTY_MINUTES_MS).toISOString(), updatedAt: new Date(Date.now() - FIFTEEN_MINUTES_MS).toISOString(), url: '#' },
+  { id: '6', name: 'Deploy Preview', repo: 'kubestellar/console', status: 'queued', conclusion: null, branch: 'feat/card-factory', event: 'pull_request', runNumber: 565, createdAt: new Date(Date.now() - ONE_MINUTE_MS).toISOString(), updatedAt: new Date(Date.now() - THIRTY_SECONDS_MS).toISOString(), url: '#' },
+  { id: '7', name: 'Security Scan', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'timed_out', branch: 'main', event: 'schedule', runNumber: 1231, createdAt: new Date(Date.now() - ONE_HOUR_MS).toISOString(), updatedAt: new Date(Date.now() - THIRTY_MINUTES_MS).toISOString(), url: '#' },
+  { id: '8', name: 'Dependabot', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'success', branch: 'dependabot/npm/react-19', event: 'pull_request', runNumber: 1230, createdAt: new Date(Date.now() - TWO_HOURS_MS).toISOString(), updatedAt: new Date(Date.now() - ONE_HOUR_MS).toISOString(), url: '#' },
 ]
 
 

--- a/web/src/lib/llmd/mockData.ts
+++ b/web/src/lib/llmd/mockData.ts
@@ -5,6 +5,9 @@
  * Used when VPN is unavailable or for demo purposes.
  */
 
+// Named time-offset constant for demo timestamp (CLAUDE.md: No Magic Numbers)
+const THIRTY_MINUTES_MS = 30 * 60 * 1000
+
 // KVCache status per pod
 export interface KVCacheStats {
   podName: string
@@ -407,7 +410,7 @@ export function generateAIInsights(): AIInsight[] {
       description: 'Average prompt length increased 40% in the last hour. This may impact prefill performance.',
       recommendation: 'Monitor TTFT metrics. Consider adjusting prefill replica count if latency increases.',
       metrics: { 'Avg Prompt Length': '+40%', 'TTFT Change': '+15%' },
-      timestamp: new Date(Date.now() - 1800000), // 30 min ago
+      timestamp: new Date(Date.now() - THIRTY_MINUTES_MS),
     },
   ]
 }

--- a/web/src/lib/unified/demo/generators/registerDemoGenerators.ts
+++ b/web/src/lib/unified/demo/generators/registerDemoGenerators.ts
@@ -8,6 +8,12 @@
 import { registerDemoDataBatch } from '../demoDataRegistry'
 import type { DemoDataEntry } from '../types'
 
+// Named time-offset constants for demo data timestamps (CLAUDE.md: No Magic Numbers)
+const ONE_HOUR_MS = 60 * 60 * 1000
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
 // Import existing demo data functions (these are scattered across the codebase)
 // We'll reference them here for registration
 
@@ -101,10 +107,10 @@ function getDemoGPUNodes() {
  */
 function getDemoHelmReleases() {
   return [
-    { name: 'nginx-ingress', namespace: 'ingress', cluster: 'eks-prod-us-east-1', chart: 'nginx-ingress', version: '4.7.1', status: 'deployed', updated: Date.now() - 86400000 },
-    { name: 'prometheus-stack', namespace: 'monitoring', cluster: 'gke-staging', chart: 'kube-prometheus-stack', version: '45.7.1', status: 'deployed', updated: Date.now() - 172800000 },
-    { name: 'redis', namespace: 'cache', cluster: 'aks-dev-westeu', chart: 'redis', version: '17.11.3', status: 'failed', updated: Date.now() - 3600000 },
-    { name: 'cert-manager', namespace: 'cert-manager', cluster: 'openshift-prod', chart: 'cert-manager', version: '1.12.0', status: 'deployed', updated: Date.now() - 604800000 },
+    { name: 'nginx-ingress', namespace: 'ingress', cluster: 'eks-prod-us-east-1', chart: 'nginx-ingress', version: '4.7.1', status: 'deployed', updated: Date.now() - ONE_DAY_MS },
+    { name: 'prometheus-stack', namespace: 'monitoring', cluster: 'gke-staging', chart: 'kube-prometheus-stack', version: '45.7.1', status: 'deployed', updated: Date.now() - TWO_DAYS_MS },
+    { name: 'redis', namespace: 'cache', cluster: 'aks-dev-westeu', chart: 'redis', version: '17.11.3', status: 'failed', updated: Date.now() - ONE_HOUR_MS },
+    { name: 'cert-manager', namespace: 'cert-manager', cluster: 'openshift-prod', chart: 'cert-manager', version: '1.12.0', status: 'deployed', updated: Date.now() - ONE_WEEK_MS },
   ]
 }
 

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -73,6 +73,25 @@ import { useCachedCloudCustodian } from '../../hooks/useCachedCloudCustodian'
 import { useCachedVitess } from '../../hooks/useCachedVitess'
 import { useCachedWasmcloud } from '../../hooks/useCachedWasmcloud'
 
+// Named time-offset constants for demo/mock data timestamps.
+// Raw ms literals are forbidden by the "No Magic Numbers" rule in CLAUDE.md.
+const THIRTY_SECONDS_MS = 30 * 1000
+const ONE_MINUTE_MS = 60 * 1000
+const TWO_MINUTES_MS = 2 * 60 * 1000
+const THREE_MINUTES_MS = 3 * 60 * 1000
+const FOUR_MINUTES_MS = 4 * 60 * 1000
+const FIVE_MINUTES_MS = 5 * 60 * 1000
+const TEN_MINUTES_MS = 10 * 60 * 1000
+const FIFTEEN_MINUTES_MS = 15 * 60 * 1000
+const THIRTY_MINUTES_MS = 30 * 60 * 1000
+const FORTY_FIVE_MINUTES_MS = 45 * 60 * 1000
+const ONE_HOUR_MS = 60 * 60 * 1000
+const TWO_HOURS_MS = 2 * 60 * 60 * 1000
+const THREE_HOURS_MS = 3 * 60 * 60 * 1000
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000
+const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000
+
 // ============================================================================
 // Wrapper hooks that convert params object to positional args
 // These are React hooks that can be safely registered
@@ -434,11 +453,11 @@ function useDemoDataHook<T>(demoData: T[]) {
 
 // Cluster metrics demo data
 const DEMO_CLUSTER_METRICS = [
-  { timestamp: Date.now() - 300000, cpu: 45, memory: 62, pods: 156 },
-  { timestamp: Date.now() - 240000, cpu: 48, memory: 64, pods: 158 },
-  { timestamp: Date.now() - 180000, cpu: 42, memory: 61, pods: 155 },
-  { timestamp: Date.now() - 120000, cpu: 51, memory: 67, pods: 162 },
-  { timestamp: Date.now() - 60000, cpu: 47, memory: 65, pods: 159 },
+  { timestamp: Date.now() - FIVE_MINUTES_MS, cpu: 45, memory: 62, pods: 156 },
+  { timestamp: Date.now() - FOUR_MINUTES_MS, cpu: 48, memory: 64, pods: 158 },
+  { timestamp: Date.now() - THREE_MINUTES_MS, cpu: 42, memory: 61, pods: 155 },
+  { timestamp: Date.now() - TWO_MINUTES_MS, cpu: 51, memory: 67, pods: 162 },
+  { timestamp: Date.now() - ONE_MINUTE_MS, cpu: 47, memory: 65, pods: 159 },
   { timestamp: Date.now(), cpu: 49, memory: 66, pods: 161 },
 ]
 
@@ -451,11 +470,11 @@ const DEMO_RESOURCE_USAGE = [
 
 // Events timeline demo data
 const DEMO_EVENTS_TIMELINE = [
-  { timestamp: Date.now() - 300000, count: 12, type: 'Normal' },
-  { timestamp: Date.now() - 240000, count: 8, type: 'Warning' },
-  { timestamp: Date.now() - 180000, count: 15, type: 'Normal' },
-  { timestamp: Date.now() - 120000, count: 5, type: 'Warning' },
-  { timestamp: Date.now() - 60000, count: 10, type: 'Normal' },
+  { timestamp: Date.now() - FIVE_MINUTES_MS, count: 12, type: 'Normal' },
+  { timestamp: Date.now() - FOUR_MINUTES_MS, count: 8, type: 'Warning' },
+  { timestamp: Date.now() - THREE_MINUTES_MS, count: 15, type: 'Normal' },
+  { timestamp: Date.now() - TWO_MINUTES_MS, count: 5, type: 'Warning' },
+  { timestamp: Date.now() - ONE_MINUTE_MS, count: 10, type: 'Normal' },
   { timestamp: Date.now(), count: 7, type: 'Warning' },
 ]
 
@@ -495,28 +514,28 @@ const DEMO_TOP_PODS = [
 
 // GitOps drift demo data
 const DEMO_GITOPS_DRIFT = [
-  { app: 'frontend', status: 'synced', cluster: 'prod-east', lastSync: Date.now() - 60000 },
-  { app: 'backend', status: 'drifted', cluster: 'staging', lastSync: Date.now() - 300000 },
-  { app: 'monitoring', status: 'synced', cluster: 'dev', lastSync: Date.now() - 120000 },
+  { app: 'frontend', status: 'synced', cluster: 'prod-east', lastSync: Date.now() - ONE_MINUTE_MS },
+  { app: 'backend', status: 'drifted', cluster: 'staging', lastSync: Date.now() - FIVE_MINUTES_MS },
+  { app: 'monitoring', status: 'synced', cluster: 'dev', lastSync: Date.now() - TWO_MINUTES_MS },
 ]
 
 // Pod health trend demo data
 const DEMO_POD_HEALTH_TREND = [
-  { timestamp: Date.now() - 300000, healthy: 145, unhealthy: 3 },
-  { timestamp: Date.now() - 240000, healthy: 148, unhealthy: 2 },
-  { timestamp: Date.now() - 180000, healthy: 142, unhealthy: 5 },
-  { timestamp: Date.now() - 120000, healthy: 150, unhealthy: 1 },
-  { timestamp: Date.now() - 60000, healthy: 147, unhealthy: 4 },
+  { timestamp: Date.now() - FIVE_MINUTES_MS, healthy: 145, unhealthy: 3 },
+  { timestamp: Date.now() - FOUR_MINUTES_MS, healthy: 148, unhealthy: 2 },
+  { timestamp: Date.now() - THREE_MINUTES_MS, healthy: 142, unhealthy: 5 },
+  { timestamp: Date.now() - TWO_MINUTES_MS, healthy: 150, unhealthy: 1 },
+  { timestamp: Date.now() - ONE_MINUTE_MS, healthy: 147, unhealthy: 4 },
   { timestamp: Date.now(), healthy: 149, unhealthy: 2 },
 ]
 
 // Resource trend demo data
 const DEMO_RESOURCE_TREND = [
-  { timestamp: Date.now() - 300000, cpu: 45, memory: 62 },
-  { timestamp: Date.now() - 240000, cpu: 52, memory: 65 },
-  { timestamp: Date.now() - 180000, cpu: 48, memory: 58 },
-  { timestamp: Date.now() - 120000, cpu: 55, memory: 70 },
-  { timestamp: Date.now() - 60000, cpu: 50, memory: 67 },
+  { timestamp: Date.now() - FIVE_MINUTES_MS, cpu: 45, memory: 62 },
+  { timestamp: Date.now() - FOUR_MINUTES_MS, cpu: 52, memory: 65 },
+  { timestamp: Date.now() - THREE_MINUTES_MS, cpu: 48, memory: 58 },
+  { timestamp: Date.now() - TWO_MINUTES_MS, cpu: 55, memory: 70 },
+  { timestamp: Date.now() - ONE_MINUTE_MS, cpu: 50, memory: 67 },
   { timestamp: Date.now(), cpu: 53, memory: 64 },
 ]
 
@@ -547,9 +566,9 @@ const DEMO_GPU_INVENTORY = [
 
 // Prow jobs demo data
 const DEMO_PROW_JOBS = [
-  { name: 'pull-kubestellar-verify', type: 'presubmit', state: 'success', startTime: Date.now() - 120000 },
-  { name: 'periodic-e2e-tests', type: 'periodic', state: 'pending', startTime: Date.now() - 60000 },
-  { name: 'post-kubestellar-deploy', type: 'postsubmit', state: 'failure', startTime: Date.now() - 300000 },
+  { name: 'pull-kubestellar-verify', type: 'presubmit', state: 'success', startTime: Date.now() - TWO_MINUTES_MS },
+  { name: 'periodic-e2e-tests', type: 'periodic', state: 'pending', startTime: Date.now() - ONE_MINUTE_MS },
+  { name: 'post-kubestellar-deploy', type: 'postsubmit', state: 'failure', startTime: Date.now() - FIVE_MINUTES_MS },
 ]
 
 // ML jobs demo data
@@ -610,8 +629,8 @@ const DEMO_COMPLIANCE_SCORE = {
 
 // Namespace events demo data
 const DEMO_NAMESPACE_EVENTS = [
-  { type: 'Normal', reason: 'Scheduled', message: 'Pod scheduled', object: 'pod/api-7d8f', namespace: 'production', count: 1, lastSeen: Date.now() - 30000 },
-  { type: 'Warning', reason: 'BackOff', message: 'Container restarting', object: 'pod/worker-5c6d', namespace: 'production', count: 5, lastSeen: Date.now() - 60000 },
+  { type: 'Normal', reason: 'Scheduled', message: 'Pod scheduled', object: 'pod/api-7d8f', namespace: 'production', count: 1, lastSeen: Date.now() - THIRTY_SECONDS_MS },
+  { type: 'Warning', reason: 'BackOff', message: 'Container restarting', object: 'pod/worker-5c6d', namespace: 'production', count: 5, lastSeen: Date.now() - ONE_MINUTE_MS },
 ]
 
 // GPU workloads demo data
@@ -651,9 +670,9 @@ const DEMO_GATEWAY_STATUS = [
 
 // Kustomization status demo data
 const DEMO_KUSTOMIZATION_STATUS = [
-  { name: 'apps', namespace: 'flux-system', ready: true, lastApplied: Date.now() - 120000 },
-  { name: 'infra', namespace: 'flux-system', ready: true, lastApplied: Date.now() - 300000 },
-  { name: 'monitoring', namespace: 'flux-system', ready: false, lastApplied: Date.now() - 600000 },
+  { name: 'apps', namespace: 'flux-system', ready: true, lastApplied: Date.now() - TWO_MINUTES_MS },
+  { name: 'infra', namespace: 'flux-system', ready: true, lastApplied: Date.now() - FIVE_MINUTES_MS },
+  { name: 'monitoring', namespace: 'flux-system', ready: false, lastApplied: Date.now() - TEN_MINUTES_MS },
 ]
 
 // Provider health demo data
@@ -679,15 +698,15 @@ const DEMO_PROW_STATUS = {
 
 // Prow history demo data
 const DEMO_PROW_HISTORY = [
-  { job: 'e2e-tests', result: 'success', duration: 1200, finishedAt: Date.now() - 3600000 },
-  { job: 'unit-tests', result: 'success', duration: 300, finishedAt: Date.now() - 7200000 },
-  { job: 'lint', result: 'failure', duration: 60, finishedAt: Date.now() - 10800000 },
+  { job: 'e2e-tests', result: 'success', duration: 1200, finishedAt: Date.now() - ONE_HOUR_MS },
+  { job: 'unit-tests', result: 'success', duration: 300, finishedAt: Date.now() - TWO_HOURS_MS },
+  { job: 'lint', result: 'failure', duration: 60, finishedAt: Date.now() - THREE_HOURS_MS },
 ]
 
 // Helm history demo data
 const DEMO_HELM_HISTORY = [
-  { revision: 5, chart: 'nginx-ingress-4.6.0', appVersion: '1.9.0', status: 'deployed', updated: Date.now() - 86400000 },
-  { revision: 4, chart: 'nginx-ingress-4.5.2', appVersion: '1.8.0', status: 'superseded', updated: Date.now() - 172800000 },
+  { revision: 5, chart: 'nginx-ingress-4.6.0', appVersion: '1.9.0', status: 'deployed', updated: Date.now() - ONE_DAY_MS },
+  { revision: 4, chart: 'nginx-ingress-4.5.2', appVersion: '1.8.0', status: 'superseded', updated: Date.now() - TWO_DAYS_MS },
 ]
 
 // External secrets demo data (stats-grid)
@@ -705,14 +724,14 @@ const DEMO_CERT_MANAGER = {
 
 // Vault secrets demo data
 const DEMO_VAULT_SECRETS = [
-  { path: 'secret/data/api-keys', status: 'synced', lastSync: Date.now() - 60000 },
-  { path: 'secret/data/db-creds', status: 'synced', lastSync: Date.now() - 120000 },
+  { path: 'secret/data/api-keys', status: 'synced', lastSync: Date.now() - ONE_MINUTE_MS },
+  { path: 'secret/data/db-creds', status: 'synced', lastSync: Date.now() - TWO_MINUTES_MS },
 ]
 
 // Falco alerts demo data
 const DEMO_FALCO_ALERTS = [
-  { rule: 'Terminal shell in container', severity: 'Warning', count: 3, lastSeen: Date.now() - 300000 },
-  { rule: 'Sensitive file read', severity: 'Notice', count: 12, lastSeen: Date.now() - 600000 },
+  { rule: 'Terminal shell in container', severity: 'Warning', count: 3, lastSeen: Date.now() - FIVE_MINUTES_MS },
+  { rule: 'Sensitive file read', severity: 'Notice', count: 12, lastSeen: Date.now() - TEN_MINUTES_MS },
 ]
 
 // Kubescape scan demo data (stats-grid)
@@ -750,20 +769,20 @@ const DEMO_GPU_STATUS = {
 
 // GPU utilization demo data (chart)
 const DEMO_GPU_UTILIZATION = [
-  { timestamp: Date.now() - 300000, utilization: 72, memory: 68 },
-  { timestamp: Date.now() - 240000, utilization: 78, memory: 72 },
-  { timestamp: Date.now() - 180000, utilization: 65, memory: 60 },
-  { timestamp: Date.now() - 120000, utilization: 82, memory: 78 },
-  { timestamp: Date.now() - 60000, utilization: 75, memory: 70 },
+  { timestamp: Date.now() - FIVE_MINUTES_MS, utilization: 72, memory: 68 },
+  { timestamp: Date.now() - FOUR_MINUTES_MS, utilization: 78, memory: 72 },
+  { timestamp: Date.now() - THREE_MINUTES_MS, utilization: 65, memory: 60 },
+  { timestamp: Date.now() - TWO_MINUTES_MS, utilization: 82, memory: 78 },
+  { timestamp: Date.now() - ONE_MINUTE_MS, utilization: 75, memory: 70 },
   { timestamp: Date.now(), utilization: 80, memory: 74 },
 ]
 
 // GPU usage trend demo data (chart)
 const DEMO_GPU_USAGE_TREND = [
-  { timestamp: Date.now() - 3600000, avgUtilization: 68 },
-  { timestamp: Date.now() - 2700000, avgUtilization: 72 },
-  { timestamp: Date.now() - 1800000, avgUtilization: 78 },
-  { timestamp: Date.now() - 900000, avgUtilization: 74 },
+  { timestamp: Date.now() - ONE_HOUR_MS, avgUtilization: 68 },
+  { timestamp: Date.now() - FORTY_FIVE_MINUTES_MS, avgUtilization: 72 },
+  { timestamp: Date.now() - THIRTY_MINUTES_MS, avgUtilization: 78 },
+  { timestamp: Date.now() - FIFTEEN_MINUTES_MS, avgUtilization: 74 },
   { timestamp: Date.now(), avgUtilization: 76 },
 ]
 
@@ -805,16 +824,16 @@ const DEMO_RESOURCE_CAPACITY = {
 
 // GitHub activity demo data
 const DEMO_GITHUB_ACTIVITY = [
-  { type: 'PushEvent', repo: 'kubestellar/console', actor: 'developer1', timestamp: Date.now() - 3600000 },
-  { type: 'PullRequestEvent', repo: 'kubestellar/console', actor: 'developer2', timestamp: Date.now() - 7200000 },
-  { type: 'IssuesEvent', repo: 'kubestellar/kubestellar', actor: 'contributor', timestamp: Date.now() - 10800000 },
+  { type: 'PushEvent', repo: 'kubestellar/console', actor: 'developer1', timestamp: Date.now() - ONE_HOUR_MS },
+  { type: 'PullRequestEvent', repo: 'kubestellar/console', actor: 'developer2', timestamp: Date.now() - TWO_HOURS_MS },
+  { type: 'IssuesEvent', repo: 'kubestellar/kubestellar', actor: 'contributor', timestamp: Date.now() - THREE_HOURS_MS },
 ]
 
 // RSS feed demo data
 const DEMO_RSS_FEED = [
-  { title: 'Kubernetes 1.30 Released', source: 'k8s.io', pubDate: Date.now() - 86400000 },
-  { title: 'New CNCF Project Announcement', source: 'cncf.io', pubDate: Date.now() - 172800000 },
-  { title: 'Cloud Native Best Practices', source: 'blog.k8s.io', pubDate: Date.now() - 259200000 },
+  { title: 'Kubernetes 1.30 Released', source: 'k8s.io', pubDate: Date.now() - ONE_DAY_MS },
+  { title: 'New CNCF Project Announcement', source: 'cncf.io', pubDate: Date.now() - TWO_DAYS_MS },
+  { title: 'Cloud Native Best Practices', source: 'blog.k8s.io', pubDate: Date.now() - THREE_DAYS_MS },
 ]
 
 // Kubecost overview demo data (chart/donut)
@@ -875,7 +894,7 @@ function useRecentEvents(params?: Record<string, unknown>) {
   // Filter to events within the last hour
   const recentEvents = (() => {
     if (!result.data) return []
-    const oneHourAgo = Date.now() - 60 * 60 * 1000
+    const oneHourAgo = Date.now() - ONE_HOUR_MS
     return result.data.filter(e => {
       if (!e.lastSeen) return false
       return new Date(e.lastSeen).getTime() >= oneHourAgo


### PR DESCRIPTION
Fixes #9719 (blame: demo data introduced raw ms literals)

## What

Replaces **81 raw millisecond numeric literals** spread across 5 files with named constants. Raw numbers like `60000`, `300000`, and `3600000` in demo/mock data violate the CLAUDE.md *No Magic Numbers* rule.

## Files changed

| File | Instances fixed | Constants added |
|------|----------------|-----------------|
| `lib/unified/registerHooks.ts` | 56 | 18 |
| `lib/unified/demo/generators/registerDemoGenerators.ts` | 4 | 4 |
| `components/cards/workload-monitor/GitHubCIMonitor.tsx` | 18 | 10 |
| `lib/llmd/mockData.ts` | 1 | 1 |
| `components/cards/Missions.tsx` | 4 | 4 |

## Example

```ts
// Before (magic number — what is 300000?)
{ timestamp: Date.now() - 300000, cpu: 45 }

// After (self-documenting)
const FIVE_MINUTES_MS = 5 * 60 * 1000
{ timestamp: Date.now() - FIVE_MINUTES_MS, cpu: 45 }
```

## Risk

Zero behavioral change — pure rename refactor. All replaced values are in demo/mock data fixtures only.