### PR TITLE
🐛 Remove unused imports breaking main build

### DIFF
--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -1,4 +1,4 @@
-import { useState, useReducer } from 'react'
+import { useReducer } from 'react'
 import { Shield, Check, X, Loader2, AlertCircle, ChevronDown } from 'lucide-react'
 import { useCanI } from '../../hooks/usePermissions'
 import { useClusters, useNamespaces } from '../../hooks/useMCP'

--- a/web/src/hooks/useCachedGPU.ts
+++ b/web/src/hooks/useCachedGPU.ts
@@ -7,7 +7,7 @@
 
 import { useState } from 'react'
 import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
-import { fetchAPI, fetchBackendAPI, fetchFromAllClusters, fetchFromAllClustersViaBackend, fetchViaSSE, fetchViaBackendSSE, getToken, AGENT_HTTP_TIMEOUT_MS } from '../lib/cache/fetcherUtils'
+import { fetchAPI, fetchBackendAPI, fetchFromAllClustersViaBackend, fetchViaSSE, fetchViaBackendSSE, getToken, AGENT_HTTP_TIMEOUT_MS } from '../lib/cache/fetcherUtils'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS } from '../lib/constants/network'


### PR DESCRIPTION
Fixes #10018
Fixes #10019
Fixes #10020
Fixes #10021
Fixes #10023

Remove two unused imports causing TS6133 build failures on main after batch-merging PRs #10014-10022:

1. useState in CanIChecker.tsx (replaced by useReducer in #10014)
2. fetchFromAllClusters in useCachedGPU.ts (replaced by fetchFromAllClustersViaBackend in #10017)

Build and lint verified passing locally.