### PR TITLE
Add fetcher tests for 29 useCached hooks to reach 91% coverage

### DIFF
--- a/web/src/hooks/__tests__/useCachedAttestation-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedAttestation-funcs.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the fetcher function from useCachedAttestation.ts.
+ *
+ * useCachedAttestation uses plain `fetch` (not authFetch) and has no
+ * __testables export, so we test only the fetcher via useCache capture.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { mockFetch, mockUseCache } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+  mockUseCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+vi.stubGlobal('fetch', mockFetch)
+vi.mock('../../lib/cache', () => ({ useCache: (...args: unknown[]) => mockUseCache(...args) }))
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+import { useCachedAttestation } from '../useCachedAttestation'
+
+// ---------------------------------------------------------------------------
+// Fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchAttestationScore (fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function captureFetcher(): () => Promise<unknown> {
+    renderHook(() => useCachedAttestation())
+    const config = mockUseCache.mock.calls[0]?.[0] as { fetcher: () => Promise<unknown> }
+    return config.fetcher
+  }
+
+  it('returns parsed data on success', async () => {
+    const validResponse = {
+      clusters: [
+        {
+          cluster: 'eks-prod',
+          overallScore: 92,
+          signals: [
+            { name: 'Image Provenance', score: 92, weight: 30, detail: 'good' },
+          ],
+          nonCompliantWorkloads: [],
+        },
+      ],
+    }
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { clusters: unknown[] }
+    expect(result.clusters).toHaveLength(1)
+  })
+
+  it('returns empty clusters array when body has no clusters', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { clusters: unknown[] }
+    expect(result.clusters).toEqual([])
+  })
+
+  it('throws on 404 status', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    })
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('attestation HTTP 404')
+  })
+
+  it('throws on 500 status', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    })
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('attestation HTTP 500')
+  })
+
+  it('throws on network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('Network error')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedBackstage-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedBackstage-funcs.test.ts
@@ -2,7 +2,14 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedBackstage.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,24 +18,37 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
 }))
 
+mockUseCache.mockReturnValue({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+})
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCache(...args),
 }))
 
-import { __testables } from '../useCachedBackstage'
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables, useCachedBackstage } from '../useCachedBackstage'
 import type {
   BackstageCatalogCounts,
   BackstagePlugin,
@@ -307,5 +327,87 @@ describe('buildBackstageStatus', () => {
     const result = buildBackstageStatus({})
     // Should be a valid ISO timestamp
     expect(new Date(result.lastCatalogSync).getTime()).not.toBeNaN()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetcher (via useCache capture)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('returns parsed Backstage status on successful response', async () => {
+    const validResponse = {
+      version: '1.32.0',
+      replicas: 2,
+      desiredReplicas: 2,
+      catalog: { Component: 50, API: 20 },
+      plugins: [{ name: '@backstage/plugin-catalog', version: '1.21.0', status: 'enabled' }],
+      templates: [{ name: 'nodejs-service', owner: 'platform-team', type: 'service' }],
+      lastCatalogSync: new Date().toISOString(),
+    }
+
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    renderHook(() => useCachedBackstage())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('healthy')
+    expect(result.version).toBe('1.32.0')
+    expect(result.replicas).toBe(2)
+    expect(result.catalog.Component).toBe(50)
+  })
+
+  it('returns not-installed status on 404 response (no throw)', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    })
+
+    renderHook(() => useCachedBackstage())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    // Backstage fetcher returns buildBackstageStatus({}) on 404 — does not throw
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws when authFetch returns a non-404 error', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    renderHook(() => useCachedBackstage())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('HTTP 500')
+  })
+
+  it('throws when authFetch rejects (network error)', async () => {
+    mockAuthFetch.mockRejectedValue(new Error('Network failure'))
+
+    renderHook(() => useCachedBackstage())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Network failure')
   })
 })

--- a/web/src/hooks/__tests__/useCachedCiliumStatus-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCiliumStatus-funcs.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Fetcher function tests for useCachedCiliumStatus.ts.
+ * This hook delegates to fetchCiliumStatus from agentFetchers,
+ * so we mock that and test the fetcher passed to useCache.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockFetchCiliumStatus = vi.fn()
+
+vi.mock('../useCachedData/agentFetchers', () => ({
+  fetchCiliumStatus: (...args: unknown[]) => mockFetchCiliumStatus(...args),
+}))
+
+vi.mock('../useCachedData/demoData', () => ({
+  getDemoCiliumStatus: () => ({
+    status: 'Healthy',
+    nodes: [{ name: 'demo-node', status: 'Ready' }],
+    networkPolicies: 5,
+    endpoints: 10,
+    hubble: { enabled: true, flowsPerSecond: 100, metrics: { forwarded: 50, dropped: 2 } },
+  }),
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+const mockUseCache = vi.fn(() => ({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+import { useCachedCiliumStatus } from '../useCachedCiliumStatus'
+
+// ---------------------------------------------------------------------------
+// Fetcher function tests (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('useCachedCiliumStatus fetcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: { status: 'Healthy', nodes: [], networkPolicies: 0, endpoints: 0, hubble: { enabled: false, flowsPerSecond: 0, metrics: { forwarded: 0, dropped: 0 } } },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('returns data from fetchCiliumStatus on success', async () => {
+    renderHook(() => useCachedCiliumStatus())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    const mockData = {
+      status: 'Healthy',
+      nodes: [{ name: 'node-1', status: 'Ready' }],
+      networkPolicies: 3,
+      endpoints: 8,
+      hubble: { enabled: true, flowsPerSecond: 50, metrics: { forwarded: 20, dropped: 1 } },
+    }
+    mockFetchCiliumStatus.mockResolvedValueOnce(mockData)
+
+    const result = await fetcher()
+    expect(result).toBe(mockData)
+  })
+
+  it('throws when fetchCiliumStatus returns null', async () => {
+    renderHook(() => useCachedCiliumStatus())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockFetchCiliumStatus.mockResolvedValueOnce(null)
+
+    await expect(fetcher()).rejects.toThrow('Cilium status unavailable')
+  })
+
+  it('propagates network error from fetchCiliumStatus', async () => {
+    renderHook(() => useCachedCiliumStatus())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockFetchCiliumStatus.mockRejectedValueOnce(new Error('Network failure'))
+
+    await expect(fetcher()).rejects.toThrow('Network failure')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedCloudCustodian-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCloudCustodian-funcs.test.ts
@@ -2,7 +2,14 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedCloudCustodian.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,24 +18,37 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
 }))
 
+mockUseCache.mockReturnValue({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+})
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCache(...args),
 }))
 
-import { __testables } from '../useCachedCloudCustodian'
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables, useCachedCloudCustodian } from '../useCachedCloudCustodian'
 import type {
   CustodianPolicy,
   CustodianSeverityCounts,
@@ -263,3 +283,84 @@ function makePolicy(overrides?: Partial<CustodianPolicy>): CustodianPolicy {
     ...overrides,
   }
 }
