### PR TITLE
🌱 Add 108 tests for 11 untested modules toward 91% coverage target

### DIFF
--- a/web/src/lib/__tests__/analytics-events.test.ts
+++ b/web/src/lib/__tests__/analytics-events.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for analytics-events.ts emit functions.
+ *
+ * We mock the `send` function from analytics-core and verify that each
+ * emitter calls it with the correct event name and parameters.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../analytics-core', () => ({
+  send: vi.fn(),
+  setAnalyticsUserProperties: vi.fn(),
+}))
+
+vi.mock('../demoMode', () => ({
+  isDemoMode: vi.fn(() => false),
+}))
+
+vi.mock('../analytics-session', () => ({
+  getDeploymentType: vi.fn(() => 'localhost'),
+}))
+
+import { send } from '../analytics-core'
+import {
+  emitCardAdded,
+  emitCardRemoved,
+  emitCardExpanded,
+  emitCardDragged,
+  emitCardConfigured,
+  emitCardReplaced,
+  emitGlobalSearchOpened,
+  emitGlobalSearchQueried,
+  emitGlobalSearchSelected,
+  emitGlobalSearchAskAI,
+  emitCardSortChanged,
+  emitCardSortDirectionChanged,
+  emitCardLimitChanged,
+  emitCardSearchUsed,
+  emitCardClusterFilterChanged,
+  emitCardPaginationUsed,
+  emitCardListItemClicked,
+  emitMissionStarted,
+  emitMissionCompleted,
+} from '../analytics-events'
+
+const mockSend = vi.mocked(send)
+
+describe('analytics-events', () => {
+  beforeEach(() => {
+    mockSend.mockClear()
+  })
+
+  describe('Dashboard & Cards', () => {
+    it('emitCardAdded sends card_type and source', () => {
+      emitCardAdded('pods', 'customize')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_added', { card_type: 'pods', source: 'customize' })
+    })
+
+    it('emitCardRemoved sends card_type', () => {
+      emitCardRemoved('pods')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_removed', { card_type: 'pods' })
+    })
+
+    it('emitCardExpanded sends card_type', () => {
+      emitCardExpanded('events')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_expanded', { card_type: 'events' })
+    })
+
+    it('emitCardDragged sends card_type', () => {
+      emitCardDragged('pods')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_dragged', { card_type: 'pods' })
+    })
+
+    it('emitCardConfigured sends card_type', () => {
+      emitCardConfigured('cluster-health')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_configured', { card_type: 'cluster-health' })
+    })
+
+    it('emitCardReplaced sends old and new types', () => {
+      emitCardReplaced('old-card', 'new-card')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_replaced', { old_type: 'old-card', new_type: 'new-card' })
+    })
+  })
+
+  describe('Global Search', () => {
+    it('emitGlobalSearchOpened sends method', () => {
+      emitGlobalSearchOpened('keyboard')
+      expect(mockSend).toHaveBeenCalledWith('ksc_global_search_opened', { method: 'keyboard' })
+    })
+
+    it('emitGlobalSearchQueried sends query length and result count', () => {
+      emitGlobalSearchQueried(5, 10)
+      expect(mockSend).toHaveBeenCalledWith('ksc_global_search_queried', { query_length: 5, result_count: 10 })
+    })
+
+    it('emitGlobalSearchSelected sends category and result index', () => {
+      emitGlobalSearchSelected('cards', 2)
+      expect(mockSend).toHaveBeenCalledWith('ksc_global_search_selected', { category: 'cards', result_index: 2 })
+    })
+
+    it('emitGlobalSearchAskAI sends query length', () => {
+      emitGlobalSearchAskAI(15)
+      expect(mockSend).toHaveBeenCalledWith('ksc_global_search_ask_ai', { query_length: 15 })
+    })
+  })
+
+  describe('Card Interactions', () => {
+    it('emitCardSortChanged sends sort field, card type, and page path', () => {
+      emitCardSortChanged('name', 'pods')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_sort_changed', {
+        sort_field: 'name',
+        card_type: 'pods',
+        page_path: expect.any(String),
+      })
+    })
+
+    it('emitCardSortDirectionChanged sends direction and card type', () => {
+      emitCardSortDirectionChanged('asc', 'events')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_sort_direction_changed', {
+        direction: 'asc',
+        card_type: 'events',
+        page_path: expect.any(String),
+      })
+    })
+
+    it('emitCardLimitChanged sends limit and card type', () => {
+      emitCardLimitChanged('50', 'pods')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_limit_changed', {
+        limit: '50',
+        card_type: 'pods',
+        page_path: expect.any(String),
+      })
+    })
+
+    it('emitCardSearchUsed sends query length and card type', () => {
+      emitCardSearchUsed(10, 'events')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_search_used', {
+        query_length: 10,
+        card_type: 'events',
+        page_path: expect.any(String),
+      })
+    })
+
+    it('emitCardClusterFilterChanged sends counts and card type', () => {
+      emitCardClusterFilterChanged(2, 5, 'pods')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_cluster_filter_changed', {
+        selected_count: 2,
+        total_count: 5,
+        card_type: 'pods',
+        page_path: expect.any(String),
+      })
+    })
+
+    it('emitCardPaginationUsed sends page and total pages', () => {
+      emitCardPaginationUsed(3, 10, 'events')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_pagination_used', {
+        page: 3,
+        total_pages: 10,
+        card_type: 'events',
+        page_path: expect.any(String),
+      })
+    })
+
+    it('emitCardListItemClicked sends card type', () => {
+      emitCardListItemClicked('deployments')
+      expect(mockSend).toHaveBeenCalledWith('ksc_card_list_item_clicked', {
+        card_type: 'deployments',
+        page_path: expect.any(String),
+      })
+    })
+  })
+
+  describe('Missions', () => {
+    it('emitMissionStarted sends mission type and provider', () => {
+      emitMissionStarted('install', 'claude')
+      expect(mockSend).toHaveBeenCalledWith('ksc_mission_started', {
+        mission_type: 'install',
+        agent_provider: 'claude',
+      })
+    })
+
+    it('emitMissionCompleted sends mission type and duration', () => {
+      emitMissionCompleted('install', 120)
+      expect(mockSend).toHaveBeenCalledWith('ksc_mission_completed', {
+        mission_type: 'install',
+        duration_sec: 120,
+      })
+    })
+  })
+})

