### PR TITLE
🧹 Deduplicate duration formatters — replace 3 local copies with shared utilities

### DIFF
--- a/web/src/components/cards/kagenti/KagentiBuildPipeline.tsx
+++ b/web/src/components/cards/kagenti/KagentiBuildPipeline.tsx
@@ -4,7 +4,7 @@ import { useCardLoadingState } from '../CardDataContext'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../../lib/cards/CardComponents'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import { Skeleton } from '../../ui/Skeleton'
-import { MS_PER_SECOND, SECONDS_PER_MINUTE, SECONDS_PER_HOUR, SECONDS_PER_DAY } from '../../../lib/constants/time'
+import { formatTimeAgo } from '../../../lib/formatters'
 
 interface KagentiBuildPipelineProps {
   config?: { cluster?: string }
@@ -23,15 +23,6 @@ function BuildStatusIcon({ status }: { status: string }) {
     default:
       return <Clock className="w-3.5 h-3.5 text-muted-foreground" />
   }
-}
-
-function timeAgo(dateStr: string): string {
-  if (!dateStr) return ''
-  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / MS_PER_SECOND)
-  if (seconds < SECONDS_PER_MINUTE) return `${seconds}s ago`
-  if (seconds < SECONDS_PER_HOUR) return `${Math.floor(seconds / SECONDS_PER_MINUTE)}m ago`
-  if (seconds < SECONDS_PER_DAY) return `${Math.floor(seconds / SECONDS_PER_HOUR)}h ago`
-  return `${Math.floor(seconds / SECONDS_PER_DAY)}d ago`
 }
 
 type SortField = 'name' | 'status' | 'cluster'
@@ -175,7 +166,7 @@ export function KagentiBuildPipeline({ config }: KagentiBuildPipelineProps) {
               </div>
             </div>
             <div className="text-xs text-muted-foreground/40">
-              {timeAgo(build.startTime || build.completionTime)}
+              {formatTimeAgo(build.startTime || build.completionTime)}
             </div>
           </div>
         ))}

--- a/web/src/components/cards/llmd/ParetoFrontier.tsx
+++ b/web/src/components/cards/llmd/ParetoFrontier.tsx
@@ -8,6 +8,7 @@
  * Connected smooth scatter lines with GPU count labels. Built with ECharts.
  */
 import { useState, useMemo, useRef } from 'react'
+import { SECONDS_PER_HOUR } from '../../../lib/constants/time'
 import { LazyEChart } from '../../charts/LazyEChart'
 import type ReactEChartsType from 'echarts-for-react'
 import { Download, RotateCcw } from 'lucide-react'
