### PR TITLE
🏗 Extract duplicate grid-threshold logic into shared utility

### DIFF
--- a/web/src/lib/stats/StatsRuntime.tsx
+++ b/web/src/lib/stats/StatsRuntime.tsx
@@ -44,6 +44,7 @@ import {
   COLOR_CLASSES,
   VALUE_COLORS,
   formatValue } from './types'
+import { getResponsiveGridCols } from './gridUtils'
 
 // ============================================================================
 // Stats Registry
@@ -245,12 +246,7 @@ export function StatsRuntime({
       return `grid-cols-2 md:grid-cols-${grid.columns}`
     }
 
-    const count = visibleBlocks.length
-    if (count <= 4) return 'grid-cols-2 md:grid-cols-4'
-    if (count <= 5) return 'grid-cols-2 md:grid-cols-5'
-    if (count <= 6) return 'grid-cols-2 md:grid-cols-3 lg:grid-cols-6'
-    if (count <= 8) return 'grid-cols-2 md:grid-cols-4 lg:grid-cols-8'
-    return 'grid-cols-2 md:grid-cols-5 lg:grid-cols-10'
+    return getResponsiveGridCols(visibleBlocks.length)
   })()
 
   return (

--- a/web/src/lib/stats/gridUtils.ts
+++ b/web/src/lib/stats/gridUtils.ts
@@ -1,0 +1,16 @@
+/**
+ * Responsive grid-column utility for stat block layouts.
+ */
+
+const SINGLE_ROW_MAX = 4
+const FIVE_COL_MAX = 5
+const TWO_ROW_MAX = 6
+const THREE_ROW_MAX = 8
+
+export function getResponsiveGridCols(count: number): string {
+  if (count <= SINGLE_ROW_MAX) return 'grid-cols-2 md:grid-cols-4'
+  if (count <= FIVE_COL_MAX) return 'grid-cols-2 md:grid-cols-5'
+  if (count <= TWO_ROW_MAX) return 'grid-cols-2 md:grid-cols-3 lg:grid-cols-6'
+  if (count <= THREE_ROW_MAX) return 'grid-cols-2 md:grid-cols-4 lg:grid-cols-8'
+  return 'grid-cols-2 md:grid-cols-5 lg:grid-cols-10'
+}

--- a/web/src/lib/unified/stats/UnifiedStatsSection.tsx
+++ b/web/src/lib/unified/stats/UnifiedStatsSection.tsx
@@ -12,6 +12,7 @@ import { StatusBadge } from '../../../components/ui/StatusBadge'
 import type { UnifiedStatsSectionProps, UnifiedStatBlockConfig, StatBlockValue } from '../types'
 import { UnifiedStatBlock } from './UnifiedStatBlock'
 import { resolveStatValue } from './valueResolvers'
+import { getResponsiveGridCols } from '../../stats/gridUtils'
 
 /**
  * UnifiedStatsSection - Renders a section of stat blocks from config
@@ -118,11 +119,7 @@ export function UnifiedStatsSection({
     }
 
     // Default responsive behavior
-    if (count <= 4) return 'grid-cols-2 md:grid-cols-4'
-    if (count <= 5) return 'grid-cols-2 md:grid-cols-5'
-    if (count <= 6) return 'grid-cols-2 md:grid-cols-3 lg:grid-cols-6'
-    if (count <= 8) return 'grid-cols-2 md:grid-cols-4 lg:grid-cols-8'
-    return 'grid-cols-2 md:grid-cols-5 lg:grid-cols-10'
+    return getResponsiveGridCols(count)
   })()
 
   const collapsible = config.collapsible !== false


### PR DESCRIPTION
## Summary
- Extract identical grid-column threshold logic from StatsRuntime.tsx and UnifiedStatsSection.tsx into shared `getResponsiveGridCols` utility in `gridUtils.ts`
- Replace magic numbers (4, 5, 6, 8) with named constants (`SINGLE_ROW_MAX`, `FIVE_COL_MAX`, `TWO_ROW_MAX`, `THREE_ROW_MAX`)

Fixes #10069

## Test plan
- [ ] Build passes
- [ ] Grid layout unchanged for all stat counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)