### PR TITLE
✨ Add keyboard navigation to dropdown components

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -284,7 +284,16 @@ export function ActiveAlerts() {
             {showDNDMenu && !dnd.isActive && (
               // Issue 9257 — same hardcoded-dark-hex fix as the snooze menu:
               // use the themed `bg-card` token so light mode isn't broken.
-              <div className="absolute top-full left-0 mt-1 z-50 bg-card border border-border rounded-lg shadow-xl py-1 min-w-[160px]">
+              <div className="absolute top-full left-0 mt-1 z-50 bg-card border border-border rounded-lg shadow-xl py-1 min-w-[160px]"
+                onKeyDown={(e) => {
+                  if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+                  e.preventDefault()
+                  const items = e.currentTarget.querySelectorAll<HTMLElement>('button:not([disabled])')
+                  const idx = Array.from(items).indexOf(document.activeElement as HTMLElement)
+                  if (e.key === 'ArrowDown') items[Math.min(idx + 1, items.length - 1)]?.focus()
+                  else items[Math.max(idx - 1, 0)]?.focus()
+                }}
+              >
                 {([
                   ['1h', 'For 1 hour'],
                   ['4h', 'For 4 hours'],

--- a/web/src/components/cards/ClusterCosts.tsx
+++ b/web/src/components/cards/ClusterCosts.tsx
@@ -432,7 +432,16 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
               <span className="hidden @sm:inline">{pricingMode === 'per-cluster' ? t('cards:clusterCosts.perCluster') : t('cards:clusterCosts.uniform')}</span>
             </button>
             {showSettingsMenu && (
-              <div className="absolute top-full left-0 mt-1 w-52 bg-card border border-border rounded-lg shadow-lg z-20 py-2">
+              <div className="absolute top-full left-0 mt-1 w-52 bg-card border border-border rounded-lg shadow-lg z-20 py-2"
+                onKeyDown={(e) => {
+                  if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+                  e.preventDefault()
+                  const items = e.currentTarget.querySelectorAll<HTMLElement>('button:not([disabled])')
+                  const idx = Array.from(items).indexOf(document.activeElement as HTMLElement)
+                  if (e.key === 'ArrowDown') items[Math.min(idx + 1, items.length - 1)]?.focus()
+                  else items[Math.max(idx - 1, 0)]?.focus()
+                }}
+              >
                 <div className="px-3 py-1.5 text-2xs font-medium text-muted-foreground uppercase tracking-wider">
                   {t('cards:clusterCosts.pricingMode')}
                 </div>
@@ -490,7 +499,16 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
                 <ChevronDown className={`w-3 h-3 text-muted-foreground transition-transform ${showProviderMenu ? 'rotate-180' : ''}`} />
               </button>
               {showProviderMenu && (
-                <div className="absolute top-full left-0 mt-1 w-44 bg-card border border-border rounded-lg shadow-lg z-10 py-1">
+                <div className="absolute top-full left-0 mt-1 w-44 bg-card border border-border rounded-lg shadow-lg z-10 py-1"
+                  onKeyDown={(e) => {
+                    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+                    e.preventDefault()
+                    const items = e.currentTarget.querySelectorAll<HTMLElement>('button:not([disabled])')
+                    const idx = Array.from(items).indexOf(document.activeElement as HTMLElement)
+                    if (e.key === 'ArrowDown') items[Math.min(idx + 1, items.length - 1)]?.focus()
+                    else items[Math.max(idx - 1, 0)]?.focus()
+                  }}
+                >
                   {(Object.keys(CLOUD_PRICING) as CloudProvider[]).map(provider => (
                     <button
                       key={provider}

--- a/web/src/components/cards/GPUTaintFilter.tsx
+++ b/web/src/components/cards/GPUTaintFilter.tsx
@@ -248,6 +248,14 @@ export function GPUTaintFilterControl({
           className="fixed max-h-72 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-dropdown"
           style={{ top: dropdownPos.top, left: dropdownPos.left, width: DROPDOWN_WIDTH_PX }}
           onMouseDown={e => e.stopPropagation()}
+          onKeyDown={(e) => {
+            if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+            e.preventDefault()
+            const items = e.currentTarget.querySelectorAll<HTMLElement>('button, label')
+            const idx = Array.from(items).indexOf(document.activeElement?.closest('button, label') as HTMLElement)
+            if (e.key === 'ArrowDown') items[Math.min(idx + 1, items.length - 1)]?.focus()
+            else items[Math.max(idx - 1, 0)]?.focus()
+          }}
         >
           <div className="p-1">
             <div className="px-2 py-1.5 text-2xs text-muted-foreground uppercase tracking-wide">


### PR DESCRIPTION
Fixes #10067

## Changes
Adds arrow key (Up/Down) navigation to 4 dropdown components:
- ActiveAlerts.tsx — Do Not Disturb menu
- GPUTaintFilter.tsx — Taint filter dropdown  
- ClusterCosts.tsx — Pricing mode and provider dropdowns

Each dropdown now supports ArrowUp/ArrowDown navigation with bounds checking and programmatic focus management, following existing patterns from CardControls.

**3 files changed, ~38 lines added (under 50-line PR guidance)**