### PR TITLE
Harden auth paths with GA4 telemetry and expanded smoke tests

### DIFF
--- a/.github/workflows/auth-login-smoke.yml
+++ b/.github/workflows/auth-login-smoke.yml
@@ -25,7 +25,10 @@ name: Auth Login Smoke Test
 #   5. /api/agent/token returns the shared KC_AGENT_TOKEN
 #   6. kc-agent rejects requests without the agent token (401)
 #   7. kc-agent accepts requests with the correct agent token (200)
-#   8. No raw fetch() calls to agent URLs bypass agentFetch/fetchWithRetry
+#   8. kc-agent rejects unauthenticated WebSocket upgrades
+#   9. /auth/refresh rejects expired/invalid cookies (not silent 200)
+#  10. /api/agent/token requires authentication (no token leak)
+#  11. No raw fetch() calls to agent URLs bypass agentFetch/fetchWithRetry
 #
 # The test uses DEV_MODE (no GitHub OAuth credentials) so the backend
 # auto-creates a dev-user on /auth/github. This takes ~60 seconds.
@@ -311,7 +314,94 @@ jobs:
           echo ""
           echo "Auth login smoke test PASSED"
 
-      # ── 13. Static analysis: no raw fetch() to agent URLs ────────
+      # ── 13. Test kc-agent WebSocket rejects without token ─────────
+      # Covers gap #3: appendWsAuthToken returns bare URL when token
+      # is missing from localStorage. Without the token query param,
+      # the WebSocket upgrade must be rejected. If it's accepted,
+      # unauthenticated users can stream live data.
+      - name: Test kc-agent WebSocket rejects unauthenticated upgrade
+        run: |
+          echo "Testing WebSocket upgrade without token..."
+          # kc-agent listens for WS upgrades on /ws. Without ?token=...,
+          # the upgrade handshake should be rejected (HTTP 401 or 403).
+          WS_CODE=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
+            -H "Connection: Upgrade" \
+            -H "Upgrade: websocket" \
+            -H "Sec-WebSocket-Version: 13" \
+            -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+            http://127.0.0.1:8585/ws 2>/dev/null)
+
+          if [ "$WS_CODE" = "101" ]; then
+            echo "::error::kc-agent accepted WebSocket upgrade WITHOUT auth token — unauthenticated WS connections should be rejected"
+            exit 1
+          fi
+          echo "kc-agent correctly rejected unauthenticated WebSocket upgrade (HTTP $WS_CODE)"
+
+          echo "Testing WebSocket upgrade with correct token..."
+          WS_CODE_AUTH=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
+            -H "Connection: Upgrade" \
+            -H "Upgrade: websocket" \
+            -H "Sec-WebSocket-Version: 13" \
+            -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+            "http://127.0.0.1:8585/ws?token=${KC_AGENT_TOKEN}" 2>/dev/null)
+
+          # 101 = upgrade accepted, or any non-401 = token was accepted
+          if [ "$WS_CODE_AUTH" = "401" ]; then
+            echo "::error::kc-agent rejected WebSocket upgrade WITH correct token — WS token auth is broken"
+            exit 1
+          fi
+          echo "kc-agent accepted WebSocket upgrade with correct token (HTTP $WS_CODE_AUTH)"
+
+      # ── 14. Test /auth/refresh rejects expired/invalid cookies ────
+      # Covers gap #4: If /auth/refresh accepts garbage cookies and
+      # returns 200, the silent-catch in the "Refresh Now" handler
+      # masks a real auth failure. The endpoint must return 401 for
+      # invalid sessions so the frontend knows the refresh failed.
+      - name: Test /auth/refresh rejects invalid cookie
+        run: |
+          echo "Testing /auth/refresh with no cookie..."
+          NO_COOKIE_CODE=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
+            -X POST \
+            -H "X-Requested-With: XMLHttpRequest" \
+            http://localhost:8081/auth/refresh)
+
+          if [ "$NO_COOKIE_CODE" = "200" ]; then
+            echo "::error::/auth/refresh returned 200 with NO cookie — should require valid session"
+            exit 1
+          fi
+          echo "/auth/refresh correctly rejected no-cookie request (HTTP $NO_COOKIE_CODE)"
+
+          echo "Testing /auth/refresh with garbage cookie..."
+          GARBAGE_CODE=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
+            -X POST \
+            -b "kc_auth=garbage-invalid-jwt-token-value" \
+            -H "X-Requested-With: XMLHttpRequest" \
+            http://localhost:8081/auth/refresh)
+
+          if [ "$GARBAGE_CODE" = "200" ]; then
+            echo "::error::/auth/refresh returned 200 with garbage cookie — invalid JWTs must be rejected"
+            exit 1
+          fi
+          echo "/auth/refresh correctly rejected garbage cookie (HTTP $GARBAGE_CODE)"
+
+      # ── 15. Test /api/agent/token requires authentication ─────────
+      # Covers gap #1: If /api/agent/token returns a token to
+      # unauthenticated requests, anyone can steal the agent shared
+      # secret. It must require a valid session cookie.
+      - name: Test /api/agent/token requires auth
+        run: |
+          echo "Testing /api/agent/token without cookie..."
+          NO_AUTH_CODE=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
+            -H "X-Requested-With: XMLHttpRequest" \
+            http://localhost:8081/api/agent/token)
+
+          if [ "$NO_AUTH_CODE" = "200" ]; then
+            echo "::error::/api/agent/token returned 200 without auth — agent token would leak to unauthenticated users"
+            exit 1
+          fi
+          echo "/api/agent/token correctly requires auth (HTTP $NO_AUTH_CODE)"
+
+      # ── 16. Static analysis: no raw fetch() to agent URLs ──────────
       # Catches the exact regression from #10398: someone adds a fetch()
       # call to LOCAL_AGENT_HTTP_URL or LOCAL_AGENT_URL without going
       # through agentFetch() or fetchWithRetry(). These calls silently
