### PR TITLE
🌱 Memoize DashboardContext and PipelineFilterContext values

### DIFF
--- a/web/src/components/cards/pipelines/PipelineFilterContext.tsx
+++ b/web/src/components/cards/pipelines/PipelineFilterContext.tsx
@@ -10,7 +10,7 @@
  * Cards on OTHER dashboards (where the provider is absent) fall back to
  * their own per-card state.
  */
-import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react'
+import { createContext, useContext, useState, useCallback, useEffect, useMemo, type ReactNode } from 'react'
 import { getPipelineRepos } from '../../../hooks/useGitHubPipelines'
 import { safeGetJSON, safeSetJSON } from '../../../lib/utils/localStorage'
 
@@ -198,7 +198,7 @@ export function PipelineFilterProvider({ children, initialRepo }: { children: Re
     }
   }, [])
 
-  const value: PipelineFilterState = {
+  const value: PipelineFilterState = useMemo(() => ({
     selectedRepos,
     toggleRepo,
     selectAll,
@@ -212,7 +212,21 @@ export function PipelineFilterProvider({ children, initialRepo }: { children: Re
     hiddenRepos: config.hidden,
     hasCustomization,
     resetToDefaults,
-  }
+  }), [
+    selectedRepos,
+    toggleRepo,
+    selectAll,
+    repoFilter,
+    setRepoFilter,
+    repos,
+    serverRepos,
+    addRepo,
+    removeRepo,
+    restoreRepo,
+    config.hidden,
+    hasCustomization,
+    resetToDefaults,
+  ])
 
   return (
     <PipelineFilterCtx.Provider value={value}>

--- a/web/src/hooks/useDashboardContext.tsx
+++ b/web/src/hooks/useDashboardContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, ReactNode } from 'react'
+import { createContext, useContext, useState, useCallback, useMemo, ReactNode } from 'react'
 import { useDashboardHealth, type DashboardHealthInfo } from './useDashboardHealth'
 
 /** Valid initial sections for Console Studio */
@@ -65,44 +65,60 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     setStudioWidgetCardType(undefined)
   }, [])
 
-  const setPendingOpenAddCardModal = (pending: boolean) => {
+  const setPendingOpenAddCardModal = useCallback((pending: boolean) => {
     setPendingOpenAddCardModalState(pending)
-  }
+  }, [])
 
-  const openTemplatesModal = () => {
+  const openTemplatesModal = useCallback(() => {
     setIsTemplatesModalOpen(true)
-  }
+  }, [])
 
-  const closeTemplatesModal = () => {
+  const closeTemplatesModal = useCallback(() => {
     setIsTemplatesModalOpen(false)
-  }
+  }, [])
 
-  const setPendingRestoreCard = (card: PendingRestoreCard | null) => {
+  const setPendingRestoreCard = useCallback((card: PendingRestoreCard | null) => {
     setPendingRestoreCardState(card)
-  }
+  }, [])
 
-  const clearPendingRestoreCard = () => {
+  const clearPendingRestoreCard = useCallback(() => {
     setPendingRestoreCardState(null)
-  }
+  }, [])
+
+  const value = useMemo(() => ({
+    isAddCardModalOpen,
+    openAddCardModal,
+    closeAddCardModal,
+    studioInitialSection,
+    studioWidgetCardType,
+    pendingOpenAddCardModal,
+    setPendingOpenAddCardModal,
+    isTemplatesModalOpen,
+    openTemplatesModal,
+    closeTemplatesModal,
+    pendingRestoreCard,
+    setPendingRestoreCard,
+    clearPendingRestoreCard,
+    health,
+  }), [
+    isAddCardModalOpen,
+    openAddCardModal,
+    closeAddCardModal,
+    studioInitialSection,
+    studioWidgetCardType,
+    pendingOpenAddCardModal,
+    setPendingOpenAddCardModal,
+    isTemplatesModalOpen,
+    openTemplatesModal,
+    closeTemplatesModal,
+    pendingRestoreCard,
+    setPendingRestoreCard,
+    clearPendingRestoreCard,
+    health,
+  ])
 
   return (
-    <DashboardContext.Provider
-      value={{
-        isAddCardModalOpen,
-        openAddCardModal,
-        closeAddCardModal,
-        studioInitialSection,
-        studioWidgetCardType,
-        pendingOpenAddCardModal,
-        setPendingOpenAddCardModal,
-        isTemplatesModalOpen,
-        openTemplatesModal,
-        closeTemplatesModal,
-        pendingRestoreCard,
-        setPendingRestoreCard,
-        clearPendingRestoreCard,
-        health }}
-    >
+    <DashboardContext.Provider value={value}>
       {children}
     </DashboardContext.Provider>
   )


### PR DESCRIPTION
## Problem

Both `DashboardProvider` and `PipelineFilterProvider` create new `value` objects on every render, causing all consumers to re-render even when no relevant state changed.

**DashboardContext** additionally had 5 callbacks defined as plain arrow functions (recreated every render) instead of `useCallback`.

## Changes

### `useDashboardContext.tsx`
- Wrap 5 callbacks in `useCallback`: `setPendingOpenAddCardModal`, `openTemplatesModal`, `closeTemplatesModal`, `setPendingRestoreCard`, `clearPendingRestoreCard`
- Wrap context `value` in `useMemo` with all 14 dependencies listed

### `PipelineFilterContext.tsx`
- Wrap context `value` in `useMemo` with all 14 dependencies listed
- Callbacks were already stabilized with `useCallback` ✅

## Impact

Eliminates unnecessary re-renders for consumers of both contexts when unrelated provider state changes. Continues the context memoization campaign from PRs #10028 (AlertsContext) and #10036 (StackContext).

## Testing

- `npm run build` ✅
- `npm run lint` ✅ (0 new errors — 6 pre-existing react-compiler errors in PipelineFilterContext unchanged)