### PR TITLE
🌱 Add tests for 7 useCached hooks to increase coverage toward 91%

### DIFF
--- a/web/src/hooks/__tests__/useCachedFlatcar.test.ts
+++ b/web/src/hooks/__tests__/useCachedFlatcar.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockUseCache = vi.fn()
+vi.mock('../../lib/cache', () => ({
+    useCache: (args: any) => mockUseCache(args),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../useDemoMode', () => ({
+    useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+    isDemoModeForced: () => false,
+    canToggleDemoMode: () => true,
+    isNetlifyDeployment: () => false,
+    isDemoToken: () => false,
+    hasRealToken: () => true,
+    setDemoToken: vi.fn(),
+    getDemoMode: () => false,
+    setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../components/cards/CardDataContext', () => ({
+    useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false }),
+}))
+
+import { useCachedFlatcar, __testables } from '../useCachedFlatcar'
+import { FLATCAR_DEMO_DATA, type FlatcarNode, type FlatcarChannel } from '../../lib/demo/flatcar'
+
+const { computeStats, deriveHealth, buildFlatcarStatus, dedupeChannels } = __testables
+
+const makeNode = (overrides: Partial<FlatcarNode> = {}): FlatcarNode => ({
+    name: 'node-1',
+    cluster: 'c1',
+    osImage: 'Flatcar Container Linux',
+    currentVersion: '3815.2.0',
+    availableVersion: null,
+    channel: 'stable',
+    state: 'up-to-date',
+    rebootRequired: false,
+    lastCheckTime: new Date().toISOString(),
+    ...overrides,
+})
+
+const makeCacheResult = (overrides: Record<string, unknown> = {}) => ({
+    data: { health: 'not-installed', nodes: [], stats: { totalNodes: 0, upToDateNodes: 0, updateAvailableNodes: 0, rebootRequiredNodes: 0, channelsInUse: [] }, summary: { latestStableVersion: '', latestBetaVersion: '', totalClusters: 0 }, lastCheckTime: '' },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: 123456789,
+    refetch: vi.fn(),
+    ...overrides,
+})
+
+describe('useCachedFlatcar', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockIsDemoMode.mockReturnValue(false)
+        mockUseCache.mockReturnValue(makeCacheResult())
+    })
+
+    it('returns data from cache when not in demo mode', () => {
+        const { result } = renderHook(() => useCachedFlatcar())
+        expect(result.current.data.health).toBe('not-installed')
+        expect(result.current.isDemoData).toBe(false)
+    })
+
+    it('returns demo data when demo mode is enabled', () => {
+        mockIsDemoMode.mockReturnValue(true)
+        mockUseCache.mockReturnValue(makeCacheResult({ data: FLATCAR_DEMO_DATA, isDemoFallback: true }))
+        const { result } = renderHook(() => useCachedFlatcar())
+        expect(result.current.isDemoData).toBe(true)
+        expect(result.current.data.nodes.length).toBeGreaterThan(0)
+    })
+
+    it('respects isLoading state — isDemoData false during loading', () => {
+        mockUseCache.mockReturnValue(makeCacheResult({ isLoading: true, isDemoFallback: true, lastRefresh: null }))
+        const { result } = renderHook(() => useCachedFlatcar())
+        expect(result.current.isLoading).toBe(true)
+        expect(result.current.isDemoData).toBe(false)
+    })
+})
+
+describe('__testables.dedupeChannels', () => {
+    it('removes duplicate channels', () => {
+        const channels: FlatcarChannel[] = ['stable', 'beta', 'stable', 'alpha', 'beta']
+        expect(dedupeChannels(channels)).toEqual(['stable', 'beta', 'alpha'])
+    })
+
+    it('handles empty array', () => {
+        expect(dedupeChannels([])).toEqual([])
+    })
+})
+
+describe('__testables.computeStats', () => {
+    it('returns zeroed stats for empty nodes', () => {
+        const s = computeStats([])
+        expect(s.totalNodes).toBe(0)
+        expect(s.upToDateNodes).toBe(0)
+        expect(s.updateAvailableNodes).toBe(0)
+        expect(s.rebootRequiredNodes).toBe(0)
+        expect(s.channelsInUse).toEqual([])
+    })
+
+    it('counts node states and channels', () => {
+        const nodes = [
+            makeNode({ state: 'up-to-date', channel: 'stable' }),
+            makeNode({ state: 'update-available', channel: 'beta', rebootRequired: true }),
+            makeNode({ state: 'up-to-date', channel: 'stable' }),
+        ]
+        const s = computeStats(nodes)
+        expect(s.totalNodes).toBe(3)
+        expect(s.upToDateNodes).toBe(2)
+        expect(s.updateAvailableNodes).toBe(1)
+        expect(s.rebootRequiredNodes).toBe(1)
+        expect(s.channelsInUse).toEqual(['stable', 'beta'])
+    })
+})
+
+describe('__testables.deriveHealth', () => {
+    it('returns not-installed for empty nodes', () => {
+        expect(deriveHealth([], { totalNodes: 0, upToDateNodes: 0, updateAvailableNodes: 0, rebootRequiredNodes: 0, channelsInUse: [] })).toBe('not-installed')
+    })
+
+    it('returns healthy when all up-to-date and no reboots', () => {
+        const nodes = [makeNode()]
+        const stats = computeStats(nodes)
+        expect(deriveHealth(nodes, stats)).toBe('healthy')
+    })
+
+    it('returns degraded when updates available', () => {
+        const nodes = [makeNode({ state: 'update-available' })]
+        const stats = computeStats(nodes)
+        expect(deriveHealth(nodes, stats)).toBe('degraded')
+    })
+
+    it('returns degraded when reboot required', () => {
+        const nodes = [makeNode({ rebootRequired: true })]
+        const stats = computeStats(nodes)
+        expect(deriveHealth(nodes, stats)).toBe('degraded')
+    })
+})
+
+describe('__testables.buildFlatcarStatus', () => {
+    it('builds complete status with nodes and summary', () => {
+        const nodes = [makeNode()]
+        const summary = { latestStableVersion: '3815.2.0', latestBetaVersion: '3850.0.0', totalClusters: 1 }
+        const status = buildFlatcarStatus(nodes, summary)
+        expect(status.health).toBe('healthy')
+        expect(status.nodes).toHaveLength(1)
+        expect(status.stats.totalNodes).toBe(1)
+        expect(status.summary.latestStableVersion).toBe('3815.2.0')
+    })
+
+    it('returns not-installed for empty nodes', () => {
+        const summary = { latestStableVersion: '', latestBetaVersion: '', totalClusters: 0 }
+        expect(buildFlatcarStatus([], summary).health).toBe('not-installed')
+    })
+})

