### PR TITLE
🧹 Replace ~50 raw time expressions with shared time constants

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { CARD_TITLES, CARD_DESCRIPTIONS, DEMO_EXEMPT_CARDS } from './cardMetadata'
 import { CARD_ICONS } from './cardIcons'
 import { BaseModal } from '../../lib/modals'
+import { MS_PER_HOUR } from '../../lib/constants/time'
 import { cn } from '../../lib/cn'
 import { Button } from '../ui/Button'
 import { useCardCollapse } from '../../lib/cards/cardHooks'
@@ -79,7 +80,7 @@ function pushEscapeHandler(close: () => void): () => void {
 }
 
 /** One hour in milliseconds — default snooze duration for card swaps */
-const ONE_HOUR_MS = 60 * 60 * 1000
+const ONE_HOUR_MS = MS_PER_HOUR
 
 // ---------------------------------------------------------------------------
 // Relative-time formatting for the card header "last updated" label.

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -33,7 +33,7 @@ import {
   CHART_DATAZOOM_DATA_AREA,
 } from '../../lib/constants'
 import { hexToRgba } from '../../lib/theme/chartColors'
-import { MS_PER_DAY } from '../../lib/constants/time'
+import { MS_PER_DAY, MS_PER_HOUR } from '../../lib/constants/time'
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
@@ -52,7 +52,7 @@ const GITHUB_PER_PAGE = 100
  */
 const MAX_PAGES = 30
 /** Cache TTL in milliseconds (1 hour) */
-const CACHE_TTL_MS = 60 * 60 * 1000
+const CACHE_TTL_MS = MS_PER_HOUR
 /** LocalStorage cache key prefix */
 const CACHE_KEY_PREFIX = 'issue_activity_chart_cache_'
 /** Bar chart color for issues opened */

--- a/web/src/components/cards/RecentEvents.tsx
+++ b/web/src/components/cards/RecentEvents.tsx
@@ -8,8 +8,9 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardControlsRow, CardPaginationFooter, CardSearchInput, CardSkeleton } from '../../lib/cards/CardComponents'
 import type { ClusterEvent } from '../../hooks/useMCP'
+import { MS_PER_HOUR } from '../../lib/constants/time'
 
-const ONE_HOUR_MS = 60 * 60 * 1000
+const ONE_HOUR_MS = MS_PER_HOUR
 
 type SortByOption = 'time' | 'reason' | 'object'
 

--- a/web/src/components/cards/rss/constants.ts
+++ b/web/src/components/cards/rss/constants.ts
@@ -1,9 +1,10 @@
 import type { FeedConfig, CorsProxy } from './types'
+import { MS_PER_MINUTE } from '../../../lib/constants/time'
 
 // Storage keys
 export const FEEDS_STORAGE_KEY = 'rss_feed_configs'
 export const CACHE_KEY_PREFIX = 'rss_feed_cache_'
-export const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+export const CACHE_TTL_MS = 5 * MS_PER_MINUTE // 5 minutes
 
 // Popular feed presets organized by category.
 // Each entry carries an explicit `category` field so the UI can group presets

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -3,6 +3,7 @@ import {
   GitBranch, AlertTriangle, CheckCircle, XCircle,
   Clock, Loader2, ExternalLink, Key, Settings, Plus, X, Check, Stethoscope } from 'lucide-react'
 import { FETCH_EXTERNAL_TIMEOUT_MS } from '../../../lib/constants'
+import { MS_PER_MINUTE, MS_PER_HOUR } from '../../../lib/constants/time'
 import { Button } from '../../ui/Button'
 import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
@@ -26,14 +27,14 @@ import { RepoSubtitle } from '../pipelines/RepoSubtitle'
 // Named time-offset constants for demo fixture data (CLAUDE.md: No Magic Numbers)
 const THIRTY_SECONDS_MS = 30 * 1000
 const ONE_MINUTE_MS = 60 * 1000
