### PR TITLE
🌱 Reduce bundle and file sizes (Auto-QA #10438 #10439)

### DIFF
--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -22,9 +22,10 @@ import { PodIssues } from './PodIssues'
 import { ResourceUsage } from './ResourceUsage'
 import { ClusterMetrics } from './ClusterMetrics'
 import { HardwareHealthCard } from './HardwareHealthCard'
-import { ConsoleOfflineDetectionCard } from './console-missions/ConsoleOfflineDetectionCard'
 import { DeploymentStatus } from './DeploymentStatus'
 // Remaining cards are lazy-loaded for code splitting
+// ConsoleOfflineDetectionCard lazy-loaded to reduce critical path bundle size
+const ConsoleOfflineDetectionCard = safeLazy(() => import('./console-missions/ConsoleOfflineDetectionCard'), 'ConsoleOfflineDetectionCard')
 const PodLogs = safeLazy(() => import('./PodLogs'), 'PodLogs')
 const TopPods = safeLazy(() => import('./TopPods'), 'TopPods')
 const AppStatus = safeLazy(() => import('./AppStatus'), 'AppStatus')


### PR DESCRIPTION
Fixes #10438 #10439

## Changes
- Converted ConsoleOfflineDetectionCard from eager to lazy loading to reduce critical path bundle size
- This reduces the size of the main index.js chunk by moving AI mission-related code off the hot path

## Impact
- Reduces initial page load time for users without AI features
- Improves Time-to-First-Interactive (TTFI) by deferring non-critical card loading
- Addresses Auto-QA findings for bundle size optimization

## Testing
- Build passes successfully
- No changes to production functionality
- Card is still available when accessed from dashboard