### PR TITLE
Restore coverage for auth hardening GA4 emit paths

### DIFF
--- a/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
@@ -96,6 +96,11 @@ vi.mock('../../../lib/constants/network', async () => {
   return { ...actual }
 })
 
+const mockEmitAgentTokenFailure = vi.hoisted(() => vi.fn())
+vi.mock('../../../lib/analytics', () => ({
+  emitAgentTokenFailure: mockEmitAgentTokenFailure,
+}))
+
 // ---------------------------------------------------------------------------
 // Imports (resolved after mocks)
 // ---------------------------------------------------------------------------
@@ -209,6 +214,58 @@ describe('agentFetch — token injection and signal fallback', () => {
     const call = mockFetch.mock.calls[0]
     // Signal should exist (the AbortSignal.timeout fallback)
     expect(call[1]?.signal).toBeTruthy()
+  })
+})
+
+// ============================================================================
+// getAgentToken — GA4 failure detection
+// ============================================================================
+describe('getAgentToken — emits GA4 on failure', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    localStorage.clear()
+    mockEmitAgentTokenFailure.mockClear()
+  })
+
+  it('emits emitAgentTokenFailure when /api/agent/token returns non-OK', async () => {
+    localStorage.removeItem(AGENT_TOKEN_STORAGE_KEY)
+    const mockFetch = vi.fn()
+    mockFetch.mockResolvedValueOnce(new Response('error', { status: 500 }))
+    mockFetch.mockResolvedValue(new Response('ok'))
+    globalThis.fetch = mockFetch
+
+    await agentFetch('http://localhost:8090/clusters')
+
+    expect(mockEmitAgentTokenFailure).toHaveBeenCalledWith('empty token from /api/agent/token')
+  })
+
+  it('emits emitAgentTokenFailure when fetch throws network error', async () => {
+    localStorage.removeItem(AGENT_TOKEN_STORAGE_KEY)
+    const mockFetch = vi.fn()
+    mockFetch.mockRejectedValueOnce(new Error('Network request failed'))
+    mockFetch.mockResolvedValue(new Response('ok'))
+    globalThis.fetch = mockFetch
+
+    await agentFetch('http://localhost:8090/clusters')
+
+    expect(mockEmitAgentTokenFailure).toHaveBeenCalledWith('Network request failed')
+  })
+
+  it('does NOT emit when /api/agent/token returns a valid token', async () => {
+    localStorage.removeItem(AGENT_TOKEN_STORAGE_KEY)
+    const mockFetch = vi.fn()
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ token: 'valid-hex-token' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+    mockFetch.mockResolvedValue(new Response('ok'))
+    globalThis.fetch = mockFetch
+
+    await agentFetch('http://localhost:8090/clusters')
+
+    expect(mockEmitAgentTokenFailure).not.toHaveBeenCalled()
   })
 })
 

--- a/web/src/lib/__tests__/analytics-events.test.ts
+++ b/web/src/lib/__tests__/analytics-events.test.ts
@@ -40,6 +40,10 @@ import {
   emitCardListItemClicked,
   emitMissionStarted,
   emitMissionCompleted,
+  emitAgentTokenFailure,
+  emitWsAuthMissing,
+  emitSseAuthFailure,
+  emitSessionRefreshFailure,
 } from '../analytics-events'
 
 const mockSend = vi.mocked(send)
@@ -184,6 +188,58 @@ describe('analytics-events', () => {
         mission_type: 'install',
         duration_sec: 120,
       })
+    })
+  })
+
+  describe('Auth / Connection Failure Detection', () => {
+    it('emitAgentTokenFailure sends ksc_error with agent_token_failure category', () => {
+      emitAgentTokenFailure('empty token from /api/agent/token')
+      expect(mockSend).toHaveBeenCalledWith('ksc_error', expect.objectContaining({
+        error_category: 'agent_token_failure',
+        error_detail: 'empty token from /api/agent/token',
+      }))
+    })
+
+    it('emitAgentTokenFailure truncates reason to 100 characters', () => {
+      const longReason = 'x'.repeat(150)
+      emitAgentTokenFailure(longReason)
+      expect(mockSend).toHaveBeenCalledWith('ksc_error', expect.objectContaining({
+        error_category: 'agent_token_failure',
+        error_detail: 'x'.repeat(100),
+      }))
+    })
+
+    it('emitWsAuthMissing sends ksc_error with ws_auth_missing category and strips host', () => {
+      emitWsAuthMissing('ws://127.0.0.1:8585/ws')
+      expect(mockSend).toHaveBeenCalledWith('ksc_error', expect.objectContaining({
+        error_category: 'ws_auth_missing',
+        error_detail: '/ws',
+      }))
+    })
+
+    it('emitSseAuthFailure sends ksc_error with sse_auth_failure category and strips host', () => {
+      emitSseAuthFailure('http://127.0.0.1:8585/pods/stream?cluster=test')
+      expect(mockSend).toHaveBeenCalledWith('ksc_error', expect.objectContaining({
+        error_category: 'sse_auth_failure',
+        error_detail: '/pods/stream?cluster=test',
+      }))
+    })
+
+    it('emitSessionRefreshFailure sends ksc_error with session_refresh_failure category', () => {
+      emitSessionRefreshFailure('network error')
+      expect(mockSend).toHaveBeenCalledWith('ksc_error', expect.objectContaining({
+        error_category: 'session_refresh_failure',
+        error_detail: 'network error',
+      }))
+    })
+
+    it('emitSessionRefreshFailure truncates reason to 100 characters', () => {
+      const longReason = 'a]'.repeat(75)
+      emitSessionRefreshFailure(longReason)
+      expect(mockSend).toHaveBeenCalledWith('ksc_error', expect.objectContaining({
+        error_category: 'session_refresh_failure',
+        error_detail: longReason.slice(0, 100),
+      }))
     })
   })
 })

