### PR TITLE
🧹 Consolidate 14 duplicate useFormatRelativeTime hooks into shared factory

### DIFF
--- a/web/src/components/cards/artifact_hub_status/index.tsx
+++ b/web/src/components/cards/artifact_hub_status/index.tsx
@@ -11,25 +11,12 @@ import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../ui/Skeleton'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { useArtifactHubStatus } from './useArtifactHubStatus'
+import { createCardSyncFormatter } from '../../../lib/formatters'
 
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('artifactHub.syncedJustNow')
-    const minute = 60_000
-    const hour = 60 * minute
-    const day = 24 * hour
-    if (diff < minute) return t('artifactHub.syncedJustNow')
-    if (diff < hour) return t('artifactHub.syncedMinutesAgo', { count: Math.floor(diff / minute) })
-    if (diff < day) return t('artifactHub.syncedHoursAgo', { count: Math.floor(diff / hour) })
-    return t('artifactHub.syncedDaysAgo', { count: Math.floor(diff / day) })
-  }
-}
 
 export function ArtifactHubStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'artifactHub')
   const { data, error, showSkeleton, showEmptyState } = useArtifactHubStatus()
 
   if (showSkeleton) {

--- a/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
+++ b/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
@@ -5,6 +5,7 @@ import { CardSearchInput, MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCloudEventsStatus } from './useCloudEventsStatus'
 import type { CloudEventResourceState } from './demoData'
+import { createCardSyncFormatter } from '../../../lib/formatters'
 
 const STATUS_STYLE: Record<CloudEventResourceState, { badge: string; icon: React.ReactNode }> = {
   ready: {
@@ -22,26 +23,10 @@ const STATUS_LABEL_KEY: Record<CloudEventResourceState, 'cloudevents.status_read
   degraded: 'cloudevents.status_degraded',
   error: 'cloudevents.status_error' }
 
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('cloudevents.syncedJustNow')
-
-    const minute = 60_000
-    const hour = 60 * minute
-    const day = 24 * hour
-
-    if (diff < minute) return t('cloudevents.syncedJustNow')
-    if (diff < hour) return t('cloudevents.syncedMinutesAgo', { count: Math.floor(diff / minute) })
-    if (diff < day) return t('cloudevents.syncedHoursAgo', { count: Math.floor(diff / hour) })
-    return t('cloudevents.syncedDaysAgo', { count: Math.floor(diff / day) })
-  }
-}
 
 export function CloudEventsStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'cloudevents')
   const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCloudEventsStatus()
   const [search, setSearch] = useState('')
 

--- a/web/src/components/cards/contour_status/index.tsx
+++ b/web/src/components/cards/contour_status/index.tsx
@@ -4,26 +4,8 @@ import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useContourStatus } from './useContourStatus'
 import type { ContourProxyStatus } from './demoData'
