### PR TITLE
🧹 Replace remaining local time constants with shared imports (#10281)

### DIFF
--- a/web/src/hooks/useCachedContainerd.ts
+++ b/web/src/hooks/useCachedContainerd.ts
@@ -19,6 +19,7 @@
 import { useCache, type RefreshCategory } from '../lib/cache'
 import { useDemoMode } from './useDemoMode'
 import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../lib/constants/network'
+import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY } from '../lib/constants/time'
 import {
   CONTAINERD_DEMO_DATA,
   type ContainerdContainer,
@@ -109,11 +110,6 @@ function formatUptime(startedAt: string | undefined, state: ContainerdContainerS
 
   const started = new Date(startedAt).getTime()
   if (Number.isNaN(started)) return UPTIME_UNKNOWN
-
-  const MS_PER_SECOND = 1000
-  const SECONDS_PER_MINUTE = 60
-  const MINUTES_PER_HOUR = 60
-  const HOURS_PER_DAY = 24
 
   const diffSeconds = Math.max(0, Math.floor((Date.now() - started) / MS_PER_SECOND))
   if (diffSeconds < SECONDS_PER_MINUTE) return `${diffSeconds}s`

--- a/web/src/hooks/useSnoozedCards.ts
+++ b/web/src/hooks/useSnoozedCards.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { POLL_INTERVAL_SLOW_MS } from '../lib/constants/network'
 import { STORAGE_KEY_SNOOZED_CARDS } from '../lib/constants/storage'
-import { MS_PER_HOUR } from '../lib/constants/time'
+import { MS_PER_HOUR, MS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY } from '../lib/constants/time'
 import { emitSnoozed, emitUnsnoozed } from '../lib/analytics'
 
 /** Default snooze duration: 1 hour */
@@ -149,13 +149,6 @@ export function formatTimeRemaining(until: Date | number): string {
   const diff = untilMs - now
 
   if (diff <= 0) return 'Expired'
-
-  /** Milliseconds per minute */
-  const MS_PER_MINUTE = 60_000
-  /** Minutes per hour */
-  const MINUTES_PER_HOUR = 60
-  /** Hours per day */
-  const HOURS_PER_DAY = 24
 
   const minutes = Math.floor(diff / MS_PER_MINUTE)
   const hours = Math.floor(minutes / MINUTES_PER_HOUR)

--- a/web/src/hooks/useUpdateProgress.ts
+++ b/web/src/hooks/useUpdateProgress.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import type { UpdateProgress, UpdateStepEntry } from '../types/updates'
 import { LOCAL_AGENT_WS_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { MS_PER_SECOND } from '../lib/constants/time'
 import { isNetlifyDeployment } from '../lib/demoMode'
 
 // WebSocket reconnection with exponential backoff
@@ -159,11 +160,9 @@ export function useUpdateProgress() {
       const RESTART_BASE_PCT = 88   // Starting progress during health polling
       const RESTART_MAX_PCT = 99    // Max progress before "done" (100%)
       const pctPerAttempt = (RESTART_MAX_PCT - RESTART_BASE_PCT) / BACKEND_POLL_MAX
-      const MS_PER_SEC = 1000
-
       for (let i = 0; i < BACKEND_POLL_MAX; i++) {
         const pct = Math.round(RESTART_BASE_PCT + (i * pctPerAttempt))
-        const elapsed = Math.round((i * BACKEND_POLL_MS) / MS_PER_SEC)
+        const elapsed = Math.round((i * BACKEND_POLL_MS) / MS_PER_SECOND)
         const TEN_SEC = 10
         const THIRTY_SEC = 30
         const SIXTY_SEC = 60

--- a/web/src/lib/constants/time.ts
+++ b/web/src/lib/constants/time.ts
@@ -13,3 +13,8 @@ export const HOURS_PER_DAY = 24
 export const MS_PER_MINUTE = MS_PER_SECOND * SECONDS_PER_MINUTE
 export const MS_PER_HOUR = MS_PER_MINUTE * MINUTES_PER_HOUR
 export const MS_PER_DAY = MS_PER_HOUR * HOURS_PER_DAY
+
+export const DAYS_PER_MONTH = 30
+export const DAYS_PER_YEAR = 365
+export const MS_PER_MONTH = MS_PER_DAY * DAYS_PER_MONTH
+export const MS_PER_YEAR = MS_PER_DAY * DAYS_PER_YEAR

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -2,7 +2,7 @@
  * Utility functions for formatting values for display
  */
 
-import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR } from './constants/time'
+import { MS_PER_SECOND, MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY, MS_PER_MONTH, MS_PER_YEAR, SECONDS_PER_MINUTE, MINUTES_PER_HOUR } from './constants/time'
 
 /**
  * Format the elapsed time between two ISO timestamps as a compact string.
@@ -184,12 +184,6 @@ export function formatK8sStorage(value: string): string {
   return formatBytes(bytes)
 }
 
-const MS_PER_MINUTE = 60_000
-const MS_PER_HOUR = 60 * MS_PER_MINUTE
-const MS_PER_DAY = 24 * MS_PER_HOUR
-const MS_PER_MONTH = 30 * MS_PER_DAY
-const MS_PER_YEAR = 365 * MS_PER_DAY
-
 function toTimestamp(input: string | Date | number): number {
   if (typeof input === 'number') return input
   if (input instanceof Date) return input.getTime()
@@ -302,13 +296,9 @@ export function createCardSyncFormatter(
     const diff = Date.now() - parsed
     if (diff < 0) return t(k.justNow)
 
-    const MS_PER_MIN = 60_000
-    const MS_PER_HR = 60 * MS_PER_MIN
-    const MS_PER_D = 24 * MS_PER_HR
-
-    if (diff < MS_PER_MIN) return t(k.justNow)
-    if (diff < MS_PER_HR) return t(k.minutesAgo, { count: Math.floor(diff / MS_PER_MIN) })
-    if (diff < MS_PER_D) return t(k.hoursAgo, { count: Math.floor(diff / MS_PER_HR) })
-    return t(k.daysAgo, { count: Math.floor(diff / MS_PER_D) })
+    if (diff < MS_PER_MINUTE) return t(k.justNow)
+    if (diff < MS_PER_HOUR) return t(k.minutesAgo, { count: Math.floor(diff / MS_PER_MINUTE) })
+    if (diff < MS_PER_DAY) return t(k.hoursAgo, { count: Math.floor(diff / MS_PER_HOUR) })
+    return t(k.daysAgo, { count: Math.floor(diff / MS_PER_DAY) })
   }
 }


### PR DESCRIPTION
## Summary
- Replace ~16 locally-declared time constants in 4 source files with imports from `lib/constants/time.ts`
- Add `MS_PER_MONTH`, `MS_PER_YEAR`, `DAYS_PER_MONTH`, `DAYS_PER_YEAR` to the shared constants file
- Continues the consolidation started in PRs #10225 and #10227
- Net -15 lines

## Files changed (5)
- `lib/constants/time.ts` — 4 new exports
- `hooks/useCachedContainerd.ts` — removed 4 local constants, added import
- `hooks/useSnoozedCards.ts` — removed 3 local constants, expanded import
- `hooks/useUpdateProgress.ts` — removed 1 local constant, added import
- `lib/formatters.ts` — removed 8 local constants across 2 locations, added import

## Test plan
- [x] `npx vitest run src/test/card-loading-standard.test.ts src/test/no-magic-numbers.test.ts src/test/ui-ux-standards.test.ts` — 718 pass
- [x] `npx vitest run src/hooks/__tests__/useSnoozeHooks.test.ts` — 86 pass
- [x] `npm run build` — clean

Fixes #10281