### PR TITLE
🐛 Fix analytics noise filter tests failing due to cross-test throttle state

### DIFF
--- a/web/src/lib/__tests__/analytics-noise-filters.test.ts
+++ b/web/src/lib/__tests__/analytics-noise-filters.test.ts
@@ -26,6 +26,7 @@ vi.mock('../analytics-session', async () => {
 })
 
 import { initAnalytics, startGlobalErrorTracking } from '../analytics'
+import { _resetErrorThrottles } from '../analytics-core'
 
 /* ── Constants ──────────────────────────────────────────────────────── */
 
@@ -67,6 +68,7 @@ describe('GA4 runtime noise filters — window.error handler', () => {
 
   beforeEach(() => {
     vi.useFakeTimers()
+    _resetErrorThrottles()
     sendBeaconSpy = vi.fn(() => true)
     Object.defineProperty(navigator, 'sendBeacon', {
       value: sendBeaconSpy,
@@ -126,6 +128,7 @@ describe('GA4 runtime noise filters — unhandledrejection handler', () => {
 
   beforeEach(() => {
     vi.useFakeTimers()
+    _resetErrorThrottles()
     sendBeaconSpy = vi.fn(() => true)
     Object.defineProperty(navigator, 'sendBeacon', {
       value: sendBeaconSpy,

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -798,6 +798,12 @@ const MAX_ERRORS_PER_PAGE_SESSION = 50
 const recentErrorEmissions = new Map<string, number>()
 const pageErrorCounts = new Map<string, number>()
 
+/** @internal — exported for test isolation only */
+export function _resetErrorThrottles() {
+  recentErrorEmissions.clear()
+  pageErrorCounts.clear()
+}
+
 function isErrorThrottled(category: string, page: string, cardId?: string): boolean {
   // Per-page session budget
   const pageCount = pageErrorCounts.get(page) ?? 0


### PR DESCRIPTION
Fixes #10123

## Problem
The 5 analytics-noise-filter tests introduced in PR #9824 fail because the error throttle maps added in PR #10092 (`recentErrorEmissions`, `pageErrorCounts`) are module-level singletons that persist across vitest test cases. When `vi.useFakeTimers()` resets between tests, the throttle window comparison (`Date.now() - lastEmit < 60s`) incorrectly blocks the baseline error emission in subsequent tests.

## Fix
- Export `_resetErrorThrottles()` from `analytics-core.ts` (test-only reset function)
- Call it in both `describe` blocks' `beforeEach` to ensure each test starts with clean throttle state

## Verification
All 6 tests pass locally:
```
 filters WebGL errors (context lost / GL_INVALID) from runtime errors
 filters canvas errors (CanvasRenderingContext / toDataURL)
 filters network errors surfacing as runtime errors
 filters Non-Error promise rejection messages
 filters WebGL / context-lost rejections (per PR #9824 handler parity)
 filters network rejections (Failed to fetch / NetworkError / net::ERR_)
```

Build and lint pass.