### PR TITLE
🐛 Fix test regression from PR #10398 agentFetch migration

### DIFF
--- a/web/src/components/auth/AuthCallback.test.tsx
+++ b/web/src/components/auth/AuthCallback.test.tsx
@@ -5,6 +5,13 @@ import { MemoryRouter } from 'react-router-dom'
 
 import '../../test/utils/setupMocks'
 
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/auth', () => ({
   useAuth: () => ({
     setToken: vi.fn(),

--- a/web/src/components/auth/__tests__/AuthCallback.contract.test.tsx
+++ b/web/src/components/auth/__tests__/AuthCallback.contract.test.tsx
@@ -24,6 +24,13 @@ const mockSetToken = vi.fn()
 const mockRefreshUser = vi.fn().mockResolvedValue(undefined)
 const mockShowToast = vi.fn()
 
+vi.mock('../../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {

--- a/web/src/components/cards/__tests__/DynamicCard.test.tsx
+++ b/web/src/components/cards/__tests__/DynamicCard.test.tsx
@@ -9,6 +9,13 @@ import type { DynamicCardDefinition, DynamicCardDefinition_T1 } from '../../../l
 // ---------------------------------------------------------------------------
 
 const mockGetDynamicCard = vi.fn()
+vi.mock('../../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/dynamic-cards/dynamicCardRegistry', () => ({
   getDynamicCard: (...args: unknown[]) => mockGetDynamicCard(...args),
 }))

--- a/web/src/components/gitops/SyncDialog.test.tsx
+++ b/web/src/components/gitops/SyncDialog.test.tsx
@@ -12,6 +12,13 @@ const DETECT_DRIFT_PATH_SUFFIX = '/gitops/detect-drift'
 // Wait budget for async state transitions inside the component.
 const ASYNC_WAIT_TIMEOUT_MS = 2000
 
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/modals', () => {
   const BaseModal = Object.assign(
     ({ children }: { children: React.ReactNode }) => <div data-testid='mock-base-modal'>{children}</div>,

--- a/web/src/components/missions/__tests__/MissionLandingPage.test.tsx
+++ b/web/src/components/missions/__tests__/MissionLandingPage.test.tsx
@@ -15,6 +15,13 @@ import { MissionLandingPage } from '../MissionLandingPage'
 
 const mockNavigate = vi.fn()
 
+vi.mock('../../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
   return {

--- a/web/src/components/namespaces/__tests__/NamespaceManager.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceManager.test.tsx
@@ -19,6 +19,13 @@ const API_TIMEOUT_MS = 3000
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
 const mockUseClusters = vi.fn()
+vi.mock('../../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../hooks/useMCP', () => ({
   useClusters: () => mockUseClusters(),
 }))

--- a/web/src/contexts/AlertsContext.deepcover.test.tsx
+++ b/web/src/contexts/AlertsContext.deepcover.test.tsx
@@ -14,6 +14,13 @@ const { mockStartMission, mockUseDemoMode, mockSendNotificationWithDeepLink } = 
   mockSendNotificationWithDeepLink: vi.fn(),
 }))
 
+vi.mock('../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./AlertsDataFetcher', () => ({
   default: () => null,
 }))

--- a/web/src/contexts/AlertsContext.lifecycle.test.tsx
+++ b/web/src/contexts/AlertsContext.lifecycle.test.tsx
@@ -14,6 +14,13 @@ const { mockStartMission, mockUseDemoMode, mockSendNotificationWithDeepLink } = 
   mockSendNotificationWithDeepLink: vi.fn(),
 }))
 
+vi.mock('../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./AlertsDataFetcher', () => ({
   default: () => null,
 }))

--- a/web/src/contexts/AlertsContext.storage.test.tsx
+++ b/web/src/contexts/AlertsContext.storage.test.tsx
@@ -14,6 +14,13 @@ const { mockStartMission, mockUseDemoMode, mockSendNotificationWithDeepLink } = 
   mockSendNotificationWithDeepLink: vi.fn(),
 }))
 
+vi.mock('../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./AlertsDataFetcher', () => ({
   default: () => null,
 }))

--- a/web/src/hooks/__tests__/useArgoCD-coverage.test.ts
+++ b/web/src/hooks/__tests__/useArgoCD-coverage.test.ts
@@ -13,6 +13,13 @@ const mockUseClusters = vi.fn(() => ({
   isLoading: false,
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useMCP', () => ({
   useClusters: (...args: unknown[]) => mockUseClusters(...args),
 }))

--- a/web/src/hooks/__tests__/useArgoCD-expand.test.ts
+++ b/web/src/hooks/__tests__/useArgoCD-expand.test.ts
@@ -13,6 +13,13 @@ const mockUseClusters = vi.fn(() => ({
   isLoading: false,
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useMCP', () => ({
   useClusters: (...args: unknown[]) => mockUseClusters(...args),
 }))

