### PR TITLE
🐛 Add wsAuth mock to kubectlProxy tests (#10204)

### DIFF
--- a/web/src/lib/__tests__/kubectlProxy-expand.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy-expand.test.ts
@@ -11,6 +11,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 let mockIsNetlify = false
 
+vi.mock('../utils/wsAuth', () => ({
+  appendWsAuthToken: (url: string) => url,
+}))
+
 vi.mock('../demoMode', () => ({
   get isNetlifyDeployment() { return mockIsNetlify },
 }))

--- a/web/src/lib/__tests__/kubectlProxy.additional.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy.additional.test.ts
@@ -21,6 +21,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 // Track whether we're simulating a Netlify environment
 let mockIsNetlify = false
 
+vi.mock('../utils/wsAuth', () => ({
+  appendWsAuthToken: (url: string) => url,
+}))
+
 vi.mock('../demoMode', () => ({
   get isNetlifyDeployment() {
     return mockIsNetlify

--- a/web/src/lib/__tests__/kubectlProxy.core.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy.core.test.ts
@@ -21,6 +21,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 // Track whether we're simulating a Netlify environment
 let mockIsNetlify = false
 
+vi.mock('../utils/wsAuth', () => ({
+  appendWsAuthToken: (url: string) => url,
+}))
+
 vi.mock('../demoMode', () => ({
   get isNetlifyDeployment() {
     return mockIsNetlify


### PR DESCRIPTION
Fixes #10204

PR #10196 added `appendWsAuthToken` from `utils/wsAuth` to `kubectlProxy.ts`, but the three kubectlProxy test files did not mock this new dependency, causing 144 test failures in the Coverage Suite.

This adds a passthrough `vi.mock` for `../utils/wsAuth` in each test file so `appendWsAuthToken` returns the URL unchanged, keeping all existing WebSocket URL expectations valid.