### PR TITLE
🐛 fix: suppress GA4 auth error for unauthenticated requests

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -7,7 +7,7 @@ import {
   DEMO_TOKEN_VALUE,
   FETCH_DEFAULT_TIMEOUT_MS,
 } from './constants'
-import { emitError, emitSessionExpired } from './analytics'
+import { emitSessionExpired } from './analytics'
 
 const API_BASE = ''
 const DEFAULT_TIMEOUT = MCP_HOOK_TIMEOUT_MS
@@ -454,7 +454,9 @@ class ApiClient {
     // Skip API calls to protected endpoints when not authenticated
     const isPublicPath = PUBLIC_API_PREFIXES.some(prefix => path.startsWith(prefix))
     if (options?.requiresAuth !== false && !isPublicPath && !this.hasToken()) {
-      emitError('auth', 'No authentication token available')
+      // Do NOT emit a GA4 error here — this is expected behavior when an
+      // unauthenticated user visits a protected page. Emitting it caused
+      // false-positive monitoring alerts (#9968, #9979, #9980, #9984).
       throw new UnauthenticatedError()
     }
 


### PR DESCRIPTION
Fixes #9968
Fixes #9979
Fixes #9980
Fixes #9984

The 'No authentication token available' error was being emitted as a GA4 auth error, causing automated monitoring alerts when unauthenticated users visit protected pages (/acmm, /arcade, /multi-tenancy, /ci-cd). This is expected behavior, not a bug.

**Changes:**
- Remove `emitError('auth', ...)` call in the pre-flight unauthenticated check in `api.ts`
- Remove now-unused `emitError` import from the same file
- The actual 401 handling (line ~490+) still tracks real token expiry/invalid cases

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>