### PR TITLE
🌱 ci: add total-coverage floor warning to coverage gate

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -123,6 +123,18 @@ jobs:
 
           TOTAL=$(jq -r '.total.lines.pct // "?"' "$SUMMARY_FILE")
           echo "total_coverage=${TOTAL}" >> "$GITHUB_OUTPUT"
+
+          # Warn when total project coverage is below the threshold floor.
+          # This is a visibility-only check — not blocking — but surfaces the gap
+          # between the per-file modified-files gate and overall project health.
+          TOTAL_INT=$(echo "$TOTAL" | grep -oE '^[0-9]+' || echo "")
+          if [ -n "$TOTAL_INT" ] && [ "$TOTAL_INT" -lt "$THRESHOLD" ]; then
+            {
+              echo ""
+              echo "> :bar_chart: **Total project coverage: ${TOTAL}%** — below the ${THRESHOLD}% threshold floor. New code meets the per-file gate, but overall coverage has room to grow."
+            } >> /tmp/coverage-report.md
+          fi
+
           echo "status=$( [ \"$ALL_PASS\" = \"true\" ] && echo pass || echo warn )" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR


### PR DESCRIPTION
## Problem

The Coverage Gate workflow checks coverage on **modified files only** (per-file ratchet). The total project coverage badge currently shows **88%** while the configured threshold is **91%** (raised by PR #9963). A PR can pass the gate while total coverage remains well below the stated target — and no signal appears in the PR comment.

## Fix

After the existing per-file check, extract the total coverage from `coverage-summary.json` and append a **non-blocking** warning to the PR comment when total is below the threshold:

> 📊 **Total project coverage: 88.x%** — below the 91% threshold floor. New code meets the per-file gate, but overall coverage has room to grow.

## Design choices

- **Non-blocking** — consistent with the existing per-file warning-only policy
- **Visibility-only** — appended to the existing comment; no new step or job
- **Graceful** — handles missing total (`"?"`) with a `grep -oE '^[0-9]+'` integer extract, skips warning when data is absent
- No status output change — `status=pass|warn` is unchanged