### PR TITLE
fix: replace invalid triple-quote syntax in 4 Playwright specs

### DIFF
--- a/web/e2e/Clusters.spec.ts
+++ b/web/e2e/Clusters.spec.ts
@@ -1,17 +1,12 @@
 import { test, expect, Page } from '@playwright/test'
+import { mockApiFallback } from './helpers/setup'
 
 /**
  * Sets up authentication and MCP mocks for cluster tests
  */
 async function setupClustersTest(page: Page) {
   // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
-  await page.route('''**/api/**''', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: '''application/json''',
-      body: JSON.stringify({}),
-    })
-  )
+  await mockApiFallback(page)
 
   // Mock authentication
   await page.route('**/api/me', (route) =>

--- a/web/e2e/Events.spec.ts
+++ b/web/e2e/Events.spec.ts
@@ -1,17 +1,12 @@
 import { test, expect, Page } from '@playwright/test'
+import { mockApiFallback } from './helpers/setup'
 
 /**
  * Sets up authentication and MCP mocks for events tests
  */
 async function setupEventsTest(page: Page) {
   // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
-  await page.route('''**/api/**''', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: '''application/json''',
-      body: JSON.stringify({}),
-    })
-  )
+  await mockApiFallback(page)
 
   // Mock authentication
   await page.route('**/api/me', (route) =>

--- a/web/e2e/Sidebar.spec.ts
+++ b/web/e2e/Sidebar.spec.ts
@@ -1,17 +1,12 @@
 import { test, expect, Page } from '@playwright/test'
+import { mockApiFallback } from './helpers/setup'
 
 /**
  * Sets up authentication and MCP mocks for sidebar tests
  */
 async function setupSidebarTest(page: Page) {
   // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
-  await page.route('''**/api/**''', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: '''application/json''',
-      body: JSON.stringify({}),
-    })
-  )
+  await mockApiFallback(page)
 
   // Mock authentication
   await page.route('**/api/me', (route) =>

--- a/web/e2e/Tour.spec.ts
+++ b/web/e2e/Tour.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test'
+import { mockApiFallback } from './helpers/setup'
 
 /**
  * Sets up authentication and MCP mocks for tour tests.
@@ -14,13 +15,7 @@ import { test, expect, Page } from '@playwright/test'
  */
 async function setupTourTest(page: Page, tourCompleted: boolean = true) {
   // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
-  await page.route('''**/api/**''', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: '''application/json''',
-      body: JSON.stringify({}),
-    })
-  )
+  await mockApiFallback(page)
 
   // Mock authentication
   await page.route('**/api/me', (route) =>


### PR DESCRIPTION
## Summary
- Copilot review on #10371 flagged invalid triple single-quotes (`'''..'''`) in 4 Playwright test files — this is not valid TypeScript and prevents the specs from compiling
- Replaced duplicated inline API mock blocks with `mockApiFallback(page)` from `helpers/setup.ts`
- Affected files: `Tour.spec.ts`, `Events.spec.ts`, `Clusters.spec.ts`, `Sidebar.spec.ts`

## Test plan
- [ ] Playwright E2E tests compile and run without syntax errors
- [ ] All 4 spec files use the shared `mockApiFallback` helper instead of inline duplicates

Fixes Copilot review comments on #10371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)