--- a/web/src/lib/__tests__/gpu.test.ts
+++ b/web/src/lib/__tests__/gpu.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeClusterName, hasGPUResourceRequest, extractImageTag } from '../gpu'
+
+describe('normalizeClusterName', () => {
+  it('extracts last segment from slash-separated path', () => {
+    expect(normalizeClusterName('context/namespace/cluster-1')).toBe('cluster-1')
+  })
+
+  it('returns the name unchanged when no slashes', () => {
+    expect(normalizeClusterName('my-cluster')).toBe('my-cluster')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(normalizeClusterName('')).toBe('')
+  })
+
+  it('handles trailing slash gracefully', () => {
+    const result = normalizeClusterName('context/')
+    expect(result).toBe('context/')
+  })
+})
+
+describe('hasGPUResourceRequest', () => {
+  it('returns true when a container requests GPUs', () => {
+    expect(hasGPUResourceRequest([{ gpuRequested: 2 }])).toBe(true)
+  })
+
+  it('returns false when no GPUs requested', () => {
+    expect(hasGPUResourceRequest([{ gpuRequested: 0 }])).toBe(false)
+  })
+
+  it('returns false when gpuRequested is undefined', () => {
+    expect(hasGPUResourceRequest([{}])).toBe(false)
+  })
+
+  it('returns false for undefined containers', () => {
+    expect(hasGPUResourceRequest(undefined)).toBe(false)
+  })
+
+  it('returns false for empty array', () => {
+    expect(hasGPUResourceRequest([])).toBe(false)
+  })
+
+  it('returns true when at least one container has GPU', () => {
+    expect(hasGPUResourceRequest([{ gpuRequested: 0 }, { gpuRequested: 1 }])).toBe(true)
+  })
+})
+
+describe('extractImageTag', () => {
+  it('extracts tag from standard image reference', () => {
+    expect(extractImageTag('nginx:1.25')).toBe('1.25')
+  })
+
+  it('returns "latest" when no tag present', () => {
+    expect(extractImageTag('nginx')).toBe('latest')
+  })
+
+  it('returns "unknown" for undefined image', () => {
+    expect(extractImageTag(undefined)).toBe('unknown')
+  })
+
+  it('truncates long tags (like sha256 digests)', () => {
+    const longTag = 'a'.repeat(25)
+    const result = extractImageTag(`registry.io/app:${longTag}`)
+    expect(result.length).toBe(12)
+  })
+
+  it('handles image with registry and port', () => {
+    expect(extractImageTag('registry.io:5000/app:v2.0')).toBe('v2.0')
+  })
+})

