### PR TITLE
🐛 Fix kubectlProxy test mocks: add missing STORAGE_KEY_TOKEN

### DIFF
--- a/web/src/lib/__tests__/kubectlProxy-expand.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy-expand.test.ts
@@ -23,6 +23,7 @@ vi.mock('../constants', () => ({
   LOCAL_AGENT_WS_URL: 'ws://127.0.0.1:8585/ws',
   WS_CONNECT_TIMEOUT_MS: 2500,
   WS_CONNECTION_COOLDOWN_MS: 5000,
+  BACKEND_HEALTH_CHECK_TIMEOUT_MS: 3000,
   KUBECTL_DEFAULT_TIMEOUT_MS: 10_000,
   KUBECTL_EXTENDED_TIMEOUT_MS: 30_000,
   KUBECTL_MAX_TIMEOUT_MS: 45_000,
@@ -30,6 +31,7 @@ vi.mock('../constants', () => ({
   MAX_CONCURRENT_KUBECTL_REQUESTS: 4,
   POD_RESTART_ISSUE_THRESHOLD: 5,
   FOCUS_DELAY_MS: 100,
+  STORAGE_KEY_TOKEN: 'token',
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/__tests__/kubectlProxy.additional.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy.additional.test.ts
@@ -35,6 +35,7 @@ vi.mock('../constants', () => ({
   LOCAL_AGENT_WS_URL: 'ws://127.0.0.1:8585/ws',
   WS_CONNECT_TIMEOUT_MS: 2500,
   WS_CONNECTION_COOLDOWN_MS: 5000,
+  BACKEND_HEALTH_CHECK_TIMEOUT_MS: 3000,
   KUBECTL_DEFAULT_TIMEOUT_MS: 10_000,
   KUBECTL_EXTENDED_TIMEOUT_MS: 30_000,
   KUBECTL_MAX_TIMEOUT_MS: 45_000,
@@ -42,6 +43,7 @@ vi.mock('../constants', () => ({
   MAX_CONCURRENT_KUBECTL_REQUESTS: 4,
   POD_RESTART_ISSUE_THRESHOLD: 5,
   FOCUS_DELAY_MS: 100,
+  STORAGE_KEY_TOKEN: 'token',
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/__tests__/kubectlProxy.core.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy.core.test.ts
@@ -35,6 +35,7 @@ vi.mock('../constants', () => ({
   LOCAL_AGENT_WS_URL: 'ws://127.0.0.1:8585/ws',
   WS_CONNECT_TIMEOUT_MS: 2500,
   WS_CONNECTION_COOLDOWN_MS: 5000,
+  BACKEND_HEALTH_CHECK_TIMEOUT_MS: 3000,
   KUBECTL_DEFAULT_TIMEOUT_MS: 10_000,
   KUBECTL_EXTENDED_TIMEOUT_MS: 30_000,
   KUBECTL_MAX_TIMEOUT_MS: 45_000,
@@ -42,6 +43,7 @@ vi.mock('../constants', () => ({
   MAX_CONCURRENT_KUBECTL_REQUESTS: 4,
   POD_RESTART_ISSUE_THRESHOLD: 5,
   FOCUS_DELAY_MS: 100,
+  STORAGE_KEY_TOKEN: 'token',
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/__tests__/kubectlProxy.quantity.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy.quantity.test.ts
@@ -31,6 +31,7 @@ vi.mock('../constants', () => ({
   LOCAL_AGENT_WS_URL: 'ws://127.0.0.1:8585/ws',
   WS_CONNECT_TIMEOUT_MS: 2500,
   WS_CONNECTION_COOLDOWN_MS: 5000,
+  BACKEND_HEALTH_CHECK_TIMEOUT_MS: 3000,
   KUBECTL_DEFAULT_TIMEOUT_MS: 10_000,
   KUBECTL_EXTENDED_TIMEOUT_MS: 30_000,
   KUBECTL_MAX_TIMEOUT_MS: 45_000,
@@ -38,6 +39,7 @@ vi.mock('../constants', () => ({
   MAX_CONCURRENT_KUBECTL_REQUESTS: 4,
   POD_RESTART_ISSUE_THRESHOLD: 5,
   FOCUS_DELAY_MS: 100,
+  STORAGE_KEY_TOKEN: 'token',
 }))
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #10140

## Problem
The `vi.mock('../constants')` in 4 kubectlProxy test files was missing `STORAGE_KEY_TOKEN` and `BACKEND_HEALTH_CHECK_TIMEOUT_MS` exports. When `wsAuth.ts` (imported transitively via `kubectlProxy.ts`) accessed `STORAGE_KEY_TOKEN`, vitest threw:

```
No "STORAGE_KEY_TOKEN" export is defined on the "../constants" mock
```

This caused **124 test failures** across hourly coverage shards 2, 4, and 12, making the hourly coverage workflow red.

## Fix
Added both missing exports to the constants mock in all 4 test files:
- `kubectlProxy.additional.test.ts` (76 failures fixed)
- `kubectlProxy.core.test.ts` (48 failures fixed)
- `kubectlProxy.quantity.test.ts`
- `kubectlProxy-expand.test.ts`

## Verification
All 157 tests across the 4 files pass locally after the fix.