### PR TITLE
🐛 Fix email overflow in profile dropdown header

### DIFF
--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, lazy, Suspense } from 'react'
+import { Tooltip } from '../ui/Tooltip'
 import { useModalState } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'
 import { User, Mail, MessageSquare, Shield, Settings, LogOut, ChevronDown, Coins, Lightbulb, Globe, Check, Download, Code2, ExternalLink, Rocket, KeyRound, CheckCircle2, XCircle, GitBranch } from 'lucide-react'
@@ -169,9 +170,11 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
                   <User className="w-6 h-6 text-purple-400" />
                 </div>
               )}
-              <div>
-                <p className="font-medium text-foreground">{user.github_login}</p>
-                <p className="text-sm text-muted-foreground">{user.email || t('profile.noEmail')}</p>
+              <div className="min-w-0 flex-1">
+                <p className="font-medium text-foreground truncate">{user.github_login}</p>
+                <Tooltip content={user.email || t('profile.noEmail')}>
+                  <p className="text-sm text-muted-foreground overflow-hidden text-ellipsis whitespace-nowrap">{user.email || t('profile.noEmail')}</p>
+                </Tooltip>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Added text truncation (`overflow-hidden text-ellipsis whitespace-nowrap`) to email display in profile dropdown header
- Added `Tooltip` wrapping the email so full address is visible on hover
- Added `min-w-0 flex-1` to the text container and `truncate` to username to prevent overflow
- Maintains existing w-72 dropdown width

Fixes #10501

## Test plan
- [ ] Long email addresses truncate with ellipsis in the dropdown header
- [ ] Hovering over truncated email shows full address in tooltip
- [ ] Short emails display normally without truncation
- [ ] Dropdown width unchanged at w-72
- [ ] Username also truncates gracefully if very long