### PR TITLE
🧹 Replace duplicate relativeTime functions with shared formatTimeAgo

### DIFF
--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -32,6 +32,7 @@ import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../ui/StatusBadge'
 import { ConfirmDialog } from '../../lib/modals'
 import { useFederationAwareness, getProviderLabel } from '../../hooks/useFederation'
+import { formatTimeAgo } from '../../lib/formatters'
 
 interface ClusterGroupsProps {
   config?: Record<string, unknown>
@@ -97,15 +98,6 @@ function formatFilter(f: ClusterFilter): string {
   }
   const op = NUM_OPERATORS.find(o => o.value === f.operator)?.label ?? f.operator
   return `${field} ${op} ${f.value}`
-}
-
-function relativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime()
-  const secs = Math.floor(diff / 1000)
-  if (secs < 60) return `${secs}s ago`
-  const mins = Math.floor(secs / 60)
-  if (mins < 60) return `${mins}m ago`
-  return `${Math.floor(mins / 60)}h ago`
 }
 
 // ============================================================================
@@ -412,7 +404,7 @@ function DroppableGroup({ group, isExpanded, clusterHealthMap, onToggle, onEdit,
                 </div>
               ))}
               {group.lastEvaluated && (
-                <div className="text-muted-foreground">{t('cards:clusterGroups.evaluated', { time: relativeTime(group.lastEvaluated) })}</div>
+                <div className="text-muted-foreground">{t('cards:clusterGroups.evaluated', { time: formatTimeAgo(group.lastEvaluated) })}</div>
               )}
             </div>
           )}

--- a/web/src/components/cards/pipelines/RecentFailures.tsx
+++ b/web/src/components/cards/pipelines/RecentFailures.tsx
@@ -23,9 +23,11 @@ import { EmbedButton } from './EmbedButton'
 import { LogsModal } from './LogsModal'
 import { useMissions } from '../../../hooks/useMissions'
 import { cn } from '../../../lib/cn'
+import { formatTimeAgo } from '../../../lib/formatters'
+import { MS_PER_SECOND, MS_PER_HOUR, SECONDS_PER_MINUTE } from '../../../lib/constants/time'
 
 /** Maximum ms duration we format compactly (1 hr). Over this, show "1h+" */
-const SHORT_DURATION_CAP_MS = 3_600_000
+const SHORT_DURATION_CAP_MS = MS_PER_HOUR
 
 /** Extracted user-visible strings. Kept out of inline JSX attributes to
  * satisfy the ui-ux-standard ratchet and make a future i18n pass easy. */
@@ -36,19 +38,11 @@ const TITLE_OPEN_RUN = 'Open run on GitHub'
 const TITLE_DIAGNOSE = 'Diagnose with AI'
 
 function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`
-  const secs = Math.floor(ms / 1000)
-  if (secs < 60) return `${secs}s`
+  if (ms < MS_PER_SECOND) return `${ms}ms`
+  const secs = Math.floor(ms / MS_PER_SECOND)
+  if (secs < SECONDS_PER_MINUTE) return `${secs}s`
   if (ms >= SHORT_DURATION_CAP_MS) return '1h+'
-  return `${Math.floor(secs / 60)}m ${secs % 60}s`
-}
-
-function relativeTime(iso: string): string {
-  const secs = Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 1000))
-  if (secs < 60) return `${secs}s ago`
-  if (secs < 3_600) return `${Math.floor(secs / 60)}m ago`
-  if (secs < 86_400) return `${Math.floor(secs / 3_600)}h ago`
-  return `${Math.floor(secs / 86_400)}d ago`
+  return `${Math.floor(secs / SECONDS_PER_MINUTE)}m ${secs % SECONDS_PER_MINUTE}s`
 }
 
 export function RecentFailures() {
@@ -174,7 +168,7 @@ export function RecentFailures() {
                     )}
                   </td>
                   <td className="py-1.5 pr-2 text-muted-foreground whitespace-nowrap">
-                    {relativeTime(r.createdAt)}
+                    {formatTimeAgo(r.createdAt)}
                   </td>
                   <td className="py-1.5 pr-2 text-muted-foreground whitespace-nowrap">
                     {formatDuration(r.durationMs)}

--- a/web/src/lib/unified/stats/valueResolvers.ts
+++ b/web/src/lib/unified/stats/valueResolvers.ts
@@ -10,6 +10,7 @@ import type {
   StatValueFormat,
 } from '../types'
 import { formatBytes, formatCurrency } from '../../formatters'
+import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR, SECONDS_PER_DAY } from '../../constants/time'
 export { formatBytes, formatCurrency }
 
 /**
@@ -340,23 +341,18 @@ export function formatNumber(value: number): string | number {
   return value
 }
 
-// Time boundary constants (in seconds) for duration formatting
-const SECS_PER_MINUTE = 60
-const SECS_PER_HOUR = 3_600
-const SECS_PER_DAY = 86_400
-
 /**
  * Format duration in seconds to human-readable
  */
 export function formatDuration(seconds: number): string {
-  if (seconds < SECS_PER_MINUTE) {
+  if (seconds < SECONDS_PER_MINUTE) {
     return `${Math.round(seconds)}s`
   }
-  if (seconds < SECS_PER_HOUR) {
-    return `${Math.round(seconds / SECS_PER_MINUTE)}m`
+  if (seconds < SECONDS_PER_HOUR) {
+    return `${Math.round(seconds / SECONDS_PER_MINUTE)}m`
   }
-  if (seconds < SECS_PER_DAY) {
-    return `${(seconds / SECS_PER_HOUR).toFixed(1)}h`
+  if (seconds < SECONDS_PER_DAY) {
+    return `${(seconds / SECONDS_PER_HOUR).toFixed(1)}h`
   }
-  return `${(seconds / SECS_PER_DAY).toFixed(1)}d`
+  return `${(seconds / SECONDS_PER_DAY).toFixed(1)}d`
 }


### PR DESCRIPTION
## Summary
- Replaced 2 local `relativeTime()` functions in `RecentFailures.tsx` and `ClusterGroups.tsx` with shared `formatTimeAgo()` from `lib/formatters.ts`
- Replaced magic numbers (`1000`, `3_600`, `86_400`, `3_600_000`) in `RecentFailures.tsx` with named constants from `lib/constants/time.ts`
- Replaced 3 local `SECS_PER_*` constants in `valueResolvers.ts` with imports from `lib/constants/time.ts`
- Net reduction: ~18 lines of duplicate code

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] RecentFailures card displays relative times correctly
- [ ] ClusterGroups card displays evaluation times correctly
- [ ] Unified stat blocks still format durations correctly

Fixes #10337