### PR TITLE
fix: update AlertListItem test after DOM nesting fix

### DIFF
--- a/web/src/components/cards/__tests__/AlertListItem.test.tsx
+++ b/web/src/components/cards/__tests__/AlertListItem.test.tsx
@@ -109,9 +109,8 @@ describe('AlertListItem', () => {
   it('calls onAlertClick when the row is clicked', () => {
     renderAlertListItem()
 
-    // Click the main container
-    const container = screen.getByText('HighCPU').closest('.p-2')!
-    fireEvent.click(container)
+    const clickable = screen.getByRole('button', { name: /viewAlertDetailsAria/i })
+    fireEvent.click(clickable)
 
     expect(mockOnAlertClick).toHaveBeenCalledWith(BASE_ALERT)
   })


### PR DESCRIPTION
## Summary
- Update `AlertListItem.test.tsx` to query the clickable area by `role="button"` instead of `.closest('.p-2')` class selector
- The DOM nesting fix (#10382) moved the `onClick` handler from the outer container to an inner `div[role="button"]`, breaking the test's class-based query

Fixes #10384

## Test plan
- [x] `npx vitest run AlertListItem.test.tsx` — all 14 tests pass
- [x] No other tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)