### PR TITLE
🌱 Memoize ClusterGroups health map and timeline demo data

### DIFF
--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useDroppable } from '@dnd-kit/core'
 import {
   Server,
@@ -152,6 +152,11 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
   const [editingGroup, setEditingGroup] = useState<string | null>(null)
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
 
+  const clusterHealthMap = useMemo(
+    () => new Map(clusters.map(c => [c.name, c.healthy])),
+    [clusters],
+  )
+
   const toggleExpanded = (name: string) => {
     setExpandedGroups(prev => {
       const next = new Set(prev)
@@ -197,7 +202,7 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
       {isCreating && (
         <CreateGroupForm
           availableClusters={availableClusterNames}
-          clusterHealthMap={new Map(clusters.map(c => [c.name, c.healthy]))}
+          clusterHealthMap={clusterHealthMap}
           onSave={(group) => {
             createGroup(group)
             setIsCreating(false)
@@ -223,7 +228,7 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
                 key={group.name}
                 group={group}
                 availableClusters={availableClusterNames}
-                clusterHealthMap={new Map(clusters.map(c => [c.name, c.healthy]))}
+                clusterHealthMap={clusterHealthMap}
                 onSave={(updates) => {
                   updateGroup(group.name, updates)
                   setEditingGroup(null)
@@ -235,7 +240,7 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
                 key={group.name}
                 group={group}
                 isExpanded={expandedGroups.has(group.name)}
-                clusterHealthMap={new Map(clusters.map(c => [c.name, c.healthy]))}
+                clusterHealthMap={clusterHealthMap}
                 onToggle={() => toggleExpanded(group.name)}
                 onEdit={() => setEditingGroup(group.name)}
                 onDelete={() => setDeleteConfirmName(group.name)}

--- a/web/src/components/cards/change_timeline/ChangeTimeline.tsx
+++ b/web/src/components/cards/change_timeline/ChangeTimeline.tsx
@@ -233,7 +233,7 @@ export function ChangeTimeline({ config: _config }: ChangeTimelineProps) {
                   : 'bg-secondary/50 text-muted-foreground hover:bg-secondary',
               )}
             >
-              {String(t(opt.labelKey))}
+              {t(opt.labelKey)}
             </button>
           ))}
         </div>

--- a/web/src/hooks/useCachedTimeline.ts
+++ b/web/src/hooks/useCachedTimeline.ts
@@ -1,4 +1,5 @@
 import { useCache, type RefreshCategory } from '../lib/cache'
+import { useMemo } from 'react'
 import { useDemoMode } from './useDemoMode'
 import { authFetch } from '../lib/api'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
@@ -58,11 +59,13 @@ export function useCachedTimeline(
 ): CachedTimelineResult {
   const { isDemoMode } = useDemoMode()
 
+  const stableDemoData = useMemo(() => getDemoTimelineEvents(), [])
+
   const cacheResult = useCache<TimelineEvent[]>({
     key: `${CACHE_KEY_TIMELINE}_${rangeMs}`,
     category: TIMELINE_CATEGORY,
     initialData: INITIAL_DATA,
-    demoData: getDemoTimelineEvents(),
+    demoData: stableDemoData,
     fetcher: () => fetchTimelineEvents(rangeMs),
   })
 
@@ -70,7 +73,7 @@ export function useCachedTimeline(
   const isDemoData = (isDemoMode || cacheResult.isDemoFallback) && !cacheResult.isLoading
 
   return {
-    data: isDemoMode ? getDemoTimelineEvents() : cacheResult.data,
+    data: isDemoMode ? stableDemoData : cacheResult.data,
     isLoading: cacheResult.isLoading,
     isRefreshing: cacheResult.isRefreshing,
     isDemoData,


### PR DESCRIPTION
## Problem

### ClusterGroups.tsx — triple Map creation
`new Map(clusters.map(c => [c.name, c.healthy]))` was created **3 times per render** (lines 200, 226, 238) — once for each child component (CreateGroupForm, EditGroupForm, DroppableGroup). Each call iterates the full cluster list and allocates a new Map object.

### useCachedTimeline.ts — demo data recreated every render
`getDemoTimelineEvents()` was called **twice per render** — once as the `demoData` prop to `useCache` (line 65) and once in the return value (line 73). Each call creates a fresh array of timeline events.

### ChangeTimeline.tsx — redundant String() wrapper
`String(t(opt.labelKey))` is redundant since `t()` already returns a string.

## Changes

- **ClusterGroups.tsx**: Extract the health Map into a single `useMemo` keyed on `[clusters]`, pass the stable reference to all 3 child components
- **useCachedTimeline.ts**: Memoize `getDemoTimelineEvents()` with `useMemo(() => ..., [])`, use stable reference in both `demoData` prop and return value
- **ChangeTimeline.tsx**: Remove redundant `String()` wrapper

## Testing

- `npm run build` ✅
- `npm run lint` ✅ (0 new errors)