### PR TITLE
🐛 Fix duplicate useTranslation import and instanceof TS error

### DIFF
--- a/web/src/components/deployments/Deployments.tsx
+++ b/web/src/components/deployments/Deployments.tsx
@@ -126,7 +126,7 @@ export function Deployments() {
           <AlertCircle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
           <div className="flex-1">
             <p className="text-sm font-medium text-red-400">{t('deployments.errorLoading', 'Error loading deployment data')}</p>
-            <p className="text-xs text-muted-foreground mt-1">{error instanceof Error ? error.message : String(error)}</p>
+            <p className="text-xs text-muted-foreground mt-1">{String(error)}</p>
           </div>
         </div>
       )}

--- a/web/src/components/settings/sections/AgentBackendSettings.tsx
+++ b/web/src/components/settings/sections/AgentBackendSettings.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next'
 import { Bot, Monitor, RefreshCw, Check, ExternalLink } from 'lucide-react'
-import { useTranslation } from 'react-i18next'
 import { AgentIcon } from '../../agent/AgentIcon'
 import type { AgentBackendType } from '../../../hooks/useKagentBackend'
 import type { KagentAgent, KagentStatus } from '../../../lib/kagentBackend'


### PR DESCRIPTION
## Summary
- Remove duplicate `useTranslation` import in `AgentBackendSettings.tsx` introduced by #10487
- Simplify error display in `Deployments.tsx` to avoid `instanceof` type mismatch on union-typed error variable

These are build-breaking regressions from the i18n wrapping PR (#10487).

## Test plan
- [ ] `npm run build` passes without TS errors
- [ ] Deployments page error display still works correctly
- [ ] AgentBackendSettings renders without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)