### PR TITLE
🐛 fix: add periodic cache refresh for cluster groups

### DIFF
--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -39,11 +39,21 @@ const (
 	workloadDeployLogsTimeout = 15 * time.Second
 )
 
+const (
+	// clusterGroupRefreshInterval is how often the in-memory cluster group
+	// cache is re-synced from the persistent store. This ensures that in
+	// multi-instance deployments each backend picks up writes made by
+	// other instances within a bounded window (#10007).
+	clusterGroupRefreshInterval = 30 * time.Second
+)
+
 // WorkloadHandlers handles workload API endpoints
 type WorkloadHandlers struct {
 	k8sClient *k8s.MultiClusterClient
 	hub       *Hub
 	store     store.Store
+	stopOnce  sync.Once
+	stopCh    chan struct{}
 }
 
 // NewWorkloadHandlers creates a new workload handlers instance
@@ -52,6 +62,7 @@ func NewWorkloadHandlers(k8sClient *k8s.MultiClusterClient, hub *Hub, s store.St
 		k8sClient: k8sClient,
 		hub:       hub,
 		store:     s,
+		stopCh:    make(chan struct{}),
 	}
 }
 
@@ -320,6 +331,38 @@ func (h *WorkloadHandlers) LoadPersistedClusterGroups() {
 		clusterGroups[name] = g
 	}
 	slog.Info("[Workloads] loaded persisted cluster groups", "count", len(persisted))
+}
+
+// StartCacheRefresh launches a background goroutine that periodically reloads
+// cluster groups from the persistent store. In multi-instance deployments this
+// ensures each backend converges on the same state within
+// clusterGroupRefreshInterval (#10007).
+func (h *WorkloadHandlers) StartCacheRefresh() {
+	if h.store == nil {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(clusterGroupRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-h.stopCh:
+				return
+			case <-ticker.C:
+				h.LoadPersistedClusterGroups()
+			}
+		}
+	}()
+	slog.Info("[Workloads] started periodic cluster group cache refresh",
+		"interval", clusterGroupRefreshInterval)
+}
+
+// StopCacheRefresh signals the background refresh goroutine to exit.
+func (h *WorkloadHandlers) StopCacheRefresh() {
+	h.stopOnce.Do(func() {
+		close(h.stopCh)
+		slog.Info("[Workloads] stopped periodic cluster group cache refresh")
+	})
 }
 
 // persistClusterGroup saves a cluster group to the store for durability (#7013).

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -177,6 +177,7 @@ type Server struct {
 	loadingSrv          *http.Server // temporary loading screen server
 	shuttingDown        int32        // atomic flag: 1 during graceful shutdown
 	gpuUtilWorker       *GPUUtilizationWorker
+	workloadHandlers    *handlers.WorkloadHandlers // for cache refresh shutdown (#10007)
 	done                chan struct{} // closed on Shutdown to stop background goroutines
 	shutdownOnce        sync.Once     // ensures Shutdown is idempotent (#6478)
 }
@@ -1235,8 +1236,11 @@ func (s *Server) setupRoutes() {
 
 	// Workload routes
 	workloadHandlers := handlers.NewWorkloadHandlers(s.k8sClient, s.hub, s.store)
-	// Reload persisted cluster groups on startup (#7013).
+	// Reload persisted cluster groups on startup (#7013) and start periodic
+	// refresh so multi-instance deployments converge on DB state (#10007).
 	workloadHandlers.LoadPersistedClusterGroups()
+	workloadHandlers.StartCacheRefresh()
+	s.workloadHandlers = workloadHandlers
 	api.Get("/workloads", workloadHandlers.ListWorkloads)
 	api.Get("/workloads/capabilities", workloadHandlers.GetClusterCapabilities)
 	api.Get("/workloads/policies", workloadHandlers.ListBindingPolicies)
@@ -1627,6 +1631,10 @@ func (s *Server) Shutdown() error {
 			s.gpuUtilWorker.Stop()
 		}
 		s.hub.Close()
+		// #10007 — stop the periodic cluster group cache refresh goroutine.
+		if s.workloadHandlers != nil {
+			s.workloadHandlers.StopCacheRefresh()
+		}
 		// #7043 — stop the SSE cache evictor goroutine that was started
 		// lazily by sseCacheSet. Without this the goroutine leaks after
 		// server shutdown.


### PR DESCRIPTION
## Summary
- Adds a background goroutine that re-syncs the in-memory cluster group cache from the persistent store every 30 seconds
- In multi-instance deployments, writes on one instance now propagate to others within 30s, eliminating split-brain UI behavior
- Includes proper shutdown cleanup (`StopCacheRefresh`) to prevent goroutine leaks

## Changes
- `pkg/api/handlers/workloads.go`: Added `StartCacheRefresh` / `StopCacheRefresh` methods with a `clusterGroupRefreshInterval` constant (30s), `stopCh` channel, and `sync.Once` for idempotent shutdown
- `pkg/api/server.go`: Store `workloadHandlers` on `Server` struct, call `StartCacheRefresh()` after startup load, call `StopCacheRefresh()` in `Shutdown()`

## Test plan
- [ ] Verify backend starts without errors and logs "started periodic cluster group cache refresh"
- [ ] Create a cluster group, confirm it persists and reloads on other instances
- [ ] Verify graceful shutdown logs "stopped periodic cluster group cache refresh"
- [ ] Confirm no goroutine leaks in test runs

Fixes #10007