### PR TITLE
🐛 Fix tautological assertion in cluster investigation test

### DIFF
--- a/web/e2e/user-flows/cluster-investigation.spec.ts
+++ b/web/e2e/user-flows/cluster-investigation.spec.ts
@@ -54,7 +54,7 @@ test.describe('Cluster Investigation — "My cluster has issues"', () => {
         // Filter options should appear
         const options = page.getByTestId('cluster-filter-option')
         const optionCount = await options.count()
-        expect(optionCount).toBeGreaterThanOrEqual(0)
+        expect(optionCount).toBeGreaterThanOrEqual(1)
       }
     }
   })


### PR DESCRIPTION
Fixes #10534

The test asserted `optionCount >= 0`, which can never fail since `.count()` always returns a non-negative integer. Changed to `>= 1` to actually verify that filter options render in the cluster investigation dropdown.