### PR TITLE
Remove ai-needs-human label from automated failure issues

### DIFF
--- a/.github/aw/config.yml
+++ b/.github/aw/config.yml
@@ -63,7 +63,6 @@ issues:
     - ai-pr-draft
     - ai-pr-ready
     - ai-processing-complete
-    - ai-needs-human
   # Labels that should trigger AI workflows
   trigger-labels:
     - ai-fix-requested

--- a/.github/workflows/auth-login-smoke.yml
+++ b/.github/workflows/auth-login-smoke.yml
@@ -264,5 +264,5 @@ jobs:
               repo: context.repo.repo,
               title,
               body,
-              labels: ['auth-smoke-failure', 'priority/critical', 'ai-needs-human'],
+              labels: ['auth-smoke-failure', 'priority/critical'],
             });

--- a/.github/workflows/console-app-roundtrip.yml
+++ b/.github/workflows/console-app-roundtrip.yml
@@ -9,8 +9,8 @@ name: Console App Roundtrip
 #
 # Creates one issue per run, immediately closes and locks it with a
 # dedicated label (test/auto-delete) so it's easy to bulk-clean later.
-# Runs daily at 06:00 UTC. Opens a priority/critical + ai-needs-human
-# failure issue on contract violation.
+# Runs daily at 06:00 UTC. Opens a priority/critical failure issue on
+# contract violation.
 
 on:
   schedule:
@@ -324,5 +324,5 @@ jobs:
                 '- App renamed (update \`EXPECTED_USER_LOGIN\` and \`EXPECTED_SLUG\` in the workflow)',
                 '- Missing \`test/auto-delete\` label the App lacks permission to create',
               ].join('\n'),
-              labels: ['console-app-roundtrip-failure', 'priority/critical', 'ai-needs-human'],
+              labels: ['console-app-roundtrip-failure', 'priority/critical'],
             });

--- a/.github/workflows/console-app-smoke.yml
+++ b/.github/workflows/console-app-smoke.yml
@@ -8,8 +8,8 @@ name: Console App Smoke
 # Also runs the rewards classifier unit tests so any change to the
 # attribution logic is caught before it hits the leaderboard.
 #
-# Runs every 30 minutes. Opens a priority/critical + ai-needs-human
-# issue on failure (deduplicated by label). Catches:
+# Runs every 30 minutes. Opens a priority/critical issue on failure
+# (deduplicated by label). Catches:
 #   - App private key rotation not propagated to the repo secret
 #   - Installation revoked on the target account
 #   - Permissions removed (e.g. Issues:write)
@@ -140,7 +140,7 @@ jobs:
                 '### Effect',
                 'While this is broken, **console-submitted issues will not get App attribution** — the backend falls back to the PAT (\`FEEDBACK_GITHUB_TOKEN\`). Rewards will continue to award points but without the anti-gaming guarantee.',
               ].join('\n'),
-              labels: ['console-app-smoke-failure', 'priority/critical', 'ai-needs-human'],
+              labels: ['console-app-smoke-failure', 'priority/critical'],
             });
 
   # ── 2. Rewards classifier unit tests ────────────────────────────


### PR DESCRIPTION
## Summary

- Remove `ai-needs-human` from labels applied by `console-app-roundtrip.yml`, `console-app-smoke.yml`, and `auth-login-smoke.yml`
- Remove `ai-needs-human` from `aw/config.yml` processing-labels list
- `triage-command.yml` also references `ai-needs-human` but both occurrences are behind `if: false` (Copilot disabled) — dead code, left as-is

**Why:** The scanner was skipping `priority/critical` issues like #9999 because `ai-needs-human` signaled "needs operator." These automated failure issues are fixable by the scanner and should not be blocked.

No other workflow labels (besides `hold/*`) would cause the scanner to skip issues.

## Test plan

- [ ] Verify next roundtrip/smoke failure issue is created without `ai-needs-human`
- [ ] Verify scanner picks up the issue on its next pass