### PR TITLE
🌱 ci: increase Playwright job timeout from 20m to 30m

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -58,7 +58,7 @@ jobs:
     name: Test (chromium, shard ${{ matrix.shard }})
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -243,7 +243,7 @@ jobs:
     name: Mobile Browser Tests
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: web
@@ -340,7 +340,7 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: web


### PR DESCRIPTION
Fixes #9110

Chromium shards and mobile-tests were hitting the 20m job timeout (run 24918977175 confirms all jobs killed at exactly 20m0s). Increase timeout-minutes 20→30 for test, mobile-tests, visual-regression jobs.

🤖 Generated with [GitHub Copilot](https://copilot.github.com)