### PR TITLE
Fix JSON parse error in update checker, clarify System Updates text

### DIFF
--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -832,7 +832,7 @@ export function UpdateSettings() {
             <p className="text-sm text-red-400 font-medium">{t('settings.updates.errorChecking')}</p>
             <p className="text-xs text-red-400/80 mt-1">{error}</p>
             <p className="text-xs text-muted-foreground mt-2">
-              Try clicking &quot;Check Now&quot; to retry, or verify that kc-agent is running and network is available.
+              {t('settings.updates.errorHint')}
             </p>
           </div>
         )}

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -26,7 +26,6 @@ const MIN_CHECK_INTERVAL_MS = 30 * MS_PER_MINUTE // 30 minutes minimum between c
 const AUTO_UPDATE_POLL_MS = 60 * 1000 // Poll kc-agent for update status every 60s
 const DEV_SHA_CACHE_KEY = 'kc-dev-latest-sha'
 
-/** Timeout for the /health fetch during install-method detection (ms) */
 /** Number of consecutive fetch failures before surfacing an error to the UI */
 const ERROR_DISPLAY_THRESHOLD = 2
 /** Timeout for the /health fetch during install-method detection (ms) */
@@ -39,6 +38,36 @@ const HEALTH_FETCH_RETRY_DELAY_MS = 3000
 const TRIGGER_UPDATE_TIMEOUT_MS = 30_000
 /** Timeout for the POST /auto-update/cancel request (ms) — cancellation should be fast */
 const CANCEL_UPDATE_TIMEOUT_MS = 5_000
