### PR TITLE
🐛 Fix MoveCard: persist dashboard_id + atomic limit check

### DIFF
--- a/pkg/api/handlers/cards.go
+++ b/pkg/api/handlers/cards.go
@@ -404,28 +404,20 @@ func (h *CardHandler) MoveCard(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusForbidden, "Access denied to target dashboard")
 	}
 
-	// Enforce per-dashboard card limit on the TARGET before moving.
-	// Without this, a Move can push a dashboard over MaxCardsPerDashboard,
-	// bypassing the limit that CreateCardWithLimit enforces on create.
-	// Note: if the source and target are the same dashboard this is a no-op
-	// from a count perspective, but we still allow it.
+	// Atomically move the card to the target dashboard, enforcing the
+	// per-dashboard card limit inside a single SQL statement to prevent
+	// TOCTOU races (two concurrent moves both passing the count check).
 	if card.DashboardID != targetDashboardID {
-		targetCards, cErr := h.store.GetDashboardCards(c.UserContext(), targetDashboardID)
-		if cErr != nil {
-			return fiber.NewError(fiber.StatusInternalServerError, "Failed to check target dashboard capacity")
+		if err := h.store.MoveCardWithLimit(c.UserContext(), cardID, targetDashboardID, MaxCardsPerDashboard); err != nil {
+			if errors.Is(err, store.ErrDashboardCardLimitReached) {
+				return fiber.NewError(
+					fiber.StatusBadRequest,
+					fmt.Sprintf("Target dashboard already has the maximum number of cards (limit %d)", MaxCardsPerDashboard),
+				)
+			}
+			return fiber.NewError(fiber.StatusInternalServerError, "Failed to move card")
 		}
-		if len(targetCards) >= MaxCardsPerDashboard {
-			return fiber.NewError(
-				fiber.StatusBadRequest,
-				fmt.Sprintf("Target dashboard already has %d cards (limit %d)", len(targetCards), MaxCardsPerDashboard),
-			)
-		}
-	}
-
-	// Update the card's dashboard ID
-	card.DashboardID = targetDashboardID
-	if err := h.store.UpdateCard(c.UserContext(), card); err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "Failed to move card")
+		card.DashboardID = targetDashboardID
 	}
 
 	// Notify via WebSocket

--- a/pkg/api/handlers/cards_test.go
+++ b/pkg/api/handlers/cards_test.go
@@ -276,6 +276,8 @@ type cardMutationStore struct {
 	updateErr      error
 	updateCalled   bool
 	lastUpdate     *models.Card
+	moveErr        error
+	moveCalled     bool
 }
 
 func (s *cardMutationStore) GetDashboard(_ context.Context, id uuid.UUID) (*models.Dashboard, error) {
@@ -309,6 +311,11 @@ func (s *cardMutationStore) UpdateCard(_ context.Context, card *models.Card) err
 	s.updateCalled = true
 	s.lastUpdate = card
 	return s.updateErr
+}
+
+func (s *cardMutationStore) MoveCardWithLimit(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ int) error {
+	s.moveCalled = true
+	return s.moveErr
 }
 
 // newCardMutationApp wires a CardHandler backed by cardMutationStore, with
@@ -389,6 +396,7 @@ func TestMoveCard_RejectsWhenTargetAtLimit(t *testing.T) {
 			DashboardID: sourceDashID,
 			CardType:    models.CardTypeClusterHealth,
 		},
+		moveErr: store.ErrDashboardCardLimitReached,
 	}
 
 	hub := NewHub()
@@ -411,7 +419,7 @@ func TestMoveCard_RejectsWhenTargetAtLimit(t *testing.T) {
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.False(t, wrapper.updateCalled, "store must not be updated when target is at limit")
+	assert.True(t, wrapper.moveCalled, "MoveCardWithLimit must be called")
 }
 
 // --- Viewer denial ---

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -1175,8 +1175,8 @@ func (s *SQLiteStore) UpdateCard(ctx context.Context, card *models.Card) error {
 		configStr = &str
 	}
 
-	res, err := s.db.ExecContext(ctx, `UPDATE cards SET card_type = ?, config = ?, position = ? WHERE id = ?`,
-		string(card.CardType), configStr, string(positionJSON), card.ID.String())
+	res, err := s.db.ExecContext(ctx, `UPDATE cards SET dashboard_id = ?, card_type = ?, config = ?, position = ? WHERE id = ?`,
+		card.DashboardID.String(), string(card.CardType), configStr, string(positionJSON), card.ID.String())
 	if err != nil {
 		return err
 	}
