### PR TITLE
security: mask agent token + validate proxy subPath (#10363 follow-up)

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1054,9 +1054,23 @@ func (s *Server) setupRoutes() {
 	// and Private Network Access checks that are fragile across browser versions.
 	// The backend injects the Bearer token server-side so the frontend never
 	// needs to know KC_AGENT_TOKEN for auto-update operations.
+	// allowedAgentSubPaths restricts which kc-agent endpoints the proxy
+	// can forward to — prevents path-traversal attacks via crafted :path.
+	allowedAgentSubPaths := map[string]bool{
+		"status":  true,
+		"config":  true,
+		"trigger": true,
+		"cancel":  true,
+	}
 	agentHTTPClient := &http.Client{Timeout: kcAgentProxyTimeout}
 	api.All("/agent/auto-update/:path", func(c *fiber.Ctx) error {
 		subPath := c.Params("path")
+
+		// Reject path-traversal sequences and non-allowlisted endpoints.
+		if strings.Contains(subPath, "..") || strings.Contains(subPath, "%2e") || strings.Contains(subPath, "%2E") || !allowedAgentSubPaths[subPath] {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid agent proxy path"})
+		}
+
 		targetURL := kcAgentBaseURL + "/auto-update/" + subPath
 
 		var bodyReader io.Reader

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -346,7 +346,7 @@ fi
 # via a backend-proxied token endpoint.
 if [ -z "$KC_AGENT_TOKEN" ]; then
     KC_AGENT_TOKEN="$(openssl rand -hex 32)"
-    echo "Auto-generated KC_AGENT_TOKEN: $KC_AGENT_TOKEN"
+    echo "Auto-generated KC_AGENT_TOKEN."
 fi
 export KC_AGENT_TOKEN
 


### PR DESCRIPTION
## Summary
- Stop echoing KC_AGENT_TOKEN value to stdout in startup-oauth.sh (prevents terminal/log leaks)
- Add path validation to kc-agent proxy handler — restrict subPath to allowlisted endpoints (`status`, `config`, `trigger`, `cancel`), reject traversal sequences

Fixes Copilot review comments on #10363.

## Test plan
- [x] startup-oauth.sh no longer prints token value
- [x] Proxy rejects `..` and non-allowlisted paths with 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)