--- a/web/src/hooks/__tests__/useCachedGrpc.test.ts
+++ b/web/src/hooks/__tests__/useCachedGrpc.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockUseCache = vi.fn()
+vi.mock('../../lib/cache', () => ({
+    useCache: (args: any) => mockUseCache(args),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../useDemoMode', () => ({
+    useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+    isDemoModeForced: () => false,
+    canToggleDemoMode: () => true,
+    isNetlifyDeployment: () => false,
+    isDemoToken: () => false,
+    hasRealToken: () => true,
+    setDemoToken: vi.fn(),
+    getDemoMode: () => false,
+    setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../components/cards/CardDataContext', () => ({
+    useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false }),
+}))
+
+import { useCachedGrpc, __testables } from '../useCachedGrpc'
+import { GRPC_DEMO_DATA, type GrpcService, type GrpcStats } from '../../components/cards/grpc_status/demoData'
+
+const { summarize, deriveHealth, buildGrpcStatus } = __testables
+
+const EMPTY_STATS: GrpcStats = { totalRps: 0, avgLatencyP99Ms: 0, avgErrorRatePct: 0, reflectionEnabled: 0 }
+
+const makeCacheResult = (overrides: Record<string, unknown> = {}) => ({
+    data: { health: 'not-installed', services: [], stats: EMPTY_STATS, summary: { totalServices: 0, servingServices: 0, totalEndpoints: 0 }, lastCheckTime: '' },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: 123456789,
+    refetch: vi.fn(),
+    ...overrides,
+})
+
+describe('useCachedGrpc', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockIsDemoMode.mockReturnValue(false)
+        mockUseCache.mockReturnValue(makeCacheResult())
+    })
+
+    it('returns data from cache when not in demo mode', () => {
+        const { result } = renderHook(() => useCachedGrpc())
+        expect(result.current.data.health).toBe('not-installed')
+        expect(result.current.isDemoData).toBe(false)
+    })
+
+    it('returns demo data when demo mode is enabled', () => {
+        mockIsDemoMode.mockReturnValue(true)
+        mockUseCache.mockReturnValue(makeCacheResult({ data: GRPC_DEMO_DATA, isDemoFallback: true }))
+        const { result } = renderHook(() => useCachedGrpc())
+        expect(result.current.isDemoData).toBe(true)
+        expect(result.current.data.services.length).toBeGreaterThan(0)
+    })
+
+    it('respects isLoading state — isDemoData should be false during loading', () => {
+        mockUseCache.mockReturnValue(makeCacheResult({ isLoading: true, isDemoFallback: true, lastRefresh: null }))
+        const { result } = renderHook(() => useCachedGrpc())
+        expect(result.current.isLoading).toBe(true)
+        expect(result.current.isDemoData).toBe(false)
+    })
+
+    it('sets error to true when isFailed and no data', () => {
+        mockUseCache.mockReturnValue(makeCacheResult({
+            data: { health: 'degraded', services: [], stats: EMPTY_STATS, summary: { totalServices: 0, servingServices: 0, totalEndpoints: 0 }, lastCheckTime: '' },
+            isFailed: true,
+        }))
+        const { result } = renderHook(() => useCachedGrpc())
+        expect(result.current.error).toBe(true)
+    })
+})
+
+describe('__testables.summarize', () => {
+    it('returns zeroed summary for empty services', () => {
+        const s = summarize([])
+        expect(s.totalServices).toBe(0)
+        expect(s.servingServices).toBe(0)
+        expect(s.totalEndpoints).toBe(0)
+    })
+
+    it('counts serving services and endpoints', () => {
+        const services = [
+            { status: 'serving', endpoints: 3 },
+            { status: 'not-serving', endpoints: 2 },
+        ] as GrpcService[]
+        const s = summarize(services)
+        expect(s.totalServices).toBe(2)
+        expect(s.servingServices).toBe(1)
+        expect(s.totalEndpoints).toBe(5)
+    })
+})
+
+describe('__testables.deriveHealth', () => {
+    it('returns not-installed for empty services', () => {
+        expect(deriveHealth([])).toBe('not-installed')
+    })
+
+    it('returns healthy when all serving', () => {
+        expect(deriveHealth([{ status: 'serving' }] as GrpcService[])).toBe('healthy')
+    })
+
+    it('returns degraded when any not serving', () => {
+        expect(deriveHealth([
+            { status: 'serving' },
+            { status: 'not-serving' },
+        ] as GrpcService[])).toBe('degraded')
+    })
+})
+
+describe('__testables.buildGrpcStatus', () => {
+    it('builds full status with services and stats', () => {
+        const services = [{ status: 'serving', endpoints: 2, name: 'svc1', namespace: 'ns', rps: 10, latencyP99Ms: 5, errorRatePct: 0, cluster: 'c1' }] as GrpcService[]
+        const stats: GrpcStats = { totalRps: 10, avgLatencyP99Ms: 5, avgErrorRatePct: 0, reflectionEnabled: 1 }
+        const result = buildGrpcStatus(services, stats)
+        expect(result.health).toBe('healthy')
+        expect(result.services).toHaveLength(1)
+        expect(result.summary.totalEndpoints).toBe(2)
+        expect(result.stats.totalRps).toBe(10)
+    })
+
+    it('returns not-installed for empty services', () => {
+        expect(buildGrpcStatus([], EMPTY_STATS).health).toBe('not-installed')
+    })
+})

