### PR TITLE
🌱 Add 79 tests for 12 more untested files (coverage 88.53% → 91%)

### DIFF
--- a/web/src/lib/cards/__tests__/statusMappers.test.ts
+++ b/web/src/lib/cards/__tests__/statusMappers.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import {
+  gatewayStatusIcons,
+  gatewayStatusColors,
+  crdStatusIcons,
+  crdStatusColors,
+  helmStatusIcons,
+  helmStatusColors,
+  operatorStatusIcons,
+  operatorStatusColors,
+  createStatusMappers,
+} from '../statusMappers'
+
+describe('statusMappers', () => {
+  describe('gatewayStatusIcons', () => {
+    it('maps all expected statuses', () => {
+      expect(gatewayStatusIcons['Programmed']).toBeDefined()
+      expect(gatewayStatusIcons['Accepted']).toBeDefined()
+      expect(gatewayStatusIcons['Pending']).toBeDefined()
+      expect(gatewayStatusIcons['NotAccepted']).toBeDefined()
+      expect(gatewayStatusIcons['Unknown']).toBeDefined()
+    })
+  })
+
+  describe('gatewayStatusColors', () => {
+    it('returns color configs with bg, text, border', () => {
+      for (const status of ['Programmed', 'Accepted', 'Pending', 'NotAccepted', 'Unknown']) {
+        const c = gatewayStatusColors[status]
+        expect(c.bg).toBeTruthy()
+        expect(c.text).toBeTruthy()
+        expect(c.border).toBeTruthy()
+      }
+    })
+  })
+
+  describe('crdStatusIcons', () => {
+    it('maps CRD statuses', () => {
+      expect(crdStatusIcons['Established']).toBeDefined()
+      expect(crdStatusIcons['NotEstablished']).toBeDefined()
+      expect(crdStatusIcons['Terminating']).toBeDefined()
+    })
+  })
+
+  describe('crdStatusColors', () => {
+    it('maps CRD status to simple color names', () => {
+      expect(crdStatusColors['Established']).toBe('green')
+      expect(crdStatusColors['NotEstablished']).toBe('red')
+      expect(crdStatusColors['Terminating']).toBe('orange')
+    })
+  })
+
+  describe('helmStatusIcons', () => {
+    it('maps Helm statuses', () => {
+      expect(helmStatusIcons['Deployed']).toBeDefined()
+      expect(helmStatusIcons['Failed']).toBeDefined()
+      expect(helmStatusIcons['Pending']).toBeDefined()
+    })
+  })
+
+  describe('helmStatusColors', () => {
+    it('returns color configs for all Helm statuses', () => {
+      for (const status of ['Deployed', 'Superseded', 'Failed', 'Pending', 'Unknown']) {
+        const c = helmStatusColors[status]
+        expect(c.bg).toBeTruthy()
+        expect(c.text).toBeTruthy()
+        expect(c.border).toBeTruthy()
+      }
+    })
+  })
+
+  describe('operatorStatusIcons + operatorStatusColors', () => {
+    it('maps operator statuses', () => {
+      for (const s of ['Running', 'Failed', 'Unknown', 'Pending']) {
+        expect(operatorStatusIcons[s]).toBeDefined()
+        expect(operatorStatusColors[s]).toBeDefined()
+      }
+    })
+  })
+
+  describe('createStatusMappers', () => {
+    it('returns getIcon and getColor functions', () => {
+      const mappers = createStatusMappers(
+        gatewayStatusIcons as Record<string, typeof gatewayStatusIcons[string]>,
+        gatewayStatusColors as Record<string, typeof gatewayStatusColors[string]>,
+      )
+      expect(typeof mappers.getIcon).toBe('function')
+      expect(typeof mappers.getColor).toBe('function')
+    })
+
+    it('getIcon returns mapped icon for known status', () => {
+      const mappers = createStatusMappers(
+        gatewayStatusIcons as Record<string, typeof gatewayStatusIcons[string]>,
+        gatewayStatusColors as Record<string, typeof gatewayStatusColors[string]>,
+      )
+      expect(mappers.getIcon('Programmed')).toBe(gatewayStatusIcons['Programmed'])
+    })
+
+    it('getColor returns mapped color for known status', () => {
+      const mappers = createStatusMappers(
+        gatewayStatusIcons as Record<string, typeof gatewayStatusIcons[string]>,
+        gatewayStatusColors as Record<string, typeof gatewayStatusColors[string]>,
+      )
+      expect(mappers.getColor('Pending')).toBe(gatewayStatusColors['Pending'])
+    })
+
+    it('returns default icon and color for unknown status', () => {
+      const mappers = createStatusMappers(
+        gatewayStatusIcons as Record<string, typeof gatewayStatusIcons[string]>,
+        gatewayStatusColors as Record<string, typeof gatewayStatusColors[string]>,
+      )
+      const icon = mappers.getIcon('nonexistent')
+      const color = mappers.getColor('nonexistent')
+      expect(icon).toBeDefined()
+      expect(color.bg).toBeTruthy()
+    })
+  })
+})

