### PR TITLE
♻️ Replace raw <button> elements with shared Button component

### DIFF
--- a/web/src/components/aiagents/AIAgents.tsx
+++ b/web/src/components/aiagents/AIAgents.tsx
@@ -5,6 +5,7 @@ import { DashboardPage } from '../../lib/dashboards'
 import { useTranslation } from 'react-i18next'
 import { AgentIcon } from '../agent/AgentIcon'
 import { ExternalLink } from 'lucide-react'
+import { Button } from '../ui/Button'
 import { aiAgentsDashboardConfig } from '../../config/dashboards/ai-agents'
 import { RotatingTip } from '../ui/RotatingTip'
 
@@ -78,15 +79,17 @@ export function AIAgents() {
   const tabBar = tabs.length > 0 ? (
     <div className="flex items-center gap-1 mb-6 border-b border-border" role="tablist">
       {tabs.map(tab => (
-        <button
+        <Button
           key={tab.id}
+          variant="ghost"
+          size="md"
           onClick={() => !tab.disabled && setActiveTab(tab.id)}
           onKeyDown={handleTabKeyDown}
           disabled={tab.disabled}
           role="tab"
           aria-selected={activeTab === tab.id}
           tabIndex={activeTab === tab.id ? 0 : -1}
-          className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px ${
+          className={`rounded-none border-b-2 -mb-px ${
             activeTab === tab.id
               ? 'border-purple-500 text-foreground'
               : tab.disabled
@@ -107,7 +110,7 @@ export function AIAgents() {
               Install <ExternalLink className="w-2.5 h-2.5" />
             </a>
           )}
-        </button>
+        </Button>
       ))}
     </div>
   ) : null

--- a/web/src/components/cards/ClusterComparison.tsx
+++ b/web/src/components/cards/ClusterComparison.tsx
@@ -10,6 +10,7 @@ import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
+import { Button } from '../ui/Button'
 
 /** Maximum number of clusters that can be compared side-by-side */
 const MAX_COMPARED_CLUSTERS = 4
@@ -163,10 +164,12 @@ function ClusterComparisonInternal({ config }: ClusterComparisonProps) {
       {/* Cluster selector */}
       <div className="flex flex-wrap gap-1 mb-4 overflow-hidden">
         {allClusters.map(c => (
-          <button
+          <Button
             key={c.name}
+            variant="ghost"
+            size="sm"
             onClick={() => toggleCluster(c.name)}
-            className={`px-2 py-1 text-xs rounded-full transition-colors max-w-[120px] truncate ${
+            className={`rounded-full max-w-[120px] truncate ${
               selectedClusters.includes(c.name) || (selectedClusters.length === 0 && clustersToCompare.includes(c))
                 ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
                 : 'bg-secondary/50 text-muted-foreground hover:text-foreground'
@@ -176,7 +179,7 @@ function ClusterComparisonInternal({ config }: ClusterComparisonProps) {
             aria-pressed={selectedClusters.includes(c.name)}
           >
             {c.name}
-          </button>
+          </Button>
         ))}
       </div>
 
@@ -188,21 +191,23 @@ function ClusterComparisonInternal({ config }: ClusterComparisonProps) {
               <th className="text-left py-2 text-muted-foreground font-medium w-20">{t('clusterComparison.metric')}</th>
               {clustersToCompare.map(c => (
                 <th key={c.name} className="text-right py-2 px-2 max-w-[100px]">
-                  <button
+                  <Button
+                    variant="ghost"
+                    size="sm"
                     onClick={() => drillToCluster(c.name, {
                       nodeCount: c.nodeCount,
                       podCount: c.podCount,
                       cpuCores: c.cpuCores,
                       gpuCount: gpuByCluster[c.name] || 0,
                       healthy: c.healthy })}
-                    className="flex items-center justify-end gap-1 w-full hover:text-purple-400 transition-colors group min-w-0"
+                    className="flex items-center justify-end w-full hover:text-purple-400 group min-w-0"
                     title={c.name}
                   >
                     <Server className="w-3 h-3 text-muted-foreground shrink-0" />
                     <span className="text-foreground font-medium group-hover:text-purple-400 truncate">{c.name}</span>
                     <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${c.healthy ? 'bg-green-400' : 'bg-red-400'}`} />
                     <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
-                  </button>
+                  </Button>
                 </th>
               ))}
             </tr>

--- a/web/src/components/cards/PodSweeper.tsx
+++ b/web/src/components/cards/PodSweeper.tsx
@@ -6,6 +6,7 @@ import { useReportCardDataState } from './CardDataContext'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { Button } from '../ui/Button'
 
 type Difficulty = 'easy' | 'medium' | 'hard'
 
@@ -274,14 +275,14 @@ function PodSweeperInternal(_props: CardComponentProps) {
             <option value="medium">{t('podSweeper.mediumMode')}</option>
             <option value="hard">{t('podSweeper.hardMode')}</option>
           </select>
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => newGame()}
-            className="p-1.5 rounded hover:bg-secondary"
+            className="p-1.5"
             title="New Game"
-            aria-label="New Game"
-          >
-            <RotateCcw className="w-4 h-4" />
-          </button>
+            icon={<RotateCcw className="w-4 h-4" />}
+          />
         </div>
       </div>
 

--- a/web/src/components/cards/cubefs_status/CubefsStatus.tsx
+++ b/web/src/components/cards/cubefs_status/CubefsStatus.tsx
@@ -13,6 +13,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { Skeleton, SkeletonStats, SkeletonList } from '../../ui/Skeleton'
 import { RefreshIndicator } from '../../ui/RefreshIndicator'
+import { Button } from '../../ui/Button'
 import { CardSearchInput } from '../../../lib/cards/CardComponents'
 import { useCubefsStatus } from './useCubefsStatus'
 import { useDemoMode } from '../../../hooks/useDemoMode'
@@ -265,23 +266,25 @@ function TabButton({
   count: number
 }) {
   return (
-    <button
+    <Button
+      variant={active ? 'accent' : 'ghost'}
+      size="sm"
       type="button"
       onClick={onClick}
-      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+      className={`rounded-md font-medium ${
         active
           ? 'bg-primary/15 text-primary'
-          : 'text-muted-foreground hover:bg-secondary/50'
+          : 'text-muted-foreground'
       }`}
+      icon={icon}
     >
-      {icon}
       {label}
       <span className={`ml-1 px-1.5 py-0.5 rounded-full text-xs ${
         active ? 'bg-primary/20 text-primary' : 'bg-muted text-muted-foreground'
       }`}>
         {count}
       </span>
-    </button>
+    </Button>
   )
 }
 

--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -414,13 +414,14 @@ export function CanIChecker() {
                   className="inline-flex items-center gap-1 px-2 py-1 text-xs rounded-full bg-blue-500/20 text-blue-400"
                 >
                   {group}
-                  <button
+                  <Button
+                    variant="ghost"
+                    size="sm"
                     onClick={() => toggleUserGroup(group)}
-                    className="hover:text-blue-200"
+                    className="p-0 hover:text-blue-200"
                     aria-label={t('rbac.removeGroup', { group })}
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
+                    icon={<X className="w-3 h-3" />}
+                  />
                 </span>
               ))}
             </div>
@@ -476,14 +477,16 @@ export function CanIChecker() {
         </div>
 
         {/* Advanced Options */}
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           type="button"
           onClick={() => dispatch({ type: 'SET_FIELD', field: 'showAdvanced', value: !showAdvanced })}
           className="text-sm text-muted-foreground hover:text-foreground"
           aria-expanded={showAdvanced}
         >
           {showAdvanced ? t('rbac.hideAdvanced') : t('rbac.showAdvanced')}
-        </button>
+        </Button>
 
         {showAdvanced && (
           <div className="text-xs text-muted-foreground p-3 bg-secondary/30 rounded-lg">


### PR DESCRIPTION
## Summary
- Converts 7 raw `<button>` elements across 5 files to use the shared `Button` component from `components/ui/Button`
- Adds `Button` import to AIAgents, ClusterComparison, PodSweeper, and CubefsStatus (CanIChecker already had it)
- Preserves existing visual appearance via `className` overrides while gaining consistent accessibility and loading state support

Fixes #10622

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Visual regression check: CanIChecker group chips, advanced toggle, AIAgents tab bar, ClusterComparison cluster pills and drill-down headers, PodSweeper reset button, CubefsStatus filter tabs
- [ ] No accessibility regressions (aria-label, aria-pressed, role="tab" preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)