--- a/web/src/hooks/__tests__/useCachedRook.test.ts
+++ b/web/src/hooks/__tests__/useCachedRook.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockUseCache = vi.fn()
+vi.mock('../../lib/cache', () => ({
+    useCache: (args: any) => mockUseCache(args),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../useDemoMode', () => ({
+    useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+    isDemoModeForced: () => false,
+    canToggleDemoMode: () => true,
+    isNetlifyDeployment: () => false,
+    isDemoToken: () => false,
+    hasRealToken: () => true,
+    setDemoToken: vi.fn(),
+    getDemoMode: () => false,
+    setGlobalDemoMode: vi.fn(),
+}))
+
+import { useCachedRook, __testables } from '../useCachedRook'
+import { ROOK_DEMO_DATA, type RookCephCluster } from '../../lib/demo/rook'
+
+const { normalizeCephHealth, extractCephVersion, itemToCluster, summarize, buildStatus } = __testables
+
+const makeCacheResult = (overrides: Record<string, unknown> = {}) => ({
+    data: { health: 'healthy', clusters: [], summary: { totalClusters: 0, healthyClusters: 0, degradedClusters: 0, totalOsdUp: 0, totalOsdTotal: 0, totalCapacityBytes: 0, totalUsedBytes: 0 }, lastCheckTime: '' },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: 123456789,
+    refetch: vi.fn(),
+    ...overrides,
+})
+
+describe('useCachedRook', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockIsDemoMode.mockReturnValue(false)
+        mockUseCache.mockReturnValue(makeCacheResult())
+    })
+
+    it('returns data from cache when not in demo mode', () => {
+        const { result } = renderHook(() => useCachedRook())
+        expect(result.current.data.health).toBe('healthy')
+        expect(result.current.isDemoFallback).toBe(false)
+    })
+
+    it('returns demo data when demo mode is enabled', () => {
+        mockIsDemoMode.mockReturnValue(true)
+        mockUseCache.mockReturnValue(makeCacheResult({ data: ROOK_DEMO_DATA, isDemoFallback: true }))
+        const { result } = renderHook(() => useCachedRook())
+        expect(result.current.isDemoFallback).toBe(true)
+        expect(result.current.data.clusters.length).toBeGreaterThan(0)
+    })
+
+    it('respects isLoading state', () => {
+        mockUseCache.mockReturnValue(makeCacheResult({ isLoading: true, lastRefresh: null }))
+        const { result } = renderHook(() => useCachedRook())
+        expect(result.current.isLoading).toBe(true)
+    })
+})
+
+describe('__testables.normalizeCephHealth', () => {
+    it('maps HEALTH_OK correctly', () => {
+        expect(normalizeCephHealth('HEALTH_OK')).toBe('HEALTH_OK')
+    })
+
+    it('maps HEALTH_ERR correctly', () => {
+        expect(normalizeCephHealth('HEALTH_ERR')).toBe('HEALTH_ERR')
+    })
+
+    it('defaults undefined to HEALTH_WARN', () => {
+        expect(normalizeCephHealth(undefined)).toBe('HEALTH_WARN')
+    })
+
+    it('defaults unknown string to HEALTH_WARN', () => {
+        expect(normalizeCephHealth('SOMETHING_ELSE')).toBe('HEALTH_WARN')
+    })
+})
+
+describe('__testables.extractCephVersion', () => {
+    it('extracts version from status.ceph.version', () => {
+        expect(extractCephVersion({ status: { ceph: { version: 'v18.2.4' } } })).toBe('v18.2.4')
+    })
+
+    it('extracts version from spec image tag', () => {
+        expect(extractCephVersion({ spec: { cephVersion: { image: 'quay.io/ceph/ceph:v18.2.4' } } })).toBe('v18.2.4')
+    })
+
+    it('returns empty string for missing data', () => {
+        expect(extractCephVersion({})).toBe('')
+    })
+
+    it('handles image with digest', () => {
+        expect(extractCephVersion({ spec: { cephVersion: { image: 'ceph:v18@sha256:abc' } } })).toBe('v18')
+    })
+})
+
+describe('__testables.itemToCluster', () => {
+    it('transforms a full CephCluster item', () => {
+        const item = {
+            metadata: { name: 'rook-ceph', namespace: 'rook-ceph' },
+            cluster: 'cluster-1',
+            status: { ceph: { health: 'HEALTH_OK', version: 'v18.2.4' } },
+        }
+        const cluster = itemToCluster(item)
+        expect(cluster.name).toBe('rook-ceph')
+        expect(cluster.namespace).toBe('rook-ceph')
+        expect(cluster.cluster).toBe('cluster-1')
+        expect(cluster.cephHealth).toBe('HEALTH_OK')
+        expect(cluster.cephVersion).toBe('v18.2.4')
+    })
+
+    it('handles missing fields gracefully', () => {
+        const cluster = itemToCluster({})
+        expect(cluster.name).toBe('')
+        expect(cluster.namespace).toBe('')
+        expect(cluster.cephHealth).toBe('HEALTH_WARN')
+    })
+})
+
+describe('__testables.summarize', () => {
+    it('returns zeroed summary for empty array', () => {
+        const summary = summarize([])
+        expect(summary.totalClusters).toBe(0)
+        expect(summary.healthyClusters).toBe(0)
+        expect(summary.degradedClusters).toBe(0)
+    })
+
+    it('counts healthy vs degraded clusters', () => {
+        const clusters = [
+            { cephHealth: 'HEALTH_OK', osdUp: 3, osdTotal: 3, capacityTotalBytes: 100, capacityUsedBytes: 50 },
+            { cephHealth: 'HEALTH_WARN', osdUp: 2, osdTotal: 3, capacityTotalBytes: 100, capacityUsedBytes: 60 },
+        ] as RookCephCluster[]
+        const summary = summarize(clusters)
+        expect(summary.totalClusters).toBe(2)
+        expect(summary.healthyClusters).toBe(1)
+        expect(summary.degradedClusters).toBe(1)
+        expect(summary.totalOsdUp).toBe(5)
+        expect(summary.totalOsdTotal).toBe(6)
+    })
+})
+
+describe('__testables.buildStatus', () => {
+    it('returns not-installed for empty clusters', () => {
+        const status = buildStatus([])
+        expect(status.health).toBe('not-installed')
+        expect(status.clusters).toHaveLength(0)
+    })
+
+    it('returns healthy when all clusters are HEALTH_OK', () => {
+        const clusters = [{ cephHealth: 'HEALTH_OK' }] as RookCephCluster[]
+        const status = buildStatus(clusters)
+        expect(status.health).toBe('healthy')
+    })
+
+    it('returns degraded when any cluster is not HEALTH_OK', () => {
+        const clusters = [
+            { cephHealth: 'HEALTH_OK' },
+            { cephHealth: 'HEALTH_WARN' },
+        ] as RookCephCluster[]
+        const status = buildStatus(clusters)
+        expect(status.health).toBe('degraded')
+    })
+})

