### PR TITLE
🐛 Fix light-mode visibility in logs, bug report preview, enterprise page

### DIFF
--- a/web/src/components/drilldown/views/LogsDrillDown.tsx
+++ b/web/src/components/drilldown/views/LogsDrillDown.tsx
@@ -259,9 +259,9 @@ export function LogsDrillDown({ data }: Props) {
       {!isLoading && !error && (
         <div
           ref={logContainerRef}
-          className="rounded-lg bg-black/50 border border-border p-4 font-mono text-sm overflow-auto max-h-[60vh]"
+          className="rounded-lg bg-card border border-border p-4 font-mono text-sm overflow-auto max-h-[60vh]"
         >
-          <pre className="text-green-400 whitespace-pre-wrap">{visibleLog}</pre>
+          <pre className="text-foreground whitespace-pre-wrap">{visibleLog}</pre>
         </div>
       )}
 

--- a/web/src/components/enterprise/ComingSoon.tsx
+++ b/web/src/components/enterprise/ComingSoon.tsx
@@ -15,14 +15,14 @@ export default function ComingSoon() {
   return (
     <div className="flex items-center justify-center h-full">
       <div className="text-center max-w-md">
-        <Construction className="w-16 h-16 text-gray-600 mx-auto mb-4" />
-        <h2 className="text-xl font-semibold text-white mb-2">{title}</h2>
-        <p className="text-sm text-gray-400 mb-6">
+        <Construction className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
+        <h2 className="text-xl font-semibold text-foreground mb-2">{title}</h2>
+        <p className="text-sm text-muted-foreground mb-6">
           This compliance vertical is under development and will be available in a future release.
         </p>
         <button
           onClick={() => navigate(ROUTES.ENTERPRISE)}
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-600 hover:bg-purple-500 text-white text-sm transition-colors"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-600 hover:bg-purple-500 text-primary-foreground text-sm transition-colors"
         >
           <ArrowLeft className="w-4 h-4" />
           Back to Enterprise Portal

--- a/web/src/components/enterprise/EnterpriseLayout.tsx
+++ b/web/src/components/enterprise/EnterpriseLayout.tsx
@@ -198,7 +198,7 @@ export default function EnterpriseLayout() {
       {/* flex flex-col is required so the flex container below stretches
           to fill remaining height, giving <main> a constrained height
           for overflow-y-auto to work (scroll fix). */}
-      <div className="h-screen bg-gray-950 text-white overflow-hidden flex flex-col">
+      <div className="h-screen bg-background text-foreground overflow-hidden flex flex-col">
         <Navbar />
 
         <div

--- a/web/src/components/enterprise/EnterprisePortal.tsx
+++ b/web/src/components/enterprise/EnterprisePortal.tsx
@@ -93,20 +93,20 @@ function VerticalCard({ sectionId, title, items, onNavigate }: {
   const Icon = meta.icon
 
   return (
-    <div className={`rounded-xl border border-gray-800 bg-linear-to-br ${meta.gradient} p-5 flex flex-col`}>
+    <div className={`rounded-xl border border-border bg-linear-to-br ${meta.gradient} p-5 flex flex-col`}>
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
-          <div className="p-2 rounded-lg bg-gray-800/50">
+          <div className="p-2 rounded-lg bg-secondary/50">
             <Icon className="w-5 h-5 text-muted-foreground" />
           </div>
           <div>
-            <h3 className="text-sm font-semibold text-white">{title}</h3>
-            <p className="text-xs text-gray-400">{items.length} dashboard{items.length !== 1 ? 's' : ''}</p>
+            <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+            <p className="text-xs text-muted-foreground">{items.length} dashboard{items.length !== 1 ? 's' : ''}</p>
           </div>
         </div>
         {meta.status === 'active' && meta.score != null && <ScoreGauge score={meta.score} />}
         {meta.status === 'coming-soon' && (
-          <span className="text-xs px-2 py-1 rounded-full bg-gray-800 text-gray-400 font-medium">
+          <span className="text-xs px-2 py-1 rounded-full bg-secondary text-muted-foreground font-medium">
             Coming Soon
           </span>
         )}
@@ -130,7 +130,7 @@ function VerticalCard({ sectionId, title, items, onNavigate }: {
           <button
             key={item.href}
             onClick={() => onNavigate(item.href)}
-            className="w-full flex items-center justify-between px-3 py-1.5 rounded-md text-sm text-muted-foreground hover:bg-gray-700/40 hover:text-white transition-colors group"
+            className="w-full flex items-center justify-between px-3 py-1.5 rounded-md text-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors group"
           >
             <span>{item.label}</span>
             <ArrowRight className="w-3.5 h-3.5 opacity-0 group-hover:opacity-100 transition-opacity" />
@@ -193,31 +193,31 @@ export default function EnterprisePortal() {
 
       {/* Summary Stats */}
       <div className="grid grid-cols-4 gap-4 mb-8">
-        <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
-          <div className="text-xs text-gray-400 mb-1">Overall Score</div>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <div className="text-xs text-muted-foreground mb-1">Overall Score</div>
           <div className="text-2xl font-bold text-green-400">83%</div>
         </div>
-        <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
-          <div className="text-xs text-gray-400 mb-1">Active Verticals</div>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <div className="text-xs text-muted-foreground mb-1">Active Verticals</div>
           <div className="flex items-center gap-2">
             <TrendingUp className="w-4 h-4 text-blue-400" />
-            <span className="text-2xl font-bold text-white">7</span>
-            <span className="text-xs text-gray-500">of 7</span>
+            <span className="text-2xl font-bold text-foreground">7</span>
+            <span className="text-xs text-muted-foreground">of 7</span>
           </div>
         </div>
-        <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
-          <div className="text-xs text-gray-400 mb-1">Controls Passed</div>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <div className="text-xs text-muted-foreground mb-1">Controls Passed</div>
           <div className="flex items-center gap-2">
             <CheckCircle2 className="w-4 h-4 text-green-400" />
-            <span className="text-2xl font-bold text-white">179</span>
-            <span className="text-xs text-gray-500">of 220</span>
+            <span className="text-2xl font-bold text-foreground">179</span>
+            <span className="text-xs text-muted-foreground">of 220</span>
           </div>
         </div>
-        <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
-          <div className="text-xs text-gray-400 mb-1">Next Audit</div>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <div className="text-xs text-muted-foreground mb-1">Next Audit</div>
           <div className="flex items-center gap-2">
             <Clock className="w-4 h-4 text-yellow-400" />
-            <span className="text-lg font-bold text-white">14 days</span>
+            <span className="text-lg font-bold text-foreground">14 days</span>
           </div>
         </div>
       </div>
@@ -237,16 +237,16 @@ export default function EnterprisePortal() {
         {/* Add More tile */}
         <button
           onClick={handleAddMore}
-          className="rounded-xl border-2 border-dashed border-gray-700 hover:border-purple-500/50 bg-gray-900/30 hover:bg-purple-500/5 p-5 flex flex-col items-center justify-center gap-3 transition-all group min-h-[200px]"
+          className="rounded-xl border-2 border-dashed border-border hover:border-purple-500/50 bg-card/30 hover:bg-purple-500/5 p-5 flex flex-col items-center justify-center gap-3 transition-all group min-h-[200px]"
         >
-          <div className="p-3 rounded-full bg-gray-800 group-hover:bg-purple-500/20 transition-colors">
-            <Plus className="w-6 h-6 text-gray-400 group-hover:text-purple-400 transition-colors" />
+          <div className="p-3 rounded-full bg-secondary group-hover:bg-purple-500/20 transition-colors">
+            <Plus className="w-6 h-6 text-muted-foreground group-hover:text-purple-400 transition-colors" />
           </div>
           <div className="text-center">
-            <p className="text-sm font-medium text-gray-400 group-hover:text-purple-300 transition-colors">
+            <p className="text-sm font-medium text-muted-foreground group-hover:text-purple-300 transition-colors">
               Add More
             </p>
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-muted-foreground/70 mt-1">
               Dashboards, cards &amp; widgets
             </p>
           </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1784,7 +1784,7 @@ layer(base);
 
 /* GitHub-flavored markdown preview (dark mode) */
 .ghmd {
-  color: #e6edf3;
+  color: hsl(var(--foreground));
   font-size: 14px;
   line-height: 1.6;
   word-wrap: break-word;
@@ -1794,14 +1794,14 @@ layer(base);
   margin-bottom: 16px;
   font-weight: 600;
   line-height: 1.25;
-  color: #e6edf3;
+  color: hsl(var(--foreground));
 }
-.ghmd h1 { font-size: 2em; padding-bottom: 0.3em; border-bottom: 1px solid #30363d; }
-.ghmd h2 { font-size: 1.5em; padding-bottom: 0.3em; border-bottom: 1px solid #30363d; }
+.ghmd h1 { font-size: 2em; padding-bottom: 0.3em; border-bottom: 1px solid hsl(var(--border)); }
+.ghmd h2 { font-size: 1.5em; padding-bottom: 0.3em; border-bottom: 1px solid hsl(var(--border)); }
 .ghmd h3 { font-size: 1.25em; }
 .ghmd h4 { font-size: 1em; }
 .ghmd p { margin-top: 0; margin-bottom: 16px; }
-.ghmd a { color: #58a6ff; text-decoration: none; }
+.ghmd a { color: hsl(var(--primary)); text-decoration: none; }
 .ghmd a:hover { text-decoration: underline; }
 .ghmd ul, .ghmd ol { padding-left: 2em; margin-top: 0; margin-bottom: 16px; }
 .ghmd li { margin-top: 0.25em; }
@@ -1809,21 +1809,21 @@ layer(base);
 .ghmd blockquote {
   margin: 0 0 16px;
   padding: 0 1em;
-  color: #8b949e;
-  border-left: 0.25em solid #30363d;
+  color: hsl(var(--muted-foreground));
+  border-left: 0.25em solid hsl(var(--border));
 }
 .ghmd hr {
   height: 0.25em;
   padding: 0;
   margin: 24px 0;
-  background-color: #30363d;
+  background-color: hsl(var(--border));
   border: 0;
 }
 .ghmd code:not(pre code) {
   padding: 0.2em 0.4em;
   margin: 0;
   font-size: 85%;
-  background-color: rgba(110, 118, 129, 0.4);
+  background-color: hsl(var(--secondary));
   border-radius: 6px;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
 }
@@ -1832,7 +1832,7 @@ layer(base);
   overflow: auto;
   font-size: 85%;
   line-height: 1.45;
-  background-color: #161b22;
+  background-color: hsl(var(--secondary));
   border-radius: 6px;
   margin-bottom: 16px;
 }
@@ -1855,14 +1855,14 @@ layer(base);
 }
 .ghmd table th, .ghmd table td {
   padding: 6px 13px;
-  border: 1px solid #30363d;
+  border: 1px solid hsl(var(--border));
 }
 .ghmd table th {
   font-weight: 600;
-  background-color: #161b22;
+  background-color: hsl(var(--secondary));
 }
-.ghmd table tr { background-color: transparent; border-top: 1px solid #21262d; }
-.ghmd table tr:nth-child(2n) { background-color: #161b22; }
+.ghmd table tr { background-color: transparent; border-top: 1px solid hsl(var(--border)); }
+.ghmd table tr:nth-child(2n) { background-color: hsl(var(--secondary) / 0.5); }
 .ghmd img { max-width: 100%; box-sizing: border-box; }
-.ghmd strong { font-weight: 600; color: #e6edf3; }
+.ghmd strong { font-weight: 600; color: hsl(var(--foreground)); }
 .ghmd em { font-style: italic; }


### PR DESCRIPTION
Fixes #10513
Fixes #10516
Fixes #10517

Fix light-mode visibility issues across three areas:
- **Logs panel** (#10513): replace `bg-black/50` + `text-green-400` with `bg-card` + `text-foreground`
- **Bug Report Preview** (#10516): replace hardcoded hex colors in `.ghmd` CSS class with CSS variables (`--foreground`, `--border`, `--secondary`, etc.)
- **Enterprise page** (#10517): replace `bg-gray-900`, `text-white`, `border-gray-800` etc. with semantic Tailwind classes across EnterprisePortal, EnterpriseLayout, and ComingSoon

All from same root cause: hardcoded dark-mode colors instead of semantic Tailwind classes that respect the theme's CSS variables.