### PR TITLE
🧹 Wire isFailed/consecutiveFailures in 17 card components

### DIFF
--- a/web/src/components/cards/ClusterComparison.tsx
+++ b/web/src/components/cards/ClusterComparison.tsx
@@ -24,7 +24,7 @@ interface ClusterComparisonProps {
 // a runtime error in the 254-line component doesn't crash the dashboard.
 function ClusterComparisonInternal({ config }: ClusterComparisonProps) {
   const { t } = useTranslation(['cards', 'common'])
-  const { deduplicatedClusters: rawClusters, isLoading: clustersLoading } = useClusters()
+  const { deduplicatedClusters: rawClusters, isLoading: clustersLoading, isFailed, consecutiveFailures } = useClusters()
   const { nodes: gpuNodes, isDemoFallback, isRefreshing, lastRefresh } = useCachedGPUNodes()
   const [selectedClusters, setSelectedClusters] = useState<string[]>(config?.clusters || [])
   const { isDemoMode } = useDemoMode()
@@ -36,6 +36,8 @@ function ClusterComparisonInternal({ config }: ClusterComparisonProps) {
     isRefreshing,
     hasAnyData: hasData,
     isDemoData: isDemoMode || isDemoFallback,
+    isFailed,
+    consecutiveFailures,
     lastRefresh })
   const {
     selectedClusters: globalSelectedClusters,

--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -115,7 +115,7 @@ function relativeTime(iso: string): string {
 export function ClusterGroups(_props: ClusterGroupsProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { groups: liveGroups, createGroup, updateGroup, deleteGroup, isPersisted } = useClusterGroups()
-  const { deduplicatedClusters: clusters, isLoading, isRefreshing } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isRefreshing, isFailed, consecutiveFailures } = useClusters()
   const { isDemoMode: demoMode } = useDemoMode()
   const federation = useFederationAwareness()
 
@@ -148,7 +148,9 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
     isLoading: isLoading && !hasData,
     isRefreshing,
     hasAnyData: hasData,
-    isDemoData: demoMode })
+    isDemoData: demoMode,
+    isFailed,
+    consecutiveFailures })
   const [editingGroup, setEditingGroup] = useState<string | null>(null)
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
 

--- a/web/src/components/cards/ClusterLocations.tsx
+++ b/web/src/components/cards/ClusterLocations.tsx
@@ -225,7 +225,7 @@ type StatusFilter = 'all' | 'healthy' | 'unhealthy'
 export function ClusterLocations({ config: _config }: ClusterLocationsProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { showToast } = useToast()
-  const { deduplicatedClusters: allClusters, isLoading, isRefreshing } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading, isRefreshing, isFailed, consecutiveFailures } = useClusters()
   const { drillToCluster } = useDrillDownActions()
   const { isDemoMode } = useDemoMode()
 
