### PR TITLE
🐛 Fix 6 test failures in Coverage Suite (shared-cache-fetch + shared-coverage)

### DIFF
--- a/web/src/hooks/mcp/__tests__/shared-cache-fetch.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-cache-fetch.test.ts
@@ -712,6 +712,9 @@ describe('fetchSingleClusterHealth', () => {
   })
 
   it('uses kubectlContext for agent request when provided', async () => {
+    mockIsAgentUnavailable.mockReturnValue(false)
+    // Pre-seed agent token to prevent getAgentToken() from calling /api/agent/token
+    localStorage.setItem('kc-agent-token', 'test-token')
     const healthData: ClusterHealth = {
       cluster: 'test',
       healthy: true,

--- a/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
@@ -24,6 +24,7 @@ import type { ClusterInfo } from '../types'
 // ---------------------------------------------------------------------------
 const CLUSTER_NOTIFY_DEBOUNCE_MS = 50
 const STORAGE_KEY_TOKEN = 'token'
+const AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — same pattern as shared.test.ts
@@ -139,7 +140,7 @@ describe('agentFetch — token injection and signal fallback', () => {
   })
 
   it('injects Authorization header when token exists in localStorage', async () => {
-    localStorage.setItem(STORAGE_KEY_TOKEN, 'my-agent-token')
+    localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, 'my-agent-token')
     const mockFetch = vi.fn().mockResolvedValue(new Response('ok'))
     globalThis.fetch = mockFetch
 
@@ -151,7 +152,7 @@ describe('agentFetch — token injection and signal fallback', () => {
   })
 
   it('does NOT inject Authorization if header already present', async () => {
-    localStorage.setItem(STORAGE_KEY_TOKEN, 'my-agent-token')
+    localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, 'my-agent-token')
     const mockFetch = vi.fn().mockResolvedValue(new Response('ok'))
     globalThis.fetch = mockFetch
 
@@ -165,19 +166,21 @@ describe('agentFetch — token injection and signal fallback', () => {
   })
 
   it('does NOT inject Authorization when no token in localStorage', async () => {
-    localStorage.removeItem(STORAGE_KEY_TOKEN)
+    localStorage.removeItem(AGENT_TOKEN_STORAGE_KEY)
     const mockFetch = vi.fn().mockResolvedValue(new Response('ok'))
     globalThis.fetch = mockFetch
 
     await agentFetch('http://localhost:8090/clusters')
 
-    const call = mockFetch.mock.calls[0]
-    const headers = call[1]?.headers as Headers
+    // First call may be the token fetch to /api/agent/token (getAgentToken fallback);
+    // the actual agentFetch call is the last one.
+    const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1]
+    const headers = lastCall[1]?.headers as Headers
     expect(headers.has('Authorization')).toBe(false)
   })
 
   it('uses caller-provided signal instead of default timeout', async () => {
-    localStorage.removeItem(STORAGE_KEY_TOKEN)
+    localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, 'skip-token-fetch')
     const controller = new AbortController()
     const mockFetch = vi.fn().mockResolvedValue(new Response('ok'))
     globalThis.fetch = mockFetch
@@ -189,7 +192,7 @@ describe('agentFetch — token injection and signal fallback', () => {
   })
 
   it('falls back to AbortSignal.timeout when no signal provided', async () => {
-    localStorage.removeItem(STORAGE_KEY_TOKEN)
+    localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, 'skip-token-fetch')
     const mockFetch = vi.fn().mockResolvedValue(new Response('ok'))
     globalThis.fetch = mockFetch
 
@@ -1056,7 +1059,7 @@ describe('agentFetch — passes additional RequestInit options', () => {
   })
 
   it('passes method and body through to fetch', async () => {
-    localStorage.removeItem(STORAGE_KEY_TOKEN)
+    localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, 'skip-token-fetch')
     const mockFetch = vi.fn().mockResolvedValue(new Response('ok'))
     globalThis.fetch = mockFetch
 


### PR DESCRIPTION
Fixes #10369

## Problem

6 tests fail in the Coverage Suite workflow (shards 1 and 4):

- `shared-cache-fetch.test.ts`: `fetchSingleClusterHealth > uses kubectlContext for agent request when provided`
- `shared-coverage.test.ts`: 5 `agentFetch` tests (token injection, signal, method/body passthrough)

Coverage badge stuck at 88.51% with the suite marked as failed.

## Root Cause

PR #10368 introduced `getAgentToken()` which reads from `'kc-agent-token'` localStorage key. The tests were still using the legacy `'token'` key (`STORAGE_KEY_TOKEN`), so `getAgentToken()` never found a cached token and issued an unexpected `fetch('/api/agent/token')` call that:
1. Shifted `mock.calls` indices (token fetch became `calls[0]`)
2. Left headers undefined when tests expected them at `calls[0]`

Additionally, the kubectlContext test never set `isAgentUnavailable=false`, so the agent path was skipped entirely.

## Fix

- Use `AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'` in agentFetch tests
- Set `mockIsAgentUnavailable.mockReturnValue(false)` + seed `'kc-agent-token'` for kubectlContext test
- Use non-empty dummy token values to prevent `getAgentToken()` from calling the API