### PR TITLE
🐛 Address Copilot review findings from PRs #10070, #10068, #10064

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -244,10 +244,11 @@ jobs:
             gh issue comment "${{ steps.issue.outputs.issue_number }}" \
               --body-file /tmp/nightly-comparison.md
           else
-            gh issue comment "${{ steps.issue.outputs.issue_number }}" \
-              --body "## Nightly Test Suite — $(date -u +%Y-%m-%d)
+            FALLBACK_BODY="## Nightly Test Suite — $(date -u +%Y-%m-%d)
 
-          _No comparison report was generated. The test suite or comparison script may have failed. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details._"
+_No comparison report was generated. The test suite or comparison script may have failed. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details._"
+            gh issue comment "${{ steps.issue.outputs.issue_number }}" \
+              --body "$FALLBACK_BODY"
           fi
 
       - name: Create issues for failing suites

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -384,7 +384,11 @@ func (s *Server) handleGetKeysStatus(w http.ResponseWriter, r *http.Request) {
 	// Include the live provider registry so the frontend settings UI can
 	// filter its display to only show providers that are actually
 	// registered in the backend, eliminating the hardcoded mismatch (#9488).
-	registeredProviders := GetRegistry().List()
+	listRegistry := s.registry
+	if listRegistry == nil {
+		listRegistry = GetRegistry()
+	}
+	registeredProviders := listRegistry.List()
 
 	json.NewEncoder(w).Encode(KeysStatusResponse{
 		Keys:                keys,

--- a/web/e2e/perf/constants.ts
+++ b/web/e2e/perf/constants.ts
@@ -9,8 +9,8 @@
 // Max number of React commits allowed during a SPA navigation. The post-fix
 // measurement (after #6161 stabilized AuthProvider value + #6178 seeded the
 // demo token so the perf spec doesn't measure auth-revalidate noise) is 13
-// commits for a real /clusters navigation. Budget is set to 25 — that's the
-// observed 21 (2026-04-23 CI measurement) plus 4 commits of headroom for
+// commits for a real /clusters navigation. Budget is set to 30 — that's the
+// observed 21 (2026-04-23 CI measurement) plus 9 commits of headroom for
 // legitimate growth (new cards, SSE streams), while still catching any
 // regression that pushes us back toward the ~461-commit cascade tracked
 // by #6149.

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -75,17 +75,19 @@ function getDeviceLabel(deviceType: string): string {
 
 type ViewMode = 'alerts' | 'inventory'
 
+const NODE_HOSTNAME_PATTERN = /([a-z0-9-]+-worker-[a-z0-9-]+|[a-z0-9-]+-gpu-[a-z0-9-]+|[a-z0-9-]+-compute-[a-z0-9-]+)/i
+const MIN_HOSTNAME_LENGTH = 5
+
 /** Extract canonical hostname from node name.
  * Handles both short names and long API/SA paths. */
 function extractHostname(nodeName: string): string {
   if (nodeName.includes(':6443/') || nodeName.includes('/system:serviceaccount:')) {
     const parts = nodeName.split('/')
     const lastPart = parts[parts.length - 1]
-    if (lastPart && !lastPart.includes(':') && lastPart.length > 5) {
+    if (lastPart && !lastPart.includes(':') && lastPart.length > MIN_HOSTNAME_LENGTH) {
       return lastPart
     }
-    const nodePattern = /([a-z0-9-]+-worker-[a-z0-9-]+|[a-z0-9-]+-gpu-[a-z0-9-]+|[a-z0-9-]+-compute-[a-z0-9-]+)/i
-    const match = nodeName.match(nodePattern)
+    const match = nodeName.match(NODE_HOSTNAME_PATTERN)
     if (match) {
       return match[1]
     }
@@ -188,7 +190,7 @@ export function HardwareHealthCard() {
       const mappedCluster = clusterNameMap[alert.cluster] || alert.cluster
       const key = `${hostname}-${alert.deviceType}`
       const existing = byHostnameAndDevice.get(key)
-      // Keep first occurrence (or update if this one has better data)
+      // Keep first occurrence, skip duplicates
       if (!existing) {
         byHostnameAndDevice.set(key, { ...alert, nodeName: hostname, cluster: mappedCluster })
       }

--- a/web/src/hooks/useSnoozedAlerts.ts
+++ b/web/src/hooks/useSnoozedAlerts.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { POLL_INTERVAL_SLOW_MS } from '../lib/constants/network'
 import { emitSnoozed, emitUnsnoozed } from '../lib/analytics'
 
@@ -128,15 +128,15 @@ export function useSnoozedAlerts() {
     emitUnsnoozed('alert')
   }
 
-  const isSnoozed = (alertId: string): boolean => {
+  const isSnoozed = useCallback((alertId: string): boolean => {
     const now = Date.now()
     return state.snoozed.some(s => s.alertId === alertId && s.expiresAt > now)
-  }
+  }, [localState])
 
-  const getSnoozedAlert = (alertId: string): SnoozedAlert | null => {
+  const getSnoozedAlert = useCallback((alertId: string): SnoozedAlert | null => {
     const now = Date.now()
     return state.snoozed.find(s => s.alertId === alertId && s.expiresAt > now) || null
-  }
+  }, [localState])
 
   const clearAllSnoozed = () => {
     state.snoozed = []


### PR DESCRIPTION
## Summary
- Stabilize `isSnoozed`/`getSnoozedAlert` refs with `useCallback` so downstream `useMemo` deps in HardwareHealthCard don't recompute every render
- Hoist `NODE_HOSTNAME_PATTERN` regex to module scope (was recompiled per `extractHostname` call)
- Prefer injected `s.registry` over singleton `GetRegistry()` in `handleGetKeys` for test consistency
- Fix YAML indentation in nightly fallback comment body that rendered as a code block
- Fix stale budget comment (said 25, value is 30) and misleading "or update" dedup comment

Fixes #10072

## Test plan
- [ ] Build passes (TypeScript + Go)
- [ ] Lint passes
- [ ] HardwareHealthCard renders correctly with snoozed alerts
- [ ] Settings API returns correct registered providers
- [ ] Nightly workflow fallback comment renders as Markdown, not code block