### PR TITLE
🐛 Fix nightly test suite: harden jq parse error handling

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -136,8 +136,8 @@ jobs:
           echo "result_file=${RESULTS_DIR}/${DATE}.json" >> "$GITHUB_OUTPUT"
           echo "date=${DATE}" >> "$GITHUB_OUTPUT"
 
-          # Check if tests passed
-          FAILED=$(jq -r '.summary.failed' /tmp/all-tests-report.json)
+          # Check if tests passed (tolerate malformed JSON from run-all-tests.sh)
+          FAILED=$(jq -r '.summary.failed' /tmp/all-tests-report.json 2>/dev/null || echo "unknown")
           echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
 
       - name: Generate comparison report
@@ -174,8 +174,8 @@ jobs:
           git add "${RESULTS_DIR}/${{ steps.tests.outputs.date }}.json"
           git commit -m "chore: nightly test results for ${{ steps.tests.outputs.date }}
 
-          Passed: $(jq -r '.summary.passed' ${{ steps.tests.outputs.result_file }})/$( jq -r '.summary.total' ${{ steps.tests.outputs.result_file }})
-          Failed: $(jq -r '.summary.failed' ${{ steps.tests.outputs.result_file }})
+          Passed: $(jq -r '.summary.passed' ${{ steps.tests.outputs.result_file }} 2>/dev/null || echo '?')/$( jq -r '.summary.total' ${{ steps.tests.outputs.result_file }} 2>/dev/null || echo '?')
+          Failed: $(jq -r '.summary.failed' ${{ steps.tests.outputs.result_file }} 2>/dev/null || echo '?')
 
           [skip ci]" || echo "No changes to commit"
           git push origin main || echo "::warning::Failed to push results — will retry next run"
@@ -265,7 +265,7 @@ _No comparison report was generated. The test suite or comparison script may hav
             --description "Needs triage" 2>/dev/null || true
 
           # Create an issue for each failing suite (skip if one already exists)
-          FAILING_SUITES=$(jq -r '.results[] | select(.status == "fail") | .suite' "$RESULT_FILE")
+          FAILING_SUITES=$(jq -r '.results[] | select(.status == "fail") | .suite' "$RESULT_FILE" 2>/dev/null || true)
           for suite in $FAILING_SUITES; do
             ISSUE_TITLE="Nightly regression: ${suite}"
 

--- a/scripts/nightly-compare.sh
+++ b/scripts/nightly-compare.sh
@@ -33,8 +33,19 @@ jq_or_fail() {
 }
 
 # ============================================================================
-# Load current results
+# Load current results (bail early if JSON is malformed)
 # ============================================================================
+
+if ! jq empty "$CURRENT_FILE" 2>/dev/null; then
+  echo "## :warning: Nightly Test Results"
+  echo ""
+  echo "_The test results JSON is malformed and cannot be parsed._"
+  echo "_Check the [workflow run](https://github.com/kubestellar/console/actions) for details._"
+  echo ""
+  echo "**Date:** $(date -u +%Y-%m-%d)"
+  echo "**File:** \`$CURRENT_FILE\`"
+  exit 1
+fi
 
 CUR_TOTAL=$(jq_or_fail -r '.summary.total' "$CURRENT_FILE")
 CUR_PASSED=$(jq_or_fail -r '.summary.passed' "$CURRENT_FILE")

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -399,19 +399,34 @@ echo ""
 
 RESULTS="${RESULTS%,}"
 
-cat > "$REPORT_JSON" << EOF
-{
-  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "fastMode": $([ -n "$FAST_MODE" ] && echo "true" || echo "false"),
-  "summary": {
-    "total": ${TOTAL},
-    "passed": ${PASSED_SUITES},
-    "failed": ${FAILED_SUITES},
-    "skipped": ${SKIPPED_SUITES}
+# Build JSON report, validating with jq to catch malformed failure_reason
+# strings (unescaped chars, shell-expanded $variables, etc.)
+CANDIDATE_JSON="{
+  \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",
+  \"fastMode\": $([ -n "$FAST_MODE" ] && echo "true" || echo "false"),
+  \"summary\": {
+    \"total\": ${TOTAL},
+    \"passed\": ${PASSED_SUITES},
+    \"failed\": ${FAILED_SUITES},
+    \"skipped\": ${SKIPPED_SUITES}
   },
-  "results": [${RESULTS}]
-}
-EOF
+  \"results\": [${RESULTS}]
+}"
+
+if echo "$CANDIDATE_JSON" | jq . > "$REPORT_JSON" 2>/dev/null; then
+  : # valid JSON written
+else
+  echo "WARNING: Generated JSON was malformed — writing minimal report" >&2
+  jq -n \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --argjson fm "$([ -n "$FAST_MODE" ] && echo "true" || echo "false")" \
+    --argjson total "$TOTAL" \
+    --argjson passed "$PASSED_SUITES" \
+    --argjson failed "$FAILED_SUITES" \
+    --argjson skipped "$SKIPPED_SUITES" \
+    '{timestamp: $ts, fastMode: $fm, summary: {total: $total, passed: $passed, failed: $failed, skipped: $skipped}, results: []}' \
+    > "$REPORT_JSON"
+fi
 
 cat > "$REPORT_MD" << EOF
 # KubeStellar Console — Full Test Suite


### PR DESCRIPTION
Fixes #9346

The nightly workflow has been failing since Apr 23 because `run-all-tests.sh` can produce malformed JSON when `failure_reason` strings contain unescaped characters. This causes a cascade:

1. `jq: parse error: Invalid numeric literal` when parsing test results
2. `nightly-compare.sh` crashes on malformed JSON → no comparison markdown
3. `gh issue comment` fails on missing `/tmp/nightly-comparison.md`

**Changes:**
- **`scripts/run-all-tests.sh`**: Validate assembled JSON with `jq` before writing. Falls back to a minimal valid report (summary only, no per-suite results) if malformed.
- **`nightly-test-suite.yml`**: Add `2>/dev/null || echo fallback` to all `jq` invocations so one parse error doesn't cascade.
- **`scripts/nightly-compare.sh`**: Detect malformed JSON early (`jq empty`) and output meaningful markdown instead of crashing.