### PR TITLE
🐛 Add animate-spin to refresh icons when isRefreshing

### DIFF
--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -649,7 +649,7 @@ export function HardwareHealthCard() {
               onClick={() => refetch()}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded bg-red-500/20 hover:bg-red-500/30 transition-colors whitespace-nowrap"
             >
-              <RefreshCw className="w-3 h-3" />
+              <RefreshCw className={cn('w-3 h-3', isRefreshing && 'animate-spin')} />
               Retry
             </button>
           </div>

--- a/web/src/components/cards/OperatorSubscriptions.tsx
+++ b/web/src/components/cards/OperatorSubscriptions.tsx
@@ -1,4 +1,5 @@
 import { Clock, AlertTriangle, AlertCircle, Settings, RefreshCw, ChevronRight } from 'lucide-react'
+import { cn } from '../../lib/cn'
 import { useClusters, OperatorSubscription } from '../../hooks/useMCP'
 import { useCachedOperatorSubscriptions } from '../../hooks/useCachedData'
 import { Skeleton } from '../ui/Skeleton'
@@ -134,7 +135,7 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
             onClick={() => refetch()}
             className="mt-1 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 transition-colors"
           >
-            <RefreshCw className="w-3 h-3" />
+            <RefreshCw className={cn('w-3 h-3', isRefreshing && 'animate-spin')} />
             {t('common:common.retry', 'Retry')}
           </button>
         </div>

--- a/web/src/components/cards/artifact_hub_status/index.tsx
+++ b/web/src/components/cards/artifact_hub_status/index.tsx
@@ -7,6 +7,7 @@ import {
   RefreshCw,
   Users,
 } from 'lucide-react'
+import { cn } from '../../../lib/cn'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../ui/Skeleton'
 import { MetricTile } from '../../../lib/cards/CardComponents'
@@ -17,7 +18,7 @@ import { createCardSyncFormatter } from '../../../lib/formatters'
 export function ArtifactHubStatus() {
   const { t } = useTranslation('cards')
   const formatRelativeTime = createCardSyncFormatter(t, 'artifactHub')
-  const { data, error, showSkeleton, showEmptyState } = useArtifactHubStatus()
+  const { data, error, isRefreshing, showSkeleton, showEmptyState } = useArtifactHubStatus()
 
   if (showSkeleton) {
     return (
@@ -67,7 +68,7 @@ export function ArtifactHubStatus() {
         </div>
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          <RefreshCw className="w-3 h-3" />
+          <RefreshCw className={cn('w-3 h-3', isRefreshing && 'animate-spin')} />
           <span>{formatRelativeTime(data.lastCheckTime)}</span>
         </div>
       </div>

--- a/web/src/components/cards/flatcar_status/index.tsx
+++ b/web/src/components/cards/flatcar_status/index.tsx
@@ -1,4 +1,5 @@
 import { CheckCircle, AlertTriangle, RefreshCw, Server } from 'lucide-react'
+import { cn } from '../../../lib/cn'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../ui/Skeleton'
 import { MetricTile } from '../../../lib/cards/CardComponents'
@@ -11,7 +12,7 @@ import { createCardSyncFormatter } from '../../../lib/formatters'
 export function FlatcarStatus() {
   const { t } = useTranslation('cards')
   const formatRelativeTime = createCardSyncFormatter(t, 'flatcar')
-  const { data, error, showSkeleton, showEmptyState } = useFlatcarStatus()
+  const { data, error, isRefreshing, showSkeleton, showEmptyState } = useFlatcarStatus()
 
   if (showSkeleton) {
     return (
@@ -67,7 +68,7 @@ export function FlatcarStatus() {
         </div>
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          <RefreshCw className="w-3 h-3" />
+          <RefreshCw className={cn('w-3 h-3', isRefreshing && 'animate-spin')} />
           <span>{formatRelativeTime(data.lastCheckTime)}</span>
         </div>
       </div>

--- a/web/src/components/cards/flatcar_status/useFlatcarStatus.ts
+++ b/web/src/components/cards/flatcar_status/useFlatcarStatus.ts
@@ -110,6 +110,7 @@ function toDemoStatus(demo: FlatcarDemoData): FlatcarStatus {
 export interface UseFlatcarStatusResult {
   data: FlatcarStatus
   loading: boolean
+  isRefreshing: boolean
   error: boolean
   consecutiveFailures: number
   showSkeleton: boolean
@@ -117,7 +118,7 @@ export interface UseFlatcarStatusResult {
 }
 
 export function useFlatcarStatus(): UseFlatcarStatusResult {
-  const { data, isLoading, isFailed, consecutiveFailures, isDemoFallback } =
+  const { data, isLoading, isRefreshing, isFailed, consecutiveFailures, isDemoFallback } =
     useCache<FlatcarStatus>({
       key: CACHE_KEY,
       category: 'default',
@@ -131,6 +132,7 @@ export function useFlatcarStatus(): UseFlatcarStatusResult {
 
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isLoading && !hasAnyData,
+    isRefreshing,
     hasAnyData,
     isFailed,
     consecutiveFailures,
@@ -140,6 +142,7 @@ export function useFlatcarStatus(): UseFlatcarStatusResult {
   return {
     data,
     loading: isLoading,
+    isRefreshing,
     error: isFailed && !hasAnyData,
     consecutiveFailures,
     showSkeleton,

--- a/web/src/components/cards/lima_status/LimaStatus.tsx
+++ b/web/src/components/cards/lima_status/LimaStatus.tsx
@@ -1,4 +1,5 @@
 import { CheckCircle, AlertTriangle, RefreshCw, Monitor, Cpu, MemoryStick, Server } from 'lucide-react'
+import { cn } from '../../../lib/cn'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../ui/Skeleton'
 import { useLimaStatus } from './useLimaStatus'
@@ -20,7 +21,7 @@ const STATUS_BG: Record<string, string> = {
 export function LimaStatus() {
   const { t } = useTranslation('cards')
   const formatRelativeTime = createCardSyncFormatter(t, 'lima')
-  const { data, error, showSkeleton, showEmptyState, isDemoData } = useLimaStatus()
+  const { data, error, isRefreshing, showSkeleton, showEmptyState, isDemoData } = useLimaStatus()
 
   if (showSkeleton) {
     return (
@@ -79,7 +80,7 @@ export function LimaStatus() {
 
         {!isDemoData && (
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <RefreshCw className="w-3 h-3" />
+            <RefreshCw className={cn('w-3 h-3', isRefreshing && 'animate-spin')} />
             <span>{formatRelativeTime(data.lastCheckTime)}</span>
           </div>
         )}

--- a/web/src/components/cards/lima_status/useLimaStatus.ts
+++ b/web/src/components/cards/lima_status/useLimaStatus.ts
@@ -143,6 +143,7 @@ function getDemoLimaStatus(noReachableClusters: boolean): LimaStatus {
 export interface UseLimaStatusResult {
   data: LimaStatus
   loading: boolean
+  isRefreshing: boolean
   error: boolean
   consecutiveFailures: number
   showSkeleton: boolean
@@ -260,6 +261,7 @@ export function useLimaStatus(): UseLimaStatusResult {
   return {
     data,
     loading: isLoading || clustersLoading,
+    isRefreshing,
     error: consecutiveFailures >= FAILURE_THRESHOLD && !hasAnyData,
     consecutiveFailures,
     showSkeleton,

--- a/web/src/components/cards/pipelines/PipelineFlow.tsx
+++ b/web/src/components/cards/pipelines/PipelineFlow.tsx
@@ -355,6 +355,7 @@ export function PipelineFlow() {
 
   const data = hasUnified ? unifiedData.flow : individual.data
   const isLoading = hasUnified ? unifiedData.isLoading : individual.isLoading
+  const isRefreshing = hasUnified ? unifiedData.isRefreshing : individual.isRefreshing
   const error = hasUnified ? unifiedData.error : individual.error
   const refetch = hasUnified ? unifiedData.refetch : individual.refetch
   const { run: runMutation } = usePipelineMutations()
@@ -362,7 +363,7 @@ export function PipelineFlow() {
 
   const runs = useMemo(() => data?.runs ?? [], [data])
   const hasData = runs.length > 0
-  useCardLoadingState({ isLoading: isLoading && !hasData, hasAnyData: hasData, isDemoData: isDemoMode })
+  useCardLoadingState({ isLoading: isLoading && !hasData, isRefreshing, hasAnyData: hasData, isDemoData: isDemoMode })
 
   // Auto-clear mutation message after a few seconds
   useEffect(() => {
@@ -416,7 +417,7 @@ export function PipelineFlow() {
             className="hover:text-foreground flex items-center gap-1"
             aria-label={LABEL_REFRESH}
           >
-            <RefreshCw className="w-3 h-3" />
+            <RefreshCw className={cn('w-3 h-3', isRefreshing && 'animate-spin')} />
           </button>
         </div>
       </div>

--- a/web/src/components/cards/pipelines/RecentFailures.tsx
+++ b/web/src/components/cards/pipelines/RecentFailures.tsx
@@ -68,6 +68,7 @@ export function RecentFailures() {
 
   const data = hasUnified ? unifiedData.failures : individual.data
   const isLoading = hasUnified ? unifiedData.isLoading : individual.isLoading
+  const isRefreshing = hasUnified ? unifiedData.isRefreshing : individual.isRefreshing
   const error = hasUnified ? unifiedData.error : individual.error
   const refetch = hasUnified ? unifiedData.refetch : individual.refetch
   const { run: runMutation } = usePipelineMutations()
@@ -75,7 +76,7 @@ export function RecentFailures() {
   const { startMission } = useMissions()
 
   const hasData = (data?.runs?.length ?? 0) > 0
-  useCardLoadingState({ isLoading: isLoading && !hasData, hasAnyData: hasData, isDemoData: isDemoMode })
+  useCardLoadingState({ isLoading: isLoading && !hasData, isRefreshing, hasAnyData: hasData, isDemoData: isDemoMode })
 
   const rows = useMemo(() => data?.runs ?? [], [data])
 
@@ -124,7 +125,7 @@ export function RecentFailures() {
             className="hover:text-foreground flex items-center gap-1"
             aria-label={LABEL_REFRESH}
           >
-            <RefreshCw className="w-3 h-3" />
+            <RefreshCw className={cn('w-3 h-3', isRefreshing && 'animate-spin')} />
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Wire `isRefreshing` through hooks and add conditional `animate-spin` class to `RefreshCw` icons in 7 card components
- Plumb `isRefreshing` from `useCache` through `useFlatcarStatus` and `useLimaStatus` hooks (artifact_hub already exposed it)
- Add `cn()` import where needed for class merging
- Pass `isRefreshing` to `useCardLoadingState()` in pipeline cards

### Files changed
| File | Fix |
|------|-----|
| `flatcar_status/useFlatcarStatus.ts` | Expose `isRefreshing` from `useCache` |
| `flatcar_status/index.tsx` | Spin RefreshCw icon when refreshing |
| `artifact_hub_status/index.tsx` | Destructure `isRefreshing`, spin icon |
| `lima_status/useLimaStatus.ts` | Expose `isRefreshing` in return |
| `lima_status/LimaStatus.tsx` | Spin RefreshCw icon when refreshing |
| `HardwareHealthCard.tsx` | Spin retry button icon when refreshing |
| `OperatorSubscriptions.tsx` | Spin retry button icon when refreshing |
| `pipelines/PipelineFlow.tsx` | Extract `isRefreshing`, spin refresh button |
| `pipelines/RecentFailures.tsx` | Extract `isRefreshing`, spin refresh button |

Fixes #10296

## Test plan
- [ ] Verify refresh icons spin during background data fetches
- [ ] Verify icons stop spinning when fetch completes
- [ ] Verify no regressions in card loading states