### PR TITLE
🐛 Fix test failure in Coverage Suite (#10189)

### DIFF
--- a/web/src/hooks/__tests__/useAIPredictions.test.ts
+++ b/web/src/hooks/__tests__/useAIPredictions.test.ts
@@ -491,9 +491,11 @@ describe('useAIPredictions', () => {
     // exists to anchor the promise settlement for debugging if the test hangs.
     void done
 
-    // Advance past all internal delays (triggerAnalysis demo delay + RETRY_DELAY_MS)
+    // Advance past the triggerAnalysis demo delay (UI_FEEDBACK_TIMEOUT_MS = 2 000 ms)
+    // and then the first poll tick (ANALYSIS_POLL_INTERVAL_MS = 4 000 ms) so that
+    // cleanup() fires and clearActiveTokenCategory is called.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000)
+      await vi.advanceTimersByTimeAsync(7000)
     })
 
     // Per-operation tracking (#6016): setActiveTokenCategory called with


### PR DESCRIPTION
Fixes #10189

The `useAIPredictions` test 'analyze in demo mode simulates delay and regenerates predictions' was failing because fake timers were only advanced by 2000ms — enough for the `triggerAnalysis` demo delay but not for the subsequent poll interval (4000ms) that triggers `cleanup()` and `clearActiveTokenCategory`.

**Fix:** Advance timers by 7000ms so the poll fires after the demo delay and the full analyze lifecycle completes.