### PR TITLE
🧹 Deduplicate StatTile component across 8 status cards

### DIFF
--- a/web/src/components/cards/cubefs_status/CubefsStatus.tsx
+++ b/web/src/components/cards/cubefs_status/CubefsStatus.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { StatTile } from '../shared/StatTile'
 import {
   CheckCircle,
   AlertTriangle,
@@ -103,30 +104,6 @@ function getRoleBadgeConfig(
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
-
-function StatTile({
-  icon,
-  label,
-  value,
-  colorClass,
-  borderClass,
-}: {
-  icon: React.ReactNode
-  label: string
-  value: number
-  colorClass: string
-  borderClass: string
-}) {
-  return (
-    <div className={`p-3 rounded-lg bg-secondary/30 border ${borderClass}`}>
-      <div className="flex items-center gap-2 mb-1">
-        {icon}
-        <span className={`text-xs ${colorClass}`}>{label}</span>
-      </div>
-      <span className="text-2xl font-bold text-foreground">{value}</span>
-    </div>
-  )
-}
 
 function UsageBar({ percent }: { percent: number }) {
   const barColor =

--- a/web/src/components/cards/fluid_status/FluidStatus.tsx
+++ b/web/src/components/cards/fluid_status/FluidStatus.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { StatTile } from '../shared/StatTile'
 import {
   CheckCircle,
   AlertTriangle,
@@ -84,30 +85,6 @@ const RUNTIME_STATUS_CONFIG: Record<
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
-
-function StatTile({
-  icon,
-  label,
-  value,
-  colorClass,
-  borderClass,
-}: {
-  icon: React.ReactNode
-  label: string
-  value: number
-  colorClass: string
-  borderClass: string
-}) {
-  return (
-    <div className={`p-3 rounded-lg bg-secondary/30 border ${borderClass}`}>
-      <div className="flex items-center gap-2 mb-1">
-        {icon}
-        <span className={`text-xs ${colorClass}`}>{label}</span>
-      </div>
-      <span className="text-2xl font-bold text-foreground">{value}</span>
-    </div>
-  )
-}
 
 function CacheBar({ percent }: { percent: number }) {
   const barColor =

--- a/web/src/components/cards/harbor_status/HarborStatus.tsx
+++ b/web/src/components/cards/harbor_status/HarborStatus.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { StatTile } from '../shared/StatTile'
 import {
   CheckCircle,
   AlertTriangle,
@@ -65,30 +66,6 @@ function getProjectStatusConfig(
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
-
-function StatTile({
-  icon,
-  label,
-  value,
-  colorClass,
-  borderClass,
-}: {
-  icon: React.ReactNode
-  label: string
-  value: number
-  colorClass: string
-  borderClass: string
-}) {
-  return (
-    <div className={`p-3 rounded-lg bg-secondary/30 border ${borderClass}`}>
-      <div className="flex items-center gap-2 mb-1">
-        {icon}
-        <span className={`text-xs ${colorClass}`}>{label}</span>
-      </div>
-      <span className="text-2xl font-bold text-foreground">{value}</span>
-    </div>
-  )
-}
 
 function UsageBar({ percent }: { percent: number }) {
   const barColor =

--- a/web/src/components/cards/karmada_status/KarmadaStatus.tsx
+++ b/web/src/components/cards/karmada_status/KarmadaStatus.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { StatTile } from '../shared/StatTile'
 import {
   CheckCircle,
   AlertTriangle,
@@ -47,29 +48,6 @@ function bindingStatusColor(status: KarmadaBindingStatus): string {
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
-
-function StatTile({
-  icon,
-  label,
-  value,
-  colorClass,
-  borderClass }: {
-  icon: React.ReactNode
-  label: string
-  value: number
-  colorClass: string
-  borderClass: string
-}) {
-  return (
-    <div className={`p-3 rounded-lg bg-secondary/30 border ${borderClass}`}>
-      <div className="flex items-center gap-2 mb-1">
-        {icon}
-        <span className={`text-xs ${colorClass}`}>{label}</span>
-      </div>
-      <span className="text-2xl font-bold text-foreground">{value}</span>
-    </div>
-  )
-}
 
 function MemberClusterRow({ cluster }: { cluster: KarmadaMemberCluster }) {
   const statusCfg = CLUSTER_STATUS_CONFIG[cluster.status]

--- a/web/src/components/cards/keda_status/KedaStatus.tsx
+++ b/web/src/components/cards/keda_status/KedaStatus.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { StatTile } from '../shared/StatTile'
 import {
   CheckCircle,
   AlertTriangle,
@@ -67,29 +68,6 @@ const TRIGGER_LABELS: Record<KedaTriggerType, string> = {
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
-
-function StatTile({
-  icon,
-  label,
-  value,
-  colorClass,
-  borderClass }: {
-  icon: React.ReactNode
-  label: string
-  value: number
-  colorClass: string
-  borderClass: string
-}) {
-  return (
-    <div className={`p-3 rounded-lg bg-secondary/30 border ${borderClass}`}>
-      <div className="flex items-center gap-2 mb-1">
-        {icon}
-        <span className={`text-xs ${colorClass}`}>{label}</span>
-      </div>
-      <span className="text-2xl font-bold text-foreground">{value}</span>
-    </div>
-  )
-}
 
 function ReplicaBar({
   current,

--- a/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
+++ b/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { StatTile } from '../shared/StatTile'
 import {
   CheckCircle,
   AlertTriangle,
@@ -68,30 +69,6 @@ const STATUS_SORT_ORDER: Record<KeycloakRealmStatus, number> = {
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
-
-function StatTile({
-  icon,
-  label,
-  value,
-  colorClass,
-  borderClass,
-}: {
-  icon: React.ReactNode
-  label: string
-  value: number
-  colorClass: string
-  borderClass: string
-}) {
-  return (
-    <div className={`p-3 rounded-lg bg-secondary/30 border ${borderClass}`}>
-      <div className="flex items-center gap-2 mb-1">
-        {icon}
-        <span className={`text-xs ${colorClass}`}>{label}</span>
-      </div>
-      <span className="text-2xl font-bold text-foreground">{value.toLocaleString()}</span>
-    </div>
-  )
-}
 
 function RealmRow({ realm }: { realm: KeycloakRealm }) {
   const { t } = useTranslation('cards')
@@ -289,28 +266,28 @@ export function KeycloakStatus() {
           <StatTile
             icon={<Globe className="w-4 h-4 text-blue-400" />}
             label={t('keycloak.realms')}
-            value={realms.length}
+            value={realms.length.toLocaleString()}
             colorClass="text-blue-400"
             borderClass="border-blue-500/20"
           />
           <StatTile
             icon={<CheckCircle className="w-4 h-4 text-green-400" />}
             label={t('keycloak.ready')}
-            value={stats.ready}
+            value={stats.ready.toLocaleString()}
             colorClass="text-green-400"
             borderClass="border-green-500/20"
           />
           <StatTile
             icon={<Users className="w-4 h-4 text-cyan-400" />}
             label={t('keycloak.sessions')}
-            value={data.totalActiveSessions}
+            value={data.totalActiveSessions.toLocaleString()}
             colorClass="text-cyan-400"
             borderClass="border-cyan-500/20"
           />
           <StatTile
             icon={<AlertTriangle className="w-4 h-4 text-red-400" />}
             label={t('keycloak.issues')}
-            value={stats.issues}
+            value={stats.issues.toLocaleString()}
             colorClass="text-red-400"
             borderClass="border-red-500/20"
           />

--- a/web/src/components/cards/knative_status/KnativeStatus.tsx
+++ b/web/src/components/cards/knative_status/KnativeStatus.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { StatTile } from '../shared/StatTile'
 import {
   CheckCircle,
   AlertTriangle,
@@ -82,30 +83,6 @@ const BROKER_STATUS_CONFIG: Record<
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
-
-function StatTile({
-  icon,
-  label,
-  value,
-  colorClass,
-  borderClass,
-}: {
-  icon: React.ReactNode
-  label: string
-  value: number
-  colorClass: string
-  borderClass: string
-}) {
-  return (
-    <div className={`p-3 rounded-lg bg-secondary/30 border ${borderClass}`}>
-      <div className="flex items-center gap-2 mb-1">
-        {icon}
-        <span className={`text-xs ${colorClass}`}>{label}</span>
-      </div>
-      <span className="text-2xl font-bold text-foreground">{value}</span>
-    </div>
-  )
-}
 
 function TrafficBar({ traffic }: { traffic: KnativeTrafficTarget[] }) {
   if (traffic.length === 0) return null

--- a/web/src/components/cards/openyurt_status/OpenYurtStatus.tsx
+++ b/web/src/components/cards/openyurt_status/OpenYurtStatus.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { StatTile } from '../shared/StatTile'
 import {
   CheckCircle,
   AlertTriangle,
@@ -82,30 +83,6 @@ const GATEWAY_STATUS_CONFIG: Record<
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
-
-function StatTile({
-  icon,
-  label,
-  value,
-  colorClass,
-  borderClass,
-}: {
-  icon: React.ReactNode
-  label: string
-  value: number
-  colorClass: string
-  borderClass: string
-}) {
-  return (
-    <div className={`p-3 rounded-lg bg-secondary/30 border ${borderClass}`}>
-      <div className="flex items-center gap-2 mb-1">
-        {icon}
-        <span className={`text-xs ${colorClass}`}>{label}</span>
-      </div>
-      <span className="text-2xl font-bold text-foreground">{value}</span>
-    </div>
-  )
-}
 
 function NodeReadinessBar({
   ready,

--- a/web/src/components/cards/shared/StatTile.tsx
+++ b/web/src/components/cards/shared/StatTile.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+export function StatTile({
+  icon,
+  label,
+  value,
+  colorClass,
+  borderClass,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: number | string
+  colorClass: string
+  borderClass: string
+}) {
+  return (
+    <div className={`p-3 rounded-lg bg-secondary/30 border ${borderClass}`}>
+      <div className="flex items-center gap-2 mb-1">
+        {icon}
+        <span className={`text-xs ${colorClass}`}>{label}</span>
+      </div>
+      <span className="text-2xl font-bold text-foreground">{value}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Extracts identical `StatTile` component from 8 status cards into `components/cards/shared/StatTile.tsx`.

All 8 cards had the same props (`{ icon, label, value, colorClass, borderClass }`) and identical JSX layout. The shared component accepts `value: number | string` to handle Keycloak's `toLocaleString()` formatting.

### Cards updated (8)
CubeFS, OpenYurt, Fluid, Harbor, KEDA, Keycloak, Karmada, Knative

### Impact
- 9 files changed, +37 / -194 lines
- `npm run build` passes cleanly

Fixes #10209