### PR TITLE
🧹 Deduplicate parseReadyCount into shared lib/k8s.ts

### DIFF
--- a/web/src/components/cards/crio_status/helpers.ts
+++ b/web/src/components/cards/crio_status/helpers.ts
@@ -48,15 +48,8 @@ export function extractCrioVersion(containerRuntime?: string): string {
   return versionMatch?.[1] ?? UNKNOWN_CRIO_VERSION
 }
 
-export function parseReadyCount(ready?: string): { ready: number; total: number } {
-  const [readyPart, totalPart] = String(ready ?? '').split('/')
-  const readyCount = Number.parseInt(readyPart, 10)
-  const totalCount = Number.parseInt(totalPart, 10)
-  return {
-    ready: Number.isFinite(readyCount) ? readyCount : 0,
-    total: Number.isFinite(totalCount) ? totalCount : 0,
-  }
-}
+import { parseReadyCount } from '../../../lib/k8s'
+export { parseReadyCount } from '../../../lib/k8s'
 
 function extractImageFromMessage(message?: string): string | undefined {
   const match = String(message ?? '').match(IMAGE_IN_MESSAGE_REGEX)

--- a/web/src/components/cards/multi-tenancy/k3s-status/helpers.ts
+++ b/web/src/components/cards/multi-tenancy/k3s-status/helpers.ts
@@ -71,18 +71,8 @@ export function isK3sNode(containerRuntime?: string): boolean {
   return (containerRuntime ?? '').toLowerCase().includes(K3S_RUNTIME_SUBSTRING)
 }
 
-/**
- * Parse a Kubernetes "ready" string like "1/1" into numeric values.
- */
-export function parseReadyCount(ready?: string): { ready: number; total: number } {
-  const [readyPart, totalPart] = String(ready ?? '').split('/')
-  const readyCount = Number.parseInt(readyPart, 10)
-  const totalCount = Number.parseInt(totalPart, 10)
-  return {
-    ready: Number.isFinite(readyCount) ? readyCount : 0,
-    total: Number.isFinite(totalCount) ? totalCount : 0,
-  }
-}
+import { parseReadyCount } from '../../../../lib/k8s'
+export { parseReadyCount } from '../../../../lib/k8s'
 
 /**
  * Determine whether a pod is healthy based on its status and ready ratio.

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/helpers.ts
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/helpers.ts
@@ -71,18 +71,8 @@ export function isKubeFlexControlPlanePod(labels?: Record<string, string>): bool
   return Boolean(l[KUBEFLEX_CP_LABEL_KEY])
 }
 
-/**
- * Parse a Kubernetes "ready" string like "1/1" into numeric values.
- */
-export function parseReadyCount(ready?: string): { ready: number; total: number } {
-  const [readyPart, totalPart] = String(ready ?? '').split('/')
-  const readyCount = Number.parseInt(readyPart, 10)
-  const totalCount = Number.parseInt(totalPart, 10)
-  return {
-    ready: Number.isFinite(readyCount) ? readyCount : 0,
-    total: Number.isFinite(totalCount) ? totalCount : 0,
-  }
-}
+import { parseReadyCount } from '../../../../lib/k8s'
+export { parseReadyCount } from '../../../../lib/k8s'
 
 /**
  * Determine whether a pod is healthy based on its status and ready ratio.

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/helpers.ts
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/helpers.ts
@@ -66,18 +66,8 @@ export function isVirtLauncher(labels?: Record<string, string>): boolean {
   return appLabel === VIRT_LAUNCHER_LABEL
 }
 
-/**
- * Parse a Kubernetes "ready" string like "1/1" into numeric values.
- */
-export function parseReadyCount(ready?: string): { ready: number; total: number } {
-  const [readyPart, totalPart] = String(ready ?? '').split('/')
-  const readyCount = Number.parseInt(readyPart, 10)
-  const totalCount = Number.parseInt(totalPart, 10)
-  return {
-    ready: Number.isFinite(readyCount) ? readyCount : 0,
-    total: Number.isFinite(totalCount) ? totalCount : 0,
-  }
-}
+import { parseReadyCount } from '../../../../lib/k8s'
+export { parseReadyCount } from '../../../../lib/k8s'
 
 /**
  * Determine whether a pod is healthy based on its status and ready ratio.

--- a/web/src/components/cards/multi-tenancy/ovn-status/helpers.ts
+++ b/web/src/components/cards/multi-tenancy/ovn-status/helpers.ts
@@ -5,6 +5,9 @@
  * pod and annotation data into the metrics shown by the card.
  */
 
+import { parseReadyCount } from '../../../../lib/k8s'
+export { parseReadyCount } from '../../../../lib/k8s'
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -86,19 +89,6 @@ export function isPodHealthy(pod: OvnPodInfo): boolean {
 
   const { ready, total } = parseReadyCount(pod.ready)
   return total > 0 && ready === total
-}
-
-/**
- * Parse a Kubernetes "ready" string like "1/1" into numeric values.
- */
-export function parseReadyCount(ready?: string): { ready: number; total: number } {
-  const [readyPart, totalPart] = String(ready ?? '').split('/')
-  const readyCount = Number.parseInt(readyPart, 10)
-  const totalCount = Number.parseInt(totalPart, 10)
-  return {
-    ready: Number.isFinite(readyCount) ? readyCount : 0,
-    total: Number.isFinite(totalCount) ? totalCount : 0,
-  }
 }
 
 /**

--- a/web/src/lib/k8s.ts
+++ b/web/src/lib/k8s.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared Kubernetes utility functions used across multiple card helpers.
+ */
+
+/**
+ * Parse a Kubernetes "ready/total" string (e.g. "2/3") into numeric parts.
+ * Returns `{ ready: 0, total: 0 }` for missing or malformed input.
+ */
+export function parseReadyCount(ready?: string): { ready: number; total: number } {
+  const [readyPart, totalPart] = String(ready ?? '').split('/')
+  const readyCount = Number.parseInt(readyPart, 10)
+  const totalCount = Number.parseInt(totalPart, 10)
+  return {
+    ready: Number.isFinite(readyCount) ? readyCount : 0,
+    total: Number.isFinite(totalCount) ? totalCount : 0,
+  }
+}


### PR DESCRIPTION
## Summary
- Extract `parseReadyCount` from 5 card helper files into `lib/k8s.ts`
- Re-export from each helper to preserve existing test imports
- All 83 helper tests pass, build clean

Fixes #10135

## Files changed
- **NEW** `web/src/lib/k8s.ts` — shared `parseReadyCount` function
- `crio_status/helpers.ts` — replaced local copy with import + re-export
- `kubevirt-status/helpers.ts` — same
- `ovn-status/helpers.ts` — same
- `kubeflex-status/helpers.ts` — same
- `k3s-status/helpers.ts` — same

## Test plan
- [x] All 5 helper test suites pass (83 tests)
- [x] `npm run build` passes
- [ ] CI build/lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)