### PR TITLE
🐛 Add Escape key handling to modal components

### DIFF
--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -108,6 +108,21 @@ function RunDot({ run, guide, isHighlighted, onMouseEnter, onMouseLeave }: {
 
   useEffect(() => () => cancelHide(), [cancelHide])
 
+  // Close popup on Escape key
+  useEffect(() => {
+    if (!showPopup) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setShowPopup(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [showPopup])
+
   const handleDotEnter = () => {
     cancelHide()
     if (dotRef.current) {

--- a/web/src/components/cards/llmd/shared/PortalTooltip.tsx
+++ b/web/src/components/cards/llmd/shared/PortalTooltip.tsx
@@ -44,6 +44,21 @@ export function PortalTooltip({ children, content, className = '' }: PortalToolt
     }
   }, [isVisible])
 
+  // Close tooltip on Escape key
+  useEffect(() => {
+    if (!isVisible) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setIsVisible(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isVisible])
+
   return (
     <>
       <span

--- a/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
@@ -157,6 +157,21 @@ export function LLMdStackMonitor({ config: _config }: LLMdStackMonitorProps) {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
+  // Close dropdown on Escape key
+  useEffect(() => {
+    if (!showClusterFilter) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setShowClusterFilter(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [showClusterFilter])
+
   // Filter servers by search and cluster
   const filteredServers = (() => {
     let result = servers


### PR DESCRIPTION
Fixes #10094

## Changes
Adds Escape key handling to 3 modal/overlay components (45 lines):

- **PortalTooltip.tsx** — tooltip closes on Escape when visible
- **NightlyE2EStatus.tsx** — RunDot popup closes on Escape
- **LLMdStackMonitor.tsx** — cluster filter dropdown closes on Escape

All follow the established `useEffect` + `document.addEventListener('keydown')` pattern from StandaloneOrbitDialog and Deploy.tsx.