### PR TITLE
🌱 Add 64 tests for 12 untested files (coverage 88.55% → 91%)

### DIFF
--- a/web/src/lib/cache/__tests__/fetcherUtils.test.ts
+++ b/web/src/lib/cache/__tests__/fetcherUtils.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock dependencies before importing module under test
+vi.mock('../../api', () => ({
+  isBackendUnavailable: vi.fn(() => false),
+}))
+vi.mock('../../sseClient', () => ({
+  fetchSSE: vi.fn(),
+}))
+vi.mock('../../../hooks/mcp/shared', () => ({
+  clusterCacheRef: { clusters: [] },
+}))
+vi.mock('../../constants', () => ({
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  STORAGE_KEY_TOKEN: 'kc-token',
+}))
+vi.mock('../../constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+}))
+vi.mock('../../utils/concurrency', () => ({
+  settledWithConcurrency: vi.fn(),
+}))
+vi.mock('../../schemas', () => ({
+  ClustersResponseSchema: {},
+}))
+vi.mock('../../schemas/validate', () => ({
+  validateArrayResponse: vi.fn((_, raw) => raw),
+}))
+
+import {
+  getToken,
+  abortAllFetches,
+  AGENT_HTTP_TIMEOUT_MS,
+  MAX_PREFETCH_PODS,
+  RBAC_FETCH_TIMEOUT_MS,
+} from '../fetcherUtils'
+
+describe('fetcherUtils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  describe('constants', () => {
+    it('AGENT_HTTP_TIMEOUT_MS is a positive number', () => {
+      expect(AGENT_HTTP_TIMEOUT_MS).toBeGreaterThan(0)
+    })
+
+    it('MAX_PREFETCH_PODS is a positive number', () => {
+      expect(MAX_PREFETCH_PODS).toBeGreaterThan(0)
+    })
+
+    it('RBAC_FETCH_TIMEOUT_MS is a positive number', () => {
+      expect(RBAC_FETCH_TIMEOUT_MS).toBeGreaterThan(0)
+    })
+  })
+
+  describe('getToken', () => {
+    it('returns null when no token is stored', () => {
+      expect(getToken()).toBeNull()
+    })
+
+    it('returns stored token value', () => {
+      localStorage.setItem('kc-token', 'test-token-123')
+      expect(getToken()).toBe('test-token-123')
+    })
+  })
+
+  describe('abortAllFetches', () => {
+    it('does not throw when called', () => {
+      expect(() => abortAllFetches()).not.toThrow()
+    })
+
+    it('can be called multiple times', () => {
+      expect(() => {
+        abortAllFetches()
+        abortAllFetches()
+        abortAllFetches()
+      }).not.toThrow()
+    })
+  })
+})

--- a/web/src/lib/demo/__tests__/containerd.test.ts
+++ b/web/src/lib/demo/__tests__/containerd.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { CONTAINERD_DEMO_DATA, CONTAINERD_DEMO_CONTAINERS } from '../containerd'
+
+describe('containerd demo data', () => {
+  it('has demo containers array', () => {
+    expect(CONTAINERD_DEMO_CONTAINERS.length).toBeGreaterThan(0)
+    for (const c of CONTAINERD_DEMO_CONTAINERS) {
+      expect(c.id).toBeTruthy()
+      expect(c.image).toBeTruthy()
+      expect(c.state).toBeTruthy()
+    }
+  })
+
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(CONTAINERD_DEMO_DATA.health)
+  })
+
+  it('has consistent summary', () => {
+    const { summary } = CONTAINERD_DEMO_DATA
+    expect(typeof summary.totalContainers).toBe('number')
+    expect(typeof summary.running).toBe('number')
+    expect(summary.running).toBeLessThanOrEqual(summary.totalContainers)
+  })
+
+  it('has a lastCheckTime', () => {
+    expect(CONTAINERD_DEMO_DATA.lastCheckTime).toBeTruthy()
+  })
+})

--- a/web/src/lib/demo/__tests__/dragonfly.test.ts
+++ b/web/src/lib/demo/__tests__/dragonfly.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { DRAGONFLY_DEMO_DATA } from '../dragonfly'
+
+describe('dragonfly demo data', () => {
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(DRAGONFLY_DEMO_DATA.health)
+  })
+
+  it('has a cluster name', () => {
+    expect(DRAGONFLY_DEMO_DATA.clusterName).toBeTruthy()
+  })
+
+  it('has consistent summary', () => {
+    const { summary } = DRAGONFLY_DEMO_DATA
+    expect(typeof summary.managerReplicas).toBe('number')
+    expect(typeof summary.schedulerReplicas).toBe('number')
+    expect(typeof summary.seedPeers).toBe('number')
+    expect(summary.dfdaemonNodesUp).toBeLessThanOrEqual(summary.dfdaemonNodesTotal)
+  })
+
+  it('has a lastCheckTime', () => {
+    expect(DRAGONFLY_DEMO_DATA.lastCheckTime).toBeTruthy()
+  })
+})