--- a/web/src/lib/constants/__tests__/github-token.test.ts
+++ b/web/src/lib/constants/__tests__/github-token.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import {
+  GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS,
+  GITHUB_TOKEN_CREATE_URL,
+  GITHUB_TOKEN_CLASSIC_URL,
+} from '../github-token'
+
+describe('github-token constants', () => {
+  it('defines fine-grained permissions with Issues scope', () => {
+    expect(GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS).toHaveLength(1)
+    expect(GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS[0].scope).toContain('Issues')
+  })
+
+  it('permissions include a reason string', () => {
+    for (const perm of GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS) {
+      expect(perm.reason).toBeTruthy()
+      expect(typeof perm.reason).toBe('string')
+    }
+  })
+
+  it('token create URL points to GitHub settings', () => {
+    expect(GITHUB_TOKEN_CREATE_URL).toContain('github.com/settings/personal-access-tokens')
+  })
+
+  it('classic token URL includes repo scope', () => {
+    expect(GITHUB_TOKEN_CLASSIC_URL).toContain('scopes=repo')
+  })
+})

--- a/web/src/lib/constants/__tests__/orbit.test.ts
+++ b/web/src/lib/constants/__tests__/orbit.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ORBIT_CADENCE_HOURS,
+  ORBIT_OVERDUE_GRACE_HOURS,
+  ORBIT_MAX_HISTORY_ENTRIES,
+  ORBIT_DEFAULT_CADENCE,
+  GROUND_CONTROL_DASHBOARD_NAME_TEMPLATE,
+  ORBIT_AUTORUN_CHECK_INTERVAL_MS,
+} from '../orbit'
+
+describe('orbit constants', () => {
+  it('defines cadence hours for all cadences', () => {
+    expect(ORBIT_CADENCE_HOURS.daily).toBe(24)
+    expect(ORBIT_CADENCE_HOURS.weekly).toBe(168)
+    expect(ORBIT_CADENCE_HOURS.monthly).toBe(720)
+  })
+
+  it('weekly cadence equals 7 days', () => {
+    const HOURS_PER_DAY = 24
+    const DAYS_PER_WEEK = 7
+    expect(ORBIT_CADENCE_HOURS.weekly).toBe(HOURS_PER_DAY * DAYS_PER_WEEK)
+  })
+
+  it('monthly cadence equals 30 days', () => {
+    const HOURS_PER_DAY = 24
+    const DAYS_PER_MONTH = 30
+    expect(ORBIT_CADENCE_HOURS.monthly).toBe(HOURS_PER_DAY * DAYS_PER_MONTH)
+  })
+
+  it('has reasonable overdue grace period', () => {
+    expect(ORBIT_OVERDUE_GRACE_HOURS).toBe(4)
+    expect(ORBIT_OVERDUE_GRACE_HOURS).toBeGreaterThan(0)
+  })
+
+  it('limits history entries', () => {
+    expect(ORBIT_MAX_HISTORY_ENTRIES).toBe(50)
+  })
+
+  it('defaults to weekly cadence', () => {
+    expect(ORBIT_DEFAULT_CADENCE).toBe('weekly')
+  })
+
+  it('dashboard template contains {project} placeholder', () => {
+    expect(GROUND_CONTROL_DASHBOARD_NAME_TEMPLATE).toContain('{project}')
+  })
+
+  it('autorun check interval is 1 minute in ms', () => {
+    const MS_PER_MINUTE = 60_000
+    expect(ORBIT_AUTORUN_CHECK_INTERVAL_MS).toBe(MS_PER_MINUTE)
+  })
+})

