### PR TITLE
🧹 Remove 6 dead exports from chartColors.ts and tokens.ts

### DIFF
--- a/web/src/lib/__tests__/chartColors.test.ts
+++ b/web/src/lib/__tests__/chartColors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { getChartColor, getChartColors, getChartColorByName } from '../chartColors'
+import { getChartColor, getChartColorByName } from '../chartColors'
 
 describe('getChartColor', () => {
   it('returns fallback color for index 1', () => {
@@ -117,57 +117,6 @@ describe('getChartColor', () => {
     expect(color).toBe('#9333ea')
 
     vi.unstubAllGlobals()
-  })
-})
-
-describe('getChartColors', () => {
-  it('returns array of correct length', () => {
-    expect(getChartColors(3)).toHaveLength(3)
-    expect(getChartColors(8)).toHaveLength(8)
-  })
-
-  it('returns empty array for 0', () => {
-    expect(getChartColors(0)).toHaveLength(0)
-  })
-
-  it('returns valid color strings', () => {
-    const colors = getChartColors(5)
-    for (const c of colors) {
-      expect(typeof c).toBe('string')
-      expect(c.length).toBeGreaterThan(0)
-    }
-  })
-
-  // --- New edge case tests ---
-
-  it('returns colors in the correct order (1-indexed from getChartColor)', () => {
-    const colors = getChartColors(3)
-    expect(colors[0]).toBe(getChartColor(1))
-    expect(colors[1]).toBe(getChartColor(2))
-    expect(colors[2]).toBe(getChartColor(3))
-  })
-
-  it('wraps colors when count exceeds 8', () => {
-    const PALETTE_SIZE = 8
-    const colors = getChartColors(PALETTE_SIZE + 2)
-    expect(colors).toHaveLength(PALETTE_SIZE + 2)
-    // Color at index 8 (9th) wraps to color at index 0 (1st)
-    expect(colors[PALETTE_SIZE]).toBe(colors[0])
-    // Color at index 9 (10th) wraps to color at index 1 (2nd)
-    expect(colors[PALETTE_SIZE + 1]).toBe(colors[1])
-  })
-
-  it('returns all 8 unique colors for count=8', () => {
-    const PALETTE_SIZE = 8
-    const colors = getChartColors(PALETTE_SIZE)
-    const unique = new Set(colors)
-    expect(unique.size).toBe(PALETTE_SIZE)
-  })
-
-  it('returns a single color for count=1', () => {
-    const colors = getChartColors(1)
-    expect(colors).toHaveLength(1)
-    expect(colors[0]).toBe(getChartColor(1))
   })
 })
 

--- a/web/src/lib/chartColors.ts
+++ b/web/src/lib/chartColors.ts
@@ -41,13 +41,6 @@ export function getChartColor(index: number): string {
 }
 
 /**
- * Get multiple chart colors as an array
- */
-export function getChartColors(count: number): string[] {
-  return Array.from({ length: count }, (_, i) => getChartColor(i + 1))
-}
-
-/**
  * Get chart color by semantic name
  */
 export function getChartColorByName(name: 'warning' | 'success' | 'error' | 'info' | 'primary'): string {

--- a/web/src/lib/tokens.ts
+++ b/web/src/lib/tokens.ts
@@ -12,46 +12,6 @@
  */
 
 // ============================================================================
-// Status Colors — semantic colors for health, alerts, badges
-// ============================================================================
-
-export const STATUS_COLORS = {
-  success: '#10b981',  // --color-success (emerald-500)
-  warning: '#f59e0b',  // --color-warning (amber-500)
-  error: '#ef4444',    // --color-error (red-500)
-  info: '#06b6d4',     // --color-info (cyan-500)
-  neutral: '#6b7280',  // --color-neutral (gray-500)
-  pending: '#eab308',  // --color-pending (yellow-500)
-} as const
-
-// ============================================================================
-// Brand Colors — KubeStellar brand palette
-// ============================================================================
-
-export const BRAND_COLORS = {
-  purple: '#9333ea',  // --ks-purple
-  blue: '#3b82f6',    // --ks-blue
-  pink: '#ec4899',    // --ks-pink
-  green: '#10b981',   // --ks-green
-  cyan: '#06b6d4',    // --ks-cyan
-} as const
-
-// ============================================================================
-// Chart Colors — ordered palette for multi-series charts
-// ============================================================================
-
-export const CHART_COLORS = [
-  '#9333ea',  // --chart-color-1 (purple)
-  '#3b82f6',  // --chart-color-2 (blue)
-  '#10b981',  // --chart-color-3 (green)
-  '#f59e0b',  // --chart-color-4 (amber)
-  '#ef4444',  // --chart-color-5 (red)
-  '#06b6d4',  // --chart-color-6 (cyan)
-  '#8b5cf6',  // --chart-color-7 (violet)
-  '#14b8a6',  // --chart-color-8 (teal)
-] as const
-
-// ============================================================================
 // Stat Block Colors — color name → hex mapping for StatsOverview charts
 // ============================================================================
 
@@ -65,31 +25,3 @@ export const STAT_BLOCK_COLORS: Record<string, string> = {
   red: '#ef4444',     // Matches --color-error
   gray: '#6b7280',
 }
-
-// ============================================================================
-// Z-Index Scale — matches tailwind.config.js zIndex extension
-// ============================================================================
-
-export const Z_INDEX = {
-  dropdown: 100,
-  sticky: 200,
-  overlay: 300,
-  modal: 400,
-  toast: 500,
-  critical: 600,
-} as const
-
-// ============================================================================
-// Spacing Constants — common named values for dynamic calculations
-// ============================================================================
-
-export const LAYOUT = {
-  /** Navbar height in pixels */
-  NAVBAR_HEIGHT_PX: 64,
-  /** Sidebar collapsed width in pixels */
-  SIDEBAR_COLLAPSED_WIDTH_PX: 64,
-  /** Sidebar minimum expanded width in pixels */
-  SIDEBAR_MIN_WIDTH_PX: 180,
-  /** Sidebar maximum expanded width in pixels */
-  SIDEBAR_MAX_WIDTH_PX: 480,
-} as const


### PR DESCRIPTION
## Summary
- Remove `getChartColors()` from `chartColors.ts` (never imported outside its test)
- Strip `tokens.ts` to only `STAT_BLOCK_COLORS` (the 5 other exports are dead)
- Remove corresponding test suite for `getChartColors`

**3 files changed, +1 −127 lines**

## Dead exports removed
| File | Export | Why dead |
|------|--------|----------|
| chartColors.ts | `getChartColors()` | Only in test file, no production imports |
| tokens.ts | `STATUS_COLORS` | Shadowed by statusColors.ts |
| tokens.ts | `BRAND_COLORS` | Never imported |
| tokens.ts | `CHART_COLORS` | Live code uses `getChartColor()` instead |
| tokens.ts | `Z_INDEX` | CSS custom properties used instead |
| tokens.ts | `LAYOUT` | Never imported |

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] Remaining `getChartColor()` and `getChartColorByName()` tests still pass
- [ ] StatsOverview.tsx still compiles (uses `STAT_BLOCK_COLORS`)

Fixes #10185