### PR TITLE
🌱 Phase 3b container-query rollout: complete flex-wrap + grid-cols sweep (31 files)

### DIFF
--- a/web/public/mockServiceWorker.js
+++ b/web/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.13.2'
+const PACKAGE_VERSION = '2.13.6'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -533,7 +533,7 @@ export function ACMMFeedbackLoops() {
                 // an explicit Close control, so the click-to-open interaction
                 // is unambiguous and dismissable.
                 <div className="mx-2 mb-2 rounded-md border border-border/60 bg-background/60 shadow-xs">
-                  <div className="flex items-center justify-between gap-2 px-3 py-1.5 border-b border-border/40 bg-muted/20 rounded-t-md">
+                  <div className="flex flex-wrap items-center justify-between gap-2 px-3 py-1.5 border-b border-border/40 bg-muted/20 rounded-t-md">
                     <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
                       Details — {c.name}
                     </div>

--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -40,7 +40,7 @@ function formatRemaining(ms: number): string {
 function AlertStatsRow({ critical, warning, acknowledged }: { critical: number; warning: number; acknowledged: number }) {
   const { t } = useTranslation('cards')
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
+    <div className="grid grid-cols-2 @sm:grid-cols-3 gap-2 mb-3">
       <div className="p-2 rounded-lg bg-red-500/10 border border-red-500/20">
         <div className="flex items-center gap-1.5 mb-1">
           <AlertTriangle className="w-3 h-3 text-red-400" />

--- a/web/src/components/cards/DeploymentRiskScore.tsx
+++ b/web/src/components/cards/DeploymentRiskScore.tsx
@@ -242,7 +242,7 @@ export function DeploymentRiskScore() {
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-3">
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
         <span>{t('deploymentRiskScore.legend')}</span>
         <span className="flex items-center gap-2">
           <span className="inline-flex items-center gap-1">

--- a/web/src/components/cards/RuntimeAttestationCard.tsx
+++ b/web/src/components/cards/RuntimeAttestationCard.tsx
@@ -126,7 +126,7 @@ export function RuntimeAttestationCard() {
       <div className="space-y-4 p-4">
         <Skeleton width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
         {Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
-          <div key={i} className="flex items-center justify-between">
+          <div key={i} className="flex flex-wrap items-center justify-between gap-y-2">
             <Skeleton width={SKELETON_TITLE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
             <Skeleton width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
           </div>

--- a/web/src/components/cards/artifact_hub_status/index.tsx
+++ b/web/src/components/cards/artifact_hub_status/index.tsx
@@ -51,7 +51,7 @@ export function ArtifactHubStatus() {
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/backstage_status/index.tsx
+++ b/web/src/components/cards/backstage_status/index.tsx
@@ -101,7 +101,7 @@ function PluginRow({
   statusLabel: string
 }) {
   return (
-    <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center justify-between gap-2">
+    <div className="rounded-md bg-secondary/30 px-3 py-2 flex flex-wrap items-center justify-between gap-2">
       <div className="min-w-0 flex items-center gap-1.5">
         <Puzzle className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
         <span className="text-xs font-mono truncate" title={plugin.name}>
@@ -125,7 +125,7 @@ function PluginRow({
 
 function TemplateRow({ template }: { template: BackstageScaffolderTemplate }) {
   return (
-    <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center justify-between gap-2">
+    <div className="rounded-md bg-secondary/30 px-3 py-2 flex flex-wrap items-center justify-between gap-2">
       <div className="min-w-0 flex items-center gap-1.5">
         <FileCode className="w-3.5 h-3.5 text-purple-400 shrink-0" />
         <span className="text-xs font-mono truncate" title={template.name}>
@@ -182,7 +182,7 @@ export function BackstageStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
@@ -233,7 +233,7 @@ export function BackstageStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
@@ -309,7 +309,7 @@ export function BackstageStatus() {
             {(BACKSTAGE_ENTITY_KINDS ?? []).map(kind => (
               <div
                 key={kind}
-                className="rounded-md bg-secondary/30 px-2 py-1.5 flex items-center justify-between"
+                className="rounded-md bg-secondary/30 px-2 py-1.5 flex flex-wrap items-center justify-between gap-y-2"
               >
                 <span className="text-[11px] text-muted-foreground truncate">
                   {kindLabels[kind] ?? kind}

--- a/web/src/components/cards/cilium_status/index.tsx
+++ b/web/src/components/cards/cilium_status/index.tsx
@@ -88,7 +88,7 @@ export const CiliumStatus: React.FC<CardComponentProps> = () => {
         return (
             <div className="p-4 space-y-4 animate-pulse">
                 <div className="h-10 bg-muted/20 rounded-lg w-1/3" />
-                <div className="grid grid-cols-3 gap-3">
+                <div className="grid grid-cols-2 @sm:grid-cols-3 gap-3">
                     {[1, 2, 3].map(i => (
                         <div key={i} className="h-20 bg-muted/10 rounded-xl" />
                     ))}
@@ -108,7 +108,7 @@ export const CiliumStatus: React.FC<CardComponentProps> = () => {
         <div className="flex flex-col h-full overflow-hidden">
             <div className="p-4 space-y-4 overflow-y-auto custom-scrollbar flex-1">
                 {/* Header Status */}
-                <div className="flex items-center justify-between">
+                <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <div className="flex items-center gap-3">
                         <div className={cn("p-2 rounded-lg", status.bg)}>
                             <Network className={cn("w-5 h-5", status.color)} />
@@ -129,7 +129,7 @@ export const CiliumStatus: React.FC<CardComponentProps> = () => {
                 </div>
 
                 {/* Metrics Grid */}
-                <div className="grid grid-cols-3 gap-3">
+                <div className="grid grid-cols-2 @sm:grid-cols-3 gap-3">
                     <MetricTile
                         icon={<Shield className="w-4 h-4 text-cyan-400" />}
                         label={t('ciliumStatus.networkPolicies')}
@@ -150,7 +150,7 @@ export const CiliumStatus: React.FC<CardComponentProps> = () => {
 
                 {/* Node Status List */}
                 <div className="space-y-2">
-                    <div className="flex items-center justify-between px-1">
+                    <div className="flex flex-wrap items-center justify-between gap-y-2 px-1">
                         <div className="text-[10px] uppercase font-bold text-muted-foreground/60 tracking-widest">
                             {t('ciliumStatus.nodes')}
                         </div>
@@ -180,7 +180,7 @@ export const CiliumStatus: React.FC<CardComponentProps> = () => {
                                 <div
                                     key={node.name}
                                     onClick={() => drillToNode('all', node.name)}
-                                    className="flex items-center justify-between p-2 rounded-lg bg-secondary/30 border border-border/40 hover:border-border/80 transition-colors cursor-pointer group/row"
+                                    className="flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg bg-secondary/30 border border-border/40 hover:border-border/80 transition-colors cursor-pointer group/row"
                                     title={`${node.name} - ${node.version}`}
                                 >
                                     <div className="flex items-center gap-2 overflow-hidden">
@@ -219,7 +219,7 @@ export const CiliumStatus: React.FC<CardComponentProps> = () => {
             </div>
 
             {/* Footer link */}
-            <div className="p-3 bg-muted/10 border-t border-border/40 flex items-center justify-between">
+            <div className="p-3 bg-muted/10 border-t border-border/40 flex flex-wrap items-center justify-between gap-y-2">
                 <div className="flex items-center gap-2 text-[10px] text-muted-foreground font-medium uppercase tracking-tighter">
                     <div className="flex items-center gap-1.5">
                         <span className="w-1.5 h-1.5 bg-emerald-400 rounded-full animate-pulse" />

--- a/web/src/components/cards/cni_status/index.tsx
+++ b/web/src/components/cards/cni_status/index.tsx
@@ -62,7 +62,7 @@ function nodeStateClass(state: CniNodeState): string {
 function NodeRow({ node }: { node: CniNodeStatus }) {
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Cpu className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-xs font-medium text-foreground truncate font-mono">
@@ -102,7 +102,7 @@ export function CniStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
@@ -143,7 +143,7 @@ export function CniStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/containerd_status/index.tsx
+++ b/web/src/components/cards/containerd_status/index.tsx
@@ -47,7 +47,7 @@ const STATE_BADGE: Record<ContainerdContainerState, string> = {
 function ContainerRow({ item }: { item: ContainerdContainer }) {
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           {STATE_ICON[item.state]}
           <span className="text-xs font-mono truncate">{item.id}</span>
@@ -59,12 +59,12 @@ function ContainerRow({ item }: { item: ContainerdContainer }) {
         </span>
       </div>
 
-      <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+      <div className="text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-2">
         <span className="truncate">{item.image || '-'}</span>
         <span className="truncate shrink-0 ml-2">{item.uptime}</span>
       </div>
 
-      <div className="text-[11px] text-muted-foreground/80 flex items-center justify-between gap-2">
+      <div className="text-[11px] text-muted-foreground/80 flex flex-wrap items-center justify-between gap-2">
         <span className="truncate">{item.namespace}</span>
         <span className="truncate shrink-0 ml-2">{item.node}</span>
       </div>
@@ -99,7 +99,7 @@ export function ContainerdStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
@@ -134,7 +134,7 @@ export function ContainerdStatus() {
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${getHealthBadgeClasses(isHealthy)}`}
         >

--- a/web/src/components/cards/cortex_status/index.tsx
+++ b/web/src/components/cards/cortex_status/index.tsx
@@ -120,7 +120,7 @@ function ComponentRow({
       : 'bg-red-500/20 text-red-400'
 
   return (
-    <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center justify-between gap-2">
+    <div className="rounded-md bg-secondary/30 px-3 py-2 flex flex-wrap items-center justify-between gap-2">
       <div className="min-w-0 flex items-center gap-1.5">
         {isRunning ? (
           <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -165,7 +165,7 @@ export function CortexStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton
             variant="rounded"
             width={SKELETON_TITLE_WIDTH}
@@ -214,7 +214,7 @@ export function CortexStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/dapr_status/index.tsx
+++ b/web/src/components/cards/dapr_status/index.tsx
@@ -87,7 +87,7 @@ function ControlPlaneRow({ pod }: { pod: DaprControlPlanePod }) {
       : 'bg-red-500/20 text-red-400'
 
   return (
-    <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center justify-between gap-2">
+    <div className="rounded-md bg-secondary/30 px-3 py-2 flex flex-wrap items-center justify-between gap-2">
       <div className="min-w-0 flex items-center gap-1.5">
         {isRunning ? (
           <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -117,7 +117,7 @@ function ComponentRow({
   t: TFunction<'cards'>
 }) {
   return (
-    <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center justify-between gap-2">
+    <div className="rounded-md bg-secondary/30 px-3 py-2 flex flex-wrap items-center justify-between gap-2">
       <div className="min-w-0 flex items-center gap-1.5">
         <ComponentIcon type={component.type} />
         <span className="text-xs font-medium text-foreground truncate">{component.name}</span>
@@ -150,7 +150,7 @@ export function DaprStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
@@ -191,7 +191,7 @@ export function DaprStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/dragonfly_status/index.tsx
+++ b/web/src/components/cards/dragonfly_status/index.tsx
@@ -132,7 +132,7 @@ export function DragonflyStatus() {
 
   return (
     <div className="h-full flex flex-col min-h-card gap-4 overflow-hidden animate-in fade-in duration-500">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
@@ -222,7 +222,7 @@ export function DragonflyStatus() {
                 key={`${row.cluster}:${row.namespace}:${row.name}`}
                 className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1"
               >
-                <div className="flex items-center justify-between gap-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
                   <div className="min-w-0 flex items-center gap-1.5">
                     {readyAll ? (
                       <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -241,7 +241,7 @@ export function DragonflyStatus() {
                   </span>
                 </div>
 
-                <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+                <div className="text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-2">
                   <span className="truncate">
                     {row.namespace || '—'}
                     {row.cluster ? ` · ${row.cluster}` : ''}

--- a/web/src/components/cards/envoy_status/index.tsx
+++ b/web/src/components/cards/envoy_status/index.tsx
@@ -51,7 +51,7 @@ function ListenerRow({ listener }: { listener: EnvoyListener }) {
       : 'bg-yellow-500/20 text-yellow-400'
 
   return (
-    <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center justify-between gap-2">
+    <div className="rounded-md bg-secondary/30 px-3 py-2 flex flex-wrap items-center justify-between gap-2">
       <div className="min-w-0 flex items-center gap-1.5">
         {isActive ? (
           <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -82,7 +82,7 @@ function ClusterRow({ cluster }: { cluster: EnvoyUpstreamCluster }) {
 
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Server className={`w-3.5 h-3.5 shrink-0 ${ringClass}`} />
           <span className="text-xs font-medium text-foreground truncate">{cluster.name}</span>
@@ -109,7 +109,7 @@ export function EnvoyStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
@@ -148,7 +148,7 @@ export function EnvoyStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/flux_status/index.tsx
+++ b/web/src/components/cards/flux_status/index.tsx
@@ -36,7 +36,7 @@ function ResourceSection({
               key={`${item.kind}:${item.cluster}:${item.namespace}:${item.name}`}
               className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1"
             >
-              <div className="flex items-center justify-between gap-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
                 <div className="min-w-0 flex items-center gap-1.5">
                   {item.ready ? (
                     <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -56,7 +56,7 @@ function ResourceSection({
                 </span>
               </div>
 
-              <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+              <div className="text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-2">
                 <span className="truncate">{item.namespace} | {item.cluster}</span>
                 <span className="truncate">{item.reason || item.revision || '-'}</span>
               </div>
@@ -79,7 +79,7 @@ export function FluxStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
@@ -110,7 +110,7 @@ export function FluxStatus() {
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/grpc_status/index.tsx
+++ b/web/src/components/cards/grpc_status/index.tsx
@@ -67,7 +67,7 @@ function ServiceRow({ service }: { service: GrpcService }) {
 
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           {isServing ? (
             <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -82,7 +82,7 @@ function ServiceRow({ service }: { service: GrpcService }) {
           {service.status}
         </span>
       </div>
-      <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-[11px] text-muted-foreground">
         <span className="truncate">
           {service.namespace} · {service.endpoints} endpoints
         </span>
@@ -113,7 +113,7 @@ export function GrpcStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
@@ -154,7 +154,7 @@ export function GrpcStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/jaeger_status/index.tsx
+++ b/web/src/components/cards/jaeger_status/index.tsx
@@ -114,7 +114,7 @@ export const JaegerStatus: React.FC<CardComponentProps> = () => {
         <div className="flex flex-col h-full overflow-hidden animate-in fade-in duration-500">
             {/* Header: Fixed Height */}
             <div className="flex-1 overflow-y-auto custom-scrollbar p-4 space-y-4">
-                <div className="flex items-center justify-between">
+                <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <div className="flex items-center gap-3">
                         <div className={cn("p-2 rounded-xl border shadow-sm transition-all", brandStatus.bg, brandStatus.border)}>
                             <Activity className={cn("w-5 h-5", brandStatus.color)} />
@@ -152,7 +152,7 @@ export const JaegerStatus: React.FC<CardComponentProps> = () => {
                 </div>
 
                 {/* Resource Metrics Grid */}
-                <div className="grid grid-cols-3 gap-2">
+                <div className="grid grid-cols-2 @sm:grid-cols-3 gap-2">
                     <MetricTile
                         icon={<Database className="w-3.5 h-3.5 text-orange-400" />}
                         label={t('jaeger.services')}
@@ -177,7 +177,7 @@ export const JaegerStatus: React.FC<CardComponentProps> = () => {
                         <Clock className="w-3 h-3" />
                         <span>{t('jaeger.latencyAnalysis')}</span>
                     </div>
-                    <div className="grid grid-cols-3 gap-2 p-2 rounded-xl bg-secondary/10 border border-border/30">
+                    <div className="grid grid-cols-2 @sm:grid-cols-3 gap-2 p-2 rounded-xl bg-secondary/10 border border-border/30">
                         <LatencyInfo label={t('jaeger.avg')} value={data.metrics.avgLatencyMs} />
                         <LatencyInfo label={t('jaeger.p95')} value={data.metrics.p95LatencyMs} isMiddle />
                         <LatencyInfo label={t('jaeger.p99')} value={data.metrics.p99LatencyMs} />
@@ -186,7 +186,7 @@ export const JaegerStatus: React.FC<CardComponentProps> = () => {
 
                 {/* Collectors List */}
                 <div className="space-y-2">
-                    <div className="flex items-center justify-between px-1">
+                    <div className="flex flex-wrap items-center justify-between gap-y-2 px-1">
                         <div className="flex items-center gap-2 text-[10px] text-muted-foreground/50 uppercase tracking-widest font-bold">
                             <ShieldCheck className="w-3 h-3" />
                             <span>{t('jaeger.collectors')}</span>
@@ -213,7 +213,7 @@ export const JaegerStatus: React.FC<CardComponentProps> = () => {
                                 <div
                                     key={collector.name}
                                     onClick={() => drillToNode(collector.cluster || 'all', collector.name)}
-                                    className="flex items-center justify-between p-2 rounded-lg bg-secondary/20 border border-border/40 hover:border-border/80 transition-all cursor-pointer group/row"
+                                    className="flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg bg-secondary/20 border border-border/40 hover:border-border/80 transition-all cursor-pointer group/row"
                                 >
                                     <div className="flex items-center gap-2 overflow-hidden">
                                         <Server className="w-3.5 h-3.5 text-muted-foreground/60 group-hover/row:text-primary transition-colors shrink-0" />
@@ -246,7 +246,7 @@ export const JaegerStatus: React.FC<CardComponentProps> = () => {
                 </div>
             </div>
 
-            <div className="p-3 bg-muted/10 border-t border-border/40 flex items-center justify-between shrink-0">
+            <div className="p-3 bg-muted/10 border-t border-border/40 flex flex-wrap items-center justify-between gap-y-2 shrink-0">
                 <div className="flex items-center gap-2 text-[10px] text-muted-foreground font-medium">
                     <span className="bg-secondary/50 px-1.5 py-0.5 rounded border border-border/20 font-mono opacity-60">
                         v{data.version}
@@ -275,7 +275,7 @@ export const JaegerStatus: React.FC<CardComponentProps> = () => {
 function KPIField({ icon, label, value, alert }: { icon: React.ReactNode, label: string, value: number, alert?: boolean }) {
     return (
         <div className={cn(
-            "flex items-center justify-between px-3 py-2 rounded-xl border transition-all",
+            "flex flex-wrap items-center justify-between gap-y-2 px-3 py-2 rounded-xl border transition-all",
             alert ? "bg-red-500/5 border-red-500/20 shadow-[var(--shadow-error-glow)]" : "bg-secondary/10 border-border/30"
         )}>
             <div className="flex items-center gap-2">

--- a/web/src/components/cards/kserve_status/index.tsx
+++ b/web/src/components/cards/kserve_status/index.tsx
@@ -113,7 +113,7 @@ function ServiceRow({
   const showTrafficSplit = service.trafficPercent < FULL_TRAFFIC_PERCENT
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <StatusIcon status={service.status} />
           <span className="text-xs font-medium font-mono truncate text-foreground">
@@ -176,7 +176,7 @@ export function KServeStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton
             variant="rounded"
             width={SKELETON_TITLE_WIDTH}
@@ -229,7 +229,7 @@ export function KServeStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + controller pod status */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',

--- a/web/src/components/cards/kubevela_status/index.tsx
+++ b/web/src/components/cards/kubevela_status/index.tsx
@@ -193,7 +193,7 @@ function ApplicationRow({
 
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1.5">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           {appStatusIcon(app.status)}
           <span className="text-xs font-medium text-foreground truncate">
@@ -210,7 +210,7 @@ function ApplicationRow({
         </span>
       </div>
 
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2 text-[11px] text-muted-foreground min-w-0">
           <span className="shrink-0">
             <Cpu className="inline w-3 h-3 mr-0.5 text-blue-400" />
@@ -273,7 +273,7 @@ export function KubeVelaStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton
             variant="rounded"
             width={SKELETON_TITLE_WIDTH}
@@ -322,7 +322,7 @@ export function KubeVelaStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/linkerd_status/index.tsx
+++ b/web/src/components/cards/linkerd_status/index.tsx
@@ -73,7 +73,7 @@ function DeploymentRow({ deployment }: { deployment: LinkerdMeshedDeployment }) 
 
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           {isFullyMeshed ? (
             <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -116,7 +116,7 @@ export function LinkerdStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
@@ -157,7 +157,7 @@ export function LinkerdStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/llmd/LLMdFlow.tsx
+++ b/web/src/components/cards/llmd/LLMdFlow.tsx
@@ -1142,7 +1142,7 @@ export function LLMdFlow() {
             <div className={`grid gap-2 ${
               selectedMetricTypes.length === 1 ? 'grid-cols-1' :
               selectedMetricTypes.length === 2 ? 'grid-cols-2' :
-              'grid-cols-3'
+              'grid-cols-2 @sm:grid-cols-3'
             }`}>
               {selectedMetricTypes.map(metric => (
                 <div key={metric} className="bg-secondary/50 rounded-lg p-2">

--- a/web/src/components/cards/longhorn_status/index.tsx
+++ b/web/src/components/cards/longhorn_status/index.tsx
@@ -93,7 +93,7 @@ function VolumeRow({ volume }: { volume: LonghornVolume }) {
 
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <RobustnessIcon robustness={volume.robustness} />
           <span className="text-xs font-medium truncate font-mono">
@@ -110,7 +110,7 @@ function VolumeRow({ volume }: { volume: LonghornVolume }) {
         </span>
       </div>
 
-      <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+      <div className="text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-2">
         <span className="truncate">
           {t('longhornStatus.replicasShort', {
             healthy: volume.replicasHealthy,
@@ -152,7 +152,7 @@ function NodeRow({ node }: { node: LonghornNode }) {
 
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Server className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-xs font-medium truncate font-mono">
@@ -169,7 +169,7 @@ function NodeRow({ node }: { node: LonghornNode }) {
         </span>
       </div>
 
-      <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+      <div className="text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-2">
         <span className="truncate">
           {t('longhornStatus.replicaCount', {
             count: node.replicaCount,
@@ -246,7 +246,7 @@ export function LonghornStatus() {
 
   return (
     <div className="h-full flex flex-col min-h-card gap-4 overflow-hidden animate-in fade-in duration-500">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',

--- a/web/src/components/cards/openfeature_status/index.tsx
+++ b/web/src/components/cards/openfeature_status/index.tsx
@@ -98,7 +98,7 @@ function ProviderRow({
 }) {
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <span
             className={`w-2 h-2 rounded-full shrink-0 ${PROVIDER_DOT_CLASS[provider.status]}`}
@@ -142,7 +142,7 @@ function FlagRow({
 
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <ToggleIcon className={`w-3.5 h-3.5 shrink-0 ${toggleClass}`} />
           <span className="text-xs font-medium text-foreground truncate font-mono">
@@ -185,7 +185,7 @@ export function OpenFeatureStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton
             variant="rounded"
             width={SKELETON_TITLE_WIDTH}
@@ -197,7 +197,7 @@ export function OpenFeatureStatus() {
             height={SKELETON_BADGE_HEIGHT}
           />
         </div>
-        <SkeletonStats className="grid-cols-3" />
+        <SkeletonStats className="grid-cols-2 @sm:grid-cols-3" />
         <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )
@@ -234,7 +234,7 @@ export function OpenFeatureStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/openfga_status/index.tsx
+++ b/web/src/components/cards/openfga_status/index.tsx
@@ -73,7 +73,7 @@ function storeStatusClass(status: OpenfgaStoreStatus): string {
 function StoreRow({ store }: { store: OpenfgaStore }) {
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Database className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-xs font-medium text-foreground truncate font-mono">
@@ -103,7 +103,7 @@ function StoreRow({ store }: { store: OpenfgaStore }) {
 function ModelRow({ model }: { model: OpenfgaAuthorizationModel }) {
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <FileCode className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-xs font-medium text-foreground truncate font-mono">
@@ -144,7 +144,7 @@ export function OpenfgaStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton
             variant="rounded"
             width={SKELETON_TITLE_WIDTH}
@@ -193,7 +193,7 @@ export function OpenfgaStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy
@@ -270,7 +270,7 @@ export function OpenfgaStatus() {
               {t('openfgaStatus.sectionLatency', 'Latency (ms)')}
             </h4>
           </div>
-          <div className="grid grid-cols-3 gap-2">
+          <div className="grid grid-cols-2 @sm:grid-cols-3 gap-2">
             <div className="rounded-md bg-secondary/30 px-3 py-2 flex flex-col items-center">
               <span className="text-[11px] text-muted-foreground">p50</span>
               <span className="text-sm font-mono text-foreground">

--- a/web/src/components/cards/spiffe_status/index.tsx
+++ b/web/src/components/cards/spiffe_status/index.tsx
@@ -69,7 +69,7 @@ function EntryRow({ entry }: { entry: SpiffeRegistrationEntry }) {
 
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Fingerprint className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-xs font-medium text-foreground truncate font-mono">
@@ -93,7 +93,7 @@ function EntryRow({ entry }: { entry: SpiffeRegistrationEntry }) {
 function FederatedRow({ domain }: { domain: SpiffeFederatedDomain }) {
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Globe className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-xs font-medium text-foreground truncate font-mono">
@@ -131,7 +131,7 @@ export function SpiffeStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
@@ -172,7 +172,7 @@ export function SpiffeStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/spire_status/index.tsx
+++ b/web/src/components/cards/spire_status/index.tsx
@@ -80,7 +80,7 @@ function ServerPodRow({
   const isHealthy = pod.ready && pod.phase === 'Running'
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           {isHealthy ? (
             <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -146,7 +146,7 @@ export function SpireStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
@@ -190,7 +190,7 @@ export function SpireStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + trust domain */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
@@ -289,7 +289,7 @@ export function SpireStatus() {
               </h4>
             </div>
             <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-              <div className="flex items-center justify-between gap-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
                 <span className="text-xs font-medium font-mono truncate">
                   {agent.namespace}/{agent.name}
                 </span>

--- a/web/src/components/cards/strimzi_status/index.tsx
+++ b/web/src/components/cards/strimzi_status/index.tsx
@@ -108,7 +108,7 @@ function ClusterRow({ cluster }: { cluster: StrimziKafkaCluster }) {
 
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-2">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Database className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-xs font-medium text-foreground truncate font-mono">
@@ -186,7 +186,7 @@ export function StrimziStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
@@ -227,7 +227,7 @@ export function StrimziStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/tikv_status/index.tsx
+++ b/web/src/components/cards/tikv_status/index.tsx
@@ -137,7 +137,7 @@ export function TikvStatus() {
 
   return (
     <div className="h-full flex flex-col min-h-card gap-4 overflow-hidden animate-in fade-in duration-500">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
@@ -210,7 +210,7 @@ export function TikvStatus() {
                 key={storeId}
                 className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1"
               >
-                <div className="flex items-center justify-between gap-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
                   <div className="min-w-0 flex items-center gap-1.5">
                     {stateUp ? (
                       <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -236,7 +236,7 @@ export function TikvStatus() {
                   </span>
                 </div>
 
-                <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+                <div className="text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-2">
                   <span className="truncate">
                     {t('tikvStatus.regionCount', { count: regionCount, defaultValue: '{{count}} regions' })} · {t('tikvStatus.leaderCount', { count: leaderCount, defaultValue: '{{count}} leaders' })}
                   </span>

--- a/web/src/components/cards/tuf_status/index.tsx
+++ b/web/src/components/cards/tuf_status/index.tsx
@@ -104,7 +104,7 @@ function RoleRow({
   const isHealthy = role.status === 'signed'
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           {isHealthy ? (
             <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
@@ -173,7 +173,7 @@ export function TufStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
@@ -213,7 +213,7 @@ export function TufStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',

--- a/web/src/components/cards/vitess_status/index.tsx
+++ b/web/src/components/cards/vitess_status/index.tsx
@@ -145,7 +145,7 @@ export function VitessStatus() {
   return (
     <div className="h-full flex flex-col min-h-card gap-4 overflow-hidden animate-in fade-in duration-500">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
@@ -258,7 +258,7 @@ function KeyspaceRow({
 
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Database className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-xs font-medium text-foreground truncate font-mono">

--- a/web/src/components/cards/volcano_status/index.tsx
+++ b/web/src/components/cards/volcano_status/index.tsx
@@ -98,7 +98,7 @@ function QueueRow({ queue }: { queue: VolcanoQueue }) {
 
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1.5">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Layers className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-xs font-medium text-foreground truncate font-mono">
@@ -150,7 +150,7 @@ function QueueRow({ queue }: { queue: VolcanoQueue }) {
 function JobRow({ job }: { job: VolcanoJob }) {
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Package className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-xs font-medium text-foreground truncate font-mono">
@@ -194,7 +194,7 @@ export function VolcanoStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton
             variant="rounded"
             width={SKELETON_TITLE_WIDTH}
@@ -243,7 +243,7 @@ export function VolcanoStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/wasmcloud_status/index.tsx
+++ b/web/src/components/cards/wasmcloud_status/index.tsx
@@ -88,7 +88,7 @@ const LINK_STATUS_CLASS: Record<WasmcloudLinkStatus, string> = {
 function HostRow({ host, t }: { host: WasmcloudHost; t: TFunction<'cards'> }) {
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Server className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-xs font-medium text-foreground truncate">
@@ -122,7 +122,7 @@ function HostRow({ host, t }: { host: WasmcloudHost; t: TFunction<'cards'> }) {
 function ProviderRow({ provider }: { provider: WasmcloudProvider }) {
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Package className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-xs font-medium text-foreground truncate">
@@ -145,7 +145,7 @@ function ProviderRow({ provider }: { provider: WasmcloudProvider }) {
 function LinkRow({ link }: { link: WasmcloudLink }) {
   return (
     <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0 flex items-center gap-1.5">
           <Link2 className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
           <span className="text-[11px] font-mono text-foreground truncate">
@@ -184,7 +184,7 @@ export function WasmcloudStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
           <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
@@ -225,7 +225,7 @@ export function WasmcloudStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Header — health pill + freshness */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy


### PR DESCRIPTION
Fixes #10577

## Summary

Completes the Phase 3 container-query rollout from #8695 RFC. After this PR + Phase 3a (#10520), **zero unwrapped `flex justify-between` control bars remain** in card components.

### Changes (31 files, 108 lines changed)

**1. Flex-wrap sweep — 99 instances across 29 card files**

Added `flex-wrap gap-y-2` (or `flex-wrap` where `gap-2` was already present) to every remaining `flex items-center justify-between` bar in card components:

ACMMFeedbackLoops, DeploymentRiskScore, RuntimeAttestationCard, artifact_hub, backstage, cilium, cni, containerd, cortex, dapr, dragonfly, envoy, flux, grpc, jaeger, kserve, kubevela, linkerd, longhorn, openfeature, openfga, spiffe, spire, strimzi, tikv, tuf, vitess, volcano, wasmcloud.

**2. Grid-cols container-query conversion — 8 instances across 6 files**

- `grid-cols-3` → `grid-cols-2 @sm:grid-cols-3`: openfga (1), jaeger (2), cilium (2)
- `SkeletonStats grid-cols-3` → `grid-cols-2 @sm:grid-cols-3`: openfeature (1)
- `sm:grid-cols-3` → `@sm:grid-cols-3`: ActiveAlerts (1) — viewport → container query
- Dynamic grid-cols-3 → `grid-cols-2 @sm:grid-cols-3`: LLMdFlow (1)

**Not changed (intentionally):**
- Modal files (trivy, kyverno, opa, kubescape, ovn, kubevirt, multi-tenancy, compliance) — these render full-viewport, so viewport `sm:` breakpoints are correct per #8695 RFC.
- SudokuGame, DynamicCard — game boards and auto-layout grids have special layout needs.

### Verification

- `npm run build` ✓
- `npm run lint` ✓ (no new errors)
- Pure CSS class changes — no logic or behavior changes
- No OAuth, auth, or update system code touched