### PR TITLE
🐛 Add back button interactability test for DrillDown

### DIFF
--- a/web/e2e/DrillDown.spec.ts
+++ b/web/e2e/DrillDown.spec.ts
@@ -131,6 +131,31 @@ test.describe('Drilldown Modal — structural assertions', () => {
     expect(laterCount).toBeLessThanOrEqual(initialCount)
   })
 
+  test('back button is visible, not obscured by sidebar, and clickable (portal z-index regression)', async ({ page }) => {
+    await setupDemoAndNavigate(page, '/')
+    await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
+
+    const opened = await openDrillDown(page)
+    if (!opened) { test.skip(true, 'No expandable card'); return }
+
+    const modal = page.getByTestId('drilldown-modal')
+    await expect(modal).toBeVisible()
+
+    const backButton = page.getByTestId('drilldown-back')
+    await expect(backButton).toBeVisible()
+    await expect(backButton).toBeEnabled()
+
+    // Verify the back button is not hidden behind the sidebar by
+    // performing an actionability check — Playwright's click() will
+    // fail if the element is obscured by another element.
+    await backButton.click()
+
+    // At root level the back button acts as close, so the modal should dismiss.
+    // If there was a nested stack it would pop instead, but either way the
+    // click must succeed (not be intercepted by sidebar).
+    await expect(modal).not.toBeVisible({ timeout: DRILLDOWN_TIMEOUT_MS })
+  })
+
   test('drilldown close button has an accessible label (aria-label or title)', async ({ page }) => {
     await setupDemoAndNavigate(page, '/')
     await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS })

--- a/web/src/components/drilldown/DrillDownModal.tsx
+++ b/web/src/components/drilldown/DrillDownModal.tsx
@@ -329,6 +329,7 @@ export function DrillDownModal() {
           <div className="flex items-center gap-2 min-w-0 flex-1">
             {/* Back button - always visible; closes modal at root level */}
             <button
+              data-testid="drilldown-back"
               onClick={state.stack.length > 1 ? pop : close}
               className="p-2 rounded-lg hover:bg-card/50 text-muted-foreground hover:text-foreground transition-colors"
               title={state.stack.length > 1 ? t('drilldown.goBack') : t('drilldown.close')}


### PR DESCRIPTION
Fixes #10533

Adds a regression test in `DrillDown.spec.ts` verifying the drilldown back button is visible, enabled, and clickable (not obscured by the sidebar). Also adds `data-testid="drilldown-back"` to the back button in `DrillDownModal.tsx` for reliable test targeting.

This guards against the z-index sidebar overlap bug documented in `DrillDownModal.tsx` (fixed via `createPortal()`).