### PR TITLE
🌱 Remove stale TODO(#9827) in DeploymentRiskScore

### DIFF
--- a/web/src/components/cards/DeploymentRiskScore.tsx
+++ b/web/src/components/cards/DeploymentRiskScore.tsx
@@ -6,10 +6,9 @@
  *
  * Higher score = higher risk.
  *
- * Issue: https://github.com/kubestellar/console/issues/9827
- *
- * TODO(#9827): Add Istio error-rate and OPA Gatekeeper constraint weights when
- * hooks for those sources land (useCachedIstio / useCachedOPA).
+ * Future enhancement: add Istio error-rate and OPA Gatekeeper constraint
+ * weights when hooks for those sources land (useCachedIstio / useCachedOPA).
+ * When added, redistribute scoring weights so the total still equals 1.0.
  */
 
 import { useMemo } from 'react'
@@ -22,8 +21,6 @@ import { useCardLoadingState } from './CardDataContext'
 import { CardSkeleton, CardEmptyState } from '../../lib/cards/CardComponents'
 
 // ── Scoring weights (sum = 1.0) ─────────────────────────────────────────────
-// When Istio/OPA hooks arrive, redistribute weights and renormalize so the
-// total still equals 1.0.
 const ARGO_WEIGHT = 0.35
 const KYVERNO_WEIGHT = 0.25
 const POD_RESTART_WEIGHT = 0.40


### PR DESCRIPTION
Fixes #10603

## What

Remove the stale `TODO(#9827)` comment in `DeploymentRiskScore.tsx`. Issue #9827 was implemented and closed — the TODO referencing it is outdated.

## Changes

- **DeploymentRiskScore.tsx**: Convert `TODO(#9827)` to a plain 'Future enhancement' note. Consolidate duplicate Istio/OPA note from weight comment section into the docblock.

## False positives in #10603

The other 3 findings are not actionable:
- **Kubedle.tsx:40,193** — Design explanation comments for #6306 (word validation). They describe _why_ a Set is used. Not TODO markers.
- **acmm.ts:763** — Description text mentioning 'TODOs' as a concept in the ACMM maturity model. Content, not a code TODO.

## Testing

- `npx tsc --noEmit` ✅
- `npx eslint` ✅
- Comment-only change, no logic affected