### PR TITLE
⚡ Memoize availableClusters + clusterInfoMap in GlobalFiltersProvider

### DIFF
--- a/web/src/hooks/useGlobalFilters.tsx
+++ b/web/src/hooks/useGlobalFilters.tsx
@@ -139,12 +139,15 @@ const DEFAULT_GROUPS: ClusterGroup[] = []
 
 export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
   const { deduplicatedClusters } = useClusters()
-  const availableClusters = deduplicatedClusters.map(c => c.name)
-  const clusterInfoMap = (() => {
+  const availableClusters = useMemo(
+    () => deduplicatedClusters.map(c => c.name),
+    [deduplicatedClusters]
+  )
+  const clusterInfoMap = useMemo(() => {
     const map: Record<string, ClusterInfo> = {}
     deduplicatedClusters.forEach(c => { map[c.name] = c })
     return map
-  })()
+  }, [deduplicatedClusters])
 
   // Initialize clusters from localStorage or default to all
   const [selectedClusters, setSelectedClustersState] = useState<string[]>(() => {


### PR DESCRIPTION
Fixes #8695

## Summary

`availableClusters` (line 142) and `clusterInfoMap` (lines 143-147) in `GlobalFiltersProvider` were recomputed on every render without `useMemo`, creating new array/object references each time. Although the context value itself was memoized (line 643), these two inputs changed identity on every render, invalidating the `useMemo` deps and causing **all GlobalFilters consumers to re-render unnecessarily**.

### Fix
Wrap both in `useMemo(() => ..., [deduplicatedClusters])`.

### Testing
- `npm run build` ✅
- `npm run lint` ✅

### Blast radius
Internal to GlobalFiltersProvider — no API/route/state contract changes.

Bead: feature-jfj