### PR TITLE
🐛 Fix 211 coverage test failures #10440

### DIFF
--- a/web/src/hooks/__tests__/useAIPredictions.test.ts
+++ b/web/src/hooks/__tests__/useAIPredictions.test.ts
@@ -37,6 +37,7 @@ vi.mock('../useTokenUsage', () => ({
 vi.mock('../mcp/shared', () => ({
   fullFetchClusters: mockFullFetchClusters,
   clusterCache: mockClusterCache,
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../../lib/constants', () => ({

--- a/web/src/hooks/__tests__/useCachedContainerd-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedContainerd-funcs.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
 }))
 
 vi.mock('../../lib/cache', () => ({

--- a/web/src/hooks/__tests__/useCachedCoreWorkloads.test.ts
+++ b/web/src/hooks/__tests__/useCachedCoreWorkloads.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../lib/kubectlProxy', () => ({
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: { clusters: [] },
   deduplicateClustersByServer: (clusters: unknown[]) => clusters,
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../useLocalAgent', () => ({

--- a/web/src/hooks/__tests__/useCachedData.agentFetchers.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.agentFetchers.test.ts
@@ -14,6 +14,7 @@ vi.mock('../useLocalAgent', () => ({
 
 vi.mock('../mcp/shared', () => ({
     clusterCacheRef: { clusters: [] },
+    agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 const originalFetch = globalThis.fetch

--- a/web/src/hooks/__tests__/useCachedData.edgecases.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.edgecases.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../lib/sseClient', () => ({
 
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: { clusters: [] },
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../useLocalAgent', () => ({

--- a/web/src/hooks/__tests__/useCachedData.fetchers.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.fetchers.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../lib/sseClient', () => ({
 
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: { clusters: [] },
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../useLocalAgent', () => ({

--- a/web/src/hooks/__tests__/useCachedData.hooks.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.hooks.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../lib/sseClient', () => ({
 
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: { clusters: [] },
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../useLocalAgent', () => ({

--- a/web/src/hooks/__tests__/useCachedData.progressive-gpu.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.progressive-gpu.test.ts
@@ -58,6 +58,7 @@ vi.mock('../../lib/sseClient', () => ({
 
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: mockClusterCacheRef,
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../useLocalAgent', () => ({

--- a/web/src/hooks/__tests__/useCachedData.rest-paths.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.rest-paths.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../lib/sseClient', () => ({
 
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: { clusters: [] },
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../useLocalAgent', () => ({

--- a/web/src/hooks/__tests__/useCachedData.security-gitops.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.security-gitops.test.ts
@@ -58,6 +58,7 @@ vi.mock('../../lib/sseClient', () => ({
 
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: mockClusterCacheRef,
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../useLocalAgent', () => ({

--- a/web/src/hooks/__tests__/useCachedData.sse-agent.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.sse-agent.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../lib/sseClient', () => ({
 
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: { clusters: [] },
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../useLocalAgent', () => ({

--- a/web/src/hooks/__tests__/useCachedISO27001.test.ts
+++ b/web/src/hooks/__tests__/useCachedISO27001.test.ts
@@ -42,6 +42,7 @@ vi.mock('../../lib/constants/network', async (importOriginal) => {
 
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: mockClusterCacheRef,
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../useLocalAgent', () => ({

--- a/web/src/hooks/__tests__/useCachedNodes.test.ts
+++ b/web/src/hooks/__tests__/useCachedNodes.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../lib/cache', () => ({
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: mockClusterCacheRef,
   deduplicateClustersByServer: (clusters: unknown[]) => clusters,
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../../lib/cache/fetcherUtils', () => ({

--- a/web/src/hooks/__tests__/useDependencies.test.ts
+++ b/web/src/hooks/__tests__/useDependencies.test.ts
@@ -25,6 +25,7 @@ vi.mock('../useLocalAgent', () => ({
 
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: mockClusterCacheRef,
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../../lib/demoMode', () => ({

--- a/web/src/hooks/__tests__/useDeployMissions-expand.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions-expand.test.ts
@@ -33,6 +33,7 @@ const mockClusterCacheRef = vi.hoisted(() => ({
 
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: mockClusterCacheRef,
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 const mockKubectlExec = vi.hoisted(() => vi.fn())

--- a/web/src/hooks/__tests__/useDeployMissions.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions.test.ts
@@ -34,6 +34,7 @@ const mockClusterCacheRef = vi.hoisted(() => ({
 
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: mockClusterCacheRef,
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 const mockKubectlExec = vi.hoisted(() => vi.fn())

--- a/web/src/hooks/__tests__/useWorkloads.test.ts
+++ b/web/src/hooks/__tests__/useWorkloads.test.ts
@@ -21,6 +21,7 @@ vi.mock('../useLocalAgent', () => ({
 
 vi.mock('../mcp/shared', () => ({
   clusterCacheRef: mockClusterCacheRef,
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
 vi.mock('../../lib/constants', () => ({

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -262,7 +262,7 @@ export default defineConfig(({ mode }) => ({
     css: true,
     include: ['src/**/*.{test,spec}.{ts,tsx}', 'netlify/functions/__tests__/*.{test,spec}.{ts,tsx}'],
     exclude: ['node_modules', 'e2e/**/*'],
-    teardownTimeout: process.env.CI ? 60_000 : 10_000, // CI runners need more time to terminate workers
+    teardownTimeout: process.env.CI ? 120_000 : 10_000, // CI: increased from 60s to 120s for worker cleanup stability (#10436)
     // CI runners (2-core, 7GB) OOM with 600+ test files at full concurrency
     maxWorkers: process.env.CI ? 2 : undefined,
     minWorkers: process.env.CI ? 1 : undefined,


### PR DESCRIPTION
Fixes #10440

## Root Cause
The test mocks for 'mcp/shared' module were missing the 'agentFetch' export, which is required by several test files that import and use agentFetch. This caused 211 test failures in the coverage suite.

## Changes
- Added 'agentFetch' mock to 15 test files that import from 'mcp/shared'
- Fixed 'useCachedContainerd-funcs.test.ts' to export 'isDemoModeForced' from 'useDemoMode' mock
- Increased 'teardownTimeout' in vite.config.ts from 60s to 120s for CI worker cleanup stability

## Files Modified
- web/src/hooks/__tests__/useCachedData.sse-agent.test.ts
- web/src/hooks/__tests__/useCachedData.edgecases.test.ts
- web/src/hooks/__tests__/useCachedData.fetchers.test.ts
- web/src/hooks/__tests__/useCachedData.hooks.test.ts
- web/src/hooks/__tests__/useCachedData.rest-paths.test.ts
- web/src/hooks/__tests__/useCachedData.progressive-gpu.test.ts
- web/src/hooks/__tests__/useCachedData.security-gitops.test.ts
- web/src/hooks/__tests__/useCachedData.agentFetchers.test.ts
- web/src/hooks/__tests__/useCachedContainerd-funcs.test.ts
- web/src/hooks/__tests__/useCachedCoreWorkloads.test.ts
- web/src/hooks/__tests__/useCachedISO27001.test.ts
- web/src/hooks/__tests__/useCachedNodes.test.ts
- web/src/hooks/__tests__/useDependencies.test.ts
- web/src/hooks/__tests__/useDeployMissions.test.ts
- web/src/hooks/__tests__/useDeployMissions-expand.test.ts
- web/src/hooks/__tests__/useWorkloads.test.ts
- web/src/hooks/__tests__/useAIPredictions.test.ts
- web/vite.config.ts