### PR TITLE
🐛 Suppress local kc-agent connections in in-cluster deployments

### DIFF
--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -267,6 +267,13 @@ spec:
             - name: CLUSTER_NAME
               value: {{ .Values.clusterName | quote }}
             {{- end }}
+            # Suppress local kc-agent connections — in-cluster deployments
+            # accessed via port-forward or ingress have no local kc-agent
+            # on the user's machine. Without this, the frontend sends
+            # WebSocket/HTTP requests to 127.0.0.1:8585 that always fail,
+            # causing console errors and 429 cascades. (#10267)
+            - name: NO_LOCAL_AGENT
+              value: "true"
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -160,6 +160,12 @@ type Config struct {
 	// KubaraCatalogPath is the directory path inside the repo containing
 	// Helm chart subdirectories. Defaults to the standard Kubara path.
 	KubaraCatalogPath string
+	// NoLocalAgent suppresses the frontend's local kc-agent connections
+	// (ws://127.0.0.1:8585). Set to true for in-cluster deployments
+	// (Helm/Kubernetes) where no local kc-agent exists on the user's machine.
+	// Exposed via /health as "no_local_agent" so the pre-built frontend image
+	// can detect this at runtime without requiring a VITE_NO_LOCAL_AGENT rebuild.
+	NoLocalAgent bool
 	// Watchdog support: when set, the backend listens on this port instead of Port
 	BackendPort int
 }
@@ -597,11 +603,16 @@ func (s *Server) setupRoutes() {
 			// If no cached health data yet, keep "ok" — health poller hasn't run yet
 		}
 
+		// Suppress local kc-agent connections when explicitly configured
+		// (NO_LOCAL_AGENT=true) or auto-detected as running in-cluster.
+		noLocalAgent := s.config.NoLocalAgent || inCluster
+
 		resp := fiber.Map{
 			"status":           healthStatus,
 			"version":          Version,
 			"oauth_configured": s.oauthConfigured(),
 			"in_cluster":       inCluster,
+			"no_local_agent":   noLocalAgent,
 			"install_method":   detectInstallMethod(inCluster),
 			"project":          s.config.ConsoleProject,
 			"branding": fiber.Map{
@@ -1783,6 +1794,8 @@ func LoadConfigFromEnv() Config {
 		BrandIssuesURL:    getEnvOrDefault("ISSUES_URL", "https://github.com/kubestellar/kubestellar/issues/new"),
 		BrandRepoURL:      getEnvOrDefault("REPO_URL", "https://github.com/kubestellar/console"),
 		BrandHostedDomain: getEnvOrDefault("HOSTED_DOMAIN", "console.kubestellar.io"),
+		// Suppress local kc-agent connections in in-cluster deployments
+		NoLocalAgent: os.Getenv("NO_LOCAL_AGENT") == "true",
 		// Watchdog backend port override
 		BackendPort: backendPort,
 	}

--- a/web/src/hooks/useBranding.tsx
+++ b/web/src/hooks/useBranding.tsx
@@ -8,7 +8,7 @@
 
 import { createContext, use, useState, useEffect, type ReactNode } from 'react'
 import { DEFAULT_BRANDING, mergeBranding, type BrandingConfig } from '../lib/branding'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS, suppressLocalAgent } from '../lib/constants/network'
 import { updateAnalyticsIds } from '../lib/analytics'
 
 const BrandingContext = createContext<BrandingConfig>(DEFAULT_BRANDING)
@@ -47,6 +47,13 @@ export function BrandingProvider({ children }: BrandingProviderProps) {
             ga4MeasurementId: merged.ga4MeasurementId,
             umamiWebsiteId: merged.umamiWebsiteId,
           })
