### PR TITLE
⚡ Lazy-load remaining drilldown view components (#10217)

### DIFF
--- a/web/src/components/drilldown/DrillDownModal.tsx
+++ b/web/src/components/drilldown/DrillDownModal.tsx
@@ -35,10 +35,9 @@ const EventsDrillDown = safeLazy(() => import('./views/EventsDrillDown'), 'Event
 const NamespaceDrillDown = safeLazy(() => import('./views/NamespaceDrillDown'), 'NamespaceDrillDown')
 const NodeDrillDown = safeLazy(() => import('./views/NodeDrillDown'), 'NodeDrillDown')
 const GPUNamespaceDrillDown = safeLazy(() => import('./views/GPUNamespaceDrillDown'), 'GPUNamespaceDrillDown')
-// Keep smaller components as direct imports for immediate loading
-import { LogsDrillDown } from './views/LogsDrillDown'
-import { GPUNodeDrillDown } from './views/GPUNodeDrillDown'
-import { YAMLDrillDown } from './views/YAMLDrillDown'
+const LogsDrillDown = safeLazy(() => import('./views/LogsDrillDown'), 'LogsDrillDown')
+const GPUNodeDrillDown = safeLazy(() => import('./views/GPUNodeDrillDown'), 'GPUNodeDrillDown')
+const YAMLDrillDown = safeLazy(() => import('./views/YAMLDrillDown'), 'YAMLDrillDown')
 
 // Loading fallback for lazy-loaded drilldown views
 function DrillDownLoading() {


### PR DESCRIPTION
Fixes #10217

## Summary
Convert the 3 remaining eagerly imported drilldown views (LogsDrillDown, GPUNodeDrillDown, YAMLDrillDown) to use `safeLazy()` for deferred chunk loading.

## Changes
- Replace direct imports with `safeLazy()` calls in `DrillDownModal.tsx`
- ~751 lines of component code deferred from initial bundle

## Notes
The 5 page components listed in the issue (FromHeadlamp, WhiteLabel, Welcome, FromLens, FromHolmesGPT) were already lazy-loaded via `safeLazy()` in `App.tsx`. This PR completes the drilldown views.