### PR TITLE
🐛 Fix cluster inventory showing only dedup'd winners instead of all contexts

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -197,8 +197,7 @@ function loadClusterCacheFromStorage(): ClusterInfo[] {
     if (stored) {
       const parsed = JSON.parse(stored)
       if (Array.isArray(parsed) && parsed.length > 0) {
-        // Filter out long context-path duplicates from cached data
-        return parsed.filter((c: ClusterInfo) => !c.name.includes('/'))
+        return parsed
       }
     }
   } catch {
@@ -210,8 +209,7 @@ function loadClusterCacheFromStorage(): ClusterInfo[] {
 function saveClusterCacheToStorage(clusters: ClusterInfo[]) {
   try {
     // Only save clusters with meaningful data
-    // Filter out long context-path duplicates before saving
-    const toSave = clusters.filter(c => c.name && !c.name.includes("/")).map(c => ({
+    const toSave = clusters.filter(c => c.name).map(c => ({
       name: c.name,
       context: c.context,
       server: c.server,
@@ -1605,13 +1603,16 @@ export async function fullFetchClusters() {
         }
         return newCluster
       })
-      // Deduplicate clusters by server URL - prefers short names when available
-      // but keeps long names (e.g., '/api-pokprod001...' or 'default/api-...') if no short alias exists
-      const dedupedClusters = deduplicateClustersByServer(mergedClusters)
+      // Store the full (raw) cluster list in the cache. Deduplication is
+      // handled lazily by the useClusters() hook's `deduplicatedClusters`
+      // computed property. Premature dedup here was the root cause of
+      // #10316: when many kubeconfig contexts shared server URLs, the
+      // cache only held the dedup winners — hiding legitimate clusters
+      // (including the active kubectl context) from the dashboard.
 
       // Show clusters immediately with preserved health data
       await finishWithMinDuration({
-        clusters: dedupedClusters,
+        clusters: mergedClusters,
         error: null,
         lastUpdated: new Date(),
         isLoading: false,
@@ -1622,9 +1623,10 @@ export async function fullFetchClusters() {
       })
       // Reset flag before returning - allows subsequent refresh calls
       fetchInProgress = false
-      // Check health progressively (non-blocking) - use deduplicated list to avoid
-      // running health checks on long context-path duplicates
-      checkHealthProgressively(dedupedClusters)
+      // Check health on deduplicated clusters to avoid redundant probes
+      // against the same physical server from multiple contexts
+      const healthCheckClusters = deduplicateClustersByServer(mergedClusters)
+      checkHealthProgressively(healthCheckClusters)
       return
     }
 
@@ -1684,8 +1686,10 @@ export async function fullFetchClusters() {
       lastRefresh: new Date(),
     })
     fetchInProgress = false
-    // Check health progressively (non-blocking) - will update each cluster's data including cpuCores
-    checkHealthProgressively(data.clusters || [])
+    // Check health on deduplicated clusters to avoid redundant probes
+    // against the same physical server from multiple contexts
+    const healthCheckClusters = deduplicateClustersByServer(data.clusters || [])
+    checkHealthProgressively(healthCheckClusters)
   } catch {
     // Always fall back gracefully to demo clusters - never show blocking errors
     // This ensures the UI always has data to display


### PR DESCRIPTION
## Summary

- **Root cause**: `fullFetchClusters()` called `deduplicateClustersByServer()` before storing the cluster list in the shared cache, so the cache only held one cluster per unique server URL. With 21 kubeconfig contexts pointing to 4 API servers, the dashboard showed 4 clusters. The active kubectl context (vllm-d) could be the dedup "loser" and vanish entirely.
- **Secondary**: `saveClusterCacheToStorage()` and `loadClusterCacheFromStorage()` filtered out any cluster name containing `/`, permanently evicting OpenShift auto-generated context names from localStorage.
- **Fix**: Store the full raw cluster list in cache; deduplication now happens only in the `useClusters()` hook's computed `deduplicatedClusters` property (where it was always intended to live). Health checks still use the dedup'd list to avoid redundant probes.

Fixes #10316

## Test plan

- [ ] User with multiple kubeconfig contexts pointing to the same server URL sees all contexts in the Clusters page
- [ ] The active kubectl context (current-context) always appears in the cluster list
- [ ] Cluster count on the Dashboard uses deduplicated count (unique physical clusters) for metrics
- [ ] Health checks do not run redundantly for contexts sharing a server URL
- [ ] Removing a context via the console still properly removes it from the cache on refresh
- [ ] Page reload restores all clusters from localStorage (including those with `/` in the name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)