### PR TITLE
🧹 Replace ~15 raw ms literals with MS_PER_MINUTE/MS_PER_HOUR/MS_PER_DAY

### DIFF
--- a/web/src/components/alerts/AlertDetail.tsx
+++ b/web/src/components/alerts/AlertDetail.tsx
@@ -22,7 +22,7 @@ import { Button } from '../ui/Button'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { TOAST_DISMISS_MS } from '../../lib/constants/network'
-import { MINUTES_PER_HOUR, HOURS_PER_DAY } from '../../lib/constants/time'
+import { MS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY } from '../../lib/constants/time'
 
 // Issue 9256 — fallback label used for acknowledgement when no authenticated
 // user is available (e.g. in demo mode without login).
@@ -40,7 +40,7 @@ function formatRelativeTime(dateString: string, t: TFunction): string {
   const date = new Date(dateString)
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
+  const diffMins = Math.floor(diffMs / MS_PER_MINUTE)
   const diffHours = Math.floor(diffMins / 60)
   const diffDays = Math.floor(diffHours / 24)
 

--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -8,6 +8,7 @@ import {
   Bell,
   BellOff } from 'lucide-react'
 import { useAlerts } from '../../hooks/useAlerts'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useGlobalFilters, type SeverityLevel } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -26,7 +27,7 @@ import { useDoNotDisturb, type TimedDuration } from '../../hooks/useDoNotDisturb
 
 /** Format remaining DND time as "Xh Ym" or "Ym" */
 function formatRemaining(ms: number): string {
-  const totalMinutes = Math.ceil(ms / 60_000)
+  const totalMinutes = Math.ceil(ms / MS_PER_MINUTE)
   const hours = Math.floor(totalMinutes / 60)
   const minutes = totalMinutes % 60
   if (hours > 0) return `${hours}h ${minutes}m`

--- a/web/src/components/cards/ClusterChangelog.tsx
+++ b/web/src/components/cards/ClusterChangelog.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AlertCircle } from 'lucide-react'
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../lib/constants/time'
 import { useCachedEvents } from '../../hooks/useCachedData'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
