### PR TITLE
🐛 Fix ChartVisualization test failure from LazyEChart Suspense

### DIFF
--- a/web/src/lib/unified/card/visualizations/__tests__/ChartVisualization.test.tsx
+++ b/web/src/lib/unified/card/visualizations/__tests__/ChartVisualization.test.tsx
@@ -57,7 +57,7 @@ describe('ChartVisualization', () => {
   // Line chart
   // -------------------------------------------------------------------------
   describe('line chart', () => {
-    it('renders a line chart with series config', () => {
+    it('renders a line chart with series config', async () => {
       renderChart({
         type: 'chart',
         chartType: 'line',
@@ -65,7 +65,9 @@ describe('ChartVisualization', () => {
         xAxis: 'time',
       })
 
-      expect(screen.getByTestId('echarts-mock')).toBeInTheDocument()
+      // LazyEChart uses React.lazy + Suspense, so the first render shows
+      // a skeleton fallback. Wait for the lazy module to resolve.
+      expect(await screen.findByTestId('echarts-mock')).toBeInTheDocument()
       expect(lastOption).not.toBeNull()
 
       // Series should be type 'line'


### PR DESCRIPTION
Fixes #10153

## Summary

The first test in `ChartVisualization.test.tsx` fails because `LazyEChart` (introduced in PR #10151) uses `React.lazy` + `Suspense`. On first render, the lazy module hasn't resolved yet so the Suspense fallback skeleton is shown instead of the mocked echarts component.

## Fix

Make the first test async and use `findByTestId` (which polls) instead of `getByTestId` to wait for the Suspense boundary to resolve.

## Test plan
- [x] All 36 ChartVisualization tests pass
- [x] `npm run build` passes
- [x] `npm run lint` passes