### PR TITLE
🐛 Fix navbar layout shift from long rotating tagline (Fixes #10467)

### DIFF
--- a/web/src/components/layout/navbar/RotatingTagline.tsx
+++ b/web/src/components/layout/navbar/RotatingTagline.tsx
@@ -71,6 +71,9 @@ function getTransitionCSS(transition: TransitionStyle, visible: boolean): React.
   }
 }
 
+/** Max width for the tagline container — prevents long quotes from causing navbar layout shift */
+const TAGLINE_MAX_WIDTH_REM = '16rem'
+
 export function RotatingTagline({ aiTagline }: { aiTagline?: string }) {
   const allTaglines = useMemo(
     () => (aiTagline ? [...TAGLINES, aiTagline] : TAGLINES),
@@ -100,8 +103,9 @@ export function RotatingTagline({ aiTagline }: { aiTagline?: string }) {
 
   return (
     <span
-      className="text-[10px] text-muted-foreground tracking-wide inline-block"
-      style={getTransitionCSS(transition, visible)}
+      className="text-[10px] text-muted-foreground tracking-wide inline-block overflow-hidden text-ellipsis whitespace-nowrap"
+      style={{ ...getTransitionCSS(transition, visible), maxWidth: TAGLINE_MAX_WIDTH_REM }}
+      title={allTaglines[safeIndex]}
     >
       {allTaglines[safeIndex]}
     </span>


### PR DESCRIPTION
## Summary
- Constrain rotating tagline width in navbar to prevent layout shift when long quotes rotate in
- Right-side navbar icons no longer get pushed off-screen

Fixes #10467

## Test plan
- [ ] Observe navbar tagline rotation — layout should not shift
- [ ] Right-side icons remain visible at all times
- [ ] Short and long quotes display correctly

Signed-off-by: Andy Anderson <andy@clubanderson.com>