-const TWO_MINUTES_MS = 2 * 60 * 1000
-const FIVE_MINUTES_MS = 5 * 60 * 1000
-const TEN_MINUTES_MS = 10 * 60 * 1000
-const FIFTEEN_MINUTES_MS = 15 * 60 * 1000
-const TWENTY_MINUTES_MS = 20 * 60 * 1000
-const THIRTY_MINUTES_MS = 30 * 60 * 1000
-const ONE_HOUR_MS = 60 * 60 * 1000
-const TWO_HOURS_MS = 2 * 60 * 60 * 1000
+const TWO_MINUTES_MS = 2 * MS_PER_MINUTE
+const FIVE_MINUTES_MS = 5 * MS_PER_MINUTE
+const TEN_MINUTES_MS = 10 * MS_PER_MINUTE
+const FIFTEEN_MINUTES_MS = 15 * MS_PER_MINUTE
+const TWENTY_MINUTES_MS = 20 * MS_PER_MINUTE
+const THIRTY_MINUTES_MS = 30 * MS_PER_MINUTE
+const ONE_HOUR_MS = MS_PER_HOUR
+const TWO_HOURS_MS = 2 * MS_PER_HOUR
 
 interface GitHubCIMonitorProps {
   config?: Record<string, unknown>

--- a/web/src/components/logs/Logs.tsx
+++ b/web/src/components/logs/Logs.tsx
@@ -6,6 +6,7 @@ import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { StatBlockValue } from '../ui/StatsOverview'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { RotatingTip } from '../ui/RotatingTip'
+import { MS_PER_HOUR } from '../../lib/constants/time'
 
 const LOGS_CARDS_KEY = 'kubestellar-logs-cards'
 
@@ -60,7 +61,7 @@ export function Logs() {
     e.type === 'Error' ||
     (e.type === 'Warning' && (e.reason?.toLowerCase().includes('error') || e.reason?.toLowerCase().includes('failed')))
   ).length
-  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000)
+  const oneHourAgo = new Date(Date.now() - MS_PER_HOUR)
   const currentRecentCount = filteredEvents.filter(e => {
     if (!e.lastSeen) return false
     const eventTime = new Date(e.lastSeen)

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -16,6 +16,7 @@ import { fetchKubaraCatalog, fetchKubaraValues, parseResourceRequests } from '..
 import type { KubaraResourceRequests } from '../../lib/kubara'
 import { getDemoMissionControlState } from './demoState'
 import { MILLICORES_PER_CORE, MIB_PER_GIB } from '../../lib/constants/units'
+import { MS_PER_DAY } from '../../lib/constants/time'
 import type {
   MissionControlState,
   PayloadProject,
@@ -27,7 +28,7 @@ import type {
 
 const STORAGE_KEY = 'kc_mission_control_state'
 // Wizard state expires after 7 days to avoid persisting abandoned mission drafts
-const WIZARD_STATE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+const WIZARD_STATE_TTL_MS = 7 * MS_PER_DAY
 /**
  * #6664 — Schema version for persisted Mission Control state. Bump when the
  * shape of `MissionControlState` changes in a backward-incompatible way.

--- a/web/src/components/missions/browser/missionCache.ts
+++ b/web/src/components/missions/browser/missionCache.ts
@@ -5,11 +5,12 @@
  */
 import type { MissionExport, MissionMatch } from '../../../lib/missions/types'
 import type { ClusterContext } from '../../../hooks/useClusterContext'
+import { MS_PER_HOUR, MS_PER_MINUTE } from '../../../lib/constants/time'
 
 /** Cache time-to-live: 6 hours */
-const MISSION_CACHE_TTL_MS = 6 * 60 * 60 * 1000
+const MISSION_CACHE_TTL_MS = 6 * MS_PER_HOUR
 /** Recommendation cache TTL: 10 minutes (shorter since it depends on cluster context) */
-const RECOMMENDATION_CACHE_TTL_MS = 10 * 60 * 1000
+const RECOMMENDATION_CACHE_TTL_MS = 10 * MS_PER_MINUTE
 /** localStorage key for persisted mission cache */
 const MISSION_CACHE_STORAGE_KEY = 'kc-mission-cache'
 

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
 import { BaseModal } from '../../lib/modals'
+import { MS_PER_HOUR, MS_PER_DAY } from '../../lib/constants/time'
 import { useVersionCheck } from '../../hooks/useVersionCheck'
 import { useSelfUpgrade } from '../../hooks/useSelfUpgrade'
 import { useToast } from '../ui/Toast'
@@ -23,9 +24,9 @@ const SNOOZE_STORAGE_KEY = 'kc-update-snoozed'
 // development don't get a dead button. Runs once on module load.
 try { localStorage.removeItem('kc-whats-new-modal-disabled') } catch { /* ignore */ }
 
-const SNOOZE_DURATION_1H_MS = 60 * 60 * 1000
-const SNOOZE_DURATION_1D_MS = 24 * 60 * 60 * 1000
-const SNOOZE_DURATION_1W_MS = 7 * 24 * 60 * 60 * 1000
+const SNOOZE_DURATION_1H_MS = MS_PER_HOUR
+const SNOOZE_DURATION_1D_MS = MS_PER_DAY
+const SNOOZE_DURATION_1W_MS = 7 * MS_PER_DAY
 
 export function isUpdateSnoozed(): boolean {
   try {

--- a/web/src/hooks/useCachedProw.ts
+++ b/web/src/hooks/useCachedProw.ts
@@ -9,6 +9,7 @@ import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/ca
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { formatTimeAgo } from '../lib/formatters'
 import { KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
+import { MS_PER_HOUR } from '../lib/constants/time'
 import type { ProwJob, ProwStatus } from './useProw'
 
 // ============================================================================
@@ -123,7 +124,7 @@ export async function fetchProwJobs(prowCluster: string, namespace: string): Pro
 }
 
 function computeProwStatus(jobs: ProwJob[], consecutiveFailures: number): ProwStatus {
-  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000)
+  const oneHourAgo = new Date(Date.now() - MS_PER_HOUR)
   const recentJobs = jobs.filter(j => new Date(j.startTime) > oneHourAgo)
 
   const pendingJobs = jobs.filter(j => j.state === 'pending' || j.state === 'triggered').length

--- a/web/src/hooks/useCachedTuf.ts
+++ b/web/src/hooks/useCachedTuf.ts
@@ -14,6 +14,7 @@
 
 import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { MS_PER_DAY } from '../lib/constants/time'
 import { authFetch } from '../lib/api'
 import {
   TUF_DEMO_DATA,
@@ -35,7 +36,7 @@ const DEFAULT_REPOSITORY = ''
 // An expiration window inside which a role is flagged "expiring-soon".
 // 7 days mirrors the typical TUF snapshot cadence and gives operators a
 // clear warning before any single role expires.
-const EXPIRING_SOON_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
+const EXPIRING_SOON_WINDOW_MS = 7 * MS_PER_DAY
 
 /** HTTP statuses that indicate "endpoint not available" — treat as empty, not
  *  as a hard failure. 401/403 cover unauthenticated/demo visitors hitting

--- a/web/src/hooks/useCertManager.ts
+++ b/web/src/hooks/useCertManager.ts
@@ -4,6 +4,7 @@ import { kubectlProxy } from '../lib/kubectlProxy'
 import { useDemoMode } from './useDemoMode'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 import { KUBECTL_DEFAULT_TIMEOUT_MS, KUBECTL_MEDIUM_TIMEOUT_MS, METRICS_SERVER_TIMEOUT_MS } from '../lib/constants/network'
+import { MS_PER_DAY } from '../lib/constants/time'
 
 
 // Days before expiration to consider "expiring soon"
@@ -423,7 +424,7 @@ export function useCertManager() {
     const failed = certificates.filter(c => c.status === 'failed')
 
     // Count recent renewals (certificates with renewalTime in last 24h)
-    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    const oneDayAgo = new Date(Date.now() - MS_PER_DAY)
     const recentRenewals = certificates.filter(c =>
       c.renewalTime && c.renewalTime > oneDayAgo
     ).length

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -5,6 +5,7 @@ import { kubectlProxy } from '../lib/kubectlProxy'
 import type { DeployStartedPayload, DeployResultPayload, DeployedDep } from '../lib/cardEvents'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN, STORAGE_KEY_MISSIONS_ACTIVE, STORAGE_KEY_MISSIONS_HISTORY } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, DEPLOY_ABORT_TIMEOUT_MS, KUBECTL_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { MS_PER_MINUTE } from '../lib/constants/time'
 
 /** HTTP status codes that indicate authentication/authorization failure */
 const HTTP_UNAUTHORIZED = 401
@@ -141,7 +142,7 @@ const MISSIONS_STORAGE_KEY = 'kubestellar-missions'
 const POLL_INTERVAL_MS = 5000
 const MAX_MISSIONS = 50
 /** Cache TTL: 5 minutes — stop polling completed missions after this duration */
-const CACHE_TTL_MS = 5 * 60 * 1000
+const CACHE_TTL_MS = 5 * MS_PER_MINUTE
 /** After this many consecutive HTTP error responses (4xx/5xx) a cluster is marked failed (#6412) */
 const MAX_STATUS_FAILURES = 6
 /**

--- a/web/src/hooks/useDoNotDisturb.ts
+++ b/web/src/hooks/useDoNotDisturb.ts
@@ -12,6 +12,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react'
+import { MS_PER_HOUR } from '../lib/constants/time'
 
 const STORAGE_KEY = 'kc_dnd'
 
@@ -139,8 +140,7 @@ export function useDoNotDisturb() {
 
   const setTimedDND = useCallback((duration: TimedDuration) => {
     const now = Date.now()
-    /** Milliseconds per hour */
-    const MS_PER_HOUR = 60 * 60 * 1000
+    /** Milliseconds per hour — imported from lib/constants/time */
     let until: number
     switch (duration) {
       case '1h': until = now + MS_PER_HOUR; break

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -3,6 +3,7 @@ import { api } from '../lib/api'
 import { addCustomTheme, removeCustomTheme } from '../lib/themes'
 import { emitMarketplaceInstall, emitMarketplaceRemove, emitMarketplaceInstallFailed } from '../lib/analytics'
 import { FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
+import { MS_PER_HOUR, MS_PER_DAY } from '../lib/constants/time'
 import { isCardTypeRegistered } from '../components/cards/cardRegistry'
 import { getDefaultCardSize } from '../components/dashboard/dashboardUtils'
 
@@ -17,7 +18,7 @@ interface DashboardSummary {
 
 const REGISTRY_URL = 'https://raw.githubusercontent.com/kubestellar/console-marketplace/main/registry.json'
 const CACHE_KEY = 'kc-marketplace-registry'
-const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
+const CACHE_TTL_MS = MS_PER_HOUR // 1 hour
 const INSTALLED_KEY = 'kc-marketplace-installed'
 
 export type MarketplaceItemType = 'dashboard' | 'card-preset' | 'theme'
@@ -503,7 +504,7 @@ export function useMarketplace() {
 // --- Author Profile Hook ---
 
 const AUTHOR_CACHE_PREFIX = 'kc-author-'
-const AUTHOR_CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+const AUTHOR_CACHE_TTL_MS = MS_PER_DAY // 24 hours
 
 interface AuthorProfile {
   consolePRs: number

--- a/web/src/hooks/useMediumBlog.ts
+++ b/web/src/hooks/useMediumBlog.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { MS_PER_HOUR } from '../lib/constants/time'
 
 export interface BlogPost {
   title: string
@@ -15,7 +16,7 @@ interface BlogResponse {
 
 const CACHE_KEY = 'ks-medium-blog-cache'
 /** Cache TTL — 1 hour */
-const CACHE_TTL_MS = 60 * 60 * 1000
+const CACHE_TTL_MS = MS_PER_HOUR
 /** Fetch timeout for Medium blog API call (10 seconds) */
 const BLOG_FETCH_TIMEOUT_MS = 10_000
 /** Local relative endpoint — Go backend / Netlify Function */

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -6,6 +6,7 @@ import { addCategoryTokens, setActiveTokenCategory, clearActiveTokenCategory } f
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { emitError, emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
 import { scanForMaliciousContent } from '../lib/missions/scanner/malicious'
+import { MS_PER_MINUTE } from '../lib/constants/time'
 import { runPreflightCheck, type PreflightResult } from '../lib/missions/preflightCheck'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { kagentiProviderChat, fetchKagentiProviderAgents } from '../lib/kagentiProviderBackend'
@@ -121,7 +122,7 @@ const MISSION_RECONNECT_DELAY_MS = 500
  * half-finished prompt. 30 minutes is conservative: it covers lunch/
  * meeting gaps while still protecting against overnight reconnects.
  */
-const MISSION_RECONNECT_MAX_AGE_MS = 30 * 60 * 1000
+const MISSION_RECONNECT_MAX_AGE_MS = 30 * MS_PER_MINUTE
 /**
  * issue 6429 — Cap how many prior messages we re-append to the prompt on
  * reconnect. Long-running missions can accumulate hundreds of turns; some

--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -19,9 +19,10 @@ import {
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { isNetlifyDeployment } from '../lib/demoMode'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { MS_PER_MINUTE } from '../lib/constants/time'
 
-const REFRESH_IDLE_MS = 5 * 60 * 1000    // 5 minutes when idle
-const REFRESH_ACTIVE_MS = 2 * 60 * 1000  // 2 minutes when jobs are running
+const REFRESH_IDLE_MS = 5 * MS_PER_MINUTE    // 5 minutes when idle
+const REFRESH_ACTIVE_MS = 2 * MS_PER_MINUTE  // 2 minutes when jobs are running
 
 const DEMO_DATA = generateDemoNightlyData()
 

--- a/web/src/hooks/usePlaylistVideos.ts
+++ b/web/src/hooks/usePlaylistVideos.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { MS_PER_MINUTE } from '../lib/constants/time'
 
 export interface PlaylistVideo {
   id: string
@@ -14,7 +15,7 @@ interface PlaylistResponse {
 }
 
 const CACHE_KEY = 'ks-playlist-cache'
-const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+const CACHE_TTL_MS = 5 * MS_PER_MINUTE // 5 minutes
 /** Fetch timeout for playlist API call (10 seconds) */
 const PLAYLIST_FETCH_TIMEOUT_MS = 10_000
 

--- a/web/src/hooks/useProw.ts
+++ b/web/src/hooks/useProw.ts
@@ -3,6 +3,7 @@ import { kubectlProxy } from '../lib/kubectlProxy'
 import { formatTimeAgo } from '../lib/formatters'
 import { useDemoMode } from './useDemoMode'
 import { KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
+import { MS_PER_HOUR } from '../lib/constants/time'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 /** Maximum number of ProwJobs to display */
@@ -179,7 +180,7 @@ export function useProwJobs(prowCluster = 'prow', namespace = 'prow') {
 
   // Compute status from jobs
   const status = useMemo((): ProwStatus => {
-    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000)
+    const oneHourAgo = new Date(Date.now() - MS_PER_HOUR)
     const recentJobs = jobs.filter(j => new Date(j.startTime) > oneHourAgo)
 
     const pendingJobs = jobs.filter(j => j.state === 'pending' || j.state === 'triggered').length

--- a/web/src/hooks/useSnoozedAlerts.ts
+++ b/web/src/hooks/useSnoozedAlerts.ts
@@ -1,16 +1,17 @@
 import { useState, useEffect, useCallback } from 'react'
 import { POLL_INTERVAL_SLOW_MS } from '../lib/constants/network'
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../lib/constants/time'
 import { emitSnoozed, emitUnsnoozed } from '../lib/analytics'
 
 const STORAGE_KEY = 'kubestellar-snoozed-alerts'
 
 // Snooze duration options in milliseconds
 export const SNOOZE_DURATIONS = {
-  '5m': 5 * 60 * 1000,
-  '15m': 15 * 60 * 1000,
-  '1h': 60 * 60 * 1000,
-  '4h': 4 * 60 * 60 * 1000,
-  '24h': 24 * 60 * 60 * 1000 } as const
+  '5m': 5 * MS_PER_MINUTE,
+  '15m': 15 * MS_PER_MINUTE,
+  '1h': MS_PER_HOUR,
+  '4h': 4 * MS_PER_HOUR,
+  '24h': MS_PER_DAY } as const
 
 export type SnoozeDuration = keyof typeof SNOOZE_DURATIONS
 
@@ -165,8 +166,8 @@ export function useSnoozedAlerts() {
 
 // Helper to format time remaining
 export function formatSnoozeRemaining(ms: number): string {
-  const hours = Math.floor(ms / (60 * 60 * 1000))
-  const minutes = Math.floor((ms % (60 * 60 * 1000)) / (60 * 1000))
+  const hours = Math.floor(ms / MS_PER_HOUR)
+  const minutes = Math.floor((ms % MS_PER_HOUR) / MS_PER_MINUTE)
 
   if (hours > 0) {
     return `${hours}h ${minutes}m`

--- a/web/src/hooks/useSnoozedCards.ts
+++ b/web/src/hooks/useSnoozedCards.ts
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react'
 import { POLL_INTERVAL_SLOW_MS } from '../lib/constants/network'
 import { STORAGE_KEY_SNOOZED_CARDS } from '../lib/constants/storage'
+import { MS_PER_HOUR } from '../lib/constants/time'
 import { emitSnoozed, emitUnsnoozed } from '../lib/analytics'
 
 /** Default snooze duration: 1 hour */
-const DEFAULT_SNOOZE_DURATION_MS = 60 * 60 * 1000
+const DEFAULT_SNOOZE_DURATION_MS = MS_PER_HOUR
 
 export interface SnoozedSwap {
   id: string

--- a/web/src/hooks/useSnoozedMissions.ts
+++ b/web/src/hooks/useSnoozedMissions.ts
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react'
 import { MissionSuggestion } from './useMissionSuggestions'
 import { emitSnoozed, emitUnsnoozed } from '../lib/analytics'
+import { MS_PER_DAY, MS_PER_HOUR, MS_PER_MINUTE } from '../lib/constants/time'
 
 const STORAGE_KEY = 'kubestellar-snoozed-missions'
-const SNOOZE_DURATION_MS = 24 * 60 * 60 * 1000 // 24 hours
+const SNOOZE_DURATION_MS = MS_PER_DAY // 24 hours
 
 export interface SnoozedMission {
   id: string
@@ -152,8 +153,8 @@ export function useSnoozedMissions() {
 
 // Helper to format time remaining
 export function formatTimeRemaining(ms: number): string {
-  const hours = Math.floor(ms / (60 * 60 * 1000))
-  const minutes = Math.floor((ms % (60 * 60 * 1000)) / (60 * 1000))
+  const hours = Math.floor(ms / MS_PER_HOUR)
+  const minutes = Math.floor((ms % MS_PER_HOUR) / MS_PER_MINUTE)
 
   if (hours > 0) {
     return `${hours}h ${minutes}m`

--- a/web/src/hooks/useSnoozedRecommendations.ts
+++ b/web/src/hooks/useSnoozedRecommendations.ts
@@ -2,11 +2,11 @@ import { useState, useEffect } from 'react'
 import { CardRecommendation } from './useCardRecommendations'
 import { POLL_INTERVAL_SLOW_MS } from '../lib/constants/network'
 import { STORAGE_KEY_SNOOZED_RECOMMENDATIONS } from '../lib/constants/storage'
-import { SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY } from '../lib/constants/time'
+import { SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY, MS_PER_DAY } from '../lib/constants/time'
 import { emitSnoozed, emitUnsnoozed } from '../lib/analytics'
 
 /** Default snooze duration for recommendations: 24 hours */
-const DEFAULT_REC_SNOOZE_DURATION_MS = 24 * 60 * 60 * 1000
+const DEFAULT_REC_SNOOZE_DURATION_MS = MS_PER_DAY
 
 export interface SnoozedRecommendation {
   id: string

--- a/web/src/hooks/useUniversalStats.ts
+++ b/web/src/hooks/useUniversalStats.ts
@@ -16,6 +16,7 @@ import { useCachedPVCs } from './useCachedData'
 import { useAlerts, useAlertRules } from './useAlerts'
 import { StatBlockValue } from '../components/ui/StatsOverview'
 import { useDrillDownActions } from './useDrillDown'
+import { MS_PER_HOUR } from '../lib/constants/time'
 
 // Cost estimation constants (per-month, rough cloud averages)
 const COST_PER_CPU = 30          // USD per vCPU per month
@@ -98,7 +99,7 @@ export function useUniversalStats() {
   const allWarningEvents = warningEvents || []
   const normalEvents = allEvents.filter(e => e.type === 'Normal').length
   const recentEvents = (() => {
-    const oneHourAgo = Date.now() - 60 * 60 * 1000
+    const oneHourAgo = Date.now() - MS_PER_HOUR
     return allEvents.filter(e => {
       if (!e.lastSeen) return false
       return new Date(e.lastSeen).getTime() > oneHourAgo

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -11,6 +11,7 @@ import type {
 import { emitSessionContext } from '../lib/analytics'
 import { UPDATE_STORAGE_KEYS } from '../types/updates'
 import { LOCAL_AGENT_HTTP_URL, FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
+import { MS_PER_MINUTE } from '../lib/constants/time'
 import { useLocalAgent } from './useLocalAgent'
 
 declare const __APP_VERSION__: string
@@ -20,8 +21,8 @@ const GITHUB_API_URL =
   '/api/github/repos/kubestellar/console/releases'
 const GITHUB_MAIN_SHA_URL =
   '/api/github/repos/kubestellar/console/git/ref/heads/main'
-const CACHE_TTL_MS = 30 * 60 * 1000 // 30 minutes cache
-const MIN_CHECK_INTERVAL_MS = 30 * 60 * 1000 // 30 minutes minimum between checks
+const CACHE_TTL_MS = 30 * MS_PER_MINUTE // 30 minutes cache
+const MIN_CHECK_INTERVAL_MS = 30 * MS_PER_MINUTE // 30 minutes minimum between checks
 const AUTO_UPDATE_POLL_MS = 60 * 1000 // Poll kc-agent for update status every 60s
 const DEV_SHA_CACHE_KEY = 'kc-dev-latest-sha'
 
@@ -413,7 +414,7 @@ function useVersionCheckCore() {
         const resetHeader = resp.headers.get('X-RateLimit-Reset')
         const backoffUntil = resetHeader
           ? parseInt(resetHeader, 10) * 1000
-          : Date.now() + 15 * 60 * 1000
+          : Date.now() + 15 * MS_PER_MINUTE
         localStorage.setItem('kc-github-rate-limit-until', String(backoffUntil))
         console.debug('[version-check] GitHub API rate-limited, backing off until', new Date(backoffUntil).toLocaleTimeString())
         setError('GitHub API rate limit — add a GitHub token in Settings for higher limits')
@@ -469,7 +470,7 @@ function useVersionCheckCore() {
         console.debug('[version-check] Fetched', commits.length, 'commits')
         setRecentCommits(commits)
       } else if (resp.status === 403 || resp.status === 429) {
-        const backoffUntil = Date.now() + 15 * 60 * 1000
+        const backoffUntil = Date.now() + 15 * MS_PER_MINUTE
         localStorage.setItem('kc-github-rate-limit-until', String(backoffUntil))
         console.debug('[version-check] Compare API rate-limited, backing off')
       } else {

--- a/web/src/lib/notificationStatus.ts
+++ b/web/src/lib/notificationStatus.ts
@@ -1,7 +1,9 @@
+import { MS_PER_DAY } from './constants/time'
+
 const STORAGE_KEY = 'kc_browser_notif_verified'
 
 /** Verification expiry — 30 days in milliseconds */
-const VERIFICATION_TTL_MS = 30 * 24 * 60 * 60 * 1000
+const VERIFICATION_TTL_MS = 30 * MS_PER_DAY
 
 /** Returns true if user has confirmed browser notifications work */
 export function isBrowserNotifVerified(): boolean {


### PR DESCRIPTION
## Summary

Fixes #10224

Replaces ~50 raw `N * 60 * 1000` time expressions across 27 production files with references to `MS_PER_MINUTE`, `MS_PER_HOUR`, and `MS_PER_DAY` from `lib/constants/time.ts`.

This is a follow-up to PR #10148, which introduced the shared constants but didn't migrate all consumers.

## Changes

- 27 files modified (hooks, components, lib)
- Raw expressions like `60 * 60 * 1000` → `MS_PER_HOUR`
- Raw expressions like `5 * 60 * 1000` → `5 * MS_PER_MINUTE`  
- Raw expressions like `24 * 60 * 60 * 1000` → `MS_PER_DAY`
- Removed locally-redefined `MS_PER_HOUR` constants in favor of the canonical import

## Test plan

- [x] `npm run build` passes (vite build completes with 0 errors)
- [x] All replacements are value-preserving (same numeric result)
- [x] No test files modified (test-local constants left as-is)