### PR TITLE
🌱 Memoize StackContext value and stabilize callbacks

### DIFF
--- a/web/src/contexts/StackContext.tsx
+++ b/web/src/contexts/StackContext.tsx
@@ -197,7 +197,9 @@ export function StackProvider({ children }: StackProviderProps) {
   const stacks = isDemoMode ? demoStacks : liveStacks
   const isLoading = isDemoMode ? false : liveLoading
   const error = isDemoMode ? null : liveError
-  const refetch = isDemoMode ? (() => {}) : liveRefetch
+  // Stable no-op for demo mode so refetch identity doesn't change every render
+  const demoRefetch = useCallback(() => {}, [])
+  const refetch = isDemoMode ? demoRefetch : liveRefetch
   const lastRefresh = isDemoMode ? new Date() : liveLastRefresh
 
   const [selectedStackId, setSelectedStackIdState] = useState<string | null>(() => {
@@ -239,20 +241,20 @@ export function StackProvider({ children }: StackProviderProps) {
     }
   }, [isLoading, stacks, selectedStackId, setSelectedStackId])
 
-  const getStackById = (id: string) => {
+  const getStackById = useCallback((id: string) => {
     return stacks.find(s => s.id === id)
-  }
+  }, [stacks])
 
-  const selectedStack = (() => {
+  const selectedStack = useMemo(() => {
     if (!selectedStackId) return null
     return stacks.find(s => s.id === selectedStackId) || null
-  })()
+  }, [stacks, selectedStackId])
 
   const healthyStacks = useMemo(() => stacks.filter(s => s.status === 'healthy'), [stacks])
 
   const disaggregatedStacks = useMemo(() => stacks.filter(s => s.hasDisaggregation), [stacks])
 
-  const value: StackContextType = {
+  const value = useMemo<StackContextType>(() => ({
     stacks,
     isLoading,
     error,
@@ -264,7 +266,11 @@ export function StackProvider({ children }: StackProviderProps) {
     isDemoMode,
     getStackById,
     healthyStacks,
-    disaggregatedStacks }
+    disaggregatedStacks }), [
+    stacks, isLoading, error, refetch, lastRefresh,
+    selectedStack, selectedStackId, setSelectedStackId,
+    isDemoMode, getStackById, healthyStacks, disaggregatedStacks
+  ])
 
   return (
     <StackContext.Provider value={value}>


### PR DESCRIPTION
## Problem

StackContext creates a new `value` object on every render, causing all consumers (StackStatusCard, LLMDStackCard) to re-render even when no stack data changed. Additionally, `getStackById` and the demo-mode `refetch` create new function references each render.

## Changes

- **`getStackById`** → wrapped in `useCallback` (depends only on `stacks`)
- **`selectedStack`** → replaced inline IIFE with `useMemo` (depends on `stacks`, `selectedStackId`)
- **Demo-mode `refetch`** → stable `useCallback(() => {}, [])` instead of inline arrow
- **Context `value`** → wrapped in `useMemo` with all dependencies listed

## Impact

Eliminates unnecessary re-renders for StackContext consumers on every provider render cycle. Follows the same proven pattern used in PR #10028 (AlertsContext memoization).

## Testing

- `npm run build` ✅
- `npm run lint` ✅ (no new errors)