### PR TITLE
🐛 Fix nightly unit-test: analytics test isolation — reset all module state

### DIFF
--- a/web/src/lib/__tests__/analytics-noise-filters.test.ts
+++ b/web/src/lib/__tests__/analytics-noise-filters.test.ts
@@ -26,7 +26,7 @@ vi.mock('../analytics-session', async () => {
 })
 
 import { initAnalytics, startGlobalErrorTracking } from '../analytics'
-import { _resetErrorThrottles } from '../analytics-core'
+import { _resetAnalyticsState } from '../analytics-core'
 
 /* ── Constants ──────────────────────────────────────────────────────── */
 
@@ -68,7 +68,7 @@ describe('GA4 runtime noise filters — window.error handler', () => {
 
   beforeEach(() => {
     vi.useFakeTimers()
-    _resetErrorThrottles()
+    _resetAnalyticsState()
     sendBeaconSpy = vi.fn(() => true)
     Object.defineProperty(navigator, 'sendBeacon', {
       value: sendBeaconSpy,
@@ -128,7 +128,7 @@ describe('GA4 runtime noise filters — unhandledrejection handler', () => {
 
   beforeEach(() => {
     vi.useFakeTimers()
-    _resetErrorThrottles()
+    _resetAnalyticsState()
     sendBeaconSpy = vi.fn(() => true)
     Object.defineProperty(navigator, 'sendBeacon', {
       value: sendBeaconSpy,

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -804,6 +804,31 @@ export function _resetErrorThrottles() {
   pageErrorCounts.clear()
 }
 
+/**
+ * @internal — exported for test isolation only.
+ * Resets ALL module-level analytics state so tests don't leak state across
+ * files when Vitest runs them in the same worker. Without this, a prior test
+ * file that calls initAnalytics() leaves `initialized = true`, which causes
+ * subsequent initAnalytics() calls to no-op — breaking tests that depend on
+ * a fresh analytics pipeline (e.g. analytics-noise-filters).
+ */
+export function _resetAnalyticsState() {
+  initialized = false
+  userHasInteracted = false
+  analyticsScriptsLoaded = false
+  gtagAvailable = false
+  gtagDecided = false
+  realMeasurementId = ''
+  pendingEvents = []
+  measurementId = ''
+  pageId = ''
+  userId = ''
+  sessionEngaged = false
+  pendingRecoveryEvent = null
+  recentErrorEmissions.clear()
+  pageErrorCounts.clear()
+}
+
 function isErrorThrottled(category: string, page: string, cardId?: string): boolean {
   // Per-page session budget
   const pageCount = pageErrorCounts.get(page) ?? 0


### PR DESCRIPTION
Fixes #10140

## Problem
`analytics-noise-filters.test.ts` passes in isolation but fails in the nightly full suite run. Root cause: `_resetErrorThrottles()` only resets throttle maps, not the 13+ module-level state variables (`initialized`, `userHasInteracted`, `gtagDecided`, etc.).


## Fix
- Added `_resetAnalyticsState()` export in `analytics-core.ts` that resets ALL module-level variables
- Updated both `beforeEach` blocks in the test file to use the new full reset

## Testing
- ✅ Tests pass locally (6/6)
- ✅ Build passes
- ✅ Lint clean (no new warnings)