### PR TITLE
🐛 Fix component edge case crashes and broken behavior (Fixes #10477)

### DIFF
--- a/web/src/components/clusters/NodeDetailPanel.tsx
+++ b/web/src/components/clusters/NodeDetailPanel.tsx
@@ -29,6 +29,9 @@ export function NodeDetailPanel({ node, clusterName, onClose }: NodeDetailPanelP
   const displayedLabels = showAllLabels ? labelEntries : labelEntries.slice(0, INITIAL_LABELS_SHOWN)
 
   const handleRepair = () => {
+    if (!clusterName) {
+      return
+    }
     const issueConditions = getConditionIssuesSummary(node.conditions)
 
     startMission({
@@ -184,7 +187,13 @@ Please proceed step by step and ask for confirmation before making any changes.`
         {hasIssues ? (
           <button
             onClick={handleRepair}
-            className="mt-2 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors w-full justify-center bg-orange-500/20 text-orange-400 hover:bg-orange-500/30 cursor-pointer"
+            disabled={!clusterName}
+            className={cn(
+              'mt-2 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors w-full justify-center',
+              clusterName
+                ? 'bg-orange-500/20 text-orange-400 hover:bg-orange-500/30 cursor-pointer'
+                : 'bg-muted text-muted-foreground cursor-not-allowed opacity-50'
+            )}
           >
             <Wrench className="w-3.5 h-3.5" />
             Repair

--- a/web/src/components/deployments/Deployments.tsx
+++ b/web/src/components/deployments/Deployments.tsx
@@ -124,7 +124,7 @@ export function Deployments() {
           <AlertCircle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
           <div className="flex-1">
             <p className="text-sm font-medium text-red-400">Error loading deployment data</p>
-            <p className="text-xs text-muted-foreground mt-1">{error}</p>
+            <p className="text-xs text-muted-foreground mt-1">{error instanceof Error ? error.message : String(error)}</p>
           </div>
         </div>
       )}

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -617,7 +617,8 @@ export function LinkedInShareButton({ onShare, compact = false }: { onShare?: ()
   const { t } = useTranslation()
   const { websiteUrl } = useBranding()
   const handleShare = () => {
-    const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(websiteUrl)}`
+    const shareTarget = websiteUrl || 'https://kubestellar.io'
+    const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareTarget)}`
     window.open(linkedInUrl, '_blank', 'noopener,noreferrer,width=600,height=600')
     emitLinkedInShare('feedback_modal')
     onShare?.()


### PR DESCRIPTION
## Summary
- Convert error objects to strings before rendering in Deployments page to prevent React crashes
- Guard LinkedIn share URL against missing websiteUrl in branding config
- Validate clusterName before starting AI Repair mission in NodeDetailPanel

Fixes #10477

## Test plan
- [ ] Deployment errors with object values don't crash React
- [ ] LinkedIn share works correctly with and without websiteUrl config
- [ ] AI Repair mission creation validates clusterName

Signed-off-by: Andy Anderson <andy@clubanderson.com>