### PR TITLE
🐛 Skip agent token fetch in demo mode / Netlify (#10643)

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -53,8 +53,14 @@ let agentTokenPromise: Promise<string> | null = null
 /**
  * Lazily fetch the kc-agent token from the backend. The token is cached
  * in localStorage so subsequent calls (and page reloads) don't re-fetch.
+ *
+ * On Netlify / demo mode there is no kc-agent backend, so we skip the
+ * fetch entirely to avoid 404 → HTML parse errors that pollute GA4
+ * (#10643, root cause of the 48-hour blank dashboard in #10398).
  */
 function getAgentToken(): Promise<string> {
+  if (isDemoMode() || isNetlifyDeployment) return Promise.resolve('')
+
   const cached = localStorage.getItem(AGENT_TOKEN_STORAGE_KEY)
   if (cached) return Promise.resolve(cached)
 

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -2042,6 +2042,9 @@ export const handlers = [
   // clean for demo visitors and avoids the MSW "unhandled request"
   // warning. Source callers already branch on `available` so semantics
   // are unchanged. See web/src/lib/kagentBackend.ts and related files.
+  http.get('/api/agent/token', () => {
+    return HttpResponse.json({ token: '' })
+  }),
   http.get('/api/kagent/status', () => {
     return HttpResponse.json({ available: false, reason: 'not configured in demo mode' })
   }),


### PR DESCRIPTION
Fixes #10643

## Problem
`getAgentToken()` in `hooks/mcp/shared.ts` unconditionally fetches `/api/agent/token` even in demo mode and on Netlify deployments. Since there's no Netlify Function for this endpoint, Netlify returns HTML (SPA fallback) which causes a JSON parse error, firing GA4 `agent_token_failure` error events — 7 errors in 2 hours on the /ai-ml page.

## Fix
- Added `isDemoMode() || isNetlifyDeployment` guard to `getAgentToken()` — returns empty string immediately instead of fetching
- Added MSW handler for `/api/agent/token` returning `{ token: '' }` (required per CLAUDE.md: new endpoints need MSW passthrough)

## Testing
- `cd web && npm run build` ✅
- `cd web && npm run lint` ✅ (no new warnings on changed files)