### PR TITLE
🐛 Use FieldSelector for event queries to prevent truncation in noisy namespaces

### DIFF
--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -280,8 +280,16 @@ func (s *Server) handleEventsHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), agentDefaultTimeout)
 	defer cancel()
 
+	// When filtering by object name, use a server-side FieldSelector so the
+	// limit is applied after filtering — prevents target events from being
+	// pushed out of the result window in noisy namespaces (issue #10167).
+	var fieldSelector string
+	if objectName != "" {
+		fieldSelector = fmt.Sprintf("involvedObject.name=%s", objectName)
+	}
+
 	// Get events from the cluster
-	events, err := s.k8sClient.GetEvents(ctx, cluster, namespace, limit)
+	events, err := s.k8sClient.GetEvents(ctx, cluster, namespace, limit, fieldSelector)
 	if err != nil {
 		slog.Warn("error fetching events", "error", err)
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")

--- a/pkg/k8s/client_resources.go
+++ b/pkg/k8s/client_resources.go
@@ -246,13 +246,17 @@ func (m *MultiClusterClient) FindPodIssues(ctx context.Context, contextName, nam
 }
 
 // GetEvents returns events from a cluster
-func (m *MultiClusterClient) GetEvents(ctx context.Context, contextName, namespace string, limit int) ([]Event, error) {
+func (m *MultiClusterClient) GetEvents(ctx context.Context, contextName, namespace string, limit int, fieldSelectors ...string) ([]Event, error) {
 	client, err := m.GetClient(contextName)
 	if err != nil {
 		return nil, err
 	}
 
-	events, err := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+	listOpts := metav1.ListOptions{}
+	if len(fieldSelectors) > 0 && fieldSelectors[0] != "" {
+		listOpts.FieldSelector = fieldSelectors[0]
+	}
+	events, err := client.CoreV1().Events(namespace).List(ctx, listOpts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #10167

When querying events for a specific object, passes `involvedObject.name` as a FieldSelector to the Kubernetes API so filtering happens server-side before the limit is applied. This prevents target pod events from being pushed out of the result window in noisy namespaces.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>