### PR TITLE
🧹 Replace timeout magic numbers in OPA + compliance cards

### DIFF
--- a/web/src/components/cards/DataComplianceCards.tsx
+++ b/web/src/components/cards/DataComplianceCards.tsx
@@ -14,6 +14,7 @@ import { kubectlProxy } from '../../lib/kubectlProxy'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
+import { KUBECTL_DEFAULT_TIMEOUT_MS, METRICS_SERVER_TIMEOUT_MS } from '../../lib/constants/network'
 
 interface CardConfig {
   config?: Record<string, unknown>
@@ -71,7 +72,7 @@ export function VaultSecrets({ config: _config }: CardConfig) {
           // Check for Vault pods (helm release or operator)
           const podsResult = await kubectlProxy.exec(
             ['get', 'pods', '-A', '-l', 'app.kubernetes.io/name=vault', '-o', 'json'],
-            { context: cluster.name, timeout: 10000 }
+            { context: cluster.name, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
           )
           if (podsResult.exitCode === 0 && podsResult.output) {
             const data = JSON.parse(podsResult.output)
@@ -88,7 +89,7 @@ export function VaultSecrets({ config: _config }: CardConfig) {
           // Count opaque secrets (user-managed) in this cluster
           const secretsResult = await kubectlProxy.exec(
             ['get', 'secrets', '-A', '-o', 'jsonpath={range .items[?(@.type=="Opaque")]}1{end}'],
-            { context: cluster.name, timeout: 10000 }
+            { context: cluster.name, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
           )
           if (secretsResult.exitCode === 0 && secretsResult.output) {
             secrets += secretsResult.output.length
@@ -242,7 +243,7 @@ export function ExternalSecrets({ config: _config }: CardConfig) {
           // Check if ESO CRD exists
           const crdCheck = await kubectlProxy.exec(
             ['get', 'crd', 'externalsecrets.external-secrets.io', '-o', 'name'],
-            { context: cluster.name, timeout: 5000 }
+            { context: cluster.name, timeout: METRICS_SERVER_TIMEOUT_MS }
           )
           if (crdCheck.exitCode !== 0) continue
           found = true
@@ -250,7 +251,7 @@ export function ExternalSecrets({ config: _config }: CardConfig) {
           // Count SecretStores + ClusterSecretStores
           const storesResult = await kubectlProxy.exec(
             ['get', 'secretstores,clustersecretstores', '-A', '-o', 'jsonpath={range .items[*]}1{end}'],
-            { context: cluster.name, timeout: 10000 }
+            { context: cluster.name, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
           )
           if (storesResult.exitCode === 0 && storesResult.output) {
             stores += storesResult.output.length
@@ -259,7 +260,7 @@ export function ExternalSecrets({ config: _config }: CardConfig) {
           // Count ExternalSecrets with status
           const esResult = await kubectlProxy.exec(
             ['get', 'externalsecrets', '-A', '-o', 'json'],
-            { context: cluster.name, timeout: 10000 }
+            { context: cluster.name, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
           )
           if (esResult.exitCode === 0 && esResult.output) {
             const data = JSON.parse(esResult.output)

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -13,6 +13,9 @@ import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 import { isDemoMode as checkIsDemoMode } from '../../lib/demoMode'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_OPA_CACHE, STORAGE_KEY_OPA_CACHE_TIME } from '../../lib/constants'
+import { KUBECTL_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
+
+const OPA_LIST_TIMEOUT_MS = 25_000
 import { safeGetItem, safeGetJSON, safeSetItem, safeSetJSON } from '../../lib/utils/localStorage'
 import { PolicyDetailModal, ClusterOPAModal, CreatePolicyModal } from './opa'
 import type { Policy, GatekeeperStatus, OPAClusterItem } from './opa'
@@ -69,7 +72,7 @@ async function checkGatekeeperInstalled(clusterName: string): Promise<Gatekeeper
   try {
     const nsResult = await kubectlProxy.exec(
       ['get', 'namespace', 'gatekeeper-system', '--ignore-not-found', '-o', 'name'],
-      { context: clusterName, timeout: 25000, priority: true }
+      { context: clusterName, timeout: OPA_LIST_TIMEOUT_MS, priority: true }
     )
     const installed = !!(nsResult.output && nsResult.output.includes('gatekeeper-system'))
     return { cluster: clusterName, installed, loading: installed } // loading=true means details pending
@@ -88,7 +91,7 @@ async function checkGatekeeperDetails(clusterName: string): Promise<GatekeeperSt
       ['get', 'constraints', '-A',
        '-o', 'custom-columns=NAME:.metadata.name,KIND:.kind,ENFORCEMENT:.spec.enforcementAction,VIOLATIONS:.status.totalViolations',
        '--no-headers'],
-      { context: clusterName, timeout: 10000 }
+      { context: clusterName, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
     ).catch(() => ({ output: '', error: '' }))
 
     const policies: Policy[] = []
@@ -132,7 +135,7 @@ async function checkGatekeeperDetails(clusterName: string): Promise<GatekeeperSt
         const violationsResult = await kubectlProxy.exec(
           ['get', policyWithViolations.kind.toLowerCase(), policyWithViolations.name,
            '-o', 'jsonpath={.status.violations[*]}'],
-          { context: clusterName, timeout: 10000 }
+          { context: clusterName, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
         )
 
         if (violationsResult.output) {

--- a/web/src/components/cards/opa/ClusterOPAModal.tsx
+++ b/web/src/components/cards/opa/ClusterOPAModal.tsx
@@ -8,6 +8,7 @@ import { useToast } from '../../ui/Toast'
 import type { Policy, Violation, StartMissionFn } from './types'
 import { POLICY_TEMPLATES } from './types'
 import { copyToClipboard } from '../../../lib/clipboard'
+import { KUBECTL_MEDIUM_TIMEOUT_MS, KUBECTL_EXTENDED_TIMEOUT_MS } from '../../../lib/constants/network'
 
 // Tab type for ClusterOPAModal
 type OPAModalTab = 'policies' | 'violations'
@@ -143,7 +144,7 @@ What would you like to modify about this policy?`,
 
     try {
       // Use priority: true to bypass the queue for immediate execution (interactive user action)
-      const result = await kubectlProxy.exec(cmd, { context: clusterName, timeout: 30000, priority: true })
+      const result = await kubectlProxy.exec(cmd, { context: clusterName, timeout: KUBECTL_EXTENDED_TIMEOUT_MS, priority: true })
 
       if (result.output && result.output.trim()) {
         setYamlContent(result.output)
@@ -193,7 +194,7 @@ Please proceed with applying this policy.`,
     try {
       await kubectlProxy.exec(
         ['patch', policy.kind.toLowerCase(), policy.name, '--type=merge', '-p', `{"spec":{"enforcementAction":"${newMode}"}}`],
-        { context: clusterName, timeout: 15000 }
+        { context: clusterName, timeout: KUBECTL_MEDIUM_TIMEOUT_MS }
       )
       showToast('Policy mode updated successfully', 'success')
       onRefresh()
@@ -208,7 +209,7 @@ Please proceed with applying this policy.`,
     try {
       await kubectlProxy.exec(
         ['delete', policy.kind.toLowerCase(), policy.name],
-        { context: clusterName, timeout: 15000 }
+        { context: clusterName, timeout: KUBECTL_MEDIUM_TIMEOUT_MS }
       )
       setDeleteConfirm(null)
       showToast('Policy deleted successfully', 'success')

--- a/web/src/components/cards/opa/CreatePolicyModal.tsx
+++ b/web/src/components/cards/opa/CreatePolicyModal.tsx
@@ -8,6 +8,8 @@ import type { GatekeeperStatus, StartMissionFn } from './types'
 import { POLICY_TEMPLATES } from './types'
 import { copyToClipboard } from '../../../lib/clipboard'
 
+const OPA_CREATE_TIMEOUT_MS = 20_000
+
 // Creation flow type for CreatePolicyModal
 type CreateFlow = 'choose' | 'describe' | 'template' | 'yaml'
 
@@ -62,7 +64,7 @@ export function CreatePolicyModal({
       try {
         const podsResult = await kubectlProxy.exec(
           ['get', 'pods', '-A', '-o', 'json'],
-          { context: selectedCluster, timeout: 20000 }
+          { context: selectedCluster, timeout: OPA_CREATE_TIMEOUT_MS }
         )
 
         if (podsResult.output) {


### PR DESCRIPTION
## Summary

- Replace 12 raw timeout numeric literals across 4 card components with named constants from `lib/constants/network.ts`
- Add file-scoped constants `OPA_LIST_TIMEOUT_MS` (25s) and `OPA_CREATE_TIMEOUT_MS` (20s) for non-standard timeout values
- Magic number ratchet test passes (6/6)

Fixes #10114

## Files changed

| File | Replacements |
|------|-------------|
| `OPAPolicies.tsx` | 25000 → `OPA_LIST_TIMEOUT_MS`, 10000 ×2 → `KUBECTL_DEFAULT_TIMEOUT_MS` |
| `DataComplianceCards.tsx` | 10000 ×4 → `KUBECTL_DEFAULT_TIMEOUT_MS`, 5000 → `METRICS_SERVER_TIMEOUT_MS` |
| `ClusterOPAModal.tsx` | 30000 → `KUBECTL_EXTENDED_TIMEOUT_MS`, 15000 ×2 → `KUBECTL_MEDIUM_TIMEOUT_MS` |
| `CreatePolicyModal.tsx` | 20000 → `OPA_CREATE_TIMEOUT_MS` |

## Test plan

- [x] Magic number ratchet test passes (all 6 assertions)
- [x] No raw `timeout: NNNNN` remaining in `cards/` directory
- [ ] CI build passes