### PR TITLE
🧹 Remove dead exports from lib/formatters.ts

### DIFF
--- a/web/src/lib/__tests__/formatters.test.ts
+++ b/web/src/lib/__tests__/formatters.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   formatBytes,
-  formatGBSmart,
   formatK8sMemory,
   formatK8sStorage,
   formatRelativeTime,
-  createRelativeTimeFormatter,
 } from '../formatters'
 
 describe('formatBytes', () => {
@@ -47,36 +45,6 @@ describe('formatBytes', () => {
 
   it('formats whole numbers without decimals', () => {
     expect(formatBytes(2048)).toBe('2 KB')
-  })
-})
-
-describe('formatGBSmart', () => {
-  it('returns 0 GB for zero', () => {
-    expect(formatGBSmart(0)).toEqual({ display: '0 GB', tooltip: '0 GB' })
-  })
-
-  it('returns 0 GB for negative', () => {
-    expect(formatGBSmart(-5)).toEqual({ display: '0 GB', tooltip: '0 GB' })
-  })
-
-  it('returns 0 GB for NaN', () => {
-    expect(formatGBSmart(NaN)).toEqual({ display: '0 GB', tooltip: '0 GB' })
-  })
-
-  it('formats GB below 1024', () => {
-    const result = formatGBSmart(256)
-    expect(result.display).toBe('256 GB')
-  })
-
-  it('formats TB for values >= 1024 GB', () => {
-    const result = formatGBSmart(2048)
-    expect(result.display).toBe('2.0 TB')
-    expect(result.tooltip).toContain('GB')
-  })
-
-  it('formats small GB values with decimals', () => {
-    const result = formatGBSmart(5.5)
-    expect(result.display).toBe('5.5 GB')
   })
 })
 
@@ -145,48 +113,5 @@ describe('formatRelativeTime', () => {
 
   it('returns just now for future date', () => {
     expect(formatRelativeTime('2026-04-01T12:00:00Z')).toBe('just now')
-  })
-})
-
-describe('createRelativeTimeFormatter', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-03-31T12:00:00Z'))
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('uses the provided translation function', () => {
-    const t = vi.fn().mockReturnValue('translated')
-    const formatter = createRelativeTimeFormatter(t)
-
-    formatter('2026-03-31T11:55:00Z')
-    expect(t).toHaveBeenCalledWith('common.minutesAgo', { count: 5 })
-  })
-
-  it('returns justNow for recent timestamps', () => {
-    const t = vi.fn().mockReturnValue('Just now')
-    const formatter = createRelativeTimeFormatter(t)
-
-    formatter('2026-03-31T11:59:50Z')
-    expect(t).toHaveBeenCalledWith('common.justNow')
-  })
-
-  it('returns hoursAgo for hour-old timestamps', () => {
-    const t = vi.fn().mockReturnValue('2 hours ago')
-    const formatter = createRelativeTimeFormatter(t)
-
-    formatter('2026-03-31T10:00:00Z')
-    expect(t).toHaveBeenCalledWith('common.hoursAgo', { count: 2 })
-  })
-
-  it('returns daysAgo for day-old timestamps', () => {
-    const t = vi.fn().mockReturnValue('3 days ago')
-    const formatter = createRelativeTimeFormatter(t)
-
-    formatter('2026-03-28T12:00:00Z')
-    expect(t).toHaveBeenCalledWith('common.daysAgo', { count: 3 })
   })
 })

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -150,23 +150,6 @@ export function formatCurrency(value: number): string {
 }
 
 /**
- * Format a value already in GB to a smart string, auto-converting to TB when large.
- * Returns { display, tooltip } so callers can show the short form and hover for detail.
- */
-export function formatGBSmart(gb: number, decimals = 1): { display: string; tooltip: string } {
-  if (!Number.isFinite(gb) || gb <= 0) return { display: '0 GB', tooltip: '0 GB' }
-  if (gb >= 1024) {
-    const tb = gb / 1024
-    return {
-      display: `${tb.toFixed(decimals)} TB`,
-      tooltip: `${Math.round(gb).toLocaleString()} GB`,
-    }
-  }
-  const rounded = gb >= 10 ? Math.round(gb) : Number(gb.toFixed(decimals))
-  return { display: `${rounded} GB`, tooltip: `${gb.toFixed(2)} GB` }
-}
-
-/**
  * Format Kubernetes resource quantity (e.g., "16077540Ki") to human-readable string
  */
 export function formatK8sMemory(value: string): string {
@@ -227,33 +210,7 @@ export function formatTimeAgo(input: string | Date | number, opts: FormatTimeAgo
 /** @deprecated Use {@link formatTimeAgo} instead. */
 export const formatRelativeTime = formatTimeAgo
 
-/**
- * Create an i18n-aware relative time formatter
- * Use this in components that need translated time strings
- * 
- * @example
- * const formatTime = createRelativeTimeFormatter(t)
- * formatTime(someISOString) // "2 minutes ago" or localized equivalent
- */
-export function createRelativeTimeFormatter(
-  t: (key: string, options?: { count?: number }) => string
-): (isoString: string) => string {
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('common.justNow')
-
-    const minute = 60_000
-    const hour = 60 * minute
-    const day = 24 * hour
-
-    if (diff < minute) return t('common.justNow')
-    if (diff < hour) return t('common.minutesAgo', { count: Math.floor(diff / minute) })
-    if (diff < day) return t('common.hoursAgo', { count: Math.floor(diff / hour) })
-    return t('common.daysAgo', { count: Math.floor(diff / day) })
-  }
-}
-
-export interface CardSyncKeys {
+interface CardSyncKeys {
   justNow: string
   minutesAgo: string
   hoursAgo: string
@@ -267,7 +224,7 @@ export interface CardSyncKeys {
  * {@link CardSyncKeys} object for cards that deviate (e.g. Thanos uses
  * `thanosStatus.justNow` without the `synced` prefix).
  */
-export function cardSyncKeys(prefix: string): CardSyncKeys {
+function cardSyncKeys(prefix: string): CardSyncKeys {
   return {
     justNow: `${prefix}.syncedJustNow`,
     minutesAgo: `${prefix}.syncedMinutesAgo`,


### PR DESCRIPTION
## Summary
- Remove `formatGBSmart` — only referenced in its own test file, never imported elsewhere
- Remove `createRelativeTimeFormatter` — only referenced in its own test file, never imported elsewhere  
- Un-export `cardSyncKeys` and `CardSyncKeys` — only used internally by `createCardSyncFormatter`
- Remove corresponding test blocks from `formatters.test.ts`

Net: −120 lines, 0 new exports, no behavior change.

## Test plan
- [x] `vitest run formatters.test.ts` — 23 tests pass
- [x] `vitest run ui-ux-standards.test.ts` — all ratchets pass
- [x] `npm run build` — clean build with all post-build safety checks

Fixes #10289

🤖 Generated with [Claude Code](https://claude.com/claude-code)