### PR TITLE
🌱 Add 52 tests for coverage increase toward 91% target

### DIFF
--- a/web/src/components/dashboard/customizer/sections/__tests__/TemplateGallerySection.test.tsx
+++ b/web/src/components/dashboard/customizer/sections/__tests__/TemplateGallerySection.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (k: string, fallback?: string) => fallback ?? k,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+vi.mock('lucide-react', () => ({
+  Check: (props: Record<string, unknown>) => <span data-testid="check-icon" {...props} />,
+  Search: (props: Record<string, unknown>) => <span data-testid="search-icon" {...props} />,
+}))
+
+vi.mock('../../../../../lib/formatCardTitle', () => ({
+  formatCardTitle: (type: string) => type.replace(/_/g, ' '),
+}))
+
+vi.mock('../../../../../lib/icons', () => ({
+  getIcon: () => (props: Record<string, unknown>) => <span data-testid="cat-icon" {...props} />,
+}))
+
+vi.mock('../../../templates', () => ({
+  DASHBOARD_TEMPLATES: [
+    {
+      id: 'tpl-1',
+      name: 'Test Template',
+      description: 'A test template',
+      icon: 'Globe',
+      category: 'cluster',
+      cards: [
+        { card_type: 'cluster_health', position: { w: 4, h: 2 } },
+        { card_type: 'pod_issues', position: { w: 4, h: 2 } },
+      ],
+    },
+    {
+      id: 'tpl-2',
+      name: 'Another Template',
+      description: 'Another test template',
+      icon: 'Box',
+      category: 'workloads',
+      cards: [
+        { card_type: 'deployment_status', position: { w: 4, h: 2 } },
+      ],
+    },
+  ],
+  TEMPLATE_CATEGORIES: [
+    { id: 'cluster', name: 'Cluster', icon: 'Globe' },
+    { id: 'workloads', name: 'Workloads', icon: 'Box' },
+  ],
+}))
+
+import { TemplateGallerySection } from '../TemplateGallerySection'
+
+describe('TemplateGallerySection', () => {
+  const onReplace = vi.fn()
+  const onAdd = vi.fn()
+
+  const renderComponent = (dashboardName?: string) =>
+    render(
+      <TemplateGallerySection
+        onReplaceWithTemplate={onReplace}
+        onAddTemplate={onAdd}
+        dashboardName={dashboardName}
+      />
+    )
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders template cards', () => {
+    renderComponent()
+    expect(screen.getByText('Test Template Collection')).toBeDefined()
+    expect(screen.getByText('Another Template Collection')).toBeDefined()
+  })
+
+  it('renders template descriptions', () => {
+    renderComponent()
+    expect(screen.getByText('A test template')).toBeDefined()
+    expect(screen.getByText('Another test template')).toBeDefined()
+  })
+
+  it('renders card count for each template', () => {
+    renderComponent()
+    expect(screen.getByText('2 cards')).toBeDefined()
+    expect(screen.getByText('1 cards')).toBeDefined()
+  })
+
+  it('shows dashboard name in description when provided', () => {
+    renderComponent('MyDash')
+    expect(screen.getByText(/MyDash dashboard/)).toBeDefined()
+  })
+
+  it('shows generic text when no dashboard name', () => {
+    renderComponent()
+    expect(screen.getByText(/current dashboard/)).toBeDefined()
+  })
+
+  it('renders category filter buttons', () => {
+    renderComponent()
+    expect(screen.getByText('All')).toBeDefined()
+    expect(screen.getByText('Cluster')).toBeDefined()
+    expect(screen.getByText('Workloads')).toBeDefined()
+  })
+
+  it('filters templates by category', () => {
+    renderComponent()
+    fireEvent.click(screen.getByText('Workloads'))
+    expect(screen.queryByText('Test Template Collection')).toBeNull()
+    expect(screen.getByText('Another Template Collection')).toBeDefined()
+  })
+
+  it('shows all templates when All filter is clicked', () => {
+    renderComponent()
+    fireEvent.click(screen.getByText('Workloads'))
+    fireEvent.click(screen.getByText('All'))
+    expect(screen.getByText('Test Template Collection')).toBeDefined()
+    expect(screen.getByText('Another Template Collection')).toBeDefined()
+  })
+
+  it('filters templates by search text', () => {
+    renderComponent()
+    const searchInput = screen.getByPlaceholderText('Search collections...')
+    fireEvent.change(searchInput, { target: { value: 'Another' } })
+    expect(screen.queryByText('Test Template Collection')).toBeNull()
+    expect(screen.getByText('Another Template Collection')).toBeDefined()
+  })
+
+  it('calls onAddTemplate when + Add is clicked', () => {
+    renderComponent()
+    const addButtons = screen.getAllByText('+ Add')
+    fireEvent.click(addButtons[0])
+    expect(onAdd).toHaveBeenCalledTimes(1)
+    expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({ id: 'tpl-1' }))
+  })
+
+  it('calls onReplaceWithTemplate when Replace is clicked', () => {
+    renderComponent()
+    const replaceButtons = screen.getAllByText('Replace')
+    fireEvent.click(replaceButtons[0])
+    expect(onReplace).toHaveBeenCalledTimes(1)
+    expect(onReplace).toHaveBeenCalledWith(expect.objectContaining({ id: 'tpl-1' }))
+  })
+
+  it('shows Applied confirmation after clicking Add', () => {
+    renderComponent()
+    const addButtons = screen.getAllByText('+ Add')
+    fireEvent.click(addButtons[0])
+    expect(screen.getByText('Applied')).toBeDefined()
+  })
+
+  it('renders search input', () => {
+    renderComponent()
+    expect(screen.getByPlaceholderText('Search collections...')).toBeDefined()
+  })
+})