--- a/web/src/hooks/__tests__/useArgoCD.test.ts
+++ b/web/src/hooks/__tests__/useArgoCD.test.ts
@@ -14,6 +14,13 @@ const mockUseClusters = vi.fn(() => ({
   isLoading: false,
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useMCP', () => ({
   useClusters: (...args: unknown[]) => mockUseClusters(...args),
 }))

--- a/web/src/hooks/__tests__/useBenchmarkData.test.ts
+++ b/web/src/hooks/__tests__/useBenchmarkData.test.ts
@@ -17,6 +17,13 @@ const STORAGE_KEY_TOKEN = 'token'
 
 const mockCacheResult = vi.fn()
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/cache', () => ({
   useCache: (opts: { fetcher: () => Promise<unknown> }) => {
     // Store fetcher so tests can call it

--- a/web/src/hooks/__tests__/useBonusPoints.test.ts
+++ b/web/src/hooks/__tests__/useBonusPoints.test.ts
@@ -12,6 +12,13 @@ const { mockUseAuth } = vi.hoisted(() => ({
   })),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/auth', () => ({
   useAuth: () => mockUseAuth(),
 }))

--- a/web/src/hooks/__tests__/useCRDs.test.ts
+++ b/web/src/hooks/__tests__/useCRDs.test.ts
@@ -22,6 +22,13 @@ let mockClustersReturn = {
   isLoading: false,
 }
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useMCP', () => ({
   useClusters: () => mockClustersReturn,
 }))

--- a/web/src/hooks/__tests__/useCachedACMMScan.test.tsx
+++ b/web/src/hooks/__tests__/useCachedACMMScan.test.tsx
@@ -20,6 +20,13 @@ const lastArgs: { current: Record<string, unknown> | null } = { current: null }
 // `forceRefetch()` actually calls through to it.
 const lastRefetch: { current: ReturnType<typeof vi.fn> | null } = { current: null }
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/cache', () => ({
   useCache: (args: Record<string, unknown>) => {
     lastArgs.current = args

--- a/web/src/hooks/__tests__/useCachedThanosStatus-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedThanosStatus-funcs.test.ts
@@ -6,6 +6,13 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
 }))

--- a/web/src/hooks/__tests__/useClusterGroups.test.ts
+++ b/web/src/hooks/__tests__/useClusterGroups.test.ts
@@ -24,6 +24,13 @@ const mockUsePersistence = vi.fn(() => ({
   isActive: false,
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../usePersistence', () => ({
   usePersistence: () => mockUsePersistence(),
 }))

--- a/web/src/hooks/__tests__/useConsoleCRs.test.ts
+++ b/web/src/hooks/__tests__/useConsoleCRs.test.ts
@@ -23,6 +23,13 @@ const mockUsePersistence = vi.fn(() => ({
   activeCluster: 'wds1',
   config: { namespace: 'kubestellar-console' },
 }))
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../usePersistence', () => ({
   usePersistence: () => mockUsePersistence(),
 }))

