### PR TITLE
🧹 Deduplicate getLoadColors + getHorseshoeColor in llmd cards

### DIFF
--- a/web/src/components/cards/llmd/EPPRouting.tsx
+++ b/web/src/components/cards/llmd/EPPRouting.tsx
@@ -11,6 +11,7 @@ import { useState, useMemo, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Zap, ArrowRight, CircleDot } from 'lucide-react'
 import { Acronym } from './shared/PortalTooltip'
+import { getLoadColors, getHorseshoeColor } from './shared/colorUtils'
 import { useOptionalStack } from '../../../contexts/StackContext'
 import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
 import { usePrometheusMetrics } from '../../../hooks/usePrometheusMetrics'
@@ -58,14 +59,6 @@ const NODES: FlowNode[] = [
   { id: 'decode-0', label: 'Decode-0', x: 90, y: 34, type: 'decode', color: '#22c55e', load: 80 },
   { id: 'decode-1', label: 'Decode-1', x: 90, y: 66, type: 'decode', color: '#22c55e', load: 67 },
 ]
-
-// Get color based on load percentage
-const getLoadColors = (load: number) => {
-  if (load >= 90) return { start: '#ef4444', end: '#f87171', glow: '#ef4444' }
-  if (load >= 70) return { start: '#f59e0b', end: '#fbbf24', glow: '#f59e0b' }
-  if (load >= 50) return { start: '#eab308', end: '#facc15', glow: '#eab308' }
-  return { start: '#22c55e', end: '#4ade80', glow: '#22c55e' }
-}
 
 // Mini sparkline for time-series data
 function Sparkline({ data, color, width = 80, height = 24 }: { data: number[]; color: string; width?: number; height?: number }) {
@@ -351,14 +344,6 @@ interface HorseshoeNodeProps {
   uniqueId: string
   isSelected?: boolean
   onClick?: () => void
-}
-
-// Color based on percentage (green -> yellow -> orange -> red)
-const getHorseshoeColor = (pct: number) => {
-  if (pct >= 90) return '#ef4444' // red
-  if (pct >= 70) return '#f59e0b' // amber/orange
-  if (pct >= 50) return '#eab308' // yellow
-  return '#22c55e' // green
 }
 
 function HorseshoeNode({ node, uniqueId, isSelected, onClick }: HorseshoeNodeProps) {

--- a/web/src/components/cards/llmd/LLMdFlow.tsx
+++ b/web/src/components/cards/llmd/LLMdFlow.tsx
@@ -18,6 +18,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { CircleDot } from 'lucide-react'
 import { generateServerMetrics, type ServerMetrics } from '../../../lib/llmd/mockData'
 import { Acronym } from './shared/PortalTooltip'
+import { getLoadColors, getHorseshoeColor } from './shared/colorUtils'
 import { useOptionalStack } from '../../../contexts/StackContext'
 import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
 import { usePrometheusMetrics } from '../../../hooks/usePrometheusMetrics'
@@ -75,14 +76,6 @@ const COLORS = {
   'kv-transfer': '#06b6d4',
   gateway: '#3b82f6',
   epp: '#f59e0b' }
-
-// Get color based on load percentage
-const getLoadColors = (load: number) => {
-  if (load >= 90) return { start: '#ef4444', end: '#f87171', glow: '#ef4444' }
-  if (load >= 70) return { start: '#f59e0b', end: '#fbbf24', glow: '#f59e0b' }
-  if (load >= 50) return { start: '#eab308', end: '#facc15', glow: '#eab308' }
-  return { start: '#22c55e', end: '#4ade80', glow: '#22c55e' }
-}
 
 // Premium gauge node with glowing arc
 interface PremiumNodeProps {
@@ -356,14 +349,6 @@ function FlowConnection({
       )}
     </g>
   )
-}
-
-// Color based on percentage for horseshoe
-const getHorseshoeColor = (pct: number) => {
-  if (pct >= 90) return '#ef4444'
-  if (pct >= 70) return '#f59e0b'
-  if (pct >= 50) return '#eab308'
-  return '#22c55e'
 }
 
 // Horseshoe node for alternative view

--- a/web/src/components/cards/llmd/shared/colorUtils.ts
+++ b/web/src/components/cards/llmd/shared/colorUtils.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared color utilities for llm-d card components.
+ *
+ * Provides load-percentage → color mappings used by LLMdFlow, EPPRouting,
+ * and horseshoe gauge nodes.
+ */
+
+// ── Threshold constants ─────────────────────────────────────────────────
+const LOAD_CRITICAL_PCT = 90
+const LOAD_HIGH_PCT = 70
+const LOAD_MEDIUM_PCT = 50
+
+// ── Color palette ───────────────────────────────────────────────────────
+const LOAD_CRITICAL = { start: '#ef4444', end: '#f87171', glow: '#ef4444' }
+const LOAD_HIGH = { start: '#f59e0b', end: '#fbbf24', glow: '#f59e0b' }
+const LOAD_MEDIUM = { start: '#eab308', end: '#facc15', glow: '#eab308' }
+const LOAD_LOW = { start: '#22c55e', end: '#4ade80', glow: '#22c55e' }
+
+export interface LoadColorSet {
+  start: string
+  end: string
+  glow: string
+}
+
+export function getLoadColors(load: number): LoadColorSet {
+  if (load >= LOAD_CRITICAL_PCT) return LOAD_CRITICAL
+  if (load >= LOAD_HIGH_PCT) return LOAD_HIGH
+  if (load >= LOAD_MEDIUM_PCT) return LOAD_MEDIUM
+  return LOAD_LOW
+}
+
+export function getHorseshoeColor(pct: number): string {
+  if (pct >= LOAD_CRITICAL_PCT) return '#ef4444'
+  if (pct >= LOAD_HIGH_PCT) return '#f59e0b'
+  if (pct >= LOAD_MEDIUM_PCT) return '#eab308'
+  return '#22c55e'
+}


### PR DESCRIPTION
## Summary
- Extract identical `getLoadColors()` and `getHorseshoeColor()` from `LLMdFlow.tsx` and `EPPRouting.tsx` into `shared/colorUtils.ts`
- Replace inline threshold magic numbers (90, 70, 50) with named constants
- Net: -32 lines removed, +39 lines added (shared module has the interface + constants)

## Test plan
- [x] `npm run build` — clean
- [x] No behavior change — functions are byte-identical copies

Fixes #10127