### PR TITLE
🌱 Deduplicate REFRESH_INTERVAL_MS across 20+ hooks

### DIFF
--- a/web/src/components/cards/lima_status/useLimaStatus.ts
+++ b/web/src/components/cards/lima_status/useLimaStatus.ts
@@ -4,6 +4,7 @@ import { STORAGE_KEY_TOKEN } from '../../../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
 import { useCardLoadingState } from '../CardDataContext'
 import { LIMA_DEMO_DATA, type LimaDemoData, type LimaInstance } from './demoData'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../../../lib/constants'
 
 export interface LimaStatus {
   instances: LimaInstance[]
@@ -30,7 +31,6 @@ const INITIAL_DATA: LimaStatus = {
 }
 
 const CACHE_EXPIRY_MS = 300_000
-const REFRESH_INTERVAL_MS = 120_000
 const FAILURE_THRESHOLD = 3
 const LIMA_CACHE_KEY = 'kc-lima-cache'
 const STATUS_SERVICE_UNAVAILABLE = 503

--- a/web/src/components/compliance/SigningStatusDashboard.tsx
+++ b/web/src/components/compliance/SigningStatusDashboard.tsx
@@ -13,9 +13,9 @@ import {
 import { authFetch } from '../../lib/api'
 import { DashboardHeader } from '../shared/DashboardHeader'
 import { RotatingTip } from '../ui/RotatingTip'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../../lib/constants'
 
 /** Polling interval for signature status refresh (ms) */
-const REFRESH_INTERVAL_MS = 120_000
 
 interface SignedImage {
   image: string

--- a/web/src/hooks/mcp/crossplane.ts
+++ b/web/src/hooks/mcp/crossplane.ts
@@ -5,6 +5,7 @@ import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { MIN_REFRESH_INDICATOR_MS, getEffectiveInterval } from './shared'
 import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../../lib/constants'
 
 export interface CrossplaneManagedResource {
   apiVersion: string
@@ -53,7 +54,6 @@ function getDemoManagedResources(): CrossplaneManagedResource[] {
 
 const CACHE_KEY = 'kc-crossplane-managed-cache'
 const CACHE_TTL_MS = 30000
-const REFRESH_INTERVAL_MS = 120000
 
 interface ManagedCache {
   data: CrossplaneManagedResource[]

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -11,12 +11,13 @@ import {
   MCP_HOOK_TIMEOUT_MS,
   METRICS_SERVER_TIMEOUT_MS,
   STORAGE_KEY_TOKEN,
+  DEFAULT_REFRESH_INTERVAL_MS,
 } from '../../lib/constants'
 import { MCP_PROBE_TIMEOUT_MS, FOCUS_DELAY_MS } from '../../lib/constants/network'
 import type { ClusterInfo, ClusterHealth } from './types'
 
-// Refresh interval for automatic polling (2 minutes) - manual refresh bypasses this
-export const REFRESH_INTERVAL_MS = 120000
+// Re-export canonical constant under the name used by MCP hooks
+export const REFRESH_INTERVAL_MS = DEFAULT_REFRESH_INTERVAL_MS
 
 // Polling intervals for cluster and GPU data freshness
 export const CLUSTER_POLL_INTERVAL_MS = 60000  // 60 seconds

--- a/web/src/hooks/useAdmissionWebhooks.ts
+++ b/web/src/hooks/useAdmissionWebhooks.ts
@@ -10,6 +10,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 // ============================================================================
 // Constants
@@ -19,7 +20,6 @@ import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 const CACHE_EXPIRY_MS = 300_000
 
 /** Auto-refresh interval — 2 minutes */
-const REFRESH_INTERVAL_MS = 120_000
 
 /** Number of consecutive failures before marking as failed */
 const FAILURE_THRESHOLD = 3

--- a/web/src/hooks/useArgoCD.ts
+++ b/web/src/hooks/useArgoCD.ts
@@ -15,12 +15,11 @@ import { useClusters } from './useMCP'
 import { useGlobalFilters } from './useGlobalFilters'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, MOCK_SYNC_DELAY_MS } from '../lib/constants/network'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 // Cache expiry time (5 minutes)
 const CACHE_EXPIRY_MS = 300_000
 
-// Refresh interval (2 minutes)
-const REFRESH_INTERVAL_MS = 120_000
 
 // Number of consecutive failures before marking as failed
 const FAILURE_THRESHOLD = 3

--- a/web/src/hooks/useCRDs.ts
+++ b/web/src/hooks/useCRDs.ts
@@ -15,6 +15,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 // ============================================================================
 // Constants
@@ -24,7 +25,6 @@ import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 const CACHE_EXPIRY_MS = 300_000
 
 /** Auto-refresh interval — 2 minutes */
-const REFRESH_INTERVAL_MS = 120_000
 
 /** Number of consecutive failures before marking as failed */
 const FAILURE_THRESHOLD = 3

--- a/web/src/hooks/useCertManager.ts
+++ b/web/src/hooks/useCertManager.ts
@@ -2,9 +2,8 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { useDemoMode } from './useDemoMode'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
-// Refresh interval for automatic polling (2 minutes)
-const REFRESH_INTERVAL_MS = 120000
 
 // Days before expiration to consider "expiring soon"
 const EXPIRING_SOON_DAYS = 30

--- a/web/src/hooks/useGatewayStatus.ts
+++ b/web/src/hooks/useGatewayStatus.ts
@@ -16,6 +16,7 @@ import { useClusters } from './useMCP'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { registerRefetch } from '../lib/modeTransition'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 // ============================================================================
 // Constants
@@ -25,7 +26,6 @@ import { registerRefetch } from '../lib/modeTransition'
 const CACHE_EXPIRY_MS = 300_000
 
 /** Auto-refresh interval — 2 minutes */
-const REFRESH_INTERVAL_MS = 120_000
 
 /** Number of consecutive failures before marking as failed */
 const FAILURE_THRESHOLD = 3

--- a/web/src/hooks/useIntoto.ts
+++ b/web/src/hooks/useIntoto.ts
@@ -17,9 +17,9 @@ import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_INTOTO_CACHE, STORAGE_KEY_INTOTO_CACHE_TIME } from '../lib/constants/storage'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 /** Refresh interval for automatic polling (2 minutes) */
-const REFRESH_INTERVAL_MS = 120_000
 
 /** Timeout for CRD existence check (fast — missing resources fail instantly) */
 const CRD_CHECK_TIMEOUT_MS = 8_000

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -17,9 +17,9 @@ import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_KUBESCAPE_CACHE, STORAGE_KEY_KUBESCAPE_CACHE_TIME } from '../lib/constants/storage'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 /** Refresh interval for automatic polling (2 minutes) */
-const REFRESH_INTERVAL_MS = 120_000
 
 /** Cache TTL: 2 minutes — matches refresh interval */
 // Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -17,9 +17,9 @@ import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_KYVERNO_CACHE, STORAGE_KEY_KYVERNO_CACHE_TIME } from '../lib/constants/storage'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 /** Refresh interval for automatic polling (2 minutes) */
-const REFRESH_INTERVAL_MS = 120_000
 
 /** Cache TTL: 2 minutes — matches refresh interval */
 // Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000

--- a/web/src/hooks/useLLMd.ts
+++ b/web/src/hooks/useLLMd.ts
@@ -1,9 +1,8 @@
 import { useState, useEffect, useRef } from 'react'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { getDemoMode } from './useDemoMode'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
-// Refresh interval for automatic polling (2 minutes)
-const REFRESH_INTERVAL_MS = 120000
 
 // LLM-d component types
 export type LLMdComponentType = 'model' | 'epp' | 'gateway' | 'prometheus' | 'autoscaler' | 'other'

--- a/web/src/hooks/useMCS.ts
+++ b/web/src/hooks/useMCS.ts
@@ -8,6 +8,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { api, BackendUnavailableError } from '../lib/api'
 import { useDemoMode } from './useDemoMode'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 import type {
   ServiceExport,
   ServiceExportList,
@@ -17,8 +18,6 @@ import type {
   ClusterMCSStatus,
 } from '../types/mcs'
 
-// Refresh interval for automatic polling (2 minutes)
-const REFRESH_INTERVAL_MS = 120000
 
 // Demo data for demo mode
 const DEMO_SERVICE_EXPORTS: ServiceExport[] = [

--- a/web/src/hooks/useProw.ts
+++ b/web/src/hooks/useProw.ts
@@ -3,9 +3,8 @@ import { kubectlProxy } from '../lib/kubectlProxy'
 import { formatTimeAgo } from '../lib/formatters'
 import { useDemoMode } from './useDemoMode'
 import { KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
-// Refresh interval for automatic polling (2 minutes)
-const REFRESH_INTERVAL_MS = 120_000
 /** Maximum number of ProwJobs to display */
 const MAX_PROW_JOBS = 100
 

--- a/web/src/hooks/useServiceExports.ts
+++ b/web/src/hooks/useServiceExports.ts
@@ -16,6 +16,7 @@ import { useClusters } from './useMCP'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type { ServiceExport } from '../types/mcs'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 // ============================================================================
 // Constants
@@ -25,7 +26,6 @@ import type { ServiceExport } from '../types/mcs'
 const CACHE_EXPIRY_MS = 300_000
 
 /** Auto-refresh interval — 2 minutes */
-const REFRESH_INTERVAL_MS = 120_000
 
 /** Number of consecutive failures before marking as failed */
 const FAILURE_THRESHOLD = 3

--- a/web/src/hooks/useServiceImportsCard.ts
+++ b/web/src/hooks/useServiceImportsCard.ts
@@ -16,6 +16,7 @@ import { useClusters } from './useMCP'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type { ServiceImport, ServiceImportList } from '../types/mcs'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 // ============================================================================
 // Constants
@@ -25,7 +26,6 @@ import type { ServiceImport, ServiceImportList } from '../types/mcs'
 const CACHE_EXPIRY_MS = 300_000
 
 /** Auto-refresh interval — 2 minutes */
-const REFRESH_INTERVAL_MS = 120_000
 
 /** Number of consecutive failures before marking as failed */
 const FAILURE_THRESHOLD = 3

--- a/web/src/hooks/useStackDiscovery.ts
+++ b/web/src/hooks/useStackDiscovery.ts
@@ -11,9 +11,8 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { getDemoMode } from './useDemoMode'
 import type { LLMdServer } from './useLLMd'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
-// Refresh interval (2 minutes)
-const REFRESH_INTERVAL_MS = 120000
 const CACHE_KEY = 'kubestellar-stack-cache'
 const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
 

--- a/web/src/hooks/useTopology.ts
+++ b/web/src/hooks/useTopology.ts
@@ -14,7 +14,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { STORAGE_KEY_TOKEN, DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type {
   TopologyResponse,
@@ -32,7 +32,6 @@ import type {
 const CACHE_EXPIRY_MS = 300_000
 
 /** Auto-refresh interval — 2 minutes */
-const REFRESH_INTERVAL_MS = 120_000
 
 /** Number of consecutive failures before marking as failed */
 const FAILURE_THRESHOLD = 3

--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -21,9 +21,9 @@ import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_TRESTLE_CACHE, STORAGE_KEY_TRESTLE_CACHE_TIME } from '../lib/constants/storage'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 /** Refresh interval for automatic polling (2 minutes) */
-const REFRESH_INTERVAL_MS = 120_000
 
 /** Cache TTL: 2 minutes — matches refresh interval */
 // Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -17,9 +17,9 @@ import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_TRIVY_CACHE, STORAGE_KEY_TRIVY_CACHE_TIME } from '../lib/constants/storage'
+import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 /** Refresh interval for automatic polling (2 minutes) */
-const REFRESH_INTERVAL_MS = 120_000
 
 /** Cache TTL: 2 minutes — matches refresh interval */
 // Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -165,6 +165,11 @@ export const MISSION_SUGGEST_INTERVAL_MS = 120_000
 /** Polling interval for nightly E2E run data (5 minutes) */
 export const NIGHTLY_E2E_POLL_INTERVAL_MS = 300_000
 
+/** Default auto-refresh interval for cached data hooks (2 minutes).
+ *  Most useCached* / use* hooks poll on this cadence. Import this
+ *  constant instead of defining a local `REFRESH_INTERVAL_MS = 120_000`. */
+export const DEFAULT_REFRESH_INTERVAL_MS = 120_000
+
 // ============================================================================
 // Loading & Timeout Thresholds
 // ============================================================================


### PR DESCRIPTION
Fixes #10085

Add `DEFAULT_REFRESH_INTERVAL_MS` to `lib/constants/network.ts` as the single source of truth for the standard 2-minute hook refresh cadence.

Replace 20 identical local `const REFRESH_INTERVAL_MS = 120_000` definitions with:
```ts
import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
```

Update `mcp/shared.ts` to re-export from the canonical location, preserving the existing import contract for all 5 MCP hooks that import from it.

**22 files changed, +28 -29 lines. Zero behavior change.**

Continues the consolidation series: PR #10075 (formatBytes), #10080 (formatTimeAgo), #10084 (formatCurrency et al.).