### PR TITLE
🧹 Replace raw hex colors and fontSize in chart files with shared constants

### DIFF
--- a/web/src/components/cards/EventsTimeline.tsx
+++ b/web/src/components/cards/EventsTimeline.tsx
@@ -17,7 +17,9 @@ import {
   CHART_GRID_STROKE,
   CHART_AXIS_STROKE,
   CHART_TOOLTIP_CONTENT_STYLE,
-  CHART_TICK_COLOR } from '../../lib/constants'
+  CHART_TICK_COLOR,
+  CHART_AXIS_FONT_SIZE,
+  CHART_BODY_FONT_SIZE } from '../../lib/constants'
 
 interface TimePoint {
   time: string
@@ -182,14 +184,14 @@ function EventsTimelineInternal() {
     xAxis: {
       type: 'category' as const,
       data: timeSeriesData.map(d => d.time),
-      axisLabel: { color: CHART_TICK_COLOR, fontSize: 10 },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
       axisLine: { lineStyle: { color: CHART_AXIS_STROKE } },
       axisTick: { show: false },
     },
     yAxis: {
       type: 'value' as const,
       minInterval: 1,
-      axisLabel: { color: CHART_TICK_COLOR, fontSize: 10 },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
       axisLine: { show: false },
       axisTick: { show: false },
       splitLine: { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } },
@@ -198,7 +200,7 @@ function EventsTimelineInternal() {
       trigger: 'axis' as const,
       backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
       borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-      textStyle: { color: CHART_TICK_COLOR, fontSize: 12 },
+      textStyle: { color: CHART_TICK_COLOR, fontSize: CHART_BODY_FONT_SIZE },
     },
     series: [
       {

--- a/web/src/components/cards/GPUInventoryHistory.tsx
+++ b/web/src/components/cards/GPUInventoryHistory.tsx
@@ -18,7 +18,10 @@ import {
   CHART_GRID_STROKE,
   CHART_AXIS_STROKE,
   CHART_TOOLTIP_CONTENT_STYLE,
-  CHART_TICK_COLOR } from '../../lib/constants'
+  CHART_TICK_COLOR,
+  CHART_AXIS_FONT_SIZE,
+  CHART_BODY_FONT_SIZE,
+  CHART_TEXT_MUTED } from '../../lib/constants'
 import { MS_PER_HOUR, MS_PER_MINUTE, MINUTES_PER_HOUR } from '../../lib/constants/time'
 
 // ---------------------------------------------------------------------------
@@ -278,14 +281,14 @@ function GPUInventoryChart({ displayChartData, chartMode, chartGPUTypes, t }: {
       xAxis: {
         type: 'category' as const,
         data: timeData,
-        axisLabel: { color: CHART_TICK_COLOR, fontSize: 10 },
+        axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
         axisLine: { lineStyle: { color: CHART_AXIS_STROKE } },
         axisTick: { show: false },
       },
       yAxis: {
         type: 'value' as const,
         minInterval: 1,
-        axisLabel: { color: CHART_TICK_COLOR, fontSize: 10 },
+        axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
         axisLine: { show: false },
         axisTick: { show: false },
         splitLine: { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } },
@@ -294,7 +297,7 @@ function GPUInventoryChart({ displayChartData, chartMode, chartGPUTypes, t }: {
         trigger: 'axis' as const,
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: CHART_TICK_COLOR, fontSize: 12 },
+        textStyle: { color: CHART_TICK_COLOR, fontSize: CHART_BODY_FONT_SIZE },
         formatter: (params: Array<{ seriesName: string; value: number; color: string }>) => {
           let html = ''
           for (const p of (params || [])) {
@@ -309,7 +312,7 @@ function GPUInventoryChart({ displayChartData, chartMode, chartGPUTypes, t }: {
       legend: {
         data: legendNames,
         bottom: 0,
-        textStyle: { color: '#888', fontSize: 10 },
+        textStyle: { color: CHART_TEXT_MUTED, fontSize: CHART_AXIS_FONT_SIZE },
         icon: 'rect',
       },
       series,

--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -18,7 +18,10 @@ import {
   CHART_GRID_STROKE,
   CHART_AXIS_STROKE,
   CHART_TOOLTIP_CONTENT_STYLE,
-  CHART_TICK_COLOR } from '../../lib/constants'
+  CHART_TICK_COLOR,
+  CHART_AXIS_FONT_SIZE,
+  CHART_BODY_FONT_SIZE,
+  CHART_TEXT_MUTED } from '../../lib/constants'
 import { MS_PER_MINUTE } from '../../lib/constants/time'
 
 /**
@@ -326,14 +329,14 @@ export function GPUUsageTrend() {
     xAxis: {
       type: 'category' as const,
       data: history.map(d => d.time),
-      axisLabel: { color: CHART_TICK_COLOR, fontSize: 10 },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
       axisLine: { lineStyle: { color: CHART_AXIS_STROKE } },
       axisTick: { show: false },
     },
     yAxis: {
       type: 'value' as const,
       minInterval: 1,
-      axisLabel: { color: CHART_TICK_COLOR, fontSize: 10 },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
       axisLine: { show: false },
       axisTick: { show: false },
       splitLine: { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } },
@@ -342,7 +345,7 @@ export function GPUUsageTrend() {
       trigger: 'axis' as const,
       backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
       borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-      textStyle: { color: CHART_TICK_COLOR, fontSize: 12 },
+      textStyle: { color: CHART_TICK_COLOR, fontSize: CHART_BODY_FONT_SIZE },
       formatter: (params: Array<{ seriesName: string; value: number; color: string }>) => {
         let html = ''
         for (const p of (params || [])) {
@@ -355,7 +358,7 @@ export function GPUUsageTrend() {
     legend: {
       data: ['In Use', 'Free'],
       bottom: 0,
-      textStyle: { color: '#888', fontSize: 10 },
+      textStyle: { color: CHART_TEXT_MUTED, fontSize: CHART_AXIS_FONT_SIZE },
       icon: 'rect',
     },
     series: [

--- a/web/src/components/cards/GPUUtilization.tsx
+++ b/web/src/components/cards/GPUUtilization.tsx
@@ -18,7 +18,8 @@ import {
   CHART_TOOLTIP_CONTENT_STYLE,
   CHART_TICK_COLOR,
   CHART_MARK_LINE_LABEL,
-  CHART_MARK_LINE_STROKE } from '../../lib/constants'
+  CHART_MARK_LINE_STROKE,
+  CHART_AXIS_FONT_SIZE_SM } from '../../lib/constants'
 import { PURPLE_600, hexToRgba } from '../../lib/theme/chartColors'
 
 const GPU_RING_SIZE_PX = 80
@@ -189,7 +190,7 @@ export function GPUUtilization() {
     xAxis: {
       type: 'category' as const,
       data: history.map(d => d.time),
-      axisLabel: { color: CHART_TICK_COLOR, fontSize: 9 },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE_SM },
       axisLine: { lineStyle: { color: CHART_AXIS_STROKE } },
       axisTick: { show: false },
     },
@@ -198,7 +199,7 @@ export function GPUUtilization() {
       min: 0,
       max: currentStats.total || undefined,
       minInterval: 1,
-      axisLabel: { color: CHART_TICK_COLOR, fontSize: 9 },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE_SM },
       axisLine: { show: false },
       axisTick: { show: false },
       splitLine: { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } },

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -31,6 +31,11 @@ import {
   CHART_DATAZOOM_TEXT,
   CHART_DATAZOOM_DATA_LINE,
   CHART_DATAZOOM_DATA_AREA,
+  CHART_TICK_COLOR,
+  CHART_GRID_STROKE,
+  CHART_TEXT_MUTED,
+  CHART_AXIS_FONT_SIZE,
+  CHART_BODY_FONT_SIZE,
 } from '../../lib/constants'
 import { hexToRgba } from '../../lib/theme/chartColors'
 import { MS_PER_DAY, MS_PER_HOUR } from '../../lib/constants/time'
@@ -458,7 +463,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
           t('issueActivityChart.prsMerged', 'PRs Merged'),
         ],
         top: 8,
-        textStyle: { color: '#aaa', fontSize: 11 },
+        textStyle: { color: CHART_TEXT_MUTED, fontSize: 11 },
         itemWidth: 14,
         itemHeight: 10,
       },
@@ -467,7 +472,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
         axisPointer: { type: 'shadow-sm' as const },
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: 12 },
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: CHART_BODY_FONT_SIZE },
         formatter: (
           params: Array<{ seriesName: string; value: number; color: string; axisValueLabel: string }>
         ) => {
@@ -488,8 +493,8 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
         type: 'category' as const,
         data: dates,
         axisLabel: {
-          color: '#888',
-          fontSize: 10,
+          color: CHART_TICK_COLOR,
+          fontSize: CHART_AXIS_FONT_SIZE,
           rotate: 45,
           formatter: (val: string) => {
             // Show "Mon Mar 15" so users can see day-of-week seasonality
@@ -501,25 +506,25 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
           // Show ~15 labels max regardless of date range
           interval: Math.max(0, Math.floor(dates.length / 15) - 1),
         },
-        axisLine: { lineStyle: { color: '#333' } },
+        axisLine: { lineStyle: { color: CHART_GRID_STROKE } },
         axisTick: { show: false },
       },
       yAxis: [
         {
           type: 'value' as const,
           name: t('issueActivityChart.issues', 'Issues'),
-          nameTextStyle: { color: '#888', fontSize: 10 },
-          axisLabel: { color: '#888', fontSize: 10 },
+          nameTextStyle: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
+          axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
           axisLine: { show: false },
           axisTick: { show: false },
-          splitLine: { lineStyle: { color: '#333', type: 'dashed' as const } },
+          splitLine: { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } },
           minInterval: 1,
         },
         {
           type: 'value' as const,
           name: t('issueActivityChart.prs', 'PRs'),
-          nameTextStyle: { color: '#888', fontSize: 10 },
-          axisLabel: { color: '#888', fontSize: 10 },
+          nameTextStyle: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
+          axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
           axisLine: { show: false },
           axisTick: { show: false },
           splitLine: { show: false },

--- a/web/src/components/cards/PodHealthTrend.tsx
+++ b/web/src/components/cards/PodHealthTrend.tsx
@@ -14,7 +14,9 @@ import {
   CHART_GRID_STROKE,
   CHART_AXIS_STROKE,
   CHART_TOOLTIP_CONTENT_STYLE,
-  CHART_TICK_COLOR } from '../../lib/constants'
+  CHART_TICK_COLOR,
+  CHART_AXIS_FONT_SIZE,
+  CHART_BODY_FONT_SIZE } from '../../lib/constants'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { safeGet, safeSet } from '../../lib/safeLocalStorage'
 import { ORANGE_500, YELLOW_500, GREEN_500_BRIGHT, hexToRgba } from '../../lib/theme/chartColors'
@@ -260,14 +262,14 @@ export function PodHealthTrend() {
     xAxis: {
       type: 'category' as const,
       data: visibleHistory.map(d => d.time),
-      axisLabel: { color: CHART_TICK_COLOR, fontSize: 10 },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
       axisLine: { lineStyle: { color: CHART_AXIS_STROKE } },
       axisTick: { show: false },
     },
     yAxis: {
       type: 'value' as const,
       minInterval: 1,
-      axisLabel: { color: CHART_TICK_COLOR, fontSize: 10 },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
       axisLine: { show: false },
       axisTick: { show: false },
       splitLine: { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } },
@@ -276,7 +278,7 @@ export function PodHealthTrend() {
       trigger: 'axis' as const,
       backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
       borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-      textStyle: { color: CHART_TICK_COLOR, fontSize: 12 },
+      textStyle: { color: CHART_TICK_COLOR, fontSize: CHART_BODY_FONT_SIZE },
     },
     series: [
       {

--- a/web/src/components/cards/ResourceTrend.tsx
+++ b/web/src/components/cards/ResourceTrend.tsx
@@ -14,7 +14,10 @@ import {
   CHART_GRID_STROKE,
   CHART_AXIS_STROKE,
   CHART_TOOLTIP_CONTENT_STYLE,
-  CHART_TICK_COLOR } from '../../lib/constants'
+  CHART_TICK_COLOR,
+  CHART_AXIS_FONT_SIZE,
+  CHART_BODY_FONT_SIZE,
+  CHART_TEXT_MUTED } from '../../lib/constants'
 import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface ResourcePoint {
@@ -220,14 +223,14 @@ export function ResourceTrend() {
     xAxis: {
       type: 'category' as const,
       data: history.map(d => d.time),
-      axisLabel: { color: CHART_TICK_COLOR, fontSize: 10 },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
       axisLine: { lineStyle: { color: CHART_AXIS_STROKE } },
       axisTick: { show: false },
     },
     yAxis: {
       type: 'value' as const,
       minInterval: 1,
-      axisLabel: { color: CHART_TICK_COLOR, fontSize: 10 },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
       axisLine: { show: false },
       axisTick: { show: false },
       splitLine: { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } },
@@ -236,12 +239,12 @@ export function ResourceTrend() {
       trigger: 'axis' as const,
       backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
       borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-      textStyle: { color: CHART_TICK_COLOR, fontSize: 12 },
+      textStyle: { color: CHART_TICK_COLOR, fontSize: CHART_BODY_FONT_SIZE },
     },
     legend: {
       data: lines.map(l => l.name),
       bottom: 0,
-      textStyle: { color: '#888', fontSize: 10 },
+      textStyle: { color: CHART_TEXT_MUTED, fontSize: CHART_AXIS_FONT_SIZE },
       icon: 'roundRect',
     },
     series: lines.map((line, idx) => ({

--- a/web/src/components/cards/insights/ClusterDeltaDetector.tsx
+++ b/web/src/components/cards/insights/ClusterDeltaDetector.tsx
@@ -7,7 +7,7 @@ import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { CardControlsRow } from '../../../lib/cards/CardComponents'
 import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
-import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_SM } from '../../../lib/constants/ui'
+import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_SM, CHART_TOOLTIP_TEXT_COLOR, CHART_AXIS_FONT_SIZE_SM } from '../../../lib/constants/ui'
 import { InsightDetailModal } from './InsightDetailModal'
 import type { MultiClusterInsight } from '../../../types/insights'
 
@@ -76,13 +76,13 @@ export function ClusterDeltaDetector() {
       xAxis: {
         type: 'category' as const,
         data: [...new Set(numericDeltas.map(d => d.dimension))],
-        axisLabel: { fontSize: 9, color: CHART_TICK_COLOR },
+        axisLabel: { fontSize: CHART_AXIS_FONT_SIZE_SM, color: CHART_TICK_COLOR },
         axisTick: { show: false },
         axisLine: { show: false },
       },
       yAxis: {
         type: 'value' as const,
-        axisLabel: { fontSize: 9, color: CHART_TICK_COLOR },
+        axisLabel: { fontSize: CHART_AXIS_FONT_SIZE_SM, color: CHART_TICK_COLOR },
         axisTick: { show: false },
         axisLine: { show: false },
         splitLine: { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } },
@@ -91,7 +91,7 @@ export function ClusterDeltaDetector() {
         trigger: 'axis' as const,
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: '#e0e0e0', fontSize: Number(CHART_TOOLTIP_FONT_SIZE_COMPACT.replace('px', '')) },
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: Number(CHART_TOOLTIP_FONT_SIZE_COMPACT.replace('px', '')) },
       },
       series: allClusters.map((clusterName, idx) => ({
         name: clusterName,

--- a/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
+++ b/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
@@ -9,7 +9,7 @@ import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { CardControlsRow } from '../../../lib/cards/CardComponents'
 import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
-import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_STANDARD } from '../../../lib/constants/ui'
+import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_STANDARD, CHART_TOOLTIP_TEXT_COLOR, CHART_AXIS_FONT_SIZE_SM } from '../../../lib/constants/ui'
 import { CROSS_CLUSTER_EVENT_PALETTE } from '../../../lib/theme/chartColors'
 import { InsightDetailModal } from './InsightDetailModal'
 import type { MultiClusterInsight } from '../../../types/insights'
@@ -86,14 +86,14 @@ export function CrossClusterEventCorrelation() {
       xAxis: {
         type: 'category' as const,
         data: chartData.map(d => d.time),
-        axisLabel: { fontSize: 9, color: CHART_TICK_COLOR },
+        axisLabel: { fontSize: CHART_AXIS_FONT_SIZE_SM, color: CHART_TICK_COLOR },
         axisTick: { show: false },
         axisLine: { show: false },
       },
       yAxis: {
         type: 'value' as const,
         minInterval: 1,
-        axisLabel: { fontSize: 9, color: CHART_TICK_COLOR },
+        axisLabel: { fontSize: CHART_AXIS_FONT_SIZE_SM, color: CHART_TICK_COLOR },
         axisLine: { show: false },
         axisTick: { show: false },
         splitLine: { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } },
@@ -102,7 +102,7 @@ export function CrossClusterEventCorrelation() {
         trigger: 'axis' as const,
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: '#e0e0e0', fontSize: Number(CHART_TOOLTIP_FONT_SIZE_COMPACT.replace('px', '')) },
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: Number(CHART_TOOLTIP_FONT_SIZE_COMPACT.replace('px', '')) },
       },
       series: (clusterNames || []).map((cluster, i) => ({
         name: cluster,

--- a/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
+++ b/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
@@ -8,7 +8,7 @@ import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { CardControlsRow } from '../../../lib/cards/CardComponents'
 import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
-import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_SM } from '../../../lib/constants/ui'
+import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_SM, CHART_TOOLTIP_TEXT_COLOR, CHART_AXIS_FONT_SIZE_SM } from '../../../lib/constants/ui'
 
 const GRID_LEFT_PX = 85
 const GRID_RIGHT_PX = 10
@@ -94,7 +94,7 @@ export function DeploymentRolloutTracker() {
         type: 'value' as const,
         min: 0,
         max: FULL_PROGRESS_PCT,
-        axisLabel: { fontSize: 9, color: CHART_TICK_COLOR, formatter: (v: number) => `${v}%` },
+        axisLabel: { fontSize: CHART_AXIS_FONT_SIZE_SM, color: CHART_TICK_COLOR, formatter: (v: number) => `${v}%` },
         axisTick: { show: false },
         axisLine: { show: false },
         splitLine: { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } },
@@ -102,14 +102,14 @@ export function DeploymentRolloutTracker() {
       yAxis: {
         type: 'category' as const,
         data: clusterProgress.map(c => c.cluster),
-        axisLabel: { fontSize: 9, color: CHART_TICK_COLOR },
+        axisLabel: { fontSize: CHART_AXIS_FONT_SIZE_SM, color: CHART_TICK_COLOR },
         axisTick: { show: false },
         axisLine: { show: false },
       },
       tooltip: {
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: '#e0e0e0', fontSize: Number(CHART_TOOLTIP_FONT_SIZE_COMPACT.replace('px', '')) },
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: Number(CHART_TOOLTIP_FONT_SIZE_COMPACT.replace('px', '')) },
         formatter: (params: { name: string; value: number }) => `${params.name}: ${params.value}%`,
       },
       series: [{

--- a/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
+++ b/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
@@ -8,7 +8,7 @@ import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { CardControlsRow } from '../../../lib/cards/CardComponents'
 import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
-import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_LG } from '../../../lib/constants/ui'
+import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_LG, CHART_TOOLTIP_TEXT_COLOR, CHART_AXIS_FONT_SIZE } from '../../../lib/constants/ui'
 
 const GRID_LEFT_PX = 105
 const GRID_RIGHT_PX = 20
@@ -69,7 +69,7 @@ export function ResourceImbalanceDetector() {
         type: 'value' as const,
         min: 0,
         max: 100,
-        axisLabel: { fontSize: 10, color: CHART_TICK_COLOR, formatter: (v: number) => `${v}%` },
+        axisLabel: { fontSize: CHART_AXIS_FONT_SIZE, color: CHART_TICK_COLOR, formatter: (v: number) => `${v}%` },
         axisTick: { show: false },
         axisLine: { show: false },
         splitLine: { show: false },
@@ -77,7 +77,7 @@ export function ResourceImbalanceDetector() {
       yAxis: {
         type: 'category' as const,
         data: chartData.map(d => d.name),
-        axisLabel: { fontSize: 10, color: CHART_TICK_COLOR },
+        axisLabel: { fontSize: CHART_AXIS_FONT_SIZE, color: CHART_TICK_COLOR },
         axisTick: { show: false },
         axisLine: { show: false },
         splitLine: { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } },
@@ -85,7 +85,7 @@ export function ResourceImbalanceDetector() {
       tooltip: {
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: '#e0e0e0', fontSize: Number(CHART_TOOLTIP_FONT_SIZE_COMPACT.replace('px', '')) },
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: Number(CHART_TOOLTIP_FONT_SIZE_COMPACT.replace('px', '')) },
         formatter: (params: { name: string; value: number }) => `${params.name}: ${params.value}%`,
       },
       series: [{
@@ -99,7 +99,7 @@ export function ResourceImbalanceDetector() {
           symbol: 'none',
           data: [{
             xAxis: avgValue,
-            label: { formatter: `Avg ${avgValue}%`, position: 'start', color: '#f59e0b', fontSize: 10 },
+            label: { formatter: `Avg ${avgValue}%`, position: 'start', color: '#f59e0b', fontSize: CHART_AXIS_FONT_SIZE },
             lineStyle: { color: '#f59e0b', type: 'dashed' },
           }],
         },

--- a/web/src/components/cards/llmd/LatencyBreakdown.tsx
+++ b/web/src/components/cards/llmd/LatencyBreakdown.tsx
@@ -22,7 +22,7 @@ import {
   TOOLTIP_SWATCH_SIZE_PX } from '../../../lib/llmd/tooltipSpacing'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
-import { CHART_MIN_HEIGHT_PX } from '../../../lib/constants/ui'
+import { CHART_MIN_HEIGHT_PX, CHART_TEXT_WHITE, CHART_AXIS_FONT_SIZE, CHART_AXIS_FONT_SIZE_SM, CHART_BODY_FONT_SIZE } from '../../../lib/constants/ui'
 
 const GRID_LEFT_PX = 55
 const GRID_RIGHT_PX = 20
@@ -148,8 +148,8 @@ function LatencyBreakdownInternal() {
         name: 'QPS (queries/sec)',
         nameLocation: 'middle' as const,
         nameGap: 30,
-        nameTextStyle: { color: '#71717a', fontSize: 10 },
-        axisLabel: { color: '#71717a', fontSize: 10 },
+        nameTextStyle: { color: '#71717a', fontSize: CHART_AXIS_FONT_SIZE },
+        axisLabel: { color: '#71717a', fontSize: CHART_AXIS_FONT_SIZE },
         axisLine: { lineStyle: { color: '#71717a' } },
         axisTick: { show: false },
       },
@@ -158,8 +158,8 @@ function LatencyBreakdownInternal() {
         name: tabInfo.unit,
         nameLocation: 'middle' as const,
         nameGap: 40,
-        nameTextStyle: { color: '#71717a', fontSize: 10 },
-        axisLabel: { color: '#71717a', fontSize: 10 },
+        nameTextStyle: { color: '#71717a', fontSize: CHART_AXIS_FONT_SIZE },
+        axisLabel: { color: '#71717a', fontSize: CHART_AXIS_FONT_SIZE },
         axisLine: { lineStyle: { color: '#71717a' } },
         axisTick: { show: false },
         splitLine: { lineStyle: { color: '#334155', opacity: 0.5, type: 'dashed' as const } },
@@ -168,7 +168,7 @@ function LatencyBreakdownInternal() {
         trigger: 'axis' as const,
         backgroundColor: 'rgba(15,23,42,0.95)',
         borderColor: 'rgba(100,116,139,0.3)',
-        textStyle: { color: '#fff', fontSize: 12 },
+        textStyle: { color: CHART_TEXT_WHITE, fontSize: CHART_BODY_FONT_SIZE },
         formatter: (params: Array<{ seriesName: string; value: number | null; color: string }>) => {
           const qps = chartData[(params[0] as unknown as { dataIndex: number }).dataIndex]?.qps ?? ''
           const items = (params || [])
@@ -190,7 +190,7 @@ function LatencyBreakdownInternal() {
             symbol: 'none',
             data: [{
               yAxis: tabInfo.sla,
-              label: { formatter: `SLA: ${tabInfo.sla}ms`, position: 'end' as const, color: '#ef4444', fontSize: 9 },
+              label: { formatter: `SLA: ${tabInfo.sla}ms`, position: 'end' as const, color: '#ef4444', fontSize: CHART_AXIS_FONT_SIZE_SM },
               lineStyle: { color: '#ef4444', type: 'dashed' as const, opacity: 0.6 },
             }],
           },

--- a/web/src/components/cards/llmd/ParetoFrontier.tsx
+++ b/web/src/components/cards/llmd/ParetoFrontier.tsx
@@ -23,7 +23,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
 import { downloadDataUrl } from '../../../lib/download'
-import { CHART_MIN_HEIGHT_PX } from '../../../lib/constants/ui'
+import { CHART_MIN_HEIGHT_PX, CHART_AXIS_FONT_SIZE, CHART_AXIS_FONT_SIZE_SM } from '../../../lib/constants/ui'
 
 // ── Tooltip spacing constants (ECharts renders its own DOM, so Tailwind/CSS vars are unavailable) ──
 /** Spacing between tooltip header and grid body */
@@ -398,7 +398,7 @@ function ParetoFrontierInternal({ config }: ParetoFrontierProps) {
               const pt = p.data?.point
               return pt && pt.gpuCount > 1 ? `${pt.gpuCount}` : ''
             },
-            fontSize: 9,
+            fontSize: CHART_AXIS_FONT_SIZE_SM,
             color: '#94a3b8',
             position: 'top',
             distance: 4 },
@@ -465,7 +465,7 @@ function ParetoFrontierInternal({ config }: ParetoFrontierProps) {
         nameTextStyle: { color: '#94a3b8', fontSize: 11, fontWeight: 500 },
         axisLine: { lineStyle: { color: '#334155' } },
         splitLine: { lineStyle: { color: '#1e293b', type: 'dashed' } },
-        axisLabel: { color: '#64748b', fontSize: 10 } },
+        axisLabel: { color: '#64748b', fontSize: CHART_AXIS_FONT_SIZE } },
       yAxis: {
         type: 'value',
         name: `${preset.yAxis.label} (${preset.yAxis.unit})`,
@@ -476,7 +476,7 @@ function ParetoFrontierInternal({ config }: ParetoFrontierProps) {
         splitLine: { lineStyle: { color: '#1e293b', type: 'dashed' } },
         axisLabel: {
           color: '#64748b',
-          fontSize: 10,
+          fontSize: CHART_AXIS_FONT_SIZE,
           formatter: preset.yAxis.formatter ?? ((v: number) => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v)) } },
       dataZoom: [
         { type: 'inside', xAxisIndex: 0, filterMode: 'weakFilter' },

--- a/web/src/components/cards/llmd/ResourceUtilization.tsx
+++ b/web/src/components/cards/llmd/ResourceUtilization.tsx
@@ -21,7 +21,7 @@ import {
   TOOLTIP_TIGHT_GAP_PX } from '../../../lib/llmd/tooltipSpacing'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
-import { CHART_MIN_HEIGHT_PX } from '../../../lib/constants/ui'
+import { CHART_MIN_HEIGHT_PX, CHART_TEXT_WHITE, CHART_AXIS_FONT_SIZE, CHART_BODY_FONT_SIZE } from '../../../lib/constants/ui'
 
 const GRID_LEFT_PX = 145
 const GRID_RIGHT_PX = 20
@@ -115,7 +115,7 @@ export function ResourceUtilization() {
         type: 'value' as const,
         axisLabel: {
           color: '#71717a',
-          fontSize: 10,
+          fontSize: CHART_AXIS_FONT_SIZE,
           formatter: (v: number) => v >= 1000 ? `${(v / 1000).toFixed(1)}k` : String(Math.round(v)),
         },
         axisLine: { lineStyle: { color: '#71717a' } },
@@ -130,7 +130,7 @@ export function ResourceUtilization() {
             const entry = data.find(d => d.name === value)
             return entry?.isBest ? '#fbbf24' : '#a1a1aa'
           },
-          fontSize: 10,
+          fontSize: CHART_AXIS_FONT_SIZE,
           fontWeight: ((value: string) => {
             const entry = data.find(d => d.name === value)
             return entry?.isBest ? 600 : 400
@@ -146,7 +146,7 @@ export function ResourceUtilization() {
       tooltip: {
         backgroundColor: 'rgba(15,23,42,0.95)',
         borderColor: 'rgba(100,116,139,0.3)',
-        textStyle: { color: '#fff', fontSize: 12 },
+        textStyle: { color: CHART_TEXT_WHITE, fontSize: CHART_BODY_FONT_SIZE },
         formatter: (params: { data: { entry: BarEntry } }) => {
           const e = params.data?.entry
           if (!e) return ''

--- a/web/src/components/cards/llmd/ThroughputComparison.tsx
+++ b/web/src/components/cards/llmd/ThroughputComparison.tsx
@@ -23,7 +23,7 @@ import {
   TOOLTIP_SWATCH_SIZE_PX } from '../../../lib/llmd/tooltipSpacing'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
-import { CHART_MIN_HEIGHT_PX } from '../../../lib/constants/ui'
+import { CHART_MIN_HEIGHT_PX, CHART_TEXT_WHITE, CHART_AXIS_FONT_SIZE, CHART_BODY_FONT_SIZE } from '../../../lib/constants/ui'
 
 const GRID_LEFT_PX = 55
 const GRID_RIGHT_PX = 20
@@ -124,8 +124,8 @@ export function ThroughputComparison() {
         name: 'QPS (queries/sec)',
         nameLocation: 'middle' as const,
         nameGap: 30,
-        nameTextStyle: { color: '#71717a', fontSize: 10 },
-        axisLabel: { color: '#71717a', fontSize: 10 },
+        nameTextStyle: { color: '#71717a', fontSize: CHART_AXIS_FONT_SIZE },
+        axisLabel: { color: '#71717a', fontSize: CHART_AXIS_FONT_SIZE },
         axisLine: { lineStyle: { color: '#71717a' } },
         axisTick: { show: false },
       },
@@ -134,10 +134,10 @@ export function ThroughputComparison() {
         name: 'tok/s',
         nameLocation: 'middle' as const,
         nameGap: 40,
-        nameTextStyle: { color: '#71717a', fontSize: 10 },
+        nameTextStyle: { color: '#71717a', fontSize: CHART_AXIS_FONT_SIZE },
         axisLabel: {
           color: '#71717a',
-          fontSize: 10,
+          fontSize: CHART_AXIS_FONT_SIZE,
           formatter: (v: number) => v >= 1000 ? `${(v / 1000).toFixed(1)}k` : String(v),
         },
         axisLine: { lineStyle: { color: '#71717a' } },
@@ -148,7 +148,7 @@ export function ThroughputComparison() {
         trigger: 'axis' as const,
         backgroundColor: 'rgba(15,23,42,0.95)',
         borderColor: 'rgba(100,116,139,0.3)',
-        textStyle: { color: '#fff', fontSize: 12 },
+        textStyle: { color: CHART_TEXT_WHITE, fontSize: CHART_BODY_FONT_SIZE },
         formatter: (params: Array<{ seriesName: string; value: number | null; color: string; dataIndex: number }>) => {
           const qps = chartData[params[0]?.dataIndex]?.qps ?? ''
           const items = (params || [])

--- a/web/src/components/charts/BarChart.tsx
+++ b/web/src/components/charts/BarChart.tsx
@@ -1,6 +1,15 @@
 import { useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
-import { CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_TEXT_COLOR, CHART_TOOLTIP_LABEL_COLOR } from '../../lib/constants'
+import {
+  CHART_TOOLTIP_CONTENT_STYLE,
+  CHART_TOOLTIP_TEXT_COLOR,
+  CHART_TOOLTIP_LABEL_COLOR,
+  CHART_TICK_COLOR,
+  CHART_AXIS_STROKE,
+  CHART_GRID_STROKE,
+  CHART_AXIS_FONT_SIZE,
+  CHART_BODY_FONT_SIZE,
+} from '../../lib/constants'
 
 interface DataItem {
   name: string
@@ -35,17 +44,17 @@ export function BarChart({
     const categoryAxis = {
       type: 'category' as const,
       data: categoryData,
-      axisLabel: { color: '#888', fontSize: 10 },
-      axisLine: horizontal ? { show: false } : { lineStyle: { color: '#333' } },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
+      axisLine: horizontal ? { show: false } : { lineStyle: { color: CHART_AXIS_STROKE } },
       axisTick: { show: false },
     }
 
     const valueAxis = {
       type: 'value' as const,
-      axisLabel: { color: '#888', fontSize: 10 },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
       axisLine: { show: false },
       axisTick: { show: false },
-      splitLine: showGrid ? { lineStyle: { color: '#333', type: 'dashed' as const } } : { show: false },
+      splitLine: showGrid ? { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } } : { show: false },
     }
 
     return {
@@ -58,7 +67,7 @@ export function BarChart({
         axisPointer: { type: 'shadow-sm' as const },
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: 12 },
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: CHART_BODY_FONT_SIZE },
         formatter: (params: Array<{ name: string; value: number; color: string }>) => {
           const p = Array.isArray(params) ? params[0] : params
           return `<span style="color:${CHART_TOOLTIP_LABEL_COLOR};font-weight:500">${p.name}</span><br/><span style="color:${CHART_TOOLTIP_TEXT_COLOR}">${p.value}${unit}</span>`
@@ -114,23 +123,23 @@ export function StackedBarChart({
     xAxis: {
       type: 'category' as const,
       data: data.map(d => d[xAxisKey]),
-      axisLabel: { color: '#888', fontSize: 10 },
-      axisLine: { lineStyle: { color: '#333' } },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
+      axisLine: { lineStyle: { color: CHART_AXIS_STROKE } },
       axisTick: { show: false },
     },
     yAxis: {
       type: 'value' as const,
-      axisLabel: { color: '#888', fontSize: 10 },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
       axisLine: { show: false },
       axisTick: { show: false },
-      splitLine: { lineStyle: { color: '#333', type: 'dashed' as const } },
+      splitLine: { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } },
     },
     tooltip: {
       trigger: 'axis' as const,
       axisPointer: { type: 'shadow-sm' as const },
       backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
       borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-      textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: 12 },
+      textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: CHART_BODY_FONT_SIZE },
     },
     series: categories.map(cat => ({
       name: cat.name || cat.dataKey,

--- a/web/src/components/charts/PieChart.tsx
+++ b/web/src/components/charts/PieChart.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
-import { CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_TEXT_COLOR, CHART_TOOLTIP_LABEL_COLOR } from '../../lib/constants'
+import { CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_TEXT_COLOR, CHART_TOOLTIP_LABEL_COLOR, CHART_BODY_FONT_SIZE } from '../../lib/constants'
 
 interface DataItem {
   name: string
@@ -41,7 +41,7 @@ export function PieChart({
         trigger: 'item' as const,
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: 12 },
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: CHART_BODY_FONT_SIZE },
         formatter: (params: { name: string; value: number; percent: number }) =>
           `<span style="color:${CHART_TOOLTIP_LABEL_COLOR};font-weight:500">${params.name}</span><br/><span style="color:${CHART_TOOLTIP_TEXT_COLOR}">${params.value} (${params.percent}%)</span>`,
       },

--- a/web/src/components/charts/RadarChart.tsx
+++ b/web/src/components/charts/RadarChart.tsx
@@ -1,6 +1,13 @@
 import { useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
-import { CHART_TOOLTIP_CONTENT_STYLE } from '../../lib/constants'
+import {
+  CHART_TOOLTIP_CONTENT_STYLE,
+  CHART_TOOLTIP_TEXT_COLOR,
+  CHART_TICK_COLOR,
+  CHART_GRID_STROKE,
+  CHART_AXIS_FONT_SIZE,
+  CHART_BODY_FONT_SIZE,
+} from '../../lib/constants'
 
 interface DataPoint {
   name: string
@@ -41,7 +48,7 @@ export function RadarChart({
       tooltip: {
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: '#e0e0e0', fontSize: 12 },
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: CHART_BODY_FONT_SIZE },
       },
       radar: {
         indicator: data.map(d => ({
@@ -51,17 +58,17 @@ export function RadarChart({
         shape: 'polygon' as const,
         splitNumber: 4,
         axisName: {
-          color: '#888',
-          fontSize: 10,
+          color: CHART_TICK_COLOR,
+          fontSize: CHART_AXIS_FONT_SIZE,
         },
         splitLine: {
           show: showGrid,
-          lineStyle: { color: '#333' },
+          lineStyle: { color: CHART_GRID_STROKE },
         },
         splitArea: { show: false },
         axisLine: {
           show: showGrid,
-          lineStyle: { color: '#333' },
+          lineStyle: { color: CHART_GRID_STROKE },
         },
       },
       series: [{
@@ -133,12 +140,12 @@ export function MultiRadarChart({
       tooltip: {
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: '#e0e0e0', fontSize: 12 },
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: CHART_BODY_FONT_SIZE },
       },
       legend: showLegend ? {
         data: series.map(s => s.name || s.dataKey),
         bottom: 0,
-        textStyle: { color: '#888', fontSize: 12 },
+        textStyle: { color: CHART_TICK_COLOR, fontSize: CHART_BODY_FONT_SIZE },
       } : undefined,
       radar: {
         indicator: data.map((d, i) => ({
@@ -146,15 +153,15 @@ export function MultiRadarChart({
           max: d.fullMark || maxVals[i] || 100,
         })),
         shape: 'polygon' as const,
-        axisName: { color: '#888', fontSize: 10 },
+        axisName: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
         splitLine: {
           show: showGrid,
-          lineStyle: { color: '#333' },
+          lineStyle: { color: CHART_GRID_STROKE },
         },
         splitArea: { show: false },
         axisLine: {
           show: showGrid,
-          lineStyle: { color: '#333' },
+          lineStyle: { color: CHART_GRID_STROKE },
         },
       },
       series: [{

--- a/web/src/components/charts/TimeSeriesChart.tsx
+++ b/web/src/components/charts/TimeSeriesChart.tsx
@@ -1,6 +1,14 @@
 import { useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
-import { CHART_TOOLTIP_CONTENT_STYLE, CHART_TICK_COLOR, CHART_TOOLTIP_TEXT_COLOR } from '../../lib/constants'
+import {
+  CHART_TOOLTIP_CONTENT_STYLE,
+  CHART_TICK_COLOR,
+  CHART_TOOLTIP_TEXT_COLOR,
+  CHART_AXIS_FONT_SIZE,
+  CHART_AXIS_STROKE,
+  CHART_GRID_STROKE,
+  CHART_BODY_FONT_SIZE,
+} from '../../lib/constants'
 
 // MultiSeriesChart layout constants — keep the legend readable and consistent
 // with other multi-series charts (e.g. ResourceTrend, GPUUsageTrend). The
@@ -48,23 +56,23 @@ export function TimeSeriesChart({
       type: 'category' as const,
       data: data.map(d => d.time),
       show: showAxis,
-      axisLabel: { color: '#888', fontSize: 10 },
-      axisLine: { lineStyle: { color: '#333' } },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE },
+      axisLine: { lineStyle: { color: CHART_AXIS_STROKE } },
       axisTick: { show: false },
     },
     yAxis: {
       type: 'value' as const,
       show: showAxis,
-      axisLabel: { color: '#888', fontSize: 10, formatter: (v: number) => `${v}${unit}` },
+      axisLabel: { color: CHART_TICK_COLOR, fontSize: CHART_AXIS_FONT_SIZE, formatter: (v: number) => `${v}${unit}` },
       axisLine: { show: false },
       axisTick: { show: false },
-      splitLine: showGrid ? { lineStyle: { color: '#333', type: 'dashed' as const } } : { show: false },
+      splitLine: showGrid ? { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } } : { show: false },
     },
     tooltip: {
       trigger: 'axis' as const,
       backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
       borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-      textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: 12 },
+      textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: CHART_BODY_FONT_SIZE },
       formatter: (params: Array<{ name: string; value: number }>) => {
         const p = Array.isArray(params) ? params[0] : params
         return `<span style="color:${CHART_TICK_COLOR}">${p.name}</span><br/>${p.value}${unit}`
@@ -141,7 +149,7 @@ export function MultiSeriesChart({
         type: 'category' as const,
         data: data.map(d => d.time),
         axisLabel: { color: CHART_TICK_COLOR, fontSize: MULTI_SERIES_LEGEND_FONT_SIZE },
-        axisLine: { lineStyle: { color: '#333' } },
+        axisLine: { lineStyle: { color: CHART_AXIS_STROKE } },
         axisTick: { show: false },
       },
       yAxis: {
@@ -149,13 +157,13 @@ export function MultiSeriesChart({
         axisLabel: { color: CHART_TICK_COLOR, fontSize: MULTI_SERIES_LEGEND_FONT_SIZE },
         axisLine: { show: false },
         axisTick: { show: false },
-        splitLine: showGrid ? { lineStyle: { color: '#333', type: 'dashed' as const } } : { show: false },
+        splitLine: showGrid ? { lineStyle: { color: CHART_GRID_STROKE, type: 'dashed' as const } } : { show: false },
       },
       tooltip: {
         trigger: 'axis' as const,
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: 12 },
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: CHART_BODY_FONT_SIZE },
       },
       // Legend identifies each line/series so multi-cluster comparisons
       // are readable (issue #8973). Matches the pattern used in

--- a/web/src/components/charts/TreeMap.tsx
+++ b/web/src/components/charts/TreeMap.tsx
@@ -1,6 +1,12 @@
 import { useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
-import { CHART_TOOLTIP_CONTENT_STYLE } from '../../lib/constants'
+import {
+  CHART_AXIS_FONT_SIZE,
+  CHART_BODY_FONT_SIZE,
+  CHART_TEXT_WHITE,
+  CHART_TOOLTIP_CONTENT_STYLE,
+  CHART_TOOLTIP_TEXT_COLOR,
+} from '../../lib/constants'
 
 interface TreeMapItem {
   name: string
@@ -52,7 +58,7 @@ export function TreeMap({
       tooltip: {
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: '#e0e0e0', fontSize: 12 },
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: CHART_BODY_FONT_SIZE },
         formatter: (params: { name: string; value: number }) =>
           `${params.name}: ${formatValue(params.value)}`,
       },
@@ -71,8 +77,8 @@ export function TreeMap({
             return `{name|${name}}\n{value|${formatValue(params.value)}}`
           },
           rich: {
-            name: { color: '#fff', fontSize: 12, fontWeight: 500, lineHeight: 18 },
-            value: { color: '#fff', fontSize: 10, opacity: 0.7, lineHeight: 14 },
+            name: { color: CHART_TEXT_WHITE, fontSize: CHART_BODY_FONT_SIZE, fontWeight: 500, lineHeight: 18 },
+            value: { color: CHART_TEXT_WHITE, fontSize: CHART_AXIS_FONT_SIZE, opacity: 0.7, lineHeight: 14 },
           },
           minMargin: 4,
         },
@@ -134,7 +140,7 @@ export function NestedTreeMap({
       tooltip: {
         backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-        textStyle: { color: '#e0e0e0', fontSize: 12 },
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: CHART_BODY_FONT_SIZE },
         formatter: (params: { name: string; value: number }) =>
           `${params.name}: ${formatValue(params.value)}`,
       },
@@ -153,8 +159,8 @@ export function NestedTreeMap({
             return `{name|${name}}\n{value|${formatValue(params.value)}}`
           },
           rich: {
-            name: { color: '#fff', fontSize: 12, fontWeight: 500, lineHeight: 18 },
-            value: { color: '#fff', fontSize: 10, opacity: 0.7, lineHeight: 14 },
+            name: { color: CHART_TEXT_WHITE, fontSize: CHART_BODY_FONT_SIZE, fontWeight: 500, lineHeight: 18 },
+            value: { color: CHART_TEXT_WHITE, fontSize: CHART_AXIS_FONT_SIZE, opacity: 0.7, lineHeight: 14 },
           },
         },
         itemStyle: { borderColor: '#1a1a2e', borderWidth: 2, gapWidth: 2 },

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -69,6 +69,20 @@ export const CHART_MARK_LINE_STROKE = '#666'
 export const CHART_TOOLTIP_TEXT_COLOR = '#e0e0e0'
 /** Tooltip label text — verified 11:1 contrast on CHART_TOOLTIP_BG (#1a1a2e) */
 export const CHART_TOOLTIP_LABEL_COLOR = '#ccc'
+/** White text for high-contrast labels on dark chart elements (treemap tiles, legends) */
+export const CHART_TEXT_WHITE = '#fff'
+/** Muted secondary text for chart labels and axis names */
+export const CHART_TEXT_MUTED = '#aaa'
+
+// ── ECharts numeric font sizes (number, not string — ECharts API) ──────
+/** Axis tick label font size (ECharts numeric) */
+export const CHART_AXIS_FONT_SIZE = 10
+/** Small axis label font size for dense charts (ECharts numeric) */
+export const CHART_AXIS_FONT_SIZE_SM = 9
+/** Standard tooltip / legend font size (ECharts numeric) */
+export const CHART_BODY_FONT_SIZE = 12
+/** Small chart body font size for compact labels (ECharts numeric) */
+export const CHART_BODY_FONT_SIZE_SM = 10
 
 // ── Kubectl proxy thresholds ────────────────────────────────────────────
 export const MAX_CONCURRENT_KUBECTL_REQUESTS = 4

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -88,7 +88,8 @@ const COMPONENTS_DIR = path.resolve(
 //   273 → 274: PR #9841 — DashboardHeader compliance pages added one new hex fallback
 //   274 → 275: PR #9941 — Flatcar card added one hex color
 //   275 → 282: PR #10047 — ChangeTimeline card ECharts event type palette (7 hex colors)
-const EXPECTED_RAW_HEX_COUNT = 282
+//   282 → 262: PR #10260 — replaced 20 raw hex colors in chart files with shared constants
+const EXPECTED_RAW_HEX_COUNT = 262
 const EXPECTED_RAW_RGBA_COUNT = 104
 //   22 → 19: PR #8547 — replaced 3 arbitrary Tailwind hex colors in Login.tsx
 //            (bg-[#0a0a0a], from-[#0a0f1c]) with semantic bg-background/from-background
@@ -100,7 +101,9 @@ const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 19
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 229
 // 80 → 96: PR #8635 — widget export modal card preview thumbnails use inline
 //           fontSize for pixel-accurate static SVG-like renderings (not DOM text).
-const EXPECTED_RAW_FONT_SIZE_COUNT = 96
+//  96 → 3: PR #10260 — replaced 93 raw fontSize values in chart/card files with
+//          shared constants (CHART_AXIS_FONT_SIZE, CHART_BODY_FONT_SIZE, etc.)
+const EXPECTED_RAW_FONT_SIZE_COUNT = 3
 
 /** Max snippet length for readable output */
 const MAX_SNIPPET_LENGTH = 120


### PR DESCRIPTION
## Summary

- Adds 6 new chart constants to `lib/constants/ui.ts`: `CHART_TEXT_WHITE`, `CHART_TEXT_MUTED`, `CHART_AXIS_FONT_SIZE`, `CHART_AXIS_FONT_SIZE_SM`, `CHART_BODY_FONT_SIZE`, `CHART_BODY_FONT_SIZE_SM`
- Replaces 20 raw hex color literals across 4 chart component files and 8 card component files with existing/new shared constants
- Replaces 93 raw `fontSize: <number>` values across chart and card ECharts configs with named constants
- Lowers `ui-ux-standards.test.ts` ratchet baselines: raw-hex 282→262, raw-font-size 96→3

## Files changed (22)

**Chart components**: BarChart, RadarChart, TreeMap, TimeSeriesChart, PieChart
**Card components**: IssueActivityChart, ResourceTrend, GPUUsageTrend, GPUInventoryHistory, GPUUtilization, EventsTimeline, PodHealthTrend, LatencyBreakdown, ParetoFrontier, ThroughputComparison, ResourceUtilization, ResourceImbalanceDetector, ClusterDeltaDetector, CrossClusterEventCorrelation, DeploymentRolloutTracker
**Constants**: `lib/constants/ui.ts`
**Test**: `ui-ux-standards.test.ts`

## Test plan

- [x] `npx vitest run src/test/ui-ux-standards.test.ts` — 7/7 pass
- [x] `npx vitest run src/test/no-magic-numbers.test.ts` — passes
- [x] `npx vitest run src/test/card-loading-standard.test.ts` — 705/705 pass
- [ ] CI build + lint

Fixes #10260