### PR TITLE
🐛 Add console.kubestellar.io to CSP connect-src for GitHub rewards

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -491,7 +491,7 @@ func (s *Server) setupMiddleware() {
 				"worker-src 'self' blob:; "+
 				"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "+
 				"img-src 'self' data: https:; "+
-				"connect-src 'self' "+kcAgentLoopback+" "+kcAgentLoopbackWS+" "+kcAgentLocalhost+" "+kcAgentLocalhostWS+" https://www.google-analytics.com https://www.googletagmanager.com https://cdn.jsdelivr.net wss:; "+
+				"connect-src 'self' "+kcAgentLoopback+" "+kcAgentLoopbackWS+" "+kcAgentLocalhost+" "+kcAgentLocalhostWS+" https://console.kubestellar.io https://www.google-analytics.com https://www.googletagmanager.com https://cdn.jsdelivr.net wss:; "+
 				"font-src 'self' data: https://fonts.gstatic.com; "+
 				"object-src 'none'; "+
 				"base-uri 'self'")


### PR DESCRIPTION
## Summary
- The `useGitHubRewards` hook fetches contributor points from `console.kubestellar.io/api/rewards/github` but the backend's CSP `connect-src` directive did not include this origin
- Browsers blocked the request, causing the coin total to show only local activity (100 coins at Observer) instead of the full GitHub-sourced total (3,942,300 at Legend)
- Added `https://console.kubestellar.io` to the CSP `connect-src` allowlist

## Test plan
- [ ] Start console with `startup-oauth.sh`
- [ ] Open Contribute modal — verify coin total matches leaderboard (3.9M+)
- [ ] Check DevTools console — no CSP violations for `console.kubestellar.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)