### PR TITLE
🐛 Fix triple-quote syntax errors in Playwright e2e tests

### DIFF
--- a/web/e2e/Clusters.spec.ts
+++ b/web/e2e/Clusters.spec.ts
@@ -5,10 +5,10 @@ import { test, expect, Page } from '@playwright/test'
  */
 async function setupClustersTest(page: Page) {
   // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
-  await page.route('''**/api/**''', (route) =>
+  await page.route('**/api/**', (route) =>
     route.fulfill({
       status: 200,
-      contentType: '''application/json''',
+      contentType: 'application/json',
       body: JSON.stringify({}),
     })
   )

--- a/web/e2e/Events.spec.ts
+++ b/web/e2e/Events.spec.ts
@@ -5,10 +5,10 @@ import { test, expect, Page } from '@playwright/test'
  */
 async function setupEventsTest(page: Page) {
   // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
-  await page.route('''**/api/**''', (route) =>
+  await page.route('**/api/**', (route) =>
     route.fulfill({
       status: 200,
-      contentType: '''application/json''',
+      contentType: 'application/json',
       body: JSON.stringify({}),
     })
   )

--- a/web/e2e/Sidebar.spec.ts
+++ b/web/e2e/Sidebar.spec.ts
@@ -5,10 +5,10 @@ import { test, expect, Page } from '@playwright/test'
  */
 async function setupSidebarTest(page: Page) {
   // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
-  await page.route('''**/api/**''', (route) =>
+  await page.route('**/api/**', (route) =>
     route.fulfill({
       status: 200,
-      contentType: '''application/json''',
+      contentType: 'application/json',
       body: JSON.stringify({}),
     })
   )

--- a/web/e2e/Tour.spec.ts
+++ b/web/e2e/Tour.spec.ts
@@ -14,10 +14,10 @@ import { test, expect, Page } from '@playwright/test'
  */
 async function setupTourTest(page: Page, tourCompleted: boolean = true) {
   // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
-  await page.route('''**/api/**''', (route) =>
+  await page.route('**/api/**', (route) =>
     route.fulfill({
       status: 200,
-      contentType: '''application/json''',
+      contentType: 'application/json',
       body: JSON.stringify({}),
     })
   )


### PR DESCRIPTION
## Problem

Playwright nightly tests are failing across all shards (chromium, mobile) with:
```
SyntaxError: Unexpected token, expected "," (17:21)
  await page.route('''**/api/**''', (route) =>
```

Four e2e test files contain Python-style triple single quotes (`'''`) instead of standard JavaScript single quotes (`'`), causing all tests that import these files to fail with a syntax error.

## Fix

Replace `'''` with `'` in the catch-all API mock routes in:
- `web/e2e/Tour.spec.ts`
- `web/e2e/Sidebar.spec.ts`
- `web/e2e/Clusters.spec.ts`
- `web/e2e/Events.spec.ts`

## Impact

This should restore Playwright nightly to green for all browsers.