### PR TITLE
🧹 Replace 3 duplicate formatTime functions with shared formatTimeAgo

### DIFF
--- a/web/src/components/cards/HelmReleaseStatus.tsx
+++ b/web/src/components/cards/HelmReleaseStatus.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { CheckCircle, AlertTriangle, XCircle, Clock, ChevronRight, Server, Package } from 'lucide-react'
+import { formatTimeAgo } from '../../lib/formatters'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedHelmReleases } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -174,32 +175,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
     }
   }
 
-  // Time unit constants (milliseconds) — used to format the relative "X ago" label
-  // on each release row. Backend sometimes returns an empty string, `null`, or a
-  // non-ISO timestamp (e.g. when a release has never been upgraded), which made
-  // `new Date(timestamp).getTime()` return NaN and rendered "NaNd ago" (#9095).
-  const MS_PER_HOUR = 3_600_000
-  const MS_PER_DAY = 86_400_000
-  /** Fallback shown when `timestamp` is missing/invalid — prevents "NaNd ago" (#9095). */
   const UNKNOWN_TIME_LABEL = 'Unknown'
-
-  const formatTime = (timestamp: string | null | undefined) => {
-    // Guard against missing / empty input before constructing a Date —
-    // `new Date('')` and `new Date(null as unknown as string)` both produce
-    // Invalid Date whose getTime() is NaN, which poisons every math op below.
-    if (!timestamp) return UNKNOWN_TIME_LABEL
-    const date = new Date(timestamp)
-    const parsed = date.getTime()
-    if (Number.isNaN(parsed)) return UNKNOWN_TIME_LABEL
-
-    const diff = new Date().getTime() - parsed
-    // Negative diffs (clock skew / future timestamps) — treat as "just now" rather
-    // than rendering a negative number of hours ago.
-    if (diff < 0) return `0h ago`
-
-    if (diff < MS_PER_DAY) return `${Math.floor(diff / MS_PER_HOUR)}h ago`
-    return `${Math.floor(diff / MS_PER_DAY)}d ago`
-  }
 
   // Counts from namespace-filtered releases (pre-pagination summary)
   const deployedCount = namespacedReleases.filter(r => r.status === 'deployed').length
@@ -371,7 +347,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
                     {release.cluster && <div className="shrink-0"><ClusterBadge cluster={release.cluster} size="sm" /></div>}
                     <span className="truncate" title={`Chart: ${release.chart}, Version: ${release.version}`}>{release.chart}@{release.version}</span>
                     <span className="shrink-0 whitespace-nowrap" title={`Helm revision: ${release.revision}`}>Rev {release.revision}</span>
-                    <span className="ml-auto shrink-0 whitespace-nowrap" title={`Last updated: ${release.updated && !Number.isNaN(new Date(release.updated).getTime()) ? new Date(release.updated).toLocaleString() : UNKNOWN_TIME_LABEL}`}>{formatTime(release.updated)}</span>
+                    <span className="ml-auto shrink-0 whitespace-nowrap" title={`Last updated: ${release.updated && !Number.isNaN(new Date(release.updated).getTime()) ? new Date(release.updated).toLocaleString() : UNKNOWN_TIME_LABEL}`}>{formatTimeAgo(release.updated ?? '', { invalidLabel: UNKNOWN_TIME_LABEL })}</span>
                   </div>
                 </div>
               )

--- a/web/src/components/cards/KustomizationStatus.tsx
+++ b/web/src/components/cards/KustomizationStatus.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { CheckCircle, AlertTriangle, XCircle, RefreshCw, Clock, GitBranch, ChevronRight } from 'lucide-react'
+import { formatTimeAgo } from '../../lib/formatters'
 import { useClusters } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -89,14 +90,6 @@ function getStatusColor(status: Kustomization['status']) {
   }
 }
 
-function formatTime(timestamp: string) {
-  const date = new Date(timestamp)
-  const now = new Date()
-  const diff = now.getTime() - date.getTime()
-  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`
-  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`
-  return `${Math.floor(diff / 86400000)}d ago`
-}
 
 export function KustomizationStatus({ config }: KustomizationStatusProps) {
   const { t } = useTranslation(['cards', 'common'])
@@ -410,7 +403,7 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
                     </div>
                     <div className="flex flex-wrap items-center justify-between gap-y-2">
                       <span className="truncate">{ks.revision.split('@')[1]?.slice(0, 12)}</span>
-                      <span>{formatTime(ks.lastApplied)}</span>
+                      <span>{formatTimeAgo(ks.lastApplied)}</span>
                     </div>
                   </div>
                   {(ks.status === 'NotReady' || ks.status === 'Suspended') && (

--- a/web/src/components/cards/buildpacks-status/BuildpacksStatus.tsx
+++ b/web/src/components/cards/buildpacks-status/BuildpacksStatus.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { CheckCircle, AlertTriangle, XCircle, Clock, ChevronRight, Server, Package } from 'lucide-react'
+import { formatTimeAgo } from '../../../lib/formatters'
 import { useClusters, BuildpackImage } from '../../../hooks/useMCP'
 import { useCachedBuildpackImages } from '../../../hooks/useCachedData'
 import { Skeleton } from '../../ui/Skeleton'
@@ -52,24 +53,6 @@ const STATUS_ORDER: Record<string, number> = {
   unknown: 2,
   succeeded: 3 }
 
-const formatTime = (timestamp: string | number | Date): string => {
-  const time = new Date(timestamp).getTime()
-  if (isNaN(time)) return ''
-
-  const diff = Date.now() - time
-
-  if (diff <= 0) return 'just now'
-
-  const minute = 60 * 1000
-  const hour = 60 * minute
-  const day = 24 * hour
-
-  if (diff < minute) return 'just now'
-  if (diff < hour) return `${Math.floor(diff / minute)}m ago`
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`
-
-  return `${Math.floor(diff / day)}d ago`
-}
 
 export function BuildpacksStatus({ config }: BuildpacksStatusProps) {
   const { t } = useTranslation('cards')
@@ -343,7 +326,7 @@ export function BuildpacksStatus({ config }: BuildpacksStatusProps) {
                 )}
                 <span>{build.builder}</span>
                 <span className="ml-auto">
-                  {formatTime(build.updated)}
+                  {formatTimeAgo(build.updated)}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Replaces local `formatTime` in KustomizationStatus, BuildpacksStatus, and HelmReleaseStatus with shared `formatTimeAgo` from `lib/formatters.ts`
- Eliminates 6 magic number literals (3600000, 86400000, 60000, 60*1000, etc.)
- Removes ~40 lines of duplicated duration formatting code
- HelmReleaseStatus uses `invalidLabel: 'Unknown'` option for null/invalid timestamps (#9095)

## Test plan
- [x] `npm run build` — passes with all post-build safety checks green
- [ ] CI pr-check passes
- [ ] CI card-standard passes
- [ ] CI ui-ux-standard passes (magic number count should not increase)

Fixes #10312