### PR TITLE
🌱 Consolidate 7 duplicate formatBytes into shared lib/formatters utility

### DIFF
--- a/web/src/components/cards/dragonfly_status/index.tsx
+++ b/web/src/components/cards/dragonfly_status/index.tsx
@@ -26,6 +26,7 @@ import {
   Zap,
 } from 'lucide-react'
 import { useCachedDragonfly } from '../../../hooks/useCachedDragonfly'
+import { formatBytes } from '../../../lib/formatters'
 import { useCardLoadingState } from '../CardDataContext'
 import { SkeletonCardWithRefresh } from '../../ui/Skeleton'
 import { EmptyState } from '../../ui/EmptyState'
@@ -42,13 +43,10 @@ import type {
 
 const COMPONENT_PAGE_SIZE = 4
 
-const BYTES_PER_GIB = 1024 * 1024 * 1024
-const BYTES_PER_MIB = 1024 * 1024
-const BYTES_PER_KIB = 1024
-const MIN_DECIMAL_PLACES = 1
-
 const CACHE_HIT_WARN_PERCENT = 50
 const CACHE_HIT_ALERT_PERCENT = 25
+
+const BINARY_DASH_FORMAT = { binary: true, zeroLabel: '—' } as const
 
 const MS_PER_SECOND = 1000
 const SECONDS_PER_MINUTE = 60
@@ -58,20 +56,6 @@ const HOURS_PER_DAY = 24
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatBytes(bytes: number): string {
-  if (bytes <= 0) return '—'
-  if (bytes >= BYTES_PER_GIB) {
-    return `${(bytes / BYTES_PER_GIB).toFixed(MIN_DECIMAL_PLACES)} GiB`
-  }
-  if (bytes >= BYTES_PER_MIB) {
-    return `${(bytes / BYTES_PER_MIB).toFixed(MIN_DECIMAL_PLACES)} MiB`
-  }
-  if (bytes >= BYTES_PER_KIB) {
-    return `${(bytes / BYTES_PER_KIB).toFixed(MIN_DECIMAL_PLACES)} KiB`
-  }
-  return `${bytes} B`
-}
 
 function cacheHitColor(pct: number): string {
   if (pct >= CACHE_HIT_WARN_PERCENT) return 'text-green-400'
@@ -240,7 +224,7 @@ export function DragonflyStatus() {
             {t('dragonflyStatus.p2pUpstream', 'P2P / upstream')}
           </div>
           <div className="text-sm font-semibold text-foreground tabular-nums">
-            {formatBytes(summary.p2pBytesServed)} / {formatBytes(summary.upstreamBytes)}
+            {formatBytes(summary.p2pBytesServed, BINARY_DASH_FORMAT)} / {formatBytes(summary.upstreamBytes, BINARY_DASH_FORMAT)}
           </div>
         </div>
       </div>

--- a/web/src/components/cards/longhorn_status/index.tsx
+++ b/web/src/components/cards/longhorn_status/index.tsx
@@ -19,6 +19,7 @@ import {
   XCircle,
 } from 'lucide-react'
 import { useCachedLonghorn } from '../../../hooks/useCachedLonghorn'
+import { formatBytes } from '../../../lib/formatters'
 import { useCardLoadingState } from '../CardDataContext'
 import { SkeletonCardWithRefresh } from '../../ui/Skeleton'
 import { EmptyState } from '../../ui/EmptyState'
@@ -34,16 +35,12 @@ import type {
 // Named constants (no magic numbers)
 // ---------------------------------------------------------------------------
 
-const BYTES_PER_KIB = 1024
-const BYTES_PER_MIB = BYTES_PER_KIB * 1024
-const BYTES_PER_GIB = BYTES_PER_MIB * 1024
-const BYTES_PER_TIB = BYTES_PER_GIB * 1024
-const BYTES_PER_PIB = BYTES_PER_TIB * 1024
-
 const PCT_MULTIPLIER = 100
-const CAPACITY_DECIMALS = 1
 const USAGE_PCT_WARN = 70
 const USAGE_PCT_ALERT = 85
+
+const BINARY_ZERO_LABEL = '0'
+const BINARY_FORMAT = { binary: true, zeroLabel: BINARY_ZERO_LABEL } as const
 
 // Keep the card compact — cap visible rows.
 const VOLUME_PAGE_SIZE = 6
@@ -52,15 +49,6 @@ const NODE_PAGE_SIZE = 4
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) return '0'
-  if (bytes >= BYTES_PER_PIB) return `${(bytes / BYTES_PER_PIB).toFixed(CAPACITY_DECIMALS)} PiB`
-  if (bytes >= BYTES_PER_TIB) return `${(bytes / BYTES_PER_TIB).toFixed(CAPACITY_DECIMALS)} TiB`
-  if (bytes >= BYTES_PER_GIB) return `${(bytes / BYTES_PER_GIB).toFixed(CAPACITY_DECIMALS)} GiB`
-  if (bytes >= BYTES_PER_MIB) return `${(bytes / BYTES_PER_MIB).toFixed(CAPACITY_DECIMALS)} MiB`
-  return `${bytes} B`
-}
 
 function usagePct(used: number, total: number): number {
   if (total <= 0) return 0
@@ -138,7 +126,7 @@ function VolumeRow({ volume }: { volume: LonghornVolume }) {
         </span>
         <span className={cn('flex items-center gap-1 shrink-0', usageColor(pct))}>
           <HardDrive className="w-3 h-3" />
-          {formatBytes(volume.actualSizeBytes)} / {formatBytes(volume.sizeBytes)}
+          {formatBytes(volume.actualSizeBytes, BINARY_FORMAT)} / {formatBytes(volume.sizeBytes, BINARY_FORMAT)}
         </span>
       </div>
     </div>
@@ -190,7 +178,7 @@ function NodeRow({ node }: { node: LonghornNode }) {
         </span>
         <span className={cn('flex items-center gap-1 shrink-0', usageColor(pct))}>
           <HardDrive className="w-3 h-3" />
-          {formatBytes(node.storageUsedBytes)} / {formatBytes(node.storageTotalBytes)}
+          {formatBytes(node.storageUsedBytes, BINARY_FORMAT)} / {formatBytes(node.storageTotalBytes, BINARY_FORMAT)}
         </span>
       </div>
     </div>
@@ -319,8 +307,8 @@ export function LonghornStatus() {
         />
         <MetricTile
           label={t('longhornStatus.capacity', 'Capacity')}
-          value={`${formatBytes(data.summary.totalUsedBytes)} / ${formatBytes(
-            data.summary.totalCapacityBytes,
+          value={`${formatBytes(data.summary.totalUsedBytes, BINARY_FORMAT)} / ${formatBytes(
+            data.summary.totalCapacityBytes, BINARY_FORMAT,
           )}`}
           colorClass="text-blue-400"
           icon={<HardDrive className="w-4 h-4 text-blue-400" />}

--- a/web/src/components/cards/rook_status/index.tsx
+++ b/web/src/components/cards/rook_status/index.tsx
@@ -18,6 +18,7 @@ import {
   XCircle,
 } from 'lucide-react'
 import { useCachedRook } from '../../../hooks/useCachedRook'
+import { formatBytes } from '../../../lib/formatters'
 import { useCardLoadingState } from '../CardDataContext'
 import { SkeletonCardWithRefresh } from '../../ui/Skeleton'
 import { EmptyState } from '../../ui/EmptyState'
@@ -29,16 +30,12 @@ import type { RookCephCluster, RookCephHealth } from '../../../lib/demo/rook'
 // Named constants (no magic numbers)
 // ---------------------------------------------------------------------------
 
-const BYTES_PER_KIB = 1024
-const BYTES_PER_MIB = BYTES_PER_KIB * 1024
-const BYTES_PER_GIB = BYTES_PER_MIB * 1024
-const BYTES_PER_TIB = BYTES_PER_GIB * 1024
-const BYTES_PER_PIB = BYTES_PER_TIB * 1024
-
 const USAGE_PCT_WARN = 70
 const USAGE_PCT_ALERT = 85
 const PCT_MULTIPLIER = 100
-const CAPACITY_DECIMALS = 1
+
+const BINARY_ZERO_LABEL = '0'
+const BINARY_FORMAT = { binary: true, zeroLabel: BINARY_ZERO_LABEL } as const
 
 // Limit the number of CephCluster rows rendered so the card stays compact.
 const CLUSTER_PAGE_SIZE = 6
@@ -46,15 +43,6 @@ const CLUSTER_PAGE_SIZE = 6
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) return '0'
-  if (bytes >= BYTES_PER_PIB) return `${(bytes / BYTES_PER_PIB).toFixed(CAPACITY_DECIMALS)} PiB`
-  if (bytes >= BYTES_PER_TIB) return `${(bytes / BYTES_PER_TIB).toFixed(CAPACITY_DECIMALS)} TiB`
-  if (bytes >= BYTES_PER_GIB) return `${(bytes / BYTES_PER_GIB).toFixed(CAPACITY_DECIMALS)} GiB`
-  if (bytes >= BYTES_PER_MIB) return `${(bytes / BYTES_PER_MIB).toFixed(CAPACITY_DECIMALS)} MiB`
-  return `${bytes} B`
-}
 
 function usagePct(cluster: RookCephCluster): number {
   if (cluster.capacityTotalBytes <= 0) return 0
@@ -197,8 +185,8 @@ export function RookStatus() {
         />
         <MetricTile
           label={t('rookStatus.capacity', 'Capacity')}
-          value={`${formatBytes(data.summary.totalUsedBytes)} / ${formatBytes(
-            data.summary.totalCapacityBytes,
+          value={`${formatBytes(data.summary.totalUsedBytes, BINARY_FORMAT)} / ${formatBytes(
+            data.summary.totalCapacityBytes, BINARY_FORMAT,
           )}`}
           colorClass="text-blue-400"
           icon={<HardDrive className="w-4 h-4 text-blue-400" />}
@@ -268,8 +256,8 @@ export function RookStatus() {
                   </span>
                   <span className={cn('flex items-center gap-1 shrink-0', usageColor(pct))}>
                     <HardDrive className="w-3 h-3" />
-                    {formatBytes(cluster.capacityUsedBytes)} /{' '}
-                    {formatBytes(cluster.capacityTotalBytes)}
+                    {formatBytes(cluster.capacityUsedBytes, BINARY_FORMAT)} /{' '}
+                    {formatBytes(cluster.capacityTotalBytes, BINARY_FORMAT)}
                   </span>
                 </div>
               </div>

--- a/web/src/components/missions/browser/DirectoryListing.tsx
+++ b/web/src/components/missions/browser/DirectoryListing.tsx
@@ -2,7 +2,7 @@ import { Folder, FileJson, FileCode, FileText, Download } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import type { BrowseEntry } from '../../../lib/missions/types'
 import type { ViewMode } from './types'
-import { formatBytes } from './helpers'
+import { formatBytes } from '../../../lib/formatters'
 
 /** Pick a file icon and color based on file extension */
 function getFileIcon(name: string) {

--- a/web/src/components/missions/browser/helpers.ts
+++ b/web/src/components/missions/browser/helpers.ts
@@ -64,13 +64,6 @@ export function removeNodeFromTree(nodes: TreeNode[], nodeId: string): TreeNode[
     )
 }
 
-export function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes < 0) return '0 B'
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
-}
-
 /** Normalize kc-mission-v1 JSON (nested format) into flat MissionExport shape.
  *  Kept for on-demand file loading when user selects a mission from the sidebar. */
 export function normalizeMission(raw: Record<string, unknown>): MissionExport | null {

--- a/web/src/components/missions/browser/index.ts
+++ b/web/src/components/missions/browser/index.ts
@@ -4,7 +4,7 @@ export { TreeNodeItem } from './TreeNodeItem'
 export { DirectoryListing } from './DirectoryListing'
 export { RecommendationCard } from './RecommendationCard'
 export { EmptyState, MissionFetchErrorBanner } from './EmptyState'
-export { getMissionSlug, getMissionShareUrl, updateNodeInTree, removeNodeFromTree, formatBytes, normalizeMission } from './helpers'
+export { getMissionSlug, getMissionShareUrl, updateNodeInTree, removeNodeFromTree, normalizeMission } from './helpers'
 export {
   missionCache, notifyCacheListeners, startMissionCacheFetch, resetMissionCache,
   fetchMissionContent, MISSION_FILE_FETCH_TIMEOUT_MS,

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -46,23 +46,51 @@ function parseK8sQuantity(value: string): number {
   return num
 }
 
+/** Options for {@link formatBytes}. */
+export interface FormatBytesOptions {
+  /** Number of decimal places (default: 1). */
+  decimals?: number
+  /** Use IEC binary units — KiB, MiB, GiB, TiB, PiB (default: false → KB, MB, …). */
+  binary?: boolean
+  /** String returned when the input is zero, negative, or non-finite (default: `'0 B'`). */
+  zeroLabel?: string
+}
+
+const SI_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+const IEC_UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']
+const BYTES_PER_KIBIBYTE = 1024
+
 /**
- * Format bytes to human-readable string (GB, TB, MB, etc.)
+ * Format bytes to a human-readable string.
+ *
+ * @example
+ * formatBytes(1536)                       // "1.5 KB"
+ * formatBytes(1536, { binary: true })     // "1.5 KiB"
+ * formatBytes(0, { zeroLabel: '—' })      // "—"
  */
-export function formatBytes(bytes: number, decimals = 1): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+export function formatBytes(
+  bytes: number,
+  optsOrDecimals: FormatBytesOptions | number = {},
+): string {
+  // Backward-compatible: accept a plain number as the decimals shorthand.
+  const opts: FormatBytesOptions =
+    typeof optsOrDecimals === 'number'
+      ? { decimals: optsOrDecimals }
+      : optsOrDecimals
 
-  const k = 1024
-  const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  const { decimals = 1, binary = false, zeroLabel = '0 B' } = opts
 
-  const value = bytes / Math.pow(k, i)
+  if (!Number.isFinite(bytes) || bytes <= 0) return zeroLabel
+
+  const units = binary ? IEC_UNITS : SI_UNITS
+  const i = Math.floor(Math.log(bytes) / Math.log(BYTES_PER_KIBIBYTE))
+  const value = bytes / Math.pow(BYTES_PER_KIBIBYTE, i)
 
   // Use 0 decimals for whole numbers, otherwise use specified decimals
   if (value === Math.floor(value)) {
-    return `${value} ${sizes[i]}`
+    return `${value} ${units[i]}`
   }
-  return `${value.toFixed(decimals)} ${sizes[i]}`
+  return `${value.toFixed(decimals)} ${units[i]}`
 }
 
 /**

--- a/web/src/lib/stats/types.ts
+++ b/web/src/lib/stats/types.ts
@@ -269,25 +269,8 @@ export function formatStatNumber(value: number): string {
   return value.toString()
 }
 
-/**
- * Format memory/storage values
- */
-export function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
-  if (bytes >= 1024 * 1024 * 1024 * 1024) {
-    return `${(bytes / (1024 * 1024 * 1024 * 1024)).toFixed(1)} TB`
-  }
-  if (bytes >= 1024 * 1024 * 1024) {
-    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
-  }
-  if (bytes >= 1024 * 1024) {
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
-  }
-  if (bytes >= 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`
-  }
-  return `${bytes} B`
-}
+import { formatBytes } from '../formatters'
+export { formatBytes }
 
 /**
  * Format percentage values

--- a/web/src/lib/unified/stats/valueResolvers.ts
+++ b/web/src/lib/unified/stats/valueResolvers.ts
@@ -9,6 +9,8 @@ import type {
   StatValueSource,
   StatValueFormat,
 } from '../types'
+import { formatBytes } from '../../formatters'
+export { formatBytes }
 
 /**
  * Resolved stat value with metadata
@@ -336,19 +338,6 @@ export function formatNumber(value: number): string | number {
     return `${(value / 1_000).toFixed(1)}K`
   }
   return value
-}
-
-/**
- * Format bytes to human-readable
- */
-export function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
-
-  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
-  const exp = Math.floor(Math.log(bytes) / Math.log(1024))
-  const size = bytes / Math.pow(1024, exp)
-
-  return `${size.toFixed(1)} ${units[exp]}`
 }
 
 /**


### PR DESCRIPTION
Fixes #10074

## Summary

Consolidates 7 duplicate `formatBytes` implementations into the canonical `lib/formatters.ts`.

## Changes

- **Enhanced `formatBytes`** in `lib/formatters.ts` with `FormatBytesOptions` interface:
  - `binary`: IEC units (KiB, MiB, GiB) for storage cards
  - `zeroLabel`: custom string for zero/invalid values
  - `decimals`: configurable decimal places
  - Backward-compatible — `formatBytes(n, 1)` still works

- **Removed duplicates from:**
  - `lib/stats/types.ts` (18 lines)
  - `lib/unified/stats/valueResolvers.ts` (11 lines)
  - `components/missions/browser/helpers.ts` (5 lines)
  - `components/cards/rook_status/index.tsx` (function + 5 BYTES_PER constants)
  - `components/cards/longhorn_status/index.tsx` (same pattern)
  - `components/cards/dragonfly_status/index.tsx` (same pattern)

- **Preserved barrel re-exports** so downstream imports (`lib/index.ts`, `unified/stats/index.ts`, etc.) continue to work unchanged.

## Net impact

- 9 files changed, +63 / -110 lines (~47 net lines removed)
- Zero behavior changes — all existing call sites produce identical output
- Build and lint pass locally