### PR TITLE
🧹 Unexport 4 file-private types with zero external importers

### DIFF
--- a/web/src/lib/accessibility.ts
+++ b/web/src/lib/accessibility.ts
@@ -25,9 +25,9 @@ export type StatusLevel =
   | 'loading'
 
 export type PatternType = 'solid' | 'striped' | 'dotted' | 'dashed' | 'none'
-export type ShapeType = 'circle' | 'triangle' | 'square' | 'diamond' | 'none'
+type ShapeType = 'circle' | 'triangle' | 'square' | 'diamond' | 'none'
 
-export interface AccessibleStatusConfig {
+interface AccessibleStatusConfig {
   icon: LucideIcon
   pattern: PatternType
   shape: ShapeType

--- a/web/src/lib/errorClassifier.ts
+++ b/web/src/lib/errorClassifier.ts
@@ -7,7 +7,7 @@ import { SECONDS_PER_MINUTE } from './constants/time'
 
 export type ClusterErrorType = 'timeout' | 'auth' | 'network' | 'certificate' | 'unknown'
 
-export interface ClassifiedError {
+interface ClassifiedError {
   type: ClusterErrorType
   message: string
   suggestion: string

--- a/web/src/lib/kubara.ts
+++ b/web/src/lib/kubara.ts
@@ -35,7 +35,7 @@ const CATALOG_CACHE_TTL_MS = 5 * 60 * 1000
 // ---------------------------------------------------------------------------
 
 /** A single entry in the Kubara chart catalog */
-export interface KubaraChartEntry {
+interface KubaraChartEntry {
   /** Chart name (e.g. "kube-prometheus-stack") */
   name: string
   /** Relative path inside the repo (e.g. "go-binary/.../helm/kube-prometheus-stack") */


### PR DESCRIPTION
## Summary

Fixes #10219

- Remove `export` from 4 types/interfaces that are only used within their declaring files and have zero importers (production or test)
- `ShapeType` and `AccessibleStatusConfig` in `lib/accessibility.ts`
- `ClassifiedError` in `lib/errorClassifier.ts`
- `KubaraChartEntry` in `lib/kubara.ts`

## Why

Reduces public API surface. These types leaked into the module's exports but were never consumed externally — keeping them private makes the module contract clearer.

## Test plan

- [x] `npm run build` passes
- [x] Verified via `rg` that no file imports any of these 4 symbols