### PR TITLE
Add microphone input to AI Missions chat (Fixes #10447)

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo } from 'react'
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Send,
@@ -38,6 +38,7 @@ import { SetupInstructionsDialog } from '../../setup/SetupInstructionsDialog'
 import { OrbitSetupOffer } from '../../missions/OrbitSetupOffer'
 import { OrbitMonitorOffer } from '../../missions/OrbitMonitorOffer'
 import type { OrbitResourceFilter } from '../../../lib/missions/types'
+import { MicrophoneButton } from '../../ui/MicrophoneButton'
 import { STATUS_CONFIG, TYPE_ICONS } from './types'
 import type { FontSize } from './types'
 import { TypingIndicator } from './TypingIndicator'
@@ -340,6 +341,12 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
     if (!prompt.trim()) return
     sendMessage(mission.id, prompt)
   }
+
+  /** Append transcribed speech to the chat input */
+  const handleMicrophoneTranscript = useCallback((text: string) => {
+    setInput((prev) => (prev ? prev + ' ' + text : text))
+    inputRef.current?.focus()
+  }, [])
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -950,6 +957,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 placeholder={t('missionChat.askFollowUp', { defaultValue: 'Ask a follow-up question...' })}
                 className="flex-1 min-w-0 px-3 py-2 text-sm rounded-lg border border-border bg-secondary/50 focus:bg-secondary focus:outline-hidden focus:ring-1 focus:ring-primary"
               />
+              <MicrophoneButton onTranscript={handleMicrophoneTranscript} compact />
               <button
                 onClick={handleSend}
                 disabled={!input.trim()}
@@ -1013,6 +1021,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 placeholder={t('missionChat.retryWithMessage')}
                 className="flex-1 min-w-0 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-primary"
               />
+              <MicrophoneButton onTranscript={handleMicrophoneTranscript} compact />
               <button
                 onClick={handleSend}
                 disabled={!input.trim()}
@@ -1041,6 +1050,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 placeholder={t('missionChat.typeMessage')}
                 className="flex-1 min-w-0 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-primary"
               />
+              <MicrophoneButton onTranscript={handleMicrophoneTranscript} compact />
               <button
                 onClick={handleSend}
                 disabled={!input.trim()}

--- a/web/src/components/ui/MicrophoneButton.tsx
+++ b/web/src/components/ui/MicrophoneButton.tsx
@@ -1,0 +1,117 @@
+import { Mic, Square, AlertCircle, Loader2 } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { cn } from '../../lib/cn'
+import { useMicrophoneInput } from '../../hooks/useMicrophoneInput'
+import { useTranslation } from 'react-i18next'
+
+/** Duration (ms) to show error tooltips before auto-dismissing */
+const ERROR_DISPLAY_MS = 5_000
+
+interface MicrophoneButtonProps {
+  /** Called with transcribed text when recording stops */
+  onTranscript: (text: string) => void
+  /** Disable the button (e.g. while agent is running) */
+  disabled?: boolean
+  /** Compact mode for inline placement next to chat inputs */
+  compact?: boolean
+}
+
+export function MicrophoneButton({ onTranscript, disabled = false, compact = false }: MicrophoneButtonProps) {
+  const { t } = useTranslation('common')
+  const { isRecording, isTranscribing, transcript, error, isSupported, startRecording, stopRecording, clearError } =
+    useMicrophoneInput()
+  const [showError, setShowError] = useState(false)
+
+  // Show error for a few seconds, then auto-dismiss
+  useEffect(() => {
+    if (error) {
+      setShowError(true)
+      const timer = setTimeout(() => {
+        setShowError(false)
+        clearError()
+      }, ERROR_DISPLAY_MS)
+      return () => clearTimeout(timer)
+    }
+  }, [error, clearError])
+
+  // Auto-apply transcript when recording stops (if not empty)
+  useEffect(() => {
+    if (!isRecording && !isTranscribing && transcript.trim()) {
+      onTranscript(transcript.trim())
+    }
+  }, [isRecording, isTranscribing, transcript, onTranscript])
+
+  if (!isSupported) {
+    return null
+  }
+
+  const handleToggleRecording = async () => {
+    if (isRecording) {
+      await stopRecording()
+    } else {
+      await startRecording()
+    }
+  }
+
+  const buttonSize = compact ? 'p-2' : 'p-3'
+  const iconSize = compact ? 'w-4 h-4' : 'w-5 h-5'
+
+  return (
+    <div className="relative flex items-center">
+      {/* Error tooltip */}
+      {showError && error && (
+        <div className="absolute bottom-full mb-2 right-0 text-xs bg-red-500/10 text-red-400 px-2 py-1 rounded border border-red-500/20 flex items-center gap-1 max-w-xs whitespace-nowrap z-50">
+          <AlertCircle className="w-3 h-3 shrink-0" />
+          <span className="line-clamp-1">{error}</span>
+        </div>
+      )}
+
+      {/* Recording indicator */}
+      {isRecording && (
+        <div className="absolute bottom-full mb-2 right-0 text-xs bg-red-500/10 text-red-400 px-2 py-1 rounded border border-red-500/20 flex items-center gap-1 whitespace-nowrap z-50">
+          <div className="w-2 h-2 bg-red-500 rounded-full animate-pulse" />
+          {t('microphone.recording', { defaultValue: 'Recording...' })}
+        </div>
+      )}
+
+      {/* Transcribing indicator */}
+      {isTranscribing && !isRecording && (
+        <div className="absolute bottom-full mb-2 right-0 text-xs bg-purple-500/10 text-purple-400 px-2 py-1 rounded border border-purple-500/20 flex items-center gap-1 whitespace-nowrap z-50">
+          <Loader2 className="w-3 h-3 animate-spin" />
+          {t('microphone.processing', { defaultValue: 'Processing...' })}
+        </div>
+      )}
+
+      {/* Microphone button */}
+      <button
+        onClick={handleToggleRecording}
+        disabled={disabled || isTranscribing}
+        className={cn(
+          buttonSize,
+          'rounded-lg transition-all duration-200 relative',
+          isRecording
+            ? 'bg-red-500 text-foreground hover:bg-red-600 ring-2 ring-red-500/50'
+            : 'bg-secondary text-muted-foreground hover:bg-secondary/80 hover:text-foreground',
+          (disabled || isTranscribing) && 'opacity-50 cursor-not-allowed'
+        )}
+        title={
+          isRecording
+            ? t('microphone.stopRecording', { defaultValue: 'Stop recording' })
+            : t('microphone.startRecording', { defaultValue: 'Start recording' })
+        }
+        data-testid="microphone-button"
+      >
+        {isRecording ? (
+          <Square className={iconSize} />
+        ) : (
+          <Mic className={iconSize} />
+        )}
+
+        {/* Pulsing ring when recording */}
+        {isRecording && (
+          <span className="absolute inset-0 rounded-lg animate-ping bg-red-500/30 pointer-events-none" />
+        )}
+      </button>
+    </div>
+  )
+}

