### PR TITLE
🐛 Fix CardChat demo mode test failure (#10512)

### DIFF
--- a/web/src/components/cards/__tests__/CardChat.test.tsx
+++ b/web/src/components/cards/__tests__/CardChat.test.tsx
@@ -415,7 +415,10 @@ describe('CardChat', () => {
       mockIsDemoMode = true
       renderChat({ messages: [] })
       expect(screen.getByText('cardChat.demoConversation')).toBeInTheDocument()
-      expect(screen.getByText('Show only unhealthy clusters')).toBeInTheDocument()
+      // "Show only unhealthy clusters" appears in both demo messages and quick
+      // prompts, so verify at least two occurrences (one from each source).
+      const matches = screen.getAllByText('Show only unhealthy clusters')
+      expect(matches.length).toBeGreaterThanOrEqual(2)
     })
 
     it('does not show demo messages when not in demo mode', () => {


### PR DESCRIPTION
Fixes #10512

Fix CardChat demo mode test that broke after i18n extraction (PR #10506) and demo data (PR #10509) PRs merged.

**Root cause:** The test used `getByText('Show only unhealthy clusters')` which matched two elements — the demo chat message AND the quick prompts footer button — causing a `getMultipleElementsFoundError`.

**Fix:** Switch to `getAllByText` and assert `>= 2` matches to confirm the text appears in both the demo conversation and quick prompts.