### PR TITLE
🧹 Centralize duplicate WebSocket reconnect constants into network.ts

### DIFF
--- a/web/src/hooks/useAIPredictions.ts
+++ b/web/src/hooks/useAIPredictions.ts
@@ -11,13 +11,15 @@ import { setActiveTokenCategory, clearActiveTokenCategory } from './useTokenUsag
 import { fullFetchClusters, clusterCache } from './mcp/shared'
 
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
-import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS, UI_FEEDBACK_TIMEOUT_MS } from '../lib/constants/network'
-
-// WebSocket reconnection with exponential backoff
-const WS_RECONNECT_BASE_DELAY_MS = 2_000  // Base delay for reconnection attempts
-const WS_RECONNECT_MAX_DELAY_MS = 30_000   // Maximum delay between reconnection attempts
-const MAX_WS_RECONNECT_ATTEMPTS = 5        // Maximum reconnection attempts before giving up
-const BACKOFF_JITTER_MAX_MS = 1_000        // Random jitter to avoid thundering herd
+import {
+  FETCH_DEFAULT_TIMEOUT_MS,
+  AI_PREDICTION_TIMEOUT_MS,
+  UI_FEEDBACK_TIMEOUT_MS,
+  WS_RECONNECT_BASE_DELAY_MS,
+  WS_RECONNECT_MAX_DELAY_MS,
+  MAX_WS_RECONNECT_ATTEMPTS,
+  BACKOFF_JITTER_MAX_MS,
+} from '../lib/constants/network'
 const DEGRADED_RECONNECT_INTERVAL_MS = 60_000 // Slow retry interval after exhausting initial attempts
 
 const AGENT_HTTP_URL = LOCAL_AGENT_HTTP_URL

--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -1,6 +1,12 @@
 import { useState, useEffect } from 'react'
 import { getDemoMode, isDemoModeForced } from './useDemoMode'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import {
+  WS_RECONNECT_BASE_DELAY_MS,
+  WS_RECONNECT_MAX_DELAY_MS,
+  MAX_WS_RECONNECT_ATTEMPTS,
+  BACKOFF_JITTER_MAX_MS,
+} from '../lib/constants/network'
 
 /**
  * Disconnect the presence WebSocket and stop the heartbeat.
@@ -20,12 +26,6 @@ export interface ActiveUsersInfo {
 const POLL_INTERVAL = 10_000 // Poll every 10 seconds
 const HEARTBEAT_INTERVAL = 30_000 // Heartbeat every 30 seconds
 const HEARTBEAT_JITTER = 3_000 // Jitter (0-3s) to spread heartbeats without long delays
-
-// WebSocket reconnection with exponential backoff
-const WS_RECONNECT_BASE_DELAY_MS = 2_000  // Base delay for reconnection attempts
-const WS_RECONNECT_MAX_DELAY_MS = 30_000   // Maximum delay between reconnection attempts
-const MAX_WS_RECONNECT_ATTEMPTS = 5        // Maximum reconnection attempts before giving up
-const BACKOFF_JITTER_MAX_MS = 1_000        // Random jitter to avoid thundering herd
 
 const RECOVERY_DELAY = 30_000 // Retry after circuit breaker trips
 /** Timeout for fetch() call to the active-users endpoint */

--- a/web/src/hooks/useClusterProgress.ts
+++ b/web/src/hooks/useClusterProgress.ts
@@ -1,14 +1,11 @@
 import { useEffect, useState, useRef } from 'react'
-import { LOCAL_AGENT_WS_URL } from '../lib/constants/network'
-
-/** Base delay for WebSocket reconnection attempts (doubles each retry) */
-const WS_RECONNECT_BASE_DELAY_MS = 2_000
-/** Maximum delay between WebSocket reconnection attempts */
-const WS_RECONNECT_MAX_DELAY_MS = 30_000
-/** Maximum WebSocket reconnection attempts before giving up */
-const MAX_WS_RECONNECT_ATTEMPTS = 5
-/** Small random jitter added to backoff to avoid thundering herd */
-const BACKOFF_JITTER_MAX_MS = 1_000
+import {
+  LOCAL_AGENT_WS_URL,
+  WS_RECONNECT_BASE_DELAY_MS,
+  WS_RECONNECT_MAX_DELAY_MS,
+  MAX_WS_RECONNECT_ATTEMPTS,
+  BACKOFF_JITTER_MAX_MS,
+} from '../lib/constants/network'
 
 /** Auto-dismiss delay after a successful operation */
 export const CLUSTER_PROGRESS_AUTO_DISMISS_MS = 8_000

--- a/web/src/hooks/useKubectl.ts
+++ b/web/src/hooks/useKubectl.ts
@@ -10,8 +10,7 @@
 
 import { getDemoMode } from './useDemoMode'
 import { LOCAL_AGENT_WS_URL } from '../lib/constants'
