### PR TITLE
🌱 Replace 15 duplicate formatRelativeTime with shared formatTimeAgo

### DIFF
--- a/web/src/components/cards/cloud_custodian_status/index.tsx
+++ b/web/src/components/cards/cloud_custodian_status/index.tsx
@@ -40,6 +40,7 @@ import type {
   CustodianTopResource,
   CustodianViolationSeverity,
 } from '../../../lib/demo/cloud-custodian'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -51,14 +52,6 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const MS_PER_SECOND = 1000
-const SECONDS_PER_MINUTE = 60
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
-const MS_PER_MINUTE = MS_PER_SECOND * SECONDS_PER_MINUTE
-const MS_PER_HOUR = MS_PER_MINUTE * MINUTES_PER_HOUR
-const MS_PER_DAY = MS_PER_HOUR * HOURS_PER_DAY
-
 // Max rows to render in the two main lists before the scroller takes over —
 // keeps the card height predictable while still giving operators signal.
 const MAX_POLICY_ROWS = 6
@@ -67,16 +60,6 @@ const MAX_TOP_RESOURCE_ROWS = 5
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || !Number.isFinite(parsed)) return 'just now'
-  const diff = Date.now() - parsed
-  if (diff < MS_PER_MINUTE) return 'just now'
-  if (diff < MS_PER_HOUR) return `${Math.floor(diff / MS_PER_MINUTE)}m ago`
-  if (diff < MS_PER_DAY) return `${Math.floor(diff / MS_PER_HOUR)}h ago`
-  return `${Math.floor(diff / MS_PER_DAY)}d ago`
-}
 
 function policyStatusBadgeClass(policy: CustodianPolicy): string {
   if (policy.failCount > 0) return 'bg-red-500/20 text-red-400'
@@ -183,7 +166,7 @@ function PolicyRow({
         </span>
         <span className="flex items-center gap-1">
           <Clock className="w-3 h-3" />
-          {formatRelativeTime(policy.lastRunAt)}
+          {formatTimeAgo(policy.lastRunAt)}
         </span>
       </div>
     </div>

--- a/web/src/components/cards/cni_status/index.tsx
+++ b/web/src/components/cards/cni_status/index.tsx
@@ -27,6 +27,7 @@ import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedCni } from '../../../hooks/useCachedCni'
 import type { CniNodeState, CniNodeStatus } from '../../../lib/demo/cni'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -38,31 +39,11 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
-
 const MAX_NODES_DISPLAYED = 6
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 const NODE_STATE_CLASS_MAP: Record<CniNodeState, string> = {
   'ready': 'bg-green-500/20 text-green-400',
@@ -178,7 +159,7 @@ export function CniStatus() {
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+          <span>{formatTimeAgo(data.lastCheckTime)}</span>
         </div>
       </div>
 

--- a/web/src/components/cards/cortex_status/index.tsx
+++ b/web/src/components/cards/cortex_status/index.tsx
@@ -35,6 +35,7 @@ import type {
   CortexComponentName,
   CortexComponentPod,
 } from '../../../lib/demo/cortex'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -45,10 +46,6 @@ const SKELETON_TITLE_HEIGHT = 28
 const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 6
-
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
 
 // Cortex has six canonical top-level components (distributor, ingester,
 // querier, store-gateway, ruler, alertmanager) — used for skeleton row
@@ -63,22 +60,6 @@ const BILLION = 1_000_000_000
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 /** Compact display for large counts (e.g. "4.25M", "125K"). */
 function formatCompactNumber(value: number): string {
@@ -257,7 +238,7 @@ export function CortexStatus() {
             {t('cortexStatus.version', 'version')}:{' '}
             <span className="text-foreground font-mono">{data.version}</span>
             {' · '}
-            {formatRelativeTime(data.lastCheckTime)}
+            {formatTimeAgo(data.lastCheckTime)}
           </span>
         </div>
       </div>

--- a/web/src/components/cards/dapr_status/index.tsx
+++ b/web/src/components/cards/dapr_status/index.tsx
@@ -35,6 +35,7 @@ import type {
   DaprComponentType,
   DaprControlPlanePod,
 } from './demoData'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -46,29 +47,9 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 function componentTypeLabel(
   type: DaprComponentType,
@@ -226,7 +207,7 @@ export function DaprStatus() {
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+          <span>{formatTimeAgo(data.lastCheckTime)}</span>
         </div>
       </div>
 

--- a/web/src/components/cards/envoy_status/index.tsx
+++ b/web/src/components/cards/envoy_status/index.tsx
@@ -24,6 +24,7 @@ import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedEnvoy } from './useCachedEnvoy'
 import type { EnvoyListener, EnvoyUpstreamCluster } from './demoData'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -35,31 +36,12 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
 const HTTP_5XX_PERCENT_DECIMALS = 2
 const THROUGHPUT_LOCALE_MIN_FRACTION = 0
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 function formatThroughput(value: number): string {
   return value.toLocaleString(undefined, {
@@ -193,7 +175,7 @@ export function EnvoyStatus() {
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+          <span>{formatTimeAgo(data.lastCheckTime)}</span>
         </div>
       </div>
 

--- a/web/src/components/cards/grpc_status/index.tsx
+++ b/web/src/components/cards/grpc_status/index.tsx
@@ -24,14 +24,12 @@ import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedGrpc } from '../../../hooks/useCachedGrpc'
 import type { GrpcService } from './demoData'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
 // ---------------------------------------------------------------------------
 
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
 const ERROR_RATE_DECIMALS = 2
 const THROUGHPUT_LOCALE_MIN_FRACTION = 0
 const LATENCY_WARN_MS = 100
@@ -42,22 +40,6 @@ const ERROR_RATE_CRIT_PCT = 2.0
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 function formatThroughput(value: number): string {
   return value.toLocaleString(undefined, {
@@ -198,7 +180,7 @@ export function GrpcStatus() {
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+          <span>{formatTimeAgo(data.lastCheckTime)}</span>
         </div>
       </div>
 

--- a/web/src/components/cards/kserve_status/index.tsx
+++ b/web/src/components/cards/kserve_status/index.tsx
@@ -38,6 +38,7 @@ import type {
   KServeService,
   KServeServiceStatus,
 } from '../../../lib/demo/kserve'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -48,10 +49,6 @@ const SKELETON_TITLE_HEIGHT = 28
 const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 4
-
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
 
 // Cap how many InferenceServices we render inline on the card. Drill-downs
 // surface the full list; the card itself stays within a consistent 6x4 grid
@@ -64,22 +61,6 @@ const FULL_TRAFFIC_PERCENT = 100
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 function statusBadgeClass(status: KServeServiceStatus): string {
   const map: Record<KServeServiceStatus, string> = {
@@ -338,7 +319,7 @@ export function KServeStatus() {
 
           {data.lastCheckTime ? (
             <div className="text-[11px] text-muted-foreground text-right">
-              {formatRelativeTime(data.lastCheckTime)}
+              {formatTimeAgo(data.lastCheckTime)}
             </div>
           ) : null}
         </section>

--- a/web/src/components/cards/kubevela_status/index.tsx
+++ b/web/src/components/cards/kubevela_status/index.tsx
@@ -37,6 +37,7 @@ import type {
   KubeVelaAppStatus,
   WorkflowStepPhase,
 } from './demoData'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -48,37 +49,18 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 4
 
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
-
 const PERCENT_FULL = 100
 const PROGRESS_BAR_WIDTH_PX = 56
 const PROGRESS_BAR_HEIGHT_PX = 4
 
 const MAX_APPS_DISPLAYED = 5
+const MINUTES_PER_HOUR = 60
 const AGE_MINUTES_HOUR_THRESHOLD = 60
 const AGE_MINUTES_DAY_THRESHOLD = 1440
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 function formatAge(ageMinutes: number): string {
   if (ageMinutes < AGE_MINUTES_HOUR_THRESHOLD) return `${ageMinutes}m`
@@ -362,7 +344,7 @@ export function KubeVelaStatus() {
           <RefreshCw
             className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`}
           />
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+          <span>{formatTimeAgo(data.lastCheckTime)}</span>
         </div>
       </div>
 

--- a/web/src/components/cards/linkerd_status/index.tsx
+++ b/web/src/components/cards/linkerd_status/index.tsx
@@ -24,6 +24,7 @@ import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedLinkerd } from '../../../hooks/useCachedLinkerd'
 import type { LinkerdMeshedDeployment } from './demoData'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -35,9 +36,6 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
 const SUCCESS_RATE_DECIMALS = 2
 const THROUGHPUT_LOCALE_MIN_FRACTION = 0
 const SUCCESS_RATE_WARN_THRESHOLD_PCT = 99.0
@@ -48,22 +46,6 @@ const P99_LATENCY_CRIT_MS = 100
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 function formatThroughput(value: number): string {
   return value.toLocaleString(undefined, {
@@ -197,7 +179,7 @@ export function LinkerdStatus() {
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+          <span>{formatTimeAgo(data.lastCheckTime)}</span>
         </div>
       </div>
 

--- a/web/src/components/cards/openfeature_status/index.tsx
+++ b/web/src/components/cards/openfeature_status/index.tsx
@@ -38,6 +38,7 @@ import type {
   OpenFeatureProvider,
   OpenFeatureProviderStatus,
 } from './demoData'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -49,32 +50,12 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
-
 const MAX_FLAGS_DISPLAYED = 6
 const ERROR_RATE_WARNING_PCT = 5
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 const PROVIDER_STATUS_CLASS: Record<OpenFeatureProviderStatus, string> = {
   healthy: 'bg-green-500/20 text-green-400',
@@ -273,7 +254,7 @@ export function OpenFeatureStatus() {
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+          <span>{formatTimeAgo(data.lastCheckTime)}</span>
         </div>
       </div>
 

--- a/web/src/components/cards/openfga_status/index.tsx
+++ b/web/src/components/cards/openfga_status/index.tsx
@@ -34,6 +34,7 @@ import type {
   OpenfgaStore,
   OpenfgaStoreStatus,
 } from './demoData'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -45,10 +46,6 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
-
 const MAX_STORES_DISPLAYED = 5
 const MAX_MODELS_DISPLAYED = 5
 
@@ -58,22 +55,6 @@ const NUMBER_LOCALE = 'en-US'
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 function formatNumber(value: number): string {
   return value.toLocaleString(NUMBER_LOCALE)
@@ -112,7 +93,7 @@ function StoreRow({ store }: { store: OpenfgaStore }) {
           {formatNumber(store.tupleCount)} tuples · {store.modelCount} models
         </span>
         <span className="ml-auto shrink-0">
-          {formatRelativeTime(store.lastWriteTime)}
+          {formatTimeAgo(store.lastWriteTime)}
         </span>
       </div>
     </div>
@@ -138,7 +119,7 @@ function ModelRow({ model }: { model: OpenfgaAuthorizationModel }) {
           {model.storeName} · {model.typeCount} types
         </span>
         <span className="ml-auto shrink-0">
-          {formatRelativeTime(model.createdAt)}
+          {formatTimeAgo(model.createdAt)}
         </span>
       </div>
     </div>
@@ -232,7 +213,7 @@ export function OpenfgaStatus() {
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+          <span>{formatTimeAgo(data.lastCheckTime)}</span>
         </div>
       </div>
 

--- a/web/src/components/cards/spiffe_status/index.tsx
+++ b/web/src/components/cards/spiffe_status/index.tsx
@@ -32,6 +32,7 @@ import type {
   SpiffeFederatedDomain,
   SpiffeRegistrationEntry,
 } from './demoData'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -43,9 +44,6 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
 const SECONDS_PER_MINUTE = 60
 const SECONDS_PER_HOUR = 3600
 const SECONDS_PER_DAY = 86400
@@ -55,22 +53,6 @@ const MAX_ENTRIES_DISPLAYED = 5
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 function formatTtl(seconds: number): string {
   if (seconds >= SECONDS_PER_DAY) {
@@ -222,7 +204,7 @@ export function SpiffeStatus() {
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+          <span>{formatTimeAgo(data.lastCheckTime)}</span>
         </div>
       </div>
 

--- a/web/src/components/cards/strimzi_status/index.tsx
+++ b/web/src/components/cards/strimzi_status/index.tsx
@@ -35,6 +35,7 @@ import type {
   StrimziConsumerGroup,
   StrimziKafkaCluster,
 } from './demoData'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -45,10 +46,6 @@ const SKELETON_TITLE_HEIGHT = 28
 const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 4
-
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
 
 // Max clusters to show in the list view before we rely on scroll.
 const MAX_CLUSTERS_DISPLAYED = 6
@@ -65,22 +62,6 @@ const LAG_CRITICAL_THRESHOLD = 1_000
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 const CLUSTER_HEALTH_CLASS: Record<ClusterHealth, string> = {
   healthy: 'bg-green-500/20 text-green-400',
@@ -262,7 +243,7 @@ export function StrimziStatus() {
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+          <span>{formatTimeAgo(data.lastCheckTime)}</span>
         </div>
       </div>
 

--- a/web/src/components/cards/volcano_status/index.tsx
+++ b/web/src/components/cards/volcano_status/index.tsx
@@ -40,6 +40,7 @@ import type {
   VolcanoPodGroup,
   VolcanoQueue,
 } from './demoData'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -51,10 +52,6 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
-
 const MAX_QUEUES_DISPLAYED = 5
 const MAX_JOBS_DISPLAYED = 5
 
@@ -64,22 +61,6 @@ const PERCENT_NEAR_FULL_THRESHOLD = 80
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 const QUEUE_STATE_CLASS: Record<QueueState, string> = {
   Open: 'bg-green-500/20 text-green-400',
@@ -282,7 +263,7 @@ export function VolcanoStatus() {
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+          <span>{formatTimeAgo(data.lastCheckTime)}</span>
         </div>
       </div>
 

--- a/web/src/components/cards/wasmcloud_status/index.tsx
+++ b/web/src/components/cards/wasmcloud_status/index.tsx
@@ -35,6 +35,7 @@ import type {
   WasmcloudProvider,
   WasmcloudProviderStatus,
 } from './demoData'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -46,9 +47,6 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const RELATIVE_TIME_MINUTE_MS = 60_000
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
 const SECONDS_PER_MINUTE = 60
 const SECONDS_PER_HOUR = 3600
 const SECONDS_PER_DAY = 86400
@@ -62,22 +60,6 @@ const HOST_ID_SHORT_LENGTH = 8
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(isoString: string): string {
-  const parsed = new Date(isoString).getTime()
-  if (!isoString || Number.isNaN(parsed)) return 'just now'
-
-  const diff = Date.now() - parsed
-  if (diff < 0) return 'just now'
-
-  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
-  const day = HOURS_PER_DAY * hour
-
-  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-  return `${Math.floor(diff / day)}d ago`
-}
 
 function formatUptime(seconds: number): string {
   if (seconds >= SECONDS_PER_DAY) {
@@ -275,7 +257,7 @@ export function WasmcloudStatus() {
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+          <span>{formatTimeAgo(data.lastCheckTime)}</span>
         </div>
       </div>
 


### PR DESCRIPTION
Fixes #10079

## Summary

Replace 15 identical `formatRelativeTime` implementations in card status files with `import { formatTimeAgo } from 'lib/formatters'`.

## Changes

- **Removed** local `formatRelativeTime` function from 15 card status files
- **Removed** per-file time constants (`RELATIVE_TIME_MINUTE_MS`, `MINUTES_PER_HOUR`, `HOURS_PER_DAY`) that were only used by the removed functions
- **Retained** `MINUTES_PER_HOUR` in kubevela_status (used by its `formatAge` helper)
- **Added** `import { formatTimeAgo } from '../../../lib/formatters'` to each file
- **Replaced** `formatRelativeTime(` calls with `formatTimeAgo(`

## Affected cards

cni, linkerd, volcano, cortex, envoy, grpc, kubevela, dapr, strimzi, openfga, openfeature, spiffe, wasmcloud, kserve, cloud_custodian

## Impact

- 15 files changed, +33 / -310 lines (~277 net lines removed)
- Zero behavior changes — all implementations produced identical output to the canonical `formatTimeAgo`
- Build and lint pass locally