--- a/web/src/hooks/__tests__/useDrasiResources.test.tsx
+++ b/web/src/hooks/__tests__/useDrasiResources.test.tsx
@@ -24,6 +24,13 @@ const mockActive: { current: {
   createdAt: number
 } | null } = { current: null }
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useDrasiConnections', () => ({
   useDrasiConnections: () => ({
     connections: mockActive.current ? [mockActive.current] : [],

--- a/web/src/hooks/__tests__/useFederationActions.test.ts
+++ b/web/src/hooks/__tests__/useFederationActions.test.ts
@@ -4,6 +4,13 @@ import type { ActionRequest, ActionResult } from '../useFederationActions'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 describe('executeFederationAction', () => {
     beforeEach(() => {
         localStorage.clear()

--- a/web/src/hooks/__tests__/useGatewayStatus.test.ts
+++ b/web/src/hooks/__tests__/useGatewayStatus.test.ts
@@ -10,6 +10,13 @@ const { mockRegisterRefetch, mockUseClusters } = vi.hoisted(() => ({
   mockUseClusters: vi.fn(),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useMCP', () => ({
   useClusters: () => mockUseClusters(),
 }))

--- a/web/src/hooks/__tests__/useGitHubPipelines.test.ts
+++ b/web/src/hooks/__tests__/useGitHubPipelines.test.ts
@@ -8,6 +8,13 @@ import { renderHook } from '@testing-library/react'
 
 const lastCacheArgs: { calls: Array<Record<string, unknown>> } = { calls: [] }
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/cache', () => ({
   useCache: (args: Record<string, unknown>) => {
     lastCacheArgs.calls.push(args)

--- a/web/src/hooks/__tests__/useGitHubRewards.test.ts
+++ b/web/src/hooks/__tests__/useGitHubRewards.test.ts
@@ -15,6 +15,13 @@ import type { GitHubRewardsResponse } from '../../types/rewards'
 // ---------------------------------------------------------------------------
 
 const mockUseAuth = vi.fn<[], { user: { github_login: string } | null; isAuthenticated: boolean }>()
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/auth', () => ({ useAuth: () => mockUseAuth() }))
 
 // Constants are simple values -- we mirror them here for localStorage setup.

--- a/web/src/hooks/__tests__/useHelmActions.test.ts
+++ b/web/src/hooks/__tests__/useHelmActions.test.ts
@@ -12,6 +12,13 @@ import { renderHook, act } from '@testing-library/react'
 // Mock dependencies
 // ---------------------------------------------------------------------------
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 10_000,
 }))

--- a/web/src/hooks/__tests__/useInsightEnrichment.test.ts
+++ b/web/src/hooks/__tests__/useInsightEnrichment.test.ts
@@ -14,6 +14,13 @@ import { renderHook } from '@testing-library/react'
 let mockAgentConnected = false
 let mockAgentUnavailable = false
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useLocalAgent', () => ({
   isAgentConnected: () => mockAgentConnected,
   isAgentUnavailable: () => mockAgentUnavailable,

--- a/web/src/hooks/__tests__/useLocalAgent.test.ts
+++ b/web/src/hooks/__tests__/useLocalAgent.test.ts
@@ -17,6 +17,13 @@ import { renderHook, act } from '@testing-library/react'
 // Mocks -- declared before module import
 // ---------------------------------------------------------------------------
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../hooks/useDemoMode', () => ({
   isDemoModeForced: false,
 }))

--- a/web/src/hooks/__tests__/useLocalClusterTools-expand.test.ts
+++ b/web/src/hooks/__tests__/useLocalClusterTools-expand.test.ts
@@ -6,6 +6,13 @@ import { renderHook, waitFor, act } from '@testing-library/react'
 // ---------------------------------------------------------------------------
 
 const mockIsConnected = vi.fn(() => false)
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useLocalAgent', () => ({
   useLocalAgent: () => ({ isConnected: mockIsConnected() }),
   isAgentUnavailable: vi.fn(() => true),

--- a/web/src/hooks/__tests__/useLocalClusterTools.test.ts
+++ b/web/src/hooks/__tests__/useLocalClusterTools.test.ts
@@ -6,6 +6,13 @@ import { renderHook, waitFor, act } from '@testing-library/react'
 // ---------------------------------------------------------------------------
 
 const mockIsConnected = vi.fn(() => false)
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useLocalAgent', () => ({
   useLocalAgent: () => ({ isConnected: mockIsConnected() }),
   isAgentUnavailable: vi.fn(() => true),

--- a/web/src/hooks/__tests__/useMarketplace.test.ts
+++ b/web/src/hooks/__tests__/useMarketplace.test.ts
@@ -8,6 +8,13 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 const mockApiGet = vi.fn()
 const mockApiPost = vi.fn()
 const mockApiDelete = vi.fn()
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/api', () => ({
   api: {
     get: (...args: unknown[]) => mockApiGet(...args),

--- a/web/src/hooks/__tests__/useMediumBlog.test.ts
+++ b/web/src/hooks/__tests__/useMediumBlog.test.ts
@@ -13,6 +13,13 @@ afterEach(() => {
   globalThis.fetch = originalFetch
 })
 
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 describe('useMediumBlog', () => {
   it('returns loading state initially', () => {
     globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}))

--- a/web/src/hooks/__tests__/useNPSSurvey.test.ts
+++ b/web/src/hooks/__tests__/useNPSSurvey.test.ts
@@ -17,6 +17,13 @@ const {
   store: new Map<string, string>(),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useRewards', () => ({
   useRewards: () => ({ awardCoins: mockAwardCoins }),
 }))

--- a/web/src/hooks/__tests__/usePersistedSettings.test.ts
+++ b/web/src/hooks/__tests__/usePersistedSettings.test.ts
@@ -12,6 +12,13 @@ import { renderHook, act } from '@testing-library/react'
 // ---------------------------------------------------------------------------
 
 const mockIsAuthenticated = vi.fn(() => true)
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/auth', () => ({
   useAuth: () => ({ isAuthenticated: mockIsAuthenticated() }),
 }))

--- a/web/src/hooks/__tests__/usePersistence.test.ts
+++ b/web/src/hooks/__tests__/usePersistence.test.ts
@@ -6,6 +6,13 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 // ---------------------------------------------------------------------------
 
 let mockAgentStatus = 'connected'
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useLocalAgent', () => ({
   useLocalAgent: () => ({ status: mockAgentStatus }),
 }))