@@ -124,7 +125,7 @@ const CHART_PRESETS: Record<string, ChartPreset> = {
     yAxis: {
       label: 'Cost per Million Tokens',
       unit: '$',
-      getValue: (p) => p.throughputPerGpu > 0 ? (p.tcoPerGpuHr / (p.throughputPerGpu * 3600)) * 1_000_000 : 0,
+      getValue: (p) => p.throughputPerGpu > 0 ? (p.tcoPerGpuHr / (p.throughputPerGpu * SECONDS_PER_HOUR)) * 1_000_000 : 0,
       formatter: (v) => `$${v.toFixed(2)}` },
     infoPills: (points) => {
       const hwCost = new Map<string, number>()
@@ -143,7 +144,7 @@ const CHART_PRESETS: Record<string, ChartPreset> = {
     yAxis: {
       label: 'Cost per Million Tokens',
       unit: '$',
-      getValue: (p) => p.throughputPerGpu > 0 ? (p.tcoPerGpuHr / (p.throughputPerGpu * 3600)) * 1_000_000 : 0,
+      getValue: (p) => p.throughputPerGpu > 0 ? (p.tcoPerGpuHr / (p.throughputPerGpu * SECONDS_PER_HOUR)) * 1_000_000 : 0,
       formatter: (v) => `$${v.toFixed(2)}` },
     infoPills: (points) => {
       const hwCost = new Map<string, number>()

--- a/web/src/components/cards/spiffe_status/index.tsx
+++ b/web/src/components/cards/spiffe_status/index.tsx
@@ -33,7 +33,7 @@ import type {
   SpiffeRegistrationEntry,
 } from './demoData'
 import { formatTimeAgo } from '../../../lib/formatters'
-import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR, SECONDS_PER_DAY } from '../../../lib/constants/time'
+import { formatDuration } from '../../../lib/stats/types'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -50,19 +50,6 @@ const MAX_ENTRIES_DISPLAYED = 5
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatTtl(seconds: number): string {
-  if (seconds >= SECONDS_PER_DAY) {
-    return `${Math.floor(seconds / SECONDS_PER_DAY)}d`
-  }
-  if (seconds >= SECONDS_PER_HOUR) {
-    return `${Math.floor(seconds / SECONDS_PER_HOUR)}h`
-  }
-  if (seconds >= SECONDS_PER_MINUTE) {
-    return `${Math.floor(seconds / SECONDS_PER_MINUTE)}m`
-  }
-  return `${seconds}s`
-}
 
 function federationStatusClass(status: SpiffeFederatedDomain['status']): string {
   if (status === 'active') return 'bg-green-500/20 text-green-400'
@@ -96,7 +83,7 @@ function EntryRow({ entry }: { entry: SpiffeRegistrationEntry }) {
       <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
         <span className="truncate">{entry.selector}</span>
         <span className="ml-auto shrink-0 font-mono">
-          ttl {formatTtl(entry.ttlSeconds)}
+          ttl {formatDuration(entry.ttlSeconds)}
         </span>
       </div>
     </div>

--- a/web/src/components/cards/wasmcloud_status/index.tsx
+++ b/web/src/components/cards/wasmcloud_status/index.tsx
@@ -36,7 +36,7 @@ import type {
   WasmcloudProviderStatus,
 } from './demoData'
 import { formatTimeAgo } from '../../../lib/formatters'
-import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR, SECONDS_PER_DAY } from '../../../lib/constants/time'
+import { formatDuration } from '../../../lib/stats/types'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -57,19 +57,6 @@ const HOST_ID_SHORT_LENGTH = 8
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatUptime(seconds: number): string {
-  if (seconds >= SECONDS_PER_DAY) {
-    return `${Math.floor(seconds / SECONDS_PER_DAY)}d`
-  }
-  if (seconds >= SECONDS_PER_HOUR) {
-    return `${Math.floor(seconds / SECONDS_PER_HOUR)}h`
-  }
-  if (seconds >= SECONDS_PER_MINUTE) {
-    return `${Math.floor(seconds / SECONDS_PER_MINUTE)}m`
-  }
-  return `${seconds}s`
-}
 
 function shortId(id: string): string {
   if (!id) return ''
@@ -125,7 +112,7 @@ function HostRow({ host, t }: { host: WasmcloudHost; t: TFunction<'cards'> }) {
           {host.providerCount} {t('wasmcloudStatus.providersShort', 'providers')}
         </span>
         <span className="ml-auto shrink-0 font-mono">
-          {t('wasmcloudStatus.uptime', 'up')} {formatUptime(host.uptimeSeconds)}
+          {t('wasmcloudStatus.uptime', 'up')} {formatDuration(host.uptimeSeconds)}
         </span>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace `formatUptime` in wasmcloud_status with `formatDuration` from `lib/stats/types`
- Replace `formatTtl` in spiffe_status with `formatDuration` from `lib/stats/types`
- Replace `timeAgo` in KagentiBuildPipeline with `formatTimeAgo` from `lib/formatters`
- Replace inline `3600` in ParetoFrontier with `SECONDS_PER_HOUR`
- Net −34 lines, zero behavior change for ≥1min durations

## Test plan
- [x] `npm run build` passes
- [ ] CI pr-check passes

Fixes #10307