@@ -235,7 +235,9 @@ export function ClusterLocations({ config: _config }: ClusterLocationsProps) {
     isLoading: isLoading && !hasData,
     isRefreshing,
     hasAnyData: hasData,
-    isDemoData: isDemoMode })
+    isDemoData: isDemoMode,
+    isFailed,
+    consecutiveFailures })
 
   const {
     selectedClusters: globalSelectedClusters,

--- a/web/src/components/cards/ClusterNetwork.tsx
+++ b/web/src/components/cards/ClusterNetwork.tsx
@@ -15,7 +15,7 @@ interface ClusterNetworkProps {
 
 export function ClusterNetwork({ config }: ClusterNetworkProps) {
   const { t } = useTranslation(['cards', 'common'])
-  const { deduplicatedClusters: allClusters, isLoading, isRefreshing } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading, isRefreshing, isFailed, consecutiveFailures } = useClusters()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const { isDemoMode } = useDemoMode()
 
@@ -24,7 +24,9 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
     isLoading,
     isRefreshing,
     hasAnyData: allClusters.length > 0,
-    isDemoData: isDemoMode })
+    isDemoData: isDemoMode,
+    isFailed,
+    consecutiveFailures })
 
   const {
     selectedClusters: globalSelectedClusters,

--- a/web/src/components/cards/FleetComplianceHeatmap.tsx
+++ b/web/src/components/cards/FleetComplianceHeatmap.tsx
@@ -163,7 +163,7 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
   const { statuses: trivyStatuses, isLoading: trivyLoading, isRefreshing: trivyRefreshing, isDemoData: trivyDemoData, installed: trivyInstalled, refetch: trivyRefetch, clustersChecked: trivyChecked, totalClusters: trivyTotal } = useTrivy()
   const { statuses: kubescapeStatuses, isLoading: kubescapeLoading, isRefreshing: kubescapeRefreshing, isDemoData: kubescapeDemoData, installed: kubescapeInstalled, refetch: kubescapeRefetch, clustersChecked: kubescapeChecked, totalClusters: kubescapeTotal } = useKubescape()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
-  const { deduplicatedClusters } = useClusters()
+  const { deduplicatedClusters, consecutiveFailures: clusterFailures } = useClusters()
   const { isDemoMode } = useDemoMode()
   const { startMission } = useMissions()
 
@@ -223,7 +223,7 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
   // error render path when all 3 underlying hooks (kyverno, trivy,
   // kubescape) finished but found no clusters to scan / no installations.
   // hasError is computed above from `clustersChecked` totals.
-  useCardLoadingState({ isLoading: isLoading && !isDemoData, isRefreshing, hasAnyData: true, isDemoData, isFailed: hasError })
+  useCardLoadingState({ isLoading: isLoading && !isDemoData, isRefreshing, hasAnyData: true, isDemoData, isFailed: hasError, consecutiveFailures: clusterFailures })
 
   const rows = useMemo((): HeatmapRow[] => {
     // Collect all cluster names from compliance hooks + useClusters fallback

--- a/web/src/components/cards/Kubectl.tsx
+++ b/web/src/components/cards/Kubectl.tsx
@@ -36,7 +36,7 @@ export function Kubectl() {
   // #6226: useToast for download error feedback.
   const { showToast } = useToast()
   const { execute } = useKubectl()
-  const { deduplicatedClusters: allClusters, isLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading, isFailed, consecutiveFailures } = useClusters()
   // Filter to only reachable & healthy clusters — running kubectl against an
   // unreachable cluster just hangs and frustrates the user. The status of
   // every kubeconfig context is already known from the cluster cache, so we
@@ -50,7 +50,9 @@ export function Kubectl() {
   useCardLoadingState({
     isLoading,
     hasAnyData: clusters.length > 0,
-    isDemoData: isDemoMode })
+    isDemoData: isDemoMode,
+    isFailed,
+    consecutiveFailures })
   const [command, setCommand] = useState('')
   const [aiPrompt, setAiPrompt] = useState('')
   const [output, setOutput] = useState<string[]>([])

--- a/web/src/components/cards/KustomizationStatus.tsx
+++ b/web/src/components/cards/KustomizationStatus.tsx
@@ -101,7 +101,7 @@ function formatTime(timestamp: string) {
 export function KustomizationStatus({ config }: KustomizationStatusProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { isDemoMode: demoMode } = useDemoMode()
-  const { deduplicatedClusters: allClusters, isLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading, isFailed, consecutiveFailures } = useClusters()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const [selectedNamespace, setSelectedNamespace] = useState<string>(config?.namespace || '')
   const {
@@ -130,7 +130,9 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: kustomizationData.length > 0,
-    isDemoData: demoMode })
+    isDemoData: demoMode,
+    isFailed,
+    consecutiveFailures })
 
   // Auto-select first cluster in demo mode so card shows data immediately
   useEffect(() => {

--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -145,7 +145,7 @@ const CLUSTER_FILTER_STORAGE_KEY = 'kubestellar-card-filter:deployment-missions-
 export function Missions(_props: MissionsProps) {
   const { t } = useTranslation(['common', 'cards'])
   const { missions: liveMissions, activeMissions: liveActive, completedMissions: liveCompleted } = useDeployMissions()
-  const { deduplicatedClusters, isLoading, isRefreshing } = useClusters()
+  const { deduplicatedClusters, isLoading, isRefreshing, isFailed, consecutiveFailures } = useClusters()
   const { isDemoMode: demoMode } = useDemoMode()
   const missions = demoMode ? DEMO_MISSIONS : liveMissions
   const activeMissions = demoMode ? [] : liveActive
@@ -184,7 +184,9 @@ export function Missions(_props: MissionsProps) {
     isLoading: isLoading && !hasData,
     isRefreshing,
     hasAnyData: hasData,
-    isDemoData: demoMode })
+    isDemoData: demoMode,
+    isFailed,
+    consecutiveFailures })
 
   // Manual cluster filter — filters by target clusters (not source).
   // Can't use useCardData's built-in cluster filter because the global

--- a/web/src/components/cards/NamespaceMonitor.tsx
+++ b/web/src/components/cards/NamespaceMonitor.tsx
@@ -109,7 +109,7 @@ const MAX_VISIBLE_ITEMS = 10
 
 export function NamespaceMonitor({ config: _config }: CardComponentProps) {
   const { isDemoMode } = useDemoMode()
-  const { deduplicatedClusters: clusters, isLoading } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isFailed, consecutiveFailures } = useClusters()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { drillToNamespace, drillToPod, drillToDeployment, drillToService, drillToPVC } = useDrillDownActions()
   // UI state
@@ -167,7 +167,9 @@ export function NamespaceMonitor({ config: _config }: CardComponentProps) {
     isLoading,
     isRefreshing: namespacesRefreshing || deploymentsRefreshing || servicesRefreshing || pvcsRefreshing || podsRefreshing || configmapsRefreshing || secretsRefreshing || jobsRefreshing,
     hasAnyData: clusters.length > 0,
-    isDemoData: isDemoMode || isDemoData })
+    isDemoData: isDemoMode || isDemoData,
+    isFailed,
+    consecutiveFailures })
 
   // Build snapshots and detect changes
   useEffect(() => {

--- a/web/src/components/cards/NamespaceRBAC.tsx
+++ b/web/src/components/cards/NamespaceRBAC.tsx
@@ -51,7 +51,7 @@ function NamespaceRBACInternal({ config }: NamespaceRBACProps) {
   const SORT_OPTIONS = SORT_OPTIONS_KEYS
     .filter(opt => opt.value !== 'rules' || TABS_WITH_RULES_COUNT.includes(activeTab))
     .map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) }))
