### PR TITLE
🌱 ci: increase Playwright shard and mobile timeout 20→30m

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -58,7 +58,7 @@ jobs:
     name: Test (chromium, shard ${{ matrix.shard }})
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -243,7 +243,7 @@ jobs:
     name: Mobile Browser Tests
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: web


### PR DESCRIPTION
## Problem

Playwright shard jobs (`test` ×4) and `mobile-tests` consistently exceed the 20-minute `timeout-minutes` wall, causing runs to be cancelled with:

```
The job has exceeded the maximum execution time of 20m0s
```

Evidence from run [24918977175](https://github.com/kubestellar/console/actions/runs/24918977175):
- All 4 chromium shards: **cancelled at 20m** 
- Mobile Browser Tests: **cancelled at 20m**
- Accessibility Tests (15m limit): ✅ completed in 7m13s

Each shard setup includes: install deps → download build artifact → install Playwright browsers → start preview server → run ~50 tests at 4 workers. This does not fit comfortably in 20 minutes.

## Fix

Bump `timeout-minutes` from **20 → 30** for the two affected jobs:
- `test` (chromium shards ×4)  
- `mobile-tests`

Accessibility tests (complete in ~7m) and visual-regression (PR-only) are unchanged.

## Note on concurrency cancellations

A secondary pattern is rapid sequential merges displacing queued runs from the concurrency group. That is a structural acceptance: with `cancel-in-progress: false` (push), queued runs are displaced but running ones complete. The timeout fix ensures those running ones actually finish.