### PR TITLE
⚡ Add React.memo to 5 chart card components + useMemo for TopPods max calcs

### DIFF
--- a/web/src/components/cards/ClusterCosts.tsx
+++ b/web/src/components/cards/ClusterCosts.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect, useCallback } from 'react'
+import { useMemo, useState, useEffect, useCallback, memo } from 'react'
 import { Server, Cpu, HardDrive, TrendingUp, Info, ExternalLink, ChevronDown, Sparkles, Settings2, ChevronRight } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedGPUNodes } from '../../hooks/useCachedData'
@@ -178,7 +178,7 @@ const SORT_COMPARATORS = {
   name: commonComparators.string<ClusterCostItem>('name'),
   cpus: commonComparators.number<ClusterCostItem>('cpus') }
 
-export function ClusterCosts({ config }: ClusterCostsProps) {
+export const ClusterCosts = memo(function ClusterCosts({ config }: ClusterCostsProps) {
   const { t } = useTranslation(['cards', 'common'])
 
   // Build sort options with translated labels
@@ -860,4 +860,4 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
       </div>
     </div>
   )
-}
+})

--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef, lazy, Suspense } from 'react'
+import { useState, useMemo, useEffect, useRef, lazy, Suspense, memo } from 'react'
 import { useClusters } from '../../hooks/useMCP'
 import { CLUSTER_POLL_INTERVAL_MS } from '../../hooks/mcp/shared'
 import { Server, Clock, Layers, TrendingUp } from 'lucide-react'
@@ -122,7 +122,7 @@ const STORAGE_KEY = 'cluster-metrics-history'
 // page reload does not discard recent points that would still be visible.
 const MAX_AGE_MS = MAX_HISTORY_DURATION_MS
 
-export function ClusterMetrics() {
+export const ClusterMetrics = memo(function ClusterMetrics() {
   const { t } = useTranslation(['cards', 'common'])
   const { isLoading, isRefreshing, deduplicatedClusters, isFailed, consecutiveFailures } = useClusters()
   const { isDemoMode } = useDemoMode()
@@ -491,4 +491,4 @@ export function ClusterMetrics() {
       )}
     </div>
   )
-}
+})

--- a/web/src/components/cards/ResourceTrend.tsx
+++ b/web/src/components/cards/ResourceTrend.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from 'react'
+import { useState, useMemo, useEffect, useRef, memo } from 'react'
 import { TrendingUp, Cpu, MemoryStick, Box, Server, Clock } from 'lucide-react'
 import { LazyEChart } from '../charts/LazyEChart'
 import { useClusters } from '../../hooks/useMCP'
@@ -38,7 +38,7 @@ const TIME_RANGE_OPTIONS: { value: TimeRange; label: string; points: number }[] 
   { value: '24h', label: '24 hours', points: 24 },
 ]
 
-export function ResourceTrend() {
+export const ResourceTrend = memo(function ResourceTrend() {
   const { t } = useTranslation()
   const { deduplicatedClusters: clusters, isLoading, isRefreshing, isFailed, consecutiveFailures } = useClusters()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
@@ -382,4 +382,4 @@ export function ResourceTrend() {
       </div>
     </div>
   )
-}
+})

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, memo } from 'react'
 import { Gauge } from '../charts'
 import { Cpu, MemoryStick, Server } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
@@ -292,10 +292,10 @@ function ResourceUsageInternal() {
   )
 }
 
-export function ResourceUsage() {
+export const ResourceUsage = memo(function ResourceUsage() {
   return (
     <DynamicCardErrorBoundary cardId="ResourceUsage">
       <ResourceUsageInternal />
     </DynamicCardErrorBoundary>
   )
-}
+})

--- a/web/src/components/cards/TopPods.tsx
+++ b/web/src/components/cards/TopPods.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from 'react'
 import { AlertTriangle, ChevronRight, Server, Cpu, MemoryStick, Zap } from 'lucide-react'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { useCachedPods } from '../../hooks/useCachedData'
@@ -166,10 +167,12 @@ function TopPodsInternal({ config }: TopPodsProps) {
   }
 
   // Find max values for visual scaling based on current sort
-  const maxRestarts = Math.max(...pods.map(p => p.restarts), 1)
-  const maxCpu = Math.max(...pods.map(p => getEffectiveCpu(p)), 1)
-  const maxMemory = Math.max(...pods.map(p => getEffectiveMemory(p)), 1)
-  const maxGpu = Math.max(...pods.map(p => p.gpuRequest || 0), 1)
+  const { maxRestarts, maxCpu, maxMemory, maxGpu } = useMemo(() => ({
+    maxRestarts: Math.max(...pods.map(p => p.restarts), 1),
+    maxCpu: Math.max(...pods.map(p => getEffectiveCpu(p)), 1),
+    maxMemory: Math.max(...pods.map(p => getEffectiveMemory(p)), 1),
+    maxGpu: Math.max(...pods.map(p => p.gpuRequest || 0), 1),
+  }), [pods])
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
@@ -433,10 +436,10 @@ function TopPodsInternal({ config }: TopPodsProps) {
   )
 }
 
-export function TopPods(props: TopPodsProps) {
+export const TopPods = memo(function TopPods(props: TopPodsProps) {
   return (
     <DynamicCardErrorBoundary cardId="TopPods">
       <TopPodsInternal {...props} />
     </DynamicCardErrorBoundary>
   )
-}
+})


### PR DESCRIPTION
Fixes #8695

## Summary

### React.memo on 5 chart card components
Wrap expensive chart card exports in `React.memo` to prevent unnecessary re-renders when parent state changes but card props haven't changed:
- `TopPods` — pod metrics visualization
- `ResourceTrend` — resource trend chart
- `ClusterMetrics` — cluster metrics chart
- `ResourceUsage` — resource usage gauges
- `ClusterCosts` — cluster cost breakdown

### useMemo for TopPods max calculations
Memoize 4 `Math.max(...pods.map())` calls (lines 169-172) that were recalculated on every render. Now wrapped in `useMemo(() => ..., [pods])`.

### Testing
- `npm run build` ✅
- `npm run lint` ✅ (no new errors)

### Blast radius
None — `React.memo` is additive and preserves existing behavior. `useMemo` is a pure optimization.

Beads: feature-4gs, feature-7w5