### PR TITLE
🐛 Fix Playwright nightly cross-browser failures (webkit, firefox, mobile)

### DIFF
--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -109,9 +109,11 @@ test.describe('Dashboard Page', () => {
 
         // Each card must render a visible <h3> heading (the title shown in
         // the card header). If a card variant ever stops rendering the
-        // heading, this catches it.
+        // heading, this catches it. On mobile viewports the card may still
+        // be loading when the loop runs, so give the heading extra time.
+        const HEADING_TIMEOUT_MS = 5_000
         const heading = card.locator('h3').first()
-        await expect(heading).toBeVisible()
+        await expect(heading).toBeVisible({ timeout: HEADING_TIMEOUT_MS })
         await expect(heading).not.toHaveText('')
       }
     })
@@ -190,6 +192,7 @@ test.describe('Dashboard Page', () => {
       await page.addInitScript(() => {
         localStorage.setItem('token', 'test-token')
         localStorage.setItem('demo-user-onboarded', 'true')
+        localStorage.setItem('kc-demo-mode', 'false')
       })
 
       await page.goto('/')
@@ -229,6 +232,7 @@ test.describe('Dashboard Page', () => {
       await page.addInitScript(() => {
         localStorage.setItem('token', 'test-token')
         localStorage.setItem('demo-user-onboarded', 'true')
+        localStorage.setItem('kc-demo-mode', 'false')
       })
 
       await page.goto('/')

--- a/web/e2e/Sidebar.spec.ts
+++ b/web/e2e/Sidebar.spec.ts
@@ -263,8 +263,9 @@ test.describe('Sidebar Navigation', () => {
         return
       }
 
-      // Click Add more
-      await addMoreBtn.click()
+      // Click Add more — force-click on webkit where CSS transitions can
+      // cause actionability checks to stall (#nightly-playwright).
+      await addMoreBtn.click({ force: true })
 
       // Modal should appear
       await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 })

--- a/web/e2e/Tour.spec.ts
+++ b/web/e2e/Tour.spec.ts
@@ -232,7 +232,10 @@ test.describe('Tour/Onboarding', () => {
       await page.goto('/')
       await page.setViewportSize({ width: 375, height: 667 })
 
-      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 10000 })
+      // Webkit may need additional time after viewport resize to re-layout
+      // (#nightly-playwright).
+      const RESPONSIVE_TIMEOUT_MS = 15_000
+      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: RESPONSIVE_TIMEOUT_MS })
     })
 
     test('adapts to tablet viewport', async ({ page }) => {

--- a/web/e2e/navbar-responsive.spec.ts
+++ b/web/e2e/navbar-responsive.spec.ts
@@ -118,11 +118,18 @@ test.describe('Navbar responsive layout', () => {
     // CSS transitions are settling. Wait for visibility first, then force
     // click to bypass the stability check (#nightly-playwright).
     await expect(overflowBtn).toBeVisible()
+    // Small settle delay for webkit — the page/context can close if the
+    // click fires while layout is still in progress (#nightly-playwright).
+    const SETTLE_MS = 500
+    await page.waitForTimeout(SETTLE_MS)
     await overflowBtn.click({ force: true })
 
-    // At least one item from the lg-hidden group should now be visible
+    // At least one item from the lg-hidden group should now be visible.
+    // Use a generous timeout — the overflow panel animates in and webkit
+    // can be slow to paint after a forced click.
+    const PANEL_TIMEOUT_MS = 10_000
     const panel = page.locator('.fixed.bg-card').last()
-    await expect(panel).toBeVisible()
+    await expect(panel).toBeVisible({ timeout: PANEL_TIMEOUT_MS })
   })
 
   test('search bar is in main nav bar at sm+ (640px)', async ({ page }) => {

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -188,17 +188,22 @@ test.describe('Smoke Tests', () => {
       await page.waitForLoadState('domcontentloaded')
       await waitForNetworkIdleBestEffort(page)
 
-      // Check for theme toggle
-      const themeToggle = page.getByTestId('theme-toggle')
+      // Check for theme toggle — use a precise locator scoped to the navbar
+      // button (aria-label contains "theme") to avoid matching non-button
+      // elements in the ThemeSection dropdown.  Force-click because on
+      // webkit / firefox the Tooltip wrapper can report the button as "not
+      // stable" during CSS transitions (#nightly-playwright).
+      const THEME_POLL_TIMEOUT_MS = 10_000
+      const themeToggle = page.locator('nav button[aria-label*="theme" i]').first()
+        .or(page.getByTestId('theme-toggle'))
         .or(page.locator('button:has-text("Theme")'))
-        .or(page.locator('[aria-label*="theme"]'))
 
       if (await themeToggle.first().isVisible({ timeout: OPTIONAL_PROBE_TIMEOUT_MS })) {
         const htmlBefore = await page.locator('html').getAttribute('class')
-        await themeToggle.first().click()
+        await themeToggle.first().click({ force: true })
 
         await expect
-          .poll(async () => page.locator('html').getAttribute('class'))
+          .poll(async () => page.locator('html').getAttribute('class'), { timeout: THEME_POLL_TIMEOUT_MS })
           .not.toBe(htmlBefore)
       }
     })


### PR DESCRIPTION
Fixes #10391

## Problem
Playwright Cross-Browser (Nightly) failing on all 4 browser projects (webkit, firefox, mobile-chrome, mobile-safari) with 29 test failures total.

## Root Causes & Fixes

### 1. Theme toggle test (smoke.spec.ts) — webkit + firefox
- **Cause**: Imprecise locator `[aria-label*="theme"]` could match non-button elements; no `force: true` for CSS-transition-blocked clicks
- **Fix**: Use `nav button[aria-label*="theme" i]` for precision; add `force: true`; increase poll timeout to 10s

### 2. Sidebar 'Add more' click (Sidebar.spec.ts) — webkit
- **Cause**: CSS transitions cause webkit actionability check to stall
- **Fix**: Add `force: true` to bypass stability check

### 3. Dashboard Data Loading tests (Dashboard.spec.ts) — firefox
- **Cause**: Missing `kc-demo-mode=false` in localStorage → useCached hooks return demo data instead of using route mocks
- **Fix**: Set `kc-demo-mode=false` in addInitScript for both Data Loading tests

### 4. Card heading visibility (Dashboard.spec.ts) — mobile-chrome
- **Cause**: Default assertion timeout too short for mobile card rendering
- **Fix**: Add explicit 5s timeout for heading visibility check

### 5. Tour responsive test (Tour.spec.ts) — webkit
- **Cause**: 10s timeout insufficient for webkit viewport resize + re-layout
- **Fix**: Increase to 15s

### 6. Overflow menu crash (navbar-responsive.spec.ts) — mobile-safari
- **Cause**: Force-click fires before webkit layout stabilizes → page crash
- **Fix**: Add 500ms settle delay after visibility check; increase panel timeout to 10s

## Test Files Modified
- `web/e2e/smoke.spec.ts`
- `web/e2e/Sidebar.spec.ts`
- `web/e2e/Dashboard.spec.ts`
- `web/e2e/Tour.spec.ts`
- `web/e2e/navbar-responsive.spec.ts`