### PR TITLE
🐛 fix: suppress GA4 auth errors for unauthenticated visitors

### DIFF
--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -988,6 +988,11 @@ export function startGlobalErrorTracking() {
       if (isNetlifyDeployment && msg.includes('Backend API is currently unavailable')) return
       // Skip WebGL context errors — benign GPU process resets
       if (msg.includes('WebGL') || msg.includes('context lost')) return
+      // Skip auth-flow errors — UnauthenticatedError is thrown by api.get() when
+      // no token is available (expected for unauthenticated visitors). Emitting
+      // these as ksc_error creates false-positive alert spikes (#9994).
+      if (errorName === 'UnauthenticatedError' || errorName === 'UnauthorizedError') return
+      if (msg.includes('No authentication token') || msg.includes('Token is invalid or expired')) return
       emitError('unhandled_rejection', msg, undefined, { error: event.reason })
     } finally {
       isEmitting = false
@@ -1041,6 +1046,9 @@ export function startGlobalErrorTracking() {
       if (event.message.includes('Non-Error')) return
       // Stale chunks can surface as runtime errors (Safari: "Importing a module script failed")
       if (tryChunkReloadRecovery(event.message)) return
+      // Skip auth-flow errors that surface as synchronous error events (#9994).
+      if (event.error?.name === 'UnauthenticatedError' || event.error?.name === 'UnauthorizedError') return
+      if (event.message.includes('No authentication token') || event.message.includes('Token is invalid or expired')) return
       emitError('runtime', event.message, undefined, { error: event.error })
     } finally {
       isEmitting = false


### PR DESCRIPTION
Fixes #9994

The 'No authentication token available' error was being emitted as a GA4
error via the global `unhandledrejection` and `window.error` handlers,
causing automated monitoring alerts when unauthenticated users visit any
page. This is expected behavior, not a bug.

**Changes (analytics-core.ts):**
- Add `UnauthenticatedError`/`UnauthorizedError` name guards to the
  `unhandledrejection` handler
- Add message-based guard matching both 'No authentication token available'
  (from `UnauthenticatedError`) and 'No authentication token' (from fetcher
  utils) so neither path emits false-positive GA4 alerts
- Add the same defense-in-depth guards to the `window.error` handler

Extends the fix from PR #9988 which removed the explicit `emitError('auth')`
call in `api.ts`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>