--- a/web/src/lib/constants/__tests__/units.test.ts
+++ b/web/src/lib/constants/__tests__/units.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import {
+  BYTES_PER_MIB,
+  BYTES_PER_GIB,
+  BYTES_PER_TIB,
+  MIB_PER_GIB,
+  KIB_PER_MIB,
+  MILLICORES_PER_CORE,
+  GB_TO_MIB,
+  MB_TO_MIB,
+} from '../units'
+
+describe('unit constants', () => {
+  it('BYTES_PER_MIB = 1024^2', () => {
+    expect(BYTES_PER_MIB).toBe(1024 * 1024)
+  })
+
+  it('BYTES_PER_GIB = 1024^3', () => {
+    expect(BYTES_PER_GIB).toBe(1024 * 1024 * 1024)
+  })
+
+  it('BYTES_PER_TIB = 1024 * GIB', () => {
+    expect(BYTES_PER_TIB).toBe(1024 * BYTES_PER_GIB)
+  })
+
+  it('MIB_PER_GIB = 1024', () => {
+    expect(MIB_PER_GIB).toBe(1024)
+  })
+
+  it('KIB_PER_MIB = 1024', () => {
+    expect(KIB_PER_MIB).toBe(1024)
+  })
+
+  it('MILLICORES_PER_CORE = 1000', () => {
+    expect(MILLICORES_PER_CORE).toBe(1000)
+  })
+
+  it('GB_TO_MIB converts decimal GB to binary MiB', () => {
+    // 1 GB = 10^9 bytes, 1 MiB = 2^20 bytes, so ratio ≈ 953.674
+    expect(GB_TO_MIB).toBeCloseTo(1_000_000 / (1024 * 1024), 5)
+  })
+
+  it('MB_TO_MIB converts decimal MB to binary MiB', () => {
+    expect(MB_TO_MIB).toBeCloseTo(1_000_000 / (1024 * 1024), 5)
+  })
+
+  it('conversion chain: GIB = MIB_PER_GIB * MIB', () => {
+    expect(BYTES_PER_GIB).toBe(MIB_PER_GIB * BYTES_PER_MIB)
+  })
+})

--- a/web/src/lib/llmd/__tests__/tooltipSpacing.test.ts
+++ b/web/src/lib/llmd/__tests__/tooltipSpacing.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import {
+  TOOLTIP_ROW_PADDING_PX,
+  TOOLTIP_TIGHT_GAP_PX,
+  TOOLTIP_HEADER_MARGIN_PX,
+  TOOLTIP_INLINE_GAP_PX,
+  TOOLTIP_SWATCH_SIZE_PX,
+} from '../tooltipSpacing'
+
+describe('tooltipSpacing constants', () => {
+  it('follows 4px grid spacing scale', () => {
+    expect(TOOLTIP_ROW_PADDING_PX).toBe(1)
+    expect(TOOLTIP_TIGHT_GAP_PX).toBe(2)
+    expect(TOOLTIP_HEADER_MARGIN_PX).toBe(4)
+    expect(TOOLTIP_INLINE_GAP_PX).toBe(6)
+    expect(TOOLTIP_SWATCH_SIZE_PX).toBe(8)
+  })
+
+  it('all values are positive integers', () => {
+    const values = [
+      TOOLTIP_ROW_PADDING_PX,
+      TOOLTIP_TIGHT_GAP_PX,
+      TOOLTIP_HEADER_MARGIN_PX,
+      TOOLTIP_INLINE_GAP_PX,
+      TOOLTIP_SWATCH_SIZE_PX,
+    ]
+    for (const v of values) {
+      expect(v).toBeGreaterThan(0)
+      expect(Number.isInteger(v)).toBe(true)
+    }
+  })
+
+  it('values are in ascending order', () => {
+    const values = [
+      TOOLTIP_ROW_PADDING_PX,
+      TOOLTIP_TIGHT_GAP_PX,
+      TOOLTIP_HEADER_MARGIN_PX,
+      TOOLTIP_INLINE_GAP_PX,
+      TOOLTIP_SWATCH_SIZE_PX,
+    ]
+    for (let i = 1; i < values.length; i++) {
+      expect(values[i]).toBeGreaterThanOrEqual(values[i - 1])
+    }
+  })
+})

