### PR TITLE
🧹 Centralize duplicate formatBytes, ISOLATION_STATUS_COLORS, DEFAULT_PAGE_SIZE

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -9,6 +9,7 @@ import {
   BellOff } from 'lucide-react'
 import { useAlerts } from '../../hooks/useAlerts'
 import { MS_PER_MINUTE } from '../../lib/constants/time'
+import { DEFAULT_PAGE_SIZE } from '../../lib/constants/ui'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useGlobalFilters, type SeverityLevel } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -65,8 +66,6 @@ function AlertStatsRow({ critical, warning, acknowledged }: { critical: number; 
   )
 }
 
-/** Default pagination size for the alerts list */
-const DEFAULT_PAGE_SIZE = 5
 
 type SortField = 'severity' | 'time'
 

--- a/web/src/components/cards/VClusterStatus.tsx
+++ b/web/src/components/cards/VClusterStatus.tsx
@@ -10,6 +10,7 @@ import { useLocalClusterTools, type VClusterInstance } from '../../hooks/useLoca
 import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { MS_PER_DAY } from '../../lib/constants/time'
+import { DEFAULT_PAGE_SIZE } from '../../lib/constants/ui'
 
 type VClusterStatusType = 'Running' | 'Paused' | 'Failed' | 'Unknown'
 
@@ -90,8 +91,6 @@ const VCLUSTER_SORT_COMPARATORS: Record<SortByOption, (a: VCluster, b: VCluster)
   hostCluster: commonComparators.string<VCluster>('hostCluster'),
   status: commonComparators.string<VCluster>('status'),
 }
-const DEFAULT_PAGE_SIZE = 5
-
 interface VClusterStatusProps { config?: Record<string, unknown> }
 
 export function VClusterStatus({ config: _config }: VClusterStatusProps) {

--- a/web/src/components/cards/gadget/NetworkTraceCard.tsx
+++ b/web/src/components/cards/gadget/NetworkTraceCard.tsx
@@ -2,6 +2,7 @@ import { Network, ArrowRight } from 'lucide-react'
 import { useCachedNetworkTraces } from '../../../hooks/useGadget'
 import { useCardLoadingState, useCardDemoState } from '../CardDataContext'
 import { ClusterBadge } from '../../ui/ClusterBadge'
+import { formatBytes } from '../../../lib/formatters'
 
 interface NetworkTraceCardProps {
   config?: Record<string, unknown>
@@ -76,8 +77,3 @@ export function NetworkTraceCard({ config }: NetworkTraceCardProps) {
   )
 }
 
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
-}

--- a/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
+++ b/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
@@ -30,10 +30,8 @@ import { RefreshIndicator } from '../../ui/RefreshIndicator'
 import { CardControls } from '../../ui/CardControls'
 import { Pagination } from '../../ui/Pagination'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
+import { DEFAULT_PAGE_SIZE } from '../../../lib/constants/ui'
 import type { IntotoLayout, IntotoStep } from '../../../hooks/useIntoto'