@@ -357,7 +447,43 @@ jobs:
           fi
           echo "No raw fetch() calls to agent URLs found (correct)"
 
-      # ── 14. Cleanup ──────────────────────────────────────────────
+      # ── 17. Static analysis: no raw WebSocket to agent URL ─────
+      # Catches WebSocket connections that bypass appendWsAuthToken.
+      # Without the token query param, kc-agent rejects the upgrade.
+      - name: Check for raw WebSocket to agent URLs
+        run: |
+          echo "Scanning for WebSocket connections that bypass appendWsAuthToken..."
+
+          # Match: new WebSocket( with agent URL patterns, excluding
+          # appendWsAuthToken calls and test files.
+          # useActiveUsers.ts is excluded — it connects to the backend
+          # (not kc-agent) and authenticates via post-open message.
+          WS_VIOLATIONS=$(grep -rn \
+            -e 'new WebSocket(' \
+            web/src/ \
+            --include='*.ts' --include='*.tsx' \
+            | grep -i -e 'LOCAL_AGENT' -e 'agent' -e '8585' \
+            | grep -v 'appendWsAuthToken' \
+            | grep -v '__tests__' \
+            | grep -v '\.test\.' \
+            | grep -v '\.spec\.' \
+            | grep -v '// ' \
+            | grep -v 'useActiveUsers' \
+            || true)
+
+          if [ -n "$WS_VIOLATIONS" ]; then
+            echo "::error::Found WebSocket connections to kc-agent that bypass appendWsAuthToken()."
+            echo "These will be rejected by kc-agent because they don't include the ?token= param."
+            echo ""
+            echo "Violations:"
+            echo "$WS_VIOLATIONS"
+            echo ""
+            echo "Fix: wrap the URL with appendWsAuthToken() from lib/utils/wsAuth.ts"
+            exit 1
+          fi
+          echo "No raw WebSocket connections to agent URLs found (correct)"
+
+      # ── 19. Cleanup ──────────────────────────────────────────────
       - name: Stop backend and kc-agent
         if: always()
         run: |
@@ -368,7 +494,7 @@ jobs:
             kill "$(cat /tmp/kc-agent.pid)" 2>/dev/null || true
           fi
 
