### PR TITLE
🐛 Fix 4 failing test suites after formatBytes + rewards refactors

### DIFF
--- a/web/src/hooks/__tests__/useFeatureRequests.test.ts
+++ b/web/src/hooks/__tests__/useFeatureRequests.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 
-vi.mock('../../lib/api', () => ({
-  api: {
-    get: vi.fn(),
-    post: vi.fn(),
-  },
-}))
+vi.mock('../../lib/api', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    api: {
+      get: vi.fn(),
+      post: vi.fn(),
+    },
+  }
+})
 
 vi.mock('../../lib/constants', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>

--- a/web/src/hooks/__tests__/useGitHubRewards.test.ts
+++ b/web/src/hooks/__tests__/useGitHubRewards.test.ts
@@ -248,8 +248,8 @@ describe('useGitHubRewards', () => {
   })
 
   // 7. Missing token -- no fetch
-  it('does not fetch when STORAGE_KEY_TOKEN is absent', async () => {
-    localStorage.removeItem(STORAGE_KEY_TOKEN)
+  it('does not fetch when user is not authenticated', async () => {
+    mockUseAuth.mockReturnValue({ user: null, isAuthenticated: false })
 
     const { useGitHubRewards } = await import('../useGitHubRewards')
     const { result } = renderHook(() => useGitHubRewards())
@@ -283,11 +283,8 @@ describe('useGitHubRewards', () => {
     expect(fetchUrl).toContain('login=octocat')
   })
 
-  // 9. Cookie-only session: no token but STORAGE_KEY_HAS_SESSION is set
-  it('fetches when token is absent but cookie session hint is set', async () => {
-    localStorage.removeItem(STORAGE_KEY_TOKEN)
-    localStorage.setItem(STORAGE_KEY_HAS_SESSION, 'true')
-
+  // 9. Authenticated fetch does not send Authorization header (server-side token resolution)
+  it('fetches without Authorization header when authenticated', async () => {
     const apiResponse = makeSampleResponse({ total_points: 2000 })
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
@@ -303,35 +300,35 @@ describe('useGitHubRewards', () => {
       expect(result.current.githubRewards!.total_points).toBe(2000)
     })
 
-    // Verify no Authorization header was sent (cookie-only path)
-    const fetchInit = vi.mocked(global.fetch).mock.calls[0][1] as RequestInit
-    expect(fetchInit.headers).toBeDefined()
-    const headers = fetchInit.headers as Record<string, string>
-    expect(headers['Authorization']).toBeUndefined()
-    // credentials: 'include' must be set for cookie transport
-    expect(fetchInit.credentials).toBe('include')
+    // Verify no Authorization header was sent (hook relies on server-side auth)
+    const fetchInit = vi.mocked(global.fetch).mock.calls[0][1] as RequestInit | undefined
+    const headers = fetchInit?.headers as Record<string, string> | undefined
+    expect(headers?.['Authorization']).toBeUndefined()
   })
 
   // 10. localStorage.getItem throwing does not crash the hook
   it('handles localStorage throwing without crashing', async () => {
-    // Remove the token set in beforeEach so we start clean
-    localStorage.removeItem(STORAGE_KEY_TOKEN)
-
     // Simulate restricted browser mode where localStorage throws on read.
     // Use vi.spyOn so jsdom's internal binding is properly intercepted.
     const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new DOMException('Access denied')
     })
 
+    // Hook is authenticated, but localStorage cache will fail to load
+    const apiResponse = makeSampleResponse()
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(apiResponse),
+    } as Response)
+
     const { useGitHubRewards } = await import('../useGitHubRewards')
     const { result } = renderHook(() => useGitHubRewards())
 
-    await act(async () => { /* flush effects */ })
-
-    // Should not crash — just skip fetching since both token and session are unavailable
-    expect(result.current.githubRewards).toBeNull()
-    expect(result.current.isLoading).toBe(false)
-    expect(global.fetch).not.toHaveBeenCalled()
+    await waitFor(() => {
+      // Should not crash — fetches from API even though localStorage is broken
+      expect(global.fetch).toHaveBeenCalled()
+      expect(result.current.githubRewards).not.toBeNull()
+    })
 
     getItemSpy.mockRestore()
   })

--- a/web/src/lib/stats/__tests__/types.test.ts
+++ b/web/src/lib/stats/__tests__/types.test.ts
@@ -48,23 +48,23 @@ describe('formatBytes', () => {
   })
 
   it('formats kilobytes', () => {
-    expect(formatBytes(1024)).toBe('1.0 KB')
+    expect(formatBytes(1024)).toBe('1 KB')
     expect(formatBytes(1536)).toBe('1.5 KB')
-    expect(formatBytes(1024 * 100)).toBe('100.0 KB')
+    expect(formatBytes(1024 * 100)).toBe('100 KB')
   })
 
   it('formats megabytes', () => {
-    expect(formatBytes(1024 * 1024)).toBe('1.0 MB')
-    expect(formatBytes(1024 * 1024 * 256)).toBe('256.0 MB')
+    expect(formatBytes(1024 * 1024)).toBe('1 MB')
+    expect(formatBytes(1024 * 1024 * 256)).toBe('256 MB')
   })
 
   it('formats gigabytes', () => {
-    expect(formatBytes(1024 * 1024 * 1024)).toBe('1.0 GB')
-    expect(formatBytes(1024 * 1024 * 1024 * 8)).toBe('8.0 GB')
+    expect(formatBytes(1024 * 1024 * 1024)).toBe('1 GB')
+    expect(formatBytes(1024 * 1024 * 1024 * 8)).toBe('8 GB')
   })
 
   it('formats terabytes', () => {
-    expect(formatBytes(1024 * 1024 * 1024 * 1024)).toBe('1.0 TB')
+    expect(formatBytes(1024 * 1024 * 1024 * 1024)).toBe('1 TB')
     expect(formatBytes(1024 * 1024 * 1024 * 1024 * 2.5)).toBe('2.5 TB')
   })
 })
@@ -139,7 +139,7 @@ describe('formatValue', () => {
   })
 
   it('formats with bytes type', () => {
-    expect(formatValue(1024, 'bytes')).toBe('1.0 KB')
+    expect(formatValue(1024, 'bytes')).toBe('1 KB')
   })
 
   it('formats with currency type', () => {

--- a/web/src/lib/unified/card/renderers/__tests__/registry.test.ts
+++ b/web/src/lib/unified/card/renderers/__tests__/registry.test.ts
@@ -124,7 +124,7 @@ describe('built-in renderers via renderCell', () => {
     expect(result).toBeDefined()
     if (typeof result === 'object' && result !== null) {
       const el = result as { props: { children: string } }
-      expect(el.props.children).toContain('1.0 GB')
+      expect(el.props.children).toContain('1 GB')
     }
   })
 


### PR DESCRIPTION
## Summary
Fixes #10077

- Update `formatBytes` test expectations to match new whole-number formatting (no trailing `.0`) from PR #10084
- Update `useGitHubRewards` tests to use `useAuth` mock instead of deprecated `localStorage` token pattern from PR #10081
- Fix `useFeatureRequests` mock to preserve original module exports (prevents missing export errors)
- Update registry renderer bytes assertion to match new `formatBytes` output

## Test plan
- [x] All 4 test files pass (112 tests total)
- [x] `npx vitest run` confirms no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)