### PR TITLE
🐛 Preserve dashboard data when kc-agent goes offline (Fixes #10470)

### DIFF
--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -41,7 +41,7 @@
 
 import { createContext, use, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useDemoMode } from '../../hooks/useDemoMode'
-import { isAgentUnavailable } from '../../hooks/useLocalAgent'
+import { isAgentUnavailable, wasAgentEverConnected } from '../../hooks/useLocalAgent'
 import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useOptionalStack } from '../../contexts/StackContext'
 import { CARD_LOADING_TIMEOUT_MS } from '../../lib/constants/network'
@@ -344,8 +344,10 @@ export function useCardDemoState(options: CardDemoStateOptions = {}): CardDemoSt
     }
 
     // 4. Agent-dependent card but agent is offline AND backend is also unavailable
-    //    When backend is connected (cluster mode), allow live data via backend API
-    if (requires === 'agent' && isAgentUnavailable() && !isInClusterMode()) {
+    //    When backend is connected (cluster mode), allow live data via backend API.
+    //    If the agent was previously connected this session, cached data is still
+    //    available — don't force demo mode, let cards show stale cached data (#10470).
+    if (requires === 'agent' && isAgentUnavailable() && !isInClusterMode() && !wasAgentEverConnected()) {
       return { shouldUseDemoData: true, reason: 'agent-offline' as DemoReason, showDemoBadge: true }
     }
 

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -32,7 +32,7 @@ import {
 } from '../../hooks/useDemoMode'
 import { setDemoMode } from '../../lib/demoMode'
 import { hasApprovedAgents } from '../agent/AgentApprovalDialog'
-import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { useLocalAgent, wasAgentEverConnected } from '../../hooks/useLocalAgent'
 import { useClusters } from '../../hooks/mcp/clusters'
 import { emitClusterInventory } from '../../lib/analytics'
 import { useNetworkStatus } from '../../hooks/useNetworkStatus'
@@ -236,8 +236,12 @@ export function Layout({ children: _children }: LayoutProps) {
           demoAutoEnabledRef.current = true
           setDemoMode(true)
         }, AGENT_CONNECT_GRACE_MS)
+      } else if (wasAgentEverConnected()) {
+        // Agent was previously connected and went offline — preserve cached data.
+        // Do NOT auto-enable demo mode; cards keep showing stale cached data
+        // with their normal refresh/failure indicators (#10470).
       } else {
-        // Initial load or agent went offline — enable demo immediately
+        // Initial load with no agent — enable demo immediately so user sees content
         demoAutoEnabledRef.current = true
         setDemoMode(true)
       }

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -97,6 +97,9 @@ class AgentManager {
   private pollInterval: ReturnType<typeof setInterval> | null = null
   private failureCount = 0
   private successCount = 0 // Track consecutive successes for hysteresis
+  /** Whether the agent has been connected at least once this session.
+   *  Used to decide if going offline should preserve cached data (#10470). */
+  private wasEverConnected = false
   private dataErrorTimestamps: number[] = [] // Track recent data errors
   private isChecking = false
   private isStarted = false
@@ -223,6 +226,7 @@ class AgentManager {
 
         // Hysteresis: require multiple successes to reconnect from disconnected (prevents flicker)
         if (wasDisconnected && this.successCount >= SUCCESS_THRESHOLD) {
+          this.wasEverConnected = true
           this.addEvent('connected', `Connected to local agent v${data.version || 'unknown'}`)
           // Reconnected - speed up polling
           this.adjustPollInterval(POLL_INTERVAL)
@@ -235,6 +239,7 @@ class AgentManager {
           emitAgentProvidersDetected(data.availableProviders || [])
         } else if (wasConnecting) {
           // Initial connection - connect immediately on first success
+          this.wasEverConnected = true
           this.addEvent('connected', `Connected to local agent v${data.version || 'unknown'}`)
           this.adjustPollInterval(POLL_INTERVAL)
           this.setState({
@@ -290,6 +295,11 @@ class AgentManager {
 
   getState() {
     return this.state
+  }
+
+  /** Whether the agent was connected at least once this session (#10470). */
+  getWasEverConnected(): boolean {
+    return this.wasEverConnected
   }
 
   // Report a data endpoint error (e.g., /clusters returned 503)
@@ -412,6 +422,15 @@ export function isAgentUnavailable(): boolean {
   // Only skip agent if we've confirmed it's disconnected
   // During 'connecting' or 'connected' or 'degraded', allow agent attempts
   return state.status === 'disconnected'
+}
+
+/**
+ * Check if the agent has been connected at least once during this session.
+ * When true, the agent going offline should NOT trigger demo mode because
+ * cached data is still available and should remain visible (#10470).
+ */
+export function wasAgentEverConnected(): boolean {
+  return agentManager.getWasEverConnected()
 }
 
 /**


### PR DESCRIPTION
## Summary
- Dashboard cards now preserve previously loaded data when kc-agent status transitions to Offline
- Cached/stale data remains visible instead of cards going blank
- Only new fetch attempts are affected by offline status

Fixes #10470

## Root cause
When the kc-agent went offline, `Layout.tsx` auto-enabled demo mode via `setDemoMode(true)`, which cleared all caches and switched every card to demo data. Additionally, `CardDataContext.useCardDemoState()` independently forced `shouldUseDemoData: true` for agent-dependent cards when `isAgentUnavailable()` was true.

## Fix
- Added `wasEverConnected` flag to `AgentManager` singleton — once the agent connects, the flag stays true for the session
- `Layout.tsx`: skip auto-enabling demo mode when agent was previously connected (cached data stays visible)
- `CardDataContext.tsx`: skip forcing demo data for agent-dependent cards when agent was previously connected

## Test plan
- [ ] Load dashboard with working kc-agent, verify data appears
- [ ] Disconnect kc-agent — data should remain visible (stale but not blank)
- [ ] Cards should show stale data, not demo data
- [ ] Reconnecting agent should refresh data normally
- [ ] Fresh load without kc-agent should still show demo data (initial load path unchanged)

Signed-off-by: Andy Anderson <andy@clubanderson.com>