### PR TITLE
🧹 Remove unused type exports from lib/ (#10219)

### DIFF
--- a/web/src/lib/accessibility.ts
+++ b/web/src/lib/accessibility.ts
@@ -25,9 +25,9 @@ export type StatusLevel =
   | 'loading'
 
 export type PatternType = 'solid' | 'striped' | 'dotted' | 'dashed' | 'none'
-export type ShapeType = 'circle' | 'triangle' | 'square' | 'diamond' | 'none'
+type ShapeType = 'circle' | 'triangle' | 'square' | 'diamond' | 'none'
 
-export interface AccessibleStatusConfig {
+interface AccessibleStatusConfig {
   icon: LucideIcon
   pattern: PatternType
   shape: ShapeType

--- a/web/src/lib/errorClassifier.ts
+++ b/web/src/lib/errorClassifier.ts
@@ -7,7 +7,7 @@ import { SECONDS_PER_MINUTE } from './constants/time'
 
 export type ClusterErrorType = 'timeout' | 'auth' | 'network' | 'certificate' | 'unknown'
 
-export interface ClassifiedError {
+interface ClassifiedError {
   type: ClusterErrorType
   message: string
   suggestion: string

--- a/web/src/lib/kubara.ts
+++ b/web/src/lib/kubara.ts
@@ -35,7 +35,7 @@ const CATALOG_CACHE_TTL_MS = 5 * 60 * 1000
 // ---------------------------------------------------------------------------
 
 /** A single entry in the Kubara chart catalog */
-export interface KubaraChartEntry {
+interface KubaraChartEntry {
   /** Chart name (e.g. "kube-prometheus-stack") */
   name: string
   /** Relative path inside the repo (e.g. "go-binary/.../helm/kube-prometheus-stack") */


### PR DESCRIPTION
## Summary
Remove 4 type exports that have zero external importers. These types are only used internally in their respective modules.

**Changes:**
- Remove `export` from `ShapeType` in `lib/accessibility.ts`
- Remove `export` from `AccessibleStatusConfig` in `lib/accessibility.ts`
- Remove `export` from `ClassifiedError` in `lib/errorClassifier.ts`
- Remove `export` from `KubaraChartEntry` in `lib/kubara.ts`

This reduces the public API surface without breaking any production or test code.

Fixes #10219

🤖 Generated with [Claude Code](https://claude.com/claude-code)