### PR TITLE
🧹 Replace duplicate formatBytes, ISOLATION_STATUS_COLORS, DEFAULT_PAGE_SIZE with shared imports

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -9,6 +9,7 @@ import {
   BellOff } from 'lucide-react'
 import { useAlerts } from '../../hooks/useAlerts'
 import { MS_PER_MINUTE } from '../../lib/constants/time'
+import { DEFAULT_PAGE_SIZE } from '../../lib/constants/ui'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useGlobalFilters, type SeverityLevel } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -64,9 +65,6 @@ function AlertStatsRow({ critical, warning, acknowledged }: { critical: number; 
     </div>
   )
 }
-
-/** Default pagination size for the alerts list */
-const DEFAULT_PAGE_SIZE = 5
 
 type SortField = 'severity' | 'time'
 

--- a/web/src/components/cards/VClusterStatus.tsx
+++ b/web/src/components/cards/VClusterStatus.tsx
@@ -10,6 +10,7 @@ import { useLocalClusterTools, type VClusterInstance } from '../../hooks/useLoca
 import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { MS_PER_DAY } from '../../lib/constants/time'
+import { DEFAULT_PAGE_SIZE } from '../../lib/constants/ui'
 
 type VClusterStatusType = 'Running' | 'Paused' | 'Failed' | 'Unknown'
 
@@ -90,7 +91,6 @@ const VCLUSTER_SORT_COMPARATORS: Record<SortByOption, (a: VCluster, b: VCluster)
   hostCluster: commonComparators.string<VCluster>('hostCluster'),
   status: commonComparators.string<VCluster>('status'),
 }
-const DEFAULT_PAGE_SIZE = 5
 
 interface VClusterStatusProps { config?: Record<string, unknown> }
 

--- a/web/src/components/cards/gadget/NetworkTraceCard.tsx
+++ b/web/src/components/cards/gadget/NetworkTraceCard.tsx
@@ -1,4 +1,5 @@
 import { Network, ArrowRight } from 'lucide-react'
+import { formatBytes } from '../../../lib/formatters'
 import { useCachedNetworkTraces } from '../../../hooks/useGadget'
 import { useCardLoadingState, useCardDemoState } from '../CardDataContext'
 import { ClusterBadge } from '../../ui/ClusterBadge'
@@ -76,8 +77,3 @@ export function NetworkTraceCard({ config }: NetworkTraceCardProps) {
   )
 }
 
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
-}

--- a/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
+++ b/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
@@ -30,10 +30,8 @@ import { RefreshIndicator } from '../../ui/RefreshIndicator'
 import { CardControls } from '../../ui/CardControls'
 import { Pagination } from '../../ui/Pagination'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
+import { DEFAULT_PAGE_SIZE } from '../../../lib/constants/ui'
 import type { IntotoLayout, IntotoStep } from '../../../hooks/useIntoto'
-
-/** Default page size for the layouts list */
-const DEFAULT_PAGE_SIZE = 5
 
 type SortField = 'name' | 'failedSteps' | 'verifiedSteps'
 

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
@@ -12,6 +12,7 @@ import { Shield, ExternalLink, CheckCircle, XCircle, AlertTriangle, Network, Lay
 import { useTranslation } from 'react-i18next'
 import { BaseModal } from '../../../../lib/modals'
 import { StatusBadge } from '../../../ui/StatusBadge'
+import { ISOLATION_STATUS_COLORS } from '../shared'
 import type { MultiTenancyOverviewData, ComponentStatus, IsolationLevel, IsolationStatus } from './useMultiTenancyOverview'
 
 // ============================================================================
@@ -60,13 +61,6 @@ const HEALTH_BG: Record<string, string> = {
   unhealthy: 'bg-red-500/10 border-red-500/20',
   'not-installed': 'bg-zinc-500/10 border-zinc-500/20',
   unknown: 'bg-zinc-500/10 border-zinc-500/20',
-}
-
-/** Isolation status colors */
-const ISOLATION_STATUS_COLORS: Record<IsolationStatus, string> = {
-  ready: 'text-green-400',
-  degraded: 'text-orange-400',
-  missing: 'text-zinc-500',
 }
 
 /** Isolation status backgrounds */

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
@@ -14,6 +14,7 @@ import { useCardLoadingState } from '../../CardDataContext'
 import { MultiTenancyDetailModal } from './MultiTenancyDetailModal'
 import { useModalState } from '../../../../lib/modals'
 
+import { ISOLATION_STATUS_COLORS } from '../shared'
 import type { ComponentStatus, IsolationLevel, IsolationStatus } from './useMultiTenancyOverview'
 
 /** Grid columns for the component status grid */
@@ -51,12 +52,6 @@ function IsolationStatusIcon({ status }: { status: IsolationStatus }) {
       return <XCircle className="w-4 h-4 text-zinc-500" />
   }
 }
