### PR TITLE
🐛 Remove broken punkpeye-awesome-mcp-servers submodule reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ web/e2e/user-flows/test-results/
 # Storybook
 web/storybook-static/
 web/node_modules
+punkpeye-awesome-mcp-servers/


### PR DESCRIPTION
Fixes OpenSSF Scorecard CI failure

## Problem
The git index contains a submodule entry (mode 160000) for `punkpeye-awesome-mcp-servers` but no `.gitmodules` file exists. This causes the OpenSSF Scorecard workflow to fail with:

```
fatal: No url found for submodule path 'punkpeye-awesome-mcp-servers' in .gitmodules
```

## Fix
- Remove the dangling submodule entry from the git index
- Add `punkpeye-awesome-mcp-servers/` to `.gitignore` to prevent re-tracking