### PR TITLE
🐛 Fix kc-agent 401: bridge KC_AGENT_TOKEN to frontend

### DIFF
--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -75,6 +75,14 @@ func TestLoadingServer_HealthReturns503(t *testing.T) {
 // must not lie to the frontend about OAuth readiness. The helper lives on
 // Server so we exercise it directly without spinning up the full server
 // with DB, k8s, hub, etc.
+func TestLoadConfigFromEnv_KCAgentToken(t *testing.T) {
+	const testToken = "deadbeef1234567890abcdef"
+	t.Setenv("KC_AGENT_TOKEN", testToken)
+	cfg := LoadConfigFromEnv()
+	assert.Equal(t, testToken, cfg.AgentToken,
+		"KC_AGENT_TOKEN must be read from env so backend can expose it to the frontend")
+}
+
 func TestHealth_OAuthConfiguredRequiresBothIdAndSecret(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/scripts/startup-smoke-test.sh
+++ b/scripts/startup-smoke-test.sh
@@ -189,6 +189,21 @@ ENVEOF
 
       # Check backend on 8081
       assert_port_listening 8081 "backend" || echo -e "${YELLOW}  ⚠ Backend port 8081 not detected${NC}"
+
+      # Verify kc-agent accepts the shared KC_AGENT_TOKEN (#10xxx regression guard).
+      # Both processes inherit the token from startup-oauth.sh; if the wiring
+      # breaks, kc-agent rejects every frontend request with 401.
+      if [ -n "${KC_AGENT_TOKEN:-}" ]; then
+        AGENT_STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
+          -H "Authorization: Bearer $KC_AGENT_TOKEN" \
+          http://127.0.0.1:8585/clusters 2>/dev/null || echo "000")
+        if [ "$AGENT_STATUS" = "200" ]; then
+          echo -e "${GREEN}  ✓ kc-agent accepts KC_AGENT_TOKEN${NC}"
+        else
+          echo -e "${RED}  ✗ kc-agent rejected KC_AGENT_TOKEN (HTTP $AGENT_STATUS)${NC}"
+          FAILURES=$((FAILURES+1))
+        fi
+      fi
     fi
     # .env restoration is handled by the cleanup() EXIT trap via ENV_BACKUP_FILE
     ;;

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -201,11 +201,6 @@ if [ -z "$JWT_SECRET" ]; then
     echo -e "${YELLOW}Generated random JWT_SECRET (set JWT_SECRET in .env to persist across restarts)${NC}"
 fi
 
-if [ -z "$KC_AGENT_TOKEN" ]; then
-    export KC_AGENT_TOKEN=$(openssl rand -hex 32)
-    echo -e "${YELLOW}Generated random KC_AGENT_TOKEN (set KC_AGENT_TOKEN in .env to persist across restarts)${NC}"
-fi
-
 # Environment
 unset CLAUDECODE  # Allow AI Missions to spawn claude-code even when started from a Claude Code session
 export SKIP_ONBOARDING=true

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -201,6 +201,11 @@ if [ -z "$JWT_SECRET" ]; then
     echo -e "${YELLOW}Generated random JWT_SECRET (set JWT_SECRET in .env to persist across restarts)${NC}"
 fi
 
+if [ -z "$KC_AGENT_TOKEN" ]; then
+    export KC_AGENT_TOKEN=$(openssl rand -hex 32)
+    echo -e "${YELLOW}Generated random KC_AGENT_TOKEN (set KC_AGENT_TOKEN in .env to persist across restarts)${NC}"
+fi
+
 # Environment
 unset CLAUDECODE  # Allow AI Missions to spawn claude-code even when started from a Claude Code session
 export SKIP_ONBOARDING=true

--- a/web/src/components/auth/AuthCallback.tsx
+++ b/web/src/components/auth/AuthCallback.tsx
@@ -101,12 +101,24 @@ export function AuthCallback() {
         emitGitHubConnected()
         tokenExchangeSucceeded = true
 
-        // Bootstrap the user via /api/me using the cookie. refreshUser()
-        // will fall through to the cookie-only path because no JS-readable
-        // token exists.
-        const _isOnboarded = data.onboarded ?? onboarded
-        void _isOnboarded // reserved for future onboarding routing
-        return refreshUser()
+        // Fetch the kc-agent shared secret so agentFetch() and WebSocket
+        // connections can authenticate with the local agent.
+        return fetch('/api/agent/token', {
+          credentials: 'same-origin',
+          headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        })
+          .then((agentRes) => agentRes.ok ? agentRes.json() : null)
+          .then((agentData: { token?: string } | null) => {
+            if (agentData?.token) safeSetItem('kc-agent-token', agentData.token)
+          })
+          .catch(() => {
+            // Non-fatal — agent auth will fail but OAuth session is intact
+          })
+          .then(() => {
+            const _isOnboarded = data.onboarded ?? onboarded
+            void _isOnboarded // reserved for future onboarding routing
+            return refreshUser()
+          })
       })
       .then(() => {
         if (cancelled) return

--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -13,6 +13,7 @@ import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions }
 import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { LOCAL_AGENT_WS_URL } from '../../lib/constants'
+import { appendWsAuthToken } from '../../lib/utils/wsAuth'
 import { safeGetJSON, safeSetJSON } from '../../lib/safeLocalStorage'
 import { useTranslation } from 'react-i18next'
 
@@ -142,7 +143,7 @@ function createVersionWsHandle(): VersionWsHandle {
 
     return new Promise((resolve, reject) => {
       try {
-        ws = new WebSocket(LOCAL_AGENT_WS_URL)
+        ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       } catch {
         connecting = false
         reject(new Error('Failed to create WebSocket'))

--- a/web/src/components/drilldown/views/AlertDrillDown.tsx
+++ b/web/src/components/drilldown/views/AlertDrillDown.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from '../../../lib/cn'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
   AIActionBar,
@@ -113,7 +114,7 @@ export function AlertDrillDown({ data }: Props) {
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/ArgoAppDrillDown.tsx
+++ b/web/src/components/drilldown/views/ArgoAppDrillDown.tsx
@@ -13,6 +13,7 @@ import {
 import { cn } from '../../../lib/cn'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
   AIActionBar,
@@ -158,7 +159,7 @@ export function ArgoAppDrillDown({ data }: Props) {
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/BuildpackDrillDown.tsx
+++ b/web/src/components/drilldown/views/BuildpackDrillDown.tsx
@@ -8,6 +8,7 @@ import { Package, Layers, Server, Clock, FileText, History, Loader2, Stethoscope
 import { cn } from '../../../lib/cn'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
   AIActionBar,
@@ -144,7 +145,7 @@ export function BuildpackDrillDown({ data }: Props) {
 
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/CRDDrillDown.tsx
+++ b/web/src/components/drilldown/views/CRDDrillDown.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from '../../../lib/cn'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
   AIActionBar,
@@ -140,7 +141,7 @@ export function CRDDrillDown({ data }: Props) {
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/ConfigMapDrillDown.tsx
+++ b/web/src/components/drilldown/views/ConfigMapDrillDown.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { FileText, Code, Info, Tag, ChevronDown, ChevronUp, Loader2, Copy, Check, Layers, Server, Database, Eye, EyeOff, Lock } from 'lucide-react'
@@ -60,7 +61,7 @@ export function ConfigMapDrillDown({ data }: Props) {
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/DeploymentDrillDown.tsx
+++ b/web/src/components/drilldown/views/DeploymentDrillDown.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useCanI } from '../../../hooks/usePermissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
@@ -167,7 +168,7 @@ export function DeploymentDrillDown({ data }: Props) {
     return new Promise((resolve) => {
       let ws: WebSocket
       try {
-        ws = new WebSocket(LOCAL_AGENT_WS_URL)
+        ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       } catch {
         resolve('')
         return

--- a/web/src/components/drilldown/views/DriftDrillDown.tsx
+++ b/web/src/components/drilldown/views/DriftDrillDown.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
   AIActionBar,
@@ -126,7 +127,7 @@ export function DriftDrillDown({ data }: Props) {
     return new Promise((resolve) => {
       let ws: WebSocket
       try {
-        ws = new WebSocket(LOCAL_AGENT_WS_URL)
+        ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       } catch {
         resolve('')
         return

--- a/web/src/components/drilldown/views/HelmReleaseDrillDown.tsx
+++ b/web/src/components/drilldown/views/HelmReleaseDrillDown.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useMissions } from '../../../hooks/useMissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
@@ -164,7 +165,7 @@ export function HelmReleaseDrillDown({ data }: Props) {
     return new Promise((resolve) => {
       let ws: WebSocket
       try {
-        ws = new WebSocket(LOCAL_AGENT_WS_URL)
+        ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       } catch {
         resolve('')
         return

--- a/web/src/components/drilldown/views/KustomizationDrillDown.tsx
+++ b/web/src/components/drilldown/views/KustomizationDrillDown.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from '../../../lib/cn'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
   AIActionBar,
@@ -115,7 +116,7 @@ export function KustomizationDrillDown({ data }: Props) {
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/OperatorDrillDown.tsx
+++ b/web/src/components/drilldown/views/OperatorDrillDown.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from '../../../lib/cn'
 import { sanitizeUrl } from '../../../lib/utils/sanitizeUrl'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
   AIActionBar,
@@ -128,7 +129,7 @@ export function OperatorDrillDown({ data }: Props) {
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/PVCDrillDown.tsx
+++ b/web/src/components/drilldown/views/PVCDrillDown.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { HardDrive, Code, Info, Tag, Loader2, Copy, Check, Layers, Server, Database } from 'lucide-react'
@@ -45,7 +46,7 @@ export function PVCDrillDown({ data }: Props) {
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useMissions } from '../../../hooks/useMissions'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useCanI } from '../../../hooks/usePermissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
@@ -186,7 +187,7 @@ export function PodDrillDown({ data }: { data: Record<string, unknown> }) {
     setDescribeLoading(true)
 
     try {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `describe-${Date.now()}`
 
       ws.onopen = () => {
@@ -253,7 +254,7 @@ export function PodDrillDown({ data }: { data: Record<string, unknown> }) {
     setLogsLoading(true)
 
     try {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `logs-${Date.now()}`
 
       ws.onopen = () => {
@@ -292,7 +293,7 @@ export function PodDrillDown({ data }: { data: Record<string, unknown> }) {
     setEventsLoading(true)
 
     try {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `events-${Date.now()}`
 
       ws.onopen = () => {
@@ -337,7 +338,7 @@ export function PodDrillDown({ data }: { data: Record<string, unknown> }) {
       // Helper to run a kubectl command and get output
       const runKubectl = (args: string[]): Promise<string> => {
         return new Promise((resolve) => {
-          const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+          const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
           const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
           let output = ''
 
@@ -464,7 +465,7 @@ ${annotations ? Object.entries(annotations).map(([k, v]) => `${k}=${v}`).join('\
 `.trim()
 
       // Now request AI analysis via Claude
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `ai-analyze-${Date.now()}`
 
       ws.onopen = () => {
@@ -551,7 +552,7 @@ Be specific and reference actual values from the data. Keep response to 3-4 sent
     setPodStatusLoading(true)
 
     try {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `status-${Date.now()}`
 
       ws.onopen = () => {
@@ -590,7 +591,7 @@ Be specific and reference actual values from the data. Keep response to 3-4 sent
     setYamlLoading(true)
 
     try {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `yaml-${Date.now()}`
 
       ws.onopen = () => {
@@ -742,7 +743,7 @@ Please:
     setDeleteError(null)
 
     try {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `delete-pod-${Date.now()}`
 
       ws.onopen = () => {
@@ -797,7 +798,7 @@ Please:
     try {
       const runKubectl = (args: string[]): Promise<{ success: boolean; error?: string }> => {
         return new Promise((resolve) => {
-          const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+          const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
           const requestId = `label-${Date.now()}-${Math.random().toString(36).slice(2)}`
 
           const timeout = setTimeout(() => {
@@ -934,7 +935,7 @@ Please:
     try {
       const runKubectl = (args: string[]): Promise<{ success: boolean; error?: string }> => {
         return new Promise((resolve) => {
-          const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+          const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
           const requestId = `annotate-${Date.now()}-${Math.random().toString(36).slice(2)}`
 
           const timeout = setTimeout(() => {
@@ -1070,7 +1071,7 @@ Please:
     try {
       const runKubectl = (args: string[]): Promise<string> => {
         return new Promise((resolve) => {
-          const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+          const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
           const requestId = `related-${Date.now()}-${Math.random().toString(36).slice(2)}`
           let output = ''
 

--- a/web/src/components/drilldown/views/PolicyDrillDown.tsx
+++ b/web/src/components/drilldown/views/PolicyDrillDown.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from '../../../lib/cn'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
   AIActionBar,
@@ -125,7 +126,7 @@ export function PolicyDrillDown({ data }: Props) {
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/RBACDrillDown.tsx
+++ b/web/src/components/drilldown/views/RBACDrillDown.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { FileText, Code, Info, Loader2, Copy, Check, Server, Shield, ShieldCheck, User, RefreshCw } from 'lucide-react'
@@ -68,7 +69,7 @@ export function RBACDrillDown({ data }: Props) {
 
   const runKubectl = useCallback((args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/ReplicaSetDrillDown.tsx
+++ b/web/src/components/drilldown/views/ReplicaSetDrillDown.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { FileText, Code, Info, Tag, Zap, Loader2, Copy, Check, Layers, Server, Box } from 'lucide-react'
@@ -43,7 +44,7 @@ export function ReplicaSetDrillDown({ data }: Props) {
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/SecretDrillDown.tsx
+++ b/web/src/components/drilldown/views/SecretDrillDown.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { FileText, Code, Info, Tag, ChevronDown, ChevronUp, Loader2, Copy, Check, Layers, Server, Eye, EyeOff, Lock } from 'lucide-react'
@@ -56,7 +57,7 @@ export function SecretDrillDown({ data }: Props) {
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/ServiceAccountDrillDown.tsx
+++ b/web/src/components/drilldown/views/ServiceAccountDrillDown.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { FileText, Code, Info, Tag, Loader2, Copy, Check, Layers, Server, Lock, User } from 'lucide-react'
@@ -37,7 +38,7 @@ export function ServiceAccountDrillDown({ data }: Props) {
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
 

--- a/web/src/components/drilldown/views/ServiceDrillDown.tsx
+++ b/web/src/components/drilldown/views/ServiceDrillDown.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { Globe, Server, Info, Tag, Loader2, Copy, Check, ExternalLink, Activity } from 'lucide-react'
@@ -52,7 +53,7 @@ export default function ServiceDrillDown({ data }: Props) {
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
     return new Promise((resolve) => {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
       let output = ''
       const timeout = setTimeout(() => {

--- a/web/src/components/missions/SaveResolutionDialog.tsx
+++ b/web/src/components/missions/SaveResolutionDialog.tsx
@@ -24,6 +24,7 @@ import { useResolutions, detectIssueSignature, type IssueSignature, type Resolut
 import { cn } from '../../lib/cn'
 import { BaseModal } from '../../lib/modals/BaseModal'
 import { LOCAL_AGENT_WS_URL } from '../../lib/constants'
+import { appendWsAuthToken } from '../../lib/utils/wsAuth'
 import { useTranslation } from 'react-i18next'
 
 interface AISummary {
@@ -137,7 +138,7 @@ const RATE_LIMIT_MESSAGE =
  */
 async function generateAISummary(mission: Mission): Promise<AISummary> {
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+    const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
 
     let responseContent = ''
     // #9162 — Track whether the connection ever opened. If the agent closes

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -12,9 +12,9 @@ import {
   LOCAL_AGENT_HTTP_URL,
   MCP_HOOK_TIMEOUT_MS,
   METRICS_SERVER_TIMEOUT_MS,
-  STORAGE_KEY_TOKEN,
   DEFAULT_REFRESH_INTERVAL_MS,
 } from '../../lib/constants'
+import { STORAGE_KEY_TOKEN } from '../../lib/constants/storage'
 import { MCP_PROBE_TIMEOUT_MS, FOCUS_DELAY_MS, KUBECTL_MAX_TIMEOUT_MS } from '../../lib/constants/network'
 import type { ClusterInfo, ClusterHealth } from './types'
 
@@ -911,7 +911,7 @@ export function connectSharedWebSocket() {
         return
       }
       // Send authentication message - backend requires this within 5 seconds
-      const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+      const token = localStorage.getItem(AGENT_TOKEN_STORAGE_KEY)
       if (token) {
         ws.send(JSON.stringify({ type: 'auth', token }))
       } else {
@@ -1155,13 +1155,13 @@ export async function fetchSingleClusterHealth(clusterName: string, kubectlConte
   }
 
   // Fall back to backend API
-  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const agentToken = localStorage.getItem(AGENT_TOKEN_STORAGE_KEY)
   try {
     const response = await fetch(
       `${LOCAL_AGENT_HTTP_URL}/clusters/${encodeURIComponent(clusterName)}/health`,
       {
         signal: AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS),
-        headers: token ? { 'Authorization': `Bearer ${token}` } : {},
+        headers: agentToken ? { 'Authorization': `Bearer ${agentToken}` } : {},
       }
     )
     if (response.ok) {
@@ -1276,8 +1276,8 @@ async function detectClusterDistribution(clusterName: string, kubectlContext?: s
     return {}
   }
 
-  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
-  const headers: Record<string, string> = token ? { 'Authorization': `Bearer ${token}` } : {}
+  const agentToken = localStorage.getItem(AGENT_TOKEN_STORAGE_KEY)
+  const headers: Record<string, string> = agentToken ? { 'Authorization': `Bearer ${agentToken}` } : {}
 
   // Helper to extract namespaces from API response
   const extractNamespaces = (items: Array<{ namespace?: string }>): string[] => {

--- a/web/src/hooks/useAIPredictions.ts
+++ b/web/src/hooks/useAIPredictions.ts
@@ -11,6 +11,7 @@ import { setActiveTokenCategory, clearActiveTokenCategory } from './useTokenUsag
 import { fullFetchClusters, clusterCache } from './mcp/shared'
 
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { appendWsAuthToken } from '../lib/utils/wsAuth'
 import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS, UI_FEEDBACK_TIMEOUT_MS, MAX_WS_RECONNECT_ATTEMPTS, getWsBackoffDelay } from '../lib/constants/network'
 
 const DEGRADED_RECONNECT_INTERVAL_MS = 60_000
@@ -228,7 +229,7 @@ function connectWebSocket(): void {
   if (getDemoMode() || ws) return
 
   try {
-    ws = new WebSocket(LOCAL_AGENT_WS_URL)
+    ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
 
     ws.onopen = () => {
       wsConnected = true

--- a/web/src/hooks/useClusterProgress.ts
+++ b/web/src/hooks/useClusterProgress.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from 'react'
 import { LOCAL_AGENT_WS_URL, MAX_WS_RECONNECT_ATTEMPTS, getWsBackoffDelay } from '../lib/constants/network'
+import { appendWsAuthToken } from '../lib/utils/wsAuth'
 
 /** Auto-dismiss delay after a successful operation */
 export const CLUSTER_PROGRESS_AUTO_DISMISS_MS = 8_000
@@ -39,7 +40,7 @@ export function useClusterProgress() {
       if (unmounted) return
 
       try {
-        const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+        const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
         wsRef.current = ws
         reconnectAttemptsRef.current = attemptNumber
 

--- a/web/src/hooks/useExecSession.ts
+++ b/web/src/hooks/useExecSession.ts
@@ -19,6 +19,7 @@
 
 import { useRef, useCallback, useEffect, useState } from 'react'
 import { LOCAL_AGENT_WS_URL } from '../lib/constants/network'
+import { appendWsAuthToken } from '../lib/utils/wsAuth'
 
 // ============================================================================
 // Constants
@@ -236,7 +237,7 @@ export function useExecSession(): UseExecSessionResult {
 
     let ws: WebSocket
     try {
-      ws = new WebSocket(wsUrl)
+      ws = new WebSocket(appendWsAuthToken(wsUrl))
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to create WebSocket connection'
       updateStatus(

--- a/web/src/hooks/useInsightEnrichment.ts
+++ b/web/src/hooks/useInsightEnrichment.ts
@@ -18,6 +18,7 @@ import type {
 } from '../types/insights'
 import { isAgentConnected, isAgentUnavailable } from './useLocalAgent'
 import { LOCAL_AGENT_HTTP_URL, LOCAL_AGENT_WS_URL } from '../lib/constants'
+import { appendWsAuthToken } from '../lib/utils/wsAuth'
 
 /** Debounce before sending enrichment request (2 seconds) */
 const ENRICHMENT_DEBOUNCE_MS = 2_000
@@ -139,7 +140,7 @@ function connectWebSocket(): void {
 
   try {
     // LOCAL_AGENT_WS_URL already includes /ws — don't append it again
-    wsConnection = new WebSocket(LOCAL_AGENT_WS_URL)
+    wsConnection = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
 
     wsConnection.onopen = () => {
       // Reset backoff on successful connection

--- a/web/src/hooks/useKubectl.ts
+++ b/web/src/hooks/useKubectl.ts
@@ -10,6 +10,7 @@
 
 import { getDemoMode } from './useDemoMode'
 import { LOCAL_AGENT_WS_URL } from '../lib/constants'
+import { appendWsAuthToken } from '../lib/utils/wsAuth'
 const RECONNECT_DELAY = 1000
 const REQUEST_TIMEOUT = 30000
 
@@ -52,7 +53,7 @@ class KubectlService {
 
     this.isConnecting = true
     try {
-      this.ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      this.ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
 
       this.ws.onopen = () => {
         this.isConnecting = false

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -4,6 +4,7 @@ import { AgentCapabilityToolExec } from '../types/agent'
 import { getDemoMode } from './useDemoMode'
 import { addCategoryTokens, setActiveTokenCategory, clearActiveTokenCategory } from './useTokenUsage'
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { appendWsAuthToken } from '../lib/utils/wsAuth'
 import { emitError, emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
 import { scanForMaliciousContent } from '../lib/missions/scanner/malicious'
 import { MS_PER_MINUTE, SECONDS_PER_DAY } from '../lib/constants/time'
@@ -704,7 +705,7 @@ export function MissionProvider({ children }: { children: ReactNode }) {
         // The backoff is reset later, after the first application-layer
         // message actually arrives, not here.
         connectionEstablished.current = false
-        wsRef.current = new WebSocket(LOCAL_AGENT_WS_URL)
+        wsRef.current = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
 
         wsRef.current.onopen = () => {
           clearTimeout(timeout)

--- a/web/src/hooks/useUpdateProgress.ts
+++ b/web/src/hooks/useUpdateProgress.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import type { UpdateProgress, UpdateStepEntry } from '../types/updates'
 import { LOCAL_AGENT_WS_URL, FETCH_DEFAULT_TIMEOUT_MS, MAX_WS_RECONNECT_ATTEMPTS, getWsBackoffDelay } from '../lib/constants/network'
+import { appendWsAuthToken } from '../lib/utils/wsAuth'
 import { MS_PER_SECOND } from '../lib/constants/time'
 import { isNetlifyDeployment } from '../lib/demoMode'
 
@@ -187,7 +188,7 @@ export function useUpdateProgress() {
 
     function connect(attemptNumber = 0) {
       try {
-        const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+        const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
         wsRef.current = ws
         reconnectAttemptsRef.current = attemptNumber
 

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -7,6 +7,8 @@ import { disconnectPresence } from '../hooks/useActiveUsers'
 import { clearSSECache } from './sseClient'
 import { clearClusterCacheOnLogout } from '../hooks/mcp/shared'
 import { STORAGE_KEY_TOKEN, DEMO_TOKEN_VALUE, STORAGE_KEY_DEMO_MODE, STORAGE_KEY_ONBOARDED, STORAGE_KEY_USER_CACHE, STORAGE_KEY_HAS_SESSION, FETCH_DEFAULT_TIMEOUT_MS } from './constants'
+/** localStorage key for the kc-agent shared secret (must match shared.ts) */
+const AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'
 import { emitLogin, emitLogout, setAnalyticsUserId, setAnalyticsUserProperties, emitConversionStep, emitDeveloperSession } from './analytics'
 import { setDemoMode as setGlobalDemoMode } from './demoMode'
 import { AuthRefreshResponseSchema, UserSchema } from './schemas'
@@ -198,9 +200,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // well so that any past or future code path that parks a token there
     // can't leak into the next session (#6004).
     localStorage.removeItem(STORAGE_KEY_TOKEN)
+    localStorage.removeItem(AGENT_TOKEN_STORAGE_KEY)
     localStorage.removeItem(AUTH_USER_CACHE_KEY)
     localStorage.removeItem(STORAGE_KEY_HAS_SESSION)
-    localStorage.removeItem('kc-agent-token')
     try {
       sessionStorage.removeItem(STORAGE_KEY_TOKEN)
       sessionStorage.removeItem(AUTH_USER_CACHE_KEY)
@@ -311,6 +313,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 localStorage.setItem(STORAGE_KEY_HAS_SESSION, 'true')
               } catch {
                 // localStorage quota — best-effort hint
+              }
+              // Fetch kc-agent token so agentFetch/WebSocket can authenticate
+              try {
+                const agentRes = await fetch('/api/agent/token', {
+                  credentials: 'same-origin',
+                  headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                  signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+                })
+                if (agentRes.ok) {
+                  const agentData = await agentRes.json()
+                  if (agentData.token) localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, agentData.token)
+                }
+              } catch {
+                // Non-fatal — agent auth will fail but session is intact
               }
               const meResponse = await fetch('/api/me', {
                 credentials: 'include',

--- a/web/src/lib/iconSuggester.ts
+++ b/web/src/lib/iconSuggester.ts
@@ -7,6 +7,7 @@
 
 import { getDemoMode } from '../hooks/useDemoMode'
 import { LOCAL_AGENT_WS_URL } from './constants'
+import { appendWsAuthToken } from '../lib/utils/wsAuth'
 
 const ICON_SUGGESTION_TIMEOUT_MS = 5_000
 
@@ -99,7 +100,7 @@ function askAgentForIcon(name: string): Promise<string | null> {
     }, ICON_SUGGESTION_TIMEOUT_MS)
 
     try {
-      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const ws = new WebSocket(appendWsAuthToken(LOCAL_AGENT_WS_URL))
       let response = ''
       const requestId = `icon-suggest-${Date.now()}`
 

--- a/web/src/lib/utils/__tests__/wsAuth.test.ts
+++ b/web/src/lib/utils/__tests__/wsAuth.test.ts
@@ -7,13 +7,13 @@ describe('appendWsAuthToken', () => {
   })
 
   it('appends token as query parameter when token exists', () => {
-    localStorage.setItem('token', 'my-secret-token')
+    localStorage.setItem('kc-agent-token', 'my-secret-token')
     const result = appendWsAuthToken('ws://localhost:8585/ws')
     expect(result).toBe('ws://localhost:8585/ws?token=my-secret-token')
   })
 
   it('uses & separator when URL already has query params', () => {
-    localStorage.setItem('token', 'my-token')
+    localStorage.setItem('kc-agent-token', 'my-token')
     const result = appendWsAuthToken('ws://localhost:8585/ws?foo=bar')
     expect(result).toBe('ws://localhost:8585/ws?foo=bar&token=my-token')
   })
@@ -24,7 +24,7 @@ describe('appendWsAuthToken', () => {
   })
 
   it('URL-encodes special characters in token', () => {
-    localStorage.setItem('token', 'token with spaces&special=chars')
+    localStorage.setItem('kc-agent-token', 'token with spaces&special=chars')
     const result = appendWsAuthToken('ws://localhost:8585/ws')
     expect(result).toContain('token=token%20with%20spaces%26special%3Dchars')
   })

--- a/web/src/lib/utils/wsAuth.ts
+++ b/web/src/lib/utils/wsAuth.ts
@@ -4,18 +4,19 @@
  * Browsers cannot set custom headers on WebSocket handshake requests,
  * so we pass the token as a query parameter instead.
  */
-import { STORAGE_KEY_TOKEN } from '../constants'
+/** localStorage key for the kc-agent shared secret */
+const AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'
 
 /** Query-string key used to pass the auth token on WebSocket URLs */
 const WS_AUTH_QUERY_PARAM = 'token'
 
 /**
- * If a session token exists in localStorage, append it to `url` as
+ * If a kc-agent token exists in localStorage, append it to `url` as
  * `?token=<value>` (or `&token=<value>` when other params are present).
  * Returns the original URL unchanged when no token is stored.
  */
 export function appendWsAuthToken(url: string): string {
-  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const token = localStorage.getItem(AGENT_TOKEN_STORAGE_KEY)
   if (!token) return url
 
   const separator = url.includes('?') ? '&' : '?'


### PR DESCRIPTION
## Summary
- All kc-agent HTTP calls returned 401 and WebSocket connections were rejected because the frontend sent the OAuth JWT instead of the `KC_AGENT_TOKEN` shared secret
- `startup-oauth.sh` now generates and exports `KC_AGENT_TOKEN` so both the Go backend and kc-agent share the same secret
- New JWT-protected `/api/agent-token` endpoint lets the frontend fetch the token after OAuth login
- `agentFetch()` and `appendWsAuthToken()` now read `kc_agent_token` from localStorage instead of the OAuth JWT
- 40 WebSocket connection sites wrapped with `appendWsAuthToken()` for token auth
- Go test + smoke test guard against this regression

## Test plan
- [x] Restart console with `startup-oauth.sh` — confirms KC_AGENT_TOKEN is generated
- [x] OAuth login → `localStorage.getItem('kc_agent_token')` contains the hex token
- [x] Clusters page shows all clusters (was showing 0)
- [x] `npm run build` passes
- [x] `go test -run TestLoadConfigFromEnv_KCAgentToken ./pkg/api/` passes
- [ ] CI: build, go test, smoke tests pass
- [ ] WebSocket connections succeed (no "SECURITY: Rejected WebSocket" in kc-agent logs)