@@ -31,7 +32,7 @@ export function ClusterChangelog() {
   const cutoff = (() => {
     const now = Date.now()
     const hours: Record<TimeRange, number> = { '1h': 1, '6h': 6, '24h': 24, '7d': 168 }
-    return now - hours[timeRange] * 3600000
+    return now - hours[timeRange] * MS_PER_HOUR
   })()
 
   const changeEvents = useMemo(() => {
@@ -72,10 +73,10 @@ export function ClusterChangelog() {
     const d = new Date(ts)
     const now = new Date()
     const diff = now.getTime() - d.getTime()
-    if (diff < 60000) return t('clusterChangelog.justNow')
-    if (diff < 3600000) return t('clusterChangelog.minutesAgo', { count: Math.floor(diff / 60000) })
-    if (diff < 86400000) return t('clusterChangelog.hoursAgo', { count: Math.floor(diff / 3600000) })
-    return t('clusterChangelog.daysAgo', { count: Math.floor(diff / 86400000) })
+    if (diff < MS_PER_MINUTE) return t('clusterChangelog.justNow')
+    if (diff < MS_PER_HOUR) return t('clusterChangelog.minutesAgo', { count: Math.floor(diff / MS_PER_MINUTE) })
+    if (diff < MS_PER_DAY) return t('clusterChangelog.hoursAgo', { count: Math.floor(diff / MS_PER_HOUR) })
+    return t('clusterChangelog.daysAgo', { count: Math.floor(diff / MS_PER_DAY) })
   }
 
   return (

--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -22,7 +22,7 @@ import {
   CHART_AXIS_FONT_SIZE,
   CHART_BODY_FONT_SIZE,
   CHART_TEXT_MUTED } from '../../lib/constants'
-import { MS_PER_MINUTE } from '../../lib/constants/time'
+import { MS_PER_MINUTE, MS_PER_HOUR } from '../../lib/constants/time'
 
 /**
  * Maximum age of a metrics-history snapshot we're willing to use as a
@@ -67,10 +67,10 @@ interface EffectiveGPUNode {
 type TimeRange = '15m' | '1h' | '6h' | '24h'
 
 const TIME_RANGE_OPTIONS: { value: TimeRange; label: string; points: number; intervalMs: number }[] = [
-  { value: '15m', label: '15 min', points: 15, intervalMs: 60000 },
-  { value: '1h', label: '1 hour', points: 20, intervalMs: 180000 },
-  { value: '6h', label: '6 hours', points: 24, intervalMs: 900000 },
-  { value: '24h', label: '24 hours', points: 24, intervalMs: 3600000 },
+  { value: '15m', label: '15 min', points: 15, intervalMs: MS_PER_MINUTE },
+  { value: '1h', label: '1 hour', points: 20, intervalMs: 3 * MS_PER_MINUTE },
+  { value: '6h', label: '6 hours', points: 24, intervalMs: 15 * MS_PER_MINUTE },
+  { value: '24h', label: '24 hours', points: 24, intervalMs: MS_PER_HOUR },
 ]
 
 export function GPUUsageTrend() {

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect, useCallback, useImperativeHandle, memo, type Ref } from 'react'
 import { GitPullRequest, GitBranch, Star, Users, Package, TrendingUp, AlertCircle, Clock, CheckCircle, XCircle, GitMerge, Settings, X, Plus, Check } from 'lucide-react'
 import { POLL_INTERVAL_SLOW_MS } from '../../lib/constants/network'
-import { MS_PER_MINUTE, MS_PER_DAY } from '../../lib/constants/time'
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../lib/constants/time'
 import { formatTimeAgo } from '../../lib/formatters'
 import { Button } from '../ui/Button'
 import { Skeleton } from '../ui/Skeleton'
@@ -208,8 +208,8 @@ async function githubFetchError(response: Response, label: string): Promise<Erro
 
 function getDemoGitHubData(repoName: string) {
   const now = new Date()
-  const daysAgo = (d: number) => new Date(now.getTime() - d * 86400000).toISOString()
-  const hoursAgo = (h: number) => new Date(now.getTime() - h * 3600000).toISOString()
+  const daysAgo = (d: number) => new Date(now.getTime() - d * MS_PER_DAY).toISOString()
+  const hoursAgo = (h: number) => new Date(now.getTime() - h * MS_PER_HOUR).toISOString()
   const demoUser = { login: 'demo-user', avatar_url: 'https://github.com/ghost.png' }
   const prs: GitHubPR[] = [
     { number: 842, title: 'feat: Add multi-cluster GPU scheduling', state: 'open', merged_at: null, created_at: hoursAgo(2), updated_at: hoursAgo(1), user: demoUser, html_url: '#', draft: false, labels: [{ name: 'enhancement', color: 'a2eeef' }] },

--- a/web/src/components/cards/NamespaceEvents.tsx
+++ b/web/src/components/cards/NamespaceEvents.tsx
@@ -10,6 +10,7 @@ import { useCardData, useCascadingSelection, commonComparators } from '../../lib
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../lib/constants/time'
 
 interface NamespaceEventsProps {
   config?: {
@@ -161,10 +162,10 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
     const now = new Date()
     const diff = now.getTime() - date.getTime()
 
-    if (diff < 60000) return t('namespaceEvents.justNow')
-    if (diff < 3600000) return t('namespaceEvents.minutesAgo', { count: Math.floor(diff / 60000) })
-    if (diff < 86400000) return t('namespaceEvents.hoursAgo', { count: Math.floor(diff / 3600000) })
-    return t('namespaceEvents.daysAgo', { count: Math.floor(diff / 86400000) })
+    if (diff < MS_PER_MINUTE) return t('namespaceEvents.justNow')
+    if (diff < MS_PER_HOUR) return t('namespaceEvents.minutesAgo', { count: Math.floor(diff / MS_PER_MINUTE) })
+    if (diff < MS_PER_DAY) return t('namespaceEvents.hoursAgo', { count: Math.floor(diff / MS_PER_HOUR) })
+    return t('namespaceEvents.daysAgo', { count: Math.floor(diff / MS_PER_DAY) })
   }
 
   if (showSkeleton) {

--- a/web/src/components/cards/NamespaceMonitor.tsx
+++ b/web/src/components/cards/NamespaceMonitor.tsx
@@ -13,6 +13,7 @@ import { BaseModal } from '../../lib/modals/BaseModal'
 import { CardComponentProps } from './cardRegistry'
 import { useCardLoadingState } from './CardDataContext'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
 
 // Resource types to monitor
 type ResourceType = 'pods' | 'deployments' | 'services' | 'configmaps' | 'secrets' | 'pvcs' | 'jobs'
@@ -495,7 +496,7 @@ export function NamespaceMonitor({ config: _config }: CardComponentProps) {
   // Count recent changes by type
   const changeCountsByType = (() => {
     const counts = { added: 0, modified: 0, deleted: 0, error: 0 }
-    const recentTime = Date.now() - 60000 // Last minute
+    const recentTime = Date.now() - MS_PER_MINUTE
     recentChanges.forEach(c => {
       if (c.timestamp > recentTime && c.type) {
         counts[c.type]++

--- a/web/src/components/cards/PodHealthTrend.tsx
+++ b/web/src/components/cards/PodHealthTrend.tsx
@@ -219,7 +219,7 @@ export function PodHealthTrend() {
       if (isDemoMode()) {
         // Seed 8 historical points so the time-series chart renders immediately
         const DEMO_SEED_POINTS = 8
-        const DEMO_INTERVAL_MS = 5 * 60000 // 5-min intervals
+        const DEMO_INTERVAL_MS = 5 * MS_PER_MINUTE
         const MAX_JITTER = 3
         const points: HealthPoint[] = []
         for (let i = DEMO_SEED_POINTS - 1; i >= 0; i--) {

--- a/web/src/components/cards/RecentEvents.tsx
+++ b/web/src/components/cards/RecentEvents.tsx
@@ -8,7 +8,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardControlsRow, CardPaginationFooter, CardSearchInput, CardSkeleton } from '../../lib/cards/CardComponents'
 import type { ClusterEvent } from '../../hooks/useMCP'
-import { MS_PER_HOUR } from '../../lib/constants/time'
+import { MS_PER_MINUTE, MS_PER_HOUR } from '../../lib/constants/time'
 
 const EVENT_CUTOFF_MS = MS_PER_HOUR
 
@@ -17,7 +17,7 @@ type SortByOption = 'time' | 'reason' | 'object'
 function getMinutesAgo(timestamp: string | undefined): string {
   if (!timestamp) return 'Unknown'
   const diffMs = Date.now() - new Date(timestamp).getTime()
-  const diffMins = Math.floor(diffMs / 60000)
+  const diffMins = Math.floor(diffMs / MS_PER_MINUTE)
   if (diffMins < 1) return 'Just now'
   if (diffMins < 60) return `${diffMins}m ago`
   return `${Math.floor(diffMins / 60)}h ago`

--- a/web/src/components/cards/WarningEvents.tsx
+++ b/web/src/components/cards/WarningEvents.tsx
@@ -8,21 +8,7 @@ import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardSkeleton, C
 import type { ClusterEvent } from '../../hooks/useMCP'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../ui/StatusBadge'
-
-function getTimeAgo(timestamp: string | undefined): string {
-  if (!timestamp) return 'Unknown'
-  const now = new Date()
-  const then = new Date(timestamp)
-  const diffMs = now.getTime() - then.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-  const diffHours = Math.floor(diffMins / 60)
-  const diffDays = Math.floor(diffHours / 24)
-
-  if (diffDays > 0) return `${diffDays}d ago`
-  if (diffHours > 0) return `${diffHours}h ago`
-  if (diffMins > 0) return `${diffMins}m ago`
-  return 'Just now'
-}
+import { formatTimeAgo } from '../../lib/formatters'
 
 type SortByOption = 'time' | 'count' | 'reason'
 
@@ -218,7 +204,7 @@ export function WarningEvents() {
                       showRepair={false}
                       className="shrink-0"
                     />
-                    <span className="text-xs text-muted-foreground ml-auto whitespace-nowrap shrink-0">{getTimeAgo(event.lastSeen)}</span>
+                    <span className="text-xs text-muted-foreground ml-auto whitespace-nowrap shrink-0">{formatTimeAgo(event.lastSeen ?? '', { invalidLabel: 'Unknown' })}</span>
                   </div>
                 </div>
               </div>

--- a/web/src/components/cards/rss/RSSFeed.tsx
+++ b/web/src/components/cards/rss/RSSFeed.tsx
@@ -22,6 +22,7 @@ import {
 import { formatTimeAgo } from '../../../lib/formatters'
 import { useTranslation } from 'react-i18next'
 import { TOAST_DISMISS_MS } from '../../../lib/constants/network'
+import { MS_PER_HOUR } from '../../../lib/constants/time'
 import { hostnameEndsWith } from '../../../lib/utils/urlHostname'
 
 const MIN_VALID_FEED_LENGTH = 50
@@ -39,7 +40,7 @@ const SORT_COMPARATORS: Record<SortByOption, (a: FeedItem, b: FeedItem) => numbe
 // Demo RSS feed items (avoids external API calls in demo mode)
 function getDemoRSSItems(): FeedItem[] {
   const now = new Date()
-  const hoursAgo = (h: number) => new Date(now.getTime() - h * 3600000)
+  const hoursAgo = (h: number) => new Date(now.getTime() - h * MS_PER_HOUR)
   return [
     { id: 'demo-1', title: 'Kubernetes 1.32: What You Need to Know', link: '#', description: 'The latest Kubernetes release brings improvements to pod scheduling, enhanced GPU support, and new security features for multi-tenant clusters.', pubDate: hoursAgo(1), author: 'CNCF Blog', sourceName: 'Kubernetes Blog', sourceIcon: '⎈' },
     { id: 'demo-2', title: 'KubeStellar: Multi-Cluster Management Made Simple', link: '#', description: 'How KubeStellar simplifies deploying and managing workloads across multiple Kubernetes clusters with its innovative control plane architecture.', pubDate: hoursAgo(3), author: 'KubeStellar Team', sourceName: 'KubeStellar Blog', sourceIcon: '🌟' },

--- a/web/src/components/gitops/GitOps.tsx
+++ b/web/src/components/gitops/GitOps.tsx
@@ -8,6 +8,7 @@ import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { RefreshCw, GitBranch, FolderGit, Box, Loader2 } from 'lucide-react'
 import { SyncDialog } from './SyncDialog'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../../lib/constants'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
 import { getDemoMode } from '../../hooks/useDemoMode'
 import { StatBlockValue } from '../ui/StatsOverview'
@@ -79,7 +80,7 @@ function getTimeAgo(timestamp: string | undefined, t: TFunction): string {
   const now = new Date()
   const then = new Date(timestamp)
   const diffMs = now.getTime() - then.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
+  const diffMins = Math.floor(diffMs / MS_PER_MINUTE)
   const diffHours = Math.floor(diffMins / 60)
   if (diffHours > 0) return t('gitops.hoursAgo', { count: diffHours })
   if (diffMins > 0) return t('gitops.minutesAgo', { count: diffMins })

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -39,6 +39,7 @@ import {
   emitUpdateStalled,
   emitUpdateRefreshed,
 } from '../../lib/analytics'
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../lib/constants/time'
 
 /** Minimum spin duration to guarantee one full rotation (matches cards) */
 const MIN_SPIN_DURATION = 1000
@@ -262,9 +263,9 @@ export function UpdateSettings() {
     if (!lastChecked) return t('settings.updates.never')
     const now = Date.now()
     const diff = now - lastChecked
-    if (diff < 60000) return t('settings.updates.justNow')
-    if (diff < 3600000) return t('settings.updates.minutesAgo', { count: Math.floor(diff / 60000) })
-    if (diff < 86400000) return t('settings.updates.hoursAgo', { count: Math.floor(diff / 3600000) })
+    if (diff < MS_PER_MINUTE) return t('settings.updates.justNow')
+    if (diff < MS_PER_HOUR) return t('settings.updates.minutesAgo', { count: Math.floor(diff / MS_PER_MINUTE) })
+    if (diff < MS_PER_DAY) return t('settings.updates.hoursAgo', { count: Math.floor(diff / MS_PER_HOUR) })
     return new Date(lastChecked).toLocaleDateString()
   }
 
@@ -1202,8 +1203,10 @@ function formatCommitDate(iso: string): string {
   const date = new Date(iso)
   const now = Date.now()
   const diff = now - date.getTime()
-  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`
-  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`
-  if (diff < 604800000) return `${Math.floor(diff / 86400000)}d ago`
+  const DAYS_PER_WEEK = 7
+  const MS_PER_WEEK = MS_PER_DAY * DAYS_PER_WEEK
+  if (diff < MS_PER_HOUR) return `${Math.floor(diff / MS_PER_MINUTE)}m ago`
+  if (diff < MS_PER_DAY) return `${Math.floor(diff / MS_PER_HOUR)}h ago`
+  if (diff < MS_PER_WEEK) return `${Math.floor(diff / MS_PER_DAY)}d ago`
   return date.toLocaleDateString()
 }


### PR DESCRIPTION
## Summary
- Replaces ~25 raw millisecond literals (60000, 3600000, 86400000, 604800000) with shared constants from `lib/constants/time.ts`
- Affects 13 files across cards, alerts, settings, and gitops components
- Replaces `getTimeAgo` in WarningEvents.tsx with shared `formatTimeAgo` from `lib/formatters.ts`
- No behavioral changes — all replacements are exact equivalents

### Files changed
ActiveAlerts, GitOps, AlertDetail, RecentEvents, UpdateSettings, GPUUsageTrend, GitHubActivity, ClusterChangelog, NamespaceEvents, NamespaceMonitor, PodHealthTrend, WarningEvents, RSSFeed

## Test plan
- [x] `npm run build` — passes with all post-build safety checks green
- [ ] CI pr-check passes
- [ ] CI ui-ux-standard passes

Fixes #10320