### PR TITLE
🐛 fix: StatefulSet health check verifies updatedReplicas and revision

### DIFF
--- a/pkg/k8s/resource_health.go
+++ b/pkg/k8s/resource_health.go
@@ -151,11 +151,35 @@ func checkDeploymentHealth(obj *unstructured.Unstructured) (ResourceHealthStatus
 func checkStatefulSetHealth(obj *unstructured.Unstructured) (ResourceHealthStatus, string) {
 	replicas, _, _ := unstructured.NestedInt64(obj.Object, "spec", "replicas")
 	readyReplicas, _, _ := unstructured.NestedInt64(obj.Object, "status", "readyReplicas")
+	// updatedReplicas is the count of pods running the latest updateRevision.
+	// During a rolling update old pods can still be ready while the new version
+	// hasn't fully rolled out — without this check we report Healthy for a
+	// mid-rollout StatefulSet (#10006).
+	updatedReplicas, _, _ := unstructured.NestedInt64(obj.Object, "status", "updatedReplicas")
+	// currentRevision and updateRevision diverge while the controller is
+	// rolling pods to a new spec. Once all pods are updated the controller
+	// sets currentRevision = updateRevision.
+	currentRevision, _, _ := unstructured.NestedString(obj.Object, "status", "currentRevision")
+	updateRevision, _, _ := unstructured.NestedString(obj.Object, "status", "updateRevision")
 
 	if replicas == 0 {
 		return HealthStatusHealthy, "Scaled to 0"
 	}
-	if readyReplicas == replicas {
+	// Revision mismatch means the controller is still rolling pods to the
+	// new version, even if all current pods happen to be ready.
+	if updateRevision != "" && currentRevision != updateRevision {
+		return HealthStatusDegraded, fmt.Sprintf("Rolling update: revision %s → %s", currentRevision, updateRevision)
+	}
+	if updatedReplicas > 0 && updatedReplicas < replicas {
+		return HealthStatusDegraded, fmt.Sprintf("%d/%d updated", updatedReplicas, replicas)
+	}
+	if readyReplicas == replicas && updatedReplicas == replicas {
+		return HealthStatusHealthy, fmt.Sprintf("%d/%d ready", readyReplicas, replicas)
+	}
+	// All ready but updatedReplicas not yet reported (zero value) — treat as
+	// healthy to avoid false positives on older API servers that don't
+	// populate updatedReplicas for StatefulSets.
+	if readyReplicas == replicas && updatedReplicas == 0 && updateRevision == "" {
 		return HealthStatusHealthy, fmt.Sprintf("%d/%d ready", readyReplicas, replicas)
 	}
 	if readyReplicas > 0 {

--- a/pkg/k8s/resource_health_test.go
+++ b/pkg/k8s/resource_health_test.go
@@ -211,7 +211,23 @@ func TestCheckResourceHealth_Variants(t *testing.T) {
 			want: "degraded",
 		},
 
-		// StatefulSet
+		// StatefulSet — fully rolled out (updatedReplicas == replicas,
+		// revisions match)
+		{
+			kind: "StatefulSet",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{"replicas": int64(3)},
+				"status": map[string]interface{}{
+					"readyReplicas":   int64(3),
+					"updatedReplicas": int64(3),
+					"currentRevision": "rev-2",
+					"updateRevision":  "rev-2",
+				},
+			},
+			want: "healthy",
+		},
+		// StatefulSet — healthy when updatedReplicas/revisions are absent
+		// (older API servers that don't populate these fields)
 		{
 			kind: "StatefulSet",
 			obj: map[string]interface{}{
@@ -222,12 +238,44 @@ func TestCheckResourceHealth_Variants(t *testing.T) {
 			},
 			want: "healthy",
 		},
+		// StatefulSet — rolling update: updatedReplicas < replicas (#10006)
 		{
 			kind: "StatefulSet",
 			obj: map[string]interface{}{
 				"spec": map[string]interface{}{"replicas": int64(3)},
 				"status": map[string]interface{}{
-					"readyReplicas": int64(2),
+					"readyReplicas":   int64(3),
+					"updatedReplicas": int64(1),
+					"currentRevision": "rev-1",
+					"updateRevision":  "rev-2",
+				},
+			},
+			want: "degraded",
+		},
+		// StatefulSet — revision mismatch even with all ready+updated
+		{
+			kind: "StatefulSet",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{"replicas": int64(3)},
+				"status": map[string]interface{}{
+					"readyReplicas":   int64(3),
+					"updatedReplicas": int64(3),
+					"currentRevision": "rev-1",
+					"updateRevision":  "rev-2",
+				},
+			},
+			want: "degraded",
+		},
+		// StatefulSet — partial readiness
+		{
+			kind: "StatefulSet",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{"replicas": int64(3)},
+				"status": map[string]interface{}{
+					"readyReplicas":   int64(2),
+					"updatedReplicas": int64(2),
+					"currentRevision": "rev-2",
+					"updateRevision":  "rev-2",
 				},
 			},
 			want: "degraded",


### PR DESCRIPTION
## Summary
- StatefulSet health check in `pkg/k8s/resource_health.go` now verifies `updatedReplicas == replicas` and `currentRevision == updateRevision` during rolling updates
- Previously only checked `readyReplicas`, causing false "Healthy" status mid-rollout when old pods were still ready
- Backwards-compatible: older API servers that don't populate `updatedReplicas`/revision fields still report healthy correctly

## Test plan
- [x] Added 3 new test cases for rolling update scenarios (updatedReplicas < replicas, revision mismatch, partial readiness)
- [x] Updated existing healthy test to include `updatedReplicas` and revision fields
- [x] All 19 `TestCheckResourceHealth_Variants` sub-tests pass
- [ ] CI build/lint

Fixes #10006