### PR TITLE
🧹 Replace 7 duplicate formatRelativeTime with formatTimeAgo

### DIFF
--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -6,7 +6,7 @@ import type { DrillDownViewType } from '../../../hooks/useDrillDown'
 import { useCachedAllNodes, useCachedPVCs } from '../../../hooks/useCachedData'
 import { useAlerts } from '../../../hooks/useAlerts'
 import { useTranslation } from 'react-i18next'
-import { formatRelativeTime } from '../../../lib/formatters'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 interface MultiClusterSummaryDrillDownProps {
   data: Record<string, unknown>
@@ -506,7 +506,7 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
           )}
           {nodesDataAge && (
             <span className="text-2xs text-muted-foreground" title={new Date(nodesLastRefresh!).toLocaleString()}>
-              Updated {formatRelativeTime(nodesDataAge)}
+              Updated {formatTimeAgo(nodesDataAge)}
             </span>
           )}
         </div>

--- a/web/src/components/drilldown/views/NodeDrillDown.tsx
+++ b/web/src/components/drilldown/views/NodeDrillDown.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { copyToClipboard } from '../../../lib/clipboard'
 import { useCachedNodes } from '../../../hooks/useCachedData'
-import { formatRelativeTime } from '../../../lib/formatters'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 interface Props {
   data: Record<string, unknown>
@@ -140,7 +140,7 @@ Please:
           <h3 className="text-lg font-semibold text-foreground">Node: {nodeName}</h3>
           {nodeDataAge && (
             <span className="text-2xs text-muted-foreground" title={new Date(nodeLastRefresh!).toLocaleString()}>
-              Updated {formatRelativeTime(nodeDataAge)}
+              Updated {formatTimeAgo(nodeDataAge)}
             </span>
           )}
         </div>

--- a/web/src/components/feedback/FeatureRequestList.tsx
+++ b/web/src/components/feedback/FeatureRequestList.tsx
@@ -19,22 +19,7 @@ import {
   type FeedbackType,
 } from '../../hooks/useFeatureRequests'
 import { useTranslation } from 'react-i18next'
-
-// Format relative time
-function formatRelativeTime(dateString: string): string {
-  const date = new Date(dateString)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-  const diffHours = Math.floor(diffMins / 60)
-  const diffDays = Math.floor(diffHours / 24)
-
-  if (diffMins < 1) return 'Just now'
-  if (diffMins < 60) return `${diffMins}m ago`
-  if (diffHours < 24) return `${diffHours}h ago`
-  if (diffDays < 7) return `${diffDays}d ago`
-  return date.toLocaleDateString()
-}
+import { formatTimeAgo } from '../../lib/formatters'
 
 interface RequestCardProps {
   request: FeatureRequest
@@ -89,7 +74,7 @@ function RequestCard({ request, onFeedback }: RequestCardProps) {
       <div className="flex items-center gap-4 mt-3 text-xs text-muted-foreground">
         <span className="flex items-center gap-1">
           <Clock className="w-3 h-3" />
-          {formatRelativeTime(request.created_at)}
+          {formatTimeAgo(request.created_at)}
         </span>
         {request.github_issue_url && (
           <a

--- a/web/src/components/feedback/FeatureRequestTypes.ts
+++ b/web/src/components/feedback/FeatureRequestTypes.ts
@@ -60,24 +60,8 @@ export interface ScreenshotItem {
 
 // ── Utility functions ──
 
-/** Format a date string as relative time (e.g. "5m ago", "3d ago") */
-export function formatRelativeTime(dateString: string | undefined): string {
-  if (!dateString) return ''
-  const date = new Date(dateString)
-  if (isNaN(date.getTime())) return ''
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const MS_PER_MINUTE = 60000
-  const diffMins = Math.floor(diffMs / MS_PER_MINUTE)
-  const diffHours = Math.floor(diffMins / MINUTES_PER_HOUR)
-  const diffDays = Math.floor(diffHours / HOURS_PER_DAY)
-
-  if (diffMins < 1) return 'Just now'
-  if (diffMins < MINUTES_PER_HOUR) return `${diffMins}m ago`
-  if (diffHours < HOURS_PER_DAY) return `${diffHours}h ago`
-  if (diffDays < DAYS_PER_WEEK) return `${diffDays}d ago`
-  return date.toLocaleDateString()
-}
+/** @deprecated Use {@link formatTimeAgo} from lib/formatters instead. */
+export { formatTimeAgo as formatRelativeTime } from '../../lib/formatters'
 
 /** Get display info (label, colors) for a request status */
 export function getStatusInfo(

--- a/web/src/components/feedback/NotificationBadge.tsx
+++ b/web/src/components/feedback/NotificationBadge.tsx
@@ -3,22 +3,7 @@ import { useModalState } from '../../lib/modals'
 import { Bell, X, Check, Clock, Bug, Sparkles, GitPullRequest, Eye } from 'lucide-react'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useNotifications, type Notification, type NotificationType } from '../../hooks/useFeatureRequests'
-
-// Format relative time
-function formatRelativeTime(dateString: string): string {
-  const date = new Date(dateString)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-  const diffHours = Math.floor(diffMins / 60)
-  const diffDays = Math.floor(diffHours / 24)
-
-  if (diffMins < 1) return 'Just now'
-  if (diffMins < 60) return `${diffMins}m ago`
-  if (diffHours < 24) return `${diffHours}h ago`
-  if (diffDays < 7) return `${diffDays}d ago`
-  return date.toLocaleDateString()
-}
+import { formatTimeAgo } from '../../lib/formatters'
 
 // Get icon for notification type
 function getNotificationIcon(type: NotificationType) {
@@ -193,7 +178,7 @@ export function NotificationBadge() {
                         </p>
                         <span className="text-xs text-muted-foreground flex items-center gap-1 mt-1">
                           <Clock className="w-3 h-3" />
-                          {formatRelativeTime(notification.created_at)}
+                          {formatTimeAgo(notification.created_at)}
                         </span>
                       </div>
                     </div>

--- a/web/src/components/ui/AlertBadge.tsx
+++ b/web/src/components/ui/AlertBadge.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Bell, AlertTriangle, CheckCircle, Clock, ChevronRight, X, Server, Search, ExternalLink, CheckSquare, Square, MinusSquare } from 'lucide-react'
 import { useAlerts } from '../../hooks/useAlerts'
+import { formatTimeAgo } from '../../lib/formatters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
 import { useMobile } from '../../hooks/useMobile'
@@ -11,15 +12,11 @@ import type { Alert, AlertSeverity } from '../../types/alerts'
 import { CardAIActions } from '../../lib/cards/CardComponents'
 import { ROUTES } from '../../config/routes'
 import { TRANSITION_DELAY_MS } from '../../lib/constants/network'
-import { HOURS_PER_DAY } from '../../lib/constants/time'
 import { useModalState } from '../../lib/modals'
 import { Button } from './Button'
 
 /** Maximum numeric value to display in the badge before switching to overflow text (e.g. "99+") */
 const BADGE_MAX_COUNT = 99
-/** Number of minutes in an hour, used for relative-time formatting */
-const MINS_PER_HOUR = 60
-/** Number of hours in a day, used for relative-time formatting */
 /** Duration of the exit animation before swapping the counter value in milliseconds */
 const ANIMATION_EXIT_DELAY_MS = 150
 
@@ -76,19 +73,7 @@ export function AnimatedCounter({ value, className }: { value: number; className
   )
 }
 
-// Format relative time
-function formatRelativeTime(dateString: string): string {
-  const date = new Date(dateString)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-  const diffHours = Math.floor(diffMins / 60)
 
-  if (diffMins < 1) return 'Just now'
-  if (diffMins < MINS_PER_HOUR) return `${diffMins}m ago`
-  if (diffHours < HOURS_PER_DAY) return `${diffHours}h ago`
-  return new Date(dateString).toLocaleDateString()
-}
 
 export function AlertBadge() {
   const { t } = useTranslation()
@@ -490,7 +475,7 @@ export function AlertBadge() {
                         )}
                         <span className="text-xs text-muted-foreground flex items-center gap-1">
                           <Clock className="w-3 h-3" />
-                          {formatRelativeTime(alert.firedAt)}
+                          {formatTimeAgo(alert.firedAt)}
                         </span>
                       </div>
                     </div>

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -1,4 +1,5 @@
 import { COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
+import { formatTimeAgo } from '../../lib/formatters'
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { Download, Clock, SkipForward, ChevronDown, Copy, Check, Loader2 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
@@ -46,18 +47,7 @@ function snoozeUpdate(durationMs: number) {
   }
 }
 
-function formatRelativeTime(date: Date): string {
-  const diffMs = Date.now() - date.getTime()
-  const diffMin = Math.floor(diffMs / 60_000)
-  if (diffMin < 1) return 'just now'
-  if (diffMin < 60) return `${diffMin}m ago`
-  const diffH = Math.floor(diffMin / 60)
-  if (diffH < 24) return `${diffH}h ago`
-  const diffD = Math.floor(diffH / 24)
-  if (diffD === 1) return 'yesterday'
-  if (diffD < 30) return `${diffD}d ago`
-  return date.toLocaleDateString()
-}
+
 
 interface WhatsNewModalProps {
   isOpen: boolean
@@ -229,7 +219,7 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
   // minimal modal with the commit SHA instead of full release notes.
   if (!latestRelease && !isOpen) return null
 
-  const relativeTime = latestRelease ? formatRelativeTime(latestRelease.publishedAt) : 'just now'
+  const relativeTime = latestRelease ? formatTimeAgo(latestRelease.publishedAt) : 'just now'
 
   return (
     <BaseModal isOpen={isOpen} onClose={onClose} size="lg">
@@ -279,7 +269,7 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
                   <span className="text-xs text-muted-foreground font-mono shrink-0">#{pr.number}</span>
                   <span className="text-sm text-foreground group-hover:text-primary transition-colors">{pr.title}</span>
                   <span className="text-xs text-muted-foreground ml-auto shrink-0">
-                    {formatRelativeTime(new Date(pr.merged_at))}
+                    {formatTimeAgo(new Date(pr.merged_at))}
                   </span>
                 </a>
               ))}
@@ -313,7 +303,7 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
                         className="flex items-center justify-between w-full px-3 py-2 text-left text-sm hover:bg-secondary/50 transition-colors rounded-lg"
                       >
                         <span className="font-medium text-foreground">{release.tag}</span>
-                        <span className="text-xs text-muted-foreground">{formatRelativeTime(release.publishedAt)}</span>
+                        <span className="text-xs text-muted-foreground">{formatTimeAgo(release.publishedAt)}</span>
                       </button>
                       {expandedRelease === release.tag && release.releaseNotes && (
                         <div className="px-3 pb-3 prose dark:prose-invert max-w-none text-xs overflow-x-auto wrap-break-word [word-break:break-word]">


### PR DESCRIPTION
## Summary
- Replace 7 local `formatRelativeTime()` implementations with the canonical `formatTimeAgo()` from `lib/formatters.ts`
- Remove dead `MINS_PER_HOUR` constant from AlertBadge.tsx exposed by the cleanup
- Keep a deprecated re-export alias in FeatureRequestTypes.ts for DraftsTab/UpdatesTab consumers

**7 files changed, +18 −89 lines (net −71)**

## Files Changed
| File | Change |
|------|--------|
| NodeDrillDown.tsx | Import swap |
| MultiClusterSummaryDrillDown.tsx | Import swap |
| AlertBadge.tsx | Remove local fn + dead constant |
| NotificationBadge.tsx | Remove local fn |
| FeatureRequestList.tsx | Remove local fn |
| FeatureRequestTypes.ts | Replace fn body with deprecated re-export |
| WhatsNewModal.tsx | Remove local fn |

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] Time-ago formatting still works in all affected components
- [ ] DraftsTab and UpdatesTab still compile (backward-compat re-export)

Fixes #10180