### PR TITLE
🐛 Add retry-on-conflict to node labeling

### DIFF
--- a/pkg/k8s/workload.go
+++ b/pkg/k8s/workload.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -15,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/kubestellar/console/pkg/api/v1alpha1"
 )
@@ -1250,7 +1252,10 @@ func (m *MultiClusterClient) GetClusterCapabilities(ctx context.Context) (*v1alp
 	}, nil
 }
 
-// LabelClusterNodes labels all nodes in a cluster with the given labels
+// LabelClusterNodes labels all nodes in a cluster with the given labels.
+// Each node update uses retry-on-conflict to handle transient ResourceVersion
+// mismatches. Errors are collected per-node so that one failure does not
+// prevent labeling the remaining nodes (#10256).
 func (m *MultiClusterClient) LabelClusterNodes(ctx context.Context, cluster string, labels map[string]string) error {
 	dynamicClient, err := m.GetDynamicClient(cluster)
 	if err != nil {
@@ -1262,24 +1267,39 @@ func (m *MultiClusterClient) LabelClusterNodes(ctx context.Context, cluster stri
 		return fmt.Errorf("failed to list nodes in %s: %w", cluster, err)
 	}
 
+	var errs []error
 	for _, node := range nodeList.Items {
-		existing := node.GetLabels()
-		if existing == nil {
-			existing = make(map[string]string)
-		}
-		for k, v := range labels {
-			existing[k] = v
-		}
-		node.SetLabels(existing)
-		_, err := dynamicClient.Resource(gvrNodes).Update(ctx, &node, metav1.UpdateOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to label node %s in %s: %w", node.GetName(), cluster, err)
+		nodeName := node.GetName()
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// Re-fetch the node to get the latest ResourceVersion.
+			fresh, getErr := dynamicClient.Resource(gvrNodes).Get(ctx, nodeName, metav1.GetOptions{})
+			if getErr != nil {
+				return fmt.Errorf("failed to get node %s in %s: %w", nodeName, cluster, getErr)
+			}
+			existing := fresh.GetLabels()
+			if existing == nil {
+				existing = make(map[string]string)
+			}
+			for k, v := range labels {
+				existing[k] = v
+			}
+			fresh.SetLabels(existing)
+			_, updateErr := dynamicClient.Resource(gvrNodes).Update(ctx, fresh, metav1.UpdateOptions{})
+			return updateErr
+		})
+		if retryErr != nil {
+			slog.Error("[LabelClusterNodes] failed to label node after retries",
+				"node", nodeName, "cluster", cluster, "error", retryErr)
+			errs = append(errs, fmt.Errorf("node %s: %w", nodeName, retryErr))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
-// RemoveClusterNodeLabels removes specified labels from all nodes in a cluster
+// RemoveClusterNodeLabels removes specified labels from all nodes in a cluster.
+// Each node update uses retry-on-conflict to handle transient ResourceVersion
+// mismatches. Errors are collected per-node so that one failure does not
+// prevent updating the remaining nodes (#10256).
 func (m *MultiClusterClient) RemoveClusterNodeLabels(ctx context.Context, cluster string, labelKeys []string) error {
 	dynamicClient, err := m.GetDynamicClient(cluster)
 	if err != nil {
@@ -1291,28 +1311,40 @@ func (m *MultiClusterClient) RemoveClusterNodeLabels(ctx context.Context, cluste
 		return fmt.Errorf("failed to list nodes in %s: %w", cluster, err)
 	}
 
+	var errs []error
 	for _, node := range nodeList.Items {
-		existing := node.GetLabels()
-		if existing == nil {
-			continue
-		}
-		changed := false
-		for _, k := range labelKeys {
-			if _, ok := existing[k]; ok {
-				delete(existing, k)
-				changed = true
+		nodeName := node.GetName()
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// Re-fetch the node to get the latest ResourceVersion.
+			fresh, getErr := dynamicClient.Resource(gvrNodes).Get(ctx, nodeName, metav1.GetOptions{})
+			if getErr != nil {
+				return fmt.Errorf("failed to get node %s in %s: %w", nodeName, cluster, getErr)
 			}
-		}
-		if !changed {
-			continue
-		}
-		node.SetLabels(existing)
-		_, err := dynamicClient.Resource(gvrNodes).Update(ctx, &node, metav1.UpdateOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to update node %s in %s: %w", node.GetName(), cluster, err)
+			existing := fresh.GetLabels()
+			if existing == nil {
+				return nil // no labels to remove
+			}
+			changed := false
+			for _, k := range labelKeys {
+				if _, ok := existing[k]; ok {
+					delete(existing, k)
+					changed = true
+				}
+			}
+			if !changed {
+				return nil // nothing to update
+			}
+			fresh.SetLabels(existing)
+			_, updateErr := dynamicClient.Resource(gvrNodes).Update(ctx, fresh, metav1.UpdateOptions{})
+			return updateErr
+		})
+		if retryErr != nil {
+			slog.Error("[RemoveClusterNodeLabels] failed to update node after retries",
+				"node", nodeName, "cluster", cluster, "error", retryErr)
+			errs = append(errs, fmt.Errorf("node %s: %w", nodeName, retryErr))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // ListBindingPolicies lists binding policies (placeholder)


### PR DESCRIPTION
## Summary
- Wraps each node `Update` call in `LabelClusterNodes` and `RemoveClusterNodeLabels` with `retry.RetryOnConflict(retry.DefaultRetry, ...)` to handle transient ResourceVersion conflicts
- Re-fetches the node inside the retry loop to pick up the latest ResourceVersion
- Collects per-node errors with `errors.Join` instead of aborting on the first failure, so remaining nodes are still processed

Fixes #10256