### PR TITLE
🧹 Replace remaining ~60 raw time expressions with shared constants

### DIFF
--- a/web/src/components/agent/AgentSetupDialog.tsx
+++ b/web/src/components/agent/AgentSetupDialog.tsx
@@ -10,10 +10,11 @@ import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import { copyToClipboard } from '../../lib/clipboard'
 import { isNetlifyDeployment } from '../../lib/demoMode'
 import { STORAGE_KEY_FIRST_AGENT_CONNECT } from '../../lib/constants/storage'
+import { MS_PER_DAY } from '../../lib/constants/time'
 
 const DISMISSED_KEY = 'kc-agent-setup-dismissed'
 const SNOOZED_KEY = 'kc-agent-setup-snoozed'
-const SNOOZE_DURATION = 24 * 60 * 60 * 1000 // 24 hours
+const SNOOZE_DURATION = MS_PER_DAY // 24 hours
 
 export function AgentSetupDialog() {
   const { t } = useTranslation('common')

--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -19,6 +19,7 @@ import {
   CHART_AXIS_STROKE,
   CHART_TOOLTIP_CONTENT_STYLE,
   CHART_TICK_COLOR } from '../../lib/constants'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
 
 /**
  * Maximum age of a metrics-history snapshot we're willing to use as a
@@ -28,7 +29,7 @@ import {
  * `MAX_AGE_MS` used by this card's own on-screen chart history so the two
  * windows stay consistent.
  */
-const GPU_SNAPSHOT_STALENESS_MS = 30 * 60 * 1000 // 30 min
+const GPU_SNAPSHOT_STALENESS_MS = 30 * MS_PER_MINUTE // 30 min
 
 /**
  * Bucket size for the staleness-tick that forces the fallback memo to
@@ -202,7 +203,7 @@ export function GPUUsageTrend() {
 
   // Track historical data points with persistence
   const STORAGE_KEY = 'gpu-usage-trend-history'
-  const MAX_AGE_MS = 30 * 60 * 1000 // 30 minutes - discard older data
+  const MAX_AGE_MS = 30 * MS_PER_MINUTE // 30 minutes - discard older data
 
   const loadSavedHistory = (): GPUDataPoint[] => {
     try {

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect, useCallback, useImperativeHandle, memo, type Ref } from 'react'
 import { GitPullRequest, GitBranch, Star, Users, Package, TrendingUp, AlertCircle, Clock, CheckCircle, XCircle, GitMerge, Settings, X, Plus, Check } from 'lucide-react'
 import { POLL_INTERVAL_SLOW_MS } from '../../lib/constants/network'
+import { MS_PER_MINUTE, MS_PER_DAY } from '../../lib/constants/time'
 import { formatTimeAgo } from '../../lib/formatters'
 import { Button } from '../ui/Button'
 import { Skeleton } from '../ui/Skeleton'
@@ -120,7 +121,7 @@ const DEFAULT_REPO = 'kubestellar/console'
 const SAVED_REPOS_KEY = 'github_activity_saved_repos'
 const CURRENT_REPO_KEY = 'github_activity_repo'
 const CACHE_KEY_PREFIX = 'github_activity_cache_v2_' // v2: fixed PR fetching
-const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes cache TTL - shorter for fresher data
+const CACHE_TTL_MS = 5 * MS_PER_MINUTE // 5 minutes cache TTL - shorter for fresher data
 
 // Cache data structure
 interface CachedGitHubData {
@@ -613,10 +614,10 @@ export function GitHubActivity({ config, ref }: { config?: GitHubActivityConfig;
   const preFilteredData = useMemo(() => {
     const now = Date.now()
     const rangeMs = {
-      '7d': 7 * 24 * 60 * 60 * 1000,
-      '30d': 30 * 24 * 60 * 60 * 1000,
-      '90d': 90 * 24 * 60 * 60 * 1000,
-      '1y': 365 * 24 * 60 * 60 * 1000 }[timeRange]
+      '7d': 7 * MS_PER_DAY,
+      '30d': 30 * MS_PER_DAY,
+      '90d': 90 * MS_PER_DAY,
+      '1y': 365 * MS_PER_DAY }[timeRange]
 
     if (viewMode === 'prs') {
       // Sort PRs: open first, then by date within each group

--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -25,12 +25,13 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
 import { useMissions } from '../../hooks/useMissions'
 import { useApiKeyCheck, ApiKeyPromptModal } from './console-missions/shared'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
 
 // Named time-offset constants for demo fixture data (CLAUDE.md: No Magic Numbers)
-const TWO_MINUTES_MS = 2 * 60 * 1000
-const THREE_MINUTES_MS = 3 * 60 * 1000
-const FOUR_MINUTES_MS = 4 * 60 * 1000
-const FIVE_MINUTES_MS = 5 * 60 * 1000
+const TWO_MINUTES_MS = 2 * MS_PER_MINUTE
+const THREE_MINUTES_MS = 3 * MS_PER_MINUTE
+const FOUR_MINUTES_MS = 4 * MS_PER_MINUTE
+const FIVE_MINUTES_MS = 5 * MS_PER_MINUTE
 
 interface MissionsProps {
   config?: Record<string, unknown>

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -14,6 +14,7 @@ import { isDemoMode as checkIsDemoMode } from '../../lib/demoMode'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_OPA_CACHE, STORAGE_KEY_OPA_CACHE_TIME } from '../../lib/constants'
 import { KUBECTL_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
 
 const OPA_LIST_TIMEOUT_MS = 25_000
 import { safeGetItem, safeGetJSON, safeSetItem, safeSetJSON } from '../../lib/utils/localStorage'
@@ -23,7 +24,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 import { useModalState } from '../../lib/modals'
 
 /** Cache TTL: 5 minutes — short enough to pick up connectivity changes */
-// Unused: const CACHE_TTL_MS = 5 * 60 * 1000
+// Unused: const CACHE_TTL_MS = 5 * MS_PER_MINUTE
 
 // Sort options for clusters
 type SortByOption = 'name' | 'violations' | 'policies'

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -14,8 +14,6 @@ import { isDemoMode as checkIsDemoMode } from '../../lib/demoMode'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_OPA_CACHE, STORAGE_KEY_OPA_CACHE_TIME } from '../../lib/constants'
 import { KUBECTL_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
-import { MS_PER_MINUTE } from '../../lib/constants/time'
-
 const OPA_LIST_TIMEOUT_MS = 25_000
 import { safeGetItem, safeGetJSON, safeSetItem, safeSetJSON } from '../../lib/utils/localStorage'
 import { PolicyDetailModal, ClusterOPAModal, CreatePolicyModal } from './opa'
@@ -24,7 +22,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 import { useModalState } from '../../lib/modals'
 
 /** Cache TTL: 5 minutes — short enough to pick up connectivity changes */
-// Unused: const CACHE_TTL_MS = 5 * MS_PER_MINUTE
+// Unused: const CACHE_TTL_MS = 5 * 60 * 1000
 
 // Sort options for clusters
 type SortByOption = 'name' | 'violations' | 'policies'

--- a/web/src/components/cards/PodHealthTrend.tsx
+++ b/web/src/components/cards/PodHealthTrend.tsx
@@ -8,6 +8,7 @@ import { useCardLoadingState } from './CardDataContext'
 import { CardClusterFilter } from '../../lib/cards/CardComponents'
 import { isDemoMode } from '../../lib/demoMode'
 import { useTranslation } from 'react-i18next'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
 import {
   CHART_HEIGHT_STANDARD,
   CHART_GRID_STROKE,
@@ -85,7 +86,7 @@ export function PodHealthTrend() {
 
   // Track historical data points with persistence
   const STORAGE_KEY = 'pod-health-trend-history'
-  const MAX_AGE_MS = 30 * 60 * 1000 // 30 minutes - discard older data
+  const MAX_AGE_MS = 30 * MS_PER_MINUTE // 30 minutes - discard older data
 
   // Load from localStorage on mount
   const loadSavedHistory = (): HealthPoint[] => {

--- a/web/src/components/cards/ResourceTrend.tsx
+++ b/web/src/components/cards/ResourceTrend.tsx
@@ -7,6 +7,9 @@ import { useCardLoadingState } from './CardDataContext'
 import { CardClusterFilter } from '../../lib/cards/CardComponents'
 import { useTranslation } from 'react-i18next'
 import {
+  MS_PER_MINUTE,
+} from '../../lib/constants/time'
+import {
   CHART_HEIGHT_STANDARD,
   CHART_GRID_STROKE,
   CHART_AXIS_STROKE,
@@ -64,7 +67,7 @@ export function ResourceTrend() {
 
   // Track historical data points with persistence
   const STORAGE_KEY = 'resource-trend-history'
-  const MAX_AGE_MS = 30 * 60 * 1000 // 30 minutes - discard older data
+  const MAX_AGE_MS = 30 * MS_PER_MINUTE // 30 minutes - discard older data
 
   // Load from localStorage on mount
   const loadSavedHistory = (): ResourcePoint[] => {

--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -7,6 +7,7 @@ import { useMissions } from '../../hooks/useMissions'
 import { ConfirmMissionPromptDialog } from '../missions/ConfirmMissionPromptDialog'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
 import { StatusBadge } from '../ui/StatusBadge'
@@ -31,7 +32,7 @@ const SORT_OPTIONS = [
 
 // Module-level cache for cluster versions (persists across component remounts + page refreshes)
 const STORAGE_KEY = 'kc-cluster-versions'
-const VERSION_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+const VERSION_CACHE_TTL = 5 * MS_PER_MINUTE // 5 minutes
 
 // Load persisted cache from localStorage on module init
 const versionCache: Record<string, { version: string; timestamp: number }> =

--- a/web/src/components/cards/WorkloadDeployment.tsx
+++ b/web/src/components/cards/WorkloadDeployment.tsx
@@ -8,6 +8,9 @@ import {
   AlertTriangle,
   Layers,
   Plus,
+} from 'lucide-react'
+import { MS_PER_DAY, MS_PER_HOUR } from '../../lib/constants/time'
+import {
   Server,
   Database,
   Gauge,
@@ -78,7 +81,7 @@ const DEMO_WORKLOADS: Workload[] = [
       { cluster: 'us-west-2', status: 'Running', replicas: 3, readyReplicas: 3, lastUpdated: new Date().toISOString() },
       { cluster: 'eu-central-1', status: 'Running', replicas: 3, readyReplicas: 3, lastUpdated: new Date().toISOString() },
     ],
-    createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString() },
+    createdAt: new Date(Date.now() - 30 * MS_PER_DAY).toISOString() },
   {
     name: 'api-gateway',
     namespace: 'production',
@@ -93,7 +96,7 @@ const DEMO_WORKLOADS: Workload[] = [
       { cluster: 'us-east-1', status: 'Running', replicas: 3, readyReplicas: 3, lastUpdated: new Date().toISOString() },
       { cluster: 'us-west-2', status: 'Degraded', replicas: 2, readyReplicas: 0, lastUpdated: new Date().toISOString() },
     ],
-    createdAt: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString() },
+    createdAt: new Date(Date.now() - 14 * MS_PER_DAY).toISOString() },
   {
     name: 'postgres-primary',
     namespace: 'databases',
@@ -107,7 +110,7 @@ const DEMO_WORKLOADS: Workload[] = [
     deployments: [
       { cluster: 'us-east-1', status: 'Running', replicas: 1, readyReplicas: 1, lastUpdated: new Date().toISOString() },
     ],
-    createdAt: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString() },
+    createdAt: new Date(Date.now() - 60 * MS_PER_DAY).toISOString() },
   {
     name: 'fluentd',
     namespace: 'logging',
@@ -123,7 +126,7 @@ const DEMO_WORKLOADS: Workload[] = [
       { cluster: 'us-west-2', status: 'Running', replicas: 4, readyReplicas: 4, lastUpdated: new Date().toISOString() },
       { cluster: 'eu-central-1', status: 'Running', replicas: 3, readyReplicas: 3, lastUpdated: new Date().toISOString() },
     ],
-    createdAt: new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString() },
+    createdAt: new Date(Date.now() - 45 * MS_PER_DAY).toISOString() },
   {
     name: 'ml-training',
     namespace: 'ml-workloads',
@@ -137,7 +140,7 @@ const DEMO_WORKLOADS: Workload[] = [
     deployments: [
       { cluster: 'gpu-cluster-1', status: 'Pending', replicas: 1, readyReplicas: 0, lastUpdated: new Date().toISOString() },
     ],
-    createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString() },
+    createdAt: new Date(Date.now() - 1 * MS_PER_HOUR).toISOString() },
   {
     name: 'payment-service',
     namespace: 'payments',
@@ -151,7 +154,7 @@ const DEMO_WORKLOADS: Workload[] = [
     deployments: [
       { cluster: 'us-east-1', status: 'Failed', replicas: 2, readyReplicas: 0, lastUpdated: new Date().toISOString() },
     ],
-    createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString() },
+    createdAt: new Date(Date.now() - 2 * MS_PER_DAY).toISOString() },
 ]
 
 const DEMO_STATS = {

--- a/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
+++ b/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
@@ -13,9 +13,10 @@ import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE
 import { CROSS_CLUSTER_EVENT_PALETTE } from '../../../lib/theme/chartColors'
 import { InsightDetailModal } from './InsightDetailModal'
 import type { MultiClusterInsight } from '../../../types/insights'
+import { MS_PER_MINUTE } from '../../../lib/constants/time'
 
 /** Time bucket size for the timeline chart (2 minutes) */
-const TIMELINE_BUCKET_MS = 2 * 60 * 1000
+const TIMELINE_BUCKET_MS = 2 * MS_PER_MINUTE
 /** Maximum number of buckets to show on the chart */
 const MAX_TIMELINE_BUCKETS = 30
 

--- a/web/src/components/cicd/useCICDStats.ts
+++ b/web/src/components/cicd/useCICDStats.ts
@@ -10,9 +10,10 @@ import { useCallback, useMemo } from 'react'
 import type { StatBlockValue } from '../ui/StatsOverview'
 import { usePipelineData } from '../cards/pipelines/PipelineDataContext'
 import type { Conclusion } from '../../hooks/useGitHubPipelines'
+import { MS_PER_DAY } from '../../lib/constants/time'
 
 /** Milliseconds in 24 hours — used to filter recent failures */
-const MS_PER_24H = 24 * 60 * 60 * 1000
+const MS_PER_24H = MS_PER_DAY
 
 /** Percentage thresholds for pass-rate coloring */
 const PASS_RATE_GOOD_PCT = 90

--- a/web/src/components/drilldown/views/pod-drilldown/podCache.ts
+++ b/web/src/components/drilldown/views/pod-drilldown/podCache.ts
@@ -1,4 +1,5 @@
 import type { CachedData } from './types'
+import { MS_PER_MINUTE } from '../../../../lib/constants/time'
 
 /**
  * Module-level pod data cache - persists when dialog is closed/reopened.
@@ -30,7 +31,7 @@ export function setPodCache(cluster: string, namespace: string, pod: string, dat
 }
 
 /** Remove cache entries older than 5 minutes */
-const POD_CACHE_MAX_AGE_MS = 5 * 60 * 1000
+const POD_CACHE_MAX_AGE_MS = 5 * MS_PER_MINUTE
 
 export function cleanupPodCache(): void {
   const now = Date.now()

--- a/web/src/config/dashboards/acmm.ts
+++ b/web/src/config/dashboards/acmm.ts
@@ -6,8 +6,9 @@
  * engineering framework, claude-reflect).
  */
 import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
 
-const AUTO_REFRESH_INTERVAL_MS = 15 * 60 * 1000
+const AUTO_REFRESH_INTERVAL_MS = 15 * MS_PER_MINUTE
 
 export const acmmDashboardConfig: UnifiedDashboardConfig = {
   id: 'acmm',

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -8,6 +8,7 @@ import type {
   AlertStats,
   AlertChannel } from '../types/alerts'
 import type { GPUHealthCheckResult } from '../hooks/mcp/types'
+import { MS_PER_MINUTE, MS_PER_HOUR } from '../lib/constants/time'
 import type { NightlyGuideStatus } from '../lib/llmd/nightlyE2EDemoData'
 import type { AlertsMCPData } from './AlertsDataFetcher'
 import { STORAGE_KEY_AUTH_TOKEN, FETCH_DEFAULT_TIMEOUT_MS, STORAGE_KEY_NOTIFIED_ALERT_KEYS } from '../lib/constants'
@@ -249,12 +250,12 @@ const DEFAULT_WIND_SPEED_THRESHOLD_MPH = 40
  *  tiered by severity so critical alerts re-notify quickly while
  *  lower-severity alerts don't spam the desktop. */
 const NOTIFICATION_COOLDOWN_BY_SEVERITY: Record<string, number> = {
-  critical: 5 * 60 * 1000,    // 5 min — urgent, re-notify quickly
-  warning: 30 * 60 * 1000,    // 30 min — important but not urgent
-  info: 4 * 60 * 60 * 1000,   // 4 hours — informational, minimal interruption
+  critical: 5 * MS_PER_MINUTE,    // 5 min — urgent, re-notify quickly
+  warning: 30 * MS_PER_MINUTE,    // 30 min — important but not urgent
+  info: 4 * MS_PER_HOUR,   // 4 hours — informational, minimal interruption
 }
 /** Fallback cooldown when severity is unknown */
-const DEFAULT_NOTIFICATION_COOLDOWN_MS = 30 * 60 * 1000 // 30 min
+const DEFAULT_NOTIFICATION_COOLDOWN_MS = 30 * MS_PER_MINUTE // 30 min
 
 /** Get the notification cooldown for a given severity level */
 function getNotificationCooldown(severity: string): number {

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -7,6 +7,7 @@ import { registerCacheReset, triggerAllRefetches } from '../../lib/modeTransitio
 import { resetFailuresForCluster, resetAllCacheFailures } from '../../lib/cache'
 import { hostnameEndsWith, hostnameContainsLabel } from '../../lib/utils/urlHostname'
 import { appendWsAuthToken } from '../../lib/utils/wsAuth'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
 import {
   LOCAL_AGENT_HTTP_URL,
   MCP_HOOK_TIMEOUT_MS,
@@ -1065,7 +1066,7 @@ const MAX_HEALTH_CHECK_FAILURES = 3
 // Per-cluster failure tracking to prevent transient errors from showing "-"
 // Track first failure timestamp - only mark unreachable after 5 minutes of consecutive failures
 const clusterHealthFailureStart = new Map<string, number>() // timestamp of first failure
-const OFFLINE_THRESHOLD_MS = 5 * 60 * 1000 // 5 minutes before marking as offline
+const OFFLINE_THRESHOLD_MS = 5 * MS_PER_MINUTE // 5 minutes before marking as offline
 
 // Helper to check if cluster has been failing long enough to mark offline
 export function shouldMarkOffline(clusterName: string): boolean {

--- a/web/src/hooks/useBonusPoints.ts
+++ b/web/src/hooks/useBonusPoints.ts
@@ -8,9 +8,10 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useAuth } from '../lib/auth'
 import { BACKEND_DEFAULT_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { MS_PER_MINUTE } from '../lib/constants/time'
 
 /** Client-side cache TTL (15 minutes) */
-const CACHE_TTL_MS = 15 * 60 * 1000
+const CACHE_TTL_MS = 15 * MS_PER_MINUTE
 const CACHE_KEY_PREFIX = 'bonus-points-cache'
 
 interface BonusEntry {

--- a/web/src/hooks/useCachedACMMScan.ts
+++ b/web/src/hooks/useCachedACMMScan.ts
@@ -10,6 +10,7 @@ import { useCallback, useRef, useSyncExternalStore } from 'react'
 import { useCache, type RefreshCategory } from '../lib/cache'
 import { computeLevel, type LevelComputation } from '../lib/acmm/computeLevel'
 import { computeRecommendations, type Recommendation } from '../lib/acmm/computeRecommendations'
+import { MS_PER_DAY } from '../lib/constants/time'
 
 const API_PATH = '/api/acmm/scan'
 /** Scan results change slowly; 10-min refresh avoids GitHub rate limits. */
@@ -82,7 +83,7 @@ function demoScan(repo: string): ACMMScanData {
     const year = d.getUTCFullYear()
     const jan1 = new Date(Date.UTC(year, 0, 1))
     const week = Math.ceil(
-      ((d.getTime() - jan1.getTime()) / (24 * 60 * 60 * 1000) + 1) / 7,
+      ((d.getTime() - jan1.getTime()) / MS_PER_DAY + 1) / 7,
     )
     weeks.push({
       week: `${year}-W${String(week).padStart(2, '0')}`,

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { api, RateLimitError } from '../lib/api'
 import { STORAGE_KEY_TOKEN, STORAGE_KEY_HAS_SESSION, DEMO_TOKEN_VALUE } from '../lib/constants'
 import { MIN_PERCEIVED_DELAY_MS } from '../lib/constants/network'
+import { MS_PER_DAY, MS_PER_HOUR } from '../lib/constants/time'
 
 /** Cache TTL: 30 seconds — polling interval for status updates */
 const CACHE_TTL_MS = 30_000
@@ -149,7 +150,7 @@ const DEMO_FEATURE_REQUESTS: FeatureRequest[] = [
     status: 'fix_ready',
     pr_number: 87,
     pr_url: 'https://github.com/kubestellar/console/pull/87',
-    created_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString() },
+    created_at: new Date(Date.now() - 3 * MS_PER_DAY).toISOString() },
   {
     id: 'demo-2',
     user_id: 'demo-user',
@@ -159,7 +160,7 @@ const DEMO_FEATURE_REQUESTS: FeatureRequest[] = [
     github_issue_number: 56,
     github_issue_url: 'https://github.com/kubestellar/console/issues/56',
     status: 'feasibility_study',
-    created_at: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString() },
+    created_at: new Date(Date.now() - 1 * MS_PER_DAY).toISOString() },
   {
     id: 'demo-3',
     user_id: 'demo-user',
@@ -171,7 +172,7 @@ const DEMO_FEATURE_REQUESTS: FeatureRequest[] = [
     status: 'fix_complete',
     pr_number: 72,
     pr_url: 'https://github.com/kubestellar/console/pull/72',
-    created_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString() },
+    created_at: new Date(Date.now() - 7 * MS_PER_DAY).toISOString() },
 ]
 
 const INITIAL_DEMO_NOTIFICATIONS: Notification[] = [
@@ -183,7 +184,7 @@ const INITIAL_DEMO_NOTIFICATIONS: Notification[] = [
     title: 'PR Ready: Add dark mode toggle',
     message: 'A pull request has been created for your feature request.',
     read: false,
-    created_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    created_at: new Date(Date.now() - 2 * MS_PER_HOUR).toISOString(),
     action_url: 'https://github.com/kubestellar/console/pull/87' },
   {
     id: 'demo-notif-2',
@@ -193,7 +194,7 @@ const INITIAL_DEMO_NOTIFICATIONS: Notification[] = [
     title: 'Merged: Export dashboard as PDF',
     message: 'Your feature request has been implemented and merged.',
     read: true,
-    created_at: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    created_at: new Date(Date.now() - 5 * MS_PER_DAY).toISOString(),
     action_url: 'https://github.com/kubestellar/console/pull/72' },
 ]
 

--- a/web/src/hooks/useGitHubRewards.ts
+++ b/web/src/hooks/useGitHubRewards.ts
@@ -12,6 +12,7 @@ import { useAuth } from '../lib/auth'
 import { BACKEND_DEFAULT_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type { GitHubRewardsResponse, GitHubContribution, GitHubRewardType } from '../types/rewards'
 import { GITHUB_REWARD_POINTS } from '../types/rewards'
+import { MS_PER_MINUTE } from '../lib/constants/time'
 
 /** Always fetch from the Netlify function (cached, no user token needed). */
 const REWARDS_API_BASE = 'https://console.kubestellar.io'
@@ -21,9 +22,9 @@ const CACHE_KEY_PREFIX = 'github-rewards-cache'
 /** Legacy cache key (pre-per-user). Cleared on first load to prevent stale data. */
 const LEGACY_CACHE_KEY = 'github-rewards-cache'
 /** How long client-side cached rewards data is considered fresh (15 minutes) */
-const CLIENT_CACHE_TTL_MS = 15 * 60 * 1000
+const CLIENT_CACHE_TTL_MS = 15 * MS_PER_MINUTE
 /** Interval between automatic background refreshes (10 minutes) */
-const REFRESH_INTERVAL_MS = 10 * 60 * 1000
+const REFRESH_INTERVAL_MS = 10 * MS_PER_MINUTE
 /** Max recent contributions to fetch from the GitHub Search API */
 const CONTRIBUTIONS_PER_PAGE = 20
 /** GitHub orgs to search for contributions */

--- a/web/src/hooks/useIntoto.ts
+++ b/web/src/hooks/useIntoto.ts
@@ -13,6 +13,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { kubectlProxy } from '../lib/kubectlProxy'
+import { MS_PER_HOUR, MS_PER_MINUTE } from '../lib/constants/time'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
@@ -152,7 +153,7 @@ function getDemoLayouts(cluster: string): IntotoLayout[] {
       expectedProducts: 4,
       verifiedSteps: 4,
       failedSteps: 0,
-      createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      createdAt: new Date(Date.now() - 2 * MS_PER_HOUR).toISOString(),
     },
     {
       name: 'deploy-pipeline',
@@ -165,7 +166,7 @@ function getDemoLayouts(cluster: string): IntotoLayout[] {
       expectedProducts: 3,
       verifiedSteps: 1,
       failedSteps: 2,
-      createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(),
+      createdAt: new Date(Date.now() - 1 * MS_PER_HOUR).toISOString(),
     },
     {
       name: 'release-signing',
@@ -177,7 +178,7 @@ function getDemoLayouts(cluster: string): IntotoLayout[] {
       expectedProducts: 2,
       verifiedSteps: 2,
       failedSteps: 0,
-      createdAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+      createdAt: new Date(Date.now() - 30 * MS_PER_MINUTE).toISOString(),
     },
   ]
 }

--- a/web/src/hooks/useMetricsHistory.ts
+++ b/web/src/hooks/useMetricsHistory.ts
@@ -2,12 +2,13 @@ import { useState, useEffect, useRef } from 'react'
 import type { MetricsSnapshot, TrendDirection } from '../types/predictions'
 import { useClusters, usePodIssues, useGPUNodes } from './useMCP'
 import { getPredictionSettings } from './usePredictionSettings'
+import { MS_PER_DAY, MS_PER_MINUTE } from '../lib/constants/time'
 
 const STORAGE_KEY = 'kubestellar-metrics-history'
 const HISTORY_CHANGED_EVENT = 'kubestellar-metrics-history-changed'
 const MAX_SNAPSHOTS = 1008 // 7 days at 10-min intervals (6 per hour * 24 hours * 7 days)
 /** Cache TTL: 7 days — remove snapshots older than this */
-const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+const CACHE_TTL_MS = 7 * MS_PER_DAY
 /** Maximum number of increasing-restart pods to include in AI context */
 const MAX_INCREASING_RESTART_PODS = 10
 /**
@@ -263,7 +264,7 @@ export function useMetricsHistory() {
   // Reads volatile data from refs so the interval stays stable across MCP polls (#5781).
   useEffect(() => {
     const settings = getPredictionSettings()
-    const interval = settings.interval * 60 * 1000 // Convert minutes to ms
+    const interval = settings.interval * MS_PER_MINUTE // Convert minutes to ms
 
     const captureSnapshot = () => {
       const now = Date.now()

--- a/web/src/hooks/useMultiClusterInsights.ts
+++ b/web/src/hooks/useMultiClusterInsights.ts
@@ -20,15 +20,16 @@ import type {
   ClusterDelta } from '../types/insights'
 import type { ClusterEvent, Deployment, PodIssue } from './mcp/types'
 import type { ClusterInfo } from './mcp/types'
+import { MS_PER_MINUTE } from '../lib/constants/time'
 
 // ── Thresholds & Constants ────────────────────────────────────────────
 
 /** Minimum clusters with events in same window to trigger correlation */
 export const MIN_CORRELATED_CLUSTERS = 2
 /** Time window in ms for event correlation grouping (5 minutes) */
-export const EVENT_CORRELATION_WINDOW_MS = 5 * 60 * 1000
+export const EVENT_CORRELATION_WINDOW_MS = 5 * MS_PER_MINUTE
 /** Time window in ms for cascade detection (15 minutes) */
-export const CASCADE_DETECTION_WINDOW_MS = 15 * 60 * 1000
+export const CASCADE_DETECTION_WINDOW_MS = 15 * MS_PER_MINUTE
 /** CPU/memory utilization percentage threshold for resource imbalance */
 const RESOURCE_IMBALANCE_THRESHOLD_PCT = 30
 /** Pod restart count threshold for restart correlation */
@@ -139,11 +140,11 @@ const FULL_PROGRESS = 100
 const PARTIAL_PROGRESS = 50
 
 /** Demo time offset: 5 minutes ago */
-const DEMO_OFFSET_5M_MS = 5 * 60 * 1000
+const DEMO_OFFSET_5M_MS = 5 * MS_PER_MINUTE
 /** Demo time offset: 10 minutes ago */
-const DEMO_OFFSET_10M_MS = 10 * 60 * 1000
+const DEMO_OFFSET_10M_MS = 10 * MS_PER_MINUTE
 /** Demo time offset: 15 minutes ago */
-const DEMO_OFFSET_15M_MS = 15 * 60 * 1000
+const DEMO_OFFSET_15M_MS = 15 * MS_PER_MINUTE
 
 // ── Helpers ───────────────────────────────────────────────────────────
 

--- a/web/src/hooks/useStackDiscovery.ts
+++ b/web/src/hooks/useStackDiscovery.ts
@@ -13,9 +13,10 @@ import { getDemoMode } from './useDemoMode'
 import type { LLMdServer } from './useLLMd'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 import { KUBECTL_MEDIUM_TIMEOUT_MS, KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
+import { MS_PER_MINUTE } from '../lib/constants/time'
 
 const CACHE_KEY = 'kubestellar-stack-cache'
-const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+const CACHE_TTL_MS = 5 * MS_PER_MINUTE // 5 minutes
 
 export interface LLMdStackComponent {
   name: string

--- a/web/src/hooks/useUsers.ts
+++ b/web/src/hooks/useUsers.ts
@@ -4,6 +4,7 @@ import { mapSettledWithConcurrency } from '../lib/utils/concurrency'
 import { getDemoMode } from './useDemoMode'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, RBAC_QUERY_TIMEOUT_MS } from '../lib/constants/network'
+import { MS_PER_DAY, MS_PER_HOUR } from '../lib/constants/time'
 import type {
   ConsoleUser,
   K8sServiceAccount,
@@ -40,8 +41,8 @@ function getDemoConsoleUsers(): ConsoleUser[] {
       avatar_url: 'https://avatars.githubusercontent.com/u/12345?v=4',
       role: 'admin',
       onboarded: true,
-      created_at: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString(),
-      last_login: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString() },
+      created_at: new Date(Date.now() - 90 * MS_PER_DAY).toISOString(),
+      last_login: new Date(Date.now() - 2 * MS_PER_HOUR).toISOString() },
     {
       id: '2',
       github_id: '23456',
@@ -50,8 +51,8 @@ function getDemoConsoleUsers(): ConsoleUser[] {
       avatar_url: 'https://avatars.githubusercontent.com/u/23456?v=4',
       role: 'editor',
       onboarded: true,
-      created_at: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString(),
-      last_login: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString() },
+      created_at: new Date(Date.now() - 60 * MS_PER_DAY).toISOString(),
+      last_login: new Date(Date.now() - 5 * MS_PER_HOUR).toISOString() },
     {
       id: '3',
       github_id: '34567',
@@ -59,8 +60,8 @@ function getDemoConsoleUsers(): ConsoleUser[] {
       email: 'bob@example.com',
       role: 'viewer',
       onboarded: true,
-      created_at: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
-      last_login: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString() },
+      created_at: new Date(Date.now() - 30 * MS_PER_DAY).toISOString(),
+      last_login: new Date(Date.now() - MS_PER_DAY).toISOString() },
     {
       id: '4',
       github_id: '45678',
@@ -69,8 +70,8 @@ function getDemoConsoleUsers(): ConsoleUser[] {
       avatar_url: 'https://avatars.githubusercontent.com/u/45678?v=4',
       role: 'editor',
       onboarded: true,
-      created_at: new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString(),
-      last_login: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString() },
+      created_at: new Date(Date.now() - 45 * MS_PER_DAY).toISOString(),
+      last_login: new Date(Date.now() - 1 * MS_PER_HOUR).toISOString() },
   ]
 }
 
@@ -236,27 +237,27 @@ function getDemoOpenShiftUsers(cluster?: string): OpenShiftUser[] {
       identities: ['htpasswd:admin'],
       groups: ['system:cluster-admins', 'system:authenticated'],
       cluster,
-      createdAt: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString() },
+      createdAt: new Date(Date.now() - 90 * MS_PER_DAY).toISOString() },
     {
       name: 'developer',
       fullName: 'Dev User',
       identities: ['htpasswd:developer'],
       groups: ['developers', 'system:authenticated'],
       cluster,
-      createdAt: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString() },
+      createdAt: new Date(Date.now() - 60 * MS_PER_DAY).toISOString() },
     {
       name: 'ops-user',
       fullName: 'Operations Engineer',
       identities: ['ldap:ops-user'],
       groups: ['operations', 'system:authenticated'],
       cluster,
-      createdAt: new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString() },
+      createdAt: new Date(Date.now() - 45 * MS_PER_DAY).toISOString() },
     {
       name: 'viewer',
       identities: ['htpasswd:viewer'],
       groups: ['viewers', 'system:authenticated'],
       cluster,
-      createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString() },
+      createdAt: new Date(Date.now() - 30 * MS_PER_DAY).toISOString() },
   ]
 }
 

--- a/web/src/lib/analytics-session.ts
+++ b/web/src/lib/analytics-session.ts
@@ -8,6 +8,7 @@
 
 import { STORAGE_KEY_ANALYTICS_OPT_OUT, STORAGE_KEY_ANONYMOUS_USER_ID } from './constants'
 import type { UtmParams } from './analytics-types'
+import { MS_PER_MINUTE } from './constants/time'
 
 // ── Storage keys ───────────────────────────────────────────────────
 
@@ -18,7 +19,7 @@ export const LAST_KEY = '_ksc_last'
 
 // ── Session ────────────────────────────────────────────────────────
 
-export const SESSION_TIMEOUT_MS = 30 * 60 * 1000 // 30 min
+export const SESSION_TIMEOUT_MS = 30 * MS_PER_MINUTE // 30 min
 
 // ── Bot / Headless Detection ────────────────────────────────────────
 // Automated installs (CI pipelines, cloud VMs running curl|bash) start

--- a/web/src/lib/kubara.ts
+++ b/web/src/lib/kubara.ts
@@ -1,4 +1,5 @@
 import { MILLICORES_PER_CORE, MIB_PER_GIB, KIB_PER_MIB, GB_TO_MIB, MB_TO_MIB, BYTES_PER_MIB } from './constants/units'
+import { MS_PER_MINUTE } from './constants/time'
 
 /**
  * Kubara catalog utilities for Mission Control integration.
@@ -28,7 +29,7 @@ const KUBARA_DEFAULT_REPO = 'kubara-io/kubara'
 const KUBARA_DEFAULT_PATH = 'go-binary/templates/embedded/managed-service-catalog/helm'
 
 /** In-memory TTL for the catalog index cache (ms) — avoids redundant fetches */
-const CATALOG_CACHE_TTL_MS = 5 * 60 * 1000
+const CATALOG_CACHE_TTL_MS = 5 * MS_PER_MINUTE
 
 // ---------------------------------------------------------------------------
 // Types

--- a/web/src/lib/llmd/mockData.ts
+++ b/web/src/lib/llmd/mockData.ts
@@ -5,8 +5,10 @@
  * Used when VPN is unavailable or for demo purposes.
  */
 
+import { MS_PER_MINUTE } from '../constants/time'
+
 // Named time-offset constant for demo timestamp (CLAUDE.md: No Magic Numbers)
-const THIRTY_MINUTES_MS = 30 * 60 * 1000
+const THIRTY_MINUTES_MS = 30 * MS_PER_MINUTE
 
 // KVCache status per pod
 export interface KVCacheStats {

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -8,12 +8,15 @@
  * IMPORTANT: These hooks are called inside the useDataSource hook,
  * which is a React hook. The registered functions must follow React's
  * rules of hooks - they are called consistently on every render.
+ *
+ * Time constants imported from lib/constants/time.
  */
 
 import { useState, useEffect } from 'react'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { registerDataHook } from './card/hooks/useDataSource'
 import { SHORT_DELAY_MS } from '../constants/network'
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../constants/time'
 import {
   useCachedPodIssues,
   useCachedEvents,
@@ -81,21 +84,21 @@ import { useCachedVolcano } from '../../hooks/useCachedVolcano'
 // Named time-offset constants for demo/mock data timestamps.
 // Raw ms literals are forbidden by the "No Magic Numbers" rule in CLAUDE.md.
 const THIRTY_SECONDS_MS = 30 * 1000
-const ONE_MINUTE_MS = 60 * 1000
-const TWO_MINUTES_MS = 2 * 60 * 1000
-const THREE_MINUTES_MS = 3 * 60 * 1000
-const FOUR_MINUTES_MS = 4 * 60 * 1000
-const FIVE_MINUTES_MS = 5 * 60 * 1000
-const TEN_MINUTES_MS = 10 * 60 * 1000
-const FIFTEEN_MINUTES_MS = 15 * 60 * 1000
-const THIRTY_MINUTES_MS = 30 * 60 * 1000
-const FORTY_FIVE_MINUTES_MS = 45 * 60 * 1000
-const ONE_HOUR_MS = 60 * 60 * 1000
-const TWO_HOURS_MS = 2 * 60 * 60 * 1000
-const THREE_HOURS_MS = 3 * 60 * 60 * 1000
-const ONE_DAY_MS = 24 * 60 * 60 * 1000
-const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000
-const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000
+const ONE_MINUTE_MS = MS_PER_MINUTE
+const TWO_MINUTES_MS = 2 * MS_PER_MINUTE
+const THREE_MINUTES_MS = 3 * MS_PER_MINUTE
+const FOUR_MINUTES_MS = 4 * MS_PER_MINUTE
+const FIVE_MINUTES_MS = 5 * MS_PER_MINUTE
+const TEN_MINUTES_MS = 10 * MS_PER_MINUTE
+const FIFTEEN_MINUTES_MS = 15 * MS_PER_MINUTE
+const THIRTY_MINUTES_MS = 30 * MS_PER_MINUTE
+const FORTY_FIVE_MINUTES_MS = 45 * MS_PER_MINUTE
+const ONE_HOUR_MS = MS_PER_HOUR
+const TWO_HOURS_MS = 2 * MS_PER_HOUR
+const THREE_HOURS_MS = 3 * MS_PER_HOUR
+const ONE_DAY_MS = MS_PER_DAY
+const TWO_DAYS_MS = 2 * MS_PER_DAY
+const THREE_DAYS_MS = 3 * MS_PER_DAY
 
 // ============================================================================
 // Wrapper hooks that convert params object to positional args


### PR DESCRIPTION
## Summary

Follow-up to PR #10225 — replaces remaining ~60 raw `N * 60 * 1000` time expressions across 28 more production files with `MS_PER_MINUTE`, `MS_PER_HOUR`, and `MS_PER_DAY` from `lib/constants/time.ts`.

## Changes

- 28 files modified (components, hooks, contexts, lib, config)
- Covers cards, hooks, contexts, and utility modules missed in the first pass
- Includes demo data timestamps within production files (useUsers, useFeatureRequests, etc.)

## Test plan

- [x] `npm run build` passes (vite build, 5506 modules, 0 errors)
- [x] All replacements are value-preserving (same numeric result)