### PR TITLE
✨ Add edit and resend for user messages in AI Missions (Fixes #10450)

### DIFF
--- a/web/src/components/layout/mission-sidebar/MemoizedMessage.tsx
+++ b/web/src/components/layout/mission-sidebar/MemoizedMessage.tsx
@@ -5,6 +5,7 @@ import {
   AlertCircle,
   User,
   Settings,
+  Pencil,
 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -21,7 +22,7 @@ import {
 import type { MessageProps } from './types'
 
 // Memoized message component to prevent re-renders on scroll
-export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent, isFullScreen, fontSize, isLastAssistantMessage, missionStatus, userAvatarUrl }: MessageProps) {
+export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent, isFullScreen, fontSize, isLastAssistantMessage, missionStatus, userAvatarUrl, onEdit }: MessageProps) {
   // Memoize the parsed content to avoid re-parsing on every render
   const parsedContent = useMemo(() => {
     if (msg.role !== 'assistant') return null
@@ -75,7 +76,7 @@ export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent
   }, [msg.agent, missionAgent])
 
   return (
-    <div className={cn('flex gap-3', msg.role === 'user' && 'flex-row-reverse')}>
+    <div className={cn('flex gap-3 group/msg', msg.role === 'user' && 'flex-row-reverse')}>
       <div className={cn(
         'w-8 h-8 rounded-full flex items-center justify-center shrink-0',
         msg.role === 'user' ? 'bg-primary/20' : msg.role === 'assistant' ? 'bg-purple-500/20' : 'bg-yellow-500/20'
@@ -132,6 +133,17 @@ export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent
           <span className="text-2xs text-muted-foreground">
             {msg.timestamp.toLocaleTimeString()}
           </span>
+          {/* Edit button for user messages — visible on hover (#10450) */}
+          {msg.role === 'user' && onEdit && (
+            <button
+              onClick={() => onEdit(msg.id)}
+              className="opacity-0 group-hover/msg:opacity-100 transition-opacity p-0.5 rounded hover:bg-primary/20"
+              title="Edit and resend"
+              data-testid="edit-message-btn"
+            >
+              <Pencil className="w-3 h-3 text-muted-foreground hover:text-primary" />
+            </button>
+          )}
           {/* Show working indicator if this is the last assistant message, mission is running, and content indicates work */}
           {isLastAssistantMessage && missionStatus === 'running' && msg.role === 'assistant' && detectWorkingIndicator(msg.content) && (
             <span className="flex items-center gap-1 text-2xs text-blue-400 animate-pulse">

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -49,7 +49,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
   // #6226: useToast for download error feedback (replaces an unhandled
   // exception path that could white-screen the dialog).
   const { showToast } = useToast()
-  const { sendMessage, retryPreflight, cancelMission, rateMission, setActiveMission, dismissMission, renameMission, runSavedMission, updateSavedMission } = useMissions()
+  const { sendMessage, editAndResend, retryPreflight, cancelMission, rateMission, setActiveMission, dismissMission, renameMission, runSavedMission, updateSavedMission } = useMissions()
   const { user } = useAuth()
   const { isDemoMode } = useDemoMode()
   const { findSimilarResolutions, recordUsage } = useResolutions()
@@ -342,11 +342,19 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
     sendMessage(mission.id, prompt)
   }
 
-  /** Append transcribed speech to the chat input */
   const handleMicrophoneTranscript = useCallback((text: string) => {
     setInput((prev) => (prev ? prev + ' ' + text : text))
     inputRef.current?.focus()
   }, [])
+
+  const handleEditMessage = useCallback((messageId: string) => {
+    const content = editAndResend(mission.id, messageId)
+    if (content) {
+      setInput(content)
+      setInputError(null)
+      setTimeout(() => inputRef.current?.focus(), 0)
+    }
+  }, [mission.id, editAndResend])
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -784,6 +792,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               isLastAssistantMessage={isLastAssistantMessage}
               missionStatus={mission.status}
               userAvatarUrl={user?.avatar_url}
+              onEdit={handleEditMessage}
             />
           )
         })}

--- a/web/src/components/layout/mission-sidebar/types.ts
+++ b/web/src/components/layout/mission-sidebar/types.ts
@@ -107,4 +107,7 @@ export interface MessageProps {
   isLastAssistantMessage?: boolean
   missionStatus?: string
   userAvatarUrl?: string
+  /** Callback to edit a user message — removes it and subsequent messages,
+   *  populating the chat input for re-sending (#10450). */
+  onEdit?: (messageId: string) => void
 }

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -79,6 +79,9 @@ interface MissionContextValue {
   runSavedMission: (missionId: string, cluster?: string) => void
   updateSavedMission: (missionId: string, updates: SavedMissionUpdates) => void
   sendMessage: (missionId: string, content: string) => void
+  /** Remove a user message and all subsequent messages, returning the content
+   *  so the caller can populate the chat input for editing. (#10450) */
+  editAndResend: (missionId: string, messageId: string) => string | null
   retryPreflight: (missionId: string) => void
   cancelMission: (missionId: string) => void
   dismissMission: (missionId: string) => void
@@ -2775,6 +2778,29 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     })
   }
 