-  const { deduplicatedClusters: clusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, error } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, error, isFailed, consecutiveFailures } = useClusters()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { drillToRBAC } = useDrillDownActions()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
@@ -108,7 +108,9 @@ function NamespaceRBACInternal({ config }: NamespaceRBACProps) {
     isLoading: isInitialLoading || !!isFetchingRBAC,
     isRefreshing,
     hasAnyData: clusters.length > 0 || k8sRoles.length > 0 || k8sBindings.length > 0 || k8sServiceAccounts.length > 0,
-    isDemoData })
+    isDemoData,
+    isFailed,
+    consecutiveFailures })
 
   // Transform raw RBAC data into RBACItem arrays (no filtering/sorting — that's handled by useCardData)
   const rbacRoles: RBACItem[] = (() => {

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -189,7 +189,7 @@ function createSortComparators(statuses: Record<string, GatekeeperStatus>) {
 function OPAPoliciesInternal({ config: _config }: OPAPoliciesProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { isDemoMode } = useDemoMode()
-  const { deduplicatedClusters: clusters, isLoading } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isFailed, consecutiveFailures } = useClusters()
   const { startMission } = useMissions()
   const { shouldUseDemoData } = useCardDemoState({ requires: 'agent' })
 
@@ -471,7 +471,9 @@ function OPAPoliciesInternal({ config: _config }: OPAPoliciesProps) {
     isLoading: shouldUseDemoData ? false : (isLoading || (isOPAChecking && !hasOPAData)),
     isRefreshing,
     hasAnyData: shouldUseDemoData ? true : (clusters.length > 0 && hasOPAData),
-    isDemoData: isDemoMode })
+    isDemoData: isDemoMode,
+    isFailed,
+    consecutiveFailures })
 
   // In demo mode, update statuses with real cluster names when they become available.
   // Initial demo statuses are already provided by useState initializer (via checkIsDemoMode).

