### PR TITLE
🧹 Lower magic number ratchet after cleanup passes

### DIFF
--- a/web/src/test/no-magic-numbers.test.ts
+++ b/web/src/test/no-magic-numbers.test.ts
@@ -51,7 +51,7 @@ const CARDS_DIR = path.resolve(
  * If the count increased, you introduced a new magic number — extract it
  * into a named constant (e.g., `const TOOLTIP_DELAY_MS = 300`).
  */
-const EXPECTED_MAGIC_NUMBER_COUNT = 54
+const EXPECTED_MAGIC_NUMBER_COUNT = 43
 
 /** Numeric values that are universally understood and not "magic" */
 const SAFE_VALUES = new Set([0, 1, -1, 2, 100])
@@ -324,14 +324,14 @@ describe('Magic Numbers Ratchet (P4-A)', () => {
   it('style-prop magic numbers must not increase', () => {
     const styleViolations = violations.filter(v => v.category === 'style-prop')
     /** Current count of inline style magic number violations */
-    const EXPECTED_STYLE_VIOLATIONS = 13
+    const EXPECTED_STYLE_VIOLATIONS = 3
     expect(styleViolations.length).toBeLessThanOrEqual(EXPECTED_STYLE_VIOLATIONS)
   })
 
   it('comparison magic numbers must not increase', () => {
     const compViolations = violations.filter(v => v.category === 'comparison')
     /** Current count of comparison threshold magic number violations */
-    const EXPECTED_COMPARISON_VIOLATIONS = 36
+    const EXPECTED_COMPARISON_VIOLATIONS = 35
     expect(compViolations.length).toBeLessThanOrEqual(EXPECTED_COMPARISON_VIOLATIONS)
   })
 


### PR DESCRIPTION
## Summary
- Tighten ratchet thresholds in `no-magic-numbers.test.ts` to match actual counts after PRs #10115, #10117, #10120, #10122
- Total: 54 → 43, style-prop: 13 → 3, comparison: 36 → 35, timer: 5 (unchanged)

## Test plan
- [x] `npx vitest run src/test/no-magic-numbers.test.ts` — all 6 tests pass
- [x] `npm run build` — clean

Fixes #10124