--- a/web/src/lib/demo/__tests__/backstage.test.ts
+++ b/web/src/lib/demo/__tests__/backstage.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import {
+  BACKSTAGE_DEMO_DATA,
+  BACKSTAGE_ENTITY_KINDS,
+  BACKSTAGE_MS_PER_HOUR,
+} from '../backstage'
+
+describe('BACKSTAGE_DEMO_DATA', () => {
+  const data = BACKSTAGE_DEMO_DATA
+
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(data.health)
+  })
+
+  it('has version and replica info', () => {
+    expect(data.version).toBeTruthy()
+    expect(data.replicas).toBeGreaterThan(0)
+    expect(data.desiredReplicas).toBeGreaterThanOrEqual(data.replicas)
+  })
+
+  it('has catalog counts for all entity kinds', () => {
+    for (const kind of BACKSTAGE_ENTITY_KINDS) {
+      expect(typeof data.catalog[kind]).toBe('number')
+      expect(data.catalog[kind]).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('has plugins with valid statuses', () => {
+    expect(data.plugins.length).toBeGreaterThan(0)
+    for (const p of data.plugins) {
+      expect(p.name).toBeTruthy()
+      expect(['enabled', 'disabled', 'error']).toContain(p.status)
+    }
+  })
+
+  it('has scaffolder templates', () => {
+    expect(data.templates.length).toBeGreaterThan(0)
+    for (const t of data.templates) {
+      expect(t.name).toBeTruthy()
+      expect(t.type).toBeTruthy()
+    }
+  })
+
+  it('has consistent summary', () => {
+    const s = data.summary
+    const totalFromCatalog = Object.values(data.catalog).reduce((a, b) => a + b, 0)
+    expect(s.totalEntities).toBe(totalFromCatalog)
+    expect(s.scaffolderTemplates).toBe(data.templates.length)
+  })
+
+  it('has valid ISO timestamps', () => {
+    expect(new Date(data.lastCatalogSync).getTime()).toBeGreaterThan(0)
+    expect(new Date(data.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+})
+
+describe('BACKSTAGE_ENTITY_KINDS', () => {
+  it('contains all expected kinds', () => {
+    expect(BACKSTAGE_ENTITY_KINDS).toContain('Component')
+    expect(BACKSTAGE_ENTITY_KINDS).toContain('API')
+    expect(BACKSTAGE_ENTITY_KINDS).toContain('User')
+    expect(BACKSTAGE_ENTITY_KINDS).toContain('Group')
+  })
+})
+
+describe('BACKSTAGE_MS_PER_HOUR', () => {
+  it('equals 3600000 ms', () => {
+    expect(BACKSTAGE_MS_PER_HOUR).toBe(3_600_000)
+  })
+})

--- a/web/src/lib/demo/__tests__/cloud-custodian.test.ts
+++ b/web/src/lib/demo/__tests__/cloud-custodian.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { CLOUD_CUSTODIAN_DEMO_DATA } from '../cloud-custodian'
+
+describe('CLOUD_CUSTODIAN_DEMO_DATA', () => {
+  const data = CLOUD_CUSTODIAN_DEMO_DATA
+
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(data.health)
+  })
+
+  it('has a version string', () => {
+    expect(data.version).toBeTruthy()
+    expect(typeof data.version).toBe('string')
+  })
+
+  it('has policies array with required fields', () => {
+    expect(data.policies.length).toBeGreaterThan(0)
+    for (const p of data.policies) {
+      expect(p.name).toBeTruthy()
+      expect(['pull', 'periodic', 'event']).toContain(p.mode)
+      expect(['aws', 'azure', 'gcp', 'k8s']).toContain(p.provider)
+      expect(typeof p.successCount).toBe('number')
+      expect(typeof p.failCount).toBe('number')
+      expect(typeof p.dryRunCount).toBe('number')
+    }
+  })
+
+  it('has topResources with required fields', () => {
+    expect(data.topResources.length).toBeGreaterThan(0)
+    for (const r of data.topResources) {
+      expect(r.type).toBeTruthy()
+      expect(typeof r.actionCount).toBe('number')
+    }
+  })
+
+  it('has violationsBySeverity with all severity levels', () => {
+    const v = data.violationsBySeverity
+    expect(typeof v.critical).toBe('number')
+    expect(typeof v.high).toBe('number')
+    expect(typeof v.medium).toBe('number')
+    expect(typeof v.low).toBe('number')
+  })
+
+  it('has consistent summary', () => {
+    const s = data.summary
+    expect(s.totalPolicies).toBe(data.policies.length)
+    expect(typeof s.successfulPolicies).toBe('number')
+    expect(typeof s.failedPolicies).toBe('number')
+    expect(typeof s.dryRunPolicies).toBe('number')
+  })
+
+  it('has a valid lastCheckTime ISO string', () => {
+    expect(new Date(data.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+})

--- a/web/src/lib/demo/__tests__/cni.test.ts
+++ b/web/src/lib/demo/__tests__/cni.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { CNI_DEMO_DATA } from '../cni'
+
+describe('CNI_DEMO_DATA', () => {
+  const data = CNI_DEMO_DATA
+
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(data.health)
+  })
+
+  it('has nodes with required fields', () => {
+    expect(data.nodes.length).toBeGreaterThan(0)
+    for (const n of data.nodes) {
+      expect(n.node).toBeTruthy()
+      expect(['ready', 'not-ready', 'unknown']).toContain(n.state)
+    }
+  })
+
+  it('has stats with network CIDRs', () => {
+    const s = data.stats
+    expect(s.podNetworkCidr).toMatch(/\d+\.\d+\.\d+\.\d+\/\d+/)
+    expect(s.serviceNetworkCidr).toMatch(/\d+\.\d+\.\d+\.\d+\/\d+/)
+    expect(s.pluginVersion).toBeTruthy()
+    expect(typeof s.nodeCount).toBe('number')
+    expect(typeof s.nodesCniReady).toBe('number')
+  })
+
+  it('has consistent summary with stats', () => {
+    expect(data.summary.activePlugin).toBe(data.stats.activePlugin)
+    expect(data.summary.pluginVersion).toBe(data.stats.pluginVersion)
+    expect(data.summary.nodeCount).toBe(data.stats.nodeCount)
+    expect(data.summary.nodesCniReady).toBe(data.stats.nodesCniReady)
+  })
+
+  it('node count matches nodes array', () => {
+    expect(data.stats.nodeCount).toBe(data.nodes.length)
+  })
+
+  it('has a valid lastCheckTime', () => {
+    expect(new Date(data.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+})

--- a/web/src/lib/demo/__tests__/cortex.test.ts
+++ b/web/src/lib/demo/__tests__/cortex.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { CORTEX_DEMO_DATA } from '../cortex'
+
+describe('CORTEX_DEMO_DATA', () => {
+  const data = CORTEX_DEMO_DATA
+
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(data.health)
+  })
+
+  it('has a version string', () => {
+    expect(data.version).toBeTruthy()
+  })
+
+  it('has components with required fields', () => {
+    expect(data.components.length).toBeGreaterThan(0)
+    for (const c of data.components) {
+      expect(c.name).toBeTruthy()
+      expect(['running', 'pending', 'failed', 'unknown']).toContain(c.status)
+      expect(typeof c.replicasDesired).toBe('number')
+      expect(typeof c.replicasReady).toBe('number')
+    }
+  })
+
+  it('includes canonical Cortex component names', () => {
+    const names = data.components.map(c => c.name)
+    expect(names).toContain('distributor')
+    expect(names).toContain('ingester')
+    expect(names).toContain('querier')
+  })
+
+  it('has ingestion metrics', () => {
+    const m = data.metrics
+    expect(typeof m.activeSeries).toBe('number')
+    expect(m.activeSeries).toBeGreaterThan(0)
+    expect(typeof m.ingestionRatePerSec).toBe('number')
+    expect(typeof m.queryRatePerSec).toBe('number')
+    expect(typeof m.tenantCount).toBe('number')
+  })
+
+  it('has consistent summary', () => {
+    const s = data.summary
+    expect(s.totalPods).toBeGreaterThanOrEqual(s.runningPods)
+    expect(s.totalComponents).toBe(new Set(data.components.map(c => c.name)).size)
+  })
+
+  it('has a valid lastCheckTime', () => {
+    expect(new Date(data.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+})

--- a/web/src/lib/demo/__tests__/dapr.test.ts
+++ b/web/src/lib/demo/__tests__/dapr.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { DAPR_DEMO_DATA } from '../dapr'
+
+describe('DAPR_DEMO_DATA re-export', () => {
+  it('exports a valid object with health status', () => {
+    expect(DAPR_DEMO_DATA).toBeDefined()
+    expect(['healthy', 'degraded', 'not-installed']).toContain(DAPR_DEMO_DATA.health)
+  })
+
+  it('has control plane pods', () => {
+    expect(DAPR_DEMO_DATA.controlPlane.length).toBeGreaterThan(0)
+  })
+
+  it('has summary with required fields', () => {
+    expect(typeof DAPR_DEMO_DATA.summary.totalControlPlanePods).toBe('number')
+    expect(typeof DAPR_DEMO_DATA.summary.runningControlPlanePods).toBe('number')
+    expect(typeof DAPR_DEMO_DATA.summary.totalComponents).toBe('number')
+    expect(typeof DAPR_DEMO_DATA.summary.totalDaprApps).toBe('number')
+  })
+})

--- a/web/src/lib/demo/__tests__/kubevela.test.ts
+++ b/web/src/lib/demo/__tests__/kubevela.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { KUBEVELA_DEMO_DATA } from '../kubevela'
+
+describe('KUBEVELA_DEMO_DATA re-export', () => {
+  it('exports a valid object with health status', () => {
+    expect(KUBEVELA_DEMO_DATA).toBeDefined()
+    expect(['healthy', 'degraded', 'not-installed']).toContain(KUBEVELA_DEMO_DATA.health)
+  })
+
+  it('has applications array', () => {
+    expect(KUBEVELA_DEMO_DATA.applications.length).toBeGreaterThan(0)
+  })
+
+  it('has summary with required fields', () => {
+    expect(typeof KUBEVELA_DEMO_DATA.summary.totalApplications).toBe('number')
+  })
+})

--- a/web/src/lib/demo/__tests__/openfeature.test.ts
+++ b/web/src/lib/demo/__tests__/openfeature.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { OPENFEATURE_DEMO_DATA } from '../openfeature'
+
+describe('OPENFEATURE_DEMO_DATA re-export', () => {
+  it('exports a valid object with health status', () => {
+    expect(OPENFEATURE_DEMO_DATA).toBeDefined()
+    expect(['healthy', 'degraded', 'not-installed']).toContain(OPENFEATURE_DEMO_DATA.health)
+  })
+
+  it('has providers array', () => {
+    expect(OPENFEATURE_DEMO_DATA.providers.length).toBeGreaterThan(0)
+  })
+
+  it('has flags array', () => {
+    expect(OPENFEATURE_DEMO_DATA.flags.length).toBeGreaterThan(0)
+  })
+})

--- a/web/src/lib/demo/__tests__/spire.test.ts
+++ b/web/src/lib/demo/__tests__/spire.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { SPIRE_DEMO_DATA } from '../spire'
+
+describe('SPIRE_DEMO_DATA', () => {
+  const data = SPIRE_DEMO_DATA
+
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(data.health)
+  })
+
+  it('has version and trust domain', () => {
+    expect(data.version).toBeTruthy()
+    expect(data.trustDomain).toBeTruthy()
+  })
+
+  it('has server pods with required fields', () => {
+    expect(data.serverPods.length).toBeGreaterThan(0)
+    for (const pod of data.serverPods) {
+      expect(pod.name).toBeTruthy()
+      expect(['Running', 'Pending', 'Failed', 'Succeeded', 'Unknown']).toContain(pod.phase)
+      expect(typeof pod.ready).toBe('boolean')
+    }
+  })
+
+  it('has agent daemonset', () => {
+    expect(data.agentDaemonSet).not.toBeNull()
+    const ds = data.agentDaemonSet!
+    expect(typeof ds.desiredNumberScheduled).toBe('number')
+    expect(typeof ds.numberReady).toBe('number')
+    expect(ds.desiredNumberScheduled).toBeGreaterThanOrEqual(ds.numberReady)
+  })
+
+  it('has consistent summary', () => {
+    const s = data.summary
+    expect(typeof s.registrationEntries).toBe('number')
+    expect(typeof s.attestedAgents).toBe('number')
+    expect(typeof s.trustBundleAgeHours).toBe('number')
+    expect(s.serverDesiredReplicas).toBeGreaterThanOrEqual(s.serverReadyReplicas)
+  })
+
+  it('has a valid lastCheckTime', () => {
+    expect(new Date(data.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+})

--- a/web/src/lib/demo/__tests__/volcano.test.ts
+++ b/web/src/lib/demo/__tests__/volcano.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { VOLCANO_DEMO_DATA } from '../volcano'
+
+describe('VOLCANO_DEMO_DATA re-export', () => {
+  it('exports a valid object with health status', () => {
+    expect(VOLCANO_DEMO_DATA).toBeDefined()
+    expect(['healthy', 'degraded', 'not-installed']).toContain(VOLCANO_DEMO_DATA.health)
+  })
+
+  it('has queues array', () => {
+    expect(VOLCANO_DEMO_DATA.queues.length).toBeGreaterThan(0)
+  })
+
+  it('has jobs array', () => {
+    expect(VOLCANO_DEMO_DATA.jobs.length).toBeGreaterThan(0)
+  })
+
+  it('has summary', () => {
+    expect(typeof VOLCANO_DEMO_DATA.summary.totalQueues).toBe('number')
+    expect(typeof VOLCANO_DEMO_DATA.summary.totalJobs).toBe('number')
+  })
+})

--- a/web/src/lib/demo/__tests__/wasmcloud.test.ts
+++ b/web/src/lib/demo/__tests__/wasmcloud.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { WASMCLOUD_DEMO_DATA } from '../wasmcloud'
+
+describe('WASMCLOUD_DEMO_DATA re-export', () => {
+  it('exports a valid object with health status', () => {
+    expect(WASMCLOUD_DEMO_DATA).toBeDefined()
+    expect(['healthy', 'degraded', 'not-installed']).toContain(WASMCLOUD_DEMO_DATA.health)
+  })
+
+  it('has hosts array', () => {
+    expect(WASMCLOUD_DEMO_DATA.hosts.length).toBeGreaterThan(0)
+  })
+
+  it('has summary', () => {
+    expect(typeof WASMCLOUD_DEMO_DATA.summary.totalHosts).toBe('number')
+  })
+})

--- a/web/src/lib/utils/__tests__/sanitizeUrl.test.ts
+++ b/web/src/lib/utils/__tests__/sanitizeUrl.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeUrl } from '../sanitizeUrl'
+
+describe('sanitizeUrl', () => {
+  it('returns about:blank for null', () => {
+    expect(sanitizeUrl(null)).toBe('about:blank')
+  })
+
+  it('returns about:blank for undefined', () => {
+    expect(sanitizeUrl(undefined)).toBe('about:blank')
+  })
+
+  it('returns about:blank for empty string', () => {
+    expect(sanitizeUrl('')).toBe('about:blank')
+  })
+
+  it('allows https URLs', () => {
+    expect(sanitizeUrl('https://example.com')).toBe('https://example.com/')
+  })
+
+  it('allows http URLs', () => {
+    expect(sanitizeUrl('http://example.com')).toBe('http://example.com/')
+  })
+
+  it('allows mailto URLs', () => {
+    const result = sanitizeUrl('mailto:user@example.com')
+    expect(result).toBe('mailto:user@example.com')
+  })
+
+  it('allows tel URLs', () => {
+    const result = sanitizeUrl('tel:+1234567890')
+    expect(result).toBe('tel:+1234567890')
+  })
+
+  it('allows protocol-relative URLs', () => {
+    expect(sanitizeUrl('//cdn.example.com/file.js')).toBe('//cdn.example.com/file.js')
+  })
+
+  it('allows relative paths starting with /', () => {
+    expect(sanitizeUrl('/api/health')).toBe('/api/health')
+  })
+
+  it('allows relative paths starting with .', () => {
+    expect(sanitizeUrl('./images/logo.png')).toBe('./images/logo.png')
+  })
+
+  it('allows paths without scheme', () => {
+    expect(sanitizeUrl('images/logo.png')).toBe('images/logo.png')
+  })
+
+  it('blocks javascript: scheme', () => {
+    expect(sanitizeUrl('javascript:alert(1)')).toBe('about:blank')
+  })
+
+  it('blocks data: scheme', () => {
+    expect(sanitizeUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank')
+  })
+
+  it('blocks vbscript: scheme', () => {
+    expect(sanitizeUrl('vbscript:msgbox')).toBe('about:blank')
+  })
+
+  it('strips control characters from obfuscated URLs', () => {
+    expect(sanitizeUrl('java\tscript:alert(1)')).toBe('about:blank')
+  })
+
+  it('strips null bytes from obfuscated URLs', () => {
+    expect(sanitizeUrl('java\0script:alert(1)')).toBe('about:blank')
+  })
+
+  it('returns about:blank for whitespace-only strings', () => {
+    expect(sanitizeUrl('   ')).toBe('about:blank')
+  })
+})


### PR DESCRIPTION
Coverage gap: CI reports 88.53%, target is 91%.

## New Tests (79 total)

### Large demo data modules (5 files)
- cloud-custodian (255 lines), backstage (204), cortex (187), spire (168), cni (165)
- Validates structure, required fields, summary consistency, ISO timestamps

### Re-export demo modules (5 files)
- dapr, kubevela, wasmcloud, openfeature, volcano
- Validates re-export chain works, data shapes correct

### Utility modules (2 files)
- `lib/cards/statusMappers` — gateway/crd/helm/operator icon+color mappers, createStatusMappers factory
- `lib/utils/sanitizeUrl` — XSS prevention: scheme allowlist, control char stripping, edge cases

All 79 tests pass locally. Combined with PR #10275 (64 tests), that's 143 new tests targeting the lowest-coverage files.