### PR TITLE
✨ Extract hardcoded strings to i18n (Auto-QA #10504)

### DIFF
--- a/web/src/components/cards/insights/RightSizeAdvisor.tsx
+++ b/web/src/components/cards/insights/RightSizeAdvisor.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Scale, ChevronDown, ChevronUp, Cpu, MemoryStick, AlertTriangle, CheckCircle2, MinusCircle, HelpCircle } from 'lucide-react'
 import { useClusters } from '../../../hooks/useMCP'
 import { useCachedGPUNodes } from '../../../hooks/useCachedData'
@@ -105,6 +106,7 @@ const VERDICT_CONFIG: Record<Verdict, { color: 'red' | 'green' | 'yellow' | 'gra
 }
 
 export function RightSizeAdvisor() {
+  const { t } = useTranslation()
   const { deduplicatedClusters, isLoading, isRefreshing, isFailed, consecutiveFailures, error } = useClusters()
   const { nodes: gpuNodes, isDemoFallback } = useCachedGPUNodes()
   const { selectedClusters: globalSelectedClusters, isAllClustersSelected } = useGlobalFilters()
@@ -341,7 +343,7 @@ export function RightSizeAdvisor() {
                     <div className="space-y-1">
                       <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                         <MemoryStick className="w-3 h-3" />
-                        <span>Memory</span>
+                        <span>{t('rightSizeAdvisor.memory')}</span>
                         <span className="ml-auto font-mono">{s.memory.used}/{s.memory.capacity} {s.memory.unit} ({s.memory.pct}%)</span>
                       </div>
                       <div className="h-2 bg-secondary rounded-full overflow-hidden">

--- a/web/src/components/cards/pipelines/PipelineFlow.tsx
+++ b/web/src/components/cards/pipelines/PipelineFlow.tsx
@@ -13,6 +13,7 @@
  * cadence) so the flow looks live without hammering the function.
  */
 import { useState, useMemo, useRef, useLayoutEffect, useEffect, type CSSProperties } from 'react'
+import { useTranslation } from 'react-i18next'
 import { RefreshCw, XCircle, ExternalLink, Stethoscope } from 'lucide-react'
 import { useReducedMotion } from 'framer-motion'
 import { useDemoMode } from '../../../hooks/useDemoMode'
@@ -341,6 +342,7 @@ function colorForStatus(status: Status, conclusion: Conclusion): string {
 // ---------------------------------------------------------------------------
 
 export function PipelineFlow() {
+  const { t } = useTranslation()
   const shared = usePipelineFilter()
   const [localRepoFilter, setLocalRepoFilter] = useState<string | null>(null)
   const repoFilter = shared?.repoFilter ?? localRepoFilter
@@ -398,7 +400,7 @@ export function PipelineFlow() {
           className="text-xs bg-secondary/40 border border-border rounded px-2 py-1 text-foreground"
           aria-label={LABEL_FILTER_REPO}
         >
-          <option value="">All repos</option>
+          <option value="">{t('pipelines.allRepos')}</option>
           {repos.map((r) => (
             <option key={r} value={r}>{r}</option>
           ))}

--- a/web/src/components/cards/pipelines/RecentFailures.tsx
+++ b/web/src/components/cards/pipelines/RecentFailures.tsx
@@ -8,6 +8,7 @@
  * button.
  */
 import { useState, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ExternalLink, RefreshCw, FileText, Stethoscope } from 'lucide-react'
 import { useDemoMode } from '../../../hooks/useDemoMode'
 import { useCardLoadingState } from '../CardDataContext'
@@ -46,6 +47,7 @@ function formatDuration(ms: number): string {
 }
 
 export function RecentFailures() {
+  const { t } = useTranslation()
   const shared = usePipelineFilter()
   const [localRepoFilter, setLocalRepoFilter] = useState<string | null>(null)
   const repoFilter = shared?.repoFilter ?? localRepoFilter
@@ -100,7 +102,7 @@ export function RecentFailures() {
           className="text-xs bg-secondary/40 border border-border rounded px-2 py-1 text-foreground"
           aria-label={LABEL_FILTER_REPO}
         >
-          <option value="">All repos</option>
+          <option value="">{t('pipelines.allRepos')}</option>
           {repos.map((r) => (
             <option key={r} value={r}>{r}</option>
           ))}

--- a/web/src/components/cards/pipelines/WorkflowMatrix.tsx
+++ b/web/src/components/cards/pipelines/WorkflowMatrix.tsx
@@ -8,6 +8,7 @@
  * of the server-side history blob).
  */
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ExternalLink } from 'lucide-react'
 import { useDemoMode } from '../../../hooks/useDemoMode'
 import { useCardLoadingState } from '../CardDataContext'
@@ -52,6 +53,7 @@ function cellClass(c: Conclusion): string {
 }
 
 export function WorkflowMatrix() {
+  const { t } = useTranslation()
   const [days, setDays] = useState<number>(RANGE_OPTIONS[0])
   // Shared dashboard filter (if inside PipelineFilterProvider on /ci-cd).
   // Falls back to per-card local state when on a different dashboard.
@@ -97,7 +99,7 @@ export function WorkflowMatrix() {
             className="text-xs bg-secondary/40 border border-border rounded px-2 py-1 text-foreground"
             aria-label={LABEL_FILTER_REPO}
           >
-            <option value="">All repos</option>
+            <option value="">{t('pipelines.allRepos')}</option>
             {repos.map((r) => (
               <option key={r} value={r}>{r}</option>
             ))}

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -4610,5 +4610,11 @@
   },
   "clusterDropZone": {
     "deployToClusterAria": "Deploy {{workload}} to cluster {{cluster}}"
+  },
+  "pipelines": {
+    "allRepos": "All repos"
+  },
+  "rightSizeAdvisor": {
+    "memory": "Memory"
   }
 }

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -4610,11 +4610,5 @@
   },
   "clusterDropZone": {
     "deployToClusterAria": "Deploy {{workload}} to cluster {{cluster}}"
-  },
-  "pipelines": {
-    "allRepos": "All repos"
-  },
-  "rightSizeAdvisor": {
-    "memory": "Memory"
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -185,7 +185,28 @@
       "privacyNote": "We collect anonymous data solely for the purpose of improving the product's user experience, using Google Analytics. No personal information is ever collected or shared."
     },
     "restoredFromBackup": "Settings restored from backup file",
-    "agentBackend": "Agent Backend",
+    "agentBackend": {
+      "title": "Agent Backend",
+      "subtitle": "Choose how AI missions connect to your clusters",
+      "refreshStatus": "Refresh status",
+      "localAgent": "Local Agent",
+      "localAgentDesc": "kc-agent on your machine",
+      "kagent": "Kagent",
+      "kagentDesc": "In-cluster AI agents",
+      "kagentNotDetected": "Not detected in cluster",
+      "kagenti": "Kagenti",
+      "kagentiDesc": "In-cluster agent platform",
+      "kagentiNotDetected": "Not detected in cluster",
+      "install": "Install",
+      "activeLabel": "Active:",
+      "kagentiInCluster": "Kagenti (in-cluster)",
+      "kagentInCluster": "Kagent (in-cluster)",
+      "localAgentKcAgent": "Local Agent (kc-agent)",
+      "kagentAgents": "Kagent Agents",
+      "kagentiAgents": "Kagenti Agents",
+      "noKagentAgents": "No kagent agents found. Agents may not be deployed yet.",
+      "noKagentiAgents": "No kagenti agents found. Agents may not be deployed yet."
+    },
     "localAgent": "Local Agent",
     "groups": {
       "aiIntelligence": "AI & Intelligence",
@@ -261,28 +282,6 @@
       "today": "Today",
       "thisMonth": "This Month",
       "tokens": "tokens"
-    },
-    "agentBackend": {
-      "title": "Agent Backend",
-      "subtitle": "Choose how AI missions connect to your clusters",
-      "refreshStatus": "Refresh status",
-      "localAgent": "Local Agent",
-      "localAgentDesc": "kc-agent on your machine",
-      "kagent": "Kagent",
-      "kagentDesc": "In-cluster AI agents",
-      "kagentNotDetected": "Not detected in cluster",
-      "kagenti": "Kagenti",
-      "kagentiDesc": "In-cluster agent platform",
-      "kagentiNotDetected": "Not detected in cluster",
-      "install": "Install",
-      "activeLabel": "Active:",
-      "kagentiInCluster": "Kagenti (in-cluster)",
-      "kagentInCluster": "Kagent (in-cluster)",
-      "localAgentKcAgent": "Local Agent (kc-agent)",
-      "kagentAgents": "Kagent Agents",
-      "kagentiAgents": "Kagenti Agents",
-      "noKagentAgents": "No kagent agents found. Agents may not be deployed yet.",
-      "noKagentiAgents": "No kagenti agents found. Agents may not be deployed yet."
     },
     "tokens": {
       "title": "Token Usage",
@@ -3852,5 +3851,11 @@
   "drafts": {
     "noSavedDrafts": "No saved drafts",
     "editing": "Editing"
+  },
+  "pipelines": {
+    "allRepos": "All repos"
+  },
+  "rightSizeAdvisor": {
+    "memory": "Memory"
   }
 }


### PR DESCRIPTION
Fixes #10504

Extract hardcoded user-facing strings to i18n translation keys per Auto-QA findings. Skips .stories.tsx files and brand names.