### PR TITLE
🐛 Fix GPU Reservations responsive layout with sidebars open (Fixes #10449)

### DIFF
--- a/web/src/components/gpu/GPUCalendarTab.tsx
+++ b/web/src/components/gpu/GPUCalendarTab.tsx
@@ -71,7 +71,7 @@ export function GPUCalendarTab({
             )
           })}
         </div>
-        <div className="border border-border/50 rounded-lg overflow-hidden">
+        <div className="border border-border/50 rounded-lg overflow-x-auto" style={{ minWidth: 0 }}>
           {/* Day-of-week header */}
           <div className="grid grid-cols-7 border-b border-border/50">
             {([

--- a/web/src/components/gpu/GPUDashboardTab.tsx
+++ b/web/src/components/gpu/GPUDashboardTab.tsx
@@ -53,7 +53,7 @@ export function GPUDashboardTab({
     <div className="space-y-4">
       {/* Cluster health summary */}
       {clusterHealth.total > 0 && (
-        <div className="flex items-center gap-4 p-3 rounded-lg bg-secondary/30 border border-border">
+        <div className="flex flex-wrap items-center gap-4 p-3 rounded-lg bg-secondary/30 border border-border">
           <span className="text-sm font-medium text-foreground">Cluster Health</span>
           <div className="flex items-center gap-1.5">
             <StatusIndicator status="healthy" size="sm" />
@@ -68,7 +68,7 @@ export function GPUDashboardTab({
         </div>
       )}
 
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <p className="text-sm text-muted-foreground">
           {t('gpuReservations.dashboard.customizable')}
         </p>

--- a/web/src/components/gpu/GPUInventoryTab.tsx
+++ b/web/src/components/gpu/GPUInventoryTab.tsx
@@ -36,7 +36,7 @@ export function GPUInventoryTab({
   return (
     <div className="space-y-4">
       {/* Search and Filter Controls */}
-      <div className="flex items-center justify-between bg-secondary/20 p-2 rounded-lg border border-border/50">
+      <div className="flex flex-wrap items-center justify-between gap-2 bg-secondary/20 p-2 rounded-lg border border-border/50">
         <div className="flex items-center gap-3">
           <GPUTaintFilterControl
             distinctTaints={distinctTaints}
@@ -77,14 +77,14 @@ export function GPUInventoryTab({
 
         return (
           <div key={cluster.name} className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
-            <div className="flex items-center justify-between mb-4">
-              <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+              <div className="flex items-center gap-3 min-w-0">
                 <ClusterBadge cluster={cluster.name} size="sm" />
-                <div className="text-sm text-muted-foreground">
+                <div className="text-sm text-muted-foreground truncate">
                   {(cluster.gpuTypes || []).join(', ')}
                 </div>
               </div>
-              <div className="flex items-center gap-4 text-sm">
+              <div className="flex flex-wrap items-center gap-4 text-sm">
                 <span className="text-foreground font-medium">{t('gpuReservations.inventory.total', { count: clusterNodes.reduce((sum, n) => sum + n.gpuCount, 0) })}</span>
                 <span className="text-green-400">{t('gpuReservations.inventory.available', { count: clusterNodes.reduce((sum, n) => sum + (n.gpuCount - n.gpuAllocated), 0) })}</span>
                 <span className="text-yellow-400">{t('gpuReservations.inventory.allocated', { count: clusterNodes.reduce((sum, n) => sum + n.gpuAllocated, 0) })}</span>

--- a/web/src/components/gpu/GPUOverviewTab.tsx
+++ b/web/src/components/gpu/GPUOverviewTab.tsx
@@ -56,7 +56,7 @@ export function GPUOverviewTab({
   return (
     <div className="space-y-6">
       {/* Quick Stats */}
-      <div className="grid grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <div className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
           <div className="flex items-center gap-3">
             <div className="p-2 rounded-lg bg-purple-500/20">
@@ -104,7 +104,7 @@ export function GPUOverviewTab({
       </div>
 
       {/* Charts Row */}
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {/* Utilization */}
         <div className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
           <h3 className="text-sm font-medium text-muted-foreground mb-4">{t('gpuReservations.charts.gpuUtilization')}</h3>
@@ -175,19 +175,19 @@ export function GPUOverviewTab({
             <div key={r.id}
               className="p-3 rounded-lg bg-purple-500/10 border border-purple-500/20"
             >
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-4">
-                  <div className="p-2 rounded-lg bg-purple-500/20">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex items-center gap-4 min-w-0">
+                  <div className="p-2 rounded-lg bg-purple-500/20 shrink-0">
                     <Zap className="w-4 h-4 text-purple-400" />
                   </div>
-                  <div>
-                    <div className="font-medium text-foreground">{r.title}</div>
-                    <div className="text-sm text-muted-foreground">
+                  <div className="min-w-0">
+                    <div className="font-medium text-foreground truncate">{r.title}</div>
+                    <div className="text-sm text-muted-foreground truncate">
                       {r.namespace} · {r.user_name}
                     </div>
                   </div>
                 </div>
-                <div className="flex items-center gap-4">
+                <div className="flex flex-wrap items-center gap-4">
                   <div className="text-right">
                     <div className="font-medium text-foreground">{r.gpu_count} <TechnicalAcronym term="GPU">{t('common:common.gpus')}</TechnicalAcronym></div>
                     <div className="text-sm text-muted-foreground">{t('gpuReservations.overview.durationHours', { hours: r.duration_hours })}</div>

--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -496,7 +496,7 @@ export function GPUReservations() {
   }
 
   return (
-    <div className="pt-16">
+    <div className="pt-16 min-w-0">
       <div className="mb-6">
         <div className="flex items-center gap-3">
           <h1 className="text-2xl font-bold text-foreground">{t('gpuReservations.title')}</h1>
@@ -512,7 +512,7 @@ export function GPUReservations() {
       {/* Tabs */}
       <div
         role="tablist"
-        className="flex gap-1 mb-6 border-b border-border"
+        className="flex flex-wrap gap-1 mb-6 border-b border-border"
         onKeyDown={(e) => {
           const ids = ['overview', 'calendar', 'quotas', 'inventory', 'dashboard'] as const
           const idx = ids.indexOf(activeTab)
@@ -553,7 +553,7 @@ export function GPUReservations() {
           )
         })}
 
-        <div className="ml-auto pb-2 flex items-center gap-3">
+        <div className="ml-auto pb-2 flex flex-wrap items-center gap-3">
           {/* My Reservations filter */}
           {user && (
             <label

--- a/web/src/components/gpu/GPUReservationsTab.tsx
+++ b/web/src/components/gpu/GPUReservationsTab.tsx
@@ -78,7 +78,7 @@ export function GPUReservationsTab({
       </div>
       {/* Filter banner when showing only user's reservations */}
       {showOnlyMine && (
-        <div className="flex items-center justify-between px-3 py-2 rounded-lg bg-purple-500/10 border border-purple-500/30">
+        <div className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 rounded-lg bg-purple-500/10 border border-purple-500/30">
           <div className="flex items-center gap-2 text-sm text-purple-300">
             <Filter className="w-4 h-4" />
             <span>{t('gpuReservations.filteringByUser', `Showing reservations for {{user}}`, { user: user?.github_login || 'you' })}</span>
@@ -121,19 +121,19 @@ export function GPUReservationsTab({
           const isExpanded = expandedReservationId === r.id
           return (
             <div key={r.id} className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
-              <div className="flex items-center justify-between mb-3">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-purple-500/20">
+              <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+                <div className="flex items-center gap-3 min-w-0">
+                  <div className="p-2 rounded-lg bg-purple-500/20 shrink-0">
                     <Zap className="w-5 h-5 text-purple-400" />
                   </div>
-                  <div>
-                    <div className="font-medium text-foreground">{r.title}</div>
-                    <div className="text-sm text-muted-foreground">
+                  <div className="min-w-0">
+                    <div className="font-medium text-foreground truncate">{r.title}</div>
+                    <div className="text-sm text-muted-foreground truncate">
                       {r.namespace} · {r.user_name}
                     </div>
                   </div>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                   <span className={cn('px-2 py-0.5 text-xs rounded-full border', STATUS_COLORS[r.status] || STATUS_COLORS.pending)}>
                     {r.status}
                   </span>


### PR DESCRIPTION
## Summary
- Fix GPU Reservations page layout breaking when both left sidebar and AI Missions right sidebar are open
- Replace fixed grid columns (`grid-cols-4`, `grid-cols-3`) with responsive breakpoints (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-4`)
- Add `flex-wrap` to tab bar, action buttons, filter bars, and list item headers so they wrap instead of compressing
- Add `min-w-0` and `truncate` on flex children to prevent text overflow
- Calendar grid gets `overflow-x-auto` for horizontal scrolling at narrow effective widths

## Test plan
- [ ] Open GPU Reservations page with both sidebars open — layout should adapt
- [ ] Verify Overview tab stats grid collapses to 2-col then 1-col at narrow widths
- [ ] Verify Charts row collapses to 2-col then 1-col
- [ ] Verify tab bar wraps instead of overflowing
- [ ] Verify Calendar tab scrolls horizontally when viewport is too narrow
- [ ] Verify Inventory and Reservations tab list items truncate properly

Fixes #10449

🤖 Generated with [Claude Code](https://claude.com/claude-code)