### PR TITLE
🧹 Wire isRefreshing in 11 card components for refresh spinner

### DIFF
--- a/web/src/components/cards/Kubectl.tsx
+++ b/web/src/components/cards/Kubectl.tsx
@@ -36,7 +36,7 @@ export function Kubectl() {
   // #6226: useToast for download error feedback.
   const { showToast } = useToast()
   const { execute } = useKubectl()
-  const { deduplicatedClusters: allClusters, isLoading, isFailed, consecutiveFailures } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading, isRefreshing, isFailed, consecutiveFailures } = useClusters()
   // Filter to only reachable & healthy clusters — running kubectl against an
   // unreachable cluster just hangs and frustrates the user. The status of
   // every kubeconfig context is already known from the cluster cache, so we
@@ -49,6 +49,7 @@ export function Kubectl() {
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: clusters.length > 0,
     isDemoData: isDemoMode,
     isFailed,

--- a/web/src/components/cards/KustomizationStatus.tsx
+++ b/web/src/components/cards/KustomizationStatus.tsx
@@ -101,7 +101,7 @@ function formatTime(timestamp: string) {
 export function KustomizationStatus({ config }: KustomizationStatusProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { isDemoMode: demoMode } = useDemoMode()
-  const { deduplicatedClusters: allClusters, isLoading, isFailed, consecutiveFailures } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading, isRefreshing, isFailed, consecutiveFailures } = useClusters()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const [selectedNamespace, setSelectedNamespace] = useState<string>(config?.namespace || '')
   const {
@@ -129,6 +129,7 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: kustomizationData.length > 0,
     isDemoData: demoMode,
     isFailed,

--- a/web/src/components/cards/OverlayComparison.tsx
+++ b/web/src/components/cards/OverlayComparison.tsx
@@ -26,7 +26,7 @@ interface OverlayDiff {
 export function OverlayComparison({ config }: OverlayComparisonProps) {
   const { t } = useTranslation()
   const { isDemoMode: demoMode } = useDemoMode()
-  const { deduplicatedClusters: allClusters, isLoading, isFailed, consecutiveFailures } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading, isRefreshing, isFailed, consecutiveFailures } = useClusters()
   const { drillToKustomization } = useDrillDownActions()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const [selectedBase, setSelectedBase] = useState<string>('')
@@ -40,6 +40,7 @@ export function OverlayComparison({ config }: OverlayComparisonProps) {
   // Report state to CardWrapper for refresh animation
   useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: allClusters.length > 0,
     isDemoData: demoMode,
     isFailed,

--- a/web/src/components/cards/PredictiveHealth.tsx
+++ b/web/src/components/cards/PredictiveHealth.tsx
@@ -54,8 +54,8 @@ function confidenceFromUsage(usagePct: number): number {
 
 export function PredictiveHealth() {
   const { t } = useTranslation('cards')
-  const { nodes: allNodes, isLoading: nodesLoading, isDemoFallback: nodesDemoFallback, isFailed: nodesFailed, consecutiveFailures: nodesFailures } = useCachedNodes()
-  const { pods: allPods, isLoading: podsLoading, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedPods()
+  const { nodes: allNodes, isLoading: nodesLoading, isRefreshing: nodesRefreshing, isDemoFallback: nodesDemoFallback, isFailed: nodesFailed, consecutiveFailures: nodesFailures } = useCachedNodes()
+  const { pods: allPods, isLoading: podsLoading, isRefreshing: podsRefreshing, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedPods()
   const { filterByCluster } = useGlobalFilters()
   const [expandedId, setExpandedId] = useState<string | null>(null)
 
@@ -65,6 +65,7 @@ export function PredictiveHealth() {
   const isLoading = nodesLoading || podsLoading
   const { showSkeleton } = useCardLoadingState({
     isLoading,
+    isRefreshing: nodesRefreshing || podsRefreshing,
     hasAnyData: allNodes.length > 0 || allPods.length > 0,
     isDemoData: nodesDemoFallback || podsDemoFallback,
     isFailed: nodesFailed || podsFailed,

--- a/web/src/components/cards/RecommendedPolicies.tsx
+++ b/web/src/components/cards/RecommendedPolicies.tsx
@@ -245,9 +245,9 @@ Deploy to ALL clusters with Kyverno installed. Proceed step by step.` },
 
 function RecommendedPoliciesInternal({ config: _config }: CardConfig) {
   const { t } = useTranslation('cards')
-  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, installed: kyvernoInstalled, isDemoData: kyvernoDemoData, clustersChecked: kyvernoChecked, totalClusters: kyvernoTotal } = useKyverno()
-  const { isLoading: kubescapeLoading, installed: kubescapeInstalled, isDemoData: kubescapeDemoData, clustersChecked: kubescapeChecked, totalClusters: kubescapeTotal } = useKubescape()
-  const { isLoading: trivyLoading, installed: trivyInstalled, isDemoData: trivyDemoData, clustersChecked: trivyChecked, totalClusters: trivyTotal } = useTrivy()
+  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, installed: kyvernoInstalled, isDemoData: kyvernoDemoData, clustersChecked: kyvernoChecked, totalClusters: kyvernoTotal } = useKyverno()
+  const { isLoading: kubescapeLoading, isRefreshing: kubescapeRefreshing, installed: kubescapeInstalled, isDemoData: kubescapeDemoData, clustersChecked: kubescapeChecked, totalClusters: kubescapeTotal } = useKubescape()
+  const { isLoading: trivyLoading, isRefreshing: trivyRefreshing, installed: trivyInstalled, isDemoData: trivyDemoData, clustersChecked: trivyChecked, totalClusters: trivyTotal } = useTrivy()
   const { deduplicatedClusters, isFailed, consecutiveFailures } = useClusters()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
@@ -332,7 +332,7 @@ function RecommendedPoliciesInternal({ config: _config }: CardConfig) {
   })()
 
   const hasAnyData = kyvernoInstalled || kubescapeInstalled || trivyInstalled || isDemoData
-  useCardLoadingState({ isLoading: isLoading && !hasAnyData, hasAnyData, isDemoData, isFailed, consecutiveFailures })
+  useCardLoadingState({ isLoading: isLoading && !hasAnyData, isRefreshing: kyvernoRefreshing || kubescapeRefreshing || trivyRefreshing, hasAnyData, isDemoData, isFailed, consecutiveFailures })
 
   const handleDeployAll = () => {
     const gaps = recommendations.filter(r => r.coveredClusters.length < r.eligibleClusters.length)

--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -77,8 +77,8 @@ export function UserManagement({ config: _config }: UserManagementProps) {
 
   const { drillToRBAC } = useDrillDownActions()
   const { user: currentUser } = useAuth()
-  const { users: allUsers, isLoading: usersLoading, error: usersError, updateUserRole, deleteUser } = useConsoleUsers()
-  const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
+  const { users: allUsers, isLoading: usersLoading, isRefreshing: usersRefreshing, error: usersError, updateUserRole, deleteUser } = useConsoleUsers()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing } = useClusters()
   const { isDemoMode } = useDemoMode()
   // Fetch ALL SAs from ALL clusters upfront, filter locally
   const { serviceAccounts: allServiceAccounts, isLoading: sasInitialLoading } = useAllK8sServiceAccounts(allClusters)
@@ -92,6 +92,7 @@ export function UserManagement({ config: _config }: UserManagementProps) {
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading || usersLoading || sasInitialLoading || openshiftInitialLoading,
+    isRefreshing: usersRefreshing || clustersRefreshing,
     hasAnyData: allClusters.length > 0 || allUsers.length > 0 || allServiceAccounts.length > 0,
     isFailed: Boolean(usersError),
     consecutiveFailures: usersError ? 1 : 0,

--- a/web/src/components/cards/console-missions/ConsoleHealthCheckCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleHealthCheckCard.tsx
@@ -15,7 +15,7 @@ import { HorseshoeGauge } from '../llmd/shared/HorseshoeGauge'
 export function ConsoleHealthCheckCard(_props: ConsoleMissionCardProps) {
   const { t } = useTranslation()
   const { startMission, missions } = useMissions()
-  const { deduplicatedClusters: allClusters, isLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading, isRefreshing } = useClusters()
   const { issues: allPodIssues, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedPodIssues()
   const { issues: allDeploymentIssues, isDemoFallback: deploysDemoFallback, isFailed: deploysFailed, consecutiveFailures: deploysFailures } = useCachedDeploymentIssues()
   const { selectedClusters, isAllClustersSelected, customFilter } = useGlobalFilters()
@@ -25,6 +25,7 @@ export function ConsoleHealthCheckCard(_props: ConsoleMissionCardProps) {
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: allClusters.length > 0,
     isDemoData: podsDemoFallback || deploysDemoFallback,
     isFailed: podsFailed || deploysFailed,

--- a/web/src/components/cards/console-missions/ConsoleIssuesCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleIssuesCard.tsx
@@ -11,8 +11,8 @@ import { useCardLoadingState } from '../CardDataContext'
 // Card 1: AI Issues Overview - Shows issues AI can help fix
 export function ConsoleIssuesCard(_props: ConsoleMissionCardProps) {
   const { startMission, missions } = useMissions()
-  const { issues: allPodIssues, isLoading: podIssuesLoading, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedPodIssues()
-  const { issues: allDeploymentIssues, isLoading: deployIssuesLoading, isDemoFallback: deploysDemoFallback, isFailed: deploysFailed, consecutiveFailures: deploysFailures } = useCachedDeploymentIssues()
+  const { issues: allPodIssues, isLoading: podIssuesLoading, isRefreshing: podsRefreshing, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedPodIssues()
+  const { issues: allDeploymentIssues, isLoading: deployIssuesLoading, isRefreshing: deploysRefreshing, isDemoFallback: deploysDemoFallback, isFailed: deploysFailed, consecutiveFailures: deploysFailures } = useCachedDeploymentIssues()
   const { selectedClusters, isAllClustersSelected, customFilter } = useGlobalFilters()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
 
@@ -20,9 +20,12 @@ export function ConsoleIssuesCard(_props: ConsoleMissionCardProps) {
 
   const isLoading = podIssuesLoading || deployIssuesLoading
 
+  const isRefreshing = podsRefreshing || deploysRefreshing
+
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: allPodIssues.length > 0 || allDeploymentIssues.length > 0 || missions.length > 0,
     isDemoData: podsDemoFallback || deploysDemoFallback,
     isFailed: podsFailed || deploysFailed,

--- a/web/src/components/cards/console-missions/ConsoleKubeconfigAuditCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleKubeconfigAuditCard.tsx
@@ -12,7 +12,7 @@ import { useDemoMode } from '../../../hooks/useDemoMode'
 // Card 2: Kubeconfig Audit - Detect stale/unreachable clusters
 export function ConsoleKubeconfigAuditCard(_props: ConsoleMissionCardProps) {
   const { startMission, missions } = useMissions()
-  const { deduplicatedClusters: allClusters, isLoading, isFailed, consecutiveFailures } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading, isRefreshing, isFailed, consecutiveFailures } = useClusters()
   const { selectedClusters, isAllClustersSelected, customFilter } = useGlobalFilters()
   const { drillToCluster } = useDrillDownActions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
@@ -21,6 +21,7 @@ export function ConsoleKubeconfigAuditCard(_props: ConsoleMissionCardProps) {
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: allClusters.length > 0,
     isDemoData: isDemoMode,
     isFailed,

--- a/web/src/components/cards/coredns_status/CoreDNSStatus.tsx
+++ b/web/src/components/cards/coredns_status/CoreDNSStatus.tsx
@@ -29,6 +29,7 @@ export function CoreDNSStatus({ config }: CoreDNSStatusProps) {
 
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
+    isRefreshing,
     isDemoData,
     hasAnyData: clusters.length > 0,
     isFailed,

--- a/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
+++ b/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
@@ -24,7 +24,7 @@ const MAX_TIMELINE_BUCKETS = 30
 const CLUSTER_COLORS = CROSS_CLUSTER_EVENT_PALETTE
 
 export function CrossClusterEventCorrelation() {
-  const { insightsByCategory, isLoading, isDemoData, isFailed, consecutiveFailures } = useMultiClusterInsights()
+  const { insightsByCategory, isLoading, isRefreshing, isDemoData, isFailed, consecutiveFailures } = useMultiClusterInsights()
   const { events: warningEvents } = useCachedWarningEvents()
   const { selectedClusters } = useGlobalFilters()
   const [selectedInsight, setSelectedInsight] = useState<MultiClusterInsight | null>(null)
@@ -38,6 +38,7 @@ export function CrossClusterEventCorrelation() {
   const hasData = correlationInsightsRaw.length > 0 || (warningEvents || []).length > 0
   useCardLoadingState({
     isLoading: isLoading && !hasData,
+    isRefreshing,
     hasAnyData: hasData,
     isDemoData,
     isFailed,

--- a/web/src/hooks/useMultiClusterInsights.ts
+++ b/web/src/hooks/useMultiClusterInsights.ts
@@ -788,14 +788,15 @@ const SEVERITY_RANK: Record<InsightSeverity, number> = {
 
 export function useMultiClusterInsights(): UseMultiClusterInsightsResult {
   const { isDemoMode } = useDemoMode()
-  const { deduplicatedClusters, isLoading: clustersLoading, isFailed, consecutiveFailures } = useClusters()
-  const { events, isLoading: eventsLoading, isDemoFallback: eventsDemoFallback } = useCachedEvents()
+  const { deduplicatedClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed, consecutiveFailures } = useClusters()
+  const { events, isLoading: eventsLoading, isRefreshing: eventsRefreshing, isDemoFallback: eventsDemoFallback } = useCachedEvents()
   const { events: warningEvents } = useCachedWarningEvents()
-  const { data: deployments, isLoading: deploymentsLoading, isDemoFallback: deploymentsDemoFallback } = useCachedDeployments()
+  const { data: deployments, isLoading: deploymentsLoading, isRefreshing: deploymentsRefreshing, isDemoFallback: deploymentsDemoFallback } = useCachedDeployments()
   const { issues: podIssues, isDemoFallback: podIssuesDemoFallback } = useCachedPodIssues()
 
   const isDemoData = isDemoMode || (eventsDemoFallback && deploymentsDemoFallback && podIssuesDemoFallback)
   const isLoading = clustersLoading || eventsLoading || deploymentsLoading
+  const isRefreshing = clustersRefreshing || eventsRefreshing || deploymentsRefreshing
 
   const insights = (() => {
     if (isDemoData) return getDemoInsights()
@@ -843,6 +844,7 @@ export function useMultiClusterInsights(): UseMultiClusterInsightsResult {
   return {
     insights: enrichedInsights,
     isLoading,
+    isRefreshing,
     isDemoData: !!isDemoData,
     isFailed: !!isFailed,
     consecutiveFailures: consecutiveFailures ?? 0,

--- a/web/src/test/card-loading-standard.test.ts
+++ b/web/src/test/card-loading-standard.test.ts
@@ -91,16 +91,16 @@ const KNOWN_VIOLATIONS: Record<string, Set<string>> = {
   'cloudevents_status/useCloudEventsStatus.ts': new Set(['bare-isLoading']),
   'ClusterChangelog.tsx': new Set(['bare-isLoading']),
   'ClusterDropZone.tsx': new Set(['bare-isLoading']),
-  'ClusterNetwork.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
-  'console-missions/ConsoleHealthCheckCard.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
-  'console-missions/ConsoleIssuesCard.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
-  'console-missions/ConsoleKubeconfigAuditCard.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
-  'coredns_status/CoreDNSStatus.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
+  'ClusterNetwork.tsx': new Set(['bare-isLoading']),
+  'console-missions/ConsoleHealthCheckCard.tsx': new Set(['bare-isLoading']),
+  'console-missions/ConsoleIssuesCard.tsx': new Set(['bare-isLoading']),
+  'console-missions/ConsoleKubeconfigAuditCard.tsx': new Set(['bare-isLoading']),
+  'coredns_status/CoreDNSStatus.tsx': new Set(['bare-isLoading']),
   'CRDHealth.tsx': new Set(['bare-isLoading']),
   'crio_status/useCrioStatus.ts': new Set(['bare-isLoading']),
   'crossplane-status/CrossplaneManagedResources.tsx': new Set(['bare-isLoading']),
   'DeploymentStatus.tsx': new Set(['bare-isLoading']),
-  'EtcdStatus.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
+  'EtcdStatus.tsx': new Set(['bare-isLoading']),
   'EventsTimeline.tsx': new Set(['bare-isLoading']),
   'EventStream.tsx': new Set(['bare-isLoading']),
   'flatcar_status/useFlatcarStatus.ts': new Set(['bare-isLoading']),
@@ -108,7 +108,6 @@ const KNOWN_VIOLATIONS: Record<string, Set<string>> = {
   'GatewayStatus.tsx': new Set(['bare-isLoading']),
   'GPUStatus.tsx': new Set(['bare-isLoading']),
   'HelmHistory.tsx': new Set(['bare-isLoading']),
-  'insights/CrossClusterEventCorrelation.tsx': new Set(['missing-isRefreshing']),
   'kagenti/KagentiAgentDiscovery.tsx': new Set(['bare-isLoading']),
   'kagenti/KagentiAgentFleet.tsx': new Set(['bare-isLoading']),
   'kagenti/KagentiBuildPipeline.tsx': new Set(['bare-isLoading']),
@@ -116,27 +115,23 @@ const KNOWN_VIOLATIONS: Record<string, Set<string>> = {
   'kagenti/KagentiToolRegistry.tsx': new Set(['bare-isLoading']),
   'karmada_status/useKarmadaStatus.ts': new Set(['bare-isLoading']),
   'keda_status/useKedaStatus.ts': new Set(['bare-isLoading']),
-  'Kubectl.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
-  'KustomizationStatus.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
+  'Kubectl.tsx': new Set(['bare-isLoading']),
+  'KustomizationStatus.tsx': new Set(['bare-isLoading']),
   'llmd/NightlyE2EStatus.tsx': new Set(['bare-isLoading']),
   'NamespaceMonitor.tsx': new Set(['bare-isLoading']),
-  'NamespaceRBAC.tsx': new Set(['missing-isRefreshing']),
   'NetworkOverview.tsx': new Set(['bare-isLoading']),
-  'NetworkPolicyCoverage.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
+  'NetworkPolicyCoverage.tsx': new Set(['bare-isLoading']),
   'NodeDebug.tsx': new Set(['bare-isLoading']),
   'openfeature_status/useOpenFeatureStatus.ts': new Set(['bare-isLoading']),
-  'OverlayComparison.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
+  'OverlayComparison.tsx': new Set(['bare-isLoading']),
   'PodHealthTrend.tsx': new Set(['bare-isLoading']),
-  'PredictiveHealth.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
+  'PredictiveHealth.tsx': new Set(['bare-isLoading']),
   'RBACExplorer.tsx': new Set(['bare-isLoading']),
-  'RecommendedPolicies.tsx': new Set(['missing-isRefreshing']),
   'ResourceMarshall.tsx': new Set(['bare-isLoading']),
   'ServiceExports.tsx': new Set(['bare-isLoading']),
   'ServiceImports.tsx': new Set(['bare-isLoading']),
   'thanos_status/useThanosStatus.ts': new Set(['bare-isLoading']),
-  'UserManagement.tsx': new Set(['missing-isRefreshing']),
   'weather/Weather.tsx': new Set(['bare-isLoading']),
-  'WorkloadDeployment.tsx': new Set(['missing-isRefreshing']),
 }
 
 /**
@@ -375,7 +370,7 @@ describe('Card Loading State Gold Standard', () => {
       // This number MUST ONLY DECREASE. If you fix a card, remove it from
       // KNOWN_VIOLATIONS and decrease this count. If this test fails because
       // the count dropped, that's great — update the expected count!
-      const EXPECTED_KNOWN_VIOLATION_COUNT = 65
+      const EXPECTED_KNOWN_VIOLATION_COUNT = 45
       expect(totalKnown).toBeLessThanOrEqual(EXPECTED_KNOWN_VIOLATION_COUNT)
     })
 
@@ -386,7 +381,7 @@ describe('Card Loading State Gold Standard', () => {
       }
 
       // Separate ratchet for isRefreshing violations. MUST ONLY DECREASE.
-      const EXPECTED_REFRESH_VIOLATION_COUNT = 17
+      const EXPECTED_REFRESH_VIOLATION_COUNT = 0
       expect(refreshCount).toBeLessThanOrEqual(EXPECTED_REFRESH_VIOLATION_COUNT)
     })
 

--- a/web/src/types/insights.ts
+++ b/web/src/types/insights.ts
@@ -68,6 +68,7 @@ export interface ClusterDelta {
 export interface UseMultiClusterInsightsResult {
   insights: MultiClusterInsight[]
   isLoading: boolean
+  isRefreshing: boolean
   isDemoData: boolean
   isFailed: boolean
   consecutiveFailures: number


### PR DESCRIPTION
## Summary

- Wire `isRefreshing` from data hooks to `useCardLoadingState()` in 11 card components
- Enables refresh spinner icon animation when background data updates are in progress
- Also exposed `isRefreshing` through `useMultiClusterInsights` hook + type interface
- Ratchet baselines lowered: total 65→45, isRefreshing 17→0

### Cards fixed

ConsoleHealthCheckCard, ConsoleIssuesCard, ConsoleKubeconfigAuditCard, CoreDNSStatus, CrossClusterEventCorrelation, Kubectl, KustomizationStatus, OverlayComparison, PredictiveHealth, RecommendedPolicies, UserManagement

### Already correct (verified, no changes needed)

ClusterNetwork, EtcdStatus, NamespaceRBAC, NetworkPolicyCoverage, WorkloadDeployment

## Test plan

- [x] `npx vitest run src/test/card-loading-standard.test.ts` — 705 tests pass, refresh ratchet at 0
- [x] `npm run build` passes (tsc + vite + safety checks)

Fixes #10250