### PR TITLE
🧹 Deduplicate formatThroughput across service mesh cards

### DIFF
--- a/web/src/components/cards/envoy_status/index.tsx
+++ b/web/src/components/cards/envoy_status/index.tsx
@@ -25,6 +25,7 @@ import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedEnvoy } from './useCachedEnvoy'
 import type { EnvoyListener, EnvoyUpstreamCluster } from './demoData'
 import { formatTimeAgo } from '../../../lib/formatters'
+import { formatThroughput } from '../../../lib/cards/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -37,18 +38,6 @@ const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
 const HTTP_5XX_PERCENT_DECIMALS = 2
-const THROUGHPUT_LOCALE_MIN_FRACTION = 0
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function formatThroughput(value: number): string {
-  return value.toLocaleString(undefined, {
-    minimumFractionDigits: THROUGHPUT_LOCALE_MIN_FRACTION,
-  })
-}
-
 // ---------------------------------------------------------------------------
 // Subsections
 // ---------------------------------------------------------------------------

--- a/web/src/components/cards/grpc_status/index.tsx
+++ b/web/src/components/cards/grpc_status/index.tsx
@@ -25,13 +25,13 @@ import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedGrpc } from '../../../hooks/useCachedGrpc'
 import type { GrpcService } from './demoData'
 import { formatTimeAgo } from '../../../lib/formatters'
+import { formatThroughput } from '../../../lib/cards/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
 // ---------------------------------------------------------------------------
 
 const ERROR_RATE_DECIMALS = 2
-const THROUGHPUT_LOCALE_MIN_FRACTION = 0
 const LATENCY_WARN_MS = 100
 const LATENCY_DEGRADED_MS = 250
 const ERROR_RATE_WARN_PCT = 0.5
@@ -40,12 +40,6 @@ const ERROR_RATE_CRIT_PCT = 2.0
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatThroughput(value: number): string {
-  return value.toLocaleString(undefined, {
-    minimumFractionDigits: THROUGHPUT_LOCALE_MIN_FRACTION,
-  })
-}
 
 function latencyColor(p99Ms: number): string {
   if (p99Ms >= LATENCY_DEGRADED_MS) return 'text-red-400'

--- a/web/src/components/cards/linkerd_status/index.tsx
+++ b/web/src/components/cards/linkerd_status/index.tsx
@@ -25,6 +25,7 @@ import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedLinkerd } from '../../../hooks/useCachedLinkerd'
 import type { LinkerdMeshedDeployment } from './demoData'
 import { formatTimeAgo } from '../../../lib/formatters'
+import { formatThroughput } from '../../../lib/cards/formatters'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -37,7 +38,6 @@ const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
 const SUCCESS_RATE_DECIMALS = 2
-const THROUGHPUT_LOCALE_MIN_FRACTION = 0
 const SUCCESS_RATE_WARN_THRESHOLD_PCT = 99.0
 const SUCCESS_RATE_CRIT_THRESHOLD_PCT = 95.0
 const P99_LATENCY_WARN_MS = 30
@@ -46,12 +46,6 @@ const P99_LATENCY_CRIT_MS = 100
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatThroughput(value: number): string {
-  return value.toLocaleString(undefined, {
-    minimumFractionDigits: THROUGHPUT_LOCALE_MIN_FRACTION,
-  })
-}
 
 function successRateColorClass(pct: number): string {
   if (pct >= SUCCESS_RATE_WARN_THRESHOLD_PCT) return 'text-green-400'

--- a/web/src/lib/cards/formatters.ts
+++ b/web/src/lib/cards/formatters.ts
@@ -1,0 +1,7 @@
+const THROUGHPUT_LOCALE_MIN_FRACTION = 0
+
+export function formatThroughput(value: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: THROUGHPUT_LOCALE_MIN_FRACTION,
+  })
+}


### PR DESCRIPTION
## Summary

- Extract `formatThroughput()` + `THROUGHPUT_LOCALE_MIN_FRACTION` from 3 service mesh cards into shared `lib/cards/formatters.ts`
- Remove ~18 lines of duplicated code across envoy_status, grpc_status, linkerd_status
- Magic number ratchet passes (6/6)

Fixes #10119

## Files changed (4)

| File | Change |
|------|--------|
| `lib/cards/formatters.ts` | New shared module |
| `envoy_status/index.tsx` | Import shared, remove local copy |
| `grpc_status/index.tsx` | Import shared, remove local copy |
| `linkerd_status/index.tsx` | Import shared, remove local copy |

## Test plan

- [x] Magic number ratchet test passes
- [x] TypeScript compiles without errors
- [ ] CI build passes