### PR TITLE
fix: prevent 429 rate-limit from triggering login redirect loop

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -113,6 +113,11 @@ function handle401(): void {
       handling401 = false
       return
     }
+    if (verifyResponse.status === 429) {
+      console.warn('[API] 401 received but /api/me returned 429 (rate-limited) — keeping session')
+      handling401 = false
+      return
+    }
     performSessionExpiry()
   }).catch(() => {
     // Verify probe failed (network error / timeout / no backend). Treat the

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -402,6 +402,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const meResponse = await fetch('/api/me', {
         headers: { Authorization: `Bearer ${effectiveToken}` },
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
+      if (meResponse.status === 429) {
+        const cachedUser = getCachedUser()
+        if (cachedUser) {
+          console.warn('Backend rate-limited (429), using cached user data')
+          setUser(prev => {
+            if (prev && prev.id === cachedUser.id && prev.github_login === cachedUser.github_login) return prev
+            return cachedUser
+          })
+          setAnalyticsUserId(cachedUser.id)
+          return
+        }
+      }
       if (!meResponse.ok) throw new Error(`/api/me returned ${meResponse.status}`)
       const rawMe = await meResponse.json().catch(() => null)
       const userData = validateResponse(UserSchema, rawMe, '/api/me') as User | null


### PR DESCRIPTION
## Summary
- When kc-agent can't reach any cluster (e.g. no VPN), it returns 401 on `/clusters` calls
- Frontend retries flood the backend, triggering the rate limiter (429)
- The `/api/me` verification probe in `handle401()` receives 429, which was treated as auth failure — clearing the session and redirecting to login in a loop
- `refreshUser()` also treated 429 from `/api/me` as auth failure, clearing cached user

## Changes
- `handle401()` now treats 429 from `/api/me` as "session still valid" (rate limiting ≠ session expired)
- `refreshUser()` uses cached user data on 429 instead of clearing auth state

## Test plan
- [ ] Start console without VPN (kc-agent returns 401 on cluster calls)
- [ ] Verify login succeeds and user stays logged in (no redirect loop)
- [ ] Verify normal logout still works when session actually expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)