--- a/web/src/hooks/__tests__/useCachedStrimzi.test.ts
+++ b/web/src/hooks/__tests__/useCachedStrimzi.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockUseCache = vi.fn()
+vi.mock('../../lib/cache', () => ({
+    useCache: (args: any) => mockUseCache(args),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../useDemoMode', () => ({
+    useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+    isDemoModeForced: () => false,
+    canToggleDemoMode: () => true,
+    isNetlifyDeployment: () => false,
+    isDemoToken: () => false,
+    hasRealToken: () => true,
+    setDemoToken: vi.fn(),
+    getDemoMode: () => false,
+    setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../components/cards/CardDataContext', () => ({
+    useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false }),
+}))
+
+import { useCachedStrimzi, __testables } from '../useCachedStrimzi'
+import { STRIMZI_DEMO_DATA, type StrimziKafkaCluster } from '../../components/cards/strimzi_status/demoData'
+
+const { summarize, aggregateStats, deriveHealth, buildStrimziStatus } = __testables
+
+const makeCluster = (overrides: Partial<StrimziKafkaCluster> = {}): StrimziKafkaCluster => ({
+    name: 'kafka-cluster',
+    namespace: 'kafka',
+    cluster: 'c1',
+    kafkaVersion: '3.7.0',
+    health: 'healthy',
+    brokers: { ready: 3, total: 3 },
+    topics: [],
+    consumerGroups: [],
+    totalLag: 0,
+    ...overrides,
+})
+
+const makeCacheResult = (overrides: Record<string, unknown> = {}) => ({
+    data: { health: 'not-installed', clusters: [], stats: { clusterCount: 0, brokerCount: 0, topicCount: 0, consumerGroupCount: 0, totalLag: 0, operatorVersion: 'unknown' }, summary: { totalClusters: 0, healthyClusters: 0, totalBrokers: 0, readyBrokers: 0 }, lastCheckTime: '' },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: 123456789,
+    refetch: vi.fn(),
+    ...overrides,
+})
+
+describe('useCachedStrimzi', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockIsDemoMode.mockReturnValue(false)
+        mockUseCache.mockReturnValue(makeCacheResult())
+    })
+
+    it('returns data from cache when not in demo mode', () => {
+        const { result } = renderHook(() => useCachedStrimzi())
+        expect(result.current.data.health).toBe('not-installed')
+        expect(result.current.isDemoData).toBe(false)
+    })
+
+    it('returns demo data when demo mode is enabled', () => {
+        mockIsDemoMode.mockReturnValue(true)
+        mockUseCache.mockReturnValue(makeCacheResult({ data: STRIMZI_DEMO_DATA, isDemoFallback: true }))
+        const { result } = renderHook(() => useCachedStrimzi())
+        expect(result.current.isDemoData).toBe(true)
+        expect(result.current.data.clusters.length).toBeGreaterThan(0)
+    })
+
+    it('respects isLoading state — isDemoData false during loading', () => {
+        mockUseCache.mockReturnValue(makeCacheResult({ isLoading: true, isDemoFallback: true, lastRefresh: null }))
+        const { result } = renderHook(() => useCachedStrimzi())
+        expect(result.current.isLoading).toBe(true)
+        expect(result.current.isDemoData).toBe(false)
+    })
+})
+
+describe('__testables.summarize', () => {
+    it('returns zeroed summary for empty clusters', () => {
+        const s = summarize([])
+        expect(s.totalClusters).toBe(0)
+        expect(s.totalBrokers).toBe(0)
+    })
+
+    it('counts healthy clusters and broker totals', () => {
+        const clusters = [
+            makeCluster({ health: 'healthy', brokers: { ready: 3, total: 3 } }),
+            makeCluster({ health: 'degraded', brokers: { ready: 1, total: 3 } }),
+        ]
+        const s = summarize(clusters)
+        expect(s.totalClusters).toBe(2)
+        expect(s.healthyClusters).toBe(1)
+        expect(s.totalBrokers).toBe(6)
+        expect(s.readyBrokers).toBe(4)
+    })
+})
+
+describe('__testables.aggregateStats', () => {
+    it('aggregates topics, consumer groups, lag, and brokers', () => {
+        const clusters = [
+            makeCluster({
+                brokers: { ready: 2, total: 3 },
+                topics: [{ name: 't1', partitions: 1, replicationFactor: 1, status: 'active' }],
+                consumerGroups: [{ groupId: 'g1', members: 1, lag: 10, status: 'ok' }],
+                totalLag: 10,
+            }),
+        ]
+        const s = aggregateStats(clusters, '0.40.0')
+        expect(s.clusterCount).toBe(1)
+        expect(s.brokerCount).toBe(3)
+        expect(s.topicCount).toBe(1)
+        expect(s.consumerGroupCount).toBe(1)
+        expect(s.totalLag).toBe(10)
+        expect(s.operatorVersion).toBe('0.40.0')
+    })
+
+    it('handles empty clusters', () => {
+        const s = aggregateStats([], 'unknown')
+        expect(s.clusterCount).toBe(0)
+        expect(s.brokerCount).toBe(0)
+    })
+})
+
+describe('__testables.deriveHealth', () => {
+    it('returns not-installed for empty clusters', () => {
+        expect(deriveHealth([])).toBe('not-installed')
+    })
+
+    it('returns healthy when all clusters healthy', () => {
+        expect(deriveHealth([makeCluster()])).toBe('healthy')
+    })
+
+    it('returns degraded when any cluster is degraded', () => {
+        expect(deriveHealth([makeCluster(), makeCluster({ health: 'degraded' })])).toBe('degraded')
+    })
+})
+
+describe('__testables.buildStrimziStatus', () => {
+    it('builds complete status object', () => {
+        const clusters = [makeCluster()]
+        const status = buildStrimziStatus(clusters, '0.40.0')
+        expect(status.health).toBe('healthy')
+        expect(status.clusters).toHaveLength(1)
+        expect(status.stats.operatorVersion).toBe('0.40.0')
+        expect(status.summary.totalClusters).toBe(1)
+    })
+
+    it('returns not-installed for empty clusters', () => {
+        expect(buildStrimziStatus([], 'unknown').health).toBe('not-installed')
+    })
+})

