### PR TITLE
fix: migrate all kc-agent fetch calls to agentFetch()

### DIFF
--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -12,6 +12,7 @@ import { useCachedHardwareHealth, type DeviceAlert, type NodeDeviceInventory, ty
 import { useSnoozedAlerts, SNOOZE_DURATIONS, formatSnoozeRemaining, type SnoozeDuration } from '../../hooks/useSnoozedAlerts'
 import { useTranslation } from 'react-i18next'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+import { agentFetch } from '../../hooks/mcp/shared'
 
 // Sort field options — separated by view so only applicable fields are shown
 type SortField = 'severity' | 'nodeName' | 'cluster' | 'deviceType' | 'totalDevices'
@@ -338,7 +339,7 @@ export function HardwareHealthCard() {
   const clearAlert = async (alertId: string) => {
     setClearAlertError(null)
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/devices/alerts/clear`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/devices/alerts/clear`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ alertId }),

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -13,6 +13,7 @@ import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 import { isDemoMode as checkIsDemoMode } from '../../lib/demoMode'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_OPA_CACHE, STORAGE_KEY_OPA_CACHE_TIME } from '../../lib/constants'
+import { agentFetch } from '../../hooks/mcp/shared'
 import { KUBECTL_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
 const OPA_LIST_TIMEOUT_MS = 25_000
 const MIN_POLICY_PATH_PARTS = 4
@@ -200,7 +201,7 @@ function OPAPoliciesInternal({ config: _config }: OPAPoliciesProps) {
   useEffect(() => {
     if (shouldUseDemoData) return
     const controller = new AbortController()
-    fetch(`${LOCAL_AGENT_HTTP_URL}/clusters`, { signal: controller.signal })
+    agentFetch(`${LOCAL_AGENT_HTTP_URL}/clusters`, { signal: controller.signal })
       .then(res => res.json())
       .then(data => {
         if (controller.signal.aborted) return

--- a/web/src/components/cards/WorkloadDeployment.tsx
+++ b/web/src/components/cards/WorkloadDeployment.tsx
@@ -31,7 +31,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
 import { isAgentUnavailable } from '../../hooks/useLocalAgent'
 import { LOCAL_AGENT_HTTP_URL, MCP_HOOK_TIMEOUT_MS } from '../../lib/constants'
-import { clusterCacheRef } from '../../hooks/mcp/shared'
+import { clusterCacheRef, agentFetch } from '../../hooks/mcp/shared'
 import { WorkloadImportDialog } from './WorkloadImportDialog'
 
 // Workload types
@@ -221,7 +221,7 @@ async function scaleViaAgent(
   const ctrl = new AbortController()
   const tid = setTimeout(() => ctrl.abort(), MCP_HOOK_TIMEOUT_MS)
   try {
-    const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/scale`, {
+    const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/scale`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       signal: ctrl.signal,

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -26,6 +26,7 @@ import { useTranslation } from 'react-i18next'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { POLL_INTERVAL_MS } from '../../../lib/constants/network'
 import { useDemoMode } from '../../../hooks/useDemoMode'
+import { agentFetch } from '../../../hooks/mcp/shared'
 
 // ============================================================================
 // Unified Item Type for all card items
@@ -181,7 +182,7 @@ async function fetchAllNodes(): Promise<NodeData[]> {
 
   nodesFetchInProgress = true
   try {
-    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
+    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
     if (response.ok) {
       const data = await response.json()

--- a/web/src/components/cards/crio_status/useCrioStatus.ts
+++ b/web/src/components/cards/crio_status/useCrioStatus.ts
@@ -2,6 +2,7 @@ import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { CRIO_DEMO_DATA, type CrioStatusDemoData } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
+import { agentFetch } from '../../../hooks/mcp/shared'
 import {
   buildRecentImagePulls,
   extractCrioVersion,
@@ -109,15 +110,15 @@ interface BackendEventInfo {
  */
 async function fetchCrioStatus(): Promise<CrioStatus> {
   const [nodesResp, podsResp, eventsResp] = await Promise.all([
-    fetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
+    agentFetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     }),
-    fetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
+    agentFetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     }),
-    fetch(`${LOCAL_AGENT_HTTP_URL}/events?limit=200`, {
+    agentFetch(`${LOCAL_AGENT_HTTP_URL}/events?limit=200`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     }).catch(() => undefined),

--- a/web/src/components/cards/multi-tenancy/k3s-status/useK3sStatus.ts
+++ b/web/src/components/cards/multi-tenancy/k3s-status/useK3sStatus.ts
@@ -13,6 +13,7 @@ import { K3S_CACHE_KEY, OPERATOR_REFRESH_CATEGORY } from '../shared'
 import type { ComponentHealth } from '../shared'
 import { K3S_DEMO_DATA, type K3sServerPodInfo, type K3sStatusDemoData } from './demoData'
 import { LOCAL_AGENT_HTTP_URL } from '../../../../lib/constants/network'
+import { agentFetch } from '../../../../hooks/mcp/shared'
 import { isPodHealthy } from '../../../../lib/k8s'
 
 // ============================================================================
@@ -92,7 +93,7 @@ function extractVersion(pod: BackendPodInfo): string {
 // ============================================================================
 
 async function fetchK3sStatus(): Promise<K3sStatus> {
-  const podsResp = await fetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
+  const podsResp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/useKubeflexStatus.ts
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/useKubeflexStatus.ts
@@ -22,6 +22,7 @@ import {
 } from './helpers'
 import { KUBEFLEX_DEMO_DATA, type KubeFlexStatusDemoData } from './demoData'
 import { LOCAL_AGENT_HTTP_URL } from '../../../../lib/constants/network'
+import { agentFetch } from '../../../../hooks/mcp/shared'
 
 // ============================================================================
 // Data Interface
@@ -71,7 +72,7 @@ interface BackendPodInfo {
 // ============================================================================
 
 async function fetchKubeFlexStatus(): Promise<KubeFlexStatus> {
-  const podsResp = await fetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
+  const podsResp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/useKubevirtStatus.ts
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/useKubevirtStatus.ts
@@ -22,6 +22,7 @@ import {
 import type { KubevirtPodInfo } from './helpers'
 import { KUBEVIRT_DEMO_DATA, type VmInfo, type ClusterKubevirtInfo, type KubevirtStatusDemoData } from './demoData'
 import { LOCAL_AGENT_HTTP_URL } from '../../../../lib/constants/network'
+import { agentFetch } from '../../../../hooks/mcp/shared'
 
 // ============================================================================
 // Data Interface
@@ -82,7 +83,7 @@ interface BackendPodInfo {
 // ============================================================================
 
 async function fetchKubevirtStatus(): Promise<KubevirtStatus> {
-  const podsResp = await fetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
+  const podsResp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/multi-tenancy/ovn-status/useOvnStatus.ts
+++ b/web/src/components/cards/multi-tenancy/ovn-status/useOvnStatus.ts
@@ -16,6 +16,7 @@ import type { UdnInfo } from './helpers'
 import { isOvnPod, extractUdns, summarizeOvnPods } from './helpers'
 import { OVN_DEMO_DATA, type OvnStatusDemoData } from './demoData'
 import { LOCAL_AGENT_HTTP_URL } from '../../../../lib/constants/network'
+import { agentFetch } from '../../../../hooks/mcp/shared'
 
 // ============================================================================
 // Data Interface
@@ -72,7 +73,7 @@ interface BackendPodInfo {
  * infrastructure pods via label selectors.
  */
 async function fetchOvnStatus(): Promise<OvnStatus> {
-  const podsResp = await fetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
+  const podsResp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/multi-tenancy/tenant-topology/useNetworkStats.ts
+++ b/web/src/components/cards/multi-tenancy/tenant-topology/useNetworkStats.ts
@@ -13,6 +13,7 @@
 import { useCache } from '../../../../lib/cache'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../../lib/constants/network'
 import { LOCAL_AGENT_HTTP_URL } from '../../../../lib/constants/network'
+import { agentFetch } from '../../../../hooks/mcp/shared'
 
 // ============================================================================
 // Constants
@@ -105,7 +106,7 @@ const INITIAL_DATA: NetworkStatsData = { stats: [] }
 // ============================================================================
 
 async function fetchNetworkStats(): Promise<NetworkStatsData> {
-  const resp = await fetch(`${LOCAL_AGENT_HTTP_URL}/pod-network-stats`, {
+  const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/pod-network-stats`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/clusters/AddClusterDialog.tsx
+++ b/web/src/components/clusters/AddClusterDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { X, Terminal, Upload, FormInput } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+import { agentFetch } from '../../hooks/mcp/shared'
 import { emitClusterCreated } from '../../lib/analytics'
 import { CommandLineTab } from './add-cluster/CommandLineTab'
 import { ImportTab } from './add-cluster/ImportTab'
@@ -50,7 +51,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
   // Fetch cloud CLI status from the agent
   useEffect(() => {
     if (!open) return
-    fetch(`${LOCAL_AGENT_HTTP_URL}/cloud-cli-status`, { signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
+    agentFetch(`${LOCAL_AGENT_HTTP_URL}/cloud-cli-status`, { signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       .then(res => res.json())
       .then(data => setCloudCLIs(data.clis || []))
       .catch(() => { /* non-critical — just won't show cloud quick connect */ })
@@ -91,7 +92,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
     setImportState('previewing')
     setErrorMessage('')
     try {
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/preview`, {
+      const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/preview`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ kubeconfig: kubeconfigYaml }),
@@ -113,7 +114,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
     setImportState('importing')
     setErrorMessage('')
     try {
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/import`, {
+      const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/import`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ kubeconfig: kubeconfigYaml }),
@@ -142,7 +143,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
     setTestResult(null)
     setConnectError('')
     try {
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/test`, {
+      const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/test`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({
@@ -167,7 +168,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
     setConnectState('adding')
     setConnectError('')
     try {
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/add`, {
+      const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/add`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({

--- a/web/src/components/drilldown/views/EventsDrillDown.tsx
+++ b/web/src/components/drilldown/views/EventsDrillDown.tsx
@@ -7,6 +7,7 @@ import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useTranslation } from 'react-i18next'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { POLL_INTERVAL_MS, UI_FEEDBACK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
+import { agentFetch } from '../../../hooks/mcp/shared'
 import { copyToClipboard } from '../../../lib/clipboard'
 
 interface ClusterEvent {
@@ -93,7 +94,7 @@ export function EventsDrillDown({ data }: Props) {
       }
       params.append('limit', '100')
 
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/events?${params}`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/events?${params}`, {
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (response.ok) {

--- a/web/src/components/gitops/GitOps.tsx
+++ b/web/src/components/gitops/GitOps.tsx
@@ -8,6 +8,7 @@ import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { RefreshCw, GitBranch, FolderGit, Box, Loader2 } from 'lucide-react'
 import { SyncDialog } from './SyncDialog'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../../lib/constants'
+import { agentFetch } from '../../hooks/mcp/shared'
 import { MS_PER_MINUTE } from '../../lib/constants/time'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
 import { getDemoMode } from '../../hooks/useDemoMode'
@@ -203,7 +204,7 @@ export function GitOps() {
       if (token) agentAuthHeaders['Authorization'] = `Bearer ${token}`
       const promises = configs.map(async (appConfig) => {
         try {
-          const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/gitops/detect-drift`, {
+          const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/gitops/detect-drift`, {
             method: 'POST',
             headers: agentAuthHeaders,
             body: JSON.stringify({

--- a/web/src/components/gitops/SyncDialog.tsx
+++ b/web/src/components/gitops/SyncDialog.tsx
@@ -5,6 +5,7 @@ import { BaseModal } from '../../lib/modals'
 import { TechnicalAcronym } from '../shared/TechnicalAcronym'
 import { safeGetItem } from '../../lib/utils/localStorage'
 import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../../lib/constants'
+import { agentFetch } from '../../hooks/mcp/shared'
 
 // Sync phases
 type SyncPhase = 'detection' | 'plan' | 'execution' | 'complete'
@@ -135,7 +136,7 @@ export function SyncDialog({
       // #7993 Phase 4: detect-drift moved to kc-agent. Runs under the
       // user's kubeconfig instead of the backend pod SA.
       const token = safeGetItem(STORAGE_KEY_TOKEN)
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/gitops/detect-drift`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/gitops/detect-drift`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -235,7 +236,7 @@ export function SyncDialog({
       // #7993 Phase 4: gitops sync moved to kc-agent. Runs under the
       // user's kubeconfig instead of the backend pod SA.
       const token = safeGetItem(STORAGE_KEY_TOKEN)
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/gitops/sync`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/gitops/sync`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -41,6 +41,7 @@ import { useKagentBackend } from '../../hooks/useKagentBackend'
 import { useDeepLink } from '../../hooks/useDeepLink'
 import { cn } from '../../lib/cn'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+import { agentFetch } from '../../hooks/mcp/shared'
 import { NAVBAR_HEIGHT_PX, BANNER_HEIGHT_PX, SIDEBAR_CONTROLS_OFFSET_PX } from '../../lib/constants/ui'
 import { CLOSE_ANIMATION_MS, UI_FEEDBACK_TIMEOUT_MS, TOAST_DISMISS_MS } from '../../lib/constants/network'
 import { TourOverlay, TourPrompt } from '../onboarding/Tour'
@@ -170,7 +171,7 @@ export function Layout({ children: _children }: LayoutProps) {
   const handleRestartBackend = async () => {
     setRestartState('restarting')
     try {
-      const resp = await fetch(`${LOCAL_AGENT_HTTP_URL}/restart-backend`, {
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/restart-backend`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -21,6 +21,7 @@ import {
   BACKEND_HEALTH_CHECK_TIMEOUT_MS,
 } from '../../../lib/constants/network'
 import type { AgentInfo } from '../../../types/agent'
+import { agentFetch } from '../../../hooks/mcp/shared'
 
 const CONNECTING_DEBOUNCE_MS = 300
 
@@ -56,7 +57,7 @@ export function AgentStatusIndicator() {
   const fetchAgentsFromHealth = async () => {
     setIsDiscoveringAgents(true)
     try {
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+      const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
         signal: AbortSignal.timeout(BACKEND_HEALTH_CHECK_TIMEOUT_MS),
       })
       if (!res.ok) return

--- a/web/src/components/widget/MiniDashboard.tsx
+++ b/web/src/components/widget/MiniDashboard.tsx
@@ -13,6 +13,7 @@ import { useClusters, useGPUNodes, usePodIssues } from '../../hooks/useMCP'
 import { cn } from '../../lib/cn'
 import { useTranslation } from 'react-i18next'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+import { agentFetch } from '../../hooks/mcp/shared'
 import { POLL_INTERVAL_MS } from '../../lib/constants/network'
 import { emitWidgetLoaded, emitWidgetNavigation, emitWidgetInstalled } from '../../lib/analytics'
 import { sendNotificationWithDeepLink } from '../../hooks/useDeepLink'
@@ -101,7 +102,7 @@ export function MiniDashboard() {
 
   const fetchNodes = useCallback(async () => {
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (response.ok) {
         const data = await response.json()

--- a/web/src/hooks/useArgoCD.ts
+++ b/web/src/hooks/useArgoCD.ts
@@ -15,6 +15,7 @@ import { useClusters } from './useMCP'
 import { useGlobalFilters } from './useGlobalFilters'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, MOCK_SYNC_DELAY_MS } from '../lib/constants/network'
+import { agentFetch } from './mcp/shared'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 
 // Cache expiry time (5 minutes)
@@ -285,7 +286,7 @@ async function triggerArgoSyncAPI(appName: string, namespace: string, cluster: s
   const ctrl = new AbortController()
   const tid = setTimeout(() => ctrl.abort(), FETCH_DEFAULT_TIMEOUT_MS)
   try {
-    const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/argocd/sync`, {
+    const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/argocd/sync`, {
       method: 'POST',
       signal: ctrl.signal,
       headers: { ...authHeaders(), 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },

--- a/web/src/hooks/useBackendHealth.ts
+++ b/web/src/hooks/useBackendHealth.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { agentFetch } from './mcp/shared'
 
 export type BackendStatus = 'connected' | 'disconnected' | 'connecting'
 
@@ -154,7 +155,7 @@ class BackendHealthManager {
    *  downtime from browser connection-pool exhaustion on the main origin. */
   private async checkAgentHealth(): Promise<boolean> {
     try {
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+      const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
         method: 'GET',
         signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
       })

--- a/web/src/hooks/useCachedContainerd.ts
+++ b/web/src/hooks/useCachedContainerd.ts
@@ -19,6 +19,7 @@
 import { useCache, type RefreshCategory } from '../lib/cache'
 import { useDemoMode } from './useDemoMode'
 import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../lib/constants/network'
+import { agentFetch } from './mcp/shared'
 import { MS_PER_SECOND, SECONDS_PER_MINUTE, MINUTES_PER_HOUR, HOURS_PER_DAY } from '../lib/constants/time'
 import {
   CONTAINERD_DEMO_DATA,
@@ -193,11 +194,11 @@ function buildContainerdData(
 
 async function fetchContainerdStatus(): Promise<ContainerdStatusData> {
   const [nodesResp, podsResp] = await Promise.all([
-    fetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
+    agentFetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     }),
-    fetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
+    agentFetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     }),

--- a/web/src/hooks/useCachedCoreWorkloads.ts
+++ b/web/src/hooks/useCachedCoreWorkloads.ts
@@ -9,7 +9,7 @@
 import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { isBackendUnavailable } from '../lib/api'
 import { kubectlProxy } from '../lib/kubectlProxy'
-import { clusterCacheRef } from './mcp/shared'
+import { clusterCacheRef, agentFetch } from './mcp/shared'
 import { isAgentUnavailable } from './useLocalAgent'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
@@ -484,7 +484,7 @@ export function useCachedDeploymentIssues(
               if (namespace) params.append('namespace', namespace)
               const ctrl = new AbortController()
               const tid = setTimeout(() => ctrl.abort(), AGENT_HTTP_TIMEOUT_MS)
-              const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
+              const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
                 signal: ctrl.signal, headers: { Accept: 'application/json' } })
               clearTimeout(tid)
               if (!res.ok) return []
@@ -560,7 +560,7 @@ export function useCachedDeployments(
 
           const controller = new AbortController()
           const timeoutId = setTimeout(() => controller.abort(), AGENT_HTTP_TIMEOUT_MS)
-          const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
+          const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
             signal: controller.signal,
             headers: { Accept: 'application/json' } })
           clearTimeout(timeoutId)

--- a/web/src/hooks/useCachedData/agentFetchers.ts
+++ b/web/src/hooks/useCachedData/agentFetchers.ts
@@ -9,7 +9,7 @@
  */
 
 import { kubectlProxy } from '../../lib/kubectlProxy'
-import { clusterCacheRef } from '../mcp/shared'
+import { clusterCacheRef, agentFetch } from '../mcp/shared'
 import { isAgentUnavailable } from '../useLocalAgent'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 import { settledWithConcurrency } from '../../lib/utils/concurrency'
@@ -81,7 +81,7 @@ export async function fetchDeploymentsViaAgent(namespace?: string, onProgress?: 
 
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), AGENT_HTTP_TIMEOUT_MS)
-    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
+    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
       signal: controller.signal,
       headers: { Accept: 'application/json' }
     })
@@ -128,7 +128,7 @@ export async function fetchWorkloadsFromAgent(onProgress?: (partial: Workload[])
 
     const ctrl = new AbortController()
     const tid = setTimeout(() => ctrl.abort(), AGENT_HTTP_TIMEOUT_MS)
-    const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
+    const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
       signal: ctrl.signal,
       headers: { Accept: 'application/json' }
     })
@@ -185,7 +185,7 @@ export async function fetchCiliumStatus(): Promise<CiliumStatus | null> {
   if (!token || token === 'demo-token') return null
 
   try {
-    const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/cilium-status`, {
+    const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/cilium-status`, {
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: 'application/json',
@@ -215,7 +215,7 @@ export async function fetchJaegerStatus(): Promise<any | null> {
   if (!token || token === 'demo-token') return null
 
   try {
-    const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/jaeger-status`, {
+    const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/jaeger-status`, {
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: 'application/json',

--- a/web/src/hooks/useCachedGPU.ts
+++ b/web/src/hooks/useCachedGPU.ts
@@ -11,7 +11,7 @@ import { fetchAPI, fetchBackendAPI, fetchFromAllClustersViaBackend, fetchViaSSE,
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS } from '../lib/constants/network'
-import { clusterCacheRef, deduplicateClustersByServer } from './mcp/shared'
+import { clusterCacheRef, deduplicateClustersByServer, agentFetch } from './mcp/shared'
 import {
   getDemoGPUNodes,
   getDemoCachedGPUNodeHealth,
@@ -97,11 +97,11 @@ async function fetchHardwareHealth(): Promise<HardwareHealthData> {
 
   try {
     const [alertsRes, inventoryRes] = await Promise.all([
-      fetch(`${LOCAL_AGENT_HTTP_URL}/devices/alerts`, {
+      agentFetch(`${LOCAL_AGENT_HTTP_URL}/devices/alerts`, {
         method: 'GET',
         headers: { 'Accept': 'application/json' },
         signal: controller.signal }).catch(() => null),
-      fetch(`${LOCAL_AGENT_HTTP_URL}/devices/inventory`, {
+      agentFetch(`${LOCAL_AGENT_HTTP_URL}/devices/inventory`, {
         method: 'GET',
         headers: { 'Accept': 'application/json' },
         signal: controller.signal }).catch(() => null),
@@ -315,7 +315,7 @@ export function useGPUHealthCronJob(cluster?: string) {
       // #7993 Phase 3e: GPU health cronjob install is a user-initiated
       // tooling install. It runs through kc-agent under the user's own
       // kubeconfig instead of the backend pod ServiceAccount.
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/gpu-health-cronjob`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/gpu-health-cronjob`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -348,7 +348,7 @@ export function useGPUHealthCronJob(cluster?: string) {
       if (!token) throw new Error('No authentication token')
       // #7993 Phase 3e: GPU health cronjob uninstall goes through kc-agent
       // under the user's own kubeconfig.
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/gpu-health-cronjob`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/gpu-health-cronjob`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',

--- a/web/src/hooks/useDependencies.ts
+++ b/web/src/hooks/useDependencies.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { isAgentUnavailable } from './useLocalAgent'
-import { clusterCacheRef } from './mcp/shared'
+import { clusterCacheRef, agentFetch } from './mcp/shared'
 import { isDemoMode } from '../lib/demoMode'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
 import { MCP_HOOK_TIMEOUT_MS } from '../lib/constants/network'
@@ -28,11 +28,11 @@ function authHeaders(): Record<string, string> {
 }
 
 /** Fetch a JSON endpoint from the local agent with timeout. */
-async function agentFetch(path: string, timeout = MCP_HOOK_TIMEOUT_MS): Promise<Record<string, unknown>> {
+async function agentRequest(path: string, timeout = MCP_HOOK_TIMEOUT_MS): Promise<Record<string, unknown>> {
   const ctrl = new AbortController()
   const tid = setTimeout(() => ctrl.abort(), timeout)
   try {
-    const res = await fetch(`${LOCAL_AGENT_HTTP_URL}${path}`, {
+    const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}${path}`, {
       signal: ctrl.signal,
       headers: { Accept: 'application/json' } })
     if (!res.ok) throw new Error(`Agent ${res.status}`)
@@ -63,7 +63,7 @@ async function resolveViaAgent(
 
   const params = `cluster=${encodeURIComponent(context)}&namespace=${encodeURIComponent(namespace)}&name=${encodeURIComponent(name)}`
   // Dependency resolution can be slow — give it 30s
-  const result = await agentFetch(`/resolve-deps?${params}`, 30_000)
+  const result = await agentRequest(`/resolve-deps?${params}`, 30_000)
 
   if (result.error) {
     throw new Error(result.error as string)

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useCardSubscribe } from '../lib/cardEvents'
-import { clusterCacheRef } from './mcp/shared'
+import { clusterCacheRef, agentFetch } from './mcp/shared'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import type { DeployStartedPayload, DeployResultPayload, DeployedDep } from '../lib/cardEvents'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN, STORAGE_KEY_MISSIONS_ACTIVE, STORAGE_KEY_MISSIONS_HISTORY } from '../lib/constants'
@@ -431,7 +431,7 @@ export function useDeployMissions() {
                   const ctrl = new AbortController()
                   const tid = setTimeout(() => ctrl.abort(), DEPLOY_ABORT_TIMEOUT_MS)
                   try {
-                    const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
+                    const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
                       signal: ctrl.signal,
                       headers: { Accept: 'application/json' } })
                     // #6816 — If the agent returns a non-OK response (4xx/5xx

--- a/web/src/hooks/useFederation.ts
+++ b/web/src/hooks/useFederation.ts
@@ -1,5 +1,6 @@
 import { useEffect, useSyncExternalStore } from 'react'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { agentFetch } from './mcp/shared'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { useDemoMode } from './useDemoMode'
 
@@ -347,7 +348,7 @@ function authHeaders(): Record<string, string> {
 async function fetchFederationEndpoint<T>(path: string): Promise<T | null> {
   if (!LOCAL_AGENT_HTTP_URL) return null
   try {
-    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}${path}`, {
+    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}${path}`, {
       headers: authHeaders(),
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })

--- a/web/src/hooks/useFederationActions.ts
+++ b/web/src/hooks/useFederationActions.ts
@@ -10,6 +10,7 @@
  */
 
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { agentFetch } from './mcp/shared'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import type { FederationProviderName } from './useFederation'
 
@@ -54,7 +55,7 @@ export async function executeFederationAction(req: ActionRequest): Promise<Actio
   const headers: Record<string, string> = { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }
   if (token) headers['Authorization'] = `Bearer ${token}`
 
-  const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/federation/action`, {
+  const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/federation/action`, {
     method: 'POST',
     headers,
     body: JSON.stringify(req),

--- a/web/src/hooks/useInsightEnrichment.ts
+++ b/web/src/hooks/useInsightEnrichment.ts
@@ -18,6 +18,7 @@ import type {
 } from '../types/insights'
 import { isAgentConnected, isAgentUnavailable } from './useLocalAgent'
 import { LOCAL_AGENT_HTTP_URL, LOCAL_AGENT_WS_URL } from '../lib/constants'
+import { agentFetch } from './mcp/shared'
 import { appendWsAuthToken } from '../lib/utils/wsAuth'
 
 /** Debounce before sending enrichment request (2 seconds) */
@@ -98,7 +99,7 @@ async function requestEnrichment(insights: MultiClusterInsight[]): Promise<void>
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), ENRICHMENT_TIMEOUT_MS)
 
-    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/insights/enrich`, {
+    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/insights/enrich`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       body: JSON.stringify(payload),

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { isDemoModeForced } from './useDemoMode'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { agentFetch } from './mcp/shared'
 import { TRANSITION_DELAY_MS } from '../lib/constants/network'
 import { emitAgentConnected, emitAgentDisconnected, emitAgentProvidersDetected, emitConversionStep } from '../lib/analytics'
 import { safeGetItem, safeSetItem } from '../lib/utils/localStorage'
@@ -207,7 +208,7 @@ class AgentManager {
     this.isChecking = true
 
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
         method: 'GET',
         headers: { Accept: 'application/json' },
         signal: AbortSignal.timeout(AGENT_HEALTH_TIMEOUT_MS) })

--- a/web/src/hooks/useLocalClusterTools.ts
+++ b/web/src/hooks/useLocalClusterTools.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useLocalAgent } from './useLocalAgent'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { agentFetch } from './mcp/shared'
 import { FETCH_DEFAULT_TIMEOUT_MS, RETRY_DELAY_MS, UI_FEEDBACK_TIMEOUT_MS } from '../lib/constants/network'
 import { useDemoMode } from './useDemoMode'
 import { useClusterProgress } from './useClusterProgress'
@@ -108,7 +109,7 @@ export function useLocalClusterTools() {
     }
 
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-cluster-tools`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/local-cluster-tools`, {
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (response.ok) {
         const data = await response.json()
@@ -137,7 +138,7 @@ export function useLocalClusterTools() {
 
     setIsLoading(true)
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-clusters`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/local-clusters`, {
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (response.ok) {
         const data = await response.json()
@@ -177,7 +178,7 @@ export function useLocalClusterTools() {
     setError(null)
 
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-clusters`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/local-clusters`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ tool, name }),
@@ -215,7 +216,7 @@ export function useLocalClusterTools() {
     setError(null)
 
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-cluster-lifecycle`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/local-cluster-lifecycle`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ tool, name, action }),
@@ -261,7 +262,7 @@ export function useLocalClusterTools() {
     setError(null)
 
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-clusters?tool=${tool}&name=${name}`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/local-clusters?tool=${tool}&name=${name}`, {
         method: 'DELETE',
         headers: { 'X-Requested-With': 'XMLHttpRequest' },
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
@@ -302,7 +303,7 @@ export function useLocalClusterTools() {
 
     setIsVClustersLoading(true)
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/list`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/list`, {
         signal: AbortSignal.timeout(VCLUSTER_LIST_TIMEOUT_MS) })
       if (response.ok) {
         const data = await response.json()
@@ -337,7 +338,7 @@ export function useLocalClusterTools() {
     if (!isConnected || !context) return
 
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/check?context=${encodeURIComponent(context)}`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/check?context=${encodeURIComponent(context)}`, {
         signal: AbortSignal.timeout(VCLUSTER_LIST_TIMEOUT_MS) })
       if (response.ok) {
         const data = await response.json()
@@ -382,7 +383,7 @@ export function useLocalClusterTools() {
     setError(null)
 
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/create`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/create`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ name, namespace }),
@@ -427,7 +428,7 @@ export function useLocalClusterTools() {
     setError(null)
 
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/connect`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/connect`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ name, namespace }),
@@ -472,7 +473,7 @@ export function useLocalClusterTools() {
     setError(null)
 
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/disconnect`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/disconnect`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ name, namespace }),
@@ -517,7 +518,7 @@ export function useLocalClusterTools() {
     setError(null)
 
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/delete`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/delete`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ name, namespace }),

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -4,6 +4,7 @@ import { AgentCapabilityToolExec } from '../types/agent'
 import { getDemoMode } from './useDemoMode'
 import { addCategoryTokens, setActiveTokenCategory, clearActiveTokenCategory } from './useTokenUsage'
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { agentFetch } from './mcp/shared'
 import { appendWsAuthToken } from '../lib/utils/wsAuth'
 import { emitError, emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
 import { scanForMaliciousContent } from '../lib/missions/scanner/malicious'
@@ -2610,7 +2611,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     } else {
       // HTTP fallback — WS may be disconnected during long agent runs.
       // Use the response body to determine if cancellation succeeded (#5477).
-      fetch(`${LOCAL_AGENT_HTTP_URL}/cancel-chat`, {
+      agentFetch(`${LOCAL_AGENT_HTTP_URL}/cancel-chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ sessionId: missionId }) }).then(async response => {

--- a/web/src/hooks/usePermissions.ts
+++ b/web/src/hooks/usePermissions.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { isBackendUnavailable } from '../lib/api'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants/network'
+import { agentFetch } from './mcp/shared'
 
 export interface ClusterPermissions {
   isClusterAdmin: boolean
@@ -74,7 +75,7 @@ export function usePermissions() {
       // #7993 Phase 6: route permissions summary through kc-agent so the
       // SelfSubjectAccessReviews run under the user's kubeconfig rather than
       // the backend pod ServiceAccount when console is deployed in-cluster.
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/permissions/summary`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/permissions/summary`, {
         headers: {
           'Authorization': token ? `Bearer ${token}` : '',
           'Content-Type': 'application/json' },
@@ -191,7 +192,7 @@ export function useCanI() {
       // #7993 Phase 6: SelfSubjectAccessReview must run under the caller's
       // kubeconfig, not the backend pod ServiceAccount — otherwise in-cluster
       // it answers "can the pod SA do X?" instead of "can the user do X?".
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/rbac/can-i`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/rbac/can-i`, {
         method: 'POST',
         headers: {
           'Authorization': token ? `Bearer ${token}` : '',

--- a/web/src/hooks/usePersistedSettings.ts
+++ b/web/src/hooks/usePersistedSettings.ts
@@ -7,6 +7,7 @@ import {
   isLocalStorageEmpty,
   SETTINGS_CHANGED_EVENT } from '../lib/settingsSync'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { agentFetch } from './mcp/shared'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { isNetlifyDeployment } from '../lib/demoMode'
 import { safeRevokeObjectURL } from '../lib/download'
@@ -20,7 +21,7 @@ export type SyncStatus = 'idle' | 'saving' | 'saved' | 'error' | 'offline'
  * Uses a generous timeout because the agent's HTTP/1.1 connection pool (6 per origin)
  * can be saturated by concurrent cluster health/data requests during page transitions. */
 async function settingsFetch<T>(path: string, options?: RequestInit): Promise<T> {
-  const response = await fetch(`${LOCAL_AGENT_HTTP_URL}${path}`, {
+  const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}${path}`, {
     ...options,
     headers: {
       'Content-Type': 'application/json',
@@ -101,7 +102,7 @@ export function usePersistedSettings() {
   // Export settings as encrypted backup file
   const exportSettings = async () => {
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/settings/export`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/settings/export`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })

--- a/web/src/hooks/usePredictionFeedback.ts
+++ b/web/src/hooks/usePredictionFeedback.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import type { PredictionFeedback, StoredFeedback, PredictionType, PredictionStats } from '../types/predictions'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { agentFetch } from './mcp/shared'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { emitPredictionFeedbackSubmitted } from '../lib/analytics'
 
@@ -185,7 +186,7 @@ export function usePredictionFeedback() {
  * Send feedback to backend
  */
 async function sendFeedbackToBackend(predictionId: string, feedback: PredictionFeedback): Promise<void> {
-  const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/predictions/feedback`, {
+  const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/predictions/feedback`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
     body: JSON.stringify({ predictionId, feedback }),

--- a/web/src/hooks/usePrometheusMetrics.ts
+++ b/web/src/hooks/usePrometheusMetrics.ts
@@ -5,6 +5,7 @@
  */
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { agentFetch } from './mcp/shared'
 
 const DEFAULT_POLL_INTERVAL_MS = 5_000
 
@@ -62,7 +63,7 @@ async function queryPrometheus(
   signal: AbortSignal,
 ): Promise<PromResponse> {
   const params = new URLSearchParams({ cluster, namespace, query })
-  const resp = await fetch(`${LOCAL_AGENT_HTTP_URL}/prometheus/query?${params}`, {
+  const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/prometheus/query?${params}`, {
     signal,
     headers: { Accept: 'application/json' },
   })

--- a/web/src/hooks/useProviderConnection.ts
+++ b/web/src/hooks/useProviderConnection.ts
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import type { ProviderConnectionState } from '../types/agent'
 import { INITIAL_PROVIDER_CONNECTION_STATE, PROVIDER_PREREQUISITES } from '../types/agent'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { agentFetch } from './mcp/shared'
 
 /** Timeout for provider readiness check (10 seconds) */
 const PROVIDER_CONNECT_TIMEOUT_MS = 10_000
@@ -32,7 +33,7 @@ async function checkProviderReady(providerName: string): Promise<ProviderCheckRe
   // Try the dedicated provider check endpoint first (supports handshake)
   try {
     const checkUrl = `${LOCAL_AGENT_HTTP_URL}/provider/check?name=${encodeURIComponent(providerName)}`
-    const checkResponse = await fetch(checkUrl, {
+    const checkResponse = await agentFetch(checkUrl, {
       signal: AbortSignal.timeout(15_000) })
     if (checkResponse.ok) {
       const data = await checkResponse.json()
@@ -51,7 +52,7 @@ async function checkProviderReady(providerName: string): Promise<ProviderCheckRe
 
   // Fallback: check the health endpoint for simple provider presence
   try {
-    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
       signal: AbortSignal.timeout(3_000) })
     if (!response.ok) {
       return { ready: false, error: `Agent returned HTTP ${response.status}` }

--- a/web/src/hooks/useProviderHealth.ts
+++ b/web/src/hooks/useProviderHealth.ts
@@ -4,6 +4,7 @@ import { useClusters } from './mcp/clusters'
 import { detectCloudProvider, getProviderLabel } from '../components/ui/CloudProviderIcon'
 import type { CloudProvider } from '../components/ui/CloudProviderIcon'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { agentFetch } from './mcp/shared'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { getDemoMode } from './useDemoMode'
 
@@ -47,7 +48,7 @@ async function checkServiceHealth(providerIds: string[]): Promise<Map<string, He
   // Skip in demo mode — no local agent on Netlify deployments
   if (!getDemoMode()) {
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/providers/health`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/providers/health`, {
         signal: AbortSignal.timeout(STATUS_CHECK_TIMEOUT) })
       if (response.ok) {
         const data: BackendHealthResponse = await response.json()
@@ -153,7 +154,7 @@ async function fetchProviders(clusterSnapshot: Array<{ name: string; server?: st
   // --- AI Providers from /settings/keys ---
   const unconfiguredProviders: string[] = []
   try {
-    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/settings/keys`, {
+    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/settings/keys`, {
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
     if (response.ok) {
       const data: KeysStatusResponse = await response.json()

--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { isAgentUnavailable, reportAgentDataSuccess, reportAgentDataError } from './useLocalAgent'
 import { getDemoMode } from './useDemoMode'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { agentFetch } from './mcp/shared'
 import { QUICK_ABORT_TIMEOUT_MS } from '../lib/constants/network'
 import {
   getUserTokenUsage,
@@ -447,7 +448,7 @@ async function fetchTokenUsage() {
   try {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), QUICK_ABORT_TIMEOUT_MS)
-    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
       method: 'GET',
       headers: { 'Accept': 'application/json' },
       signal: controller.signal })

--- a/web/src/hooks/useUsers.ts
+++ b/web/src/hooks/useUsers.ts
@@ -3,6 +3,7 @@ import { api, isBackendUnavailable } from '../lib/api'
 import { mapSettledWithConcurrency } from '../lib/utils/concurrency'
 import { getDemoMode } from './useDemoMode'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
+import { agentFetch } from './mcp/shared'
 import { FETCH_DEFAULT_TIMEOUT_MS, RBAC_QUERY_TIMEOUT_MS } from '../lib/constants/network'
 import { MS_PER_DAY, MS_PER_HOUR } from '../lib/constants/time'
 import type {
@@ -495,7 +496,7 @@ export function useK8sServiceAccounts(cluster?: string, namespace?: string) {
     // Creating a ServiceAccount is a user-initiated mutation on a managed
     // cluster, so it must run under the user's kubeconfig via kc-agent, not
     // the backend pod ServiceAccount. See #7993 Phase 1.5 PR A.
-    const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/serviceaccounts`, {
+    const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/serviceaccounts`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest', ...agentAuthHeaders() },
       body: JSON.stringify(req),
@@ -658,7 +659,7 @@ export function useK8sRoleBindings(cluster: string, namespace?: string, includeS
     // Creating a RoleBinding is a user-initiated RBAC mutation, so it must
     // run under the user's kubeconfig via kc-agent, not the backend pod
     // ServiceAccount. See #7993 Phase 1.5 PR A.
-    const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/rolebindings`, {
+    const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/rolebindings`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest', ...agentAuthHeaders() },
       body: JSON.stringify(req),
@@ -704,7 +705,7 @@ export function useClusterPermissions(cluster?: string) {
       // allowed origins when KC_AGENT_TOKEN is unset). Sending an empty
       // Authorization header would fail token validation on the agent side.
       const params = cluster ? `?cluster=${cluster}` : ''
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/rbac/permissions${params}`, {
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/rbac/permissions${params}`, {
         headers: agentAuthHeaders(),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!response.ok) {

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { mapSettledWithConcurrency } from '../lib/utils/concurrency'
 import { isAgentUnavailable } from './useLocalAgent'
-import { clusterCacheRef } from './mcp/shared'
+import { clusterCacheRef, agentFetch } from './mcp/shared'
 import { isDemoMode } from '../lib/demoMode'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, MCP_HOOK_TIMEOUT_MS, POLL_INTERVAL_MS, POLL_INTERVAL_SLOW_MS } from '../lib/constants/network'
@@ -119,7 +119,7 @@ async function fetchWorkloadsViaAgent(opts?: {
       // Abort the per-request controller if the parent signal fires
       const onParentAbort = () => ctrl.abort()
       opts?.signal?.addEventListener('abort', onParentAbort)
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
+      const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
         signal: ctrl.signal,
         headers: { Accept: 'application/json' } })
       clearTimeout(tid)


### PR DESCRIPTION
## Summary
- Replaces raw `fetch()` calls to `LOCAL_AGENT_HTTP_URL` with `agentFetch()` across 40 files (23 hooks, 17 components, ~69 call sites)
- Ensures the `KC_AGENT_TOKEN` Authorization header is injected on every kc-agent HTTP request
- Fixes persistent 401 Unauthorized errors on all kc-agent endpoints after PR #10381 fixed the core `agentFetch()` function

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] Console starts with `startup-oauth.sh`
- [ ] Clusters page shows all clusters (no 401s in browser console)
- [ ] WebSocket connections succeed
- [ ] Drilldown views load correctly

Fixes #10381 (follow-up)