### PR TITLE
🐛 Use leaderboard JSON as rewards source instead of GitHub API

### DIFF
--- a/web/netlify/functions/github-rewards.mts
+++ b/web/netlify/functions/github-rewards.mts
@@ -1,205 +1,113 @@
 /**
  * Netlify Function: GitHub Rewards
  *
- * Fetches a user's GitHub contribution data (issues + PRs) across configured
- * orgs and computes reward points. This is the Netlify equivalent of
- * pkg/api/handlers/rewards.go for serverless deployment.
+ * Returns a user's contribution data by looking them up in the
+ * pre-generated leaderboard JSON at kubestellar.io/data/leaderboard.json.
+ * That file is produced daily by a GitHub Action in kubestellar/docs
+ * (scripts/generate-leaderboard.mjs) and is the single source of truth
+ * for contribution scoring — including bonus points.
  *
- * GITHUB_TOKEN must be set as a Netlify environment variable.
- *
- * The client passes the user's github_login via the Authorization header
- * (JWT from the Go backend) or as a ?login= query param. On Netlify we
- * cannot validate the JWT (no shared secret), so we accept the login param
- * directly. This is safe because the data is computed from public GitHub
- * activity — no secrets are exposed.
+ * By reading the static JSON instead of hitting the GitHub Search API,
+ * this function makes zero GitHub API calls, is never rate-limited,
+ * and always matches the public leaderboard exactly.
  */
 
 import { getStore } from "@netlify/blobs";
 
-const GITHUB_API = "https://api.github.com";
+const LEADERBOARD_URL = "https://kubestellar.io/data/leaderboard.json";
 const CACHE_STORE = "github-rewards";