--- a/web/src/hooks/__tests__/usePlaylistVideos.test.ts
+++ b/web/src/hooks/__tests__/usePlaylistVideos.test.ts
@@ -38,6 +38,13 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 describe('usePlaylistVideos', () => {
   it('returns expected shape', () => {
     fetchMock.mockResolvedValue({

--- a/web/src/hooks/__tests__/usePredictionFeedback-expand.test.ts
+++ b/web/src/hooks/__tests__/usePredictionFeedback-expand.test.ts
@@ -11,6 +11,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/constants', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return { ...actual, LOCAL_AGENT_HTTP_URL: 'http://localhost:8585' }

--- a/web/src/hooks/__tests__/usePrometheusMetrics.test.ts
+++ b/web/src/hooks/__tests__/usePrometheusMetrics.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/constants', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {

--- a/web/src/hooks/__tests__/useProviderConnection.test.ts
+++ b/web/src/hooks/__tests__/useProviderConnection.test.ts
@@ -16,6 +16,13 @@ import { renderHook, act } from '@testing-library/react'
 // Mocks
 // ---------------------------------------------------------------------------
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/constants', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://127.0.0.1:8585',
 }))

--- a/web/src/hooks/__tests__/useProviderHealth-coverage.test.ts
+++ b/web/src/hooks/__tests__/useProviderHealth-coverage.test.ts
@@ -25,6 +25,13 @@ const mockCacheResult = {
 // Mocks
 // ---------------------------------------------------------------------------
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useDemoMode', () => ({
   getDemoMode: () => mockDemoMode,
   useDemoMode: () => ({ isDemoMode: mockDemoMode }),

--- a/web/src/hooks/__tests__/useServiceExports.test.ts
+++ b/web/src/hooks/__tests__/useServiceExports.test.ts
@@ -17,6 +17,13 @@ const mockUseClusters = vi.fn(() => ({
   deduplicatedClusters: [] as Array<{ name: string; reachable?: boolean }>,
   isLoading: false,
 }))
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useMCP', () => ({
   useClusters: () => mockUseClusters(),
 }))

--- a/web/src/hooks/__tests__/useServiceImportsCard.test.ts
+++ b/web/src/hooks/__tests__/useServiceImportsCard.test.ts
@@ -9,6 +9,13 @@ const { mockUseClusters } = vi.hoisted(() => ({
   mockUseClusters: vi.fn(),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useMCP', () => ({
   useClusters: () => mockUseClusters(),
 }))

--- a/web/src/hooks/__tests__/useSidebarConfig.test.ts
+++ b/web/src/hooks/__tests__/useSidebarConfig.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useDemoMode', () => ({
   useDemoMode: vi.fn(() => ({ isDemoMode: true })),
 }))

--- a/web/src/hooks/__tests__/useTokenUsage.test.ts
+++ b/web/src/hooks/__tests__/useTokenUsage.test.ts
@@ -12,6 +12,13 @@ const { mockGetDemoMode, mockIsAgentUnavailable, mockReportAgentDataSuccess, moc
   mockReportAgentDataError: vi.fn(),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useLocalAgent', () => ({
   isAgentUnavailable: mockIsAgentUnavailable,
   reportAgentDataSuccess: mockReportAgentDataSuccess,

--- a/web/src/hooks/__tests__/useUpdateProgress.test.ts
+++ b/web/src/hooks/__tests__/useUpdateProgress.test.ts
@@ -55,6 +55,13 @@ class MockWebSocket implements MockWebSocketInstance {
 // Mocks — before module import
 // ---------------------------------------------------------------------------
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/constants/network', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return { ...actual,

--- a/web/src/hooks/__tests__/useVersionCheck.test.tsx
+++ b/web/src/hooks/__tests__/useVersionCheck.test.tsx
@@ -27,6 +27,13 @@ const mockUseLocalAgent = vi.hoisted(() =>
     }))
 )
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../useLocalAgent', () => ({
     useLocalAgent: mockUseLocalAgent,
 }))

--- a/web/src/hooks/__tests__/useWorkloadMonitor.test.ts
+++ b/web/src/hooks/__tests__/useWorkloadMonitor.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../lib/constants', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {

--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
@@ -30,6 +30,13 @@ const {
   mockSubscribePolling: vi.fn(() => vi.fn()),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },

--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage2.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage2.test.ts
@@ -22,6 +22,13 @@ const {
   mockSubscribePolling: vi.fn(() => vi.fn()),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },

--- a/web/src/hooks/mcp/__tests__/buildpacks.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks.test.ts
@@ -19,6 +19,13 @@ const {
   mockRegisterCacheReset: vi.fn(() => vi.fn()),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },

--- a/web/src/hooks/mcp/__tests__/compute.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.test.ts
@@ -36,6 +36,13 @@ const {
   },
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/mcp/__tests__/config.test.ts
+++ b/web/src/hooks/mcp/__tests__/config.test.ts
@@ -23,6 +23,13 @@ const {
   mockRegisterRefetch: vi.fn(() => vi.fn()),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/mcp/__tests__/crossplane-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/crossplane-coverage.test.ts
@@ -21,6 +21,13 @@ const {
   mockSubscribePolling: vi.fn(() => vi.fn()),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },

--- a/web/src/hooks/mcp/__tests__/crossplane.test.ts
+++ b/web/src/hooks/mcp/__tests__/crossplane.test.ts
@@ -19,6 +19,13 @@ const {
   mockRegisterCacheReset: vi.fn(() => vi.fn()),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },

--- a/web/src/hooks/mcp/__tests__/events.test.ts
+++ b/web/src/hooks/mcp/__tests__/events.test.ts
@@ -31,6 +31,13 @@ const {
   }
 })
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/mcp/__tests__/helm-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-coverage.test.ts
@@ -23,6 +23,13 @@ const {
   mockSubscribePolling: vi.fn(() => vi.fn()),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },

--- a/web/src/hooks/mcp/__tests__/helm.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm.test.ts
@@ -23,6 +23,13 @@ const {
   mockSubscribePolling: vi.fn(() => vi.fn()),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },

--- a/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
@@ -25,6 +25,13 @@ const {
   mockMapSettled: vi.fn(),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../useLocalAgent', () => ({
   isAgentUnavailable: () => mockIsAgentUnavailable(),
   reportAgentDataSuccess: () => mockReportAgentDataSuccess(),

--- a/web/src/hooks/mcp/__tests__/kagenti.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagenti.test.ts
@@ -23,6 +23,13 @@ const {
   mockUseCache: vi.fn(),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../useLocalAgent', () => ({
   isAgentUnavailable: () => mockIsAgentUnavailable(),
   reportAgentDataSuccess: () => mockReportAgentDataSuccess(),

--- a/web/src/hooks/mcp/__tests__/namespaces.test.ts
+++ b/web/src/hooks/mcp/__tests__/namespaces.test.ts
@@ -30,6 +30,13 @@ const {
   },
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/mcp/__tests__/networking.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking.test.ts
@@ -33,6 +33,13 @@ const {
   }
 })
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/mcp/__tests__/security.test.ts
+++ b/web/src/hooks/mcp/__tests__/security.test.ts
@@ -19,6 +19,13 @@ const {
   mockSubscribePolling: vi.fn(() => vi.fn()),
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/mcp/__tests__/shared-cache-fetch.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-cache-fetch.test.ts
@@ -28,6 +28,13 @@ const mockResetAllCacheFailures = vi.hoisted(() => vi.fn())
 const mockKubectlProxyExec = vi.hoisted(() => vi.fn())
 const mockApiGet = vi.hoisted(() => vi.fn())
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/api', () => ({
   api: { get: mockApiGet },
   isBackendUnavailable: mockIsBackendUnavailable,

--- a/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
@@ -44,6 +44,13 @@ const mockResetAllCacheFailures = vi.hoisted(() => vi.fn())
 const mockKubectlProxyExec = vi.hoisted(() => vi.fn())
 const mockApiGet = vi.hoisted(() => vi.fn())
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/api', () => ({
   api: { get: mockApiGet },
   isBackendUnavailable: mockIsBackendUnavailable,

--- a/web/src/hooks/mcp/__tests__/shared-pure-funcs.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-pure-funcs.test.ts
@@ -28,6 +28,13 @@ const mockResetAllCacheFailures = vi.hoisted(() => vi.fn())
 const mockKubectlProxyExec = vi.hoisted(() => vi.fn())
 const mockApiGet = vi.hoisted(() => vi.fn())
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/api', () => ({
   api: { get: mockApiGet },
   isBackendUnavailable: mockIsBackendUnavailable,

--- a/web/src/hooks/mcp/__tests__/shared-websocket-detect.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-websocket-detect.test.ts
@@ -28,6 +28,13 @@ const mockResetAllCacheFailures = vi.hoisted(() => vi.fn())
 const mockKubectlProxyExec = vi.hoisted(() => vi.fn())
 const mockApiGet = vi.hoisted(() => vi.fn())
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/api', () => ({
   api: { get: mockApiGet },
   isBackendUnavailable: mockIsBackendUnavailable,

--- a/web/src/hooks/mcp/__tests__/storage.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage.test.ts
@@ -39,6 +39,13 @@ const {
   }
 })
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
@@ -37,6 +37,13 @@ const {
   },
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/mcp/__tests__/workloads.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.test.ts
@@ -41,6 +41,13 @@ const {
   },
 }))
 
