### PR TITLE
🐛 Add missing assertion to a11y heading hierarchy test

### DIFF
--- a/web/e2e/a11y.spec.ts
+++ b/web/e2e/a11y.spec.ts
@@ -227,13 +227,10 @@ test.describe('Accessibility Audits', () => {
         .withRules(['heading-order'])
         .analyze()
 
-      // Log violations but allow some flexibility
-      if (results.violations.length > 0) {
-        console.log('\n=== Heading order violations ===')
-        for (const violation of results.violations) {
-          console.log(`${violation.description}: ${violation.nodes.length} occurrences`)
-        }
-      }
+      expect(
+        results.violations,
+        `Heading order violations found:\n${JSON.stringify(results.violations, null, 2)}`
+      ).toHaveLength(0)
     })
   })
 


### PR DESCRIPTION
Fixes #10532

The `headings have proper hierarchy` test in `web/e2e/a11y.spec.ts` logged violations but had no `expect()` call, allowing heading order violations to pass CI silently. Added a proper assertion that fails when violations are found, with a descriptive error message showing the violation details.