### PR TITLE
⚡ Lazy-load ECharts in 18 card files via shared LazyEChart wrapper

### DIFF
--- a/web/src/components/acmm/TargetBalanceCharts.tsx
+++ b/web/src/components/acmm/TargetBalanceCharts.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useMemo } from 'react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../charts/LazyEChart'
 import {
   CHART_TOOLTIP_BG,
   CHART_TOOLTIP_BORDER,
@@ -148,7 +148,7 @@ export function TargetBalanceCharts({ level }: TargetBalanceChartsProps) {
   return (
     <div className="grid grid-cols-2 gap-2">
       <div>
-        <ReactECharts
+        <LazyEChart
           option={prOption}
           notMerge={false}
           style={{ height: CHART_HEIGHT_PX, width: '100%' }}
@@ -159,7 +159,7 @@ export function TargetBalanceCharts({ level }: TargetBalanceChartsProps) {
         </div>
       </div>
       <div>
-        <ReactECharts
+        <LazyEChart
           option={issueOption}
           notMerge={false}
           style={{ height: CHART_HEIGHT_PX, width: '100%' }}

--- a/web/src/components/cards/EventsTimeline.tsx
+++ b/web/src/components/cards/EventsTimeline.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
 import { Activity, AlertTriangle, CheckCircle, Clock, Server } from 'lucide-react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../charts/LazyEChart'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedEvents } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
@@ -345,7 +345,7 @@ function EventsTimelineInternal() {
           </div>
         ) : (
           <div style={{ width: '100%', minHeight: CHART_HEIGHT_STANDARD, height: CHART_HEIGHT_STANDARD }} role="img" aria-label={`Events timeline chart showing ${totalWarnings} warnings and ${totalNormal} normal events, peak ${peakEvents} events`}>
-            <ReactECharts
+            <LazyEChart
               option={chartOption}
               style={{ height: CHART_HEIGHT_STANDARD, width: '100%' }}
               notMerge={true}

--- a/web/src/components/cards/GPUInventoryHistory.tsx
+++ b/web/src/components/cards/GPUInventoryHistory.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useRef, useEffect } from 'react'
 import {
   Cpu, TrendingUp, TrendingDown, Minus, Clock, Server,
   BarChart3, Table2, ChevronDown, ArrowUpDown } from 'lucide-react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../charts/LazyEChart'
 import { useMetricsHistory } from '../../hooks/useMetricsHistory'
 import type { MetricsSnapshot } from '../../types/predictions'
 import { useCachedGPUNodes } from '../../hooks/useCachedData'
@@ -317,7 +317,7 @@ function GPUInventoryChart({ displayChartData, chartMode, chartGPUTypes, t }: {
   }, [displayChartData, chartMode, chartGPUTypes, t])
 
   return (
-    <ReactECharts
+    <LazyEChart
       option={chartOption}
       style={{ height: CHART_HEIGHT_STANDARD, width: '100%' }}
       notMerge={true}

--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { TrendingUp, Cpu, Server, Clock } from 'lucide-react'
 import { CardClusterFilter } from '../../lib/cards/CardComponents'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../charts/LazyEChart'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
@@ -493,7 +493,7 @@ export function GPUUsageTrend() {
           </div>
         ) : (
           <div style={{ width: '100%', minHeight: CHART_HEIGHT_STANDARD, height: CHART_HEIGHT_STANDARD }} role="img" aria-label={`GPU usage trend chart: ${currentTotals.allocated} of ${currentTotals.available} GPUs in use (${usagePercent}% utilization)`}>
-            <ReactECharts
+            <LazyEChart
               option={chartOption}
               style={{ height: CHART_HEIGHT_STANDARD, width: '100%' }}
               notMerge={true}

--- a/web/src/components/cards/GPUUtilization.tsx
+++ b/web/src/components/cards/GPUUtilization.tsx
@@ -5,7 +5,7 @@ import { useGPUTaintFilter, GPUTaintFilterControl } from './GPUTaintFilter'
 import { Skeleton, SkeletonStats } from '../ui/Skeleton'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardLoadingState } from './CardDataContext'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../charts/LazyEChart'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
@@ -346,7 +346,7 @@ export function GPUUtilization() {
       {/* Stats and pie chart row */}
       <div className="flex items-center gap-4 mb-4">
         <div className="w-20 h-20 relative" style={{ minWidth: GPU_RING_SIZE_PX, minHeight: GPU_RING_SIZE_PX }}>
-          <ReactECharts
+          <LazyEChart
             option={pieOption}
             style={{ height: GPU_RING_SIZE_PX, width: GPU_RING_SIZE_PX }}
             notMerge={true}
@@ -384,7 +384,7 @@ export function GPUUtilization() {
           </div>
         ) : (
           <div style={{ width: '100%', minHeight: CHART_HEIGHT_COMPACT, height: CHART_HEIGHT_COMPACT }}>
-            <ReactECharts
+            <LazyEChart
               option={trendOption}
               style={{ height: CHART_HEIGHT_COMPACT, width: '100%' }}
               notMerge={true}

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -9,7 +9,8 @@
  */
 
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../charts/LazyEChart'
+import type ReactEChartsType from 'echarts-for-react'
 import { Calendar, RefreshCw, GitPullRequest } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../ui/Skeleton'
@@ -317,7 +318,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
     start: ZOOM_RANGE_START,
     end: ZOOM_RANGE_END,
   })
-  const chartRef = useRef<ReactECharts>(null)
+  const chartRef = useRef<ReactEChartsType>(null)
 
   const hasData = stats.length > 0
   useCardLoadingState({ isLoading: isLoading && !hasData, hasAnyData: hasData, isDemoData: isDemoMode || isDemoFallback })
@@ -666,7 +667,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
 
       {/* Chart */}
       <div className="w-full overflow-hidden" style={{ minWidth: 0 }}>
-        <ReactECharts
+        <LazyEChart
           ref={chartRef}
           option={chartOption}
           style={{ height: CHART_HEIGHT_PX, width: '100%' }}

--- a/web/src/components/cards/PodHealthTrend.tsx
+++ b/web/src/components/cards/PodHealthTrend.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useEffect, useRef } from 'react'
 import { CheckCircle, AlertTriangle, Clock, Server } from 'lucide-react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../charts/LazyEChart'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedPodIssues } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
@@ -429,7 +429,7 @@ export function PodHealthTrend() {
           </div>
         ) : (
           <div style={{ width: '100%', minHeight: CHART_HEIGHT_STANDARD, height: CHART_HEIGHT_STANDARD }}>
-            <ReactECharts
+            <LazyEChart
               option={chartOption}
               style={{ height: CHART_HEIGHT_STANDARD, width: '100%' }}
               notMerge={true}

--- a/web/src/components/cards/ResourceTrend.tsx
+++ b/web/src/components/cards/ResourceTrend.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { TrendingUp, Cpu, MemoryStick, Box, Server, Clock } from 'lucide-react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../charts/LazyEChart'
 import { useClusters } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useCardLoadingState } from './CardDataContext'
@@ -363,7 +363,7 @@ export function ResourceTrend() {
           </div>
         ) : (
           <div style={{ width: '100%', minHeight: CHART_HEIGHT_STANDARD, height: CHART_HEIGHT_STANDARD }} role="img" aria-label={`Resource trend chart showing ${lines.map(l => l.name).join(', ')} over time`}>
-            <ReactECharts
+            <LazyEChart
               option={chartOption}
               style={{ height: CHART_HEIGHT_STANDARD, width: '100%' }}
               notMerge={true}

--- a/web/src/components/cards/change_timeline/ChangeTimeline.tsx
+++ b/web/src/components/cards/change_timeline/ChangeTimeline.tsx
@@ -6,7 +6,7 @@
  * Click a dot → drills down to EventsDrillDown for that cluster.
  */
 import { useState, useMemo, useCallback } from 'react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../../charts/LazyEChart'
 import { Clock, Activity } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useCardLoadingState } from '../CardDataContext'
@@ -240,7 +240,7 @@ export function ChangeTimeline({ config: _config }: ChangeTimelineProps) {
       </div>
 
       {/* Chart */}
-      <ReactECharts
+      <LazyEChart
         option={chartOption}
         style={{ height: `${CHART_HEIGHT_PX}px`, width: '100%' }}
         onEvents={onEvents}

--- a/web/src/components/cards/insights/ClusterDeltaDetector.tsx
+++ b/web/src/components/cards/insights/ClusterDeltaDetector.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import { GitCompare, ChevronRight } from 'lucide-react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../../charts/LazyEChart'
 import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
 import { useCardLoadingState } from '../CardDataContext'
 import { InsightSourceBadge } from './InsightSourceBadge'
@@ -175,7 +175,7 @@ export function ClusterDeltaDetector() {
           {/* Numeric deltas as bar chart */}
           {numericDeltas.length > 0 && allClusters.length >= 2 && (
             <div className="h-32">
-              <ReactECharts
+              <LazyEChart
                 option={chartOption}
                 style={{ height: CHART_HEIGHT_SM, width: '100%' }}
                 notMerge={true}

--- a/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
+++ b/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { Activity, ChevronRight } from 'lucide-react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../../charts/LazyEChart'
 import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
 import { useCachedWarningEvents } from '../../../hooks/useCachedData'
 import { useCardLoadingState } from '../CardDataContext'
@@ -141,7 +141,7 @@ export function CrossClusterEventCorrelation() {
       {/* Timeline chart */}
       {chartData.length > 0 && (
         <div className="h-40">
-          <ReactECharts
+          <LazyEChart
             option={chartOption}
             style={{ height: CHART_HEIGHT_STANDARD, width: '100%' }}
             notMerge={true}

--- a/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
+++ b/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import { Rocket, CheckCircle2, AlertTriangle, Clock, ChevronRight } from 'lucide-react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../../charts/LazyEChart'
 import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
 import { useCardLoadingState } from '../CardDataContext'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
@@ -181,7 +181,7 @@ export function DeploymentRolloutTracker() {
           {/* Per-cluster progress chart */}
           {clusterProgress.length > 0 && (
             <div className="h-32">
-              <ReactECharts
+              <LazyEChart
                 option={chartOption}
                 style={{ height: CHART_HEIGHT_SM, width: '100%' }}
                 notMerge={true}

--- a/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
+++ b/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { Scale, ChevronRight } from 'lucide-react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../../charts/LazyEChart'
 import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
 import { useCardLoadingState } from '../CardDataContext'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
@@ -157,7 +157,7 @@ export function ResourceImbalanceDetector() {
 
       {chartData.length > 0 && (
         <div className="h-48">
-          <ReactECharts
+          <LazyEChart
             option={chartOption}
             style={{ height: CHART_HEIGHT_LG, width: '100%' }}
             notMerge={true}

--- a/web/src/components/cards/llmd/LatencyBreakdown.tsx
+++ b/web/src/components/cards/llmd/LatencyBreakdown.tsx
@@ -6,7 +6,7 @@
  * Shows how latency degrades as load increases.
  */
 import { useState, useMemo } from 'react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../../charts/LazyEChart'
 import { Clock, AlertTriangle } from 'lucide-react'
 import { useReportCardDataState } from '../CardDataContext'
 import { useCachedBenchmarkReports } from '../../../hooks/useBenchmarkData'
@@ -260,7 +260,7 @@ function LatencyBreakdownInternal() {
       {/* Chart */}
       <div className="flex-1 min-h-0" style={{ minHeight: CHART_MIN_HEIGHT_PX }}>
         {chartData.length > 0 ? (
-          <ReactECharts
+          <LazyEChart
             option={chartOption}
             style={{ height: '100%', width: '100%' }}
             notMerge={true}

--- a/web/src/components/cards/llmd/ParetoFrontier.tsx
+++ b/web/src/components/cards/llmd/ParetoFrontier.tsx
@@ -8,7 +8,8 @@
  * Connected smooth scatter lines with GPU count labels. Built with ECharts.
  */
 import { useState, useMemo, useRef } from 'react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../../charts/LazyEChart'
+import type ReactEChartsType from 'echarts-for-react'
 import { Download, RotateCcw } from 'lucide-react'
 import { useReportCardDataState } from '../CardDataContext'
 import { useCachedBenchmarkReports } from '../../../hooks/useBenchmarkData'
@@ -239,7 +240,7 @@ interface ParetoFrontierProps {
 
 function ParetoFrontierInternal({ config }: ParetoFrontierProps) {
   const { t } = useTranslation(['cards', 'common'])
-  const chartRef = useRef<ReactECharts>(null)
+  const chartRef = useRef<ReactEChartsType>(null)
 
   // ---- Data ----
   const { data: reports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing, lastRefresh } = useCachedBenchmarkReports()
@@ -549,7 +550,7 @@ function ParetoFrontierInternal({ config }: ParetoFrontierProps) {
       <div className="flex flex-1 min-h-0 gap-2">
         {/* ECharts chart */}
         <div className="flex-1 min-w-0 rounded overflow-hidden" style={{ minHeight: CHART_MIN_HEIGHT_PX }}>
-          <ReactECharts
+          <LazyEChart
             ref={chartRef}
             option={option}
             style={{ height: '100%', width: '100%' }}

--- a/web/src/components/cards/llmd/ResourceUtilization.tsx
+++ b/web/src/components/cards/llmd/ResourceUtilization.tsx
@@ -6,7 +6,7 @@
  * Highlight best-in-class for each metric.
  */
 import { useState, useMemo } from 'react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../../charts/LazyEChart'
 import { BarChart3, Trophy } from 'lucide-react'
 import { RefreshIndicator } from '../../ui/RefreshIndicator'
 import { useReportCardDataState } from '../CardDataContext'
@@ -232,7 +232,7 @@ export function ResourceUtilization() {
       {/* Chart */}
       <div className="flex-1 min-h-0" style={{ minHeight: CHART_MIN_HEIGHT_PX }}>
         {data.length > 0 ? (
-          <ReactECharts
+          <LazyEChart
             option={chartOption}
             style={{ height: '100%', width: '100%' }}
             notMerge={true}

--- a/web/src/components/cards/llmd/ThroughputComparison.tsx
+++ b/web/src/components/cards/llmd/ThroughputComparison.tsx
@@ -6,7 +6,7 @@
  * Filter by experiment category, ISL/OSL, and model.
  */
 import { useState, useMemo } from 'react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../../charts/LazyEChart'
 import { Zap, TrendingUp } from 'lucide-react'
 import { useReportCardDataState } from '../CardDataContext'
 import { useCachedBenchmarkReports } from '../../../hooks/useBenchmarkData'
@@ -210,7 +210,7 @@ export function ThroughputComparison() {
       {/* Chart */}
       <div className="flex-1 min-h-0" style={{ minHeight: CHART_MIN_HEIGHT_PX }}>
         {chartData.length > 0 ? (
-          <ReactECharts
+          <LazyEChart
             option={chartOption}
             style={{ height: '100%', width: '100%' }}
             notMerge={true}

--- a/web/src/components/charts/LazyEChart.tsx
+++ b/web/src/components/charts/LazyEChart.tsx
@@ -1,0 +1,28 @@
+import { lazy, Suspense, type Ref } from 'react'
+import type { EChartsReactProps } from 'echarts-for-react/lib/types'
+import type EChartsReact from 'echarts-for-react'
+
+const SKELETON_MIN_HEIGHT_PX = 120
+
+const ReactEChartsLazy = lazy(() => import('echarts-for-react'))
+
+interface LazyEChartProps extends EChartsReactProps {
+  ref?: Ref<EChartsReact>
+}
+
+function ChartSkeleton({ style }: { style?: React.CSSProperties }) {
+  return (
+    <div
+      className="animate-pulse bg-muted/30 rounded w-full"
+      style={{ minHeight: SKELETON_MIN_HEIGHT_PX, ...style }}
+    />
+  )
+}
+
+export function LazyEChart({ ref, ...props }: LazyEChartProps) {
+  return (
+    <Suspense fallback={<ChartSkeleton style={props.style} />}>
+      <ReactEChartsLazy ref={ref} {...props} />
+    </Suspense>
+  )
+}

--- a/web/src/lib/unified/card/visualizations/ChartVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/ChartVisualization.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useMemo } from 'react'
-import ReactECharts from 'echarts-for-react'
+import { LazyEChart } from '../../../../components/charts/LazyEChart'
 import type { CardContentChart, CardChartSeries, CardAxisConfig } from '../../types'
 import { CHART_TOOLTIP_CONTENT_STYLE_GRAY } from '../../../constants'
 
@@ -214,7 +214,7 @@ function LineChartRenderer({
 
   return (
     <div style={{ width: '100%', height }}>
-      <ReactECharts option={option} style={{ height, width: '100%' }} notMerge={true} opts={{ renderer: 'svg' }} />
+      <LazyEChart option={option} style={{ height, width: '100%' }} notMerge={true} opts={{ renderer: 'svg' }} />
     </div>
   )
 }
@@ -281,7 +281,7 @@ function AreaChartRenderer({
 
   return (
     <div style={{ width: '100%', height }}>
-      <ReactECharts option={option} style={{ height, width: '100%' }} notMerge={true} opts={{ renderer: 'svg' }} />
+      <LazyEChart option={option} style={{ height, width: '100%' }} notMerge={true} opts={{ renderer: 'svg' }} />
     </div>
   )
 }
@@ -344,7 +344,7 @@ function BarChartRenderer({
 
   return (
     <div style={{ width: '100%', height }}>
-      <ReactECharts option={option} style={{ height, width: '100%' }} notMerge={true} opts={{ renderer: 'svg' }} />
+      <LazyEChart option={option} style={{ height, width: '100%' }} notMerge={true} opts={{ renderer: 'svg' }} />
     </div>
   )
 }
@@ -401,7 +401,7 @@ function DonutChartRenderer({
 
   return (
     <div style={{ width: '100%', height }}>
-      <ReactECharts option={option} style={{ height, width: '100%' }} notMerge={true} opts={{ renderer: 'svg' }} />
+      <LazyEChart option={option} style={{ height, width: '100%' }} notMerge={true} opts={{ renderer: 'svg' }} />
     </div>
   )
 }
@@ -440,7 +440,7 @@ function GaugeChartRenderer({
 
   return (
     <div style={{ width: '100%', height }} className="relative">
-      <ReactECharts option={option} style={{ height, width: '100%' }} notMerge={true} opts={{ renderer: 'svg' }} />
+      <LazyEChart option={option} style={{ height, width: '100%' }} notMerge={true} opts={{ renderer: 'svg' }} />
       <div className="absolute inset-0 flex items-center justify-center pt-4">
         <span className="text-2xl font-bold text-foreground">{Math.round(value)}%</span>
       </div>
@@ -479,7 +479,7 @@ function SparklineRenderer({
 
   return (
     <div style={{ width: '100%', height }}>
-      <ReactECharts option={option} style={{ height, width: '100%' }} notMerge={true} opts={{ renderer: 'svg' }} />
+      <LazyEChart option={option} style={{ height, width: '100%' }} notMerge={true} opts={{ renderer: 'svg' }} />
     </div>
   )
 }


### PR DESCRIPTION
Fixes #10150, Fixes #10152

## Summary

- Add `LazyEChart` wrapper component that uses `React.lazy()` + `Suspense` to defer the ~1.14 MB ECharts vendor chunk
- Replace direct `echarts-for-react` imports in 18 card/chart files with the lazy wrapper
- Cards show a skeleton placeholder until the chart chunk loads
- The 6 shared chart components in `components/charts/` keep direct imports (already behind route-level lazy loading)

## Files

- **New:** `web/src/components/charts/LazyEChart.tsx` (28 lines)
- **Updated:** 18 card files — import swap + `<ReactECharts` → `<LazyEChart`

## Test plan

- [x] `npm run build` passes (tsc + vite)
- [x] `npm run lint` passes
- [ ] Cards with charts render correctly after lazy load
- [ ] Skeleton placeholder visible during chunk load
- [ ] Ref-using cards (ParetoFrontier, IssueActivityChart) maintain zoom/download functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)