--- a/web/src/hooks/__tests__/useCachedKeda.test.ts
+++ b/web/src/hooks/__tests__/useCachedKeda.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockUseCache = vi.fn()
+vi.mock('../../lib/cache', () => ({
+    useCache: (args: Record<string, unknown>) => mockUseCache(args),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../useDemoMode', () => ({
+    useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+    isDemoModeForced: () => false,
+    canToggleDemoMode: () => true,
+    isNetlifyDeployment: () => false,
+    isDemoToken: () => false,
+    hasRealToken: () => true,
+    setDemoToken: vi.fn(),
+    getDemoMode: () => false,
+    setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../components/cards/CardDataContext', () => ({
+    useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false }),
+}))
+
+vi.mock('../../lib/api', () => ({
+    authFetch: vi.fn(),
+}))
+
+vi.mock('../../lib/constants', () => ({
+    FETCH_DEFAULT_TIMEOUT_MS: 10000,
+}))
+
+vi.mock('../../lib/constants/network', () => ({
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+import { useCachedKeda } from '../useCachedKeda'
+
+describe('useCachedKeda', () => {
+    const defaultData = {
+        health: 'not-installed',
+        operatorPods: { ready: 0, total: 0 },
+        scaledObjects: [],
+        totalScaledJobs: 0,
+        lastCheckTime: '2024-01-01T00:00:00.000Z',
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockIsDemoMode.mockReturnValue(false)
+        mockUseCache.mockReturnValue({
+            data: defaultData,
+            isLoading: false,
+            isRefreshing: false,
+            isDemoFallback: false,
+            error: null,
+            isFailed: false,
+            consecutiveFailures: 0,
+            lastRefresh: 123456789,
+            refetch: vi.fn(),
+        })
+    })
+
+    it('returns data from cache when not in demo mode', () => {
+        const { result } = renderHook(() => useCachedKeda())
+        expect(result.current.data.health).toBe('not-installed')
+        expect(result.current.isDemoFallback).toBe(false)
+    })
+
+    it('returns isDemoFallback from cache result', () => {
+        mockUseCache.mockReturnValue({
+            data: defaultData,
+            isLoading: false,
+            isRefreshing: false,
+            isDemoFallback: true,
+            error: null,
+            isFailed: false,
+            consecutiveFailures: 0,
+            lastRefresh: null,
+            refetch: vi.fn(),
+        })
+        const { result } = renderHook(() => useCachedKeda())
+        expect(result.current.isDemoFallback).toBe(true)
+    })
+
+    it('respects isLoading state', () => {
+        mockUseCache.mockReturnValue({
+            data: defaultData,
+            isLoading: true,
+            isRefreshing: false,
+            isDemoFallback: false,
+            error: null,
+            isFailed: false,
+            consecutiveFailures: 0,
+            lastRefresh: null,
+            refetch: vi.fn(),
+        })
+        const { result } = renderHook(() => useCachedKeda())
+        expect(result.current.loading).toBe(true)
+    })
+
+    it('passes correct cache key to useCache', () => {
+        renderHook(() => useCachedKeda())
+        expect(mockUseCache).toHaveBeenCalledWith(
+            expect.objectContaining({ key: 'keda-status' })
+        )
+    })
+
+    it('forwards error from cache result', () => {
+        mockUseCache.mockReturnValue({
+            data: defaultData,
+            isLoading: false,
+            isRefreshing: false,
+            isDemoFallback: false,
+            error: new Error('test'),
+            isFailed: true,
+            consecutiveFailures: 2,
+            lastRefresh: null,
+            refetch: vi.fn(),
+        })
+        const { result } = renderHook(() => useCachedKeda())
+        expect(result.current.error).toBe(true)
+    })
+})

--- a/web/src/lib/acmm/sources/__tests__/acmm.test.ts
+++ b/web/src/lib/acmm/sources/__tests__/acmm.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { acmmSource } from '../acmm'
+
+const VALID_CATEGORIES = new Set([
+  'feedback-loop', 'readiness', 'autonomy', 'observability',
+  'governance', 'self-tuning', 'prerequisite', 'learning', 'traceability',
+])
+
+describe('acmmSource', () => {
+  it('has required source metadata fields', () => {
+    expect(acmmSource.id).toBe('acmm')
+    expect(acmmSource.name).toBe('AI Codebase Maturity Model')
+    expect(acmmSource.url).toBeTruthy()
+    expect(acmmSource.citation).toBeTruthy()
+    expect(acmmSource.definesLevels).toBe(true)
+    expect(acmmSource.levels).toBeDefined()
+    expect(acmmSource.criteria).toBeDefined()
+  })
+
+  describe('levels', () => {
+    it('has 7 levels (0-6)', () => {
+      expect(acmmSource.levels).toHaveLength(7)
+    })
+
+    it('levels are ordered 0 through 6', () => {
+      const levels = acmmSource.levels!
+      for (let i = 0; i < levels.length; i++) {
+        expect(levels[i].n).toBe(i)
+      }
+    })
+
+    it('each level has required fields', () => {
+      for (const level of acmmSource.levels!) {
+        expect(typeof level.n).toBe('number')
+        expect(level.name).toBeTruthy()
+        expect(typeof level.characteristic).toBe('string')
+        expect(typeof level.transitionTrigger).toBe('string')
+        expect(typeof level.antiPattern).toBe('string')
+      }
+    })
+
+    it('each level except L0 has a role', () => {
+      const levels = acmmSource.levels!
+      expect(levels[0].role).toBe('')
+      for (let i = 1; i < levels.length; i++) {
+        expect(levels[i].role).toBeTruthy()
+      }
+    })
+  })
+
+  describe('criteria', () => {
+    it('has a non-empty criteria array', () => {
+      expect(acmmSource.criteria.length).toBeGreaterThan(0)
+    })
+
+    it('each criterion has required fields', () => {
+      for (const c of acmmSource.criteria) {
+        expect(c.id).toBeTruthy()
+        expect(c.source).toBe('acmm')
+        expect(typeof c.level).toBe('number')
+        expect(c.category).toBeTruthy()
+        expect(c.name).toBeTruthy()
+        expect(c.description).toBeTruthy()
+        expect(c.rationale).toBeTruthy()
+        expect(c.detection).toBeDefined()
+      }
+    })
+
+    it('all criterion levels are in range 0-6', () => {
+      for (const c of acmmSource.criteria) {
+        expect(c.level).toBeGreaterThanOrEqual(0)
+        expect(c.level).toBeLessThanOrEqual(6)
+      }
+    })
+
+    it('has no duplicate criterion IDs', () => {
+      const ids = acmmSource.criteria.map(c => c.id)
+      expect(new Set(ids).size).toBe(ids.length)
+    })
+
+    it('all criterion IDs start with acmm:', () => {
+      for (const c of acmmSource.criteria) {
+        expect(c.id.startsWith('acmm:')).toBe(true)
+      }
+    })
+
+    it('all categories are from the expected set', () => {
+      for (const c of acmmSource.criteria) {
+        expect(VALID_CATEGORIES.has(c.category)).toBe(true)
+      }
+    })
+
+    it('scannable criteria have a detection field', () => {
+      const scannableCriteria = acmmSource.criteria.filter(c => c.scannable === true)
+      for (const c of scannableCriteria) {
+        expect(c.detection).toBeDefined()
+        expect(c.detection.type).toBeTruthy()
+      }
+    })
+
+    it('all criteria have valid detection types', () => {
+      for (const c of acmmSource.criteria) {
+        expect(['path', 'glob', 'any-of']).toContain(c.detection.type)
+        const patterns = Array.isArray(c.detection.pattern)
+          ? c.detection.pattern
+          : [c.detection.pattern]
+        expect(patterns.length).toBeGreaterThan(0)
+      }
+    })
+
+    it('has criteria across multiple levels', () => {
+      const levelsUsed = new Set(acmmSource.criteria.map(c => c.level))
+      expect(levelsUsed.size).toBeGreaterThanOrEqual(5)
+    })
+  })
+})

--- a/web/src/lib/acmm/sources/__tests__/agentic-engineering-framework.test.ts
+++ b/web/src/lib/acmm/sources/__tests__/agentic-engineering-framework.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { agenticEngineeringFrameworkSource } from '../agentic-engineering-framework'
+
+describe('agenticEngineeringFrameworkSource', () => {
+  it('has the correct source metadata', () => {
+    expect(agenticEngineeringFrameworkSource.id).toBe('agentic-engineering-framework')
+    expect(agenticEngineeringFrameworkSource.name).toBe('Agentic Engineering Framework')
+    expect(agenticEngineeringFrameworkSource.definesLevels).toBe(false)
+    expect(agenticEngineeringFrameworkSource.url).toContain('github.com')
+    expect(agenticEngineeringFrameworkSource.citation).toBeTruthy()
+  })
+
+  it('does not define levels', () => {
+    expect(agenticEngineeringFrameworkSource.levels).toBeUndefined()
+  })
+
+  it('has a non-empty criteria array', () => {
+    expect(agenticEngineeringFrameworkSource.criteria.length).toBeGreaterThan(0)
+  })
+
+  it('all criteria have required fields', () => {
+    for (const c of agenticEngineeringFrameworkSource.criteria) {
+      expect(c.id).toBeTruthy()
+      expect(c.source).toBe('agentic-engineering-framework')
+      expect(typeof c.level).toBe('number')
+      expect(c.level).toBeGreaterThanOrEqual(0)
+      expect(c.level).toBeLessThanOrEqual(6)
+      expect(c.name).toBeTruthy()
+      expect(c.description).toBeTruthy()
+      expect(c.rationale).toBeTruthy()
+      expect(c.detection).toBeDefined()
+    }
+  })
+
+  it('all criteria IDs start with aef:', () => {
+    for (const c of agenticEngineeringFrameworkSource.criteria) {
+      expect(c.id.startsWith('aef:')).toBe(true)
+    }
+  })
+
+  it('criteria IDs are unique', () => {
+    const ids = agenticEngineeringFrameworkSource.criteria.map(c => c.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('all criteria have valid detection types', () => {
+    for (const c of agenticEngineeringFrameworkSource.criteria) {
+      expect(c.detection.type).toBe('any-of')
+      const patterns = Array.isArray(c.detection.pattern)
+        ? c.detection.pattern
+        : [c.detection.pattern]
+      expect(patterns.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('all criteria are in governance category', () => {
+    for (const c of agenticEngineeringFrameworkSource.criteria) {
+      expect(c.category).toBe('governance')
+    }
+  })
+})

--- a/web/src/lib/acmm/sources/__tests__/claude-reflect.test.ts
+++ b/web/src/lib/acmm/sources/__tests__/claude-reflect.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { claudeReflectSource } from '../claude-reflect'
+
+describe('claudeReflectSource', () => {
+  it('has the correct source metadata', () => {
+    expect(claudeReflectSource.id).toBe('claude-reflect')
+    expect(claudeReflectSource.name).toBe('Claude Reflect')
+    expect(claudeReflectSource.definesLevels).toBe(false)
+    expect(claudeReflectSource.url).toContain('github.com')
+    expect(claudeReflectSource.citation).toBeTruthy()
+  })
+
+  it('does not define levels', () => {
+    expect(claudeReflectSource.levels).toBeUndefined()
+  })
+
+  it('has a non-empty criteria array', () => {
+    expect(claudeReflectSource.criteria.length).toBeGreaterThan(0)
+  })
+
+  it('all criteria have required fields', () => {
+    for (const c of claudeReflectSource.criteria) {
+      expect(c.id).toBeTruthy()
+      expect(c.source).toBe('claude-reflect')
+      expect(typeof c.level).toBe('number')
+      expect(c.level).toBeGreaterThanOrEqual(0)
+      expect(c.level).toBeLessThanOrEqual(6)
+      expect(c.name).toBeTruthy()
+      expect(c.description).toBeTruthy()
+      expect(c.rationale).toBeTruthy()
+      expect(c.detection).toBeDefined()
+    }
+  })
+
+  it('all criteria IDs start with claude-reflect:', () => {
+    for (const c of claudeReflectSource.criteria) {
+      expect(c.id.startsWith('claude-reflect:')).toBe(true)
+    }
+  })
+
+  it('criteria IDs are unique', () => {
+    const ids = claudeReflectSource.criteria.map(c => c.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('all criteria have valid detection types', () => {
+    for (const c of claudeReflectSource.criteria) {
+      expect(c.detection.type).toBe('any-of')
+      const patterns = Array.isArray(c.detection.pattern)
+        ? c.detection.pattern
+        : [c.detection.pattern]
+      expect(patterns.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('all criteria are in self-tuning category', () => {
+    for (const c of claudeReflectSource.criteria) {
+      expect(c.category).toBe('self-tuning')
+    }
+  })
+})

--- a/web/src/lib/cards/__tests__/StablePaginatedContent.test.tsx
+++ b/web/src/lib/cards/__tests__/StablePaginatedContent.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('../useStablePageHeight', () => ({
+  useStablePageHeight: (_pageSize: number, _totalItems: number) => ({
+    containerRef: { current: null },
+    containerStyle: { minHeight: '200px' },
+  }),
+}))
+
+import { StablePaginatedContent } from '../StablePaginatedContent'
+
+describe('StablePaginatedContent', () => {
+  it('renders children', () => {
+    render(
+      <StablePaginatedContent pageSize={10} totalItems={25}>
+        <span data-testid="child">Hello</span>
+      </StablePaginatedContent>
+    )
+    expect(screen.getByTestId('child')).toBeDefined()
+    expect(screen.getByText('Hello')).toBeDefined()
+  })
+
+  it('applies className to wrapper div', () => {
+    const { container } = render(
+      <StablePaginatedContent pageSize={5} totalItems={20} className="my-class">
+        <p>Content</p>
+      </StablePaginatedContent>
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.className).toContain('my-class')
+  })
+
+  it('applies stable height style from hook', () => {
+    const { container } = render(
+      <StablePaginatedContent pageSize={5} totalItems={10}>
+        <p>Content</p>
+      </StablePaginatedContent>
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.style.minHeight).toBe('200px')
+  })
+
+  it('renders without className prop', () => {
+    const { container } = render(
+      <StablePaginatedContent pageSize={5} totalItems={10}>
+        <p>Content</p>
+      </StablePaginatedContent>
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.tagName).toBe('DIV')
+  })
+})


### PR DESCRIPTION
## Coverage improvement

Coverage was 88.51% (badge: 89%), target is 91%. Added 52 tests for 6 previously uncovered or low-coverage files.

### New test files
| File | Tests | Source lines covered |
|------|-------|---------------------|
| acmm.test.ts | 14 | 855 lines (ACMM source data) |
| claude-reflect.test.ts | 8 | 79 lines |
| agentic-engineering-framework.test.ts | 8 | 79 lines |
| StablePaginatedContent.test.tsx | 4 | 26 lines |
| useCachedKeda.test.ts | 5 | 16 lines |
| TemplateGallerySection.test.tsx | 13 | 173 lines |

All 52 tests pass locally. CI will measure the actual coverage improvement.