### PR TITLE
🐛 Fix arbitrary registry eviction and add provider validation

### DIFF
--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -133,6 +133,13 @@ func (r *Registry) GetSelectedAgent(sessionID string) string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	if r.selectedAgent == nil {
+		r.selectedAgent = make(map[string]string)
+	}
+	if r.selectedAgentLRU == nil {
+		r.selectedAgentLRU = make(map[string]time.Time)
+	}
+
 	if agent, ok := r.selectedAgent[sessionID]; ok {
 		r.selectedAgentLRU[sessionID] = time.Now()
 		return agent
@@ -163,13 +170,15 @@ func (r *Registry) SetSelectedAgent(sessionID, agentName string) error {
 	if len(r.selectedAgent) >= maxSelectedAgentEntries {
 		var oldestKey string
 		var oldestTime time.Time
+		var foundOldest bool
 		for k, t := range r.selectedAgentLRU {
-			if oldestKey == "" || t.Before(oldestTime) {
+			if !foundOldest || t.Before(oldestTime) {
 				oldestKey = k
 				oldestTime = t
+				foundOldest = true
 			}
 		}
-		if oldestKey != "" {
+		if foundOldest {
 			delete(r.selectedAgent, oldestKey)
 			delete(r.selectedAgentLRU, oldestKey)
 		}

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -5,14 +5,16 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+	"time"
 )
 
 // Registry manages available AI providers
 type Registry struct {
-	mu            sync.RWMutex
-	providers     map[string]AIProvider
-	defaultAgent  string
-	selectedAgent map[string]string // sessionID -> agentName
+	mu               sync.RWMutex
+	providers        map[string]AIProvider
+	defaultAgent     string
+	selectedAgent    map[string]string    // sessionID -> agentName
+	selectedAgentLRU map[string]time.Time // sessionID -> last access time
 }
 
 // Global registry instance
@@ -25,8 +27,9 @@ var (
 func GetRegistry() *Registry {
 	registryOnce.Do(func() {
 		globalRegistry = &Registry{
-			providers:     make(map[string]AIProvider),
-			selectedAgent: make(map[string]string),
+			providers:        make(map[string]AIProvider),
+			selectedAgent:    make(map[string]string),
+			selectedAgentLRU: make(map[string]time.Time),
 		}
 	})
 	return globalRegistry
@@ -127,10 +130,11 @@ func (r *Registry) GetSelectedAgent(sessionID string) string {
 	if r == nil {
 		return ""
 	}
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if agent, ok := r.selectedAgent[sessionID]; ok {
+		r.selectedAgentLRU[sessionID] = time.Now()
 		return agent
 	}
 	return r.defaultAgent
@@ -152,18 +156,27 @@ func (r *Registry) SetSelectedAgent(sessionID, agentName string) error {
 		return fmt.Errorf("provider %s is not available", agentName)
 	}
 
-	// Evict oldest entries when map exceeds a safety cap to prevent unbounded
-	// growth from sessions that never call RemoveSelectedAgent (#7209).
+	// Evict the least-recently-used entry when map exceeds a safety cap to
+	// prevent unbounded growth from sessions that never call
+	// RemoveSelectedAgent (#7209, #10063).
 	const maxSelectedAgentEntries = 10000
 	if len(r.selectedAgent) >= maxSelectedAgentEntries {
-		// Delete an arbitrary entry (map iteration order is random in Go).
-		for k := range r.selectedAgent {
-			delete(r.selectedAgent, k)
-			break
+		var oldestKey string
+		var oldestTime time.Time
+		for k, t := range r.selectedAgentLRU {
+			if oldestKey == "" || t.Before(oldestTime) {
+				oldestKey = k
+				oldestTime = t
+			}
+		}
+		if oldestKey != "" {
+			delete(r.selectedAgent, oldestKey)
+			delete(r.selectedAgentLRU, oldestKey)
 		}
 	}
 
 	r.selectedAgent[sessionID] = agentName
+	r.selectedAgentLRU[sessionID] = time.Now()
 	return nil
 }
 
@@ -176,6 +189,7 @@ func (r *Registry) RemoveSelectedAgent(sessionID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.selectedAgent, sessionID)
+	delete(r.selectedAgentLRU, sessionID)
 }
 
 // List returns all registered providers

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 )
 
 // MockProvider for testing registry
@@ -27,8 +28,9 @@ func (m *MockProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk
 
 func TestRegistry(t *testing.T) {
 	r := &Registry{
-		providers:     make(map[string]AIProvider),
-		selectedAgent: make(map[string]string),
+		providers:        make(map[string]AIProvider),
+		selectedAgent:    make(map[string]string),
+		selectedAgentLRU: make(map[string]time.Time),
 	}
 
 	p1 := &MockProvider{name: "p1", available: true}
@@ -96,8 +98,9 @@ func TestRegistry(t *testing.T) {
 func TestInitializeProviders(t *testing.T) {
 	// Reset registry for test
 	globalRegistry = &Registry{
-		providers:     make(map[string]AIProvider),
-		selectedAgent: make(map[string]string),
+		providers:        make(map[string]AIProvider),
+		selectedAgent:    make(map[string]string),
+		selectedAgentLRU: make(map[string]time.Time),
 	}
 	registryOnce = sync.Once{}
 

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -412,6 +412,14 @@ func (s *Server) handleSetKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reject unknown provider names so typos don't create orphaned config
+	// entries (#10060).
+	if _, err := GetRegistry().Get(req.Provider); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "unknown_provider", Message: fmt.Sprintf("Provider %q is not registered", req.Provider)})
+		return
+	}
+
 	// At least one actionable field must be present — a request with none
 	// is a programming bug we should reject rather than silently store
 	// nothing. ClearBaseURL counts as actionable (it reverts the URL to

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -413,8 +413,13 @@ func (s *Server) handleSetKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Reject unknown provider names so typos don't create orphaned config
-	// entries (#10060).
-	if _, err := GetRegistry().Get(req.Provider); err != nil {
+	// entries (#10060). Prefer the server's injected registry so tests
+	// validate against the active provider set for this server instance.
+	registry := s.registry
+	if registry == nil {
+		registry = GetRegistry()
+	}
+	if _, err := registry.Get(req.Provider); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "unknown_provider", Message: fmt.Sprintf("Provider %q is not registered", req.Provider)})
 		return

--- a/pkg/agent/server_test.go
+++ b/pkg/agent/server_test.go
@@ -431,6 +431,14 @@ func TestServer_SettingsHandlers(t *testing.T) {
 		SkipKeyValidation: true,
 	}
 
+	// Register a mock "openai" provider so the validation gate accepts it.
+	reg := GetRegistry()
+	reg.mu.Lock()
+	if _, exists := reg.providers["openai"]; !exists {
+		reg.providers["openai"] = &ServerMockProvider{name: "openai"}
+	}
+	reg.mu.Unlock()
+
 	// 2. Test handleSetKey
 	reqBody := `{"provider":"openai", "apiKey":"test-key", "model":"gpt-4"}`
 	req := httptest.NewRequest("POST", "/settings/keys", strings.NewReader(reqBody))

--- a/pkg/agent/server_test.go
+++ b/pkg/agent/server_test.go
@@ -432,12 +432,8 @@ func TestServer_SettingsHandlers(t *testing.T) {
 	}
 
 	// Register a mock "openai" provider so the validation gate accepts it.
-	reg := GetRegistry()
-	reg.mu.Lock()
-	if _, exists := reg.providers["openai"]; !exists {
-		reg.providers["openai"] = &ServerMockProvider{name: "openai"}
-	}
-	reg.mu.Unlock()
+	// Ignore "already registered" errors from concurrent tests.
+	_ = GetRegistry().Register(&ServerMockProvider{name: "openai"})
 
 	// 2. Test handleSetKey
 	reqBody := `{"provider":"openai", "apiKey":"test-key", "model":"gpt-4"}`


### PR DESCRIPTION
## Summary
- Replace random map-iteration eviction in agent registry with LRU (least-recently-used) strategy using timestamp tracking (Fixes #10063)
- Add provider name validation in `handleSetKey` to reject unknown providers with 400 Bad Request (Fixes #10060)

## Test plan
- [ ] Verify `SetSelectedAgent` evicts the least-recently-used session when at capacity
- [ ] Verify `GetSelectedAgent` updates LRU timestamp on access
- [ ] Verify `handleSetKey` returns 400 for unknown provider names
- [ ] Verify `RemoveSelectedAgent` cleans up LRU entries
- [ ] Go build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)