+vi.mock('../mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/useFederation.test.ts
+++ b/web/src/hooks/useFederation.test.ts
@@ -4,16 +4,34 @@ import { renderHook, act } from '@testing-library/react'
 const mockIsDemoMode = vi.fn(() => false)
 
 vi.mock('./useDemoMode', () => ({
+  isDemoModeForced: false,
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
 }))
 
-vi.mock('../lib/constants/network', () => ({
-  LOCAL_AGENT_HTTP_URL: 'http://127.0.0.1:8585',
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+vi.mock('../lib/demoMode', () => ({
+  isDemoModeForced: false,
+  isDemoMode: () => false,
+  isNetlifyDeployment: false,
+  isDemoToken: () => false,
+  getDemoMode: () => false,
+  subscribeDemoMode: () => () => {},
+  STORAGE_KEY_DEMO_MODE: 'kc-demo-mode',
 }))
 
-vi.mock('../lib/constants', () => ({
-  STORAGE_KEY_TOKEN: 'token',
+vi.mock('../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    LOCAL_AGENT_HTTP_URL: 'http://127.0.0.1:8585',
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+  }
+})
+
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
 describe('useFederation', () => {

--- a/web/src/hooks/useInsightEnrichment-edge.test.ts
+++ b/web/src/hooks/useInsightEnrichment-edge.test.ts
@@ -22,6 +22,13 @@ const { mockIsAgentConnected, mockIsAgentUnavailable } = vi.hoisted(() => ({
   mockIsAgentUnavailable: vi.fn(() => false),
 }))
 
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./useLocalAgent', () => ({
   isAgentConnected: () => mockIsAgentConnected(),
   isAgentUnavailable: () => mockIsAgentUnavailable(),

--- a/web/src/hooks/useInsightEnrichment-http.test.ts
+++ b/web/src/hooks/useInsightEnrichment-http.test.ts
@@ -22,6 +22,13 @@ const { mockIsAgentConnected, mockIsAgentUnavailable } = vi.hoisted(() => ({
   mockIsAgentUnavailable: vi.fn(() => false),
 }))
 
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./useLocalAgent', () => ({
   isAgentConnected: () => mockIsAgentConnected(),
   isAgentUnavailable: () => mockIsAgentUnavailable(),

--- a/web/src/hooks/useInsightEnrichment-ws.test.ts
+++ b/web/src/hooks/useInsightEnrichment-ws.test.ts
@@ -22,6 +22,13 @@ const { mockIsAgentConnected, mockIsAgentUnavailable } = vi.hoisted(() => ({
   mockIsAgentUnavailable: vi.fn(() => false),
 }))
 
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./useLocalAgent', () => ({
   isAgentConnected: () => mockIsAgentConnected(),
   isAgentUnavailable: () => mockIsAgentUnavailable(),

--- a/web/src/hooks/useMissions.analytics-agents.test.tsx
+++ b/web/src/hooks/useMissions.analytics-agents.test.tsx
@@ -7,6 +7,13 @@ import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMission
 
 // ── External module mocks ─────────────────────────────────────────────────────
 
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),

--- a/web/src/hooks/useMissions.edgecases.test.tsx
+++ b/web/src/hooks/useMissions.edgecases.test.tsx
@@ -7,6 +7,13 @@ import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMission
 
 // ── External module mocks ─────────────────────────────────────────────────────
 
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),

--- a/web/src/hooks/useMissions.messages-stream.test.tsx
+++ b/web/src/hooks/useMissions.messages-stream.test.tsx
@@ -7,6 +7,13 @@ import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMission
 
 // ── External module mocks ─────────────────────────────────────────────────────
 
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),

--- a/web/src/hooks/useMissions.preflight-agents.test.tsx
+++ b/web/src/hooks/useMissions.preflight-agents.test.tsx
@@ -7,6 +7,13 @@ import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMission
 
 // ── External module mocks ─────────────────────────────────────────────────────
 
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),

--- a/web/src/hooks/useMissions.provider-start.test.tsx
+++ b/web/src/hooks/useMissions.provider-start.test.tsx
@@ -7,6 +7,13 @@ import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMission
 
 // ── External module mocks ─────────────────────────────────────────────────────
 
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),

--- a/web/src/hooks/useMissions.save-run.test.tsx
+++ b/web/src/hooks/useMissions.save-run.test.tsx
@@ -7,6 +7,13 @@ import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMission
 
 // ── External module mocks ─────────────────────────────────────────────────────
 
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),

--- a/web/src/hooks/useMissions.state-persist.test.tsx
+++ b/web/src/hooks/useMissions.state-persist.test.tsx
@@ -7,6 +7,13 @@ import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMission
 
 // ── External module mocks ─────────────────────────────────────────────────────
 
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),

--- a/web/src/hooks/useMissions.websocket-reconnect.test.tsx
+++ b/web/src/hooks/useMissions.websocket-reconnect.test.tsx
@@ -7,6 +7,13 @@ import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMission
 
 // ── External module mocks ─────────────────────────────────────────────────────
 
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),

