### PR TITLE
🧹 Consolidate duplicate formatDuration in Prow hooks (#10279)

### DIFF
--- a/web/src/hooks/useCachedProw.ts
+++ b/web/src/hooks/useCachedProw.ts
@@ -7,7 +7,7 @@
 
 import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { kubectlProxy } from '../lib/kubectlProxy'
-import { formatTimeAgo } from '../lib/formatters'
+import { formatTimeAgo, formatProwDuration } from '../lib/formatters'
 import { KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
 import { MS_PER_HOUR } from '../lib/constants/time'
 import type { ProwJob, ProwStatus } from './useProw'
@@ -61,22 +61,6 @@ interface ProwJobResource {
   }
 }
 
-function formatDuration(startTime: string, endTime?: string): string {
-  const start = new Date(startTime)
-  const end = endTime ? new Date(endTime) : new Date()
-  const diffMs = end.getTime() - start.getTime()
-
-  if (diffMs < 0) return '-'
-
-  const seconds = Math.floor(diffMs / 1000)
-  const minutes = Math.floor(seconds / 60)
-  const hours = Math.floor(minutes / 60)
-
-  if (hours > 0) return `${hours}h ${minutes % 60}m`
-  if (minutes > 0) return `${minutes}m`
-  return `${seconds}s`
-}
-
 export { formatTimeAgo }
 
 /** @internal Exported for use in `lib/prefetchCardData.ts` specialtyFetchers */
@@ -115,7 +99,7 @@ export async function fetchProwJobs(prowCluster: string, namespace: string): Pro
         cluster: prowCluster,
         startTime,
         completionTime,
-        duration: state === 'pending' || state === 'triggered' ? '-' : formatDuration(startTime, completionTime),
+        duration: state === 'pending' || state === 'triggered' ? '-' : formatProwDuration(startTime, completionTime),
         pr: pj.spec.refs?.pulls?.[0]?.number,
         url: pj.status.url,
         buildId: pj.status.build_id || pj.metadata.labels?.['prow.k8s.io/build-id'],

--- a/web/src/hooks/useProw.ts
+++ b/web/src/hooks/useProw.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
 import { kubectlProxy } from '../lib/kubectlProxy'
-import { formatTimeAgo } from '../lib/formatters'
+import { formatTimeAgo, formatProwDuration } from '../lib/formatters'
 import { useDemoMode } from './useDemoMode'
 import { KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
 import { MS_PER_HOUR } from '../lib/constants/time'
@@ -63,27 +63,6 @@ interface ProwJobResource {
   }
 }
 
-function formatDuration(startTime: string, endTime?: string): string {
-  const start = new Date(startTime)
-  const end = endTime ? new Date(endTime) : new Date()
-  const diffMs = end.getTime() - start.getTime()
-
-  if (diffMs < 0) return '-'
-
-  const seconds = Math.floor(diffMs / 1000)
-  const minutes = Math.floor(seconds / 60)
-  const hours = Math.floor(minutes / 60)
-
-  if (hours > 0) {
-    return `${hours}h ${minutes % 60}m`
-  }
-  if (minutes > 0) {
-    return `${minutes}m`
-  }
-  return `${seconds}s`
-}
-
-
 /**
  * Hook to fetch ProwJobs from a cluster
  */
@@ -133,7 +112,7 @@ export function useProwJobs(prowCluster = 'prow', namespace = 'prow') {
             cluster: prowCluster,
             startTime,
             completionTime,
-            duration: state === 'pending' || state === 'triggered' ? '-' : formatDuration(startTime, completionTime),
+            duration: state === 'pending' || state === 'triggered' ? '-' : formatProwDuration(startTime, completionTime),
             pr: pj.spec.refs?.pulls?.[0]?.number,
             url: pj.status.url,
             buildId: pj.status.build_id || pj.metadata.labels?.['prow.k8s.io/build-id'] }

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -2,6 +2,28 @@
  * Utility functions for formatting values for display
  */
 
+import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR } from './constants/time'
+
+/**
+ * Format the elapsed time between two ISO timestamps as a compact string.
+ * Used by ProwJob listings to display run duration.
+ */
+export function formatProwDuration(startTime: string, endTime?: string): string {
+  const start = new Date(startTime)
+  const end = endTime ? new Date(endTime) : new Date()
+  const diffMs = end.getTime() - start.getTime()
+
+  if (diffMs < 0) return '-'
+
+  const seconds = Math.floor(diffMs / MS_PER_SECOND)
+  const minutes = Math.floor(seconds / SECONDS_PER_MINUTE)
+  const hours = Math.floor(minutes / MINUTES_PER_HOUR)
+
+  if (hours > 0) return `${hours}h ${minutes % MINUTES_PER_HOUR}m`
+  if (minutes > 0) return `${minutes}m`
+  return `${seconds}s`
+}
+
 /**
  * Parse Kubernetes resource quantity strings (e.g., "16077540Ki", "4Gi", "500Mi")
  * and convert to bytes


### PR DESCRIPTION
## Summary
- Extract identical `formatDuration(startTime, endTime?)` from `useProw.ts` and `useCachedProw.ts` into shared `formatProwDuration` in `lib/formatters.ts`
- Replace magic numbers (1000, 60) with time constants from `lib/constants/time.ts`
- Net -15 lines (26 added, 41 removed)

## Context
6 different `formatDuration` variants exist across the codebase — this PR consolidates only the two that are functionally identical (Prow-specific, taking ISO timestamps). The other 4 have different signatures/units and remain intentionally separate.

## Test plan
- [x] `npx vitest run src/hooks/useCachedData.test.ts` — 74 pass
- [x] `npx vitest run src/test/card-loading-standard.test.ts src/test/no-magic-numbers.test.ts src/test/ui-ux-standards.test.ts` — 718 pass
- [x] `npm run build` — clean

Fixes #10279