+
+// ---------------------------------------------------------------------------
+// fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetcher (via useCache capture)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('returns parsed Cloud Custodian status on successful response', async () => {
+    const validResponse = {
+      version: '0.9.25',
+      policies: [
+        { name: 'ec2-stop', resource: 'aws.ec2', provider: 'aws', mode: 'pull', successCount: 10, failCount: 0, dryRunCount: 0, resourcesMatched: 5, lastRunAt: new Date().toISOString() },
+      ],
+      topResources: [{ id: 'arn:aws:ec2:i-123', type: 'ec2-instance', actionCount: 3 }],
+      violationsBySeverity: { critical: 0, high: 0, medium: 2, low: 1 },
+    }
+
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    renderHook(() => useCachedCloudCustodian())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('healthy')
+    expect(result.version).toBe('0.9.25')
+    expect(result.policies).toHaveLength(1)
+    expect(result.topResources).toHaveLength(1)
+  })
+
+  it('returns not-installed status on 404 response (no throw)', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    })
+
+    renderHook(() => useCachedCloudCustodian())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    // CloudCustodian fetcher returns buildCloudCustodianStatus on 404
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws when authFetch returns a non-404 error', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    renderHook(() => useCachedCloudCustodian())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('HTTP 500')
+  })
+
+  it('throws when authFetch rejects (network error)', async () => {
+    mockAuthFetch.mockRejectedValue(new Error('Network failure'))
+
+    renderHook(() => useCachedCloudCustodian())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Network failure')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedCni-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCni-funcs.test.ts
@@ -1,8 +1,12 @@
 /**
  * Tests for the pure helper functions exported via __testables
- * from useCachedCni.ts.
+ * from useCachedCni.ts, PLUS fetcher function tests.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockAuthFetch = vi.fn()
+vi.mock('../../lib/api', () => ({ authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,21 +15,35 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+const mockUseCache = vi.fn(() => ({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
 }))
 
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
 }))
 
 import { __testables } from '../useCachedCni'
@@ -202,5 +220,118 @@ describe('buildCniStatus', () => {
     const stats = makeStats()
     const result = buildCniStatus(stats, [])
     expect(result.stats).toBe(stats)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher function tests (via useCache capture)
+// ---------------------------------------------------------------------------
+
+import { useCachedCni } from '../useCachedCni'
+
+describe('fetchCniStatus (via useCache fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: { health: 'not-installed', nodes: [], stats: { activePlugin: 'unknown', pluginVersion: 'unknown', podNetworkCidr: '', serviceNetworkCidr: '', nodeCount: 0, nodesCniReady: 0, networkPolicyCount: 0, servicesWithNetworkPolicy: 0, totalServices: 0, podsWithIp: 0, totalPods: 0 }, summary: { activePlugin: 'unknown', pluginVersion: 'unknown', podNetworkCidr: '', nodesCniReady: 0, nodeCount: 0, networkPolicyCount: 0, servicesWithNetworkPolicy: 0 }, lastCheckTime: '' },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('parses a successful API response into CniStatusData', async () => {
+    renderHook(() => useCachedCni())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          nodes: [
+            {
+              node: 'worker-1',
+              cluster: 'cluster-1',
+              state: 'ready',
+              plugin: 'cilium',
+              pluginVersion: '1.15.1',
+              podCidr: '10.244.1.0/24',
+              lastHeartbeat: new Date().toISOString(),
+            },
+          ],
+          stats: {
+            activePlugin: 'cilium',
+            pluginVersion: '1.15.1',
+            podNetworkCidr: '10.244.0.0/16',
+            serviceNetworkCidr: '10.96.0.0/12',
+            nodeCount: 1,
+            nodesCniReady: 1,
+            networkPolicyCount: 5,
+            servicesWithNetworkPolicy: 2,
+            totalServices: 10,
+            podsWithIp: 50,
+            totalPods: 50,
+          },
+        }),
+    })
+
+    const result = await fetcher()
+    expect(result.health).toBe('healthy')
+    expect(result.nodes).toHaveLength(1)
+    expect(result.stats.activePlugin).toBe('cilium')
+    expect(result.summary.activePlugin).toBe('cilium')
+  })
+
+  it('throws on non-ok response (non-404) so cache falls back to demo', async () => {
+    renderHook(() => useCachedCni())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch CNI status')
+  })
+
+  it('returns not-installed data on 404 (treated as empty)', async () => {
+    renderHook(() => useCachedCni())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const result = await fetcher()
+    expect(result.health).toBe('not-installed')
+    expect(result.nodes).toEqual([])
+  })
+
+  it('throws on network error so cache falls back to demo', async () => {
+    renderHook(() => useCachedCni())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch CNI status')
+  })
+
+  it('handles empty body fields gracefully', async () => {
+    renderHook(() => useCachedCni())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })
+
+    const result = await fetcher()
+    expect(result.nodes).toEqual([])
+    expect(result.stats.activePlugin).toBe('unknown')
   })
 })

--- a/web/src/hooks/__tests__/useCachedContainerd-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedContainerd-funcs.test.ts
@@ -2,20 +2,12 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedContainerd.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
-
-vi.mock('../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
-}))
-
-vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
+const { mockAgentFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAgentFetch: vi.fn(),
+  mockUseCache: vi.fn(() => ({
     data: null,
     isLoading: false,
     isRefreshing: false,
@@ -27,8 +19,21 @@ vi.mock('../../lib/cache', () => ({
     refetch: vi.fn(),
   })),
 }))
+vi.mock('../mcp/shared', () => ({ agentFetch: mockAgentFetch }))
 
-import { __testables } from '../useCachedContainerd'
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/cache', () => ({ useCache: (...args: unknown[]) => mockUseCache(...args) }))
+
+import { __testables, useCachedContainerd } from '../useCachedContainerd'
 
 const { isContainerdRuntime, normalizeContainerId, mapContainerState, formatUptime, buildContainerdData } = __testables
 
@@ -227,5 +232,90 @@ describe('buildContainerdData', () => {
     ]
     const result = buildContainerdData(nodes, pods)
     expect(result.containers).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchContainerdStatus (fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function captureFetcher(): () => Promise<unknown> {
+    renderHook(() => useCachedContainerd())
+    const config = mockUseCache.mock.calls[0]?.[0] as { fetcher: () => Promise<unknown> }
+    return config.fetcher
+  }
+
+  it('returns parsed data on success', async () => {
+    mockAgentFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          nodes: [{ name: 'worker-1', containerRuntime: 'containerd://1.6.20' }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          pods: [
+            {
+              name: 'nginx-abc',
+              namespace: 'default',
+              node: 'worker-1',
+              containers: [{ name: 'nginx', image: 'nginx:1.25', state: 'running', containerID: 'containerd://abc123def456789' }],
+            },
+          ],
+        }),
+      })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; containers: unknown[] }
+    expect(result.health).toBe('healthy')
+    expect(result.containers).toHaveLength(1)
+  })
+
+  it('throws when nodes endpoint returns non-ok', async () => {
+    mockAgentFetch
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ pods: [] }) })
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('nodes HTTP 500')
+  })
+
+  it('throws when pods endpoint returns non-ok', async () => {
+    mockAgentFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ nodes: [] }) })
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('pods HTTP 503')
+  })
+
+  it('throws on network error', async () => {
+    mockAgentFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('Network error')
+  })
+
+  it('returns not-installed when no containerd nodes found', async () => {
+    mockAgentFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ nodes: [{ name: 'node1', containerRuntime: 'cri-o://1.27' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ pods: [] }),
+      })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
   })
 })

--- a/web/src/hooks/__tests__/useCachedCortex-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCortex-funcs.test.ts
@@ -2,7 +2,14 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedCortex.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,24 +18,37 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
 }))
 
+mockUseCache.mockReturnValue({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+})
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCache(...args),
 }))
 
-import { __testables } from '../useCachedCortex'
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables, useCachedCortex } from '../useCachedCortex'
 import type {
   CortexComponentPod,
   CortexIngestionMetrics,
@@ -229,3 +249,89 @@ function makeComponent(overrides?: Partial<CortexComponentPod>): CortexComponent
     ...overrides,
   }
 }
+
+// ---------------------------------------------------------------------------
+// fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetcher (via useCache capture)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: {
+        health: 'not-installed',
+        version: 'unknown',
+        components: [],
+        metrics: { activeSeries: 0, ingestionRatePerSec: 0, queryRatePerSec: 0, tenantCount: 0 },
+        summary: { totalPods: 0, runningPods: 0, totalComponents: 0, runningComponents: 0 },
+        lastCheckTime: new Date().toISOString(),
+      },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('returns parsed Cortex status on successful response', async () => {
+    const validResponse = {
+      version: '1.16.0',
+      components: [
+        { name: 'distributor', namespace: 'cortex', status: 'running', replicasDesired: 3, replicasReady: 3, cluster: 'default' },
+      ],
+      metrics: { activeSeries: 500000, ingestionRatePerSec: 12000, queryRatePerSec: 50, tenantCount: 4 },
+    }
+
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    renderHook(() => useCachedCortex())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('healthy')
+    expect(result.version).toBe('1.16.0')
+    expect(result.components).toHaveLength(1)
+    expect(result.metrics.activeSeries).toBe(500000)
+  })
+
+  it('returns not-installed status on 404 (treat404AsEmpty path)', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    })
+
+    renderHook(() => useCachedCortex())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws when authFetch returns a non-404 error', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    renderHook(() => useCachedCortex())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Unable to fetch Cortex status')
+  })
+
+  it('throws when authFetch rejects (network error)', async () => {
+    mockAuthFetch.mockRejectedValue(new Error('Network failure'))
+
+    renderHook(() => useCachedCortex())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Unable to fetch Cortex status')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedDapr-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedDapr-funcs.test.ts
@@ -2,7 +2,14 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedDapr.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,24 +18,37 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
 }))
 
+mockUseCache.mockReturnValue({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+})
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCache(...args),
 }))
 
-import { __testables } from '../useCachedDapr'
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables, useCachedDapr } from '../useCachedDapr'
 import type {
   DaprControlPlanePod,
   DaprComponent,
@@ -241,5 +261,96 @@ describe('buildDaprStatus', () => {
     ]
     const result = buildDaprStatus(pods, [], EMPTY_APPS)
     expect(result.health).toBe('degraded')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetcher (via useCache capture)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: {
+        health: 'not-installed',
+        controlPlane: [],
+        components: [],
+        apps: { total: 0, namespaces: 0 },
+        buildingBlocks: { stateStores: 0, pubsubs: 0, bindings: 0 },
+        summary: { totalControlPlanePods: 0, runningControlPlanePods: 0, totalComponents: 0, totalDaprApps: 0 },
+        lastCheckTime: new Date().toISOString(),
+      },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('returns parsed Dapr status on successful response', async () => {
+    const validResponse = {
+      controlPlane: [
+        { name: 'operator', namespace: 'dapr-system', status: 'running', replicasDesired: 1, replicasReady: 1, cluster: 'default' },
+      ],
+      components: [
+        { name: 'statestore', namespace: 'default', type: 'state-store', componentImpl: 'state.redis', cluster: 'default' },
+      ],
+      apps: { total: 5, namespaces: 2 },
+    }
+
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    renderHook(() => useCachedDapr())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('healthy')
+    expect(result.controlPlane).toHaveLength(1)
+    expect(result.components).toHaveLength(1)
+    expect(result.apps.total).toBe(5)
+  })
+
+  it('returns not-installed status on 404 response', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    })
+
+    renderHook(() => useCachedDapr())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    // Dapr uses NOT_INSTALLED_STATUSES which includes 404 — returns
+    // { data: null, failed: false }, so the fetcher builds empty status
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws when authFetch returns a non-listed error status', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    renderHook(() => useCachedDapr())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Unable to fetch Dapr status')
+  })
+
+  it('throws when authFetch rejects (network error)', async () => {
+    mockAuthFetch.mockRejectedValue(new Error('Network failure'))
+
+    renderHook(() => useCachedDapr())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Unable to fetch Dapr status')
   })
 })

--- a/web/src/hooks/__tests__/useCachedDragonfly-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedDragonfly-funcs.test.ts
@@ -2,18 +2,16 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedDragonfly.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
 }))
 
-vi.mock('../../lib/api', () => ({
-  authFetch: vi.fn(),
-}))
-
-vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(() => ({
     data: null,
     isLoading: false,
     isRefreshing: false,
@@ -25,8 +23,10 @@ vi.mock('../../lib/cache', () => ({
     refetch: vi.fn(),
   })),
 }))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
+vi.mock('../../lib/cache', () => ({ useCache: (...args: unknown[]) => mockUseCache(...args) }))
 
-import { __testables } from '../useCachedDragonfly'
+import { __testables, useCachedDragonfly } from '../useCachedDragonfly'
 
 const { classifyDragonflyPod, podIsReady, parseVersion, buildStatus } = __testables
 
@@ -237,5 +237,93 @@ describe('buildStatus (dragonfly)', () => {
     const result = buildStatus(pods)
     const comp = result.components.find(c => c.component === 'seed-peer')
     expect(comp?.version).toBe('v2.0.8')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchDragonflyStatus (fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function captureFetcher(): () => Promise<unknown> {
+    renderHook(() => useCachedDragonfly())
+    const config = mockUseCache.mock.calls[0]?.[0] as { fetcher: () => Promise<unknown> }
+    return config.fetcher
+  }
+
+  it('returns parsed data on success', async () => {
+    const dragonflyPod = {
+      name: 'dragonfly-manager-0',
+      namespace: 'dragonfly-system',
+      cluster: 'prod',
+      status: {
+        phase: 'Running',
+        containerStatuses: [{ name: 'manager', ready: true, image: 'dragonflyoss/manager:v2.1.0' }],
+      },
+      metadata: { labels: { 'app.kubernetes.io/component': 'dragonfly-manager' } },
+    }
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ items: [dragonflyPod] }),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; components: unknown[] }
+    expect(result.health).toBe('healthy')
+    expect(result.components).toHaveLength(1)
+  })
+
+  it('returns not-installed for 404 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('returns not-installed for 503 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws on non-whitelisted error status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    })
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('HTTP 500')
+  })
+
+  it('throws on network error', async () => {
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('Network error')
+  })
+
+  it('returns not-installed when JSON parse fails', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
   })
 })

--- a/web/src/hooks/__tests__/useCachedFlatcar-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedFlatcar-funcs.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Fetcher function tests for useCachedFlatcar.ts.
+ * Tests the fetchFlatcarStatus function via useCache capture,
+ * plus __testables pure functions.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockAuthFetch = vi.fn()
+vi.mock('../../lib/api', () => ({ authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+const mockUseCache = vi.fn(() => ({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { useCachedFlatcar } from '../useCachedFlatcar'
+
+// ---------------------------------------------------------------------------
+// Fetcher function tests (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchFlatcarStatus (via useCache fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: { health: 'not-installed', nodes: [], stats: { totalNodes: 0, upToDateNodes: 0, updateAvailableNodes: 0, rebootRequiredNodes: 0, channelsInUse: [] }, summary: { latestStableVersion: '', latestBetaVersion: '', totalClusters: 0 }, lastCheckTime: '' },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('parses a successful API response into FlatcarStatusData', async () => {
+    renderHook(() => useCachedFlatcar())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          nodes: [
+            {
+              name: 'node-1',
+              cluster: 'c1',
+              osImage: 'Flatcar Container Linux',
+              currentVersion: '3815.2.0',
+              availableVersion: null,
+              channel: 'stable',
+              state: 'up-to-date',
+              rebootRequired: false,
+              lastCheckTime: new Date().toISOString(),
+            },
+          ],
+          summary: {
+            latestStableVersion: '3815.2.0',
+            latestBetaVersion: '3816.0.0',
+            totalClusters: 1,
+          },
+        }),
+    })
+
+    const result = await fetcher()
+    expect(result.health).toBe('healthy')
+    expect(result.nodes).toHaveLength(1)
+    expect(result.summary.latestStableVersion).toBe('3815.2.0')
+    expect(result.stats.totalNodes).toBe(1)
+    expect(result.stats.upToDateNodes).toBe(1)
+  })
+
+  it('throws on non-ok response (non-404) so cache falls back to demo', async () => {
+    renderHook(() => useCachedFlatcar())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch Flatcar status')
+  })
+
+  it('returns not-installed data on 404 (treated as empty)', async () => {
+    renderHook(() => useCachedFlatcar())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const result = await fetcher()
+    expect(result.health).toBe('not-installed')
+    expect(result.nodes).toEqual([])
+  })
+
+  it('throws on network error so cache falls back to demo', async () => {
+    renderHook(() => useCachedFlatcar())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch Flatcar status')
+  })
+
+  it('handles empty body fields gracefully', async () => {
+    renderHook(() => useCachedFlatcar())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })
+
+    const result = await fetcher()
+    expect(result.nodes).toEqual([])
+    expect(result.health).toBe('not-installed')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedGrpc-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedGrpc-funcs.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedGrpc.ts, PLUS fetcher function tests.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockAuthFetch = vi.fn()
+vi.mock('../../lib/api', () => ({ authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+const mockUseCache = vi.fn(() => ({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables } from '../useCachedGrpc'
+import { useCachedGrpc } from '../useCachedGrpc'
+import type { GrpcService } from '../../components/cards/grpc_status/demoData'
+
+const { summarize, deriveHealth, buildGrpcStatus } = __testables
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function makeService(overrides: Partial<GrpcService> = {}): GrpcService {
+  return {
+    name: 'grpc.health.v1.Health',
+    namespace: 'default',
+    cluster: 'cluster-1',
+    status: 'serving',
+    endpoints: 3,
+    rps: 100,
+    latencyP99Ms: 12,
+    errorRatePct: 0.1,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeros for empty services', () => {
+    const result = summarize([])
+    expect(result).toEqual({
+      totalServices: 0,
+      servingServices: 0,
+      totalEndpoints: 0,
+    })
+  })
+
+  it('counts serving services and sums endpoints', () => {
+    const services = [
+      makeService({ status: 'serving', endpoints: 3 }),
+      makeService({ name: 'svc2', status: 'not-serving', endpoints: 2 }),
+      makeService({ name: 'svc3', status: 'serving', endpoints: 5 }),
+    ]
+    const result = summarize(services)
+    expect(result.totalServices).toBe(3)
+    expect(result.servingServices).toBe(2)
+    expect(result.totalEndpoints).toBe(10)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when no services', () => {
+    expect(deriveHealth([])).toBe('not-installed')
+  })
+
+  it('returns healthy when all services are serving', () => {
+    expect(deriveHealth([makeService(), makeService({ name: 'svc2' })])).toBe('healthy')
+  })
+
+  it('returns degraded when a service is not serving', () => {
+    const services = [
+      makeService(),
+      makeService({ name: 'svc2', status: 'not-serving' }),
+    ]
+    expect(deriveHealth(services)).toBe('degraded')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildGrpcStatus
+// ---------------------------------------------------------------------------
+
+describe('buildGrpcStatus', () => {
+  it('builds not-installed status with no services', () => {
+    const stats = { totalRps: 0, avgLatencyP99Ms: 0, avgErrorRatePct: 0, reflectionEnabled: 0 }
+    const result = buildGrpcStatus([], stats)
+    expect(result.health).toBe('not-installed')
+    expect(result.services).toEqual([])
+    expect(result.stats).toBe(stats)
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('builds healthy status with serving services', () => {
+    const services = [makeService()]
+    const stats = { totalRps: 100, avgLatencyP99Ms: 12, avgErrorRatePct: 0.1, reflectionEnabled: 1 }
+    const result = buildGrpcStatus(services, stats)
+    expect(result.health).toBe('healthy')
+    expect(result.services).toHaveLength(1)
+    expect(result.summary.servingServices).toBe(1)
+  })
+
+  it('sets lastCheckTime to a valid ISO string', () => {
+    const stats = { totalRps: 0, avgLatencyP99Ms: 0, avgErrorRatePct: 0, reflectionEnabled: 0 }
+    const result = buildGrpcStatus([], stats)
+    expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher function tests (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchGrpcStatus (via useCache fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: { health: 'not-installed', services: [], stats: { totalRps: 0, avgLatencyP99Ms: 0, avgErrorRatePct: 0, reflectionEnabled: 0 }, summary: { totalServices: 0, servingServices: 0, totalEndpoints: 0 }, lastCheckTime: '' },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('parses a successful API response into GrpcStatusData', async () => {
+    renderHook(() => useCachedGrpc())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          services: [
+            {
+              name: 'grpc.health.v1.Health',
+              namespace: 'default',
+              cluster: 'cluster-1',
+              status: 'serving',
+              endpoints: 3,
+              rps: 100,
+              latencyP99Ms: 12,
+              errorRatePct: 0.1,
+            },
+          ],
+          stats: {
+            totalRps: 100,
+            avgLatencyP99Ms: 12,
+            avgErrorRatePct: 0.1,
+            reflectionEnabled: 1,
+          },
+        }),
+    })
+
+    const result = await fetcher()
+    expect(result.health).toBe('healthy')
+    expect(result.services).toHaveLength(1)
+    expect(result.stats.totalRps).toBe(100)
+    expect(result.summary.servingServices).toBe(1)
+  })
+
+  it('throws on non-ok response (non-404) so cache falls back to demo', async () => {
+    renderHook(() => useCachedGrpc())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch gRPC status')
+  })
+
+  it('returns not-installed data on 404 (treated as empty)', async () => {
+    renderHook(() => useCachedGrpc())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const result = await fetcher()
+    expect(result.health).toBe('not-installed')
+    expect(result.services).toEqual([])
+  })
+
+  it('throws on network error so cache falls back to demo', async () => {
+    renderHook(() => useCachedGrpc())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch gRPC status')
+  })
+
+  it('handles empty body fields gracefully', async () => {
+    renderHook(() => useCachedGrpc())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })
+
+    const result = await fetcher()
+    expect(result.services).toEqual([])
+    expect(result.stats.totalRps).toBe(0)
+  })
+})

--- a/web/src/hooks/__tests__/useCachedJaegerStatus-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedJaegerStatus-funcs.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Fetcher function tests for useCachedJaegerStatus.ts.
+ * This hook delegates to fetchJaegerStatus from agentFetchers,
+ * so we mock that and test the fetcher passed to useCache.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockFetchJaegerStatus = vi.fn()
+
+vi.mock('../useCachedData/agentFetchers', () => ({
+  fetchJaegerStatus: (...args: unknown[]) => mockFetchJaegerStatus(...args),
+}))
+
+vi.mock('../useCachedData/demoData', () => ({
+  getDemoJaegerStatus: () => ({
+    status: 'Healthy',
+    version: '1.53.0',
+    collectors: { count: 2, status: 'Healthy' },
+    query: { status: 'Healthy' },
+    metrics: {
+      servicesCount: 10,
+      tracesLastHour: 5000,
+      dependenciesCount: 15,
+      avgLatencyMs: 25,
+      p95LatencyMs: 100,
+      p99LatencyMs: 250,
+      spansDroppedLastHour: 0,
+      avgQueueLength: 2,
+    },
+  }),
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+const mockUseCache = vi.fn(() => ({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+import { useCachedJaegerStatus } from '../useCachedJaegerStatus'
+
+// ---------------------------------------------------------------------------
+// Fetcher function tests (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('useCachedJaegerStatus fetcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: { status: 'Healthy', version: '', collectors: { count: 0, status: 'Healthy' }, query: { status: 'Healthy' }, metrics: { servicesCount: 0, tracesLastHour: 0, dependenciesCount: 0, avgLatencyMs: 0, p95LatencyMs: 0, p99LatencyMs: 0, spansDroppedLastHour: 0, avgQueueLength: 0 } },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('returns data from fetchJaegerStatus on success', async () => {
+    renderHook(() => useCachedJaegerStatus())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    const mockData = {
+      status: 'Healthy',
+      version: '1.53.0',
+      collectors: { count: 2, status: 'Healthy' },
+      query: { status: 'Healthy' },
+      metrics: {
+        servicesCount: 10,
+        tracesLastHour: 5000,
+        dependenciesCount: 15,
+        avgLatencyMs: 25,
+        p95LatencyMs: 100,
+        p99LatencyMs: 250,
+        spansDroppedLastHour: 0,
+        avgQueueLength: 2,
+      },
+    }
+    mockFetchJaegerStatus.mockResolvedValueOnce(mockData)
+
+    const result = await fetcher()
+    expect(result).toBe(mockData)
+  })
+
+  it('throws when fetchJaegerStatus returns null', async () => {
+    renderHook(() => useCachedJaegerStatus())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockFetchJaegerStatus.mockResolvedValueOnce(null)
+
+    await expect(fetcher()).rejects.toThrow('Jaeger status unavailable')
+  })
+
+  it('propagates network error from fetchJaegerStatus', async () => {
+    renderHook(() => useCachedJaegerStatus())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockFetchJaegerStatus.mockRejectedValueOnce(new Error('Network failure'))
+
+    await expect(fetcher()).rejects.toThrow('Network failure')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedKserve-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedKserve-funcs.test.ts
@@ -2,7 +2,14 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedKserve.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,24 +18,37 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
 }))
 
+mockUseCache.mockReturnValue({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+})
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCache(...args),
 }))
 
-import { __testables } from '../useCachedKserve'
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables, useCachedKserve } from '../useCachedKserve'
 import type {
   KServeControllerPods,
   KServeService,
@@ -247,3 +267,86 @@ function makeService(overrides?: Partial<KServeService>): KServeService {
     ...overrides,
   }
 }
+
+// ---------------------------------------------------------------------------
+// fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetcher (via useCache capture)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: {
+        health: 'not-installed',
+        controllerPods: { ready: 0, total: 0 },
+        services: [],
+        summary: { totalServices: 0, readyServices: 0, notReadyServices: 0, totalRequestsPerSecond: 0, avgP95LatencyMs: 0 },
+        lastCheckTime: new Date().toISOString(),
+      },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('returns parsed KServe status on successful response', async () => {
+    const validResponse = {
+      controllerPods: { ready: 2, total: 2 },
+      services: [
+        { id: 'svc-1', name: 'iris', namespace: 'default', cluster: 'c1', status: 'ready', modelName: 'sklearn-iris', runtime: 'kserve-sklearnserver', url: 'https://iris.example.com', trafficPercent: 100, readyReplicas: 1, desiredReplicas: 1, requestsPerSecond: 10, p95LatencyMs: 50, updatedAt: new Date().toISOString() },
+      ],
+    }
+
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    renderHook(() => useCachedKserve())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('healthy')
+    expect(result.controllerPods.ready).toBe(2)
+    expect(result.services).toHaveLength(1)
+  })
+
+  it('returns not-installed status on 404 (treat404AsEmpty path)', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    })
+
+    renderHook(() => useCachedKserve())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws when authFetch returns a non-404 error', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    renderHook(() => useCachedKserve())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Unable to fetch KServe status')
+  })
+
+  it('throws when authFetch rejects (network error)', async () => {
+    mockAuthFetch.mockRejectedValue(new Error('Network failure'))
+
+    renderHook(() => useCachedKserve())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Unable to fetch KServe status')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedKubevela-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedKubevela-funcs.test.ts
@@ -2,7 +2,14 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedKubevela.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { mockAuthFetch, mockUseCache: mockUseCacheHoisted } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,24 +18,38 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
 }))
 
+const mockUseCache = mockUseCacheHoisted
+mockUseCache.mockReturnValue({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+})
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCacheHoisted(...args),
 }))
 
-import { __testables } from '../useCachedKubevela'
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables, useCachedKubevela } from '../useCachedKubevela'
 import type {
   KubeVelaApplication,
   KubeVelaControllerPod,
@@ -293,5 +314,119 @@ describe('buildKubeVelaStatus', () => {
     const pods = [makePod({ status: 'running' })]
     const result = buildKubeVelaStatus(apps, pods, '1.9.11')
     expect(result.health).toBe('degraded')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetcher (via useCache capture)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: {
+        health: 'not-installed',
+        applications: [],
+        controllerPods: [],
+        stats: { totalApplications: 0, runningApplications: 0, failedApplications: 0, totalComponents: 0, totalTraits: 0, controllerVersion: 'unknown' },
+        summary: { totalApplications: 0, runningApplications: 0, failedApplications: 0, totalControllerPods: 0, runningControllerPods: 0 },
+        lastCheckTime: new Date().toISOString(),
+      },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('returns parsed KubeVela status on successful response', async () => {
+    const validResponse = {
+      applications: [
+        {
+          name: 'app-1',
+          namespace: 'default',
+          cluster: 'c1',
+          status: 'running',
+          componentCount: 2,
+          traitCount: 1,
+          workflowSteps: [],
+          workflowStepsCompleted: 0,
+          workflowStepsTotal: 0,
+          traits: [],
+          ageMinutes: 60,
+        },
+      ],
+      controllerPods: [
+        {
+          name: 'vela-core-abc',
+          namespace: 'vela-system',
+          cluster: 'c1',
+          status: 'running',
+          replicasReady: 1,
+          replicasDesired: 1,
+        },
+      ],
+      stats: { controllerVersion: '1.9.11' },
+    }
+
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    renderHook(() => useCachedKubevela())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+    const result = await fetcher()
+
+    expect(result.health).toBe('healthy')
+    expect(result.applications).toHaveLength(1)
+    expect(result.controllerPods).toHaveLength(1)
+    expect(result.stats.controllerVersion).toBe('1.9.11')
+  })
+
+  it('throws when authFetch returns a 404 (treat404AsEmpty path)', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    })
+
+    renderHook(() => useCachedKubevela())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    // 404 with treat404AsEmpty returns { data: null, failed: false }
+    // but null data means empty arrays, which builds a not-installed status
+    // — this does NOT throw, it returns a valid status object
+    const result = await fetcher()
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws when authFetch returns a non-404 error', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    renderHook(() => useCachedKubevela())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch KubeVela status')
+  })
+
+  it('throws when authFetch rejects (network error)', async () => {
+    mockAuthFetch.mockRejectedValue(new Error('Network failure'))
+
+    renderHook(() => useCachedKubevela())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch KubeVela status')
   })
 })

--- a/web/src/hooks/__tests__/useCachedLinkerd-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedLinkerd-funcs.test.ts
@@ -2,7 +2,14 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedLinkerd.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,24 +18,37 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
 }))
 
+mockUseCache.mockReturnValue({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+})
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCache(...args),
 }))
 
-import { __testables } from '../useCachedLinkerd'
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables, useCachedLinkerd } from '../useCachedLinkerd'
 import type { LinkerdMeshedDeployment, LinkerdStats } from '../../components/cards/linkerd_status/demoData'
 
 const { summarize, deriveHealth, buildLinkerdStatus } = __testables
@@ -181,5 +201,88 @@ describe('buildLinkerdStatus', () => {
     expect(result.health).toBe('degraded')
     expect(result.summary.fullyMeshedDeployments).toBe(1)
     expect(result.summary.totalDeployments).toBe(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetcher (via useCache capture)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: {
+        health: 'not-installed',
+        deployments: [],
+        stats: { totalRps: 0, avgSuccessRatePct: 0, avgP99LatencyMs: 0, controlPlaneVersion: 'unknown' },
+        summary: { totalDeployments: 0, fullyMeshedDeployments: 0, totalMeshedPods: 0, totalPods: 0 },
+        lastCheckTime: new Date().toISOString(),
+      },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('returns parsed Linkerd status on successful response', async () => {
+    const validResponse = {
+      deployments: [
+        { namespace: 'ns', deployment: 'd1', meshedPods: 3, totalPods: 3, successRatePct: 100, requestsPerSecond: 50, p99LatencyMs: 5, status: 'meshed', cluster: 'c' },
+      ],
+      stats: { totalRps: 50, avgSuccessRatePct: 100, avgP99LatencyMs: 5, controlPlaneVersion: 'stable-2.14.10' },
+    }
+
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    renderHook(() => useCachedLinkerd())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('healthy')
+    expect(result.deployments).toHaveLength(1)
+    expect(result.stats.controlPlaneVersion).toBe('stable-2.14.10')
+  })
+
+  it('returns not-installed status on 404 (treat404AsEmpty path)', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    })
+
+    renderHook(() => useCachedLinkerd())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws when authFetch returns a non-404 error', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    renderHook(() => useCachedLinkerd())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Unable to fetch Linkerd status')
+  })
+
+  it('throws when authFetch rejects (network error)', async () => {
+    mockAuthFetch.mockRejectedValue(new Error('Network failure'))
+
+    renderHook(() => useCachedLinkerd())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Unable to fetch Linkerd status')
   })
 })

--- a/web/src/hooks/__tests__/useCachedLonghorn-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedLonghorn-funcs.test.ts
@@ -2,18 +2,16 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedLonghorn.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
 }))
 
-vi.mock('../../lib/api', () => ({
-  authFetch: vi.fn(),
-}))
-
-vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(() => ({
     data: null,
     isLoading: false,
     isRefreshing: false,
@@ -25,8 +23,10 @@ vi.mock('../../lib/cache', () => ({
     refetch: vi.fn(),
   })),
 }))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
+vi.mock('../../lib/cache', () => ({ useCache: (...args: unknown[]) => mockUseCache(...args) }))
 
-import { __testables } from '../useCachedLonghorn'
+import { __testables, useCachedLonghorn } from '../useCachedLonghorn'
 
 const { normalizeVolumeState, normalizeRobustness, summarize, deriveHealth, buildStatus } = __testables
 
@@ -191,5 +191,85 @@ describe('buildStatus (longhorn)', () => {
     expect(result.summary.totalVolumes).toBe(1)
     expect(result.summary.totalNodes).toBe(1)
     expect(result.summary.healthyVolumes).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchLonghornStatus (fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function captureFetcher(): () => Promise<unknown> {
+    renderHook(() => useCachedLonghorn())
+    const config = mockUseCache.mock.calls[0]?.[0] as { fetcher: () => Promise<unknown> }
+    return config.fetcher
+  }
+
+  it('returns parsed data on success', async () => {
+    const validResponse = {
+      volumes: [
+        { name: 'v1', namespace: 'ns', state: 'attached', robustness: 'healthy', replicasDesired: 3, replicasHealthy: 3, sizeBytes: 1000, actualSizeBytes: 500, nodeAttached: 'n1', cluster: 'c1' },
+      ],
+      nodes: [
+        { name: 'n1', cluster: 'c1', ready: true, schedulable: true, storageTotalBytes: 100000, storageUsedBytes: 40000, replicaCount: 3 },
+      ],
+    }
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; volumes: unknown[]; nodes: unknown[] }
+    expect(result.health).toBe('healthy')
+    expect(result.volumes).toHaveLength(1)
+    expect(result.nodes).toHaveLength(1)
+  })
+
+  it('returns not-installed for 404 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; volumes: unknown[]; nodes: unknown[] }
+    expect(result.health).toBe('not-installed')
+    expect(result.volumes).toEqual([])
+    expect(result.nodes).toEqual([])
+  })
+
+  it('throws on non-404 error status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    })
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('HTTP 500')
+  })
+
+  it('throws on network error', async () => {
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('Network error')
+  })
+
+  it('handles empty body arrays gracefully', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; volumes: unknown[]; nodes: unknown[] }
+    expect(result.health).toBe('not-installed')
+    expect(result.volumes).toEqual([])
+    expect(result.nodes).toEqual([])
   })
 })

--- a/web/src/hooks/__tests__/useCachedOpenfeature-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedOpenfeature-funcs.test.ts
@@ -2,7 +2,14 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedOpenfeature.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,24 +18,37 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
 }))
 
+mockUseCache.mockReturnValue({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+})
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCache(...args),
 }))
 
-import { __testables } from '../useCachedOpenfeature'
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables, useCachedOpenfeature } from '../useCachedOpenfeature'
 import type {
   OpenFeatureFlag,
   OpenFeatureProvider,
@@ -220,3 +240,88 @@ function makeProvider(overrides?: Partial<OpenFeatureProvider>): OpenFeatureProv
     ...overrides,
   }
 }
+
+// ---------------------------------------------------------------------------
+// fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetcher (via useCache capture)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: {
+        health: 'not-installed',
+        providers: [],
+        flags: [],
+        featureFlags: { total: 0, enabled: 0, disabled: 0, errorRate: 0 },
+        totalEvaluations: 0,
+        lastCheckTime: new Date().toISOString(),
+      },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('returns parsed OpenFeature status on successful response', async () => {
+    const validResponse = {
+      providers: [{ name: 'flagd', status: 'healthy', evaluations: 200, cacheHitRate: 95 }],
+      flags: [{ key: 'dark-mode', type: 'boolean', enabled: true, defaultVariant: 'on', variants: 2, provider: 'flagd', evaluations: 100 }],
+      featureFlags: { total: 1, enabled: 1, disabled: 0, errorRate: 0 },
+      totalEvaluations: 200,
+    }
+
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    renderHook(() => useCachedOpenfeature())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('healthy')
+    expect(result.providers).toHaveLength(1)
+    expect(result.flags).toHaveLength(1)
+    expect(result.totalEvaluations).toBe(200)
+  })
+
+  it('returns not-installed status on 404 (treat404AsEmpty path)', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    })
+
+    renderHook(() => useCachedOpenfeature())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws when authFetch returns a non-404 error', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    renderHook(() => useCachedOpenfeature())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Unable to fetch OpenFeature status')
+  })
+
+  it('throws when authFetch rejects (network error)', async () => {
+    mockAuthFetch.mockRejectedValue(new Error('Network failure'))
+
+    renderHook(() => useCachedOpenfeature())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Unable to fetch OpenFeature status')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedOpenfga-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedOpenfga-funcs.test.ts
@@ -1,8 +1,12 @@
 /**
  * Tests for the pure helper functions exported via __testables
- * from useCachedOpenfga.ts.
+ * from useCachedOpenfga.ts, PLUS fetcher function tests.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockAuthFetch = vi.fn()
+vi.mock('../../lib/api', () => ({ authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,21 +15,35 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+const mockUseCache = vi.fn(() => ({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
 }))
 
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
 }))
 
 import { __testables } from '../useCachedOpenfga'
@@ -227,5 +245,125 @@ describe('buildOpenfgaStatus', () => {
     const result = buildOpenfgaStatus('', [], [], makeStats())
     expect(() => new Date(result.lastCheckTime)).not.toThrow()
     expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher function tests (via useCache capture)
+// ---------------------------------------------------------------------------
+
+import { useCachedOpenfga } from '../useCachedOpenfga'
+
+describe('fetchOpenfgaStatus (via useCache fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: { health: 'not-installed', stores: [], models: [], stats: { totalTuples: 0, totalStores: 0, totalModels: 0, serverVersion: 'unknown', rps: { check: 0, expand: 0, listObjects: 0 }, latency: { p50: 0, p95: 0, p99: 0 } }, summary: { endpoint: '', totalTuples: 0, totalStores: 0, totalModels: 0 }, lastCheckTime: '' },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('parses a successful API response into OpenfgaStatusData', async () => {
+    renderHook(() => useCachedOpenfga())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          endpoint: 'http://openfga:8080',
+          stores: [
+            {
+              id: 'store-1',
+              name: 'production',
+              tupleCount: 1500,
+              modelCount: 2,
+              status: 'active',
+              lastWriteTime: new Date().toISOString(),
+            },
+          ],
+          models: [
+            {
+              id: 'model-1',
+              storeName: 'production',
+              schemaVersion: '1.1',
+              typeCount: 5,
+              createdAt: new Date().toISOString(),
+            },
+          ],
+          stats: {
+            totalTuples: 3000,
+            totalStores: 1,
+            totalModels: 1,
+            serverVersion: '1.5.0',
+            rps: { check: 100, expand: 20, listObjects: 10 },
+            latency: { p50: 5, p95: 15, p99: 30 },
+          },
+        }),
+    })
+
+    const result = await fetcher()
+    expect(result.health).toBe('healthy')
+    expect(result.stores).toHaveLength(1)
+    expect(result.models).toHaveLength(1)
+    expect(result.summary.endpoint).toBe('http://openfga:8080')
+    expect(result.stats.totalTuples).toBe(3000)
+    expect(result.stats.serverVersion).toBe('1.5.0')
+  })
+
+  it('throws on non-ok response (non-404) so cache falls back to demo', async () => {
+    renderHook(() => useCachedOpenfga())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch OpenFGA status')
+  })
+
+  it('returns not-installed data on 404 (treated as empty)', async () => {
+    renderHook(() => useCachedOpenfga())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const result = await fetcher()
+    expect(result.health).toBe('not-installed')
+    expect(result.stores).toEqual([])
+  })
+
+  it('throws on network error so cache falls back to demo', async () => {
+    renderHook(() => useCachedOpenfga())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch OpenFGA status')
+  })
+
+  it('handles empty body fields gracefully', async () => {
+    renderHook(() => useCachedOpenfga())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })
+
+    const result = await fetcher()
+    expect(result.stores).toEqual([])
+    expect(result.models).toEqual([])
+    expect(result.stats.totalTuples).toBe(0)
   })
 })

--- a/web/src/hooks/__tests__/useCachedOtel-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedOtel-funcs.test.ts
@@ -2,18 +2,16 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedOtel.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
 }))
 
-vi.mock('../../lib/api', () => ({
-  authFetch: vi.fn(),
-}))
-
-vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(() => ({
     data: null,
     isLoading: false,
     isRefreshing: false,
@@ -25,8 +23,10 @@ vi.mock('../../lib/cache', () => ({
     refetch: vi.fn(),
   })),
 }))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
+vi.mock('../../lib/cache', () => ({ useCache: (...args: unknown[]) => mockUseCache(...args) }))
 
-import { __testables } from '../useCachedOtel'
+import { __testables, useCachedOtel } from '../useCachedOtel'
 
 const {
   isOtelCollectorPod,
@@ -401,5 +401,96 @@ describe('buildStatus (otel)', () => {
     }]
     const result = buildStatus(collectors)
     expect(result.health).toBe('degraded')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchOtelStatus (fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function captureFetcher(): () => Promise<unknown> {
+    renderHook(() => useCachedOtel())
+    const config = mockUseCache.mock.calls[0]?.[0] as { fetcher: () => Promise<unknown> }
+    return config.fetcher
+  }
+
+  it('returns parsed data on success', async () => {
+    const otelPod = {
+      name: 'otel-collector-0',
+      namespace: 'monitoring',
+      cluster: 'prod',
+      status: {
+        phase: 'Running',
+        containerStatuses: [{ name: 'otel-collector', ready: true, image: 'otel/collector:0.90.0' }],
+      },
+      metadata: {
+        labels: { 'app.kubernetes.io/name': 'opentelemetry-collector' },
+        annotations: {},
+      },
+    }
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ items: [otelPod] }),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; collectors: unknown[] }
+    expect(result.health).toBe('healthy')
+    expect(result.collectors).toHaveLength(1)
+  })
+
+  it('returns not-installed for 404 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('returns not-installed for 503 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws on non-whitelisted error status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    })
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('HTTP 500')
+  })
+
+  it('throws on network error', async () => {
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('Network error')
+  })
+
+  it('returns not-installed when JSON parse fails', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
   })
 })

--- a/web/src/hooks/__tests__/useCachedRook-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedRook-funcs.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for the pure helper functions and fetcher function exported via
+ * __testables / useCache capture from useCachedRook.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
+vi.mock('../../lib/cache', () => ({ useCache: (...args: unknown[]) => mockUseCache(...args) }))
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+}))
+
+import { useCachedRook, __testables } from '../useCachedRook'
+
+const {
+  normalizeCephHealth,
+  extractCephVersion,
+  itemToCluster,
+  summarize,
+  buildStatus,
+} = __testables
+
+// ---------------------------------------------------------------------------
+// normalizeCephHealth
+// ---------------------------------------------------------------------------
+
+describe('normalizeCephHealth', () => {
+  it('returns HEALTH_OK for HEALTH_OK', () => {
+    expect(normalizeCephHealth('HEALTH_OK')).toBe('HEALTH_OK')
+  })
+
+  it('returns HEALTH_ERR for HEALTH_ERR', () => {
+    expect(normalizeCephHealth('HEALTH_ERR')).toBe('HEALTH_ERR')
+  })
+
+  it('defaults to HEALTH_WARN for unknown values', () => {
+    expect(normalizeCephHealth('SOMETHING_ELSE')).toBe('HEALTH_WARN')
+    expect(normalizeCephHealth(undefined)).toBe('HEALTH_WARN')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractCephVersion
+// ---------------------------------------------------------------------------
+
+describe('extractCephVersion', () => {
+  it('extracts from status.ceph.version', () => {
+    const item = { status: { ceph: { version: '17.2.6' } } }
+    expect(extractCephVersion(item)).toBe('17.2.6')
+  })
+
+  it('extracts from status.version.version as fallback', () => {
+    const item = { status: { version: { version: '17.2.5' } } }
+    expect(extractCephVersion(item)).toBe('17.2.5')
+  })
+
+  it('extracts from spec.cephVersion.image tag', () => {
+    const item = { spec: { cephVersion: { image: 'quay.io/ceph/ceph:v17.2.6' } } }
+    expect(extractCephVersion(item)).toBe('v17.2.6')
+  })
+
+  it('returns empty string when no version info', () => {
+    expect(extractCephVersion({})).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// itemToCluster
+// ---------------------------------------------------------------------------
+
+describe('itemToCluster', () => {
+  it('maps a CephCluster item to RookCephCluster', () => {
+    const item = {
+      name: 'rook-ceph',
+      namespace: 'rook-ceph',
+      cluster: 'prod',
+      metadata: { name: 'rook-ceph', namespace: 'rook-ceph' },
+      status: { ceph: { health: 'HEALTH_OK', version: '17.2.6' } },
+    }
+    const cluster = itemToCluster(item)
+    expect(cluster.name).toBe('rook-ceph')
+    expect(cluster.namespace).toBe('rook-ceph')
+    expect(cluster.cephHealth).toBe('HEALTH_OK')
+    expect(cluster.cephVersion).toBe('17.2.6')
+  })
+
+  it('uses item name/namespace when metadata is missing', () => {
+    const item = { name: 'my-cluster', namespace: 'ns1' }
+    const cluster = itemToCluster(item)
+    expect(cluster.name).toBe('my-cluster')
+    expect(cluster.namespace).toBe('ns1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize (rook)', () => {
+  it('returns zeros for empty clusters', () => {
+    const result = summarize([])
+    expect(result.totalClusters).toBe(0)
+    expect(result.healthyClusters).toBe(0)
+    expect(result.degradedClusters).toBe(0)
+  })
+
+  it('counts healthy vs degraded clusters', () => {
+    const clusters = [
+      { name: 'c1', namespace: 'ns', cluster: '', cephVersion: '', cephHealth: 'HEALTH_OK' as const, osdTotal: 0, osdUp: 0, osdIn: 0, monQuorum: 0, monExpected: 0, mgrActive: 0, mgrStandby: 0, capacityTotalBytes: 1000, capacityUsedBytes: 500, pools: 0, pgActiveClean: 0, pgTotal: 0 },
+      { name: 'c2', namespace: 'ns', cluster: '', cephVersion: '', cephHealth: 'HEALTH_WARN' as const, osdTotal: 0, osdUp: 0, osdIn: 0, monQuorum: 0, monExpected: 0, mgrActive: 0, mgrStandby: 0, capacityTotalBytes: 2000, capacityUsedBytes: 1000, pools: 0, pgActiveClean: 0, pgTotal: 0 },
+    ]
+    const result = summarize(clusters)
+    expect(result.totalClusters).toBe(2)
+    expect(result.healthyClusters).toBe(1)
+    expect(result.degradedClusters).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildStatus
+// ---------------------------------------------------------------------------
+
+describe('buildStatus (rook)', () => {
+  it('returns not-installed for empty clusters', () => {
+    const result = buildStatus([])
+    expect(result.health).toBe('not-installed')
+    expect(result.clusters).toEqual([])
+  })
+
+  it('returns healthy when all clusters are HEALTH_OK', () => {
+    const clusters = [
+      { name: 'c1', namespace: 'ns', cluster: '', cephVersion: '', cephHealth: 'HEALTH_OK' as const, osdTotal: 0, osdUp: 0, osdIn: 0, monQuorum: 0, monExpected: 0, mgrActive: 0, mgrStandby: 0, capacityTotalBytes: 0, capacityUsedBytes: 0, pools: 0, pgActiveClean: 0, pgTotal: 0 },
+    ]
+    const result = buildStatus(clusters)
+    expect(result.health).toBe('healthy')
+  })
+
+  it('returns degraded when some clusters are not HEALTH_OK', () => {
+    const clusters = [
+      { name: 'c1', namespace: 'ns', cluster: '', cephVersion: '', cephHealth: 'HEALTH_OK' as const, osdTotal: 0, osdUp: 0, osdIn: 0, monQuorum: 0, monExpected: 0, mgrActive: 0, mgrStandby: 0, capacityTotalBytes: 0, capacityUsedBytes: 0, pools: 0, pgActiveClean: 0, pgTotal: 0 },
+      { name: 'c2', namespace: 'ns', cluster: '', cephVersion: '', cephHealth: 'HEALTH_ERR' as const, osdTotal: 0, osdUp: 0, osdIn: 0, monQuorum: 0, monExpected: 0, mgrActive: 0, mgrStandby: 0, capacityTotalBytes: 0, capacityUsedBytes: 0, pools: 0, pgActiveClean: 0, pgTotal: 0 },
+    ]
+    const result = buildStatus(clusters)
+    expect(result.health).toBe('degraded')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchRookStatus (fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function captureFetcher(): () => Promise<unknown> {
+    renderHook(() => useCachedRook())
+    const config = mockUseCache.mock.calls[0]?.[0] as { fetcher: () => Promise<unknown> }
+    return config.fetcher
+  }
+
+  it('returns parsed data on success', async () => {
+    const cephCluster = {
+      name: 'rook-ceph',
+      namespace: 'rook-ceph',
+      cluster: 'prod',
+      metadata: { name: 'rook-ceph', namespace: 'rook-ceph' },
+      status: { ceph: { health: 'HEALTH_OK', version: '17.2.6' } },
+    }
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ items: [cephCluster] }),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; clusters: unknown[] }
+    expect(result.health).toBe('healthy')
+    expect(result.clusters).toHaveLength(1)
+  })
+
+  it('returns not-installed for 404 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; clusters: unknown[] }
+    expect(result.health).toBe('not-installed')
+    expect(result.clusters).toEqual([])
+  })
+
+  it('returns not-installed for 401 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('returns not-installed for 503 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws on non-whitelisted error status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    })
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('HTTP 500')
+  })
+
+  it('throws on network error', async () => {
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('Network error')
+  })
+
+  it('returns not-installed when JSON parse fails', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedSpiffe-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedSpiffe-funcs.test.ts
@@ -1,8 +1,12 @@
 /**
  * Tests for the pure helper functions exported via __testables
- * from useCachedSpiffe.ts.
+ * from useCachedSpiffe.ts, PLUS fetcher function tests.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockAuthFetch = vi.fn()
+vi.mock('../../lib/api', () => ({ authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,21 +15,35 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+const mockUseCache = vi.fn(() => ({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
 }))
 
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
 }))
 
 import { __testables } from '../useCachedSpiffe'
@@ -196,5 +214,116 @@ describe('buildSpiffeStatus', () => {
     const result = buildSpiffeStatus('', [], [], makeStats())
     expect(() => new Date(result.lastCheckTime)).not.toThrow()
     expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher function tests (via useCache capture)
+// ---------------------------------------------------------------------------
+
+import { useCachedSpiffe } from '../useCachedSpiffe'
+
+describe('fetchSpiffeStatus (via useCache fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: { health: 'not-installed', entries: [], federatedDomains: [], stats: { x509SvidCount: 0, jwtSvidCount: 0, registrationEntryCount: 0, agentCount: 0, serverVersion: 'unknown' }, summary: { trustDomain: '', totalSvids: 0, totalFederatedDomains: 0, totalEntries: 0 }, lastCheckTime: '' },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('parses a successful API response into SpiffeStatusData', async () => {
+    renderHook(() => useCachedSpiffe())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          trustDomain: 'example.org',
+          entries: [
+            {
+              spiffeId: 'spiffe://example.org/wl-1',
+              parentId: 'spiffe://example.org/node-1',
+              selector: 'k8s:pod-label:app=web',
+              svidType: 'x509',
+              ttlSeconds: 3600,
+              cluster: 'cluster-1',
+            },
+          ],
+          federatedDomains: [],
+          stats: {
+            x509SvidCount: 10,
+            jwtSvidCount: 5,
+            registrationEntryCount: 1,
+            agentCount: 2,
+            serverVersion: '1.9.0',
+          },
+        }),
+    })
+
+    const result = await fetcher()
+    expect(result.health).toBe('healthy')
+    expect(result.entries).toHaveLength(1)
+    expect(result.summary.trustDomain).toBe('example.org')
+    expect(result.summary.totalSvids).toBe(15)
+    expect(result.stats.serverVersion).toBe('1.9.0')
+  })
+
+  it('throws on non-ok response (non-404) so cache falls back to demo', async () => {
+    renderHook(() => useCachedSpiffe())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch SPIFFE status')
+  })
+
+  it('returns not-installed data on 404 (treated as empty)', async () => {
+    renderHook(() => useCachedSpiffe())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    // Spiffe uses NOT_INSTALLED_STATUSES which includes 404
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const result = await fetcher()
+    expect(result.health).toBe('not-installed')
+    expect(result.entries).toEqual([])
+  })
+
+  it('throws on network error so cache falls back to demo', async () => {
+    renderHook(() => useCachedSpiffe())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch SPIFFE status')
+  })
+
+  it('handles null body fields gracefully', async () => {
+    renderHook(() => useCachedSpiffe())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })
+
+    const result = await fetcher()
+    expect(result.entries).toEqual([])
+    expect(result.federatedDomains).toEqual([])
+    expect(result.stats.x509SvidCount).toBe(0)
   })
 })

--- a/web/src/hooks/__tests__/useCachedSpire-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedSpire-funcs.test.ts
@@ -2,7 +2,14 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedSpire.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,24 +18,37 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
 }))
 
+mockUseCache.mockReturnValue({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+})
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCache(...args),
 }))
 
-import { __testables } from '../useCachedSpire'
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables, useCachedSpire } from '../useCachedSpire'
 import type {
   SpireServerPod,
   SpireAgentDaemonSet,
@@ -251,5 +271,87 @@ describe('buildSpireStatus', () => {
       serverDesiredReplicas: 5,
     })
     expect(result.summary.serverDesiredReplicas).toBe(5)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetcher (via useCache capture)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('returns parsed SPIRE status on successful response', async () => {
+    const validResponse = {
+      version: '1.10.4',
+      trustDomain: 'example.org',
+      serverPods: [
+        { name: 'spire-server-0', phase: 'Running', ready: true, restarts: 0, startedAt: new Date().toISOString(), node: 'node-1' },
+      ],
+      agentDaemonSet: { name: 'spire-agent', namespace: 'spire-system', desiredNumberScheduled: 3, numberReady: 3, numberAvailable: 3, numberMisscheduled: 0 },
+      summary: { registrationEntries: 50, attestedAgents: 3, trustBundleAgeHours: 12, serverDesiredReplicas: 1 },
+    }
+
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    renderHook(() => useCachedSpire())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('healthy')
+    expect(result.version).toBe('1.10.4')
+    expect(result.trustDomain).toBe('example.org')
+    expect(result.serverPods).toHaveLength(1)
+  })
+
+  it('returns not-installed status on 404 response (no throw)', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    })
+
+    renderHook(() => useCachedSpire())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    // SPIRE fetcher returns buildSpireStatus on 404 — does not throw
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws when authFetch returns a non-404 error', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    renderHook(() => useCachedSpire())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('HTTP 500')
+  })
+
+  it('throws when authFetch rejects (network error)', async () => {
+    mockAuthFetch.mockRejectedValue(new Error('Network failure'))
+
+    renderHook(() => useCachedSpire())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Network failure')
   })
 })

--- a/web/src/hooks/__tests__/useCachedStrimzi-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedStrimzi-funcs.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedStrimzi.ts, PLUS fetcher function tests.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockAuthFetch = vi.fn()
+vi.mock('../../lib/api', () => ({ authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+const mockUseCache = vi.fn(() => ({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables } from '../useCachedStrimzi'
+import { useCachedStrimzi } from '../useCachedStrimzi'
+import type { StrimziKafkaCluster } from '../../components/cards/strimzi_status/demoData'
+
+const { summarize, aggregateStats, deriveHealth, buildStrimziStatus } = __testables
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function makeCluster(overrides: Partial<StrimziKafkaCluster> = {}): StrimziKafkaCluster {
+  return {
+    name: 'my-kafka',
+    namespace: 'kafka',
+    cluster: 'cluster-1',
+    health: 'healthy',
+    brokers: { total: 3, ready: 3 },
+    listeners: [{ name: 'plain', type: 'internal', port: 9092 }],
+    topics: [{ name: 'orders', partitions: 3, replicas: 3 }],
+    consumerGroups: [{ name: 'order-processor', members: 2, lag: 10 }],
+    totalLag: 10,
+    version: '3.7.0',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeros for empty clusters', () => {
+    const result = summarize([])
+    expect(result).toEqual({
+      totalClusters: 0,
+      healthyClusters: 0,
+      totalBrokers: 0,
+      readyBrokers: 0,
+    })
+  })
+
+  it('counts clusters and brokers', () => {
+    const clusters = [
+      makeCluster({ health: 'healthy', brokers: { total: 3, ready: 3 } }),
+      makeCluster({ name: 'k2', health: 'degraded', brokers: { total: 3, ready: 2 } }),
+    ]
+    const result = summarize(clusters)
+    expect(result.totalClusters).toBe(2)
+    expect(result.healthyClusters).toBe(1)
+    expect(result.totalBrokers).toBe(6)
+    expect(result.readyBrokers).toBe(5)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// aggregateStats
+// ---------------------------------------------------------------------------
+
+describe('aggregateStats', () => {
+  it('aggregates stats from clusters', () => {
+    const clusters = [
+      makeCluster({
+        topics: [{ name: 't1', partitions: 3, replicas: 3 }, { name: 't2', partitions: 1, replicas: 1 }],
+        consumerGroups: [{ name: 'cg1', members: 2, lag: 5 }],
+        totalLag: 5,
+        brokers: { total: 3, ready: 3 },
+      }),
+    ]
+    const result = aggregateStats(clusters, '0.39.0')
+    expect(result.clusterCount).toBe(1)
+    expect(result.topicCount).toBe(2)
+    expect(result.consumerGroupCount).toBe(1)
+    expect(result.totalLag).toBe(5)
+    expect(result.brokerCount).toBe(3)
+    expect(result.operatorVersion).toBe('0.39.0')
+  })
+
+  it('handles clusters with no topics or consumer groups', () => {
+    const clusters = [makeCluster({ topics: undefined as unknown as StrimziKafkaCluster['topics'], consumerGroups: undefined as unknown as StrimziKafkaCluster['consumerGroups'], totalLag: undefined as unknown as number })]
+    const result = aggregateStats(clusters, '0.39.0')
+    expect(result.topicCount).toBe(0)
+    expect(result.consumerGroupCount).toBe(0)
+    expect(result.totalLag).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when no clusters', () => {
+    expect(deriveHealth([])).toBe('not-installed')
+  })
+
+  it('returns healthy when all clusters are healthy', () => {
+    expect(deriveHealth([makeCluster(), makeCluster({ name: 'k2' })])).toBe('healthy')
+  })
+
+  it('returns degraded when a cluster is not healthy', () => {
+    expect(deriveHealth([makeCluster(), makeCluster({ name: 'k2', health: 'degraded' })])).toBe('degraded')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildStrimziStatus
+// ---------------------------------------------------------------------------
+
+describe('buildStrimziStatus', () => {
+  it('builds not-installed status with empty clusters', () => {
+    const result = buildStrimziStatus([], 'unknown')
+    expect(result.health).toBe('not-installed')
+    expect(result.clusters).toEqual([])
+    expect(result.stats.operatorVersion).toBe('unknown')
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('builds healthy status', () => {
+    const result = buildStrimziStatus([makeCluster()], '0.39.0')
+    expect(result.health).toBe('healthy')
+    expect(result.clusters).toHaveLength(1)
+    expect(result.stats.operatorVersion).toBe('0.39.0')
+  })
+
+  it('sets lastCheckTime to a valid ISO string', () => {
+    const result = buildStrimziStatus([], 'unknown')
+    expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher function tests (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchStrimziStatus (via useCache fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: { health: 'not-installed', clusters: [], stats: { clusterCount: 0, brokerCount: 0, topicCount: 0, consumerGroupCount: 0, totalLag: 0, operatorVersion: 'unknown' }, summary: { totalClusters: 0, healthyClusters: 0, totalBrokers: 0, readyBrokers: 0 }, lastCheckTime: '' },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('parses a successful API response into StrimziStatusData', async () => {
+    renderHook(() => useCachedStrimzi())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          clusters: [
+            {
+              name: 'my-kafka',
+              namespace: 'kafka',
+              cluster: 'cluster-1',
+              health: 'healthy',
+              brokers: { total: 3, ready: 3 },
+              listeners: [],
+              topics: [],
+              consumerGroups: [],
+              totalLag: 0,
+              version: '3.7.0',
+            },
+          ],
+          stats: { operatorVersion: '0.39.0' },
+        }),
+    })
+
+    const result = await fetcher()
+    expect(result.health).toBe('healthy')
+    expect(result.clusters).toHaveLength(1)
+    expect(result.stats.operatorVersion).toBe('0.39.0')
+  })
+
+  it('throws on non-ok response (non-404) so cache falls back to demo', async () => {
+    renderHook(() => useCachedStrimzi())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch Strimzi status')
+  })
+
+  it('returns not-installed data on 404 (treated as empty)', async () => {
+    renderHook(() => useCachedStrimzi())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const result = await fetcher()
+    expect(result.health).toBe('not-installed')
+    expect(result.clusters).toEqual([])
+  })
+
+  it('throws on network error so cache falls back to demo', async () => {
+    renderHook(() => useCachedStrimzi())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch Strimzi status')
+  })
+
+  it('handles empty body fields gracefully', async () => {
+    renderHook(() => useCachedStrimzi())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })
+
+    const result = await fetcher()
+    expect(result.clusters).toEqual([])
+    expect(result.stats.operatorVersion).toBe('unknown')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedTikv-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedTikv-funcs.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Tests for the pure helper functions and fetcher function exported via
+ * __testables / useCache capture from useCachedTikv.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
+vi.mock('../../lib/cache', () => ({ useCache: (...args: unknown[]) => mockUseCache(...args) }))
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+}))
+
+import { useCachedTikv, __testables } from '../useCachedTikv'
+
+const {
+  isTikvPod,
+  parseIntOrZero,
+  deriveStoreState,
+  parseVersion,
+  podToStore,
+  summarize,
+  buildStatus,
+} = __testables
+
+// ---------------------------------------------------------------------------
+// isTikvPod
+// ---------------------------------------------------------------------------
+
+describe('isTikvPod', () => {
+  it('matches by app.kubernetes.io/component label', () => {
+    const pod = { name: 'pod1', metadata: { labels: { 'app.kubernetes.io/component': 'tikv' } } }
+    expect(isTikvPod(pod)).toBe(true)
+  })
+
+  it('matches by app.kubernetes.io/name label', () => {
+    const pod = { name: 'pod1', metadata: { labels: { 'app.kubernetes.io/name': 'tikv' } } }
+    expect(isTikvPod(pod)).toBe(true)
+  })
+
+  it('matches by app label', () => {
+    const pod = { name: 'pod1', metadata: { labels: { app: 'tikv' } } }
+    expect(isTikvPod(pod)).toBe(true)
+  })
+
+  it('matches by pod name prefix tikv-', () => {
+    expect(isTikvPod({ name: 'tikv-0' })).toBe(true)
+  })
+
+  it('matches by pod name containing -tikv-', () => {
+    expect(isTikvPod({ name: 'cluster-tikv-0' })).toBe(true)
+  })
+
+  it('returns false for unrelated pods', () => {
+    expect(isTikvPod({ name: 'nginx-abc' })).toBe(false)
+    expect(isTikvPod({ name: 'pd-0' })).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseIntOrZero
+// ---------------------------------------------------------------------------
+
+describe('parseIntOrZero', () => {
+  it('parses valid integer string', () => {
+    expect(parseIntOrZero('42')).toBe(42)
+  })
+
+  it('returns 0 for undefined', () => {
+    expect(parseIntOrZero(undefined)).toBe(0)
+  })
+
+  it('returns 0 for empty string', () => {
+    expect(parseIntOrZero('')).toBe(0)
+  })
+
+  it('returns 0 for non-numeric string', () => {
+    expect(parseIntOrZero('abc')).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveStoreState
+// ---------------------------------------------------------------------------
+
+describe('deriveStoreState', () => {
+  it('returns Up when Running and all containers ready', () => {
+    const pod = { name: 'p', status: { phase: 'Running', containerStatuses: [{ ready: true }] } }
+    expect(deriveStoreState(pod)).toBe('Up')
+  })
+
+  it('returns Down when Running but not all containers ready', () => {
+    const pod = { name: 'p', status: { phase: 'Running', containerStatuses: [{ ready: false }] } }
+    expect(deriveStoreState(pod)).toBe('Down')
+  })
+
+  it('returns Offline for Pending phase', () => {
+    const pod = { name: 'p', status: { phase: 'Pending' } }
+    expect(deriveStoreState(pod)).toBe('Offline')
+  })
+
+  it('returns Down for Failed phase', () => {
+    const pod = { name: 'p', status: { phase: 'Failed' } }
+    expect(deriveStoreState(pod)).toBe('Down')
+  })
+
+  it('returns Down for unknown phase', () => {
+    const pod = { name: 'p', status: { phase: 'Succeeded' } }
+    expect(deriveStoreState(pod)).toBe('Down')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseVersion
+// ---------------------------------------------------------------------------
+
+describe('parseVersion', () => {
+  it('extracts version from tikv container image', () => {
+    const pod = {
+      name: 'p',
+      status: { containerStatuses: [{ name: 'tikv', image: 'pingcap/tikv:v7.1.0' }] },
+    }
+    expect(parseVersion(pod)).toBe('v7.1.0')
+  })
+
+  it('strips digest before extracting version', () => {
+    const pod = {
+      name: 'p',
+      status: { containerStatuses: [{ name: 'tikv', image: 'tikv:v6.5.0@sha256:abc123' }] },
+    }
+    expect(parseVersion(pod)).toBe('v6.5.0')
+  })
+
+  it('returns empty string when no containers', () => {
+    expect(parseVersion({ name: 'p' })).toBe('')
+  })
+
+  it('returns empty string for image without tag', () => {
+    const pod = { name: 'p', status: { containerStatuses: [{ name: 'tikv', image: 'tikv' }] } }
+    expect(parseVersion(pod)).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// podToStore
+// ---------------------------------------------------------------------------
+
+describe('podToStore', () => {
+  it('maps a pod with annotations to a TikvStore', () => {
+    const pod = {
+      name: 'tikv-0',
+      namespace: 'tikv',
+      status: {
+        phase: 'Running',
+        podIP: '10.0.0.1',
+        containerStatuses: [{ name: 'tikv', ready: true, image: 'tikv:v7.1.0' }],
+      },
+      metadata: {
+        labels: {},
+        annotations: {
+          'tikv.kubestellar.io/store-id': '5',
+          'tikv.kubestellar.io/region-count': '100',
+          'tikv.kubestellar.io/leader-count': '50',
+        },
+      },
+    }
+    const store = podToStore(pod, 1)
+    expect(store.storeId).toBe(5)
+    expect(store.address).toBe('10.0.0.1:20160')
+    expect(store.state).toBe('Up')
+    expect(store.regionCount).toBe(100)
+    expect(store.leaderCount).toBe(50)
+  })
+
+  it('uses fallback store ID when annotation is missing', () => {
+    const pod = { name: 'tikv-0', status: { phase: 'Running', containerStatuses: [] } }
+    const store = podToStore(pod, 3)
+    expect(store.storeId).toBe(3)
+  })
+
+  it('uses pod name as address when podIP is missing', () => {
+    const pod = { name: 'tikv-0', status: { phase: 'Running', containerStatuses: [] } }
+    const store = podToStore(pod, 1)
+    expect(store.address).toBe('tikv-0')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeros for empty stores', () => {
+    const result = summarize([])
+    expect(result.totalStores).toBe(0)
+    expect(result.upStores).toBe(0)
+    expect(result.downStores).toBe(0)
+  })
+
+  it('counts up and down stores', () => {
+    const stores = [
+      { storeId: 1, address: '', state: 'Up' as const, version: '', regionCount: 10, leaderCount: 5, capacityBytes: 0, availableBytes: 0 },
+      { storeId: 2, address: '', state: 'Down' as const, version: '', regionCount: 20, leaderCount: 10, capacityBytes: 0, availableBytes: 0 },
+    ]
+    const result = summarize(stores)
+    expect(result.totalStores).toBe(2)
+    expect(result.upStores).toBe(1)
+    expect(result.downStores).toBe(1)
+    expect(result.totalRegions).toBe(30)
+    expect(result.totalLeaders).toBe(15)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildStatus
+// ---------------------------------------------------------------------------
+
+describe('buildStatus', () => {
+  it('returns not-installed for empty stores', () => {
+    const result = buildStatus([])
+    expect(result.health).toBe('not-installed')
+    expect(result.stores).toEqual([])
+  })
+
+  it('returns healthy when all stores are Up', () => {
+    const stores = [
+      { storeId: 1, address: '', state: 'Up' as const, version: '', regionCount: 0, leaderCount: 0, capacityBytes: 0, availableBytes: 0 },
+    ]
+    const result = buildStatus(stores)
+    expect(result.health).toBe('healthy')
+  })
+
+  it('returns degraded when some stores are Down', () => {
+    const stores = [
+      { storeId: 1, address: '', state: 'Up' as const, version: '', regionCount: 0, leaderCount: 0, capacityBytes: 0, availableBytes: 0 },
+      { storeId: 2, address: '', state: 'Down' as const, version: '', regionCount: 0, leaderCount: 0, capacityBytes: 0, availableBytes: 0 },
+    ]
+    const result = buildStatus(stores)
+    expect(result.health).toBe('degraded')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchTikvStatus (fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function captureFetcher(): () => Promise<unknown> {
+    renderHook(() => useCachedTikv())
+    const config = mockUseCache.mock.calls[0]?.[0] as { fetcher: () => Promise<unknown> }
+    return config.fetcher
+  }
+
+  it('returns parsed data on success', async () => {
+    const tikvPod = {
+      name: 'tikv-0',
+      namespace: 'tikv',
+      status: {
+        phase: 'Running',
+        podIP: '10.0.0.1',
+        containerStatuses: [{ name: 'tikv', ready: true, image: 'tikv:v7.1.0' }],
+      },
+      metadata: {
+        labels: { 'app.kubernetes.io/component': 'tikv' },
+        annotations: {},
+      },
+    }
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ items: [tikvPod] }),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; stores: unknown[] }
+    expect(result.health).toBe('healthy')
+    expect(result.stores).toHaveLength(1)
+  })
+
+  it('returns not-installed for 404 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; stores: unknown[] }
+    expect(result.health).toBe('not-installed')
+    expect(result.stores).toEqual([])
+  })
+
+  it('returns not-installed for 503 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws on non-404/501/503 error status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    })
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('HTTP 500')
+  })
+
+  it('throws on network error', async () => {
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('Network error')
+  })
+
+  it('returns not-installed when JSON parse fails', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedTimeline-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedTimeline-funcs.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Fetcher function tests for useCachedTimeline.ts.
+ * Tests the fetchTimelineEvents function via useCache capture.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockAuthFetch = vi.fn()
+vi.mock('../../lib/api', () => ({ authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+}))
+
+vi.mock('../../lib/constants/time', () => ({
+  MS_PER_DAY: 86400000,
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../components/cards/change_timeline/demoData', () => ({
+  getDemoTimelineEvents: () => [
+    { timestamp: '2024-01-01T00:00:00Z', kind: 'Deployment', name: 'demo', action: 'created', namespace: 'default' },
+  ],
+}))
+
+const mockUseCache = vi.fn(() => ({
+  data: [],
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+import { useCachedTimeline } from '../useCachedTimeline'
+
+// ---------------------------------------------------------------------------
+// Fetcher function tests (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchTimelineEvents (via useCache fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('parses a successful API response into TimelineEvent array', async () => {
+    renderHook(() => useCachedTimeline())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    const events = [
+      { timestamp: '2024-01-01T00:00:00Z', kind: 'Deployment', name: 'web', action: 'updated', namespace: 'default' },
+      { timestamp: '2024-01-01T01:00:00Z', kind: 'Service', name: 'api', action: 'created', namespace: 'default' },
+    ]
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(events),
+    })
+
+    const result = await fetcher()
+    expect(result).toHaveLength(2)
+    expect(result[0].kind).toBe('Deployment')
+  })
+
+  it('throws on non-ok response', async () => {
+    renderHook(() => useCachedTimeline())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+    await expect(fetcher()).rejects.toThrow('Timeline API returned HTTP 500')
+  })
+
+  it('throws on non-array response body', async () => {
+    renderHook(() => useCachedTimeline())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ notAnArray: true }),
+    })
+
+    await expect(fetcher()).rejects.toThrow('Timeline API returned non-array payload')
+  })
+
+  it('throws on network error', async () => {
+    renderHook(() => useCachedTimeline())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+    await expect(fetcher()).rejects.toThrow('Network failure')
+  })
+
+  it('returns empty array for empty response', async () => {
+    renderHook(() => useCachedTimeline())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    })
+
+    const result = await fetcher()
+    expect(result).toEqual([])
+  })
+})

--- a/web/src/hooks/__tests__/useCachedTuf-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedTuf-funcs.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the pure helper functions and fetcher function exported via
+ * __testables / useCache capture from useCachedTuf.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+  })),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
+vi.mock('../../lib/cache', () => ({ useCache: (...args: unknown[]) => mockUseCache(...args) }))
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+}))
+
+vi.mock('../../lib/constants/time', () => ({
+  MS_PER_DAY: 86400000,
+}))
+
+import { useCachedTuf, __testables } from '../useCachedTuf'
+
+const {
+  deriveStatus,
+  summarize,
+  deriveHealth,
+  buildTufStatus,
+  EXPIRING_SOON_WINDOW_MS,
+} = __testables
+
+// ---------------------------------------------------------------------------
+// deriveStatus
+// ---------------------------------------------------------------------------
+
+describe('deriveStatus', () => {
+  it('returns unsigned when role status is unsigned', () => {
+    const role = { name: 'targets', status: 'unsigned' as const, version: 1, expiresAt: '2099-01-01T00:00:00Z', signedAt: '2024-01-01T00:00:00Z', keyId: 'abc' }
+    expect(deriveStatus(role, Date.now())).toBe('unsigned')
+  })
+
+  it('returns expired when expiresAt is in the past', () => {
+    const role = { name: 'root', status: 'signed' as const, version: 1, expiresAt: '2020-01-01T00:00:00Z', signedAt: '2019-01-01T00:00:00Z', keyId: 'abc' }
+    expect(deriveStatus(role, Date.now())).toBe('expired')
+  })
+
+  it('returns expiring-soon when within the window', () => {
+    const soonMs = Date.now() + EXPIRING_SOON_WINDOW_MS / 2
+    const role = { name: 'snapshot', status: 'signed' as const, version: 1, expiresAt: new Date(soonMs).toISOString(), signedAt: '2024-01-01T00:00:00Z', keyId: 'abc' }
+    expect(deriveStatus(role, Date.now())).toBe('expiring-soon')
+  })
+
+  it('returns signed when expiry is far in the future', () => {
+    const role = { name: 'timestamp', status: 'signed' as const, version: 1, expiresAt: '2099-01-01T00:00:00Z', signedAt: '2024-01-01T00:00:00Z', keyId: 'abc' }
+    expect(deriveStatus(role, Date.now())).toBe('signed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize (tuf)', () => {
+  it('returns zeros for empty roles', () => {
+    const result = summarize([])
+    expect(result.totalRoles).toBe(0)
+    expect(result.signedRoles).toBe(0)
+    expect(result.expiredRoles).toBe(0)
+    expect(result.expiringSoonRoles).toBe(0)
+  })
+
+  it('counts roles by status', () => {
+    const roles = [
+      { name: 'root', status: 'signed' as const, version: 1, expiresAt: '', signedAt: '', keyId: '' },
+      { name: 'targets', status: 'expired' as const, version: 1, expiresAt: '', signedAt: '', keyId: '' },
+      { name: 'snapshot', status: 'expiring-soon' as const, version: 1, expiresAt: '', signedAt: '', keyId: '' },
+    ]
+    const result = summarize(roles)
+    expect(result.totalRoles).toBe(3)
+    expect(result.signedRoles).toBe(1)
+    expect(result.expiredRoles).toBe(1)
+    expect(result.expiringSoonRoles).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth (tuf)', () => {
+  it('returns not-installed for empty roles', () => {
+    expect(deriveHealth([])).toBe('not-installed')
+  })
+
+  it('returns healthy when all roles are signed', () => {
+    const roles = [
+      { name: 'root', status: 'signed' as const, version: 1, expiresAt: '', signedAt: '', keyId: '' },
+    ]
+    expect(deriveHealth(roles)).toBe('healthy')
+  })
+
+  it('returns degraded when any role is expired', () => {
+    const roles = [
+      { name: 'root', status: 'signed' as const, version: 1, expiresAt: '', signedAt: '', keyId: '' },
+      { name: 'targets', status: 'expired' as const, version: 1, expiresAt: '', signedAt: '', keyId: '' },
+    ]
+    expect(deriveHealth(roles)).toBe('degraded')
+  })
+
+  it('returns degraded when any role is expiring-soon', () => {
+    const roles = [
+      { name: 'root', status: 'expiring-soon' as const, version: 1, expiresAt: '', signedAt: '', keyId: '' },
+    ]
+    expect(deriveHealth(roles)).toBe('degraded')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildTufStatus
+// ---------------------------------------------------------------------------
+
+describe('buildTufStatus', () => {
+  it('builds full status with roles', () => {
+    const roles = [
+      { name: 'root', status: 'signed' as const, version: 1, expiresAt: '2099-01-01T00:00:00Z', signedAt: '2024-01-01T00:00:00Z', keyId: 'abc' },
+    ]
+    const result = buildTufStatus(roles, '1.0.31', 'https://tuf.example.com')
+    expect(result.health).toBe('healthy')
+    expect(result.specVersion).toBe('1.0.31')
+    expect(result.repository).toBe('https://tuf.example.com')
+    expect(result.roles).toHaveLength(1)
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('returns not-installed for empty roles', () => {
+    const result = buildTufStatus([], 'unknown', '')
+    expect(result.health).toBe('not-installed')
+    expect(result.summary.totalRoles).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchTufStatus (fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function captureFetcher(): () => Promise<unknown> {
+    renderHook(() => useCachedTuf())
+    const config = mockUseCache.mock.calls[0]?.[0] as { fetcher: () => Promise<unknown> }
+    return config.fetcher
+  }
+
+  it('returns parsed data on success', async () => {
+    const validResponse = {
+      specVersion: '1.0.31',
+      repository: 'https://tuf.example.com',
+      roles: [
+        { name: 'root', status: 'signed', version: 1, expiresAt: '2099-01-01T00:00:00Z', signedAt: '2024-01-01T00:00:00Z', keyId: 'abc' },
+      ],
+    }
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; specVersion: string; roles: unknown[] }
+    expect(result.health).toBe('healthy')
+    expect(result.specVersion).toBe('1.0.31')
+    expect(result.roles).toHaveLength(1)
+  })
+
+  it('returns not-installed for 404 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('returns not-installed for 401 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('returns not-installed for 503 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws on non-whitelisted error status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    })
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('HTTP 500')
+  })
+
+  it('throws on network error', async () => {
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('Network error')
+  })
+
+  it('returns not-installed when JSON parse fails', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string }
+    expect(result.health).toBe('not-installed')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedVitess-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedVitess-funcs.test.ts
@@ -2,18 +2,16 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedVitess.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
 }))
 
-vi.mock('../../lib/api', () => ({
-  authFetch: vi.fn(),
-}))
-
-vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(() => ({
     data: null,
     isLoading: false,
     isRefreshing: false,
@@ -25,8 +23,10 @@ vi.mock('../../lib/cache', () => ({
     refetch: vi.fn(),
   })),
 }))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
+vi.mock('../../lib/cache', () => ({ useCache: (...args: unknown[]) => mockUseCache(...args) }))
 
-import { __testables } from '../useCachedVitess'
+import { __testables, useCachedVitess } from '../useCachedVitess'
 
 const { buildShards, buildKeyspaces, summarize, deriveHealth, buildStatus } = __testables
 
@@ -205,5 +205,81 @@ describe('buildStatus', () => {
     expect(result.summary.primaryTablets).toBe(1)
     expect(result.summary.replicaTablets).toBe(1)
     expect(result.summary.servingTablets).toBe(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchVitessStatus (fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function captureFetcher(): () => Promise<unknown> {
+    renderHook(() => useCachedVitess())
+    const config = mockUseCache.mock.calls[0]?.[0] as { fetcher: () => Promise<unknown> }
+    return config.fetcher
+  }
+
+  it('returns parsed data on success', async () => {
+    const validResponse = {
+      tablets: [
+        { alias: 'z1-001', keyspace: 'commerce', shard: '0', type: 'PRIMARY', state: 'SERVING', replicationLagSeconds: 0 },
+        { alias: 'z1-002', keyspace: 'commerce', shard: '0', type: 'REPLICA', state: 'SERVING', replicationLagSeconds: 1 },
+      ],
+      version: 'v18.0.0',
+    }
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; keyspaces: unknown[]; vitessVersion: string }
+    expect(result.health).toBe('healthy')
+    expect(result.keyspaces).toHaveLength(1)
+    expect(result.vitessVersion).toBe('v18.0.0')
+  })
+
+  it('returns not-installed for 404 status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { health: string; tablets: unknown[] }
+    expect(result.health).toBe('not-installed')
+    expect(result.tablets).toEqual([])
+  })
+
+  it('throws on non-404 error status', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    })
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('HTTP 500')
+  })
+
+  it('throws on network error', async () => {
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const fetcher = captureFetcher()
+    await expect(fetcher()).rejects.toThrow('Network error')
+  })
+
+  it('uses default version when body has no version', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ tablets: [] }),
+    })
+
+    const fetcher = captureFetcher()
+    const result = await fetcher() as { vitessVersion: string }
+    expect(result.vitessVersion).toBe('unknown')
   })
 })

--- a/web/src/hooks/__tests__/useCachedVolcano-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedVolcano-funcs.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for the pure helper functions exported via __testables
+ * from useCachedVolcano.ts, PLUS fetcher function tests.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockAuthFetch = vi.fn()
+vi.mock('../../lib/api', () => ({ authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
+}))
+
+const mockUseCache = vi.fn(() => ({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables } from '../useCachedVolcano'
+import { useCachedVolcano } from '../useCachedVolcano'
+import type {
+  VolcanoQueue,
+  VolcanoJob,
+  VolcanoPodGroup,
+} from '../../components/cards/volcano_status/demoData'
+
+const { summarize, deriveHealth, deriveStatsFromLists, buildVolcanoStatus } = __testables
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function makeQueue(overrides: Partial<VolcanoQueue> = {}): VolcanoQueue {
+  return {
+    name: 'default',
+    state: 'Open',
+    weight: 1,
+    allocatedGpu: 4,
+    pendingJobs: 0,
+    runningJobs: 2,
+    cluster: 'cluster-1',
+    ...overrides,
+  }
+}
+
+function makeJob(overrides: Partial<VolcanoJob> = {}): VolcanoJob {
+  return {
+    name: 'training-job-1',
+    namespace: 'ml',
+    queue: 'default',
+    phase: 'Running',
+    minAvailable: 1,
+    replicas: 2,
+    createdAt: new Date().toISOString(),
+    cluster: 'cluster-1',
+    ...overrides,
+  }
+}
+
+function makePodGroup(overrides: Partial<VolcanoPodGroup> = {}): VolcanoPodGroup {
+  return {
+    name: 'pg-1',
+    namespace: 'ml',
+    phase: 'Running',
+    minMember: 1,
+    currentMembers: 2,
+    cluster: 'cluster-1',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zeros for empty data', () => {
+    const stats = { totalQueues: 0, openQueues: 0, totalJobs: 0, pendingJobs: 0, runningJobs: 0, completedJobs: 0, failedJobs: 0, totalPodGroups: 0, allocatedGpu: 0, schedulerVersion: 'unknown' }
+    const result = summarize([], [], [], stats)
+    expect(result.totalQueues).toBe(0)
+    expect(result.totalJobs).toBe(0)
+    expect(result.totalPodGroups).toBe(0)
+    expect(result.allocatedGpu).toBe(0)
+  })
+
+  it('counts from array lengths', () => {
+    const queues = [makeQueue()]
+    const jobs = [makeJob(), makeJob({ name: 'job2' })]
+    const podGroups = [makePodGroup()]
+    const stats = { totalQueues: 1, openQueues: 1, totalJobs: 2, pendingJobs: 0, runningJobs: 2, completedJobs: 0, failedJobs: 0, totalPodGroups: 1, allocatedGpu: 4, schedulerVersion: '1.0' }
+    const result = summarize(queues, jobs, podGroups, stats)
+    expect(result.totalQueues).toBe(1)
+    expect(result.totalJobs).toBe(2)
+    expect(result.totalPodGroups).toBe(1)
+    expect(result.allocatedGpu).toBe(4)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when no queues and no jobs', () => {
+    expect(deriveHealth([], [])).toBe('not-installed')
+  })
+
+  it('returns healthy when jobs are not failed', () => {
+    expect(deriveHealth([makeQueue()], [makeJob()])).toBe('healthy')
+  })
+
+  it('returns degraded when a job is Failed', () => {
+    const jobs = [makeJob(), makeJob({ name: 'j2', phase: 'Failed' })]
+    expect(deriveHealth([makeQueue()], jobs)).toBe('degraded')
+  })
+
+  it('returns healthy with queues but no jobs', () => {
+    expect(deriveHealth([makeQueue()], [])).toBe('healthy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveStatsFromLists
+// ---------------------------------------------------------------------------
+
+describe('deriveStatsFromLists', () => {
+  it('derives stats from queues and jobs', () => {
+    const queues = [makeQueue({ state: 'Open', allocatedGpu: 8 })]
+    const jobs = [
+      makeJob({ phase: 'Running' }),
+      makeJob({ name: 'j2', phase: 'Pending' }),
+      makeJob({ name: 'j3', phase: 'Completed' }),
+      makeJob({ name: 'j4', phase: 'Failed' }),
+    ]
+    const podGroups = [makePodGroup()]
+    const result = deriveStatsFromLists(queues, jobs, podGroups, undefined)
+    expect(result.openQueues).toBe(1)
+    expect(result.runningJobs).toBe(1)
+    expect(result.pendingJobs).toBe(1)
+    expect(result.completedJobs).toBe(1)
+    expect(result.failedJobs).toBe(1)
+    expect(result.allocatedGpu).toBe(8)
+    expect(result.totalPodGroups).toBe(1)
+  })
+
+  it('uses partial overrides when provided', () => {
+    const partial = { totalQueues: 99, schedulerVersion: '2.0.0' }
+    const result = deriveStatsFromLists([makeQueue()], [makeJob()], [], partial)
+    expect(result.totalQueues).toBe(99)
+    expect(result.schedulerVersion).toBe('2.0.0')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildVolcanoStatus
+// ---------------------------------------------------------------------------
+
+describe('buildVolcanoStatus', () => {
+  it('builds not-installed status with empty data', () => {
+    const stats = { totalQueues: 0, openQueues: 0, totalJobs: 0, pendingJobs: 0, runningJobs: 0, completedJobs: 0, failedJobs: 0, totalPodGroups: 0, allocatedGpu: 0, schedulerVersion: 'unknown' }
+    const result = buildVolcanoStatus([], [], [], stats)
+    expect(result.health).toBe('not-installed')
+    expect(result.queues).toEqual([])
+    expect(result.jobs).toEqual([])
+    expect(result.podGroups).toEqual([])
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('builds healthy status', () => {
+    const queues = [makeQueue()]
+    const jobs = [makeJob()]
+    const podGroups = [makePodGroup()]
+    const stats = { totalQueues: 1, openQueues: 1, totalJobs: 1, pendingJobs: 0, runningJobs: 1, completedJobs: 0, failedJobs: 0, totalPodGroups: 1, allocatedGpu: 4, schedulerVersion: '1.0' }
+    const result = buildVolcanoStatus(queues, jobs, podGroups, stats)
+    expect(result.health).toBe('healthy')
+    expect(result.queues).toHaveLength(1)
+    expect(result.jobs).toHaveLength(1)
+  })
+
+  it('sets lastCheckTime to a valid ISO string', () => {
+    const stats = { totalQueues: 0, openQueues: 0, totalJobs: 0, pendingJobs: 0, runningJobs: 0, completedJobs: 0, failedJobs: 0, totalPodGroups: 0, allocatedGpu: 0, schedulerVersion: 'unknown' }
+    const result = buildVolcanoStatus([], [], [], stats)
+    expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetcher function tests (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetchVolcanoStatus (via useCache fetcher)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: { health: 'not-installed', queues: [], jobs: [], podGroups: [], stats: { totalQueues: 0, openQueues: 0, totalJobs: 0, pendingJobs: 0, runningJobs: 0, completedJobs: 0, failedJobs: 0, totalPodGroups: 0, allocatedGpu: 0, schedulerVersion: 'unknown' }, summary: { totalQueues: 0, totalJobs: 0, totalPodGroups: 0, allocatedGpu: 0 }, lastCheckTime: '' },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('parses a successful API response into VolcanoStatusData', async () => {
+    renderHook(() => useCachedVolcano())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          queues: [
+            { name: 'default', state: 'Open', weight: 1, allocatedGpu: 4, pendingJobs: 0, runningJobs: 1, cluster: 'c1' },
+          ],
+          jobs: [
+            { name: 'job1', namespace: 'ml', queue: 'default', phase: 'Running', minAvailable: 1, replicas: 2, createdAt: new Date().toISOString(), cluster: 'c1' },
+          ],
+          podGroups: [],
+          stats: { schedulerVersion: '1.9.0' },
+        }),
+    })
+
+    const result = await fetcher()
+    expect(result.health).toBe('healthy')
+    expect(result.queues).toHaveLength(1)
+    expect(result.jobs).toHaveLength(1)
+    expect(result.stats.schedulerVersion).toBe('1.9.0')
+  })
+
+  it('throws on non-ok response (non-404) so cache falls back to demo', async () => {
+    renderHook(() => useCachedVolcano())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch Volcano status')
+  })
+
+  it('returns not-installed data on 404 (treated as empty)', async () => {
+    renderHook(() => useCachedVolcano())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const result = await fetcher()
+    expect(result.health).toBe('not-installed')
+    expect(result.queues).toEqual([])
+  })
+
+  it('throws on network error so cache falls back to demo', async () => {
+    renderHook(() => useCachedVolcano())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+    await expect(fetcher()).rejects.toThrow('Unable to fetch Volcano status')
+  })
+
+  it('handles empty body fields gracefully', async () => {
+    renderHook(() => useCachedVolcano())
+    const config = mockUseCache.mock.calls[0][0]
+    const fetcher = config.fetcher
+
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })
+
+    const result = await fetcher()
+    expect(result.queues).toEqual([])
+    expect(result.jobs).toEqual([])
+    expect(result.podGroups).toEqual([])
+  })
+})

--- a/web/src/hooks/__tests__/useCachedWasmcloud-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedWasmcloud-funcs.test.ts
@@ -2,7 +2,14 @@
  * Tests for the pure helper functions exported via __testables
  * from useCachedWasmcloud.ts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockUseCache: vi.fn(),
+}))
+vi.mock('../../lib/api', () => ({ authFetch: mockAuthFetch }))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
@@ -11,24 +18,37 @@ vi.mock('../../lib/constants/network', () => ({
 
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false }),
-  isDemoModeForced: false,
+  isDemoModeForced: () => false,
+  canToggleDemoMode: () => true,
+  isNetlifyDeployment: () => false,
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  getDemoMode: () => false,
+  setGlobalDemoMode: vi.fn(),
 }))
 
+mockUseCache.mockReturnValue({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: null,
+  refetch: vi.fn(),
+})
 vi.mock('../../lib/cache', () => ({
-  useCache: vi.fn(() => ({
-    data: null,
-    isLoading: false,
-    isRefreshing: false,
-    isDemoFallback: false,
-    error: null,
-    isFailed: false,
-    consecutiveFailures: 0,
-    lastRefresh: null,
-    refetch: vi.fn(),
-  })),
+  useCache: (...args: unknown[]) => mockUseCache(...args),
 }))
 
-import { __testables } from '../useCachedWasmcloud'
+vi.mock('../../components/cards/CardDataContext', () => ({
+  useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: vi.fn(),
+}))
+
+import { __testables, useCachedWasmcloud } from '../useCachedWasmcloud'
 import type {
   WasmcloudHost,
   WasmcloudActor,
@@ -245,5 +265,95 @@ describe('buildWasmcloudStatus', () => {
     const result = buildWasmcloudStatus('', [], [], [], [], baseStats)
     expect(() => new Date(result.lastCheckTime)).not.toThrow()
     expect(new Date(result.lastCheckTime).toISOString()).toBe(result.lastCheckTime)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fetcher (via useCache capture)
+// ---------------------------------------------------------------------------
+
+describe('fetcher (via useCache capture)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: {
+        health: 'not-installed',
+        hosts: [],
+        actors: [],
+        providers: [],
+        links: [],
+        stats: { hostCount: 0, actorCount: 0, providerCount: 0, linkCount: 0, latticeVersion: 'unknown' },
+        summary: { latticeId: '', totalHosts: 0, totalActors: 0, totalProviders: 0, totalLinks: 0 },
+        lastCheckTime: new Date().toISOString(),
+      },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('returns parsed wasmCloud status on successful response', async () => {
+    const validResponse = {
+      latticeId: 'lattice-abc',
+      hosts: [{ hostId: 'host-1', friendlyName: 'Host 1', status: 'ready', labels: {}, uptimeSeconds: 3600, actorCount: 2, providerCount: 1, cluster: 'c1' }],
+      actors: [{ actorId: 'actor-1', name: 'echo', imageRef: 'ghcr.io/wasmcloud/echo:0.3.8', instanceCount: 1, hostId: 'host-1', cluster: 'c1' }],
+      providers: [{ providerId: 'prov-1', name: 'httpserver', contractId: 'wasmcloud:httpserver', linkName: 'default', imageRef: 'ghcr.io/wasmcloud/httpserver:0.19.1', status: 'running', hostId: 'host-1', cluster: 'c1' }],
+      links: [{ actorId: 'actor-1', providerId: 'prov-1', contractId: 'wasmcloud:httpserver', linkName: 'default', status: 'active' }],
+      stats: { hostCount: 1, actorCount: 1, providerCount: 1, linkCount: 1, latticeVersion: '0.82.0' },
+    }
+
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validResponse),
+    })
+
+    renderHook(() => useCachedWasmcloud())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('healthy')
+    expect(result.hosts).toHaveLength(1)
+    expect(result.actors).toHaveLength(1)
+    expect(result.providers).toHaveLength(1)
+    expect(result.links).toHaveLength(1)
+  })
+
+  it('returns not-installed status on 404 (treat404AsEmpty path)', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    })
+
+    renderHook(() => useCachedWasmcloud())
+    const config = mockUseCache.mock.calls[0][0]
+    const result = await config.fetcher()
+
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('throws when authFetch returns a non-404 error', async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    renderHook(() => useCachedWasmcloud())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Unable to fetch wasmCloud status')
+  })
+
+  it('throws when authFetch rejects (network error)', async () => {
+    mockAuthFetch.mockRejectedValue(new Error('Network failure'))
+
+    renderHook(() => useCachedWasmcloud())
+    const config = mockUseCache.mock.calls[0][0]
+
+    await expect(config.fetcher()).rejects.toThrow('Unable to fetch wasmCloud status')
   })
 })


### PR DESCRIPTION
## Summary
- Adds fetcher function tests to 29 useCached hook test files using the useCache callback capture pattern
- Tests success, 404 (treat as empty/not-installed), 500 (throw), and network error paths for each hook's fetcher
- 598 tests across 30 `-funcs.test.ts` files, all passing
- Combined with PR #10576 (pure function tests), this should push coverage from 89% past the 91% target

## Test plan
- [x] All 598 tests pass (`npx vitest run src/hooks/__tests__/useCached*-funcs.test.ts`)
- [x] `npm run build` passes clean
- [ ] CI pr-check and coverage-gate pass
- [ ] Coverage-hourly badge updates to ≥91%