### PR TITLE
🐛 Apply container-query responsive grids to high-visibility cards

### DIFF
--- a/web/src/components/cards/EnterpriseComplianceCards.tsx
+++ b/web/src/components/cards/EnterpriseComplianceCards.tsx
@@ -103,7 +103,7 @@ export function GxPCard() {
               : <XCircle className="w-4 h-4 text-red-400" />}
             <span className="text-sm text-muted-foreground">Hash Chain {data.chain_integrity ? 'Intact' : 'Broken'}</span>
           </div>
-          <div className="grid grid-cols-3 gap-2">
+          <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
             <MiniStat label="Records" value={Number(data.total_records ?? 0)} />
             <MiniStat label="Signatures" value={Number(data.total_signatures ?? 0)} />
             <MiniStat label="Pending" value={Number(data.pending_signatures ?? 0)} color="text-yellow-400" />

--- a/web/src/components/cards/FleetComplianceHeatmap.tsx
+++ b/web/src/components/cards/FleetComplianceHeatmap.tsx
@@ -369,7 +369,7 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
       </div>
 
       {/* Header row */}
-      <div className="grid grid-cols-4 gap-1 text-xs font-medium text-muted-foreground">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-1 text-xs font-medium text-muted-foreground">
         <div className="px-2 py-1">Cluster</div>
         {tools.map((tool, i) => {
           const key = toolKeys[i]
@@ -394,7 +394,7 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
 
       {/* Data rows */}
       {rows.map(row => (
-        <div key={row.cluster} className="grid grid-cols-4 gap-1">
+        <div key={row.cluster} className="grid grid-cols-2 @md:grid-cols-4 gap-1">
           <div className="px-2 py-1.5 text-xs font-mono truncate" title={row.cluster}>
             {row.cluster}
           </div>

--- a/web/src/components/cards/cloud_custodian_status/index.tsx
+++ b/web/src/components/cards/cloud_custodian_status/index.tsx
@@ -247,7 +247,7 @@ export function CloudCustodianStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )
@@ -348,7 +348,7 @@ export function CloudCustodianStatus() {
             {t('cloudCustodianStatus.sectionViolations', 'Violations by severity')}
           </h4>
         </div>
-        <div className="grid grid-cols-4 gap-2 text-xs">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 text-xs">
           <div>
             <span className={cn('text-base font-semibold', severityClass('critical'))}>
               {violations.critical}

--- a/web/src/components/cards/harbor_status/HarborStatus.tsx
+++ b/web/src/components/cards/harbor_status/HarborStatus.tsx
@@ -275,7 +275,7 @@ export function HarborStatus() {
   if (showSkeleton) {
     return (
       <div className="flex flex-col h-full overflow-hidden">
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <div className="flex items-center gap-2 px-1 mb-2">
           <div className="w-20 h-6 rounded bg-muted animate-pulse" />
           <div className="w-24 h-6 rounded bg-muted animate-pulse" />
@@ -364,7 +364,7 @@ export function HarborStatus() {
         </div>
       </div>
 
-      <div className="grid grid-cols-4 gap-3 mb-4 shrink-0 px-0.5">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-3 mb-4 shrink-0 px-0.5">
         <StatTile
           icon={<FolderOpen className="w-4 h-4 text-blue-400" />}
           label={t('harbor.projects', 'Projects')}

--- a/web/src/components/cards/nats_status/index.tsx
+++ b/web/src/components/cards/nats_status/index.tsx
@@ -60,7 +60,7 @@ function NatsStatusInternal() {
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={3} className="flex-1" />
       </div>
@@ -117,7 +117,7 @@ function NatsStatusInternal() {
       </div>
 
       {/* 4 metric tiles — the key numbers at a glance */}
-      <div className="grid grid-cols-4 gap-2">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
         <MetricTile
           label={t('nats_status.metric.connections')}
           value={data.messaging.totalConnections}

--- a/web/src/components/cards/openyurt_status/OpenYurtStatus.tsx
+++ b/web/src/components/cards/openyurt_status/OpenYurtStatus.tsx
@@ -242,7 +242,7 @@ export function OpenYurtStatus() {
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={3} className="flex-1" />
       </div>
@@ -315,7 +315,7 @@ export function OpenYurtStatus() {
 
       {/* ── Stats grid ── */}
       {nodePools.length > 0 && (
-        <div className="grid grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
           <StatTile
             icon={<Server className="w-4 h-4 text-blue-400" />}
             label={t('openyurt.totalNodes', 'Nodes')}


### PR DESCRIPTION
Fixes #8695

Convert fixed `grid-cols-N` classes to responsive `@md:grid-cols-N` variants across 6 card components so stat grids, skeleton loaders, and heatmap rows collapse properly when cards are narrow (Phase 3a rollout).

### Changes (11 edits across 6 files)

| Component | What changed |
|-----------|-------------|
| nats_status | skeleton + stat grid: `grid-cols-4` → `grid-cols-2 @md:grid-cols-4` |
| openyurt_status | skeleton + stat grid: `grid-cols-4` → `grid-cols-2 @md:grid-cols-4` |
| harbor_status | skeleton + stat grid: `grid-cols-4` → `grid-cols-2 @md:grid-cols-4` |
| cloud_custodian_status | skeleton + violations grid: `grid-cols-4` → `grid-cols-2 @md:grid-cols-4` |
| EnterpriseComplianceCards | GxP stat grid: `grid-cols-3` → `grid-cols-2 @md:grid-cols-3` |
| FleetComplianceHeatmap | header + data rows: `grid-cols-4` → `grid-cols-2 @md:grid-cols-4` |

### Testing
- `npm run build` ✅
- `npm run lint` ✅ (no new errors)