-
-/** Status color text for isolation levels */
-const ISOLATION_STATUS_COLORS: Record<IsolationStatus, string> = {
-  ready: 'text-green-400',
-  degraded: 'text-orange-400',
-  missing: 'text-zinc-500' }
 
 /** Single component badge in the 2x2 grid */
 function ComponentBadge({ component, onClick }: { component: ComponentStatus; onClick?: () => void }) {

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/useMultiTenancyOverview.ts
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/useMultiTenancyOverview.ts
@@ -8,6 +8,7 @@
  * while KubeFlex is still a stub returning flat `{ detected, health, ... }`.
  */
 import { useMemo } from 'react'
+import type { IsolationStatus } from '../shared'
 import { useOvnStatus } from '../ovn-status/useOvnStatus'
 import { useKubeFlexStatus } from '../kubeflex-status/useKubeflexStatus'
 import { useK3sStatus } from '../k3s-status/useK3sStatus'
@@ -23,7 +24,7 @@ export interface ComponentStatus {
   icon: string
 }
 
-export type IsolationStatus = 'ready' | 'missing' | 'degraded'
+export type { IsolationStatus }
 
 export interface IsolationLevel {
   type: string

--- a/web/src/components/cards/multi-tenancy/shared.ts
+++ b/web/src/components/cards/multi-tenancy/shared.ts
@@ -22,6 +22,16 @@ export interface IsolationLevel {
   provider: string
 }
 
+/** Isolation readiness state (alias for IsolationLevel['status']) */
+export type IsolationStatus = 'ready' | 'missing' | 'degraded'
+
+/** Text-color classes for isolation status badges */
+export const ISOLATION_STATUS_COLORS: Record<IsolationStatus, string> = {
+  ready: 'text-green-400',
+  degraded: 'text-orange-400',
+  missing: 'text-zinc-500',
+}
+
 // ============================================================================
 // Cache Keys
 // ============================================================================

--- a/web/src/components/cards/multi-tenancy/tenant-isolation-setup/TenantIsolationSetup.tsx
+++ b/web/src/components/cards/multi-tenancy/tenant-isolation-setup/TenantIsolationSetup.tsx
@@ -23,6 +23,7 @@ import {
   KUBEVIRT_INSTALL_PROMPT } from './missionPrompts'
 import { loadMissionPrompt } from '../missionLoader'
 
+import { ISOLATION_STATUS_COLORS } from '../shared'
 import type { ComponentReadiness, IsolationLevel, IsolationStatus } from './useTenantIsolationSetup'
 
 /** Icon map for component keys */
@@ -50,12 +51,6 @@ function IsolationStatusIcon({ status }: { status: IsolationStatus }) {
       return <XCircle className="w-3.5 h-3.5 text-zinc-500" />
   }
 }
-
-/** Color classes for isolation status */
-const ISOLATION_STATUS_COLORS: Record<IsolationStatus, string> = {
-  ready: 'text-green-400',
-  degraded: 'text-orange-400',
-  missing: 'text-zinc-500' }
 
 /** Component readiness badge */
 function ReadinessBadge({ component, onInstall }: {

--- a/web/src/components/cards/multi-tenancy/tenant-isolation-setup/useTenantIsolationSetup.ts
+++ b/web/src/components/cards/multi-tenancy/tenant-isolation-setup/useTenantIsolationSetup.ts
@@ -4,6 +4,7 @@
  *
  * No caching needed — purely derived from the individual status hooks.
  */
+import type { IsolationStatus } from '../shared'
 import { useOvnStatus } from '../ovn-status/useOvnStatus'
 import { useKubeFlexStatus } from '../kubeflex-status/useKubeflexStatus'
 import { useK3sStatus } from '../k3s-status/useK3sStatus'
@@ -19,7 +20,7 @@ export interface ComponentReadiness {
   health: string
 }
 
-export type IsolationStatus = 'ready' | 'missing' | 'degraded'
+export type { IsolationStatus }
 
 export interface IsolationLevel {
   type: string


### PR DESCRIPTION
## Summary
- Replace local `formatBytes` in `NetworkTraceCard.tsx` with import from `lib/formatters.ts`
- Extract `ISOLATION_STATUS_COLORS` and `IsolationStatus` type to `multi-tenancy/shared.ts`, replacing 3 identical inline definitions
- Replace local `DEFAULT_PAGE_SIZE = 5` in `ActiveAlerts`, `VClusterStatus`, `IntotoSupplyChain` with import from `lib/constants/ui.ts`

Net: 10 files changed, 21 insertions, 33 deletions — zero behavior change.

Fixes #10353

## Test plan
- [x] `npm run build` passes
- [ ] CI pr-check + coverage-gate pass