### PR TITLE
fix: correct off-by-one threshold in partial failure resilience test

### DIFF
--- a/web/e2e/compliance/error-resilience.spec.ts
+++ b/web/e2e/compliance/error-resilience.spec.ts
@@ -349,7 +349,7 @@ test.describe('Error Resilience', () => {
       }
 
       // At least some cards should have content (healthy endpoints)
-      const status = loadedCards > 0 ? 'pass' : 'warn'
+      const status = loadedCards > 0 ? 'pass' : 'fail'
 
       addResult({
         testName: 'Partial failure',


### PR DESCRIPTION
## Summary
- Fix off-by-one in error-resilience.spec.ts where loadedCards === 0 incorrectly sets status to 'warn' instead of 'fail'
- Zero loaded cards from healthy endpoints is a complete failure, not a warning

Fixes #10273

## Test plan
- [ ] Verify the test correctly reports 'fail' when no cards load
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)