@@ -1185,6 +1185,41 @@ func (s *SQLiteStore) UpdateCard(ctx context.Context, card *models.Card) error {
 		return fmt.Errorf("failed to read rows affected: %w", err)
 	}
 	if rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// MoveCardWithLimit atomically moves a card to a different dashboard,
+// enforcing the per-dashboard card limit. The count check and the update
+// happen in a single SQL statement so that SQLite's write lock serializes
+// concurrent moves the same way CreateCardWithLimit serializes creates.
+// Returns ErrDashboardCardLimitReached when the target dashboard already
+// has maxCards cards (the card that is being moved is excluded from the
+// count because it still belongs to the source dashboard at check time).
+func (s *SQLiteStore) MoveCardWithLimit(ctx context.Context, cardID uuid.UUID, targetDashboardID uuid.UUID, maxCards int) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE cards SET dashboard_id = ?
+		 WHERE id = ?
+		 AND (SELECT COUNT(*) FROM cards WHERE dashboard_id = ?) < ?`,
+		targetDashboardID.String(), cardID.String(),
+		targetDashboardID.String(), maxCards,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to move card: %w", err)
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to read rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		// Could be either: card doesn't exist, or limit reached.
+		// Check if card exists to distinguish.
+		var exists int
+		_ = s.db.QueryRowContext(ctx, `SELECT 1 FROM cards WHERE id = ?`, cardID.String()).Scan(&exists)
+		if exists == 1 {
+			return ErrDashboardCardLimitReached
+		}
 		return sql.ErrNoRows
 	}
 	return nil

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -95,6 +95,7 @@ type Store interface {
 	CreateCard(ctx context.Context, card *models.Card) error
 	CreateCardWithLimit(ctx context.Context, card *models.Card, maxCards int) error
 	UpdateCard(ctx context.Context, card *models.Card) error
+	MoveCardWithLimit(ctx context.Context, cardID uuid.UUID, targetDashboardID uuid.UUID, maxCards int) error
 	DeleteCard(ctx context.Context, id uuid.UUID) error
 	UpdateCardFocus(ctx context.Context, cardID uuid.UUID, summary string) error
 

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -100,6 +100,21 @@ func (m *MockStore) UpdateCard(ctx context.Context, card *models.Card) error    
 func (m *MockStore) DeleteCard(ctx context.Context, id uuid.UUID) error                          { return nil }
 func (m *MockStore) UpdateCardFocus(ctx context.Context, cardID uuid.UUID, summary string) error { return nil }
 
+// MoveCardWithLimit is overridable so tests can exercise both the success
+// path and the ErrDashboardCardLimitReached branch of the atomic move.
+func (m *MockStore) MoveCardWithLimit(ctx context.Context, cardID uuid.UUID, targetDashboardID uuid.UUID, maxCards int) error {
+	if len(m.ExpectedCalls) == 0 {
+		return nil
+	}
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "MoveCardWithLimit" {
+			args := m.Called(cardID, targetDashboardID, maxCards)
+			return args.Error(0)
+		}
+	}
+	return nil
+}
+
 func (m *MockStore) AddCardHistory(ctx context.Context, history *models.CardHistory) error { return nil }
 func (m *MockStore) GetUserCardHistory(ctx context.Context, userID uuid.UUID, limit int) ([]models.CardHistory, error) {
 	return nil, nil


### PR DESCRIPTION
Fixes #10188

## Changes

**Defect 1 fix (silent persistence failure):** Added `dashboard_id` to the `UpdateCard` SQL SET clause in `pkg/store/sqlite.go`. Previously, setting `card.DashboardID` in Go memory was never written to the database.

**Defect 2 fix (TOCTOU race):** Added a new `MoveCardWithLimit` store method that atomically counts the target dashboard's cards and updates the card's `dashboard_id` in a single SQL statement. This mirrors the existing `CreateCardWithLimit` pattern and eliminates the race where two concurrent moves could both pass the limit check.

**Handler update:** `MoveCard` handler now calls `MoveCardWithLimit` instead of the non-atomic count-then-update sequence.

## Files changed
- `pkg/store/sqlite.go` — fix UpdateCard SQL, add MoveCardWithLimit
- `pkg/store/store.go` — add MoveCardWithLimit to Store interface
- `pkg/api/handlers/cards.go` — use atomic MoveCardWithLimit in handler