### PR TITLE
🐛 Fix data race in SSE offline-cluster streaming

### DIFF
--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -418,15 +418,21 @@ func streamClusters(
 			return true
 		}
 
-		// Instantly emit skipped events for offline clusters
+		// Instantly emit skipped events for offline clusters.
+		// Must hold mu — background goroutines for healthy clusters also
+		// call emitEvent (writes to a non-thread-safe bufio.Writer) and
+		// increment completedClusters under the same lock (#10254).
 		for _, cl := range offline {
-			if !emitEvent(sseEventClusterSkipped, fiber.Map{
+			mu.Lock()
+			ok := emitEvent(sseEventClusterSkipped, fiber.Map{
 				"cluster": cl.Name,
 				"reason":  "offline",
-			}) {
+			})
+			completedClusters++
+			mu.Unlock()
+			if !ok {
 				return
 			}
-			completedClusters++
 		}
 
 		// Spawn goroutines only for healthy/unknown clusters


### PR DESCRIPTION
## Summary
- Guards the offline-cluster loop in `streamClusters` with the shared mutex `mu` before calling `emitEvent` and incrementing `completedClusters`, matching the locking pattern used by healthy-cluster goroutines
- Prevents concurrent writes to the non-thread-safe `bufio.Writer` and race on `completedClusters`

Fixes #10254

## Test plan
- [ ] `go vet ./...` passes (CI)
- [ ] `go build ./...` passes (CI)
- [ ] SSE streaming with a mix of healthy and offline clusters emits events without data corruption