+import { createCardSyncFormatter } from '../../../lib/formatters'
 
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const parsed = new Date(isoString).getTime()
-    if (!isoString || Number.isNaN(parsed)) return t('contourStatus.syncedJustNow')
-
-    const diff = Date.now() - parsed
-    if (diff < 0) return t('contourStatus.syncedJustNow')
-
-    const minute = 60_000
-    const hour = 60 * minute
-    const day = 24 * hour
-
-    if (diff < minute) return t('contourStatus.syncedJustNow')
-    if (diff < hour) return t('contourStatus.syncedMinutesAgo', { count: Math.floor(diff / minute) })
-    if (diff < day) return t('contourStatus.syncedHoursAgo', { count: Math.floor(diff / hour) })
-    return t('contourStatus.syncedDaysAgo', { count: Math.floor(diff / day) })
-  }
-}
 
 function ProxySection({
   title,
@@ -88,7 +70,7 @@ function ProxySection({
 
 export function ContourStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'contourStatus')
   const { data, isRefreshing, error, showSkeleton, showEmptyState } = useContourStatus()
 
   const isHealthy = data.health === 'healthy'

--- a/web/src/components/cards/crio_status/CrioStatus.tsx
+++ b/web/src/components/cards/crio_status/CrioStatus.tsx
@@ -3,25 +3,11 @@ import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../ui/Skeleton'
 import { useCrioStatus } from './useCrioStatus'
 import { MetricTile } from '../../../lib/cards/CardComponents'
-
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('crio.syncedJustNow')
-    const minute = 60_000
-    const hour = 60 * minute
-    const day = 24 * hour
-    if (diff < minute) return t('crio.syncedJustNow')
-    if (diff < hour) return t('crio.syncedMinutesAgo', { count: Math.floor(diff / minute) })
-    if (diff < day) return t('crio.syncedHoursAgo', { count: Math.floor(diff / hour) })
-    return t('crio.syncedDaysAgo', { count: Math.floor(diff / day) })
-  }
-}
+import { createCardSyncFormatter } from '../../../lib/formatters'
 
 export function CrioStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'crio')
   const { data, error, showSkeleton, showEmptyState, isRefreshing, isDemoData } = useCrioStatus()
 
   if (showSkeleton) {

--- a/web/src/components/cards/flatcar_status/index.tsx
+++ b/web/src/components/cards/flatcar_status/index.tsx
@@ -4,26 +4,13 @@ import { Skeleton } from '../../ui/Skeleton'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { useFlatcarStatus } from './useFlatcarStatus'
 import { compareFlatcarVersions } from './versionUtils'
+import { createCardSyncFormatter } from '../../../lib/formatters'
 
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('flatcar.syncedJustNow')
-    const minute = 60_000
-    const hour = 60 * minute
-    const day = 24 * hour
-    if (diff < minute) return t('flatcar.syncedJustNow')
-    if (diff < hour) return t('flatcar.syncedMinutesAgo', { count: Math.floor(diff / minute) })
-    if (diff < day) return t('flatcar.syncedHoursAgo', { count: Math.floor(diff / hour) })
-    return t('flatcar.syncedDaysAgo', { count: Math.floor(diff / day) })
-  }
-}
 
 
 export function FlatcarStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'flatcar')
   const { data, error, showSkeleton, showEmptyState } = useFlatcarStatus()
 
   if (showSkeleton) {

--- a/web/src/components/cards/flux_status/index.tsx
+++ b/web/src/components/cards/flux_status/index.tsx
@@ -4,26 +4,8 @@ import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useFluxStatus } from './useFluxStatus'
 import type { FluxResourceStatus } from './demoData'
