### PR TITLE
🧹 Replace style-prop magic numbers in llmd + GPU cards

### DIFF
--- a/web/src/components/cards/GPUUtilization.tsx
+++ b/web/src/components/cards/GPUUtilization.tsx
@@ -21,6 +21,8 @@ import {
   CHART_MARK_LINE_STROKE } from '../../lib/constants'
 import { PURPLE_600, hexToRgba } from '../../lib/theme/chartColors'
 
+const GPU_RING_SIZE_PX = 80
+
 interface GPUPoint {
   time: string
   allocated: number
@@ -343,10 +345,10 @@ export function GPUUtilization() {
 
       {/* Stats and pie chart row */}
       <div className="flex items-center gap-4 mb-4">
-        <div className="w-20 h-20 relative" style={{ minWidth: 80, minHeight: 80 }}>
+        <div className="w-20 h-20 relative" style={{ minWidth: GPU_RING_SIZE_PX, minHeight: GPU_RING_SIZE_PX }}>
           <ReactECharts
             option={pieOption}
-            style={{ height: 80, width: 80 }}
+            style={{ height: GPU_RING_SIZE_PX, width: GPU_RING_SIZE_PX }}
             notMerge={true}
             opts={{ renderer: 'svg' }}
           />

--- a/web/src/components/cards/llmd/LatencyBreakdown.tsx
+++ b/web/src/components/cards/llmd/LatencyBreakdown.tsx
@@ -22,6 +22,7 @@ import {
   TOOLTIP_SWATCH_SIZE_PX } from '../../../lib/llmd/tooltipSpacing'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
+import { CHART_MIN_HEIGHT_PX } from '../../../lib/constants/ui'
 
 const GRID_LEFT_PX = 55
 const GRID_RIGHT_PX = 20
@@ -257,7 +258,7 @@ function LatencyBreakdownInternal() {
       </div>
 
       {/* Chart */}
-      <div className="flex-1 min-h-0" style={{ minHeight: 200 }}>
+      <div className="flex-1 min-h-0" style={{ minHeight: CHART_MIN_HEIGHT_PX }}>
         {chartData.length > 0 ? (
           <ReactECharts
             option={chartOption}

--- a/web/src/components/cards/llmd/ParetoFrontier.tsx
+++ b/web/src/components/cards/llmd/ParetoFrontier.tsx
@@ -22,6 +22,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
 import { downloadDataUrl } from '../../../lib/download'
+import { CHART_MIN_HEIGHT_PX } from '../../../lib/constants/ui'
 
 // ── Tooltip spacing constants (ECharts renders its own DOM, so Tailwind/CSS vars are unavailable) ──
 /** Spacing between tooltip header and grid body */
@@ -36,6 +37,8 @@ const TOOLTIP_GRID_GAP_ROW_PX = '4px'
 const TOOLTIP_GRID_GAP_COL_PX = '16px'
 /** Badge border-radius */
 const TOOLTIP_BADGE_RADIUS_PX = '4px'
+
+const LEGEND_PANEL_WIDTH_PX = 130
 
 // Minimal parameter type for ECharts label/tooltip formatter callbacks
 interface EChartsFormatterParam {
@@ -545,7 +548,7 @@ function ParetoFrontierInternal({ config }: ParetoFrontierProps) {
       {/* Chart area + right legend */}
       <div className="flex flex-1 min-h-0 gap-2">
         {/* ECharts chart */}
-        <div className="flex-1 min-w-0 rounded overflow-hidden" style={{ minHeight: 200 }}>
+        <div className="flex-1 min-w-0 rounded overflow-hidden" style={{ minHeight: CHART_MIN_HEIGHT_PX }}>
           <ReactECharts
             ref={chartRef}
             option={option}
@@ -556,7 +559,7 @@ function ParetoFrontierInternal({ config }: ParetoFrontierProps) {
         </div>
 
         {/* Right legend panel */}
-        <div className="shrink-0 flex flex-col" style={{ width: 130 }}>
+        <div className="shrink-0 flex flex-col" style={{ width: LEGEND_PANEL_WIDTH_PX }}>
           {/* Hardware series list */}
           <div className="flex-1 overflow-y-auto space-y-px" style={{ scrollbarWidth: 'thin' }}>
             {legendItems.map(({ hw, color }) => {

--- a/web/src/components/cards/llmd/PerformanceTimeline.tsx
+++ b/web/src/components/cards/llmd/PerformanceTimeline.tsx
@@ -15,6 +15,7 @@ import {
   getFilterOptions } from '../../../lib/llmd/benchmarkDataUtils'
 import type { BenchmarkReport } from '../../../lib/llmd/benchmarkMockData'
 import { useTranslation } from 'react-i18next'
+import { CHART_MIN_HEIGHT_TALL_PX } from '../../../lib/constants/ui'
 
 type MetricMode = 'throughput' | 'ttft' | 'p99' | 'tpot'
 
@@ -171,7 +172,7 @@ export function PerformanceTimeline() {
       </div>
 
       {/* Heatmap */}
-      <div className="flex-1 min-h-0 flex items-center justify-center" style={{ minHeight: 250 }}>
+      <div className="flex-1 min-h-0 flex items-center justify-center" style={{ minHeight: CHART_MIN_HEIGHT_TALL_PX }}>
         {cells.length > 0 ? (
           <div className="relative">
             {/* Y-axis label */}

--- a/web/src/components/cards/llmd/ResourceUtilization.tsx
+++ b/web/src/components/cards/llmd/ResourceUtilization.tsx
@@ -21,6 +21,7 @@ import {
   TOOLTIP_TIGHT_GAP_PX } from '../../../lib/llmd/tooltipSpacing'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
+import { CHART_MIN_HEIGHT_PX } from '../../../lib/constants/ui'
 
 const GRID_LEFT_PX = 145
 const GRID_RIGHT_PX = 20
@@ -229,7 +230,7 @@ export function ResourceUtilization() {
       </div>
 
       {/* Chart */}
-      <div className="flex-1 min-h-0" style={{ minHeight: 200 }}>
+      <div className="flex-1 min-h-0" style={{ minHeight: CHART_MIN_HEIGHT_PX }}>
         {data.length > 0 ? (
           <ReactECharts
             option={chartOption}

--- a/web/src/components/cards/llmd/ThroughputComparison.tsx
+++ b/web/src/components/cards/llmd/ThroughputComparison.tsx
@@ -23,6 +23,7 @@ import {
   TOOLTIP_SWATCH_SIZE_PX } from '../../../lib/llmd/tooltipSpacing'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
+import { CHART_MIN_HEIGHT_PX } from '../../../lib/constants/ui'
 
 const GRID_LEFT_PX = 55
 const GRID_RIGHT_PX = 20
@@ -207,7 +208,7 @@ export function ThroughputComparison() {
       </div>
 
       {/* Chart */}
-      <div className="flex-1 min-h-0" style={{ minHeight: 200 }}>
+      <div className="flex-1 min-h-0" style={{ minHeight: CHART_MIN_HEIGHT_PX }}>
         {chartData.length > 0 ? (
           <ReactECharts
             option={chartOption}

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -12,6 +12,8 @@ export const CHART_HEIGHT_STANDARD = 160
 export const CHART_HEIGHT_COMPACT = 100
 export const CHART_HEIGHT_SM = 128
 export const CHART_HEIGHT_LG = 192
+export const CHART_MIN_HEIGHT_PX = 200
+export const CHART_MIN_HEIGHT_TALL_PX = 250
 
 // ── Recharts shared styles ──────────────────────────────────────────────
 export const CHART_TOOLTIP_BG = '#1a1a2e'


### PR DESCRIPTION
## Summary

- Extract 8 inline style dimension values into named constants
- Add `CHART_MIN_HEIGHT_PX` (200) and `CHART_MIN_HEIGHT_TALL_PX` (250) to `lib/constants/ui.ts`
- Add file-scoped `GPU_RING_SIZE_PX` (80) and `LEGEND_PANEL_WIDTH_PX` (130)
- Magic number ratchet test passes (6/6)

Fixes #10116

## Files changed (7)

| File | Replacement |
|------|------------|
| `ui.ts` | New shared constants |
| `ThroughputComparison.tsx` | minHeight → `CHART_MIN_HEIGHT_PX` |
| `ResourceUtilization.tsx` | minHeight → `CHART_MIN_HEIGHT_PX` |
| `LatencyBreakdown.tsx` | minHeight → `CHART_MIN_HEIGHT_PX` |
| `ParetoFrontier.tsx` | minHeight → `CHART_MIN_HEIGHT_PX`, width → `LEGEND_PANEL_WIDTH_PX` |
| `PerformanceTimeline.tsx` | minHeight → `CHART_MIN_HEIGHT_TALL_PX` |
| `GPUUtilization.tsx` | 3× 80 → `GPU_RING_SIZE_PX` |

## Test plan

- [x] Magic number ratchet test passes (all 6 assertions)
- [ ] CI build passes