### PR TITLE
🐛 Fix release rate limit by using local git changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,10 +66,10 @@ checksum:
   name_template: "checksums.txt"
 
 changelog:
-  # Use GitHub's auto-generated release notes (based on merged PR titles)
-  # instead of raw commit messages. This populates the release body so the
-  # "What's New" modal has content for nightly and weekly releases.
-  use: github
+  # Use local git log for changelog generation instead of the GitHub compare
+  # API. The GitHub API hits secondary rate limits when there are many commits
+  # between nightly releases (#10574, #10575).
+  use: git
   sort: asc
   filters:
     exclude:


### PR DESCRIPTION
Fixes #10574
Fixes #10575

goreleaser's `changelog.use: github` calls the GitHub compare API to generate release notes. With many commits between nightly releases, this hits the secondary rate limit (403), causing repeated release failures.

**Root cause:** Both attempt 1 and attempt 2 of run 25013124055 failed at the same point:
```
GET .../compare/v0.3.23-nightly.20260426...v0.3.24-nightly.20260427?page=2: 403 API secondary rate limit exceeded
```

**Fix:** Switch `changelog.use` from `github` to `git`. This generates the changelog from local git log instead of the GitHub API, avoiding the rate limit entirely while still producing useful release notes.

Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>