+import { createCardSyncFormatter } from '../../../lib/formatters'
 
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const parsed = new Date(isoString).getTime()
-    if (!isoString || Number.isNaN(parsed)) return t('fluxStatus.syncedJustNow')
-
-    const diff = Date.now() - parsed
-    if (diff < 0) return t('fluxStatus.syncedJustNow')
-
-    const minute = 60_000
-    const hour = 60 * minute
-    const day = 24 * hour
-
-    if (diff < minute) return t('fluxStatus.syncedJustNow')
-    if (diff < hour) return t('fluxStatus.syncedMinutesAgo', { count: Math.floor(diff / minute) })
-    if (diff < day) return t('fluxStatus.syncedHoursAgo', { count: Math.floor(diff / hour) })
-    return t('fluxStatus.syncedDaysAgo', { count: Math.floor(diff / day) })
-  }
-}
 
 function ResourceSection({
   title,
@@ -88,7 +70,7 @@ function ResourceSection({
 
 export function FluxStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'fluxStatus')
   const { data, isRefreshing, error, showSkeleton, showEmptyState } = useFluxStatus()
 
   const totalNotReady = data.sources.notReady + data.kustomizations.notReady + data.helmReleases.notReady

--- a/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
+++ b/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
@@ -20,6 +20,7 @@ import {
 import { useCardData } from '../../../lib/cards/cardHooks'
 import { useKeycloakStatus } from './useKeycloakStatus'
 import type { KeycloakRealm, KeycloakRealmStatus } from './demoData'
+import { createCardSyncFormatter } from '../../../lib/formatters'
 
 // Default page size for the paginated realm list. Named constant per
 // CLAUDE.md "No magic numbers" rule.
@@ -63,20 +64,6 @@ const STATUS_SORT_ORDER: Record<KeycloakRealmStatus, number> = {
   ready: 3,
 }
 
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('keycloak.syncedJustNow')
-    const minute = 60_000
-    const hour = 60 * minute
-    const day = 24 * hour
-    if (diff < minute) return t('keycloak.syncedJustNow')
-    if (diff < hour) return t('keycloak.syncedMinutesAgo', { count: Math.floor(diff / minute) })
-    if (diff < day) return t('keycloak.syncedHoursAgo', { count: Math.floor(diff / hour) })
-    return t('keycloak.syncedDaysAgo', { count: Math.floor(diff / day) })
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -156,7 +143,7 @@ function RealmRow({ realm }: { realm: KeycloakRealm }) {
 
 export function KeycloakStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'keycloak')
   const { data, isRefreshing, isFailed, showSkeleton, showEmptyState } =
     useKeycloakStatus()
 

--- a/web/src/components/cards/lima_status/LimaStatus.tsx
+++ b/web/src/components/cards/lima_status/LimaStatus.tsx
@@ -3,21 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../ui/Skeleton'
 import { useLimaStatus } from './useLimaStatus'
 import { MetricTile } from '../../../lib/cards/CardComponents'
-
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('lima.syncedJustNow')
-    const minute = 60_000
-    const hour = 60 * minute
-    const day = 24 * hour
-    if (diff < minute) return t('lima.syncedJustNow')
-    if (diff < hour) return t('lima.syncedMinutesAgo', { count: Math.floor(diff / minute) })
-    if (diff < day) return t('lima.syncedHoursAgo', { count: Math.floor(diff / hour) })
-    return t('lima.syncedDaysAgo', { count: Math.floor(diff / day) })
-  }
-}
+import { createCardSyncFormatter } from '../../../lib/formatters'
 
 const STATUS_COLORS: Record<string, string> = {
   running: 'text-green-400',
@@ -33,7 +19,7 @@ const STATUS_BG: Record<string, string> = {
 
 export function LimaStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'lima')
   const { data, error, showSkeleton, showEmptyState, isDemoData } = useLimaStatus()
 
   if (showSkeleton) {

--- a/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
@@ -19,6 +19,7 @@ import { useK3sStatus } from './useK3sStatus'
 import { K3S_INSTALL_PROMPT } from '../shared'
 import { loadMissionPrompt } from '../missionLoader'
 import { K3sDetailModal } from './K3sDetailModal'
+import { createCardSyncFormatter } from '../../../../lib/formatters'
 
 // ============================================================================
 // Constants
@@ -34,25 +35,6 @@ const SKELETON_POD_ROWS = 3
 // Relative time formatting
 // ============================================================================
 
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('k3sStatus.syncedJustNow')
-
-    /** Milliseconds in one minute */
-    const MINUTE_MS = 60_000
-    /** Milliseconds in one hour */
-    const HOUR_MS = 60 * MINUTE_MS
-    /** Milliseconds in one day */
-    const DAY_MS = 24 * HOUR_MS
-
-    if (diff < MINUTE_MS) return t('k3sStatus.syncedJustNow')
-    if (diff < HOUR_MS) return t('k3sStatus.syncedMinutesAgo', { count: Math.floor(diff / MINUTE_MS) })
-    if (diff < DAY_MS) return t('k3sStatus.syncedHoursAgo', { count: Math.floor(diff / HOUR_MS) })
-    return t('k3sStatus.syncedDaysAgo', { count: Math.floor(diff / DAY_MS) })
-  }
-}
 
 // ============================================================================
 // Component
@@ -60,7 +42,7 @@ function useFormatRelativeTime() {
 
 export function K3sStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'k3sStatus')
   const { data, error, showSkeleton, showEmptyState, isRefreshing, isDemoData } = useK3sStatus()
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexStatus.tsx
@@ -19,6 +19,7 @@ import { useKubeFlexStatus } from './useKubeflexStatus'
 import { KUBEFLEX_INSTALL_PROMPT } from '../shared'
 import { loadMissionPrompt } from '../missionLoader'
 import { KubeFlexDetailModal } from './KubeFlexDetailModal'
+import { createCardSyncFormatter } from '../../../../lib/formatters'
 
 // ============================================================================
 // Constants
@@ -31,25 +32,6 @@ const SKELETON_CP_ROWS = 3
 // Relative time formatting
 // ============================================================================
 
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('kubeFlexStatus.syncedJustNow')
-
-    /** Milliseconds in one minute */
-    const MINUTE_MS = 60_000
-    /** Milliseconds in one hour */
-    const HOUR_MS = 60 * MINUTE_MS
-    /** Milliseconds in one day */
-    const DAY_MS = 24 * HOUR_MS
-
-    if (diff < MINUTE_MS) return t('kubeFlexStatus.syncedJustNow')
-    if (diff < HOUR_MS) return t('kubeFlexStatus.syncedMinutesAgo', { count: Math.floor(diff / MINUTE_MS) })
-    if (diff < DAY_MS) return t('kubeFlexStatus.syncedHoursAgo', { count: Math.floor(diff / HOUR_MS) })
-    return t('kubeFlexStatus.syncedDaysAgo', { count: Math.floor(diff / DAY_MS) })
-  }
-}
 
 // ============================================================================
 // Component
