### PR TITLE
🐛 Fix Playwright nightly cross-browser failures (webkit/firefox/mobile)

### DIFF
--- a/web/e2e/Clusters.spec.ts
+++ b/web/e2e/Clusters.spec.ts
@@ -4,6 +4,15 @@ import { test, expect, Page } from '@playwright/test'
  * Sets up authentication and MCP mocks for cluster tests
  */
 async function setupClustersTest(page: Page) {
+  // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+  await page.route('''**/api/**''', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: '''application/json''',
+      body: JSON.stringify({}),
+    })
+  )
+
   // Mock authentication
   await page.route('**/api/me', (route) =>
     route.fulfill({

--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -159,6 +159,22 @@ test.describe('Dashboard Page', () => {
 
   test.describe('Data Loading', () => {
     test('shows loading state initially', async ({ page }) => {
+      // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+      await page.route('**/api/**', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({}),
+        })
+      )
+      await page.route('**/api/me', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: '1', github_id: '12345', github_login: 'testuser', email: 'test@example.com', onboarded: true }),
+        })
+      )
+
       // Delay the API response to see loading state
       await page.route('**/api/mcp/**', async (route) => {
         const API_DELAY_MS = 2000
@@ -185,6 +201,22 @@ test.describe('Dashboard Page', () => {
     })
 
     test('handles API errors gracefully', async ({ page }) => {
+      // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+      await page.route('**/api/**', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({}),
+        })
+      )
+      await page.route('**/api/me', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: '1', github_id: '12345', github_login: 'testuser', email: 'test@example.com', onboarded: true }),
+        })
+      )
+
       await page.route('**/api/mcp/clusters', (route) =>
         route.fulfill({
           status: 500,
@@ -285,8 +317,18 @@ test.describe('Dashboard Page', () => {
       // **/api/mcp/**. Unroute them here so our deterministic payload is the
       // ONLY source of data for these Data Accuracy tests — otherwise the
       // outer mock with 2 clusters could race with our EXPECTED_CLUSTER_COUNT.
+      await page.unroute('**/api/**')
       await page.unroute('**/api/me')
       await page.unroute('**/api/mcp/**')
+
+      // Re-register catch-all (prevents unmocked API hangs in webkit/firefox)
+      await page.route('**/api/**', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({}),
+        })
+      )
 
       // Mock authentication
       await page.route('**/api/me', (route) =>

--- a/web/e2e/Events.spec.ts
+++ b/web/e2e/Events.spec.ts
@@ -4,6 +4,15 @@ import { test, expect, Page } from '@playwright/test'
  * Sets up authentication and MCP mocks for events tests
  */
 async function setupEventsTest(page: Page) {
+  // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+  await page.route('''**/api/**''', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: '''application/json''',
+      body: JSON.stringify({}),
+    })
+  )
+
   // Mock authentication
   await page.route('**/api/me', (route) =>
     route.fulfill({

--- a/web/e2e/Login.spec.ts
+++ b/web/e2e/Login.spec.ts
@@ -37,6 +37,15 @@ test.describe('Login Page', () => {
   })
 
   test('redirects to dashboard after successful login', async ({ page }) => {
+    // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+    await page.route('**/api/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      })
+    )
+
     // Mock the /api/me endpoint to simulate an authenticated user
     await page.route('**/api/me', (route) =>
       route.fulfill({
@@ -75,7 +84,7 @@ test.describe('Login Page', () => {
     await page.goto('/')
     await page.waitForLoadState('domcontentloaded')
 
-    await expect(page).toHaveURL(/^\/$/, { timeout: 10000 })
+    await expect(page).toHaveURL(/\/$/, { timeout: 10000 })
     await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 10000 })
   })
 

--- a/web/e2e/Sidebar.spec.ts
+++ b/web/e2e/Sidebar.spec.ts
@@ -4,6 +4,15 @@ import { test, expect, Page } from '@playwright/test'
  * Sets up authentication and MCP mocks for sidebar tests
  */
 async function setupSidebarTest(page: Page) {
+  // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+  await page.route('''**/api/**''', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: '''application/json''',
+      body: JSON.stringify({}),
+    })
+  )
+
   // Mock authentication
   await page.route('**/api/me', (route) =>
     route.fulfill({
@@ -80,13 +89,19 @@ test.describe('Sidebar Navigation', () => {
       const SIDEBAR_TIMEOUT_MS = 10_000
       await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
 
+      // Navigate away first — in webkit, clicking <a href="/"> when already
+      // on "/" hangs because no navigation event fires.
+      await page.goto('/clusters')
+      await page.waitForLoadState('domcontentloaded')
+      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
+
       // Find dashboard link by href since sidebar uses NavLink with icons + text
       const dashboardLink = page.getByTestId('sidebar-primary-nav').locator('a[href="/"]').first()
       await expect(dashboardLink).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
       await dashboardLink.click()
 
       // Should be on dashboard
-      await expect(page).toHaveURL(/^\/$/, { timeout: SIDEBAR_TIMEOUT_MS })
+      await expect(page).toHaveURL(/\/$/, { timeout: SIDEBAR_TIMEOUT_MS })
     })
 
     test('clusters link navigates to clusters page', async ({ page }) => {

--- a/web/e2e/Tour.spec.ts
+++ b/web/e2e/Tour.spec.ts
@@ -13,6 +13,15 @@ import { test, expect, Page } from '@playwright/test'
  *   Defaults to `true` so most tests start on the dashboard without the prompt.
  */
 async function setupTourTest(page: Page, tourCompleted: boolean = true) {
+  // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+  await page.route('''**/api/**''', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: '''application/json''',
+      body: JSON.stringify({}),
+    })
+  )
+
   // Mock authentication
   await page.route('**/api/me', (route) =>
     route.fulfill({

--- a/web/e2e/deep-links-and-data-flow.spec.ts
+++ b/web/e2e/deep-links-and-data-flow.spec.ts
@@ -41,7 +41,7 @@ test.describe('Deep Links', () => {
     await setupDemoAndNavigate(page, '/')
     await waitForDashboard(page)
 
-    await expect(page).toHaveURL(/^\/$/)
+    await expect(page).toHaveURL(/\/$/)
     await expect(page.getByTestId('dashboard-page')).toBeVisible()
 
     const content = await page.textContent('body')

--- a/web/e2e/helpers/setup.ts
+++ b/web/e2e/helpers/setup.ts
@@ -137,7 +137,24 @@ export async function mockApiMe(page: Page) {
   )
 }
 
+/**
+ * Catch-all mock for /api/** requests. Returns empty JSON 200.
+ * Prevents unmocked calls from hanging against the Vite preview server
+ * (no backend), causing webkit/firefox/mobile-safari timeouts.
+ * Register BEFORE specific mocks (Playwright matches in reverse order).
+ */
+export async function mockApiFallback(page: Page) {
+  await page.route('**/api/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    })
+  )
+}
+
 export async function setupDemoMode(page: Page) {
+  await mockApiFallback(page)
   // Seed localStorage before page scripts execute — prevents the app from
   // briefly rendering the /login screen before the demo flag is picked up.
   await page.addInitScript(() => {
@@ -254,6 +271,7 @@ export const DEFAULT_AUTH_USER: MockApiUser = {
  * instead (or both, depending on what the app under test expects).
  */
 export async function setupAuth(page: Page, user?: Partial<MockApiUser>): Promise<void> {
+  await mockApiFallback(page)
   const u: MockApiUser = { ...DEFAULT_AUTH_USER, ...(user || {}) }
   await page.route('**/api/me', (route) =>
     route.fulfill({

--- a/web/e2e/navbar-responsive.spec.ts
+++ b/web/e2e/navbar-responsive.spec.ts
@@ -1,6 +1,15 @@
 import { test, expect, Page } from '@playwright/test'
 
 async function setupPage(page: Page) {
+  // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+  await page.route('**/api/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    })
+  )
+
   await page.route('**/api/me', (route) =>
     route.fulfill({
       status: 200,

--- a/web/e2e/nightly/rce-vector-scan.spec.ts
+++ b/web/e2e/nightly/rce-vector-scan.spec.ts
@@ -128,13 +128,7 @@ async function setupMocks(page: Page) {
   await page.route('**/health', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: '{"status":"ok"}' })
   )
-  await page.route('**/api/me', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: '1', github_login: 'test-user', email: 'test@test.com', onboarded: true }),
-    })
-  )
+  // Catch-all FIRST — specific mocks registered after take priority
   await page.route('**/api/**', (route) => {
     const url = route.request().url()
     if (url.includes('/stream') || url.includes('/events')) {
@@ -142,6 +136,13 @@ async function setupMocks(page: Page) {
     }
     route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
   })
+  await page.route('**/api/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: '1', github_login: 'test-user', email: 'test@test.com', onboarded: true }),
+    })
+  )
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The Playwright Cross-Browser (Nightly) workflow has never passed in 30+ runs. All 4 non-chromium jobs fail (webkit: 9, firefox: 7, mobile-chrome: 6, mobile-safari: 14 failures).

## Root Cause

E2E tests mock specific API routes but leave others unmocked. The nightly workflow runs against `npm run preview` (no backend), so unmocked requests hang. Webkit/firefox/mobile-safari are sensitive to this.

Additional: `toHaveURL(/^\/$/)` regex never matches full URLs; clicking same-URL links hangs in webkit.

## Fix

1. Add centralized `mockApiFallback()` catch-all `**/api/**` mock
2. Wire into all setup functions (10 files)
3. Fix URL regex `/^\/$/` → `/\/$/`
4. Navigate away before clicking dashboard link in webkit
5. Fix RCE route registration order

## Files Changed (10)
`helpers/setup.ts`, `Sidebar.spec.ts`, `Clusters.spec.ts`, `Events.spec.ts`, `Tour.spec.ts`, `navbar-responsive.spec.ts`, `Login.spec.ts`, `Dashboard.spec.ts`, `deep-links-and-data-flow.spec.ts`, `rce-vector-scan.spec.ts`