### PR TITLE
🐛 Add isDemoMode checks to workloads + data_residency handlers

### DIFF
--- a/pkg/api/handlers/data_residency.go
+++ b/pkg/api/handlers/data_residency.go
@@ -27,12 +27,28 @@ func (h *DataResidencyHandler) RegisterPublicRoutes(group fiber.Router) {
 // ListRules returns all configured residency rules.
 // GET /api/compliance/residency/rules
 func (h *DataResidencyHandler) ListRules(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return demoResponse(c, "rules", h.engine.Rules())
+	}
 	return c.JSON(h.engine.Rules())
 }
 
 // ListRegions returns all available region codes with labels.
 // GET /api/compliance/residency/regions
 func (h *DataResidencyHandler) ListRegions(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		type regionInfo struct {
+			Code  residency.Region `json:"code"`
+			Label string           `json:"label"`
+		}
+		regions := residency.AllRegions()
+		result := make([]regionInfo, len(regions))
+		for i, r := range regions {
+			result[i] = regionInfo{Code: r, Label: residency.RegionLabel(r)}
+		}
+		return demoResponse(c, "regions", result)
+	}
+
 	type regionInfo struct {
 		Code  residency.Region `json:"code"`
 		Label string           `json:"label"`
@@ -49,12 +65,19 @@ func (h *DataResidencyHandler) ListRegions(c *fiber.Ctx) error {
 // ListClusterRegions returns the cluster-to-region mapping.
 // GET /api/compliance/residency/clusters
 func (h *DataResidencyHandler) ListClusterRegions(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return demoResponse(c, "clusterRegions", h.engine.ClusterRegions())
+	}
 	return c.JSON(h.engine.ClusterRegions())
 }
 
 // ListViolations evaluates all rules and returns violations.
 // GET /api/compliance/residency/violations
 func (h *DataResidencyHandler) ListViolations(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		violations, _ := h.engine.Evaluate()
+		return demoResponse(c, "violations", violations)
+	}
 	violations, _ := h.engine.Evaluate()
 	return c.JSON(violations)
 }
@@ -62,5 +85,8 @@ func (h *DataResidencyHandler) ListViolations(c *fiber.Ctx) error {
 // GetSummary returns an overview of the data residency posture.
 // GET /api/compliance/residency/summary
 func (h *DataResidencyHandler) GetSummary(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return demoResponse(c, "summary", h.engine.Summary())
+	}
 	return c.JSON(h.engine.Summary())
 }

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -86,6 +86,9 @@ func (h *WorkloadHandlers) requireAdmin(c *fiber.Ctx) error {
 // ListWorkloads returns all workloads across clusters
 // GET /api/workloads
 func (h *WorkloadHandlers) ListWorkloads(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return demoResponse(c, "workloads", getDemoWorkloads())
+	}
 	if h.k8sClient == nil {
 		return errNoClusterAccess(c)
 	}
@@ -109,6 +112,13 @@ func (h *WorkloadHandlers) ListWorkloads(c *fiber.Ctx) error {
 // GetWorkload returns a specific workload
 // GET /api/workloads/:cluster/:namespace/:name
 func (h *WorkloadHandlers) GetWorkload(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		demos := getDemoWorkloads()
+		if len(demos) > 0 {
+			return c.JSON(demos[0])
+		}
+		return c.JSON(fiber.Map{})
+	}
 	if h.k8sClient == nil {
 		return errNoClusterAccess(c)
 	}
@@ -140,6 +150,16 @@ func (h *WorkloadHandlers) GetWorkload(c *fiber.Ctx) error {
 // ResolveDependencies returns the dependency tree for a workload without deploying (dry-run).
 // GET /api/workloads/resolve-deps/:cluster/:namespace/:name
 func (h *WorkloadHandlers) ResolveDependencies(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(fiber.Map{
+			"workload":     c.Params("name"),
+			"kind":         "Deployment",
+			"namespace":    c.Params("namespace"),
+			"cluster":      c.Params("cluster"),
+			"dependencies": make([]fiber.Map, 0),
+			"warnings":     make([]string, 0),
+		})
+	}
 	if h.k8sClient == nil {
 		return errNoClusterAccess(c)
 	}
@@ -197,6 +217,16 @@ func (h *WorkloadHandlers) ResolveDependencies(c *fiber.Ctx) error {
 // MonitorWorkload returns a workload's dependencies with health status and detected issues.
 // GET /api/workloads/monitor/:cluster/:namespace/:name
 func (h *WorkloadHandlers) MonitorWorkload(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(fiber.Map{
+			"workload":     c.Params("name"),
+			"namespace":    c.Params("namespace"),
+			"cluster":      c.Params("cluster"),
+			"status":       "Healthy",
+			"dependencies": make([]fiber.Map, 0),
+			"issues":       make([]fiber.Map, 0),
+		})
+	}
 	if h.k8sClient == nil {
 		return errNoClusterAccess(c)
 	}
@@ -223,6 +253,16 @@ func (h *WorkloadHandlers) MonitorWorkload(c *fiber.Ctx) error {
 // GetDeployStatus returns the current replica status of a deployment on a cluster
 // GET /api/workloads/deploy-status/:cluster/:namespace/:name
 func (h *WorkloadHandlers) GetDeployStatus(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(fiber.Map{
+			"cluster":       c.Params("cluster"),
+			"namespace":     c.Params("namespace"),
+			"name":          c.Params("name"),
+			"status":        "Running",
+			"replicas":      3,
+			"readyReplicas": 3,
+		})
+	}
 	if h.k8sClient == nil {
 		return errNoClusterAccess(c)
 	}


### PR DESCRIPTION
Fixes #8695

## Summary

7 Go API handlers across 2 files were missing `isDemoMode` guards, violating the CLAUDE.md requirement that every data-returning endpoint check demo mode first.

### Handlers fixed

**pkg/api/handlers/workloads.go** (5 handlers):
- `ListWorkloads` — returns demo workloads list
- `GetWorkload` — returns first demo workload
- `ResolveDependencies` — returns empty dependency tree
- `MonitorWorkload` — returns healthy status
- `GetDeployStatus` — returns running deployment status

**pkg/api/handlers/data_residency.go** (5 handlers):
- `ListRules`, `ListRegions`, `ListClusterRegions`, `ListViolations`, `GetSummary`

### Testing
- `go build ./...` passes

### Blast radius
Demo mode path only — no changes to live-data request path.

Bead: feature-e1w