### PR TITLE
🐛 fix deploy-pok-prod: recover failed Helm state + increase timeout to 8m

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -250,8 +250,8 @@ jobs:
       - name: Recover stuck Helm release
         run: |
           RELEASE_STATUS=$(helm status ${{ env.HELM_RELEASE_NAME }} -n kc -o json 2>/dev/null | jq -r '.info.status // empty' || true)
-          if [[ "$RELEASE_STATUS" == "pending-"* ]]; then
-            echo "::warning::Helm release stuck in '$RELEASE_STATUS' — rolling back to recover"
+          if [[ "$RELEASE_STATUS" == "pending-"* || "$RELEASE_STATUS" == "failed" ]]; then
+            echo "::warning::Helm release in '$RELEASE_STATUS' — rolling back to recover"
             helm rollback ${{ env.HELM_RELEASE_NAME }} -n kc --wait --timeout 2m || true
           fi
 
@@ -344,8 +344,8 @@ jobs:
       - name: Recover stuck Helm release
         run: |
           RELEASE_STATUS=$(helm status ${{ env.HELM_RELEASE_NAME }} -n kubestellar-console -o json 2>/dev/null | jq -r '.info.status // empty' || true)
-          if [[ "$RELEASE_STATUS" == "pending-"* ]]; then
-            echo "::warning::Helm release stuck in '$RELEASE_STATUS' — rolling back to recover"
+          if [[ "$RELEASE_STATUS" == "pending-"* || "$RELEASE_STATUS" == "failed" ]]; then
+            echo "::warning::Helm release in '$RELEASE_STATUS' — rolling back to recover"
             helm rollback ${{ env.HELM_RELEASE_NAME }} -n kubestellar-console --wait --timeout 2m || true
           fi
 
@@ -374,7 +374,7 @@ jobs:
             --set securityContext.runAsGroup=null \
             --atomic \
             --wait \
-            --timeout 5m
+            --timeout 8m
 
       - name: Verify deployment
         run: |


### PR DESCRIPTION
Fixes #10618

## Root Cause

After a failed `--atomic` Helm upgrade, the release lands in `failed` state — **not** `pending-*`. The existing "Recover stuck Helm release" step only matched `pending-*`, so the next CI run would attempt a fresh upgrade without first rolling back, causing another `Available: 0/1` progress-deadline exceeded failure in a loop.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/build-deploy.yml` | `deploy-vllm-d` recover step: also handle `failed` Helm state |
| `.github/workflows/build-deploy.yml` | `deploy-pok-prod` recover step: also handle `failed` Helm state |
| `.github/workflows/build-deploy.yml` | `deploy-pok-prod` Helm timeout: `5m` → `8m` (pok-prod image pull is consistently slower) |

## Why 8m for pok-prod?

Runs 25024001366 and 25025102750 both timed out at exactly 5m with `Available: 0/1`. The intermediate success run (25024126861) at 23:00 UTC likely completed just under the limit. 8m gives headroom for slower image pulls on the pok-prod node.