### PR TITLE
🌱 Phase 3a container-query rollout: SkeletonStats + flex-wrap in 32 CNCF status cards

### DIFF
--- a/web/src/components/cards/backstage_status/index.tsx
+++ b/web/src/components/cards/backstage_status/index.tsx
@@ -186,7 +186,7 @@ export function BackstageStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/cloud_custodian_status/index.tsx
+++ b/web/src/components/cards/cloud_custodian_status/index.tsx
@@ -126,7 +126,7 @@ function PolicyRow({
   const isHealthy = policy.failCount === 0 && policy.dryRunCount === 0
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           {isHealthy ? (
             <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -175,7 +175,7 @@ function PolicyRow({
 
 function TopResourceRow({ resource }: { resource: CustodianTopResource }) {
   return (
-    <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center justify-between gap-2">
+    <div className="rounded-md bg-secondary/30 px-3 py-2 flex flex-wrap items-center justify-between gap-2">
       <div className="min-w-0 flex items-center gap-1.5">
         <Zap className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
         <span className="text-xs font-mono text-foreground truncate">{resource.id}</span>
@@ -226,7 +226,7 @@ export function CloudCustodianStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
@@ -261,7 +261,7 @@ export function CloudCustodianStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + version freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',

--- a/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
+++ b/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
@@ -53,7 +53,7 @@ export function CloudEventsStatus() {
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={4} className="flex-1" />
       </div>

--- a/web/src/components/cards/cni_status/index.tsx
+++ b/web/src/components/cards/cni_status/index.tsx
@@ -106,7 +106,7 @@ export function CniStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/containerd_status/index.tsx
+++ b/web/src/components/cards/containerd_status/index.tsx
@@ -103,7 +103,7 @@ export function ContainerdStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_ROW_COUNT} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/contour_status/index.tsx
+++ b/web/src/components/cards/contour_status/index.tsx
@@ -36,7 +36,7 @@ function ProxySection({
               key={`${item.cluster}:${item.namespace}:${item.name}`}
               className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1"
             >
-              <div className="flex items-center justify-between gap-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
                 <div className="min-w-0 flex items-center gap-1.5">
                   {item.status === 'Valid' ? (
                     <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -56,7 +56,7 @@ function ProxySection({
                 </span>
               </div>
 
-              <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+              <div className="text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-2">
                 <span className="truncate">{item.namespace} | {item.cluster}</span>
                 <span className="truncate">{item.fqdn || '-'}</span>
               </div>
@@ -78,11 +78,11 @@ export function ContourStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={6} className="flex-1" />
       </div>
     )
@@ -109,7 +109,7 @@ export function ContourStatus() {
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/cortex_status/index.tsx
+++ b/web/src/components/cards/cortex_status/index.tsx
@@ -177,7 +177,7 @@ export function CortexStatus() {
             height={SKELETON_BADGE_HEIGHT}
           />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/cubefs_status/CubefsStatus.tsx
+++ b/web/src/components/cards/cubefs_status/CubefsStatus.tsx
@@ -373,7 +373,7 @@ export function CubefsStatus() {
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={3} className="flex-1" />
       </div>

--- a/web/src/components/cards/dapr_status/index.tsx
+++ b/web/src/components/cards/dapr_status/index.tsx
@@ -154,7 +154,7 @@ export function DaprStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )
@@ -244,7 +244,7 @@ export function DaprStatus() {
       </div>
 
       {/* Building block breakdown */}
-      <div className="grid grid-cols-3 gap-2">
+      <div className="grid grid-cols-2 @sm:grid-cols-3 gap-2">
         <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center gap-2">
           <Database className="w-4 h-4 text-emerald-400 shrink-0" />
           <div className="min-w-0">

--- a/web/src/components/cards/envoy_status/index.tsx
+++ b/web/src/components/cards/envoy_status/index.tsx
@@ -113,7 +113,7 @@ export function EnvoyStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/fluid_status/FluidStatus.tsx
+++ b/web/src/components/cards/fluid_status/FluidStatus.tsx
@@ -309,7 +309,7 @@ export function FluidStatus() {
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={3} className="flex-1" />
       </div>

--- a/web/src/components/cards/flux_status/index.tsx
+++ b/web/src/components/cards/flux_status/index.tsx
@@ -83,7 +83,7 @@ export function FluxStatus() {
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={6} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/grpc_status/index.tsx
+++ b/web/src/components/cards/grpc_status/index.tsx
@@ -117,7 +117,7 @@ export function GrpcStatus() {
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={5} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/harbor_status/HarborStatus.tsx
+++ b/web/src/components/cards/harbor_status/HarborStatus.tsx
@@ -143,7 +143,7 @@ function ProjectRow({
       tabIndex={onClick ? 0 : undefined}
       onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } } : undefined}
     >
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-1.5 min-w-0">
           {project.isPublic ? (
             <Globe className="w-3.5 h-3.5 text-blue-400 shrink-0" />
@@ -199,7 +199,7 @@ function RepositoryRow({
       tabIndex={onClick ? 0 : undefined}
       onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } } : undefined}
     >
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-1.5 min-w-0 text-xs">
           <FolderOpen className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
           {projectName && <span className="text-muted-foreground">{projectName}/</span>}
@@ -210,7 +210,7 @@ function RepositoryRow({
         </div>
       </div>
 
-      <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 text-[11px] text-muted-foreground">
         <div className="flex items-center gap-3">
           <span className="flex items-center gap-1" title={t('harbor.artifacts', 'Artifacts')}>
             <Layers className="w-3 h-3" /> {repo.artifactCount}
@@ -320,7 +320,7 @@ export function HarborStatus() {
     <div className="flex flex-col h-full overflow-hidden relative">
       {isRefreshing && <RefreshIndicator isRefreshing={isRefreshing} />}
 
-      <div className="flex items-center justify-between mb-4 shrink-0 px-1 gap-2">
+      <div className="flex flex-wrap items-center justify-between mb-4 shrink-0 px-1 gap-2">
         <div className="flex items-center gap-2">
           {currentData.health === 'healthy' ? (
             <span className="flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium bg-green-500/15 text-green-400">

--- a/web/src/components/cards/karmada_status/KarmadaStatus.tsx
+++ b/web/src/components/cards/karmada_status/KarmadaStatus.tsx
@@ -140,7 +140,7 @@ export function KarmadaStatus() {
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={4} className="flex-1" />
       </div>

--- a/web/src/components/cards/keda_status/KedaStatus.tsx
+++ b/web/src/components/cards/keda_status/KedaStatus.tsx
@@ -218,7 +218,7 @@ export function KedaStatus() {
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={3} className="flex-1" />
       </div>

--- a/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
+++ b/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
@@ -192,7 +192,7 @@ export function KeycloakStatus() {
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={3} className="flex-1" />
       </div>

--- a/web/src/components/cards/knative_status/KnativeStatus.tsx
+++ b/web/src/components/cards/knative_status/KnativeStatus.tsx
@@ -293,7 +293,7 @@ export function KnativeStatus() {
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <Skeleton variant="rounded" height={32} />
         <SkeletonList items={3} className="flex-1" />
       </div>

--- a/web/src/components/cards/kserve_status/index.tsx
+++ b/web/src/components/cards/kserve_status/index.tsx
@@ -188,7 +188,7 @@ export function KServeStatus() {
             height={SKELETON_BADGE_HEIGHT}
           />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/kubevela_status/index.tsx
+++ b/web/src/components/cards/kubevela_status/index.tsx
@@ -285,7 +285,7 @@ export function KubeVelaStatus() {
             height={SKELETON_BADGE_HEIGHT}
           />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/linkerd_status/index.tsx
+++ b/web/src/components/cards/linkerd_status/index.tsx
@@ -120,7 +120,7 @@ export function LinkerdStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/nats_status/index.tsx
+++ b/web/src/components/cards/nats_status/index.tsx
@@ -56,7 +56,7 @@ function NatsStatusInternal() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
@@ -94,7 +94,7 @@ function NatsStatusInternal() {
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
 
       {/* Health badge + refresh indicator */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy
@@ -167,7 +167,7 @@ function NatsStatusInternal() {
                   key={`${server.cluster}/${server.name}`}
                   className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1"
                 >
-                  <div className="flex items-center justify-between gap-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
                     <div className="flex items-center gap-1.5 min-w-0">
                       {style.icon}
                       <span className="text-xs font-medium truncate">{server.name}</span>
@@ -176,7 +176,7 @@ function NatsStatusInternal() {
                       {server.state}
                     </span>
                   </div>
-                  <div className="text-xs text-muted-foreground flex items-center justify-between">
+                  <div className="text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-y-2">
                     <span className="truncate">{server.cluster} · v{server.version}</span>
                     <span>{server.connections} conn · {server.subscriptions} subs</span>
                   </div>
@@ -204,7 +204,7 @@ function NatsStatusInternal() {
                     key={`${stream.cluster}/${stream.name}`}
                     className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1"
                   >
-                    <div className="flex items-center justify-between gap-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
                       <div className="flex items-center gap-1.5 min-w-0">
                         {style.icon}
                         <span className="text-xs font-medium truncate">{stream.name}</span>
@@ -213,7 +213,7 @@ function NatsStatusInternal() {
                         {stream.state}
                       </span>
                     </div>
-                    <div className="text-xs text-muted-foreground flex items-center justify-between">
+                    <div className="text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-y-2">
                       <span className="truncate">{stream.cluster}</span>
                       <span>{stream.messages.toLocaleString()} msgs · {stream.consumers} consumers</span>
                     </div>

--- a/web/src/components/cards/openfga_status/index.tsx
+++ b/web/src/components/cards/openfga_status/index.tsx
@@ -156,7 +156,7 @@ export function OpenfgaStatus() {
             height={SKELETON_BADGE_HEIGHT}
           />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/openyurt_status/OpenYurtStatus.tsx
+++ b/web/src/components/cards/openyurt_status/OpenYurtStatus.tsx
@@ -113,7 +113,7 @@ function NodePoolRow({ pool }: { pool: OpenYurtNodePool }) {
   return (
     <div className="rounded-md bg-muted/30 px-3 py-2 space-y-1.5">
       {/* Row 1: name + status + node count */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-1.5 min-w-0">
           {statusCfg.icon}
           <span className="text-xs font-medium truncate">{pool.name}</span>
@@ -127,7 +127,7 @@ function NodePoolRow({ pool }: { pool: OpenYurtNodePool }) {
       </div>
 
       {/* Row 2: pool type + autonomy */}
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
         <span className="flex items-center gap-1">
           {typeCfg.icon}
           {typeCfg.label}
@@ -150,7 +150,7 @@ function GatewayRow({ gw }: { gw: OpenYurtGateway }) {
   const cfg = GATEWAY_STATUS_CONFIG[gw.status]
 
   return (
-    <div className="flex items-center justify-between gap-2 px-3 py-1.5 rounded-md bg-muted/20">
+    <div className="flex flex-wrap items-center justify-between gap-2 px-3 py-1.5 rounded-md bg-muted/20">
       <div className="flex items-center gap-1.5 min-w-0">
         {cfg.icon}
         <span className="text-xs truncate">{gw.name}</span>
@@ -202,7 +202,7 @@ export function OpenYurtStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
@@ -251,7 +251,7 @@ export function OpenYurtStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* ── Header: health badge + controller pods + last check ── */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className="flex items-center gap-2">
           <div
             className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${healthColorClass}`}

--- a/web/src/components/cards/otel_status/index.tsx
+++ b/web/src/components/cards/otel_status/index.tsx
@@ -123,7 +123,7 @@ export function OtelStatus() {
 
   return (
     <div className="h-full flex flex-col min-h-card gap-4 overflow-hidden animate-in fade-in duration-500">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
@@ -256,7 +256,7 @@ export function OtelStatus() {
                 key={`${collector.cluster}:${collector.namespace}:${collector.name}`}
                 className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1"
               >
-                <div className="flex items-center justify-between gap-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
                   <div className="min-w-0 flex items-center gap-1.5">
                     {healthy ? (
                       <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -305,7 +305,7 @@ export function OtelStatus() {
                   )}
                 </div>
 
-                <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+                <div className="text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-2">
                   <span className="truncate">
                     {t('otelStatus.mode', 'Mode')}: {collector.mode}
                     {collector.version ? ` · v${collector.version}` : ''}

--- a/web/src/components/cards/rook_status/index.tsx
+++ b/web/src/components/cards/rook_status/index.tsx
@@ -131,7 +131,7 @@ export function RookStatus() {
 
   return (
     <div className="h-full flex flex-col min-h-card gap-4 overflow-hidden animate-in fade-in duration-500">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
@@ -207,7 +207,7 @@ export function RookStatus() {
                 key={`${cluster.cluster}:${cluster.namespace}:${cluster.name}`}
                 className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1"
               >
-                <div className="flex items-center justify-between gap-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
                   <div className="min-w-0 flex items-center gap-1.5">
                     <HealthIcon health={cluster.cephHealth} />
                     <span className="text-xs font-medium truncate font-mono">
@@ -229,7 +229,7 @@ export function RookStatus() {
                   </span>
                 </div>
 
-                <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+                <div className="text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-2">
                   <span className="truncate">
                     {t('rookStatus.osdShort', {
                       up: cluster.osdUp,

--- a/web/src/components/cards/spiffe_status/index.tsx
+++ b/web/src/components/cards/spiffe_status/index.tsx
@@ -135,7 +135,7 @@ export function SpiffeStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/spire_status/index.tsx
+++ b/web/src/components/cards/spire_status/index.tsx
@@ -150,7 +150,7 @@ export function SpireStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/strimzi_status/index.tsx
+++ b/web/src/components/cards/strimzi_status/index.tsx
@@ -190,7 +190,7 @@ export function StrimziStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/tuf_status/index.tsx
+++ b/web/src/components/cards/tuf_status/index.tsx
@@ -177,7 +177,7 @@ export function TufStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )

--- a/web/src/components/cards/volcano_status/index.tsx
+++ b/web/src/components/cards/volcano_status/index.tsx
@@ -206,7 +206,7 @@ export function VolcanoStatus() {
             height={SKELETON_BADGE_HEIGHT}
           />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )
@@ -308,7 +308,7 @@ export function VolcanoStatus() {
               <span className="text-foreground">{data.stats.schedulerVersion}</span>
             </span>
           </div>
-          <div className="grid grid-cols-3 gap-2 text-[11px]">
+          <div className="grid grid-cols-2 @sm:grid-cols-3 gap-2 text-[11px]">
             <div className="rounded-md bg-secondary/30 px-2 py-1.5">
               <div className="text-muted-foreground">
                 {t('volcanoStatus.podGroups', 'Pod groups')}

--- a/web/src/components/cards/wasmcloud_status/index.tsx
+++ b/web/src/components/cards/wasmcloud_status/index.tsx
@@ -188,7 +188,7 @@ export function WasmcloudStatus() {
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
-        <SkeletonStats className="grid-cols-4" />
+        <SkeletonStats className="grid-cols-2 @md:grid-cols-4" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )


### PR DESCRIPTION
Fixes #10514

## Summary

Continues the container-query rollout from #8695 RFC (Phase 3a — high-visibility cards).

### Changes (32 files, 57 lines changed)

**1. SkeletonStats `grid-cols-4` → `grid-cols-2 @md:grid-cols-4` (26 files)**

Loading skeletons in CNCF status cards used bare `grid-cols-4` which doesn't respond to container width. The live stat grids in the same cards were already converted in Phase 2 — but the skeleton loading states were missed. This caused a layout shift: skeleton shows 4 columns at all widths → live data snaps to 2 columns on narrow cards.

Files: contour, cubefs, cni, cloudevents, linkerd, fluid, keda, volcano, cortex, backstage, envoy, grpc, containerd, keycloak, kubevela, dapr, strimzi, openfga, tuf, flux, karmada, spiffe, wasmcloud, kserve, knative, spire.

**2. Add `flex-wrap` to unwrapped control bars (7 CNCF status cards, 27 instances)**

Cards: nats_status, openyurt_status, cloud_custodian_status, rook_status, contour_status, otel_status, harbor_status.

These flex bars lacked `flex-wrap` and overlapped when sidebars expanded (the original #8695 bug). Added `flex-wrap gap-y-2` where no gap existed, `flex-wrap` where `gap-2` was already present.

**3. Fixed grid-cols-3 → responsive (2 files)**

volcano_status and dapr_status: `grid-cols-3` → `grid-cols-2 @sm:grid-cols-3`.

### Scope

- Pure CSS class changes — no logic or behavior changes
- No OAuth, auth, or update system code touched
- Build + lint pass ✓