### PR TITLE
fix: extend auth smoke test to cover kc-agent token flow

### DIFF
--- a/.github/workflows/auth-login-smoke.yml
+++ b/.github/workflows/auth-login-smoke.yml
@@ -325,6 +325,8 @@ jobs:
           # Match: fetch(LOCAL_AGENT_HTTP_URL  or  fetch(LOCAL_AGENT_URL
           # Match: fetch(`http://127.0.0.1:8585
           # Exclude: agentFetch, fetchWithRetry, test files, comments
+          # /health is intentionally public (no auth required, used for
+          # agent discovery) so raw fetch() to /health is allowed.
           VIOLATIONS=$(grep -rn \
             -e 'fetch(`${LOCAL_AGENT_HTTP_URL}' \
             -e 'fetch(`${LOCAL_AGENT_URL}' \
@@ -340,6 +342,7 @@ jobs:
             | grep -v '\.spec\.' \
             | grep -v '// ' \
             | grep -v 'shared\.ts' \
+            | grep -v '/health' \
             || true)
 
           if [ -n "$VIOLATIONS" ]; then

--- a/.github/workflows/auth-login-smoke.yml
+++ b/.github/workflows/auth-login-smoke.yml
@@ -1,12 +1,18 @@
 name: Auth Login Smoke Test
 
 # Verifies the auth login contract by building and running the Go backend
-# in dev mode. No external dependencies — everything runs against localhost.
+# AND kc-agent in dev mode. No external dependencies — everything runs
+# against localhost.
 #
 # #6590 contract (enforced by #8107): the refreshed JWT is delivered
 # EXCLUSIVELY via the HttpOnly `kc_auth` cookie. The JSON body carries
 # only `{ refreshed: true, onboarded }` — any `token` field in the body
 # would be an XSS/extension-readable leak and must fail the smoke test.
+#
+# #10398 contract: ALL frontend fetch calls to kc-agent (LOCAL_AGENT_URL /
+# LOCAL_AGENT_HTTP_URL) must go through agentFetch() or fetchWithRetry()
+# which inject the KC_AGENT_TOKEN. Raw fetch() to agent URLs bypasses auth
+# and produces silent 401 errors on every kc-agent endpoint.
 #
 # What it checks:
 #   1. /health returns JSON with status and oauth_configured fields
@@ -15,6 +21,11 @@ name: Auth Login Smoke Test
 #      - response body with { refreshed: true, onboarded }
 #      - Set-Cookie: kc_auth=... (refreshed JWT)
 #      - NO `token` field in the body
+#   4. kc-agent /health is reachable (no auth required)
+#   5. /api/agent/token returns the shared KC_AGENT_TOKEN
+#   6. kc-agent rejects requests without the agent token (401)
+#   7. kc-agent accepts requests with the correct agent token (200)
+#   8. No raw fetch() calls to agent URLs bypass agentFetch/fetchWithRetry
 #
 # The test uses DEV_MODE (no GitHub OAuth credentials) so the backend
 # auto-creates a dev-user on /auth/github. This takes ~60 seconds.
@@ -39,6 +50,8 @@ jobs:
     name: Auth Login Smoke
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      KC_AGENT_TOKEN: smoke-test-agent-token-do-not-use-in-prod
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -46,11 +59,71 @@ jobs:
         with:
           go-version-file: go.mod
 
-      # ── 1. Build the Go backend ──────────────────────────────────
-      - name: Build backend
-        run: go build -o console-bin ./cmd/console
+      # ── 1. Build the Go backend and kc-agent ─────────────────────
+      - name: Build backend and kc-agent
+        run: |
+          go build -o console-bin ./cmd/console
+          go build -o kc-agent-bin ./cmd/kc-agent
 
