### PR TITLE
🧹 Deduplicate isPodHealthy into shared lib/k8s.ts

### DIFF
--- a/web/src/components/cards/multi-tenancy/k3s-status/helpers.ts
+++ b/web/src/components/cards/multi-tenancy/k3s-status/helpers.ts
@@ -71,19 +71,7 @@ export function isK3sNode(containerRuntime?: string): boolean {
   return (containerRuntime ?? '').toLowerCase().includes(K3S_RUNTIME_SUBSTRING)
 }
 
-import { parseReadyCount } from '../../../../lib/k8s'
-export { parseReadyCount } from '../../../../lib/k8s'
-
-/**
- * Determine whether a pod is healthy based on its status and ready ratio.
- */
-export function isPodHealthy(pod: K3sPodInfo): boolean {
-  const status = (pod.status ?? '').toLowerCase()
-  if (status !== 'running') return false
-
-  const { ready, total } = parseReadyCount(pod.ready)
-  return total > 0 && ready === total
-}
+export { parseReadyCount, isPodHealthy } from '../../../../lib/k8s'
 
 /**
  * Returns true if a pod qualifies as a K3s pod (by label OR by image).

--- a/web/src/components/cards/multi-tenancy/k3s-status/useK3sStatus.ts
+++ b/web/src/components/cards/multi-tenancy/k3s-status/useK3sStatus.ts
@@ -13,6 +13,7 @@ import { K3S_CACHE_KEY, OPERATOR_REFRESH_CATEGORY } from '../shared'
 import type { ComponentHealth } from '../shared'
 import { K3S_DEMO_DATA, type K3sServerPodInfo, type K3sStatusDemoData } from './demoData'
 import { LOCAL_AGENT_HTTP_URL } from '../../../../lib/constants/network'
+import { isPodHealthy } from '../../../../lib/k8s'
 
 // ============================================================================
 // Data Interface
@@ -72,14 +73,6 @@ function isK3sPod(pod: BackendPodInfo): boolean {
   return containers.some((c) => (c.image ?? '').includes(K3S_IMAGE_MARKER))
 }
 
-function isPodHealthy(status?: string, ready?: string): boolean {
-  if ((status ?? '').toLowerCase() !== 'running') return false
-  const parts = String(ready ?? '').split('/')
-  const readyCount = Number.parseInt(parts[0] ?? '0', 10)
-  const totalCount = Number.parseInt(parts[1] ?? '0', 10)
-  return totalCount > 0 && readyCount === totalCount
-}
-
 function extractVersion(pod: BackendPodInfo): string {
   const containers = pod.containers ?? []
   for (const c of containers) {
@@ -127,7 +120,7 @@ async function fetchK3sStatus(): Promise<K3sStatus> {
   const serverPods: K3sServerPodInfo[] = []
 
   for (const pod of k3sPods) {
-    const isHealthy = isPodHealthy(pod.status, pod.ready)
+    const isHealthy = isPodHealthy(pod)
     if (isHealthy) {
       healthy += 1
     } else {

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/helpers.ts
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/helpers.ts
@@ -71,19 +71,8 @@ export function isKubeFlexControlPlanePod(labels?: Record<string, string>): bool
   return Boolean(l[KUBEFLEX_CP_LABEL_KEY])
 }
 
-import { parseReadyCount } from '../../../../lib/k8s'
-export { parseReadyCount } from '../../../../lib/k8s'
-
-/**
- * Determine whether a pod is healthy based on its status and ready ratio.
- */
-export function isPodHealthy(pod: KubeFlexPodInfo): boolean {
-  const status = (pod.status ?? '').toLowerCase()
-  if (status !== 'running') return false
-
-  const { ready, total } = parseReadyCount(pod.ready)
-  return total > 0 && ready === total
-}
+import { isPodHealthy } from '../../../../lib/k8s'
+export { parseReadyCount, isPodHealthy } from '../../../../lib/k8s'
 
 /**
  * Group control-plane pods by control plane name and determine health per CP.

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/helpers.ts
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/helpers.ts
@@ -66,19 +66,8 @@ export function isVirtLauncher(labels?: Record<string, string>): boolean {
   return appLabel === VIRT_LAUNCHER_LABEL
 }
 
-import { parseReadyCount } from '../../../../lib/k8s'
-export { parseReadyCount } from '../../../../lib/k8s'
-
-/**
- * Determine whether a pod is healthy based on its status and ready ratio.
- */
-export function isPodHealthy(pod: KubevirtPodInfo): boolean {
-  const status = (pod.status ?? '').toLowerCase()
-  if (status !== 'running') return false
-
-  const { ready, total } = parseReadyCount(pod.ready)
-  return total > 0 && ready === total
-}
+import { parseReadyCount, isPodHealthy } from '../../../../lib/k8s'
+export { parseReadyCount, isPodHealthy } from '../../../../lib/k8s'
 
 /**
  * Extract VM state from a virt-launcher pod's status.

--- a/web/src/components/cards/multi-tenancy/ovn-status/helpers.ts
+++ b/web/src/components/cards/multi-tenancy/ovn-status/helpers.ts
@@ -5,8 +5,8 @@
  * pod and annotation data into the metrics shown by the card.
  */
 
