### PR TITLE
Fix test spy restoration leak and unused variable from #10317

### DIFF
--- a/web/src/lib/acmm/__tests__/scannableIdsByLevel.test.ts
+++ b/web/src/lib/acmm/__tests__/scannableIdsByLevel.test.ts
@@ -51,7 +51,7 @@ describe('ACMM_DETECTION_PATHS', () => {
   })
 
   it('each entry maps to a non-empty array of strings', () => {
-    for (const [id, patterns] of Object.entries(ACMM_DETECTION_PATHS)) {
+    for (const [, patterns] of Object.entries(ACMM_DETECTION_PATHS)) {
       expect(Array.isArray(patterns)).toBe(true)
       expect(patterns.length).toBeGreaterThan(0)
       for (const p of patterns) {

--- a/web/src/lib/schemas/__tests__/validate.test.ts
+++ b/web/src/lib/schemas/__tests__/validate.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { z } from 'zod'
 import { validateResponse, validateArrayResponse } from '../validate'
 
 describe('validateResponse', () => {
   beforeEach(() => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('returns parsed data on valid input', () => {
@@ -58,6 +62,10 @@ describe('validateResponse', () => {
 describe('validateArrayResponse', () => {
   beforeEach(() => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   const schema = z.object({


### PR DESCRIPTION
## Summary
- Add `afterEach(() => vi.restoreAllMocks())` to both `describe` blocks in `validate.test.ts` that spy on `console.warn` in `beforeEach` — prevents spy leaks across tests
- Remove unused destructured `id` variable in `scannableIdsByLevel.test.ts` (`[id, patterns]` -> `[, patterns]`)

Addresses Copilot review comments from #10317.

## Test plan
- [ ] CI build/lint passes
- [ ] Existing tests in affected files still pass