### PR TITLE
🐛 Clear stale agent errors on reconnect

### DIFF
--- a/.github/workflows/auth-login-smoke.yml
+++ b/.github/workflows/auth-login-smoke.yml
@@ -338,12 +338,15 @@ jobs:
           echo "kc-agent correctly rejected unauthenticated WebSocket upgrade (HTTP $WS_CODE)"
 
           echo "Testing WebSocket upgrade with correct token..."
+          # A successful WS upgrade (101) keeps the connection open, so curl
+          # will hit --max-time and exit with code 28 (timeout). Capture the
+          # exit code separately so `set -e` doesn't kill the step.
           WS_CODE_AUTH=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
             -H "Connection: Upgrade" \
             -H "Upgrade: websocket" \
             -H "Sec-WebSocket-Version: 13" \
             -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
-            "http://127.0.0.1:8585/ws?token=${KC_AGENT_TOKEN}" 2>/dev/null)
+            "http://127.0.0.1:8585/ws?token=${KC_AGENT_TOKEN}" 2>/dev/null) || true
 
           # 101 = upgrade accepted, or any non-401 = token was accepted
           if [ "$WS_CODE_AUTH" = "401" ]; then

--- a/web/src/hooks/useMissions.analytics-agents.test.tsx
+++ b/web/src/hooks/useMissions.analytics-agents.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.edgecases.test.tsx
+++ b/web/src/hooks/useMissions.edgecases.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.messages-stream.test.tsx
+++ b/web/src/hooks/useMissions.messages-stream.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.preflight-agents.test.tsx
+++ b/web/src/hooks/useMissions.preflight-agents.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -45,6 +56,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.provider-start.test.tsx
+++ b/web/src/hooks/useMissions.provider-start.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.save-run.test.tsx
+++ b/web/src/hooks/useMissions.save-run.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.state-persist.test.tsx
+++ b/web/src/hooks/useMissions.state-persist.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -4,6 +4,7 @@ import { AgentCapabilityToolExec } from '../types/agent'
 import { getDemoMode } from './useDemoMode'
 import { addCategoryTokens, setActiveTokenCategory, clearActiveTokenCategory } from './useTokenUsage'
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { useLocalAgent } from './useLocalAgent'
 import { agentFetch } from './mcp/shared'
 import { appendWsAuthToken } from '../lib/utils/wsAuth'
 import { emitError, emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
@@ -198,6 +199,7 @@ const WAITING_INPUT_TIMEOUT_MS = 600_000 // 10 minutes
 
 export function MissionProvider({ children }: { children: ReactNode }) {
   const [missions, setMissions] = useState<Mission[]>(() => loadMissions())
+  const { isConnected: isAgentConnected } = useLocalAgent()
   // #7313 — Restore the active mission ID from localStorage so a reload
   // remembers which mission was selected. Sidebar visibility is restored
   // separately via SIDEBAR_OPEN_STORAGE_KEY (kc_mission_sidebar_open).
@@ -566,6 +568,58 @@ export function MissionProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     saveUnreadMissionIds(unreadMissionIds)
   }, [unreadMissionIds])
+
+  // #10525 — Clear stale agent-unavailable errors when the agent reconnects.
+  // When a mission fails because the local agent was disconnected, the error
+  // message gets locked into the chat history. Once the agent reconnects, we
+  // transition those failed missions back to 'saved' so the user can retry
+  // cleanly without seeing the stale "Local Agent Not Connected" error.
+  const prevAgentConnected = useRef(isAgentConnected)
+  useEffect(() => {
+    const wasConnected = prevAgentConnected.current
+    prevAgentConnected.current = isAgentConnected
+    if (!wasConnected && isAgentConnected) {
+      setMissions(prev => {
+        const hasStale = prev.some(m =>
+          m.status === 'failed' &&
+          m.messages.some(msg =>
+            msg.role === 'system' && (
+              msg.content.includes('Local Agent Not Connected') ||
+              msg.content.includes('agent not available') ||
+              msg.content.includes('agent not responding')
+            )
+          )
+        )
+        if (!hasStale) return prev
+        return prev.map(m => {
+          if (m.status !== 'failed') return m
+          // Find the last system message with stale agent error
+          let staleIdx = -1
+          for (let i = m.messages.length - 1; i >= 0; i--) {
+            const msg = m.messages[i]
+            if (
+              msg.role === 'system' && (
+                msg.content.includes('Local Agent Not Connected') ||
+                msg.content.includes('agent not available') ||
+                msg.content.includes('agent not responding')
+              )
+            ) {
+              staleIdx = i
+              break
+            }
+          }
+          if (staleIdx === -1) return m
+          const cleanedMessages = m.messages.filter((_, i) => i !== staleIdx)
+          return {
+            ...m,
+            status: 'saved' as MissionStatus,
+            currentStep: undefined,
+            messages: cleanedMessages,
+          }
+        })
+      })
+    }
+  }, [isAgentConnected])
 
   // Periodically check for missions stuck in "running" state.
   // Two failure conditions are detected (#2375, #3079):

--- a/web/src/hooks/useMissions.websocket-reconnect.test.tsx
+++ b/web/src/hooks/useMissions.websocket-reconnect.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./useDemoMode', () => ({
   getDemoMode: vi.fn(() => false),
   default: vi.fn(() => false),
 }))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
 
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
@@ -44,6 +55,10 @@ vi.mock('../lib/analytics', () => ({
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../lib/missions/preflightCheck', () => ({


### PR DESCRIPTION
Fixes #10525

## Problem

When a mission fails due to local agent unavailability, the error message (`Local Agent Not Connected`) gets locked into the mission's chat history. After the agent reconnects and the navbar shows "Connected", the failed mission still displays the stale error — even on retry. New missions work correctly.

## Solution

`MissionProvider` now subscribes to agent status via `useLocalAgent()` and detects disconnected→connected transitions. When the agent reconnects:

1. Scans all missions for `status: 'failed'` with agent-unavailable system messages
2. Removes the stale error message from chat history
3. Transitions the mission to `'saved'` status so the user can retry cleanly

### Error patterns detected:
- `Local Agent Not Connected`
- `agent not available`
- `agent not responding`

## Verification
- Build passes
- Lint passes (no new issues)
- All 337 useMissions + useAIPredictions tests pass
- Includes cherry-picked test infrastructure from #10531 (`useLocalAgent` + `wsAuth` mocks)