### PR TITLE
🌱 Add 51 tests for 6 untested modules toward 91% coverage target

### DIFF
--- a/web/src/lib/__tests__/analytics-types.test.ts
+++ b/web/src/lib/__tests__/analytics-types.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CAPABILITY_CHAT,
+  CAPABILITY_TOOL_EXEC,
+} from '../analytics-types'
+
+describe('analytics-types constants', () => {
+  it('CAPABILITY_CHAT is bitmask value 1', () => {
+    expect(CAPABILITY_CHAT).toBe(1)
+  })
+
+  it('CAPABILITY_TOOL_EXEC is bitmask value 2', () => {
+    expect(CAPABILITY_TOOL_EXEC).toBe(2)
+  })
+
+  it('capabilities are distinct bits (no overlap)', () => {
+    expect(CAPABILITY_CHAT & CAPABILITY_TOOL_EXEC).toBe(0)
+  })
+
+  it('capabilities can be combined with bitwise OR', () => {
+    const both = CAPABILITY_CHAT | CAPABILITY_TOOL_EXEC
+    expect(both & CAPABILITY_CHAT).toBe(CAPABILITY_CHAT)
+    expect(both & CAPABILITY_TOOL_EXEC).toBe(CAPABILITY_TOOL_EXEC)
+  })
+})

