### PR TITLE
🧹 Zero arbitrary-tw-color ratchet and remove 5 unused UI constants (#10271)

### DIFF
--- a/web/src/components/auth/AuthCallback.tsx
+++ b/web/src/components/auth/AuthCallback.tsx
@@ -140,7 +140,7 @@ export function AuthCallback() {
   }, [searchParams, refreshUser, navigate, showToast, t])
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#0a0a0a]">
+    <div className="min-h-screen flex items-center justify-center bg-terminal">
       <div className="text-center">
         <div className="spinner w-12 h-12 mx-auto mb-4" role="status" />
         <p className="text-muted-foreground">{status}</p>

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1168,7 +1168,7 @@ export function CardWrapper({
                   </button>
                   {showMenu && menuPosition && createPortal(
                     <div
-                      className="fixed w-48 glass rounded-lg py-1 z-50 shadow-xl bg-[rgba(10,15,25,0.98)]!"
+                      className="fixed w-48 glass rounded-lg py-1 z-50 shadow-xl bg-glass-overlay!"
                       role="menu"
                       aria-label={t('cardWrapper.cardMenuTooltip')}
                       style={{ top: menuPosition.top, right: menuPosition.right }}

--- a/web/src/components/drilldown/RemediationConsole.tsx
+++ b/web/src/components/drilldown/RemediationConsole.tsx
@@ -464,7 +464,7 @@ Labels:       app=${resourceName.split('-')[0]}
         </div>
 
         {/* Console Output */}
-        <div className="flex-1 overflow-y-auto p-4 bg-[#0d0d0d] font-mono text-sm">
+        <div className="flex-1 overflow-y-auto p-4 bg-terminal font-mono text-sm">
           {activeTab === 'ai' ? (
             // AI Tab Content
             logs.length === 0 ? (
@@ -584,7 +584,7 @@ Labels:       app=${resourceName.split('-')[0]}
 
         {/* Shell Input (only shown in shell tab) */}
         {activeTab === 'shell' && (
-          <div className="p-3 border-t border-border bg-[#0d0d0d]">
+          <div className="p-3 border-t border-border bg-terminal">
             {shellError && (
               <div className="mb-2 px-3 py-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-yellow-400 text-xs">
                 <div className="flex items-center gap-2 mb-2">

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -627,7 +627,7 @@ export function LinkedInShareButton({ onShare, compact = false }: { onShare?: ()
     return (
       <button
         onClick={handleShare}
-        className="flex items-center gap-2 px-3 py-2 text-sm rounded-lg bg-[#0A66C2]/20 hover:bg-[#0A66C2]/30 text-[#0A66C2] transition-colors"
+        className="flex items-center gap-2 px-3 py-2 text-sm rounded-lg bg-linkedin/20 hover:bg-linkedin/30 text-linkedin transition-colors"
         title="Share on LinkedIn"
       >
         <Linkedin className="w-4 h-4" />
@@ -640,7 +640,7 @@ export function LinkedInShareButton({ onShare, compact = false }: { onShare?: ()
   return (
     <button
       onClick={handleShare}
-      className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-[#0A66C2] hover:bg-[#004182] text-white font-medium transition-colors"
+      className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-linkedin hover:bg-linkedin-dark text-white font-medium transition-colors"
     >
       <Linkedin className="w-4 h-4" />
       <span>{t('feedback.shareOnLinkedIn')}</span>

--- a/web/src/components/feedback/UpdatesTab.tsx
+++ b/web/src/components/feedback/UpdatesTab.tsx
@@ -767,7 +767,7 @@ function GitHubContributionsSection({
                 window.open(linkedInUrl, '_blank', `noopener,noreferrer,width=${LINKEDIN_POPUP_SIZE},height=${LINKEDIN_POPUP_SIZE}`)
                 emitLinkedInShare('feature_request')
               }}
-              className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-[#0A66C2] transition-colors"
+              className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-linkedin transition-colors"
               title={`Share ${githubPoints.toLocaleString()} coins on LinkedIn`}
             >
               <Linkedin className="w-3.5 h-3.5" />

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -379,7 +379,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
               onClick={handleLinkedInShare}
               className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-foreground hover:bg-secondary rounded-lg transition-colors"
             >
-              <Linkedin className="w-4 h-4 text-[#0A66C2]" />
+              <Linkedin className="w-4 h-4 text-linkedin" />
               <span>{t('feedback.shareOnLinkedIn')}</span>
               <span className="ml-auto text-xs px-1.5 py-0.5 rounded bg-yellow-900 text-yellow-400">+{REWARD_ACTIONS.linkedin_share.coins}</span>
             </button>

--- a/web/src/components/rewards/ContributorLadder.tsx
+++ b/web/src/components/rewards/ContributorLadder.tsx
@@ -65,7 +65,7 @@ export function ContributorBanner() {
             {totalCoins > 0 && (
               <button
                 onClick={handleLinkedInShare}
-                className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-[#0A66C2] transition-colors"
+                className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-linkedin transition-colors"
                 title={`Share your ${current.name} status on LinkedIn`}
               >
                 <Linkedin className="w-3.5 h-3.5" />

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -18,21 +18,15 @@ export const CHART_MIN_HEIGHT_TALL_PX = 250
 // ── Recharts shared styles ──────────────────────────────────────────────
 export const CHART_TOOLTIP_BG = '#1a1a2e'
 export const CHART_TOOLTIP_BORDER = '#333'
-/** Standard border-radius for chart tooltip containers (Tailwind rounded-lg equivalent) */
-export const CHART_TOOLTIP_BORDER_RADIUS = '8px'
 /** Standard font size for chart tooltip text */
 export const CHART_TOOLTIP_FONT_SIZE = '12px'
 /** Compact font size for insight-card tooltips */
 export const CHART_TOOLTIP_FONT_SIZE_COMPACT = '11px'
-/** Compact legend font size (10px) — kept for backward compat with callers */
-export const CHART_LEGEND_WRAPPER_STYLE: React.CSSProperties = { fontSize: '10px' }
-/** Standard legend font size (12px) — kept for backward compat with callers */
-export const CHART_LEGEND_WRAPPER_STYLE_SM: React.CSSProperties = { fontSize: '12px' }
 /** Shared tooltip content style — used to extract bg/border for echarts tooltip config */
 export const CHART_TOOLTIP_CONTENT_STYLE: React.CSSProperties = {
   backgroundColor: CHART_TOOLTIP_BG,
   border: `1px solid ${CHART_TOOLTIP_BORDER}`,
-  borderRadius: CHART_TOOLTIP_BORDER_RADIUS,
+  borderRadius: '8px',
   fontSize: CHART_TOOLTIP_FONT_SIZE,
 }
 /** Tailwind-gray tooltip style for unified card system charts */
@@ -81,8 +75,6 @@ export const CHART_AXIS_FONT_SIZE = 10
 export const CHART_AXIS_FONT_SIZE_SM = 9
 /** Standard tooltip / legend font size (ECharts numeric) */
 export const CHART_BODY_FONT_SIZE = 12
-/** Small chart body font size for compact labels (ECharts numeric) */
-export const CHART_BODY_FONT_SIZE_SM = 10
 /** Legend text font size for chart legends (ECharts numeric) */
 export const CHART_LEGEND_FONT_SIZE = 11
 /** Tiny marker label font size for map cluster markers (DOM px) */
@@ -104,8 +96,6 @@ export const DEFAULT_PAGE_SIZE = 5
 export const NAVBAR_HEIGHT_PX = 64
 /** Height of each status banner (network, demo, offline) in pixels */
 export const BANNER_HEIGHT_PX = 36
-/** Height of the green dev-mode indicator bar in pixels (h-5 = 20px) */
-export const DEV_BAR_HEIGHT_PX = 20
 /**
  * Horizontal offset (in pixels) from the sidebar's right edge at which the
  * floating collapse + pin control container is anchored (see Sidebar.tsx).

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -94,7 +94,9 @@ const EXPECTED_RAW_HEX_COUNT = 256
 const EXPECTED_RAW_RGBA_COUNT = 104
 //   22 → 19: PR #8547 — replaced 3 arbitrary Tailwind hex colors in Login.tsx
 //            (bg-[#0a0a0a], from-[#0a0f1c]) with semantic bg-background/from-background
-const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 19
+//   19 →  0: PR #10271 — added linkedin/terminal/glass-overlay to Tailwind config,
+//            replaced all 9 remaining arbitrary hex colors across 6 files
+const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 0
 // Inline style color ratchet — bump history:
 //   213 → 215: Drasi reactive graph (PRs #7832, #7857) — two new
 //              echarts/flow-node inline colors not covered by theming utils.

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -83,6 +83,12 @@ export default {
           neutral: "var(--color-neutral)",
           pending: "var(--color-pending)",
         },
+        linkedin: {
+          DEFAULT: '#0A66C2',
+          dark: '#004182',
+        },
+        terminal: '#0d0d0d',
+        'glass-overlay': 'rgba(10,15,25,0.98)',
       },
       /**
        * Z-Index Scale — semantic layers for global stacking.


### PR DESCRIPTION
## Summary
- Add `linkedin`, `terminal`, and `glass-overlay` semantic colors to Tailwind config
- Replace all 9 hardcoded hex values in arbitrary Tailwind classes (`bg-[#0A66C2]`, `text-[#0A66C2]`, `bg-[#0d0d0d]`, `bg-[#0a0a0a]`, `bg-[rgba(10,15,25,0.98)]`) across 6 files
- Remove 5 unused exports from `lib/constants/ui.ts`: `CHART_TOOLTIP_BORDER_RADIUS`, `CHART_LEGEND_WRAPPER_STYLE`, `CHART_LEGEND_WRAPPER_STYLE_SM`, `CHART_BODY_FONT_SIZE_SM`, `DEV_BAR_HEIGHT_PX`
- Lower `EXPECTED_ARBITRARY_TW_COLOR_COUNT` ratchet from 19 → 0

## Files changed (10)
- `tailwind.config.js` — 3 new semantic colors
- `ui.ts` — removed 5 dead exports, inlined border-radius
- 6 component files — replaced arbitrary hex with semantic classes
- `ui-ux-standards.test.ts` — zeroed ratchet with bump comment

## Test plan
- [x] `npx vitest run src/test/ui-ux-standards.test.ts` — all 7 pass, ratchet at 0
- [x] `npx vitest run src/test/card-loading-standard.test.ts src/test/no-magic-numbers.test.ts` — 711 pass
- [x] `npm run build` — clean

Fixes #10271