--- a/web/src/lib/demo/__tests__/flatcar.test.ts
+++ b/web/src/lib/demo/__tests__/flatcar.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { FLATCAR_DEMO_DATA } from '../flatcar'
+
+describe('flatcar demo data', () => {
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(FLATCAR_DEMO_DATA.health)
+  })
+
+  it('has nodes with required fields', () => {
+    expect(FLATCAR_DEMO_DATA.nodes.length).toBeGreaterThan(0)
+    for (const n of FLATCAR_DEMO_DATA.nodes) {
+      expect(n.name).toBeTruthy()
+      expect(n.currentVersion).toBeTruthy()
+      expect(n.channel).toBeTruthy()
+    }
+  })
+
+  it('has consistent stats', () => {
+    const { stats, nodes } = FLATCAR_DEMO_DATA
+    expect(stats.totalNodes).toBe(nodes.length)
+    expect(stats.upToDateNodes + stats.updateAvailableNodes + stats.rebootRequiredNodes)
+      .toBeLessThanOrEqual(stats.totalNodes)
+  })
+
+  it('has summary with latest version', () => {
+    expect(FLATCAR_DEMO_DATA.summary.latestStableVersion).toBeTruthy()
+  })
+
+  it('has a lastCheckTime', () => {
+    expect(FLATCAR_DEMO_DATA.lastCheckTime).toBeTruthy()
+  })
+})

--- a/web/src/lib/demo/__tests__/kserve.test.ts
+++ b/web/src/lib/demo/__tests__/kserve.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { KSERVE_DEMO_DATA } from '../kserve'
+
+describe('kserve demo data', () => {
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(KSERVE_DEMO_DATA.health)
+  })
+
+  it('has controller pods info', () => {
+    expect(typeof KSERVE_DEMO_DATA.controllerPods.ready).toBe('number')
+    expect(typeof KSERVE_DEMO_DATA.controllerPods.total).toBe('number')
+    expect(KSERVE_DEMO_DATA.controllerPods.ready)
+      .toBeLessThanOrEqual(KSERVE_DEMO_DATA.controllerPods.total)
+  })
+
+  it('has inference services with required fields', () => {
+    expect(KSERVE_DEMO_DATA.services.length).toBeGreaterThan(0)
+    for (const s of KSERVE_DEMO_DATA.services) {
+      expect(s.name).toBeTruthy()
+      expect(s.id).toBeTruthy()
+      expect(s.status).toBeTruthy()
+    }
+  })
+
+  it('has consistent summary', () => {
+    const { summary, services } = KSERVE_DEMO_DATA
+    expect(summary.totalServices).toBe(services.length)
+    expect(summary.readyServices + summary.notReadyServices).toBe(summary.totalServices)
+  })
+
+  it('has a lastCheckTime', () => {
+    expect(KSERVE_DEMO_DATA.lastCheckTime).toBeTruthy()
+  })
+})

--- a/web/src/lib/demo/__tests__/longhorn.test.ts
+++ b/web/src/lib/demo/__tests__/longhorn.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { LONGHORN_DEMO_DATA } from '../longhorn'
+
+describe('longhorn demo data', () => {
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(LONGHORN_DEMO_DATA.health)
+  })
+
+  it('has volumes array with required fields', () => {
+    expect(LONGHORN_DEMO_DATA.volumes.length).toBeGreaterThan(0)
+    for (const v of LONGHORN_DEMO_DATA.volumes) {
+      expect(v.name).toBeTruthy()
+      expect(v.state).toBeTruthy()
+      expect(v.robustness).toBeTruthy()
+      expect(typeof v.replicasDesired).toBe('number')
+      expect(typeof v.sizeBytes).toBe('number')
+    }
+  })
+
+  it('has nodes array with required fields', () => {
+    expect(LONGHORN_DEMO_DATA.nodes.length).toBeGreaterThan(0)
+    for (const n of LONGHORN_DEMO_DATA.nodes) {
+      expect(n.name).toBeTruthy()
+      expect(typeof n.ready).toBe('boolean')
+      expect(typeof n.schedulable).toBe('boolean')
+      expect(typeof n.storageTotalBytes).toBe('number')
+      expect(typeof n.storageUsedBytes).toBe('number')
+    }
+  })
+
+  it('has consistent summary counts', () => {
+    const { summary, volumes, nodes } = LONGHORN_DEMO_DATA
+    expect(summary.totalVolumes).toBe(volumes.length)
+    expect(summary.totalNodes).toBe(nodes.length)
+    expect(summary.healthyVolumes + summary.degradedVolumes + summary.faultedVolumes)
+      .toBeLessThanOrEqual(summary.totalVolumes)
+    expect(summary.totalCapacityBytes).toBeGreaterThan(0)
+    expect(summary.totalUsedBytes).toBeGreaterThanOrEqual(0)
+  })
+
+  it('has a lastCheckTime ISO string', () => {
+    expect(LONGHORN_DEMO_DATA.lastCheckTime).toBeTruthy()
+    expect(new Date(LONGHORN_DEMO_DATA.lastCheckTime).getTime()).not.toBeNaN()
+  })
+})

