### PR TITLE
🧹 Replace final raw time expressions in cache hooks and demo generators

### DIFF
--- a/web/src/components/cards/EventsTimeline.tsx
+++ b/web/src/components/cards/EventsTimeline.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
 import { Activity, AlertTriangle, CheckCircle, Clock, Server } from 'lucide-react'
 import { LazyEChart } from '../charts/LazyEChart'
 import { useClusters } from '../../hooks/useMCP'
@@ -39,7 +40,7 @@ const TIME_RANGE_OPTIONS_KEYS: { value: TimeRange; labelKey: TimeRangeTranslatio
 // Group events by time buckets
 function groupEventsByTime(events: Array<{ type: string; lastSeen?: string; firstSeen?: string; count: number }>, bucketMinutes = 5, numBuckets = 12): TimePoint[] {
   const now = Date.now()
-  const bucketMs = bucketMinutes * 60 * 1000
+  const bucketMs = bucketMinutes * MS_PER_MINUTE
 
   // Initialize buckets
   const buckets: TimePoint[] = []

--- a/web/src/lib/cache/hooks.ts
+++ b/web/src/lib/cache/hooks.ts
@@ -8,6 +8,7 @@
  */
 
 import { useState, useEffect, useRef } from 'react'
+import { MS_PER_MINUTE } from '../constants/time'
 
 // ============================================================================
 // localStorage Hook for Preferences
@@ -143,7 +144,7 @@ interface UseIndexedDataResult<T> {
  * const { data, save, isStale } = useIndexedData<EventLog[]>({
  *   key: 'events:prod-cluster',
  *   defaultValue: [],
- *   maxAge: 5 * 60 * 1000, // 5 minutes
+ *   maxAge: 5 * MS_PER_MINUTE, // 5 minutes
  * })
  *
  * // Save new data
@@ -152,7 +153,7 @@ interface UseIndexedDataResult<T> {
 export function useIndexedData<T>({
   key,
   defaultValue,
-  maxAge = 5 * 60 * 1000 }: UseIndexedDataOptions<T>): UseIndexedDataResult<T> {
+  maxAge = 5 * MS_PER_MINUTE }: UseIndexedDataOptions<T>): UseIndexedDataResult<T> {
   const [data, setData] = useState<T>(defaultValue)
   const [isLoading, setIsLoading] = useState(true)
   const [lastSaved, setLastSaved] = useState<number | null>(null)
@@ -399,7 +400,7 @@ interface UseTrendHistoryOptions {
  * const { history, addPoint, clear, isStale } = useTrendHistory<ResourcePoint>({
  *   key: 'resource-trend',
  *   maxPoints: 24,
- *   maxAge: 30 * 60 * 1000, // 30 minutes
+ *   maxAge: 30 * MS_PER_MINUTE, // 30 minutes
  * })
  *
  * // Add new data point
@@ -408,7 +409,7 @@ interface UseTrendHistoryOptions {
 export function useTrendHistory<T extends TrendPoint>({
   key,
   maxPoints = 50,
-  maxAge = 30 * 60 * 1000 }: UseTrendHistoryOptions) {
+  maxAge = 30 * MS_PER_MINUTE }: UseTrendHistoryOptions) {
   const {
     data: history,
     isLoading,

--- a/web/src/lib/demo/flatcar.ts
+++ b/web/src/lib/demo/flatcar.ts
@@ -76,11 +76,13 @@ const DEMO_PRIOR_STABLE = '3975.2.1'
 const DEMO_PRIOR_BETA = '4011.0.0'
 const DEMO_TOTAL_CLUSTERS = 2
 
+import { MS_PER_MINUTE, MS_PER_HOUR } from '../constants/time'
+
 // Last-check timestamps (milliseconds before "now")
-const FIVE_MINUTES_MS = 5 * 60 * 1000
-const FIFTEEN_MINUTES_MS = 15 * 60 * 1000
-const THIRTY_MINUTES_MS = 30 * 60 * 1000
-const TWO_HOURS_MS = 2 * 60 * 60 * 1000
+const FIVE_MINUTES_MS = 5 * MS_PER_MINUTE
+const FIFTEEN_MINUTES_MS = 15 * MS_PER_MINUTE
+const THIRTY_MINUTES_MS = 30 * MS_PER_MINUTE
+const TWO_HOURS_MS = 2 * MS_PER_HOUR
 
 // ---------------------------------------------------------------------------
 // Demo nodes — 6 total:

--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -5,6 +5,8 @@
  * so the card renders correctly without a GitHub token.
  */
 
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../constants/time'
+
 export interface NightlyWorkflowConfig {
   repo: string
   workflowFile: string
@@ -121,15 +123,15 @@ function computePassRate(runs: NightlyRun[]): number {
 
 export function generateDemoNightlyData(): NightlyGuideStatus[] {
   const now = Date.now()
-  const DAY_MS = 24 * 60 * 60 * 1000
+  const DAY_MS = MS_PER_DAY
 
   return NIGHTLY_WORKFLOWS.map((wf, wfIdx) => {
     const key = `${wf.guide}-${wf.platform}`
     const pattern = DEMO_PATTERNS[key] ?? ['success', 'success', 'success', 'success', 'success', 'success', 'success']
 
     const runs: NightlyRun[] = pattern.map((result, i) => {
-      const createdAt = new Date(now - (i * DAY_MS) - (2 * 60 * 60 * 1000)) // 2am each night
-      const duration = result === 'in_progress' ? 0 : (30 + Math.random() * 30) * 60 * 1000 // 30-60 min
+      const createdAt = new Date(now - (i * DAY_MS) - (2 * MS_PER_HOUR)) // 2am each night
+      const duration = result === 'in_progress' ? 0 : (30 + Math.random() * 30) * MS_PER_MINUTE // 30-60 min
       const updatedAt = result === 'in_progress' ? new Date() : new Date(createdAt.getTime() + duration)
 
       return {

--- a/web/src/lib/unified/demo/generators/registerDemoGenerators.ts
+++ b/web/src/lib/unified/demo/generators/registerDemoGenerators.ts
@@ -9,8 +9,6 @@ import { registerDemoDataBatch } from '../demoDataRegistry'
 import type { DemoDataEntry } from '../types'
 import { MS_PER_HOUR, MS_PER_DAY } from '../../../constants/time'
 
-const ONE_HOUR_MS = MS_PER_HOUR
-const ONE_DAY_MS = MS_PER_DAY
 const TWO_DAYS_MS = 2 * MS_PER_DAY
 const ONE_WEEK_MS = 7 * MS_PER_DAY
 
@@ -107,9 +105,9 @@ function getDemoGPUNodes() {
  */
 function getDemoHelmReleases() {
   return [
-    { name: 'nginx-ingress', namespace: 'ingress', cluster: 'eks-prod-us-east-1', chart: 'nginx-ingress', version: '4.7.1', status: 'deployed', updated: Date.now() - ONE_DAY_MS },
+    { name: 'nginx-ingress', namespace: 'ingress', cluster: 'eks-prod-us-east-1', chart: 'nginx-ingress', version: '4.7.1', status: 'deployed', updated: Date.now() - MS_PER_DAY },
     { name: 'prometheus-stack', namespace: 'monitoring', cluster: 'gke-staging', chart: 'kube-prometheus-stack', version: '45.7.1', status: 'deployed', updated: Date.now() - TWO_DAYS_MS },
-    { name: 'redis', namespace: 'cache', cluster: 'aks-dev-westeu', chart: 'redis', version: '17.11.3', status: 'failed', updated: Date.now() - ONE_HOUR_MS },
+    { name: 'redis', namespace: 'cache', cluster: 'aks-dev-westeu', chart: 'redis', version: '17.11.3', status: 'failed', updated: Date.now() - MS_PER_HOUR },
     { name: 'cert-manager', namespace: 'cert-manager', cluster: 'openshift-prod', chart: 'cert-manager', version: '1.12.0', status: 'deployed', updated: Date.now() - ONE_WEEK_MS },
   ]
 }

--- a/web/src/lib/unified/demo/generators/registerDemoGenerators.ts
+++ b/web/src/lib/unified/demo/generators/registerDemoGenerators.ts
@@ -7,12 +7,12 @@
 
 import { registerDemoDataBatch } from '../demoDataRegistry'
 import type { DemoDataEntry } from '../types'
+import { MS_PER_HOUR, MS_PER_DAY } from '../../../constants/time'
 
-// Named time-offset constants for demo data timestamps (CLAUDE.md: No Magic Numbers)
-const ONE_HOUR_MS = 60 * 60 * 1000
-const ONE_DAY_MS = 24 * 60 * 60 * 1000
-const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000
-const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+const ONE_HOUR_MS = MS_PER_HOUR
+const ONE_DAY_MS = MS_PER_DAY
+const TWO_DAYS_MS = 2 * MS_PER_DAY
+const ONE_WEEK_MS = 7 * MS_PER_DAY
 
 // Import existing demo data functions (these are scattered across the codebase)
 // We'll reference them here for registration


### PR DESCRIPTION
## Summary

Fixes #10232

Final batch — replaces remaining raw `N * 60 * 1000` expressions in 5 files with shared constants from `lib/constants/time.ts`.

## Changes

| File | What |
|------|------|
| `lib/cache/hooks.ts` | Default `maxAge` params (5min, 30min) |
| `lib/unified/demo/generators/registerDemoGenerators.ts` | `ONE_HOUR_MS`, `ONE_DAY_MS`, `TWO_DAYS_MS`, `ONE_WEEK_MS` |
| `lib/demo/flatcar.ts` | Timestamp offset constants |
| `lib/llmd/nightlyE2EDemoData.ts` | `DAY_MS`, run duration/offset calculations |
| `components/cards/EventsTimeline.tsx` | Dynamic `bucketMs` calculation |

## Test plan

- [x] `npm run build` passes (0 errors)
- [x] All replacements are value-preserving