### PR TITLE
🌱 Convert render-path IIFEs to useMemo in 4 card components

### DIFF
--- a/web/src/components/cards/DNSHealth.tsx
+++ b/web/src/components/cards/DNSHealth.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCachedPods } from '../../hooks/useCachedData'
 import { useCardLoadingState } from './CardDataContext'
@@ -22,14 +23,14 @@ export function DNSHealth() {
     isFailed,
     consecutiveFailures })
 
-  const dnsPods = pods.filter(p => {
+  const dnsPods = useMemo(() => pods.filter(p => {
       // Only consider pods in known DNS namespaces
       if (!DNS_NAMESPACES.includes(p.namespace || '')) return false
       const name = p.name?.toLowerCase() || ''
       return DNS_POD_PATTERNS.some(pattern => name.includes(pattern))
-    })
+    }), [pods])
 
-  const byCluster = (() => {
+  const byCluster = useMemo(() => {
     const map = new Map<string, typeof dnsPods>()
     for (const pod of dnsPods) {
       const cluster = pod.cluster || 'unknown'
@@ -37,7 +38,7 @@ export function DNSHealth() {
       map.get(cluster)!.push(pod)
     }
     return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b))
-  })()
+  }, [dnsPods])
 
   if (showSkeleton) {
     return (

--- a/web/src/components/cards/HelmHistory.tsx
+++ b/web/src/components/cards/HelmHistory.tsx
@@ -1,7 +1,7 @@
 // Modal safety: HelmHistoryDetailModal is a read-only detail pane (no form
 // inputs the user could lose). Inline search is transient filter state.
 // Treat as closeOnBackdropClick={false}.
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import { CheckCircle, XCircle, RotateCcw, ArrowUp, Clock, ChevronRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useClusters, type HelmHistoryEntry } from '../../hooks/useMCP'
@@ -107,13 +107,13 @@ export function HelmHistory({ config }: HelmHistoryProps) {
   }, [isDemoData, allHelmReleases, allClusters])
 
   // Look up namespace from the selected release (required for helm history command)
-  const selectedReleaseNamespace = (() => {
+  const selectedReleaseNamespace = useMemo(() => {
     if (!selectedCluster || !selectedRelease) return undefined
     const release = allHelmReleases.find(
       r => r.cluster === selectedCluster && r.name === selectedRelease
     )
     return release?.namespace
-  })()
+  }, [selectedCluster, selectedRelease, allHelmReleases])
 
   // Fetch history for selected release (hook handles caching)
   const {
@@ -138,7 +138,7 @@ export function HelmHistory({ config }: HelmHistoryProps) {
     isDemoData })
 
   // Apply global filters to clusters
-  const clusters = (() => {
+  const clusters = useMemo(() => {
     let result = allClusters
 
     if (!isAllClustersSelected) {
@@ -154,19 +154,19 @@ export function HelmHistory({ config }: HelmHistoryProps) {
     }
 
     return result
-  })()
+  }, [allClusters, isAllClustersSelected, globalSelectedClusters, customFilter])
 
   // Filter releases locally by selected cluster (no API call)
-  const filteredReleases = (() => {
+  const filteredReleases = useMemo(() => {
     if (!selectedCluster) return allHelmReleases
     return allHelmReleases.filter(r => r.cluster === selectedCluster)
-  })()
+  }, [allHelmReleases, selectedCluster])
 
   // Get unique release names for dropdown
-  const releases = (() => {
+  const releases = useMemo(() => {
     const releaseSet = new Set(filteredReleases.map(r => r.name))
     return Array.from(releaseSet).sort()
-  })()
+  }, [filteredReleases])
 
   // Use shared card data hook for filtering, sorting, and pagination
   const {

--- a/web/src/components/cards/NetworkPolicyCoverage.tsx
+++ b/web/src/components/cards/NetworkPolicyCoverage.tsx
@@ -36,7 +36,7 @@ export function NetworkPolicyCoverage() {
     errorMessage: isFailed ? t('networkPolicyCoverage.failedToLoad') : undefined })
 
   // Build a set of namespace keys that have real NetworkPolicy resources
-  const policyNamespaceKeys = (() => {
+  const policyNamespaceKeys = useMemo(() => {
     const keys = new Set<string>()
     for (const policy of networkpolicies) {
       const cluster = policy.cluster || 'unknown'
@@ -44,17 +44,17 @@ export function NetworkPolicyCoverage() {
       keys.add(`${cluster}/${ns}`)
     }
     return keys
-  })()
+  }, [networkpolicies])
 
   // Count policies per namespace key
-  const policyCountByNs = (() => {
+  const policyCountByNs = useMemo(() => {
     const counts = new Map<string, number>()
     for (const policy of networkpolicies) {
       const key = `${policy.cluster || 'unknown'}/${policy.namespace || 'default'}`
       counts.set(key, (counts.get(key) || 0) + 1)
     }
     return counts
-  })()
+  }, [networkpolicies])
 
   // Build namespace coverage from pod data + real policy data
   const coverage = useMemo((): NamespaceCoverage[] => {

--- a/web/src/components/cards/QuotaHeatmap.tsx
+++ b/web/src/components/cards/QuotaHeatmap.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCachedPods } from '../../hooks/useCachedData'
 import { useCardLoadingState } from './CardDataContext'
@@ -26,7 +26,7 @@ export function QuotaHeatmap() {
     isFailed,
     consecutiveFailures })
 
-  const namespaceData = (() => {
+  const namespaceData = useMemo(() => {
     const map = new Map<string, NamespaceUsage>()
     for (const pod of pods) {
       const key = `${pod.cluster || 'unknown'}/${pod.namespace || 'default'}`
@@ -39,7 +39,7 @@ export function QuotaHeatmap() {
       map.get(key)!.podCount++
     }
     return Array.from(map.values()).sort((a, b) => b.podCount - a.podCount)
-  })()
+  }, [pods])
 
   const maxPods = Math.max(1, ...namespaceData.map(d => d.podCount))
 


### PR DESCRIPTION
## Summary

Replace immediately-invoked function expressions (IIFEs) with `useMemo` to avoid redundant Map/Set/sort recomputation on every render.

### Changes

| Component | What changed | Deps |
|-----------|-------------|------|
| **QuotaHeatmap** | `namespaceData` IIFE → `useMemo` | `[pods]` |
| **DNSHealth** | `dnsPods` filter + `byCluster` IIFE → `useMemo` chain | `[pods]`, `[dnsPods]` |
| **HelmHistory** | 4 IIFEs (`selectedReleaseNamespace`, `clusters`, `filteredReleases`, `releases`) → `useMemo` | various |
| **NetworkPolicyCoverage** | `policyNamespaceKeys` + `policyCountByNs` IIFEs → `useMemo` | `[networkpolicies]` |

### Notable fix
NetworkPolicyCoverage's two IIFEs created new Set/Map objects every render, which were listed as deps of the downstream `coverage` useMemo — causing it to recompute every render despite being wrapped in useMemo. Converting to useMemo fixes this referential instability.

### Testing
- `npm run build` ✅
- `npm run lint` ✅ (no new errors)