### PR TITLE
fix: enforce per-user dashboard limit in ImportDashboard (#10162)

### DIFF
--- a/pkg/api/handlers/dashboard.go
+++ b/pkg/api/handlers/dashboard.go
@@ -271,6 +271,16 @@ func (h *DashboardHandler) ImportDashboard(c *fiber.Ctx) error {
 		input.Name = "Imported Dashboard"
 	}
 
+	// Enforce per-user dashboard limit (#10162) — same check as CreateDashboard.
+	count, err := h.store.CountUserDashboards(c.UserContext(), userID)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to check dashboard count")
+	}
+	if count >= MaxDashboardsPerUser {
+		return fiber.NewError(fiber.StatusTooManyRequests,
+			fmt.Sprintf("Dashboard limit reached (%d), maximum is %d per user", count, MaxDashboardsPerUser))
+	}
+
 	// Enforce the per-dashboard card limit BEFORE creating anything.
 	// This avoids a partial import that exceeds MaxCardsPerDashboard and
 	// avoids the need to rollback a large number of card rows.

--- a/pkg/api/handlers/dashboard_test.go
+++ b/pkg/api/handlers/dashboard_test.go
@@ -253,3 +253,27 @@ func TestImportDashboard_ExceedsCardLimit(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+// TestImportDashboard_ExceedsUserLimit verifies that an import is rejected
+// with HTTP 429 when the user has already reached MaxDashboardsPerUser (#10162).
+func TestImportDashboard_ExceedsUserLimit(t *testing.T) {
+	userID := uuid.New()
+	app, mockStore, handler := setupDashboardTest(userID)
+
+	// Override the default CountUserDashboards mock to simulate the user
+	// already being at the dashboard limit.
+	mockStore.ExpectedCalls = nil
+	mockStore.On("CountUserDashboards", userID).Return(MaxDashboardsPerUser, nil)
+
+	app.Post("/api/dashboards/import", handler.ImportDashboard)
+
+	body := `{"format":"kc-dashboard-v1","name":"ShouldFail","cards":[]}`
+	req, err := http.NewRequest("POST", "/api/dashboards/import", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	mockStore.AssertExpectations(t)
+}
+


### PR DESCRIPTION
## Problem

The `POST /api/dashboards/import` endpoint (`ImportDashboard`) created dashboards directly via `h.store.CreateDashboard()` **without** checking whether the user had reached the `MaxDashboardsPerUser` (50) limit. This allowed users to bypass the dashboard cap by repeatedly calling the import endpoint.

The `CreateDashboard` handler correctly enforces this limit, but `ImportDashboard` bypassed it entirely.

## Solution

Added the same `CountUserDashboards` check that `CreateDashboard` uses, placed **before** any dashboard creation or card validation:

```go
count, err := h.store.CountUserDashboards(c.UserContext(), userID)
if err != nil {
    return fiber.NewError(fiber.StatusInternalServerError, "Failed to check dashboard count")
}
if count >= MaxDashboardsPerUser {
    return fiber.NewError(fiber.StatusTooManyRequests,
        fmt.Sprintf("Dashboard limit reached (%d), maximum is %d per user", count, MaxDashboardsPerUser))
}
```

## Changes

- `pkg/api/handlers/dashboard.go`: Added per-user dashboard limit check in `ImportDashboard`
- `pkg/api/handlers/dashboard_test.go`: Added `TestImportDashboard_ExceedsUserLimit` to verify HTTP 429 is returned when limit is reached

## Testing

- Added `TestImportDashboard_ExceedsUserLimit` that mocks `CountUserDashboards` returning `MaxDashboardsPerUser` and asserts HTTP 429
- Existing `TestImportDashboard_Success` continues to pass (default mock returns 0, under limit)

## Checklist

- [x] Bug fix (non-breaking change)
- [x] Added tests
- [x] Follows existing code style
- [x] References issue #10162

## Proof

The fix mirrors the exact pattern already used in `CreateDashboard` (~line 106), ensuring consistent behavior across both endpoints.
