### PR TITLE
🐛 Filter clusters with slash in name from localStorage cache

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -208,8 +208,11 @@ function loadClusterCacheFromStorage(): ClusterInfo[] {
 
 function saveClusterCacheToStorage(clusters: ClusterInfo[]) {
   try {
-    // Only save clusters with meaningful data
-    const toSave = clusters.filter(c => c.name).map(c => ({
+    // Only save clusters with meaningful data.
+    // Filter out clusters whose name contains a slash — these are auto-generated
+    // OpenShift context names (e.g. "default/api-*.openshiftapps.com:6443/kube:admin")
+    // that should not pollute the persistent cache.
+    const toSave = clusters.filter(c => c.name && !c.name.includes('/')).map(c => ({
       name: c.name,
       context: c.context,
       server: c.server,


### PR DESCRIPTION
## Summary
- Add slash-name filter to `saveClusterCacheToStorage` in `web/src/hooks/mcp/shared.ts`
- Auto-generated OpenShift context names (e.g. `default/api-*.openshiftapps.com:6443/kube:admin`) are now excluded from the persistent localStorage cache
- Fixes the failing `shared-cache-fetch.test.ts` test that expected this filtering behavior

## Test plan
- [x] `npx vitest run src/hooks/mcp/__tests__/shared-cache-fetch.test.ts` — all 44 tests pass
- [ ] CI build/lint passes

Fixes #10338