### PR TITLE
🐛 Fix auth expiry test to use correct localStorage keys

### DIFF
--- a/web/e2e/compliance/error-resilience.spec.ts
+++ b/web/e2e/compliance/error-resilience.spec.ts
@@ -446,15 +446,38 @@ test.describe('Error Resilience', () => {
       // Wait for initial content to load before simulating expiry
       await page.locator('[data-card-type]').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => { /* best-effort */ })
 
-      // Clear auth token to simulate expiry
+      // Clear all auth-related localStorage keys to simulate full expiry.
+      // The app's primary auth key is 'token' (STORAGE_KEY_TOKEN); the others
+      // are agent token, user cache, session hint, and cache-validation stamp.
+      // 'github_token' is legacy (kept for cleanup) — clear it too.
       await page.evaluate(() => {
-        localStorage.removeItem('github_token')
         localStorage.removeItem('token')
-        localStorage.removeItem('user')
+        localStorage.removeItem('kc-agent-token')
+        localStorage.removeItem('kc-user-cache')
+        localStorage.removeItem('kc-has-session')
+        localStorage.removeItem('kc-user-cache-validated')
+        localStorage.removeItem('github_token')
+        try { sessionStorage.removeItem('token') } catch { /* private mode */ }
+        try { sessionStorage.removeItem('kc-user-cache') } catch { /* private mode */ }
       })
 
-      // Mock /api/me to return 401
+      // Mock /api/me and all SSE/streaming endpoints to return 401 so cached
+      // data can't keep the dashboard alive after token expiry.
       await page.route('**/api/me', async (route) => {
+        await route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'unauthorized', message: 'Token expired' }),
+        })
+      })
+      await page.route('**/*stream*', async (route) => {
+        await route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'unauthorized', message: 'Token expired' }),
+        })
+      })
+      await page.route('**/api/auth/**', async (route) => {
         await route.fulfill({
           status: 401,
           contentType: 'application/json',


### PR DESCRIPTION
Fixes #10536

The auth expiry test in `error-resilience.spec.ts` was removing legacy/incorrect localStorage keys (`github_token`, `user`) while the app's auth guard reads `token` as the primary key. The test also didn't mock SSE endpoints, so cached data kept the dashboard alive.

**Changes:**
- Clear all auth-related localStorage keys matching what the app's logout function clears: `token`, `kc-agent-token`, `kc-user-cache`, `kc-has-session`, `kc-user-cache-validated`, plus legacy `github_token`
- Also clear sessionStorage auth keys
- Mock all SSE/streaming endpoints (`**/*stream*`) to return 401
- Mock `**/api/auth/**` to return 401
- This ensures complete auth expiry simulation where cached data can't keep the dashboard alive