### PR TITLE
fix: use agentFetch in fetchWithRetry for kc-agent auth

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1932,7 +1932,7 @@ export async function fetchWithRetry(
     }
 
     try {
-      const response = await fetch(url, {
+      const response = await agentFetch(url, {
         ...fetchOptions,
         signal: controller.signal,
       })

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -5,7 +5,6 @@ import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode } from '../../lib/demoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { kubectlProxy } from '../../lib/kubectlProxy'
-import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef, fetchWithRetry } from './shared'
 import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
@@ -1145,12 +1144,9 @@ export function useDeployments(cluster?: string, namespace?: string) {
         return
       }
 
-      const token = localStorage.getItem(STORAGE_KEY_TOKEN)
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-      headers['Authorization'] = `Bearer ${token}`
       const response = await fetchWithRetry(url, {
         method: 'GET',
-        headers,
+        headers: { 'Content-Type': 'application/json' },
         timeoutMs: MCP_HOOK_TIMEOUT_MS,
       })
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- Changes `fetchWithRetry()` to use `agentFetch()` instead of raw `fetch()`, ensuring KC_AGENT_TOKEN is injected on all kc-agent requests
- Removes incorrect manual OAuth JWT injection in `useDeployments` REST API fallback (was using `STORAGE_KEY_TOKEN` which is the OAuth JWT, not the agent token)
- Fixes 401 errors on workload hooks: deployments, jobs, HPAs, replicasets, statefulsets, daemonsets, cronjobs

Follow-up to #10398 which migrated direct `fetch()` calls but missed `fetchWithRetry()`.

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] Console starts with `startup-oauth.sh`
- [ ] Zero 401 errors in browser console on clusters page
- [ ] Workloads page loads deployments without errors