### PR TITLE
🐛 Fix fetchSingleClusterHealth auth test using wrong localStorage key

### DIFF
--- a/web/src/hooks/mcp/__tests__/shared-websocket-detect.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-websocket-detect.test.ts
@@ -469,7 +469,7 @@ describe('fetchSingleClusterHealth — backend error paths', () => {
 
   it('sends Authorization header when token exists', async () => {
     mockIsAgentUnavailable.mockReturnValue(true) // skip agent
-    localStorage.setItem('token', 'my-jwt')
+    localStorage.setItem('kc-agent-token', 'my-jwt')
 
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -484,7 +484,7 @@ describe('fetchSingleClusterHealth — backend error paths', () => {
 
   it('omits Authorization header when no token', async () => {
     mockIsAgentUnavailable.mockReturnValue(true)
-    localStorage.removeItem('token')
+    localStorage.removeItem('kc-agent-token')
 
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,


### PR DESCRIPTION
Fixes #10395

## Summary
The `fetchSingleClusterHealth` auth header test was using `localStorage.setItem('token', ...)` but the function reads from `'kc-agent-token'` (`AGENT_TOKEN_STORAGE_KEY`) since PR #10381 introduced agent token bridging.

## Root Cause
PR #10381 changed the storage key from `'token'` to `'kc-agent-token'` for kc-agent auth. The test in `shared-websocket-detect.test.ts` was not updated to match.

## Fix
Update both auth tests (line 472 and 487) to use `'kc-agent-token'` instead of `'token'`.

## Verification
- All 41 tests in `shared-websocket-detect.test.ts` pass
- `npm run build` ✅
- `npm run lint` ✅