--- a/web/src/lib/__tests__/auth-coverage.test.tsx
+++ b/web/src/lib/__tests__/auth-coverage.test.tsx
@@ -49,6 +49,7 @@ vi.mock('../analytics', () => ({
   setAnalyticsUserProperties: vi.fn(),
   emitConversionStep: vi.fn(),
   emitDeveloperSession: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
 }))
 
 vi.mock('../demoMode', () => ({
@@ -463,6 +464,87 @@ describe('token expiry timer', () => {
 
     // Token should remain unchanged
     expect(localStorage.getItem(STORAGE_KEY_TOKEN)).toBe(nearExpiryToken)
+  })
+
+  it('emits emitSessionRefreshFailure GA4 event when /auth/refresh fails', async () => {
+    const { emitSessionRefreshFailure } = await import('../analytics')
+    const mockEmitRefreshFailure = vi.mocked(emitSessionRefreshFailure)
+    mockEmitRefreshFailure.mockClear()
+
+    const MS_PER_SECOND = 1000
+    const MINUTES_15 = 15
+    const nowSec = Math.floor(Date.now() / MS_PER_SECOND)
+    const nearExpiryToken = makeJwt({ exp: nowSec + (MINUTES_15 * 60) })
+
+    localStorage.setItem(STORAGE_KEY_TOKEN, nearExpiryToken)
+    const cachedUser = { id: 'u1', github_id: '1', github_login: 'test', onboarded: true }
+    localStorage.setItem(AUTH_USER_CACHE_KEY, JSON.stringify(cachedUser))
+
+    const mockFetch = vi.fn()
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue(cachedUser),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    await renderWithAuthProvider()
+    await vi.advanceTimersByTimeAsync(100)
+
+    await waitFor(() => {
+      expect(document.getElementById('session-expiry-warning')).not.toBeNull()
+    })
+
+    mockFetch.mockRejectedValueOnce(new Error('Connection refused'))
+
+    const btn = document.querySelector('#session-expiry-warning button') as HTMLButtonElement
+    await act(async () => {
+      btn.click()
+      await vi.advanceTimersByTimeAsync(100)
+    })
+
+    expect(mockEmitRefreshFailure).toHaveBeenCalledWith('Connection refused')
+  })
+
+  it('does NOT emit emitSessionRefreshFailure when /auth/refresh succeeds', async () => {
+    const { emitSessionRefreshFailure } = await import('../analytics')
+    const mockEmitRefreshFailure = vi.mocked(emitSessionRefreshFailure)
+    mockEmitRefreshFailure.mockClear()
+
+    const MS_PER_SECOND = 1000
+    const MINUTES_15 = 15
+    const nowSec = Math.floor(Date.now() / MS_PER_SECOND)
+    const nearExpiryToken = makeJwt({ exp: nowSec + (MINUTES_15 * 60) })
+
+    localStorage.setItem(STORAGE_KEY_TOKEN, nearExpiryToken)
+    const cachedUser = { id: 'u1', github_id: '1', github_login: 'test', onboarded: true }
+    localStorage.setItem(AUTH_USER_CACHE_KEY, JSON.stringify(cachedUser))
+
+    const mockFetch = vi.fn()
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue(cachedUser),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    await renderWithAuthProvider()
+    await vi.advanceTimersByTimeAsync(100)
+
+    await waitFor(() => {
+      expect(document.getElementById('session-expiry-warning')).not.toBeNull()
+    })
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ refreshed: true, onboarded: true }),
+    })
+
+    const btn = document.querySelector('#session-expiry-warning button') as HTMLButtonElement
+    await act(async () => {
+      btn.click()
+      await vi.advanceTimersByTimeAsync(100)
+    })
+
+    expect(mockEmitRefreshFailure).not.toHaveBeenCalled()
   })
 
   it('does not run checkExpiry for demo tokens', async () => {

--- a/web/src/lib/__tests__/sseClient-expand.test.ts
+++ b/web/src/lib/__tests__/sseClient-expand.test.ts
@@ -96,6 +96,13 @@ vi.mock('../../hooks/mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
+vi.mock('../analytics', () => ({
+  emitSseAuthFailure: vi.fn(),
+}))
+
+import { emitSseAuthFailure } from '../analytics'
+const mockEmitSseAuth = vi.mocked(emitSseAuthFailure)
+
 describe('sseClient expanded', () => {
 
   // =========================================================================
@@ -732,6 +739,50 @@ describe('sseClient expanded', () => {
       const call = vi.mocked(fetch).mock.calls[0]
       const url = String(call[0])
       expect(url).toContain('limit=0')
+    })
+  })
+
+  describe('SSE auth failure GA4 emit', () => {
+    it('emits emitSseAuthFailure on 401 response', async () => {
+      vi.mocked(fetch).mockResolvedValue(new Response('Unauthorized', { status: 401 }))
+
+      const result = await fetchSSE({
+        url: `/api/sse-401-${testId++}`,
+        itemsKey: 'items',
+        onClusterData: vi.fn(),
+      })
+
+      expect(mockEmitSseAuth).toHaveBeenCalledTimes(1)
+      expect(mockEmitSseAuth).toHaveBeenCalledWith(expect.stringContaining('/api/sse-401-'))
+      expect(result).toEqual([])
+    })
+
+    it('does not emit emitSseAuthFailure on 503 response', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.mocked(fetch).mockResolvedValue(new Response('Unavailable', { status: 503 }))
+
+      const result = await fetchSSE({
+        url: `/api/sse-503-${testId++}`,
+        itemsKey: 'items',
+        onClusterData: vi.fn(),
+      })
+
+      expect(mockEmitSseAuth).not.toHaveBeenCalled()
+      expect(result).toEqual([])
+    })
+
+    it('does not emit emitSseAuthFailure on successful response', async () => {
+      vi.mocked(fetch).mockResolvedValue(makeSSEResponse([
+        { event: 'done', data: {} },
+      ]))
+
+      await fetchSSE({
+        url: `/api/sse-ok-${testId++}`,
+        itemsKey: 'items',
+        onClusterData: vi.fn(),
+      })
+
+      expect(mockEmitSseAuth).not.toHaveBeenCalled()
     })
   })
 })

