### PR TITLE
🔒 fix: add CSRF defense to kc-agent mutation endpoints

### DIFF
--- a/pkg/agent/csrf.go
+++ b/pkg/agent/csrf.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+const (
+	// csrfHeaderName is the custom header required on state-changing requests.
+	// Browsers will not send this header on cross-origin form POSTs, so
+	// requiring it blocks a malicious site from triggering mutations via a
+	// forged form submission even if the victim's cookie is SameSite=Lax.
+	csrfHeaderName = "X-Requested-With"
+
+	// csrfHeaderValue is the expected value for csrfHeaderName.
+	csrfHeaderValue = "XMLHttpRequest"
+
+	// csrfForbiddenMsg is the error message returned when the CSRF header
+	// is missing or has an incorrect value on a state-changing request.
+	csrfForbiddenMsg = "CSRF header required"
+)
+
+// csrfSafeMethods are HTTP methods that do not change server state and are
+// therefore exempt from the CSRF check. RFC 7231 section 4.2.1.
+var csrfSafeMethods = map[string]bool{
+	http.MethodGet:     true,
+	http.MethodHead:    true,
+	http.MethodOptions: true,
+}
+
+// requireCSRF wraps an http.Handler and rejects state-changing requests
+// (POST, PUT, DELETE, PATCH) that lack the X-Requested-With: XMLHttpRequest
+// header. GET, HEAD, and OPTIONS requests pass through unconditionally
+// because they must not cause side effects per HTTP semantics.
+//
+// This is a defence-in-depth measure against cross-site request forgery:
+// browsers never attach custom headers to requests initiated by <form> or
+// navigation, so a cross-origin attacker cannot forge a request with this
+// header. Mirrors the Fiber middleware in pkg/api/middleware/csrf.go.
+// See #10000 for background.
+func requireCSRF(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if csrfSafeMethods[r.Method] {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if r.Header.Get(csrfHeaderName) != csrfHeaderValue {
+			slog.Warn("[CSRF] request rejected: missing or invalid CSRF header",
+				"ip", r.RemoteAddr, "method", r.Method, "path", r.URL.Path)
+			http.Error(w, csrfForbiddenMsg, http.StatusForbidden)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/agent/csrf_test.go
+++ b/pkg/agent/csrf_test.go
@@ -1,0 +1,111 @@
+package agent
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// testCSRFOKBody is the response body returned by the downstream handler in
+// CSRF middleware tests.
+const testCSRFOKBody = "ok"
+
+// newCSRFTestHandler wraps a simple 200 "ok" handler with the CSRF middleware.
+func newCSRFTestHandler() http.Handler {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(testCSRFOKBody)) //nolint:errcheck // test helper
+	})
+	return requireCSRF(inner)
+}
+
+func TestCSRF_SafeMethodsPassThrough(t *testing.T) {
+	t.Parallel()
+	handler := newCSRFTestHandler()
+
+	safeMethods := []string{
+		http.MethodGet,
+		http.MethodHead,
+		http.MethodOptions,
+	}
+
+	for _, method := range safeMethods {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/any-path", nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Errorf("expected 200, got %d", rr.Code)
+			}
+		})
+	}
+}
+
+func TestCSRF_UnsafeMethodsRejectedWithoutHeader(t *testing.T) {
+	t.Parallel()
+	handler := newCSRFTestHandler()
+
+	unsafeMethods := []string{
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodPatch,
+	}
+
+	for _, method := range unsafeMethods {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/any-path", nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusForbidden {
+				t.Errorf("expected 403, got %d", rr.Code)
+			}
+		})
+	}
+}
+
+func TestCSRF_UnsafeMethodsRejectedWithWrongValue(t *testing.T) {
+	t.Parallel()
+	handler := newCSRFTestHandler()
+
+	req := httptest.NewRequest(http.MethodPost, "/any-path", nil)
+	req.Header.Set(csrfHeaderName, "BadValue")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", rr.Code)
+	}
+}
+
+func TestCSRF_UnsafeMethodsPassWithCorrectHeader(t *testing.T) {
+	t.Parallel()
+	handler := newCSRFTestHandler()
+
+	unsafeMethods := []string{
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodPatch,
+	}
+
+	for _, method := range unsafeMethods {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/any-path", nil)
+			req.Header.Set(csrfHeaderName, csrfHeaderValue)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Errorf("expected 200, got %d", rr.Code)
+			}
+			body, _ := io.ReadAll(rr.Body)
+			if string(body) != testCSRFOKBody {
+				t.Errorf("expected body %q, got %q", testCSRFOKBody, string(body))
+			}
+		})
+	}
+}

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -667,7 +667,7 @@ func (s *Server) Start() error {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 		}
 		w.Header().Set("Access-Control-Allow-Methods", catchallCORSAllowedMethods)
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 		w.Header().Set("Access-Control-Allow-Private-Network", "true")
 		if r.Method == "OPTIONS" {
 			w.WriteHeader(http.StatusOK)
@@ -675,6 +675,12 @@ func (s *Server) Start() error {
 		}
 		http.NotFound(w, r)
 	})
