### PR TITLE
🧹 Replace final raw time expressions with shared constants

### DIFF
--- a/web/src/components/cards/EventsTimeline.tsx
+++ b/web/src/components/cards/EventsTimeline.tsx
@@ -17,6 +17,7 @@ import {
   CHART_AXIS_STROKE,
   CHART_TOOLTIP_CONTENT_STYLE,
   CHART_TICK_COLOR } from '../../lib/constants'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
 
 interface TimePoint {
   time: string
@@ -39,7 +40,7 @@ const TIME_RANGE_OPTIONS_KEYS: { value: TimeRange; labelKey: TimeRangeTranslatio
 // Group events by time buckets
 function groupEventsByTime(events: Array<{ type: string; lastSeen?: string; firstSeen?: string; count: number }>, bucketMinutes = 5, numBuckets = 12): TimePoint[] {
   const now = Date.now()
-  const bucketMs = bucketMinutes * 60 * 1000
+  const bucketMs = bucketMinutes * MS_PER_MINUTE
 
   // Initialize buckets
   const buckets: TimePoint[] = []

--- a/web/src/lib/cache/hooks.ts
+++ b/web/src/lib/cache/hooks.ts
@@ -8,6 +8,7 @@
  */
 
 import { useState, useEffect, useRef } from 'react'
+import { MS_PER_MINUTE } from '../constants/time'
 
 // ============================================================================
 // localStorage Hook for Preferences
@@ -152,7 +153,7 @@ interface UseIndexedDataResult<T> {
 export function useIndexedData<T>({
   key,
   defaultValue,
-  maxAge = 5 * 60 * 1000 }: UseIndexedDataOptions<T>): UseIndexedDataResult<T> {
+  maxAge = 5 * MS_PER_MINUTE }: UseIndexedDataOptions<T>): UseIndexedDataResult<T> {
   const [data, setData] = useState<T>(defaultValue)
   const [isLoading, setIsLoading] = useState(true)
   const [lastSaved, setLastSaved] = useState<number | null>(null)
@@ -408,7 +409,7 @@ interface UseTrendHistoryOptions {
 export function useTrendHistory<T extends TrendPoint>({
   key,
   maxPoints = 50,
-  maxAge = 30 * 60 * 1000 }: UseTrendHistoryOptions) {
+  maxAge = 30 * MS_PER_MINUTE }: UseTrendHistoryOptions) {
   const {
     data: history,
     isLoading,

--- a/web/src/lib/demo/flatcar.ts
+++ b/web/src/lib/demo/flatcar.ts
@@ -76,11 +76,13 @@ const DEMO_PRIOR_STABLE = '3975.2.1'
 const DEMO_PRIOR_BETA = '4011.0.0'
 const DEMO_TOTAL_CLUSTERS = 2
 
+import { MS_PER_MINUTE, MS_PER_HOUR } from '../constants/time'
+
 // Last-check timestamps (milliseconds before "now")
-const FIVE_MINUTES_MS = 5 * 60 * 1000
-const FIFTEEN_MINUTES_MS = 15 * 60 * 1000
-const THIRTY_MINUTES_MS = 30 * 60 * 1000
-const TWO_HOURS_MS = 2 * 60 * 60 * 1000
+const FIVE_MINUTES_MS = 5 * MS_PER_MINUTE
+const FIFTEEN_MINUTES_MS = 15 * MS_PER_MINUTE
+const THIRTY_MINUTES_MS = 30 * MS_PER_MINUTE
+const TWO_HOURS_MS = 2 * MS_PER_HOUR
 
 // ---------------------------------------------------------------------------
 // Demo nodes — 6 total:

--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -119,17 +119,19 @@ function computePassRate(runs: NightlyRun[]): number {
   return Math.round((completed.filter(r => r.conclusion === 'success').length / completed.length) * 100)
 }
 
+import { MS_PER_DAY, MS_PER_HOUR, MS_PER_MINUTE } from '../constants/time'
+
 export function generateDemoNightlyData(): NightlyGuideStatus[] {
   const now = Date.now()
-  const DAY_MS = 24 * 60 * 60 * 1000
 
   return NIGHTLY_WORKFLOWS.map((wf, wfIdx) => {
     const key = `${wf.guide}-${wf.platform}`
     const pattern = DEMO_PATTERNS[key] ?? ['success', 'success', 'success', 'success', 'success', 'success', 'success']
 
     const runs: NightlyRun[] = pattern.map((result, i) => {
-      const createdAt = new Date(now - (i * DAY_MS) - (2 * 60 * 60 * 1000)) // 2am each night
-      const duration = result === 'in_progress' ? 0 : (30 + Math.random() * 30) * 60 * 1000 // 30-60 min
+      const RUN_START_OFFSET_MS = 2 * MS_PER_HOUR // 2am each night
+      const createdAt = new Date(now - (i * MS_PER_DAY) - RUN_START_OFFSET_MS)
+      const duration = result === 'in_progress' ? 0 : (30 + Math.random() * 30) * MS_PER_MINUTE // 30-60 min
       const updatedAt = result === 'in_progress' ? new Date() : new Date(createdAt.getTime() + duration)
 
       return {

--- a/web/src/lib/unified/demo/generators/registerDemoGenerators.ts
+++ b/web/src/lib/unified/demo/generators/registerDemoGenerators.ts
@@ -8,11 +8,13 @@
 import { registerDemoDataBatch } from '../demoDataRegistry'
 import type { DemoDataEntry } from '../types'
 
+import { MS_PER_HOUR, MS_PER_DAY } from '../../../constants/time'
+
 // Named time-offset constants for demo data timestamps (CLAUDE.md: No Magic Numbers)
-const ONE_HOUR_MS = 60 * 60 * 1000
-const ONE_DAY_MS = 24 * 60 * 60 * 1000
-const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000
-const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+const ONE_HOUR_MS = MS_PER_HOUR
+const ONE_DAY_MS = MS_PER_DAY
+const TWO_DAYS_MS = 2 * MS_PER_DAY
+const ONE_WEEK_MS = 7 * MS_PER_DAY
 
 // Import existing demo data functions (these are scattered across the codebase)
 // We'll reference them here for registration


### PR DESCRIPTION
Fixes #10232

Final cleanup of raw time expressions missed by PRs #10225 and #10227.

Replaces raw arithmetic in:
- lib/cache/hooks.ts — default maxAge parameters
- lib/unified/demo/generators/registerDemoGenerators.ts — demo timestamp offsets
- lib/demo/flatcar.ts — demo timestamp offsets
- lib/llmd/nightlyE2EDemoData.ts — demo run timestamps
- components/cards/EventsTimeline. dynamic bucket calculationtsx 

All values replaced with constants from lib/constants/time.ts.

## Test plan
- [x] npm run build passes
- [x] npm run lint passes
- [x] All replacements are value-preserving (same numeric result)