### PR TITLE
🐛 Fix stale data and freshness indicator issues

### DIFF
--- a/web/src/components/compliance/ComplianceReports.tsx
+++ b/web/src/components/compliance/ComplianceReports.tsx
@@ -12,6 +12,7 @@ import { useComplianceFrameworks, type Framework } from '../../hooks/useComplian
 import { useClusters } from '../../hooks/useMCP'
 import { authFetch } from '../../lib/api'
 import { Select } from '../ui/Select'
+import { Skeleton } from '../ui/Skeleton'
 import { DashboardHeader } from '../shared/DashboardHeader'
 import { RotatingTip } from '../ui/RotatingTip'
 
@@ -111,18 +112,20 @@ export const ComplianceReportsContent = memo(function ComplianceReportsContent()
           {/* Framework Picker */}
           <div>
             <label className="block text-sm font-medium text-muted-foreground mb-1.5">Framework</label>
-            <Select
-              value={selectedFw}
-              onChange={(e) => setSelectedFw(e.target.value)}
-              disabled={fwLoading}
-            >
-              {fwLoading && <option>Loading...</option>}
-              {frameworks.map((fw: Framework) => (
-                <option key={fw.id} value={fw.id}>
-                  {fw.name} {fw.version}
-                </option>
-              ))}
-            </Select>
+            {fwLoading ? (
+              <Skeleton variant="rounded" height={38} className="w-full" />
+            ) : (
+              <Select
+                value={selectedFw}
+                onChange={(e) => setSelectedFw(e.target.value)}
+              >
+                {(frameworks || []).map((fw: Framework) => (
+                  <option key={fw.id} value={fw.id}>
+                    {fw.name} {fw.version}
+                  </option>
+                ))}
+              </Select>
+            )}
           </div>
 
           {/* Cluster Picker */}


### PR DESCRIPTION
Fixes #10039

## Summary
- Replace "Loading..." text with Skeleton component in ComplianceReports framework picker
- Show skeleton placeholder during loading instead of disabled select with hardcoded text
- Add array safety guard on `frameworks.map()` call

## Test plan
- [ ] ComplianceReports shows skeleton during loading instead of "Loading..." text
- [ ] Framework picker renders correctly after data loads
- [ ] No regressions in compliance report generation flow