### PR TITLE
🧹 Remove dead exports from lib/constants/ and lib/utils/

### DIFF
--- a/web/src/lib/constants/github-token.ts
+++ b/web/src/lib/constants/github-token.ts
@@ -12,16 +12,6 @@ export const GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS = [
   { scope: 'Issues: Read and write', reason: 'create issues, add comments, and attach screenshots' },
 ] as const
 
-/** Classic PAT scope required (covers all of the above) */
-export const GITHUB_TOKEN_CLASSIC_SCOPE = 'repo'
-
 /** URLs for creating tokens on GitHub */
 export const GITHUB_TOKEN_CREATE_URL = 'https://github.com/settings/personal-access-tokens/new'
-export const GITHUB_TOKEN_MANAGE_URL = 'https://github.com/settings/personal-access-tokens'
 export const GITHUB_TOKEN_CLASSIC_URL = 'https://github.com/settings/tokens/new?description=KubeStellar%20Console&scopes=repo'
-
-/** Human-readable summary for UI display */
-export const GITHUB_TOKEN_PERMISSION_SUMMARY = {
-  fineGrained: GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS.map(p => p.scope).join(' + '),
-  classic: `'${GITHUB_TOKEN_CLASSIC_SCOPE}' scope`,
-} as const

--- a/web/src/lib/constants/k8sResources.ts
+++ b/web/src/lib/constants/k8sResources.ts
@@ -1,4 +1,4 @@
-export interface K8sKindMeta {
+interface K8sKindMeta {
   kind: string
   clusterScoped: boolean
   label: string

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -220,9 +220,6 @@ export const DEFAULT_REFRESH_INTERVAL_MS = 120_000
 /** Timeout before showing "loading took too long" UI (5 seconds) */
 export const LOADING_TIMEOUT_MS = 5_000
 
-/** Extended loading timeout for cluster/page loads (10 seconds) */
-export const LOADING_TIMEOUT_EXTENDED_MS = 10_000
-
 /** Timeout for skeleton placeholder before showing fallback (100ms) */
 export const SKELETON_DELAY_MS = 100
 

--- a/web/src/lib/constants/storage.ts
+++ b/web/src/lib/constants/storage.ts
@@ -29,7 +29,6 @@ export const STORAGE_KEY_USER_CACHE = 'kc-user-cache'
  *  cookie exists (#6925). HttpOnly cookies are invisible to JS, so this
  *  localStorage flag acts as a proxy for "we had a session at some point". */
 export const STORAGE_KEY_HAS_SESSION = 'kc-has-session'
-export const STORAGE_KEY_BACKEND_STATUS = 'kc-backend-status'
 export const STORAGE_KEY_SQLITE_MIGRATED = 'kc-sqlite-migrated'
 
 // ── Settings (synced via settingsSync.ts) ──────────────────────────────
@@ -75,8 +74,6 @@ export const STORAGE_KEY_SEEN_TIPS = 'ksc-seen-tips'
 export const STORAGE_KEY_NPS_STATE = 'kc-nps-state'
 
 // ── Orbit (Recurring Maintenance) ─────────────────────────────────
-export const STORAGE_KEY_ORBIT_MISSIONS = 'kc-orbit-missions'
-export const STORAGE_KEY_ORBIT_HISTORY = 'kc-orbit-history'
 export const STORAGE_KEY_GROUND_CONTROL_DASHBOARDS = 'kc-ground-control-dashboards'
 
 // ── Snooze persistence ────────────────────────────────────────────────

--- a/web/src/lib/constants/units.ts
+++ b/web/src/lib/constants/units.ts
@@ -1,5 +1,3 @@
-/** Bytes per kibibyte (KiB) */
-export const BYTES_PER_KIB = 1024
 /** Bytes per mebibyte (MiB) */
 export const BYTES_PER_MIB = 1024 * 1024
 /** Bytes per gibibyte (GiB) */

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -69,7 +69,7 @@ function parseK8sQuantity(value: string): number {
 }
 
 /** Options for {@link formatBytes}. */
-export interface FormatBytesOptions {
+interface FormatBytesOptions {
   /** Number of decimal places (default: 1). */
   decimals?: number
   /** Use IEC binary units — KiB, MiB, GiB, TiB, PiB (default: false → KB, MB, …). */
@@ -173,7 +173,7 @@ function toTimestamp(input: string | Date | number): number {
   return new Date(input).getTime()
 }
 
-export interface FormatTimeAgoOptions {
+interface FormatTimeAgoOptions {
   /** Omit the " ago" suffix (e.g. "5m" instead of "5m ago"). */
   compact?: boolean
   /** Include month/year ranges for older timestamps (default: false — stops at days). */

--- a/web/src/lib/utils/wsAuth.ts
+++ b/web/src/lib/utils/wsAuth.ts
@@ -7,7 +7,7 @@
 import { STORAGE_KEY_TOKEN } from '../constants'
 
 /** Query-string key used to pass the auth token on WebSocket URLs */
-export const WS_AUTH_QUERY_PARAM = 'token'
+const WS_AUTH_QUERY_PARAM = 'token'
 
 /**
  * If a session token exists in localStorage, append it to `url` as


### PR DESCRIPTION
## Summary
- Remove 8 unused exports (zero references outside defining file)
- Un-export 4 symbols that are only used internally within their file
- 7 files touched, −22 lines, no behavior change

**Removed:**
- `BYTES_PER_KIB`, `STORAGE_KEY_BACKEND_STATUS`, `STORAGE_KEY_ORBIT_MISSIONS`, `STORAGE_KEY_ORBIT_HISTORY`, `LOADING_TIMEOUT_EXTENDED_MS`, `GITHUB_TOKEN_MANAGE_URL`, `GITHUB_TOKEN_PERMISSION_SUMMARY`, `GITHUB_TOKEN_CLASSIC_SCOPE`

**Un-exported (still used internally):**
- `K8sKindMeta`, `WS_AUTH_QUERY_PARAM`, `FormatBytesOptions`, `FormatTimeAgoOptions`

## Test plan
- [x] `npm run build` — clean build with all post-build safety checks
- [x] Verified each symbol has zero external imports via grep

Fixes #10293

🤖 Generated with [Claude Code](https://claude.com/claude-code)