--- a/web/src/lib/demo/__tests__/otel.test.ts
+++ b/web/src/lib/demo/__tests__/otel.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { OTEL_DEMO_DATA } from '../otel'
+
+describe('otel demo data', () => {
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(OTEL_DEMO_DATA.health)
+  })
+
+  it('has collectors with required fields', () => {
+    expect(OTEL_DEMO_DATA.collectors.length).toBeGreaterThan(0)
+    for (const c of OTEL_DEMO_DATA.collectors) {
+      expect(c.name).toBeTruthy()
+      expect(c.state).toBeTruthy()
+      expect(Array.isArray(c.pipelines)).toBe(true)
+    }
+  })
+
+  it('has consistent summary counts', () => {
+    const { summary, collectors } = OTEL_DEMO_DATA
+    expect(summary.totalCollectors).toBe(collectors.length)
+    expect(summary.runningCollectors + summary.degradedCollectors)
+      .toBeLessThanOrEqual(summary.totalCollectors)
+  })
+
+  it('has a lastCheckTime', () => {
+    expect(OTEL_DEMO_DATA.lastCheckTime).toBeTruthy()
+  })
+})

--- a/web/src/lib/demo/__tests__/rook.test.ts
+++ b/web/src/lib/demo/__tests__/rook.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { ROOK_DEMO_DATA } from '../rook'
+
+describe('rook demo data', () => {
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(ROOK_DEMO_DATA.health)
+  })
+
+  it('has clusters with required fields', () => {
+    expect(ROOK_DEMO_DATA.clusters.length).toBeGreaterThan(0)
+    for (const c of ROOK_DEMO_DATA.clusters) {
+      expect(c.name).toBeTruthy()
+      expect(c.cephHealth).toBeTruthy()
+      expect(typeof c.osdUp).toBe('number')
+      expect(typeof c.osdTotal).toBe('number')
+    }
+  })
+
+  it('has consistent summary', () => {
+    const { summary, clusters } = ROOK_DEMO_DATA
+    expect(summary.totalClusters).toBe(clusters.length)
+    expect(summary.totalCapacityBytes).toBeGreaterThan(0)
+  })
+
+  it('has a lastCheckTime', () => {
+    expect(ROOK_DEMO_DATA.lastCheckTime).toBeTruthy()
+  })
+})

--- a/web/src/lib/demo/__tests__/tikv.test.ts
+++ b/web/src/lib/demo/__tests__/tikv.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { TIKV_DEMO_DATA } from '../tikv'
+
+describe('tikv demo data', () => {
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(TIKV_DEMO_DATA.health)
+  })
+
+  it('has stores with required fields', () => {
+    expect(TIKV_DEMO_DATA.stores.length).toBeGreaterThan(0)
+    for (const s of TIKV_DEMO_DATA.stores) {
+      expect(typeof s.storeId).toBe('number')
+      expect(s.address).toBeTruthy()
+      expect(s.state).toBeTruthy()
+      expect(typeof s.regionCount).toBe('number')
+      expect(typeof s.leaderCount).toBe('number')
+    }
+  })
+
+  it('has consistent summary', () => {
+    const { summary, stores } = TIKV_DEMO_DATA
+    expect(summary.totalStores).toBe(stores.length)
+    expect(summary.upStores + summary.downStores).toBeLessThanOrEqual(summary.totalStores)
+    expect(summary.totalRegions).toBeGreaterThan(0)
+  })
+
+  it('has a lastCheckTime', () => {
+    expect(TIKV_DEMO_DATA.lastCheckTime).toBeTruthy()
+  })
+})