--- a/web/src/components/cards/OverlayComparison.tsx
+++ b/web/src/components/cards/OverlayComparison.tsx
@@ -26,7 +26,7 @@ interface OverlayDiff {
 export function OverlayComparison({ config }: OverlayComparisonProps) {
   const { t } = useTranslation()
   const { isDemoMode: demoMode } = useDemoMode()
-  const { deduplicatedClusters: allClusters, isLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading, isFailed, consecutiveFailures } = useClusters()
   const { drillToKustomization } = useDrillDownActions()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const [selectedBase, setSelectedBase] = useState<string>('')
@@ -42,6 +42,8 @@ export function OverlayComparison({ config }: OverlayComparisonProps) {
     isLoading,
     hasAnyData: allClusters.length > 0,
     isDemoData: demoMode,
+    isFailed,
+    consecutiveFailures,
   })
 
   // Apply global filters

--- a/web/src/components/cards/RecommendedPolicies.tsx
+++ b/web/src/components/cards/RecommendedPolicies.tsx
@@ -248,7 +248,7 @@ function RecommendedPoliciesInternal({ config: _config }: CardConfig) {
   const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, installed: kyvernoInstalled, isDemoData: kyvernoDemoData, clustersChecked: kyvernoChecked, totalClusters: kyvernoTotal } = useKyverno()
   const { isLoading: kubescapeLoading, installed: kubescapeInstalled, isDemoData: kubescapeDemoData, clustersChecked: kubescapeChecked, totalClusters: kubescapeTotal } = useKubescape()
   const { isLoading: trivyLoading, installed: trivyInstalled, isDemoData: trivyDemoData, clustersChecked: trivyChecked, totalClusters: trivyTotal } = useTrivy()
-  const { deduplicatedClusters } = useClusters()
+  const { deduplicatedClusters, isFailed, consecutiveFailures } = useClusters()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
   const { isDemoMode } = useDemoMode()
@@ -332,7 +332,7 @@ function RecommendedPoliciesInternal({ config: _config }: CardConfig) {
   })()
 
   const hasAnyData = kyvernoInstalled || kubescapeInstalled || trivyInstalled || isDemoData