--- a/web/src/lib/schemas/__tests__/auth.test.ts
+++ b/web/src/lib/schemas/__tests__/auth.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { AuthRefreshResponseSchema, UserSchema } from '../auth'
+
+describe('AuthRefreshResponseSchema', () => {
+  it('parses valid response with both fields', () => {
+    const result = AuthRefreshResponseSchema.parse({ refreshed: true, onboarded: false })
+    expect(result.refreshed).toBe(true)
+    expect(result.onboarded).toBe(false)
+  })
+
+  it('parses response with optional fields missing', () => {
+    const result = AuthRefreshResponseSchema.parse({})
+    expect(result.refreshed).toBeUndefined()
+    expect(result.onboarded).toBeUndefined()
+  })
+
+  it('rejects invalid types', () => {
+    expect(() => AuthRefreshResponseSchema.parse({ refreshed: 'yes' })).toThrow()
+  })
+})
+
+describe('UserSchema', () => {
+  const validUser = {
+    id: '1',
+    github_id: '12345',
+    github_login: 'testuser',
+    onboarded: true,
+  }
+
+  it('parses valid user with required fields only', () => {
+    const result = UserSchema.parse(validUser)
+    expect(result.github_login).toBe('testuser')
+    expect(result.onboarded).toBe(true)
+  })
+
+  it('parses user with all optional fields', () => {
+    const result = UserSchema.parse({
+      ...validUser,
+      email: 'test@example.com',
+      slack_id: 'U123',
+      avatar_url: 'https://example.com/avatar.png',
+      role: 'admin',
+    })
+    expect(result.email).toBe('test@example.com')
+    expect(result.role).toBe('admin')
+  })
+
+  it('rejects invalid role', () => {
+    expect(() => UserSchema.parse({ ...validUser, role: 'superadmin' })).toThrow()
+  })
+
+  it('rejects missing required fields', () => {
+    expect(() => UserSchema.parse({ id: '1' })).toThrow()
+  })
+
+  it('accepts all valid roles', () => {
+    for (const role of ['admin', 'editor', 'viewer']) {
+      const result = UserSchema.parse({ ...validUser, role })
+      expect(result.role).toBe(role)
+    }
+  })
+})

--- a/web/src/lib/schemas/__tests__/security.test.ts
+++ b/web/src/lib/schemas/__tests__/security.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { SecurityIssueSchema, SecurityIssuesResponseSchema } from '../security'
+
+describe('SecurityIssueSchema', () => {
+  it('parses valid issue with required fields', () => {
+    const result = SecurityIssueSchema.parse({
+      name: 'pod-1',
+      namespace: 'default',
+      issue: 'Privileged container',
+      severity: 'high',
+    })
+    expect(result.name).toBe('pod-1')
+    expect(result.severity).toBe('high')
+  })
+
+  it('parses issue with optional fields', () => {
+    const result = SecurityIssueSchema.parse({
+      name: 'pod-1',
+      namespace: 'default',
+      issue: 'No resource limits',
+      severity: 'medium',
+      cluster: 'prod-east',
+      details: 'Container lacks memory limits',
+    })
+    expect(result.cluster).toBe('prod-east')
+    expect(result.details).toBe('Container lacks memory limits')
+  })
+
+  it('rejects invalid severity', () => {
+    expect(() =>
+      SecurityIssueSchema.parse({
+        name: 'pod-1',
+        namespace: 'default',
+        issue: 'test',
+        severity: 'critical',
+      })
+    ).toThrow()
+  })
+
+  it('accepts all valid severities', () => {
+    for (const severity of ['high', 'medium', 'low']) {
+      const result = SecurityIssueSchema.parse({
+        name: 'pod-1',
+        namespace: 'default',
+        issue: 'test',
+        severity,
+      })
+      expect(result.severity).toBe(severity)
+    }
+  })
+})
+
+describe('SecurityIssuesResponseSchema', () => {
+  it('parses valid response with issues array', () => {
+    const result = SecurityIssuesResponseSchema.parse({
+      issues: [
+        { name: 'pod-1', namespace: 'default', issue: 'test', severity: 'low' },
+      ],
+    })
+    expect(result.issues).toHaveLength(1)
+  })
+
+  it('parses empty issues array', () => {
+    const result = SecurityIssuesResponseSchema.parse({ issues: [] })
+    expect(result.issues).toHaveLength(0)
+  })
+
+  it('rejects missing issues field', () => {
+    expect(() => SecurityIssuesResponseSchema.parse({})).toThrow()
+  })
+})

