### PR TITLE
🐛 Fix 26% coverage test failure rate from ESM live-binding breakage

### DIFF
--- a/web/src/hooks/mcp/__tests__/shared-cache-fetch.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-cache-fetch.test.ts
@@ -116,6 +116,8 @@ import {
   updateSingleClusterInCache,
   setInitialFetchStarted,
   setHealthCheckFailures,
+  getInitialFetchStarted,
+  getHealthCheckFailures,
   initialFetchStarted,
   healthCheckFailures,
   // WebSocket
@@ -715,7 +717,7 @@ describe('fetchSingleClusterHealth', () => {
 
     setHealthCheckFailures(0)
     await fetchSingleClusterHealth('test')
-    expect(healthCheckFailures).toBe(1)
+    expect(getHealthCheckFailures()).toBe(1)
   })
 
   it('uses kubectlContext for agent request when provided', async () => {

--- a/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
@@ -44,12 +44,13 @@ const mockResetAllCacheFailures = vi.hoisted(() => vi.fn())
 const mockKubectlProxyExec = vi.hoisted(() => vi.fn())
 const mockApiGet = vi.hoisted(() => vi.fn())
 
-vi.mock('../mcp/shared', () => ({
-  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
-  clusterCacheRef: { clusters: [] },
-  REFRESH_INTERVAL_MS: 120_000,
-  CLUSTER_POLL_INTERVAL_MS: 60_000,
-}))
+// The global test setup (setup.ts) mocks agentFetch to delegate to
+// global.fetch. For tests that need the REAL agentFetch (token injection,
+// signal fallback), import the actual module and restore the real impl.
+vi.mock('../shared', async () => {
+  const actual = await vi.importActual<typeof import('../shared')>('../shared')
+  return { ...actual }
+})
 
 vi.mock('../../../lib/api', () => ({
   api: { get: mockApiGet },
@@ -695,8 +696,15 @@ describe('deduplicateClustersByServer — cross-merge scenarios', () => {
 describe('fetchWithRetry — signal forwarding and cleanup', () => {
   const originalFetch = globalThis.fetch
 
+  beforeEach(() => {
+    // Pre-seed agent token so agentFetch() skips the token-fetch call,
+    // keeping globalThis.fetch call counts predictable.
+    localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, 'test-token')
+  })
+
   afterEach(() => {
     globalThis.fetch = originalFetch
+    localStorage.removeItem(AGENT_TOKEN_STORAGE_KEY)
     vi.restoreAllMocks()
   })
 
@@ -1087,8 +1095,14 @@ describe('agentFetch — passes additional RequestInit options', () => {
 describe('fetchWithRetry — default parameter behavior', () => {
   const originalFetch = globalThis.fetch
 
+  beforeEach(() => {
+    // Pre-seed agent token so agentFetch() skips the token-fetch call
+    localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, 'test-token')
+  })
+
   afterEach(() => {
     globalThis.fetch = originalFetch
+    localStorage.removeItem(AGENT_TOKEN_STORAGE_KEY)
   })
 
   it('uses default maxRetries=2 and initialBackoffMs=500 when not specified', async () => {

--- a/web/src/hooks/mcp/__tests__/shared-pure-funcs.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-pure-funcs.test.ts
@@ -117,6 +117,8 @@ import {
   updateSingleClusterInCache,
   setInitialFetchStarted,
   setHealthCheckFailures,
+  getInitialFetchStarted,
+  getHealthCheckFailures,
   initialFetchStarted,
   healthCheckFailures,
   // WebSocket
@@ -686,17 +688,17 @@ describe('updateSingleClusterInCache', () => {
 describe('setInitialFetchStarted / setHealthCheckFailures', () => {
   it('sets initialFetchStarted', () => {
     setInitialFetchStarted(true)
-    expect(initialFetchStarted).toBe(true)
+    expect(getInitialFetchStarted()).toBe(true)
     setInitialFetchStarted(false)
-    expect(initialFetchStarted).toBe(false)
+    expect(getInitialFetchStarted()).toBe(false)
   })
 
   it('sets healthCheckFailures', () => {
     const FIVE = 5
     setHealthCheckFailures(FIVE)
-    expect(healthCheckFailures).toBe(FIVE)
+    expect(getHealthCheckFailures()).toBe(FIVE)
     setHealthCheckFailures(0)
-    expect(healthCheckFailures).toBe(0)
+    expect(getHealthCheckFailures()).toBe(0)
   })
 })
 
@@ -770,8 +772,15 @@ describe('cleanupSharedWebSocket', () => {
 describe('fetchWithRetry', () => {
   const originalFetch = globalThis.fetch
 
+  beforeEach(() => {
+    // Pre-seed agent token so agentFetch() does not call fetch('/api/agent/token')
+    // which would interfere with call-count assertions.
+    localStorage.setItem('kc-agent-token', 'test-token')
+  })
+
   afterEach(() => {
     globalThis.fetch = originalFetch
+    localStorage.removeItem('kc-agent-token')
     vi.restoreAllMocks()
   })
 

--- a/web/src/hooks/mcp/__tests__/shared-websocket-detect.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-websocket-detect.test.ts
@@ -117,6 +117,7 @@ import {
   updateSingleClusterInCache,
   setInitialFetchStarted,
   setHealthCheckFailures,
+  getHealthCheckFailures,
   initialFetchStarted,
   healthCheckFailures,
   // WebSocket
@@ -413,7 +414,7 @@ describe('fetchSingleClusterHealth — backend error paths', () => {
     setHealthCheckFailures(0)
     await fetchSingleClusterHealth('err-cluster')
 
-    expect(healthCheckFailures).toBe(1)
+    expect(getHealthCheckFailures()).toBe(1)
   })
 
   it('resets healthCheckFailures to 0 on successful backend response', async () => {
@@ -424,7 +425,7 @@ describe('fetchSingleClusterHealth — backend error paths', () => {
     })
 
     await fetchSingleClusterHealth('ok-cluster')
-    expect(healthCheckFailures).toBe(0)
+    expect(getHealthCheckFailures()).toBe(0)
   })
 
   it('returns null when backend JSON parse fails', async () => {

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -407,7 +407,7 @@ export function clearClusterCacheOnLogout(): void {
     // Ignore storage errors
   }
 
-  clusterCache = {
+  Object.assign(clusterCache, {
     clusters: [],
     lastUpdated: null,
     isLoading: true,
@@ -416,7 +416,7 @@ export function clearClusterCacheOnLogout(): void {
     consecutiveFailures: 0,
     isFailed: false,
     lastRefresh: null,
-  }
+  })
   notifyClusterSubscribers()
 }
 
@@ -443,7 +443,7 @@ function handleClusterDemoModeChange() {
       }
 
       // Reset cluster cache to demo data
-      clusterCache = {
+      Object.assign(clusterCache, {
         clusters: getDemoClusters(),
         lastUpdated: new Date(),
         isLoading: false,
@@ -452,7 +452,7 @@ function handleClusterDemoModeChange() {
         consecutiveFailures: 0,
         isFailed: false,
         lastRefresh: new Date(),
-      }
+      })
       notifyClusterSubscribers()
     }
     // When switching FROM demo mode, fullFetchClusters will be called by useClusters hook
@@ -475,7 +475,7 @@ if (typeof window !== 'undefined') {
     }
 
     // Reset to loading state (shows skeletons) with empty data
-    clusterCache = {
+    Object.assign(clusterCache, {
       clusters: [],
       lastUpdated: null,
       isLoading: true, // Triggers skeleton display
@@ -484,7 +484,7 @@ if (typeof window !== 'undefined') {
       consecutiveFailures: 0,
       isFailed: false,
       lastRefresh: null,
-    }
+    })
     notifyClusterSubscribers()
   })
 }
@@ -519,7 +519,10 @@ export function updateClusterCache(updates: Partial<ClusterCache>) {
     saveClusterCacheToStorage(updates.clusters)
     updateDistributionCache(updates.clusters)
   }
-  clusterCache = { ...clusterCache, ...updates }
+  // Mutate in place so that any module holding a reference to the exported
+  // `clusterCache` object sees the update (ESM live-binding of `let` exports
+  // is not preserved by all bundlers / test runners).
+  Object.assign(clusterCache, updates)
 
   // Route notifications based on which slice the updates touch (#7865).
   // UI fires first (urgent) so spinner on/off commits immediately, then
@@ -812,10 +815,7 @@ export function updateSingleClusterInCache(clusterName: string, updates: Partial
     updatedClusters = shareMetricsBetweenSameServerClusters(updatedClusters)
   }
 
-  clusterCache = {
-    ...clusterCache,
-    clusters: updatedClusters,
-  }
+  Object.assign(clusterCache, { clusters: updatedClusters })
   // Persist all cluster data to localStorage
   saveClusterCacheToStorage(updatedClusters)
   // Persist distribution changes
@@ -993,7 +993,7 @@ if (import.meta.hot) {
     initialFetchStarted = false
     healthCheckFailures = 0 // Reset health check failures on HMR
     cleanupSharedWebSocket()
-    clusterCache = {
+    Object.assign(clusterCache, {
       clusters: [],
       lastUpdated: null,
       isLoading: true,
@@ -1002,7 +1002,7 @@ if (import.meta.hot) {
       consecutiveFailures: 0,
       isFailed: false,
       lastRefresh: null,
-    }
+    })
     clusterSubscribers.clear()
     dataSubscribers.clear()
     uiSubscribers.clear()
@@ -1758,12 +1758,11 @@ export async function refreshSingleCluster(clusterName: string): Promise<void> {
 
   // Mark the cluster as refreshing immediately and clear stale error state
   // so it shows as "loading" instead of "offline" while fetching
-  clusterCache = {
-    ...clusterCache,
+  Object.assign(clusterCache, {
     clusters: clusterCache.clusters.map(c =>
       c.name === clusterName ? { ...c, refreshing: true, reachable: undefined, errorType: undefined, errorMessage: undefined } : c
     ),
-  }
+  })
   notifyClusterSubscribers() // Immediate notification for user feedback
 
   const health = await fetchSingleClusterHealth(clusterName, kubectlContext)

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1860,13 +1860,23 @@ export function subscribeClusterUI(callback: (cache: ClusterCache) => void): () 
   return () => uiSubscribers.delete(callback)
 }
 
-// Setter functions for module-level state (ES modules can't assign to imported bindings)
+// Getter/setter functions for module-level state (vitest CJS transform does
+// not preserve ESM live bindings for `let` exports, so tests must use these
+// functions instead of reading the exported variable directly).
 export function setInitialFetchStarted(value: boolean) {
   initialFetchStarted = value
 }
 
+export function getInitialFetchStarted(): boolean {
+  return initialFetchStarted
+}
+
 export function setHealthCheckFailures(value: number) {
   healthCheckFailures = value
+}
+
+export function getHealthCheckFailures(): number {
+  return healthCheckFailures
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Fixes the root cause of 26% test failure rate in the Coverage Suite (70+ tests failing per run across 5 test files)
- The vitest CJS transform does not preserve ESM live bindings for `let` exports — when `shared.ts` reassigned `clusterCache = { ... }`, test files holding an imported reference saw stale data
- Replaced all `clusterCache` reassignments with `Object.assign()` to preserve object identity
- Added getter functions for `healthCheckFailures` and `initialFetchStarted` since `let` exports have the same binding issue
- Fixed `shared-coverage.test.ts` to restore real `agentFetch` via `vi.importActual` instead of inheriting the global mock
- Pre-seeded `kc-agent-token` in fetchWithRetry tests to prevent double fetch calls

Fixes #10460

## Test plan
- [x] All 44 tests in `shared-cache-fetch.test.ts` pass (was 29 failing)
- [x] All 53 tests in `shared-coverage.test.ts` pass (was 6 failing)
- [x] All 82 tests in `shared-pure-funcs.test.ts` pass (was 7 failing)
- [x] All 34 tests in `shared-websocket-detect.test.ts` pass (was 2 failing)
- [x] All 453 tests across all 9 affected test files pass
- [x] No regressions in useCachedData or useUsers tests