### PR TITLE
🐛 Reset MissionChat state when switching missions (#10638)

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -1189,6 +1189,7 @@ export function MissionSidebar() {
               </button>
             )}
             <MissionChat
+              key={activeMission?.id}
               mission={activeMission}
               isFullScreen={isFullScreen}
               onToggleFullScreen={() => setFullScreen(true)}


### PR DESCRIPTION
Fixes #10638

## Problem
When starting a new AI Mission, previous mission history/content remains visible below the chat input. This happens because `MissionChat` is rendered without a `key` prop — React reuses the same component instance, so internal state (input text, scroll position, message refs, `initialMessageCountRef`) persists from the previous mission.

## Fix
Add `key={activeMission?.id}` to the `MissionChat` component in `MissionSidebar.tsx`. This forces React to unmount and remount the component when the active mission changes, giving a clean slate for the new mission.

## Testing
- `cd web && npm run build` ✅
- `cd web && npm run lint` ✅ (no new issues)