--- a/web/src/lib/stats/__tests__/gridUtils.test.ts
+++ b/web/src/lib/stats/__tests__/gridUtils.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { getResponsiveGridCols } from '../gridUtils'
+
+describe('getResponsiveGridCols', () => {
+  it('returns 4-col layout for up to 4 items', () => {
+    expect(getResponsiveGridCols(1)).toBe('grid-cols-2 md:grid-cols-4')
+    expect(getResponsiveGridCols(4)).toBe('grid-cols-2 md:grid-cols-4')
+  })
+
+  it('returns 5-col layout for 5 items', () => {
+    expect(getResponsiveGridCols(5)).toBe('grid-cols-2 md:grid-cols-5')
+  })
+
+  it('returns 6-col layout for 6 items', () => {
+    expect(getResponsiveGridCols(6)).toBe('grid-cols-2 md:grid-cols-3 lg:grid-cols-6')
+  })
+
+  it('returns 8-col layout for 7-8 items', () => {
+    expect(getResponsiveGridCols(7)).toBe('grid-cols-2 md:grid-cols-4 lg:grid-cols-8')
+    expect(getResponsiveGridCols(8)).toBe('grid-cols-2 md:grid-cols-4 lg:grid-cols-8')
+  })
+
+  it('returns 10-col layout for 9+ items', () => {
+    expect(getResponsiveGridCols(9)).toBe('grid-cols-2 md:grid-cols-5 lg:grid-cols-10')
+    expect(getResponsiveGridCols(20)).toBe('grid-cols-2 md:grid-cols-5 lg:grid-cols-10')
+  })
+
+  it('all layouts start with grid-cols-2 for mobile', () => {
+    for (const count of [1, 3, 5, 7, 10]) {
+      expect(getResponsiveGridCols(count)).toContain('grid-cols-2')
+    }
+  })
+})

--- a/web/src/lib/utils/__tests__/urlHostname.test.ts
+++ b/web/src/lib/utils/__tests__/urlHostname.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parsedHostname,
+  hostnameEndsWith,
+  hostnameContainsLabel,
+  parsedProtocol,
+  isHttpUrl,
+} from '../urlHostname'
+
+describe('parsedHostname', () => {
+  it('extracts hostname from a full HTTPS URL', () => {
+    expect(parsedHostname('https://api.cluster.eks.amazonaws.com:6443')).toBe(
+      'api.cluster.eks.amazonaws.com'
+    )
+  })
+
+  it('lowercases the hostname', () => {
+    expect(parsedHostname('https://API.Example.COM/path')).toBe('api.example.com')
+  })
+
+  it('returns empty string for malformed URLs', () => {
+    expect(parsedHostname('not-a-url')).toBe('')
+  })
+
+  it('returns empty string for empty string', () => {
+    expect(parsedHostname('')).toBe('')
+  })
+
+  it('strips port from hostname', () => {
+    expect(parsedHostname('http://localhost:8080')).toBe('localhost')
+  })
+
+  it('handles URLs with paths and query strings', () => {
+    expect(parsedHostname('https://example.com/path?q=foo')).toBe('example.com')
+  })
+})
+
+describe('hostnameEndsWith', () => {
+  it('returns true when hostname ends with suffix', () => {
+    expect(
+      hostnameEndsWith('https://api.cluster.eks.amazonaws.com:6443', 'eks.amazonaws.com')
+    ).toBe(true)
+  })
+
+  it('returns true when hostname exactly equals suffix', () => {
+    expect(hostnameEndsWith('https://example.com', 'example.com')).toBe(true)
+  })
+
+  it('returns false when suffix appears in path, not hostname', () => {
+    expect(
+      hostnameEndsWith('https://evil.com/path?q=eks.amazonaws.com', 'eks.amazonaws.com')
+    ).toBe(false)
+  })
+
+  it('returns false for malformed URL', () => {
+    expect(hostnameEndsWith('not-a-url', 'example.com')).toBe(false)
+  })
+
+  it('is case-insensitive', () => {
+    expect(hostnameEndsWith('https://API.EXAMPLE.COM', 'example.com')).toBe(true)
+  })
+})
+
+describe('hostnameContainsLabel', () => {
+  it('returns true when segment is a label in hostname', () => {
+    expect(hostnameContainsLabel('https://api.fmaas.res.ibm.com:6443', 'fmaas')).toBe(true)
+  })
+
+  it('returns false when segment only appears in path', () => {
+    expect(hostnameContainsLabel('https://evil.com/fmaas', 'fmaas')).toBe(false)
+  })
+
+  it('returns false for partial label match', () => {
+    expect(hostnameContainsLabel('https://xfmaasy.com', 'fmaas')).toBe(false)
+  })
+
+  it('returns false for malformed URL', () => {
+    expect(hostnameContainsLabel('not-a-url', 'fmaas')).toBe(false)
+  })
+
+  it('is case-insensitive', () => {
+    expect(hostnameContainsLabel('https://api.FMAAS.com', 'fmaas')).toBe(true)
+  })
+})
+
+describe('parsedProtocol', () => {
+  it('returns protocol for HTTPS URL', () => {
+    expect(parsedProtocol('https://example.com')).toBe('https:')
+  })
+
+  it('returns protocol for HTTP URL', () => {
+    expect(parsedProtocol('http://example.com')).toBe('http:')
+  })
+
+  it('returns empty string for malformed URL', () => {
+    expect(parsedProtocol('not-a-url')).toBe('')
+  })
+
+  it('lowercases the protocol', () => {
+    expect(parsedProtocol('HTTPS://example.com')).toBe('https:')
+  })
+})
+
+describe('isHttpUrl', () => {
+  it('returns true for https URL', () => {
+    expect(isHttpUrl('https://example.com')).toBe(true)
+  })
+
+  it('returns true for http URL', () => {
+    expect(isHttpUrl('http://example.com')).toBe(true)
+  })
+
+  it('returns false for ftp URL', () => {
+    expect(isHttpUrl('ftp://example.com')).toBe(false)
+  })
+
+  it('returns false for malformed URL', () => {
+    expect(isHttpUrl('not-a-url')).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isHttpUrl('')).toBe(false)
+  })
+})