@@ -57,7 +39,7 @@ function useFormatRelativeTime() {
 
 export function KubeFlexStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'kubeFlexStatus')
   const { data, error, showSkeleton, showEmptyState, isRefreshing, isDemoData } = useKubeFlexStatus()
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
@@ -19,6 +19,7 @@ import { useKubevirtStatus } from './useKubevirtStatus'
 import { KUBEVIRT_INSTALL_PROMPT } from '../shared'
 import { loadMissionPrompt } from '../missionLoader'
 import { KubevirtDetailModal } from './KubevirtDetailModal'
+import { createCardSyncFormatter } from '../../../../lib/formatters'
 
 // ============================================================================
 // Constants
@@ -34,25 +35,6 @@ const SKELETON_VM_ROWS = 3
 // Relative time formatting
 // ============================================================================
 
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('kubevirtStatus.syncedJustNow')
-
-    /** Milliseconds in one minute */
-    const MINUTE_MS = 60_000
-    /** Milliseconds in one hour */
-    const HOUR_MS = 60 * MINUTE_MS
-    /** Milliseconds in one day */
-    const DAY_MS = 24 * HOUR_MS
-
-    if (diff < MINUTE_MS) return t('kubevirtStatus.syncedJustNow')
-    if (diff < HOUR_MS) return t('kubevirtStatus.syncedMinutesAgo', { count: Math.floor(diff / MINUTE_MS) })
-    if (diff < DAY_MS) return t('kubevirtStatus.syncedHoursAgo', { count: Math.floor(diff / HOUR_MS) })
-    return t('kubevirtStatus.syncedDaysAgo', { count: Math.floor(diff / DAY_MS) })
-  }
-}
 
 // ============================================================================
 // VM state badge helper
@@ -77,7 +59,7 @@ function vmStateColorClass(state: string): string {
 
 export function KubevirtStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'kubevirtStatus')
   const { data, error, showSkeleton, showEmptyState, isRefreshing, isDemoData } = useKubevirtStatus()
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()

--- a/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
@@ -19,6 +19,7 @@ import { useOvnStatus } from './useOvnStatus'
 import { OVN_INSTALL_PROMPT } from '../shared'
 import { loadMissionPrompt } from '../missionLoader'
 import { OvnDetailModal } from './OvnDetailModal'
+import { createCardSyncFormatter } from '../../../../lib/formatters'
 
 // ============================================================================
 // Constants
@@ -34,25 +35,6 @@ const SKELETON_UDN_ROWS = 2
 // Relative time formatting
 // ============================================================================
 
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('ovnStatus.syncedJustNow')
-
-    /** Milliseconds in one minute */
-    const MINUTE_MS = 60_000
-    /** Milliseconds in one hour */
-    const HOUR_MS = 60 * MINUTE_MS
-    /** Milliseconds in one day */
-    const DAY_MS = 24 * HOUR_MS
-
-    if (diff < MINUTE_MS) return t('ovnStatus.syncedJustNow')
-    if (diff < HOUR_MS) return t('ovnStatus.syncedMinutesAgo', { count: Math.floor(diff / MINUTE_MS) })
-    if (diff < DAY_MS) return t('ovnStatus.syncedHoursAgo', { count: Math.floor(diff / HOUR_MS) })
-    return t('ovnStatus.syncedDaysAgo', { count: Math.floor(diff / DAY_MS) })
-  }
-}
 
 // ============================================================================
 // Component
