### PR TITLE
fix(tsconfig): downgrade ignoreDeprecations from "6.0" to "5.0" for compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "kubestellar-console-status-helpers",
+  "name": "console",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -16,7 +16,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
### Summary

Downgrades the `ignoreDeprecations` value in `tsconfig.json` from `"6.0"` to `"5.0"` to ensure compatibility with the current TypeScript version used in the project.

---

### Problem

The project currently specifies:

```
"ignoreDeprecations": "6.0"
```

This value is not supported by the TypeScript version used by the project/tooling, resulting in the following error during development:

```
Invalid value for '--ignoreDeprecations'
```

This breaks local setup and prevents contributors from compiling or running the project successfully.

---

### Solution

Updated the configuration to:

```
"ignoreDeprecations": "5.0"
```

This ensures compatibility with the existing TypeScript setup while still preserving the intent of suppressing deprecation warnings.

---

### Why this approach

* Maintains the purpose of the `ignoreDeprecations` setting instead of removing it entirely
* Avoids forcing a full TypeScript version upgrade across the codebase
* Ensures smooth onboarding and local development for contributors

---

### Impact

* Fixes TypeScript configuration error
* Restores working local development environment
* No changes to runtime or application behavior

---

### Testing

* Ran `npm install` and verified setup
* Confirmed TypeScript no longer throws configuration error
* Project runs/builds successfully after change

---

### Note

If/when the project upgrades to a TypeScript version that supports `"6.0"`, this value can be safely reverted.
