### PR TITLE
🐛 Parallelize PredictionWorker cluster data gathering (Fixes #10058)

### DIFF
--- a/pkg/agent/prediction_worker.go
+++ b/pkg/agent/prediction_worker.go
@@ -18,6 +18,10 @@ import (
 const (
 	predictionInitialDelay = 30 * time.Second
 	predictionTimeout      = 60 * time.Second
+
+	// perClusterDataTimeout bounds each goroutine's data-gathering work
+	// (pod issues + GPU nodes + offline nodes) for a single cluster.
+	perClusterDataTimeout = 15 * time.Second
 )
 
 // PredictionSettings holds configuration from the frontend
@@ -504,83 +508,110 @@ func (w *PredictionWorker) gatherClusterData(ctx context.Context) (*ClusterAnaly
 		}
 	}
 
-	// Get pod issues from healthy clusters only
-	clusters, err := w.k8sClient.ListClusters(ctx)
+	// Gather pod issues, GPU nodes, and offline nodes in parallel across
+	// healthy clusters. Uses DeduplicatedClusters to avoid querying the same
+	// physical cluster twice when multiple kubeconfig contexts exist.
+	clusters, err := w.k8sClient.DeduplicatedClusters(ctx)
 	if err != nil {
 		slog.Error("[PredictionWorker] error listing clusters", "error", err)
 	} else {
+		podIssues := make([]PodIssueSummary, 0)
+		gpuNodes := make([]GPUNodeSummary, 0)
+		offlineNodes := make([]NodeSummary, 0)
+
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+
 		for _, cluster := range clusters {
 			if !healthyClusterSet[cluster.Name] {
 				slog.Info("[PredictionWorker] skipping offline cluster", "cluster", cluster.Name)
 				continue
 			}
-			pods, err := w.k8sClient.FindPodIssues(ctx, cluster.Context, "")
-			if err != nil {
-				slog.Error("[PredictionWorker] error getting pod issues", "cluster", cluster.Name, "error", err)
-				continue
-			}
-			for _, p := range pods {
-				data.PodIssues = append(data.PodIssues, PodIssueSummary{
-					Name:      p.Name,
-					Namespace: p.Namespace,
-					Cluster:   cluster.Name,
-					Restarts:  p.Restarts,
-					Status:    p.Status,
-				})
-			}
-		}
-	}
+			wg.Add(1)
+			go func(cl k8s.ClusterInfo) {
+				defer wg.Done()
 
-	// Get GPU nodes from healthy clusters only
-	if clusters == nil {
-		var fallbackErr error
-		clusters, fallbackErr = w.k8sClient.ListClusters(ctx)
-		if fallbackErr != nil {
-			slog.Error("[PredictionWorker] fallback ListClusters for GPU nodes failed", "error", fallbackErr)
-		}
-	}
-	for _, cluster := range clusters {
-		if !healthyClusterSet[cluster.Name] {
-			continue
-		}
-		gpuNodes, err := w.k8sClient.GetGPUNodes(ctx, cluster.Context)
-		if err != nil {
-			slog.Error("[PredictionWorker] error getting GPU nodes", "cluster", cluster.Name, "error", err)
-			continue
-		}
-		for _, g := range gpuNodes {
-			data.GPUNodes = append(data.GPUNodes, GPUNodeSummary{
-				Name:      g.Name,
-				Cluster:   g.Cluster,
-				Allocated: g.GPUAllocated,
-				Total:     g.GPUCount,
-			})
-		}
-	}
-
-	// Get offline/unhealthy nodes from healthy clusters only
-	for _, cluster := range clusters {
-		if !healthyClusterSet[cluster.Name] {
-			continue
-		}
-		nodes, err := w.k8sClient.GetNodes(ctx, cluster.Context)
-		if err != nil {
-			slog.Error("[PredictionWorker] error getting nodes", "cluster", cluster.Name, "error", err)
-			continue
-		}
-		for _, n := range nodes {
-			if n.Status != "Ready" || n.Unschedulable {
-				status := n.Status
-				if n.Unschedulable {
-					status = "Cordoned"
+				// Check parent context before starting work
+				select {
+				case <-ctx.Done():
+					return
+				default:
 				}
-				data.OfflineNodes = append(data.OfflineNodes, NodeSummary{
-					Name:    n.Name,
-					Cluster: cluster.Name,
-					Status:  status,
-				})
-			}
+
+				clusterCtx, cancel := context.WithTimeout(ctx, perClusterDataTimeout)
+				defer cancel()
+
+				// --- Pod issues ---
+				pods, podErr := w.k8sClient.FindPodIssues(clusterCtx, cl.Context, "")
+				if podErr != nil {
+					slog.Error("[PredictionWorker] error getting pod issues", "cluster", cl.Name, "error", podErr)
+				} else {
+					localPods := make([]PodIssueSummary, 0, len(pods))
+					for _, p := range pods {
+						localPods = append(localPods, PodIssueSummary{
+							Name:      p.Name,
+							Namespace: p.Namespace,
+							Cluster:   cl.Name,
+							Restarts:  p.Restarts,
+							Status:    p.Status,
+						})
+					}
+					mu.Lock()
+					podIssues = append(podIssues, localPods...)
+					mu.Unlock()
+				}
+
+				// --- GPU nodes ---
+				gpus, gpuErr := w.k8sClient.GetGPUNodes(clusterCtx, cl.Context)
+				if gpuErr != nil {
+					slog.Error("[PredictionWorker] error getting GPU nodes", "cluster", cl.Name, "error", gpuErr)
+				} else {
+					localGPU := make([]GPUNodeSummary, 0, len(gpus))
+					for _, g := range gpus {
+						localGPU = append(localGPU, GPUNodeSummary{
+							Name:      g.Name,
+							Cluster:   g.Cluster,
+							Allocated: g.GPUAllocated,
+							Total:     g.GPUCount,
+						})
+					}
+					mu.Lock()
+					gpuNodes = append(gpuNodes, localGPU...)
+					mu.Unlock()
+				}
+
+				// --- Offline / unhealthy nodes ---
+				nodes, nodeErr := w.k8sClient.GetNodes(clusterCtx, cl.Context)
+				if nodeErr != nil {
+					slog.Error("[PredictionWorker] error getting nodes", "cluster", cl.Name, "error", nodeErr)
+				} else {
+					localOffline := make([]NodeSummary, 0)
+					for _, n := range nodes {
+						if n.Status != "Ready" || n.Unschedulable {
+							status := n.Status
+							if n.Unschedulable {
+								status = "Cordoned"
+							}
+							localOffline = append(localOffline, NodeSummary{
+								Name:    n.Name,
+								Cluster: cl.Name,
+								Status:  status,
+							})
+						}
+					}
+					if len(localOffline) > 0 {
+						mu.Lock()
+						offlineNodes = append(offlineNodes, localOffline...)
+						mu.Unlock()
+					}
+				}
+			}(cluster)
 		}
+		wg.Wait()
+
+		data.PodIssues = podIssues
+		data.GPUNodes = gpuNodes
+		data.OfflineNodes = offlineNodes
 	}
 
 	return data, nil


### PR DESCRIPTION
## Summary
- Replaces three sequential loops in `gatherClusterData` (pod issues, GPU nodes, offline nodes) with a single parallel loop using goroutines + `sync.WaitGroup` + `sync.Mutex`
- Each healthy cluster now gathers all three data types concurrently with a per-cluster timeout (`perClusterDataTimeout = 15s`), preventing total wall-clock time from exceeding the 60s `predictionTimeout` when many clusters or high-latency clusters are present
- Switches from `ListClusters` to `DeduplicatedClusters` to avoid querying the same physical cluster twice through different kubeconfig contexts

Fixes #10058

## Changes
- **`pkg/agent/prediction_worker.go`**: Merged three sequential cluster loops into one parallel loop per cluster, following the existing `GetAllClusterHealth` goroutine pattern. Added `perClusterDataTimeout` named constant (no magic numbers). Uses `make([]T, 0)` for all slice initialization. Local slices are built per-goroutine and appended under mutex to minimize lock contention.

## Test plan
- [ ] `go vet ./pkg/agent/...` passes (verified locally)
- [ ] `go build ./pkg/agent/...` passes (verified locally)
- [ ] CI build passes
- [ ] With multiple clusters configured, prediction worker completes data gathering within timeout
- [ ] Pod issues, GPU nodes, and offline nodes are all populated correctly in predictions
- [ ] Offline/unhealthy clusters are still skipped (logged as "skipping offline cluster")