--- a/web/src/hooks/__tests__/useCachedTikv.test.ts
+++ b/web/src/hooks/__tests__/useCachedTikv.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockUseCache = vi.fn()
+vi.mock('../../lib/cache', () => ({
+    useCache: (args: any) => mockUseCache(args),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../useDemoMode', () => ({
+    useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+    isDemoModeForced: () => false,
+    canToggleDemoMode: () => true,
+    isNetlifyDeployment: () => false,
+    isDemoToken: () => false,
+    hasRealToken: () => true,
+    setDemoToken: vi.fn(),
+    getDemoMode: () => false,
+    setGlobalDemoMode: vi.fn(),
+}))
+
+import { useCachedTikv, __testables } from '../useCachedTikv'
+import { TIKV_DEMO_DATA, type TikvStore } from '../../lib/demo/tikv'
+
+const { isTikvPod, parseIntOrZero, deriveStoreState, parseVersion, podToStore, summarize, buildStatus } = __testables
+
+const makeCacheResult = (overrides: Record<string, unknown> = {}) => ({
+    data: { health: 'not-installed', stores: [], summary: { totalStores: 0, upStores: 0, downStores: 0, totalRegions: 0, totalLeaders: 0 }, lastCheckTime: '' },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: 123456789,
+    refetch: vi.fn(),
+    ...overrides,
+})
+
+describe('useCachedTikv', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockIsDemoMode.mockReturnValue(false)
+        mockUseCache.mockReturnValue(makeCacheResult())
+    })
+
+    it('returns data from cache when not in demo mode', () => {
+        const { result } = renderHook(() => useCachedTikv())
+        expect(result.current.data.health).toBe('not-installed')
+        expect(result.current.isDemoFallback).toBe(false)
+    })
+
+    it('returns demo data when demo mode is enabled', () => {
+        mockIsDemoMode.mockReturnValue(true)
+        mockUseCache.mockReturnValue(makeCacheResult({ data: TIKV_DEMO_DATA, isDemoFallback: true }))
+        const { result } = renderHook(() => useCachedTikv())
+        expect(result.current.isDemoFallback).toBe(true)
+        expect(result.current.data.stores.length).toBeGreaterThan(0)
+    })
+
+    it('respects isLoading state', () => {
+        mockUseCache.mockReturnValue(makeCacheResult({ isLoading: true, lastRefresh: null }))
+        const { result } = renderHook(() => useCachedTikv())
+        expect(result.current.isLoading).toBe(true)
+    })
+})
+
+describe('__testables.isTikvPod', () => {
+    it('detects pod by label app.kubernetes.io/component', () => {
+        expect(isTikvPod({ name: 'x', metadata: { labels: { 'app.kubernetes.io/component': 'tikv' } } })).toBe(true)
+    })
+
+    it('detects pod by name prefix tikv-', () => {
+        expect(isTikvPod({ name: 'tikv-0' })).toBe(true)
+    })
+
+    it('detects pod by name containing -tikv-', () => {
+        expect(isTikvPod({ name: 'tc-tikv-0' })).toBe(true)
+    })
+
+    it('rejects non-tikv pod', () => {
+        expect(isTikvPod({ name: 'redis-0', metadata: { labels: { app: 'redis' } } })).toBe(false)
+    })
+})
+
+describe('__testables.parseIntOrZero', () => {
+    it('parses valid integer', () => {
+        expect(parseIntOrZero('42')).toBe(42)
+    })
+
+    it('returns 0 for undefined', () => {
+        expect(parseIntOrZero(undefined)).toBe(0)
+    })
+
+    it('returns 0 for non-numeric string', () => {
+        expect(parseIntOrZero('abc')).toBe(0)
+    })
+})
+
+describe('__testables.deriveStoreState', () => {
+    it('returns Up when Running and all containers ready', () => {
+        expect(deriveStoreState({ name: 'a', status: { phase: 'Running', containerStatuses: [{ ready: true }] } })).toBe('Up')
+    })
+
+    it('returns Down when Running but containers not ready', () => {
+        expect(deriveStoreState({ name: 'a', status: { phase: 'Running', containerStatuses: [{ ready: false }] } })).toBe('Down')
+    })
+
+    it('returns Offline when Pending', () => {
+        expect(deriveStoreState({ name: 'a', status: { phase: 'Pending' } })).toBe('Offline')
+    })
+
+    it('returns Down when Failed', () => {
+        expect(deriveStoreState({ name: 'a', status: { phase: 'Failed' } })).toBe('Down')
+    })
+})
+
+describe('__testables.parseVersion', () => {
+    it('extracts version tag from tikv container image', () => {
+        const pod = { name: 'tikv-0', status: { containerStatuses: [{ name: 'tikv', image: 'pingcap/tikv:v7.5.1' }] } }
+        expect(parseVersion(pod)).toBe('v7.5.1')
+    })
+
+    it('returns empty for pod with no containers', () => {
+        expect(parseVersion({ name: 'tikv-0' })).toBe('')
+    })
+})
+
+describe('__testables.summarize', () => {
+    it('returns zeroed summary for empty stores', () => {
+        const s = summarize([])
+        expect(s.totalStores).toBe(0)
+        expect(s.upStores).toBe(0)
+        expect(s.downStores).toBe(0)
+    })
+
+    it('aggregates store stats', () => {
+        const stores = [
+            { state: 'Up', regionCount: 10, leaderCount: 5 },
+            { state: 'Down', regionCount: 8, leaderCount: 3 },
+        ] as TikvStore[]
+        const s = summarize(stores)
+        expect(s.totalStores).toBe(2)
+        expect(s.upStores).toBe(1)
+        expect(s.downStores).toBe(1)
+        expect(s.totalRegions).toBe(18)
+        expect(s.totalLeaders).toBe(8)
+    })
+})
+
+describe('__testables.buildStatus', () => {
+    it('returns not-installed for empty stores', () => {
+        expect(buildStatus([]).health).toBe('not-installed')
+    })
+
+    it('returns healthy when all stores are Up', () => {
+        const stores = [{ state: 'Up', regionCount: 0, leaderCount: 0 }] as TikvStore[]
+        expect(buildStatus(stores).health).toBe('healthy')
+    })
+
+    it('returns degraded when any store is Down', () => {
+        const stores = [
+            { state: 'Up', regionCount: 0, leaderCount: 0 },
+            { state: 'Down', regionCount: 0, leaderCount: 0 },
+        ] as TikvStore[]
+        expect(buildStatus(stores).health).toBe('degraded')
+    })
+})

