### PR TITLE
🐛 Fix cross-browser Playwright failures on Firefox

### DIFF
--- a/web/e2e/Clusters.spec.ts
+++ b/web/e2e/Clusters.spec.ts
@@ -72,9 +72,11 @@ test.describe('Clusters Page', () => {
       await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
 
       // Should show cluster names from our mock data
-      await expect(page.getByText('prod-east')).toBeVisible({ timeout: 5000 })
-      await expect(page.getByText('prod-west')).toBeVisible()
-      await expect(page.getByText('staging')).toBeVisible()
+      // Firefox renders mock data slightly later — use consistent timeouts
+      const CLUSTER_NAME_TIMEOUT_MS = 10_000
+      await expect(page.getByText('prod-east')).toBeVisible({ timeout: CLUSTER_NAME_TIMEOUT_MS })
+      await expect(page.getByText('prod-west')).toBeVisible({ timeout: CLUSTER_NAME_TIMEOUT_MS })
+      await expect(page.getByText('staging')).toBeVisible({ timeout: CLUSTER_NAME_TIMEOUT_MS })
     })
 
     test('shows cluster health status indicators', async ({ page }) => {
@@ -157,8 +159,10 @@ test.describe('Clusters Page', () => {
     test('page has heading', async ({ page }) => {
       await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
 
-      // Should have a heading with "Clusters"
-      await expect(page.getByRole('heading', { name: /clusters/i })).toBeVisible()
+      // Should have a heading with "Clusters" — use the DashboardHeader testid
+      // to avoid strict-mode violations when card titles also match /clusters/i
+      await expect(page.getByTestId('dashboard-title')).toBeVisible()
+      await expect(page.getByTestId('dashboard-title')).toContainText(/clusters/i)
     })
   })
 
@@ -198,8 +202,10 @@ test.describe('Clusters Page', () => {
       await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
 
       // The Healthy filter button should show count 2 (both node-healthy-flag-false and flag-healthy-no-nodes)
+      // Firefox renders filter tabs slightly later — use generous timeout
+      const FILTER_TAB_TIMEOUT_MS = 10_000
       const healthyTab = page.getByRole('button', { name: /Healthy \(2\)/ })
-      await expect(healthyTab).toBeVisible({ timeout: 5000 })
+      await expect(healthyTab).toBeVisible({ timeout: FILTER_TAB_TIMEOUT_MS })
 
       // Click the Healthy filter
       await healthyTab.click()
@@ -241,8 +247,9 @@ test.describe('Clusters Page', () => {
       await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
 
       // The Unhealthy tab must show count 1
+      const FILTER_TAB_TIMEOUT_MS = 10_000
       const unhealthyTab = page.getByRole('button', { name: /Unhealthy \(1\)/ })
-      await expect(unhealthyTab).toBeVisible({ timeout: 5000 })
+      await expect(unhealthyTab).toBeVisible({ timeout: FILTER_TAB_TIMEOUT_MS })
 
       // Click the Unhealthy filter
       await unhealthyTab.click()

--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -20,8 +20,9 @@ test.describe('Dashboard Page', () => {
     test('displays navigation items in sidebar', async ({ page }, testInfo) => {
       test.skip(testInfo.project.name.startsWith('mobile-'), 'sidebar is hidden by design on mobile breakpoints')
       // Sidebar should have navigation
-      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: 5000 })
-      await expect(page.getByTestId('sidebar-primary-nav')).toBeVisible()
+      const SIDEBAR_NAV_TIMEOUT_MS = 10_000
+      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: SIDEBAR_NAV_TIMEOUT_MS })
+      await expect(page.getByTestId('sidebar-primary-nav')).toBeVisible({ timeout: SIDEBAR_NAV_TIMEOUT_MS })
 
       // Should have navigation links
       const navLinks = page.getByTestId('sidebar-primary-nav').locator('a')
@@ -160,7 +161,8 @@ test.describe('Dashboard Page', () => {
     test('shows loading state initially', async ({ page }) => {
       // Delay the API response to see loading state
       await page.route('**/api/mcp/**', async (route) => {
-        await new Promise((resolve) => setTimeout(resolve, 2000))
+        const API_DELAY_MS = 2000
+        await new Promise((resolve) => setTimeout(resolve, API_DELAY_MS))
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
@@ -175,9 +177,11 @@ test.describe('Dashboard Page', () => {
       })
 
       await page.goto('/')
+      await page.waitForLoadState('domcontentloaded')
 
       // Dashboard page should be visible even during loading
-      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 10000 })
+      const PAGE_VISIBLE_TIMEOUT_MS = 15_000
+      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: PAGE_VISIBLE_TIMEOUT_MS })
     })
 
     test('handles API errors gracefully', async ({ page }) => {
@@ -196,9 +200,11 @@ test.describe('Dashboard Page', () => {
       })
 
       await page.goto('/')
+      await page.waitForLoadState('domcontentloaded')
 
       // Dashboard should still render (not crash)
-      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 10000 })
+      const PAGE_VISIBLE_TIMEOUT_MS = 15_000
+      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: PAGE_VISIBLE_TIMEOUT_MS })
     })
 
     test('refresh button triggers data reload', async ({ page }) => {
@@ -353,6 +359,10 @@ test.describe('Dashboard Page', () => {
       await page.goto('/clusters')
       await page.waitForLoadState('domcontentloaded')
 
+      // Wait for clusters page to fully render — Firefox may need extra time
+      const PAGE_RENDER_TIMEOUT_MS = 15_000
+      await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: PAGE_RENDER_TIMEOUT_MS }).catch(() => {})
+
       // The clusters page renders a row per cluster. We count any element
       // whose data-testid matches the cluster-row pattern. If the test
       // infra doesn't expose cluster-row testids, fall back to counting
@@ -363,12 +373,13 @@ test.describe('Dashboard Page', () => {
       let clustersPageCount = rowCountByTestId
       if (clustersPageCount === 0) {
         // Fallback: count unique cluster-name text occurrences.
+        const NAME_CHECK_TIMEOUT_MS = 5_000
         let found = 0
         for (let i = 1; i <= EXPECTED_CLUSTER_COUNT; i++) {
           const hasName = await page
             .getByText(`accuracy-cluster-${i}`)
             .first()
-            .isVisible()
+            .isVisible({ timeout: NAME_CHECK_TIMEOUT_MS })
             .catch(() => false)
           if (hasName) found++
         }
@@ -382,7 +393,7 @@ test.describe('Dashboard Page', () => {
       await page.goto('/')
       await page.waitForLoadState('domcontentloaded')
       await expect(page.getByTestId('dashboard-page')).toBeVisible({
-        timeout: 10000,
+        timeout: PAGE_RENDER_TIMEOUT_MS,
       })
 
       // PR #6574 items A+B — target the StatBlock for `clusters` directly
@@ -392,8 +403,9 @@ test.describe('Dashboard Page', () => {
       // through to the structural fallback. Now we address the block
       // directly and use a word-boundary regex so the count can't
       // false-positive on substrings (e.g. "3" matching inside "30 nodes").
+      const STAT_BLOCK_TIMEOUT_MS = 10_000
       const clusterStatBlock = page.getByTestId('stat-block-clusters').first()
-      const hasStatBlock = await clusterStatBlock.isVisible().catch(() => false)
+      const hasStatBlock = await clusterStatBlock.isVisible({ timeout: STAT_BLOCK_TIMEOUT_MS }).catch(() => false)
       if (hasStatBlock) {
         // Word-boundary match: the StatBlock wraps the numeric value in a
         // div with header text ("Clusters") and optional sublabel, so we
@@ -413,7 +425,7 @@ test.describe('Dashboard Page', () => {
           .getByRole('status')
           .filter({ hasText: /cluster/i })
           .first()
-        const labelVisible = await countByLabel.isVisible().catch(() => false)
+        const labelVisible = await countByLabel.isVisible({ timeout: STAT_BLOCK_TIMEOUT_MS }).catch(() => false)
         if (labelVisible) {
           await expect(countByLabel).toHaveText(
             new RegExp(`\\b${EXPECTED_CLUSTER_COUNT}\\b`)

--- a/web/e2e/Events.spec.ts
+++ b/web/e2e/Events.spec.ts
@@ -90,9 +90,11 @@ test.describe('Events Page', () => {
     test('shows event reasons from mock data', async ({ page }) => {
       await expect(page.getByTestId('dashboard-header')).toBeVisible({ timeout: 10000 })
 
-      // Reasons from our mock data
+      // Reasons from our mock data — Firefox renders card content later,
+      // so use a generous timeout for cross-browser reliability. #10134
+      const EVENT_REASON_TIMEOUT_MS = 10_000
       const backoffText = page.getByText(/BackOff|FailedScheduling|Scheduled/i).first()
-      await expect(backoffText).toBeVisible({ timeout: 5000 })
+      await expect(backoffText).toBeVisible({ timeout: EVENT_REASON_TIMEOUT_MS })
     })
   })
 

--- a/web/e2e/Settings.spec.ts
+++ b/web/e2e/Settings.spec.ts
@@ -89,7 +89,10 @@ test.describe('Settings Page', () => {
 
       // Verify the theme is actually applied to the DOM, not just stored. #9521
       // The app sets class="light" or class="dark" on <html>.
-      await expect(page.locator('html')).toHaveClass(/light/)
+      // Firefox may apply the class slightly after domcontentloaded — use
+      // a generous timeout for cross-browser reliability. #10134
+      const THEME_CLASS_TIMEOUT_MS = 10_000
+      await expect(page.locator('html')).toHaveClass(/light/, { timeout: THEME_CLASS_TIMEOUT_MS })
     })
   })
 

--- a/web/e2e/Sidebar.spec.ts
+++ b/web/e2e/Sidebar.spec.ts
@@ -65,8 +65,9 @@ test.describe('Sidebar Navigation', () => {
   test.describe('Navigation Links', () => {
     test('displays sidebar with primary navigation', async ({ page }) => {
       // Wait for sidebar to be visible
-      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: 10000 })
-      await expect(page.getByTestId('sidebar-primary-nav')).toBeVisible()
+      const SIDEBAR_TIMEOUT_MS = 10_000
+      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
+      await expect(page.getByTestId('sidebar-primary-nav')).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
 
       // Should have navigation links
       const navLinks = page.getByTestId('sidebar-primary-nav').locator('a')
@@ -75,41 +76,44 @@ test.describe('Sidebar Navigation', () => {
     })
 
     test('dashboard link navigates to home', async ({ page }) => {
-      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: 10000 })
+      const SIDEBAR_TIMEOUT_MS = 10_000
+      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
 
       // Find dashboard link by href since sidebar uses NavLink with icons + text
       const dashboardLink = page.getByTestId('sidebar-primary-nav').locator('a[href="/"]').first()
-      await expect(dashboardLink).toBeVisible({ timeout: 5000 })
+      await expect(dashboardLink).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
       await dashboardLink.click()
 
       // Should be on dashboard
-      await expect(page).toHaveURL(/^\/$/, { timeout: 5000 })
+      await expect(page).toHaveURL(/^\/$/, { timeout: SIDEBAR_TIMEOUT_MS })
     })
 
     test('clusters link navigates to clusters page', async ({ page }) => {
-      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: 10000 })
+      const SIDEBAR_TIMEOUT_MS = 10_000
+      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
 
-      // Find clusters link by href
+      // Find clusters link by href — fall back to sidebar-scoped locator
       const clustersLink = page.getByTestId('sidebar-primary-nav').locator('a[href="/clusters"]').first()
         .or(page.getByTestId('sidebar').locator('a[href="/clusters"]').first())
-      await expect(clustersLink).toBeVisible({ timeout: 5000 })
+      await expect(clustersLink).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
       await clustersLink.click()
 
       // Should be on clusters page
-      await expect(page).toHaveURL(/\/clusters/, { timeout: 5000 })
+      await expect(page).toHaveURL(/\/clusters/, { timeout: SIDEBAR_TIMEOUT_MS })
     })
 
     test('events link navigates to events page', async ({ page }) => {
-      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: 10000 })
+      const SIDEBAR_TIMEOUT_MS = 10_000
+      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
 
-      // Find events link by href
+      // Find events link by href — fall back to sidebar-scoped locator
       const eventsLink = page.getByTestId('sidebar-primary-nav').locator('a[href="/events"]').first()
         .or(page.getByTestId('sidebar').locator('a[href="/events"]').first())
-      await expect(eventsLink).toBeVisible({ timeout: 5000 })
+      await expect(eventsLink).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
       await eventsLink.click()
 
       // Should be on events page
-      await expect(page).toHaveURL(/\/events/, { timeout: 5000 })
+      await expect(page).toHaveURL(/\/events/, { timeout: SIDEBAR_TIMEOUT_MS })
     })
   })
 
@@ -321,15 +325,18 @@ test.describe('Sidebar Navigation', () => {
       await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: 10000 })
 
       // Collapse sidebar
+      const COLLAPSE_TIMEOUT_MS = 5_000
       await page.getByTestId('sidebar-collapse-toggle').click()
-      await expect(page.getByTestId('sidebar-add-card')).not.toBeVisible({ timeout: 5000 })
+      await expect(page.getByTestId('sidebar-add-card')).not.toBeVisible({ timeout: COLLAPSE_TIMEOUT_MS })
 
       // Navigate to clusters
       await page.goto('/clusters')
       await page.waitForLoadState('domcontentloaded')
 
       // Sidebar should still be collapsed (Add Card hidden)
-      await expect(page.getByTestId('sidebar-add-card')).not.toBeVisible()
+      // Firefox may need extra time to apply persisted sidebar state. #10134
+      const PERSIST_CHECK_TIMEOUT_MS = 10_000
+      await expect(page.getByTestId('sidebar-add-card')).not.toBeVisible({ timeout: PERSIST_CHECK_TIMEOUT_MS })
     })
   })
 })

--- a/web/e2e/nightly/rce-vector-scan.spec.ts
+++ b/web/e2e/nightly/rce-vector-scan.spec.ts
@@ -168,7 +168,10 @@ test('RCE vector scan — all attack surfaces', async ({ page }, testInfo) => {
     demoUserOnboarded: true,
   })
   await setupMocks(page)
+  // Firefox WebSocket connections may prevent networkidle from settling —
+  // fall back to domcontentloaded on timeout. #10134
   await page.goto('/', { waitUntil: 'networkidle', timeout: PAGE_LOAD_TIMEOUT_MS })
+    .catch(() => page.waitForLoadState('domcontentloaded'))
 
   // ══════════════════════════════════════════════════════════════════════
   // Phase 2: DOM XSS Vectors

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -67,9 +67,9 @@ test.describe('Smoke Tests', () => {
       await waitForNetworkIdleBestEffort(page)
 
       const navLinks = [
-        { text: 'Clusters', expectedPath: '/clusters' },
-        { text: 'Deploy', expectedPath: '/deploy' },
-        { text: 'Settings', expectedPath: '/settings' },
+        { href: '/clusters', expectedPath: '/clusters' },
+        { href: '/deploy', expectedPath: '/deploy' },
+        { href: '/settings', expectedPath: '/settings' },
       ]
 
       // Scope to the sidebar (data-testid="sidebar") because the main <nav>
@@ -97,17 +97,18 @@ test.describe('Smoke Tests', () => {
         }
       }
 
-      for (const { text, expectedPath } of navLinks) {
-        // Use `.first()` to guard against duplicate renderings (e.g., when a
-        // responsive variant renders both a mobile and desktop label).
-        await sidebar.getByText(text, { exact: true }).first().click()
+      for (const { href, expectedPath } of navLinks) {
+        // Use href-based locators for cross-browser reliability — text labels
+        // can differ (e.g. "My Clusters" vs "Clusters") and exact text
+        // matching is fragile across browsers. #10134
+        const link = sidebar.locator(`a[href="${href}"]`).first()
+        await expect(link).toBeVisible({ timeout: 5000 })
+        await link.click()
         await waitForNetworkIdleBestEffort(page, NETWORK_IDLE_TIMEOUT_MS, `nav to ${expectedPath}`)
         expect(page.url()).toContain(expectedPath)
         // Re-open mobile sidebar if navigation closed it.
         if (viewportSize && viewportSize.width < MOBILE_SIDEBAR_MAX_WIDTH_PX) {
-          const stillVisible = await sidebar
-            .getByText(text, { exact: true })
-            .first()
+          const stillVisible = await link
             .isVisible({ timeout: HAMBURGER_PROBE_TIMEOUT_MS })
             .catch(() => false)
           if (!stillVisible) {
@@ -184,6 +185,7 @@ test.describe('Smoke Tests', () => {
     test('settings page interactions work', async ({ page }) => {
       await setupDemoMode(page)
       await page.goto('/settings')
+      await page.waitForLoadState('domcontentloaded')
       await waitForNetworkIdleBestEffort(page)
 
       // Check for theme toggle

--- a/web/src/components/layout/SidebarShell.tsx
+++ b/web/src/components/layout/SidebarShell.tsx
@@ -550,7 +550,7 @@ export function SidebarShell({
 
         {/* Section items */}
         {(isOpen || !section.collapsible) && (
-          <nav className="space-y-1">
+          <nav data-testid={`sidebar-${section.id}-nav`} className="space-y-1">
             {section.items.map(item => renderNavItem(item, section.id))}
           </nav>
         )}
@@ -609,6 +609,7 @@ export function SidebarShell({
               {/* "Add more" button — placed after the primary dashboard list */}
               {index === PRIMARY_SECTION_INDEX && features.addMore && !isCollapsed && (
                 <button
+                  data-testid="sidebar-customize"
                   onClick={() => onAddMore?.() ?? dashboardContext?.openAddCardModal('dashboards')}
                   className="w-full flex items-center gap-3 px-3 py-1.5 mt-1 text-xs text-muted-foreground/60 hover:text-muted-foreground hover:bg-secondary/30 rounded-lg transition-colors"
                 >


### PR DESCRIPTION
Fixes #10134

## Problem
17+ Playwright tests fail on Firefox (and likely webkit/mobile) in the nightly cross-browser workflow, while all pass on Chromium.

## Root Causes & Fixes

### Component fix: Missing test anchors in SidebarShell
- Added `data-testid="sidebar-primary-nav"` and `data-testid="sidebar-secondary-nav"` to the `<nav>` elements in `SidebarShell.tsx`. Many tests relied on `sidebar-primary-nav` but it didn't exist in the DOM.
- Added `data-testid="sidebar-customize"` to the "Add more" button for custom-dashboard tests.

### Test fixes
- **Clusters heading strict mode**: Replaced `getByRole('heading', {name: /clusters/i})` (which matched both the page `<h1>` and card `<h3>` titles) with `getByTestId('dashboard-title')` for precision.
- **smoke.spec.ts nav links**: Replaced `getByText('Clusters', {exact: true})` (which can't match "My Clusters") with href-based locators for cross-browser reliability.
- **Timeout hardening**: Added named timeout constants throughout all affected tests. Firefox renders slower than Chromium, so assertions need generous timeouts.
- **RCE vector scan**: Added `domcontentloaded` fallback for `networkidle` waits that hang on Firefox due to persistent WebSocket connections.

### Files changed
- `web/src/components/layout/SidebarShell.tsx` — add missing data-testid attributes
- `web/e2e/Clusters.spec.ts` — fix heading locator + timeouts
- `web/e2e/Dashboard.spec.ts` — add timeouts for Firefox
- `web/e2e/Events.spec.ts` — increase timeout
- `web/e2e/Settings.spec.ts` — add timeout for theme class check
- `web/e2e/Sidebar.spec.ts` — add timeouts for nav assertions
- `web/e2e/smoke.spec.ts` — use href-based nav locators
- `web/e2e/nightly/rce-vector-scan.spec.ts` — networkidle fallback

### Verified
- `npm run build` ✅
- `npm run lint` ✅ (no new issues)