### PR TITLE
🐛 Fix auth smoke test + 6 test failures from 366709c

### DIFF
--- a/.github/workflows/auth-login-smoke.yml
+++ b/.github/workflows/auth-login-smoke.yml
@@ -338,12 +338,15 @@ jobs:
           echo "kc-agent correctly rejected unauthenticated WebSocket upgrade (HTTP $WS_CODE)"
 
           echo "Testing WebSocket upgrade with correct token..."
+          # A successful WS upgrade (101) keeps the connection open, so curl
+          # will hit --max-time and exit with code 28 (timeout). Capture the
+          # exit code separately so `set -e` doesn't kill the step.
           WS_CODE_AUTH=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
             -H "Connection: Upgrade" \
             -H "Upgrade: websocket" \
             -H "Sec-WebSocket-Version: 13" \
             -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
-            "http://127.0.0.1:8585/ws?token=${KC_AGENT_TOKEN}" 2>/dev/null)
+            "http://127.0.0.1:8585/ws?token=${KC_AGENT_TOKEN}" 2>/dev/null) || true
 
           # 101 = upgrade accepted, or any non-401 = token was accepted
           if [ "$WS_CODE_AUTH" = "401" ]; then

--- a/web/src/hooks/__tests__/useAIPredictions.test.ts
+++ b/web/src/hooks/__tests__/useAIPredictions.test.ts
@@ -40,10 +40,14 @@ vi.mock('../mcp/shared', () => ({
   agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
-vi.mock('../../lib/constants', () => ({
-  LOCAL_AGENT_WS_URL: 'ws://localhost:8585/ws',
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    LOCAL_AGENT_WS_URL: 'ws://localhost:8585/ws',
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 10000,

--- a/web/src/hooks/__tests__/useActiveUsers.test.ts
+++ b/web/src/hooks/__tests__/useActiveUsers.test.ts
@@ -10,9 +10,13 @@ vi.mock('../useDemoMode', () => ({
   isDemoModeForced: true,
 }))
 
-vi.mock('../../lib/constants', () => ({
-  STORAGE_KEY_TOKEN: 'kc-auth-token',
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    STORAGE_KEY_TOKEN: 'kc-auth-token',
+  }
+})
 
 import { useActiveUsers, __resetForTest } from '../useActiveUsers'
 

--- a/web/src/hooks/__tests__/useBonusPoints.test.ts
+++ b/web/src/hooks/__tests__/useBonusPoints.test.ts
@@ -23,9 +23,13 @@ vi.mock('../../lib/auth', () => ({
   useAuth: () => mockUseAuth(),
 }))
 
-vi.mock('../../lib/constants', () => ({
-  BACKEND_DEFAULT_URL: 'http://localhost:8080',
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    BACKEND_DEFAULT_URL: 'http://localhost:8080',
+  }
+})
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,

--- a/web/src/hooks/__tests__/useCRDs.test.ts
+++ b/web/src/hooks/__tests__/useCRDs.test.ts
@@ -33,9 +33,13 @@ vi.mock('../useMCP', () => ({
   useClusters: () => mockClustersReturn,
 }))
 
-vi.mock('../../lib/constants', () => ({
-  STORAGE_KEY_TOKEN: 'token',
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    STORAGE_KEY_TOKEN: 'token',
+  }
+})
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 10_000,

--- a/web/src/hooks/__tests__/useCachedCoreWorkloads.test.ts
+++ b/web/src/hooks/__tests__/useCachedCoreWorkloads.test.ts
@@ -40,9 +40,13 @@ vi.mock('../useLocalAgent', () => ({
   isAgentUnavailable: vi.fn(() => true),
 }))
 
-vi.mock('../../lib/constants', () => ({
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,

--- a/web/src/hooks/__tests__/useCachedKeda.test.ts
+++ b/web/src/hooks/__tests__/useCachedKeda.test.ts
@@ -27,9 +27,13 @@ vi.mock('../../lib/api', () => ({
     authFetch: vi.fn(),
 }))
 
-vi.mock('../../lib/constants', () => ({
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     FETCH_DEFAULT_TIMEOUT_MS: 10000,
-}))
+  }
+})
 
 vi.mock('../../lib/constants/network', () => ({
     LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',

--- a/web/src/hooks/__tests__/useDeployMissions-expand.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions-expand.test.ts
@@ -42,12 +42,16 @@ vi.mock('../../lib/kubectlProxy', () => ({
   kubectlProxy: { exec: (...args: unknown[]) => mockKubectlExec(...args) },
 }))
 
-vi.mock('../../lib/constants', () => ({
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-  STORAGE_KEY_TOKEN: 'kc-auth-token',
-  STORAGE_KEY_MISSIONS_ACTIVE: 'kc-missions-active',
-  STORAGE_KEY_MISSIONS_HISTORY: 'kc-missions-history',
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+    STORAGE_KEY_TOKEN: 'kc-auth-token',
+    STORAGE_KEY_MISSIONS_ACTIVE: 'kc-missions-active',
+    STORAGE_KEY_MISSIONS_HISTORY: 'kc-missions-history',
+  }
+})
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 10000,

--- a/web/src/hooks/__tests__/useGatewayStatus.test.ts
+++ b/web/src/hooks/__tests__/useGatewayStatus.test.ts
@@ -25,10 +25,14 @@ vi.mock('../../lib/modeTransition', () => ({
   registerRefetch: (...args: unknown[]) => mockRegisterRefetch(...args),
 }))
 
-vi.mock('../../lib/constants', () => ({
-  STORAGE_KEY_TOKEN: 'kc-auth-token',
-  DEFAULT_REFRESH_INTERVAL_MS: 120_000,
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    STORAGE_KEY_TOKEN: 'kc-auth-token',
+    DEFAULT_REFRESH_INTERVAL_MS: 120_000,
+  }
+})
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,

--- a/web/src/hooks/__tests__/useGitHubPipelines.test.ts
+++ b/web/src/hooks/__tests__/useGitHubPipelines.test.ts
@@ -39,9 +39,13 @@ vi.mock('../../hooks/useDemoMode', () => ({
   getDemoMode: () => true,
   useDemoMode: () => ({ isDemoMode: true }),
 }))
-vi.mock('../../lib/constants', () => ({
-  STORAGE_KEY_TOKEN: 'token',
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    STORAGE_KEY_TOKEN: 'token',
+  }
+})
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 30000,
 }))

--- a/web/src/hooks/__tests__/useProviderConnection.test.ts
+++ b/web/src/hooks/__tests__/useProviderConnection.test.ts
@@ -23,9 +23,13 @@ vi.mock('../mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('../../lib/constants', () => ({
-  LOCAL_AGENT_HTTP_URL: 'http://127.0.0.1:8585',
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    LOCAL_AGENT_HTTP_URL: 'http://127.0.0.1:8585',
+  }
+})
 
 let useProviderConnection: typeof import('../useProviderConnection').useProviderConnection
 

--- a/web/src/hooks/__tests__/useServiceImportsCard.test.ts
+++ b/web/src/hooks/__tests__/useServiceImportsCard.test.ts
@@ -20,10 +20,14 @@ vi.mock('../useMCP', () => ({
   useClusters: () => mockUseClusters(),
 }))
 
-vi.mock('../../lib/constants', () => ({
-  STORAGE_KEY_TOKEN: 'kc-auth-token',
-  DEFAULT_REFRESH_INTERVAL_MS: 120_000,
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    STORAGE_KEY_TOKEN: 'kc-auth-token',
+    DEFAULT_REFRESH_INTERVAL_MS: 120_000,
+  }
+})
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,

--- a/web/src/hooks/__tests__/useWorkloads.test.ts
+++ b/web/src/hooks/__tests__/useWorkloads.test.ts
@@ -24,10 +24,14 @@ vi.mock('../mcp/shared', () => ({
   agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
 }))
 
-vi.mock('../../lib/constants', () => ({
-  LOCAL_AGENT_HTTP_URL: 'http://127.0.0.1:8585',
-  STORAGE_KEY_TOKEN: 'token',
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    LOCAL_AGENT_HTTP_URL: 'http://127.0.0.1:8585',
+    STORAGE_KEY_TOKEN: 'token',
+  }
+})
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 10_000,

--- a/web/src/hooks/useMissions.analytics-agents.test.tsx
+++ b/web/src/hooks/useMissions.analytics-agents.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.edgecases.test.tsx
+++ b/web/src/hooks/useMissions.edgecases.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.messages-stream.test.tsx
+++ b/web/src/hooks/useMissions.messages-stream.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.preflight-agents.test.tsx
+++ b/web/src/hooks/useMissions.preflight-agents.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -45,6 +56,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.provider-start.test.tsx
+++ b/web/src/hooks/useMissions.provider-start.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.save-run.test.tsx
+++ b/web/src/hooks/useMissions.save-run.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.state-persist.test.tsx
+++ b/web/src/hooks/useMissions.state-persist.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.websocket-reconnect.test.tsx
+++ b/web/src/hooks/useMissions.websocket-reconnect.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({


### PR DESCRIPTION
Fixes #10524
Fixes #10526

## Root Cause

Commit 366709c (auth hardening) introduced 4 new GA4 telemetry functions and added imports of `emitWsAuthMissing` in `wsAuth.ts` and `emitAgentTokenFailure` in `shared.ts`. These broke:

### Auth Smoke Test (#10526)
- `curl` exit code 28 (timeout) on successful WS upgrade — `bash -e` killed the step
- Fix: `|| true` on the curl command to capture HTTP code regardless

### 6 Test Failures (#10524)
1. **5 useMissions tests**: `wsAuth.ts` now calls `emitWsAuthMissing()` which was undefined in test mocks → TypeError → mission status 'failed' instead of 'running'
2. **useAIPredictions test**: constants mock missing `STORAGE_KEY_DEMO_MODE` (needed by analytics → demoMode chain)

### Fixes Applied
- Mock `../lib/utils/wsAuth` in all 8 useMissions test files
- Add 4 new analytics functions to all analytics mocks
- Use `importOriginal` for constants mock in useAIPredictions
- Add `useLocalAgent` mock (needed for #10525)
- Add `|| true` to WS upgrade curl in auth smoke workflow

## Verification
- All 337 useMissions + useAIPredictions tests pass
- Build passes
- Lint passes (no new issues)