### PR TITLE
🐛 Fix System Updates to mention Marketplace-sourced components

### DIFF
--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -22,6 +22,7 @@ import {
   HardDrive,
   GitCommitHorizontal,
   Info,
+  Store,
 } from 'lucide-react'
 import { useVersionCheck } from '../../hooks/useVersionCheck'
 import { useUpdateProgress } from '../../hooks/useUpdateProgress'
@@ -369,6 +370,13 @@ export function UpdateSettings() {
             <div>
               <span className="font-medium text-foreground">{t('settings.updates.scopeCardDataTitle')}</span>
               <span className="text-muted-foreground"> — {t('settings.updates.scopeCardDataDesc')}</span>
+            </div>
+            <div className="flex items-start gap-2 pt-2 border-t border-border">
+              <Store className="w-4 h-4 mt-0.5 text-purple-400 shrink-0" />
+              <div>
+                <span className="font-medium text-foreground">{t('settings.updates.scopeMarketplaceTitle')}</span>
+                <span className="text-muted-foreground"> — {t('settings.updates.scopeMarketplaceDesc')}</span>
+              </div>
             </div>
           </div>
         )}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -590,7 +590,7 @@
     },
     "updates": {
       "title": "System Updates",
-      "subtitle": "Check for and install console updates",
+      "subtitle": "Manage updates for the console and Marketplace components",
       "checkNow": "Check Now",
       "updateChannel": "Update Channel",
       "stable": "Stable (Weekly releases)",
@@ -707,7 +707,9 @@
       "scopeReloadTitle": "Post-Deploy Page Reload",
       "scopeReloadDesc": "After a new version is deployed (whether via auto-update or manual upgrade), the browser detects the updated build and shows a banner prompting you to reload the page. This happens automatically and has no settings on this page.",
       "scopeCardDataTitle": "Dashboard Card Data",
-      "scopeCardDataDesc": "Dashboard cards fetch live data (cluster health, pod status, metrics) on their own schedules, independent of console version updates. Card refresh intervals are not controlled by these settings."
+      "scopeCardDataDesc": "Dashboard cards fetch live data (cluster health, pod status, metrics) on their own schedules, independent of console version updates. Card refresh intervals are not controlled by these settings.",
+      "scopeMarketplaceTitle": "Marketplace Components",
+      "scopeMarketplaceDesc": "Cards, themes, and integrations installed from the Marketplace are updated independently by their publishers. These items are not covered by the console version update channel above. Check the Marketplace page for available updates to installed components, or enable per-item auto-update from each item's settings."
     },
     "theme": {
       "title": "Appearance",


### PR DESCRIPTION
Fixes #10414

Updates the System Updates section in Settings to clarify that some components come from the Marketplace and may have different update sources/mechanisms. Addresses community feedback from @MikeSpreitzer.

## Changes

- **Updated subtitle**: Now reads "Manage updates for the console and Marketplace components" instead of only mentioning console updates
- **Added Marketplace Components scope entry**: New entry in the expandable "What do these settings control?" panel explaining that Marketplace-sourced items (cards, themes, integrations) are updated independently by their publishers and are not covered by the console version update channel
- **i18n keys added**: `scopeMarketplaceTitle` and `scopeMarketplaceDesc` in `common.json`