### PR TITLE
🏗 Replace hardcoded storage keys with constants

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -36,6 +36,7 @@ import { getDefaultCardsForDashboard } from '../../config/dashboards'
 import { safeLazy } from '../../lib/safeLazy'
 import { CardRecommendations } from './CardRecommendations'
 import { safeGetItem, safeSetItem, safeGetJSON, safeSetJSON } from '../../lib/utils/localStorage'
+import { STORAGE_KEY_DASHBOARD_AUTO_REFRESH } from '../../lib/constants'
 import { MissionSuggestions } from './MissionSuggestions'
 import { GettingStartedBanner } from './GettingStartedBanner'
 import { useMissions } from '../../hooks/useMissions'
@@ -238,7 +239,7 @@ export function Dashboard() {
 
   // Auto-refresh state (persisted in localStorage)
   const [autoRefresh, setAutoRefresh] = useState(() => {
-    const stored = safeGetItem('dashboard-auto-refresh')
+    const stored = safeGetItem(STORAGE_KEY_DASHBOARD_AUTO_REFRESH)
     return stored !== null ? stored === 'true' : true // default to true
   })
   const autoRefreshIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -246,7 +247,7 @@ export function Dashboard() {
   // Persist auto-refresh setting and propagate to global cache layer.
   // When the user unchecks "Auto", all card cache intervals are also paused.
   useEffect(() => {
-    safeSetItem('dashboard-auto-refresh', String(autoRefresh))
+    safeSetItem(STORAGE_KEY_DASHBOARD_AUTO_REFRESH, String(autoRefresh))
     setAutoRefreshPaused(!autoRefresh)
     return () => {
       // Re-enable auto-refresh when the Dashboard unmounts (e.g., navigating away)

--- a/web/src/components/dashboard/__tests__/Dashboard.test.tsx
+++ b/web/src/components/dashboard/__tests__/Dashboard.test.tsx
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { type ReactNode } from 'react'
+import { STORAGE_KEY_DASHBOARD_AUTO_REFRESH } from '../../../lib/constants'
 
 // ── Minimal mock surface ────────────────────────────────────────────
 const mockSafeGetItem = vi.fn().mockReturnValue(null)
@@ -319,15 +320,15 @@ describe('Dashboard', () => {
 
   it('persists auto-refresh true by default', () => {
     render(<Dashboard />)
-    expect(mockSafeSetItem).toHaveBeenCalledWith('dashboard-auto-refresh', 'true')
+    expect(mockSafeSetItem).toHaveBeenCalledWith(STORAGE_KEY_DASHBOARD_AUTO_REFRESH, 'true')
   })
 
   it('reads auto-refresh=false from localStorage', () => {
     mockSafeGetItem.mockImplementation((key: string) =>
-      key === 'dashboard-auto-refresh' ? 'false' : null
+      key === STORAGE_KEY_DASHBOARD_AUTO_REFRESH ? 'false' : null
     )
     render(<Dashboard />)
-    expect(mockSafeSetItem).toHaveBeenCalledWith('dashboard-auto-refresh', 'false')
+    expect(mockSafeSetItem).toHaveBeenCalledWith(STORAGE_KEY_DASHBOARD_AUTO_REFRESH, 'false')
   })
 
   it('persists cards to localStorage', async () => {

--- a/web/src/components/gitops/SyncDialog.tsx
+++ b/web/src/components/gitops/SyncDialog.tsx
@@ -4,7 +4,7 @@ import { Check, AlertTriangle, Play, Loader2, ChevronRight, GitBranch, Box, Serv
 import { BaseModal } from '../../lib/modals'
 import { TechnicalAcronym } from '../shared/TechnicalAcronym'
 import { safeGetItem } from '../../lib/utils/localStorage'
-import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../../lib/constants'
 
 // Sync phases
 type SyncPhase = 'detection' | 'plan' | 'execution' | 'complete'
@@ -134,7 +134,7 @@ export function SyncDialog({
     try {
       // #7993 Phase 4: detect-drift moved to kc-agent. Runs under the
       // user's kubeconfig instead of the backend pod SA.
-      const token = safeGetItem('token')
+      const token = safeGetItem(STORAGE_KEY_TOKEN)
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/gitops/detect-drift`, {
         method: 'POST',
         headers: {
@@ -234,7 +234,7 @@ export function SyncDialog({
     try {
       // #7993 Phase 4: gitops sync moved to kc-agent. Runs under the
       // user's kubeconfig instead of the backend pod SA.
-      const token = safeGetItem('token')
+      const token = safeGetItem(STORAGE_KEY_TOKEN)
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/gitops/sync`, {
         method: 'POST',
         headers: {

--- a/web/src/lib/constants/storage.ts
+++ b/web/src/lib/constants/storage.ts
@@ -46,6 +46,7 @@ export const STORAGE_KEY_ANONYMOUS_USER_ID = 'kc-anonymous-user-id'
 
 // ── Dashboard persistence ─────────────────────────────────────────────
 export const STORAGE_KEY_MAIN_DASHBOARD_CARDS = 'kubestellar-main-dashboard-cards'
+export const STORAGE_KEY_DASHBOARD_AUTO_REFRESH = 'dashboard-auto-refresh'
 
 // ── UI state persistence ───────────────────────────────────────────────
 export const STORAGE_KEY_CLUSTER_LAYOUT = 'kubestellar-cluster-layout-mode'

--- a/web/src/lib/iconSuggester.ts
+++ b/web/src/lib/iconSuggester.ts
@@ -8,6 +8,8 @@
 import { getDemoMode } from '../hooks/useDemoMode'
 import { LOCAL_AGENT_WS_URL } from './constants'
 
+const ICON_SUGGESTION_TIMEOUT_MS = 5_000
+
 // All Lucide icons available in the sidebar
 const ICON_POOL = [
   'LayoutDashboard', 'Server', 'Box', 'Activity', 'Shield', 'GitBranch',
@@ -94,7 +96,7 @@ function askAgentForIcon(name: string): Promise<string | null> {
   return new Promise((resolve) => {
     const timeout = setTimeout(() => {
       resolve(null)
-    }, 5000)
+    }, ICON_SUGGESTION_TIMEOUT_MS)
 
     try {
       const ws = new WebSocket(LOCAL_AGENT_WS_URL)


### PR DESCRIPTION
## Summary

- **SyncDialog.tsx**: safeGetItem('token') → safeGetItem(STORAGE_KEY_TOKEN) (2 call sites)
- **Dashboard.tsx**: 'dashboard-auto-refresh' → STORAGE_KEY_DASHBOARD_AUTO_REFRESH (2 call sites)
- **iconSuggester.ts**: raw 5000 → ICON_SUGGESTION_TIMEOUT_MS named constant
- **storage.ts**: add STORAGE_KEY_DASHBOARD_AUTO_REFRESH to centralized constant module
- **Dashboard.test.tsx**: use constant in test assertions

## Why

Every other file uses STORAGE_KEY_TOKEN from lib/constants/storage.ts. SyncDialog was the only production file using raw 'token' — a key-drift risk. Dashboard's 'dashboard-auto-refresh' was the only localStorage key without a centralized constant. iconSuggester.ts timeout was the last raw numeric timeout in lib/.

## Risk

Zero behavior change — only variable references change, not the underlying string values.

Fixes #10098