### PR TITLE
🐛 Fix PR Verifier startup_failure by inlining reusable workflow

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -7,8 +7,38 @@ on:
 permissions:
   checks: write
   pull-requests: read
+  packages: read
 
 jobs:
-  verify:
-    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
-    secrets: inherit
+  verify-pr:
+    name: verify PR contents
+    # Skip verification for dependabot PRs — they use different title conventions
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull verifier image
+        run: docker pull ghcr.io/kubestellar/pr-verifier:v0.4.3
+
+      - name: Verifier action
+        id: verifier
+        continue-on-error: true
+        run: |
+          docker run --rm \
+            -e INPUT_GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+            -e GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+            -e GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" \
+            -e GITHUB_EVENT_PATH="/github/event.json" \
+            -e GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
+            -e GITHUB_SHA="$GITHUB_SHA" \
+            -e GITHUB_REF="$GITHUB_REF" \
+            -e GITHUB_WORKSPACE="/github/workspace" \
+            -v "$GITHUB_EVENT_PATH:/github/event.json:ro" \
+            -v "$GITHUB_WORKSPACE:/github/workspace:ro" \
+            ghcr.io/kubestellar/pr-verifier:v0.4.3


### PR DESCRIPTION
Fixes the PR Verifier workflow which has been failing with `startup_failure` on ALL runs since 05:19 UTC today (20+ consecutive failures).

## Root cause
The cross-repo reusable workflow call to `kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main` is causing `startup_failure`. Other `pull_request_target` workflows (e.g., Greetings) are unaffected, confirming the issue is specific to the cross-repo `workflow_call` dispatch mechanism.

## Fix
Inline the reusable workflow steps directly into `pr-verifier.yml`. This eliminates the cross-repo dependency while preserving identical behavior:
- Same Docker image (`ghcr.io/kubestellar/pr-verifier:v0.4.3`)
- Same environment variables
- Same GHCR login step
- Same dependabot skip logic

Also adds `packages: read` permission which the reusable workflow required but the caller did not declare — this permission mismatch may have contributed to the startup failures.

## Impact
- All PR verification has been blocked since 05:19 UTC
- This restores the verification pipeline for all new/updated PRs