### PR TITLE
chore: remove unused UI constants and extract hex colors to Tailwind config

### DIFF
--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -75,6 +75,14 @@ export default {
          * Usage: text-status-success, bg-status-error, border-status-warning
          * Note: opacity modifiers (e.g., /20) are not supported with var() values.
          */
+        /** LinkedIn brand blue (#0A66C2) — used for LinkedIn share buttons */
+        linkedin: {
+          DEFAULT: '#0A66C2',
+          dark: '#004182',
+        },
+        /** Near-black backgrounds for terminal/console UIs */
+        terminal: '#0d0d0d',
+        'near-black': '#0a0a0a',
         status: {
           success: "var(--color-success)",
           warning: "var(--color-warning)",


### PR DESCRIPTION
## Summary
- Removes 5 unused exported constants from `lib/constants/ui.ts` (`CHART_TOOLTIP_BORDER_RADIUS`, `CHART_LEGEND_WRAPPER_STYLE`, `CHART_LEGEND_WRAPPER_STYLE_SM`, `CHART_BODY_FONT_SIZE_SM`, `DEV_BAR_HEIGHT_PX`)
- Extracts 4 hardcoded hex colors into `tailwind.config.js` named colors: `linkedin` (#0A66C2), `linkedin-dark` (#004182), `terminal` (#0d0d0d), `near-black` (#0a0a0a)
- Replaces 11 arbitrary Tailwind hex color usages across 6 component files with the new semantic names
- Lowers `EXPECTED_ARBITRARY_TW_COLOR_COUNT` ratchet from 19 to 8

Fixes #10271