### PR TITLE
Restore wsAuth GA4 emit and add 236 tests for useCached hooks

### DIFF
--- a/web/src/hooks/__tests__/useCachedBackstage-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedBackstage-funcs.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedBackstage.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedBackstage'
+import type {
+  BackstageCatalogCounts,
+  BackstagePlugin,
+  BackstageScaffolderTemplate,
+} from '../../lib/demo/backstage'
+
+const {
+  normalizeCatalog,
+  totalEntities,
+  summarize,
+  deriveHealth,
+  buildBackstageStatus,
+  STALE_CATALOG_WINDOW_MS,
+} = __testables
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const EMPTY_CATALOG: BackstageCatalogCounts = {
+  Component: 0,
+  API: 0,
+  System: 0,
+  Domain: 0,
+  Resource: 0,
+  User: 0,
+  Group: 0,
+}
+
+function makePlugin(overrides: Partial<BackstagePlugin> = {}): BackstagePlugin {
+  return {
+    name: '@backstage/plugin-catalog',
+    version: '1.21.0',
+    status: 'enabled',
+    ...overrides,
+  }
+}
+
+function makeTemplate(
+  overrides: Partial<BackstageScaffolderTemplate> = {},
+): BackstageScaffolderTemplate {
+  return {
+    name: 'nodejs-service',
+    owner: 'platform-team',
+    type: 'service',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// normalizeCatalog
+// ---------------------------------------------------------------------------
+
+describe('normalizeCatalog', () => {
+  it('returns all zeros for undefined input', () => {
+    expect(normalizeCatalog(undefined)).toEqual(EMPTY_CATALOG)
+  })
+
+  it('returns all zeros for empty object', () => {
+    expect(normalizeCatalog({})).toEqual(EMPTY_CATALOG)
+  })
+
+  it('copies valid counts', () => {
+    const result = normalizeCatalog({ Component: 10, API: 5 })
+    expect(result.Component).toBe(10)
+    expect(result.API).toBe(5)
+    expect(result.System).toBe(0)
+  })
+
+  it('ignores negative values', () => {
+    const result = normalizeCatalog({ Component: -1 })
+    expect(result.Component).toBe(0)
+  })
+
+  it('ignores NaN values', () => {
+    const result = normalizeCatalog({ Component: NaN })
+    expect(result.Component).toBe(0)
+  })
+
+  it('ignores Infinity values', () => {
+    const result = normalizeCatalog({ Component: Infinity })
+    expect(result.Component).toBe(0)
+  })
+
+  it('accepts zero as a valid value', () => {
+    const result = normalizeCatalog({ Component: 0 })
+    expect(result.Component).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// totalEntities
+// ---------------------------------------------------------------------------
+
+describe('totalEntities', () => {
+  it('returns 0 for empty catalog', () => {
+    expect(totalEntities(EMPTY_CATALOG)).toBe(0)
+  })
+
+  it('sums all entity kinds', () => {
+    const catalog: BackstageCatalogCounts = {
+      Component: 10,
+      API: 5,
+      System: 3,
+      Domain: 2,
+      Resource: 7,
+      User: 20,
+      Group: 4,
+    }
+    expect(totalEntities(catalog)).toBe(51)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeroes for empty inputs', () => {
+    const result = summarize(EMPTY_CATALOG, [], [])
+    expect(result).toEqual({
+      totalEntities: 0,
+      enabledPlugins: 0,
+      pluginErrors: 0,
+      scaffolderTemplates: 0,
+    })
+  })
+
+  it('counts enabled plugins and plugin errors', () => {
+    const plugins = [
+      makePlugin({ status: 'enabled' }),
+      makePlugin({ status: 'enabled' }),
+      makePlugin({ status: 'error' }),
+      makePlugin({ status: 'disabled' }),
+    ]
+    const templates = [makeTemplate(), makeTemplate()]
+    const catalog: BackstageCatalogCounts = {
+      ...EMPTY_CATALOG,
+      Component: 10,
+    }
+    const result = summarize(catalog, plugins, templates)
+    expect(result.totalEntities).toBe(10)
+    expect(result.enabledPlugins).toBe(2)
+    expect(result.pluginErrors).toBe(1)
+    expect(result.scaffolderTemplates).toBe(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  const recentSync = new Date().toISOString()
+
+  it('returns not-installed when no entities, no plugins, and desiredReplicas is 0', () => {
+    expect(deriveHealth(0, 0, [], recentSync, 0, Date.now())).toBe('not-installed')
+  })
+
+  it('returns healthy when replicas match and no errors', () => {
+    const plugins = [makePlugin({ status: 'enabled' })]
+    expect(deriveHealth(2, 2, plugins, recentSync, 10, Date.now())).toBe('healthy')
+  })
+
+  it('returns degraded when replicas < desiredReplicas', () => {
+    const plugins = [makePlugin({ status: 'enabled' })]
+    expect(deriveHealth(1, 3, plugins, recentSync, 10, Date.now())).toBe('degraded')
+  })
+
+  it('returns degraded when a plugin has error status', () => {
+    const plugins = [
+      makePlugin({ status: 'enabled' }),
+      makePlugin({ status: 'error' }),
+    ]
+    expect(deriveHealth(2, 2, plugins, recentSync, 10, Date.now())).toBe('degraded')
+  })
+
+  it('returns degraded when catalog sync is stale', () => {
+    const staleSync = new Date(
+      Date.now() - STALE_CATALOG_WINDOW_MS - 1,
+    ).toISOString()
+    const plugins = [makePlugin({ status: 'enabled' })]
+    expect(deriveHealth(2, 2, plugins, staleSync, 10, Date.now())).toBe('degraded')
+  })
+
+  it('returns healthy when catalog sync is within window', () => {
+    const freshSync = new Date(
+      Date.now() - STALE_CATALOG_WINDOW_MS + 60000,
+    ).toISOString()
+    const plugins = [makePlugin({ status: 'enabled' })]
+    expect(deriveHealth(2, 2, plugins, freshSync, 10, Date.now())).toBe('healthy')
+  })
+
+  it('handles invalid lastCatalogSync date gracefully', () => {
+    const plugins = [makePlugin({ status: 'enabled' })]
+    // Invalid date string -> NaN -> Number.isFinite(NaN) = false -> skip stale check
+    expect(deriveHealth(2, 2, plugins, 'not-a-date', 10, Date.now())).toBe('healthy')
+  })
+
+  it('returns not-installed with desiredReplicas > 0 but no entities and no plugins', () => {
+    // desiredReplicas > 0 prevents the not-installed check from triggering
+    expect(deriveHealth(1, 1, [], recentSync, 0, Date.now())).toBe('healthy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildBackstageStatus
+// ---------------------------------------------------------------------------
+
+describe('buildBackstageStatus', () => {
+  it('builds a complete status from a full response', () => {
+    const raw = {
+      version: '1.32.0',
+      replicas: 2,
+      desiredReplicas: 2,
+      catalog: { Component: 50, API: 20 } as Partial<BackstageCatalogCounts>,
+      plugins: [makePlugin({ status: 'enabled' })],
+      templates: [makeTemplate()],
+      lastCatalogSync: new Date().toISOString(),
+    }
+    const result = buildBackstageStatus(raw)
+
+    expect(result.health).toBe('healthy')
+    expect(result.version).toBe('1.32.0')
+    expect(result.replicas).toBe(2)
+    expect(result.desiredReplicas).toBe(2)
+    expect(result.catalog.Component).toBe(50)
+    expect(result.catalog.API).toBe(20)
+    expect(result.catalog.System).toBe(0)
+    expect(result.plugins).toHaveLength(1)
+    expect(result.templates).toHaveLength(1)
+    expect(result.summary.totalEntities).toBe(70)
+    expect(result.summary.enabledPlugins).toBe(1)
+    expect(result.summary.pluginErrors).toBe(0)
+    expect(result.summary.scaffolderTemplates).toBe(1)
+    expect(result.lastCheckTime).toBeTruthy()
+    expect(result.lastCatalogSync).toBeTruthy()
+  })
+
+  it('builds not-installed status from empty response', () => {
+    const result = buildBackstageStatus({})
+    expect(result.health).toBe('not-installed')
+    expect(result.version).toBe('unknown')
+    expect(result.replicas).toBe(0)
+    expect(result.desiredReplicas).toBe(0)
+    expect(result.catalog).toEqual(EMPTY_CATALOG)
+    expect(result.plugins).toEqual([])
+    expect(result.templates).toEqual([])
+    expect(result.summary.totalEntities).toBe(0)
+  })
+
+  it('defaults version to unknown when missing', () => {
+    const result = buildBackstageStatus({ replicas: 1, desiredReplicas: 1 })
+    expect(result.version).toBe('unknown')
+  })
+
+  it('defaults replicas to 0 for non-finite values', () => {
+    const result = buildBackstageStatus({
+      replicas: NaN,
+      desiredReplicas: Infinity,
+    })
+    expect(result.replicas).toBe(0)
+    expect(result.desiredReplicas).toBe(0)
+  })
+
+  it('handles non-array plugins/templates gracefully', () => {
+    const result = buildBackstageStatus({
+      plugins: 'not-an-array' as unknown as BackstagePlugin[],
+      templates: null as unknown as BackstageScaffolderTemplate[],
+    })
+    expect(result.plugins).toEqual([])
+    expect(result.templates).toEqual([])
+  })
+
+  it('generates lastCatalogSync when not provided', () => {
+    const result = buildBackstageStatus({})
+    // Should be a valid ISO timestamp
+    expect(new Date(result.lastCatalogSync).getTime()).not.toBeNaN()
+  })
+})

--- a/web/src/hooks/__tests__/useCachedCloudCustodian-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCloudCustodian-funcs.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedCloudCustodian.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedCloudCustodian'
+import type {
+  CustodianPolicy,
+  CustodianSeverityCounts,
+} from '../../lib/demo/cloud-custodian'
+
+const { summarize, deriveHealth, mergeSeverityCounts, buildCloudCustodianStatus } =
+  __testables
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeroes for an empty array', () => {
+    const result = summarize([])
+    expect(result).toEqual({
+      totalPolicies: 0,
+      successfulPolicies: 0,
+      failedPolicies: 0,
+      dryRunPolicies: 0,
+    })
+  })
+
+  it('counts failed policies (failCount > 0)', () => {
+    const policies: CustodianPolicy[] = [
+      makePolicy({ failCount: 3, dryRunCount: 0, successCount: 10 }),
+    ]
+    const result = summarize(policies)
+    expect(result.failedPolicies).toBe(1)
+    expect(result.successfulPolicies).toBe(0)
+    expect(result.dryRunPolicies).toBe(0)
+  })
+
+  it('counts dry-run policies (dryRunCount > 0, failCount === 0)', () => {
+    const policies: CustodianPolicy[] = [
+      makePolicy({ failCount: 0, dryRunCount: 5, successCount: 0 }),
+    ]
+    const result = summarize(policies)
+    expect(result.dryRunPolicies).toBe(1)
+    expect(result.failedPolicies).toBe(0)
+    expect(result.successfulPolicies).toBe(0)
+  })
+
+  it('counts successful policies (both failCount and dryRunCount are 0)', () => {
+    const policies: CustodianPolicy[] = [
+      makePolicy({ failCount: 0, dryRunCount: 0, successCount: 15 }),
+    ]
+    const result = summarize(policies)
+    expect(result.successfulPolicies).toBe(1)
+    expect(result.failedPolicies).toBe(0)
+    expect(result.dryRunPolicies).toBe(0)
+  })
+
+  it('prioritizes failed over dry-run (failCount > 0 and dryRunCount > 0)', () => {
+    const policies: CustodianPolicy[] = [
+      makePolicy({ failCount: 1, dryRunCount: 2 }),
+    ]
+    const result = summarize(policies)
+    expect(result.failedPolicies).toBe(1)
+    expect(result.dryRunPolicies).toBe(0)
+  })
+
+  it('counts a mix of policies correctly', () => {
+    const policies: CustodianPolicy[] = [
+      makePolicy({ failCount: 0, dryRunCount: 0 }), // successful
+      makePolicy({ failCount: 2, dryRunCount: 0 }), // failed
+      makePolicy({ failCount: 0, dryRunCount: 3 }), // dry-run
+      makePolicy({ failCount: 0, dryRunCount: 0 }), // successful
+      makePolicy({ failCount: 1, dryRunCount: 1 }), // failed (priority)
+    ]
+    const result = summarize(policies)
+    expect(result.totalPolicies).toBe(5)
+    expect(result.successfulPolicies).toBe(2)
+    expect(result.failedPolicies).toBe(2)
+    expect(result.dryRunPolicies).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  const NO_VIOLATIONS: CustodianSeverityCounts = { critical: 0, high: 0, medium: 0, low: 0 }
+
+  it('returns not-installed for empty policies', () => {
+    expect(deriveHealth([], NO_VIOLATIONS)).toBe('not-installed')
+  })
+
+  it('returns healthy when no failures and no critical/high violations', () => {
+    const policies: CustodianPolicy[] = [
+      makePolicy({ failCount: 0 }),
+    ]
+    expect(deriveHealth(policies, NO_VIOLATIONS)).toBe('healthy')
+  })
+
+  it('returns degraded when a policy has failures', () => {
+    const policies: CustodianPolicy[] = [
+      makePolicy({ failCount: 1 }),
+    ]
+    expect(deriveHealth(policies, NO_VIOLATIONS)).toBe('degraded')
+  })
+
+  it('returns degraded when critical violations exist', () => {
+    const policies: CustodianPolicy[] = [
+      makePolicy({ failCount: 0 }),
+    ]
+    const violations: CustodianSeverityCounts = { critical: 1, high: 0, medium: 0, low: 0 }
+    expect(deriveHealth(policies, violations)).toBe('degraded')
+  })
+
+  it('returns degraded when high violations exist', () => {
+    const policies: CustodianPolicy[] = [
+      makePolicy({ failCount: 0 }),
+    ]
+    const violations: CustodianSeverityCounts = { critical: 0, high: 3, medium: 0, low: 0 }
+    expect(deriveHealth(policies, violations)).toBe('degraded')
+  })
+
+  it('returns healthy when only medium/low violations exist', () => {
+    const policies: CustodianPolicy[] = [
+      makePolicy({ failCount: 0 }),
+    ]
+    const violations: CustodianSeverityCounts = { critical: 0, high: 0, medium: 10, low: 5 }
+    expect(deriveHealth(policies, violations)).toBe('healthy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mergeSeverityCounts
+// ---------------------------------------------------------------------------
+
+describe('mergeSeverityCounts', () => {
+  it('returns all zeroes for undefined input', () => {
+    expect(mergeSeverityCounts(undefined)).toEqual({
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+    })
+  })
+
+  it('returns all zeroes for empty partial', () => {
+    expect(mergeSeverityCounts({})).toEqual({
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+    })
+  })
+
+  it('fills missing fields with 0', () => {
+    expect(mergeSeverityCounts({ critical: 5 })).toEqual({
+      critical: 5,
+      high: 0,
+      medium: 0,
+      low: 0,
+    })
+  })
+
+  it('passes through all provided values', () => {
+    const input = { critical: 1, high: 2, medium: 3, low: 4 }
+    expect(mergeSeverityCounts(input)).toEqual(input)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildCloudCustodianStatus
+// ---------------------------------------------------------------------------
+
+describe('buildCloudCustodianStatus', () => {
+  const NO_VIOLATIONS: CustodianSeverityCounts = { critical: 0, high: 0, medium: 0, low: 0 }
+
+  it('builds a complete status object', () => {
+    const policies: CustodianPolicy[] = [makePolicy({ failCount: 0 })]
+    const topResources = [{ id: 'arn:aws:ec2:i-123', type: 'ec2-instance', actionCount: 3 }]
+    const result = buildCloudCustodianStatus(policies, topResources, NO_VIOLATIONS, '0.9.25')
+
+    expect(result.health).toBe('healthy')
+    expect(result.version).toBe('0.9.25')
+    expect(result.policies).toBe(policies)
+    expect(result.topResources).toBe(topResources)
+    expect(result.violationsBySeverity).toBe(NO_VIOLATIONS)
+    expect(result.summary.totalPolicies).toBe(1)
+    expect(result.lastCheckTime).toBeDefined()
+  })
+
+  it('returns not-installed for empty policies', () => {
+    const result = buildCloudCustodianStatus([], [], NO_VIOLATIONS, 'unknown')
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('returns degraded when policies have failures', () => {
+    const policies: CustodianPolicy[] = [makePolicy({ failCount: 2 })]
+    const result = buildCloudCustodianStatus(policies, [], NO_VIOLATIONS, '0.9.25')
+    expect(result.health).toBe('degraded')
+  })
+
+  it('computes summary from policies', () => {
+    const policies: CustodianPolicy[] = [
+      makePolicy({ failCount: 0, dryRunCount: 0 }),
+      makePolicy({ failCount: 1, dryRunCount: 0 }),
+    ]
+    const result = buildCloudCustodianStatus(policies, [], NO_VIOLATIONS, '0.9.25')
+    expect(result.summary.totalPolicies).toBe(2)
+    expect(result.summary.successfulPolicies).toBe(1)
+    expect(result.summary.failedPolicies).toBe(1)
+  })
+
+  it('sets lastCheckTime to a valid ISO string', () => {
+    const result = buildCloudCustodianStatus([], [], NO_VIOLATIONS, 'unknown')
+    expect(() => new Date(result.lastCheckTime)).not.toThrow()
+    expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helpers — factory functions for test data
+// ---------------------------------------------------------------------------
+
+function makePolicy(overrides?: Partial<CustodianPolicy>): CustodianPolicy {
+  return {
+    name: 'test-policy',
+    resource: 'aws.ec2',
+    provider: 'aws',
+    mode: 'pull',
+    successCount: 10,
+    failCount: 0,
+    dryRunCount: 0,
+    resourcesMatched: 5,
+    lastRunAt: new Date().toISOString(),
+    ...overrides,
+  }
+}

--- a/web/src/hooks/__tests__/useCachedCni-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCni-funcs.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedCni.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedCni'
+import type { CniStats, CniNodeStatus } from '../../lib/demo/cni'
+
+const { summarize, deriveHealth, buildCniStatus } = __testables
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function makeStats(overrides: Partial<CniStats> = {}): CniStats {
+  return {
+    activePlugin: 'cilium',
+    pluginVersion: '1.15.1',
+    podNetworkCidr: '10.244.0.0/16',
+    serviceNetworkCidr: '10.96.0.0/12',
+    nodeCount: 3,
+    nodesCniReady: 3,
+    networkPolicyCount: 5,
+    servicesWithNetworkPolicy: 2,
+    totalServices: 10,
+    podsWithIp: 50,
+    totalPods: 50,
+    ...overrides,
+  }
+}
+
+function makeNode(overrides: Partial<CniNodeStatus> = {}): CniNodeStatus {
+  return {
+    node: 'worker-1',
+    cluster: 'cluster-1',
+    state: 'ready',
+    plugin: 'cilium',
+    pluginVersion: '1.15.1',
+    podCidr: '10.244.1.0/24',
+    lastHeartbeat: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('extracts summary fields from stats', () => {
+    const stats = makeStats()
+    const result = summarize(stats)
+    expect(result).toEqual({
+      activePlugin: 'cilium',
+      pluginVersion: '1.15.1',
+      podNetworkCidr: '10.244.0.0/16',
+      nodesCniReady: 3,
+      nodeCount: 3,
+      networkPolicyCount: 5,
+      servicesWithNetworkPolicy: 2,
+    })
+  })
+
+  it('reflects unknown plugin', () => {
+    const stats = makeStats({ activePlugin: 'unknown', pluginVersion: 'unknown' })
+    const result = summarize(stats)
+    expect(result.activePlugin).toBe('unknown')
+    expect(result.pluginVersion).toBe('unknown')
+  })
+
+  it('reflects zero counts', () => {
+    const stats = makeStats({
+      nodeCount: 0,
+      nodesCniReady: 0,
+      networkPolicyCount: 0,
+      servicesWithNetworkPolicy: 0,
+    })
+    const result = summarize(stats)
+    expect(result.nodeCount).toBe(0)
+    expect(result.nodesCniReady).toBe(0)
+    expect(result.networkPolicyCount).toBe(0)
+    expect(result.servicesWithNetworkPolicy).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when plugin is unknown and no nodes', () => {
+    const stats = makeStats({ activePlugin: 'unknown' })
+    expect(deriveHealth(stats, [])).toBe('not-installed')
+  })
+
+  it('returns healthy when all nodes are ready and counts match', () => {
+    const stats = makeStats({ nodeCount: 2, nodesCniReady: 2 })
+    const nodes = [makeNode(), makeNode({ node: 'worker-2' })]
+    expect(deriveHealth(stats, nodes)).toBe('healthy')
+  })
+
+  it('returns degraded when a node is not-ready', () => {
+    const stats = makeStats({ nodeCount: 2, nodesCniReady: 1 })
+    const nodes = [makeNode(), makeNode({ node: 'worker-2', state: 'not-ready' })]
+    expect(deriveHealth(stats, nodes)).toBe('degraded')
+  })
+
+  it('returns degraded when a node state is unknown', () => {
+    const stats = makeStats()
+    const nodes = [makeNode({ state: 'unknown' })]
+    expect(deriveHealth(stats, nodes)).toBe('degraded')
+  })
+
+  it('returns degraded when nodesCniReady < nodeCount (even if all node states are ready)', () => {
+    // This tests the second degraded condition
+    const stats = makeStats({ nodeCount: 3, nodesCniReady: 2 })
+    const nodes = [makeNode(), makeNode({ node: 'w2' }), makeNode({ node: 'w3' })]
+    // All nodes have state: 'ready', but stats say only 2 of 3 are CNI ready
+    expect(deriveHealth(stats, nodes)).toBe('degraded')
+  })
+
+  it('returns healthy when nodeCount is 0 but plugin is known', () => {
+    const stats = makeStats({ activePlugin: 'cilium', nodeCount: 0, nodesCniReady: 0 })
+    const nodes = [makeNode()]
+    // activePlugin !== 'unknown' so not "not-installed"; nodes all ready, nodeCount is 0 so
+    // the nodeCount > 0 check doesn't trigger
+    expect(deriveHealth(stats, nodes)).toBe('healthy')
+  })
+
+  it('returns not-installed only when BOTH plugin=unknown AND nodes empty', () => {
+    // If plugin is unknown but there are nodes, it's not "not-installed"
+    const stats = makeStats({ activePlugin: 'unknown' })
+    const nodes = [makeNode()]
+    // node state is ready so no degradation from that, but nodes exist so not "not-installed"
+    expect(deriveHealth(stats, nodes)).not.toBe('not-installed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildCniStatus
+// ---------------------------------------------------------------------------
+
+describe('buildCniStatus', () => {
+  it('builds not-installed status with unknown plugin and no nodes', () => {
+    const stats = makeStats({ activePlugin: 'unknown' })
+    const result = buildCniStatus(stats, [])
+    expect(result.health).toBe('not-installed')
+    expect(result.nodes).toEqual([])
+    expect(result.stats).toBe(stats)
+    expect(result.summary.activePlugin).toBe('unknown')
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('builds healthy status with ready nodes', () => {
+    const stats = makeStats()
+    const nodes = [makeNode(), makeNode({ node: 'worker-2' })]
+    const result = buildCniStatus(stats, nodes)
+    expect(result.health).toBe('healthy')
+    expect(result.nodes).toHaveLength(2)
+    expect(result.summary.activePlugin).toBe('cilium')
+  })
+
+  it('builds degraded status with not-ready node', () => {
+    const stats = makeStats()
+    const nodes = [makeNode({ state: 'not-ready' })]
+    const result = buildCniStatus(stats, nodes)
+    expect(result.health).toBe('degraded')
+  })
+
+  it('sets lastCheckTime to a valid ISO string', () => {
+    const result = buildCniStatus(makeStats(), [])
+    expect(() => new Date(result.lastCheckTime)).not.toThrow()
+    expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+
+  it('preserves stats reference', () => {
+    const stats = makeStats()
+    const result = buildCniStatus(stats, [])
+    expect(result.stats).toBe(stats)
+  })
+})

--- a/web/src/hooks/__tests__/useCachedCortex-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCortex-funcs.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedCortex.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedCortex'
+import type {
+  CortexComponentPod,
+  CortexIngestionMetrics,
+} from '../../lib/demo/cortex'
+
+const { summarize, deriveHealth, buildCortexStatus } = __testables
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeroes for an empty array', () => {
+    const result = summarize([])
+    expect(result).toEqual({
+      totalPods: 0,
+      runningPods: 0,
+      totalComponents: 0,
+      runningComponents: 0,
+    })
+  })
+
+  it('sums replica counts across components', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ replicasDesired: 3, replicasReady: 3, status: 'running' }),
+      makeComponent({ replicasDesired: 6, replicasReady: 5, status: 'running' }),
+    ]
+    const result = summarize(components)
+    expect(result.totalPods).toBe(9)
+    expect(result.runningPods).toBe(8)
+  })
+
+  it('counts components where status is running AND all replicas ready', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ status: 'running', replicasDesired: 3, replicasReady: 3 }),
+      makeComponent({ status: 'running', replicasDesired: 6, replicasReady: 5 }),
+      makeComponent({ status: 'pending', replicasDesired: 2, replicasReady: 2 }),
+    ]
+    const result = summarize(components)
+    expect(result.totalComponents).toBe(3)
+    // Only the first one is fully running (status=running AND ready===desired)
+    expect(result.runningComponents).toBe(1)
+  })
+
+  it('counts single fully-running component', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ status: 'running', replicasDesired: 2, replicasReady: 2 }),
+    ]
+    const result = summarize(components)
+    expect(result.totalComponents).toBe(1)
+    expect(result.runningComponents).toBe(1)
+  })
+
+  it('returns 0 runningComponents when all are degraded', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ status: 'pending', replicasDesired: 3, replicasReady: 0 }),
+      makeComponent({ status: 'failed', replicasDesired: 2, replicasReady: 0 }),
+    ]
+    const result = summarize(components)
+    expect(result.runningComponents).toBe(0)
+    expect(result.totalComponents).toBe(2)
+    expect(result.totalPods).toBe(5)
+    expect(result.runningPods).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed for an empty array', () => {
+    expect(deriveHealth([])).toBe('not-installed')
+  })
+
+  it('returns healthy when all components are running with full replicas', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ status: 'running', replicasDesired: 3, replicasReady: 3 }),
+      makeComponent({ status: 'running', replicasDesired: 2, replicasReady: 2 }),
+    ]
+    expect(deriveHealth(components)).toBe('healthy')
+  })
+
+  it('returns degraded when a component is not running', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ status: 'running', replicasDesired: 3, replicasReady: 3 }),
+      makeComponent({ status: 'pending', replicasDesired: 2, replicasReady: 2 }),
+    ]
+    expect(deriveHealth(components)).toBe('degraded')
+  })
+
+  it('returns degraded when replicas are not fully ready', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ status: 'running', replicasDesired: 3, replicasReady: 2 }),
+    ]
+    expect(deriveHealth(components)).toBe('degraded')
+  })
+
+  it('returns degraded for failed status', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ status: 'failed', replicasDesired: 1, replicasReady: 0 }),
+    ]
+    expect(deriveHealth(components)).toBe('degraded')
+  })
+
+  it('returns degraded for unknown status', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ status: 'unknown', replicasDesired: 1, replicasReady: 1 }),
+    ]
+    expect(deriveHealth(components)).toBe('degraded')
+  })
+
+  it('returns healthy for a single fully healthy component', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ status: 'running', replicasDesired: 1, replicasReady: 1 }),
+    ]
+    expect(deriveHealth(components)).toBe('healthy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildCortexStatus
+// ---------------------------------------------------------------------------
+
+describe('buildCortexStatus', () => {
+  const DEFAULT_METRICS: CortexIngestionMetrics = {
+    activeSeries: 0,
+    ingestionRatePerSec: 0,
+    queryRatePerSec: 0,
+    tenantCount: 0,
+  }
+
+  it('builds a complete status object', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ status: 'running', replicasDesired: 3, replicasReady: 3 }),
+    ]
+    const metrics: CortexIngestionMetrics = {
+      activeSeries: 500_000,
+      ingestionRatePerSec: 12_000,
+      queryRatePerSec: 50,
+      tenantCount: 4,
+    }
+    const result = buildCortexStatus(components, metrics, '1.16.0')
+
+    expect(result.health).toBe('healthy')
+    expect(result.version).toBe('1.16.0')
+    expect(result.components).toBe(components)
+    expect(result.metrics).toBe(metrics)
+    expect(result.summary.totalComponents).toBe(1)
+    expect(result.summary.runningComponents).toBe(1)
+    expect(result.lastCheckTime).toBeDefined()
+  })
+
+  it('returns not-installed for empty components', () => {
+    const result = buildCortexStatus([], DEFAULT_METRICS, 'unknown')
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('returns degraded when a component is degraded', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ status: 'running', replicasDesired: 3, replicasReady: 2 }),
+    ]
+    const result = buildCortexStatus(components, DEFAULT_METRICS, '1.16.0')
+    expect(result.health).toBe('degraded')
+  })
+
+  it('computes summary from components', () => {
+    const components: CortexComponentPod[] = [
+      makeComponent({ status: 'running', replicasDesired: 3, replicasReady: 3 }),
+      makeComponent({ status: 'running', replicasDesired: 6, replicasReady: 5 }),
+    ]
+    const result = buildCortexStatus(components, DEFAULT_METRICS, '1.16.0')
+    expect(result.summary.totalPods).toBe(9)
+    expect(result.summary.runningPods).toBe(8)
+    expect(result.summary.totalComponents).toBe(2)
+    expect(result.summary.runningComponents).toBe(1)
+  })
+
+  it('sets lastCheckTime to a valid ISO string', () => {
+    const result = buildCortexStatus([], DEFAULT_METRICS, 'unknown')
+    expect(() => new Date(result.lastCheckTime)).not.toThrow()
+    expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helpers — factory functions for test data
+// ---------------------------------------------------------------------------
+
+function makeComponent(overrides?: Partial<CortexComponentPod>): CortexComponentPod {
+  return {
+    name: 'distributor',
+    namespace: 'cortex',
+    status: 'running',
+    replicasDesired: 3,
+    replicasReady: 3,
+    cluster: 'default',
+    ...overrides,
+  }
+}

--- a/web/src/hooks/__tests__/useCachedDapr-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedDapr-funcs.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedDapr.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedDapr'
+import type {
+  DaprControlPlanePod,
+  DaprComponent,
+  DaprAppSidecar,
+} from '../../components/cards/dapr_status/demoData'
+
+const {
+  summarize,
+  deriveHealth,
+  buildDaprStatus,
+  buildBuildingBlocks,
+  countByType,
+} = __testables
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function makePod(overrides: Partial<DaprControlPlanePod> = {}): DaprControlPlanePod {
+  return {
+    name: 'operator',
+    namespace: 'dapr-system',
+    status: 'running',
+    replicasDesired: 1,
+    replicasReady: 1,
+    cluster: 'default',
+    ...overrides,
+  }
+}
+
+function makeComponent(overrides: Partial<DaprComponent> = {}): DaprComponent {
+  return {
+    name: 'my-statestore',
+    namespace: 'default',
+    type: 'state-store',
+    componentImpl: 'state.redis',
+    cluster: 'default',
+    ...overrides,
+  }
+}
+
+const EMPTY_APPS: DaprAppSidecar = { total: 0, namespaces: 0 }
+
+// ---------------------------------------------------------------------------
+// countByType
+// ---------------------------------------------------------------------------
+
+describe('countByType', () => {
+  it('returns 0 for empty array', () => {
+    expect(countByType([], 'state-store')).toBe(0)
+  })
+
+  it('counts components of the given type', () => {
+    const components = [
+      makeComponent({ type: 'state-store' }),
+      makeComponent({ type: 'pubsub' }),
+      makeComponent({ type: 'state-store' }),
+      makeComponent({ type: 'binding' }),
+    ]
+    expect(countByType(components, 'state-store')).toBe(2)
+    expect(countByType(components, 'pubsub')).toBe(1)
+    expect(countByType(components, 'binding')).toBe(1)
+  })
+
+  it('returns 0 when no components match', () => {
+    const components = [makeComponent({ type: 'pubsub' })]
+    expect(countByType(components, 'binding')).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildBuildingBlocks
+// ---------------------------------------------------------------------------
+
+describe('buildBuildingBlocks', () => {
+  it('returns zeroes for empty components', () => {
+    const result = buildBuildingBlocks([])
+    expect(result).toEqual({ stateStores: 0, pubsubs: 0, bindings: 0 })
+  })
+
+  it('counts each type correctly', () => {
+    const components = [
+      makeComponent({ type: 'state-store' }),
+      makeComponent({ type: 'state-store' }),
+      makeComponent({ type: 'pubsub' }),
+      makeComponent({ type: 'binding' }),
+      makeComponent({ type: 'binding' }),
+      makeComponent({ type: 'binding' }),
+    ]
+    const result = buildBuildingBlocks(components)
+    expect(result.stateStores).toBe(2)
+    expect(result.pubsubs).toBe(1)
+    expect(result.bindings).toBe(3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeroes for empty inputs', () => {
+    const result = summarize([], [], EMPTY_APPS)
+    expect(result).toEqual({
+      totalControlPlanePods: 0,
+      runningControlPlanePods: 0,
+      totalComponents: 0,
+      totalDaprApps: 0,
+    })
+  })
+
+  it('counts running pods and total components', () => {
+    const pods = [
+      makePod({ status: 'running' }),
+      makePod({ status: 'pending' }),
+      makePod({ status: 'running' }),
+    ]
+    const components = [
+      makeComponent(),
+      makeComponent(),
+    ]
+    const apps: DaprAppSidecar = { total: 10, namespaces: 3 }
+    const result = summarize(pods, components, apps)
+    expect(result.totalControlPlanePods).toBe(3)
+    expect(result.runningControlPlanePods).toBe(2)
+    expect(result.totalComponents).toBe(2)
+    expect(result.totalDaprApps).toBe(10)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when everything is empty', () => {
+    expect(deriveHealth([], [], EMPTY_APPS)).toBe('not-installed')
+  })
+
+  it('returns healthy when all pods are running with full replicas', () => {
+    const pods = [makePod({ status: 'running', replicasReady: 1, replicasDesired: 1 })]
+    const components = [makeComponent()]
+    const apps: DaprAppSidecar = { total: 5, namespaces: 2 }
+    expect(deriveHealth(pods, components, apps)).toBe('healthy')
+  })
+
+  it('returns degraded when a pod is not running', () => {
+    const pods = [makePod({ status: 'pending' })]
+    expect(deriveHealth(pods, [], EMPTY_APPS)).toBe('degraded')
+  })
+
+  it('returns degraded when a pod has insufficient ready replicas', () => {
+    const pods = [makePod({ status: 'running', replicasReady: 1, replicasDesired: 3 })]
+    expect(deriveHealth(pods, [], EMPTY_APPS)).toBe('degraded')
+  })
+
+  it('returns healthy with only components (no pods)', () => {
+    expect(deriveHealth([], [makeComponent()], EMPTY_APPS)).toBe('healthy')
+  })
+
+  it('returns healthy with only apps (no pods or components)', () => {
+    expect(deriveHealth([], [], { total: 5, namespaces: 1 })).toBe('healthy')
+  })
+
+  it('returns degraded when pod status is failed', () => {
+    const pods = [makePod({ status: 'failed' })]
+    expect(deriveHealth(pods, [], EMPTY_APPS)).toBe('degraded')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildDaprStatus
+// ---------------------------------------------------------------------------
+
+describe('buildDaprStatus', () => {
+  it('builds a complete status object', () => {
+    const pods = [makePod({ status: 'running' })]
+    const components = [
+      makeComponent({ type: 'state-store' }),
+      makeComponent({ type: 'pubsub' }),
+    ]
+    const apps: DaprAppSidecar = { total: 10, namespaces: 3 }
+    const result = buildDaprStatus(pods, components, apps)
+
+    expect(result.health).toBe('healthy')
+    expect(result.controlPlane).toHaveLength(1)
+    expect(result.components).toHaveLength(2)
+    expect(result.apps).toEqual(apps)
+    expect(result.buildingBlocks.stateStores).toBe(1)
+    expect(result.buildingBlocks.pubsubs).toBe(1)
+    expect(result.buildingBlocks.bindings).toBe(0)
+    expect(result.summary.totalControlPlanePods).toBe(1)
+    expect(result.summary.runningControlPlanePods).toBe(1)
+    expect(result.summary.totalComponents).toBe(2)
+    expect(result.summary.totalDaprApps).toBe(10)
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('returns not-installed for empty inputs', () => {
+    const result = buildDaprStatus([], [], EMPTY_APPS)
+    expect(result.health).toBe('not-installed')
+    expect(result.controlPlane).toEqual([])
+    expect(result.components).toEqual([])
+  })
+
+  it('returns degraded when a control plane pod is pending', () => {
+    const pods = [
+      makePod({ status: 'running' }),
+      makePod({ status: 'pending', name: 'sentry' }),
+    ]
+    const result = buildDaprStatus(pods, [], EMPTY_APPS)
+    expect(result.health).toBe('degraded')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedKserve-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedKserve-funcs.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedKserve.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedKserve'
+import type {
+  KServeControllerPods,
+  KServeService,
+} from '../../lib/demo/kserve'
+
+const { countByStatus, summarize, deriveHealth, buildKserveStatus } = __testables
+
+// ---------------------------------------------------------------------------
+// countByStatus
+// ---------------------------------------------------------------------------
+
+describe('countByStatus', () => {
+  it('returns 0 for an empty array', () => {
+    expect(countByStatus([], 'ready')).toBe(0)
+  })
+
+  it('counts services matching the given status', () => {
+    const services: KServeService[] = [
+      makeService({ status: 'ready' }),
+      makeService({ status: 'not-ready' }),
+      makeService({ status: 'ready' }),
+      makeService({ status: 'unknown' }),
+    ]
+    expect(countByStatus(services, 'ready')).toBe(2)
+    expect(countByStatus(services, 'not-ready')).toBe(1)
+    expect(countByStatus(services, 'unknown')).toBe(1)
+  })
+
+  it('returns 0 when no services match', () => {
+    const services: KServeService[] = [
+      makeService({ status: 'ready' }),
+    ]
+    expect(countByStatus(services, 'not-ready')).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeroes for an empty array', () => {
+    const result = summarize([])
+    expect(result).toEqual({
+      totalServices: 0,
+      readyServices: 0,
+      notReadyServices: 0,
+      totalRequestsPerSecond: 0,
+      avgP95LatencyMs: 0,
+    })
+  })
+
+  it('counts ready and not-ready services', () => {
+    const services: KServeService[] = [
+      makeService({ status: 'ready' }),
+      makeService({ status: 'not-ready' }),
+      makeService({ status: 'ready' }),
+    ]
+    const result = summarize(services)
+    expect(result.totalServices).toBe(3)
+    expect(result.readyServices).toBe(2)
+    expect(result.notReadyServices).toBe(1)
+  })
+
+  it('sums requestsPerSecond with rounding', () => {
+    const services: KServeService[] = [
+      makeService({ requestsPerSecond: 10.15 }),
+      makeService({ requestsPerSecond: 5.27 }),
+    ]
+    const result = summarize(services)
+    // Rounded to 1 decimal: (10.15 + 5.27) = 15.42 -> round(15.42 * 10) / 10 = 15.4
+    expect(result.totalRequestsPerSecond).toBe(15.4)
+  })
+
+  it('computes average p95 latency', () => {
+    const services: KServeService[] = [
+      makeService({ p95LatencyMs: 100 }),
+      makeService({ p95LatencyMs: 200 }),
+      makeService({ p95LatencyMs: 300 }),
+    ]
+    const result = summarize(services)
+    expect(result.avgP95LatencyMs).toBe(200)
+  })
+
+  it('handles a single service', () => {
+    const services: KServeService[] = [
+      makeService({ requestsPerSecond: 42.5, p95LatencyMs: 150, status: 'ready' }),
+    ]
+    const result = summarize(services)
+    expect(result.totalServices).toBe(1)
+    expect(result.readyServices).toBe(1)
+    expect(result.totalRequestsPerSecond).toBe(42.5)
+    expect(result.avgP95LatencyMs).toBe(150)
+  })
+
+  it('handles non-finite requestsPerSecond gracefully', () => {
+    const services: KServeService[] = [
+      makeService({ requestsPerSecond: NaN }),
+      makeService({ requestsPerSecond: 10 }),
+    ]
+    const result = summarize(services)
+    expect(result.totalRequestsPerSecond).toBe(10)
+  })
+
+  it('handles non-finite p95LatencyMs gracefully', () => {
+    const services: KServeService[] = [
+      makeService({ p95LatencyMs: Infinity }),
+      makeService({ p95LatencyMs: 100 }),
+    ]
+    const result = summarize(services)
+    // (0 + 100) / 2 = 50
+    expect(result.avgP95LatencyMs).toBe(50)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when no controller pods and no services', () => {
+    expect(deriveHealth({ ready: 0, total: 0 }, [])).toBe('not-installed')
+  })
+
+  it('returns healthy when controller pods are fully ready and services are ready', () => {
+    const pods: KServeControllerPods = { ready: 3, total: 3 }
+    const services: KServeService[] = [makeService({ status: 'ready' })]
+    expect(deriveHealth(pods, services)).toBe('healthy')
+  })
+
+  it('returns degraded when controller pods are not fully ready', () => {
+    const pods: KServeControllerPods = { ready: 1, total: 3 }
+    expect(deriveHealth(pods, [makeService({ status: 'ready' })])).toBe('degraded')
+  })
+
+  it('returns degraded when a service is not ready', () => {
+    const pods: KServeControllerPods = { ready: 3, total: 3 }
+    const services: KServeService[] = [
+      makeService({ status: 'ready' }),
+      makeService({ status: 'not-ready' }),
+    ]
+    expect(deriveHealth(pods, services)).toBe('degraded')
+  })
+
+  it('returns degraded when a service has unknown status', () => {
+    const pods: KServeControllerPods = { ready: 2, total: 2 }
+    const services: KServeService[] = [makeService({ status: 'unknown' })]
+    expect(deriveHealth(pods, services)).toBe('degraded')
+  })
+
+  it('returns healthy with controller pods but no services', () => {
+    const pods: KServeControllerPods = { ready: 2, total: 2 }
+    expect(deriveHealth(pods, [])).toBe('healthy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildKserveStatus
+// ---------------------------------------------------------------------------
+
+describe('buildKserveStatus', () => {
+  it('builds a complete status object', () => {
+    const pods: KServeControllerPods = { ready: 2, total: 2 }
+    const services: KServeService[] = [makeService({ status: 'ready' })]
+    const result = buildKserveStatus(pods, services)
+
+    expect(result.health).toBe('healthy')
+    expect(result.controllerPods).toBe(pods)
+    expect(result.services).toEqual(services)
+    expect(result.summary.totalServices).toBe(1)
+    expect(result.summary.readyServices).toBe(1)
+    expect(result.lastCheckTime).toBeDefined()
+  })
+
+  it('returns not-installed for empty controller pods and services', () => {
+    const result = buildKserveStatus({ ready: 0, total: 0 }, [])
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('returns degraded when controller pods are degraded', () => {
+    const pods: KServeControllerPods = { ready: 1, total: 3 }
+    const result = buildKserveStatus(pods, [])
+    expect(result.health).toBe('degraded')
+  })
+
+  it('sets lastCheckTime to a valid ISO string', () => {
+    const result = buildKserveStatus({ ready: 0, total: 0 }, [])
+    expect(() => new Date(result.lastCheckTime)).not.toThrow()
+    expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helpers — factory functions for test data
+// ---------------------------------------------------------------------------
+
+let serviceIdCounter = 0
+
+function makeService(overrides?: Partial<KServeService>): KServeService {
+  serviceIdCounter++
+  return {
+    id: `svc-${serviceIdCounter}`,
+    name: `test-service-${serviceIdCounter}`,
+    namespace: 'default',
+    cluster: 'cluster-1',
+    status: 'ready',
+    modelName: 'sklearn-iris',
+    runtime: 'kserve-sklearnserver',
+    url: 'https://test-service.example.com',
+    trafficPercent: 100,
+    readyReplicas: 1,
+    desiredReplicas: 1,
+    requestsPerSecond: 10,
+    p95LatencyMs: 50,
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}

--- a/web/src/hooks/__tests__/useCachedKubevela-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedKubevela-funcs.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedKubevela.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedKubevela'
+import type {
+  KubeVelaApplication,
+  KubeVelaControllerPod,
+} from '../../components/cards/kubevela_status/demoData'
+
+const {
+  countApps,
+  countPods,
+  summarize,
+  deriveHealth,
+  buildStats,
+  buildKubeVelaStatus,
+  FAILED_STATUSES,
+} = __testables
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function makeApp(overrides: Partial<KubeVelaApplication> = {}): KubeVelaApplication {
+  return {
+    name: 'app-1',
+    namespace: 'default',
+    cluster: 'cluster-1',
+    status: 'running',
+    componentCount: 2,
+    traitCount: 1,
+    workflowSteps: [],
+    workflowStepsCompleted: 0,
+    workflowStepsTotal: 0,
+    traits: [],
+    ageMinutes: 60,
+    ...overrides,
+  }
+}
+
+function makePod(overrides: Partial<KubeVelaControllerPod> = {}): KubeVelaControllerPod {
+  return {
+    name: 'vela-core-abc',
+    namespace: 'vela-system',
+    cluster: 'cluster-1',
+    status: 'running',
+    replicasReady: 1,
+    replicasDesired: 1,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FAILED_STATUSES
+// ---------------------------------------------------------------------------
+
+describe('FAILED_STATUSES', () => {
+  it('includes workflowFailed and unhealthy', () => {
+    expect(FAILED_STATUSES).toContain('workflowFailed')
+    expect(FAILED_STATUSES).toContain('unhealthy')
+  })
+
+  it('does not include running or other statuses', () => {
+    expect(FAILED_STATUSES).not.toContain('running')
+    expect(FAILED_STATUSES).not.toContain('workflowSuspending')
+    expect(FAILED_STATUSES).not.toContain('deleting')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// countApps
+// ---------------------------------------------------------------------------
+
+describe('countApps', () => {
+  it('returns 0 for empty array', () => {
+    expect(countApps([], () => true)).toBe(0)
+  })
+
+  it('counts apps matching predicate', () => {
+    const apps = [
+      makeApp({ status: 'running' }),
+      makeApp({ status: 'workflowFailed' }),
+      makeApp({ status: 'running' }),
+    ]
+    expect(countApps(apps, a => a.status === 'running')).toBe(2)
+  })
+
+  it('returns 0 when no apps match', () => {
+    const apps = [makeApp({ status: 'running' })]
+    expect(countApps(apps, a => a.status === 'workflowFailed')).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// countPods
+// ---------------------------------------------------------------------------
+
+describe('countPods', () => {
+  it('returns 0 for empty array', () => {
+    expect(countPods([], () => true)).toBe(0)
+  })
+
+  it('counts pods matching predicate', () => {
+    const pods = [
+      makePod({ status: 'running' }),
+      makePod({ status: 'pending' }),
+      makePod({ status: 'running' }),
+    ]
+    expect(countPods(pods, p => p.status === 'running')).toBe(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeroes for empty inputs', () => {
+    const result = summarize([], [])
+    expect(result).toEqual({
+      totalApplications: 0,
+      runningApplications: 0,
+      failedApplications: 0,
+      totalControllerPods: 0,
+      runningControllerPods: 0,
+    })
+  })
+
+  it('counts running and failed applications correctly', () => {
+    const apps = [
+      makeApp({ status: 'running' }),
+      makeApp({ status: 'workflowFailed' }),
+      makeApp({ status: 'unhealthy' }),
+      makeApp({ status: 'workflowSuspending' }),
+    ]
+    const pods = [
+      makePod({ status: 'running' }),
+      makePod({ status: 'pending' }),
+    ]
+    const result = summarize(apps, pods)
+    expect(result.totalApplications).toBe(4)
+    expect(result.runningApplications).toBe(1)
+    expect(result.failedApplications).toBe(2)
+    expect(result.totalControllerPods).toBe(2)
+    expect(result.runningControllerPods).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when both arrays are empty', () => {
+    expect(deriveHealth([], [])).toBe('not-installed')
+  })
+
+  it('returns healthy when all pods running and no failed apps', () => {
+    const apps = [makeApp({ status: 'running' })]
+    const pods = [makePod({ status: 'running', replicasReady: 1, replicasDesired: 1 })]
+    expect(deriveHealth(apps, pods)).toBe('healthy')
+  })
+
+  it('returns degraded when a controller pod is not running', () => {
+    const apps = [makeApp({ status: 'running' })]
+    const pods = [makePod({ status: 'pending' })]
+    expect(deriveHealth(apps, pods)).toBe('degraded')
+  })
+
+  it('returns degraded when a controller pod has insufficient ready replicas', () => {
+    const apps = [makeApp({ status: 'running' })]
+    const pods = [makePod({ status: 'running', replicasReady: 0, replicasDesired: 1 })]
+    expect(deriveHealth(apps, pods)).toBe('degraded')
+  })
+
+  it('returns degraded when any app has a failed status', () => {
+    const apps = [
+      makeApp({ status: 'running' }),
+      makeApp({ status: 'workflowFailed' }),
+    ]
+    const pods = [makePod({ status: 'running' })]
+    expect(deriveHealth(apps, pods)).toBe('degraded')
+  })
+
+  it('returns degraded for unhealthy app status', () => {
+    const apps = [makeApp({ status: 'unhealthy' })]
+    const pods = [makePod({ status: 'running' })]
+    expect(deriveHealth(apps, pods)).toBe('degraded')
+  })
+
+  it('returns healthy with apps but no pods', () => {
+    const apps = [makeApp({ status: 'running' })]
+    expect(deriveHealth(apps, [])).toBe('healthy')
+  })
+
+  it('returns healthy with pods but no apps', () => {
+    const pods = [makePod({ status: 'running' })]
+    expect(deriveHealth([], pods)).toBe('healthy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildStats
+// ---------------------------------------------------------------------------
+
+describe('buildStats', () => {
+  it('returns zeroes for empty applications', () => {
+    const result = buildStats([], 'v1.0.0')
+    expect(result).toEqual({
+      totalApplications: 0,
+      runningApplications: 0,
+      failedApplications: 0,
+      totalComponents: 0,
+      totalTraits: 0,
+      controllerVersion: 'v1.0.0',
+    })
+  })
+
+  it('aggregates component and trait counts', () => {
+    const apps = [
+      makeApp({ componentCount: 3, traitCount: 2, status: 'running' }),
+      makeApp({ componentCount: 5, traitCount: 4, status: 'workflowFailed' }),
+    ]
+    const result = buildStats(apps, '1.9.11')
+    expect(result.totalApplications).toBe(2)
+    expect(result.runningApplications).toBe(1)
+    expect(result.failedApplications).toBe(1)
+    expect(result.totalComponents).toBe(8)
+    expect(result.totalTraits).toBe(6)
+    expect(result.controllerVersion).toBe('1.9.11')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildKubeVelaStatus
+// ---------------------------------------------------------------------------
+
+describe('buildKubeVelaStatus', () => {
+  it('builds a complete status object', () => {
+    const apps = [makeApp({ status: 'running', componentCount: 2, traitCount: 1 })]
+    const pods = [makePod({ status: 'running' })]
+    const result = buildKubeVelaStatus(apps, pods, '1.9.11')
+
+    expect(result.health).toBe('healthy')
+    expect(result.applications).toHaveLength(1)
+    expect(result.controllerPods).toHaveLength(1)
+    expect(result.stats.controllerVersion).toBe('1.9.11')
+    expect(result.stats.totalApplications).toBe(1)
+    expect(result.stats.totalComponents).toBe(2)
+    expect(result.stats.totalTraits).toBe(1)
+    expect(result.summary.totalApplications).toBe(1)
+    expect(result.summary.runningApplications).toBe(1)
+    expect(result.summary.runningControllerPods).toBe(1)
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('returns not-installed for empty inputs', () => {
+    const result = buildKubeVelaStatus([], [], 'unknown')
+    expect(result.health).toBe('not-installed')
+    expect(result.applications).toEqual([])
+    expect(result.controllerPods).toEqual([])
+  })
+
+  it('returns degraded when apps have failures', () => {
+    const apps = [makeApp({ status: 'unhealthy' })]
+    const pods = [makePod({ status: 'running' })]
+    const result = buildKubeVelaStatus(apps, pods, '1.9.11')
+    expect(result.health).toBe('degraded')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedLinkerd-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedLinkerd-funcs.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedLinkerd.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedLinkerd'
+import type { LinkerdMeshedDeployment, LinkerdStats } from '../../components/cards/linkerd_status/demoData'
+
+const { summarize, deriveHealth, buildLinkerdStatus } = __testables
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeros for empty deployments array', () => {
+    const result = summarize([])
+    expect(result).toEqual({
+      totalDeployments: 0,
+      fullyMeshedDeployments: 0,
+      totalMeshedPods: 0,
+      totalPods: 0,
+    })
+  })
+
+  it('counts fully meshed deployments', () => {
+    const deployments: LinkerdMeshedDeployment[] = [
+      { namespace: 'ns1', deployment: 'd1', meshedPods: 3, totalPods: 3, successRatePct: 100, requestsPerSecond: 10, p99LatencyMs: 5, status: 'meshed', cluster: 'c1' },
+      { namespace: 'ns1', deployment: 'd2', meshedPods: 1, totalPods: 3, successRatePct: 95, requestsPerSecond: 5, p99LatencyMs: 10, status: 'partial', cluster: 'c1' },
+      { namespace: 'ns2', deployment: 'd3', meshedPods: 0, totalPods: 2, successRatePct: 0, requestsPerSecond: 0, p99LatencyMs: 0, status: 'unmeshed', cluster: 'c1' },
+    ]
+    const result = summarize(deployments)
+    expect(result.totalDeployments).toBe(3)
+    expect(result.fullyMeshedDeployments).toBe(1)
+    expect(result.totalMeshedPods).toBe(4)
+    expect(result.totalPods).toBe(8)
+  })
+
+  it('handles single deployment', () => {
+    const deployments: LinkerdMeshedDeployment[] = [
+      { namespace: 'ns', deployment: 'd', meshedPods: 5, totalPods: 5, successRatePct: 100, requestsPerSecond: 50, p99LatencyMs: 2, status: 'meshed', cluster: 'c' },
+    ]
+    const result = summarize(deployments)
+    expect(result.totalDeployments).toBe(1)
+    expect(result.fullyMeshedDeployments).toBe(1)
+    expect(result.totalMeshedPods).toBe(5)
+    expect(result.totalPods).toBe(5)
+  })
+
+  it('handles all unmeshed', () => {
+    const deployments: LinkerdMeshedDeployment[] = [
+      { namespace: 'ns', deployment: 'd1', meshedPods: 0, totalPods: 2, successRatePct: 0, requestsPerSecond: 0, p99LatencyMs: 0, status: 'unmeshed', cluster: 'c' },
+      { namespace: 'ns', deployment: 'd2', meshedPods: 0, totalPods: 3, successRatePct: 0, requestsPerSecond: 0, p99LatencyMs: 0, status: 'unmeshed', cluster: 'c' },
+    ]
+    const result = summarize(deployments)
+    expect(result.fullyMeshedDeployments).toBe(0)
+    expect(result.totalMeshedPods).toBe(0)
+    expect(result.totalPods).toBe(5)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed for empty deployments', () => {
+    expect(deriveHealth([])).toBe('not-installed')
+  })
+
+  it('returns healthy when all meshed with high success rate', () => {
+    const deployments: LinkerdMeshedDeployment[] = [
+      { namespace: 'ns', deployment: 'd1', meshedPods: 3, totalPods: 3, successRatePct: 99.9, requestsPerSecond: 10, p99LatencyMs: 5, status: 'meshed', cluster: 'c' },
+      { namespace: 'ns', deployment: 'd2', meshedPods: 2, totalPods: 2, successRatePct: 100, requestsPerSecond: 20, p99LatencyMs: 3, status: 'meshed', cluster: 'c' },
+    ]
+    expect(deriveHealth(deployments)).toBe('healthy')
+  })
+
+  it('returns degraded when a deployment is partial', () => {
+    const deployments: LinkerdMeshedDeployment[] = [
+      { namespace: 'ns', deployment: 'd1', meshedPods: 3, totalPods: 3, successRatePct: 100, requestsPerSecond: 10, p99LatencyMs: 5, status: 'meshed', cluster: 'c' },
+      { namespace: 'ns', deployment: 'd2', meshedPods: 1, totalPods: 3, successRatePct: 100, requestsPerSecond: 5, p99LatencyMs: 8, status: 'partial', cluster: 'c' },
+    ]
+    expect(deriveHealth(deployments)).toBe('degraded')
+  })
+
+  it('returns degraded when success rate is below threshold', () => {
+    const deployments: LinkerdMeshedDeployment[] = [
+      { namespace: 'ns', deployment: 'd1', meshedPods: 3, totalPods: 3, successRatePct: 98.5, requestsPerSecond: 10, p99LatencyMs: 5, status: 'meshed', cluster: 'c' },
+    ]
+    expect(deriveHealth(deployments)).toBe('degraded')
+  })
+
+  it('returns degraded when unmeshed deployments exist', () => {
+    const deployments: LinkerdMeshedDeployment[] = [
+      { namespace: 'ns', deployment: 'd1', meshedPods: 0, totalPods: 2, successRatePct: 0, requestsPerSecond: 0, p99LatencyMs: 0, status: 'unmeshed', cluster: 'c' },
+    ]
+    expect(deriveHealth(deployments)).toBe('degraded')
+  })
+
+  it('returns healthy at exactly the threshold (99.0)', () => {
+    const deployments: LinkerdMeshedDeployment[] = [
+      { namespace: 'ns', deployment: 'd1', meshedPods: 2, totalPods: 2, successRatePct: 99.0, requestsPerSecond: 10, p99LatencyMs: 5, status: 'meshed', cluster: 'c' },
+    ]
+    // 99.0 is NOT < 99.0, so not unhealthy
+    expect(deriveHealth(deployments)).toBe('healthy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildLinkerdStatus
+// ---------------------------------------------------------------------------
+
+describe('buildLinkerdStatus', () => {
+  const baseStats: LinkerdStats = {
+    totalRps: 100,
+    avgSuccessRatePct: 99.5,
+    avgP99LatencyMs: 12,
+    controlPlaneVersion: 'stable-2.14.10',
+  }
+
+  it('builds a complete status with empty deployments', () => {
+    const result = buildLinkerdStatus([], baseStats)
+    expect(result.health).toBe('not-installed')
+    expect(result.deployments).toEqual([])
+    expect(result.stats).toBe(baseStats)
+    expect(result.summary.totalDeployments).toBe(0)
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('builds a healthy status with meshed deployments', () => {
+    const deployments: LinkerdMeshedDeployment[] = [
+      { namespace: 'ns', deployment: 'd1', meshedPods: 3, totalPods: 3, successRatePct: 100, requestsPerSecond: 50, p99LatencyMs: 5, status: 'meshed', cluster: 'c' },
+    ]
+    const result = buildLinkerdStatus(deployments, baseStats)
+    expect(result.health).toBe('healthy')
+    expect(result.deployments).toHaveLength(1)
+    expect(result.summary.totalDeployments).toBe(1)
+    expect(result.summary.fullyMeshedDeployments).toBe(1)
+    expect(result.summary.totalMeshedPods).toBe(3)
+    expect(result.summary.totalPods).toBe(3)
+  })
+
+  it('sets lastCheckTime to a valid ISO string', () => {
+    const result = buildLinkerdStatus([], baseStats)
+    expect(() => new Date(result.lastCheckTime)).not.toThrow()
+    expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+
+  it('builds degraded status with mixed deployments', () => {
+    const deployments: LinkerdMeshedDeployment[] = [
+      { namespace: 'ns', deployment: 'd1', meshedPods: 3, totalPods: 3, successRatePct: 100, requestsPerSecond: 50, p99LatencyMs: 5, status: 'meshed', cluster: 'c' },
+      { namespace: 'ns', deployment: 'd2', meshedPods: 0, totalPods: 2, successRatePct: 0, requestsPerSecond: 0, p99LatencyMs: 0, status: 'unmeshed', cluster: 'c' },
+    ]
+    const result = buildLinkerdStatus(deployments, baseStats)
+    expect(result.health).toBe('degraded')
+    expect(result.summary.fullyMeshedDeployments).toBe(1)
+    expect(result.summary.totalDeployments).toBe(2)
+  })
+})

--- a/web/src/hooks/__tests__/useCachedOpenfeature-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedOpenfeature-funcs.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedOpenfeature.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedOpenfeature'
+import type {
+  OpenFeatureFlag,
+  OpenFeatureProvider,
+} from '../../components/cards/openfeature_status/demoData'
+
+const { rollupFlagStats, sumProviderEvaluations, deriveHealth, buildOpenFeatureStatus } =
+  __testables
+
+// ---------------------------------------------------------------------------
+// rollupFlagStats
+// ---------------------------------------------------------------------------
+
+describe('rollupFlagStats', () => {
+  it('returns zeroes for an empty array', () => {
+    const result = rollupFlagStats([])
+    expect(result).toEqual({ total: 0, enabled: 0, disabled: 0, errorRate: 0 })
+  })
+
+  it('counts enabled and disabled flags correctly', () => {
+    const flags: OpenFeatureFlag[] = [
+      makeFlag({ enabled: true }),
+      makeFlag({ enabled: false }),
+      makeFlag({ enabled: true }),
+      makeFlag({ enabled: true }),
+    ]
+    const result = rollupFlagStats(flags)
+    expect(result.total).toBe(4)
+    expect(result.enabled).toBe(3)
+    expect(result.disabled).toBe(1)
+    expect(result.errorRate).toBe(0)
+  })
+
+  it('counts all disabled when none are enabled', () => {
+    const flags: OpenFeatureFlag[] = [
+      makeFlag({ enabled: false }),
+      makeFlag({ enabled: false }),
+    ]
+    const result = rollupFlagStats(flags)
+    expect(result.total).toBe(2)
+    expect(result.enabled).toBe(0)
+    expect(result.disabled).toBe(2)
+  })
+
+  it('counts all enabled when none are disabled', () => {
+    const flags: OpenFeatureFlag[] = [
+      makeFlag({ enabled: true }),
+      makeFlag({ enabled: true }),
+    ]
+    const result = rollupFlagStats(flags)
+    expect(result.enabled).toBe(2)
+    expect(result.disabled).toBe(0)
+  })
+
+  it('handles a single flag', () => {
+    const result = rollupFlagStats([makeFlag({ enabled: true })])
+    expect(result.total).toBe(1)
+    expect(result.enabled).toBe(1)
+    expect(result.disabled).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sumProviderEvaluations
+// ---------------------------------------------------------------------------
+
+describe('sumProviderEvaluations', () => {
+  it('returns 0 for an empty array', () => {
+    expect(sumProviderEvaluations([])).toBe(0)
+  })
+
+  it('sums evaluations across providers', () => {
+    const providers: OpenFeatureProvider[] = [
+      makeProvider({ evaluations: 100 }),
+      makeProvider({ evaluations: 250 }),
+      makeProvider({ evaluations: 50 }),
+    ]
+    expect(sumProviderEvaluations(providers)).toBe(400)
+  })
+
+  it('returns the value for a single provider', () => {
+    expect(sumProviderEvaluations([makeProvider({ evaluations: 42 })])).toBe(42)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when both providers and flags are empty', () => {
+    expect(deriveHealth([], [])).toBe('not-installed')
+  })
+
+  it('returns healthy when all providers are healthy', () => {
+    const providers: OpenFeatureProvider[] = [
+      makeProvider({ status: 'healthy' }),
+      makeProvider({ status: 'healthy' }),
+    ]
+    expect(deriveHealth(providers, [makeFlag()])).toBe('healthy')
+  })
+
+  it('returns degraded when a provider is unhealthy', () => {
+    const providers: OpenFeatureProvider[] = [
+      makeProvider({ status: 'healthy' }),
+      makeProvider({ status: 'unhealthy' }),
+    ]
+    expect(deriveHealth(providers, [makeFlag()])).toBe('degraded')
+  })
+
+  it('returns degraded when a provider is degraded', () => {
+    const providers: OpenFeatureProvider[] = [
+      makeProvider({ status: 'degraded' }),
+    ]
+    expect(deriveHealth(providers, [])).toBe('degraded')
+  })
+
+  it('returns healthy with flags but no providers', () => {
+    expect(deriveHealth([], [makeFlag()])).toBe('healthy')
+  })
+
+  it('returns healthy with providers but no flags', () => {
+    expect(deriveHealth([makeProvider({ status: 'healthy' })], [])).toBe('healthy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildOpenFeatureStatus
+// ---------------------------------------------------------------------------
+
+describe('buildOpenFeatureStatus', () => {
+  it('builds a complete status object', () => {
+    const providers: OpenFeatureProvider[] = [makeProvider({ status: 'healthy' })]
+    const flags: OpenFeatureFlag[] = [makeFlag({ enabled: true })]
+    const featureFlags = { total: 1, enabled: 1, disabled: 0, errorRate: 0 }
+    const totalEvaluations = 500
+
+    const result = buildOpenFeatureStatus(providers, flags, featureFlags, totalEvaluations)
+
+    expect(result.health).toBe('healthy')
+    expect(result.providers).toBe(providers)
+    expect(result.flags).toBe(flags)
+    expect(result.featureFlags).toBe(featureFlags)
+    expect(result.totalEvaluations).toBe(totalEvaluations)
+    expect(result.lastCheckTime).toBeDefined()
+  })
+
+  it('returns not-installed when no providers and no flags', () => {
+    const result = buildOpenFeatureStatus([], [], { total: 0, enabled: 0, disabled: 0, errorRate: 0 }, 0)
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('returns degraded when a provider is unhealthy', () => {
+    const providers: OpenFeatureProvider[] = [makeProvider({ status: 'unhealthy' })]
+    const flags: OpenFeatureFlag[] = [makeFlag()]
+    const result = buildOpenFeatureStatus(providers, flags, { total: 1, enabled: 1, disabled: 0, errorRate: 0 }, 100)
+    expect(result.health).toBe('degraded')
+  })
+
+  it('sets lastCheckTime to a valid ISO string', () => {
+    const result = buildOpenFeatureStatus([], [], { total: 0, enabled: 0, disabled: 0, errorRate: 0 }, 0)
+    expect(() => new Date(result.lastCheckTime)).not.toThrow()
+    expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helpers — factory functions for test data
+// ---------------------------------------------------------------------------
+
+function makeFlag(overrides?: Partial<OpenFeatureFlag>): OpenFeatureFlag {
+  return {
+    key: 'test-flag',
+    type: 'boolean',
+    enabled: true,
+    defaultVariant: 'on',
+    variants: 2,
+    provider: 'flagd',
+    evaluations: 100,
+    ...overrides,
+  }
+}
+
+function makeProvider(overrides?: Partial<OpenFeatureProvider>): OpenFeatureProvider {
+  return {
+    name: 'test-provider',
+    status: 'healthy',
+    evaluations: 100,
+    cacheHitRate: 90,
+    ...overrides,
+  }
+}

--- a/web/src/hooks/__tests__/useCachedOpenfga-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedOpenfga-funcs.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedOpenfga.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedOpenfga'
+import type {
+  OpenfgaStore,
+  OpenfgaAuthorizationModel,
+  OpenfgaStats,
+  OpenfgaApiRps,
+  OpenfgaLatencyMs,
+} from '../../components/cards/openfga_status/demoData'
+
+const { sumTuples, summarize, deriveHealth, buildOpenfgaStatus } = __testables
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function makeStore(overrides: Partial<OpenfgaStore> = {}): OpenfgaStore {
+  return {
+    id: 'store-1',
+    name: 'production',
+    tupleCount: 1500,
+    modelCount: 2,
+    status: 'active',
+    lastWriteTime: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function makeModel(overrides: Partial<OpenfgaAuthorizationModel> = {}): OpenfgaAuthorizationModel {
+  return {
+    id: 'model-1',
+    storeName: 'production',
+    schemaVersion: '1.1',
+    typeCount: 5,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function makeStats(overrides: Partial<OpenfgaStats> = {}): OpenfgaStats {
+  return {
+    totalTuples: 3000,
+    totalStores: 2,
+    totalModels: 3,
+    serverVersion: '1.5.0',
+    rps: { check: 100, expand: 20, listObjects: 10 },
+    latency: { p50: 5, p95: 15, p99: 30 },
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// sumTuples
+// ---------------------------------------------------------------------------
+
+describe('sumTuples', () => {
+  it('returns 0 for empty stores array', () => {
+    expect(sumTuples([])).toBe(0)
+  })
+
+  it('sums tupleCount across stores', () => {
+    const stores = [
+      makeStore({ tupleCount: 100 }),
+      makeStore({ id: 's2', tupleCount: 250 }),
+      makeStore({ id: 's3', tupleCount: 50 }),
+    ]
+    expect(sumTuples(stores)).toBe(400)
+  })
+
+  it('handles stores with undefined tupleCount', () => {
+    const stores = [
+      makeStore({ tupleCount: 100 }),
+      { ...makeStore({ id: 's2' }), tupleCount: undefined as unknown as number },
+    ]
+    // (store.tupleCount ?? 0) handles undefined
+    expect(sumTuples(stores)).toBe(100)
+  })
+
+  it('handles single store', () => {
+    expect(sumTuples([makeStore({ tupleCount: 42 })])).toBe(42)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeros for empty data', () => {
+    const stats = makeStats({ totalTuples: 0 })
+    const result = summarize('', [], [], stats)
+    expect(result).toEqual({
+      endpoint: '',
+      totalTuples: 0,
+      totalStores: 0,
+      totalModels: 0,
+    })
+  })
+
+  it('uses stats.totalTuples when provided', () => {
+    const stats = makeStats({ totalTuples: 5000 })
+    const stores = [makeStore({ tupleCount: 100 })]
+    const result = summarize('http://openfga:8080', stores, [makeModel()], stats)
+    expect(result.totalTuples).toBe(5000)
+    expect(result.totalStores).toBe(1)
+    expect(result.totalModels).toBe(1)
+    expect(result.endpoint).toBe('http://openfga:8080')
+  })
+
+  it('falls back to sumTuples when stats.totalTuples is 0', () => {
+    const stats = makeStats({ totalTuples: 0 })
+    const stores = [makeStore({ tupleCount: 200 }), makeStore({ id: 's2', tupleCount: 300 })]
+    const result = summarize('ep', stores, [], stats)
+    // totalTuples = stats.totalTuples || sumTuples(stores) => 0 is falsy, so 500
+    expect(result.totalTuples).toBe(500)
+  })
+
+  it('counts stores and models by array length', () => {
+    const stores = [makeStore(), makeStore({ id: 's2' })]
+    const models = [makeModel(), makeModel({ id: 'm2' }), makeModel({ id: 'm3' })]
+    const result = summarize('ep', stores, models, makeStats())
+    expect(result.totalStores).toBe(2)
+    expect(result.totalModels).toBe(3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when no endpoint and no stores', () => {
+    expect(deriveHealth('', [])).toBe('not-installed')
+  })
+
+  it('returns healthy with endpoint and active stores', () => {
+    expect(deriveHealth('http://openfga:8080', [makeStore()])).toBe('healthy')
+  })
+
+  it('returns healthy with endpoint only (no stores)', () => {
+    expect(deriveHealth('http://openfga:8080', [])).toBe('healthy')
+  })
+
+  it('returns healthy with stores only (no endpoint)', () => {
+    // endpoint is falsy but stores.length > 0, so not "not-installed"
+    expect(deriveHealth('', [makeStore()])).not.toBe('not-installed')
+  })
+
+  it('returns degraded when a store is draining', () => {
+    const stores = [makeStore(), makeStore({ id: 's2', status: 'draining' })]
+    expect(deriveHealth('http://openfga:8080', stores)).toBe('degraded')
+  })
+
+  it('returns healthy when all stores are active', () => {
+    const stores = [makeStore({ status: 'active' }), makeStore({ id: 's2', status: 'active' })]
+    expect(deriveHealth('ep', stores)).toBe('healthy')
+  })
+
+  it('returns healthy when store status is paused (not draining)', () => {
+    expect(deriveHealth('ep', [makeStore({ status: 'paused' })])).toBe('healthy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildOpenfgaStatus
+// ---------------------------------------------------------------------------
+
+describe('buildOpenfgaStatus', () => {
+  it('builds not-installed status with empty data', () => {
+    const stats = makeStats({ totalTuples: 0 })
+    const result = buildOpenfgaStatus('', [], [], stats)
+    expect(result.health).toBe('not-installed')
+    expect(result.stores).toEqual([])
+    expect(result.models).toEqual([])
+    expect(result.stats).toBe(stats)
+    expect(result.summary.endpoint).toBe('')
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('builds healthy status with stores and models', () => {
+    const stores = [makeStore()]
+    const models = [makeModel()]
+    const stats = makeStats()
+    const result = buildOpenfgaStatus('http://openfga:8080', stores, models, stats)
+    expect(result.health).toBe('healthy')
+    expect(result.stores).toHaveLength(1)
+    expect(result.models).toHaveLength(1)
+    expect(result.summary.endpoint).toBe('http://openfga:8080')
+  })
+
+  it('builds degraded status with draining store', () => {
+    const stores = [makeStore({ status: 'draining' })]
+    const result = buildOpenfgaStatus('ep', stores, [], makeStats())
+    expect(result.health).toBe('degraded')
+  })
+
+  it('sets lastCheckTime to a valid ISO string', () => {
+    const result = buildOpenfgaStatus('', [], [], makeStats())
+    expect(() => new Date(result.lastCheckTime)).not.toThrow()
+    expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})

--- a/web/src/hooks/__tests__/useCachedSpiffe-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedSpiffe-funcs.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedSpiffe.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedSpiffe'
+import type {
+  SpiffeRegistrationEntry,
+  SpiffeFederatedDomain,
+  SpiffeStats,
+} from '../../components/cards/spiffe_status/demoData'
+
+const { summarize, deriveHealth, buildSpiffeStatus } = __testables
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<SpiffeRegistrationEntry> = {}): SpiffeRegistrationEntry {
+  return {
+    spiffeId: 'spiffe://example.org/workload-1',
+    parentId: 'spiffe://example.org/node-1',
+    selector: 'k8s:pod-label:app=web',
+    svidType: 'x509',
+    ttlSeconds: 3600,
+    cluster: 'cluster-1',
+    ...overrides,
+  }
+}
+
+function makeFederatedDomain(overrides: Partial<SpiffeFederatedDomain> = {}): SpiffeFederatedDomain {
+  return {
+    trustDomain: 'partner.example.com',
+    bundleEndpoint: 'https://partner.example.com/bundle',
+    status: 'active',
+    lastRefresh: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function makeStats(overrides: Partial<SpiffeStats> = {}): SpiffeStats {
+  return {
+    x509SvidCount: 10,
+    jwtSvidCount: 5,
+    registrationEntryCount: 8,
+    agentCount: 3,
+    serverVersion: '1.9.0',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeros for empty data', () => {
+    const stats = makeStats({ x509SvidCount: 0, jwtSvidCount: 0 })
+    const result = summarize('', [], [], stats)
+    expect(result).toEqual({
+      trustDomain: '',
+      totalSvids: 0,
+      totalFederatedDomains: 0,
+      totalEntries: 0,
+    })
+  })
+
+  it('sums x509 and jwt SVID counts', () => {
+    const stats = makeStats({ x509SvidCount: 12, jwtSvidCount: 8 })
+    const result = summarize('example.org', [makeEntry()], [], stats)
+    expect(result.totalSvids).toBe(20)
+    expect(result.trustDomain).toBe('example.org')
+    expect(result.totalEntries).toBe(1)
+  })
+
+  it('counts federated domains', () => {
+    const stats = makeStats()
+    const domains = [makeFederatedDomain(), makeFederatedDomain({ trustDomain: 'other.com' })]
+    const result = summarize('example.org', [], domains, stats)
+    expect(result.totalFederatedDomains).toBe(2)
+  })
+
+  it('counts entries', () => {
+    const entries = [makeEntry(), makeEntry({ spiffeId: 'spiffe://example.org/wl-2' }), makeEntry({ spiffeId: 'spiffe://example.org/wl-3' })]
+    const result = summarize('example.org', entries, [], makeStats())
+    expect(result.totalEntries).toBe(3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when no trustDomain and no entries', () => {
+    expect(deriveHealth('', [], [])).toBe('not-installed')
+  })
+
+  it('returns healthy with trustDomain and no federated domains', () => {
+    expect(deriveHealth('example.org', [makeEntry()], [])).toBe('healthy')
+  })
+
+  it('returns healthy with trustDomain only (no entries, no domains)', () => {
+    expect(deriveHealth('example.org', [], [])).toBe('healthy')
+  })
+
+  it('returns healthy when all federated domains are active', () => {
+    const domains = [
+      makeFederatedDomain({ status: 'active' }),
+      makeFederatedDomain({ trustDomain: 'other.com', status: 'active' }),
+    ]
+    expect(deriveHealth('example.org', [], domains)).toBe('healthy')
+  })
+
+  it('returns degraded when a federated domain has failed', () => {
+    const domains = [
+      makeFederatedDomain({ status: 'active' }),
+      makeFederatedDomain({ trustDomain: 'broken.com', status: 'failed' }),
+    ]
+    expect(deriveHealth('example.org', [], domains)).toBe('degraded')
+  })
+
+  it('returns healthy when federated domain is pending (not failed)', () => {
+    const domains = [makeFederatedDomain({ status: 'pending' })]
+    expect(deriveHealth('example.org', [], domains)).toBe('healthy')
+  })
+
+  it('returns not-installed when trustDomain is empty but entries exist', () => {
+    // trustDomain is falsy, but entries.length > 0 — the condition is &&
+    // so it requires BOTH to be falsy for not-installed
+    expect(deriveHealth('', [makeEntry()], [])).not.toBe('not-installed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildSpiffeStatus
+// ---------------------------------------------------------------------------
+
+describe('buildSpiffeStatus', () => {
+  it('builds not-installed status with empty data', () => {
+    const stats = makeStats({ x509SvidCount: 0, jwtSvidCount: 0 })
+    const result = buildSpiffeStatus('', [], [], stats)
+    expect(result.health).toBe('not-installed')
+    expect(result.entries).toEqual([])
+    expect(result.federatedDomains).toEqual([])
+    expect(result.stats).toBe(stats)
+    expect(result.summary.trustDomain).toBe('')
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('builds healthy status with entries and domains', () => {
+    const entries = [makeEntry()]
+    const domains = [makeFederatedDomain()]
+    const stats = makeStats()
+    const result = buildSpiffeStatus('example.org', entries, domains, stats)
+    expect(result.health).toBe('healthy')
+    expect(result.entries).toHaveLength(1)
+    expect(result.federatedDomains).toHaveLength(1)
+    expect(result.summary.totalSvids).toBe(15) // 10 + 5
+    expect(result.summary.totalEntries).toBe(1)
+    expect(result.summary.totalFederatedDomains).toBe(1)
+  })
+
+  it('builds degraded status with failed federation', () => {
+    const domains = [makeFederatedDomain({ status: 'failed' })]
+    const result = buildSpiffeStatus('example.org', [], domains, makeStats())
+    expect(result.health).toBe('degraded')
+  })
+
+  it('sets lastCheckTime to a valid ISO string', () => {
+    const result = buildSpiffeStatus('', [], [], makeStats())
+    expect(() => new Date(result.lastCheckTime)).not.toThrow()
+    expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})

--- a/web/src/hooks/__tests__/useCachedSpire-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedSpire-funcs.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedSpire.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedSpire'
+import type {
+  SpireServerPod,
+  SpireAgentDaemonSet,
+  SpireSummary,
+} from '../../lib/demo/spire'
+
+const { countReadyPods, deriveHealth, buildSpireStatus } = __testables
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function makeServerPod(overrides: Partial<SpireServerPod> = {}): SpireServerPod {
+  return {
+    name: 'spire-server-0',
+    phase: 'Running',
+    ready: true,
+    restarts: 0,
+    startedAt: new Date().toISOString(),
+    node: 'node-1',
+    ...overrides,
+  }
+}
+
+function makeAgentDaemonSet(
+  overrides: Partial<SpireAgentDaemonSet> = {},
+): SpireAgentDaemonSet {
+  return {
+    name: 'spire-agent',
+    namespace: 'spire-system',
+    desiredNumberScheduled: 3,
+    numberReady: 3,
+    numberAvailable: 3,
+    numberMisscheduled: 0,
+    ...overrides,
+  }
+}
+
+function makeSummary(overrides: Partial<SpireSummary> = {}): SpireSummary {
+  return {
+    registrationEntries: 0,
+    attestedAgents: 0,
+    trustBundleAgeHours: 0,
+    serverReadyReplicas: 0,
+    serverDesiredReplicas: 0,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// countReadyPods
+// ---------------------------------------------------------------------------
+
+describe('countReadyPods', () => {
+  it('returns 0 for empty array', () => {
+    expect(countReadyPods([])).toBe(0)
+  })
+
+  it('counts only pods that are ready AND Running', () => {
+    const pods = [
+      makeServerPod({ ready: true, phase: 'Running' }),
+      makeServerPod({ ready: false, phase: 'Running' }),
+      makeServerPod({ ready: true, phase: 'Pending' }),
+      makeServerPod({ ready: true, phase: 'Running' }),
+    ]
+    expect(countReadyPods(pods)).toBe(2)
+  })
+
+  it('returns 0 when no pods are ready', () => {
+    const pods = [
+      makeServerPod({ ready: false, phase: 'Failed' }),
+      makeServerPod({ ready: false, phase: 'Pending' }),
+    ]
+    expect(countReadyPods(pods)).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when no server pods and no agent', () => {
+    expect(deriveHealth([], null, makeSummary())).toBe('not-installed')
+  })
+
+  it('returns healthy when all server pods are ready and agent is fully scheduled', () => {
+    const pods = [
+      makeServerPod({ ready: true, phase: 'Running' }),
+      makeServerPod({ ready: true, phase: 'Running' }),
+    ]
+    const agent = makeAgentDaemonSet({
+      desiredNumberScheduled: 3,
+      numberReady: 3,
+      numberMisscheduled: 0,
+    })
+    const summary = makeSummary({ serverDesiredReplicas: 2 })
+    expect(deriveHealth(pods, agent, summary)).toBe('healthy')
+  })
+
+  it('returns degraded when server pods are not all ready', () => {
+    const pods = [
+      makeServerPod({ ready: true, phase: 'Running' }),
+      makeServerPod({ ready: false, phase: 'Pending' }),
+    ]
+    const summary = makeSummary({ serverDesiredReplicas: 2 })
+    expect(deriveHealth(pods, null, summary)).toBe('degraded')
+  })
+
+  it('returns degraded when agent numberReady < desiredNumberScheduled', () => {
+    const pods = [makeServerPod({ ready: true, phase: 'Running' })]
+    const agent = makeAgentDaemonSet({
+      desiredNumberScheduled: 5,
+      numberReady: 3,
+    })
+    const summary = makeSummary({ serverDesiredReplicas: 1 })
+    expect(deriveHealth(pods, agent, summary)).toBe('degraded')
+  })
+
+  it('returns degraded when agent has misscheduled nodes', () => {
+    const pods = [makeServerPod({ ready: true, phase: 'Running' })]
+    const agent = makeAgentDaemonSet({
+      desiredNumberScheduled: 3,
+      numberReady: 3,
+      numberMisscheduled: 2,
+    })
+    const summary = makeSummary({ serverDesiredReplicas: 1 })
+    expect(deriveHealth(pods, agent, summary)).toBe('degraded')
+  })
+
+  it('returns healthy with only agent (no server pods)', () => {
+    const agent = makeAgentDaemonSet()
+    const summary = makeSummary({ serverDesiredReplicas: 0 })
+    expect(deriveHealth([], agent, summary)).toBe('healthy')
+  })
+
+  it('uses pods.length as expected replicas when serverDesiredReplicas is 0', () => {
+    const pods = [
+      makeServerPod({ ready: true, phase: 'Running' }),
+      makeServerPod({ ready: false, phase: 'Pending' }),
+    ]
+    const summary = makeSummary({ serverDesiredReplicas: 0 })
+    // expectedServerReplicas = pods.length = 2, readyPods = 1 < 2 → degraded
+    expect(deriveHealth(pods, null, summary)).toBe('degraded')
+  })
+
+  it('returns healthy when all pods ready and serverDesiredReplicas is 0', () => {
+    const pods = [
+      makeServerPod({ ready: true, phase: 'Running' }),
+    ]
+    const summary = makeSummary({ serverDesiredReplicas: 0 })
+    // expectedServerReplicas = pods.length = 1, readyPods = 1 → not degraded
+    expect(deriveHealth(pods, null, summary)).toBe('healthy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildSpireStatus
+// ---------------------------------------------------------------------------
+
+describe('buildSpireStatus', () => {
+  it('builds a complete status with healthy health', () => {
+    const pods = [makeServerPod({ ready: true, phase: 'Running' })]
+    const agent = makeAgentDaemonSet()
+    const result = buildSpireStatus('1.10.4', 'example.org', pods, agent, {
+      registrationEntries: 50,
+      attestedAgents: 3,
+      trustBundleAgeHours: 12,
+      serverDesiredReplicas: 1,
+    })
+
+    expect(result.health).toBe('healthy')
+    expect(result.version).toBe('1.10.4')
+    expect(result.trustDomain).toBe('example.org')
+    expect(result.serverPods).toHaveLength(1)
+    expect(result.agentDaemonSet).not.toBeNull()
+    expect(result.summary.registrationEntries).toBe(50)
+    expect(result.summary.attestedAgents).toBe(3)
+    expect(result.summary.trustBundleAgeHours).toBe(12)
+    expect(result.summary.serverReadyReplicas).toBe(1)
+    expect(result.summary.serverDesiredReplicas).toBe(1)
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('returns not-installed for empty inputs', () => {
+    const result = buildSpireStatus('unknown', '', [], null, {})
+    expect(result.health).toBe('not-installed')
+    expect(result.serverPods).toEqual([])
+    expect(result.agentDaemonSet).toBeNull()
+  })
+
+  it('defaults serverReadyReplicas from countReadyPods when not in summary', () => {
+    const pods = [
+      makeServerPod({ ready: true, phase: 'Running' }),
+      makeServerPod({ ready: true, phase: 'Running' }),
+    ]
+    const result = buildSpireStatus('1.10.4', 'test.org', pods, null, {})
+    expect(result.summary.serverReadyReplicas).toBe(2)
+  })
+
+  it('defaults attestedAgents from agent numberReady when not in summary', () => {
+    const agent = makeAgentDaemonSet({ numberReady: 7 })
+    const result = buildSpireStatus('1.10.4', 'test.org', [], agent, {})
+    expect(result.summary.attestedAgents).toBe(7)
+  })
+
+  it('defaults serverDesiredReplicas to pods.length when not in summary', () => {
+    const pods = [
+      makeServerPod(),
+      makeServerPod(),
+      makeServerPod(),
+    ]
+    const result = buildSpireStatus('1.10.4', 'test.org', pods, null, {})
+    expect(result.summary.serverDesiredReplicas).toBe(3)
+  })
+
+  it('uses provided serverDesiredReplicas from summary', () => {
+    const pods = [makeServerPod()]
+    const result = buildSpireStatus('1.10.4', 'test.org', pods, null, {
+      serverDesiredReplicas: 5,
+    })
+    expect(result.summary.serverDesiredReplicas).toBe(5)
+  })
+})

--- a/web/src/hooks/__tests__/useCachedWasmcloud-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedWasmcloud-funcs.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedWasmcloud.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+import { __testables } from '../useCachedWasmcloud'
+import type {
+  WasmcloudHost,
+  WasmcloudActor,
+  WasmcloudProvider,
+  WasmcloudLink,
+  WasmcloudStats,
+} from '../../components/cards/wasmcloud_status/demoData'
+
+const { summarize, deriveHealth, buildWasmcloudStatus } = __testables
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function makeHost(overrides: Partial<WasmcloudHost> = {}): WasmcloudHost {
+  return {
+    hostId: 'host-1',
+    friendlyName: 'Host 1',
+    status: 'ready',
+    labels: {},
+    uptimeSeconds: 3600,
+    actorCount: 2,
+    providerCount: 1,
+    cluster: 'cluster-1',
+    ...overrides,
+  }
+}
+
+function makeActor(overrides: Partial<WasmcloudActor> = {}): WasmcloudActor {
+  return {
+    actorId: 'actor-1',
+    name: 'echo',
+    imageRef: 'ghcr.io/wasmcloud/echo:0.3.8',
+    instanceCount: 1,
+    hostId: 'host-1',
+    cluster: 'cluster-1',
+    ...overrides,
+  }
+}
+
+function makeProvider(overrides: Partial<WasmcloudProvider> = {}): WasmcloudProvider {
+  return {
+    providerId: 'prov-1',
+    name: 'httpserver',
+    contractId: 'wasmcloud:httpserver',
+    linkName: 'default',
+    imageRef: 'ghcr.io/wasmcloud/httpserver:0.19.1',
+    status: 'running',
+    hostId: 'host-1',
+    cluster: 'cluster-1',
+    ...overrides,
+  }
+}
+
+function makeLink(overrides: Partial<WasmcloudLink> = {}): WasmcloudLink {
+  return {
+    actorId: 'actor-1',
+    providerId: 'prov-1',
+    contractId: 'wasmcloud:httpserver',
+    linkName: 'default',
+    status: 'active',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeros for empty arrays', () => {
+    const result = summarize('', [], [], [], [])
+    expect(result).toEqual({
+      latticeId: '',
+      totalHosts: 0,
+      totalActors: 0,
+      totalProviders: 0,
+      totalLinks: 0,
+    })
+  })
+
+  it('counts all resource types', () => {
+    const result = summarize(
+      'lattice-abc',
+      [makeHost(), makeHost({ hostId: 'host-2' })],
+      [makeActor()],
+      [makeProvider(), makeProvider({ providerId: 'prov-2' }), makeProvider({ providerId: 'prov-3' })],
+      [makeLink()],
+    )
+    expect(result.latticeId).toBe('lattice-abc')
+    expect(result.totalHosts).toBe(2)
+    expect(result.totalActors).toBe(1)
+    expect(result.totalProviders).toBe(3)
+    expect(result.totalLinks).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when no latticeId and no hosts', () => {
+    expect(deriveHealth('', [], [], [])).toBe('not-installed')
+  })
+
+  it('returns healthy when latticeId present with ready hosts', () => {
+    expect(deriveHealth('lattice-1', [makeHost()], [makeProvider()], [makeLink()])).toBe('healthy')
+  })
+
+  it('returns healthy with only latticeId (no hosts)', () => {
+    // latticeId is truthy, so not "not-installed"
+    expect(deriveHealth('lattice-1', [], [], [])).toBe('healthy')
+  })
+
+  it('returns degraded when a host is unreachable', () => {
+    const hosts = [makeHost(), makeHost({ hostId: 'host-2', status: 'unreachable' })]
+    expect(deriveHealth('lattice-1', hosts, [], [])).toBe('degraded')
+  })
+
+  it('returns degraded when a provider has failed', () => {
+    const providers = [makeProvider({ status: 'failed' })]
+    expect(deriveHealth('lattice-1', [makeHost()], providers, [])).toBe('degraded')
+  })
+
+  it('returns degraded when a link has failed', () => {
+    const links = [makeLink({ status: 'failed' })]
+    expect(deriveHealth('lattice-1', [makeHost()], [], links)).toBe('degraded')
+  })
+
+  it('returns healthy when providers are running and links are active', () => {
+    expect(
+      deriveHealth(
+        'lattice-1',
+        [makeHost()],
+        [makeProvider({ status: 'running' })],
+        [makeLink({ status: 'active' })],
+      ),
+    ).toBe('healthy')
+  })
+
+  it('returns healthy when host is starting (not unreachable)', () => {
+    expect(
+      deriveHealth('lattice-1', [makeHost({ status: 'starting' })], [], []),
+    ).toBe('healthy')
+  })
+
+  it('returns healthy when provider is starting (not failed)', () => {
+    expect(
+      deriveHealth('lattice-1', [], [makeProvider({ status: 'starting' })], []),
+    ).toBe('healthy')
+  })
+
+  it('returns healthy when link is pending (not failed)', () => {
+    expect(
+      deriveHealth('lattice-1', [], [], [makeLink({ status: 'pending' })]),
+    ).toBe('healthy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildWasmcloudStatus
+// ---------------------------------------------------------------------------
+
+describe('buildWasmcloudStatus', () => {
+  const baseStats: WasmcloudStats = {
+    hostCount: 1,
+    actorCount: 2,
+    providerCount: 1,
+    linkCount: 1,
+    latticeVersion: '0.82.0',
+  }
+
+  it('builds a not-installed status with empty inputs', () => {
+    const result = buildWasmcloudStatus('', [], [], [], [], baseStats)
+    expect(result.health).toBe('not-installed')
+    expect(result.hosts).toEqual([])
+    expect(result.actors).toEqual([])
+    expect(result.providers).toEqual([])
+    expect(result.links).toEqual([])
+    expect(result.stats).toBe(baseStats)
+    expect(result.summary.totalHosts).toBe(0)
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('builds a healthy status with populated data', () => {
+    const hosts = [makeHost()]
+    const actors = [makeActor()]
+    const providers = [makeProvider()]
+    const links = [makeLink()]
+    const result = buildWasmcloudStatus('lattice-abc', hosts, actors, providers, links, baseStats)
+    expect(result.health).toBe('healthy')
+    expect(result.hosts).toHaveLength(1)
+    expect(result.actors).toHaveLength(1)
+    expect(result.providers).toHaveLength(1)
+    expect(result.links).toHaveLength(1)
+    expect(result.summary.latticeId).toBe('lattice-abc')
+    expect(result.summary.totalHosts).toBe(1)
+  })
+
+  it('builds a degraded status with failed provider', () => {
+    const result = buildWasmcloudStatus(
+      'lattice-1',
+      [makeHost()],
+      [],
+      [makeProvider({ status: 'failed' })],
+      [],
+      baseStats,
+    )
+    expect(result.health).toBe('degraded')
+  })
+
+  it('sets lastCheckTime to a valid ISO string', () => {
+    const result = buildWasmcloudStatus('', [], [], [], [], baseStats)
+    expect(() => new Date(result.lastCheckTime)).not.toThrow()
+    expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})

--- a/web/src/lib/utils/wsAuth.ts
+++ b/web/src/lib/utils/wsAuth.ts
@@ -4,11 +4,16 @@
  * Browsers cannot set custom headers on WebSocket handshake requests,
  * so we pass the token as a query parameter instead.
  */
+import { emitWsAuthMissing } from '../analytics'
+
 /** localStorage key for the kc-agent shared secret */
 const AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'
 
 /** Query-string key used to pass the auth token on WebSocket URLs */
 const WS_AUTH_QUERY_PARAM = 'token'
+
+/** Throttle: only emit once per session to avoid spamming GA4 */
+let wsAuthMissingEmitted = false
 
 /**
  * If a kc-agent token exists in localStorage, append it to `url` as
@@ -17,7 +22,13 @@ const WS_AUTH_QUERY_PARAM = 'token'
  */
 export function appendWsAuthToken(url: string): string {
   const token = localStorage.getItem(AGENT_TOKEN_STORAGE_KEY)
-  if (!token) return url
+  if (!token) {
+    if (!wsAuthMissingEmitted) {
+      wsAuthMissingEmitted = true
+      emitWsAuthMissing(url)
+    }
+    return url
+  }
 
   const separator = url.includes('?') ? '&' : '?'
   return `${url}${separator}${WS_AUTH_QUERY_PARAM}=${encodeURIComponent(token)}`


### PR DESCRIPTION
## Summary
- Restores the `emitWsAuthMissing` GA4 instrumentation in `wsAuth.ts` that was accidentally reverted by Copilot PR #10529
- Adds 13 new `-funcs.test.ts` files with 236 tests covering the `__testables` pure functions in useCached hooks that were at 23-38% line coverage
- Hooks covered: Kubevela, Dapr, Spire, Backstage, OpenFeature, CloudCustodian, Kserve, Cortex, Linkerd, Wasmcloud, Spiffe, OpenFGA, CNI

## Test plan
- [x] All 236 new tests pass (`npx vitest run` on all 13 files)
- [x] `npm run build` passes clean
- [ ] CI coverage-gate passes
- [ ] Coverage-hourly badge improves from 88% toward 91%