--- a/web/src/hooks/__tests__/useCachedTuf.test.ts
+++ b/web/src/hooks/__tests__/useCachedTuf.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockUseCache = vi.fn()
+vi.mock('../../lib/cache', () => ({
+    useCache: (args: any) => mockUseCache(args),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../useDemoMode', () => ({
+    useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+    isDemoModeForced: () => false,
+    canToggleDemoMode: () => true,
+    isNetlifyDeployment: () => false,
+    isDemoToken: () => false,
+    hasRealToken: () => true,
+    setDemoToken: vi.fn(),
+    getDemoMode: () => false,
+    setGlobalDemoMode: vi.fn(),
+}))
+
+import { useCachedTuf, __testables } from '../useCachedTuf'
+import { TUF_DEMO_DATA, type TufRole } from '../../lib/demo/tuf'
+
+const { deriveStatus, summarize, deriveHealth, buildTufStatus, EXPIRING_SOON_WINDOW_MS } = __testables
+
+const makeRole = (overrides: Partial<TufRole> = {}): TufRole => ({
+    name: 'root',
+    version: 1,
+    expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    threshold: 1,
+    keyCount: 1,
+    status: 'signed',
+    ...overrides,
+})
+
+const makeCacheResult = (overrides: Record<string, unknown> = {}) => ({
+    data: { health: 'not-installed', specVersion: 'unknown', repository: '', roles: [], summary: { totalRoles: 0, signedRoles: 0, expiredRoles: 0, expiringSoonRoles: 0 }, lastCheckTime: '' },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: 123456789,
+    refetch: vi.fn(),
+    ...overrides,
+})
+
+describe('useCachedTuf', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockIsDemoMode.mockReturnValue(false)
+        mockUseCache.mockReturnValue(makeCacheResult())
+    })
+
+    it('returns data from cache when not in demo mode', () => {
+        const { result } = renderHook(() => useCachedTuf())
+        expect(result.current.data.health).toBe('not-installed')
+        expect(result.current.isDemoFallback).toBe(false)
+    })
+
+    it('returns demo data when demo mode is enabled', () => {
+        mockIsDemoMode.mockReturnValue(true)
+        mockUseCache.mockReturnValue(makeCacheResult({ data: TUF_DEMO_DATA, isDemoFallback: true }))
+        const { result } = renderHook(() => useCachedTuf())
+        expect(result.current.isDemoFallback).toBe(true)
+        expect(result.current.data.roles.length).toBeGreaterThan(0)
+    })
+
+    it('respects isLoading state', () => {
+        mockUseCache.mockReturnValue(makeCacheResult({ isLoading: true, lastRefresh: null }))
+        const { result } = renderHook(() => useCachedTuf())
+        expect(result.current.isLoading).toBe(true)
+    })
+})
+
+describe('__testables.deriveStatus', () => {
+    const NOW = Date.now()
+
+    it('returns unsigned for unsigned roles', () => {
+        expect(deriveStatus(makeRole({ status: 'unsigned' }), NOW)).toBe('unsigned')
+    })
+
+    it('returns expired when expiresAt is in the past', () => {
+        const pastDate = new Date(NOW - 1000).toISOString()
+        expect(deriveStatus(makeRole({ expiresAt: pastDate, status: 'signed' }), NOW)).toBe('expired')
+    })
+
+    it('returns expiring-soon within the window', () => {
+        const soonDate = new Date(NOW + EXPIRING_SOON_WINDOW_MS / 2).toISOString()
+        expect(deriveStatus(makeRole({ expiresAt: soonDate, status: 'signed' }), NOW)).toBe('expiring-soon')
+    })
+
+    it('returns signed when well in the future', () => {
+        const futureDate = new Date(NOW + EXPIRING_SOON_WINDOW_MS * 2).toISOString()
+        expect(deriveStatus(makeRole({ expiresAt: futureDate, status: 'signed' }), NOW)).toBe('signed')
+    })
+
+    it('returns original status for invalid date', () => {
+        expect(deriveStatus(makeRole({ expiresAt: 'not-a-date', status: 'signed' }), NOW)).toBe('signed')
+    })
+})
+
+describe('__testables.summarize', () => {
+    it('returns zeroed summary for empty roles', () => {
+        const s = summarize([])
+        expect(s.totalRoles).toBe(0)
+        expect(s.signedRoles).toBe(0)
+    })
+
+    it('counts roles by status', () => {
+        const roles = [
+            makeRole({ status: 'signed' }),
+            makeRole({ status: 'expired' }),
+            makeRole({ status: 'expiring-soon' }),
+        ]
+        const s = summarize(roles)
+        expect(s.totalRoles).toBe(3)
+        expect(s.signedRoles).toBe(1)
+        expect(s.expiredRoles).toBe(1)
+        expect(s.expiringSoonRoles).toBe(1)
+    })
+})
+
+describe('__testables.deriveHealth', () => {
+    it('returns not-installed for empty roles', () => {
+        expect(deriveHealth([])).toBe('not-installed')
+    })
+
+    it('returns healthy when all roles signed', () => {
+        expect(deriveHealth([makeRole()])).toBe('healthy')
+    })
+
+    it('returns degraded when any role is expired', () => {
+        expect(deriveHealth([makeRole(), makeRole({ status: 'expired' })])).toBe('degraded')
+    })
+
+    it('returns degraded when any role is unsigned', () => {
+        expect(deriveHealth([makeRole({ status: 'unsigned' })])).toBe('degraded')
+    })
+
+    it('returns degraded when any role is expiring-soon', () => {
+        expect(deriveHealth([makeRole({ status: 'expiring-soon' })])).toBe('degraded')
+    })
+})
+
+describe('__testables.buildTufStatus', () => {
+    it('builds complete status from roles', () => {
+        const roles = [makeRole({ name: 'root' }), makeRole({ name: 'targets' })]
+        const status = buildTufStatus(roles, '1.0.31', 'https://tuf.example.com')
+        expect(status.specVersion).toBe('1.0.31')
+        expect(status.repository).toBe('https://tuf.example.com')
+        expect(status.roles).toHaveLength(2)
+        expect(status.health).toBe('healthy')
+    })
+
+    it('returns not-installed for empty roles', () => {
+        expect(buildTufStatus([], '1.0.31', '').health).toBe('not-installed')
+    })
+})

