### PR TITLE
🐛 Add periodic update indicator to console coins

### DIFF
--- a/web/src/components/rewards/CoinDisplay.tsx
+++ b/web/src/components/rewards/CoinDisplay.tsx
@@ -1,9 +1,15 @@
 /**
- * Coin display component for showing user's coin balance
+ * Coin display component for showing user's coin balance.
+ *
+ * Both CoinDisplay and CoinBadge wrap the coin count in a Tooltip that
+ * explains coins update periodically (same cadence as the leaderboard),
+ * addressing user confusion about delayed balance changes (#10495).
  */
 
 import { Coins } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { useRewards } from '../../hooks/useRewards'
+import { Tooltip } from '../ui/Tooltip'
 
 interface CoinDisplayProps {
   size?: 'sm' | 'md' | 'lg'
@@ -13,6 +19,7 @@ interface CoinDisplayProps {
 
 export function CoinDisplay({ size = 'md', showLabel = false, className = '' }: CoinDisplayProps) {
   const { totalCoins, isLoading } = useRewards()
+  const { t } = useTranslation()
 
   const sizeClasses = {
     sm: 'text-xs',
@@ -36,32 +43,35 @@ export function CoinDisplay({ size = 'md', showLabel = false, className = '' }: 
   }
 
   return (
-    <div
-      className={`flex items-center gap-1.5 ${sizeClasses[size]} ${className}`}
-      title={`${totalCoins.toLocaleString()} coins`}
-    >
-      <Coins className={`${iconSizes[size]} text-yellow-500`} />
-      <span className="font-medium text-foreground">{totalCoins.toLocaleString()}</span>
-      {showLabel && <span className="text-muted-foreground">coins</span>}
-    </div>
+    <Tooltip content={t('profile.coinsUpdateHint')} side="bottom">
+      <div
+        className={`flex items-center gap-1.5 ${sizeClasses[size]} ${className} cursor-help`}
+      >
+        <Coins className={`${iconSizes[size]} text-yellow-500`} />
+        <span className="font-medium text-foreground">{totalCoins.toLocaleString()}</span>
+        {showLabel && <span className="text-muted-foreground">coins</span>}
+      </div>
+    </Tooltip>
   )
 }
 
 // Compact version for header/navbar
 export function CoinBadge({ className = '' }: { className?: string }) {
   const { totalCoins, isLoading } = useRewards()
+  const { t } = useTranslation()
 
   if (isLoading) {
     return null
   }
 
   return (
-    <div
-      className={`flex items-center gap-1 px-2 py-1 rounded-full bg-yellow-500/10 border border-yellow-500/20 ${className}`}
-      title={`${totalCoins.toLocaleString()} coins`}
-    >
-      <Coins className="w-3.5 h-3.5 text-yellow-500" />
-      <span className="text-xs font-medium text-yellow-400">{totalCoins.toLocaleString()}</span>
-    </div>
+    <Tooltip content={t('profile.coinsUpdateHint')} side="bottom">
+      <div
+        className={`flex items-center gap-1 px-2 py-1 rounded-full bg-yellow-500/10 border border-yellow-500/20 cursor-help ${className}`}
+      >
+        <Coins className="w-3.5 h-3.5 text-yellow-500" />
+        <span className="text-xs font-medium text-yellow-400">{totalCoins.toLocaleString()}</span>
+      </div>
+    </Tooltip>
   )
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -758,6 +758,7 @@
     "slack": "Slack:",
     "role": "Role:",
     "coins": "Coins:",
+    "coinsUpdateHint": "Coins update periodically with the leaderboard (approximately every 4 hours), not in real-time.",
     "language": "Language:",
     "noEmail": "No email set",
     "notSet": "Not set",


### PR DESCRIPTION
## Summary
- Wrapped `CoinDisplay` and `CoinBadge` in a `Tooltip` explaining that coins update periodically with the leaderboard (~4 hours), not in real-time
- Added i18n key `profile.coinsUpdateHint` to `common.json`
- Uses existing `Tooltip` primitive from `components/ui/Tooltip.tsx`
- Added `cursor-help` to signal the tooltip is available on hover

Fixes #10495

## Test plan
- [ ] Hover over coin balance in profile area — tooltip appears explaining periodic updates
- [ ] Hover over coin badge in navbar — same tooltip appears
- [ ] Verify tooltip text is clear and uses i18n (not hardcoded)
- [ ] Verify no console errors