### PR TITLE
🧹 Extract duplicate health badge CSS ternaries into shared constants

### DIFF
--- a/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
+++ b/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
@@ -6,6 +6,7 @@ import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCloudEventsStatus } from './useCloudEventsStatus'
 import type { CloudEventResourceState } from './demoData'
 import { createCardSyncFormatter } from '../../../lib/formatters'
+import { getHealthBadgeClasses } from '../../../lib/cards/statusColors'
 
 const STATUS_STYLE: Record<CloudEventResourceState, { badge: string; icon: React.ReactNode }> = {
   ready: {
@@ -82,9 +83,7 @@ export function CloudEventsStatus() {
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div
-          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400'
-          }`}
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${getHealthBadgeClasses(isHealthy)}`}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
           {isHealthy ? t('cloudevents.healthy') : t('cloudevents.degraded')}

--- a/web/src/components/cards/containerd_status/index.tsx
+++ b/web/src/components/cards/containerd_status/index.tsx
@@ -20,6 +20,7 @@ import { useCachedContainerd } from '../../../hooks/useCachedContainerd'
 import { useCardLoadingState } from '../CardDataContext'
 import type { ContainerdContainer, ContainerdContainerState } from '../../../lib/demo/containerd'
 import { formatTimeAgo } from '../../../lib/formatters'
+import { getHealthBadgeClasses } from '../../../lib/cards/statusColors'
 
 // ---------------------------------------------------------------------------
 // Constants (no magic numbers)
@@ -135,9 +136,7 @@ export function ContainerdStatus() {
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       <div className="flex items-center justify-between gap-2">
         <div
-          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400'
-          }`}
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${getHealthBadgeClasses(isHealthy)}`}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
           {isHealthy

--- a/web/src/components/cards/dragonfly_status/index.tsx
+++ b/web/src/components/cards/dragonfly_status/index.tsx
@@ -36,6 +36,7 @@ import type {
   DragonflyComponent,
   DragonflyComponentRow,
 } from '../../../lib/demo/dragonfly'
+import { getHealthBadgeClasses } from '../../../lib/cards/statusColors'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -135,7 +136,7 @@ export function DragonflyStatus() {
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400',
+            getHealthBadgeClasses(isHealthy),
           )}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}

--- a/web/src/components/cards/otel_status/index.tsx
+++ b/web/src/components/cards/otel_status/index.tsx
@@ -25,6 +25,7 @@ import { EmptyState } from '../../ui/EmptyState'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { cn } from '../../../lib/cn'
 import type { OtelCollector } from '../../../lib/demo/otel'
+import { getHealthBadgeClasses } from '../../../lib/cards/statusColors'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -126,7 +127,7 @@ export function OtelStatus() {
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400',
+            getHealthBadgeClasses(isHealthy),
           )}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}

--- a/web/src/components/cards/rook_status/index.tsx
+++ b/web/src/components/cards/rook_status/index.tsx
@@ -25,6 +25,7 @@ import { EmptyState } from '../../ui/EmptyState'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { cn } from '../../../lib/cn'
 import type { RookCephCluster, RookCephHealth } from '../../../lib/demo/rook'
+import { getHealthBadgeClasses } from '../../../lib/cards/statusColors'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -134,7 +135,7 @@ export function RookStatus() {
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400',
+            getHealthBadgeClasses(isHealthy),
           )}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}

--- a/web/src/components/cards/tikv_status/index.tsx
+++ b/web/src/components/cards/tikv_status/index.tsx
@@ -17,6 +17,7 @@ import { MetricTile } from '../../../lib/cards/CardComponents'
 import { cn } from '../../../lib/cn'
 import type { TikvStore } from '../../../lib/demo/tikv'
 import { BYTES_PER_GIB } from '../../../lib/constants/units'
+import { getHealthBadgeClasses } from '../../../lib/cards/statusColors'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -140,7 +141,7 @@ export function TikvStatus() {
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400',
+            getHealthBadgeClasses(isHealthy),
           )}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}

--- a/web/src/components/cards/vitess_status/index.tsx
+++ b/web/src/components/cards/vitess_status/index.tsx
@@ -26,6 +26,7 @@ import { EmptyState } from '../../ui/EmptyState'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { cn } from '../../../lib/cn'
 import type { VitessKeyspace, VitessTablet, VitessTabletType } from '../../../lib/demo/vitess'
+import { getHealthBadgeClasses } from '../../../lib/cards/statusColors'
 
 // ---------------------------------------------------------------------------
 // Named constants (no magic numbers)
@@ -148,7 +149,7 @@ export function VitessStatus() {
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400',
+            getHealthBadgeClasses(isHealthy),
           )}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}

--- a/web/src/lib/cards/statusColors.ts
+++ b/web/src/lib/cards/statusColors.ts
@@ -131,3 +131,26 @@ export function getStatusColors(status: string | undefined | null): StatusColorS
 export function getSeverityColors(severity: StatusSeverity): StatusColorSet {
   return STATUS_COLORS[severity]
 }
+
+// ---------------------------------------------------------------------------
+// Health Badge Constants
+//
+// Shared CSS class strings for the healthy/unhealthy badge used across
+// status cards (OTel, Rook, TiKV, CloudEvents, Containerd, Vitess, Dragonfly).
+// ---------------------------------------------------------------------------
+
+/** CSS classes for a "Healthy" badge (green background + text) */
+export const HEALTH_BADGE_HEALTHY = 'bg-green-500/15 text-green-400'
+
+/** CSS classes for an "Unhealthy / Warning" badge (yellow background + text) */
+export const HEALTH_BADGE_UNHEALTHY = 'bg-yellow-500/15 text-yellow-400'
+
+/**
+ * Return the appropriate health badge CSS classes based on a boolean health flag.
+ *
+ * @example
+ * <div className={cn('flex items-center gap-2', getHealthBadgeClasses(isHealthy))}>
+ */
+export function getHealthBadgeClasses(isHealthy: boolean): string {
+  return isHealthy ? HEALTH_BADGE_HEALTHY : HEALTH_BADGE_UNHEALTHY
+}


### PR DESCRIPTION
## Summary
- Add `HEALTH_BADGE_HEALTHY`, `HEALTH_BADGE_UNHEALTHY` constants and `getHealthBadgeClasses()` helper to `lib/cards/statusColors.ts`
- Replace 7 duplicate inline ternaries across status card files (otel, rook, tikv, cloudevents, containerd, vitess, dragonfly)

Fixes #10362

## Test plan
- [ ] Build passes in CI
- [ ] Status cards render health badges correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)