+        }
+        // Suppress local kc-agent connections when backend reports
+        // no_local_agent (in-cluster Helm deployments where no local
+        // kc-agent exists). This is the runtime counterpart of the
+        // build-time VITE_NO_LOCAL_AGENT env var.
+        if (!cancelled && data.no_local_agent === true) {
+          suppressLocalAgent(true)
         }
       } catch {
         // Intentionally silent — branding is non-critical.

--- a/web/src/lib/constants/__tests__/network.test.ts
+++ b/web/src/lib/constants/__tests__/network.test.ts
@@ -44,6 +44,11 @@ describe('network constants', () => {
     expect(network.MAX_MESSAGE_SIZE_CHARS).toBeGreaterThan(0)
   })
 
+  it('exports suppressLocalAgent and isLocalAgentSuppressed functions', () => {
+    expect(typeof network.suppressLocalAgent).toBe('function')
+    expect(typeof network.isLocalAgentSuppressed).toBe('function')
+  })
+
   it('all numeric exports are positive numbers', () => {
     const numericKeys = Object.entries(network).filter(
       ([, v]) => typeof v === 'number'

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -22,18 +22,58 @@ const _isNetlify = typeof window !== 'undefined' && (
 )
 
 /**
- * WebSocket URL for the local kc-agent.
- * On Netlify, uses a syntactically-valid but unroutable URL so that `new WebSocket(url)`
- * never throws (Safari throws TypeError for empty/invalid URLs). The connection simply
- * fails via `onerror`, which all consumers already handle.
+ * Whether the local kc-agent should be suppressed.
+ * True on Netlify deployments, or when VITE_NO_LOCAL_AGENT is set at build time,
+ * or when the backend reports no_local_agent via /health (in-cluster deployments).
+ *
+ * The build-time VITE_NO_LOCAL_AGENT covers custom builds (e.g. CI, Docker).
+ * The runtime flag (set via suppressLocalAgent()) covers pre-built images
+ * deployed in-cluster where Vite env vars cannot be injected at runtime.
  */
-export const LOCAL_AGENT_WS_URL = _isNetlify ? 'ws://localhost:1/disabled' : 'ws://127.0.0.1:8585/ws'
+let _suppressAgent = _isNetlify || import.meta.env.VITE_NO_LOCAL_AGENT === 'true'
+
+/**
+ * Called by the BrandingProvider after fetching /health to suppress agent
+ * connections at runtime (e.g. in-cluster Helm deployments that ship a
+ * pre-built frontend image where VITE_NO_LOCAL_AGENT cannot be set).
+ *
+ * Once called with `true`, the agent URLs are permanently disabled for
+ * the lifetime of the page — there is no "un-suppress" path.
+ */
+export function suppressLocalAgent(suppress: boolean): void {
+  if (suppress && !_suppressAgent) {
+    _suppressAgent = true
+    // Update the mutable URLs so any future reads get the suppressed values
+    LOCAL_AGENT_WS_URL = AGENT_WS_DISABLED_URL
+    LOCAL_AGENT_HTTP_URL = ''
+  }
+}
+
+/** Check whether the local agent is suppressed (build-time or runtime). */
+export function isLocalAgentSuppressed(): boolean {
+  return _suppressAgent
+}
+
+/** Syntactically-valid but unroutable WS URL used when the agent is suppressed.
+ * Safari throws TypeError for empty/invalid URLs in `new WebSocket(url)`,
+ * so this ensures the constructor succeeds but the connection simply fails
+ * via `onerror`, which all consumers already handle. */
+const AGENT_WS_DISABLED_URL = 'ws://localhost:1/disabled'
+
+/**
+ * WebSocket URL for the local kc-agent.
+ * Suppressed (unroutable) when running on Netlify, in-cluster, or with
+ * VITE_NO_LOCAL_AGENT=true. The connection fails via `onerror`, which
+ * all consumers already handle.
+ */
+export let LOCAL_AGENT_WS_URL = _suppressAgent ? AGENT_WS_DISABLED_URL : 'ws://127.0.0.1:8585/ws'
 
 /**
  * HTTP URL for the local kc-agent.
- * Empty on Netlify — fetch calls become relative URLs (e.g. '/settings'), which 404 silently.
+ * Empty when suppressed — fetch calls become relative URLs (e.g. '/settings'),
+ * which 404 silently.
  */
-export const LOCAL_AGENT_HTTP_URL = _isNetlify ? '' : 'http://127.0.0.1:8585'
+export let LOCAL_AGENT_HTTP_URL = _suppressAgent ? '' : 'http://127.0.0.1:8585'
 
 /** Default backend URL — empty string means same-origin relative URL.
  * This ensures API requests work in deployed environments (custom domain,

--- a/web/src/lib/demoMode.ts
+++ b/web/src/lib/demoMode.ts
@@ -28,11 +28,16 @@ const GPU_CACHE_KEY = 'kubestellar-gpu-cache'
 // ============================================================================
 
 /**
- * Whether running on a Netlify deployment (console.kubestellar.io, preview deploys).
+ * Whether running on a Netlify deployment (console.kubestellar.io, preview deploys)
+ * or an environment where the local kc-agent is explicitly suppressed.
  * These environments have no backend/agent access, so demo mode is forced.
+ *
+ * VITE_NO_LOCAL_AGENT is set at build time for in-cluster deployments
+ * (Helm/Kubernetes) where no local kc-agent exists on the user's machine.
  */
 export const isNetlifyDeployment = typeof window !== 'undefined' && (
   import.meta.env.VITE_DEMO_MODE === 'true' ||
+  import.meta.env.VITE_NO_LOCAL_AGENT === 'true' ||
   window.location.hostname.includes('netlify.app') ||
   window.location.hostname.includes('deploy-preview-') ||
   window.location.hostname === 'console.kubestellar.io'


### PR DESCRIPTION
## Summary
- Adds build-time `VITE_NO_LOCAL_AGENT` env var to suppress local kc-agent WebSocket/HTTP connections
- Adds runtime detection via `/health` endpoint (`no_local_agent` field, auto-set when running in-cluster)
- Helm deployment template always sets `NO_LOCAL_AGENT=true` since in-cluster deployments never have a local kc-agent
- Local dev with kc-agent on `127.0.0.1:8585` is completely unaffected

## Details

When the console is deployed in-cluster (Helm/Kubernetes) and accessed via `kubectl port-forward`, the frontend unconditionally tries WebSocket/HTTP connections to `ws://127.0.0.1:8585/ws` and `http://127.0.0.1:8585` (kc-agent endpoints). No local kc-agent exists in this scenario, causing console errors and 429 cascades.

**Three-layer suppression:**

1. **Build-time**: `VITE_NO_LOCAL_AGENT=true` in `network.ts` and `demoMode.ts` — for custom builds/CI
2. **Runtime**: Go backend exposes `no_local_agent: true` in `/health` response (auto-detected via `IsInCluster()` or explicit `NO_LOCAL_AGENT` env var). `BrandingProvider` calls `suppressLocalAgent()` to update mutable URL exports.
3. **Helm chart**: `deployment.yaml` always sets `NO_LOCAL_AGENT=true` — in-cluster deployments never have a local kc-agent on the user's machine.

### Files changed
- `web/src/lib/constants/network.ts` — `export let` for mutable URLs, `suppressLocalAgent()` / `isLocalAgentSuppressed()` functions
- `web/src/lib/demoMode.ts` — `isNetlifyDeployment` also checks `VITE_NO_LOCAL_AGENT`
- `web/src/hooks/useBranding.tsx` — calls `suppressLocalAgent(true)` when `/health` reports `no_local_agent`
- `pkg/api/server.go` — `NoLocalAgent` config field, `no_local_agent` in `/health` response
- `deploy/helm/kubestellar-console/templates/deployment.yaml` — `NO_LOCAL_AGENT=true` env var
- `web/src/lib/constants/__tests__/network.test.ts` — test for new exports

## Test plan
- [ ] Local dev with `./start-dev.sh` still connects to kc-agent on 8585
- [ ] Build with `VITE_NO_LOCAL_AGENT=true` suppresses agent URLs at module load
- [ ] `/health` endpoint returns `no_local_agent: true` when `NO_LOCAL_AGENT=true` env var is set
- [ ] `/health` endpoint returns `no_local_agent: true` when running in-cluster (auto-detected)
- [ ] Helm install sets `NO_LOCAL_AGENT=true` by default
- [ ] No WebSocket/HTTP errors to 127.0.0.1:8585 in browser console when accessed via port-forward

Fixes #10267

🤖 Generated with [Claude Code](https://claude.com/claude-code)