+
+	// Wrap the mux with CSRF middleware: state-changing requests (POST, PUT,
+	// DELETE, PATCH) must include the X-Requested-With: XMLHttpRequest header.
+	// GET/HEAD/OPTIONS pass through unconditionally. This mirrors the Fiber
+	// middleware in pkg/api/middleware/csrf.go. See #10000.
+	handler := requireCSRF(mux)
 
 	addr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	slog.Info("KC Agent starting", "version", Version, "addr", addr)
@@ -739,7 +745,7 @@ func (s *Server) Start() error {
 	)
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           mux,
+		Handler:           handler,
 		ReadHeaderTimeout: serverReadHeaderTimeout,
 		ReadTimeout:       serverReadTimeout,
 		WriteTimeout:      serverWriteTimeout,

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -906,7 +906,7 @@ func (s *Server) handleCancelChatHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 	}
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 
 	if r.Method == "OPTIONS" {

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -1995,7 +1995,7 @@ func (s *Server) setCORSHeaders(w http.ResponseWriter, r *http.Request, methods 
 		allowed = strings.Join(methods, ", ")
 	}
 	w.Header().Set("Access-Control-Allow-Methods", allowed)
-	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Requested-With")
 }
 
 // watchdogPidFileStat is indirected through a package variable so unit tests
