### PR TITLE
🏗 Extract grid magic numbers to named constants in insight/llmd cards

### DIFF
--- a/web/src/components/cards/insights/ClusterDeltaDetector.tsx
+++ b/web/src/components/cards/insights/ClusterDeltaDetector.tsx
@@ -7,7 +7,7 @@ import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { CardControlsRow } from '../../../lib/cards/CardComponents'
 import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
-import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR } from '../../../lib/constants/ui'
+import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_SM } from '../../../lib/constants/ui'
 import { InsightDetailModal } from './InsightDetailModal'
 import type { MultiClusterInsight } from '../../../types/insights'
 
@@ -177,7 +177,7 @@ export function ClusterDeltaDetector() {
             <div className="h-32">
               <ReactECharts
                 option={chartOption}
-                style={{ height: 128, width: '100%' }}
+                style={{ height: CHART_HEIGHT_SM, width: '100%' }}
                 notMerge={true}
                 opts={{ renderer: 'svg' }}
               />

--- a/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
+++ b/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
@@ -9,7 +9,7 @@ import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { CardControlsRow } from '../../../lib/cards/CardComponents'
 import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
-import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR } from '../../../lib/constants/ui'
+import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_STANDARD } from '../../../lib/constants/ui'
 import { CROSS_CLUSTER_EVENT_PALETTE } from '../../../lib/theme/chartColors'
 import { InsightDetailModal } from './InsightDetailModal'
 import type { MultiClusterInsight } from '../../../types/insights'
@@ -143,7 +143,7 @@ export function CrossClusterEventCorrelation() {
         <div className="h-40">
           <ReactECharts
             option={chartOption}
-            style={{ height: 160, width: '100%' }}
+            style={{ height: CHART_HEIGHT_STANDARD, width: '100%' }}
             notMerge={true}
             opts={{ renderer: 'svg' }}
           />

--- a/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
+++ b/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
@@ -8,7 +8,12 @@ import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { CardControlsRow } from '../../../lib/cards/CardComponents'
 import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
-import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR } from '../../../lib/constants/ui'
+import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_SM } from '../../../lib/constants/ui'
+
+const GRID_LEFT_PX = 85
+const GRID_RIGHT_PX = 10
+const GRID_TOP_PX = 5
+const GRID_BOTTOM_PX = 20
 import { InsightDetailModal } from './InsightDetailModal'
 import type { MultiClusterInsight } from '../../../types/insights'
 
