### PR TITLE
🌱 Add 49 tests for 5 untested files (coverage toward 91%)

### DIFF
--- a/web/src/hooks/__tests__/useCachedAttestation.test.ts
+++ b/web/src/hooks/__tests__/useCachedAttestation.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockUseCache = vi.fn()
+vi.mock('../../lib/cache', () => ({
+  useCache: (args: unknown) => mockUseCache(args),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+import {
+  useCachedAttestation,
+  WEIGHT_IMAGE_PROVENANCE,
+  WEIGHT_WORKLOAD_IDENTITY,
+  WEIGHT_POLICY_COMPLIANCE,
+  WEIGHT_PRIVILEGE_POSTURE,
+  SCORE_THRESHOLD_HIGH,
+  SCORE_THRESHOLD_MEDIUM,
+} from '../useCachedAttestation'
+import type { AttestationData } from '../useCachedAttestation'
+
+describe('useCachedAttestation', () => {
+  const emptyData: AttestationData = { clusters: [] }
+
+  const defaultCacheReturn = {
+    data: emptyData,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: 123456789,
+    refetch: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsDemoMode.mockReturnValue(false)
+    mockUseCache.mockReturnValue({ ...defaultCacheReturn })
+  })
+
+  it('returns data from cache when not in demo mode', () => {
+    const { result } = renderHook(() => useCachedAttestation())
+    expect(result.current.data).toEqual(emptyData)
+    expect(result.current.isDemoData).toBe(false)
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('passes correct cache key to useCache', () => {
+    renderHook(() => useCachedAttestation())
+    expect(mockUseCache).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'runtime_attestation_score' }),
+    )
+  })
+
+  it('returns demo data in demo mode', () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useCachedAttestation())
+    expect(result.current.isDemoData).toBe(true)
+    expect(result.current.data.clusters.length).toBeGreaterThan(0)
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isRefreshing).toBe(false)
+    expect(result.current.isFailed).toBe(false)
+    expect(result.current.consecutiveFailures).toBe(0)
+  })
+
+  it('isDemoData is true when isDemoFallback is true and not loading', () => {
+    mockUseCache.mockReturnValue({
+      ...defaultCacheReturn,
+      isDemoFallback: true,
+    })
+    const { result } = renderHook(() => useCachedAttestation())
+    expect(result.current.isDemoData).toBe(true)
+  })
+
+  it('isDemoData is false during loading even when isDemoFallback is true', () => {
+    mockUseCache.mockReturnValue({
+      ...defaultCacheReturn,
+      isLoading: true,
+      isDemoFallback: true,
+    })
+    const { result } = renderHook(() => useCachedAttestation())
+    expect(result.current.isDemoData).toBe(false)
+  })
+
+  it('respects isLoading state', () => {
+    mockUseCache.mockReturnValue({
+      ...defaultCacheReturn,
+      isLoading: true,
+    })
+    const { result } = renderHook(() => useCachedAttestation())
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('respects isRefreshing state when not in demo mode', () => {
+    mockUseCache.mockReturnValue({
+      ...defaultCacheReturn,
+      isRefreshing: true,
+    })
+    const { result } = renderHook(() => useCachedAttestation())
+    expect(result.current.isRefreshing).toBe(true)
+  })
+
+  it('isRefreshing is always false in demo mode', () => {
+    mockIsDemoMode.mockReturnValue(true)
+    mockUseCache.mockReturnValue({
+      ...defaultCacheReturn,
+      isRefreshing: true,
+    })
+    const { result } = renderHook(() => useCachedAttestation())
+    expect(result.current.isRefreshing).toBe(false)
+  })
+
+  it('exposes failure state', () => {
+    mockUseCache.mockReturnValue({
+      ...defaultCacheReturn,
+      isFailed: true,
+      consecutiveFailures: 3,
+    })
+    const { result } = renderHook(() => useCachedAttestation())
+    expect(result.current.isFailed).toBe(true)
+    expect(result.current.consecutiveFailures).toBe(3)
+  })
+
+  it('provides refetch function', () => {
+    const mockRefetch = vi.fn()
+    mockUseCache.mockReturnValue({
+      ...defaultCacheReturn,
+      refetch: mockRefetch,
+    })
+    const { result } = renderHook(() => useCachedAttestation())
+    expect(result.current.refetch).toBe(mockRefetch)
+  })
+})
+
+describe('useCachedAttestation constants', () => {
+  it('exports weight constants summing to 100', () => {
+    const total =
+      WEIGHT_IMAGE_PROVENANCE +
+      WEIGHT_WORKLOAD_IDENTITY +
+      WEIGHT_POLICY_COMPLIANCE +
+      WEIGHT_PRIVILEGE_POSTURE
+    expect(total).toBe(100)
+  })
+
+  it('exports score thresholds in correct order', () => {
+    expect(SCORE_THRESHOLD_HIGH).toBeGreaterThan(SCORE_THRESHOLD_MEDIUM)
+    expect(SCORE_THRESHOLD_MEDIUM).toBeGreaterThan(0)
+  })
+})