-      # ── 15. Alert on failure ─────────────────────────────────────
+      # ── 20. Alert on failure ─────────────────────────────────────
       - name: Create issue on failure
         if: failure()
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -393,7 +519,10 @@ jobs:
               '- kc-agent rejects requests without `KC_AGENT_TOKEN` (401)',
               '- kc-agent accepts requests with the correct token',
               '- `/api/agent/token` returns the same token kc-agent was started with',
+              '- `/api/agent/token` requires authentication (no token leak)',
               '- End-to-end: token from backend → kc-agent auth succeeds',
+              '- kc-agent rejects unauthenticated WebSocket upgrades',
+              '- `/auth/refresh` rejects expired/invalid cookies',
               '- No raw `fetch()` calls to agent URLs bypass `agentFetch()`',
               '',
               '### Action required',
@@ -401,6 +530,8 @@ jobs:
               '2. If **agent token**: verify `KC_AGENT_TOKEN` env var flows from startup-oauth.sh → backend → `/api/agent/token` → frontend → kc-agent',
               '3. If **raw fetch**: replace `fetch()` with `agentFetch()` from `hooks/mcp/shared.ts`',
               '4. If **OAuth login**: verify `/auth/refresh` contract (see #6590)',
+              '5. If **WebSocket auth**: verify `appendWsAuthToken()` is called and kc-agent validates the `?token=` param',
+              '6. If **agent token leak**: verify `/api/agent/token` middleware requires a valid session cookie',
             ].join('\n');
 
             const existing = await github.rest.issues.listForRepo({

--- a/.github/workflows/ga4-error-monitor.yml
+++ b/.github/workflows/ga4-error-monitor.yml
@@ -296,6 +296,29 @@ jobs:
                   'Common causes: accessing properties of undefined, type errors, DOM manipulation issues',
                   'Review recent PRs that touched the affected page',
                 ],
+                agent_token_failure: [
+                  'The frontend failed to fetch the kc-agent token from /api/agent/token — ALL agent data (clusters, workloads, drilldowns) will silently return empty',
+                  'Check that startup-oauth.sh exports KC_AGENT_TOKEN and the Go backend reads it in LoadConfigFromEnv()',
+                  'Verify /api/agent/token returns { token: "<hex>" } with a valid auth cookie',
+                  'This is a CRITICAL regression — it was the root cause of the 48-hour blank dashboard incident (#10398, #10407)',
+                ],
+                ws_auth_missing: [
+                  'WebSocket connections to kc-agent are being opened WITHOUT the auth token — drilldowns and live data will silently fail',
+                  'Check that localStorage has kc-agent-token set (populated by /api/agent/token after login)',
+                  'If the token is missing, the OAuth callback or refreshUser flow may not be fetching /api/agent/token',
+                  'Verify appendWsAuthToken() in lib/utils/wsAuth.ts is called for all new WebSocket() sites',
+                ],
+                sse_auth_failure: [
+                  'SSE streaming connections got 401 Unauthorized — dashboard cards will render blank with no error shown',
+                  'Check if the user JWT has expired (look for ksc_session_expired events around the same time)',
+                  'If JWT is valid, check that the SSE endpoint accepts Authorization: Bearer headers',
+                  'This silently degrades the entire dashboard — users see empty cards with no feedback',
+                ],
+                session_refresh_failure: [
+                  'The "Refresh Now" button in the session expiry banner failed silently — user will be logged out ~60s later',
+                  'Check /auth/refresh endpoint health and that it accepts HttpOnly kc_auth cookies',
+                  'Network issues or backend restarts during refresh window can trigger this',
+                ],
               };
 
               const fixes = categoryGuide[category] || [

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -7,6 +7,7 @@ import { registerCacheReset, triggerAllRefetches } from '../../lib/modeTransitio
 import { resetFailuresForCluster, resetAllCacheFailures } from '../../lib/cache'
 import { hostnameEndsWith, hostnameContainsLabel } from '../../lib/utils/urlHostname'
 import { appendWsAuthToken } from '../../lib/utils/wsAuth'
+import { emitAgentTokenFailure } from '../../lib/analytics'
 import { MS_PER_MINUTE } from '../../lib/constants/time'
 import {
   LOCAL_AGENT_HTTP_URL,
@@ -65,11 +66,16 @@ function getAgentToken(): Promise<string> {
       .then(r => r.ok ? r.json() : { token: '' })
       .then((data: { token?: string }) => {
         const token = data.token || ''
-        if (token) localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, token)
+        if (token) {
+          localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, token)
+        } else {
+          emitAgentTokenFailure('empty token from /api/agent/token')
+        }
         agentTokenPromise = null
         return token
       })
-      .catch(() => {
+      .catch((err) => {
+        emitAgentTokenFailure(err?.message || 'network error')
         agentTokenPromise = null
         return ''
       })

--- a/web/src/lib/analytics-events.ts
+++ b/web/src/lib/analytics-events.ts
@@ -350,6 +350,42 @@ export function emitDemoModeToggled(enabled: boolean) {
   setAnalyticsUserProperties({ demo_mode: String(enabled) })
 }
 
+// ── Auth / Connection Failure Detection ─────────────────────────
+// These events fire when auth-dependent paths silently degrade.
+// The GA4 error monitor workflow creates issues when thresholds are hit.
+
+export function emitAgentTokenFailure(reason: string) {
+  send('ksc_error', {
+    error_category: 'agent_token_failure',
+    error_detail: reason.slice(0, 100),
+    error_page: typeof window !== 'undefined' ? window.location.pathname : '',
+  })
+}
+
+export function emitWsAuthMissing(url: string) {
+  send('ksc_error', {
+    error_category: 'ws_auth_missing',
+    error_detail: url.replace(/^wss?:\/\/[^/]+/, '').slice(0, 100),
+    error_page: typeof window !== 'undefined' ? window.location.pathname : '',
+  })
+}
+
+export function emitSseAuthFailure(url: string) {
+  send('ksc_error', {
+    error_category: 'sse_auth_failure',
+    error_detail: url.replace(/^https?:\/\/[^/]+/, '').slice(0, 100),
+    error_page: typeof window !== 'undefined' ? window.location.pathname : '',
+  })
+}
+
+export function emitSessionRefreshFailure(reason: string) {
+  send('ksc_error', {
+    error_category: 'session_refresh_failure',
+    error_detail: reason.slice(0, 100),
+    error_page: typeof window !== 'undefined' ? window.location.pathname : '',
+  })
+}
+
 // ── kc-agent Connection ─────────────────────────────────────────
 
 export function emitAgentConnected(version: string, clusterCount: number) {

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -96,6 +96,10 @@ export {
 
   // Errors (domain-level, separate from core error tracking)
   emitSessionExpired,
+  emitAgentTokenFailure,
+  emitWsAuthMissing,
+  emitSseAuthFailure,
+  emitSessionRefreshFailure,
 
   // Tour
   emitTourStarted,

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -9,7 +9,7 @@ import { clearClusterCacheOnLogout } from '../hooks/mcp/shared'
 import { STORAGE_KEY_TOKEN, DEMO_TOKEN_VALUE, STORAGE_KEY_DEMO_MODE, STORAGE_KEY_ONBOARDED, STORAGE_KEY_USER_CACHE, STORAGE_KEY_HAS_SESSION, FETCH_DEFAULT_TIMEOUT_MS } from './constants'
 /** localStorage key for the kc-agent shared secret (must match shared.ts) */
 const AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'
-import { emitLogin, emitLogout, setAnalyticsUserId, setAnalyticsUserProperties, emitConversionStep, emitDeveloperSession } from './analytics'
+import { emitLogin, emitLogout, setAnalyticsUserId, setAnalyticsUserProperties, emitConversionStep, emitDeveloperSession, emitSessionRefreshFailure } from './analytics'
 import { setDemoMode as setGlobalDemoMode } from './demoMode'
 import { AuthRefreshResponseSchema, UserSchema } from './schemas'
 import { validateResponse } from './schemas/validate'
@@ -630,8 +630,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
               localStorage.removeItem(STORAGE_KEY_HAS_SESSION)
             }
           }
-        } catch {
-          // Refresh failed — user will see session-expired redirect naturally
+        } catch (err) {
+          emitSessionRefreshFailure(err instanceof Error ? err.message : 'network error')
         }
       })
     }

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -14,6 +14,7 @@
  */
 
 import { STORAGE_KEY_TOKEN } from './constants'
