### PR TITLE
🐛 Fix sidebar icons overlapping navbar dropdowns

### DIFF
--- a/web/src/components/layout/SidebarShell.tsx
+++ b/web/src/components/layout/SidebarShell.tsx
@@ -740,7 +740,7 @@ export function SidebarShell({
       {/* Collapse + Pin controls */}
       {features.collapsePin !== false && !isMobile && !isMissionFullScreen && (
         <div
-          className="fixed top-18 z-sticky flex flex-col gap-1.5 items-center transition-[left] duration-300 bg-background border border-border/50 rounded-full p-1 shadow-md"
+          className="fixed top-18 z-sidebar flex flex-col gap-1.5 items-center transition-[left] duration-300 bg-background border border-border/50 rounded-full p-1 shadow-md"
           style={{ left: sidebarWidth + SIDEBAR_CONTROLS_LEFT_OFFSET_PX }}
         >
           <button
@@ -784,7 +784,7 @@ export function SidebarShell({
         <div
           onMouseDown={handleResizeStart}
           className={cn(
-            "fixed bottom-0 cursor-col-resize z-sticky hover:bg-purple-500/30 transition-colors hidden md:block",
+            "fixed bottom-0 cursor-col-resize z-sidebar hover:bg-purple-500/30 transition-colors hidden md:block",
             isResizing && "bg-purple-500/50"
           )}
           style={{ top: 160, left: sidebarWidth - 3, width: 6 }}


### PR DESCRIPTION
## Summary
- Lowered sidebar collapse/pin controls and resize handle from `z-sticky` (200) to `z-sidebar` (150)
- Navbar dropdowns (which live inside the `z-sticky` navbar stacking context) now correctly render above the sidebar icons
- Sidebar icons still function correctly at the sidebar layer

Fixes #10494

## Test plan
- [ ] Open navbar dropdown (e.g., cluster filter) while sidebar is visible
- [ ] Verify dropdown renders above sidebar collapse/pin icons
- [ ] Verify sidebar collapse and pin icons still function correctly
- [ ] Verify sidebar resize handle still works