### PR TITLE
🐛 Fix Playwright nightly mobile-safari timeouts

### DIFF
--- a/web/e2e/helpers/setup.ts
+++ b/web/e2e/helpers/setup.ts
@@ -412,4 +412,9 @@ export async function setupDashboardTest(page: Page): Promise<void> {
   })
   await page.goto('/')
   await page.waitForLoadState('domcontentloaded')
+  // Webkit mobile emulation (mobile-safari) is significantly slower to
+  // stabilize the DOM after domcontentloaded — wait for the main layout
+  // element to be visible so assertions in beforeEach don't time out
+  // (#nightly-playwright).
+  await page.locator('#root').waitFor({ state: 'visible', timeout: 15000 })
 }

--- a/web/e2e/navbar-responsive.spec.ts
+++ b/web/e2e/navbar-responsive.spec.ts
@@ -39,10 +39,15 @@ async function setupPage(page: Page) {
   // page.addInitScript() injects the snippet ahead of any page code (#9096).
   await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
+    localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
   })
   await page.goto('/')
   await page.waitForLoadState('domcontentloaded')
+  // Wait for the navbar to be fully rendered — webkit/mobile-safari can be
+  // slower to stabilize layout after domcontentloaded, causing click actions
+  // to fail with "waiting for element to be stable" (#nightly-playwright).
+  await page.locator('nav[data-tour="navbar"]').waitFor({ state: 'visible' })
 }
 
 // Breakpoints from Navbar.tsx:
@@ -109,7 +114,11 @@ test.describe('Navbar responsive layout', () => {
 
     const nav = page.locator('nav[data-tour="navbar"]')
     const overflowBtn = nav.getByRole('button', { name: /more options/i })
-    await overflowBtn.click()
+    // Webkit mobile emulation can report the button as "not stable" while
+    // CSS transitions are settling. Wait for visibility first, then force
+    // click to bypass the stability check (#nightly-playwright).
+    await expect(overflowBtn).toBeVisible()
+    await overflowBtn.click({ force: true })
 
     // At least one item from the lg-hidden group should now be visible
     const panel = page.locator('.fixed.bg-card').last()


### PR DESCRIPTION
Fixes persistent mobile-safari failures in Playwright Cross-Browser (Nightly) workflow.

## Root cause
Mobile-safari (webkit) emulation on CI runners is significantly slower than Chromium. Three issues:

1. **Missing demo mode** in navbar-responsive `setupPage()` — without `kc-demo-mode=true`, the app makes API calls that stall webkit
2. **Insufficient DOM readiness wait** — `domcontentloaded` fires before webkit stabilizes layout, causing 30s timeouts in `beforeEach`
3. **Button click instability** — webkit reports overflow button as 'not stable' during CSS transitions

## Changes
- `web/e2e/navbar-responsive.spec.ts`: Add `kc-demo-mode=true` to localStorage, wait for navbar visibility, use `force: true` on overflow click
- `web/e2e/helpers/setup.ts`: Add `#root` visibility wait after navigation in `setupDashboardTest()`

## Failing tests fixed
- `[mobile-safari] navbar-responsive.spec.ts:97` — overflow menu button timeout
- `[mobile-safari] Dashboard.spec.ts:47,355,445` — beforeEach timeout
- 5 flaky mobile-safari tests stabilized