### PR TITLE
🐛 Add missing DEFAULT_REFRESH_INTERVAL_MS to test mocks (#10091)

### DIFF
--- a/web/src/hooks/__tests__/useGatewayStatus.test.ts
+++ b/web/src/hooks/__tests__/useGatewayStatus.test.ts
@@ -20,6 +20,7 @@ vi.mock('../../lib/modeTransition', () => ({
 
 vi.mock('../../lib/constants', () => ({
   STORAGE_KEY_TOKEN: 'kc-auth-token',
+  DEFAULT_REFRESH_INTERVAL_MS: 120_000,
 }))
 
 vi.mock('../../lib/constants/network', () => ({

--- a/web/src/hooks/__tests__/useServiceImportsCard.test.ts
+++ b/web/src/hooks/__tests__/useServiceImportsCard.test.ts
@@ -15,6 +15,7 @@ vi.mock('../useMCP', () => ({
 
 vi.mock('../../lib/constants', () => ({
   STORAGE_KEY_TOKEN: 'kc-auth-token',
+  DEFAULT_REFRESH_INTERVAL_MS: 120_000,
 }))
 
 vi.mock('../../lib/constants/network', () => ({


### PR DESCRIPTION
Fixes #10091

Both `useGatewayStatus` and `useServiceImportsCard` hooks now import `DEFAULT_REFRESH_INTERVAL_MS` from `lib/constants` (added in PR #10086), but their test mocks only provided `STORAGE_KEY_TOKEN`. This caused 3 cache-related tests to fail when the auto-refresh effect tried to read the unmocked export.

**Changes:**
- Added `DEFAULT_REFRESH_INTERVAL_MS: 120_000` to the `vi.mock('../../lib/constants')` block in both test files

**Tests fixed (3):**
- `useGatewayStatus — cache loads from cache when valid cache exists`
- `useGatewayStatus — cache starts with isLoading=false when cache is populated`
- `useServiceImportsCard — cache loads from valid cache on mount`

All 50 tests in both suites now pass.