-      # ── 2. Start backend in dev mode ─────────────────────────────
+      # ── 2. Start kc-agent with token auth ────────────────────────
+      - name: Start kc-agent
+        run: |
+          DEV_MODE=true \
+          ./kc-agent-bin --port 8585 &
+          echo $! > /tmp/kc-agent.pid
+
+      # ── 3. Wait for kc-agent health ──────────────────────────────
+      - name: Wait for kc-agent health
+        run: |
+          MAX_WAIT_SECONDS=30
+          for i in $(seq 1 "$MAX_WAIT_SECONDS"); do
+            HTTP_CODE=$(curl -sS --max-time 2 -o /dev/null -w '%{http_code}' \
+              http://127.0.0.1:8585/health 2>/dev/null || echo "000")
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "kc-agent healthy after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::kc-agent did not become healthy within ${MAX_WAIT_SECONDS}s"
+          exit 1
+
+      # ── 4. Test kc-agent rejects unauthenticated requests ────────
+      - name: Test kc-agent rejects unauthenticated requests
+        run: |
+          echo "Testing kc-agent rejects requests without token..."
+          HTTP_CODE=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
+            http://127.0.0.1:8585/deployments 2>/dev/null)
+          if [ "$HTTP_CODE" != "401" ]; then
+            echo "::error::kc-agent /deployments returned $HTTP_CODE without auth — expected 401"
+            exit 1
+          fi
+          echo "kc-agent correctly rejected unauthenticated request (401)"
+
+          echo "Testing kc-agent rejects wrong token..."
+          HTTP_CODE=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer wrong-token-value" \
+            http://127.0.0.1:8585/deployments 2>/dev/null)
+          if [ "$HTTP_CODE" != "401" ]; then
+            echo "::error::kc-agent /deployments returned $HTTP_CODE with wrong token — expected 401"
+            exit 1
+          fi
+          echo "kc-agent correctly rejected wrong token (401)"
+
+      # ── 5. Test kc-agent accepts correct token ───────────────────
+      - name: Test kc-agent accepts correct agent token
+        run: |
+          echo "Testing kc-agent accepts correct agent token..."
+          HTTP_CODE=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer ${KC_AGENT_TOKEN}" \
+            http://127.0.0.1:8585/deployments 2>/dev/null)
+          if [ "$HTTP_CODE" = "401" ]; then
+            echo "::error::kc-agent /deployments returned 401 with correct token — agent token auth is broken"
+            exit 1
+          fi
+          echo "kc-agent accepted correct token (HTTP $HTTP_CODE)"
+
+      # ── 6. Start backend in dev mode ─────────────────────────────
       - name: Start backend
         run: |
           JWT_SECRET="smoke-test-$(openssl rand -hex 16)" \
@@ -58,15 +131,7 @@ jobs:
           ./console-bin --dev --port 8081 &
           echo $! > /tmp/backend.pid
 
-      # ── 3. Wait for health ───────────────────────────────────────
-      # Wait for the REAL backend (status=ok), not the loading server.
-      # The temporary loading server returns HTTP 503 with body
-      # {"status":"starting"} while the real Fiber app is still
-      # initializing (#9904). Previously `curl -sf` accepted any 2xx and
-      # the suite raced ahead to /auth/github before the real routes were
-      # registered — the loading page's catch-all `/` handler answered
-      # with HTTP 200 + HTML, which looked like a broken auth contract
-      # but was actually the loading page. Assert status=ok explicitly.
+      # ── 7. Wait for backend health ──────────────────────────────
       - name: Wait for backend health
         run: |
           MAX_WAIT_SECONDS=60
@@ -82,7 +147,7 @@ jobs:
           echo "::error::Backend did not reach status=ok within ${MAX_WAIT_SECONDS}s"
           exit 1
 
-      # ── 4. Test /health returns JSON with expected fields ────────
+      # ── 8. Test /health returns JSON with expected fields ────────
       - name: Test /health endpoint
         run: |
           echo "Checking /health endpoint..."
@@ -101,13 +166,10 @@ jobs:
           echo "oauth_configured=$OAUTH"
           echo "/health OK"
 
-      # ── 5. Dev-mode login via /auth/github ───────────────────────
+      # ── 9. Dev-mode login via /auth/github ───────────────────────
       - name: Get dev-mode auth cookie
         run: |
           echo "Calling GET /auth/github (dev mode login)..."
-          # Dev mode redirects and sets kc_auth HttpOnly cookie.
-          # Use -c to capture the cookie jar, -L to NOT follow redirects
-          # (we just need the Set-Cookie header).
           COOKIE_JAR=/tmp/cookies.txt
           HTTP_CODE=$(curl -sS --max-time 5 \
             -o /dev/null -w '%{http_code}' \
@@ -126,12 +188,65 @@ jobs:
           echo "Got kc_auth cookie (${#KC_AUTH} chars)"
           echo "$KC_AUTH" > /tmp/kc_auth_token.txt
 
-      # ── 6. Test /auth/refresh contract (#6590) ───────────────────
-      # The refreshed JWT is delivered via the HttpOnly kc_auth cookie
-      # ONLY. The JSON body must NOT contain a `token` field — any such
-      # field is readable by XSS/extension content scripts and is the
-      # regression #8107 fixed. We drive this call exactly like the
-      # frontend does: cookie jar + CSRF header, no Authorization.
+      # ── 10. Test /api/agent/token returns the shared secret ──────
+      # This is the endpoint the frontend calls after login to get the
+      # kc-agent token. It must return the same KC_AGENT_TOKEN that
+      # kc-agent was started with. If this breaks, every agentFetch()
+      # call sends the wrong (or empty) token → 401 on all agent data.
+      - name: Test /api/agent/token endpoint
+        run: |
+          COOKIE_JAR=/tmp/cookies.txt
+
+          echo "Testing /api/agent/token..."
+          AGENT_TOKEN_RESP=$(curl -sS --max-time 5 \
+            -b "$COOKIE_JAR" \
+            -H "X-Requested-With: XMLHttpRequest" \
+            http://localhost:8081/api/agent/token)
+          echo "Response: $AGENT_TOKEN_RESP"
+
+          RETURNED_TOKEN=$(echo "$AGENT_TOKEN_RESP" | jq -r '.token // empty')
+          if [ -z "$RETURNED_TOKEN" ]; then
+            echo "::error::/api/agent/token returned empty token — frontend will not be able to auth with kc-agent"
+            exit 1
+          fi
+
+          if [ "$RETURNED_TOKEN" != "$KC_AGENT_TOKEN" ]; then
+            echo "::error::/api/agent/token returned a different token than KC_AGENT_TOKEN — backend/agent token mismatch"
+            echo "Expected: ${KC_AGENT_TOKEN:0:8}..."
+            echo "Got:      ${RETURNED_TOKEN:0:8}..."
+            exit 1
+          fi
+          echo "/api/agent/token returns correct KC_AGENT_TOKEN"
+
+      # ── 11. End-to-end: token from backend works on kc-agent ─────
+      # Simulates the full frontend flow: get token from backend, use
+      # it to call kc-agent. This is the exact path that broke in
+      # #10398/#10407 — raw fetch() bypassed agentFetch() and sent the
+      # wrong token (OAuth JWT instead of agent token).
+      - name: Test end-to-end agent token flow
+        run: |
+          COOKIE_JAR=/tmp/cookies.txt
+
+          # Get token from backend (like frontend does after login)
+          E2E_TOKEN=$(curl -sS --max-time 5 \
+            -b "$COOKIE_JAR" \
+            -H "X-Requested-With: XMLHttpRequest" \
+            http://localhost:8081/api/agent/token | jq -r '.token')
+
+          # Use that token to call kc-agent (like agentFetch does)
+          echo "Testing kc-agent with token from /api/agent/token..."
+          HTTP_CODE=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer ${E2E_TOKEN}" \
+            http://127.0.0.1:8585/deployments 2>/dev/null)
+
+          if [ "$HTTP_CODE" = "401" ]; then
+            echo "::error::END-TO-END FAILURE: token from /api/agent/token was rejected by kc-agent (401)"
+            echo "This means the backend and kc-agent are using different tokens."
+            exit 1
+          fi
+          echo "End-to-end agent token flow PASSED (HTTP $HTTP_CODE)"
+
+      # ── 12. Test /auth/refresh contract (#6590) ──────────────────
       - name: Test /auth/refresh contract
         run: |
           COOKIE_JAR=/tmp/cookies.txt
@@ -148,8 +263,6 @@ jobs:
           echo "Response: $REFRESH_RESP"
 
           # #6590 CONTRACT: response body MUST NOT contain a `token` field.
-          # Presence of `token` means the refreshed JWT is JS-readable,
-          # which is the XSS leak that #8107 fixed.
           HAS_TOKEN=$(echo "$REFRESH_RESP" | jq 'has("token")')
           if [ "$HAS_TOKEN" != "false" ]; then
             echo "::error::CONTRACT VIOLATION: /auth/refresh response includes 'token' field — this is the #6590 XSS leak that #8107 fixed. Refreshed JWT must live in the HttpOnly kc_auth cookie only."
@@ -177,11 +290,6 @@ jobs:
           echo "refreshed field present"
 
           # #6590 CONTRACT: Set-Cookie must refresh the kc_auth cookie.
-          # curl writes Netscape-format cookie jars. HttpOnly cookies are prefixed
-          # with "#HttpOnly_" on the line (e.g. "#HttpOnly_localhost\tFALSE\t/\tTRUE\t...\tkc_auth\t<token>").
-          # We WANT the HttpOnly form — it proves the HttpOnly flag is set — so we
-          # match the cookie name as a tab-separated field regardless of leading
-          # host/HttpOnly prefix, then separately assert the HttpOnly line exists.
           REFRESHED_KC_AUTH=$(grep -E $'(^|\t)kc_auth\t' "$REFRESH_COOKIE_JAR" 2>/dev/null | awk -F'\t' '{print $NF}' | tail -n1)
           if [ -z "$REFRESHED_KC_AUTH" ]; then
             echo "::error::CONTRACT VIOLATION: /auth/refresh did not set a new kc_auth cookie. The refreshed JWT must be delivered exclusively via the HttpOnly cookie."
@@ -192,9 +300,6 @@ jobs:
           echo "kc_auth cookie refreshed (${#REFRESHED_KC_AUTH} chars)"
 
           # #6590 CONTRACT: the refreshed kc_auth cookie must be HttpOnly.
-          # curl's Netscape jar encodes this by prefixing the line with "#HttpOnly_".
-          # Assert that a line starting with "#HttpOnly_" contains "kc_auth" — this
-          # proves the Set-Cookie response included HttpOnly (the #8107 XSS fix).
           if ! grep -E '^#HttpOnly_.*[[:space:]]kc_auth[[:space:]]' "$REFRESH_COOKIE_JAR" >/dev/null 2>&1; then
             echo "::error::CONTRACT VIOLATION: refreshed kc_auth cookie is NOT HttpOnly. The #8107 XSS fix requires Set-Cookie: kc_auth=...; HttpOnly."
             echo "Cookie jar contents:"
@@ -206,47 +311,95 @@ jobs:
           echo ""
           echo "Auth login smoke test PASSED"
 
-      # ── 7. Cleanup ───────────────────────────────────────────────
-      - name: Stop backend
+      # ── 13. Static analysis: no raw fetch() to agent URLs ────────
+      # Catches the exact regression from #10398: someone adds a fetch()
+      # call to LOCAL_AGENT_HTTP_URL or LOCAL_AGENT_URL without going
+      # through agentFetch() or fetchWithRetry(). These calls silently
+      # skip the KC_AGENT_TOKEN header and produce 401s on every
+      # kc-agent endpoint.
+      - name: Check for raw fetch to agent URLs
+        run: |
+          echo "Scanning for raw fetch() calls to kc-agent URLs..."
+
+          # Match: fetch(`${LOCAL_AGENT_HTTP_URL}  or  fetch(`${LOCAL_AGENT_URL}
+          # Match: fetch(LOCAL_AGENT_HTTP_URL  or  fetch(LOCAL_AGENT_URL
+          # Match: fetch(`http://127.0.0.1:8585
+          # Exclude: agentFetch, fetchWithRetry, test files, comments
+          VIOLATIONS=$(grep -rn \
+            -e 'fetch(`${LOCAL_AGENT_HTTP_URL}' \
+            -e 'fetch(`${LOCAL_AGENT_URL}' \
+            -e 'fetch(LOCAL_AGENT_HTTP_URL' \
+            -e 'fetch(LOCAL_AGENT_URL' \
+            -e 'fetch(`http://127\.0\.0\.1:8585' \
+            web/src/ \
+            --include='*.ts' --include='*.tsx' \
+            | grep -v 'agentFetch' \
+            | grep -v 'fetchWithRetry' \
+            | grep -v '__tests__' \
+            | grep -v '\.test\.' \
+            | grep -v '\.spec\.' \
+            | grep -v '// ' \
+            | grep -v 'shared\.ts' \
+            || true)
+
+          if [ -n "$VIOLATIONS" ]; then
+            echo "::error::Found raw fetch() calls to kc-agent URLs that bypass agentFetch()."
+            echo "These will produce 401 Unauthorized errors because they don't include the KC_AGENT_TOKEN header."
+            echo ""
+            echo "Violations:"
+            echo "$VIOLATIONS"
+            echo ""
+            echo "Fix: replace fetch() with agentFetch() from hooks/mcp/shared.ts"
+            exit 1
+          fi
+          echo "No raw fetch() calls to agent URLs found (correct)"
+
+      # ── 14. Cleanup ──────────────────────────────────────────────
+      - name: Stop backend and kc-agent
         if: always()
         run: |
           if [ -f /tmp/backend.pid ]; then
             kill "$(cat /tmp/backend.pid)" 2>/dev/null || true
           fi
+          if [ -f /tmp/kc-agent.pid ]; then
+            kill "$(cat /tmp/kc-agent.pid)" 2>/dev/null || true
+          fi
 
-      # ── 8. Alert on failure ──────────────────────────────────────
+      # ── 15. Alert on failure ─────────────────────────────────────
       - name: Create issue on failure
         if: failure()
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const title = `Auth login smoke test failed — OAuth login contract may be broken`;
+            const title = `Auth smoke test failed — login or agent token contract may be broken`;
             const body = [
-              '## Auth Login Smoke Test Failure',
+              '## Auth Smoke Test Failure',
               '',
               `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               `**Time:** ${new Date().toISOString()}`,
               '',
-              'The auth contract test failed against a local backend in dev mode.',
-              'This means the `/auth/refresh` endpoint is not returning the expected response shape.',
+              'The auth smoke test failed against a local backend + kc-agent in dev mode.',
               '',
-              '### #6590 contract (enforced by #8107)',
-              'The refreshed JWT must be delivered EXCLUSIVELY via the HttpOnly `kc_auth` cookie.',
-              'The JSON body carries only `{ refreshed: true, onboarded }`. Any `token` field in the body',
-              'is an XSS/extension-readable leak and MUST fail this smoke test.',
+              '### What this test covers',
+              '',
+              '**OAuth login contract (#6590, enforced by #8107):**',
+              '- `/auth/refresh` body contains `{ refreshed: true, onboarded }` only',
+              '- Refreshed JWT is in the HttpOnly `kc_auth` cookie, NOT in the response body',
+              '',
+              '**Agent token contract (#10398, #10407):**',
+              '- kc-agent rejects requests without `KC_AGENT_TOKEN` (401)',
+              '- kc-agent accepts requests with the correct token',
+              '- `/api/agent/token` returns the same token kc-agent was started with',
+              '- End-to-end: token from backend → kc-agent auth succeeds',
+              '- No raw `fetch()` calls to agent URLs bypass `agentFetch()`',
               '',
               '### Action required',
-              '1. Check the workflow run logs above for the specific failure',
-              '2. Verify /auth/refresh:',
-              '   - body contains `refreshed: true` and `onboarded`',
-              '   - body does NOT contain `token`',
-              '   - response sets a fresh `kc_auth` HttpOnly cookie',
-              '3. Run `go test ./pkg/api/handlers/ -run TestAuthRefreshContract` locally',
-              '4. DO NOT "fix" this by re-adding `token` to the response body — that is the #6590 regression',
-              '   and will be reverted.',
+              '1. Check the workflow run logs for the specific failure step',
+              '2. If **agent token**: verify `KC_AGENT_TOKEN` env var flows from startup-oauth.sh → backend → `/api/agent/token` → frontend → kc-agent',
+              '3. If **raw fetch**: replace `fetch()` with `agentFetch()` from `hooks/mcp/shared.ts`',
+              '4. If **OAuth login**: verify `/auth/refresh` contract (see #6590)',
             ].join('\n');
 
-            // Don't create duplicate issues
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary
- Extends the hourly `auth-login-smoke` workflow to also validate the full kc-agent token auth chain
- Builds and starts kc-agent alongside the Go backend in CI
- Tests: unauthenticated rejection (401), correct token acceptance, `/api/agent/token` returns matching token, end-to-end flow
- Adds static analysis check: no raw `fetch()` calls to agent URLs bypassing `agentFetch()`
- Updates the auto-created failure issue to cover both OAuth and agent token contracts

## Context
PRs #10398 and #10407 fixed a regression where raw `fetch()` calls sent the OAuth JWT instead of the `KC_AGENT_TOKEN` to kc-agent, causing 401s on all agent endpoints. This silently broke clusters, workloads, deployments, and every other kc-agent-backed view. The existing hourly smoke test only covered OAuth login — not the agent token flow.

## Test plan
- [ ] Trigger `auth-login-smoke` workflow manually via `workflow_dispatch` — all steps pass
- [ ] Run 25 times to verify stability
- [ ] Introduce a deliberate raw `fetch()` to an agent URL → static analysis step catches it

Fixes #10398 (prevention)