@@ -60,7 +42,7 @@ function useFormatRelativeTime() {
 
 export function OvnStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'ovnStatus')
   const { data, error, showSkeleton, showEmptyState, isRefreshing, isDemoData } = useOvnStatus()
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()

--- a/web/src/components/cards/openyurt_status/OpenYurtStatus.tsx
+++ b/web/src/components/cards/openyurt_status/OpenYurtStatus.tsx
@@ -16,6 +16,7 @@ import { Skeleton, SkeletonStats, SkeletonList } from '../../ui/Skeleton'
 import { CardSearchInput } from '../../../lib/cards/CardComponents'
 import { useOpenYurtStatus } from './useOpenYurtStatus'
 import type { OpenYurtNodePool, NodePoolStatus, NodePoolType, OpenYurtGateway, GatewayStatus } from './demoData'
+import { createCardSyncFormatter } from '../../../lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -77,20 +78,6 @@ const GATEWAY_STATUS_CONFIG: Record<
   },
 }
 
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('openyurt.syncedJustNow')
-    const minute = 60_000
-    const hour = 60 * minute
-    const day = 24 * hour
-    if (diff < minute) return t('openyurt.syncedJustNow')
-    if (diff < hour) return t('openyurt.syncedMinutesAgo', { count: Math.floor(diff / minute) })
-    if (diff < day) return t('openyurt.syncedHoursAgo', { count: Math.floor(diff / hour) })
-    return t('openyurt.syncedDaysAgo', { count: Math.floor(diff / day) })
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -203,7 +190,7 @@ function GatewayRow({ gw }: { gw: OpenYurtGateway }) {
 
 export function OpenYurtStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
+  const formatRelativeTime = createCardSyncFormatter(t, 'openyurt')
   const { data, isRefreshing, error, showSkeleton, showEmptyState } = useOpenYurtStatus()
   const [search, setSearch] = useState('')
 

--- a/web/src/components/cards/thanos_status/index.tsx
+++ b/web/src/components/cards/thanos_status/index.tsx
@@ -3,20 +3,13 @@ import { Skeleton } from '../../ui/Skeleton'
 import { useCachedThanosStatus } from '../../../hooks/useCachedThanosStatus'
 import { useTranslation } from 'react-i18next'
 import { useCardLoadingState } from '../CardDataContext'
+import { createCardSyncFormatter } from '../../../lib/formatters'
 
-function useFormatRelativeTime() {
-    const { t } = useTranslation('cards')
-    return (isoString: string): string => {
-        const diff = Date.now() - new Date(isoString).getTime()
-        if (isNaN(diff) || diff < 0) return t('thanosStatus.justNow')
-        const minute = 60_000
-        const hour = 60 * minute
-        const day = 24 * hour
-        if (diff < minute) return t('thanosStatus.justNow')
-        if (diff < hour) return t('thanosStatus.minutesAgo', { count: Math.floor(diff / minute) })
-        if (diff < day) return t('thanosStatus.hoursAgo', { count: Math.floor(diff / hour) })
-        return t('thanosStatus.daysAgo', { count: Math.floor(diff / day) })
-    }
+const THANOS_TIME_KEYS = {
+  justNow: 'thanosStatus.justNow',
+  minutesAgo: 'thanosStatus.minutesAgo',
+  hoursAgo: 'thanosStatus.hoursAgo',
+  daysAgo: 'thanosStatus.daysAgo',
 }
 
 interface MetricTileProps {
@@ -40,7 +33,7 @@ function MetricTile({ label, value, colorClass, icon }: MetricTileProps) {
 
 export function ThanosStatus() {
     const { t } = useTranslation('cards')
-    const formatRelativeTime = useFormatRelativeTime()
+    const formatRelativeTime = createCardSyncFormatter(t, THANOS_TIME_KEYS)
     const {
         data,
         isLoading,

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -225,14 +225,68 @@ export function createRelativeTimeFormatter(
   return (isoString: string): string => {
     const diff = Date.now() - new Date(isoString).getTime()
     if (isNaN(diff) || diff < 0) return t('common.justNow')
-    
+
     const minute = 60_000
     const hour = 60 * minute
     const day = 24 * hour
-    
+
     if (diff < minute) return t('common.justNow')
     if (diff < hour) return t('common.minutesAgo', { count: Math.floor(diff / minute) })
     if (diff < day) return t('common.hoursAgo', { count: Math.floor(diff / hour) })
     return t('common.daysAgo', { count: Math.floor(diff / day) })
+  }
+}
+
+export interface CardSyncKeys {
+  justNow: string
+  minutesAgo: string
+  hoursAgo: string
+  daysAgo: string
+}
+
+/**
+ * Build the standard `synced*` i18n key set for a card prefix.
+ *
+ * Most status cards use `<prefix>.syncedJustNow`, etc.  Pass a custom
+ * {@link CardSyncKeys} object for cards that deviate (e.g. Thanos uses
+ * `thanosStatus.justNow` without the `synced` prefix).
+ */
+export function cardSyncKeys(prefix: string): CardSyncKeys {
+  return {
+    justNow: `${prefix}.syncedJustNow`,
+    minutesAgo: `${prefix}.syncedMinutesAgo`,
+    hoursAgo: `${prefix}.syncedHoursAgo`,
+    daysAgo: `${prefix}.syncedDaysAgo`,
+  }
+}
+
+/**
+ * Create a card-specific i18n-aware relative time formatter.
+ *
+ * Accepts either a card prefix (uses the standard `synced*` key convention)
+ * or an explicit {@link CardSyncKeys} object for non-standard cards.
+ */
+export function createCardSyncFormatter(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  t: (key: any, options?: any) => string,
+  keys: string | CardSyncKeys,
+): (isoString: string) => string {
+  const k = typeof keys === 'string' ? cardSyncKeys(keys) : keys
+
+  return (isoString: string): string => {
+    const parsed = new Date(isoString).getTime()
+    if (!isoString || isNaN(parsed)) return t(k.justNow)
+
+    const diff = Date.now() - parsed
+    if (diff < 0) return t(k.justNow)
+
+    const MS_PER_MIN = 60_000
+    const MS_PER_HR = 60 * MS_PER_MIN
+    const MS_PER_D = 24 * MS_PER_HR
+
+    if (diff < MS_PER_MIN) return t(k.justNow)
+    if (diff < MS_PER_HR) return t(k.minutesAgo, { count: Math.floor(diff / MS_PER_MIN) })
+    if (diff < MS_PER_D) return t(k.hoursAgo, { count: Math.floor(diff / MS_PER_HR) })
+    return t(k.daysAgo, { count: Math.floor(diff / MS_PER_D) })
   }
 }


### PR DESCRIPTION
## Summary
- Add `createCardSyncFormatter()` factory to `lib/formatters.ts` that accepts a card i18n prefix and returns a time formatter
- Replace 14 identical local `useFormatRelativeTime()` hook definitions with a one-line call to the shared factory
- Support custom key maps for non-standard cards (Thanos uses `justNow` instead of `syncedJustNow`)

**15 files changed, +89 −245 lines (net −156)**

## Files Changed
| File | Change |
|------|--------|
| `lib/formatters.ts` | Add `createCardSyncFormatter`, `cardSyncKeys`, `CardSyncKeys` |
| 13 status cards | Remove local hook, import + call factory with prefix |
| `thanos_status/index.tsx` | Custom key map (non-standard i18n keys) |

## Affected Cards
lima, crio, flatcar, contour, artifact_hub, flux, cloudevents, openyurt, keycloak, thanos, kubevirt, kubeflex, k3s, ovn

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] Time-ago formatting still works in all 14 status cards
- [ ] Thanos card uses correct non-synced key format

Fixes #10187