### PR TITLE
🧹 Consolidate ~10 duplicate COPY_FEEDBACK_MS constants into lib/constants/ui.ts

### DIFF
--- a/web/src/components/cards/pipelines/EmbedCodeDialog.tsx
+++ b/web/src/components/cards/pipelines/EmbedCodeDialog.tsx
@@ -1,3 +1,4 @@
+import { COPY_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants'
 /**
  * EmbedCodeDialog — modal that generates an iframe embed URL and a markdown
  * badge snippet for a CI/CD pipeline card. Opened from each card's settings
@@ -15,7 +16,6 @@ import { Input } from '../../ui/Input'
 import { cn } from '../../../lib/cn'
 
 /** Minimum ms the "Copied!" confirmation stays visible */
-const COPY_FEEDBACK_MS = 2000
 
 /** Default iframe width in pixels */
 const DEFAULT_IFRAME_WIDTH = 600
@@ -75,7 +75,7 @@ export function EmbedCodeDialog({ open, cardType, cardTitle, currentRepo, onClos
     try {
       await navigator.clipboard.writeText(text)
       setCopiedField(fieldId)
-      setTimeout(() => setCopiedField(null), COPY_FEEDBACK_MS)
+      setTimeout(() => setCopiedField(null), COPY_FEEDBACK_TIMEOUT_MS)
     } catch {
       // Fallback for insecure contexts (e.g. HTTP iframe)
       const el = document.createElement('textarea')
@@ -85,7 +85,7 @@ export function EmbedCodeDialog({ open, cardType, cardTitle, currentRepo, onClos
       document.execCommand('copy')
       document.body.removeChild(el)
       setCopiedField(fieldId)
-      setTimeout(() => setCopiedField(null), COPY_FEEDBACK_MS)
+      setTimeout(() => setCopiedField(null), COPY_FEEDBACK_TIMEOUT_MS)
     }
   }, [])
 

--- a/web/src/components/dashboard/DemoToLocalCTA.tsx
+++ b/web/src/components/dashboard/DemoToLocalCTA.tsx
@@ -1,3 +1,4 @@
+import { COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
 /**
  * Demo-to-Local CTA — shown on console.kubestellar.io to convert demo visitors.
  *
@@ -23,7 +24,6 @@ import { useTranslation } from 'react-i18next'
 const NETLIFY_INSTALL_COMMAND = 'curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash'
 
 /** How many seconds the "Copied!" confirmation shows */
-const COPY_FEEDBACK_MS = 2000
 
 export function DemoToLocalCTA() {
   const { showToast } = useToast()
@@ -76,7 +76,7 @@ export function DemoToLocalCTA() {
       emitDemoToLocalActioned('copy_command')
       emitInstallCommandCopied('demo_to_local', NETLIFY_INSTALL_COMMAND)
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
-      copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
+      copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_TIMEOUT_MS)
     } catch {
       // Clipboard API not available — select the text instead
       showToast(t('common.errors.clipboardFailed', 'Failed to copy to clipboard'), 'error')

--- a/web/src/components/dashboard/WelcomeCard.tsx
+++ b/web/src/components/dashboard/WelcomeCard.tsx
@@ -1,3 +1,4 @@
+import { COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
 import { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Terminal, Globe, Rocket, X, ExternalLink, Copy, Check } from 'lucide-react'
@@ -12,7 +13,6 @@ const DISMISSED_KEY = 'kc-welcome-dismissed'
 const INSTALL_COMMAND = 'curl -sL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash'
 
 /** How long the "Copied!" confirmation shows (ms) */
-const COPY_FEEDBACK_MS = 2000
 
 export function WelcomeCard() {
   const { t } = useTranslation()
@@ -40,7 +40,7 @@ export function WelcomeCard() {
       await copyToClipboard(INSTALL_COMMAND)
       setCopied(true)
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
-      copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
+      copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_TIMEOUT_MS)
     } catch {
       showToast(t('common.errors.clipboardFailed', 'Failed to copy to clipboard'), 'error')
     }

--- a/web/src/components/missions/PreflightFailure.tsx
+++ b/web/src/components/missions/PreflightFailure.tsx
@@ -1,3 +1,4 @@
+import { COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
 /**
  * PreflightFailure — Renders a structured preflight error with remediation actions.
  *
@@ -7,7 +8,6 @@
 
 import { useState, useRef, useEffect } from 'react'
 
-const COPY_FEEDBACK_MS = 2000
 import {
   ShieldAlert,
   KeyRound,
@@ -102,7 +102,7 @@ function ActionButton({
       copyTimeoutRef.current = setTimeout(() => {
         setCopied(false)
         copyTimeoutRef.current = null
-      }, COPY_FEEDBACK_MS)
+      }, COPY_FEEDBACK_TIMEOUT_MS)
     }
   }
 

--- a/web/src/components/missions/UnstructuredFilePreview.tsx
+++ b/web/src/components/missions/UnstructuredFilePreview.tsx
@@ -1,3 +1,5 @@
+import { COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
+
 /**
  * Unstructured File Preview
  *
@@ -89,8 +91,7 @@ export function UnstructuredFilePreview({
     await copyToClipboard(content)
     setCopied(true)
     if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
-    const COPY_FEEDBACK_MS = 2_000
-    copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
+    copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_TIMEOUT_MS)
   }
 
   return (

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -1,3 +1,4 @@
+import { COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { Download, Clock, SkipForward, ChevronDown, Copy, Check, Loader2 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
@@ -205,9 +206,7 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
   const handleCopyCommand = useCallback(async (cmd: string) => {
     await copyToClipboard(cmd)
     setCopiedCommand(cmd)
-    /** Delay before clearing the "copied" indicator so user sees feedback (ms) */
-    const COPY_FEEDBACK_CLEAR_MS = 2000
-    setTimeout(() => setCopiedCommand(null), COPY_FEEDBACK_CLEAR_MS)
+    setTimeout(() => setCopiedCommand(null), COPY_FEEDBACK_TIMEOUT_MS)
   }, [])
 
   const manualCommands: { label: string; command: string }[] = useMemo(() => {

--- a/web/src/pages/FromHeadlamp.tsx
+++ b/web/src/pages/FromHeadlamp.tsx
@@ -1,3 +1,4 @@
+import { COPY_FEEDBACK_TIMEOUT_MS } from '../lib/constants'
 import { useEffect, useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import {
@@ -30,7 +31,6 @@ import { copyToClipboard } from '../lib/clipboard'
 type DeployTab = 'localhost' | 'cluster-portforward' | 'cluster-ingress'
 
 /** How long the "Copied!" checkmark shows (ms) */
-const COPY_FEEDBACK_MS = 2000
 
 /* ------------------------------------------------------------------ */
 /*  Comparison data — respectful, factual side-by-side                */
@@ -225,7 +225,7 @@ function DeploymentSection() {
     const key = `${activeTab}-${step}`
     setCopiedStep(key)
     clearTimeout(copiedTimerRef.current)
-    copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_MS)
+    copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_TIMEOUT_MS)
     const firstCommand = commands.find(c => !c.startsWith('#') && c !== '') ?? commands[0]
     emitFromHeadlampCommandCopy(activeTab, step, firstCommand)
     emitInstallCommandCopied('from_headlamp', firstCommand)

--- a/web/src/pages/FromHolmesGPT.tsx
+++ b/web/src/pages/FromHolmesGPT.tsx
@@ -1,3 +1,4 @@
+import { COPY_FEEDBACK_TIMEOUT_MS } from '../lib/constants'
 import { useEffect, useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import {
@@ -17,7 +18,6 @@ import {
 import { copyToClipboard } from '../lib/clipboard'
 import { emitInstallCommandCopied } from '../lib/analytics'
 
-const COPY_FEEDBACK_MS = 2000
 
 /* ------------------------------------------------------------------ */
 /*  Comparison table data                                              */
@@ -196,7 +196,7 @@ export function FromHolmesGPT() {
     if (!ok) return
     setCopiedStep(`step-${step}`)
     clearTimeout(copiedTimerRef.current)
-    copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_MS)
+    copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_TIMEOUT_MS)
     const firstCommand = commands.find(c => !c.startsWith('#') && c !== '') ?? commands[0]
     emitInstallCommandCopied('from_holmesgpt', firstCommand)
   }

--- a/web/src/pages/FromLens.tsx
+++ b/web/src/pages/FromLens.tsx
@@ -1,3 +1,4 @@
+import { COPY_FEEDBACK_TIMEOUT_MS } from '../lib/constants'
 import { useEffect, useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import {
@@ -29,7 +30,6 @@ import { copyToClipboard } from '../lib/clipboard'
 type DeployTab = 'localhost' | 'cluster-portforward' | 'cluster-ingress'
 
 /** How long the "Copied!" checkmark shows (ms) */
-const COPY_FEEDBACK_MS = 2000
 
 /* ------------------------------------------------------------------ */
 /*  Comparison table data                                             */
@@ -237,7 +237,7 @@ function DeploymentSection() {
     const key = `${activeTab}-${step}`
     setCopiedStep(key)
     clearTimeout(copiedTimerRef.current)
-    copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_MS)
+    copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_TIMEOUT_MS)
     const firstCommand = commands.find(c => !c.startsWith('#') && c !== '') ?? commands[0]
     emitFromLensCommandCopy(activeTab, step, firstCommand)
     emitInstallCommandCopied('from_lens', firstCommand)

--- a/web/src/pages/WhiteLabel.tsx
+++ b/web/src/pages/WhiteLabel.tsx
@@ -1,3 +1,4 @@
+import { COPY_FEEDBACK_TIMEOUT_MS } from '../lib/constants'
 import { useEffect, useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import {
@@ -28,7 +29,6 @@ import { copyToClipboard } from '../lib/clipboard'
 type DeployTab = 'binary' | 'helm' | 'docker'
 
 /** How long the "Copied!" checkmark shows (ms) */
-const COPY_FEEDBACK_MS = 2000
 
 /* ------------------------------------------------------------------ */
 /*  What You Get — feature highlights for white-label                 */
@@ -245,7 +245,7 @@ function DeploymentSection() {
     const key = `${activeTab}-${step}`
     setCopiedStep(key)
     clearTimeout(copiedTimerRef.current)
-    copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_MS)
+    copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_TIMEOUT_MS)
     const firstCommand = commands.find(c => !c.startsWith('#') && c !== '') ?? commands[0]
     emitWhiteLabelCommandCopy(activeTab, step, firstCommand)
     emitInstallCommandCopied('white_label', firstCommand)


### PR DESCRIPTION
## Summary
- Replaced 10 local `COPY_FEEDBACK_MS` / `COPY_FEEDBACK_CLEAR_MS` constant definitions with imports from the canonical `COPY_FEEDBACK_TIMEOUT_MS` in `lib/constants/ui.ts`
- Skipped `cardFactoryTemplatesT2.ts` (code generator that needs literal value in template strings)
- Skipped `ClusterGrid.tsx` (intentionally uses 1500ms, not 2000ms)
- Net zero lines changed — same behavior, single source of truth

Fixes #10170

## Test plan
- [ ] Copy-to-clipboard feedback still shows briefly then clears in all affected components
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)