+
+/**
+ * Safely parse a fetch Response as JSON.
+ *
+ * When the backend proxy is unavailable (e.g. on Netlify where /api/github/*
+ * has no matching function), the SPA catch-all returns the index.html page.
+ * Calling `response.json()` on that HTML body throws:
+ *   SyntaxError: JSON.parse: expected double-quoted property name
+ * which surfaces as "Error checking updates" (#4555).
+ *
+ * This helper checks the Content-Type before parsing and throws a descriptive
+ * error when the body is not JSON, so callers get a useful message instead of
+ * an opaque SyntaxError.
+ */
+async function safeJsonParse<T>(response: Response, label: string): Promise<T> {
+  const contentType = response.headers.get('Content-Type') || ''
+  if (!contentType.includes('application/json') && !contentType.includes('application/vnd.github')) {
+    throw new Error(
+      `${label}: expected JSON response but received ${contentType || 'unknown content type'} (status ${response.status})`
+    )
+  }
+  try {
+    return (await response.json()) as T
+  } catch (err) {
+    // Guard against malformed JSON even when Content-Type looks correct
+    throw new Error(
+      `${label}: failed to parse response as JSON — ${err instanceof Error ? err.message : String(err)}`
+    )
+  }
+}
 
 /**
  * Parse a release tag to determine its type and extract date.
@@ -345,7 +374,7 @@ function useVersionCheckCore() {
       const resp = await fetch(`${LOCAL_AGENT_HTTP_URL}/auto-update/status`, {
         signal: AbortSignal.timeout(10000) })
       if (resp.ok) {
-        const data = (await resp.json()) as AutoUpdateStatus
+        const data = await safeJsonParse<AutoUpdateStatus>(resp, 'Auto-update status')
         console.debug('[version-check] Auto-update status:', data)
         setAutoUpdateStatus(data)
         // Clear any stale error from a previous failed check
@@ -397,7 +426,7 @@ function useVersionCheckCore() {
         headers,
         signal: AbortSignal.timeout(5000) })
       if (resp.ok) {
-        const data = await resp.json()
+        const data = await safeJsonParse<{ object?: { sha?: string } }>(resp, 'GitHub main SHA')
         const sha = data?.object?.sha as string | undefined
         if (sha) {
           console.debug('[version-check] Latest main SHA:', sha.slice(0, 7))
@@ -461,7 +490,7 @@ function useVersionCheckCore() {
         { headers, signal: AbortSignal.timeout(10000) }
       )
       if (resp.ok) {
-        const data = await resp.json()
+        const data = await safeJsonParse<{ commits?: Array<{ sha: string; commit: { message: string; author: { name: string; date: string } } }> }>(resp, 'GitHub compare')
         const commits = (data.commits || []).slice(-20).reverse().map((c: { sha: string; commit: { message: string; author: { name: string; date: string } } }) => ({
           sha: c.sha,
           message: c.commit.message.split('\n')[0], // First line only
@@ -631,7 +660,7 @@ function useVersionCheckCore() {
         throw new Error(`GitHub API error: ${response.status}`)
       }
 
-      const data = (await response.json()) as GitHubRelease[]
+      const data = await safeJsonParse<GitHubRelease[]>(response, 'GitHub releases')
       const etag = response.headers.get('ETag')
 
       // Filter out drafts
@@ -829,7 +858,7 @@ function useVersionCheckCore() {
       try {
         const resp = await fetch('/health', { signal: AbortSignal.timeout(HEALTH_FETCH_TIMEOUT_MS) })
         if (resp.ok) {
-          const data = await resp.json()
+          const data = await safeJsonParse<{ install_method?: string }>(resp, 'Backend health')
           if (data.install_method && !cancelled) {
             setInstallMethod(data.install_method as InstallMethod)
             return // success — no retry needed

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -700,13 +700,14 @@
       "prereqGitCleanFail": "Uncommitted changes",
       "allPrereqsMet": "All prerequisites met — update notifications active",
       "prereqsMissing": "{{count}} prerequisite(s) not met — some features unavailable",
+      "errorHint": "Try clicking \"Check Now\" to retry, or verify that kc-agent is running and network is available.",
       "scopeInfoToggle": "What do these settings control?",
-      "scopeSystemTitle": "System Updates (Automatic Updates)",
-      "scopeSystemDesc": "Pulls and applies new console versions from the configured Update Channel. The Automatic Updates toggle on this page controls whether this happens automatically or only when you click Update Now. This updates all console code, including card components.",
-      "scopeReloadTitle": "Browser Reload on Deploy",
-      "scopeReloadDesc": "Separately from System Updates, the browser detects when a new build has been deployed and prompts you to reload the page so the updated code takes effect. This detection runs automatically and is not controlled by the settings on this page.",
-      "scopeCardDataTitle": "Card Data Refresh",
-      "scopeCardDataDesc": "Individual dashboard cards periodically fetch fresh data (e.g., cluster status, metrics) on their own schedules. These data refreshes are independent of both System Updates and browser reloads."
+      "scopeSystemTitle": "Console Version Updates",
+      "scopeSystemDesc": "Checks for new console releases on the selected Update Channel and lets you apply them. For self-hosted installs with kc-agent, enabling Automatic Updates will pull and apply new versions in the background. Without kc-agent, you will see a notification with manual upgrade instructions (Helm command, brew command, or git pull).",
+      "scopeReloadTitle": "Post-Deploy Page Reload",
+      "scopeReloadDesc": "After a new version is deployed (whether via auto-update or manual upgrade), the browser detects the updated build and shows a banner prompting you to reload the page. This happens automatically and has no settings on this page.",
+      "scopeCardDataTitle": "Dashboard Card Data",
+      "scopeCardDataDesc": "Dashboard cards fetch live data (cluster health, pod status, metrics) on their own schedules, independent of console version updates. Card refresh intervals are not controlled by these settings."
     },
     "theme": {
       "title": "Appearance",


### PR DESCRIPTION
## Summary
- **Fix #4555**: Replace all bare `response.json()` calls in `useVersionCheck` with a `safeJsonParse` helper that validates `Content-Type` before parsing. When the backend proxy is unavailable (e.g. Netlify SPA fallback returning HTML), the opaque `SyntaxError: JSON.parse: expected double-quoted property name` is replaced with a descriptive error message.
- **Fix #9491**: Rewrite the "What do these settings control?" explanations in Settings > System Updates to be clearer for self-hosted users — distinguishes console version updates, post-deploy page reload, and dashboard card data refresh. Move a hardcoded English error hint into i18n.

Fixes #4555, Fixes #9491

## Changes
- `web/src/hooks/useVersionCheck.tsx` — Add `safeJsonParse<T>()` helper; replace 5 unsafe `response.json()` calls (fetchAutoUpdateStatus, fetchLatestMainSHA, fetchRecentCommits, fetchReleases, /health effect); remove duplicate comment
- `web/src/locales/en/common.json` — Rewrite scope descriptions, add `errorHint` i18n key
- `web/src/components/settings/UpdateSettings.tsx` — Replace hardcoded English error hint with `t('settings.updates.errorHint')`

## Test plan
- [ ] Open Settings > System Updates — verify no "Error checking updates" when proxy is available
- [ ] In demo mode (no backend), verify the error message is descriptive rather than a raw SyntaxError
- [ ] Click "What do these settings control?" — verify the rewritten descriptions are clear
- [ ] Click "Check Now" — verify normal update check still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)