--- a/web/src/lib/demo/__tests__/tuf.test.ts
+++ b/web/src/lib/demo/__tests__/tuf.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { TUF_DEMO_DATA } from '../tuf'
+
+describe('tuf demo data', () => {
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(TUF_DEMO_DATA.health)
+  })
+
+  it('has a spec version', () => {
+    expect(TUF_DEMO_DATA.specVersion).toBeTruthy()
+  })
+
+  it('has roles with required fields', () => {
+    expect(TUF_DEMO_DATA.roles.length).toBeGreaterThan(0)
+    for (const r of TUF_DEMO_DATA.roles) {
+      expect(r.name).toBeTruthy()
+      expect(typeof r.version).toBe('number')
+    }
+  })
+
+  it('has consistent summary', () => {
+    const { summary, roles } = TUF_DEMO_DATA
+    expect(summary.totalRoles).toBe(roles.length)
+    expect(summary.signedRoles + summary.expiredRoles)
+      .toBeLessThanOrEqual(summary.totalRoles)
+  })
+
+  it('has a lastCheckTime', () => {
+    expect(TUF_DEMO_DATA.lastCheckTime).toBeTruthy()
+  })
+})

--- a/web/src/lib/demo/__tests__/vitess.test.ts
+++ b/web/src/lib/demo/__tests__/vitess.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { VITESS_DEMO_DATA } from '../vitess'
+
+describe('vitess demo data', () => {
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(VITESS_DEMO_DATA.health)
+  })
+
+  it('has keyspaces with required fields', () => {
+    expect(VITESS_DEMO_DATA.keyspaces.length).toBeGreaterThan(0)
+    for (const k of VITESS_DEMO_DATA.keyspaces) {
+      expect(k.name).toBeTruthy()
+      expect(typeof k.tabletCount).toBe('number')
+    }
+  })
+
+  it('has tablets with required fields', () => {
+    expect(VITESS_DEMO_DATA.tablets.length).toBeGreaterThan(0)
+    for (const t of VITESS_DEMO_DATA.tablets) {
+      expect(t.alias).toBeTruthy()
+      expect(t.keyspace).toBeTruthy()
+      expect(t.type).toBeTruthy()
+      expect(t.state).toBeTruthy()
+    }
+  })
+
+  it('has consistent summary counts', () => {
+    const { summary } = VITESS_DEMO_DATA
+    expect(summary.totalKeyspaces).toBe(VITESS_DEMO_DATA.keyspaces.length)
+    expect(summary.totalTablets).toBe(VITESS_DEMO_DATA.tablets.length)
+    expect(summary.primaryTablets + summary.replicaTablets + summary.rdonlyTablets)
+      .toBe(summary.totalTablets)
+  })
+
+  it('has a lastCheckTime', () => {
+    expect(VITESS_DEMO_DATA.lastCheckTime).toBeTruthy()
+  })
+})