-
-/** Default page size for the layouts list */
-const DEFAULT_PAGE_SIZE = 5
 
 type SortField = 'name' | 'failedSteps' | 'verifiedSteps'
 

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
@@ -12,7 +12,9 @@ import { Shield, ExternalLink, CheckCircle, XCircle, AlertTriangle, Network, Lay
 import { useTranslation } from 'react-i18next'
 import { BaseModal } from '../../../../lib/modals'
 import { StatusBadge } from '../../../ui/StatusBadge'
-import type { MultiTenancyOverviewData, ComponentStatus, IsolationLevel, IsolationStatus } from './useMultiTenancyOverview'
+import type { MultiTenancyOverviewData, ComponentStatus } from './useMultiTenancyOverview'
+import type { IsolationLevel, IsolationStatus } from '../shared'
+import { ISOLATION_STATUS_COLORS } from '../shared'
 
 // ============================================================================
 // Constants
@@ -62,12 +64,6 @@ const HEALTH_BG: Record<string, string> = {
   unknown: 'bg-zinc-500/10 border-zinc-500/20',
 }
 
-/** Isolation status colors */
-const ISOLATION_STATUS_COLORS: Record<IsolationStatus, string> = {
-  ready: 'text-green-400',
-  degraded: 'text-orange-400',
-  missing: 'text-zinc-500',
-}
 
 /** Isolation status backgrounds */
 const ISOLATION_STATUS_BG: Record<IsolationStatus, string> = {

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
@@ -14,7 +14,9 @@ import { useCardLoadingState } from '../../CardDataContext'
 import { MultiTenancyDetailModal } from './MultiTenancyDetailModal'
 import { useModalState } from '../../../../lib/modals'
 
-import type { ComponentStatus, IsolationLevel, IsolationStatus } from './useMultiTenancyOverview'
+import type { ComponentStatus } from './useMultiTenancyOverview'
+import type { IsolationLevel, IsolationStatus } from '../shared'
+import { ISOLATION_STATUS_COLORS } from '../shared'
 
 /** Grid columns for the component status grid */
 const COMPONENT_GRID_COLS = 2
@@ -51,12 +53,6 @@ function IsolationStatusIcon({ status }: { status: IsolationStatus }) {
       return <XCircle className="w-4 h-4 text-zinc-500" />
   }
 }
-
-/** Status color text for isolation levels */
-const ISOLATION_STATUS_COLORS: Record<IsolationStatus, string> = {
-  ready: 'text-green-400',
-  degraded: 'text-orange-400',
-  missing: 'text-zinc-500' }
 
 /** Single component badge in the 2x2 grid */
 function ComponentBadge({ component, onClick }: { component: ComponentStatus; onClick?: () => void }) {

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/useMultiTenancyOverview.ts
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/useMultiTenancyOverview.ts
@@ -23,13 +23,8 @@ export interface ComponentStatus {
   icon: string
 }
 
-export type IsolationStatus = 'ready' | 'missing' | 'degraded'
-
-export interface IsolationLevel {
-  type: string
-  status: IsolationStatus
-  provider: string
-}
+export type { IsolationStatus, IsolationLevel } from '../shared'
+import type { IsolationStatus, IsolationLevel } from '../shared'
 
 export interface MultiTenancyOverviewData {
   components: ComponentStatus[]

--- a/web/src/components/cards/multi-tenancy/shared.ts
+++ b/web/src/components/cards/multi-tenancy/shared.ts
@@ -12,14 +12,28 @@
 /** Overall component health across the cluster */
 export type ComponentHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
+/** Possible isolation readiness states */
+export type IsolationStatus = 'ready' | 'missing' | 'degraded'
+
 /** Describes one axis of tenant isolation provided by a technology */
 export interface IsolationLevel {
-  /** The isolation plane this entry covers */
-  type: 'control-plane' | 'data-plane' | 'network'
+  /** The isolation plane this entry covers (e.g. "Control-plane", "Data-plane", "Network") */
+  type: string
   /** Current readiness of this isolation capability */
-  status: 'ready' | 'missing' | 'degraded'
+  status: IsolationStatus
   /** Technology that provides this isolation (e.g. "OVN-Kubernetes", "KubeVirt") */
   provider: string
+}
+
+// ============================================================================
+// Isolation Status Colors
+// ============================================================================
+
+/** Text color classes for isolation status — shared across multi-tenancy cards */
+export const ISOLATION_STATUS_COLORS: Record<IsolationStatus, string> = {
+  ready: 'text-green-400',
+  degraded: 'text-orange-400',
+  missing: 'text-zinc-500',
 }
 
 // ============================================================================

--- a/web/src/components/cards/multi-tenancy/tenant-isolation-setup/TenantIsolationSetup.tsx
+++ b/web/src/components/cards/multi-tenancy/tenant-isolation-setup/TenantIsolationSetup.tsx
@@ -23,7 +23,9 @@ import {
   KUBEVIRT_INSTALL_PROMPT } from './missionPrompts'
 import { loadMissionPrompt } from '../missionLoader'
 
-import type { ComponentReadiness, IsolationLevel, IsolationStatus } from './useTenantIsolationSetup'
+import type { ComponentReadiness } from './useTenantIsolationSetup'
+import type { IsolationLevel, IsolationStatus } from '../shared'
+import { ISOLATION_STATUS_COLORS } from '../shared'
 
 /** Icon map for component keys */
 const COMPONENT_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
@@ -50,12 +52,6 @@ function IsolationStatusIcon({ status }: { status: IsolationStatus }) {
       return <XCircle className="w-3.5 h-3.5 text-zinc-500" />
   }
 }
-
-/** Color classes for isolation status */
-const ISOLATION_STATUS_COLORS: Record<IsolationStatus, string> = {
-  ready: 'text-green-400',
-  degraded: 'text-orange-400',
-  missing: 'text-zinc-500' }
 
 /** Component readiness badge */
 function ReadinessBadge({ component, onInstall }: {

--- a/web/src/components/cards/multi-tenancy/tenant-isolation-setup/useTenantIsolationSetup.ts
+++ b/web/src/components/cards/multi-tenancy/tenant-isolation-setup/useTenantIsolationSetup.ts
@@ -19,13 +19,8 @@ export interface ComponentReadiness {
   health: string
 }
 
-export type IsolationStatus = 'ready' | 'missing' | 'degraded'
-
-export interface IsolationLevel {
-  type: string
-  status: IsolationStatus
-  provider: string
-}
+export type { IsolationStatus, IsolationLevel } from '../shared'
+import type { IsolationStatus, IsolationLevel } from '../shared'
 
 export interface TenantIsolationSetupData {
   components: ComponentReadiness[]


### PR DESCRIPTION
## Summary
- Replace local `formatBytes` in `NetworkTraceCard.tsx` with import from `lib/formatters`
- Extract `ISOLATION_STATUS_COLORS` to `multi-tenancy/shared.ts`, remove duplicate definitions from 3 card files
- Replace local `DEFAULT_PAGE_SIZE = 5` in `ActiveAlerts`, `IntotoSupplyChain`, `VClusterStatus` with import from `lib/constants/ui`
- Consolidate `IsolationStatus`/`IsolationLevel` types into `shared.ts`, re-export from hooks for backward compatibility

Fixes #10353

## Test plan
- [ ] Build passes in CI
- [ ] Lint passes in CI
- [ ] Multi-tenancy cards render correctly with isolation status colors
- [ ] NetworkTraceCard displays byte formatting correctly
- [ ] Paginated cards (ActiveAlerts, IntotoSupplyChain, VClusterStatus) use correct page size