### PR TITLE
🐛 Fix WebSocket handshake with KC_AGENT_TOKEN (#10183)

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -6,6 +6,7 @@ import { kubectlProxy } from '../../lib/kubectlProxy'
 import { registerCacheReset, triggerAllRefetches } from '../../lib/modeTransition'
 import { resetFailuresForCluster, resetAllCacheFailures } from '../../lib/cache'
 import { hostnameEndsWith, hostnameContainsLabel } from '../../lib/utils/urlHostname'
+import { appendWsAuthToken } from '../../lib/utils/wsAuth'
 import {
   LOCAL_AGENT_HTTP_URL,
   MCP_HOOK_TIMEOUT_MS,
@@ -865,7 +866,7 @@ export function connectSharedWebSocket() {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
     const wsUrl = `${protocol}//${window.location.host}/ws`
 
-    const ws = new WebSocket(wsUrl)
+    const ws = new WebSocket(appendWsAuthToken(wsUrl))
 
     ws.onopen = () => {
       // Guard against race condition where onclose fires before onopen

--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -7,6 +7,7 @@
 
 import { isNetlifyDeployment } from './demoMode'
 import { isInClusterMode } from '../hooks/useBackendHealth'
+import { appendWsAuthToken } from './utils/wsAuth'
 import {
   LOCAL_AGENT_WS_URL,
   WS_CONNECT_TIMEOUT_MS,
@@ -160,7 +161,7 @@ class KubectlProxy {
           cb()
         }
         try {
-          this.ws = new WebSocket(wsURL)
+          this.ws = new WebSocket(appendWsAuthToken(wsURL))
           connectTimeout = setTimeout(() => {
             try {
               this.ws?.close()

--- a/web/src/lib/utils/wsAuth.ts
+++ b/web/src/lib/utils/wsAuth.ts
@@ -1,0 +1,23 @@
+/**
+ * Append the kc-agent authentication token to a WebSocket URL.
+ *
+ * Browsers cannot set custom headers on WebSocket handshake requests,
+ * so we pass the token as a query parameter instead.
+ */
+import { STORAGE_KEY_TOKEN } from '../constants'
+
+/** Query-string key used to pass the auth token on WebSocket URLs */
+export const WS_AUTH_QUERY_PARAM = 'token'
+
+/**
+ * If a session token exists in localStorage, append it to `url` as
+ * `?token=<value>` (or `&token=<value>` when other params are present).
+ * Returns the original URL unchanged when no token is stored.
+ */
+export function appendWsAuthToken(url: string): string {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  if (!token) return url
+
+  const separator = url.includes('?') ? '&' : '?'
+  return `${url}${separator}${WS_AUTH_QUERY_PARAM}=${encodeURIComponent(token)}`
+}


### PR DESCRIPTION
Fixes #10183

When `KC_AGENT_TOKEN` is configured, the kc-agent enforces token validation at the HTTP Upgrade step for WebSockets. Browsers cannot set custom headers on WebSocket handshake requests, so the token must be passed as a `?token=<value>` query parameter.

The server-side validation in `pkg/agent/server.go` (`validateToken`) already supports reading the token from the query string, and the `appendWsAuthToken()` utility in `web/src/lib/utils/wsAuth.ts` already exists to append it. However, neither the **Shared WebSocket** (`web/src/hooks/mcp/shared.ts`) nor the **Kubectl Proxy** (`web/src/lib/kubectlProxy.ts`) was calling this utility before creating the WebSocket connection.

### Changes

- **`web/src/hooks/mcp/shared.ts`** — import and apply `appendWsAuthToken()` to the WebSocket URL before calling `new WebSocket()`
- **`web/src/lib/kubectlProxy.ts`** — import and apply `appendWsAuthToken()` to the resolved WebSocket URL before calling `new WebSocket()`

### Testing

- `go build ./...` ✅
- `go test ./pkg/api/... ./pkg/agent/... -count=1` ✅
- `cd web && npm run build` ✅
- `cd web && npm run lint` ✅