### PR TITLE
🐛 Fix nightly suite timeouts and JSON parse error

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -118,15 +118,17 @@ declare -A SUITE_STATUS=()  # Tracks actual pass/fail/skip per suite name
 extract_failure_reason() {
   local log_file="$1"
   local reason
-  # Strip ANSI codes, grab last 5 non-empty lines, join with \n
+  # Strip ANSI codes, grab last 5 non-empty lines, join with newlines,
+  # then use jq to produce a properly JSON-escaped string (handles
+  # backslashes, tabs, control chars, quotes — all of which broke the
+  # hand-rolled sed escaping and caused jq parse errors in the nightly
+  # comparison step, see #9346).
   reason=$(sed 's/\x1b\[[0-9;]*m//g' "$log_file" 2>/dev/null \
     | grep -v '^\s*$' \
     | tail -5 \
-    | tr '\n' '|' \
-    | sed 's/|$//' \
-    | sed 's/|/\\n/g' \
-    | sed 's/"/\\"/g' \
-    | cut -c1-500) || true
+    | head -c 500 \
+    | jq -Rs '.' 2>/dev/null \
+    | sed 's/^"//;s/"$//') || true
   echo "$reason"
 }
 
@@ -309,14 +311,20 @@ if [ -z "$FAST_MODE" ]; then
         #     from-clusters/rapid-nav) × ~60-120s each ≈ 480-720s total.
         #     Default 300s cap killed it mid-run after warm-nav completed.
         #   #9099 perf-test: same serial scenario structure as nav-test.
+        #   #9346 nav-test, perf-test, ai-ml-test: 600s not enough — all 3
+        #     consistently hit the cap mid-run with work remaining (nav-test
+        #     completes 5/6 scenarios, perf-test still iterating dashboards,
+        #     ai-ml-test retries consuming budget). 900s matches their
+        #     Playwright-level timeout (900_000ms) and fits within the 120m
+        #     workflow backstop.
         declare -A PLAYWRIGHT_SUITE_TIMEOUT_OVERRIDES=(
           ["console-error-scan"]=600
           ["ui-compliance-test"]=600
           ["cache-test"]=600
           ["benchmark-test"]=600
-          ["ai-ml-test"]=600
-          ["nav-test"]=600
-          ["perf-test"]=600
+          ["ai-ml-test"]=900
+          ["nav-test"]=900
+          ["perf-test"]=900
         )
 
         for script in "${PLAYWRIGHT_SCRIPTS[@]}"; do


### PR DESCRIPTION
Fixes #9346

## Changes

### 1. Increase timeout caps for 3 still-timing-out suites
`nav-test`, `perf-test`, and `ai-ml-test` consistently hit the 600s wall mid-run:
- nav-test completes 5/6 scenarios before being killed
- perf-test still iterating dashboards at 600s
- ai-ml-test retries consuming time budget

Bumped to 900s which matches their Playwright-level timeout (900,000ms) and fits within the 120m workflow backstop (worst case: 3×900s = 45min + ~20min other suites + ~3min build = ~68min).

### 2. Fix JSON escaping in extract_failure_reason()
The hand-rolled sed escaping failed on backslashes, tabs, and control characters in log output, producing malformed JSON. This caused:
- `jq: parse error: Invalid numeric literal` in nightly-compare.sh
- `/tmp/nightly-comparison.md` never generated
- Issue #9346 tracking comment not posted

Now uses `jq -Rs` for robust JSON string escaping.

### Progress on original 6 timeout suites
| Suite | Before | After this PR |
|-------|--------|---------------|
| console-error-scan | ❌ 600s timeout | ✅ PASS (122s) — already fixed |
| cache-test | ❌ 600s timeout | ✅ PASS (126s) — already fixed |
| nav-test | ❌ 600s timeout | 🔧 Cap raised to 900s |
| perf-test | ❌ 600s timeout | 🔧 Cap raised to 900s |
| ai-ml-test | ❌ 600s timeout | 🔧 Cap raised to 900s |
| ui-compliance-test | ❌ 600s timeout | ⚠️ Now fails at 248s (assertion, not timeout) |