--- a/web/src/hooks/__tests__/useCachedTimeline.test.ts
+++ b/web/src/hooks/__tests__/useCachedTimeline.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockUseCache = vi.fn()
+vi.mock('../../lib/cache', () => ({
+  useCache: (args: unknown) => mockUseCache(args),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../components/cards/change_timeline/demoData', () => ({
+  getDemoTimelineEvents: () => [
+    { id: 'demo-1', type: 'deploy', cluster: 'demo-cluster', timestamp: '2024-01-01T00:00:00Z' },
+  ],
+}))
+
+vi.mock('../../lib/api', () => ({
+  authFetch: vi.fn(),
+}))
+
+import { useCachedTimeline } from '../useCachedTimeline'
+
+describe('useCachedTimeline', () => {
+  const defaultCacheReturn = {
+    data: [],
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: 123456789,
+    refetch: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsDemoMode.mockReturnValue(false)
+    mockUseCache.mockReturnValue({ ...defaultCacheReturn })
+  })
+
+  it('returns data from cache when not in demo mode', () => {
+    const { result } = renderHook(() => useCachedTimeline())
+    expect(result.current.data).toEqual([])
+    expect(result.current.isDemoData).toBe(false)
+  })
+
+  it('passes cache key with default range', () => {
+    renderHook(() => useCachedTimeline())
+    expect(mockUseCache).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: expect.stringContaining('change_timeline_events_'),
+      }),
+    )
+  })
+
+  it('uses custom rangeMs in cache key', () => {
+    const CUSTOM_RANGE = 7200000
+    renderHook(() => useCachedTimeline(CUSTOM_RANGE))
+    expect(mockUseCache).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: `change_timeline_events_${CUSTOM_RANGE}`,
+      }),
+    )
+  })
+
+  it('returns demo data in demo mode', () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useCachedTimeline())
+    expect(result.current.isDemoData).toBe(true)
+    expect(result.current.data.length).toBeGreaterThan(0)
+  })
+
+  it('isDemoData is false during loading even when isDemoFallback is true', () => {
+    mockUseCache.mockReturnValue({
+      ...defaultCacheReturn,
+      isLoading: true,
+      isDemoFallback: true,
+    })
+    const { result } = renderHook(() => useCachedTimeline())
+    expect(result.current.isDemoData).toBe(false)
+  })
+
+  it('isDemoData is true when isDemoFallback and not loading', () => {
+    mockUseCache.mockReturnValue({
+      ...defaultCacheReturn,
+      isDemoFallback: true,
+    })
+    const { result } = renderHook(() => useCachedTimeline())
+    expect(result.current.isDemoData).toBe(true)
+  })
+
+  it('respects isLoading state', () => {
+    mockUseCache.mockReturnValue({
+      ...defaultCacheReturn,
+      isLoading: true,
+    })
+    const { result } = renderHook(() => useCachedTimeline())
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('exposes failure state', () => {
+    mockUseCache.mockReturnValue({
+      ...defaultCacheReturn,
+      isFailed: true,
+      consecutiveFailures: 5,
+    })
+    const { result } = renderHook(() => useCachedTimeline())
+    expect(result.current.isFailed).toBe(true)
+    expect(result.current.consecutiveFailures).toBe(5)
+  })
+
+  it('provides refetch function', () => {
+    const mockRefetch = vi.fn()
+    mockUseCache.mockReturnValue({
+      ...defaultCacheReturn,
+      refetch: mockRefetch,
+    })
+    const { result } = renderHook(() => useCachedTimeline())
+    expect(result.current.refetch).toBe(mockRefetch)
+  })
+})

