### PR TITLE
🐛 Return pending_review count in ListFeatureRequests (#10174)

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -431,7 +431,24 @@ func (h *FeedbackHandler) ListFeatureRequests(c *fiber.Ctx) error {
 		}
 	}
 
-	return c.JSON(triaged)
+	// #10174: Count untriaged submissions so the frontend can distinguish
+	// "no submissions" from "submissions pending review".
+	pendingReview, err := h.store.CountUserPendingFeatureRequests(c.UserContext(), userID)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to count pending feature requests")
+	}
+
+	type listResponse struct {
+		Items         []models.FeatureRequest `json:"items"`
+		Total         int                     `json:"total"`
+		PendingReview int                     `json:"pending_review"`
+	}
+
+	return c.JSON(listResponse{
+		Items:         triaged,
+		Total:         len(triaged) + pendingReview,
+		PendingReview: pendingReview,
+	})
 }
 
 // GitHubIssue represents an issue from GitHub API

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -1527,6 +1527,17 @@ func (s *SQLiteStore) GetUserFeatureRequests(ctx context.Context, userID uuid.UU
 	return requests, rows.Err()
 }
 
+// CountUserPendingFeatureRequests returns how many of the user's submissions
+// are still untriaged (open or needs_triage). #10174
+func (s *SQLiteStore) CountUserPendingFeatureRequests(ctx context.Context, userID uuid.UUID) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM feature_requests WHERE user_id = ? AND status IN (?, ?)`,
+		userID.String(), string(models.RequestStatusOpen), string(models.RequestStatusNeedsTriage),
+	).Scan(&count)
+	return count, err
+}
+
 // GetAllFeatureRequests returns a single page of feature_requests, newest
 // first. Callers that need to walk the full table must page by passing
 // successive offsets; this function never returns more than `limit` rows

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -131,6 +131,10 @@ type Store interface {
 	// GetUserFeatureRequests returns a user's feature requests, newest first.
 	// #6601: limit/offset required. Pass 0 for limit to use the store default.
 	GetUserFeatureRequests(ctx context.Context, userID uuid.UUID, limit, offset int) ([]models.FeatureRequest, error)
+	// CountUserPendingFeatureRequests returns the number of a user's feature
+	// requests that are still untriaged (status = open or needs_triage).
+	// #10174: lets the handler tell the frontend about pending submissions.
+	CountUserPendingFeatureRequests(ctx context.Context, userID uuid.UUID) (int, error)
 	// GetAllFeatureRequests returns the global feature-request table, newest first.
 	// #6602: limit/offset required; admin dashboard uses a smaller default (100)
 	// because this is hit on every dashboard load. Pass 0 for limit to use the

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -132,6 +132,9 @@ func (m *MockStore) GetFeatureRequestByPRNumber(ctx context.Context, prNumber in
 func (m *MockStore) GetUserFeatureRequests(ctx context.Context, userID uuid.UUID, limit, offset int) ([]models.FeatureRequest, error) {
 	return nil, nil
 }
+func (m *MockStore) CountUserPendingFeatureRequests(ctx context.Context, userID uuid.UUID) (int, error) {
+	return 0, nil
+}
 func (m *MockStore) GetAllFeatureRequests(ctx context.Context, limit, offset int) ([]models.FeatureRequest, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Fixes #10174

`ListFeatureRequests` now returns a structured JSON response with `items`, `total`, and `pending_review` fields instead of a bare array. This lets the frontend distinguish "no submissions" from "submissions pending review" when a user has only untriaged requests.