--- a/web/src/lib/utils/__tests__/wsAuth.test.ts
+++ b/web/src/lib/utils/__tests__/wsAuth.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { appendWsAuthToken } from '../wsAuth'
+
+describe('appendWsAuthToken', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('appends token as query parameter when token exists', () => {
+    localStorage.setItem('token', 'my-secret-token')
+    const result = appendWsAuthToken('ws://localhost:8585/ws')
+    expect(result).toBe('ws://localhost:8585/ws?token=my-secret-token')
+  })
+
+  it('uses & separator when URL already has query params', () => {
+    localStorage.setItem('token', 'my-token')
+    const result = appendWsAuthToken('ws://localhost:8585/ws?foo=bar')
+    expect(result).toBe('ws://localhost:8585/ws?foo=bar&token=my-token')
+  })
+
+  it('returns original URL when no token in storage', () => {
+    const result = appendWsAuthToken('ws://localhost:8585/ws')
+    expect(result).toBe('ws://localhost:8585/ws')
+  })
+
+  it('URL-encodes special characters in token', () => {
+    localStorage.setItem('token', 'token with spaces&special=chars')
+    const result = appendWsAuthToken('ws://localhost:8585/ws')
+    expect(result).toContain('token=token%20with%20spaces%26special%3Dchars')
+  })
+})


### PR DESCRIPTION
Fixes #10139

## Coverage Improvement

CI coverage is at 89% (target: 91%). This PR adds 108 tests across 11 previously untested modules:

| Test File | Tests | Module |
|-----------|-------|--------|
| urlHostname.test.ts | 25 | URL hostname parsing (security) |
| analytics-events.test.ts | 19 | Card/search/mission event emitters |
| gpu.test.ts | 15 | Cluster name, GPU detection, image tags |
| units.test.ts | 9 | Byte/core conversion constants |
| auth.test.ts | 8 | Zod auth schema validation |
| orbit.test.ts | 8 | Orbit cadence/timing constants |
| security.test.ts | 7 | Zod security issue schema validation |
| gridUtils.test.ts | 6 | Responsive grid column utility |
| wsAuth.test.ts | 4 | WebSocket auth token appending |
| github-token.test.ts | 4 | GitHub token permission constants |
| tooltipSpacing.test.ts | 3 | ECharts tooltip spacing constants |

All 108 tests pass locally. No source code changes — tests only.