--- a/web/src/hooks/__tests__/useCachedVolcano.test.ts
+++ b/web/src/hooks/__tests__/useCachedVolcano.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockUseCache = vi.fn()
+vi.mock('../../lib/cache', () => ({
+    useCache: (args: any) => mockUseCache(args),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../useDemoMode', () => ({
+    useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+    isDemoModeForced: () => false,
+    canToggleDemoMode: () => true,
+    isNetlifyDeployment: () => false,
+    isDemoToken: () => false,
+    hasRealToken: () => true,
+    setDemoToken: vi.fn(),
+    getDemoMode: () => false,
+    setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../components/cards/CardDataContext', () => ({
+    useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false }),
+}))
+
+import { useCachedVolcano, __testables } from '../useCachedVolcano'
+import {
+    VOLCANO_DEMO_DATA,
+    type VolcanoQueue,
+    type VolcanoJob,
+    type VolcanoPodGroup,
+    type VolcanoStats,
+} from '../../components/cards/volcano_status/demoData'
+
+const { summarize, deriveHealth, deriveStatsFromLists, buildVolcanoStatus } = __testables
+
+const makeQueue = (overrides: Partial<VolcanoQueue> = {}): VolcanoQueue => ({
+    name: 'default',
+    state: 'Open',
+    weight: 1,
+    runningJobs: 0,
+    pendingJobs: 0,
+    allocatedCpu: 0,
+    allocatedMemGiB: 0,
+    allocatedGpu: 2,
+    capabilityCpu: 0,
+    capabilityMemGiB: 0,
+    capabilityGpu: 4,
+    cluster: 'c1',
+    ...overrides,
+})
+
+const makeJob = (overrides: Partial<VolcanoJob> = {}): VolcanoJob => ({
+    name: 'train-job',
+    namespace: 'ml',
+    queue: 'default',
+    phase: 'Running',
+    minAvailable: 1,
+    replicas: 1,
+    runningTasks: 1,
+    pendingTasks: 0,
+    failedTasks: 0,
+    succeededTasks: 0,
+    creationTime: new Date().toISOString(),
+    cluster: 'c1',
+    ...overrides,
+})
+
+const makePodGroup = (overrides: Partial<VolcanoPodGroup> = {}): VolcanoPodGroup => ({
+    name: 'pg-1',
+    namespace: 'ml',
+    phase: 'Running',
+    minMember: 1,
+    currentMembers: 1,
+    queue: 'default',
+    cluster: 'c1',
+    ...overrides,
+})
+
+const EMPTY_STATS: VolcanoStats = {
+    totalQueues: 0, openQueues: 0, totalJobs: 0, pendingJobs: 0,
+    runningJobs: 0, completedJobs: 0, failedJobs: 0, totalPodGroups: 0,
+    allocatedGpu: 0, schedulerVersion: 'unknown',
+}
+
+const makeCacheResult = (overrides: Record<string, unknown> = {}) => ({
+    data: { health: 'not-installed', queues: [], jobs: [], podGroups: [], stats: EMPTY_STATS, summary: { totalQueues: 0, totalJobs: 0, totalPodGroups: 0, allocatedGpu: 0 }, lastCheckTime: '' },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: 123456789,
+    refetch: vi.fn(),
+    ...overrides,
+})
+
+describe('useCachedVolcano', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockIsDemoMode.mockReturnValue(false)
+        mockUseCache.mockReturnValue(makeCacheResult())
+    })
+
+    it('returns data from cache when not in demo mode', () => {
+        const { result } = renderHook(() => useCachedVolcano())
+        expect(result.current.data.health).toBe('not-installed')
+        expect(result.current.isDemoData).toBe(false)
+    })
+
+    it('returns demo data when demo mode is enabled', () => {
+        mockIsDemoMode.mockReturnValue(true)
+        mockUseCache.mockReturnValue(makeCacheResult({ data: VOLCANO_DEMO_DATA, isDemoFallback: true }))
+        const { result } = renderHook(() => useCachedVolcano())
+        expect(result.current.isDemoData).toBe(true)
+        expect((result.current.data.queues || []).length).toBeGreaterThan(0)
+    })
+
+    it('respects isLoading state — isDemoData false during loading', () => {
+        mockUseCache.mockReturnValue(makeCacheResult({ isLoading: true, isDemoFallback: true, lastRefresh: null }))
+        const { result } = renderHook(() => useCachedVolcano())
+        expect(result.current.isLoading).toBe(true)
+        expect(result.current.isDemoData).toBe(false)
+    })
+})
+
+describe('__testables.summarize', () => {
+    it('returns zeroed summary for empty lists', () => {
+        const s = summarize([], [], [], EMPTY_STATS)
+        expect(s.totalQueues).toBe(0)
+        expect(s.totalJobs).toBe(0)
+        expect(s.totalPodGroups).toBe(0)
+        expect(s.allocatedGpu).toBe(0)
+    })
+
+    it('counts queues, jobs, pod groups, and GPU from stats', () => {
+        const s = summarize([makeQueue()], [makeJob()], [makePodGroup()], { ...EMPTY_STATS, allocatedGpu: 4 })
+        expect(s.totalQueues).toBe(1)
+        expect(s.totalJobs).toBe(1)
+        expect(s.totalPodGroups).toBe(1)
+        expect(s.allocatedGpu).toBe(4)
+    })
+})
+
+describe('__testables.deriveHealth', () => {
+    it('returns not-installed for empty queues and jobs', () => {
+        expect(deriveHealth([], [])).toBe('not-installed')
+    })
+
+    it('returns healthy when no failed jobs', () => {
+        expect(deriveHealth([makeQueue()], [makeJob()])).toBe('healthy')
+    })
+
+    it('returns degraded when any job is Failed', () => {
+        expect(deriveHealth([makeQueue()], [makeJob({ phase: 'Failed' })])).toBe('degraded')
+    })
+})
+
+describe('__testables.deriveStatsFromLists', () => {
+    it('derives stats from lists', () => {
+        const queues = [makeQueue({ state: 'Open', allocatedGpu: 4 })]
+        const jobs = [makeJob({ phase: 'Running' }), makeJob({ phase: 'Pending' })]
+        const podGroups = [makePodGroup()]
+        const s = deriveStatsFromLists(queues, jobs, podGroups, undefined)
+        expect(s.totalQueues).toBe(1)
+        expect(s.openQueues).toBe(1)
+        expect(s.runningJobs).toBe(1)
+        expect(s.pendingJobs).toBe(1)
+        expect(s.allocatedGpu).toBe(4)
+    })
+
+    it('prefers partial overrides when provided', () => {
+        const s = deriveStatsFromLists([makeQueue()], [], [], { totalQueues: 99 })
+        expect(s.totalQueues).toBe(99)
+    })
+})
+
+describe('__testables.buildVolcanoStatus', () => {
+    it('builds complete status', () => {
+        const status = buildVolcanoStatus([makeQueue()], [makeJob()], [makePodGroup()], { ...EMPTY_STATS, allocatedGpu: 2 })
+        expect(status.health).toBe('healthy')
+        expect(status.queues).toHaveLength(1)
+        expect(status.jobs).toHaveLength(1)
+    })
+
+    it('returns not-installed for empty data', () => {
+        expect(buildVolcanoStatus([], [], [], EMPTY_STATS).health).toBe('not-installed')
+    })
+})


### PR DESCRIPTION
Fixes #10140

## Coverage Improvement

Coverage was **87.77%** lines (from hourly CI run 24958436609), target is **91%**.

Added **104 unit tests** across 7 useCached hooks that had 7-18% coverage:

| Hook | Tests | Previously |
|------|-------|-----------|
| useCachedRook | 18 | 11.7% |
| useCachedTikv | 21 | 12.2% |
| useCachedGrpc | 11 | 12.5% |
| useCachedStrimzi | 12 | 13.7% |
| useCachedTuf | 17 | 13.8% |
| useCachedVolcano | 12 | 14.0% |
| useCachedFlatcar | 13 | 14.8% |

Each test covers:
- Hook integration (cache data return, demo mode, loading state)
- All `__testables` pure functions with normal + edge case inputs

All 104 tests pass. Build and lint pass.