### PR TITLE
🌱 Extract 14 magic-number timeouts to named constants

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -51,6 +51,7 @@ const DEFAULT_SNOOZE_MS = MS_PER_HOUR
  * One minute is enough resolution for an "Xm/Xh/Xd" label and is cheap.
  */
 const LAST_UPDATED_TICK_MS = 60_000
+const COLLAPSE_DELAY_MS = 300
 
 // Cards that need extra-large expanded modal (for maps, complex visualizations, etc.)
 // These use 95vh height and 7xl width instead of the default 80vh/4xl
@@ -559,7 +560,7 @@ export function CardWrapper({
     if (hasCompletedInitialLoad && !collapseDelayPassed) {
       const timer = setTimeout(() => {
         setCollapseDelayPassed(true)
-      }, 300) // 300ms delay to show content before collapsing
+      }, COLLAPSE_DELAY_MS)
       return () => clearTimeout(timer)
     }
   }, [hasCompletedInitialLoad, collapseDelayPassed])

--- a/web/src/components/cards/Checkers.tsx
+++ b/web/src/components/cards/Checkers.tsx
@@ -81,7 +81,11 @@ const PRE_GAME_TAUNTS = [
 ]
 
 const PRE_GAME_TAUNT_DELAY_MS = 2_000
-const TAUNT_DISPLAY_MS = 3000
+const TAUNT_DISPLAY_MS = 3_000
+const INITIAL_TAUNT_DELAY_MS = 3_000
+const TAUNT_CYCLE_INTERVAL_MS = 8_000
+const AI_MOVE_DELAY_MS = 1_000
+const COMBAT_ANIMATION_MS = 500
 
 // Initialize board with starting positions
 function createInitialBoard(): Board {
@@ -498,12 +502,12 @@ export function Checkers(_props: CardComponentProps) {
     // Show initial taunt after a short delay
     const initialTimeout = setTimeout(() => {
       setPirateTaunt(PIRATE_TAUNTS[Math.floor(Math.random() * PIRATE_TAUNTS.length)])
-    }, 3000)
+    }, INITIAL_TAUNT_DELAY_MS)
 
     // Change taunt every 8 seconds
     tauntIntervalRef.current = setInterval(() => {
       setPirateTaunt(PIRATE_TAUNTS[Math.floor(Math.random() * PIRATE_TAUNTS.length)])
-    }, 8000)
+    }, TAUNT_CYCLE_INTERVAL_MS)
 
     return () => {
       clearTimeout(initialTimeout)
@@ -552,7 +556,7 @@ export function Checkers(_props: CardComponentProps) {
           setTimeout(() => {
             setShowCombat(false)
             setCombatCell(null)
-          }, 500)
+          }, COMBAT_ANIMATION_MS)
         }
 
         // Handle chain jumps
@@ -579,7 +583,7 @@ export function Checkers(_props: CardComponentProps) {
       setCurrentPlayer('pods')
       setIsThinking(false)
       thinkingTimeoutRef.current = null
-    }, 1000) // 1 second delay before AI moves
+    }, AI_MOVE_DELAY_MS)
 
     return () => {
       if (thinkingTimeoutRef.current) {

--- a/web/src/components/cards/MatchGame.tsx
+++ b/web/src/components/cards/MatchGame.tsx
@@ -47,6 +47,11 @@ const DIFFICULTY_CONFIG = {
   medium: { rows: 4, cols: 4, pairs: 8 },
   hard: { rows: 4, cols: 6, pairs: 12 } }
 
+const TIMER_TICK_MS = 1_000
+const MATCH_REVEAL_DELAY_MS = 500
+const NO_MATCH_FLIP_DELAY_MS = 1_000
+const CONFETTI_DURATION_MS = 5_000
+
 export function MatchGame(_props: CardComponentProps) {
   const { t } = useTranslation()
   const { showToast } = useToast()
@@ -111,7 +116,7 @@ export function MatchGame(_props: CardComponentProps) {
     if (isPlaying && !isPaused && !gameWon) {
       timerRef.current = setInterval(() => {
         setTime(t => t + 1)
-      }, 1000)
+      }, TIMER_TICK_MS)
     } else if (timerRef.current) {
       clearInterval(timerRef.current)
     }
@@ -176,12 +181,12 @@ export function MatchGame(_props: CardComponentProps) {
             )
           )
           setFlippedCards([])
-        }, 500)
+        }, MATCH_REVEAL_DELAY_MS)
       } else {
         // No match
         setTimeout(() => {
           setFlippedCards([])
-        }, 1000)
+        }, NO_MATCH_FLIP_DELAY_MS)
       }
     }
   }
