### PR TITLE
🐛 Fix Playwright nightly: add kc-demo-mode to setupDashboardTest, fix RCE nav race

### DIFF
--- a/web/e2e/helpers/setup.ts
+++ b/web/e2e/helpers/setup.ts
@@ -378,6 +378,7 @@ export async function setupDashboardTest(page: Page): Promise<void> {
   // late for webkit/Safari where the auth redirect fires synchronously.
   await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
+    localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
   })
   await page.goto('/')

--- a/web/e2e/nightly/rce-vector-scan.spec.ts
+++ b/web/e2e/nightly/rce-vector-scan.spec.ts
@@ -179,7 +179,8 @@ test('RCE vector scan — all attack surfaces', async ({ page }, testInfo) => {
   console.log('[RCE] Phase 2: DOM XSS vectors')
 
   for (const route of ROUTES_TO_SCAN) {
-    await page.goto(route, { waitUntil: 'networkidle', timeout: PAGE_LOAD_TIMEOUT_MS }).catch(() => {})
+    await page.goto(route, { waitUntil: 'networkidle', timeout: PAGE_LOAD_TIMEOUT_MS })
+      .catch(() => page.waitForLoadState('domcontentloaded').catch(() => {}))
 
     // 2a: No javascript: links
     const jsLinks = await page.evaluate(() =>


### PR DESCRIPTION
Fixes #10139

## Problem
Two remaining Playwright nightly failures in Firefox/WebKit:

1. **Dashboard.spec.ts**: `setupDashboardTest()` was missing `kc-demo-mode` in localStorage, causing the app to attempt real API calls against vite preview (no backend). Firefox/WebKit stall on unmocked requests → `toBeVisible()` failures.

2. **rce-vector-scan.spec.ts**: `page.goto()` with `.catch(() => {})` swallowed navigation failures, then `page.evaluate()` hit a destroyed execution context in Firefox.

## Fix
- Add `localStorage.setItem('kc-demo-mode', 'true')` to `setupDashboardTest()` in `e2e/helpers/setup.ts`
- Fall back to `domcontentloaded` in RCE scan instead of silently swallowing goto errors

## Context
PRs #10149 (Firefox testids) and #10246 (WebKit CORS patterns) fixed most Playwright nightly failures but were merged after the nightly at 07:06 UTC. This PR addresses the remaining gaps.