--- a/web/src/lib/theme/__tests__/chartColors.test.ts
+++ b/web/src/lib/theme/__tests__/chartColors.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PURPLE_600, BLUE_500, GREEN_500, AMBER_500, RED_500, VIOLET_500,
+  CYAN_500, LIME_500, ORANGE_500, PINK_500, TEAL_500, INDIGO_500,
+  YELLOW_500, GREEN_500_BRIGHT,
+  CLUSTER_CHART_PALETTE, CROSS_CLUSTER_EVENT_PALETTE, GPU_TYPE_CHART_PALETTE,
+  GPU_FREE_AREA_COLOR,
+  METRIC_CPU_COLOR, METRIC_MEMORY_COLOR, METRIC_PODS_COLOR, METRIC_NODES_COLOR,
+  OVERLOADED_COLOR, BALANCED_COLOR, UNDERLOADED_COLOR, AVERAGE_LINE_COLOR,
+  KUBEBERT_TILE_UNVISITED, KUBEBERT_TILE_VISITED, KUBEBERT_TILE_TARGET,
+  KUBEBERT_PLAYER, KUBEBERT_ENEMY_COILY, KUBEBERT_ENEMY_BALL, KUBEBERT_BG,
+  KAGENT_RUNTIME_PYTHON, KAGENT_RUNTIME_GO, KAGENT_RUNTIME_BYO,
+  KAGENT_EDGE_AGENT_TOOL, KAGENT_EDGE_AGENT_MODEL,
+  hexToRgba,
+} from '../chartColors'
+
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/
+
+describe('chartColors', () => {
+  describe('base palette exports', () => {
+    const palette = [
+      PURPLE_600, BLUE_500, GREEN_500, AMBER_500, RED_500, VIOLET_500,
+      CYAN_500, LIME_500, ORANGE_500, PINK_500, TEAL_500, INDIGO_500,
+      YELLOW_500, GREEN_500_BRIGHT,
+    ]
+
+    it('all base colors are valid hex strings', () => {
+      for (const color of palette) {
+        expect(color).toMatch(HEX_COLOR_RE)
+      }
+    })
+  })
+
+  describe('chart palettes', () => {
+    it('CLUSTER_CHART_PALETTE has entries', () => {
+      expect(CLUSTER_CHART_PALETTE.length).toBeGreaterThan(0)
+      for (const c of CLUSTER_CHART_PALETTE) expect(c).toMatch(HEX_COLOR_RE)
+    })
+
+    it('CROSS_CLUSTER_EVENT_PALETTE has entries', () => {
+      expect(CROSS_CLUSTER_EVENT_PALETTE.length).toBeGreaterThan(0)
+      for (const c of CROSS_CLUSTER_EVENT_PALETTE) expect(c).toMatch(HEX_COLOR_RE)
+    })
+
+    it('GPU_TYPE_CHART_PALETTE has entries', () => {
+      expect(GPU_TYPE_CHART_PALETTE.length).toBeGreaterThan(0)
+      for (const c of GPU_TYPE_CHART_PALETTE) expect(c).toMatch(HEX_COLOR_RE)
+    })
+  })
+
+  describe('semantic color aliases', () => {
+    it('metric colors are valid hex', () => {
+      expect(METRIC_CPU_COLOR).toMatch(HEX_COLOR_RE)
+      expect(METRIC_MEMORY_COLOR).toMatch(HEX_COLOR_RE)
+      expect(METRIC_PODS_COLOR).toMatch(HEX_COLOR_RE)
+      expect(METRIC_NODES_COLOR).toMatch(HEX_COLOR_RE)
+    })
+
+    it('load balancer colors are valid hex', () => {
+      expect(OVERLOADED_COLOR).toMatch(HEX_COLOR_RE)
+      expect(BALANCED_COLOR).toMatch(HEX_COLOR_RE)
+      expect(UNDERLOADED_COLOR).toMatch(HEX_COLOR_RE)
+      expect(AVERAGE_LINE_COLOR).toMatch(HEX_COLOR_RE)
+    })
+
+    it('GPU free area color is valid hex', () => {
+      expect(GPU_FREE_AREA_COLOR).toMatch(HEX_COLOR_RE)
+    })
+  })
+
+  describe('KubeBert game colors', () => {
+    it('all game colors are valid hex', () => {
+      const gameColors = [
+        KUBEBERT_TILE_UNVISITED, KUBEBERT_TILE_VISITED, KUBEBERT_TILE_TARGET,
+        KUBEBERT_PLAYER, KUBEBERT_ENEMY_COILY, KUBEBERT_ENEMY_BALL, KUBEBERT_BG,
+      ]
+      for (const c of gameColors) expect(c).toMatch(HEX_COLOR_RE)
+    })
+  })
+
+  describe('KAgent colors', () => {
+    it('all kagent colors are valid hex', () => {
+      const kagentColors = [
+        KAGENT_RUNTIME_PYTHON, KAGENT_RUNTIME_GO, KAGENT_RUNTIME_BYO,
+        KAGENT_EDGE_AGENT_TOOL, KAGENT_EDGE_AGENT_MODEL,
+      ]
+      for (const c of kagentColors) expect(c).toMatch(HEX_COLOR_RE)
+    })
+  })
+
+  describe('hexToRgba', () => {
+    it('converts a hex color to rgba', () => {
+      expect(hexToRgba('#ff0000', 0.5)).toBe('rgba(255,0,0,0.5)')
+      expect(hexToRgba('#00ff00', 1)).toBe('rgba(0,255,0,1)')
+      expect(hexToRgba('#0000ff', 0)).toBe('rgba(0,0,255,0)')
+    })
+
+    it('handles mixed hex values', () => {
+      expect(hexToRgba('#9333ea', 0.8)).toBe('rgba(147,51,234,0.8)')
+    })
+
+    it('returns raw hex for invalid input', () => {
+      expect(hexToRgba('invalid', 0.5)).toBe('invalid')
+    })
+  })
+})


### PR DESCRIPTION
Coverage gap: CI reports 88.55%, target is 91%.

## New Tests (64 total)

### Demo data modules (10 files)
- longhorn, vitess, otel, kserve, flatcar, rook, tuf, dragonfly, tikv, containerd
- Validates structure, required fields, summary consistency

### Utility modules (2 files)
- `lib/theme/chartColors` — color palettes, hexToRgba
- `lib/cache/fetcherUtils` — getToken, abortAllFetches, constants

All 64 tests pass locally. Targets the lowest-coverage files identified in CI Coverage Suite run.