### PR TITLE
🐛 Show warning status in pod detail when events have warnings (Fixes #10444)

### DIFF
--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -172,8 +172,45 @@ export function PodDrillDown({ data }: { data: Record<string, unknown> }) {
       allIssues.push(reason)
     }
 
+    // Parse warning events from kubectl events output (#10444)
+    // Events with TYPE=Warning indicate active issues even if pod status is Running
+    if (eventsOutput && !eventsOutput.includes('No resources found')) {
+      const eventLines = eventsOutput.split('\n')
+      // Find header to locate TYPE and MESSAGE columns
+      const headerLine = eventLines[0] || ''
+      const typeIdx = headerLine.indexOf('TYPE')
+      const reasonIdx = headerLine.indexOf('REASON')
+      const messageIdx = headerLine.indexOf('MESSAGE')
+
+      if (typeIdx >= 0 && messageIdx >= 0) {
+        for (const line of eventLines.slice(1)) {
+          if (!line.trim()) continue
+          // Extract TYPE field — use REASON column start as the end boundary if available
+          const typeEnd = reasonIdx > typeIdx ? reasonIdx : typeIdx + 10
+          const eventType = line.substring(typeIdx, typeEnd).trim()
+          if (eventType.toLowerCase() === 'warning') {
+            const message = messageIdx < line.length
+              ? line.substring(messageIdx).trim()
+              : ''
+            // Use a shortened version: "Warning: <reason>" or "Warning: <message snippet>"
+            const eventReason = reasonIdx >= 0
+              ? line.substring(reasonIdx, messageIdx > reasonIdx ? messageIdx : reasonIdx + 30).trim()
+              : ''
+            const MAX_EVENT_MSG_LENGTH = 80
+            const issueText = eventReason
+              ? `Warning: ${eventReason}${message ? ' — ' + message.substring(0, MAX_EVENT_MSG_LENGTH) : ''}`
+              : `Warning: ${message.substring(0, MAX_EVENT_MSG_LENGTH)}`
+            // Avoid duplicate issues (case-insensitive)
+            if (!allIssues.some(i => i.toLowerCase() === issueText.toLowerCase())) {
+              allIssues.push(issueText)
+            }
+          }
+        }
+      }
+    }
+
     return allIssues
-  }, [passedIssues, status, reason, podStatusOutput, podName])
+  }, [passedIssues, status, reason, podStatusOutput, podName, eventsOutput])
 
   // Use passed labels/annotations if available
   useEffect(() => {
@@ -1363,7 +1400,7 @@ Please:
                   )}
 
                 </div>
-              ) : (podStatusLoading || describeLoading) ? (
+              ) : (podStatusLoading || describeLoading || eventsLoading) ? (
                 <div className="p-4 rounded-lg bg-secondary/30 border border-border text-center">
                   <div className="flex items-center justify-center gap-2">
                     <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />

--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -182,19 +182,23 @@ export function PodDrillDown({ data }: { data: Record<string, unknown> }) {
       const reasonIdx = headerLine.indexOf('REASON')
       const messageIdx = headerLine.indexOf('MESSAGE')
 
+      /** Fallback column width for TYPE field when REASON column is absent */
+      const TYPE_COLUMN_FALLBACK_WIDTH = 10
       if (typeIdx >= 0 && messageIdx >= 0) {
         for (const line of eventLines.slice(1)) {
           if (!line.trim()) continue
           // Extract TYPE field — use REASON column start as the end boundary if available
-          const typeEnd = reasonIdx > typeIdx ? reasonIdx : typeIdx + 10
+          const typeEnd = reasonIdx > typeIdx ? reasonIdx : typeIdx + TYPE_COLUMN_FALLBACK_WIDTH
           const eventType = line.substring(typeIdx, typeEnd).trim()
           if (eventType.toLowerCase() === 'warning') {
             const message = messageIdx < line.length
               ? line.substring(messageIdx).trim()
               : ''
             // Use a shortened version: "Warning: <reason>" or "Warning: <message snippet>"
+            /** Fallback column width for REASON field when MESSAGE column is absent */
+            const REASON_COLUMN_FALLBACK_WIDTH = 30
             const eventReason = reasonIdx >= 0
-              ? line.substring(reasonIdx, messageIdx > reasonIdx ? messageIdx : reasonIdx + 30).trim()
+              ? line.substring(reasonIdx, messageIdx > reasonIdx ? messageIdx : reasonIdx + REASON_COLUMN_FALLBACK_WIDTH).trim()
               : ''
             const MAX_EVENT_MSG_LENGTH = 80
             const issueText = eventReason


### PR DESCRIPTION
## Summary
- Parse Warning-type events from `kubectl get events` output and include them in the pod detail issues array, so the health section shows warning badges instead of "Pod is healthy"
- Add `eventsLoading` to the loading guard so the healthy badge does not flash before events finish loading
- Fixes the contradiction where clicking a "Readiness probe failed" warning event opens pod detail showing "Pod is healthy — No issues detected"

Fixes #10444

## Test plan
- [ ] Open pod detail for a pod with active Warning events (e.g., Readiness probe failed) — should show warning badges, not "Pod is healthy"
- [ ] Open pod detail for a pod with no Warning events and healthy status — should still show "Pod is healthy"
- [ ] Verify loading spinner shows while events are being fetched (not premature healthy badge)