-import { parseReadyCount } from '../../../../lib/k8s'
-export { parseReadyCount } from '../../../../lib/k8s'
+import { isPodHealthy } from '../../../../lib/k8s'
+export { parseReadyCount, isPodHealthy } from '../../../../lib/k8s'
 
 // ============================================================================
 // Types
@@ -78,17 +78,6 @@ export function isOvnPod(labels?: Record<string, string>): boolean {
     appLabel === OVN_MASTER_LABEL ||
     appLabel === OVN_CONTROLLER_LABEL
   )
-}
-
-/**
- * Determine whether a pod is healthy based on its status and ready ratio.
- */
-export function isPodHealthy(pod: OvnPodInfo): boolean {
-  const status = (pod.status ?? '').toLowerCase()
-  if (status !== 'running') return false
-
-  const { ready, total } = parseReadyCount(pod.ready)
-  return total > 0 && ready === total
 }
 
 /**

--- a/web/src/lib/k8s.ts
+++ b/web/src/lib/k8s.ts
@@ -15,3 +15,15 @@ export function parseReadyCount(ready?: string): { ready: number; total: number 
     total: Number.isFinite(totalCount) ? totalCount : 0,
   }
 }
+
+/**
+ * Determine whether a pod is healthy based on its status and ready ratio.
+ * Accepts any object with optional `status` and `ready` fields.
+ */
+export function isPodHealthy(pod: { status?: string; ready?: string }): boolean {
+  const status = (pod.status ?? '').toLowerCase()
+  if (status !== 'running') return false
+
+  const { ready, total } = parseReadyCount(pod.ready)
+  return total > 0 && ready === total
+}


### PR DESCRIPTION
## Summary

Extracts identical `isPodHealthy()` logic from 5 multi-tenancy card helpers into `lib/k8s.ts` with a generic `{ status?: string; ready?: string }` interface.

All 5 copies had the same body: lowercase status, check `'running'`, parse ready ratio via `parseReadyCount`, verify `ready === total`. The function naturally belongs in `lib/k8s.ts` alongside `parseReadyCount` which it calls.

### Files changed (6)
- `lib/k8s.ts` — added `isPodHealthy()` with generic interface
- `k3s-status/helpers.ts` — replaced local definition with re-export
- `kubeflex-status/helpers.ts` — replaced local definition with re-export
- `kubevirt-status/helpers.ts` — replaced local definition with re-export
- `ovn-status/helpers.ts` — replaced local definition with re-export
- `k3s-status/useK3sStatus.ts` — replaced local copy (different signature) with import; call changed from `isPodHealthy(pod.status, pod.ready)` to `isPodHealthy(pod)`

Fixes #10203