### PR TITLE
🧹 Remove dead code: duplicate formatCurrency + inline getColor

### DIFF
--- a/web/src/components/charts/ProgressBar.tsx
+++ b/web/src/components/charts/ProgressBar.tsx
@@ -1,5 +1,22 @@
 import { cn } from '../../lib/cn'
 
+const DEFAULT_PROGRESS_COLOR = '#9333ea'
+const THRESHOLD_CRITICAL_COLOR = '#ef4444'
+const THRESHOLD_WARNING_COLOR = '#eab308'
+const THRESHOLD_OK_COLOR = '#22c55e'
+
+function resolveThresholdColor(
+  percentage: number,
+  color: string | undefined,
+  thresholds: { warning: number; critical: number } | undefined,
+): string {
+  if (color) return color
+  if (!thresholds) return DEFAULT_PROGRESS_COLOR
+  if (percentage >= thresholds.critical) return THRESHOLD_CRITICAL_COLOR
+  if (percentage >= thresholds.warning) return THRESHOLD_WARNING_COLOR
+  return THRESHOLD_OK_COLOR
+}
+
 interface ProgressBarProps {
   value: number
   max?: number
@@ -25,16 +42,7 @@ export function ProgressBar({
   thresholds,
 }: ProgressBarProps) {
   const percentage = max > 0 ? Math.min((value / max) * 100, 100) : 0
-
-  const getColor = () => {
-    if (color) return color
-    if (!thresholds) return '#9333ea'
-    if (percentage >= thresholds.critical) return '#ef4444'
-    if (percentage >= thresholds.warning) return '#eab308'
-    return '#22c55e'
-  }
-
-  const currentColor = getColor()
+  const currentColor = resolveThresholdColor(percentage, color, thresholds)
 
   const sizeClasses = {
     sm: 'h-1.5',
@@ -178,16 +186,7 @@ export function CircularProgress({
   const radius = (size - strokeWidth) / 2
   const circumference = radius * 2 * Math.PI
   const offset = circumference - (percentage / 100) * circumference
-
-  const getColor = () => {
-    if (color) return color
-    if (!thresholds) return '#9333ea'
-    if (percentage >= thresholds.critical) return '#ef4444'
-    if (percentage >= thresholds.warning) return '#eab308'
-    return '#22c55e'
-  }
-
-  const currentColor = getColor()
+  const currentColor = resolveThresholdColor(percentage, color, thresholds)
 
   return (
     <div className="flex flex-col items-center">

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -648,15 +648,3 @@ export function formatPercentage(value: number): string {
   return `${Math.round(value)}%`
 }
 
-/** Threshold above which currency values are abbreviated to K (e.g. $1.5K) */
-const CURRENCY_KILO_THRESHOLD = 1_000
-
-/**
- * Helper to format currency values
- */
-export function formatCurrency(value: number): string {
-  if (value >= CURRENCY_KILO_THRESHOLD) {
-    return `$${(value / CURRENCY_KILO_THRESHOLD).toFixed(1)}K`
-  }
-  return `$${value.toFixed(2)}`
-}


### PR DESCRIPTION
## Summary
- Removed dead `formatCurrency` + `CURRENCY_KILO_THRESHOLD` from StatsOverview.tsx (canonical version lives in `lib/formatters.ts`, this copy was never imported)
- Extracted `resolveThresholdColor()` helper in ProgressBar.tsx, replacing identical inline `getColor` in both `ProgressBar` and `CircularProgress` components
- Named color constants replace magic hex values

Fixes #10160

## Test plan
- [ ] ProgressBar renders with correct threshold colors (green/yellow/red)
- [ ] CircularProgress renders with correct threshold colors
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)