+  // Edit and resend: remove a user message and everything after it,
+  // returning the original content so the UI can populate the input (#10450).
+  const editAndResend = (missionId: string, messageId: string): string | null => {
+    let removedContent: string | null = null
+    setMissions(prev => prev.map(m => {
+      if (m.id !== missionId) return m
+      const msgIndex = m.messages.findIndex(msg => msg.id === messageId)
+      if (msgIndex < 0) return m
+      const targetMsg = m.messages[msgIndex]
+      if (targetMsg.role !== 'user') return m
+      removedContent = targetMsg.content
+      return {
+        ...m,
+        // Truncate from the edited message onward
+        messages: m.messages.slice(0, msgIndex),
+        // Reset status so the user can re-send
+        status: m.status === 'running' || m.status === 'cancelling' ? m.status : 'waiting_input' as MissionStatus,
+        updatedAt: new Date(),
+      }
+    }))
+    return removedContent
+  }
+
   // Dismiss/remove a mission from the list
   const dismissMission = (missionId: string) => {
     // Cancel backend execution before removing from UI to prevent
@@ -3053,13 +3079,13 @@ Install the console locally with the KubeStellar Console agent to use AI mission
   // state changes.
   const handlersRef = useRef({
     startMission, saveMission, runSavedMission, updateSavedMission, sendMessage,
-    retryPreflight, cancelMission, dismissMission, renameMission, rateMission,
+    editAndResend, retryPreflight, cancelMission, dismissMission, renameMission, rateMission,
     setActiveMission, markMissionAsRead, selectAgent, connectToAgent,
     toggleSidebar, openSidebar, closeSidebar, minimizeSidebar, expandSidebar,
     handleSetFullScreen, confirmPendingReview, cancelPendingReview })
   handlersRef.current = {
     startMission, saveMission, runSavedMission, updateSavedMission, sendMessage,
-    retryPreflight, cancelMission, dismissMission, renameMission, rateMission,
+    editAndResend, retryPreflight, cancelMission, dismissMission, renameMission, rateMission,
     setActiveMission, markMissionAsRead, selectAgent, connectToAgent,
     toggleSidebar, openSidebar, closeSidebar, minimizeSidebar, expandSidebar,
     handleSetFullScreen, confirmPendingReview, cancelPendingReview }
@@ -3076,6 +3102,8 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       handlersRef.current.updateSavedMission(...args),
     sendMessage: (...args: Parameters<typeof sendMessage>) =>
       handlersRef.current.sendMessage(...args),
+    editAndResend: (...args: Parameters<typeof editAndResend>) =>
+      handlersRef.current.editAndResend(...args),
     retryPreflight: (...args: Parameters<typeof retryPreflight>) =>
       handlersRef.current.retryPreflight(...args),
     cancelMission: (...args: Parameters<typeof cancelMission>) =>
@@ -3191,6 +3219,7 @@ const MISSIONS_FALLBACK: MissionContextValue = {
   runSavedMission: () => {},
   updateSavedMission: () => {},
   sendMessage: () => {},
+  editAndResend: () => null,
   retryPreflight: () => {},
   cancelMission: () => {},
   dismissMission: () => {},


### PR DESCRIPTION
## Summary
- Adds an **edit and resend** button (pencil icon) on user messages in AI Missions chat, visible on hover
- Clicking the edit button removes the selected message and all subsequent messages, populates the chat input with the original text, and focuses the input for immediate editing
- Adds `editAndResend()` to the mission context for state management (message truncation + status reset)

Fixes #10450

## Test plan
- [ ] Open an AI Mission chat with at least one user message and one assistant response
- [ ] Hover over a user message — verify pencil icon appears
- [ ] Click the pencil icon — verify the message and all subsequent messages are removed
- [ ] Verify the chat input is populated with the original message text and focused
- [ ] Edit the text and send — verify the message is sent successfully
- [ ] Verify the edit button does NOT appear on assistant or system messages
- [ ] Verify behavior when editing the first user message (all messages removed)
- [ ] Verify no console errors throughout the workflow