--- a/web/src/lib/__tests__/cncf-constants.test.ts
+++ b/web/src/lib/__tests__/cncf-constants.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CNCF_CATEGORY_GRADIENTS,
+  CNCF_CATEGORY_ICONS,
+  MATURITY_CONFIG,
+  DIFFICULTY_CONFIG,
+} from '../../lib/cncf-constants'
+
+describe('CNCF_CATEGORY_GRADIENTS', () => {
+  it('has entries for core CNCF categories', () => {
+    const expectedCategories = [
+      'Observability',
+      'Orchestration',
+      'Runtime',
+      'Provisioning',
+      'Security',
+      'Service Mesh',
+      'Networking',
+      'Storage',
+    ]
+    for (const cat of expectedCategories) {
+      expect(CNCF_CATEGORY_GRADIENTS).toHaveProperty(cat)
+    }
+  })
+
+  it('each gradient entry is a tuple of two CSS var strings', () => {
+    for (const [, gradient] of Object.entries(CNCF_CATEGORY_GRADIENTS)) {
+      expect(gradient).toHaveLength(2)
+      expect(gradient[0]).toMatch(/^var\(--/)
+      expect(gradient[1]).toMatch(/^var\(--/)
+    }
+  })
+})
+
+describe('CNCF_CATEGORY_ICONS', () => {
+  it('has an SVG path for every gradient category', () => {
+    for (const key of Object.keys(CNCF_CATEGORY_GRADIENTS)) {
+      expect(CNCF_CATEGORY_ICONS).toHaveProperty(key)
+      expect(typeof CNCF_CATEGORY_ICONS[key]).toBe('string')
+      expect(CNCF_CATEGORY_ICONS[key].length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('MATURITY_CONFIG', () => {
+  it('has graduated, incubating, and sandbox entries', () => {
+    expect(MATURITY_CONFIG).toHaveProperty('graduated')
+    expect(MATURITY_CONFIG).toHaveProperty('incubating')
+    expect(MATURITY_CONFIG).toHaveProperty('sandbox')
+  })
+
+  it('each entry has color, bg, border, and label', () => {
+    for (const [, config] of Object.entries(MATURITY_CONFIG)) {
+      expect(config).toHaveProperty('color')
+      expect(config).toHaveProperty('bg')
+      expect(config).toHaveProperty('border')
+      expect(config).toHaveProperty('label')
+      expect(typeof config.label).toBe('string')
+    }
+  })
+})
+
+describe('DIFFICULTY_CONFIG', () => {
+  it('has beginner, intermediate, and advanced entries', () => {
+    expect(DIFFICULTY_CONFIG).toHaveProperty('beginner')
+    expect(DIFFICULTY_CONFIG).toHaveProperty('intermediate')
+    expect(DIFFICULTY_CONFIG).toHaveProperty('advanced')
+  })
+
+  it('each entry has color and bg', () => {
+    for (const [, config] of Object.entries(DIFFICULTY_CONFIG)) {
+      expect(config).toHaveProperty('color')
+      expect(config).toHaveProperty('bg')
+    }
+  })
+})

--- a/web/src/lib/__tests__/k8s.test.ts
+++ b/web/src/lib/__tests__/k8s.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { parseReadyCount, isPodHealthy } from '../../lib/k8s'
+
+describe('parseReadyCount', () => {
+  it('parses valid "ready/total" string', () => {
+    expect(parseReadyCount('2/3')).toEqual({ ready: 2, total: 3 })
+  })
+
+  it('parses "0/0" string', () => {
+    expect(parseReadyCount('0/0')).toEqual({ ready: 0, total: 0 })
+  })
+
+  it('parses fully ready pod', () => {
+    expect(parseReadyCount('3/3')).toEqual({ ready: 3, total: 3 })
+  })
+
+  it('returns zeros for undefined input', () => {
+    expect(parseReadyCount(undefined)).toEqual({ ready: 0, total: 0 })
+  })
+
+  it('returns zeros for empty string', () => {
+    expect(parseReadyCount('')).toEqual({ ready: 0, total: 0 })
+  })
+
+  it('returns zeros for malformed string without slash', () => {
+    expect(parseReadyCount('invalid')).toEqual({ ready: 0, total: 0 })
+  })
+
+  it('returns zeros for non-numeric parts', () => {
+    expect(parseReadyCount('abc/def')).toEqual({ ready: 0, total: 0 })
+  })
+})
+
+describe('isPodHealthy', () => {
+  it('returns true for running pod with all containers ready', () => {
+    expect(isPodHealthy({ status: 'Running', ready: '3/3' })).toBe(true)
+  })
+
+  it('returns false for running pod with not all containers ready', () => {
+    expect(isPodHealthy({ status: 'Running', ready: '1/3' })).toBe(false)
+  })
+
+  it('returns false for non-running pod', () => {
+    expect(isPodHealthy({ status: 'Pending', ready: '0/1' })).toBe(false)
+  })
+
+  it('returns false for CrashLoopBackOff', () => {
+    expect(isPodHealthy({ status: 'CrashLoopBackOff', ready: '0/1' })).toBe(false)
+  })
+
+  it('returns false when status is undefined', () => {
+    expect(isPodHealthy({ ready: '1/1' })).toBe(false)
+  })
+
+  it('returns false when ready is undefined', () => {
+    expect(isPodHealthy({ status: 'Running' })).toBe(false)
+  })
+
+  it('returns false for empty pod object', () => {
+    expect(isPodHealthy({})).toBe(false)
+  })
+
+  it('handles case-insensitive status check', () => {
+    expect(isPodHealthy({ status: 'RUNNING', ready: '2/2' })).toBe(true)
+    expect(isPodHealthy({ status: 'running', ready: '1/1' })).toBe(true)
+  })
+
+  it('returns false when total is zero even if running', () => {
+    expect(isPodHealthy({ status: 'Running', ready: '0/0' })).toBe(false)
+  })
+})

--- a/web/src/lib/__tests__/tokens.test.ts
+++ b/web/src/lib/__tests__/tokens.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { STAT_BLOCK_COLORS } from '../../lib/tokens'
+
+describe('STAT_BLOCK_COLORS', () => {
+  it('exports a record of color names to hex values', () => {
+    expect(typeof STAT_BLOCK_COLORS).toBe('object')
+    expect(Object.keys(STAT_BLOCK_COLORS).length).toBeGreaterThan(0)
+  })
+
+  it('includes standard color names', () => {
+    const expectedColors = ['purple', 'green', 'orange', 'yellow', 'cyan', 'blue', 'red', 'gray']
+    for (const color of expectedColors) {
+      expect(STAT_BLOCK_COLORS).toHaveProperty(color)
+    }
+  })
+
+  it('all values are valid hex color strings', () => {
+    const hexPattern = /^#[0-9a-fA-F]{6}$/
+    for (const [, value] of Object.entries(STAT_BLOCK_COLORS)) {
+      expect(value).toMatch(hexPattern)
+    }
+  })
+
+  it('green matches success color', () => {
+    expect(STAT_BLOCK_COLORS.green).toBe('#10b981')
+  })
+
+  it('red matches error color', () => {
+    expect(STAT_BLOCK_COLORS.red).toBe('#ef4444')
+  })
+})


### PR DESCRIPTION
Fixes #10140

## Coverage Improvement

Coverage baseline is ~87.74% (CI sharded). This PR adds **49 tests** across **5** previously untested files in the coverage scope.

### Files tested:
- **hooks/useCachedAttestation.ts** (11 tests): cache key, demo mode, loading/refreshing states, failure, weight constants
- **hooks/useCachedTimeline.ts** (9 tests): cache key with custom range, demo mode, loading, failure
- **lib/k8s.ts** (16 tests): parseReadyCount edge cases, isPodHealthy with various pod states
- **lib/cncf-constants.ts** (7 tests): gradient entries, icon paths, maturity/difficulty configs
- **lib/tokens.ts** (5 tests): STAT_BLOCK_COLORS hex validation

All 49 tests pass. Build and lint verified.