### PR TITLE
🐛 Fix UnifiedCard chart test for lazy-loaded ChartVisualization

### DIFF
--- a/web/src/lib/unified/card/__tests__/UnifiedCard.test.tsx
+++ b/web/src/lib/unified/card/__tests__/UnifiedCard.test.tsx
@@ -16,6 +16,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { Suspense } from 'react'
 import { UnifiedCard } from '../UnifiedCard'
 import type { UnifiedCardConfig, CardContentList, CardContentTable } from '../../types'
 
@@ -132,12 +133,16 @@ describe('UnifiedCard', () => {
     expect(screen.getByTestId('table-viz')).toBeInTheDocument()
   })
 
-  it('renders chart visualization for chart content type', () => {
+  it('renders chart visualization for chart content type', async () => {
     const config = makeConfig({
       content: { type: 'chart', chartType: 'bar', dataKey: 'value', categoryKey: 'name' },
     })
-    render(<UnifiedCard config={config} />)
-    expect(screen.getByTestId('chart-viz')).toBeInTheDocument()
+    render(
+      <Suspense fallback={<div>Loading</div>}>
+        <UnifiedCard config={config} />
+      </Suspense>,
+    )
+    expect(await screen.findByTestId('chart-viz')).toBeInTheDocument()
   })
 
   it('renders status-grid visualization for status-grid content type', () => {


### PR DESCRIPTION
Fixes #10048

The chart visualization test broke after #10045 converted `ChartVisualization` to `React.lazy`. The test was using synchronous `getByTestId` but the lazy-loaded component needs async resolution.

**Fix**: Wrap render in `<Suspense>` and use `findByTestId` (async) for the chart content type test. All 27 UnifiedCard tests pass.