### PR TITLE
🧹 Consolidate duplicate Condition interfaces + extract named constant

### DIFF
--- a/web/src/components/drilldown/views/KustomizationDrillDown.tsx
+++ b/web/src/components/drilldown/views/KustomizationDrillDown.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import type { Condition } from '../../../types/mcs'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useMissions } from '../../../hooks/useMissions'
@@ -55,21 +56,6 @@ interface InventoryEntryRaw {
   v?: string
 }
 
-interface Condition {
-  type: string
-  status: string
-  reason?: string
-  message?: string
-  lastTransitionTime?: string
-}
-
-interface ConditionRaw {
-  type: string
-  status: string
-  reason?: string
-  message?: string
-  lastTransitionTime?: string
-}
 
 export function KustomizationDrillDown({ data }: Props) {
   const { t } = useTranslation()
@@ -192,7 +178,7 @@ export function KustomizationDrillDown({ data }: Props) {
 
         // Get conditions
         const conds = ks.status?.conditions || []
-        setConditions(conds.map((c: ConditionRaw) => ({
+        setConditions(conds.map((c: Condition) => ({
           type: c.type,
           status: c.status,
           reason: c.reason,

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -22,6 +22,8 @@ import {
 } from '../../../lib/constants/network'
 import type { AgentInfo } from '../../../types/agent'
 
+const CONNECTING_DEBOUNCE_MS = 300
+
 export function AgentStatusIndicator() {
   const { t } = useTranslation(['common'])
   const {
@@ -105,7 +107,7 @@ export function AgentStatusIndicator() {
       // Don't immediately show "connecting" — wait 300ms to confirm it's real
       connectingTimerRef.current = setTimeout(() => {
         setStableStatus('connecting')
-      }, 300)
+      }, CONNECTING_DEBOUNCE_MS)
     } else {
       // Any non-connecting status applies immediately
       if (connectingTimerRef.current) clearTimeout(connectingTimerRef.current)

--- a/web/src/components/shared/ConditionBadges.tsx
+++ b/web/src/components/shared/ConditionBadges.tsx
@@ -1,11 +1,7 @@
 import { cn } from '../../lib/cn'
+import type { Condition } from '../../types/mcs'
 
-export interface Condition {
-  type: string
-  status: string
-  reason?: string
-  message?: string
-}
+export type { Condition }
 
 interface ConditionBadgesProps {
   conditions: Condition[]


### PR DESCRIPTION
## Summary
- **ConditionBadges.tsx**: Replace local `Condition` interface with import from `types/mcs.ts` (re-exports for existing consumers — no breaking change)
- **KustomizationDrillDown.tsx**: Remove both duplicate `Condition` and identical `ConditionRaw` interfaces, import from `types/mcs.ts`
- **AgentStatusIndicator.tsx**: Extract raw `300` ms timeout → `CONNECTING_DEBOUNCE_MS` named constant
- Leaves `useConsoleCRs.ts` private `Condition` as-is (intentionally narrower `status: 'True'|'False'|'Unknown'`)

Removes ~20 lines of duplicated type definitions.

## Test plan
- [x] `npm run build` — passes with all post-build safety checks green
- [ ] CI pr-check passes
- [ ] CI card-standard passes

Fixes #10328