--- a/web/src/lib/acmm/__tests__/scannableIdsByLevel.test.ts
+++ b/web/src/lib/acmm/__tests__/scannableIdsByLevel.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SCANNABLE_IDS_BY_LEVEL,
+  ACMM_DETECTION_PATHS,
+  AGENT_INSTRUCTION_FILE_IDS,
+} from '../scannableIdsByLevel'
+
+describe('SCANNABLE_IDS_BY_LEVEL', () => {
+  it('covers levels 2 through 6', () => {
+    for (let level = 2; level <= 6; level++) {
+      expect(SCANNABLE_IDS_BY_LEVEL[level]).toBeDefined()
+      expect(Array.isArray(SCANNABLE_IDS_BY_LEVEL[level])).toBe(true)
+    }
+  })
+
+  it('does not include level 0 or 1', () => {
+    expect(SCANNABLE_IDS_BY_LEVEL[0]).toBeUndefined()
+    expect(SCANNABLE_IDS_BY_LEVEL[1]).toBeUndefined()
+  })
+
+  it('L2 contains the virtual agent-instructions group', () => {
+    expect(SCANNABLE_IDS_BY_LEVEL[2]).toContain('acmm:agent-instructions')
+  })
+
+  it('L2 does not contain individual instruction-file IDs', () => {
+    for (const id of AGENT_INSTRUCTION_FILE_IDS) {
+      expect(SCANNABLE_IDS_BY_LEVEL[2]).not.toContain(id)
+    }
+  })
+
+  it('all IDs are non-empty strings', () => {
+    for (const level of Object.keys(SCANNABLE_IDS_BY_LEVEL)) {
+      for (const id of SCANNABLE_IDS_BY_LEVEL[Number(level)]) {
+        expect(typeof id).toBe('string')
+        expect(id.length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('no duplicate IDs within a level', () => {
+    for (const level of Object.keys(SCANNABLE_IDS_BY_LEVEL)) {
+      const ids = SCANNABLE_IDS_BY_LEVEL[Number(level)]
+      expect(new Set(ids).size).toBe(ids.length)
+    }
+  })
+})
+
+describe('ACMM_DETECTION_PATHS', () => {
+  it('is a non-empty object', () => {
+    expect(Object.keys(ACMM_DETECTION_PATHS).length).toBeGreaterThan(0)
+  })
+
+  it('each entry maps to a non-empty array of strings', () => {
+    for (const [id, patterns] of Object.entries(ACMM_DETECTION_PATHS)) {
+      expect(Array.isArray(patterns)).toBe(true)
+      expect(patterns.length).toBeGreaterThan(0)
+      for (const p of patterns) {
+        expect(typeof p).toBe('string')
+        expect(p.length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('includes individual instruction-file IDs (not collapsed)', () => {
+    for (const id of AGENT_INSTRUCTION_FILE_IDS) {
+      expect(ACMM_DETECTION_PATHS[id]).toBeDefined()
+    }
+  })
+})
+
+describe('AGENT_INSTRUCTION_FILE_IDS', () => {
+  it('is a Set of 4 instruction file criteria', () => {
+    expect(AGENT_INSTRUCTION_FILE_IDS.size).toBe(4)
+  })
+
+  it('contains expected IDs', () => {
+    expect(AGENT_INSTRUCTION_FILE_IDS.has('acmm:claude-md')).toBe(true)
+    expect(AGENT_INSTRUCTION_FILE_IDS.has('acmm:copilot-instructions')).toBe(true)
+    expect(AGENT_INSTRUCTION_FILE_IDS.has('acmm:agents-md')).toBe(true)
+    expect(AGENT_INSTRUCTION_FILE_IDS.has('acmm:cursor-rules')).toBe(true)
+  })
+})

--- a/web/src/lib/acmm/sources/__tests__/fullsend.test.ts
+++ b/web/src/lib/acmm/sources/__tests__/fullsend.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { fullsendSource } from '../fullsend'
+
+describe('fullsendSource', () => {
+  it('has the correct source metadata', () => {
+    expect(fullsendSource.id).toBe('fullsend')
+    expect(fullsendSource.name).toBe('Fullsend')
+    expect(fullsendSource.definesLevels).toBe(false)
+    expect(fullsendSource.url).toContain('github.com')
+  })
+
+  it('has a non-empty criteria array', () => {
+    expect(fullsendSource.criteria.length).toBeGreaterThan(0)
+  })
+
+  it('all criteria have required fields', () => {
+    for (const c of fullsendSource.criteria) {
+      expect(c.id).toBeTruthy()
+      expect(c.source).toBe('fullsend')
+      expect(typeof c.level).toBe('number')
+      expect(c.level).toBeGreaterThanOrEqual(2)
+      expect(c.name).toBeTruthy()
+      expect(c.description).toBeTruthy()
+      expect(c.rationale).toBeTruthy()
+      expect(c.detection).toBeDefined()
+    }
+  })
+
+  it('all criteria IDs start with fullsend:', () => {
+    for (const c of fullsendSource.criteria) {
+      expect(c.id.startsWith('fullsend:')).toBe(true)
+    }
+  })
+
+  it('all criteria have valid detection types', () => {
+    for (const c of fullsendSource.criteria) {
+      expect(c.detection.type).toBe('any-of')
+      const patterns = Array.isArray(c.detection.pattern)
+        ? c.detection.pattern
+        : [c.detection.pattern]
+      expect(patterns.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('criteria IDs are unique', () => {
+    const ids = fullsendSource.criteria.map((c) => c.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('includes test-coverage and ci-cd-maturity criteria', () => {
+    const ids = fullsendSource.criteria.map((c) => c.id)
+    expect(ids).toContain('fullsend:test-coverage')
+    expect(ids).toContain('fullsend:ci-cd-maturity')
+  })
+})

--- a/web/src/lib/constants/__tests__/k8sResources.test.ts
+++ b/web/src/lib/constants/__tests__/k8sResources.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ORBIT_CLUSTER_SCOPED_KINDS,
+  ORBIT_NAMESPACED_KINDS,
+  DEFAULT_MONITOR_KINDS,
+} from '../k8sResources'
+
+describe('ORBIT_CLUSTER_SCOPED_KINDS', () => {
+  it('contains only cluster-scoped entries', () => {
+    for (const kind of ORBIT_CLUSTER_SCOPED_KINDS) {
+      expect(kind.clusterScoped).toBe(true)
+    }
+  })
+
+  it('includes expected kinds', () => {
+    const kinds = ORBIT_CLUSTER_SCOPED_KINDS.map((k) => k.kind)
+    expect(kinds).toContain('Node')
+    expect(kinds).toContain('Namespace')
+    expect(kinds).toContain('ClusterRole')
+    expect(kinds).toContain('CustomResourceDefinition')
+  })
+
+  it('has valid group assignments', () => {
+    const validGroups = new Set(['Infrastructure', 'Storage', 'RBAC', 'Extensions'])
+    for (const kind of ORBIT_CLUSTER_SCOPED_KINDS) {
+      expect(validGroups.has(kind.group)).toBe(true)
+    }
+  })
+
+  it('every entry has a non-empty label', () => {
+    for (const kind of ORBIT_CLUSTER_SCOPED_KINDS) {
+      expect(kind.label.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('ORBIT_NAMESPACED_KINDS', () => {
+  it('contains only namespaced entries', () => {
+    for (const kind of ORBIT_NAMESPACED_KINDS) {
+      expect(kind.clusterScoped).toBe(false)
+    }
+  })
+
+  it('includes core workload kinds', () => {
+    const kinds = ORBIT_NAMESPACED_KINDS.map((k) => k.kind)
+    expect(kinds).toContain('Deployment')
+    expect(kinds).toContain('Pod')
+    expect(kinds).toContain('Service')
+    expect(kinds).toContain('ConfigMap')
+  })
+
+  it('has unique kind names', () => {
+    const kinds = ORBIT_NAMESPACED_KINDS.map((k) => k.kind)
+    expect(new Set(kinds).size).toBe(kinds.length)
+  })
+})
+
+describe('DEFAULT_MONITOR_KINDS', () => {
+  it('all defaults are namespaced (not cluster-scoped)', () => {
+    for (const kind of DEFAULT_MONITOR_KINDS) {
+      expect(kind.clusterScoped).toBe(false)
+    }
+  })
+
+  it('defaults start with empty namespaces', () => {
+    for (const kind of DEFAULT_MONITOR_KINDS) {
+      expect(kind.namespaces).toEqual([])
+    }
+  })
+
+  it('includes Deployment and Pod', () => {
+    const kinds = DEFAULT_MONITOR_KINDS.map((k) => k.kind)
+    expect(kinds).toContain('Deployment')
+    expect(kinds).toContain('Pod')
+  })
+})

--- a/web/src/lib/schemas/__tests__/github.test.ts
+++ b/web/src/lib/schemas/__tests__/github.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import {
+  GitHubWorkflowRunSchema,
+  GitHubWorkflowRunsResponseSchema,
+} from '../github'
+
+describe('GitHubWorkflowRunSchema', () => {
+  it('accepts a full workflow run object', () => {
+    const run = {
+      id: 12345,
+      name: 'CI',
+      status: 'completed',
+      conclusion: 'success',
+      html_url: 'https://github.com/org/repo/actions/runs/12345',
+      head_branch: 'main',
+      event: 'push',
+      pull_requests: [{ number: 42, url: 'https://api.github.com/repos/org/repo/pulls/42' }],
+      head_commit: { message: 'fix: something' },
+    }
+    const result = GitHubWorkflowRunSchema.safeParse(run)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a minimal workflow run (all fields optional)', () => {
+    const result = GitHubWorkflowRunSchema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts conclusion as null', () => {
+    const result = GitHubWorkflowRunSchema.safeParse({ conclusion: null })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts head_commit as null', () => {
+    const result = GitHubWorkflowRunSchema.safeParse({ head_commit: null })
+    expect(result.success).toBe(true)
+  })
+
+  it('passes through unknown fields via passthrough()', () => {
+    const run = { id: 1, unknown_field: 'hello', actor: { login: 'user' } }
+    const result = GitHubWorkflowRunSchema.safeParse(run)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toHaveProperty('unknown_field', 'hello')
+    }
+  })
+})
+
+describe('GitHubWorkflowRunsResponseSchema', () => {
+  it('accepts a response with workflow_runs array', () => {
+    const response = {
+      workflow_runs: [
+        { id: 1, name: 'CI', status: 'completed' },
+        { id: 2, name: 'Deploy', status: 'in_progress' },
+      ],
+    }
+    const result = GitHubWorkflowRunsResponseSchema.safeParse(response)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a response with no workflow_runs (optional)', () => {
+    const result = GitHubWorkflowRunsResponseSchema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts empty workflow_runs array', () => {
+    const result = GitHubWorkflowRunsResponseSchema.safeParse({ workflow_runs: [] })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects workflow_runs as a non-array', () => {
+    const result = GitHubWorkflowRunsResponseSchema.safeParse({ workflow_runs: 'not-array' })
+    expect(result.success).toBe(false)
+  })
+})

--- a/web/src/lib/schemas/__tests__/validate.test.ts
+++ b/web/src/lib/schemas/__tests__/validate.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { z } from 'zod'
+import { validateResponse, validateArrayResponse } from '../validate'
+
+describe('validateResponse', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  it('returns parsed data on valid input', () => {
+    const schema = z.object({ name: z.string(), age: z.number() })
+    const data = { name: 'Alice', age: 30 }
+    const result = validateResponse(schema, data, '/test')
+    expect(result).toEqual({ name: 'Alice', age: 30 })
+  })
+
+  it('returns null on invalid input', () => {
+    const schema = z.object({ name: z.string() })
+    const data = { name: 123 }
+    const result = validateResponse(schema, data, '/test')
+    expect(result).toBeNull()
+  })
+
+  it('logs a warning on validation failure', () => {
+    const schema = z.object({ id: z.number() })
+    validateResponse(schema, { id: 'not-a-number' }, '/api/users')
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('[Zod] API response validation failed for "/api/users"'),
+    )
+  })
+
+  it('coerces values when the schema supports it', () => {
+    const schema = z.object({ count: z.coerce.number() })
+    const result = validateResponse(schema, { count: '42' }, '/coerce')
+    expect(result).toEqual({ count: 42 })
+  })
+
+  it('truncates logged issues when there are more than 5', () => {
+    const schema = z.object({
+      a: z.string(), b: z.string(), c: z.string(),
+      d: z.string(), e: z.string(), f: z.string(), g: z.string(),
+    })
+    validateResponse(schema, {
+      a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7,
+    }, '/many-errors')
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('and'),
+    )
+  })
+
+  it('handles null and undefined data gracefully', () => {
+    const schema = z.object({ id: z.number() })
+    expect(validateResponse(schema, null, '/null')).toBeNull()
+    expect(validateResponse(schema, undefined, '/undefined')).toBeNull()
+  })
+})
+
+describe('validateArrayResponse', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  const schema = z.object({
+    pods: z.array(z.object({ name: z.string() })),
+  })
+
+  it('returns original data on valid input', () => {
+    const data = { pods: [{ name: 'pod-1' }, { name: 'pod-2' }] }
+    const result = validateArrayResponse<{ pods: { name: string }[] }>(
+      schema, data, '/pods', 'pods',
+    )
+    expect(result.pods).toHaveLength(2)
+    expect(result.pods[0].name).toBe('pod-1')
+  })
+
+  it('returns fallback with empty array on invalid input', () => {
+    const result = validateArrayResponse<{ pods: { name: string }[] }>(
+      schema, { pods: 'not-an-array' }, '/pods', 'pods',
+    )
+    expect(result.pods).toEqual([])
+  })
+
+  it('returns fallback with correct resultKey on missing data', () => {
+    const result = validateArrayResponse<{ nodes: unknown[] }>(
+      z.object({ nodes: z.array(z.unknown()) }),
+      null,
+      '/nodes',
+      'nodes',
+    )
+    expect(result.nodes).toEqual([])
+  })
+
+  it('logs warning on validation failure', () => {
+    validateArrayResponse(schema, { pods: 123 }, '/pods-bad', 'pods')
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('/pods-bad'),
+    )
+  })
+})


### PR DESCRIPTION
Fixes #10139

## Coverage Improvement

CI coverage is at **88.53%**, target is **91%**. This PR adds 51 tests covering 6 previously untested modules:

| File | Tests | What's Tested |
|------|-------|---------------|
| `lib/schemas/validate.ts` | 10 | `validateResponse`, `validateArrayResponse`, error truncation |
| `lib/schemas/github.ts` | 9 | Zod schemas for GitHub Actions API responses |
| `lib/constants/k8sResources.ts` | 10 | K8s kind metadata, cluster/namespace scoping |
| `lib/analytics-types.ts` | 4 | Capability bitmask constants |
| `lib/acmm/scannableIdsByLevel.ts` | 11 | Level grouping, detection paths, OR-group virtual IDs |
| `lib/acmm/sources/fullsend.ts` | 7 | Source criteria validation, detection types |

All 51 tests pass locally. Build and lint verified.