### PR TITLE
🏗 Replace hardcoded timeout values with named constants in 4 hooks

### DIFF
--- a/web/src/hooks/useCachedLLMd.ts
+++ b/web/src/hooks/useCachedLLMd.ts
@@ -7,7 +7,7 @@
 
 import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { kubectlProxy } from '../lib/kubectlProxy'
-import { KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
+import { KUBECTL_DEFAULT_TIMEOUT_MS, KUBECTL_MEDIUM_TIMEOUT_MS, KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import type { LLMdServer, LLMdStatus, LLMdModel } from './useLLMd'
 
@@ -129,7 +129,7 @@ async function fetchLLMdServersForCluster(cluster: string): Promise<LLMdServer[]
   // Query all namespaces to discover llm-d workloads regardless of namespace naming
   const allDeployments: DeploymentResource[] = []
   try {
-    const resp = await kubectlProxy.exec(['get', 'deployments', '-A', '-o', 'json'], { context: cluster, timeout: 15000 })
+    const resp = await kubectlProxy.exec(['get', 'deployments', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_MEDIUM_TIMEOUT_MS })
     if (resp.exitCode === 0 && resp.output) {
       allDeployments.push(...(JSON.parse(resp.output).items || []))
     }
@@ -141,9 +141,9 @@ async function fetchLLMdServersForCluster(cluster: string): Promise<LLMdServer[]
   const autoscalerItems: LLMdServer[] = []
 
   const [hpaResult, vaResult, vpaResult] = await Promise.allSettled([
-    kubectlProxy.exec(['get', 'hpa', '-A', '-o', 'json'], { context: cluster, timeout: 10000 }),
-    kubectlProxy.exec(['get', 'variantautoscalings', '-A', '-o', 'json'], { context: cluster, timeout: 10000 }),
-    kubectlProxy.exec(['get', 'vpa', '-A', '-o', 'json'], { context: cluster, timeout: 10000 }),
+    kubectlProxy.exec(['get', 'hpa', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }),
+    kubectlProxy.exec(['get', 'variantautoscalings', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }),
+    kubectlProxy.exec(['get', 'vpa', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }),
   ])
 
   // Process HPA results

--- a/web/src/hooks/useCertManager.ts
+++ b/web/src/hooks/useCertManager.ts
@@ -3,6 +3,7 @@ import { useClusters } from './useMCP'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { useDemoMode } from './useDemoMode'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
+import { KUBECTL_DEFAULT_TIMEOUT_MS, KUBECTL_MEDIUM_TIMEOUT_MS, METRICS_SERVER_TIMEOUT_MS } from '../lib/constants/network'
 
 
 // Days before expiration to consider "expiring soon"
@@ -255,7 +256,7 @@ export function useCertManager() {
           // First check if cert-manager CRD exists
           const crdCheck = await kubectlProxy.exec(
             ['get', 'crd', 'certificates.cert-manager.io', '-o', 'name'],
-            { context: cluster, timeout: 5000 }
+            { context: cluster, timeout: METRICS_SERVER_TIMEOUT_MS }
           )
 
           if (crdCheck.exitCode !== 0) {
@@ -268,7 +269,7 @@ export function useCertManager() {
           // Fetch Certificates
           const certResponse = await kubectlProxy.exec(
             ['get', 'certificates', '-A', '-o', 'json'],
-            { context: cluster, timeout: 15000 }
+            { context: cluster, timeout: KUBECTL_MEDIUM_TIMEOUT_MS }
           )
 
           if (certResponse.exitCode === 0 && certResponse.output) {
@@ -297,7 +298,7 @@ export function useCertManager() {
           // Fetch Issuers
           const issuerResponse = await kubectlProxy.exec(
             ['get', 'issuers', '-A', '-o', 'json'],
-            { context: cluster, timeout: 10000 }
+            { context: cluster, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
           )
 
           if (issuerResponse.exitCode === 0 && issuerResponse.output) {
@@ -321,7 +322,7 @@ export function useCertManager() {
           // Fetch ClusterIssuers
           const clusterIssuerResponse = await kubectlProxy.exec(
             ['get', 'clusterissuers', '-o', 'json'],
-            { context: cluster, timeout: 10000 }
+            { context: cluster, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
           )
 
           if (clusterIssuerResponse.exitCode === 0 && clusterIssuerResponse.output) {

--- a/web/src/hooks/useMCS.ts
+++ b/web/src/hooks/useMCS.ts
@@ -9,6 +9,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { api, BackendUnavailableError } from '../lib/api'
 import { useDemoMode } from './useDemoMode'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS, FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
 import type {
   ServiceExport,
   ServiceExportList,
@@ -61,7 +62,7 @@ export function useMCSStatus() {
     }))
 
     try {
-      const { data } = await api.get<MCSStatusResponse>('/api/mcs/status', { timeout: 10000 })
+      const { data } = await api.get<MCSStatusResponse>('/api/mcs/status', { timeout: FETCH_DEFAULT_TIMEOUT_MS })
       setState({
         data: data.clusters,
         isLoading: false,
@@ -139,7 +140,7 @@ export function useServiceExports(cluster?: string, namespace?: string) {
       const query = params.toString()
       const url = `/api/mcs/exports${query ? `?${query}` : ''}`
 
-      const { data } = await api.get<ServiceExportList>(url, { timeout: 15000 })
+      const { data } = await api.get<ServiceExportList>(url, { timeout: FETCH_EXTERNAL_TIMEOUT_MS })
       setState({
         data: data.items,
         isLoading: false,
@@ -231,7 +232,7 @@ export function useServiceImports(cluster?: string, namespace?: string) {
       const query = params.toString()
       const url = `/api/mcs/imports${query ? `?${query}` : ''}`
 
-      const { data } = await api.get<ServiceImportList>(url, { timeout: 15000 })
+      const { data } = await api.get<ServiceImportList>(url, { timeout: FETCH_EXTERNAL_TIMEOUT_MS })
       setState({
         data: data.items,
         isLoading: false,
@@ -314,7 +315,7 @@ export function useServiceExport(cluster: string, namespace: string, name: strin
 
     try {
       const url = `/api/mcs/exports/${encodeURIComponent(cluster)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`
-      const { data } = await api.get<ServiceExport>(url, { timeout: 10000 })
+      const { data } = await api.get<ServiceExport>(url, { timeout: FETCH_DEFAULT_TIMEOUT_MS })
       setState({
         data,
         isLoading: false,
@@ -379,7 +380,7 @@ export function useServiceImport(cluster: string, namespace: string, name: strin
 
     try {
       const url = `/api/mcs/imports/${encodeURIComponent(cluster)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`
-      const { data } = await api.get<ServiceImport>(url, { timeout: 10000 })
+      const { data } = await api.get<ServiceImport>(url, { timeout: FETCH_DEFAULT_TIMEOUT_MS })
       setState({
         data,
         isLoading: false,

--- a/web/src/hooks/useStackDiscovery.ts
+++ b/web/src/hooks/useStackDiscovery.ts
@@ -12,6 +12,7 @@ import { kubectlProxy } from '../lib/kubectlProxy'
 import { getDemoMode } from './useDemoMode'
 import type { LLMdServer } from './useLLMd'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
+import { KUBECTL_MEDIUM_TIMEOUT_MS, KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
 
 const CACHE_KEY = 'kubestellar-stack-cache'
 const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
@@ -430,13 +431,13 @@ export function useStackDiscovery(clusters: string[]) {
           //          NO bulk deployment query — that's Phase 2.
           // ════════════════════════════════════════════════════════════════
           const [podsResponse, poolsResponse, svcResponse, gwResponse, hpaResponse, wvaResponse, vpaResponse] = await Promise.all([
-            kubectlProxy.exec(['get', 'pods', '-A', '-l', 'llm-d.ai/role', '-o', 'json'], { context: cluster, timeout: 30000 }),
-            kubectlProxy.exec(['get', 'inferencepools', '-A', '-o', 'json'], { context: cluster, timeout: 30000 }),
-            kubectlProxy.exec(['get', 'services', '-A', '-o', 'json'], { context: cluster, timeout: 30000 }),
-            kubectlProxy.exec(['get', 'gateway', '-A', '-o', 'json'], { context: cluster, timeout: 30000 }),
-            kubectlProxy.exec(['get', 'hpa', '-A', '-o', 'json'], { context: cluster, timeout: 30000 }),
-            kubectlProxy.exec(['get', 'variantautoscalings', '-A', '-o', 'json'], { context: cluster, timeout: 30000 }),
-            kubectlProxy.exec(['get', 'vpa', '-A', '-o', 'json'], { context: cluster, timeout: 30000 }),
+            kubectlProxy.exec(['get', 'pods', '-A', '-l', 'llm-d.ai/role', '-o', 'json'], { context: cluster, timeout: KUBECTL_EXTENDED_TIMEOUT_MS }),
+            kubectlProxy.exec(['get', 'inferencepools', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_EXTENDED_TIMEOUT_MS }),
+            kubectlProxy.exec(['get', 'services', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_EXTENDED_TIMEOUT_MS }),
+            kubectlProxy.exec(['get', 'gateway', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_EXTENDED_TIMEOUT_MS }),
+            kubectlProxy.exec(['get', 'hpa', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_EXTENDED_TIMEOUT_MS }),
+            kubectlProxy.exec(['get', 'variantautoscalings', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_EXTENDED_TIMEOUT_MS }),
+            kubectlProxy.exec(['get', 'vpa', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_EXTENDED_TIMEOUT_MS }),
           ])
 
           // Skip cluster entirely if it's unreachable (connection error or timeout)
@@ -624,7 +625,7 @@ export function useStackDiscovery(clusters: string[]) {
           // Get all namespaces in the cluster (lightweight query)
           const nsResponse = await kubectlProxy.exec(
             ['get', 'namespaces', '-o', 'jsonpath={.items[*].metadata.name}'],
-            { context: cluster, timeout: 15000 },
+            { context: cluster, timeout: KUBECTL_MEDIUM_TIMEOUT_MS },
           )
           const allClusterNamespaces = nsResponse.exitCode === 0
             ? nsResponse.output.split(/\s+/).filter(Boolean)
@@ -640,7 +641,7 @@ export function useStackDiscovery(clusters: string[]) {
             const batch = candidateNamespaces.slice(i, i + DEPLOYMENT_BATCH_SIZE)
             const batchResults = await Promise.all(
               batch.map(ns =>
-                kubectlProxy.exec(['get', 'deployments', '-n', ns, '-o', 'json'], { context: cluster, timeout: 15000 })
+                kubectlProxy.exec(['get', 'deployments', '-n', ns, '-o', 'json'], { context: cluster, timeout: KUBECTL_MEDIUM_TIMEOUT_MS })
               ),
             )
 


### PR DESCRIPTION
## Summary
- Replace 22 inline timeout literals with named constants from `lib/constants/network.ts`
- Covers 4 hooks: useMCS, useCachedLLMd, useCertManager, useStackDiscovery
- Pure mechanical rename — identical values, no behavior change

Fixes #10108

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Timeout behavior unchanged (same numeric values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)