### PR TITLE
fix(acmm): badge direct-fallback uses shared detection paths — fixes L2 badge showing L5 repo

### DIFF
--- a/.github/workflows/acmm-level-monitor.yml
+++ b/.github/workflows/acmm-level-monitor.yml
@@ -1,0 +1,104 @@
+name: ACMM Level Monitor
+
+on:
+  schedule:
+    # Run daily at 08:00 UTC
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+    inputs:
+      min_level:
+        description: 'Minimum acceptable ACMM level (default: 5)'
+        required: false
+        default: '5'
+
+jobs:
+  check-acmm-level:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Fetch ACMM badge score
+        id: badge
+        run: |
+          MIN_LEVEL="${{ github.event.inputs.min_level || '5' }}"
+          RESPONSE=$(curl -sf "https://console.kubestellar.io/api/acmm/badge?repo=kubestellar%2Fconsole&force=true" || echo "")
+          if [ -z "$RESPONSE" ]; then
+            echo "level=0" >> "$GITHUB_OUTPUT"
+            echo "message=badge endpoint unreachable" >> "$GITHUB_OUTPUT"
+            echo "score=?/?" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          LEVEL=$(echo "$RESPONSE" | python3 -c "import sys,json,re; d=json.load(sys.stdin); m=re.match(r'L(\d+)', d.get('message','')); print(m.group(1) if m else '0')")
+          SCORE=$(echo "$RESPONSE" | python3 -c "import sys,json,re; d=json.load(sys.stdin); m=re.search(r'(\d+/\d+)', d.get('message','')); print(m.group(1) if m else '?/?')")
+          MESSAGE=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('message','unknown'))")
+          echo "level=$LEVEL" >> "$GITHUB_OUTPUT"
+          echo "score=$SCORE" >> "$GITHUB_OUTPUT"
+          echo "message=$MESSAGE" >> "$GITHUB_OUTPUT"
+          echo "min_level=$MIN_LEVEL" >> "$GITHUB_OUTPUT"
+          echo "ACMM badge: $MESSAGE (level=$LEVEL, required>=$MIN_LEVEL)"
+
+      - name: Check for existing regression issue
+        id: existing
+        if: ${{ fromJson(steps.badge.outputs.level) < fromJson(steps.badge.outputs.min_level) }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list \
+            --repo kubestellar/console \
+            --state open \
+            --label "acmm-regression" \
+            --json number \
+            --jq '.[0].number // empty' 2>/dev/null || echo "")
+          echo "number=$EXISTING" >> "$GITHUB_OUTPUT"
+
+      - name: Open regression issue
+        if: ${{ fromJson(steps.badge.outputs.level) < fromJson(steps.badge.outputs.min_level) && steps.existing.outputs.number == '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LEVEL="${{ steps.badge.outputs.level }}"
+          MIN="${{ steps.badge.outputs.min_level }}"
+          SCORE="${{ steps.badge.outputs.score }}"
+          MESSAGE="${{ steps.badge.outputs.message }}"
+          gh issue create \
+            --repo kubestellar/console \
+            --title "🔴 ACMM regression: badge dropped to L${LEVEL} (required L${MIN})" \
+            --label "bug,acmm-regression" \
+            --body "## ACMM Level Regression
+
+**Detected:** $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+**Current badge:** \`${MESSAGE}\` (L${LEVEL})
+**Required minimum:** L${MIN}
+**Score:** ${SCORE}
+
+## What this means
+
+The ACMM badge on the \`kubestellar/console\` README has dropped below L${MIN}. One or more criteria that the badge endpoint detects are now missing from the repo tree.
+
+## Investigation steps
+
+1. Check the [ACMM leaderboard](https://console.kubestellar.io/acmm?repo=kubestellar%2Fconsole) for the full breakdown.
+2. Compare the detected criteria between L${LEVEL} and L${MIN} — which L$(( LEVEL + 1 )) criteria are now missing?
+3. Check recent merged PRs that may have removed or renamed files the scanner detects.
+4. Restore the missing files/workflows or update detection paths in \`web/src/lib/acmm/sources/acmm.ts\`.
+
+## Badge URL
+
+\`https://console.kubestellar.io/api/acmm/badge?repo=kubestellar%2Fconsole&force=true\`"
+
+      - name: Comment on existing issue
+        if: ${{ fromJson(steps.badge.outputs.level) < fromJson(steps.badge.outputs.min_level) && steps.existing.outputs.number != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LEVEL="${{ steps.badge.outputs.level }}"
+          SCORE="${{ steps.badge.outputs.score }}"
+          MESSAGE="${{ steps.badge.outputs.message }}"
+          gh issue comment "${{ steps.existing.outputs.number }}" \
+            --repo kubestellar/console \
+            --body "Still regressed as of $(date -u '+%Y-%m-%dT%H:%M:%SZ'): badge is \`${MESSAGE}\` (L${LEVEL}, score ${SCORE})"
+
+      - name: Pass — log and exit
+        if: ${{ fromJson(steps.badge.outputs.level) >= fromJson(steps.badge.outputs.min_level) }}
+        run: |
+          echo "✅ ACMM level L${{ steps.badge.outputs.level }} >= required L${{ steps.badge.outputs.min_level }} (score: ${{ steps.badge.outputs.score }})"

--- a/web/netlify/functions/acmm-badge.mts
+++ b/web/netlify/functions/acmm-badge.mts
@@ -13,7 +13,7 @@
  */
 
 import { getStore } from "@netlify/blobs";
-import { SCANNABLE_IDS_BY_LEVEL, AGENT_INSTRUCTION_FILE_IDS } from "../../src/lib/acmm/scannableIdsByLevel";
+import { SCANNABLE_IDS_BY_LEVEL, AGENT_INSTRUCTION_FILE_IDS, ACMM_DETECTION_PATHS } from "../../src/lib/acmm/scannableIdsByLevel";
 
 const GITHUB_API = "https://api.github.com";
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
@@ -185,92 +185,8 @@ async function fetchFromScanEndpoint(origin: string, repo: string, force = false
   return body.detectedIds || [];
 }
 
-/**
- * Fallback: call GitHub directly when the scan endpoint isn't reachable
- * from this function (same-origin fetch timed out, scan function cold-
- * started, etc.). Detects a representative subset of criteria by path —
- * enough to produce a plausible level for the badge so we never show
- * "custom badge inaccessible" (issue #8979). Previously this used a
- * naive `id.replace("acmm:", "").replace(/-/g, "_") + ".md"` heuristic
- * that never matched anything real (e.g. `claude_md.md` is not a file
- * on any repo), so every fallback path computed to L1.
- */
-const BADGE_FALLBACK_PATHS: Record<string, readonly string[]> = {
-  // L2 — individual instruction files still detected; computeLevel synthesises
-  // the virtual "acmm:agent-instructions" from any one of these matches.
-  "acmm:claude-md": ["CLAUDE.md", ".claude/CLAUDE.md"],
-  "acmm:copilot-instructions": [".github/copilot-instructions.md"],
-  "acmm:agents-md": ["AGENTS.md"],
-  "acmm:cursor-rules": [".cursorrules", ".cursor/rules"],
-  "acmm:prompts-catalog": [
-    "prompts/",
-    ".prompts/",
-    "docs/prompts/",
-    ".github/prompts/",
-    ".github/agents/",
-  ],
-  "acmm:editor-config": [".editorconfig"],
-  // L3
-  "acmm:pr-review-rubric": [
-    ".github/review-rubric.md",
-    "docs/review-criteria.md",
-    ".github/prompts/review.md",
-  ],
-  "acmm:ci-matrix": [
-    ".github/workflows/ci.yml",
-    ".github/workflows/test.yml",
-    ".github/workflows/build.yml",
-    ".github/workflows/build-deploy.yml",
-  ],
-  // L4
-  "acmm:security-ai-md": [
-    "docs/security/SECURITY-AI.md",
-    "SECURITY-AI.md",
-    "docs/SECURITY-AI.md",
-  ],
-  "acmm:ai-fix-workflow": [
-    ".github/workflows/ai-fix.yml",
-    ".github/workflows/ai-fix-requested.yml",
-    ".github/workflows/claude.yml",
-  ],
-  "acmm:nightly-compliance": [
-    ".github/workflows/nightly-compliance.yml",
-    ".github/workflows/nightly.yml",
-    ".github/workflows/nightly-test.yml",
-  ],
-  "acmm:auto-label": [
-    ".github/labeler.yml",
-    ".github/workflows/labeler.yml",
-    ".github/workflows/triage.yml",
-  ],
-  // L5
-  "acmm:policy-as-code": [
-    ".github/policies/",
-    "policies/",
-  ],
-  "acmm:github-actions-ai": [
-    ".github/workflows/claude.yml",
-    ".github/workflows/claude-code-review.yml",
-  ],
-  "acmm:reflection-log": [
-    "docs/reflections/",
-    "memory/",
-    ".memory/",
-    "REFLECTIONS.md",
-    ".github/REFLECTIONS.md",
-  ],
-  "acmm:audit-trail": [
-    ".github/workflows/audit-trail.yml",
-    ".github/workflows/ai-attribution.yml",
-  ],
-  // L6
-  "acmm:merge-queue": [
-    ".github/workflows/merge-queue.yml",
-    ".github/merge-queue.yml",
-    ".prow.yaml",
-    "tide.yaml",
-  ],
-};
+// ACMM_DETECTION_PATHS is derived from acmmSource.criteria in scannableIdsByLevel.ts —
+// the single source of truth shared with acmm-scan.mts. No hand-maintained copy here.
 
 function pathMatches(paths: Set<string>, pattern: string): boolean {
   if (pattern.endsWith("/")) {
@@ -310,7 +226,7 @@ async function fetchDetectedIdsDirect(repo: string, token: string): Promise<stri
   const paths = new Set((body.tree || []).map((e) => e.path));
 
   const detected: string[] = [];
-  for (const [id, patterns] of Object.entries(BADGE_FALLBACK_PATHS)) {
+  for (const [id, patterns] of Object.entries(ACMM_DETECTION_PATHS)) {
     for (const p of patterns) {
       if (pathMatches(paths, p)) {
         detected.push(id);

--- a/web/src/lib/acmm/scannableIdsByLevel.ts
+++ b/web/src/lib/acmm/scannableIdsByLevel.ts
@@ -1,9 +1,9 @@
 /**
- * Scannable ACMM criterion IDs grouped by level.
+ * Scannable ACMM criterion IDs grouped by level, and detection-path map.
  *
  * SINGLE SOURCE OF TRUTH consumed by:
- *   - web/src/lib/acmm/computeLevel.ts   (frontend dashboard)
- *   - web/netlify/functions/acmm-badge.mts (shields.io badge endpoint)
+ *   - web/src/lib/acmm/computeLevel.ts         (frontend dashboard)
+ *   - web/netlify/functions/acmm-badge.mts      (shields.io badge endpoint)
  *
  * Derived from the criteria definitions in sources/acmm.ts by filtering out
  * items where `scannable === false`. For L2, the four individual instruction-
@@ -67,3 +67,29 @@ function buildScannableIdsByLevel(): Record<number, string[]> {
  * to ensure identical level calculations.
  */
 export const SCANNABLE_IDS_BY_LEVEL: Record<number, string[]> = buildScannableIdsByLevel()
+
+/**
+ * Detection-path map derived from acmmSource.criteria.
+ *
+ * Maps criterion ID → array of file/directory patterns from the criterion's
+ * `detection.pattern` field. Used by the badge function's direct-GitHub
+ * fallback path so it detects the same criteria as the full scan function —
+ * no more hand-maintained `BADGE_FALLBACK_PATHS` that diverges from the
+ * canonical CRITERIA list.
+ *
+ * Only ACMM source, scannable criteria are included (same filter as
+ * SCANNABLE_IDS_BY_LEVEL). The individual instruction-file IDs (L2) are kept
+ * as-is here because `computeLevel` in the badge synthesises the virtual
+ * "acmm:agent-instructions" OR-group from whichever individual file is found.
+ */
+export const ACMM_DETECTION_PATHS: Record<string, readonly string[]> = (() => {
+  const result: Record<string, string[]> = {}
+  for (const c of acmmSource.criteria) {
+    if (c.scannable === false) continue
+    const patterns = Array.isArray(c.detection.pattern)
+      ? c.detection.pattern
+      : [c.detection.pattern]
+    result[c.id] = patterns
+  }
+  return result
+})()


### PR DESCRIPTION
## Problem

The ACMM badge in the README showed **L2 · Instructed · 12/26** while the leaderboard correctly showed **L5 · 20/28**.

The badge endpoint has 4 data layers:
1. Netlify Blobs cache (populated by full scan) — ✅ correct
2. `/api/acmm/scan` same-origin fetch — ✅ correct  
3. **Direct GitHub tree fetch** — ❌ was using a hand-maintained `BADGE_FALLBACK_PATHS` with only 15 criterion IDs, missing most L3–L5 criteria
4. Stale blob / "unavailable"

When the badge hit layer 3 (scan endpoint cold-start or timeout), it detected only the L2 files and computed L2 — even though the repo is L5.

## Fix

- Export `ACMM_DETECTION_PATHS` from `scannableIdsByLevel.ts`, derived directly from `acmmSource.criteria` detection patterns — the same source used by `acmm-scan.mts`
- Replace the 91-line hand-maintained `BADGE_FALLBACK_PATHS` in `acmm-badge.mts` with a single import of `ACMM_DETECTION_PATHS`
- Badge layer 3 now detects the full criterion catalog, not a stale subset

## Also adds

`acmm-level-monitor.yml` — daily workflow that:
- Fetches the live badge with `force=true`
- Opens a `bug,acmm-regression` issue if level drops below L5
- Comments on existing open regression issue instead of duplicating

## Test plan
- [ ] Trigger the badge with `?force=true` — should return L5
- [ ] Verify `ACMM_DETECTION_PATHS` covers all scannable criteria in `acmm.ts`
- [ ] Run `acmm-level-monitor` workflow manually — should pass (L5 ≥ 5)