### PR TITLE
🐛 Fix GitHub 429 rate limit errors and unify rewards data source

### DIFF
--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -217,16 +217,27 @@ function jsonResponse(
 }
 
 /** GitHub API fetch with auth + typed error */
+const GH_RETRY_MAX_ATTEMPTS = 3;
+const GH_RETRY_BASE_DELAY_MS = 1_000;
+
 async function gh(path: string, token: string, init: RequestInit = {}): Promise<Response> {
   const url = path.startsWith("http") ? path : `${GITHUB_API}${path}`;
-  return fetch(url, {
-    ...init,
-    headers: {
-      Accept: "application/vnd.github.v3+json",
-      Authorization: `Bearer ${token}`,
-      ...(init.headers ?? {}),
-    },
-  });
+  const headers = {
+    Accept: "application/vnd.github.v3+json",
+    Authorization: `Bearer ${token}`,
+    ...(init.headers ?? {}),
+  };
+  for (let attempt = 0; attempt < GH_RETRY_MAX_ATTEMPTS; attempt++) {
+    const resp = await fetch(url, { ...init, headers });
+    if (resp.status !== 429 && resp.status !== 403) return resp;
+    if (attempt === GH_RETRY_MAX_ATTEMPTS - 1) return resp;
+    const retryAfter = resp.headers.get("Retry-After");
+    const waitMs = retryAfter
+      ? Math.min(parseInt(retryAfter, 10) * 1000, 10_000)
+      : GH_RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+    await new Promise((r) => setTimeout(r, waitMs));
+  }
+  return fetch(url, { ...init, headers });
 }
 
 /** Matches `owner/repo` format — allows any valid GitHub repo, not just

--- a/web/netlify/functions/github-rewards.mts
+++ b/web/netlify/functions/github-rewards.mts
@@ -15,7 +15,6 @@
  */
 
 import { getStore } from "@netlify/blobs";
-import { buildCorsHeaders, handlePreflight } from "./_shared/cors";
 
 const GITHUB_API = "https://api.github.com";
 const CACHE_STORE = "github-rewards";
@@ -27,6 +26,8 @@ const PER_PAGE = 100;
 const MAX_PAGES = 10;
 /** Request timeout for GitHub API calls (30 seconds) */
 const API_TIMEOUT_MS = 30_000;
+const GH_RETRY_MAX_ATTEMPTS = 3;
+const GH_RETRY_BASE_DELAY_MS = 1_000;
 
 /** Point values for contribution types — must match rewards.go */
 const POINTS_BUG_ISSUE = 300;
@@ -172,12 +173,22 @@ async function searchItems(
     };
     if (token) headers["Authorization"] = `Bearer ${token}`;
 
