### PR TITLE
🧹 Centralize duplicate WebSocket reconnect constants into lib/constants/network.ts

### DIFF
--- a/web/src/hooks/useAIPredictions.ts
+++ b/web/src/hooks/useAIPredictions.ts
@@ -11,14 +11,9 @@ import { setActiveTokenCategory, clearActiveTokenCategory } from './useTokenUsag
 import { fullFetchClusters, clusterCache } from './mcp/shared'
 
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
-import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS, UI_FEEDBACK_TIMEOUT_MS } from '../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS, UI_FEEDBACK_TIMEOUT_MS, MAX_WS_RECONNECT_ATTEMPTS, getWsBackoffDelay } from '../lib/constants/network'
 
-// WebSocket reconnection with exponential backoff
-const WS_RECONNECT_BASE_DELAY_MS = 2_000  // Base delay for reconnection attempts
-const WS_RECONNECT_MAX_DELAY_MS = 30_000   // Maximum delay between reconnection attempts
-const MAX_WS_RECONNECT_ATTEMPTS = 5        // Maximum reconnection attempts before giving up
-const BACKOFF_JITTER_MAX_MS = 1_000        // Random jitter to avoid thundering herd
-const DEGRADED_RECONNECT_INTERVAL_MS = 60_000 // Slow retry interval after exhausting initial attempts
+const DEGRADED_RECONNECT_INTERVAL_MS = 60_000
 
 const AGENT_HTTP_URL = LOCAL_AGENT_HTTP_URL
 const POLL_INTERVAL_MS = 30_000 // Poll every 30 seconds as fallback
@@ -69,19 +64,6 @@ let degradedRetryInterval: ReturnType<typeof setInterval> | null = null
 let wsReconnectAttempts = 0  // Track current reconnect attempt number
 let inDegradedMode = false   // True when initial reconnect attempts exhausted
 const subscribers = new Set<() => void>()