--- a/web/src/hooks/useMicrophoneInput.ts
+++ b/web/src/hooks/useMicrophoneInput.ts
@@ -1,0 +1,210 @@
+import { useState, useRef, useCallback } from 'react'
+
+interface SpeechRecognitionEvent extends Event {
+  resultIndex: number
+  results: SpeechRecognitionResultList
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  error: string
+}
+
+interface SpeechRecognitionResultList {
+  length: number
+  item(index: number): SpeechRecognitionResult
+  [index: number]: SpeechRecognitionResult
+}
+
+interface SpeechRecognitionResult {
+  isFinal: boolean
+  length: number
+  item(index: number): SpeechRecognitionAlternative
+  [index: number]: SpeechRecognitionAlternative
+}
+
+interface SpeechRecognitionAlternative {
+  transcript: string
+  confidence: number
+}
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean
+  interimResults: boolean
+  lang: string
+  maxAlternatives: number
+  start(): void
+  stop(): void
+  abort(): void
+  onstart: ((this: SpeechRecognition, ev: Event) => unknown) | null
+  onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => unknown) | null
+  onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => unknown) | null
+  onend: ((this: SpeechRecognition, ev: Event) => unknown) | null
+}
+
+interface SpeechRecognitionConstructor {
+  prototype: SpeechRecognition
+  new (): SpeechRecognition
+}
+
+declare global {
+  interface Window {
+    SpeechRecognition: SpeechRecognitionConstructor | undefined
+    webkitSpeechRecognition: SpeechRecognitionConstructor | undefined
+  }
+}
+
+export interface MicrophoneState {
+  isRecording: boolean
+  isTranscribing: boolean
+  transcript: string
+  error: string | null
+  isSupported: boolean
+}
+
+interface UseMicrophoneInputReturn extends MicrophoneState {
+  startRecording: () => Promise<void>
+  stopRecording: () => Promise<void>
+  clearTranscript: () => void
+  clearError: () => void
+}
+
+/** Maximum recording duration before auto-stop (ms) */
+const RECORDING_TIMEOUT_MS = 60_000
+
+export function useMicrophoneInput(): UseMicrophoneInputReturn {
+  const [isRecording, setIsRecording] = useState(false)
+  const [isTranscribing, setIsTranscribing] = useState(false)
+  const [transcript, setTranscript] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const mediaStreamRef = useRef<MediaStream | null>(null)
+  const recordingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const recognitionRef = useRef<SpeechRecognition | null>(null)
+
+  // Check if browser supports Web Speech API
+  const isSupported =
+    typeof window !== 'undefined' &&
+    (typeof window.webkitSpeechRecognition !== 'undefined' || typeof window.SpeechRecognition !== 'undefined')
+
+  const clearError = useCallback(() => setError(null), [])
+  const clearTranscript = useCallback(() => setTranscript(''), [])
+
+  const stopRecordingInternal = useCallback(async () => {
+    if (recordingTimeoutRef.current) {
+      clearTimeout(recordingTimeoutRef.current)
+      recordingTimeoutRef.current = null
+    }
+
+    if (mediaStreamRef.current) {
+      for (const track of mediaStreamRef.current.getTracks()) {
+        track.stop()
+      }
+      mediaStreamRef.current = null
+    }
+
+    setIsRecording(false)
+  }, [])
+
+  const startRecording = useCallback(async () => {
+    try {
+      clearError()
+      clearTranscript()
+
+      // Request microphone access
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      mediaStreamRef.current = stream
+
+      // Initialize Web Speech API for transcription
+      const SpeechRecognitionAPI = window.webkitSpeechRecognition || window.SpeechRecognition
+      if (!SpeechRecognitionAPI) {
+        throw new Error('Speech Recognition not supported in this browser')
+      }
+
+      const recognition = new SpeechRecognitionAPI()
+      recognitionRef.current = recognition
+
+      // Configure recognition
+      recognition.continuous = true
+      recognition.interimResults = true
+      recognition.lang = 'en-US'
+
+      recognition.onstart = () => {
+        setIsRecording(true)
+        setIsTranscribing(true)
+
+        // Auto-stop after max duration
+        recordingTimeoutRef.current = setTimeout(() => {
+          stopRecordingInternal()
+        }, RECORDING_TIMEOUT_MS)
+      }
+
+      recognition.onresult = (event: Event) => {
+        const speechEvent = event as SpeechRecognitionEvent
+
+        for (let i = speechEvent.resultIndex; i < speechEvent.results.length; i++) {
+          const transcriptSegment = speechEvent.results[i][0].transcript
+
+          if (speechEvent.results[i].isFinal) {
+            setTranscript((prev) => prev + transcriptSegment + ' ')
+          }
+        }
+      }
+
+      recognition.onerror = (event: Event) => {
+        const errorEvent = event as SpeechRecognitionErrorEvent
+        const errorMessage = getErrorMessage(errorEvent.error)
+        setError(errorMessage)
+        stopRecordingInternal()
+      }
+
+      recognition.onend = () => {
+        setIsTranscribing(false)
+        stopRecordingInternal()
+      }
+
+      recognition.start()
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to access microphone'
+      setError(errorMessage)
+      setIsRecording(false)
+    }
+  }, [clearError, clearTranscript, stopRecordingInternal])
+
+  const stopRecording = useCallback(async () => {
+    try {
+      if (recognitionRef.current) {
+        recognitionRef.current.stop()
+      }
+      await stopRecordingInternal()
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to stop recording'
+      setError(errorMessage)
+    }
+  }, [stopRecordingInternal])
+
+  return {
+    isRecording,
+    isTranscribing,
+    transcript,
+    error,
+    isSupported,
+    startRecording,
+    stopRecording,
+    clearTranscript,
+    clearError,
+  }
+}
+
+function getErrorMessage(error: string): string {
+  const errorMap: Record<string, string> = {
+    'no-speech': 'No speech detected. Please try again.',
+    'audio-capture': 'No microphone found. Please check your device.',
+    'network': 'Network error. Please check your connection.',
+    'permission-denied': 'Microphone access was denied. Please enable it in settings.',
+    'service-not-allowed': 'Speech recognition service not allowed.',
+    'bad-grammar': 'Grammar error. Please try again.',
+    'aborted': 'Recording was cancelled.',
+  }
+
+  return errorMap[error] || `Error: ${error}`
+}


### PR DESCRIPTION
## Summary
- Adds speech-to-text microphone button to the AI Missions chat input using the Web Speech API (SpeechRecognition)
- Button appears in all active input states (default, completed follow-up, failed) with compact inline styling
- Shows pulsing red indicator while recording, status/error tooltips, and auto-appends transcribed text to the input field
- Gracefully hidden in browsers that don't support SpeechRecognition

Fixes #10447

## Test plan
- [ ] Verify microphone button appears next to chat input in default, completed, and failed mission states
- [ ] Click microphone, speak, verify transcribed text appears in input
- [ ] Click stop (square icon) to end recording early
- [ ] Verify pulsing red indicator and "Recording..." tooltip while active
- [ ] Verify button is hidden in Firefox (no SpeechRecognition support)
- [ ] Verify button is disabled while agent is running
- [ ] Deny microphone permission and verify error tooltip appears