### PR TITLE
🧹 Consolidate ~70 duplicate time constants into lib/constants/time.ts

### DIFF
--- a/web/src/components/alerts/AlertDetail.tsx
+++ b/web/src/components/alerts/AlertDetail.tsx
@@ -22,14 +22,13 @@ import { Button } from '../ui/Button'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { TOAST_DISMISS_MS } from '../../lib/constants/network'
+import { MINUTES_PER_HOUR, HOURS_PER_DAY } from '../../lib/constants/time'
 
 // Issue 9256 — fallback label used for acknowledgement when no authenticated
 // user is available (e.g. in demo mode without login).
 const ANONYMOUS_ACK_LABEL = 'anonymous'
 
 // Time thresholds for relative time formatting
-const MINUTES_PER_HOUR = 60 // Minutes in an hour
-const HOURS_PER_DAY = 24 // Hours in a day
 
 interface AlertDetailProps {
   alert: Alert

--- a/web/src/components/alerts/RunbookProgress.tsx
+++ b/web/src/components/alerts/RunbookProgress.tsx
@@ -1,7 +1,6 @@
 import { CheckCircle2, XCircle, Loader2, SkipForward, Clock } from 'lucide-react'
 import type { EvidenceStepResult } from '../../lib/runbooks/types'
-
-const MS_PER_SECOND = 1_000 // Milliseconds in one second
+import { MS_PER_SECOND } from '../../lib/constants/time'
 
 interface RunbookProgressProps {
   title: string

--- a/web/src/components/cards/AlertListItem.tsx
+++ b/web/src/components/cards/AlertListItem.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import type { Mission } from '../../hooks/useMissions'
 import { useSnoozedAlerts, SNOOZE_DURATIONS, formatSnoozeRemaining, type SnoozeDuration } from '../../hooks/useSnoozedAlerts'
+import { MS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY } from '../../lib/constants/time'
 
 // Severity color map — defined at module level to avoid re-creation on each render
 const SEVERITY_COLORS: Record<AlertSeverity, string> = {
@@ -23,12 +24,6 @@ const SEVERITY_COLORS: Record<AlertSeverity, string> = {
   info: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
 }
 
-/** Milliseconds in one minute — used for relative time formatting */
-const MS_PER_MINUTE = 60000
-/** Minutes in one hour */
-const MINUTES_PER_HOUR = 60
-/** Hours in one day */
-const HOURS_PER_DAY = 24
 
 // Severity indicator badge
 function SeverityBadge({ severity }: { severity: AlertSeverity }) {

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -36,6 +36,7 @@ const FeatureRequestModal = lazy(() =>
   import('../feedback/FeatureRequestModal').then(m => ({ default: m.FeatureRequestModal }))
 )
 import { LOADING_TIMEOUT_MS, SKELETON_DELAY_MS, INITIAL_RENDER_TIMEOUT_MS, TICK_INTERVAL_MS, CARD_LOADING_TIMEOUT_MS, MIN_SKELETON_DISPLAY_MS } from '../../lib/constants/network'
+import { SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY } from '../../lib/constants/time'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { copyToClipboard } from '../../lib/clipboard'
 
@@ -84,12 +85,6 @@ const ONE_HOUR_MS = 60 * 60 * 1000
 // Relative-time formatting for the card header "last updated" label.
 // Named constants (not magic numbers) so every threshold is explicit.
 // ---------------------------------------------------------------------------
-/** Seconds in one minute — rollover from "Xs" to "Xm" */
-const SECONDS_PER_MINUTE = 60
-/** Minutes in one hour — rollover from "Xm" to "Xh" */
-const MINUTES_PER_HOUR = 60
-/** Hours in one day — rollover from "Xh" to "Xd" */
-const HOURS_PER_DAY = 24
 /** Fallback when the timestamp isn't a valid Date — prevents "NaNd" (#9095) */
 const INVALID_TIMESTAMP_LABEL = 'Unknown'
 /**

--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -7,6 +7,7 @@ import { useChartFilters } from '../../lib/cards/cardHooks'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR } from '../../lib/constants/time'
 
 type TimeRange = '15m' | '1h' | '6h' | '24h'
 
@@ -19,9 +20,6 @@ type TimeRange = '15m' | '1h' | '6h' | '24h'
 const MAX_HISTORY_POINTS = 60                                                  // buffer cap (points)
 const MAX_HISTORY_DURATION_MS = MAX_HISTORY_POINTS * CLUSTER_POLL_INTERVAL_MS  // max wall-clock span of buffer
 const MIN_POINT_SPACING_MS = 30 * 1000                                         // min delta between recorded points (30s)
-const MS_PER_SECOND = 1000
-const SECONDS_PER_MINUTE = 60
-const MINUTES_PER_HOUR = 60
 const MINUTES_15 = 15
 const HOURS_1 = 1
 const HOURS_6 = 6

--- a/web/src/components/cards/GPUInventoryHistory.tsx
+++ b/web/src/components/cards/GPUInventoryHistory.tsx
@@ -19,6 +19,7 @@ import {
   CHART_AXIS_STROKE,
   CHART_TOOLTIP_CONTENT_STYLE,
   CHART_TICK_COLOR } from '../../lib/constants'
+import { MS_PER_HOUR, MS_PER_MINUTE, MINUTES_PER_HOUR } from '../../lib/constants/time'
 
 // ---------------------------------------------------------------------------
 // Constants — no magic numbers
@@ -52,14 +53,8 @@ const UNKNOWN_GPU_TYPE = 'Unknown'
 const DEMO_GPU_TYPE_COUNT = 3
 /** Number of demo nodes to simulate */
 const DEMO_NODE_COUNT = 4
-/** Milliseconds per hour — used for demo data time offsets */
-const MS_PER_HOUR = 60 * 60 * 1000
-/** Milliseconds per minute — used for snapshot interval display */
-const MS_PER_MINUTE = 60 * 1000
 /** Default snapshot interval in minutes (used when actual cannot be computed) */
 const DEFAULT_SNAPSHOT_INTERVAL_MIN = 10
-/** Minutes per hour — used for converting interval-based durations */
-const MINUTES_PER_HOUR = 60
 /** Minimum snapshots needed for churn computation (need at least 2 to diff) */
 const MIN_CHURN_SNAPSHOTS = 2
 /** Maximum rows to show in the table view per page */

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -32,6 +32,7 @@ import {
   CHART_DATAZOOM_DATA_AREA,
 } from '../../lib/constants'
 import { hexToRgba } from '../../lib/theme/chartColors'
+import { MS_PER_DAY } from '../../lib/constants/time'
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
@@ -53,8 +54,6 @@ const MAX_PAGES = 30
 const CACHE_TTL_MS = 60 * 60 * 1000
 /** LocalStorage cache key prefix */
 const CACHE_KEY_PREFIX = 'issue_activity_chart_cache_'
-/** Milliseconds in one day */
-const MS_PER_DAY = 86_400_000
 /** Bar chart color for issues opened */
 const COLOR_OPENED = '#4472C4'
 /** Bar chart color for issues closed */

--- a/web/src/components/cards/VClusterStatus.tsx
+++ b/web/src/components/cards/VClusterStatus.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next'
 import { useLocalClusterTools, type VClusterInstance } from '../../hooks/useLocalClusterTools'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import { MS_PER_DAY } from '../../lib/constants/time'
 
 type VClusterStatusType = 'Running' | 'Paused' | 'Failed' | 'Unknown'
 
@@ -26,7 +27,6 @@ const DEMO_AGE_STAGING_DAYS = 21
 const DEMO_AGE_TEST_DAYS = 10
 const DEMO_AGE_SANDBOX_DAYS = 3
 const DEMO_AGE_QA_DAYS = 7
-const MS_PER_DAY = 24 * 60 * 60 * 1000
 
 const DEMO_VCLUSTERS: VCluster[] = [
   { name: 'dev-vcluster', namespace: 'vcluster-dev', hostCluster: 'us-east-1', status: 'Running', k8sVersion: 'v1.30.2', createdAt: new Date(Date.now() - DEMO_AGE_OLDEST_DAYS * MS_PER_DAY).toISOString() },

--- a/web/src/components/cards/backstage_status/index.tsx
+++ b/web/src/components/cards/backstage_status/index.tsx
@@ -38,6 +38,7 @@ import {
   type BackstagePluginStatus,
   type BackstageScaffolderTemplate,
 } from '../../../lib/demo/backstage'
+import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY, MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../../lib/constants/time'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -49,13 +50,6 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const MS_PER_SECOND = 1000
-const SECONDS_PER_MINUTE = 60
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
-const MS_PER_MINUTE = MS_PER_SECOND * SECONDS_PER_MINUTE
-const MS_PER_HOUR = MS_PER_MINUTE * MINUTES_PER_HOUR
-const MS_PER_DAY = MS_PER_HOUR * HOURS_PER_DAY
 
 // Max number of rows the card surfaces per section — keeps the 6-wide card
 // height bounded when an install has dozens of plugins or templates.

--- a/web/src/components/cards/backstage_status/index.tsx
+++ b/web/src/components/cards/backstage_status/index.tsx
@@ -38,7 +38,7 @@ import {
   type BackstagePluginStatus,
   type BackstageScaffolderTemplate,
 } from '../../../lib/demo/backstage'
-import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY, MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../../lib/constants/time'
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../../lib/constants/time'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)

--- a/web/src/components/cards/failover_timeline/FailoverTimeline.tsx
+++ b/web/src/components/cards/failover_timeline/FailoverTimeline.tsx
@@ -10,19 +10,12 @@ import { Skeleton, SkeletonStats, SkeletonList } from '../../ui/Skeleton'
 import { useFailoverTimeline } from './useFailoverTimeline'
 import { formatTimeAgo } from '../../../lib/formatters'
 import type { FailoverEvent, FailoverEventType, FailoverSeverity } from './demoData'
+import { MINUTES_PER_HOUR, HOURS_PER_DAY, MS_PER_MINUTE } from '../../../lib/constants/time'
 
 // ---------------------------------------------------------------------------
 // Named constants
 // ---------------------------------------------------------------------------
 
-/** Number of minutes in one hour */
-const MINUTES_PER_HOUR = 60
-
-/** Number of hours in one day */
-const HOURS_PER_DAY = 24
-
-/** Number of milliseconds in one minute */
-const MS_PER_MINUTE = 60_000
 
 // ---------------------------------------------------------------------------
 // Severity styling

--- a/web/src/components/cards/failover_timeline/demoData.ts
+++ b/web/src/components/cards/failover_timeline/demoData.ts
@@ -8,6 +8,8 @@
  * Used in demo mode or when no Karmada control plane is accessible.
  */
 
+import { MS_PER_MINUTE } from '../../../lib/constants/time'
+
 /** Demo data shows as checked 30 seconds ago */
 const DEMO_LAST_CHECK_OFFSET_MS = 30_000
 
@@ -29,8 +31,6 @@ const CLUSTER_RECOVERY_OFFSET_MIN = 12
 /** Offset in minutes for post-recovery rebalance */
 const RECOVERY_REBALANCE_OFFSET_MIN = 10
 
-/** Number of minutes per millisecond conversion factor */
-const MS_PER_MINUTE = 60_000
 
 export type FailoverEventType =
   | 'cluster_down'

--- a/web/src/components/cards/kubevela_status/index.tsx
+++ b/web/src/components/cards/kubevela_status/index.tsx
@@ -38,6 +38,7 @@ import type {
   WorkflowStepPhase,
 } from './demoData'
 import { formatTimeAgo } from '../../../lib/formatters'
+import { MINUTES_PER_HOUR } from '../../../lib/constants/time'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -54,7 +55,6 @@ const PROGRESS_BAR_WIDTH_PX = 56
 const PROGRESS_BAR_HEIGHT_PX = 4
 
 const MAX_APPS_DISPLAYED = 5
-const MINUTES_PER_HOUR = 60
 const AGE_MINUTES_HOUR_THRESHOLD = 60
 const AGE_MINUTES_DAY_THRESHOLD = 1440
 

--- a/web/src/components/cards/openkruise_status/index.tsx
+++ b/web/src/components/cards/openkruise_status/index.tsx
@@ -32,7 +32,7 @@ import { useDemoMode } from '../../../hooks/useDemoMode'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
 import { useTranslation } from 'react-i18next'
 import { useOpenKruiseStatus } from './useOpenKruiseStatus'
-import { MS_PER_SECOND, MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../../lib/constants/time'
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../../lib/constants/time'
 
 interface OpenKruiseStatusProps {
   config?: {

--- a/web/src/components/cards/openkruise_status/index.tsx
+++ b/web/src/components/cards/openkruise_status/index.tsx
@@ -32,6 +32,7 @@ import { useDemoMode } from '../../../hooks/useDemoMode'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
 import { useTranslation } from 'react-i18next'
 import { useOpenKruiseStatus } from './useOpenKruiseStatus'
+import { MS_PER_SECOND, MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../../lib/constants/time'
 
 interface OpenKruiseStatusProps {
   config?: {
@@ -110,10 +111,6 @@ const BADGE_COLOR_CLASS: Record<string, string> = {
 }
 
 // Named constants for relative-time formatting (previously magic numbers).
-const MS_PER_SECOND = 1000
-const MS_PER_MINUTE = 60 * MS_PER_SECOND
-const MS_PER_HOUR = 60 * MS_PER_MINUTE
-const MS_PER_DAY = 24 * MS_PER_HOUR
 
 const SORT_OPTIONS_KEYS: ReadonlyArray<{
   value: SortByOption

--- a/web/src/components/cards/spiffe_status/index.tsx
+++ b/web/src/components/cards/spiffe_status/index.tsx
@@ -33,6 +33,7 @@ import type {
   SpiffeRegistrationEntry,
 } from './demoData'
 import { formatTimeAgo } from '../../../lib/formatters'
+import { SECONDS_PER_MINUTE } from '../../../lib/constants/time'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -44,7 +45,6 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const SECONDS_PER_MINUTE = 60
 const SECONDS_PER_HOUR = 3600
 const SECONDS_PER_DAY = 86400
 

--- a/web/src/components/cards/tuf_status/index.tsx
+++ b/web/src/components/cards/tuf_status/index.tsx
@@ -26,6 +26,7 @@ import { useCachedTuf } from '../../../hooks/useCachedTuf'
 import { useCardLoadingState } from '../CardDataContext'
 import { cn } from '../../../lib/cn'
 import type { TufMetadataStatus, TufRole } from '../../../lib/demo/tuf'
+import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY, MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../../lib/constants/time'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -37,13 +38,6 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 4
 
-const MS_PER_SECOND = 1000
-const SECONDS_PER_MINUTE = 60
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
-const MS_PER_MINUTE = MS_PER_SECOND * SECONDS_PER_MINUTE
-const MS_PER_HOUR = MS_PER_MINUTE * MINUTES_PER_HOUR
-const MS_PER_DAY = MS_PER_HOUR * HOURS_PER_DAY
 
 // Role count used for skeleton row pre-allocation — TUF has exactly four
 // top-level roles per the spec (root, targets, snapshot, timestamp).

--- a/web/src/components/cards/tuf_status/index.tsx
+++ b/web/src/components/cards/tuf_status/index.tsx
@@ -26,7 +26,7 @@ import { useCachedTuf } from '../../../hooks/useCachedTuf'
 import { useCardLoadingState } from '../CardDataContext'
 import { cn } from '../../../lib/cn'
 import type { TufMetadataStatus, TufRole } from '../../../lib/demo/tuf'
-import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY, MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../../lib/constants/time'
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../../lib/constants/time'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)

--- a/web/src/components/cards/wasmcloud_status/index.tsx
+++ b/web/src/components/cards/wasmcloud_status/index.tsx
@@ -36,6 +36,7 @@ import type {
   WasmcloudProviderStatus,
 } from './demoData'
 import { formatTimeAgo } from '../../../lib/formatters'
+import { SECONDS_PER_MINUTE } from '../../../lib/constants/time'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -47,7 +48,6 @@ const SKELETON_BADGE_WIDTH = 90
 const SKELETON_BADGE_HEIGHT = 20
 const SKELETON_LIST_ITEMS = 5
 
-const SECONDS_PER_MINUTE = 60
 const SECONDS_PER_HOUR = 3600
 const SECONDS_PER_DAY = 86400
 

--- a/web/src/components/dashboard/AdopterNudge.tsx
+++ b/web/src/components/dashboard/AdopterNudge.tsx
@@ -15,6 +15,7 @@ import {
   STORAGE_KEY_FIRST_AGENT_CONNECT,
   STORAGE_KEY_HINTS_SUPPRESSED,
 } from '../../lib/constants/storage'
+import { MS_PER_DAY } from '../../lib/constants/time'
 import {
   emitAdopterNudgeShown,
   emitAdopterNudgeActioned,
@@ -27,8 +28,6 @@ const ADOPTERS_EDIT_URL =
 
 /** Number of days after first agent connection before showing the nudge */
 const ADOPTER_NUDGE_DELAY_DAYS = 3
-/** Milliseconds per day, used for time-since calculation */
-const MS_PER_DAY = 86_400_000
 
 export function AdopterNudge() {
   const { isConnected } = useLocalAgent()

--- a/web/src/components/feedback/FeatureRequestTypes.ts
+++ b/web/src/components/feedback/FeatureRequestTypes.ts
@@ -7,12 +7,8 @@ import {
   type TargetRepo,
 } from '../../hooks/useFeatureRequests'
 import type { FeedbackDraft } from '../../hooks/useFeedbackDrafts'
-
-// ── Time thresholds for relative time formatting ──
-/** Minutes in an hour */
-export const MINUTES_PER_HOUR = 60
-/** Hours in a day */
-export const HOURS_PER_DAY = 24
+import { MINUTES_PER_HOUR, HOURS_PER_DAY } from '../../lib/constants/time'
+export { MINUTES_PER_HOUR, HOURS_PER_DAY }
 /** Days in a week */
 export const DAYS_PER_WEEK = 7
 /** Delay before showing preview link (Netlify route warmup) */

--- a/web/src/components/feedback/UpdatesTab.tsx
+++ b/web/src/components/feedback/UpdatesTab.tsx
@@ -10,6 +10,7 @@ import { isTriaged } from '../../hooks/useFeatureRequests'
 import type { FeatureRequest } from '../../hooks/useFeatureRequests'
 import { emitLinkedInShare } from '../../lib/analytics'
 import { BACKEND_DEFAULT_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+import { MS_PER_SECOND } from '../../lib/constants/time'
 import { ContributorBanner } from '../rewards/ContributorLadder'
 import { GITHUB_REWARD_LABELS } from '../../types/rewards'
 import type { GitHubContribution } from '../../types/rewards'
@@ -56,8 +57,6 @@ interface UpdatesTabProps {
   onShowLoginPrompt: () => void
 }
 
-/** Number of milliseconds in one second (for preview warmup countdown) */
-const MS_PER_SECOND = 1000
 
 export function UpdatesTab({
   requests,

--- a/web/src/components/history/CardHistory.tsx
+++ b/web/src/components/history/CardHistory.tsx
@@ -4,14 +4,12 @@ import { useCardHistory, CardHistoryEntry } from '../../hooks/useCardHistory'
 import { cn } from '../../lib/cn'
 import { formatCardTitle } from '../../lib/formatCardTitle'
 import { useTranslation } from 'react-i18next'
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../lib/constants/time'
 
 function formatCardType(type: string): string {
   return formatCardTitle(type)
 }
 
-const MS_PER_MINUTE = 60_000      // Milliseconds in one minute
-const MS_PER_HOUR   = 3_600_000   // Milliseconds in one hour
-const MS_PER_DAY    = 86_400_000  // Milliseconds in one day
 const MS_PER_WEEK   = 604_800_000 // Milliseconds in one week
 
 function formatTimestamp(timestamp: number): string {

--- a/web/src/components/missions/OrbitReminderBanner.tsx
+++ b/web/src/components/missions/OrbitReminderBanner.tsx
@@ -8,11 +8,10 @@ import { useTranslation } from 'react-i18next'
 import { Satellite, X, Play } from 'lucide-react'
 import type { Mission } from '../../hooks/useMissions'
 import { ORBIT_CADENCE_HOURS, ORBIT_OVERDUE_GRACE_HOURS } from '../../lib/constants/orbit'
+import { HOURS_PER_DAY } from '../../lib/constants/time'
 import type { OrbitConfig } from '../../lib/missions/types'
 import { cn } from '../../lib/cn'
 
-/** Hours per unit for human-readable display */
-const HOURS_PER_DAY = 24
 
 function formatDuration(hours: number): string {
   if (hours < 1) return 'less than 1 hour'

--- a/web/src/components/settings/sections/SettingsBackupSection.tsx
+++ b/web/src/components/settings/sections/SettingsBackupSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { HardDrive, Check, Loader2, AlertCircle, WifiOff, Download, Upload, Shield } from 'lucide-react'
 import type { SyncStatus } from '../../../hooks/usePersistedSettings'
 import { TOAST_DISMISS_MS } from '../../../lib/constants/network'
+import { SECONDS_PER_MINUTE, MINUTES_PER_HOUR } from '../../../lib/constants/time'
 
 interface SettingsBackupSectionProps {
   syncStatus: SyncStatus
@@ -33,8 +34,6 @@ interface LastSavedLabels {
 const JUST_NOW_THRESHOLD_SEC = 5
 // Boundary for switching from seconds-ago to minutes-ago / minutes-ago to
 // absolute time. 60s in a minute, 60m in an hour.
-const SECONDS_PER_MINUTE = 60
-const MINUTES_PER_HOUR = 60
 function formatLastSaved(date: Date | null, labels: LastSavedLabels): string {
   if (!date) return labels.never
   const now = new Date()

--- a/web/src/components/ui/AlertBadge.tsx
+++ b/web/src/components/ui/AlertBadge.tsx
@@ -11,6 +11,7 @@ import type { Alert, AlertSeverity } from '../../types/alerts'
 import { CardAIActions } from '../../lib/cards/CardComponents'
 import { ROUTES } from '../../config/routes'
 import { TRANSITION_DELAY_MS } from '../../lib/constants/network'
+import { HOURS_PER_DAY } from '../../lib/constants/time'
 import { useModalState } from '../../lib/modals'
 import { Button } from './Button'
 
@@ -19,7 +20,6 @@ const BADGE_MAX_COUNT = 99
 /** Number of minutes in an hour, used for relative-time formatting */
 const MINS_PER_HOUR = 60
 /** Number of hours in a day, used for relative-time formatting */
-const HOURS_PER_DAY = 24
 /** Duration of the exit animation before swapping the counter value in milliseconds */
 const ANIMATION_EXIT_DELAY_MS = 150
 

--- a/web/src/components/ui/RefreshIndicator.tsx
+++ b/web/src/components/ui/RefreshIndicator.tsx
@@ -2,6 +2,7 @@ import { memo, useState, useEffect, useRef } from 'react'
 import { RefreshCw, Clock, AlertTriangle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../lib/cn'
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../lib/constants/time'
 import { formatLastSeen } from '../../lib/errorClassifier'
 import { Button } from './Button'
 
@@ -9,12 +10,6 @@ import { Button } from './Button'
 // Must match animation duration (1s) defined in index.css for animate-spin-min
 const MIN_SPIN_DURATION = 1000
 
-/** Milliseconds per minute, used for relative-time formatting */
-const MS_PER_MINUTE = 60_000
-/** Milliseconds per hour, used for relative-time formatting */
-const MS_PER_HOUR = 3_600_000
-/** Milliseconds per day, used for relative-time formatting */
-const MS_PER_DAY = 86_400_000
 
 interface RefreshIndicatorProps {
   isRefreshing: boolean

--- a/web/src/hooks/useGatewayStatus.ts
+++ b/web/src/hooks/useGatewayStatus.ts
@@ -17,6 +17,7 @@ import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { registerRefetch } from '../lib/modeTransition'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
+import { MS_PER_DAY, MS_PER_HOUR } from '../lib/constants/time'
 
 // ============================================================================
 // Constants
@@ -119,10 +120,6 @@ function saveToCache(data: Gateway[], isDemoData: boolean): void {
 // Demo Data Generator
 // ============================================================================
 
-/** Days in milliseconds */
-const MS_PER_DAY = 86_400_000
-/** Hours in milliseconds */
-const MS_PER_HOUR = 3_600_000
 
 function getDemoGateways(clusterNames: string[]): Gateway[] {
   const gateways: Gateway[] = []

--- a/web/src/hooks/useNPSSurvey.ts
+++ b/web/src/hooks/useNPSSurvey.ts
@@ -4,6 +4,7 @@ import { STORAGE_KEY_NPS_STATE, STORAGE_KEY_SESSION_COUNT } from '../lib/constan
 import { emitNPSSurveyShown, emitNPSResponse, emitNPSDismissed } from '../lib/analytics'
 import { api } from '../lib/api'
 import { useRewards } from './useRewards'
+import { MS_PER_DAY } from '../lib/constants/time'
 
 /** Minimum sessions before showing NPS for the first time */
 const MIN_SESSIONS_BEFORE_NPS = 2
@@ -15,8 +16,6 @@ const NPS_REPROMPT_DAYS = 30
 const NPS_DISMISS_RETRY_DAYS = 7
 /** Max dismissals before stopping for NPS_REPROMPT_DAYS */
 const NPS_MAX_DISMISSALS = 3
-/** Milliseconds per day */
-const MS_PER_DAY = 86_400_000
 /** Timeout for the NPS POST — keep short; the UI is blocked on this */
 const NPS_POST_TIMEOUT_MS = 5_000
 

--- a/web/src/hooks/useServiceExports.ts
+++ b/web/src/hooks/useServiceExports.ts
@@ -17,6 +17,7 @@ import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type { ServiceExport } from '../types/mcs'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
+import { MS_PER_DAY, MS_PER_HOUR } from '../lib/constants/time'
 
 // ============================================================================
 // Constants
@@ -97,10 +98,6 @@ function saveToCache(data: ServiceExport[], isDemoData: boolean): void {
 // Demo Data Generator
 // ============================================================================
 
-/** Days in milliseconds */
-const MS_PER_DAY = 86_400_000
-/** Hours in milliseconds */
-const MS_PER_HOUR = 3_600_000
 
 function getDemoServiceExports(clusterNames: string[]): ServiceExport[] {
   const exports: ServiceExport[] = []

--- a/web/src/hooks/useServiceImportsCard.ts
+++ b/web/src/hooks/useServiceImportsCard.ts
@@ -17,6 +17,7 @@ import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type { ServiceImport, ServiceImportList } from '../types/mcs'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
+import { MS_PER_DAY, MS_PER_HOUR } from '../lib/constants/time'
 
 // ============================================================================
 // Constants
@@ -92,10 +93,6 @@ function saveToCache(data: ServiceImport[], isDemoData: boolean): void {
 // Demo Data Generator
 // ============================================================================
 
-/** Days in milliseconds */
-const MS_PER_DAY = 86_400_000
-/** Hours in milliseconds */
-const MS_PER_HOUR = 3_600_000
 
 function getDemoServiceImports(clusterNames: string[]): ServiceImport[] {
   const imports: ServiceImport[] = []

--- a/web/src/hooks/useSnoozedRecommendations.ts
+++ b/web/src/hooks/useSnoozedRecommendations.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { CardRecommendation } from './useCardRecommendations'
 import { POLL_INTERVAL_SLOW_MS } from '../lib/constants/network'
 import { STORAGE_KEY_SNOOZED_RECOMMENDATIONS } from '../lib/constants/storage'
+import { SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY } from '../lib/constants/time'
 import { emitSnoozed, emitUnsnoozed } from '../lib/analytics'
 
 /** Default snooze duration for recommendations: 24 hours */
@@ -147,9 +148,6 @@ export function useSnoozedRecommendations() {
 }
 
 // Time boundary constants for elapsed time formatting
-const SECONDS_PER_MINUTE = 60
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
 
 // Helper to format elapsed time since snooze
 export function formatElapsedTime(since: Date | number): string {

--- a/web/src/hooks/useVisitStreak.ts
+++ b/web/src/hooks/useVisitStreak.ts
@@ -13,9 +13,7 @@ import { useState } from 'react'
 import { safeGetJSON, safeSetJSON } from '../lib/utils/localStorage'
 import { STORAGE_KEY_VISIT_STREAK } from '../lib/constants/storage'
 import { emitStreakDay } from '../lib/analytics'
-
-/** Number of milliseconds in one day */
-const MS_PER_DAY = 86_400_000
+import { MS_PER_DAY } from '../lib/constants/time'
 
 interface StreakData {
   /** Last visit date in YYYY-MM-DD format */

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,4 +1,5 @@
 import { createContext, use, useState, useEffect, useCallback, useMemo, useRef, ReactNode } from 'react'
+import { MS_PER_SECOND } from './constants/time'
 import { checkOAuthConfigured, checkOAuthConfiguredWithRetry } from './api'
 import { dashboardSync } from './dashboards/dashboardSync'
 import { clearPermissionsCache } from '../hooks/usePermissions'
@@ -47,8 +48,6 @@ const EXPIRY_WARNING_THRESHOLD_MS = 30 * 60_000
 const MAX_CACHED_USER_AGE_MS = 5 * 60 * 1_000
 /** #6067 — interval for background re-validation when the backend is unreachable. */
 const BACKEND_REVALIDATE_INTERVAL_MS = 30_000
-/** Milliseconds per second — JWT `exp` is in seconds. */
-const MS_PER_SECOND = 1_000
 
 /**
  * Decode the expiry timestamp from a JWT without verifying signature.

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -298,9 +298,7 @@ export const SERVICES_CACHE_TTL_MS = 60_000
  * SERVICES_CACHE_TTL_MS. */
 export const SERVICES_CACHE_STALE_MS = 30_000
 
-/** Conversion factor from milliseconds to seconds, used when formatting
- * the "Cached • Ns ago" label. */
-export const MS_PER_SECOND = 1_000
+export { MS_PER_SECOND } from './time'
 
 // ============================================================================
 // Service port rendering (issue #6163)

--- a/web/src/lib/constants/time.ts
+++ b/web/src/lib/constants/time.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared time-unit constants used across hooks, cards, and demo data.
+ *
+ * Consolidates the ~70 duplicate `MS_PER_*` / `SECONDS_PER_*` definitions
+ * that were scattered across the codebase.
+ */
+
+export const MS_PER_SECOND = 1_000
+export const SECONDS_PER_MINUTE = 60
+export const MINUTES_PER_HOUR = 60
+export const HOURS_PER_DAY = 24
+
+export const MS_PER_MINUTE = MS_PER_SECOND * SECONDS_PER_MINUTE
+export const MS_PER_HOUR = MS_PER_MINUTE * MINUTES_PER_HOUR
+export const MS_PER_DAY = MS_PER_HOUR * HOURS_PER_DAY

--- a/web/src/lib/demo/backstage.ts
+++ b/web/src/lib/demo/backstage.ts
@@ -8,7 +8,7 @@
  * entity catalog was successfully reconciled.
  */
 
-import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR, MS_PER_MINUTE, MS_PER_HOUR } from '../constants/time'
+import { MS_PER_MINUTE, MS_PER_HOUR } from '../constants/time'
 
 // ---------------------------------------------------------------------------
 // Types

--- a/web/src/lib/demo/backstage.ts
+++ b/web/src/lib/demo/backstage.ts
@@ -8,6 +8,8 @@
  * entity catalog was successfully reconciled.
  */
 
+import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR, MS_PER_MINUTE, MS_PER_HOUR } from '../constants/time'
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -86,12 +88,6 @@ export interface BackstageStatusData {
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
 // ---------------------------------------------------------------------------
-
-const MS_PER_SECOND = 1000
-const SECONDS_PER_MINUTE = 60
-const MINUTES_PER_HOUR = 60
-const MS_PER_MINUTE = MS_PER_SECOND * SECONDS_PER_MINUTE
-const MS_PER_HOUR = MS_PER_MINUTE * MINUTES_PER_HOUR
 
 // Demo replica topology — typical small-to-medium Backstage install.
 const DEMO_REPLICAS_RUNNING = 2

--- a/web/src/lib/demo/cloud-custodian.ts
+++ b/web/src/lib/demo/cloud-custodian.ts
@@ -12,7 +12,7 @@
  *   - Policy execution mode (pull / periodic / event)
  */
 
-import { MS_PER_SECOND, SECONDS_PER_MINUTE, MS_PER_MINUTE } from '../constants/time'
+import { MS_PER_MINUTE } from '../constants/time'
 
 // ---------------------------------------------------------------------------
 // Types

--- a/web/src/lib/demo/cloud-custodian.ts
+++ b/web/src/lib/demo/cloud-custodian.ts
@@ -12,6 +12,8 @@
  *   - Policy execution mode (pull / periodic / event)
  */
 
+import { MS_PER_SECOND, SECONDS_PER_MINUTE, MS_PER_MINUTE } from '../constants/time'
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -87,9 +89,6 @@ export interface CloudCustodianStatusData {
 // ---------------------------------------------------------------------------
 
 // Named constants (no magic numbers)
-const MS_PER_SECOND = 1000
-const SECONDS_PER_MINUTE = 60
-const MS_PER_MINUTE = MS_PER_SECOND * SECONDS_PER_MINUTE
 
 // Last-run offsets (minutes ago) chosen to feel realistic across pull/periodic/event.
 const POLICY_LAST_RUN_EC2_MIN = 4

--- a/web/src/lib/demo/kserve.ts
+++ b/web/src/lib/demo/kserve.ts
@@ -16,7 +16,7 @@
  * Source: kubestellar/console-marketplace#38
  */
 
-import { MS_PER_SECOND, SECONDS_PER_MINUTE, MS_PER_MINUTE } from '../constants/time'
+import { MS_PER_MINUTE } from '../constants/time'
 
 // ---------------------------------------------------------------------------
 // Types

--- a/web/src/lib/demo/kserve.ts
+++ b/web/src/lib/demo/kserve.ts
@@ -16,6 +16,8 @@
  * Source: kubestellar/console-marketplace#38
  */
 
+import { MS_PER_SECOND, SECONDS_PER_MINUTE, MS_PER_MINUTE } from '../constants/time'
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -80,10 +82,6 @@ export interface KServeStatusData {
 // ---------------------------------------------------------------------------
 // Demo-data constants (named — no magic numbers)
 // ---------------------------------------------------------------------------
-
-const MS_PER_SECOND = 1000
-const SECONDS_PER_MINUTE = 60
-const MS_PER_MINUTE = MS_PER_SECOND * SECONDS_PER_MINUTE
 
 // Relative "last update" offsets for each demo service — small, realistic ranges
 // that exercise the formatRelativeTime helper in the card UI.

--- a/web/src/lib/demo/spire.ts
+++ b/web/src/lib/demo/spire.ts
@@ -14,6 +14,8 @@
  *   - Trust bundle age (how long since the last rotation)
  */
 
+import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY, MS_PER_HOUR, MS_PER_DAY } from '../constants/time'
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -80,12 +82,6 @@ export interface SpireStatusData {
 // Demo data — shown when SPIRE is not installed or in demo mode
 // ---------------------------------------------------------------------------
 
-const MS_PER_SECOND = 1000
-const SECONDS_PER_MINUTE = 60
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
-const MS_PER_HOUR = MS_PER_SECOND * SECONDS_PER_MINUTE * MINUTES_PER_HOUR
-const MS_PER_DAY = MS_PER_HOUR * HOURS_PER_DAY
 
 // Demo SPIRE server — highly-available 3-replica deployment
 const DEMO_SERVER_REPLICAS_DESIRED = 3

--- a/web/src/lib/demo/spire.ts
+++ b/web/src/lib/demo/spire.ts
@@ -14,7 +14,7 @@
  *   - Trust bundle age (how long since the last rotation)
  */
 
-import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY, MS_PER_HOUR, MS_PER_DAY } from '../constants/time'
+import { MS_PER_HOUR, MS_PER_DAY } from '../constants/time'
 
 // ---------------------------------------------------------------------------
 // Types

--- a/web/src/lib/demo/tuf.ts
+++ b/web/src/lib/demo/tuf.ts
@@ -8,6 +8,8 @@
  * metadata has expired or is about to expire.
  */
 
+import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY, MS_PER_DAY } from '../constants/time'
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -57,12 +59,6 @@ export interface TufStatusData {
 // ---------------------------------------------------------------------------
 
 // Named constants (no magic numbers)
-const MS_PER_SECOND = 1000
-const SECONDS_PER_MINUTE = 60
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
-const MS_PER_DAY =
-  MS_PER_SECOND * SECONDS_PER_MINUTE * MINUTES_PER_HOUR * HOURS_PER_DAY
 
 // Role expiration offsets (days from "now") chosen to mirror realistic TUF
 // cadence: timestamp rotates daily, snapshot weekly, targets monthly, root yearly.

--- a/web/src/lib/demo/tuf.ts
+++ b/web/src/lib/demo/tuf.ts
@@ -8,7 +8,7 @@
  * metadata has expired or is about to expire.
  */
 
-import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY, MS_PER_DAY } from '../constants/time'
+import { MS_PER_DAY } from '../constants/time'
 
 // ---------------------------------------------------------------------------
 // Types

--- a/web/src/lib/errorClassifier.ts
+++ b/web/src/lib/errorClassifier.ts
@@ -3,6 +3,8 @@
  * and providing actionable suggestions to users.
  */
 
+import { SECONDS_PER_MINUTE } from './constants/time'
+
 export type ClusterErrorType = 'timeout' | 'auth' | 'network' | 'certificate' | 'unknown'
 
 export interface ClassifiedError {
@@ -163,7 +165,6 @@ function truncateMessage(message: string, maxLength = 100): string {
 }
 
 // Time boundary constants for relative time formatting (in seconds)
-const SECONDS_PER_MINUTE = 60
 const SECONDS_PER_HOUR = 3_600
 const SECONDS_PER_DAY = 86_400
 const TWO_MINUTES_IN_SECONDS = 120

--- a/web/src/lib/unified/card/renderers/registry.ts
+++ b/web/src/lib/unified/card/renderers/registry.ts
@@ -14,10 +14,9 @@ import {
   formatPercent,
   formatDuration,
 } from '../../../stats/types'
+import { MINUTES_PER_HOUR, HOURS_PER_DAY } from '../../../constants/time'
 
 // ── Time boundary constants for relative time formatting ────────────────
-const MINUTES_PER_HOUR = 60
-const HOURS_PER_DAY = 24
 const DAYS_PER_MONTH = 30
 const MONTHS_PER_YEAR = 12
 const DAYS_PER_YEAR = 365


### PR DESCRIPTION
## Summary
- Create `lib/constants/time.ts` with 7 shared time-unit constants
- Replace ~70 local definitions across 39 source files with imports
- Net -89 lines removed, zero behavior change

Fixes #10147

## Files changed
- **NEW** `web/src/lib/constants/time.ts` — shared time constants
- 39 source files: removed local `const MS_PER_*` / `SECONDS_PER_*` / `MINUTES_PER_*` / `HOURS_PER_*` definitions, added imports from time.ts

## What was NOT changed
- Test files (keep local defs for isolation)
- `lib/formatters.ts` (private non-exported defs)
- Function-body locals (only module-level replaced)

## Test plan
- [x] `npm run build` passes
- [ ] CI build/lint/tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)