### PR TITLE
🐛 Fix CI Go version: update 1.25 → 1.26 to match go.mod

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   api-contract:

--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -43,7 +43,7 @@ env:
   COPILOT_ASSIGNMENT_DELAY_S: 120  # Seconds between Copilot assignments to avoid rate limiting
   ISSUE_PREFIX: "[Auto-QA]"
   NODE_VERSION: "22"
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 permissions: read-all
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       # Full suite — must match what release.yml runs or main can still

--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   RESULTS_DIR: test-results/nightly
   NODE_VERSION: '22'
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   test:

--- a/.github/workflows/nil-safety.yml
+++ b/.github/workflows/nil-safety.yml
@@ -22,7 +22,7 @@ on:
         type: boolean
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Set up Node.js
@@ -209,7 +209,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Set up Node.js

--- a/.github/workflows/startup-smoke.yml
+++ b/.github/workflows/startup-smoke.yml
@@ -36,7 +36,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   NODE_VERSION: '22'
 
 jobs:

--- a/.github/workflows/update-guard.yml
+++ b/.github/workflows/update-guard.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes #10574

## Problem

`go.mod` requires `go 1.26.0` but 8 CI workflow files hardcode Go 1.25, causing all Go builds to fail with:
```
go: go.mod requires go >= 1.26.0 (running go 1.25.9; GOTOOLCHAIN=local)
```

This breaks:
- `go test ./...` in PRs (go-test, api-contract, nil-safety, nightly-test-suite)
- Release workflow (goreleaser)
- Startup smoke tests
- Auto-QA and update-guard workflows

## Fix

Updated `GO_VERSION` from `1.25` to `1.26` in all 8 affected workflow files:
- `.github/workflows/api-contract.yml`
- `.github/workflows/auto-qa.yml`
- `.github/workflows/go-test.yml`
- `.github/workflows/nil-safety.yml`
- `.github/workflows/nightly-test-suite.yml`
- `.github/workflows/release.yml`
- `.github/workflows/startup-smoke.yml`
- `.github/workflows/update-guard.yml`

Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>