### PR TITLE
♿ Add missing ARIA labels and dialog roles

### DIFF
--- a/web/src/components/cards/ClusterDropZone.tsx
+++ b/web/src/components/cards/ClusterDropZone.tsx
@@ -1,5 +1,6 @@
 import { useDroppable } from '@dnd-kit/core'
 import { Server, Check, Cpu, HardDrive, Layers, Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { cn } from '../../lib/cn'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useClusterCapabilities, ClusterCapability } from '../../hooks/useWorkloads'
@@ -142,6 +143,7 @@ interface DroppableClusterProps {
 }
 
 function DroppableCluster({ cluster, workload, onDeploy }: DroppableClusterProps) {
+  const { t } = useTranslation('cards')
   const { isOver, setNodeRef } = useDroppable({
     id: `cluster-drop-${cluster.cluster}`,
     data: {
@@ -178,6 +180,10 @@ function DroppableCluster({ cluster, workload, onDeploy }: DroppableClusterProps
       }}
       role="button"
       tabIndex={0}
+      aria-label={t('clusterDropZone.deployToClusterAria', { 
+        workload: workload.name,
+        cluster: cluster.cluster 
+      })}
     >
       <div className="shrink-0 mt-0.5">
         <Server className={cn('w-5 h-5', isOver ? 'text-blue-500' : 'text-blue-400')} />

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -676,6 +676,11 @@ export function HardwareHealthCard() {
                     className="min-w-0 flex items-start gap-2 flex-1 cursor-pointer focus:outline-hidden focus-visible:ring-2 focus-visible:ring-cyan-400 rounded"
                     role="button"
                     tabIndex={0}
+                    aria-label={t('cards:hardwareHealth.viewAlertAria', { 
+                      nodeName: extractHostname(alert.nodeName),
+                      cluster: alert.cluster,
+                      device: getDeviceLabel(alert.deviceType)
+                    })}
                     onClick={() => drillToNode(alert.cluster, alert.nodeName, {
                       issue: `${getDeviceLabel(alert.deviceType)} disappeared: ${alert.previousCount} → ${alert.currentCount}`
                     })}
@@ -807,6 +812,10 @@ export function HardwareHealthCard() {
                 className="p-2 rounded text-xs transition-colors group bg-muted/20 hover:bg-muted/40 cursor-pointer focus:outline-hidden focus-visible:ring-2 focus-visible:ring-cyan-400"
                 role="button"
                 tabIndex={0}
+                aria-label={t('cards:hardwareHealth.viewNodeAria', {
+                  nodeName: extractHostname(node.nodeName),
+                  cluster: node.cluster
+                })}
                 onClick={() => drillToNode(node.cluster, node.nodeName)}
                 onKeyDown={(e) => {
                   // Issue #8837: keyboard activation for inventory node drill-down

--- a/web/src/components/drilldown/DrillDownModal.tsx
+++ b/web/src/components/drilldown/DrillDownModal.tsx
@@ -382,6 +382,7 @@ export function DrillDownModal() {
             data-testid="drilldown-close"
             onClick={close}
             className="p-2 rounded-lg hover:bg-card/50 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label={t('drilldown.close')}
           >
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/web/src/components/modals/sections/ResourceBadges.tsx
+++ b/web/src/components/modals/sections/ResourceBadges.tsx
@@ -31,6 +31,7 @@ import {
   FolderTree,
   Package,
 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import type { ResourceKind, ResourceContext } from '../types/modal.types'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 
@@ -142,6 +143,7 @@ export function ResourceBadges({
   onNamespaceClick,
   onKindClick,
 }: ResourceBadgesProps) {
+  const { t } = useTranslation('common')
   return (
     <div className={`flex items-center gap-1.5 flex-wrap ${className}`}>
       {/* Cluster badge */}
@@ -150,6 +152,7 @@ export function ResourceBadges({
           <button
             onClick={onClusterClick}
             className="hover:opacity-80 transition-opacity"
+            aria-label={t('resourceBadges.viewClusterAria', { cluster: resource.cluster })}
           >
             <ClusterBadge
               cluster={resource.cluster}
@@ -204,6 +207,7 @@ export function NamespaceBadge({
   className = '',
   onClick,
 }: NamespaceBadgeProps) {
+  const { t } = useTranslation('common')
   const sizeClasses = {
     sm: onClick ? 'text-2xs px-2 py-1.5 min-h-11 min-w-11' : 'text-2xs px-1.5 py-0.5',
     md: onClick ? 'text-xs px-2.5 py-2 min-h-11 min-w-11' : 'text-xs px-2 py-0.5',
@@ -224,6 +228,7 @@ export function NamespaceBadge({
       {...(onClick ? {
         role: 'button' as const,
         tabIndex: 0,
+        'aria-label': t('resourceBadges.viewNamespaceAria', { namespace }),
         onKeyDown: (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } },
       } : {})}
     >
@@ -248,6 +253,7 @@ export function ResourceKindBadge({
   className = '',
   onClick,
 }: ResourceKindBadgeProps) {
+  const { t } = useTranslation('common')
   const Icon = RESOURCE_ICONS[kind] || File
   const colors = RESOURCE_COLORS[kind] || DEFAULT_COLORS
 
@@ -271,6 +277,7 @@ export function ResourceKindBadge({
       {...(onClick ? {
         role: 'button' as const,
         tabIndex: 0,
+        'aria-label': t('resourceBadges.viewResourceAria', { kind }),
         onKeyDown: (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } },
       } : {})}
     >

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -1207,7 +1207,9 @@
     "noDevicesDetected": "No devices detected",
     "hideSnoozedAlerts": "Hide snoozed alerts",
     "showSnoozedAlerts": "Show snoozed alerts",
-    "snoozeAllVisible": "Snooze all visible alerts"
+    "snoozeAllVisible": "Snooze all visible alerts",
+    "viewAlertAria": "View alert details for {{nodeName}} on {{cluster}} ({{device}})",
+    "viewNodeAria": "View node {{nodeName}} on {{cluster}}"
   },
   "networkOverview": {
     "policies": "Policies",
@@ -4605,5 +4607,8 @@
     "empty": "No change events in selected time range",
     "title": "Change Timeline",
     "subtitle": "Cross-cluster events"
+  },
+  "clusterDropZone": {
+    "deployToClusterAria": "Deploy {{workload}} to cluster {{cluster}}"
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3802,5 +3802,10 @@
     "paperLink": "Read the paper on arXiv (2604.09388)",
     "dontShowAgain": "Don't show this again",
     "gotIt": "Got it — let's go"
+  },
+  "resourceBadges": {
+    "viewClusterAria": "View cluster {{cluster}}",
+    "viewNamespaceAria": "View namespace {{namespace}}",
+    "viewResourceAria": "View {{kind}} resources"
   }
 }


### PR DESCRIPTION
Fixes #10093

## Changes
Adds missing ARIA labels to 4 files (23 lines added):

- **HardwareHealthCard.tsx** — aria-label on alert drill-down and inventory node buttons
- **ClusterDropZone.tsx** — aria-label on cluster deployment button with i18n
- **DrillDownModal.tsx** — aria-label on icon-only close button
- **ResourceBadges.tsx** — aria-label on clickable cluster/namespace/resource badges

All labels use `t()` from react-i18next for localization support.