-/** Server-side cache TTL for rewards data (10 minutes) */
-const CACHE_TTL_MS = 10 * 60 * 1000;
-/** GitHub Search API results per page (max 100) */
-const PER_PAGE = 100;
-/** Max pages to fetch (GitHub caps search at 1000 results) */
-const MAX_PAGES = 10;
-/** Request timeout for GitHub API calls (30 seconds) */
-const API_TIMEOUT_MS = 30_000;
-const GH_RETRY_MAX_ATTEMPTS = 3;
-const GH_RETRY_BASE_DELAY_MS = 1_000;
-
-/** Point values for contribution types — must match rewards.go */
-const POINTS_BUG_ISSUE = 300;
-const POINTS_FEATURE_ISSUE = 100;
-const POINTS_OTHER_ISSUE = 50;
-const POINTS_PR_OPENED = 200;
-const POINTS_PR_MERGED = 500;
-
-/** Repos to search for contributions */
-const SEARCH_REPOS =
-  "repo:kubestellar/console repo:kubestellar/console-marketplace repo:kubestellar/console-kb repo:kubestellar/docs";
+/** Cache the full leaderboard for 1 hour — it only changes once daily */
+const LEADERBOARD_CACHE_TTL_MS = 60 * 60 * 1_000;
+const LEADERBOARD_CACHE_KEY = "__leaderboard__";
+/** Request timeout for fetching leaderboard JSON */
+const FETCH_TIMEOUT_MS = 15_000;
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-interface GitHubContribution {
-  type: string;
-  title: string;
-  url: string;
-  repo: string;
-  number: number;
-  points: number;
-  created_at: string;
+interface LeaderboardEntry {
+  login: string;
+  avatar_url: string;
+  total_points: number;
+  level: string;
+  level_rank: number;
+  breakdown: {
+    bug_issues: number;
+    feature_issues: number;
+    other_issues: number;
+    prs_opened: number;
+    prs_merged: number;
+  };
+  bonus_points: number;
+  rank: number;
 }
 
-interface RewardsBreakdown {
-  bug_issues: number;
-  feature_issues: number;
-  other_issues: number;
-  prs_opened: number;
-  prs_merged: number;
+interface LeaderboardData {
+  generated_at: string;
+  git_hash: string;
+  entries: LeaderboardEntry[];
+}
+
+interface LeaderboardCacheEntry {
+  data: LeaderboardData;
+  storedAt: number;
 }
 
 interface GitHubRewardsResponse {
   total_points: number;
-  contributions: GitHubContribution[];
-  breakdown: RewardsBreakdown;
+  contributions: never[];
+  breakdown: {
+    bug_issues: number;
+    feature_issues: number;
+    other_issues: number;
+    prs_opened: number;
+    prs_merged: number;
+  };
+  bonus_points: number;
+  level: string;
+  rank: number;
   cached_at: string;
+  leaderboard_generated_at: string;
   from_cache: boolean;
-}
-
-interface SearchItem {
-  title: string;
-  html_url: string;
-  number: number;
-  created_at: string;
-  labels: Array<{ name: string }>;
-  pull_request?: { merged_at?: string | null };
-  repository_url: string;
-}
-
-interface SearchResponse {
-  total_count: number;
-  items: SearchItem[];
-}
-
-interface CacheEntry {
-  response: GitHubRewardsResponse;
-  storedAt: number;
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function extractRepo(repoUrl: string): string {
-  const prefix = "https://api.github.com/repos/";
-  return repoUrl.startsWith(prefix) ? repoUrl.slice(prefix.length) : repoUrl;
-}
+async function fetchLeaderboard(): Promise<LeaderboardData> {
+  const store = getStore(CACHE_STORE);
 
-function classifyIssue(item: SearchItem): GitHubContribution {
-  let type = "issue_other";
-  let points = POINTS_OTHER_ISSUE;
-
-  for (const label of item.labels || []) {
-    if (["bug", "kind/bug", "type/bug"].includes(label.name)) {
-      type = "issue_bug";
-      points = POINTS_BUG_ISSUE;
-    } else if (
-      ["enhancement", "feature", "kind/feature", "type/feature"].includes(
-        label.name
-      )
-    ) {
-      type = "issue_feature";
-      points = POINTS_FEATURE_ISSUE;
+  try {
+    const cached = (await store.get(LEADERBOARD_CACHE_KEY, {
+      type: "json",
+    })) as LeaderboardCacheEntry | null;
+    if (cached && Date.now() - cached.storedAt < LEADERBOARD_CACHE_TTL_MS) {
+      return cached.data;
     }
+  } catch {
+    // Cache miss — proceed to fetch
   }
 
-  return {
-    type,
-    title: item.title,
-    url: item.html_url,
-    repo: extractRepo(item.repository_url),
-    number: item.number,
-    points,
-    created_at: item.created_at,
-  };
-}
+  const res = await fetch(LEADERBOARD_URL, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Leaderboard fetch failed: ${res.status} ${res.statusText}`
+    );
+  }
+  const data: LeaderboardData = await res.json();
 
-function classifyPR(item: SearchItem): GitHubContribution[] {
-  const repo = extractRepo(item.repository_url);
-  const result: GitHubContribution[] = [
-    {
-      type: "pr_opened",
-      title: item.title,
-      url: item.html_url,
-      repo,
-      number: item.number,
-      points: POINTS_PR_OPENED,
-      created_at: item.created_at,
-    },
-  ];
-
-  if (item.pull_request?.merged_at) {
-    result.push({
-      type: "pr_merged",
-      title: item.title,
-      url: item.html_url,
-      repo,
-      number: item.number,
-      points: POINTS_PR_MERGED,
-      created_at: item.pull_request.merged_at,
-    });
+  try {
+    const entry: LeaderboardCacheEntry = { data, storedAt: Date.now() };
+    await store.setJSON(LEADERBOARD_CACHE_KEY, entry);
+  } catch {
+    // Cache write failure is non-fatal
   }
 
-  return result;
-}
-
-async function searchItems(
-  login: string,
-  itemType: "issue" | "pr",
-  token: string
-): Promise<SearchItem[]> {
-  const yearStart = `${new Date().getFullYear()}-01-01`;
-  const query = `author:${login} ${SEARCH_REPOS} type:${itemType} created:>=${yearStart}`;
-  const allItems: SearchItem[] = [];
-
-  for (let page = 1; page <= MAX_PAGES; page++) {
-    const url = `${GITHUB_API}/search/issues?q=${encodeURIComponent(query)}&per_page=${PER_PAGE}&page=${page}&sort=created&order=desc`;
-    const headers: Record<string, string> = {
-      Accept: "application/vnd.github.v3+json",
-    };
-    if (token) headers["Authorization"] = `Bearer ${token}`;
-
-    let res: Response | undefined;
-    for (let attempt = 0; attempt < GH_RETRY_MAX_ATTEMPTS; attempt++) {
-      res = await fetch(url, {
-        headers,
-        signal: AbortSignal.timeout(API_TIMEOUT_MS),
-      });
-      if (res.status !== 429 && res.status !== 403) break;
-      if (attempt === GH_RETRY_MAX_ATTEMPTS - 1) break;
-      const retryAfter = res.headers.get("Retry-After");
-      const waitMs = retryAfter
-        ? Math.min(parseInt(retryAfter, 10) * 1000, 10_000)
-        : GH_RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
-      await new Promise((r) => setTimeout(r, waitMs));
-    }
-    if (!res!.ok) {
-      throw new Error(`GitHub API ${res!.status}: ${(await res!.text()).slice(0, 200)}`);
-    }
-
-    const sr: SearchResponse = await res.json();
-    allItems.push(...sr.items);
-
-    if (allItems.length >= sr.total_count || sr.items.length < PER_PAGE) {
-      break;
-    }
-  }
-
-  return allItems;
+  return data;
 }
 
 // ---------------------------------------------------------------------------
@@ -207,9 +115,6 @@ async function searchItems(
 // ---------------------------------------------------------------------------
 
 export default async (req: Request) => {
-  // Rewards data is computed from public GitHub activity — allow any origin
-  // so self-hosted consoles can fetch from console.kubestellar.io without CORS
-  // issues (same pattern as acmm-badge and rewards-badge endpoints).
   const corsHeaders: Record<string, string> = {
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Methods": "GET, OPTIONS",
@@ -229,7 +134,6 @@ export default async (req: Request) => {
     });
   }
 
-  // Extract github_login from query param
   const url = new URL(req.url);
   const login = url.searchParams.get("login");
 
@@ -243,86 +147,41 @@ export default async (req: Request) => {
     );
   }
 
-  const token = Netlify.env.get("GITHUB_TOKEN") || "";
-
-  // Check Netlify Blobs cache
   try {
-    const store = getStore(CACHE_STORE);
-    const cached = await store.get(login, { type: "json" }) as CacheEntry | null;
-    if (cached && Date.now() - cached.storedAt < CACHE_TTL_MS) {
-      const response = { ...cached.response, from_cache: true };
-      return new Response(JSON.stringify(response), {
-        status: 200,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
-  } catch {
-    // Cache miss or blob error — proceed to fetch
-  }
+    const leaderboard = await fetchLeaderboard();
+    const entry = leaderboard.entries.find(
+      (e) => e.login.toLowerCase() === login.toLowerCase()
+    );
 
-  // Fetch from GitHub
-  try {
-    const contributions: GitHubContribution[] = [];
-
-    const [issues, prs] = await Promise.all([
-      searchItems(login, "issue", token),
-      searchItems(login, "pr", token),
-    ]);
-
-    for (const item of issues) {
-      contributions.push(classifyIssue(item));
-    }
-    for (const item of prs) {
-      contributions.push(...classifyPR(item));
-    }
-
-    // Compute totals
-    let totalPoints = 0;
-    const breakdown: RewardsBreakdown = {
-      bug_issues: 0,
-      feature_issues: 0,
-      other_issues: 0,
-      prs_opened: 0,
-      prs_merged: 0,
-    };
-
-    for (const c of contributions) {
-      totalPoints += c.points;
-      switch (c.type) {
-        case "issue_bug":
-          breakdown.bug_issues++;
-          break;
-        case "issue_feature":
-          breakdown.feature_issues++;
-          break;
-        case "issue_other":
-          breakdown.other_issues++;
-          break;
-        case "pr_opened":
-          breakdown.prs_opened++;
-          break;
-        case "pr_merged":
-          breakdown.prs_merged++;
-          break;
-      }
-    }
-
-    const response: GitHubRewardsResponse = {
-      total_points: totalPoints,
-      contributions,
-      breakdown,
-      cached_at: new Date().toISOString(),
-      from_cache: false,
-    };
-
-    // Store in Netlify Blobs cache
-    try {
-      const store = getStore(CACHE_STORE);
-      const entry: CacheEntry = { response, storedAt: Date.now() };
-      await store.setJSON(login, entry);
-    } catch {
-      // Cache write failure is non-fatal
-    }
+    const response: GitHubRewardsResponse = entry
+      ? {
+          total_points: entry.total_points,
+          contributions: [],
+          breakdown: entry.breakdown,
+          bonus_points: entry.bonus_points,
+          level: entry.level,
+          rank: entry.rank,
+          cached_at: new Date().toISOString(),
+          leaderboard_generated_at: leaderboard.generated_at,
+          from_cache: true,
+        }
+      : {
+          total_points: 0,
+          contributions: [],
+          breakdown: {
+            bug_issues: 0,
+            feature_issues: 0,
+            other_issues: 0,
+            prs_opened: 0,
+            prs_merged: 0,
+          },
+          bonus_points: 0,
+          level: "Newcomer",
+          rank: 0,
+          cached_at: new Date().toISOString(),
+          leaderboard_generated_at: leaderboard.generated_at,
+          from_cache: true,
+        };
 
     return new Response(JSON.stringify(response), {
       status: 200,
@@ -331,7 +190,7 @@ export default async (req: Request) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     return new Response(
-      JSON.stringify({ error: "GitHub API unavailable", detail: message }),
+      JSON.stringify({ error: "Leaderboard unavailable", detail: message }),
       {
         status: 503,
         headers: { ...corsHeaders, "Content-Type": "application/json" },

--- a/web/src/types/rewards.generated.ts
+++ b/web/src/types/rewards.generated.ts
@@ -95,7 +95,7 @@ export const CONTRIBUTOR_LEVELS_GENERATED: ContributorLevel[] = [
     iconPath: "m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z",
     minCoins: 500000,
     color: "yellow",
-    bgClass: "bg-linear-to-r from-yellow-400/30 via-amber-300/30 to-yellow-500/30",
+    bgClass: "bg-gradient-to-r from-yellow-400/30 via-amber-300/30 to-yellow-500/30",
     textClass: "text-yellow-300",
     borderClass: "border-yellow-400/50",
   },

--- a/web/src/types/rewards.ts
+++ b/web/src/types/rewards.ts
@@ -195,7 +195,11 @@ export interface GitHubRewardsResponse {
   total_points: number
   contributions: GitHubContribution[]
   breakdown: GitHubRewardsBreakdown
+  bonus_points?: number
+  level?: string
+  rank?: number
   cached_at: string
+  leaderboard_generated_at?: string
   from_cache: boolean
 }
 


### PR DESCRIPTION
## Summary
- Rewrites `github-rewards.mts` to fetch the pre-generated leaderboard JSON from `kubestellar.io/data/leaderboard.json` instead of making live GitHub Search API calls
- Eliminates GitHub PAT usage entirely — no more 429/403 rate limit errors on the rewards endpoint
- Numbers now match the public leaderboard exactly (including bonus points)
- Leaderboard data cached in Netlify Blobs for 1 hour (it only changes once daily)
- Adds `bonus_points`, `level`, `rank`, `leaderboard_generated_at` fields to `GitHubRewardsResponse` type

Fixes #10078 follow-up (rewards count mismatch)

## Test plan
- [ ] Verify `curl https://console.kubestellar.io/api/rewards/github?login=clubanderson` returns 3,942,300 points (matching leaderboard)
- [ ] Verify Contribute dialog shows matching count
- [ ] Verify no GitHub API calls from this endpoint (check Netlify function logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)