### PR TITLE
🧹 Deduplicate isPodHealthy into shared lib/k8s.ts (#10203)

### DIFF
--- a/web/src/components/cards/multi-tenancy/k3s-status/useK3sStatus.ts
+++ b/web/src/components/cards/multi-tenancy/k3s-status/useK3sStatus.ts
@@ -73,7 +73,6 @@ function isK3sPod(pod: BackendPodInfo): boolean {
   return containers.some((c) => (c.image ?? '').includes(K3S_IMAGE_MARKER))
 }
 
-import { isPodHealthy } from '../../../../lib/k8s'
 
 function extractVersion(pod: BackendPodInfo): string {
   const containers = pod.containers ?? []

--- a/web/src/components/cards/multi-tenancy/k3s-status/useK3sStatus.ts
+++ b/web/src/components/cards/multi-tenancy/k3s-status/useK3sStatus.ts
@@ -73,6 +73,8 @@ function isK3sPod(pod: BackendPodInfo): boolean {
   return containers.some((c) => (c.image ?? '').includes(K3S_IMAGE_MARKER))
 }
 
+import { isPodHealthy } from '../../../../lib/k8s'
+
 function extractVersion(pod: BackendPodInfo): string {
   const containers = pod.containers ?? []
   for (const c of containers) {

--- a/web/src/lib/k8s.ts
+++ b/web/src/lib/k8s.ts
@@ -2,6 +2,12 @@
  * Shared Kubernetes utility functions used across multiple card helpers.
  */
 
+/** Minimal pod shape accepted by {@link isPodHealthy}. */
+export interface PodHealthInfo {
+  status?: string
+  ready?: string
+}
+
 /**
  * Parse a Kubernetes "ready/total" string (e.g. "2/3") into numeric parts.
  * Returns `{ ready: 0, total: 0 }` for missing or malformed input.


### PR DESCRIPTION
Fixes #10203

Moves the identical `isPodHealthy()` function from four multi-tenancy card helpers (k3s, kubeflex, kubevirt, ovn) and the standalone copy in `useK3sStatus.ts` into the shared `lib/k8s.ts` module.

Each helper re-exports `isPodHealthy` from `lib/k8s` for backwards compatibility — no downstream import changes needed.

**Changes:**
- Added `PodHealthInfo` interface and `isPodHealthy()` to `web/src/lib/k8s.ts`
- Replaced 5 duplicate implementations with imports/re-exports
- Net: +29 lines, −60 lines