### PR TITLE
🐛 Replace raw fetch with agentFetch in AgentStatusIndicator (#10508)

### DIFF
--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -20,6 +20,7 @@ import {
   LOCAL_AGENT_HTTP_URL,
   BACKEND_HEALTH_CHECK_TIMEOUT_MS,
 } from '../../../lib/constants/network'
+import { agentFetch } from '@/hooks/mcp/shared'
 import type { AgentInfo } from '../../../types/agent'
 
 const CONNECTING_DEBOUNCE_MS = 300
@@ -56,10 +57,7 @@ export function AgentStatusIndicator() {
   const fetchAgentsFromHealth = async () => {
     setIsDiscoveringAgents(true)
     try {
-      // Use plain fetch instead of agentFetch — the /health endpoint does not
-      // require auth, and plain fetch avoids the X-Requested-With header that
-      // triggers CORS preflight failures when origin is not in allowed list (#10459).
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+      const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
         method: 'GET',
         headers: { Accept: 'application/json' },
         signal: AbortSignal.timeout(BACKEND_HEALTH_CHECK_TIMEOUT_MS),


### PR DESCRIPTION
Fixes #10508

Replace raw fetch() call to kc-agent /health endpoint with agentFetch() to satisfy the auth smoke test contract. agentFetch() automatically injects the KC_AGENT_TOKEN Authorization header.