### PR TITLE
🐛 Filter slash-containing cluster names from localStorage cache

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -208,8 +208,9 @@ function loadClusterCacheFromStorage(): ClusterInfo[] {
 
 function saveClusterCacheToStorage(clusters: ClusterInfo[]) {
   try {
-    // Only save clusters with meaningful data
-    const toSave = clusters.filter(c => c.name).map(c => ({
+    // Only save clusters with meaningful data; exclude auto-generated names with slashes
+    // (e.g. OpenShift context paths like "api-cluster.example.com:6443/user")
+    const toSave = clusters.filter(c => c.name && !c.name.includes('/')).map(c => ({
       name: c.name,
       context: c.context,
       server: c.server,


### PR DESCRIPTION
Fixes the failing `shared-cache-fetch.test.ts` test in the Coverage Suite workflow.

## Problem
The test `filters out clusters with slash in name from localStorage` expected slash-containing cluster names to be excluded from localStorage persistence, but `saveClusterCacheToStorage()` was not filtering them.

## Fix

## Testing
- All 44 tests in `shared-cache-fetch.test.ts` pass
- `npm run build` passes
- `npm run lint` passes