### PR TITLE
🐛 Fix unhandled rejections in sseClient tests

### DIFF
--- a/web/src/lib/__tests__/sseClient-expand.test.ts
+++ b/web/src/lib/__tests__/sseClient-expand.test.ts
@@ -349,11 +349,13 @@ describe('sseClient expanded', () => {
         signal: controller.signal,
       })
 
-      // Abort
+      // Attach catch handler BEFORE aborting to prevent unhandled rejection
+      const assertion = expect(promise).rejects.toThrow('Aborted')
+
       controller.abort()
       await vi.advanceTimersByTimeAsync(100)
 
-      await expect(promise).rejects.toThrow('Aborted')
+      await assertion
     })
 
     it('aborted streams do not populate cache', async () => {

--- a/web/src/lib/__tests__/sseClient-expand2.test.ts
+++ b/web/src/lib/__tests__/sseClient-expand2.test.ts
@@ -347,12 +347,15 @@ describe('fetchSSE — expanded edge cases', () => {
       itemsKey: 'pods',
     })
 
+    // Attach catch handler BEFORE advancing timers to prevent unhandled rejection
+    const assertion = expect(promise).rejects.toThrow('SSE stream error')
+
     // Advance past all retries (5 attempts with exponential backoff)
     for (let i = 0; i < 6; i++) {
       await vi.advanceTimersByTimeAsync(35_000)
     }
 
-    await expect(promise).rejects.toThrow('SSE stream error')
+    await assertion
   })
 
   // 14. Stream ending without done event resolves with accumulated data


### PR DESCRIPTION
Fixes #10436

## Problem
Two sseClient test files produced 'Unhandled Rejection' errors in the nightly test suite. The `reject()` fired before the test attached a `.catch()` handler, so Node's microtask queue flagged them as unhandled.

## Fix
Attach `expect(promise).rejects.toThrow()` assertion **before** triggering the rejection (abort or timer advance), so the catch handler is in place before the rejection fires.

### Files changed
- `sseClient-expand.test.ts`: abort test — move assertion before `controller.abort()`
- `sseClient-expand2.test.ts`: retry exhaustion test — move assertion before timer advances

## Verification
```
37 passed, 0 failed, 0 errors, 0 unhandled rejections
```