### PR TITLE
🌱 Add standalone Dockerfile for kc-agent MCP server

### DIFF
--- a/cmd/kc-agent/.dockerignore
+++ b/cmd/kc-agent/.dockerignore
@@ -1,0 +1,15 @@
+web/
+node_modules/
+.git/
+.github/
+docs/
+deploy/
+presets/
+data/
+test-results/
+*.md
+LICENSE
+DCO
+Makefile
+crowdin.yml
+netlify.toml

--- a/cmd/kc-agent/Dockerfile
+++ b/cmd/kc-agent/Dockerfile
@@ -1,0 +1,27 @@
+# Stage 1: Build the kc-agent binary
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /kc-agent ./cmd/kc-agent
+
+# Stage 2: Minimal runtime image
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /kc-agent /usr/local/bin/kc-agent
+
+EXPOSE 8585
+
+ENTRYPOINT ["kc-agent"]
+CMD []
+
+LABEL org.opencontainers.image.source="https://github.com/kubestellar/console" \
+      org.opencontainers.image.title="kc-agent" \
+      org.opencontainers.image.description="KubeStellar Console MCP server — bridges browser to kubeconfig and MCP-capable AI providers"


### PR DESCRIPTION
Fixes #10054

## Summary
Adds a standalone Dockerfile for the kc-agent MCP server component, needed for:
1. Glama submission (glama.ai/mcp/servers) — required for awesome-mcp-servers listing
2. Independent container deployment of kc-agent

## Changes
- `cmd/kc-agent/Dockerfile` — Multi-stage build (golang:1.25-alpine → alpine:3.21)
- `cmd/kc-agent/.dockerignore` — Build context exclusions

## Testing
- Dockerfile builds successfully
- Container starts and listens on port 8585