### PR TITLE
🐛 Fix 3 nightly failures: gosec G204, ai-ml timeouts, health checks

### DIFF
--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -737,7 +737,7 @@ func (uc *UpdateChecker) restartViaStartupScript(repoPath string) {
 	}
 
 	// Spawn the script in a new process group so it survives our exit
-	cmd := exec.Command("bash", scriptPath)
+	cmd := exec.Command("bash", scriptPath) // #nosec G204 -- scriptPath is repoPath+"/startup-oauth.sh", not user input
 	cmd.Dir = repoPath
 	if logFile != nil {
 		cmd.Stdout = logFile

--- a/web/e2e/ai-ml/ai-ml-dashboard.spec.ts
+++ b/web/e2e/ai-ml/ai-ml-dashboard.spec.ts
@@ -27,7 +27,7 @@ const AI_ML_ROUTE = '/ai-ml'
 /** Timeout for page load */
 const PAGE_LOAD_TIMEOUT_MS = 60_000
 /** Timeout for stack discovery (queries multiple clusters via backend) */
-const STACK_DISCOVERY_TIMEOUT_MS = 50_000
+const STACK_DISCOVERY_TIMEOUT_MS = 15_000
 /** Timeout for Prometheus metrics or demo fallback to render */
 const PROMETHEUS_POLL_TIMEOUT_MS = 15_000
 /** Timeout for card content to render */
@@ -44,7 +44,7 @@ const STACK_POLL_INTERVAL_MS = 2_000
  * enough time to mount and render all 13 cards (including lazy-loaded chunks)
  * without relying on a network-idle signal that will never arrive.
  */
-const CARD_RENDER_WAIT_MS = 30_000
+const CARD_RENDER_WAIT_MS = 10_000
 
 /** Expected card count on the AI/ML route */
 const EXPECTED_CARD_COUNT = 13
@@ -250,7 +250,12 @@ test.describe('AI/ML Dashboard — stack discovery', () => {
     }
   })
 
-  test('stacks include Prefill and Decode components (disaggregated)', async ({ page }) => {
+  test('stacks include Prefill and Decode components (disaggregated)', async ({ page, request }) => {
+    try {
+      const healthCheck = await request.get('http://127.0.0.1:8080/api/health', { timeout: 5_000 })
+      if (!healthCheck.ok()) { test.skip(true, 'Backend not reachable'); return }
+    } catch { test.skip(true, 'Backend not reachable'); return }
+
     await setupAndNavigate(page, AI_ML_ROUTE)
     const stacks = await waitForStackDiscovery(page)
 
@@ -289,7 +294,12 @@ test.describe('AI/ML Dashboard — stack discovery', () => {
     expect(stacksWithPods.length).toBeGreaterThan(0)
   })
 
-  test('stacks include WVA autoscaler where configured', async ({ page }) => {
+  test('stacks include WVA autoscaler where configured', async ({ page, request }) => {
+    try {
+      const healthCheck = await request.get('http://127.0.0.1:8080/api/health', { timeout: 5_000 })
+      if (!healthCheck.ok()) { test.skip(true, 'Backend not reachable'); return }
+    } catch { test.skip(true, 'Backend not reachable'); return }
+
     await setupAndNavigate(page, AI_ML_ROUTE)
     const stacks = await waitForStackDiscovery(page)
 
@@ -323,7 +333,12 @@ test.describe('AI/ML Dashboard — stack discovery', () => {
     expect(stacks.length).toBeGreaterThan(0)
   })
 
-  test('stacks span multiple clusters', async ({ page }) => {
+  test('stacks span multiple clusters', async ({ page, request }) => {
+    try {
+      const healthCheck = await request.get('http://127.0.0.1:8080/api/health', { timeout: 5_000 })
+      if (!healthCheck.ok()) { test.skip(true, 'Backend not reachable'); return }
+    } catch { test.skip(true, 'Backend not reachable'); return }
+
     await setupAndNavigate(page, AI_ML_ROUTE)
     const stacks = await waitForStackDiscovery(page)
 


### PR DESCRIPTION
Fixes #10140

## Problem
Three nightly test suites fail persistently:
1. **gosec-test**: HIGH finding G204 (subprocess with variable) on `update_checker.go:740`
2. **ai-ml-test**: Tests burn 80s+ before skipping — 50s stack discovery + 30s card render wait. 3 tests lack health checks entirely.
3. **perf-test**: Hit 900s wall-clock timeout (already fixed by 1200s override in prior PR, nightly ran before merge)

## Fix
- **gosec**: Added `#nosec G204` annotation — `scriptPath` is `repoPath+"/startup-oauth.sh"`, not user input
- **ai-ml**: Reduced `STACK_DISCOVERY_TIMEOUT_MS` 50s→15s, `CARD_RENDER_WAIT_MS` 30s→10s. Added health checks to disaggregation, autoscaler, and multi-cluster tests
- **perf**: No change needed — 1200s override already merged

## Testing
- ✅ Build passes
- ✅ Lint clean