-const RECONNECT_DELAY = 1000
-const REQUEST_TIMEOUT = 30000
+import { KUBECTL_WS_RECONNECT_DELAY_MS, KUBECTL_WS_REQUEST_TIMEOUT_MS } from '../lib/constants/network'
 
 interface PendingRequest {
   resolve: (output: string) => void
@@ -134,10 +133,10 @@ class KubectlService {
       if (this.subscribers > 0) {
         this.connect()
       }
-    }, RECONNECT_DELAY)
+    }, KUBECTL_WS_RECONNECT_DELAY_MS)
   }
 
-  async execute(context: string, args: string[], timeout = REQUEST_TIMEOUT): Promise<string> {
+  async execute(context: string, args: string[], timeout = KUBECTL_WS_REQUEST_TIMEOUT_MS): Promise<string> {
     const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
     const message = {
       id: requestId,

--- a/web/src/hooks/useUpdateProgress.ts
+++ b/web/src/hooks/useUpdateProgress.ts
@@ -1,14 +1,15 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import type { UpdateProgress, UpdateStepEntry } from '../types/updates'
-import { LOCAL_AGENT_WS_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import {
+  LOCAL_AGENT_WS_URL,
+  FETCH_DEFAULT_TIMEOUT_MS,
+  WS_RECONNECT_BASE_DELAY_MS,
+  WS_RECONNECT_MAX_DELAY_MS,
+  MAX_WS_RECONNECT_ATTEMPTS,
+  BACKOFF_JITTER_MAX_MS,
+} from '../lib/constants/network'
 import { MS_PER_SECOND } from '../lib/constants/time'
 import { isNetlifyDeployment } from '../lib/demoMode'
-
-// WebSocket reconnection with exponential backoff
-const WS_RECONNECT_BASE_DELAY_MS = 2_000  // Base delay for reconnection attempts
-const WS_RECONNECT_MAX_DELAY_MS = 30_000   // Maximum delay between reconnection attempts
-const MAX_WS_RECONNECT_ATTEMPTS = 5        // Maximum reconnection attempts before giving up
-const BACKOFF_JITTER_MAX_MS = 1_000        // Random jitter to avoid thundering herd
 
 const BACKEND_POLL_MS = 2000  // Poll interval when waiting for backend to come up
 const BACKEND_POLL_MAX = 90   // Max attempts (~3 min) before giving up

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -283,6 +283,28 @@ export const FLASH_ANIMATION_MS = 1_100
 /** WebSocket reconnect delay (5 seconds) */
 export const WS_RECONNECT_DELAY_MS = 5_000
 
+// ============================================================================
+// WebSocket Reconnection — Exponential Backoff
+// ============================================================================
+
+/** Base delay for WebSocket reconnection attempts (doubles each retry) */
+export const WS_RECONNECT_BASE_DELAY_MS = 2_000
+
+/** Maximum delay between WebSocket reconnection attempts */
+export const WS_RECONNECT_MAX_DELAY_MS = 30_000
+
+/** Maximum WebSocket reconnection attempts before giving up */
+export const MAX_WS_RECONNECT_ATTEMPTS = 5
+
+/** Small random jitter added to backoff to avoid thundering herd */
+export const BACKOFF_JITTER_MAX_MS = 1_000
+
+/** Reconnect delay for the shared kubectl WebSocket service */
+export const KUBECTL_WS_RECONNECT_DELAY_MS = 1_000
+
+/** Default timeout for kubectl WebSocket request/response round-trips */
+export const KUBECTL_WS_REQUEST_TIMEOUT_MS = 30_000
+
 /** Delay for simulated AI thinking/processing (300ms) */
 export const AI_THINKING_DELAY_MS = 300
 


### PR DESCRIPTION
## Summary
- Moved 4 identical WebSocket reconnect constants (`WS_RECONNECT_BASE_DELAY_MS`, `WS_RECONNECT_MAX_DELAY_MS`, `MAX_WS_RECONNECT_ATTEMPTS`, `BACKOFF_JITTER_MAX_MS`) from 4 hooks into `web/src/lib/constants/network.ts`
- Updated `useClusterProgress.ts`, `useUpdateProgress.ts`, `useAIPredictions.ts`, and `useActiveUsers.ts` to import from the shared constants file
- Renamed `useKubectl.ts`'s unnamed `RECONNECT_DELAY` / `REQUEST_TIMEOUT` to `KUBECTL_WS_RECONNECT_DELAY_MS` / `KUBECTL_WS_REQUEST_TIMEOUT_MS` and moved to the shared file

## Test plan
- [x] All 104 existing tests pass (`useClusterProgress`, `useUpdateProgress`, `useAIPredictions`)
- [ ] CI build/lint pass

Fixes #10332

🤖 Generated with [Claude Code](https://claude.com/claude-code)