### PR TITLE
🧹 Extract 43 magic numbers into named constants, ratchet to zero

### DIFF
--- a/web/src/components/cards/Checkers.tsx
+++ b/web/src/components/cards/Checkers.tsx
@@ -81,6 +81,7 @@ const PRE_GAME_TAUNTS = [
 ]
 
 const PRE_GAME_TAUNT_DELAY_MS = 2_000
+const TAUNT_DISPLAY_MS = 3000
 
 // Initialize board with starting positions
 function createInitialBoard(): Board {
@@ -571,7 +572,7 @@ export function Checkers(_props: CardComponentProps) {
         // Show capture taunt
         if (capturedAny) {
           setPirateTaunt(CAPTURE_TAUNTS[Math.floor(Math.random() * CAPTURE_TAUNTS.length)])
-          setTimeout(() => setPirateTaunt(''), 3000)
+          setTimeout(() => setPirateTaunt(''), TAUNT_DISPLAY_MS)
         }
       }
 

--- a/web/src/components/cards/ClusterComparison.tsx
+++ b/web/src/components/cards/ClusterComparison.tsx
@@ -11,6 +11,9 @@ import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 
+/** Maximum number of clusters that can be compared side-by-side */
+const MAX_COMPARED_CLUSTERS = 4
+
 interface ClusterComparisonProps {
   config?: {
     clusters?: string[]
@@ -100,7 +103,7 @@ function ClusterComparisonInternal({ config }: ClusterComparisonProps) {
       if (prev.includes(name)) {
         return prev.filter(c => c !== name)
       }
-      if (prev.length >= 4) return prev // Max 4 clusters
+      if (prev.length >= MAX_COMPARED_CLUSTERS) return prev
       return [...prev, name]
     })
   }

--- a/web/src/components/cards/ClusterLocations.tsx
+++ b/web/src/components/cards/ClusterLocations.tsx
@@ -16,6 +16,11 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 /** Search input debounce delay (#6213). */
 const SEARCH_DEBOUNCE_MS = 250
 
+/** Cluster name display threshold before truncation */
+const MAX_CLUSTER_NAME_DISPLAY = 12
+/** Length to truncate cluster names to when they exceed the display threshold */
+const TRUNCATED_NAME_LENGTH = 10
+
 interface ClusterLocationsProps {
   config?: Record<string, unknown>
 }
@@ -581,7 +586,7 @@ export function ClusterLocations({ config: _config }: ClusterLocationsProps) {
                     >
                       <CloudProviderIcon provider={provider} size={10} />
                       <span className="text-[9px] font-medium text-foreground max-w-[60px] truncate">
-                        {cluster.name.length > 12 ? cluster.name.substring(0, 10) + '…' : cluster.name}
+                        {cluster.name.length > MAX_CLUSTER_NAME_DISPLAY ? cluster.name.substring(0, TRUNCATED_NAME_LENGTH) + '…' : cluster.name}
                       </span>
                       <div className={`w-1.5 h-1.5 rounded-full ${cluster.healthy ? 'bg-green-400' : 'bg-red-400'}`} />
                     </button>

--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -33,6 +33,11 @@ const LEGACY_6H_INTERVAL_MS = 15 * MS_PER_MINUTE
 const LEGACY_24H_POINTS = 24
 const LEGACY_24H_INTERVAL_MS = MS_PER_HOUR
 
+/** Metric name display threshold before truncation */
+const MAX_METRIC_NAME_DISPLAY = 15
+/** Length to truncate metric names to when they exceed the display threshold */
+const TRUNCATED_METRIC_NAME = 12
+
 const TIME_RANGE_KEYS: Array<{
   value: TimeRange
   labelKey:
@@ -296,7 +301,7 @@ export function ClusterMetrics() {
     const series = Array.from(clusterNames).map((name, i) => ({
       dataKey: name,
       color: clusterColors[i % clusterColors.length],
-      name: name.length > 15 ? name.slice(0, 12) + '...' : name }))
+      name: name.length > MAX_METRIC_NAME_DISPLAY ? name.slice(0, TRUNCATED_METRIC_NAME) + '...' : name }))
 
     // Build data with all clusters as keys
     const chartData = filteredHistory.map(point => {

--- a/web/src/components/cards/CrossClusterPolicyComparison.tsx
+++ b/web/src/components/cards/CrossClusterPolicyComparison.tsx
@@ -30,6 +30,9 @@ const MAX_SELECTED_CLUSTERS = 4
 /** Default number of clusters to show when none are selected */
 const DEFAULT_CLUSTER_COUNT = 3
 
+/** Maximum policy name length before truncation in table headers */
+const MAX_POLICY_NAME_DISPLAY = 12
+
 type PolicyStatus = 'pass' | 'fail' | 'na'
 
 interface PolicyRow {
@@ -251,7 +254,7 @@ function CrossClusterPolicyComparisonInternal({ config: _config }: CardConfig) {
                 <th className="text-left py-1 px-1 font-medium text-muted-foreground">Policy</th>
                 {clustersToCompare.map(c => (
                   <th key={c} className="text-center py-1 px-1 font-mono font-medium text-muted-foreground truncate max-w-[80px]" title={c}>
-                    {c.length > 12 ? `${c.slice(0, 12)}...` : c}
+                    {c.length > MAX_POLICY_NAME_DISPLAY ? `${c.slice(0, MAX_POLICY_NAME_DISPLAY)}...` : c}
                   </th>
                 ))}
               </tr>

--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -13,6 +13,8 @@ import type { DynamicCardDefinition, DynamicCardDefinition_T1 } from '../../lib/
 import type { CardComponentProps, CardComponent } from './cardRegistry'
 import { useTranslation } from 'react-i18next'
 
+const MAX_AUTO_GRID_COLS = 3
+
 /**
  * DynamicCard: Meta-component that renders dynamic card definitions.
  *
@@ -249,7 +251,7 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
       {showStats && cardDefinition.stats && cardDefinition.stats.length > 0 && (
         <div className={cn(
           'grid gap-2 mb-3',
-          cardDefinition.stats.length <= 3 ? `grid-cols-${cardDefinition.stats.length}` : 'grid-cols-4',
+          cardDefinition.stats.length <= MAX_AUTO_GRID_COLS ? `grid-cols-${cardDefinition.stats.length}` : 'grid-cols-4',
         )}>
           {cardDefinition.stats.map((stat, idx) => {
             // Resolve stat value from data

--- a/web/src/components/cards/Game2048.tsx
+++ b/web/src/components/cards/Game2048.tsx
@@ -8,6 +8,8 @@ import { useGameKeys } from '../../hooks/useGameKeys'
 
 type Grid = (number | null)[][]
 
+const GRID_SIZE = 4
+
 // Tile colors based on value - Kubernetes themed
 const TILE_COLORS: Record<number, { bg: string; text: string }> = {
   2: { bg: 'bg-blue-500/80', text: 'text-white' },
@@ -26,7 +28,7 @@ const TILE_COLORS: Record<number, { bg: string; text: string }> = {
 
 // Create empty 4x4 grid
 function createEmptyGrid(): Grid {
-  return Array(4).fill(null).map(() => Array(4).fill(null))
+  return Array(GRID_SIZE).fill(null).map(() => Array(GRID_SIZE).fill(null))
 }
 
 // Add random tile (2 or 4) to empty cell
@@ -34,8 +36,8 @@ function addRandomTile(grid: Grid): Grid {
   const newGrid = grid.map(row => [...row])
   const emptyCells: [number, number][] = []
 
-  for (let r = 0; r < 4; r++) {
-    for (let c = 0; c < 4; c++) {
+  for (let r = 0; r < GRID_SIZE; r++) {
+    for (let c = 0; c < GRID_SIZE; c++) {
       if (newGrid[r][c] === null) {
         emptyCells.push([r, c])
       }
@@ -81,12 +83,12 @@ function slideLine(line: (number | null)[]): [(number | null)[], number, boolean
   }
 
   // Pad with nulls
-  while (newLine.length < 4) {
+  while (newLine.length < GRID_SIZE) {
     newLine.push(null)
   }
 
   // Check if moved
-  for (let j = 0; j < 4; j++) {
+  for (let j = 0; j < GRID_SIZE; j++) {
     if (line[j] !== newLine[j]) {
       moved = true
       break

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -55,6 +55,10 @@ const MAX_PAGES = 30
 const CACHE_TTL_MS = MS_PER_HOUR
 /** LocalStorage cache key prefix */
 const CACHE_KEY_PREFIX = 'issue_activity_chart_cache_'
+const CHART_GRID_LEFT = 50
+const CHART_GRID_RIGHT = 50
+const CHART_GRID_TOP = 40
+const CHART_GRID_BOTTOM = 80
 /** Bar chart color for issues opened */
 const COLOR_OPENED = '#4472C4'
 /** Bar chart color for issues closed */
@@ -446,7 +450,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
 
     return {
       backgroundColor: 'transparent',
-      grid: { left: 50, right: 50, top: 40, bottom: 80, containLabel: false },
+      grid: { left: CHART_GRID_LEFT, right: CHART_GRID_RIGHT, top: CHART_GRID_TOP, bottom: CHART_GRID_BOTTOM, containLabel: false },
       legend: {
         data: [
           t('issueActivityChart.opened', 'Opened'),

--- a/web/src/components/cards/KubeKart.tsx
+++ b/web/src/components/cards/KubeKart.tsx
@@ -20,6 +20,7 @@ const ACCELERATION = 0.15
 const DECELERATION = 0.08
 const TURN_SPEED = 0.06
 const FRICTION = 0.98
+const COUNTDOWN_INTERVAL_MS = 1000
 const AI_COUNT = 3
 const FORWARD_ANGLE = -Math.PI / 2 // Pointing "up" on screen
 
@@ -483,7 +484,7 @@ export function KubeKart() {
     if (gameState !== 'countdown') return
 
     if (countdown > 0) {
-      const timer = setTimeout(() => setCountdown(c => c - 1), 1000)
+      const timer = setTimeout(() => setCountdown(c => c - 1), COUNTDOWN_INTERVAL_MS)
       return () => clearTimeout(timer)
     } else {
       setGameState('playing')

--- a/web/src/components/cards/KubeKong.tsx
+++ b/web/src/components/cards/KubeKong.tsx
@@ -22,6 +22,7 @@ const BARREL_SPEED = 2.5
 const PLAYER_WIDTH = 16
 const PLAYER_HEIGHT = 24
 const BARREL_SIZE = 14
+const BOSS_FRAME_RESET_MS = 300
 
 // Sloped platform structure - like classic DK
 interface Platform {
@@ -531,7 +532,7 @@ export function KubeKong(_props: CardComponentProps) {
       if (barrelSpawnCounter >= spawnRate) {
         barrelSpawnCounter = 0
         setBossFrame(1)
-        setTimeout(() => setBossFrame(0), 300)
+        setTimeout(() => setBossFrame(0), BOSS_FRAME_RESET_MS)
 
         barrelIdRef.current++
         setBarrels(bs => [...bs, {

--- a/web/src/components/cards/Kubectl.tsx
+++ b/web/src/components/cards/Kubectl.tsx
@@ -13,6 +13,8 @@ import { copyToClipboard } from '../../lib/clipboard'
 import { downloadText } from '../../lib/download'
 import { useToast } from '../ui/Toast'
 
+const YAML_PREVIEW_LINES = 5
+
 interface CommandHistoryItem {
   id: string
   context: string
@@ -406,7 +408,7 @@ data:
         ...prev,
         `$ kubectl apply -f -`,
         isDryRun ? `(dry-run) ${result || 'Manifest validated successfully'}` : result || `Applied manifest "${manifestName}"`,
-        yamlContent.split('\n').slice(0, 5).join('\n') + (yamlContent.split('\n').length > 5 ? '\n...' : ''),
+        yamlContent.split('\n').slice(0, YAML_PREVIEW_LINES).join('\n') + (yamlContent.split('\n').length > YAML_PREVIEW_LINES ? '\n...' : ''),
         ''
       ])
 

--- a/web/src/components/cards/Kubedle.tsx
+++ b/web/src/components/cards/Kubedle.tsx
@@ -69,6 +69,7 @@ const SHAKE_DURATION_MS = 500
 
 // Standard Wordle-style game: 6 guesses per puzzle.
 const MAX_GUESSES = 6
+const WORD_LENGTH = 5
 
 function loadStats(): GameStats {
   const defaults: GameStats = {
@@ -175,7 +176,7 @@ export function Kubedle(_props: CardComponentProps) {
     if (gameOver) return
 
     if (key === 'ENTER' || key === 'Enter') {
-      if (currentGuess.length !== 5) {
+      if (currentGuess.length !== WORD_LENGTH) {
         setShake(true)
         setMessage(tCards('kubedle.notEnoughLetters'))
         if (shakeTimeoutRef.current) clearTimeout(shakeTimeoutRef.current)
@@ -243,7 +244,7 @@ export function Kubedle(_props: CardComponentProps) {
       }
     } else if (key === '⌫' || key === 'Backspace') {
       setCurrentGuess(prev => prev.slice(0, -1))
-    } else if (/^[A-Za-z]$/.test(key) && currentGuess.length < 5) {
+    } else if (/^[A-Za-z]$/.test(key) && currentGuess.length < WORD_LENGTH) {
       setCurrentGuess(prev => prev + key.toUpperCase())
     }
   }

--- a/web/src/components/cards/NamespaceMonitor.tsx
+++ b/web/src/components/cards/NamespaceMonitor.tsx
@@ -105,6 +105,7 @@ const MAX_NAMESPACES_RENDERED_PER_CLUSTER = 30
 // Shared empty result for clusters that aren't the selected one — avoids
 // allocating a fresh Map on every render of every non-selected cluster row.
 const EMPTY_NAMESPACE_DATA: Map<string, NamespaceData> = new Map()
+const MAX_VISIBLE_ITEMS = 10
 
 export function NamespaceMonitor({ config: _config }: CardComponentProps) {
   const { isDemoMode } = useDemoMode()
@@ -935,7 +936,7 @@ function ResourceSection({
         <span>({items.length})</span>
       </div>
       <div className="space-y-0.5">
-        {items.slice(0, 10).map(item => {
+        {items.slice(0, MAX_VISIBLE_ITEMS).map(item => {
           const changeType = getResourceChange(cluster, namespace, type, item.name)
           const key = `${cluster}:${namespace}:${type}:${item.name}`
 
@@ -975,9 +976,9 @@ function ResourceSection({
             </div>
           )
         })}
-        {items.length > 10 && (
+        {items.length > MAX_VISIBLE_ITEMS && (
           <div className="text-2xs text-muted-foreground px-2 py-1">
-            +{items.length - 10} more
+            +{items.length - MAX_VISIBLE_ITEMS} more
           </div>
         )}
       </div>

--- a/web/src/components/cards/NodeConditions.tsx
+++ b/web/src/components/cards/NodeConditions.tsx
@@ -6,6 +6,8 @@ import { useKubectl } from '../../hooks/useKubectl'
 import { useCardLoadingState } from './CardDataContext'
 import { useDemoMode } from '../../hooks/useDemoMode'
 
+const MAX_VISIBLE_CONDITIONS = 20
+
 type ConditionFilter = 'all' | 'healthy' | 'cordoned' | 'pressure'
 
 /** Confirmation dialog state for cordon/uncordon actions */
@@ -186,7 +188,7 @@ export function NodeConditions() {
       </div>
 
       <div className="space-y-1 max-h-[300px] overflow-y-auto">
-        {filtered.slice(0, 20).map(node => {
+        {filtered.slice(0, MAX_VISIBLE_CONDITIONS).map(node => {
           const conditions = (node.conditions || []) as Array<{ type: string; status: string }>
           const ready = conditions.find(c => c.type === 'Ready')
           const isReady = ready?.status === 'True'
@@ -231,9 +233,9 @@ export function NodeConditions() {
             </div>
           )
         })}
-        {filtered.length > 20 && (
+        {filtered.length > MAX_VISIBLE_CONDITIONS && (
           <div className="text-xs text-muted-foreground text-center py-1">
-            {t('nodeConditions.moreNodes', { count: filtered.length - 20 })}
+            {t('nodeConditions.moreNodes', { count: filtered.length - MAX_VISIBLE_CONDITIONS })}
           </div>
         )}
       </div>

--- a/web/src/components/cards/NodeInvaders.tsx
+++ b/web/src/components/cards/NodeInvaders.tsx
@@ -20,6 +20,7 @@ const INVADER_ROWS = 4
 const INVADER_COLS = 8
 const INVADER_WIDTH = 24
 const INVADER_HEIGHT = 16
+const SHOOT_COOLDOWN_MS = 300
 
 interface Player {
   x: number
@@ -232,7 +233,7 @@ export function NodeInvaders(_props: CardComponentProps) {
           y: CANVAS_HEIGHT - 45,
           isPlayer: true }])
         setCanShoot(false)
-        setTimeout(() => setCanShoot(true), 300)
+        setTimeout(() => setCanShoot(true), SHOOT_COOLDOWN_MS)
       }
 
       // Move bullets

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -15,6 +15,7 @@ import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_OPA_CACHE, STORAGE_KEY_OPA_CACHE_TIME } from '../../lib/constants'
 import { KUBECTL_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
 const OPA_LIST_TIMEOUT_MS = 25_000
+const MIN_POLICY_PATH_PARTS = 4
 import { safeGetItem, safeGetJSON, safeSetItem, safeSetJSON } from '../../lib/utils/localStorage'
 import { PolicyDetailModal, ClusterOPAModal, CreatePolicyModal } from './opa'
 import type { Policy, GatekeeperStatus, OPAClusterItem } from './opa'
@@ -101,7 +102,7 @@ async function checkGatekeeperDetails(clusterName: string): Promise<GatekeeperSt
       const lines = constraintsResult.output.trim().split('\n').filter((l: string) => l.trim())
       for (const line of lines) {
         const parts = line.trim().split(/\s+/)
-        if (parts.length >= 4) {
+        if (parts.length >= MIN_POLICY_PATH_PARTS) {
           const name = parts[0]
           const kind = parts[1]
           const enforcement = (parts[2] || 'warn').toLowerCase() as Policy['mode']

--- a/web/src/components/cards/PodPitfall.tsx
+++ b/web/src/components/cards/PodPitfall.tsx
@@ -12,6 +12,10 @@ const CANVAS_HEIGHT = 200
 const GRAVITY = 0.4
 const JUMP_FORCE = -8
 const MOVE_SPEED = 4
+const PIT_OFFSET_X = 100
+const PIT_Y = 180
+const PIT_WIDTH = 120
+const NARROW_PLATFORM_WIDTH = 60
 
 interface Player {
   x: number
@@ -102,9 +106,9 @@ export function PodPitfall(_props: CardComponentProps) {
         newPlatforms.push({ x: baseX, y: 160, width: CANVAS_WIDTH, type: 'ground' })
       } else {
         // Pit with crocodiles
-        newPlatforms.push({ x: baseX, y: 160, width: 100, type: 'ground' })
-        newPlatforms.push({ x: baseX + 100, y: 180, width: 120, type: 'pit' })
-        newPlatforms.push({ x: baseX + 220, y: 160, width: 100, type: 'ground' })
+        newPlatforms.push({ x: baseX, y: 160, width: PIT_OFFSET_X, type: 'ground' })
+        newPlatforms.push({ x: baseX + PIT_OFFSET_X, y: PIT_Y, width: PIT_WIDTH, type: 'pit' })
+        newPlatforms.push({ x: baseX + PIT_OFFSET_X + PIT_WIDTH, y: 160, width: PIT_OFFSET_X, type: 'ground' })
         newObstacles.push({ x: baseX + 140, y: 165, type: 'croc', direction: 1 })
       }
 
@@ -113,7 +117,7 @@ export function PodPitfall(_props: CardComponentProps) {
         newPlatforms.push({
           x: baseX + 80 + Math.random() * 100,
           y: 120,
-          width: 60,
+          width: NARROW_PLATFORM_WIDTH,
           type: 'log'
         })
       }

--- a/web/src/components/cards/PredictiveHealth.tsx
+++ b/web/src/components/cards/PredictiveHealth.tsx
@@ -5,6 +5,9 @@ import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 
+const RESTART_WARNING_THRESHOLD = 3
+const RESTART_CRITICAL_THRESHOLD = 10
+
 interface Prediction {
   id: string
   cluster: string
@@ -129,12 +132,12 @@ export function PredictiveHealth() {
 
       // Restart storm detection
       const highRestarts = clusterPods.filter(p => (p.restarts || 0) > 5)
-      if (highRestarts.length > 3) {
+      if (highRestarts.length > RESTART_WARNING_THRESHOLD) {
         results.push({
           id: `restarts-${cluster}`,
           cluster,
           resource: 'Stability',
-          severity: highRestarts.length > 10 ? 'critical' : 'warning',
+          severity: highRestarts.length > RESTART_CRITICAL_THRESHOLD ? 'critical' : 'warning',
           message: `${highRestarts.length} pods with high restart counts — potential instability`,
           confidence: 0.78 })
       }

--- a/web/src/components/cards/QuotaHeatmap.tsx
+++ b/web/src/components/cards/QuotaHeatmap.tsx
@@ -4,6 +4,8 @@ import { useCachedPods } from '../../hooks/useCachedData'
 import { useCardLoadingState } from './CardDataContext'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 
+const MAX_VISIBLE_NAMESPACES = 60
+
 interface NamespaceUsage {
   namespace: string
   cluster: string
@@ -120,8 +122,8 @@ export function QuotaHeatmap() {
           </div>
         )
       })()}
-      {namespaceData.length > 60 && (
-        <div className="text-xs text-muted-foreground text-center">{t('quotaHeatmap.more', { count: namespaceData.length - 60 })}</div>
+      {namespaceData.length > MAX_VISIBLE_NAMESPACES && (
+        <div className="text-xs text-muted-foreground text-center">{t('quotaHeatmap.more', { count: namespaceData.length - MAX_VISIBLE_NAMESPACES })}</div>
       )}
     </div>
   )

--- a/web/src/components/cards/Solitaire.tsx
+++ b/web/src/components/cards/Solitaire.tsx
@@ -16,6 +16,8 @@ const SUITS: Suit[] = ['pods', 'containers', 'clusters', 'nodes']
 const VALUES: CardValue[] = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K']
 
 // Suit colors: red suits (pods, containers) and black suits (clusters, nodes)
+const TIMER_TICK_MS = 1000
+
 const SUIT_CONFIG: Record<Suit, { Icon: typeof Box; color: string; isRed: boolean }> = {
   pods: { Icon: Box, color: 'text-blue-400', isRed: true },
   containers: { Icon: Database, color: 'text-green-400', isRed: true },
@@ -257,7 +259,7 @@ export function Solitaire(_props: CardComponentProps) {
   useEffect(() => {
     let interval: ReturnType<typeof setInterval>
     if (isPlaying && !hasWon) {
-      interval = setInterval(() => setTime(t => t + 1), 1000)
+      interval = setInterval(() => setTime(t => t + 1), TIMER_TICK_MS)
     }
     return () => clearInterval(interval)
   }, [isPlaying, hasWon])

--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -24,6 +24,8 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 import { emitUserRoleChanged, emitUserRemoved } from '../../lib/analytics'
 import { ConfirmDialog } from '../../lib/modals'
 
+const MAX_VISIBLE_GROUPS = 3
+
 interface UserManagementProps {
   config?: Record<string, unknown>
 }
@@ -768,7 +770,7 @@ function ClusterUsersTab({
               )}
               {user.groups && user.groups.length > 0 && (
                 <div className="flex flex-wrap gap-1 mt-1">
-                  {user.groups.slice(0, 3).map((group, i) => (
+                  {user.groups.slice(0, MAX_VISIBLE_GROUPS).map((group, i) => (
                     <span
                       key={i}
                       className="px-1.5 py-0.5 rounded text-xs bg-blue-500/20 text-blue-400"
@@ -776,8 +778,8 @@ function ClusterUsersTab({
                       {group}
                     </span>
                   ))}
-                  {user.groups.length > 3 && (
-                    <span className="text-xs text-muted-foreground">+{user.groups.length - 3} more</span>
+                  {user.groups.length > MAX_VISIBLE_GROUPS && (
+                    <span className="text-xs text-muted-foreground">+{user.groups.length - MAX_VISIBLE_GROUPS} more</span>
                   )}
                 </div>
               )}

--- a/web/src/components/cards/kagent/KagentTopology.tsx
+++ b/web/src/components/cards/kagent/KagentTopology.tsx
@@ -13,6 +13,9 @@ import {
   KAGENT_EDGE_AGENT_TOOL, KAGENT_EDGE_AGENT_MODEL,
 } from '../../../lib/theme/chartColors'
 
+const MAX_NODE_LABEL_DISPLAY = 16
+const TRUNCATED_NODE_LABEL = 14
+
 const RUNTIME_COLORS: Record<string, string> = {
   python: KAGENT_RUNTIME_PYTHON,
   go: KAGENT_RUNTIME_GO,
@@ -271,7 +274,7 @@ function KagentTopologyInternal({ config }: { config?: Record<string, unknown> }
                 textAnchor={node.type === 'agent' ? 'end' : node.type === 'model' ? 'start' : 'middle'}
                 className="select-none text-muted-foreground"
               >
-                {node.label.length > 16 ? node.label.slice(0, 14) + '...' : node.label}
+                {node.label.length > MAX_NODE_LABEL_DISPLAY ? node.label.slice(0, TRUNCATED_NODE_LABEL) + '...' : node.label}
               </text>
             </g>
           ))}

--- a/web/src/components/cards/kagenti/KagentiTopology.tsx
+++ b/web/src/components/cards/kagenti/KagentiTopology.tsx
@@ -4,6 +4,9 @@ import { useKagentiAgents, useKagentiTools, type KagentiAgent, type KagentiTool 
 import { useCardLoadingState } from '../CardDataContext'
 import { useTranslation } from 'react-i18next'
 
+const MAX_NODE_LABEL_DISPLAY = 16
+const TRUNCATED_NODE_LABEL = 14
+
 const FRAMEWORK_COLORS: Record<string, string> = {
   langgraph: '#60a5fa',
   crewai: '#34d399',
@@ -176,7 +179,7 @@ export function KagentiTopology({ config }: { config?: Record<string, unknown> }
                 textAnchor={node.type === 'agent' ? 'end' : 'start'}
                 className="select-none text-muted-foreground"
               >
-                {node.label.length > 16 ? node.label.slice(0, 14) + '...' : node.label}
+                {node.label.length > MAX_NODE_LABEL_DISPLAY ? node.label.slice(0, TRUNCATED_NODE_LABEL) + '...' : node.label}
               </text>
             </g>
           ))}

--- a/web/src/components/cards/llmd/KVCacheMonitor.tsx
+++ b/web/src/components/cards/llmd/KVCacheMonitor.tsx
@@ -20,6 +20,12 @@ import { useTranslation } from 'react-i18next'
 import { KV_CACHE_UPDATE_INTERVAL_MS } from '../../../lib/constants/network'
 import { StatusBadge } from '../../ui/StatusBadge'
 
+const GRID_BREAKPOINT_FEW = 2
+const GRID_BREAKPOINT_SMALL = 3
+const GRID_BREAKPOINT_MEDIUM = 4
+const GRID_BREAKPOINT_LARGE = 6
+const GRID_BREAKPOINT_DENSE = 9
+
 // Premium gauge with glowing arcs and ambient lighting
 interface PremiumGaugeProps {
   value: number
@@ -773,14 +779,14 @@ export function KVCacheMonitor() {
               key="gauges"
               className={`h-full overflow-auto ${
                 isExpanded
-                  ? (stats.length <= 2 ? 'flex items-center justify-evenly gap-16' :
-                     stats.length <= 4 ? 'grid grid-cols-2 @md:grid-cols-4 gap-8 place-items-center' :
-                     stats.length <= 6 ? 'grid grid-cols-2 @md:grid-cols-3 gap-6 place-items-center' :
+                  ? (stats.length <= GRID_BREAKPOINT_FEW ? 'flex items-center justify-evenly gap-16' :
+                     stats.length <= GRID_BREAKPOINT_MEDIUM ? 'grid grid-cols-2 @md:grid-cols-4 gap-8 place-items-center' :
+                     stats.length <= GRID_BREAKPOINT_LARGE ? 'grid grid-cols-2 @md:grid-cols-3 gap-6 place-items-center' :
                      'grid grid-cols-2 @md:grid-cols-4 gap-4 place-items-center')
-                  : (stats.length <= 2 ? 'flex items-center justify-evenly gap-12' :
-                     stats.length <= 3 ? 'grid grid-cols-2 @md:grid-cols-3 gap-6 place-items-center' :
-                     stats.length <= 6 ? 'grid grid-cols-2 @md:grid-cols-3 gap-3 place-items-center' :
-                     stats.length <= 9 ? 'grid grid-cols-2 @md:grid-cols-3 gap-2 place-items-center' :
+                  : (stats.length <= GRID_BREAKPOINT_FEW ? 'flex items-center justify-evenly gap-12' :
+                     stats.length <= GRID_BREAKPOINT_SMALL ? 'grid grid-cols-2 @md:grid-cols-3 gap-6 place-items-center' :
+                     stats.length <= GRID_BREAKPOINT_LARGE ? 'grid grid-cols-2 @md:grid-cols-3 gap-3 place-items-center' :
+                     stats.length <= GRID_BREAKPOINT_DENSE ? 'grid grid-cols-2 @md:grid-cols-3 gap-2 place-items-center' :
                      'grid grid-cols-2 @md:grid-cols-4 gap-2 place-items-center')
               }`}
               initial={{ opacity: 0, y: 10 }}
@@ -789,8 +795,8 @@ export function KVCacheMonitor() {
             >
               {stats.slice(0, isExpanded ? 20 : 12).map((stat) => {
                 const gaugeSize = isExpanded
-                  ? (stats.length <= 2 ? 200 : stats.length <= 4 ? 180 : stats.length <= 6 ? 160 : 140)
-                  : (stats.length <= 2 ? 120 : stats.length <= 3 ? 130 : stats.length <= 6 ? 110 : stats.length <= 9 ? 100 : 85)
+                  ? (stats.length <= GRID_BREAKPOINT_FEW ? 200 : stats.length <= GRID_BREAKPOINT_MEDIUM ? 180 : stats.length <= GRID_BREAKPOINT_LARGE ? 160 : 140)
+                  : (stats.length <= GRID_BREAKPOINT_FEW ? 120 : stats.length <= GRID_BREAKPOINT_SMALL ? 130 : stats.length <= GRID_BREAKPOINT_LARGE ? 110 : stats.length <= GRID_BREAKPOINT_DENSE ? 100 : 85)
                 return (
                   <div
                     key={stat.podName}
@@ -814,13 +820,13 @@ export function KVCacheMonitor() {
               key="horseshoe"
               className={`grid h-full place-items-center overflow-auto ${
                 isExpanded
-                  ? (stats.length <= 2 ? 'grid-cols-2 gap-6' :
-                     stats.length <= 4 ? 'grid-cols-2 @md:grid-cols-4 gap-4' :
-                     stats.length <= 6 ? 'grid-cols-2 @md:grid-cols-3 gap-4' :
+                  ? (stats.length <= GRID_BREAKPOINT_FEW ? 'grid-cols-2 gap-6' :
+                     stats.length <= GRID_BREAKPOINT_MEDIUM ? 'grid-cols-2 @md:grid-cols-4 gap-4' :
+                     stats.length <= GRID_BREAKPOINT_LARGE ? 'grid-cols-2 @md:grid-cols-3 gap-4' :
                      'grid-cols-2 @md:grid-cols-4 gap-3')
-                  : (stats.length <= 2 ? 'grid-cols-2 gap-2' :
-                     stats.length <= 3 ? 'grid-cols-2 @md:grid-cols-3 gap-1' :
-                     stats.length <= 6 ? 'grid-cols-2 @md:grid-cols-3 gap-1' :
+                  : (stats.length <= GRID_BREAKPOINT_FEW ? 'grid-cols-2 gap-2' :
+                     stats.length <= GRID_BREAKPOINT_SMALL ? 'grid-cols-2 @md:grid-cols-3 gap-1' :
+                     stats.length <= GRID_BREAKPOINT_LARGE ? 'grid-cols-2 @md:grid-cols-3 gap-1' :
                      'grid-cols-2 @md:grid-cols-4 gap-1')
               }`}
               initial={{ opacity: 0, y: 10 }}
@@ -829,8 +835,8 @@ export function KVCacheMonitor() {
             >
               {stats.slice(0, isExpanded ? 16 : 8).map((stat) => {
                 const gaugeSize = isExpanded
-                  ? (stats.length <= 2 ? 240 : stats.length <= 4 ? 200 : stats.length <= 6 ? 180 : 160)
-                  : (stats.length <= 2 ? 180 : stats.length <= 3 ? 160 : stats.length <= 6 ? 140 : 120)
+                  ? (stats.length <= GRID_BREAKPOINT_FEW ? 240 : stats.length <= GRID_BREAKPOINT_MEDIUM ? 200 : stats.length <= GRID_BREAKPOINT_LARGE ? 180 : 160)
+                  : (stats.length <= GRID_BREAKPOINT_FEW ? 180 : stats.length <= GRID_BREAKPOINT_SMALL ? 160 : stats.length <= GRID_BREAKPOINT_LARGE ? 140 : 120)
                 return (
                   <div
                     key={stat.podName}

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -25,6 +25,9 @@ import { formatTimeAgo } from '../../../lib/formatters'
 
 const PLATFORM_ORDER = ['OCP', 'GKE', 'CKS'] as const
 
+/** Minimum number of runs required before a guide's pass rate is considered meaningful */
+const MIN_RUNS_FOR_RATE = 3
+
 const PLATFORM_COLORS: Record<string, string> = {
   OCP: '#ef4444',  // red
   GKE: '#3b82f6',  // blue
@@ -552,7 +555,7 @@ function generateNightlySummary(guides: NightlyGuideStatus[]): [string, string] 
 
   if (allWithRuns.length > 0) {
     const best = allWithRuns.reduce((a, b) => a.passRate > b.passRate ? a : b)
-    const worst = allWithRuns.filter(g => g.runs.length >= 3).reduce(
+    const worst = allWithRuns.filter(g => g.runs.length >= MIN_RUNS_FOR_RATE).reduce(
       (a, b) => a.passRate < b.passRate ? a : b, allWithRuns[0]
     )
 
@@ -562,7 +565,7 @@ function generateNightlySummary(guides: NightlyGuideStatus[]): [string, string] 
       const durStr = dur !== null ? ` (avg ${formatDuration(dur)}, ${meta.model} on ${meta.gpuCount}× ${meta.gpuType})` : ''
       para2Parts.push(`${best.acronym} (${best.platform}) leads at ${best.passRate}%${durStr}.`)
     }
-    if (worst.passRate === 0 && worst.runs.length >= 3) {
+    if (worst.passRate === 0 && worst.runs.length >= MIN_RUNS_FOR_RATE) {
       para2Parts.push(`${worst.acronym} (${worst.platform}) has never passed in ${worst.runs.length} runs and needs investigation.`)
     }
 

--- a/web/src/components/cards/rss/RSSFeed.tsx
+++ b/web/src/components/cards/rss/RSSFeed.tsx
@@ -24,6 +24,8 @@ import { useTranslation } from 'react-i18next'
 import { TOAST_DISMISS_MS } from '../../../lib/constants/network'
 import { hostnameEndsWith } from '../../../lib/utils/urlHostname'
 
+const MIN_VALID_FEED_LENGTH = 50
+
 type SortByOption = 'date' | 'title'
 
 const SORT_COMPARATORS: Record<SortByOption, (a: FeedItem, b: FeedItem) => number> = {
@@ -311,7 +313,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
         } else {
           const feedXml = await response.text()
           // Check for empty or error response
-          if (!feedXml || feedXml.length < 50) {
+          if (!feedXml || feedXml.length < MIN_VALID_FEED_LENGTH) {
             throw new Error('Empty response')
           }
           // Check for error pages

--- a/web/src/components/cards/thanos_status/index.tsx
+++ b/web/src/components/cards/thanos_status/index.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next'
 import { useCardLoadingState } from '../CardDataContext'
 import { createCardSyncFormatter } from '../../../lib/formatters'
 
+const MAX_VISIBLE_TARGETS = 5
+
 const THANOS_TIME_KEYS = {
   justNow: 'thanosStatus.justNow',
   minutesAgo: 'thanosStatus.minutesAgo',
@@ -137,7 +139,7 @@ export function ThanosStatus() {
             <div className="flex-1 flex flex-col gap-2">
                 <p className="text-xs font-medium text-muted-foreground">{t('thanosStatus.targets')}</p>
                 <div className="space-y-1.5">
-                    {(data.targets || []).slice(0, 5).map((target) => (
+                    {(data.targets || []).slice(0, MAX_VISIBLE_TARGETS).map((target) => (
                         <div key={target.name} className="flex items-center gap-2 text-xs">
                             <span
                                 className={`w-2 h-2 rounded-full shrink-0 ${target.health === 'up' ? 'bg-green-400' : 'bg-red-400'
@@ -149,9 +151,9 @@ export function ThanosStatus() {
                             </span>
                         </div>
                     ))}
-                    {data.targets.length > 5 && (
+                    {data.targets.length > MAX_VISIBLE_TARGETS && (
                         <p className="text-[10px] text-muted-foreground italic">
-                            + {data.targets.length - 5} more targets
+                            + {data.targets.length - MAX_VISIBLE_TARGETS} more targets
                         </p>
                     )}
                 </div>

--- a/web/src/components/cards/workload-monitor/ClusterHealthMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/ClusterHealthMonitor.tsx
@@ -15,6 +15,8 @@ import { WorkloadMonitorDiagnose } from './WorkloadMonitorDiagnose'
 import type { MonitorIssue, ResourceHealthStatus } from '../../../types/workloadMonitor'
 import { useTranslation } from 'react-i18next'
 
+const MAX_VISIBLE_ISSUES = 5
+
 interface ClusterHealthMonitorProps {
   config?: Record<string, unknown>
 }
@@ -291,7 +293,7 @@ export function ClusterHealthMonitor({ config: _config }: ClusterHealthMonitorPr
                           Pod Issues ({clusterPodIssues.length})
                         </span>
                       </div>
-                      {clusterPodIssues.slice(0, 5).map((p, i) => (
+                      {clusterPodIssues.slice(0, MAX_VISIBLE_ISSUES).map((p, i) => (
                         <div key={`pod-${i}`} className="flex items-center gap-2 py-0.5 px-1 ml-4 rounded hover:bg-card/30 transition-colors">
                           <XCircle className="w-3 h-3 text-red-400 shrink-0" />
                           <span className="text-xs text-foreground truncate flex-1">{p.name}</span>
@@ -301,9 +303,9 @@ export function ClusterHealthMonitor({ config: _config }: ClusterHealthMonitorPr
                           </StatusBadge>
                         </div>
                       ))}
-                      {clusterPodIssues.length > 5 && (
+                      {clusterPodIssues.length > MAX_VISIBLE_ISSUES && (
                         <p className="text-2xs text-muted-foreground ml-4 px-1">
-                          +{clusterPodIssues.length - 5} more
+                          +{clusterPodIssues.length - MAX_VISIBLE_ISSUES} more
                         </p>
                       )}
                     </div>
@@ -318,7 +320,7 @@ export function ClusterHealthMonitor({ config: _config }: ClusterHealthMonitorPr
                           Deployment Issues ({clusterDeployIssues.length})
                         </span>
                       </div>
-                      {clusterDeployIssues.slice(0, 5).map((d, i) => (
+                      {clusterDeployIssues.slice(0, MAX_VISIBLE_ISSUES).map((d, i) => (
                         <div key={`deploy-${i}`} className="flex items-center gap-2 py-0.5 px-1 ml-4 rounded hover:bg-card/30 transition-colors">
                           <AlertTriangle className="w-3 h-3 text-yellow-400 shrink-0" />
                           <span className="text-xs text-foreground truncate flex-1">{d.name}</span>
@@ -328,9 +330,9 @@ export function ClusterHealthMonitor({ config: _config }: ClusterHealthMonitorPr
                           </StatusBadge>
                         </div>
                       ))}
-                      {clusterDeployIssues.length > 5 && (
+                      {clusterDeployIssues.length > MAX_VISIBLE_ISSUES && (
                         <p className="text-2xs text-muted-foreground ml-4 px-1">
-                          +{clusterDeployIssues.length - 5} more
+                          +{clusterDeployIssues.length - MAX_VISIBLE_ISSUES} more
                         </p>
                       )}
                     </div>

--- a/web/src/test/no-magic-numbers.test.ts
+++ b/web/src/test/no-magic-numbers.test.ts
@@ -51,7 +51,7 @@ const CARDS_DIR = path.resolve(
  * If the count increased, you introduced a new magic number — extract it
  * into a named constant (e.g., `const TOOLTIP_DELAY_MS = 300`).
  */
-const EXPECTED_MAGIC_NUMBER_COUNT = 43
+const EXPECTED_MAGIC_NUMBER_COUNT = 0
 
 /** Numeric values that are universally understood and not "magic" */
 const SAFE_VALUES = new Set([0, 1, -1, 2, 100])
@@ -317,21 +317,21 @@ describe('Magic Numbers Ratchet (P4-A)', () => {
   it('timer magic numbers must not increase', () => {
     const timerViolations = violations.filter(v => v.category === 'timer')
     /** Current count of timer-related magic number violations */
-    const EXPECTED_TIMER_VIOLATIONS = 5
+    const EXPECTED_TIMER_VIOLATIONS = 0
     expect(timerViolations.length).toBeLessThanOrEqual(EXPECTED_TIMER_VIOLATIONS)
   })
 
   it('style-prop magic numbers must not increase', () => {
     const styleViolations = violations.filter(v => v.category === 'style-prop')
     /** Current count of inline style magic number violations */
-    const EXPECTED_STYLE_VIOLATIONS = 3
+    const EXPECTED_STYLE_VIOLATIONS = 0
     expect(styleViolations.length).toBeLessThanOrEqual(EXPECTED_STYLE_VIOLATIONS)
   })
 
   it('comparison magic numbers must not increase', () => {
     const compViolations = violations.filter(v => v.category === 'comparison')
     /** Current count of comparison threshold magic number violations */
-    const EXPECTED_COMPARISON_VIOLATIONS = 35
+    const EXPECTED_COMPARISON_VIOLATIONS = 0
     expect(compViolations.length).toBeLessThanOrEqual(EXPECTED_COMPARISON_VIOLATIONS)
   })
 


### PR DESCRIPTION
## Summary

- Extract all 43 magic number violations flagged by the no-magic-numbers ratchet test into semantically named `UPPER_SNAKE_CASE` constants
- Lower all ratchet baselines to 0: total (43→0), timer (5→0), style-prop (3→0), comparison (35→0)
- 28 card component files + 1 test file updated, zero behavior change

### Constants added (examples)

| File | Constants |
|------|-----------|
| KVCacheMonitor.tsx | `GRID_BREAKPOINT_FEW/SMALL/MEDIUM/LARGE/DENSE` |
| ClusterComparison.tsx | `MAX_COMPARED_CLUSTERS` |
| ClusterLocations.tsx | `MAX_CLUSTER_NAME_DISPLAY`, `TRUNCATED_NAME_LENGTH` |
| PredictiveHealth.tsx | `RESTART_WARNING_THRESHOLD`, `RESTART_CRITICAL_THRESHOLD` |
| Checkers/KubeKart/etc. | Timer constants (`TAUNT_DISPLAY_MS`, `COUNTDOWN_INTERVAL_MS`, etc.) |

## Test plan

- [x] `npx vitest run src/test/no-magic-numbers.test.ts` passes with 0 violations
- [x] `npm run build` passes (tsc + vite)
- [x] No new lint errors introduced (pre-existing warnings only)

Fixes #10243