### PR TITLE
🌱 Wrap GitHubActivity list items in React.memo

### DIFF
--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback, useImperativeHandle, type Ref } from 'react'
+import { useState, useMemo, useEffect, useCallback, useImperativeHandle, memo, type Ref } from 'react'
 import { GitPullRequest, GitBranch, Star, Users, Package, TrendingUp, AlertCircle, Clock, CheckCircle, XCircle, GitMerge, Settings, X, Plus, Check } from 'lucide-react'
 import { POLL_INTERVAL_SLOW_MS } from '../../lib/constants/network'
 import { Button } from '../ui/Button'
@@ -1118,7 +1118,7 @@ export function GitHubActivity({ config, ref }: { config?: GitHubActivityConfig;
 }
 
 // Sub-components for rendering different item types
-function PRItem({ pr }: { pr: GitHubPR }) {
+const PRItem = memo(function PRItem({ pr }: { pr: GitHubPR }) {
   const { t } = useTranslation(['cards', 'common'])
   const isOpen = pr.state === 'open'
   const isMerged = pr.merged_at != null
@@ -1186,9 +1186,9 @@ function PRItem({ pr }: { pr: GitHubPR }) {
       </div>
     </a>
   )
-}
+})
 
-function IssueItem({ issue }: { issue: GitHubIssue }) {
+const IssueItem = memo(function IssueItem({ issue }: { issue: GitHubIssue }) {
   const { t } = useTranslation(['cards', 'common'])
   const isOpen = issue.state === 'open'
   const isStaleItem = isOpen && isStale(issue.updated_at)
@@ -1246,9 +1246,9 @@ function IssueItem({ issue }: { issue: GitHubIssue }) {
       </div>
     </a>
   )
-}
+})
 
-function ReleaseItem({ release }: { release: GitHubRelease }) {
+const ReleaseItem = memo(function ReleaseItem({ release }: { release: GitHubRelease }) {
   const { t } = useTranslation(['cards'])
   return (
     <a
@@ -1279,9 +1279,9 @@ function ReleaseItem({ release }: { release: GitHubRelease }) {
       </div>
     </a>
   )
-}
+})
 
-function ContributorItem({ contributor }: { contributor: GitHubContributor }) {
+const ContributorItem = memo(function ContributorItem({ contributor }: { contributor: GitHubContributor }) {
   const { t } = useTranslation(['cards'])
   return (
     <a
@@ -1302,4 +1302,4 @@ function ContributorItem({ contributor }: { contributor: GitHubContributor }) {
       </div>
     </a>
   )
-}
+})


### PR DESCRIPTION
## Problem

GitHubActivity renders 4 list item components (`PRItem`, `IssueItem`, `ReleaseItem`, `ContributorItem`) inside `.map()` loops with potentially 50+ items. None were wrapped in `React.memo`, so every parent re-render (pagination, filtering, polling refresh) caused **all** list items to re-render even when their individual props were unchanged.

## Changes

Wrap all 4 list item components in `memo()`:
- `PRItem` (68 lines of JSX)
- `IssueItem` (58 lines of JSX)
- `ReleaseItem` (30 lines of JSX)
- `ContributorItem` (22 lines of JSX)

Each component receives a single immutable data prop (PR/issue/release/contributor object) — `memo()` shallow comparison is ideal here since the objects come from a memoized data array.

## Impact

Reduces unnecessary DOM diffing from O(n) to O(changed) on parent re-renders. Most impactful during:
- Polling refresh (every 30s) — only new/changed items re-render
- Pagination — only items entering/leaving the viewport re-render
- Filter changes — React can skip diffing unchanged items

## Testing

- `npm run build` ✅
- `npm run lint` ✅ (0 new errors — 6 pre-existing unchanged)