### PR TITLE
🐛 Fix Playwright nightly cross-browser failures: disable demo mode in data-accuracy tests

### DIFF
--- a/web/e2e/Clusters.spec.ts
+++ b/web/e2e/Clusters.spec.ts
@@ -50,7 +50,7 @@ async function setupClustersTest(page: Page) {
   // page.addInitScript() injects the snippet ahead of any page code (#9096).
   await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
-    localStorage.setItem('kc-demo-mode', 'true')
+    localStorage.setItem('kc-demo-mode', 'false')
     localStorage.setItem('demo-user-onboarded', 'true')
   })
 

--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -346,9 +346,12 @@ test.describe('Dashboard Page', () => {
       })
 
       // Seed localStorage BEFORE any page script runs (#9096).
+      // Disable demo mode so the app fetches from the mocked API routes
+      // above instead of returning built-in demo data (12 clusters).
       await page.addInitScript(() => {
         localStorage.setItem('token', 'test-token')
         localStorage.setItem('demo-user-onboarded', 'true')
+        localStorage.setItem('kc-demo-mode', 'false')
       })
     })
 

--- a/web/e2e/helpers/setup.ts
+++ b/web/e2e/helpers/setup.ts
@@ -373,6 +373,17 @@ export async function setupMCP(page: Page, options?: SetupMCPOptions): Promise<v
 export async function setupDashboardTest(page: Page): Promise<void> {
   await setupAuth(page)
   await setupMCP(page)
+  // Mock /api/dashboards so the dashboard component doesn't wait for a
+  // backend response before falling back to demo cards. Without this mock,
+  // the unmocked request can time out on slower mobile-emulation runtimes,
+  // causing card-rendering assertions to fail.
+  await page.route('**/api/dashboards', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    })
+  )
   // Seed localStorage BEFORE any page script runs — page.evaluate() runs
   // after the page has already parsed and executed scripts, which is too
   // late for webkit/Safari where the auth redirect fires synchronously.


### PR DESCRIPTION
Fixes #10309

## Problem

The Playwright Cross-Browser (Nightly) workflow fails on mobile-chrome (3 tests), mobile-safari (4 tests), and firefox (9 tests). Common failures:

- **Dashboard Data Accuracy tests** (Dashboard.spec.ts:355, :445): Expected 3 injected clusters but got 0/12 demo clusters
- **Clusters.spec.ts** (:72, :171, :222): Expected mocked cluster names (prod-east/west/staging) but got demo data
- **"cards have proper structure"** on mobile: Slow fallback from unmocked `/api/dashboards` request

## Root Cause

Tests that mock API routes with deterministic data had `kc-demo-mode=true` in localStorage. When demo mode is on, the `useCached*` hooks skip API calls entirely and return built-in demo data. The mocked routes never get hit.

This worked on Chromium desktop due to timing differences but fails consistently on Firefox, WebKit, and mobile viewports.

## Fix

1. **Dashboard Data Accuracy beforeEach**: Add `kc-demo-mode=false` so mocked routes (3 deterministic clusters) are used
2. **Clusters.spec.ts setupClustersTest**: Change `kc-demo-mode` from `true` to `false` so mocked cluster names appear
3. **setupDashboardTest helper**: Add `/api/dashboards` mock returning `[]` to prevent unmocked request timeout on slower mobile runtimes