### PR TITLE
🌱 ci: stop cancelling in-progress Playwright runs on main/dev

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,8 +12,8 @@ on:
 permissions: read-all
 
 concurrency:
-  group: playwright-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CI: true


### PR DESCRIPTION
## Problem

The Playwright workflow used `cancel-in-progress: true` with a group keyed on `github.ref`. During rapid merge batches to `main` (e.g. 10 PRs merged in ~1.5h on 2026-04-24), every new push cancelled the previous Playwright run — the full suite **never completed** on `main` in 5+ consecutive triggers.

## Root cause

`cancel-in-progress: true` is the right setting for **PR builds** (avoid wasting runners on stale iterations), but wrong for **branch validation** where every push to `main`/`dev` must produce a completed result.

## Fix

```yaml
# Before
concurrency:
  group: playwright-${{ github.ref }}
  cancel-in-progress: true

# After
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Since this workflow only triggers on `push` to `main`/`dev` and `workflow_dispatch` (no `pull_request` trigger), `cancel-in-progress` evaluates to `false` for all current triggers. The group key is also standardised to `workflow-ref` to prevent cross-workflow collisions.

## Effect

- Main/dev pushes: runs **queue** instead of cancel; each merge gets validated
- If a `pull_request` trigger is ever added: will correctly cancel stale PR runs