### PR TITLE
🧹 Deduplicate GPU + deployment card utilities into lib/gpu.ts

### DIFF
--- a/web/src/components/cards/DeploymentProgress.tsx
+++ b/web/src/components/cards/DeploymentProgress.tsx
@@ -12,6 +12,7 @@ import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import type { SortDirection } from '../../lib/cards/cardHooks'
 import type { Deployment } from '../../hooks/useMCP'
 import { useTranslation } from 'react-i18next'
+import { extractImageTag } from '../../lib/gpu'
 
 type StatusFilter = 'all' | 'running' | 'deploying' | 'failed'
 type SortByOption = 'status' | 'name' | 'cluster'
@@ -56,18 +57,6 @@ interface DeploymentProgressProps {
     cluster?: string
     namespace?: string
   }
-}
-
-// Extract version from container image
-function extractVersion(image?: string): string {
-  if (!image) return 'unknown'
-  const parts = image.split(':')
-  if (parts.length > 1) {
-    const tag = parts[parts.length - 1]
-    if (tag.length > 20) return tag.substring(0, 12)
-    return tag
-  }
-  return 'latest'
 }
 
 const SORT_COMPARATORS: Record<SortByOption, (a: Deployment, b: Deployment) => number> = {
@@ -182,7 +171,7 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
     const clusterName = deployment.cluster || 'unknown'
     drillToDeployment(clusterName, deployment.namespace, deployment.name, {
       status: deployment.status,
-      version: extractVersion(deployment.image),
+      version: extractImageTag(deployment.image),
       replicas: deployment.replicas,
       readyReplicas: deployment.readyReplicas,
       progress: deployment.progress })
@@ -313,7 +302,7 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
             const statusStyle = statusConfig[deployment.status] || UNKNOWN_STATUS_STYLE
             const StatusIcon = statusStyle.icon
             const clusterName = deployment.cluster || 'unknown'
-            const version = extractVersion(deployment.image)
+            const version = extractImageTag(deployment.image)
 
             return (
               <div

--- a/web/src/components/cards/DeploymentStatus.tsx
+++ b/web/src/components/cards/DeploymentStatus.tsx
@@ -11,6 +11,7 @@ import { useCardLoadingState } from './CardDataContext'
 import { CardClusterFilter, CardSearchInput, CardAIActions, CardEmptyState } from '../../lib/cards/CardComponents'
 import { useCardData, useCardFilters, useStatusFilter, commonComparators, type SortDirection } from '../../lib/cards/cardHooks'
 import { useTranslation } from 'react-i18next'
+import { extractImageTag } from '../../lib/gpu'
 
 type StatusFilter = 'all' | 'running' | 'deploying' | 'failed'
 type SortByOption = 'status' | 'name' | 'cluster'
@@ -42,18 +43,6 @@ const statusConfig = {
     bg: 'bg-red-500/20',
     barColor: 'bg-red-500',
     label: 'Failed' } }
-
-// Extract version from container image
-function extractVersion(image?: string): string {
-  if (!image) return 'unknown'
-  const parts = image.split(':')
-  if (parts.length > 1) {
-    const tag = parts[parts.length - 1]
-    if (tag.length > 20) return tag.substring(0, 12)
-    return tag
-  }
-  return 'latest'
-}
 
 // Shared filter config for counting and display
 const FILTER_CONFIG = {
@@ -179,7 +168,7 @@ export function DeploymentStatus() {
     const clusterName = deployment.cluster || 'unknown'
     drillToDeployment(clusterName, deployment.namespace, deployment.name, {
       status: deployment.status,
-      version: extractVersion(deployment.image),
+      version: extractImageTag(deployment.image),
       replicas: deployment.replicas,
       readyReplicas: deployment.readyReplicas,
       progress: deployment.progress })
@@ -301,7 +290,7 @@ export function DeploymentStatus() {
             const config = statusConfig[deployment.status as keyof typeof statusConfig] || statusConfig.running
             const StatusIcon = config.icon
             const clusterName = deployment.cluster || 'unknown'
-            const version = extractVersion(deployment.image)
+            const version = extractImageTag(deployment.image)
 
             return (
               <div

--- a/web/src/components/cards/GPUNamespaceAllocations.tsx
+++ b/web/src/components/cards/GPUNamespaceAllocations.tsx
@@ -13,6 +13,7 @@ import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { useCardLoadingState } from './CardDataContext'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { useTranslation } from 'react-i18next'
+import { hasGPUResourceRequest, normalizeClusterName } from '../../lib/gpu'
 
 interface GPUNamespaceAllocationsProps {
   config?: Record<string, unknown>
@@ -31,19 +32,6 @@ interface NamespaceGPUAllocation {
   gpuRequested: number
   podCount: number
   clusters: string[]
-}
-
-// Check if any container in the pod requests GPUs
-function hasGPUResourceRequest(containers?: { gpuRequested?: number }[]): boolean {
-  if (!containers) return false
-  return containers.some(c => (c.gpuRequested ?? 0) > 0)
-}
-
-// Normalize cluster name for matching
-function normalizeClusterName(cluster: string): string {
-  if (!cluster) return ''
-  const parts = cluster.split('/')
-  return parts[parts.length - 1] || cluster
 }
 
 const NAMESPACE_SORT_COMPARATORS: Record<SortByOption, (a: NamespaceGPUAllocation, b: NamespaceGPUAllocation) => number> = {

--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -12,6 +12,7 @@ import { Skeleton, SkeletonStats } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import { normalizeClusterName } from '../../lib/gpu'
 import {
   CHART_HEIGHT_STANDARD,
   CHART_GRID_STROKE,
@@ -67,13 +68,6 @@ const TIME_RANGE_OPTIONS: { value: TimeRange; label: string; points: number; int
   { value: '6h', label: '6 hours', points: 24, intervalMs: 900000 },
   { value: '24h', label: '24 hours', points: 24, intervalMs: 3600000 },
 ]
-
-// Normalize cluster name for matching
-function normalizeClusterName(cluster: string): string {
-  if (!cluster) return ''
-  const parts = cluster.split('/')
-  return parts[parts.length - 1] || cluster
-}
 
 export function GPUUsageTrend() {
   const { t } = useTranslation()

--- a/web/src/components/cards/GPUWorkloads.tsx
+++ b/web/src/components/cards/GPUWorkloads.tsx
@@ -13,6 +13,7 @@ import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import type { PodInfo } from '../../hooks/useMCP'
 import { useTranslation } from 'react-i18next'
+import { hasGPUResourceRequest, normalizeClusterName } from '../../lib/gpu'
 
 interface GPUWorkloadsProps {
   config?: Record<string, unknown>
@@ -41,21 +42,6 @@ const GPU_SORT_COMPARATORS: Record<SortByOption, (a: PodInfo, b: PodInfo) => num
   name: commonComparators.string<PodInfo>('name'),
   namespace: commonComparators.string<PodInfo>('namespace'),
   cluster: commonComparators.string<PodInfo>('cluster') }
-
-// Check if any container in the pod requests GPUs
-function hasGPUResourceRequest(containers?: { gpuRequested?: number }[]): boolean {
-  if (!containers) return false
-  return containers.some(c => (c.gpuRequested ?? 0) > 0)
-}
-
-// Normalize cluster name for matching (handle kubeconfig/xxx format)
-function normalizeClusterName(cluster: string): string {
-  if (!cluster) return ''
-  // If it's a path like "kubeconfig/cluster-name", extract just the cluster name
-  const parts = cluster.split('/')
-  return parts[parts.length - 1] || cluster
-}
-
 
 export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
   const { t } = useTranslation(['cards', 'common'])

--- a/web/src/components/drilldown/views/GPUNamespaceDrillDown.tsx
+++ b/web/src/components/drilldown/views/GPUNamespaceDrillDown.tsx
@@ -3,21 +3,10 @@ import { useGPUNodes, useAllPods } from '../../../hooks/useMCP'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { StatusIndicator, type Status } from '../../charts/StatusIndicator'
+import { hasGPUResourceRequest, normalizeClusterName } from '../../../lib/gpu'
 
 interface Props {
   data: Record<string, unknown>
-}
-
-// Check if any container requests GPUs
-function hasGPUResourceRequest(containers?: { gpuRequested?: number }[]): boolean {
-  if (!containers) return false
-  return containers.some(c => (c.gpuRequested ?? 0) > 0)
-}
-
-function normalizeClusterName(cluster: string): string {
-  if (!cluster) return ''
-  const parts = cluster.split('/')
-  return parts[parts.length - 1] || cluster
 }
 
 function podStatusToIndicator(status: string): Status {

--- a/web/src/components/drilldown/views/GPUNodeDrillDown.tsx
+++ b/web/src/components/drilldown/views/GPUNodeDrillDown.tsx
@@ -5,21 +5,10 @@ import { useAllPods } from '../../../hooks/useMCP'
 import { Gauge } from '../../charts/Gauge'
 import { StatusIndicator, type Status } from '../../charts/StatusIndicator'
 import { useTranslation } from 'react-i18next'
+import { hasGPUResourceRequest, normalizeClusterName } from '../../../lib/gpu'
 
 interface Props {
   data: Record<string, unknown>
-}
-
-// Check if any container requests GPUs
-function hasGPUResourceRequest(containers?: { gpuRequested?: number }[]): boolean {
-  if (!containers) return false
-  return containers.some(c => (c.gpuRequested ?? 0) > 0)
-}
-
-function normalizeClusterName(cluster: string): string {
-  if (!cluster) return ''
-  const parts = cluster.split('/')
-  return parts[parts.length - 1] || cluster
 }
 
 function podStatusToIndicator(status: string): Status {

--- a/web/src/lib/gpu.ts
+++ b/web/src/lib/gpu.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared GPU card utilities.
+ *
+ * Functions used by GPUWorkloads, GPUUsageTrend, and GPUNamespaceAllocations
+ * to normalise cluster identifiers and detect GPU resource requests.
+ */
+
+const MAX_TAG_DISPLAY_LENGTH = 20
+const TAG_TRUNCATE_LENGTH = 12
+
+export function normalizeClusterName(cluster: string): string {
+  if (!cluster) return ''
+  const parts = cluster.split('/')
+  return parts[parts.length - 1] || cluster
+}
+
+export function hasGPUResourceRequest(containers?: { gpuRequested?: number }[]): boolean {
+  if (!containers) return false
+  return containers.some(c => (c.gpuRequested ?? 0) > 0)
+}
+
+/**
+ * Extract the image tag (version) from a container image reference.
+ *
+ * @example
+ * extractImageTag('nginx:1.25')           // '1.25'
+ * extractImageTag('registry.io/app:sha256:abc...def')  // 'abc...def' (truncated)
+ * extractImageTag('nginx')                // 'latest'
+ * extractImageTag(undefined)              // 'unknown'
+ */
+export function extractImageTag(image?: string): string {
+  if (!image) return 'unknown'
+  const parts = image.split(':')
+  if (parts.length > 1) {
+    const tag = parts[parts.length - 1]
+    if (tag.length > MAX_TAG_DISPLAY_LENGTH) return tag.substring(0, TAG_TRUNCATE_LENGTH)
+    return tag
+  }
+  return 'latest'
+}


### PR DESCRIPTION
## Summary
- Extract `normalizeClusterName` (5 copies), `hasGPUResourceRequest` (4 copies), and `extractVersion` → `extractImageTag` (2 copies) into shared `lib/gpu.ts`
- Files updated: GPUWorkloads, GPUUsageTrend, GPUNamespaceAllocations, GPUNodeDrillDown, GPUNamespaceDrillDown, DeploymentProgress, DeploymentStatus
- Net: -87 lines removed, +51 lines added (11 fewer duplicate functions)

## Test plan
- [x] `npm run build` — clean
- [x] No behavior change — functions are byte-identical copies

Fixes #10131