### PR TITLE
🧹 Centralize duplicate severity order maps into shared constants

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -13,6 +13,7 @@ import { StatusBadge } from '../ui/StatusBadge'
 import { useGlobalFilters, type SeverityLevel } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
+import { ALERT_SEVERITY_ORDER } from '../../types/alerts'
 import type { Alert, AlertSeverity } from '../../types/alerts'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
@@ -145,8 +146,6 @@ export function ActiveAlerts() {
     return result
   })()
 
-  const severityOrder: Record<AlertSeverity, number> = { critical: 0, warning: 1, info: 2 }
-
   // Use shared card data hook for filtering, sorting, and pagination
   const {
     items: displayedAlerts,
@@ -181,7 +180,7 @@ export function ActiveAlerts() {
       defaultDirection: 'asc',
       comparators: {
         severity: (a, b) => {
-          const severityDiff = severityOrder[a.severity] - severityOrder[b.severity]
+          const severityDiff = ALERT_SEVERITY_ORDER[a.severity] - ALERT_SEVERITY_ORDER[b.severity]
           if (severityDiff !== 0) return severityDiff
           return new Date(b.firedAt).getTime() - new Date(a.firedAt).getTime()
         },

--- a/web/src/components/cards/AlertRules.tsx
+++ b/web/src/components/cards/AlertRules.tsx
@@ -7,7 +7,7 @@ import {
   Pencil,
 } from 'lucide-react'
 import { useAlertRules } from '../../hooks/useAlerts'
-import { formatCondition } from '../../types/alerts'
+import { formatCondition, ALERT_SEVERITY_ORDER } from '../../types/alerts'
 import type { AlertRule, AlertSeverity } from '../../types/alerts'
 import { Button } from '../ui/Button'
 import { AlertRuleEditor } from '../alerts/AlertRuleEditor'
@@ -27,11 +27,9 @@ const SORT_OPTIONS_KEYS: ReadonlyArray<{ value: SortField; labelKey: SortTransla
   { value: 'enabled' as const, labelKey: 'alertRules.sortStatus' },
 ]
 
-const SEVERITY_ORDER: Record<AlertSeverity, number> = { critical: 0, warning: 1, info: 2 }
-
 const ALERT_SORT_COMPARATORS = {
   name: commonComparators.string<AlertRule>('name'),
-  severity: (a: AlertRule, b: AlertRule) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity],
+  severity: (a: AlertRule, b: AlertRule) => ALERT_SEVERITY_ORDER[a.severity] - ALERT_SEVERITY_ORDER[b.severity],
   enabled: (a: AlertRule, b: AlertRule) => (b.enabled ? 1 : 0) - (a.enabled ? 1 : 0),
 }
 

--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -1,4 +1,5 @@
 import { Shield, AlertTriangle, User, Network, Server, ChevronRight } from 'lucide-react'
+import { VULN_SEVERITY_ORDER } from '../../types/alerts'
 import type { SecurityIssue } from '../../hooks/useMCP'
 import { useCachedSecurityIssues } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -120,7 +121,7 @@ function SecurityIssuesInternal({ config }: SecurityIssuesProps) {
     consecutiveFailures,
     lastRefresh: isDemoMode ? null : lastRefresh })
 
-  const severityOrder: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3, info: 4 }
+  const severityOrder = VULN_SEVERITY_ORDER
 
   // Use shared card data hook for filtering, sorting, and pagination
   const {

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -17,6 +17,7 @@ import { cn } from '../../../lib/cn'
 import { useApiKeyCheck, ApiKeyPromptModal } from './shared'
 import type { ConsoleMissionCardProps } from './shared'
 import { useCardLoadingState } from '../CardDataContext'
+import { ALERT_SEVERITY_ORDER } from '../../../types/alerts'
 import type { PredictedRisk, TrendDirection } from '../../../types/predictions'
 import { CardControlsRow, CardSearchInput, CardPaginationFooter, CardAIActions } from '../../../lib/cards/CardComponents'
 import { ClusterBadge } from '../../ui/ClusterBadge'
@@ -634,7 +635,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
 
   // Sort items
   const sortedItems = (() => {
-    const severityOrder: Record<string, number> = { critical: 0, warning: 1, info: 2 }
+    const sevOrder = ALERT_SEVERITY_ORDER as Record<string, number>
     const categoryOrder: Record<string, number> = { offline: 0, gpu: 1, prediction: 2 }
 
     return [...filteredItems].sort((a, b) => {
@@ -647,7 +648,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
           cmp = a.cluster.localeCompare(b.cluster)
           break
         case 'severity':
-          cmp = (severityOrder[a.severity] ?? 999) - (severityOrder[b.severity] ?? 999)
+          cmp = (sevOrder[a.severity] ?? 999) - (sevOrder[b.severity] ?? 999)
           break
         case 'category':
           cmp = (categoryOrder[a.category] ?? 999) - (categoryOrder[b.category] ?? 999)
@@ -764,8 +765,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
       // First by count (descending)
       if (b.items.length !== a.items.length) return b.items.length - a.items.length
       // Then by severity
-      const severityOrder = { critical: 0, warning: 1, info: 2 }
-      return severityOrder[a.severity] - severityOrder[b.severity]
+      return (ALERT_SEVERITY_ORDER as Record<string, number>)[a.severity] - (ALERT_SEVERITY_ORDER as Record<string, number>)[b.severity]
     })
   }, [sortedItems])
 

--- a/web/src/components/cards/opa/ClusterOPAModal.tsx
+++ b/web/src/components/cards/opa/ClusterOPAModal.tsx
@@ -9,6 +9,7 @@ import type { Policy, Violation, StartMissionFn } from './types'
 import { POLICY_TEMPLATES } from './types'
 import { copyToClipboard } from '../../../lib/clipboard'
 import { KUBECTL_MEDIUM_TIMEOUT_MS, KUBECTL_EXTENDED_TIMEOUT_MS } from '../../../lib/constants/network'
+import { ALERT_SEVERITY_ORDER } from '../../../types/alerts'
 
 // Tab type for ClusterOPAModal
 type OPAModalTab = 'policies' | 'violations'
@@ -412,8 +413,7 @@ Please proceed with applying this policy.`,
                 ) : (
                   [...violations]
                     .sort((a, b) => {
-                      const severityOrder = { critical: 0, warning: 1, info: 2 }
-                      return severityOrder[a.severity] - severityOrder[b.severity]
+                      return (ALERT_SEVERITY_ORDER as Record<string, number>)[a.severity] - (ALERT_SEVERITY_ORDER as Record<string, number>)[b.severity]
                     })
                     .map((violation, idx) => (
                     <div

--- a/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
@@ -9,6 +9,7 @@ import {
   RefreshCw, Loader2, ChevronDown, ChevronRight, Filter,
   AlertTriangle
 } from 'lucide-react'
+import { ALERT_SEVERITY_ORDER } from '../../../types/alerts'
 import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
 import { CardControls } from '../../ui/CardControls'
@@ -58,11 +59,6 @@ const SEVERITY_FILTER_OPTIONS = [
   { value: 'warning', label: 'Warning' },
   { value: 'info', label: 'Info' },
 ]
-
-const SEVERITY_ORDER: Record<string, number> = {
-  critical: 0,
-  warning: 1,
-  info: 2 }
 
 const STATUS_ORDER: Record<string, number> = {
   unhealthy: 0,
@@ -385,7 +381,7 @@ export function LLMdStackMonitor({ config: _config }: LLMdStackMonitorProps) {
       let compare = 0
       switch (issueSortBy) {
         case 'severity':
-          compare = (SEVERITY_ORDER[a.severity] ?? 5) - (SEVERITY_ORDER[b.severity] ?? 5)
+          compare = ((ALERT_SEVERITY_ORDER as Record<string, number>)[a.severity] ?? 5) - ((ALERT_SEVERITY_ORDER as Record<string, number>)[b.severity] ?? 5)
           break
         case 'title':
           compare = a.title.localeCompare(b.title)

--- a/web/src/components/ui/AlertBadge.tsx
+++ b/web/src/components/ui/AlertBadge.tsx
@@ -7,7 +7,7 @@ import { formatTimeAgo } from '../../lib/formatters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
 import { useMobile } from '../../hooks/useMobile'
-import { getSeverityIcon } from '../../types/alerts'
+import { getSeverityIcon, ALERT_SEVERITY_ORDER } from '../../types/alerts'
 import type { Alert, AlertSeverity } from '../../types/alerts'
 import { CardAIActions } from '../../lib/cards/CardComponents'
 import { ROUTES } from '../../config/routes'
@@ -151,8 +151,7 @@ export function AlertBadge() {
 
     // Sort by severity and time
     return result.sort((a, b) => {
-      const severityOrder: Record<AlertSeverity, number> = { critical: 0, warning: 1, info: 2 }
-      const severityDiff = severityOrder[a.severity] - severityOrder[b.severity]
+      const severityDiff = ALERT_SEVERITY_ORDER[a.severity] - ALERT_SEVERITY_ORDER[b.severity]
       if (severityDiff !== 0) return severityDiff
       return new Date(b.firedAt).getTime() - new Date(a.firedAt).getTime()
     })

--- a/web/src/hooks/useCachedCoreWorkloads.ts
+++ b/web/src/hooks/useCachedCoreWorkloads.ts
@@ -13,6 +13,7 @@ import { clusterCacheRef } from './mcp/shared'
 import { isAgentUnavailable } from './useLocalAgent'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
+import { VULN_SEVERITY_ORDER } from '../types/alerts'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import {
   fetchAPI,
@@ -73,7 +74,7 @@ async function fetchSecurityIssuesViaKubectl(cluster?: string, namespace?: strin
   const clusters = getAgentClusters()
   if (clusters.length === 0) return []
 
-  const severityOrder: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3, info: 4 }
+  const severityOrder = VULN_SEVERITY_ORDER
 
   const tasks = clusters
     .filter(c => !cluster || c.name === cluster)

--- a/web/src/hooks/useIntoto.ts
+++ b/web/src/hooks/useIntoto.ts
@@ -19,7 +19,7 @@ import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_INTOTO_CACHE, STORAGE_KEY_INTOTO_CACHE_TIME } from '../lib/constants/storage'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
-import { CRD_CHECK_TIMEOUT_MS, CRD_CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
+import { CRD_CHECK_TIMEOUT_MS, CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
 
 // ── Types ────────────────────────────────────────────────────────────────
 

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -18,7 +18,7 @@ import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_KUBESCAPE_CACHE, STORAGE_KEY_KUBESCAPE_CACHE_TIME } from '../lib/constants/storage'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
-import { CRD_CHECK_TIMEOUT_MS, CRD_CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
+import { CRD_CHECK_TIMEOUT_MS, CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
 
 /** Default overall score for demo clusters */
 const DEMO_OVERALL_SCORE = 78

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -18,7 +18,7 @@ import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_KYVERNO_CACHE, STORAGE_KEY_KYVERNO_CACHE_TIME } from '../lib/constants/storage'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
-import { CRD_CHECK_TIMEOUT_MS, CRD_CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
+import { CRD_CHECK_TIMEOUT_MS, CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
 
 // ── Types ────────────────────────────────────────────────────────────────
 

--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -22,7 +22,7 @@ import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_TRESTLE_CACHE, STORAGE_KEY_TRESTLE_CACHE_TIME } from '../lib/constants/storage'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
-import { CRD_CHECK_TIMEOUT_MS, CRD_CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
+import { CRD_CHECK_TIMEOUT_MS, CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
 
 /** Demo overall compliance percentage */
 const DEMO_OVERALL_SCORE = 82

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -18,7 +18,7 @@ import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_TRIVY_CACHE, STORAGE_KEY_TRIVY_CACHE_TIME } from '../lib/constants/storage'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
-import { CRD_CHECK_TIMEOUT_MS, CRD_CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
+import { CRD_CHECK_TIMEOUT_MS, CRD_DATA_FETCH_TIMEOUT_MS } from '../lib/constants/network'
 
 /** Maximum images to store per cluster to keep cache size reasonable */
 const MAX_IMAGES_PER_CLUSTER = 50

--- a/web/src/types/alerts.ts
+++ b/web/src/types/alerts.ts
@@ -17,6 +17,12 @@ export type AlertConditionType =
 // Alert severity levels
 export type AlertSeverity = 'critical' | 'warning' | 'info'
 
+/** Sort order for alert severity (lower = more severe). Used by sort comparators. */
+export const ALERT_SEVERITY_ORDER: Record<AlertSeverity, number> = { critical: 0, warning: 1, info: 2 }
+
+/** Sort order for vulnerability severity (5-level: critical > high > medium > low > info). */
+export const VULN_SEVERITY_ORDER: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3, info: 4 }
+
 // Alert status
 export type AlertStatus = 'firing' | 'resolved'
 


### PR DESCRIPTION
## Summary
- Add `ALERT_SEVERITY_ORDER` and `VULN_SEVERITY_ORDER` to `types/alerts.ts`
- Replace 7+ inline `severityOrder` / `SEVERITY_ORDER` definitions across 8 components/hooks
- Fix `CRD_CRD_DATA_FETCH_TIMEOUT_MS` double-prefix in 5 CRD hooks (rebase artifact)

Net: 14 files changed, 29 insertions, 29 deletions — zero behavior change.

Fixes #10346

## Test plan
- [x] `npm run build` passes
- [ ] CI pr-check + coverage-gate pass