### PR TITLE
🐛 kc-agent: fix /federation/detect returning 500

### DIFF
--- a/pkg/agent/server_federation.go
+++ b/pkg/agent/server_federation.go
@@ -12,7 +12,7 @@ package agent
 // Identity: all reads run through the dynamic client that kc-agent resolves
 // from the user's kubeconfig via MultiClusterClient.GetRestConfig. There is
 // NO pod-ServiceAccount fallback — if the user's bearer token is not on
-// the request the handler returns 500 to make the absence of identity loud
+// the request the handler returns 401 to make the absence of identity loud
 // instead of silently falling through to cluster-level credentials.
 //
 // Fan-out: when `?cluster=` is omitted, the handler iterates every
@@ -31,6 +31,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -80,7 +81,8 @@ func (s *Server) handleFederationDetect(w http.ResponseWriter, r *http.Request) 
 
 	contexts, err := s.resolveFederationContexts(ctx, r)
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		slog.Warn("federation detect: failed to resolve contexts, returning empty", "error", err)
+		writeJSON(w, []federation.ProviderHubStatus{})
 		return
 	}
 	providers := federation.All()
@@ -188,15 +190,16 @@ func (s *Server) handleFederationRead(
 // requireBearerToken enforces the "no pod-SA fallback" contract. It returns
 // true only when the request carries a valid bearer token (or the agent was
 // started without token auth — which is the dev-only path). On missing /
-// mismatching tokens it responds 500 and returns false, per the plan's
-// explicit requirement. This is intentionally stricter than the 401 used by
-// most other kc-agent handlers: federation reads must NEVER execute without
-// user identity, and 500 signals that loudly to anyone monitoring the agent.
+// mismatching tokens it responds 401 Unauthorized and returns false.
+// Federation reads must NEVER execute without user identity; 401 is the
+// semantically correct HTTP status for missing or invalid authentication
+// and lets clients (and monitoring) distinguish auth failures from real
+// server errors.
 func (s *Server) requireBearerToken(w http.ResponseWriter, r *http.Request) bool {
 	if s.validateToken(r) {
 		return true
 	}
-	writeJSONError(w, http.StatusInternalServerError, "bearer token required for federation reads — no pod-SA fallback")
+	writeJSONError(w, http.StatusUnauthorized, "bearer token required for federation reads — no pod-SA fallback")
 	return false
 }
 

--- a/pkg/agent/server_federation_test.go
+++ b/pkg/agent/server_federation_test.go
@@ -172,12 +172,11 @@ func writeTestKubeconfig(t *testing.T, path string, entries map[string]string) {
 	}
 }
 
-// TestHandler_MissingBearerToken_500 asserts the plan's "no pod-SA fallback"
+// TestHandler_MissingBearerToken_401 asserts the "no pod-SA fallback"
 // contract: a federation read request without a valid bearer token returns
-// HTTP 500, loudly signaling the missing identity. 500 (not 401) is
-// intentional — it flags the class of request that must never execute
-// against the pod SA's identity.
-func TestHandler_MissingBearerToken_500(t *testing.T) {
+// HTTP 401 Unauthorized, loudly signaling the missing identity with the
+// semantically correct status code.
+func TestHandler_MissingBearerToken_401(t *testing.T) {
 	s := newTestServer(t, "", testBearerToken)
 
 	endpoints := []string{
@@ -199,8 +198,8 @@ func TestHandler_MissingBearerToken_500(t *testing.T) {
 			// No Authorization header at all — the strict test.
 			w := httptest.NewRecorder()
 			handlers[e](w, req)
-			if w.Code != http.StatusInternalServerError {
-				t.Fatalf("%s: got %d, want 500", e, w.Code)
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("%s: got %d, want 401", e, w.Code)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #10390

## Summary
The `/federation/detect` endpoint was returning 500 Internal Server Error when kubeconfig contexts were unavailable or auth token was missing. This fix:

1. Returns an empty array (`[]`) with 200 OK when contexts can't be resolved (graceful degradation)
2. Changes `requireBearerToken` to return 401 instead of 500 (semantically correct HTTP status)
3. Logs a warning instead of failing hard

## Impact
- No more 500 errors in browser console when federation is not configured
- Clean empty response allows the frontend to handle gracefully
- Auth failures now return proper 401 status

## Testing
- Existing federation tests pass (`go test ./pkg/agent/... -count=1`)
- Updated `TestHandler_MissingBearerToken_401` to match new 401 status