### PR TITLE
🌱 Phase 3a: responsive skeleton grids + flex-wrap in CNCF status cards (#10514)

### DIFF
--- a/web/src/components/cards/backstage_status/index.tsx
+++ b/web/src/components/cards/backstage_status/index.tsx
@@ -186,7 +186,7 @@ export function BackstageStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/cloud_custodian_status/index.tsx
+++ b/web/src/components/cards/cloud_custodian_status/index.tsx
@@ -156,7 +156,7 @@ function PolicyRow({
           </span>
         </div>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         <span className="truncate">
           <span className="text-foreground font-mono">{policy.resource}</span>
         </span>

--- a/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
+++ b/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
@@ -53,7 +53,7 @@ export function CloudEventsStatus() {
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={4} className="flex-1" />
       </div>

--- a/web/src/components/cards/cni_status/index.tsx
+++ b/web/src/components/cards/cni_status/index.tsx
@@ -77,7 +77,7 @@ function NodeRow({ node }: { node: CniNodeStatus }) {
           {node.state}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         <span className="truncate font-mono">{node.podCidr}</span>
         <span className="ml-auto shrink-0">
           {node.plugin} {node.pluginVersion}
@@ -106,7 +106,7 @@ export function CniStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/containerd_status/index.tsx
+++ b/web/src/components/cards/containerd_status/index.tsx
@@ -103,7 +103,7 @@ export function ContainerdStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_ROW_COUNT} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/contour_status/index.tsx
+++ b/web/src/components/cards/contour_status/index.tsx
@@ -82,7 +82,7 @@ export function ContourStatus() {
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={6} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/cortex_status/index.tsx
+++ b/web/src/components/cards/cortex_status/index.tsx
@@ -177,7 +177,7 @@ export function CortexStatus() {
             height={SKELETON_BADGE_HEIGHT}
           />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/cubefs_status/CubefsStatus.tsx
+++ b/web/src/components/cards/cubefs_status/CubefsStatus.tsx
@@ -373,7 +373,7 @@ export function CubefsStatus() {
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={3} className="flex-1" />
       </div>

--- a/web/src/components/cards/dapr_status/index.tsx
+++ b/web/src/components/cards/dapr_status/index.tsx
@@ -154,7 +154,7 @@ export function DaprStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/envoy_status/index.tsx
+++ b/web/src/components/cards/envoy_status/index.tsx
@@ -113,7 +113,7 @@ export function EnvoyStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/fluid_status/FluidStatus.tsx
+++ b/web/src/components/cards/fluid_status/FluidStatus.tsx
@@ -309,7 +309,7 @@ export function FluidStatus() {
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={3} className="flex-1" />
       </div>

--- a/web/src/components/cards/flux_status/index.tsx
+++ b/web/src/components/cards/flux_status/index.tsx
@@ -83,7 +83,7 @@ export function FluxStatus() {
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={6} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/grpc_status/index.tsx
+++ b/web/src/components/cards/grpc_status/index.tsx
@@ -117,7 +117,7 @@ export function GrpcStatus() {
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={5} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/karmada_status/KarmadaStatus.tsx
+++ b/web/src/components/cards/karmada_status/KarmadaStatus.tsx
@@ -140,7 +140,7 @@ export function KarmadaStatus() {
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={4} className="flex-1" />
       </div>

--- a/web/src/components/cards/keda_status/KedaStatus.tsx
+++ b/web/src/components/cards/keda_status/KedaStatus.tsx
@@ -218,7 +218,7 @@ export function KedaStatus() {
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={3} className="flex-1" />
       </div>

--- a/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
+++ b/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
@@ -192,7 +192,7 @@ export function KeycloakStatus() {
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={3} className="flex-1" />
       </div>

--- a/web/src/components/cards/knative_status/KnativeStatus.tsx
+++ b/web/src/components/cards/knative_status/KnativeStatus.tsx
@@ -293,7 +293,7 @@ export function KnativeStatus() {
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={3} className="flex-1" />
       </div>

--- a/web/src/components/cards/kserve_status/index.tsx
+++ b/web/src/components/cards/kserve_status/index.tsx
@@ -132,7 +132,7 @@ function ServiceRow({
           {statusLabel(service.status, t)}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         <span className="flex items-center gap-1">
           <Layers className="w-3 h-3" />
           {service.readyReplicas}/{service.desiredReplicas}{' '}
@@ -188,7 +188,7 @@ export function KServeStatus() {
             height={SKELETON_BADGE_HEIGHT}
           />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/kubevela_status/index.tsx
+++ b/web/src/components/cards/kubevela_status/index.tsx
@@ -285,7 +285,7 @@ export function KubeVelaStatus() {
             height={SKELETON_BADGE_HEIGHT}
           />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/linkerd_status/index.tsx
+++ b/web/src/components/cards/linkerd_status/index.tsx
@@ -88,7 +88,7 @@ function DeploymentRow({ deployment }: { deployment: LinkerdMeshedDeployment }) 
           {deployment.meshedPods}/{deployment.totalPods}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] font-mono">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] font-mono">
         <span className={successRateColorClass(deployment.successRatePct)}>
           {deployment.successRatePct.toFixed(SUCCESS_RATE_DECIMALS)}%
         </span>
@@ -120,7 +120,7 @@ export function LinkerdStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/openfeature_status/index.tsx
+++ b/web/src/components/cards/openfeature_status/index.tsx
@@ -114,7 +114,7 @@ function ProviderRow({
           {providerStatusLabel(provider.status, t)}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         {provider.evaluations > 0 && (
           <span>
             {provider.evaluations.toLocaleString()} {t('openFeature.evals', 'evals')}
@@ -155,7 +155,7 @@ function FlagRow({
           {flag.type}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         <span className="truncate">
           {t('openFeature.flagProvider', 'provider')}:{' '}
           <span className="text-foreground">{flag.provider}</span>

--- a/web/src/components/cards/openfga_status/index.tsx
+++ b/web/src/components/cards/openfga_status/index.tsx
@@ -88,7 +88,7 @@ function StoreRow({ store }: { store: OpenfgaStore }) {
           {store.status}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         <span className="truncate">
           {formatNumber(store.tupleCount)} tuples · {store.modelCount} models
         </span>
@@ -114,7 +114,7 @@ function ModelRow({ model }: { model: OpenfgaAuthorizationModel }) {
           v{model.schemaVersion}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         <span className="truncate">
           {model.storeName} · {model.typeCount} types
         </span>
@@ -156,7 +156,7 @@ export function OpenfgaStatus() {
             height={SKELETON_BADGE_HEIGHT}
           />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/spiffe_status/index.tsx
+++ b/web/src/components/cards/spiffe_status/index.tsx
@@ -80,7 +80,7 @@ function EntryRow({ entry }: { entry: SpiffeRegistrationEntry }) {
           {entry.svidType.toUpperCase()}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         <span className="truncate">{entry.selector}</span>
         <span className="ml-auto shrink-0 font-mono">
           ttl {formatDuration(entry.ttlSeconds)}
@@ -135,7 +135,7 @@ export function SpiffeStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/spire_status/index.tsx
+++ b/web/src/components/cards/spire_status/index.tsx
@@ -98,7 +98,7 @@ function ServerPodRow({
           {phaseLabel}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         <span className="truncate">{pod.node}</span>
         {pod.restarts > 0 ? (
           <span className="text-yellow-400 shrink-0">
@@ -150,7 +150,7 @@ export function SpireStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/strimzi_status/index.tsx
+++ b/web/src/components/cards/strimzi_status/index.tsx
@@ -125,7 +125,7 @@ function ClusterRow({ cluster }: { cluster: StrimziKafkaCluster }) {
         </span>
       </div>
 
-      <div className="grid grid-cols-4 gap-2 text-[11px]">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 text-[11px]">
         <div className="flex flex-col">
           <span className="text-muted-foreground">
             {t('strimziStatus.brokers', 'Brokers')}
@@ -190,7 +190,7 @@ export function StrimziStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )
@@ -305,7 +305,7 @@ export function StrimziStatus() {
           )}
         </section>
 
-        <section className="flex items-center gap-4 text-[11px] text-muted-foreground pt-1">
+        <section className="flex flex-wrap items-center gap-4 text-[11px] text-muted-foreground pt-1">
           <div className="flex items-center gap-1">
             <Users className="w-3 h-3" />
             <span>

--- a/web/src/components/cards/tuf_status/index.tsx
+++ b/web/src/components/cards/tuf_status/index.tsx
@@ -123,7 +123,7 @@ function RoleRow({
           {statusLabel}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         <span className="flex items-center gap-1">
           <Clock className="w-3 h-3" />
           <span className={statusTextColor(role.status)}>{formatExpiration(role.expiresAt)}</span>
@@ -177,7 +177,7 @@ export function TufStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/volcano_status/index.tsx
+++ b/web/src/components/cards/volcano_status/index.tsx
@@ -111,7 +111,7 @@ function QueueRow({ queue }: { queue: VolcanoQueue }) {
           {queue.state}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         <span>
           {queue.runningJobs} run · {queue.pendingJobs} pend
         </span>
@@ -163,7 +163,7 @@ function JobRow({ job }: { job: VolcanoJob }) {
           {job.phase}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         <span className="truncate">
           queue {job.queue} · {job.runningPods}/{job.totalPods} pods
         </span>
@@ -206,7 +206,7 @@ export function VolcanoStatus() {
             height={SKELETON_BADGE_HEIGHT}
           />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/wasmcloud_status/index.tsx
+++ b/web/src/components/cards/wasmcloud_status/index.tsx
@@ -104,7 +104,7 @@ function HostRow({ host, t }: { host: WasmcloudHost; t: TFunction<'cards'> }) {
           {host.status}
         </span>
       </div>
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
         <span>
           {host.actorCount} {t('wasmcloudStatus.actorsShort', 'actors')}
         </span>
@@ -188,7 +188,7 @@ export function WasmcloudStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )


### PR DESCRIPTION
Fixes #10514

Mechanical fix: convert skeleton loading grids from `grid-cols-4` to `grid-cols-2 @md:grid-cols-4` across 26 CNCF status cards, matching the live grid responsive behavior from Phase 2. Also adds `flex-wrap` to stat rows that could overflow on narrow containers.