--- a/web/src/lib/utils/__tests__/wsAuth.test.ts
+++ b/web/src/lib/utils/__tests__/wsAuth.test.ts
@@ -1,9 +1,21 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { appendWsAuthToken } from '../wsAuth'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const mockEmitWsAuthMissing = vi.fn()
+
+vi.mock('../../analytics', () => ({
+  emitWsAuthMissing: mockEmitWsAuthMissing,
+}))
 
 describe('appendWsAuthToken', () => {
-  beforeEach(() => {
+  let appendWsAuthToken: (url: string) => string
+
+  beforeEach(async () => {
     localStorage.clear()
+    mockEmitWsAuthMissing.mockClear()
+    // Reset module to clear the wsAuthMissingEmitted flag
+    vi.resetModules()
+    const mod = await import('../wsAuth')
+    appendWsAuthToken = mod.appendWsAuthToken
   })
 
   it('appends token as query parameter when token exists', () => {
@@ -27,5 +39,23 @@ describe('appendWsAuthToken', () => {
     localStorage.setItem('kc-agent-token', 'token with spaces&special=chars')
     const result = appendWsAuthToken('ws://localhost:8585/ws')
     expect(result).toContain('token=token%20with%20spaces%26special%3Dchars')
+  })
+
+  it('does not emit when token is present', () => {
+    localStorage.setItem('kc-agent-token', 'valid-token')
+    appendWsAuthToken('ws://localhost:8585/ws')
+    expect(mockEmitWsAuthMissing).not.toHaveBeenCalled()
+  })
+
+  it('emits emitWsAuthMissing when token is missing', () => {
+    appendWsAuthToken('ws://localhost:8585/ws')
+    expect(mockEmitWsAuthMissing).toHaveBeenCalledWith('ws://localhost:8585/ws')
+    expect(mockEmitWsAuthMissing).toHaveBeenCalledTimes(1)
+  })
+
+  it('throttles emit to once per module lifecycle', () => {
+    appendWsAuthToken('ws://localhost:8585/ws')
+    appendWsAuthToken('ws://localhost:8585/ws/other')
+    expect(mockEmitWsAuthMissing).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- Adds 14 unit tests across 5 test files covering the GA4 error emission code paths introduced in PR #10523
- Targets the specific files that caused coverage to drop from 91% to 88%: `analytics-events.ts`, `wsAuth.ts`, `sseClient.ts`, `shared.ts` (mcp), `auth.tsx`
- Tests verify correct event emission, parameter formatting (host stripping, truncation), and throttling behavior

## Test plan
- [x] All 5 modified test files pass individually (wsAuth 7/7, sseClient-expand 23/23, shared-coverage 56/56, auth-coverage 25/25, analytics-events 25/25)
- [x] Full test suite passes (18147/18147 — 6 flaky worker fork crashes unrelated to changes)
- [x] `npm run build` passes clean
- [ ] CI coverage gate reports ≥91% on modified files