### PR TITLE
✨ Add event journal table + timeline API (Phase 1 of #9967)

### DIFF
--- a/pkg/api/handlers/timeline.go
+++ b/pkg/api/handlers/timeline.go
@@ -1,0 +1,286 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/k8s"
+	"github.com/kubestellar/console/pkg/store"
+)
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+// eventPollInterval is how often the collector polls clusters for events.
+const eventPollInterval = 60 * time.Second
+
+// eventRetentionSweepInterval is how often the retention sweep runs.
+const eventRetentionSweepInterval = 1 * time.Hour
+
+// defaultEventRetentionDays is the fallback when KSC_EVENT_RETENTION_DAYS is
+// unset or invalid.
+const defaultEventRetentionDays = 7
+
+// eventCollectTimeout is the per-cluster fetch timeout.
+const eventCollectTimeout = 15 * time.Second
+
+// eventsPerClusterLimit caps the number of events fetched per cluster per poll.
+const eventsPerClusterLimit = 200
+
+// timelineDefaultLimit is the default limit for the GET /api/timeline endpoint.
+const timelineDefaultLimit = 100
+
+// timelineMaxLimit is the hard upper bound for timeline query results.
+const timelineMaxLimit = 1000
+
+// demoTimelineSpanHours defines how far back demo events extend.
+const demoTimelineSpanHours = 24
+
+// ---------------------------------------------------------------------------
+// TimelineHandler
+// ---------------------------------------------------------------------------
+
+// TimelineHandler serves the GET /api/timeline endpoint and owns the
+// background event journal collector goroutine.
+type TimelineHandler struct {
+	store     store.Store
+	k8sClient *k8s.MultiClusterClient
+}
+
+// NewTimelineHandler creates a TimelineHandler.
+func NewTimelineHandler(s store.Store, k8sClient *k8s.MultiClusterClient) *TimelineHandler {
+	return &TimelineHandler{store: s, k8sClient: k8sClient}
+}
+
+// GetTimeline handles GET /api/timeline.
+// Query params: cluster, namespace, since, until, kind, limit.
+func (h *TimelineHandler) GetTimeline(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(demoTimelineEvents())
+	}
+
+	filter := store.TimelineFilter{
+		Cluster:   c.Query("cluster"),
+		Namespace: c.Query("namespace"),
+		Since:     c.Query("since"),
+		Until:     c.Query("until"),
+		Kind:      c.Query("kind"),
+	}
+
+	if limitStr := c.Query("limit"); limitStr != "" {
+		if v, err := strconv.Atoi(limitStr); err == nil && v > 0 {
+			filter.Limit = v
+		}
+	}
+	if filter.Limit <= 0 {
+		filter.Limit = timelineDefaultLimit
+	}
+	if filter.Limit > timelineMaxLimit {
+		filter.Limit = timelineMaxLimit
+	}
+
+	events, err := h.store.QueryTimeline(c.Context(), filter)
+	if err != nil {
+		slog.Error("[Timeline] query failed", "error", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to query timeline")
+	}
+	return c.JSON(events)
+}
+
+// ---------------------------------------------------------------------------
+// Background collector
+// ---------------------------------------------------------------------------
+
+// StartEventCollector launches the background goroutine that polls clusters
+// for events and writes them to the store. It stops when done is closed.
+func (h *TimelineHandler) StartEventCollector(done <-chan struct{}) {
+	if h.k8sClient == nil {
+		slog.Info("[Timeline] no k8s client — event collector disabled")
+		return
+	}
+	go h.runCollector(done)
+}
+
+func (h *TimelineHandler) runCollector(done <-chan struct{}) {
+	slog.Info("[Timeline] event collector started",
+		"poll_interval", eventPollInterval,
+		"retention_days", retentionDays())
+
+	pollTicker := time.NewTicker(eventPollInterval)
+	defer pollTicker.Stop()
+
+	sweepTicker := time.NewTicker(eventRetentionSweepInterval)
+	defer sweepTicker.Stop()
+
+	// Run an initial collection immediately.
+	h.collectAll()
+
+	for {
+		select {
+		case <-done:
+			slog.Info("[Timeline] event collector stopping")
+			return
+		case <-pollTicker.C:
+			h.collectAll()
+		case <-sweepTicker.C:
+			h.sweepOld()
+		}
+	}
+}
+
+func (h *TimelineHandler) collectAll() {
+	healthy, _, err := h.k8sClient.HealthyClusters(context.Background())
+	if err != nil {
+		slog.Error("[Timeline] failed to list clusters", "error", err)
+		return
+	}
+
+	var wg sync.WaitGroup
+	for _, ci := range healthy {
+		wg.Add(1)
+		go func(cluster k8s.ClusterInfo) {
+			defer wg.Done()
+			h.collectCluster(cluster)
+		}(ci)
+	}
+	wg.Wait()
+}
+
+func (h *TimelineHandler) collectCluster(ci k8s.ClusterInfo) {
+	ctx, cancel := context.WithTimeout(context.Background(), eventCollectTimeout)
+	defer cancel()
+
+	events, err := h.k8sClient.GetEvents(ctx, ci.Name, "", eventsPerClusterLimit)
+	if err != nil {
+		slog.Warn("[Timeline] collect failed",
+			"cluster", ci.Name, "error", err)
+		return
+	}
+
+	var inserted int
+	for _, ev := range events {
+		kind, name := parseObject(ev.Object)
+		ce := store.ClusterEvent{
+			ID:                 uuid.NewString(),
+			ClusterName:        ci.Name,
+			Namespace:          ev.Namespace,
+			EventType:          ev.Type,
+			Reason:             ev.Reason,
+			Message:            ev.Message,
+			InvolvedObjectKind: kind,
+			InvolvedObjectName: name,
+			EventUID:           fmt.Sprintf("%s/%s", ci.Name, ev.Object+"/"+ev.Reason+"/"+ev.Namespace),
+			EventCount:         ev.Count,
+			FirstSeen:          ev.FirstSeen,
+			LastSeen:           ev.LastSeen,
+		}
+		if ce.FirstSeen == "" {
+			ce.FirstSeen = time.Now().UTC().Format(time.RFC3339)
+		}
+		if ce.LastSeen == "" {
+			ce.LastSeen = ce.FirstSeen
+		}
+
+		if err := h.store.InsertOrUpdateEvent(ctx, ce); err != nil {
+			slog.Warn("[Timeline] upsert failed",
+				"cluster", ci.Name, "error", err)
+			continue
+		}
+		inserted++
+	}
+	if inserted > 0 {
+		slog.Debug("[Timeline] collected events",
+			"cluster", ci.Name, "count", inserted)
+	}
+}
+
+// parseObject splits "Kind/Name" into its parts.
+func parseObject(obj string) (kind, name string) {
+	idx := strings.IndexByte(obj, '/')
+	if idx < 0 {
+		return obj, ""
+	}
+	return obj[:idx], obj[idx+1:]
+}
+
+func (h *TimelineHandler) sweepOld() {
+	ctx, cancel := context.WithTimeout(context.Background(), eventCollectTimeout)
+	defer cancel()
+	deleted, err := h.store.SweepOldEvents(ctx, retentionDays())
+	if err != nil {
+		slog.Error("[Timeline] sweep failed", "error", err)
+		return
+	}
+	if deleted > 0 {
+		slog.Info("[Timeline] swept old events", "deleted", deleted)
+	}
+}
+
+func retentionDays() int {
+	if v := os.Getenv("KSC_EVENT_RETENTION_DAYS"); v != "" {
+		if days, err := strconv.Atoi(v); err == nil && days > 0 {
+			return days
+		}
+	}
+	return defaultEventRetentionDays
+}
+
+// ---------------------------------------------------------------------------
+// Demo mode data
+// ---------------------------------------------------------------------------
+
+func demoTimelineEvents() []store.ClusterEvent {
+	now := time.Now().UTC()
+	clusters := []string{"kind-ks1", "kind-ks2", "gke-prod-us-east1"}
+	reasons := []struct {
+		reason  string
+		evType  string
+		kind    string
+		name    string
+		message string
+	}{
+		{"ScalingReplicaSet", "Normal", "Deployment", "nginx-ingress", "Scaled up replica set nginx-ingress-7f8b6c to 3"},
+		{"SuccessfulCreate", "Normal", "ReplicaSet", "api-server-5d9f8a", "Created pod: api-server-5d9f8a-xk92m"},
+		{"Killing", "Normal", "Pod", "worker-batch-j29sl", "Stopping container worker"},
+		{"FailedScheduling", "Warning", "Pod", "gpu-train-abc12", "0/4 nodes are available: insufficient nvidia.com/gpu"},
+		{"Pulling", "Normal", "Pod", "frontend-v2-lm84n", "Pulling image \"ghcr.io/kubestellar/frontend:v2.1.0\""},
+		{"Pulled", "Normal", "Pod", "frontend-v2-lm84n", "Successfully pulled image in 3.2s"},
+		{"Started", "Normal", "Pod", "monitoring-agent-qr7x", "Started container prometheus-exporter"},
+	}
+
+	events := make([]store.ClusterEvent, 0, len(clusters)*len(reasons))
+	for ci, cluster := range clusters {
+		for ri, r := range reasons {
+			minutesAgo := (ci*len(reasons) + ri) * 47 // spread events over demo window
+			if minutesAgo > demoTimelineSpanHours*60 {
+				minutesAgo = demoTimelineSpanHours * 60
+			}
+			t := now.Add(-time.Duration(minutesAgo) * time.Minute)
+			events = append(events, store.ClusterEvent{
+				ID:                 uuid.NewString(),
+				ClusterName:        cluster,
+				Namespace:          "default",
+				EventType:          r.evType,
+				Reason:             r.reason,
+				Message:            r.message,
+				InvolvedObjectKind: r.kind,
+				InvolvedObjectName: r.name,
+				EventUID:           fmt.Sprintf("demo-%s-%s-%d", cluster, r.reason, ri),
+				EventCount:         1,
+				FirstSeen:          t.Format(time.RFC3339),
+				LastSeen:           t.Format(time.RFC3339),
+				RecordedAt:         t.Format(time.RFC3339),
+			})
+		}
+	}
+	return events
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1088,6 +1088,11 @@ func (s *Server) setupRoutes() {
 	orbit.RegisterRoutes(api.Group("/orbit"))
 	orbit.StartScheduler(s.done)
 
+	// Cross-cluster event journal (#9967 Phase 1)
+	timeline := handlers.NewTimelineHandler(s.store, s.k8sClient)
+	api.Get("/timeline", timeline.GetTimeline)
+	timeline.StartEventCollector(s.done)
+
 	// MCP routes (cluster operations via kubestellar tools and direct k8s)
 	// SECURITY: All MCP routes require authentication in both dev and production modes
 	api.Get("/mcp/status", mcpHandlers.GetStatus)

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -534,6 +534,25 @@ func (s *SQLiteStore) migrate() error {
 		detail TEXT
 	);
 	CREATE INDEX IF NOT EXISTS idx_audit_log_user_time ON audit_log(user_id, timestamp);
+
+	-- Cross-cluster event journal (#9967 Phase 1)
+	CREATE TABLE IF NOT EXISTS cluster_events (
+		id TEXT PRIMARY KEY,
+		cluster_name TEXT NOT NULL,
+		namespace TEXT NOT NULL DEFAULT '',
+		event_type TEXT NOT NULL,
+		reason TEXT NOT NULL,
+		message TEXT,
+		involved_object_kind TEXT,
+		involved_object_name TEXT,
+		event_uid TEXT NOT NULL UNIQUE,
+		event_count INTEGER DEFAULT 1,
+		first_seen DATETIME NOT NULL,
+		last_seen DATETIME NOT NULL,
+		recorded_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+	CREATE INDEX IF NOT EXISTS idx_ce_cluster_time ON cluster_events(cluster_name, last_seen DESC);
+	CREATE INDEX IF NOT EXISTS idx_ce_uid ON cluster_events(event_uid);
 	`
 	_, err := s.db.ExecContext(ctx, schema)
 	if err != nil {
@@ -3139,4 +3158,118 @@ func rollbackConn(conn *sql.Conn) {
 	ctx, cancel := context.WithTimeout(context.Background(), rollbackTimeout)
 	defer cancel()
 	_, _ = conn.ExecContext(ctx, "ROLLBACK")
+}
+
+// ---------------------------------------------------------------------------
+// Cluster Events — cross-cluster event journal (#9967 Phase 1)
+// ---------------------------------------------------------------------------
+
+// InsertOrUpdateEvent upserts a cluster event keyed by event_uid. On conflict
+// it updates last_seen, event_count, and message so the journal reflects the
+// latest occurrence without duplicating rows.
+func (s *SQLiteStore) InsertOrUpdateEvent(ctx context.Context, event ClusterEvent) error {
+	const query = `
+		INSERT INTO cluster_events
+			(id, cluster_name, namespace, event_type, reason, message,
+			 involved_object_kind, involved_object_name, event_uid,
+			 event_count, first_seen, last_seen, recorded_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(event_uid) DO UPDATE SET
+			last_seen   = excluded.last_seen,
+			event_count = excluded.event_count,
+			message     = excluded.message,
+			recorded_at = CURRENT_TIMESTAMP
+	`
+	_, err := s.db.ExecContext(ctx, query,
+		event.ID, event.ClusterName, event.Namespace, event.EventType,
+		event.Reason, event.Message, event.InvolvedObjectKind,
+		event.InvolvedObjectName, event.EventUID, event.EventCount,
+		event.FirstSeen, event.LastSeen,
+	)
+	return err
+}
+
+// clusterEventMaxLimit is the hard upper bound for QueryTimeline results.
+const clusterEventMaxLimit = 1000
+
+// clusterEventDefaultLimit is used when the caller passes limit <= 0.
+const clusterEventDefaultLimit = 100
+
+// QueryTimeline returns cluster events matching the filter, sorted by
+// last_seen DESC. Limit is clamped to clusterEventMaxLimit.
+func (s *SQLiteStore) QueryTimeline(ctx context.Context, filter TimelineFilter) ([]ClusterEvent, error) {
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = clusterEventDefaultLimit
+	}
+	if limit > clusterEventMaxLimit {
+		limit = clusterEventMaxLimit
+	}
+
+	var clauses []string
+	var args []interface{}
+
+	if filter.Cluster != "" {
+		clauses = append(clauses, "cluster_name = ?")
+		args = append(args, filter.Cluster)
+	}
+	if filter.Namespace != "" {
+		clauses = append(clauses, "namespace = ?")
+		args = append(args, filter.Namespace)
+	}
+	if filter.Since != "" {
+		clauses = append(clauses, "last_seen >= ?")
+		args = append(args, filter.Since)
+	}
+	if filter.Until != "" {
+		clauses = append(clauses, "last_seen <= ?")
+		args = append(args, filter.Until)
+	}
+	if filter.Kind != "" {
+		clauses = append(clauses, "involved_object_kind = ?")
+		args = append(args, filter.Kind)
+	}
+
+	query := "SELECT id, cluster_name, namespace, event_type, reason, message, involved_object_kind, involved_object_name, event_uid, event_count, first_seen, last_seen, recorded_at FROM cluster_events"
+	if len(clauses) > 0 {
+		query += " WHERE " + strings.Join(clauses, " AND ")
+	}
+	query += " ORDER BY last_seen DESC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query timeline: %w", err)
+	}
+	defer rows.Close()
+
+	results := make([]ClusterEvent, 0)
+	for rows.Next() {
+		var e ClusterEvent
+		var msg, objKind, objName sql.NullString
+		if err := rows.Scan(
+			&e.ID, &e.ClusterName, &e.Namespace, &e.EventType,
+			&e.Reason, &msg, &objKind, &objName,
+			&e.EventUID, &e.EventCount, &e.FirstSeen, &e.LastSeen,
+			&e.RecordedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan cluster event: %w", err)
+		}
+		e.Message = msg.String
+		e.InvolvedObjectKind = objKind.String
+		e.InvolvedObjectName = objName.String
+		results = append(results, e)
+	}
+	return results, rows.Err()
+}
+
+// SweepOldEvents deletes cluster events whose last_seen is older than
+// retentionDays. Returns the number of rows deleted.
+func (s *SQLiteStore) SweepOldEvents(ctx context.Context, retentionDays int) (int64, error) {
+	const query = `DELETE FROM cluster_events WHERE last_seen < datetime('now', '-' || ? || ' days')`
+	res, err := s.db.ExecContext(ctx, query, retentionDays)
+	if err != nil {
+		return 0, fmt.Errorf("sweep old events: %w", err)
+	}
+	return res.RowsAffected()
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -265,6 +265,41 @@ type Store interface {
 	DeleteClusterGroup(ctx context.Context, name string) error
 	ListClusterGroups(ctx context.Context) (map[string][]byte, error)
 
+	// Cluster Events — cross-cluster event journal (#9967 Phase 1).
+	// InsertOrUpdateEvent upserts an event keyed by event_uid.
+	InsertOrUpdateEvent(ctx context.Context, event ClusterEvent) error
+	// QueryTimeline returns events matching the filter, sorted by last_seen DESC.
+	QueryTimeline(ctx context.Context, filter TimelineFilter) ([]ClusterEvent, error)
+	// SweepOldEvents deletes events older than retentionDays. Returns rows deleted.
+	SweepOldEvents(ctx context.Context, retentionDays int) (int64, error)
+
 	// Lifecycle
 	Close() error
+}
+
+// ClusterEvent represents a single Kubernetes event recorded from a cluster.
+type ClusterEvent struct {
+	ID                 string `json:"id"`
+	ClusterName        string `json:"cluster_name"`
+	Namespace          string `json:"namespace"`
+	EventType          string `json:"event_type"`
+	Reason             string `json:"reason"`
+	Message            string `json:"message,omitempty"`
+	InvolvedObjectKind string `json:"involved_object_kind,omitempty"`
+	InvolvedObjectName string `json:"involved_object_name,omitempty"`
+	EventUID           string `json:"event_uid"`
+	EventCount         int32  `json:"event_count"`
+	FirstSeen          string `json:"first_seen"`
+	LastSeen           string `json:"last_seen"`
+	RecordedAt         string `json:"recorded_at,omitempty"`
+}
+
+// TimelineFilter controls which events QueryTimeline returns.
+type TimelineFilter struct {
+	Cluster   string
+	Namespace string
+	Since     string // ISO 8601
+	Until     string // ISO 8601
+	Kind      string // involved_object_kind
+	Limit     int
 }

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -399,4 +399,20 @@ func (m *MockStore) QueryAuditLogs(_ context.Context, limit int, userID, action 
 	return args.Get(0).([]store.AuditEntry), args.Error(1)
 }
 
+func (m *MockStore) InsertOrUpdateEvent(_ context.Context, _ store.ClusterEvent) error {
+	return nil
+}
+
+func (m *MockStore) QueryTimeline(_ context.Context, filter store.TimelineFilter) ([]store.ClusterEvent, error) {
+	args := m.Called(filter)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]store.ClusterEvent), args.Error(1)
+}
+
+func (m *MockStore) SweepOldEvents(_ context.Context, _ int) (int64, error) {
+	return 0, nil
+}
+
 func (m *MockStore) Close() error { return nil }


### PR DESCRIPTION
Fixes #9967

## Phase 1: Event Journal Table + Background Collector

Adds cross-cluster change tracking infrastructure:

### Changes
- **SQLite schema**: `cluster_events` table with indexes on `(cluster_name, last_seen)` and `(event_uid)` for fast lookups and UPSERT deduplication
- **Store methods**: `InsertOrUpdateEvent` (UPSERT on event_uid), `QueryTimeline` (filtered query), `SweepOldEvents` (retention cleanup)
- **Background collector**: polls healthy clusters every 60s, fetches events in parallel with per-cluster timeout, deduplicates via UPSERT, sweeps old events hourly (configurable via `KSC_EVENT_RETENTION_DAYS`, default 7)
- **REST endpoint**: `GET /api/timeline` with query params: `cluster`, `namespace`, `since`, `until`, `kind`, `limit`
- **Demo mode**: returns synthetic events across 3 clusters with realistic K8s event reasons
- **Mock store**: updated to satisfy the new interface methods

### Testing
- `go build ./...` ✅
- `go test ./pkg/store/...` ✅
- `go test ./pkg/api/...` ✅
- `npm run build` ✅