### PR TITLE
🐛 Fix 6 test failures: replace require() with dynamic import() in ESM tests

### DIFF
--- a/web/src/lib/__tests__/analytics-core.test.ts
+++ b/web/src/lib/__tests__/analytics-core.test.ts
@@ -21,11 +21,9 @@ describe('analytics-core module', () => {
     expect(exports.length).toBeGreaterThan(0)
   })
 
-  it('can be instantiated without errors', () => {
-    expect(() => {
-      const module = require('../analytics-core')
-      expect(module).toBeDefined()
-    }).not.toThrow()
+  it('can be instantiated without errors', async () => {
+    const module = await import('../analytics-core')
+    expect(module).toBeDefined()
   })
 
   it('module structure is consistent', () => {

--- a/web/src/lib/__tests__/analytics-session.test.ts
+++ b/web/src/lib/__tests__/analytics-session.test.ts
@@ -20,10 +20,8 @@ describe('analytics-session module', () => {
     expect(Object.keys(analyticsSessionModule).length).toBeGreaterThanOrEqual(0)
   })
 
-  it('can be imported without errors', () => {
-    expect(() => {
-      const module = require('../analytics-session')
-      expect(module).toBeDefined()
-    }).not.toThrow()
+  it('can be imported without errors', async () => {
+    const module = await import('../analytics-session')
+    expect(module).toBeDefined()
   })
 })

--- a/web/src/lib/__tests__/analytics.test.ts
+++ b/web/src/lib/__tests__/analytics.test.ts
@@ -10,12 +10,12 @@ describe('analytics module exports', () => {
     vi.restoreAllMocks()
   })
 
-  it('exports useAnalytics hook', () => {
-    expect(typeof analyticsModule.useAnalytics).toBe('function')
+  it('exports initAnalytics function', () => {
+    expect(typeof analyticsModule.initAnalytics).toBe('function')
   })
 
-  it('exports AnalyticsProvider component', () => {
-    expect(analyticsModule.AnalyticsProvider).toBeDefined()
+  it('exports emitPageView function', () => {
+    expect(typeof analyticsModule.emitPageView).toBe('function')
   })
 
   it('exports analytics event types', () => {

--- a/web/src/lib/__tests__/index.test.ts
+++ b/web/src/lib/__tests__/index.test.ts
@@ -33,10 +33,8 @@ describe('lib/index exports', () => {
     expect(requiredExports.length).toBeGreaterThan(0)
   })
 
-  it('can be imported by components', () => {
-    expect(() => {
-      const mod = require('../index')
-      expect(mod).toBeDefined()
-    }).not.toThrow()
+  it('can be imported by components', async () => {
+    const mod = await import('../index')
+    expect(mod).toBeDefined()
   })
 })

--- a/web/src/lib/__tests__/kubectlProxy.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy.test.ts
@@ -25,11 +25,9 @@ describe('kubectlProxy module', () => {
     expect(kubectlProxyModule).toBeTypeOf('object')
   })
 
-  it('can be imported without errors', () => {
-    expect(() => {
-      const module = require('../kubectlProxy')
-      expect(module).toBeDefined()
-    }).not.toThrow()
+  it('can be imported without errors', async () => {
+    const module = await import('../kubectlProxy')
+    expect(module).toBeDefined()
   })
 
   it('exports are not empty', () => {


### PR DESCRIPTION
Fixes #10600

## Problem
6 tests in the Coverage Suite were failing because they used CommonJS `require()` in an ESM/Vitest environment. Additionally, `analytics.test.ts` asserted exports (`useAnalytics`, `AnalyticsProvider`) that don't exist in the module.

## Changes
- **analytics-core.test.ts**: `require('../analytics-core')` → `await import()`
- **analytics-session.test.ts**: `require('../analytics-session')` → `await import()`
- **index.test.ts**: `require('../index')` → `await import()`
- **kubectlProxy.test.ts**: `require('../kubectlProxy')` → `await import()`
- **analytics.test.ts**: replaced non-existent `useAnalytics`/`AnalyticsProvider` assertions with actual exports (`initAnalytics`, `emitPageView`)

## Testing
All 24 tests pass locally. Build and lint verified.