@@ -261,7 +266,7 @@ export function MatchGame(_props: CardComponentProps) {
     setTimeout(() => {
       if (animationFrame) cancelAnimationFrame(animationFrame)
       ctx.clearRect(0, 0, canvas.width, canvas.height)
-    }, 5000)
+    }, CONFETTI_DURATION_MS)
   }
 
   const togglePause = () => {

--- a/web/src/components/cards/StockMarketTicker.tsx
+++ b/web/src/components/cards/StockMarketTicker.tsx
@@ -14,6 +14,8 @@ import { GREEN_500_BRIGHT, RED_500 } from '../../lib/theme/chartColors'
 import { useToast } from '../ui/Toast'
 import type { TFunction } from 'i18next'
 
+const SEARCH_DEBOUNCE_MS = 300
+
 // Stock search result interface
 interface StockSearchResult {
   symbol: string
@@ -633,7 +635,7 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
 
     searchTimeoutRef.current = setTimeout(() => {
       performStockSearch(stockSearchInput)
-    }, 300)
+    }, SEARCH_DEBOUNCE_MS)
 
     return () => {
       if (searchTimeoutRef.current) {

--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -18,6 +18,8 @@ import { safeGetJSON, safeSetJSON } from '../../lib/safeLocalStorage'
 import { useTranslation } from 'react-i18next'
 
 const WS_CONNECTION_TIMEOUT_MS = 5000
+const WS_READY_CHECK_INTERVAL_MS = 100
+const VERSION_REQUEST_TIMEOUT_MS = 10_000
 
 interface UpgradeStatusProps {
   config?: Record<string, unknown>
@@ -125,7 +127,7 @@ function createVersionWsHandle(): VersionWsHandle {
         const checkInterval = setInterval(() => {
           if (destroyed) { clearInterval(checkInterval); reject(new Error('Handle destroyed')); return }
           if (ws?.readyState === WebSocket.OPEN) { clearInterval(checkInterval); resolve(ws) }
-        }, 100)
+        }, WS_READY_CHECK_INTERVAL_MS)
         // #6206: store the timeout handle so destroy() can cancel it.
         // Without this, the timeout would fire after unmount, call
         // clearInterval on a dead handle, and reject an already-settled
@@ -156,7 +158,7 @@ function createVersionWsHandle(): VersionWsHandle {
           closeWs()
           reject(new Error('WebSocket connection timeout'))
         }
-      }, 10000)
+      }, VERSION_REQUEST_TIMEOUT_MS)
 
       ws.onopen = () => {
         clearTimeout(connectionTimeout)
@@ -219,7 +221,7 @@ function createVersionWsHandle(): VersionWsHandle {
         const timeout = setTimeout(() => {
           pendingRequests.delete(requestId)
           resolve(getCachedVersion(clusterName))
-        }, 10000)
+        }, VERSION_REQUEST_TIMEOUT_MS)
 
         pendingRequests.set(requestId, (version) => {
           clearTimeout(timeout)


### PR DESCRIPTION
Fixes #10615

## What

Replace 14 inline numeric literals with descriptive named constants across 5 card components, per the codebase rule requiring named constants for all numeric literals.

## Changes

| File | Constants |
|------|-----------|
| `UpgradeStatus.tsx` | `WS_READY_CHECK_INTERVAL_MS` (100), `VERSION_REQUEST_TIMEOUT_MS` (10_000) |
| `StockMarketTicker.tsx` | `SEARCH_DEBOUNCE_MS` (300) |
| `CardWrapper.tsx` | `COLLAPSE_DELAY_MS` (300) |
| `MatchGame.tsx` | `TIMER_TICK_MS`, `MATCH_REVEAL_DELAY_MS`, `NO_MATCH_FLIP_DELAY_MS`, `CONFETTI_DURATION_MS` |
| `Checkers.tsx` | `INITIAL_TAUNT_DELAY_MS`, `TAUNT_CYCLE_INTERVAL_MS`, `AI_MOVE_DELAY_MS`, `COMBAT_ANIMATION_MS` |

## Testing

- `npx tsc --noEmit` ✅
- `npx eslint` — same error count as main (all pre-existing)
- Pure refactor: no logic changes, no behavior changes