### PR TITLE
🐛 Fetch contributions directly from GitHub Search API

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -491,7 +491,7 @@ func (s *Server) setupMiddleware() {
 				"worker-src 'self' blob:; "+
 				"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "+
 				"img-src 'self' data: https:; "+
-				"connect-src 'self' "+kcAgentLoopback+" "+kcAgentLoopbackWS+" "+kcAgentLocalhost+" "+kcAgentLocalhostWS+" https://console.kubestellar.io https://www.google-analytics.com https://www.googletagmanager.com https://cdn.jsdelivr.net wss:; "+
+				"connect-src 'self' "+kcAgentLoopback+" "+kcAgentLoopbackWS+" "+kcAgentLocalhost+" "+kcAgentLocalhostWS+" https://console.kubestellar.io https://api.github.com https://www.google-analytics.com https://www.googletagmanager.com https://cdn.jsdelivr.net wss:; "+
 				"font-src 'self' data: https://fonts.gstatic.com; "+
 				"object-src 'none'; "+
 				"base-uri 'self'")

--- a/web/src/components/feedback/UpdatesTab.tsx
+++ b/web/src/components/feedback/UpdatesTab.tsx
@@ -883,7 +883,7 @@ function GitHubContributionsSection({
         })()
       )}
 
-      {githubRewards?.contributions && githubRewards.contributions.length > 0 && currentGitHubLogin && (
+      {githubRewards && currentGitHubLogin && (
         <div className="p-2.5 border-t border-border/50 text-center">
           <a
             href={`https://github.com/search?q=author:${encodeURIComponent(currentGitHubLogin)}+org:kubestellar+org:llm-d&type=issues&s=updated&o=desc`}

--- a/web/src/hooks/useGitHubRewards.ts
+++ b/web/src/hooks/useGitHubRewards.ts
@@ -3,13 +3,13 @@
  * Calls the Netlify function on console.kubestellar.io (10-min Blob cache)
  * instead of the local Go backend, saving the user's GitHub API quota.
  *
- * Also fetches the last 20 contributions (issues/PRs) via the Go backend's
- * GitHub proxy (/api/github/search/issues) using the user's stored token.
+ * Also fetches the last 20 contributions (issues/PRs) directly from the
+ * public GitHub Search API (no auth needed for public repos).
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useAuth } from '../lib/auth'
-import { BACKEND_DEFAULT_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type { GitHubRewardsResponse, GitHubContribution, GitHubRewardType } from '../types/rewards'
 import { GITHUB_REWARD_POINTS } from '../types/rewards'
 
@@ -110,19 +110,18 @@ function repoFromUrl(repositoryUrl: string): string {
   return len >= 2 ? `${parts[len - 2]}/${parts[len - 1]}` : repositoryUrl
 }
 
+/** GitHub Search API base — public, no auth needed for public repos */
+const GITHUB_SEARCH_API = 'https://api.github.com/search/issues'
+
 async function fetchRecentContributions(
   login: string,
-  token: string | null,
 ): Promise<GitHubContribution[]> {
   const orgFilter = CONTRIBUTIONS_SEARCH_ORGS.map(o => `org:${o}`).join('+')
   const query = `author:${encodeURIComponent(login)}+${orgFilter}`
-  const url = `${BACKEND_DEFAULT_URL}/api/github/search/issues?q=${query}&sort=updated&per_page=${CONTRIBUTIONS_PER_PAGE}`
-
-  const headers: Record<string, string> = {}
-  if (token) headers['Authorization'] = `Bearer ${token}`
+  const url = `${GITHUB_SEARCH_API}?q=${query}&sort=updated&per_page=${CONTRIBUTIONS_PER_PAGE}`
 
   const res = await fetch(url, {
-    headers,
+    headers: { Accept: 'application/vnd.github.v3+json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
   if (!res.ok) return []
@@ -145,7 +144,7 @@ async function fetchRecentContributions(
 }
 
 export function useGitHubRewards() {
-  const { user, isAuthenticated, token } = useAuth()
+  const { user, isAuthenticated } = useAuth()
   const [data, setData] = useState<GitHubRewardsResponse | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -180,7 +179,7 @@ export function useGitHubRewards() {
         fetch(`${REWARDS_API_BASE}/api/rewards/github?login=${encodeURIComponent(githubLogin)}`, {
           signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
         }),
-        fetchRecentContributions(githubLogin, token).catch(() => [] as GitHubContribution[]),
+        fetchRecentContributions(githubLogin).catch(() => [] as GitHubContribution[]),
       ])
 
       if (!rewardsRes.ok) throw new Error(`API error: ${rewardsRes.status}`)
@@ -206,7 +205,7 @@ export function useGitHubRewards() {
     } finally {
       setIsLoading(false)
     }
-  }, [isAuthenticated, isDemoUser, githubLogin, token])
+  }, [isAuthenticated, isDemoUser, githubLogin])
 
   // Fetch on mount and refresh periodically
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Switch contributions fetch from Go proxy (`/api/github/search/issues`) to direct GitHub Search API (`https://api.github.com/search/issues`) — the proxy was getting 429'd by the shared rate limiter
- Add `https://api.github.com` to CSP `connect-src` in the Go backend (Netlify CSP already had it)
- Make "View all contributions on GitHub" link always visible when logged in (not only when contributions list is non-empty)

## Test plan
- [x] `npm run build` passes
- [x] 13/13 vitest tests pass for `useGitHubRewards`
- [x] CDP: Verified 20 contributions display in Updates tab with correct types and point values
- [x] CDP: Verified "View all contributions on GitHub" link renders with correct filter URL
- [x] CDP: Verified issue submission form accepts input and shows proper error/fallback
- [x] CDP: Verified Settings > Updates > Check Now works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)