### PR TITLE
🧹 Consolidate byte/unit conversion constants into lib/constants/units.ts

### DIFF
--- a/web/src/components/cards/tikv_status/index.tsx
+++ b/web/src/components/cards/tikv_status/index.tsx
@@ -16,12 +16,12 @@ import { EmptyState } from '../../ui/EmptyState'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { cn } from '../../../lib/cn'
 import type { TikvStore } from '../../../lib/demo/tikv'
+import { BYTES_PER_GIB } from '../../../lib/constants/units'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
 // ---------------------------------------------------------------------------
 
-const BYTES_PER_GIB = 1024 * 1024 * 1024
 const USAGE_PCT_WARN = 70
 const USAGE_PCT_ALERT = 85
 const PCT_MULTIPLIER = 100

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -15,6 +15,7 @@ import { isDemoMode } from '../../lib/demoMode'
 import { fetchKubaraCatalog, fetchKubaraValues, parseResourceRequests } from '../../lib/kubara'
 import type { KubaraResourceRequests } from '../../lib/kubara'
 import { getDemoMissionControlState } from './demoState'
+import { MILLICORES_PER_CORE, MIB_PER_GIB } from '../../lib/constants/units'
 import type {
   MissionControlState,
   PayloadProject,
@@ -1641,10 +1642,6 @@ Order phases by dependency — prerequisites first. Each phase completes before 
       const clusterScores = new Map<string, number>()
       // #8485 — Track remaining capacity per cluster (in real units) so
       // Kubara resource requests can be subtracted as projects are assigned.
-      /** Millicores per core for unit conversion */
-      const MILLICORES_PER_CORE = 1000
-      /** MiB per GiB for unit conversion */
-      const MIB_PER_GIB = 1024
       const clusterCpuFreeMillicores = new Map<string, number>()
       const clusterMemFreeMiB = new Map<string, number>()
       for (const c of availableClusters) {

--- a/web/src/lib/constants/index.ts
+++ b/web/src/lib/constants/index.ts
@@ -4,3 +4,4 @@
 export * from './network'
 export * from './storage'
 export * from './ui'
+export * from './units'

--- a/web/src/lib/constants/units.ts
+++ b/web/src/lib/constants/units.ts
@@ -1,0 +1,18 @@
+/** Bytes per kibibyte (KiB) */
+export const BYTES_PER_KIB = 1024
+/** Bytes per mebibyte (MiB) */
+export const BYTES_PER_MIB = 1024 * 1024
+/** Bytes per gibibyte (GiB) */
+export const BYTES_PER_GIB = 1024 * 1024 * 1024
+/** Bytes per tebibyte (TiB) */
+export const BYTES_PER_TIB = 1024 * BYTES_PER_GIB
+/** Mebibytes per gibibyte — Gi → Mi conversion factor */
+export const MIB_PER_GIB = 1024
+/** Kibibytes per mebibyte — Ki → Mi conversion factor */
+export const KIB_PER_MIB = 1024
+/** Millicores per CPU core — Kubernetes represents CPU in millicores (1 core = 1000m) */
+export const MILLICORES_PER_CORE = 1000
+/** Decimal gigabyte → mebibyte conversion factor (1 GB = 10^9 bytes / 2^20) */
+export const GB_TO_MIB = (1000 * 1000) / (1024 * 1024)
+/** Decimal megabyte → mebibyte conversion factor (1 MB = 10^6 bytes / 2^20) */
+export const MB_TO_MIB = (1000 * 1000) / (1024 * 1024)

--- a/web/src/lib/demo/dragonfly.ts
+++ b/web/src/lib/demo/dragonfly.ts
@@ -1,3 +1,5 @@
+import { BYTES_PER_GIB } from '../constants/units'
+
 /**
  * Dragonfly Status Card — Demo Data & Type Definitions
  *
@@ -71,8 +73,6 @@ export interface DragonflyStatusData {
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers) — demo values only
 // ---------------------------------------------------------------------------
-
-const BYTES_PER_GIB = 1024 * 1024 * 1024
 
 const DEMO_MANAGER_REPLICAS = 3
 const DEMO_SCHEDULER_REPLICAS = 3

--- a/web/src/lib/demo/longhorn.ts
+++ b/web/src/lib/demo/longhorn.ts
@@ -1,3 +1,5 @@
+import { BYTES_PER_GIB, BYTES_PER_TIB } from '../constants/units'
+
 /**
  * Longhorn Status Card — Demo Data & Type Definitions
  *
@@ -93,9 +95,6 @@ export interface LonghornStatusData {
 // ---------------------------------------------------------------------------
 // Demo data constants — no magic numbers
 // ---------------------------------------------------------------------------
-
-const BYTES_PER_GIB = 1024 * 1024 * 1024
-const BYTES_PER_TIB = 1024 * BYTES_PER_GIB
 
 // Per-volume sizes
 const VOL_SIZE_SMALL_GIB = 10

--- a/web/src/lib/demo/rook.ts
+++ b/web/src/lib/demo/rook.ts
@@ -1,3 +1,5 @@
+import { BYTES_PER_GIB, BYTES_PER_TIB } from '../constants/units'
+
 /**
  * Rook Status Card — Demo Data & Type Definitions
  *
@@ -69,9 +71,6 @@ export interface RookStatusData {
 // ---------------------------------------------------------------------------
 // Demo data constants — no magic numbers
 // ---------------------------------------------------------------------------
-
-const BYTES_PER_GIB = 1024 * 1024 * 1024
-const BYTES_PER_TIB = 1024 * BYTES_PER_GIB
 
 // Primary (production-like) CephCluster
 const PROD_OSD_TOTAL = 12

--- a/web/src/lib/demo/tikv.ts
+++ b/web/src/lib/demo/tikv.ts
@@ -1,3 +1,5 @@
+import { BYTES_PER_GIB } from '../constants/units'
+
 /**
  * TiKV Status Card — Demo Data & Type Definitions
  *
@@ -45,7 +47,6 @@ export interface TikvStatusData {
 // ---------------------------------------------------------------------------
 
 // Named constants (no magic numbers)
-const BYTES_PER_GIB = 1024 * 1024 * 1024
 const DEMO_CAPACITY_GIB = 500
 const DEMO_AVAILABLE_GIB_HEALTHY = 320
 const DEMO_AVAILABLE_GIB_WARM = 180

--- a/web/src/lib/kubara.ts
+++ b/web/src/lib/kubara.ts
@@ -1,3 +1,5 @@
+import { MILLICORES_PER_CORE, MIB_PER_GIB, KIB_PER_MIB, GB_TO_MIB, MB_TO_MIB, BYTES_PER_MIB } from './constants/units'
+
 /**
  * Kubara catalog utilities for Mission Control integration.
  *
@@ -224,24 +226,15 @@ function parseCpuToMillicores(cpu: string): number {
   if (cpu.endsWith('m')) {
     return parseInt(cpu.slice(0, -1), 10) || 0
   }
-  // Whole or decimal cores → millicores
-  const MILLICORES_PER_CORE = 1000
   return Math.round((parseFloat(cpu) || 0) * MILLICORES_PER_CORE)
 }
 
 /** Convert a Kubernetes memory string (e.g. "128Mi", "1Gi", "512M") to MiB */
 function parseMemoryToMiB(mem: string): number {
-  const GI_TO_MIB = 1024
-  const KI_TO_MIB = 1 / 1024
-  const G_TO_MIB = 1000 * 1000 / (1024 * 1024) // ~953.67
-  const M_TO_MIB = 1000 * 1000 / (1024 * 1024)  // ~0.954 per MB
-
-  if (mem.endsWith('Gi')) return Math.round((parseFloat(mem) || 0) * GI_TO_MIB)
+  if (mem.endsWith('Gi')) return Math.round((parseFloat(mem) || 0) * MIB_PER_GIB)
   if (mem.endsWith('Mi')) return Math.round(parseFloat(mem) || 0)
-  if (mem.endsWith('Ki')) return Math.round((parseFloat(mem) || 0) * KI_TO_MIB)
-  if (mem.endsWith('G')) return Math.round((parseFloat(mem) || 0) * G_TO_MIB)
-  if (mem.endsWith('M')) return Math.round((parseFloat(mem) || 0) * M_TO_MIB)
-  // Raw number — assume bytes → MiB
-  const BYTES_PER_MIB = 1024 * 1024
+  if (mem.endsWith('Ki')) return Math.round((parseFloat(mem) || 0) / KIB_PER_MIB)
+  if (mem.endsWith('G')) return Math.round((parseFloat(mem) || 0) * GB_TO_MIB)
+  if (mem.endsWith('M')) return Math.round((parseFloat(mem) || 0) * MB_TO_MIB)
   return Math.round((parseFloat(mem) || 0) / BYTES_PER_MIB)
 }


### PR DESCRIPTION
Fixes #10154

## Summary

- Create `lib/constants/units.ts` with BYTES_PER_KIB/MIB/GIB/TIB, MILLICORES_PER_CORE, MIB_PER_GIB, and decimal conversion factors
- Remove 7 duplicate local definitions across demo data, kubara.ts, tikv_status, and useMissionControl
- Re-export via the constants barrel (`lib/constants/index.ts`)
- No behavioral change — identical constant values

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] Demo mode renders storage cards correctly (Longhorn, Rook, TiKV, Dragonfly)
- [ ] Mission Control cluster sizing calculations unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)