### PR TITLE
🧹 Centralize duplicate CRD timeout constants across 5 security hooks

### DIFF
--- a/web/src/hooks/useIntoto.ts
+++ b/web/src/hooks/useIntoto.ts
@@ -19,14 +19,7 @@ import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_INTOTO_CACHE, STORAGE_KEY_INTOTO_CACHE_TIME } from '../lib/constants/storage'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
-
-/** Refresh interval for automatic polling (2 minutes) */
-
-/** Timeout for CRD existence check (fast — missing resources fail instantly) */
-const CRD_CHECK_TIMEOUT_MS = 8_000
-
-/** Timeout for layout and link data fetch */
-const DATA_FETCH_TIMEOUT_MS = 30_000
+import { CRD_CHECK_TIMEOUT_MS, CRD_CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -259,7 +252,7 @@ async function fetchSingleCluster(cluster: string): Promise<IntotoClusterStatus>
     // Phase 2: Fetch Layouts
     const layoutResult = await kubectlProxy.exec(
       ['get', 'layouts.in-toto.io', '-A', '-o', 'json'],
-      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+      { context: cluster, timeout: CRD_DATA_FETCH_TIMEOUT_MS }
     )
 
     if (layoutResult.exitCode !== 0) {
@@ -297,7 +290,7 @@ async function fetchSingleCluster(cluster: string): Promise<IntotoClusterStatus>
     // Phase 3: Fetch Links to back-populate step verification status
     const linkResult = await kubectlProxy.exec(
       ['get', 'links.in-toto.io', '-A', '-o', 'json'],
-      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+      { context: cluster, timeout: CRD_DATA_FETCH_TIMEOUT_MS }
     )
 
     if (linkResult.exitCode === 0 && linkResult.output) {

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -18,18 +18,7 @@ import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_KUBESCAPE_CACHE, STORAGE_KEY_KUBESCAPE_CACHE_TIME } from '../lib/constants/storage'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
-
-/** Refresh interval for automatic polling (2 minutes) */
-
-/** Cache TTL: 2 minutes — matches refresh interval */
-// Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000
-
-/** Timeout for CRD/API existence check (fast — missing resources fail instantly) */
-const CRD_CHECK_TIMEOUT_MS = 8_000
-
-/** Timeout for data fetch — large clusters (vllm-d has 4155 items, 6MB JSON)
- *  need extra time when queued behind other kubectl requests */
-const DATA_FETCH_TIMEOUT_MS = 30_000
+import { CRD_CHECK_TIMEOUT_MS, CRD_CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
 
 /** Default overall score for demo clusters */
 const DEMO_OVERALL_SCORE = 78
@@ -194,7 +183,7 @@ async function fetchSingleCluster(cluster: string): Promise<KubescapeClusterStat
 
     const scanResult = await kubectlProxy.exec(
       ['get', 'workloadconfigurationscansummaries', '-A', '-o', 'json'],
-      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+      { context: cluster, timeout: CRD_DATA_FETCH_TIMEOUT_MS }
     )
 
     if (scanResult.exitCode !== 0) {
@@ -223,7 +212,7 @@ async function fetchSingleCluster(cluster: string): Promise<KubescapeClusterStat
     const controlResults = new Map<string, { name: string; passed: number; failed: number }>()
     const detailResult = await kubectlProxy.exec(
       ['get', 'workloadconfigurationscans', '-A', '-o', 'json', '--chunk-size=50'],
-      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+      { context: cluster, timeout: CRD_DATA_FETCH_TIMEOUT_MS }
     )
 
     if (detailResult.exitCode === 0 && detailResult.output) {

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -18,17 +18,7 @@ import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_KYVERNO_CACHE, STORAGE_KEY_KYVERNO_CACHE_TIME } from '../lib/constants/storage'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
-
-/** Refresh interval for automatic polling (2 minutes) */
-
-/** Cache TTL: 2 minutes — matches refresh interval */
-// Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000
-
-/** Timeout for CRD existence check (fast — missing resources fail instantly) */
-const CRD_CHECK_TIMEOUT_MS = 8_000
-
-/** Timeout for data fetch */
-const DATA_FETCH_TIMEOUT_MS = 30_000
+import { CRD_CHECK_TIMEOUT_MS, CRD_CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -195,7 +185,7 @@ async function fetchSingleCluster(cluster: string): Promise<KyvernoClusterStatus
 
     const cpResult = await kubectlProxy.exec(
       ['get', 'clusterpolicies', '-o', 'json'],
-      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+      { context: cluster, timeout: CRD_DATA_FETCH_TIMEOUT_MS }
     )
 
     if (cpResult.exitCode !== 0) {
@@ -224,7 +214,7 @@ async function fetchSingleCluster(cluster: string): Promise<KyvernoClusterStatus
     // Fetch namespaced Policies
     const pResult = await kubectlProxy.exec(
       ['get', 'policies', '-A', '-o', 'json'],
-      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+      { context: cluster, timeout: CRD_DATA_FETCH_TIMEOUT_MS }
     )
 
     if (pResult.exitCode === 0 && pResult.output) {
@@ -248,7 +238,7 @@ async function fetchSingleCluster(cluster: string): Promise<KyvernoClusterStatus
     const reports: KyvernoPolicyReport[] = []
     const reportResult = await kubectlProxy.exec(
       ['get', 'policyreports', '-A', '-o', 'json'],
-      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+      { context: cluster, timeout: CRD_DATA_FETCH_TIMEOUT_MS }
     )
 
     let totalViolations = 0
@@ -284,7 +274,7 @@ async function fetchSingleCluster(cluster: string): Promise<KyvernoClusterStatus
     // Also check ClusterPolicyReports
     const clusterReportResult = await kubectlProxy.exec(
       ['get', 'clusterpolicyreports', '-o', 'json'],
-      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+      { context: cluster, timeout: CRD_DATA_FETCH_TIMEOUT_MS }
     )
 
     if (clusterReportResult.exitCode === 0 && clusterReportResult.output) {

--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -22,17 +22,7 @@ import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_TRESTLE_CACHE, STORAGE_KEY_TRESTLE_CACHE_TIME } from '../lib/constants/storage'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
-
-/** Refresh interval for automatic polling (2 minutes) */
-
-/** Cache TTL: 2 minutes — matches refresh interval */
-// Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000
-
-/** Timeout for CRD/deployment existence check (fast — missing resources fail instantly) */
-const CRD_CHECK_TIMEOUT_MS = 8_000
-
-/** Timeout for data fetch */
-const DATA_FETCH_TIMEOUT_MS = 30_000
+import { CRD_CHECK_TIMEOUT_MS, CRD_CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
 
 /** Demo overall compliance percentage */
 const DEMO_OVERALL_SCORE = 82
@@ -293,7 +283,7 @@ async function fetchSingleCluster(cluster: string): Promise<TrestleClusterStatus
     for (const api of (apiGroups || [])) {
       const result = await kubectlProxy.exec(
         ['get', `${api.resource}.${api.group}`, '-A', '-o', 'json'],
-        { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+        { context: cluster, timeout: CRD_DATA_FETCH_TIMEOUT_MS }
       )
 
       if (result.exitCode === 0 && result.output) {

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -18,17 +18,7 @@ import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_TRIVY_CACHE, STORAGE_KEY_TRIVY_CACHE_TIME } from '../lib/constants/storage'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
-
-/** Refresh interval for automatic polling (2 minutes) */
-
-/** Cache TTL: 2 minutes — matches refresh interval */
-// Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000
-
-/** Timeout for CRD existence check (fast — missing resources fail instantly) */
-const CRD_CHECK_TIMEOUT_MS = 8_000
-
-/** Timeout for data fetch */
-const DATA_FETCH_TIMEOUT_MS = 30_000
+import { CRD_CHECK_TIMEOUT_MS, CRD_CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
 
 /** Maximum images to store per cluster to keep cache size reasonable */
 const MAX_IMAGES_PER_CLUSTER = 50
@@ -169,7 +159,7 @@ async function fetchSingleCluster(cluster: string): Promise<TrivyClusterStatus> 
     // Phase 2: Fetch VulnerabilityReports
     const result = await kubectlProxy.exec(
       ['get', 'vulnerabilityreports', '-A', '-o', 'json'],
-      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+      { context: cluster, timeout: CRD_DATA_FETCH_TIMEOUT_MS }
     )
 
     if (result.exitCode !== 0) {

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -107,6 +107,16 @@ export const KUBECTL_EXTENDED_TIMEOUT_MS = 30_000
 export const KUBECTL_MAX_TIMEOUT_MS = 45_000
 
 // ============================================================================
+// CRD Discovery Timeouts (shared by useKyverno, useTrivy, useKubescape, etc.)
+// ============================================================================
+
+/** Timeout for checking whether a CRD exists on a cluster */
+export const CRD_CHECK_TIMEOUT_MS = 8_000
+
+/** Timeout for fetching data after CRD presence is confirmed */
+export const CRD_DATA_FETCH_TIMEOUT_MS = 30_000
+
+// ============================================================================
 // API & Health Check Timeouts
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Added `CRD_CHECK_TIMEOUT_MS` (8s) and `CRD_DATA_FETCH_TIMEOUT_MS` (30s) to `lib/constants/network.ts`
- Replaced 10 local constant definitions across `useKyverno`, `useIntoto`, `useTrestle`, `useTrivy`, `useKubescape` with imports
- Removed stale commented-out `CACHE_TTL_MS` lines
- Net reduction: 38 lines

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Kyverno, Trivy, Kubescape, In-toto, Trestle cards still load data correctly
- [ ] CRD check timeouts unchanged (8s)
- [ ] Data fetch timeouts unchanged (30s)

Fixes #10342