-
-/**
- * Calculate exponential backoff delay with jitter.
- * Delay = min(base * 2^attempt, max) + random jitter
- */
-function getBackoffDelay(attempt: number): number {
-  const delay = Math.min(
-    WS_RECONNECT_BASE_DELAY_MS * Math.pow(2, attempt),
-    WS_RECONNECT_MAX_DELAY_MS,
-  )
-  const jitter = Math.random() * BACKOFF_JITTER_MAX_MS
-  return delay + jitter
-}
 
 // Notify all subscribers
 function notifySubscribers() {
@@ -297,7 +279,7 @@ function connectWebSocket(): void {
           return
         }
 
-        const delay = getBackoffDelay(wsReconnectAttempts)
+        const delay = getWsBackoffDelay(wsReconnectAttempts)
         console.debug(`[AIPredictions] Connection lost, reconnecting in ${Math.round(delay)}ms (attempt ${wsReconnectAttempts + 1}/${MAX_WS_RECONNECT_ATTEMPTS})`)
 
         wsReconnectTimeout = setTimeout(() => {

--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -21,11 +21,7 @@ const POLL_INTERVAL = 10_000 // Poll every 10 seconds
 const HEARTBEAT_INTERVAL = 30_000 // Heartbeat every 30 seconds
 const HEARTBEAT_JITTER = 3_000 // Jitter (0-3s) to spread heartbeats without long delays
 
-// WebSocket reconnection with exponential backoff
-const WS_RECONNECT_BASE_DELAY_MS = 2_000  // Base delay for reconnection attempts
-const WS_RECONNECT_MAX_DELAY_MS = 30_000   // Maximum delay between reconnection attempts
-const MAX_WS_RECONNECT_ATTEMPTS = 5        // Maximum reconnection attempts before giving up
-const BACKOFF_JITTER_MAX_MS = 1_000        // Random jitter to avoid thundering herd
+import { MAX_WS_RECONNECT_ATTEMPTS, getWsBackoffDelay } from '../lib/constants/network'
 
 const RECOVERY_DELAY = 30_000 // Retry after circuit breaker trips
 /** Timeout for fetch() call to the active-users endpoint */
@@ -64,23 +60,6 @@ let presencePingInterval: ReturnType<typeof setInterval> | null = null
 let presenceReconnectTimer: ReturnType<typeof setTimeout> | null = null
 /** Track current reconnect attempt number for presence WebSocket */
 let presenceReconnectAttempts = 0
-
-/**
- * Calculate exponential backoff delay with jitter.
- * Delay = min(base * 2^attempt, max) + random jitter
- */
-function getBackoffDelay(attempt: number): number {
-  const delay = Math.min(
-    WS_RECONNECT_BASE_DELAY_MS * Math.pow(2, attempt),
-    WS_RECONNECT_MAX_DELAY_MS,
-  )
-  // Use crypto.getRandomValues() for unbiased jitter — Math.random() is not
-  // cryptographically secure. BACKOFF_JITTER_MAX_MS fits comfortably in Uint32.
-  const arr = new Uint32Array(1)
-  crypto.getRandomValues(arr)
-  const jitter = (arr[0] / 0x100000000) * BACKOFF_JITTER_MAX_MS
-  return delay + jitter
-}
 
 // Netlify heartbeat state (serverless mode)
 let heartbeatStarted = false
@@ -255,7 +234,7 @@ function startPresenceConnection() {
         return
       }
 
-      const delay = getBackoffDelay(presenceReconnectAttempts)
+      const delay = getWsBackoffDelay(presenceReconnectAttempts)
       console.debug(`[ActiveUsers] Connection lost, reconnecting in ${Math.round(delay)}ms (attempt ${presenceReconnectAttempts + 1}/${MAX_WS_RECONNECT_ATTEMPTS})`)
 
       // Reconnect after exponential backoff delay

--- a/web/src/hooks/useClusterProgress.ts
+++ b/web/src/hooks/useClusterProgress.ts
@@ -1,14 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { LOCAL_AGENT_WS_URL } from '../lib/constants/network'
-
-/** Base delay for WebSocket reconnection attempts (doubles each retry) */
-const WS_RECONNECT_BASE_DELAY_MS = 2_000
-/** Maximum delay between WebSocket reconnection attempts */
-const WS_RECONNECT_MAX_DELAY_MS = 30_000
-/** Maximum WebSocket reconnection attempts before giving up */
-const MAX_WS_RECONNECT_ATTEMPTS = 5
-/** Small random jitter added to backoff to avoid thundering herd */
-const BACKOFF_JITTER_MAX_MS = 1_000
+import { LOCAL_AGENT_WS_URL, MAX_WS_RECONNECT_ATTEMPTS, getWsBackoffDelay } from '../lib/constants/network'
 
 /** Auto-dismiss delay after a successful operation */
 export const CLUSTER_PROGRESS_AUTO_DISMISS_MS = 8_000
@@ -27,19 +18,6 @@ export interface ClusterProgress {
   message: string
   /** 0-100 percentage of completion */
   progress: number
-}
-
-/**
- * Calculate exponential backoff delay with jitter.
- * Delay = min(base * 2^attempt, max) + random jitter
- */
-function getBackoffDelay(attempt: number): number {
-  const delay = Math.min(
-    WS_RECONNECT_BASE_DELAY_MS * Math.pow(2, attempt),
-    WS_RECONNECT_MAX_DELAY_MS,
-  )
-  const jitter = Math.random() * BACKOFF_JITTER_MAX_MS
-  return delay + jitter
 }
 
 /**
@@ -91,7 +69,7 @@ export function useClusterProgress() {
             return
           }
 
-          const delay = getBackoffDelay(reconnectAttemptsRef.current)
+          const delay = getWsBackoffDelay(reconnectAttemptsRef.current)
           console.debug(`[ClusterProgress] Connection lost, reconnecting in ${Math.round(delay)}ms (attempt ${reconnectAttemptsRef.current + 1}/${MAX_WS_RECONNECT_ATTEMPTS})`)
 
           reconnectTimerRef.current = setTimeout(() => {
@@ -114,7 +92,7 @@ export function useClusterProgress() {
           return
         }
 
-        const delay = getBackoffDelay(reconnectAttemptsRef.current)
+        const delay = getWsBackoffDelay(reconnectAttemptsRef.current)
         console.debug(`[ClusterProgress] Agent unavailable, retrying in ${Math.round(delay)}ms (attempt ${reconnectAttemptsRef.current + 1}/${MAX_WS_RECONNECT_ATTEMPTS})`)
 
         reconnectTimerRef.current = setTimeout(() => {

--- a/web/src/hooks/useUpdateProgress.ts
+++ b/web/src/hooks/useUpdateProgress.ts
@@ -1,14 +1,8 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import type { UpdateProgress, UpdateStepEntry } from '../types/updates'
-import { LOCAL_AGENT_WS_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { LOCAL_AGENT_WS_URL, FETCH_DEFAULT_TIMEOUT_MS, MAX_WS_RECONNECT_ATTEMPTS, getWsBackoffDelay } from '../lib/constants/network'
 import { MS_PER_SECOND } from '../lib/constants/time'
 import { isNetlifyDeployment } from '../lib/demoMode'
-
-// WebSocket reconnection with exponential backoff
-const WS_RECONNECT_BASE_DELAY_MS = 2_000  // Base delay for reconnection attempts
-const WS_RECONNECT_MAX_DELAY_MS = 30_000   // Maximum delay between reconnection attempts
-const MAX_WS_RECONNECT_ATTEMPTS = 5        // Maximum reconnection attempts before giving up
-const BACKOFF_JITTER_MAX_MS = 1_000        // Random jitter to avoid thundering herd
 
 const BACKEND_POLL_MS = 2000  // Poll interval when waiting for backend to come up
 const BACKEND_POLL_MAX = 90   // Max attempts (~3 min) before giving up
@@ -31,19 +25,6 @@ const DEV_UPDATE_STEP_LABELS: Record<number, string> = {
 
 /** Statuses that indicate an update is actively running */
 const ACTIVE_UPDATE_STATUSES = new Set(['pulling', 'building', 'restarting'])
-
-/**
- * Calculate exponential backoff delay with jitter.
- * Delay = min(base * 2^attempt, max) + random jitter
- */
-function getBackoffDelay(attempt: number): number {
-  const delay = Math.min(
-    WS_RECONNECT_BASE_DELAY_MS * Math.pow(2, attempt),
-    WS_RECONNECT_MAX_DELAY_MS,
-  )
-  const jitter = Math.random() * BACKOFF_JITTER_MAX_MS
-  return delay + jitter
-}
 
 /**
  * Hook that listens for update_progress WebSocket broadcasts from kc-agent.
@@ -262,7 +243,7 @@ export function useUpdateProgress() {
             return
           }
 
-          const delay = getBackoffDelay(reconnectAttemptsRef.current)
+          const delay = getWsBackoffDelay(reconnectAttemptsRef.current)
           console.debug(`[UpdateProgress] Connection lost, reconnecting in ${Math.round(delay)}ms (attempt ${reconnectAttemptsRef.current + 1}/${MAX_WS_RECONNECT_ATTEMPTS})`)
 
           reconnectTimer = setTimeout(() => {
@@ -282,7 +263,7 @@ export function useUpdateProgress() {
           return
         }
 
-        const delay = getBackoffDelay(reconnectAttemptsRef.current)
+        const delay = getWsBackoffDelay(reconnectAttemptsRef.current)
         console.debug(`[UpdateProgress] Agent unavailable, retrying in ${Math.round(delay)}ms (attempt ${reconnectAttemptsRef.current + 1}/${MAX_WS_RECONNECT_ATTEMPTS})`)
 
         reconnectTimer = setTimeout(() => {

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -283,6 +283,35 @@ export const FLASH_ANIMATION_MS = 1_100
 /** WebSocket reconnect delay (5 seconds) */
 export const WS_RECONNECT_DELAY_MS = 5_000
 
+// ============================================================================
+// WebSocket Reconnect with Exponential Backoff
+// ============================================================================
+
+/** Base delay for WebSocket reconnection attempts (doubles each retry) */
+export const WS_RECONNECT_BASE_DELAY_MS = 2_000
+
+/** Maximum delay between WebSocket reconnection attempts */
+export const WS_RECONNECT_MAX_DELAY_MS = 30_000
+
+/** Maximum WebSocket reconnection attempts before giving up */
+export const MAX_WS_RECONNECT_ATTEMPTS = 5
+
+/** Small random jitter added to backoff to avoid thundering herd */
+export const WS_BACKOFF_JITTER_MAX_MS = 1_000
+
+/**
+ * Calculate exponential backoff delay with jitter.
+ * Delay = min(base * 2^attempt, max) + random jitter
+ */
+export function getWsBackoffDelay(attempt: number): number {
+  const delay = Math.min(
+    WS_RECONNECT_BASE_DELAY_MS * Math.pow(2, attempt),
+    WS_RECONNECT_MAX_DELAY_MS,
+  )
+  const jitter = Math.random() * WS_BACKOFF_JITTER_MAX_MS
+  return delay + jitter
+}
+
 /** Delay for simulated AI thinking/processing (300ms) */
 export const AI_THINKING_DELAY_MS = 300
 


### PR DESCRIPTION
## Summary
- Moved 4 duplicate WebSocket reconnect constants (`WS_RECONNECT_BASE_DELAY_MS`, `WS_RECONNECT_MAX_DELAY_MS`, `MAX_WS_RECONNECT_ATTEMPTS`, `WS_BACKOFF_JITTER_MAX_MS`) into `lib/constants/network.ts`
- Extracted shared `getWsBackoffDelay()` function to replace 4 identical `getBackoffDelay()` implementations
- Updated `useClusterProgress`, `useUpdateProgress`, `useAIPredictions`, `useActiveUsers` to import from the shared module
- Net reduction: ~51 lines of duplicate code

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] All 4 hooks still reconnect with exponential backoff (same constants, same logic)
- [ ] No new TypeScript errors

Fixes #10332