@@ -2043,7 +2043,7 @@ func (s *Server) handleRestartBackend(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -2466,7 +2466,7 @@ func (s *Server) handleRenameContextHTTP(w http.ResponseWriter, r *http.Request)
 	}
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -2536,7 +2536,7 @@ func (s *Server) handleKubeconfigPreviewHTTP(w http.ResponseWriter, r *http.Requ
 	}
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -2587,7 +2587,7 @@ func (s *Server) handleKubeconfigImportHTTP(w http.ResponseWriter, r *http.Reque
 	}
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -2693,7 +2693,7 @@ func (s *Server) handleKubeconfigAddHTTP(w http.ResponseWriter, r *http.Request)
 	}
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -2738,7 +2738,7 @@ func (s *Server) handleKubeconfigTestHTTP(w http.ResponseWriter, r *http.Request
 	}
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -24,7 +24,7 @@ func (s *Server) handleSettingsKeys(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -57,7 +57,7 @@ func (s *Server) handleSettingsKeyByProvider(w http.ResponseWriter, r *http.Requ
 	}
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 	w.Header().Set("Access-Control-Allow-Methods", "DELETE, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -122,7 +122,7 @@ func (s *Server) handleSettingsAll(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 	w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -188,7 +188,7 @@ func (s *Server) handleSettingsExport(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -232,7 +232,7 @@ func (s *Server) handleSettingsImport(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 	w.Header().Set("Access-Control-Allow-Methods", "PUT, POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -343,7 +343,7 @@ export function HardwareHealthCard() {
     try {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/devices/alerts/clear`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ alertId }),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!response.ok) {

--- a/web/src/components/cards/WorkloadDeployment.tsx
+++ b/web/src/components/cards/WorkloadDeployment.tsx
@@ -220,7 +220,7 @@ async function scaleViaAgent(
   try {
     const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/scale`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       signal: ctrl.signal,
       body: JSON.stringify({ cluster: context, namespace, name, replicas }) })
     if (!res.ok) throw new Error(`Agent ${res.status}`)

--- a/web/src/components/clusters/AddClusterDialog.tsx
+++ b/web/src/components/clusters/AddClusterDialog.tsx
@@ -93,7 +93,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
     try {
       const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/preview`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ kubeconfig: kubeconfigYaml }),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!res.ok) {
@@ -115,7 +115,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
     try {
       const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/import`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ kubeconfig: kubeconfigYaml }),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!res.ok) {
@@ -144,7 +144,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
     try {
       const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/test`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({
           serverUrl,
           authType,
@@ -169,7 +169,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
     try {
       const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/add`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({
           contextName,
           clusterName,

--- a/web/src/components/gitops/GitOps.tsx
+++ b/web/src/components/gitops/GitOps.tsx
@@ -197,6 +197,7 @@ export function GitOps() {
       const token = localStorage.getItem(STORAGE_KEY_TOKEN)
       const agentAuthHeaders: Record<string, string> = {
         'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
       }
       if (token) agentAuthHeaders['Authorization'] = `Bearer ${token}`
       const promises = configs.map(async (appConfig) => {

--- a/web/src/components/gitops/SyncDialog.tsx
+++ b/web/src/components/gitops/SyncDialog.tsx
@@ -139,6 +139,7 @@ export function SyncDialog({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
           ...(token && { 'Authorization': `Bearer ${token}` }) },
         body: JSON.stringify({
           repoUrl,
@@ -238,6 +239,7 @@ export function SyncDialog({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
           ...(token && { 'Authorization': `Bearer ${token}` }) },
         body: JSON.stringify({
           repoUrl,

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -172,7 +172,7 @@ export function Layout({ children: _children }: LayoutProps) {
     try {
       const resp = await fetch(`${LOCAL_AGENT_HTTP_URL}/restart-backend`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (resp.ok) {

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -52,6 +52,13 @@ export function agentFetch(input: RequestInfo | URL, init?: RequestInit): Promis
   if (token && !headers.has('Authorization')) {
     headers.set('Authorization', `Bearer ${token}`)
   }
+  // #10000 — CSRF defence-in-depth: state-changing requests must carry a
+  // custom header that browsers never attach to cross-origin form POSTs.
+  // The kc-agent requireCSRF middleware rejects POST/PUT/DELETE/PATCH
+  // without this header.
+  if (!headers.has('X-Requested-With')) {
+    headers.set('X-Requested-With', 'XMLHttpRequest')
+  }
   // Use caller-provided signal, or fall back to a default timeout
   const signal = init?.signal ?? AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS)
   return fetch(input, { ...init, headers, signal })

--- a/web/src/hooks/useAIPredictions.ts
+++ b/web/src/hooks/useAIPredictions.ts
@@ -271,7 +271,7 @@ async function triggerAnalysis(specificProviders?: string[]): Promise<boolean> {
   try {
     const response = await fetch(`${AGENT_HTTP_URL}/predictions/analyze`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       body: JSON.stringify({ providers: specificProviders }),
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS)
     })

--- a/web/src/hooks/useArgoCD.ts
+++ b/web/src/hooks/useArgoCD.ts
@@ -289,7 +289,7 @@ async function triggerArgoSyncAPI(appName: string, namespace: string, cluster: s
     const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/argocd/sync`, {
       method: 'POST',
       signal: ctrl.signal,
-      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      headers: { ...authHeaders(), 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       body: JSON.stringify({ appName, namespace, cluster }) })
     const data = await res.json()
     return { success: data.success === true, error: data.error }

--- a/web/src/hooks/useCachedGPU.ts
+++ b/web/src/hooks/useCachedGPU.ts
@@ -317,6 +317,7 @@ export function useGPUHealthCronJob(cluster?: string) {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
           Authorization: `Bearer ${token}` },
         body: JSON.stringify({
           cluster,
@@ -349,6 +350,7 @@ export function useGPUHealthCronJob(cluster?: string) {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
           Authorization: `Bearer ${token}` },
         body: JSON.stringify({
           cluster,

--- a/web/src/hooks/useConsoleCRs.ts
+++ b/web/src/hooks/useConsoleCRs.ts
@@ -273,7 +273,7 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
     try {
       const response = await fetch(agentWriteURL(), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify(item),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (response.ok) {
@@ -299,7 +299,7 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
     try {
       const response = await fetch(agentWriteURL('', { name }), {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify(item),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (response.ok) {
@@ -325,6 +325,7 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
     try {
       const response = await fetch(agentWriteURL('', { name }), {
         method: 'DELETE',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (response.ok || response.status === 204) {
         // Optimistic update
@@ -394,7 +395,7 @@ export function useWorkloadDeployments() {
       const url = `${LOCAL_AGENT_HTTP_URL}/console-cr/deployments/status?${params.toString()}`
       const response = await fetch(url, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify(status),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (response.ok) {

--- a/web/src/hooks/useFederationActions.ts
+++ b/web/src/hooks/useFederationActions.ts
@@ -51,7 +51,7 @@ export interface ActionResult {
  */
 export async function executeFederationAction(req: ActionRequest): Promise<ActionResult> {
   const token = localStorage.getItem(STORAGE_KEY_TOKEN)
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  const headers: Record<string, string> = { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }
   if (token) headers['Authorization'] = `Bearer ${token}`
 
   const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/federation/action`, {

--- a/web/src/hooks/useHelmActions.ts
+++ b/web/src/hooks/useHelmActions.ts
@@ -15,7 +15,7 @@ import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
 // the URL changes.
 function helmAgentAuthHeaders(): Record<string, string> {
   const token = localStorage.getItem(STORAGE_KEY_TOKEN)
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  const headers: Record<string, string> = { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }
   if (token) headers['Authorization'] = `Bearer ${token}`
   return headers
 }

--- a/web/src/hooks/useInsightEnrichment.ts
+++ b/web/src/hooks/useInsightEnrichment.ts
@@ -99,7 +99,7 @@ async function requestEnrichment(insights: MultiClusterInsight[]): Promise<void>
 
     const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/insights/enrich`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       body: JSON.stringify(payload),
       signal: controller.signal,
     })

--- a/web/src/hooks/useLocalClusterTools.ts
+++ b/web/src/hooks/useLocalClusterTools.ts
@@ -179,7 +179,7 @@ export function useLocalClusterTools() {
     try {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-clusters`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ tool, name }),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
 
@@ -217,7 +217,7 @@ export function useLocalClusterTools() {
     try {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-cluster-lifecycle`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ tool, name, action }),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
 
@@ -263,6 +263,7 @@ export function useLocalClusterTools() {
     try {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-clusters?tool=${tool}&name=${name}`, {
         method: 'DELETE',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
 
       if (response.ok) {
@@ -383,7 +384,7 @@ export function useLocalClusterTools() {
     try {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/create`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ name, namespace }),
         signal: AbortSignal.timeout(VCLUSTER_CREATE_TIMEOUT_MS) })
 
@@ -428,7 +429,7 @@ export function useLocalClusterTools() {
     try {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/connect`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ name, namespace }),
         signal: AbortSignal.timeout(VCLUSTER_CONNECT_TIMEOUT_MS) })
 
@@ -473,7 +474,7 @@ export function useLocalClusterTools() {
     try {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/disconnect`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ name, namespace }),
         signal: AbortSignal.timeout(VCLUSTER_CONNECT_TIMEOUT_MS) })
 
@@ -518,7 +519,7 @@ export function useLocalClusterTools() {
     try {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/delete`, {
         method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ name, namespace }),
         signal: AbortSignal.timeout(VCLUSTER_CONNECT_TIMEOUT_MS) })
 

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -2611,7 +2611,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       // Use the response body to determine if cancellation succeeded (#5477).
       fetch(`${LOCAL_AGENT_HTTP_URL}/cancel-chat`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ sessionId: missionId }) }).then(async response => {
         // #7303 — Guard against post-unmount finalization from HTTP fallback
         if (unmountedRef.current) return

--- a/web/src/hooks/usePermissions.ts
+++ b/web/src/hooks/usePermissions.ts
@@ -195,7 +195,8 @@ export function useCanI() {
         method: 'POST',
         headers: {
           'Authorization': token ? `Bearer ${token}` : '',
-          'Content-Type': 'application/json' },
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify(request),
         signal: AbortSignal.timeout(PERMISSION_REQUEST_TIMEOUT_MS) })
 

--- a/web/src/hooks/usePersistedSettings.ts
+++ b/web/src/hooks/usePersistedSettings.ts
@@ -24,6 +24,7 @@ async function settingsFetch<T>(path: string, options?: RequestInit): Promise<T>
     ...options,
     headers: {
       'Content-Type': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest', // #10000 CSRF defence-in-depth
       ...options?.headers },
     signal: options?.signal ?? AbortSignal.timeout(15000) })
   if (!response.ok) throw new Error(`HTTP ${response.status}`)

--- a/web/src/hooks/usePredictionFeedback.ts
+++ b/web/src/hooks/usePredictionFeedback.ts
@@ -187,7 +187,7 @@ export function usePredictionFeedback() {
 async function sendFeedbackToBackend(predictionId: string, feedback: PredictionFeedback): Promise<void> {
   const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/predictions/feedback`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
     body: JSON.stringify({ predictionId, feedback }),
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
   if (!response.ok) {

--- a/web/src/hooks/useUsers.ts
+++ b/web/src/hooks/useUsers.ts
@@ -496,7 +496,7 @@ export function useK8sServiceAccounts(cluster?: string, namespace?: string) {
     // the backend pod ServiceAccount. See #7993 Phase 1.5 PR A.
     const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/serviceaccounts`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...agentAuthHeaders() },
+      headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest', ...agentAuthHeaders() },
       body: JSON.stringify(req),
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
@@ -659,7 +659,7 @@ export function useK8sRoleBindings(cluster: string, namespace?: string, includeS
     // ServiceAccount. See #7993 Phase 1.5 PR A.
     const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/rolebindings`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...agentAuthHeaders() },
+      headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest', ...agentAuthHeaders() },
       body: JSON.stringify(req),
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -496,7 +496,7 @@ function useVersionCheckCore() {
     try {
       await fetch(`${LOCAL_AGENT_HTTP_URL}/auto-update/config`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ enabled: autoUpdateEnabled, channel: newChannel }),
         signal: AbortSignal.timeout(3000) })
     } catch {
@@ -515,7 +515,7 @@ function useVersionCheckCore() {
     try {
       await fetch(`${LOCAL_AGENT_HTTP_URL}/auto-update/config`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ enabled, channel }),
         signal: AbortSignal.timeout(3000) })
     } catch {
@@ -532,7 +532,7 @@ function useVersionCheckCore() {
     try {
       const resp = await fetch(`${LOCAL_AGENT_HTTP_URL}/auto-update/trigger`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ channel }),
         signal: AbortSignal.timeout(TRIGGER_UPDATE_TIMEOUT_MS) })
       if (resp.ok) {
@@ -562,7 +562,7 @@ function useVersionCheckCore() {
     try {
       const resp = await fetch(`${LOCAL_AGENT_HTTP_URL}/auto-update/cancel`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         signal: AbortSignal.timeout(CANCEL_UPDATE_TIMEOUT_MS) })
       if (resp.ok) {
         console.debug('[version-check] Cancel request accepted')

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -338,7 +338,7 @@ export function useDeployWorkload() {
       const agentBase = requireLocalAgentHttp('Deploying workloads')
       const res = await fetch(`${agentBase}/workloads/deploy`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest', ...authHeaders() },
         body: JSON.stringify(request),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!res.ok) {
@@ -388,7 +388,7 @@ export function useScaleWorkload() {
       const agentBase = requireLocalAgentHttp('Scaling workloads')
       const res = await fetch(`${agentBase}/scale`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest', ...authHeaders() },
         body: JSON.stringify(request),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!res.ok) {
@@ -439,7 +439,7 @@ export function useDeleteWorkload() {
       const agentBase = requireLocalAgentHttp('Deleting workloads')
       const res = await fetch(`${agentBase}/workloads/delete`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest', ...authHeaders() },
         body: JSON.stringify({
           cluster: params.cluster,
           namespace: params.namespace,

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -988,6 +988,11 @@ export function startGlobalErrorTracking() {
       if (isNetlifyDeployment && msg.includes('Backend API is currently unavailable')) return
       // Skip WebGL context errors — benign GPU process resets
       if (msg.includes('WebGL') || msg.includes('context lost')) return
+      // Skip auth-flow errors — UnauthenticatedError is thrown by api.get() when
+      // no token is available (expected for unauthenticated visitors). Emitting
+      // these as ksc_error creates false-positive alert spikes (#9994).
+      if (errorName === 'UnauthenticatedError' || errorName === 'UnauthorizedError') return
+      if (msg.includes('No authentication token') || msg.includes('Token is invalid or expired')) return
       emitError('unhandled_rejection', msg, undefined, { error: event.reason })
     } finally {
       isEmitting = false
@@ -1041,6 +1046,9 @@ export function startGlobalErrorTracking() {
       if (event.message.includes('Non-Error')) return
       // Stale chunks can surface as runtime errors (Safari: "Importing a module script failed")
       if (tryChunkReloadRecovery(event.message)) return
+      // Skip auth-flow errors that surface as synchronous error events (#9994).
+      if (event.error?.name === 'UnauthenticatedError' || event.error?.name === 'UnauthorizedError') return
+      if (event.message.includes('No authentication token') || event.message.includes('Token is invalid or expired')) return
       emitError('runtime', event.message, undefined, { error: event.error })
     } finally {
       isEmitting = false


### PR DESCRIPTION
## Summary
- Adds `requireCSRF` middleware to kc-agent that rejects state-changing requests (POST/PUT/DELETE/PATCH) missing the `X-Requested-With: XMLHttpRequest` header
- Updates all frontend mutation calls (both `agentFetch` and direct `fetch`) to include the CSRF header
- Updates all CORS `Access-Control-Allow-Headers` in the agent to advertise `X-Requested-With`

Mirrors the existing Fiber CSRF middleware in `pkg/api/middleware/csrf.go`. GET/HEAD/OPTIONS pass through unconditionally per RFC 7231.

Fixes #10000

## Test plan
- [x] Go unit tests pass (`go test ./pkg/agent/ -run TestCSRF`)
- [ ] CI build and lint pass
- [ ] Verify agent mutation endpoints (deploy, scale, delete, helm, gitops sync) work with the header
- [ ] Verify requests without the header are rejected with 403