### PR TITLE
🐛 Fix agent status showing Offline by using plain fetch for health checks (Fixes #10459)

### DIFF
--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -21,7 +21,6 @@ import {
   BACKEND_HEALTH_CHECK_TIMEOUT_MS,
 } from '../../../lib/constants/network'
 import type { AgentInfo } from '../../../types/agent'
-import { agentFetch } from '../../../hooks/mcp/shared'
 
 const CONNECTING_DEBOUNCE_MS = 300
 
@@ -57,7 +56,12 @@ export function AgentStatusIndicator() {
   const fetchAgentsFromHealth = async () => {
     setIsDiscoveringAgents(true)
     try {
-      const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+      // Use plain fetch instead of agentFetch — the /health endpoint does not
+      // require auth, and plain fetch avoids the X-Requested-With header that
+      // triggers CORS preflight failures when origin is not in allowed list (#10459).
+      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
         signal: AbortSignal.timeout(BACKEND_HEALTH_CHECK_TIMEOUT_MS),
       })
       if (!res.ok) return

--- a/web/src/hooks/useBackendHealth.ts
+++ b/web/src/hooks/useBackendHealth.ts
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
-import { agentFetch } from './mcp/shared'
 
 export type BackendStatus = 'connected' | 'disconnected' | 'connecting'
 
@@ -152,11 +151,14 @@ class BackendHealthManager {
   }
 
   /** Probe kc-agent on a separate origin to disambiguate real backend
-   *  downtime from browser connection-pool exhaustion on the main origin. */
+   *  downtime from browser connection-pool exhaustion on the main origin.
+   *  Uses plain fetch instead of agentFetch — the /health endpoint does not
+   *  require auth, and plain fetch avoids CORS preflight failures (#10459). */
   private async checkAgentHealth(): Promise<boolean> {
     try {
-      const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
         method: 'GET',
+        headers: { Accept: 'application/json' },
         signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
       })
       return res.ok

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { isDemoModeForced } from './useDemoMode'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
-import { agentFetch } from './mcp/shared'
 import { TRANSITION_DELAY_MS } from '../lib/constants/network'
 import { emitAgentConnected, emitAgentDisconnected, emitAgentProvidersDetected, emitConversionStep } from '../lib/analytics'
 import { safeGetItem, safeSetItem } from '../lib/utils/localStorage'
@@ -208,7 +207,24 @@ class AgentManager {
     this.isChecking = true
 
     try {
-      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+      // Use plain fetch() instead of agentFetch() for the health check.
+      // The /health endpoint does not require authentication (see server.go
+      // comment: "Health endpoint doesn't require token auth"). Using plain
+      // fetch avoids two problems that cause false "Offline" status (#10459):
+      //
+      // 1. agentFetch adds X-Requested-With header, which triggers a CORS
+      //    preflight (OPTIONS) request. If the browser's origin is not in the
+      //    kc-agent's allowed origins list (e.g. accessing via IP instead of
+      //    localhost), the preflight fails and the health check always fails —
+      //    even though the WebSocket (used by AI Missions) is unaffected by
+      //    CORS restrictions.
+      //
+      // 2. agentFetch awaits getAgentToken(), which fetches /api/agent/token
+      //    from the backend. If the user is not yet authenticated or the
+      //    backend is slow, this delays the health check. The AbortSignal
+      //    timeout starts when created (at call site), not when fetch starts,
+      //    so the token delay can consume the timeout budget.
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
         method: 'GET',
         headers: { Accept: 'application/json' },
         signal: AbortSignal.timeout(AGENT_HEALTH_TIMEOUT_MS) })

--- a/web/src/hooks/useProviderConnection.ts
+++ b/web/src/hooks/useProviderConnection.ts
@@ -50,9 +50,13 @@ async function checkProviderReady(providerName: string): Promise<ProviderCheckRe
     // /provider/check not available -- fall through to health check
   }
 
-  // Fallback: check the health endpoint for simple provider presence
+  // Fallback: check the health endpoint for simple provider presence.
+  // Use plain fetch — /health does not require auth and avoids CORS
+  // preflight failures from X-Requested-With header (#10459).
   try {
-    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(3_000) })
     if (!response.ok) {
       return { ready: false, error: `Agent returned HTTP ${response.status}` }

--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react'
 import { isAgentUnavailable, reportAgentDataSuccess, reportAgentDataError } from './useLocalAgent'
 import { getDemoMode } from './useDemoMode'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
-import { agentFetch } from './mcp/shared'
 import { QUICK_ABORT_TIMEOUT_MS } from '../lib/constants/network'
 import {
   getUserTokenUsage,
@@ -448,7 +447,9 @@ async function fetchTokenUsage() {
   try {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), QUICK_ABORT_TIMEOUT_MS)
-    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+    // Use plain fetch — /health does not require auth and avoids CORS
+    // preflight failures from X-Requested-With header (#10459).
+    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
       method: 'GET',
       headers: { 'Accept': 'application/json' },
       signal: controller.signal })


### PR DESCRIPTION
Fixes #10459

## Summary
- Use plain `fetch()` instead of `agentFetch()` for health check endpoints
- `/health` doesn't require auth — `agentFetch` added X-Requested-With headers causing CORS preflight failures
- Also avoided token fetch delay consuming the health check timeout budget