### PR TITLE
Fixes  #10647 — the external link security issue in `RepoPicker.tsx`.

### DIFF
--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -88,7 +88,7 @@ export function RepoPicker() {
   const badgeImg = `https://img.shields.io/endpoint?url=${encodeURIComponent(badgeEndpoint)}`
   const badgeHref = `${BADGE_SITE}/acmm?repo=${encodeURIComponent(repo)}`
   const badgeMarkdown = `[![ACMM](${badgeImg})](${badgeHref})`
-  const badgeHtml = `<a href="${badgeHref}"><img src="${badgeImg}" alt="ACMM" /></a>`
+  const badgeHtml = `<a href="${badgeHref}" target="_blank" rel="noopener noreferrer"><img src="${badgeImg}" alt="ACMM" /></a>`
 
   function copy(text: string, tag: string) {
     navigator.clipboard.writeText(text).then(


### PR DESCRIPTION
### 📌 Fixes

Fixes #10647

---

###  Summary of Changes

- Added `target="_blank"` and `rel="noopener noreferrer"` to the external badge link in `RepoPicker.tsx`
- Investigated the drill-down back navigation findings and confirmed it was a false positive

---

### Changes Made

- [x] Fixed the missing security attributes on the external badge anchor tag in `web/src/components/acmm/RepoPicker.tsx`

---

### Checklist

- [ ] I used a coding agent
- [x] I have reviewed the contribution guidelines
- [ ] New cards target console-marketplace (N/A)
- [ ] isDemoData is wired correctly (N/A)
- [ ] I have written unit tests (N/A)
- [x] I have tested the changes locally
- [x] All commits are signed with DCO

---

### Screenshots or Logs (if applicable)

Before:
```tsx
const badgeHtml = `<a href="${badgeHref}"><img src="${badgeImg}" alt="ACMM" /></a>`
```

After:
```tsx
const badgeHtml = `<a href="${badgeHref}" target="_blank" rel="noopener noreferrer"><img src="${badgeImg}" alt="ACMM" /></a>`
```

---

### 👀 Reviewer Notes

Hey! Issue #10647 flagged two things. I looked into both before touching anything.

The external link fix was real — the badge anchor tag in `RepoPicker.tsx` was 
missing `target="_blank"` and `rel="noopener noreferrer"`, so I added them. 
Simple one line change.

The drill-down back navigation part turned out to be a false positive. The 
Auto-QA scanner checked inside individual view files and didn't find a back 
button there, but back navigation is already handled by `DrillDownModal.tsx` 
which wraps all the views. It has a back button, breadcrumb navigation, and 
keyboard shortcuts already. So no changes needed there.