### PR TITLE
⚡ Lazy-load Security and ClusterAdmin routes in App.tsx

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -58,7 +58,7 @@ const Storage = safeLazy(() => import('./components/storage/Storage'), 'Storage'
 const Compute = safeLazy(() => import('./components/compute/Compute'), 'Compute')
 const ClusterComparisonPage = safeLazy(() => import('./components/compute/ClusterComparisonPage'), 'ClusterComparisonPage')
 const Network = safeLazy(() => import('./components/network/Network'), 'Network')
-import { Security } from './components/security/Security'
+const Security = safeLazy(() => import('./components/security/Security'), 'Security')
 const GitOps = safeLazy(() => import('./components/gitops/GitOps'), 'GitOps')
 const Alerts = safeLazy(() => import('./components/alerts/Alerts'), 'Alerts')
 const Cost = safeLazy(() => import('./components/cost/Cost'), 'Cost')
@@ -109,7 +109,7 @@ const Deploy = safeLazy(() => import('./components/deploy/Deploy'), 'Deploy')
 const AIML = safeLazy(() => import('./components/aiml/AIML'), 'AIML')
 const AIAgents = safeLazy(() => import('./components/aiagents/AIAgents'), 'AIAgents')
 const LLMdBenchmarks = safeLazy(() => import('./components/llmd-benchmarks/LLMdBenchmarks'), 'LLMdBenchmarks')
-import { ClusterAdmin } from './components/cluster-admin/ClusterAdmin'
+const ClusterAdmin = safeLazy(() => import('./components/cluster-admin/ClusterAdmin'), 'ClusterAdmin')
 const CICD = safeLazy(() => import('./components/cicd/CICD'), 'CICD')
 const Insights = safeLazy(() => import('./components/insights/Insights'), 'Insights')
 const MultiTenancy = safeLazy(() => import('./components/multi-tenancy/MultiTenancy'), 'MultiTenancy')


### PR DESCRIPTION
## Summary

Converts two non-primary routes from eager static imports to `safeLazy()` in App.tsx:

- **Security** — not the landing page, no justification for eager import
- **ClusterAdmin** — heavy admin route, not visited on initial load

This defers loading their chunks until the user actually navigates to those routes, reducing initial bundle parse time.

### Not changed
- **Dashboard** — landing page, intentionally eager
- **Login/AuthCallback** — OAuth safety (#9803), intentionally eager
- **Clusters** — has existing startTransition justification comment, left as-is

### Impact
- 1 file changed, 2 lines
- `tsc --noEmit` passes

Fixes #10213