### PR TITLE
🧹 Extract duplicate health badge CSS ternaries into shared healthBadgeClass()

### DIFF
--- a/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
+++ b/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
@@ -6,6 +6,7 @@ import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCloudEventsStatus } from './useCloudEventsStatus'
 import type { CloudEventResourceState } from './demoData'
 import { createCardSyncFormatter } from '../../../lib/formatters'
+import { healthBadgeClass } from '../../../lib/cards/statusColors'
 
 const STATUS_STYLE: Record<CloudEventResourceState, { badge: string; icon: React.ReactNode }> = {
   ready: {
@@ -83,7 +84,7 @@ export function CloudEventsStatus() {
       <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400'
+            healthBadgeClass(isHealthy)
           }`}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}

--- a/web/src/components/cards/containerd_status/index.tsx
+++ b/web/src/components/cards/containerd_status/index.tsx
@@ -20,6 +20,7 @@ import { useCachedContainerd } from '../../../hooks/useCachedContainerd'
 import { useCardLoadingState } from '../CardDataContext'
 import type { ContainerdContainer, ContainerdContainerState } from '../../../lib/demo/containerd'
 import { formatTimeAgo } from '../../../lib/formatters'
+import { healthBadgeClass } from '../../../lib/cards/statusColors'
 
 // ---------------------------------------------------------------------------
 // Constants (no magic numbers)
@@ -136,7 +137,7 @@ export function ContainerdStatus() {
       <div className="flex items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400'
+            healthBadgeClass(isHealthy)
           }`}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}

--- a/web/src/components/cards/dragonfly_status/index.tsx
+++ b/web/src/components/cards/dragonfly_status/index.tsx
@@ -32,6 +32,7 @@ import { SkeletonCardWithRefresh } from '../../ui/Skeleton'
 import { EmptyState } from '../../ui/EmptyState'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { cn } from '../../../lib/cn'
+import { healthBadgeClass } from '../../../lib/cards/statusColors'
 import type {
   DragonflyComponent,
   DragonflyComponentRow,
@@ -135,7 +136,7 @@ export function DragonflyStatus() {
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400',
+            healthBadgeClass(isHealthy),
           )}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}

--- a/web/src/components/cards/otel_status/index.tsx
+++ b/web/src/components/cards/otel_status/index.tsx
@@ -24,6 +24,7 @@ import { SkeletonCardWithRefresh } from '../../ui/Skeleton'
 import { EmptyState } from '../../ui/EmptyState'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { cn } from '../../../lib/cn'
+import { healthBadgeClass } from '../../../lib/cards/statusColors'
 import type { OtelCollector } from '../../../lib/demo/otel'
 
 // ---------------------------------------------------------------------------
@@ -126,7 +127,7 @@ export function OtelStatus() {
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400',
+            healthBadgeClass(isHealthy),
           )}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}

--- a/web/src/components/cards/rook_status/index.tsx
+++ b/web/src/components/cards/rook_status/index.tsx
@@ -24,6 +24,7 @@ import { SkeletonCardWithRefresh } from '../../ui/Skeleton'
 import { EmptyState } from '../../ui/EmptyState'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { cn } from '../../../lib/cn'
+import { healthBadgeClass } from '../../../lib/cards/statusColors'
 import type { RookCephCluster, RookCephHealth } from '../../../lib/demo/rook'
 
 // ---------------------------------------------------------------------------
@@ -134,7 +135,7 @@ export function RookStatus() {
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400',
+            healthBadgeClass(isHealthy),
           )}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}

--- a/web/src/components/cards/tikv_status/index.tsx
+++ b/web/src/components/cards/tikv_status/index.tsx
@@ -15,6 +15,7 @@ import { SkeletonCardWithRefresh } from '../../ui/Skeleton'
 import { EmptyState } from '../../ui/EmptyState'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { cn } from '../../../lib/cn'
+import { healthBadgeClass } from '../../../lib/cards/statusColors'
 import type { TikvStore } from '../../../lib/demo/tikv'
 import { BYTES_PER_GIB } from '../../../lib/constants/units'
 
@@ -140,7 +141,7 @@ export function TikvStatus() {
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400',
+            healthBadgeClass(isHealthy),
           )}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}

--- a/web/src/components/cards/vitess_status/index.tsx
+++ b/web/src/components/cards/vitess_status/index.tsx
@@ -25,6 +25,7 @@ import { SkeletonCardWithRefresh } from '../../ui/Skeleton'
 import { EmptyState } from '../../ui/EmptyState'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { cn } from '../../../lib/cn'
+import { healthBadgeClass } from '../../../lib/cards/statusColors'
 import type { VitessKeyspace, VitessTablet, VitessTabletType } from '../../../lib/demo/vitess'
 
 // ---------------------------------------------------------------------------
@@ -148,7 +149,7 @@ export function VitessStatus() {
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
-            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400',
+            healthBadgeClass(isHealthy),
           )}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}

--- a/web/src/lib/cards/statusColors.ts
+++ b/web/src/lib/cards/statusColors.ts
@@ -76,6 +76,15 @@ export const STATUS_COLORS: Record<StatusSeverity, StatusColorSet> = {
   },
 }
 
+/** Pre-combined badge classes for the healthy/unhealthy ternary used by status cards. */
+export const HEALTH_BADGE_HEALTHY = 'bg-green-500/15 text-green-400'
+export const HEALTH_BADGE_UNHEALTHY = 'bg-yellow-500/15 text-yellow-400'
+
+/** Returns the appropriate health badge class string. */
+export function healthBadgeClass(healthy: boolean): string {
+  return healthy ? HEALTH_BADGE_HEALTHY : HEALTH_BADGE_UNHEALTHY
+}
+
 // Keywords mapped to severity levels (lowercase, checked with includes)
 const SEVERITY_KEYWORDS: Array<[string[], StatusSeverity]> = [
   // Error — check first (most specific)


### PR DESCRIPTION
## Summary
- Add `healthBadgeClass()` helper and `HEALTH_BADGE_HEALTHY`/`HEALTH_BADGE_UNHEALTHY` constants to `lib/cards/statusColors.ts`
- Replace 7 identical inline `isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400'` ternaries across CNCF status cards (otel, rook, tikv, cloudevents, containerd, vitess, dragonfly)

Net: 8 files changed, 23 insertions, 7 deletions — zero behavior change.

Fixes #10362

## Test plan
- [x] `npm run build` passes
- [ ] CI pr-check + coverage-gate pass