### PR TITLE
🌱 security: pin uuid to ^14.0.0 via npm override (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10369,9 +10369,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/web/package.json
+++ b/web/package.json
@@ -141,6 +141,7 @@
       "three-mesh-bvh": "^0.8.0"
     },
     "minimatch": "^10.2.1",
-    "follow-redirects": "^1.15.12"
+    "follow-redirects": "^1.15.12",
+    "uuid": "^14.0.0"
   }
 }


### PR DESCRIPTION
## Security fix

**CVE:** GHSA-w5hq-g745-h8pq  
**Severity:** Medium  
**Scorecard rule:** VulnerabilitiesID umbrella

### Root cause

`uuid@13.0.0` is pulled in transitively by `@netlify/dev-utils` which has a direct dependency pinned to `^13.0.0`. uuid 14.0.0 patches this vulnerability.

### Fix

Add `overrides.uuid = "^14.0.0"` in `web/package.json` so npm resolves all uuid instances to v14.

```json
"overrides": {
  "uuid": "^14.0.0"
}
```

### Verification

```
npm install → found 0 vulnerabilities
node_modules/uuid → 14.0.0  ✓
npm run build → All post-build safety checks passed  ✓
```