### PR TITLE
🌱 security: pin actions/github-script to SHA in ai-attribution.yml

### DIFF
--- a/.github/workflows/ai-attribution.yml
+++ b/.github/workflows/ai-attribution.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for AI authorship signals
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const PR_AUTHOR_TYPE_BOT = 'Bot';


### PR DESCRIPTION
## Security fix

**CodeQL alert:** #647  
**Scorecard rule:** PinnedDependenciesID  
**Severity:** Medium

### Root cause

`.github/workflows/ai-attribution.yml` used `actions/github-script@v7` (mutable tag). A tag force-push could silently swap in malicious code.

### Fix

Pin to full commit SHA:
```yaml
uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
```

This is the SHA for the `v7` tag at the time of this fix (verified via `gh api repos/actions/github-script/git/ref/tags/v7`).

### Verification

```
grep 'uses:.*@v' .github/workflows/ai-attribution.yml
# no output — all actions pinned
```