+import { emitSseAuthFailure } from './analytics'
 
 export interface SSEFetchOptions<T> {
   /** SSE endpoint URL path (e.g. `${LOCAL_AGENT_HTTP_URL}/pods/stream`) */
@@ -369,7 +370,11 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
           }
 
           // Don't retry on auth (401) or service unavailable (503) — expected in demo mode
-          const isNonRetryable = err.message?.includes('401') || err.message?.includes('503')
+          const is401 = err.message?.includes('401')
+          const isNonRetryable = is401 || err.message?.includes('503')
+          if (is401) {
+            emitSseAuthFailure(fullUrl)
+          }
           if (isNonRetryable) {
             console.debug('[SSE] Non-retryable error — skipping retries (demo mode)')
             // Clear the in-flight entry and timers so future requests for the

--- a/web/src/lib/utils/wsAuth.ts
+++ b/web/src/lib/utils/wsAuth.ts
@@ -4,11 +4,16 @@
  * Browsers cannot set custom headers on WebSocket handshake requests,
  * so we pass the token as a query parameter instead.
  */
+import { emitWsAuthMissing } from '../analytics'
+
 /** localStorage key for the kc-agent shared secret */
 const AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'
 
 /** Query-string key used to pass the auth token on WebSocket URLs */
 const WS_AUTH_QUERY_PARAM = 'token'
+
+/** Throttle: only emit once per session to avoid spamming GA4 */
+let wsAuthMissingEmitted = false
 
 /**
  * If a kc-agent token exists in localStorage, append it to `url` as
@@ -17,7 +22,13 @@ const WS_AUTH_QUERY_PARAM = 'token'
  */
 export function appendWsAuthToken(url: string): string {
   const token = localStorage.getItem(AGENT_TOKEN_STORAGE_KEY)
-  if (!token) return url
+  if (!token) {
+    if (!wsAuthMissingEmitted) {
+      wsAuthMissingEmitted = true
+      emitWsAuthMissing(url)
+    }
+    return url
+  }
 
   const separator = url.includes('?') ? '&' : '?'
   return `${url}${separator}${WS_AUTH_QUERY_PARAM}=${encodeURIComponent(token)}`


### PR DESCRIPTION
## Summary
- Add 4 new GA4 error events (`agent_token_failure`, `ws_auth_missing`, `sse_auth_failure`, `session_refresh_failure`) that detect when auth-dependent paths silently degrade in production — the exact class of failure that caused the 48-hour blank dashboard incident (#10398, #10407)
- Extend the hourly `auth-login-smoke` workflow with 4 new test steps: WebSocket auth rejection, expired cookie rejection, agent token endpoint auth requirement, and WebSocket static analysis
- Add remediation guides to `ga4-error-monitor.yml` so auto-created issues include specific fix instructions for each auth failure category

## What each GA4 event detects

| Event category | Fires when | User impact |
|---|---|---|
| `agent_token_failure` | `/api/agent/token` returns empty or fails | ALL agent data (clusters, workloads, drilldowns) silently empty |
| `ws_auth_missing` | `appendWsAuthToken()` finds no token in localStorage | WebSocket drilldowns silently fail to connect |
| `sse_auth_failure` | SSE connection gets 401 Unauthorized | Dashboard cards render blank with no error |
| `session_refresh_failure` | "Refresh Now" button catch fires | User thinks they refreshed, gets logged out ~60s later |

## New hourly smoke test steps

| Step | Validates |
|---|---|
| WebSocket auth rejection | kc-agent rejects unauthenticated WS upgrade, accepts with token |
| Invalid cookie rejection | `/auth/refresh` returns non-200 for missing/garbage cookies |
| Agent token auth gate | `/api/agent/token` requires valid session (no token leak) |
| WS static analysis | No `new WebSocket()` to agent URLs bypasses `appendWsAuthToken` |

## Test plan
- [x] `npm run build` passes
- [ ] CI build/lint passes
- [ ] Auth smoke test passes on this branch
- [ ] GA4 error monitor workflow YAML is valid

Fixes #10388