### PR TITLE
🐛 Collect all cluster errors in multi-cluster deploy and scale

### DIFF
--- a/pkg/k8s/workload.go
+++ b/pkg/k8s/workload.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -689,7 +690,9 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 	var mu sync.Mutex
 	deployed := make([]string, 0, len(targetClusters))
 	failed := make([]string, 0)
-	var lastErr error
+	// Collect all per-cluster errors so partial failures report every cluster's
+	// error, not just the last one to finish (#10257).
+	errs := make([]error, 0)
 	allDepResults := make([]v1alpha1.DeployedDep, 0)
 
 	for _, target := range targetClusters {
@@ -701,7 +704,7 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 			if err != nil {
 				mu.Lock()
 				failed = append(failed, targetCluster)
-				lastErr = fmt.Errorf("cluster %s: %w", targetCluster, err)
+				errs = append(errs, fmt.Errorf("cluster %s: %w", targetCluster, err))
 				mu.Unlock()
 				return
 			}
@@ -739,12 +742,12 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 					failed = append(failed, targetCluster)
 					if apierrors.IsNotFound(getErr) {
 						// Genuine "does not exist" — the Create error is authoritative.
-						lastErr = fmt.Errorf("cluster %s: create failed: %w", targetCluster, err)
+						errs = append(errs, fmt.Errorf("cluster %s: create failed: %w", targetCluster, err))
 					} else {
 						// Non-NotFound Get error (network, auth, server) — surface
 						// BOTH errors with %w so callers can errors.Is/As either
 						// one. Go 1.20+ supports multi-error %w. (#6547)
-						lastErr = fmt.Errorf("cluster %s: create failed: %w; also get failed: %w", targetCluster, err, getErr)
+						errs = append(errs, fmt.Errorf("cluster %s: create failed: %w; also get failed: %w", targetCluster, err, getErr))
 					}
 					mu.Unlock()
 					return
@@ -754,7 +757,7 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 				if err != nil {
 					mu.Lock()
 					failed = append(failed, targetCluster)
-					lastErr = fmt.Errorf("cluster %s: update failed: %w", targetCluster, err)
+					errs = append(errs, fmt.Errorf("cluster %s: update failed: %w", targetCluster, err))
 					mu.Unlock()
 					return
 				}
@@ -800,9 +803,9 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 	if len(failed) == 0 {
 		resp.Message = fmt.Sprintf("Deployed %s/%s to %d cluster(s)%s", namespace, name, len(deployed), depSummary)
 	} else if len(deployed) > 0 {
-		resp.Message = fmt.Sprintf("Partially deployed: %d succeeded, %d failed%s", len(deployed), len(failed), depSummary)
+		resp.Message = fmt.Sprintf("Partially deployed: %d succeeded, %d failed%s: %v", len(deployed), len(failed), depSummary, errors.Join(errs...))
 	} else {
-		resp.Message = fmt.Sprintf("Deployment failed on all clusters: %v", lastErr)
+		resp.Message = fmt.Sprintf("Deployment failed on all clusters: %v", errors.Join(errs...))
 	}
 
 	return resp, nil
@@ -1053,7 +1056,9 @@ func (m *MultiClusterClient) ScaleWorkload(ctx context.Context, namespace, name 
 	var mu sync.Mutex
 	deployed := make([]string, 0, len(targetClusters))
 	failed := make([]string, 0)
-	var lastErr error
+	// Collect all per-cluster errors so partial failures report every cluster's
+	// error, not just the last one to finish (#10257).
+	scaleErrs := make([]error, 0)
 
 	for _, cluster := range targetClusters {
 		wg.Add(1)
@@ -1064,7 +1069,7 @@ func (m *MultiClusterClient) ScaleWorkload(ctx context.Context, namespace, name 
 			if err != nil {
 				mu.Lock()
 				failed = append(failed, clusterName)
-				lastErr = fmt.Errorf("cluster %s: %w", clusterName, err)
+				scaleErrs = append(scaleErrs, fmt.Errorf("cluster %s: %w", clusterName, err))
 				mu.Unlock()
 				return
 			}
@@ -1080,7 +1085,7 @@ func (m *MultiClusterClient) ScaleWorkload(ctx context.Context, namespace, name 
 					}
 					mu.Lock()
 					failed = append(failed, clusterName)
-					lastErr = fmt.Errorf("cluster %s: get %s: %w", clusterName, g.kind, getErr)
+					scaleErrs = append(scaleErrs, fmt.Errorf("cluster %s: get %s: %w", clusterName, g.kind, getErr))
 					mu.Unlock()
 					return
 				}
@@ -1090,7 +1095,7 @@ func (m *MultiClusterClient) ScaleWorkload(ctx context.Context, namespace, name 
 				if !ok {
 					mu.Lock()
 					failed = append(failed, clusterName)
-					lastErr = fmt.Errorf("cluster %s: invalid spec in %s %s/%s", clusterName, g.kind, namespace, name)
+					scaleErrs = append(scaleErrs, fmt.Errorf("cluster %s: invalid spec in %s %s/%s", clusterName, g.kind, namespace, name))
 					mu.Unlock()
 					return
 				}
@@ -1100,7 +1105,7 @@ func (m *MultiClusterClient) ScaleWorkload(ctx context.Context, namespace, name 
 				if updateErr != nil {
 					mu.Lock()
 					failed = append(failed, clusterName)
-					lastErr = fmt.Errorf("cluster %s: scale %s: %w", clusterName, g.kind, updateErr)
+					scaleErrs = append(scaleErrs, fmt.Errorf("cluster %s: scale %s: %w", clusterName, g.kind, updateErr))
 					mu.Unlock()
 					return
 				}
@@ -1114,7 +1119,7 @@ func (m *MultiClusterClient) ScaleWorkload(ctx context.Context, namespace, name 
 				deployed = append(deployed, clusterName)
 			} else {
 				failed = append(failed, clusterName)
-				lastErr = fmt.Errorf("cluster %s: workload %s/%s not found as Deployment or StatefulSet", clusterName, namespace, name)
+				scaleErrs = append(scaleErrs, fmt.Errorf("cluster %s: workload %s/%s not found as Deployment or StatefulSet", clusterName, namespace, name))
 			}
 			mu.Unlock()
 		}(cluster)
@@ -1124,8 +1129,10 @@ func (m *MultiClusterClient) ScaleWorkload(ctx context.Context, namespace, name 
 
 	success := len(deployed) > 0
 	msg := fmt.Sprintf("Scaled %s/%s to %d replicas on %d/%d clusters", namespace, name, replicas, len(deployed), len(targetClusters))
-	if lastErr != nil && !success {
-		msg = lastErr.Error()
+	if len(scaleErrs) > 0 && !success {
+		msg = fmt.Sprintf("Scale failed on all clusters: %v", errors.Join(scaleErrs...))
+	} else if len(scaleErrs) > 0 {
+		msg = fmt.Sprintf("%s (errors: %v)", msg, errors.Join(scaleErrs...))
 	}
 
 	return &v1alpha1.DeployResponse{


### PR DESCRIPTION
## Summary
- Replace shared `lastErr` variable with an error slice in both `DeployWorkload` and `ScaleWorkload`
- Each goroutine appends its cluster-specific error under mutex protection
- Use `errors.Join` to combine all errors into the response message so operators see every failing cluster and its reason, not just the last one

Fixes #10257

## Test plan
- [ ] Deploy a workload to multiple clusters where >1 target fails — verify all errors appear in the response message
- [ ] Scale a workload across clusters with mixed failures — verify all errors are reported
- [ ] Successful multi-cluster deploy still shows clean success message