-    const res = await fetch(url, {
-      headers,
-      signal: AbortSignal.timeout(API_TIMEOUT_MS),
-    });
-    if (!res.ok) {
-      throw new Error(`GitHub API ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    let res: Response | undefined;
+    for (let attempt = 0; attempt < GH_RETRY_MAX_ATTEMPTS; attempt++) {
+      res = await fetch(url, {
+        headers,
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      });
+      if (res.status !== 429 && res.status !== 403) break;
+      if (attempt === GH_RETRY_MAX_ATTEMPTS - 1) break;
+      const retryAfter = res.headers.get("Retry-After");
+      const waitMs = retryAfter
+        ? Math.min(parseInt(retryAfter, 10) * 1000, 10_000)
+        : GH_RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+      await new Promise((r) => setTimeout(r, waitMs));
+    }
+    if (!res!.ok) {
+      throw new Error(`GitHub API ${res!.status}: ${(await res!.text()).slice(0, 200)}`);
     }
 
     const sr: SearchResponse = await res.json();
@@ -196,18 +207,19 @@ async function searchItems(
 // ---------------------------------------------------------------------------
 
 export default async (req: Request) => {
-  // See web/netlify/functions/_shared/cors.ts for allowlist rationale (#9879).
-  const corsOpts = {
-    methods: "GET, OPTIONS",
-    headers: "Content-Type, Authorization, Accept",
-  };
-  const corsHeaders = {
-    ...buildCorsHeaders(req, corsOpts),
+  // Rewards data is computed from public GitHub activity — allow any origin
+  // so self-hosted consoles can fetch from console.kubestellar.io without CORS
+  // issues (same pattern as acmm-badge and rewards-badge endpoints).
+  const corsHeaders: Record<string, string> = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Accept",
     "Cache-Control": "no-cache, no-store",
+    "X-Content-Type-Options": "nosniff",
   };
 
   if (req.method === "OPTIONS") {
-    return handlePreflight(req, corsOpts);
+    return new Response(null, { status: 204, headers: corsHeaders });
   }
 
   if (req.method !== "GET") {

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -12,6 +12,7 @@ import { buildReleaseNotesComponents } from '../../lib/markdown/releaseNotesComp
 import { cn } from '../../lib/cn'
 import { copyToClipboard } from '../../lib/clipboard'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+import { api, RateLimitError } from '../../lib/api'
 import { emitWhatsNewUpdateClicked, emitWhatsNewRemindLater } from '../../lib/analytics'
 
 const SNOOZE_STORAGE_KEY = 'kc-update-snoozed'
@@ -105,44 +106,42 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
         // Step 1: Get the date of the currently running commit
         let sinceDate: string | null = null
         if (commitHash && commitHash !== 'unknown') {
-          const commitResp = await fetch(
-            `/api/github/repos/kubestellar/console/commits/${commitHash}`,
-            { credentials: 'include', signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) },
-          )
-          if (commitResp.ok) {
-            const commitData = await commitResp.json()
+          try {
+            const { data: commitData } = await api.get<{ commit?: { committer?: { date?: string } } }>(
+              `/api/github/repos/kubestellar/console/commits/${commitHash}`,
+              { timeout: FETCH_DEFAULT_TIMEOUT_MS },
+            )
             sinceDate = commitData?.commit?.committer?.date ?? null
+          } catch {
+            // Commit lookup failure is non-fatal — show all PRs
           }
         }
 
         // Step 2: Fetch recent merged PRs
-        const resp = await fetch(
+        if (cancelled) return
+        const { data } = await api.get<Array<{ number: number; title: string; merged_at: string | null }>>(
           `/api/github/repos/kubestellar/console/pulls?state=closed&sort=updated&direction=desc&per_page=${MAX_RECENT_PRS}`,
-          { credentials: 'include', signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) },
+          { timeout: FETCH_DEFAULT_TIMEOUT_MS },
         )
         if (cancelled) return
-        if (!resp.ok) {
-          setPrsError(`GitHub responded ${resp.status}`)
-          return
-        }
-        const data = await resp.json()
-        if (cancelled) return
         const merged = (data || [])
-          .filter((pr: { merged_at: string | null }) => pr.merged_at)
-          // Only show PRs merged AFTER the running commit
-          .filter((pr: { merged_at: string }) => {
-            if (!sinceDate) return true // no commit date = show all
-            return new Date(pr.merged_at) > new Date(sinceDate)
+          .filter((pr) => pr.merged_at)
+          .filter((pr) => {
+            if (!sinceDate) return true
+            return new Date(pr.merged_at!) > new Date(sinceDate)
           })
-          .map((pr: { number: number; title: string; merged_at: string }) => ({
+          .map((pr) => ({
             number: pr.number,
             title: pr.title,
-            merged_at: pr.merged_at,
+            merged_at: pr.merged_at!,
           }))
         setRecentPRs(merged)
       } catch (err) {
         if (cancelled) return
-        // Don't surface AbortError (user closed modal) as an error
+        if (err instanceof RateLimitError) {
+          setPrsError('GitHub API rate limit reached — data will refresh automatically. Try again in a moment.')
+          return
+        }
         const message = err instanceof Error ? err.message : 'Network error'
         setPrsError(message)
       } finally {

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { api } from '../lib/api'
+import { api, RateLimitError } from '../lib/api'
 import { STORAGE_KEY_TOKEN, STORAGE_KEY_HAS_SESSION, DEMO_TOKEN_VALUE } from '../lib/constants'
 import { MIN_PERCEIVED_DELAY_MS } from '../lib/constants/network'
 
@@ -359,6 +359,11 @@ export function useFeatureRequests(currentUserId?: string, options?: UseFeatureR
       const { data } = await api.post<FeatureRequest>('/api/feedback/requests', input, mergedOpts)
       setRequests(prev => [data, ...prev])
       return data
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        throw new Error('Too many requests — please wait a moment and try again.')
+      }
+      throw err
     } finally {
       setIsSubmitting(false)
     }

--- a/web/src/hooks/useGitHubRewards.ts
+++ b/web/src/hooks/useGitHubRewards.ts
@@ -1,15 +1,16 @@
 /**
  * Hook for fetching GitHub-sourced reward data.
- * Queries the backend which proxies GitHub Search API for the logged-in user's
- * issues and PRs across configured orgs, computes points on the fly.
+ * Calls the Netlify function on console.kubestellar.io (10-min Blob cache)
+ * instead of the local Go backend, saving the user's GitHub API quota.
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useAuth } from '../lib/auth'
-import { STORAGE_KEY_TOKEN, STORAGE_KEY_HAS_SESSION } from '../lib/constants'
-import { BACKEND_DEFAULT_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type { GitHubRewardsResponse } from '../types/rewards'
+
+/** Always fetch from the Netlify function (cached, no user token needed). */
+const REWARDS_API_BASE = 'https://console.kubestellar.io'
 
 /** Prefix for per-user localStorage cache keys */
 const CACHE_KEY_PREFIX = 'github-rewards-cache'
@@ -105,38 +106,9 @@ export function useGitHubRewards() {
   const fetchRewards = useCallback(async () => {
     if (!isAuthenticated || isDemoUser || !githubLogin) return
 
-    // #8494 — Support cookie-only sessions (#6590). The JWT may live
-    // exclusively in the HttpOnly kc_auth cookie with no token in
-    // localStorage. Check both the token AND the session hint so we
-    // don't bail out for cookie-only authenticated users.
-    // Both reads are wrapped because localStorage can throw in
-    // restricted browser modes (private browsing, disabled storage).
-    let token: string | null = null
-    let hasCookieSession = false
-    try {
-      token = localStorage.getItem(STORAGE_KEY_TOKEN)
-      hasCookieSession = localStorage.getItem(STORAGE_KEY_HAS_SESSION) === 'true'
-    } catch {
-      // localStorage unavailable — fall through
-    }
-    if (!token && !hasCookieSession) return
-
     setIsLoading(true)
     try {
-      const apiBase = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
-      // Pass login as query param for Netlify Function compatibility (no JWT
-      // validation on serverless). The Go backend ignores this param and reads
-      // the login from the JWT instead — no security impact either way since
-      // reward data is computed from public GitHub activity.
-      const headers: Record<string, string> = {}
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`
-      }
-      const res = await fetch(`${apiBase}/api/rewards/github?login=${encodeURIComponent(githubLogin)}`, {
-        headers,
-        // #8494 — credentials: 'include' sends the HttpOnly kc_auth cookie
-        // for cookie-only sessions where no Bearer token is available.
-        credentials: 'include',
+      const res = await fetch(`${REWARDS_API_BASE}/api/rewards/github?login=${encodeURIComponent(githubLogin)}`, {
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!res.ok) throw new Error(`API error: ${res.status}`)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -39,6 +39,32 @@ export class UnauthorizedError extends Error {
   }
 }
 
+/** localStorage key for global API rate-limit backoff deadline (epoch ms). */
+const STORAGE_KEY_RATE_LIMIT_UNTIL = 'kc-api-rate-limit-until'
+/** Default Retry-After when the header is missing or unparseable. */
+const DEFAULT_RATE_LIMIT_RETRY_AFTER_S = 60
+
+export class RateLimitError extends Error {
+  retryAfter: number
+  constructor(retryAfter: number) {
+    super(`Rate limited. Try again in ${retryAfter} seconds.`)
+    this.name = 'RateLimitError'
+    this.retryAfter = retryAfter
+  }
+}
+
+function handle429(response: Response): never {
+  const retryAfterRaw = response.headers.get('Retry-After')
+  const retryAfter = retryAfterRaw ? parseInt(retryAfterRaw, 10) : DEFAULT_RATE_LIMIT_RETRY_AFTER_S
+  const effectiveRetry = Number.isFinite(retryAfter) && retryAfter > 0
+    ? retryAfter : DEFAULT_RATE_LIMIT_RETRY_AFTER_S
+  try {
+    localStorage.setItem(STORAGE_KEY_RATE_LIMIT_UNTIL,
+      String(Date.now() + effectiveRetry * 1000))
+  } catch { /* storage quota / private browsing */ }
+  throw new RateLimitError(effectiveRetry)
+}
+
 // Debounce 401 handling to avoid multiple simultaneous logouts
 let handling401 = false
 /** Safety cap: reset the 401 debounce flag after this many ms so future
@@ -493,6 +519,9 @@ class ApiClient {
         if (response.status === 401) {
           throw new UnauthorizedError()
         }
+        if (response.status === 429) {
+          handle429(response)
+        }
         const errorText = await response.text().catch(() => '')
         // Note: We don't mark backend as failed on 500 responses here.
         // The health check is the source of truth for backend availability.
@@ -547,6 +576,9 @@ class ApiClient {
         if (response.status === 401) {
           throw new UnauthorizedError()
         }
+        if (response.status === 429) {
+          handle429(response)
+        }
         const errorText = await response.text().catch(() => '')
         // Note: Don't mark backend as failed on 500s - health check is source of truth
         throw new Error(errorText || `API error: ${response.status}`)
@@ -599,6 +631,9 @@ class ApiClient {
         if (response.status === 401) {
           throw new UnauthorizedError()
         }
+        if (response.status === 429) {
+          handle429(response)
+        }
         const errorText = await response.text().catch(() => '')
         // Note: Don't mark backend as failed on 500s - health check is source of truth
         throw new Error(errorText || `API error: ${response.status}`)
@@ -649,6 +684,9 @@ class ApiClient {
         }
         if (response.status === 401) {
           throw new UnauthorizedError()
+        }
+        if (response.status === 429) {
+          handle429(response)
         }
         const errorText = await response.text().catch(() => '')
         // Note: Don't mark backend as failed on 500s - health check is source of truth


### PR DESCRIPTION
## Summary
- **Global 429 interceptor** in `api.ts` — reads `Retry-After` header, stores backoff deadline in localStorage, throws typed `RateLimitError` that consumers can catch
- **WhatsNewModal** — replaced raw `fetch()` with `api.get()` so 429s show "GitHub API rate limit reached" instead of raw "GitHub responded 429"
- **useFeatureRequests** — surfaces rate-limit errors with a clear user-facing message
- **useGitHubRewards** — fetches from the Netlify function on `console.kubestellar.io` (10-min Blob cache) instead of the local Go backend, saving the user's GitHub API quota and matching leaderboard point counts exactly
- **github-rewards.mts** — opened CORS (`Access-Control-Allow-Origin: *`) so self-hosted consoles can fetch rewards data cross-origin (rewards data is public, same pattern as badge endpoints)
- **Netlify functions** (`github-pipelines.mts`, `github-rewards.mts`) — added 3x exponential backoff retry on 429/403 responses from GitHub API

## Test plan
- [ ] Open What's New dialog — should show PR list or graceful rate-limit message (not "GitHub responded 429")
- [ ] Open Contribute dialog — verify coin count matches leaderboard at kubestellar.io/leaderboard
- [ ] Submit a feature request under rate limit — should show "Too many requests" message
- [ ] Verify CI/CD pipeline cards load on Netlify deploy preview
- [ ] Verify 401 session expiry flow is unchanged (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)