-  useCardLoadingState({ isLoading: isLoading && !hasAnyData, hasAnyData, isDemoData })
+  useCardLoadingState({ isLoading: isLoading && !hasAnyData, hasAnyData, isDemoData, isFailed, consecutiveFailures })
 
   const handleDeployAll = () => {
     const gaps = recommendations.filter(r => r.coveredClusters.length < r.eligibleClusters.length)

--- a/web/src/components/cards/ResourceTrend.tsx
+++ b/web/src/components/cards/ResourceTrend.tsx
@@ -37,7 +37,7 @@ const TIME_RANGE_OPTIONS: { value: TimeRange; label: string; points: number }[] 
 
 export function ResourceTrend() {
   const { t } = useTranslation()
-  const { deduplicatedClusters: clusters, isLoading, isRefreshing } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isRefreshing, isFailed, consecutiveFailures } = useClusters()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { isDemoMode } = useDemoMode()
   const [view, setView] = useState<MetricView>('all')
@@ -52,7 +52,9 @@ export function ResourceTrend() {
     isLoading: isLoading && !hasData,
     isRefreshing,
     hasAnyData: hasData,
-    isDemoData: isDemoMode })
+    isDemoData: isDemoMode,
+    isFailed,
+    consecutiveFailures })
 
   // Close dropdown when clicking outside
   useEffect(() => {

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -20,7 +20,7 @@ function ResourceUsageInternal() {
   // #6217: destructure lastRefresh so the card can render a freshness
   // indicator instead of leaving users guessing how stale the data is.
   // #6271: useClusters returns Date|null; normalize to numeric epoch.
-  const { isLoading: clustersLoading, isRefreshing: clustersRefreshing, lastRefresh: clustersLastRefreshDate } = useClusters()
+  const { isLoading: clustersLoading, isRefreshing: clustersRefreshing, lastRefresh: clustersLastRefreshDate, isFailed, consecutiveFailures } = useClusters()
   const clustersLastRefresh: number | null = clustersLastRefreshDate instanceof Date
     ? clustersLastRefreshDate.getTime()
     : (typeof clustersLastRefreshDate === 'number' ? clustersLastRefreshDate : null)
@@ -98,7 +98,9 @@ function ResourceUsageInternal() {
     isLoading: clustersLoading && !hasData,
     isRefreshing: clustersRefreshing || gpuRefreshing,
     hasAnyData: hasData,
-    isDemoData: isDemoMode || isDemoFallback })
+    isDemoData: isDemoMode || isDemoFallback,
+    isFailed,
+    consecutiveFailures })
 
   if (showSkeleton) {
     return (

--- a/web/src/components/cards/console-missions/ConsoleKubeconfigAuditCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleKubeconfigAuditCard.tsx
@@ -12,7 +12,7 @@ import { useDemoMode } from '../../../hooks/useDemoMode'
 // Card 2: Kubeconfig Audit - Detect stale/unreachable clusters
 export function ConsoleKubeconfigAuditCard(_props: ConsoleMissionCardProps) {
   const { startMission, missions } = useMissions()
-  const { deduplicatedClusters: allClusters, isLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading, isFailed, consecutiveFailures } = useClusters()
   const { selectedClusters, isAllClustersSelected, customFilter } = useGlobalFilters()
   const { drillToCluster } = useDrillDownActions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
@@ -22,7 +22,9 @@ export function ConsoleKubeconfigAuditCard(_props: ConsoleMissionCardProps) {
   useCardLoadingState({
     isLoading,
     hasAnyData: allClusters.length > 0,
-    isDemoData: isDemoMode })
+    isDemoData: isDemoMode,
+    isFailed,
+    consecutiveFailures })
 
   // Filter clusters by global filter
   const clusters = (() => {

--- a/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
+++ b/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
@@ -24,7 +24,7 @@ const MAX_TIMELINE_BUCKETS = 30
 const CLUSTER_COLORS = CROSS_CLUSTER_EVENT_PALETTE
 
 export function CrossClusterEventCorrelation() {
-  const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
+  const { insightsByCategory, isLoading, isDemoData, isFailed, consecutiveFailures } = useMultiClusterInsights()
   const { events: warningEvents } = useCachedWarningEvents()
   const { selectedClusters } = useGlobalFilters()
   const [selectedInsight, setSelectedInsight] = useState<MultiClusterInsight | null>(null)
@@ -40,6 +40,8 @@ export function CrossClusterEventCorrelation() {
     isLoading: isLoading && !hasData,
     hasAnyData: hasData,
     isDemoData,
+    isFailed,
+    consecutiveFailures,
   })
 
   // Build timeline chart data from warning events

--- a/web/src/hooks/useMultiClusterInsights.ts
+++ b/web/src/hooks/useMultiClusterInsights.ts
@@ -788,7 +788,7 @@ const SEVERITY_RANK: Record<InsightSeverity, number> = {
 
 export function useMultiClusterInsights(): UseMultiClusterInsightsResult {
   const { isDemoMode } = useDemoMode()
-  const { deduplicatedClusters, isLoading: clustersLoading } = useClusters()
+  const { deduplicatedClusters, isLoading: clustersLoading, isFailed, consecutiveFailures } = useClusters()
   const { events, isLoading: eventsLoading, isDemoFallback: eventsDemoFallback } = useCachedEvents()
   const { events: warningEvents } = useCachedWarningEvents()
   const { data: deployments, isLoading: deploymentsLoading, isDemoFallback: deploymentsDemoFallback } = useCachedDeployments()
@@ -844,6 +844,8 @@ export function useMultiClusterInsights(): UseMultiClusterInsightsResult {
     insights: enrichedInsights,
     isLoading,
     isDemoData: !!isDemoData,
+    isFailed: !!isFailed,
+    consecutiveFailures: consecutiveFailures ?? 0,
     insightsByCategory,
     topInsights }
 }

--- a/web/src/test/card-loading-standard.test.ts
+++ b/web/src/test/card-loading-standard.test.ts
@@ -146,23 +146,6 @@ const KNOWN_VIOLATIONS: Record<string, Set<string>> = {
  * Same ratchet rules as KNOWN_VIOLATIONS: this list MUST ONLY SHRINK.
  */
 const KNOWN_FAILURE_VIOLATIONS: Record<string, Set<string>> = {
-  'ClusterComparison.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'ClusterGroups.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'ClusterLocations.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'ClusterNetwork.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'console-missions/ConsoleKubeconfigAuditCard.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'FleetComplianceHeatmap.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'insights/CrossClusterEventCorrelation.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'Kubectl.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'KustomizationStatus.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'Missions.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'NamespaceMonitor.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'NamespaceRBAC.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'OPAPolicies.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'OverlayComparison.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'RecommendedPolicies.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'ResourceTrend.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'ResourceUsage.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
 }
 
 /** Check if a violation is known (grandfathered in) */
@@ -415,7 +398,7 @@ describe('Card Loading State Gold Standard', () => {
 
       // Separate ratchet for failure-wiring violations. MUST ONLY DECREASE.
       // Each card entry has 2 violations (missing-isFailed + missing-consecutiveFailures).
-      const EXPECTED_FAILURE_VIOLATION_COUNT = 34
+      const EXPECTED_FAILURE_VIOLATION_COUNT = 0
       expect(failureCount).toBeLessThanOrEqual(EXPECTED_FAILURE_VIOLATION_COUNT)
     })
   })

--- a/web/src/types/insights.ts
+++ b/web/src/types/insights.ts
@@ -69,6 +69,8 @@ export interface UseMultiClusterInsightsResult {
   insights: MultiClusterInsight[]
   isLoading: boolean
   isDemoData: boolean
+  isFailed: boolean
+  consecutiveFailures: number
   insightsByCategory: Record<InsightCategory, MultiClusterInsight[]>
   topInsights: MultiClusterInsight[]
 }


### PR DESCRIPTION
## Summary

- Wire `isFailed` and `consecutiveFailures` from data hooks to `useCardLoadingState()` in 17 card components
- This enables CardWrapper to show failure indicators (red outline, retry UI) when a card's data source fails repeatedly
- Failure-wiring ratchet lowered from 34 → 0
- Also exposed `isFailed`/`consecutiveFailures` through `useMultiClusterInsights` hook and its type interface

### Cards fixed

ClusterComparison, ClusterGroups, ClusterLocations, ClusterNetwork, ConsoleKubeconfigAuditCard, FleetComplianceHeatmap, CrossClusterEventCorrelation, Kubectl, KustomizationStatus, Missions, NamespaceMonitor, NamespaceRBAC, OPAPolicies, OverlayComparison, RecommendedPolicies, ResourceTrend, ResourceUsage

## Test plan

- [x] `npx vitest run src/test/card-loading-standard.test.ts` — 705 tests pass, failure ratchet at 0
- [x] `npm run build` passes (tsc + vite + safety checks)

Fixes #10247