@@ -84,7 +89,7 @@ export function DeploymentRolloutTracker() {
     if (clusterProgress.length === 0) return {}
     return {
       backgroundColor: 'transparent',
-      grid: { left: 85, right: 10, top: 5, bottom: 20 },
+      grid: { left: GRID_LEFT_PX, right: GRID_RIGHT_PX, top: GRID_TOP_PX, bottom: GRID_BOTTOM_PX },
       xAxis: {
         type: 'value' as const,
         min: 0,
@@ -178,7 +183,7 @@ export function DeploymentRolloutTracker() {
             <div className="h-32">
               <ReactECharts
                 option={chartOption}
-                style={{ height: 128, width: '100%' }}
+                style={{ height: CHART_HEIGHT_SM, width: '100%' }}
                 notMerge={true}
                 opts={{ renderer: 'svg' }}
               />

--- a/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
+++ b/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
@@ -8,7 +8,12 @@ import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { CardControlsRow } from '../../../lib/cards/CardComponents'
 import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
-import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR } from '../../../lib/constants/ui'
+import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_LG } from '../../../lib/constants/ui'
+
+const GRID_LEFT_PX = 105
+const GRID_RIGHT_PX = 20
+const GRID_TOP_PX = 15
+const GRID_BOTTOM_PX = 20
 import { InsightDetailModal } from './InsightDetailModal'
 import type { MultiClusterInsight } from '../../../types/insights'
 
@@ -59,7 +64,7 @@ export function ResourceImbalanceDetector() {
     if (chartData.length === 0) return {}
     return {
       backgroundColor: 'transparent',
-      grid: { left: 105, right: 20, top: 15, bottom: 20 },
+      grid: { left: GRID_LEFT_PX, right: GRID_RIGHT_PX, top: GRID_TOP_PX, bottom: GRID_BOTTOM_PX },
       xAxis: {
         type: 'value' as const,
         min: 0,
@@ -154,7 +159,7 @@ export function ResourceImbalanceDetector() {
         <div className="h-48">
           <ReactECharts
             option={chartOption}
-            style={{ height: 192, width: '100%' }}
+            style={{ height: CHART_HEIGHT_LG, width: '100%' }}
             notMerge={true}
             opts={{ renderer: 'svg' }}
           />

--- a/web/src/components/cards/llmd/LatencyBreakdown.tsx
+++ b/web/src/components/cards/llmd/LatencyBreakdown.tsx
@@ -23,6 +23,11 @@ import {
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
 
+const GRID_LEFT_PX = 55
+const GRID_RIGHT_PX = 20
+const GRID_TOP_PX = 10
+const GRID_BOTTOM_PX = 45
+
 type MetricTab = 'ttftP50Ms' | 'tpotP50Ms' | 'p99LatencyMs' | 'itlP50Ms' | 'requestLatencyMs'
 
 const TABS: { key: MetricTab; label: string; unit: string; sla?: number }[] = [
@@ -135,7 +140,7 @@ function LatencyBreakdownInternal() {
 
     return {
       backgroundColor: 'transparent',
-      grid: { left: 55, right: 20, top: 10, bottom: 45 },
+      grid: { left: GRID_LEFT_PX, right: GRID_RIGHT_PX, top: GRID_TOP_PX, bottom: GRID_BOTTOM_PX },
       xAxis: {
         type: 'category' as const,
         data: chartData.map(d => d.qps),

--- a/web/src/components/cards/llmd/ResourceUtilization.tsx
+++ b/web/src/components/cards/llmd/ResourceUtilization.tsx
@@ -22,6 +22,11 @@ import {
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
 
+const GRID_LEFT_PX = 145
+const GRID_RIGHT_PX = 20
+const GRID_TOP_PX = 5
+const GRID_BOTTOM_PX = 20
+
 type MetricMode = 'throughput' | 'ttftP50Ms' | 'tpotP50Ms' | 'p99LatencyMs'
 
 const MODES: { key: MetricMode; label: string; unit: string; higherBetter: boolean }[] = [
@@ -104,7 +109,7 @@ export function ResourceUtilization() {
     if (data.length === 0) return {}
     return {
       backgroundColor: 'transparent',
-      grid: { left: 145, right: 20, top: 5, bottom: 20 },
+      grid: { left: GRID_LEFT_PX, right: GRID_RIGHT_PX, top: GRID_TOP_PX, bottom: GRID_BOTTOM_PX },
       xAxis: {
         type: 'value' as const,
         axisLabel: {

--- a/web/src/components/cards/llmd/ThroughputComparison.tsx
+++ b/web/src/components/cards/llmd/ThroughputComparison.tsx
@@ -24,6 +24,11 @@ import {
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
 
+const GRID_LEFT_PX = 55
+const GRID_RIGHT_PX = 20
+const GRID_TOP_PX = 10
+const GRID_BOTTOM_PX = 45
+
 interface ChartRow {
   qps: number
   [lineKey: string]: number | undefined
@@ -111,7 +116,7 @@ export function ThroughputComparison() {
 
     return {
       backgroundColor: 'transparent',
-      grid: { left: 55, right: 20, top: 10, bottom: 45 },
+      grid: { left: GRID_LEFT_PX, right: GRID_RIGHT_PX, top: GRID_TOP_PX, bottom: GRID_BOTTOM_PX },
       xAxis: {
         type: 'category' as const,
         data: chartData.map(d => d.qps),

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -10,6 +10,8 @@ import type React from 'react'
 // ── Chart dimensions ────────────────────────────────────────────────────
 export const CHART_HEIGHT_STANDARD = 160
 export const CHART_HEIGHT_COMPACT = 100
+export const CHART_HEIGHT_SM = 128
+export const CHART_HEIGHT_LG = 192
 
 // ── Recharts shared styles ──────────────────────────────────────────────
 export const CHART_TOOLTIP_BG = '#1a1a2e'


### PR DESCRIPTION
## Summary
- Extract inline grid pixel values (`left`, `right`, `top`, `bottom`) to named `GRID_*_PX` constants in 7 card components
- Add `CHART_HEIGHT_SM` (128) and `CHART_HEIGHT_LG` (192) to centralized `lib/constants/ui.ts`
- Replace hardcoded chart height literals with shared constants

Fixes #10105

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Magic number ratchet test passes (`no-magic-numbers.test.ts`)
- [ ] Cards render correctly (grid spacing unchanged — same numeric values, just named)

🤖 Generated with [Claude Code](https://claude.com/claude-code)