### PR TITLE
🐛 Fix Playwright SyntaxError: remove duplicate closing brace in Dashboard.spec.ts

### DIFF
--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -309,8 +309,6 @@ test.describe('Dashboard Page', () => {
       await expect(refreshButton).toHaveAttribute('title', 'Refresh cluster data')
     })
   })
-
-  })
 })
 
 // #6459 — Data accuracy (not just structural presence). These tests


### PR DESCRIPTION
## Problem

All 5 Playwright shards (chromium ×4 + mobile) fail immediately with:

```
SyntaxError: /home/runner/work/console/console/web/e2e/Dashboard.spec.ts: Unexpected token (314:0)
```

## Root Cause

The Data Accuracy describe refactor in #10457 left an extra `})` on line 313, making the file syntactically invalid. The brace depth goes negative at line 314.

## Fix

Remove the duplicate closing brace (line 313). This restores correct brace balance (depth 0 at EOF).

## Verification

- Before: brace depth reaches -1 at line 314
- After: brace depth is 0 at EOF, all 532 lines parse cleanly

Fixes Playwright nightly/push RED indicator.