### PR TITLE
fix: remove overflow-hidden from navbar to show profile dropdown

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -60,7 +60,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
   }, [location.pathname])
 
   return (
-    <nav data-tour="navbar" style={{ top: topOffset }} className="fixed left-0 right-0 h-16 glass z-sticky px-3 md:px-6 flex items-center justify-between overflow-hidden">
+    <nav data-tour="navbar" style={{ top: topOffset }} className="fixed left-0 right-0 h-16 glass z-sticky px-3 md:px-6 flex items-center justify-between overflow-x-clip">
       {/* Left side: Hamburger + Logo — shrink-0 so logo is never compressed */}
       <div className="flex items-center gap-2 md:gap-3 shrink-0">
         {/* Hamburger menu - mobile only */}
@@ -122,7 +122,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
       {/* Right side — no shrink-0 here so the container participates in flex
            negotiation with the search bar, preventing overlap when the AI Mission
            button is visible (#4409). Individual critical items use shrink-0. */}
-      <div className="flex items-center gap-1 md:gap-3 min-w-0 overflow-hidden">
+      <div className="flex items-center gap-1 md:gap-3 min-w-0">
         {/* Core desktop items: md+ (768px) */}
         <div className="hidden md:flex items-center gap-2">
           {/* Unified Filter */}


### PR DESCRIPTION
## Summary
- Replace `overflow-hidden` with `overflow-x-clip` on the `<nav>` element so the absolutely-positioned `UserProfileDropdown` menu is no longer clipped vertically
- Remove `overflow-hidden` from the right-side flex container (`min-w-0` already prevents layout overflow)

Fixes #10270

## Test plan
- [ ] Open the console and click the user profile avatar in the navbar
- [ ] Verify the dropdown menu renders fully below the navbar without being clipped
- [ ] Resize the browser to mobile widths and confirm no horizontal overflow appears in the navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)