--- a/web/src/lib/__tests__/analytics-coverage-send.test.ts
+++ b/web/src/lib/__tests__/analytics-coverage-send.test.ts
@@ -24,6 +24,13 @@ function srcHasHostname(el: Element, hostname: string): boolean {
 
 // ── Shared mock setup ──────────────────────────────────────────────
 
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../constants', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
   return {

--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -6,6 +6,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import { STORAGE_KEY_HAS_SESSION } from '../constants/storage'
 
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 vi.mock('../constants', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {

--- a/web/src/lib/__tests__/kubara.test.ts
+++ b/web/src/lib/__tests__/kubara.test.ts
@@ -6,6 +6,13 @@ const resetCache = async () => {
   vi.resetModules()
 }
 
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 describe('parseResourceRequests', () => {
   it('returns null when no resources block', () => {
     const yaml = 'replicaCount: 1\nimage:\n  tag: latest\n'

--- a/web/src/lib/__tests__/kubectlProxy-expand.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy-expand.test.ts
@@ -16,7 +16,22 @@ vi.mock('../utils/wsAuth', () => ({
 }))
 
 vi.mock('../demoMode', () => ({
+  isDemoModeForced: false,
   get isNetlifyDeployment() { return mockIsNetlify },
+}))
+
+vi.mock('../../hooks/useBackendHealth', () => ({
+  isInClusterMode: () => false,
+  useBackendHealth: () => ({ status: 'connected', isConnected: true }),
+}))
+
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+  reportAgentDataError: () => {},
+  reportAgentDataSuccess: () => {},
 }))
 
 vi.mock('../constants', () => ({
@@ -32,6 +47,15 @@ vi.mock('../constants', () => ({
   POD_RESTART_ISSUE_THRESHOLD: 5,
   FOCUS_DELAY_MS: 100,
   STORAGE_KEY_TOKEN: 'token',
+  MCP_HOOK_TIMEOUT_MS: 15_000,
+  FETCH_DEFAULT_TIMEOUT_MS: 5_000,
+  STORAGE_KEY_USER_CACHE: 'userCache',
+  STORAGE_KEY_HAS_SESSION: 'hasSession',
+  DEMO_TOKEN_VALUE: 'demo-token',
+  DEFAULT_REFRESH_INTERVAL_MS: 120_000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  MCP_PROBE_TIMEOUT_MS: 3_000,
+  STORAGE_KEY_DEMO_MODE: 'kc-demo-mode',
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/__tests__/kubectlProxy.additional.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy.additional.test.ts
@@ -26,9 +26,24 @@ vi.mock('../utils/wsAuth', () => ({
 }))
 
 vi.mock('../demoMode', () => ({
+  isDemoModeForced: false,
   get isNetlifyDeployment() {
     return mockIsNetlify
   },
+}))
+
+vi.mock('../../hooks/useBackendHealth', () => ({
+  isInClusterMode: () => false,
+  useBackendHealth: () => ({ status: 'connected', isConnected: true }),
+}))
+
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+  reportAgentDataError: () => {},
+  reportAgentDataSuccess: () => {},
 }))
 
 vi.mock('../constants', () => ({
@@ -44,6 +59,15 @@ vi.mock('../constants', () => ({
   POD_RESTART_ISSUE_THRESHOLD: 5,
   FOCUS_DELAY_MS: 100,
   STORAGE_KEY_TOKEN: 'token',
+  MCP_HOOK_TIMEOUT_MS: 15_000,
+  FETCH_DEFAULT_TIMEOUT_MS: 5_000,
+  STORAGE_KEY_USER_CACHE: 'userCache',
+  STORAGE_KEY_HAS_SESSION: 'hasSession',
+  DEMO_TOKEN_VALUE: 'demo-token',
+  DEFAULT_REFRESH_INTERVAL_MS: 120_000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  MCP_PROBE_TIMEOUT_MS: 3_000,
+  STORAGE_KEY_DEMO_MODE: 'kc-demo-mode',
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/__tests__/kubectlProxy.core.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy.core.test.ts
@@ -26,9 +26,24 @@ vi.mock('../utils/wsAuth', () => ({
 }))
 
 vi.mock('../demoMode', () => ({
+  isDemoModeForced: false,
   get isNetlifyDeployment() {
     return mockIsNetlify
   },
+}))
+
+vi.mock('../../hooks/useBackendHealth', () => ({
+  isInClusterMode: () => false,
+  useBackendHealth: () => ({ status: 'connected', isConnected: true }),
+}))
+
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+  reportAgentDataError: () => {},
+  reportAgentDataSuccess: () => {},
 }))
 
 vi.mock('../constants', () => ({
@@ -44,6 +59,15 @@ vi.mock('../constants', () => ({
   POD_RESTART_ISSUE_THRESHOLD: 5,
   FOCUS_DELAY_MS: 100,
   STORAGE_KEY_TOKEN: 'token',
+  MCP_HOOK_TIMEOUT_MS: 15_000,
+  FETCH_DEFAULT_TIMEOUT_MS: 5_000,
+  STORAGE_KEY_USER_CACHE: 'userCache',
+  STORAGE_KEY_HAS_SESSION: 'hasSession',
+  DEMO_TOKEN_VALUE: 'demo-token',
+  DEFAULT_REFRESH_INTERVAL_MS: 120_000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  MCP_PROBE_TIMEOUT_MS: 3_000,
+  STORAGE_KEY_DEMO_MODE: 'kc-demo-mode',
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/__tests__/kubectlProxy.quantity.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy.quantity.test.ts
@@ -22,9 +22,24 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 let mockIsNetlify = false
 
 vi.mock('../demoMode', () => ({
+  isDemoModeForced: false,
   get isNetlifyDeployment() {
     return mockIsNetlify
   },
+}))
+
+vi.mock('../../hooks/useBackendHealth', () => ({
+  isInClusterMode: () => false,
+  useBackendHealth: () => ({ status: 'connected', isConnected: true }),
+}))
+
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+  reportAgentDataError: () => {},
+  reportAgentDataSuccess: () => {},
 }))
 
 vi.mock('../constants', () => ({
@@ -40,6 +55,15 @@ vi.mock('../constants', () => ({
   POD_RESTART_ISSUE_THRESHOLD: 5,
   FOCUS_DELAY_MS: 100,
   STORAGE_KEY_TOKEN: 'token',
+  MCP_HOOK_TIMEOUT_MS: 15_000,
+  FETCH_DEFAULT_TIMEOUT_MS: 5_000,
+  STORAGE_KEY_USER_CACHE: 'userCache',
+  STORAGE_KEY_HAS_SESSION: 'hasSession',
+  DEMO_TOKEN_VALUE: 'demo-token',
+  DEFAULT_REFRESH_INTERVAL_MS: 120_000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  MCP_PROBE_TIMEOUT_MS: 3_000,
+  STORAGE_KEY_DEMO_MODE: 'kc-demo-mode',
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/__tests__/sseClient-expand.test.ts
+++ b/web/src/lib/__tests__/sseClient-expand.test.ts
@@ -89,6 +89,13 @@ let testId = 1000
 // Tests
 // ---------------------------------------------------------------------------
 
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 describe('sseClient expanded', () => {
 
   // =========================================================================

--- a/web/src/lib/__tests__/sseClient-expand2.test.ts
+++ b/web/src/lib/__tests__/sseClient-expand2.test.ts
@@ -64,6 +64,13 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 describe('fetchSSE — expanded edge cases', () => {
   // 1. Non-ok response with no accumulated data retries
   it('retries on non-ok response status', async () => {

--- a/web/src/lib/__tests__/sseClient.test.ts
+++ b/web/src/lib/__tests__/sseClient.test.ts
@@ -79,6 +79,13 @@ afterEach(() => {
 // Unique URL counter to avoid SSE cache/dedup collisions between tests
 let testId = 0
 
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 describe('sseClient', () => {
 
   describe('module exports', () => {

--- a/web/src/lib/dynamic-cards/__tests__/useCardFetch.test.ts
+++ b/web/src/lib/dynamic-cards/__tests__/useCardFetch.test.ts
@@ -22,6 +22,13 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
+vi.mock('../../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 describe('createCardFetchScope', () => {
   it('returns useCardFetch and resetCount', () => {
     const scope = createCardFetchScope()

--- a/web/src/lib/unified/card/hooks/__tests__/useDataSource.test.ts
+++ b/web/src/lib/unified/card/hooks/__tests__/useDataSource.test.ts
@@ -23,6 +23,13 @@ import useDataSource from '../useDataSource'
 // Registry tests
 // ---------------------------------------------------------------------------
 
+vi.mock('../../../../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
 describe('registerDataHook', () => {
   it('registers a hook that can be retrieved by name', () => {
     const mockHook = vi.fn().mockReturnValue({


### PR DESCRIPTION
Fixes the test regression introduced by PR #10398 which migrated all kc-agent fetch calls to agentFetch().

## Problem

PR #10398 replaced raw `fetch()` calls with `agentFetch()` from `mcp/shared` across ~23 hooks and components. This broke ~130 test files in the coverage-hourly CI workflow across 3 failure modes:

### 1. Missing `isDemoModeForced` export (110 files)
`useLocalAgent.ts` uses `isDemoModeForced` from `useDemoMode` at class initialization (line 83). Tests mocking `useDemoMode` without this export fail with: *No "isDemoModeForced" export is defined on the mock*.

### 2. Missing `agentFetch` mock (89 files) 
Tests mocking `globalThis.fetch` lost interception because `agentFetch` wrapper handles the call. Tests expecting `fetch.mock.calls[0]` to contain the API URL instead got `/api/agent/token` (agentFetch's internal token request).

### 3. Incomplete constants mock (4 kubectlProxy files)
The import chain `kubectlProxy` → `useBackendHealth` → `mcp/shared` → `api.ts` needs `MCP_HOOK_TIMEOUT_MS`, `DEFAULT_REFRESH_INTERVAL_MS`, etc. from constants.

## Fix

- Added `isDemoModeForced: false` to all `useDemoMode`/`demoMode` mocks
- Added `mcp/shared` mock that delegates `agentFetch` to `globalThis.fetch` 
- Added missing constants + `useBackendHealth` mock to kubectlProxy tests
- Fixed `useDependencies.test.ts` mock to include `agentFetch` 
- Fixed `usePersistedSettings.test.ts` hoisted mock ordering
- Fixed `useFederation.test.ts` demoMode + mcp/shared mock

## Files changed
92 test files across hooks, components, contexts, and lib.