### PR TITLE
Fetch contributions from GitHub + fix OAuth login loop

### DIFF
--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -83,6 +83,7 @@ func getGitHubProxyLimiter(userID string) *rate.Limiter {
 // Any path not matching one of these prefixes is rejected with 403 Forbidden.
 var allowedGitHubPrefixes = []string{
 	"/repos/",        // repo info, PRs, issues, releases, contributors, actions, git refs, compare
+	"/search/",       // issue/PR search for contributions list
 	"/rate_limit",    // rate-limit check / token validation
 	"/user",          // token validation (GET /user returns the authenticated user)
 	"/notifications", // notification badge (if used by frontend)

--- a/pkg/api/handlers/github_proxy_test.go
+++ b/pkg/api/handlers/github_proxy_test.go
@@ -20,7 +20,7 @@ func TestIsAllowedGitHubPath(t *testing.T) {
 		// Blocked paths
 		{"gists", "/gists", false},
 		{"orgs", "/orgs/kubestellar", false},
-		{"search", "/search/issues", false},
+		{"search", "/search/issues", true},
 		{"empty", "/", false},
 		{"admin", "/admin/users", false},
 		{"events", "/events", false},

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -949,10 +949,12 @@ func (s *Server) setupRoutes() {
 
 	api := s.app.Group("/api", apiLimiter, bodyGuard, csrfGuard, middleware.JWTAuth(s.config.JWTSecret))
 
-	// User routes
+	// User identity routes — mounted outside apiLimiter so they survive
+	// the initial card burst that can exhaust the 600/min API budget before
+	// the user even logs in (#10100).
 	user := handlers.NewUserHandler(s.store)
-	api.Get("/me", user.GetCurrentUser)
-	api.Put("/me", user.UpdateCurrentUser)
+	s.app.Get("/api/me", authLimiter, bodyGuard, csrfGuard, middleware.JWTAuth(s.config.JWTSecret), user.GetCurrentUser)
+	s.app.Put("/api/me", authLimiter, bodyGuard, csrfGuard, middleware.JWTAuth(s.config.JWTSecret), user.UpdateCurrentUser)
 
 	// GitHub API proxy — keeps PAT server-side, frontend calls /api/github/*
 	githubProxy := handlers.NewGitHubProxyHandler(s.config.GitHubToken, s.store)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -898,7 +898,7 @@ func (s *Server) setupRoutes() {
 	// an independent counter, so the effective limit is `max × N` where N is the
 	// pod count. A shared Redis/Valkey storage backend is recommended for strict
 	// enforcement across replicas but is out of scope for this change.
-	apiLimiterMaxRequests := 600        // max requests per window per user+IP (#9969: raised from 200 — dashboard loads 30+ cards with SWR refresh)
+	apiLimiterMaxRequests := 2000       // max requests per window per user+IP (#10100: raised from 600 — dashboard + background polling can exceed 600 in the first minute)
 	apiLimiterWindow := 1 * time.Minute // sliding window duration
 	apiLimiter := limiter.New(limiter.Config{
 		Max:          apiLimiterMaxRequests,

--- a/web/src/components/feedback/UpdatesTab.tsx
+++ b/web/src/components/feedback/UpdatesTab.tsx
@@ -884,6 +884,20 @@ function GitHubContributionsSection({
         })()
       )}
 
+      {githubRewards?.contributions && githubRewards.contributions.length > 0 && currentGitHubLogin && (
+        <div className="p-2.5 border-t border-border/50 text-center">
+          <a
+            href={`https://github.com/search?q=author:${encodeURIComponent(currentGitHubLogin)}+org:kubestellar+org:llm-d&type=issues&s=updated&o=desc`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-xs text-blue-400 hover:text-blue-300 transition-colors"
+          >
+            View all contributions on GitHub
+            <ExternalLink className="w-3 h-3" />
+          </a>
+        </div>
+      )}
+
       {githubRewards?.from_cache && (
         <div className="p-2 border-t border-border/50">
           <p className="text-2xs text-muted-foreground text-center">

--- a/web/src/hooks/__tests__/useGitHubRewards.test.ts
+++ b/web/src/hooks/__tests__/useGitHubRewards.test.ts
@@ -229,7 +229,8 @@ describe('useGitHubRewards', () => {
     })
 
     const callsAfterMount = vi.mocked(global.fetch).mock.calls.length
-    expect(callsAfterMount).toBe(1)
+    // 2 calls: one for rewards (Netlify), one for contributions (local proxy)
+    expect(callsAfterMount).toBe(2)
 
     // Set up the next fetch response
     vi.mocked(global.fetch).mockResolvedValue({
@@ -279,8 +280,11 @@ describe('useGitHubRewards', () => {
       expect(global.fetch).toHaveBeenCalled()
     })
 
-    const fetchUrl = vi.mocked(global.fetch).mock.calls[0][0] as string
-    expect(fetchUrl).toContain('login=octocat')
+    const rewardsCall = vi.mocked(global.fetch).mock.calls.find(
+      c => (c[0] as string).includes('rewards/github'),
+    )
+    expect(rewardsCall).toBeDefined()
+    expect(rewardsCall![0] as string).toContain('login=octocat')
   })
 
   // 9. Authenticated fetch does not send Authorization header (server-side token resolution)
@@ -300,8 +304,12 @@ describe('useGitHubRewards', () => {
       expect(result.current.githubRewards!.total_points).toBe(2000)
     })
 
-    // Verify no Authorization header was sent (hook relies on server-side auth)
-    const fetchInit = vi.mocked(global.fetch).mock.calls[0][1] as RequestInit | undefined
+    // Verify the rewards fetch (Netlify) sends no Authorization header
+    const rewardsCall = vi.mocked(global.fetch).mock.calls.find(
+      c => (c[0] as string).includes('rewards/github'),
+    )
+    expect(rewardsCall).toBeDefined()
+    const fetchInit = rewardsCall![1] as RequestInit | undefined
     const headers = fetchInit?.headers as Record<string, string> | undefined
     expect(headers?.['Authorization']).toBeUndefined()
   })

--- a/web/src/hooks/useGitHubRewards.ts
+++ b/web/src/hooks/useGitHubRewards.ts
@@ -2,12 +2,16 @@
  * Hook for fetching GitHub-sourced reward data.
  * Calls the Netlify function on console.kubestellar.io (10-min Blob cache)
  * instead of the local Go backend, saving the user's GitHub API quota.
+ *
+ * Also fetches the last 20 contributions (issues/PRs) via the Go backend's
+ * GitHub proxy (/api/github/search/issues) using the user's stored token.
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useAuth } from '../lib/auth'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
-import type { GitHubRewardsResponse } from '../types/rewards'
+import { BACKEND_DEFAULT_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import type { GitHubRewardsResponse, GitHubContribution, GitHubRewardType } from '../types/rewards'
+import { GITHUB_REWARD_POINTS } from '../types/rewards'
 
 /** Always fetch from the Netlify function (cached, no user token needed). */
 const REWARDS_API_BASE = 'https://console.kubestellar.io'
@@ -20,6 +24,10 @@ const LEGACY_CACHE_KEY = 'github-rewards-cache'
 const CLIENT_CACHE_TTL_MS = 15 * 60 * 1000
 /** Interval between automatic background refreshes (10 minutes) */
 const REFRESH_INTERVAL_MS = 10 * 60 * 1000
+/** Max recent contributions to fetch from the GitHub Search API */
+const CONTRIBUTIONS_PER_PAGE = 20
+/** GitHub orgs to search for contributions */
+const CONTRIBUTIONS_SEARCH_ORGS = ['kubestellar', 'llm-d']
 
 /** Returns a per-user localStorage cache key */
 function userCacheKey(login: string): string {
@@ -75,8 +83,69 @@ function saveCache(login: string, data: GitHubRewardsResponse): void {
   }
 }
 
+interface GitHubSearchItem {
+  html_url: string
+  title: string
+  number: number
+  created_at: string
+  pull_request?: { merged_at: string | null }
+  labels: Array<{ name: string }>
+  repository_url: string
+}
+
+function classifySearchItem(item: GitHubSearchItem): GitHubRewardType {
+  const isPR = !!item.pull_request
+  if (isPR) {
+    return item.pull_request?.merged_at ? 'pr_merged' : 'pr_opened'
+  }
+  const labelNames = (item.labels || []).map(l => l.name.toLowerCase())
+  if (labelNames.some(l => l.includes('bug'))) return 'issue_bug'
+  if (labelNames.some(l => l.includes('feature') || l.includes('enhancement'))) return 'issue_feature'
+  return 'issue_other'
+}
+
+function repoFromUrl(repositoryUrl: string): string {
+  const parts = repositoryUrl.split('/')
+  const len = parts.length
+  return len >= 2 ? `${parts[len - 2]}/${parts[len - 1]}` : repositoryUrl
+}
+
+async function fetchRecentContributions(
+  login: string,
+  token: string | null,
+): Promise<GitHubContribution[]> {
+  const orgFilter = CONTRIBUTIONS_SEARCH_ORGS.map(o => `org:${o}`).join('+')
+  const query = `author:${encodeURIComponent(login)}+${orgFilter}`
+  const url = `${BACKEND_DEFAULT_URL}/api/github/search/issues?q=${query}&sort=updated&per_page=${CONTRIBUTIONS_PER_PAGE}`
+
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+
+  const res = await fetch(url, {
+    headers,
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
+  if (!res.ok) return []
+
+  const json = await res.json().catch(() => null) as { items?: GitHubSearchItem[] } | null
+  if (!json?.items) return []
+
+  return (json.items || []).map((item): GitHubContribution => {
+    const type = classifySearchItem(item)
+    return {
+      type,
+      title: item.title,
+      url: item.html_url,
+      repo: repoFromUrl(item.repository_url),
+      number: item.number,
+      points: GITHUB_REWARD_POINTS[type],
+      created_at: item.created_at,
+    }
+  })
+}
+
 export function useGitHubRewards() {
-  const { user, isAuthenticated } = useAuth()
+  const { user, isAuthenticated, token } = useAuth()
   const [data, setData] = useState<GitHubRewardsResponse | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -98,7 +167,6 @@ export function useGitHubRewards() {
     if (cached) {
       setData(cached)
     } else {
-      // No valid cache — clear any stale data from a previous user
       setData(null)
     }
   }, [githubLogin, isDemoUser])
@@ -108,25 +176,29 @@ export function useGitHubRewards() {
 
     setIsLoading(true)
     try {
-      const res = await fetch(`${REWARDS_API_BASE}/api/rewards/github?login=${encodeURIComponent(githubLogin)}`, {
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
-      })
-      if (!res.ok) throw new Error(`API error: ${res.status}`)
-      // Use .catch() on .json() to prevent Firefox from firing unhandledrejection
-      // before the outer try/catch processes the rejection (microtask timing issue).
-      const result = await res.json().catch(() => null) as GitHubRewardsResponse | null
+      const [rewardsRes, contributions] = await Promise.all([
+        fetch(`${REWARDS_API_BASE}/api/rewards/github?login=${encodeURIComponent(githubLogin)}`, {
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+        }),
+        fetchRecentContributions(githubLogin, token).catch(() => [] as GitHubContribution[]),
+      ])
+
+      if (!rewardsRes.ok) throw new Error(`API error: ${rewardsRes.status}`)
+      const result = await rewardsRes.json().catch(() => null) as GitHubRewardsResponse | null
       if (!result) throw new Error('Invalid JSON response')
 
-      // Guard against stale response arriving after user switched accounts
       if (loginRef.current !== githubLogin) return
 
-      setData(result)
-      saveCache(githubLogin, result)
+      const merged: GitHubRewardsResponse = {
+        ...result,
+        contributions: contributions.length > 0 ? contributions : result.contributions,
+      }
+
+      setData(merged)
+      saveCache(githubLogin, merged)
       setError(null)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error')
-      // On failure, clear data if the cache has also expired (prevents
-      // indefinite stale display). If cache is still valid, keep showing it.
       const cached = loadCache(githubLogin)
       if (!cached) {
         setData(null)
@@ -134,7 +206,7 @@ export function useGitHubRewards() {
     } finally {
       setIsLoading(false)
     }
-  }, [isAuthenticated, isDemoUser, githubLogin])
+  }, [isAuthenticated, isDemoUser, githubLogin, token])
 
   // Fetch on mount and refresh periodically
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **Contributions list**: Fetch last 20 issues/PRs from GitHub Search API via the Go backend proxy (`/api/github/search/issues`) and display them in the Contribute modal's Updates tab. Add `/search/` to the allowed GitHub proxy prefixes. Add "View all contributions on GitHub" link.
- **OAuth login loop fix**: Move `/api/me` out of the `apiLimiter` group onto `authLimiter` so the user identity endpoint can't be starved by dashboard card traffic.
- **Rate limiter increase**: Raise API rate limiter from 600 to 2000 req/min — dashboard loads 30+ cards with SWR refresh plus background health polling, which exhausted the 600/min budget within the first minute.

## Test plan
- [ ] Log in via GitHub OAuth — should not loop back to login page
- [ ] Open Contribute modal → Updates tab — should show last 20 issues/PRs with correct types (bug/feature/issue/PR)
- [ ] "View all contributions on GitHub" link opens GitHub search in new tab
- [ ] Submit a bug report via the Contribute modal — should succeed without 429
- [ ] Coins should show correct total (3.9M+ for clubanderson)

🤖 Generated with [Claude Code](https://claude.com/claude-code)