### PR TITLE
fix: navigate to home before opening Add More popup when not on dashb…

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -17,6 +17,17 @@ function toNavItem(item: SidebarItem): SidebarNavItem {
   }
 }
 
+const CARD_DASHBOARD_PATHS = [
+  '/',
+  '/workloads',
+  '/security',
+  '/gitops',
+  '/storage',
+  '/compute',
+  '/network',
+  '/events',
+  '/clusters',
+]
 export function Sidebar() {
   const { config } = useSidebarConfig()
   const dashboardContext = useDashboardContextOptional()
@@ -30,11 +41,11 @@ export function Sidebar() {
 
   // Handle Add Card click - work with current dashboard
   const handleAddCardClick = () => {
-    const cardDashboards = ['/', '/workloads', '/security', '/gitops', '/storage', '/compute', '/network', '/events', '/clusters']
+
     const currentPath = location.pathname
     const isCustomDashboard = currentPath.startsWith('/custom-dashboard/')
 
-    if (cardDashboards.includes(currentPath) || isCustomDashboard) {
+if (CARD_DASHBOARD_PATHS.includes(currentPath) || isCustomDashboard) {
       if (currentPath === ROUTES.HOME) {
         dashboardContext?.openAddCardModal()
       } else {
@@ -61,7 +72,18 @@ export function Sidebar() {
         collapsePin: true,
         snoozedCards: true,
       }}
-      onAddMore={() => dashboardContext?.openAddCardModal('dashboards')}
+     onAddMore={() => {
+  const currentPath = location.pathname
+  const isOnDashboard =
+    CARD_DASHBOARD_PATHS.includes(currentPath) ||
+    currentPath.startsWith('/custom-dashboard/')
+
+  if (isOnDashboard) {
+    dashboardContext?.openAddCardModal('dashboards')
+  } else {
+    navigate(`${ROUTES.HOME}?customizeSidebar=true`)
+  }
+}}
       onAddCard={handleAddCardClick}
     />
   )


### PR DESCRIPTION
### 📌 Fixes

Fixes #10663

---

### 📝 Summary of Changes

- Fixed "Add More" popup not appearing when clicked from the Settings page
- The popup was invisible because `DashboardPage` (which renders the modal) 
  is not mounted on non-dashboard pages like Settings
- Also extracted duplicate dashboard paths array into a shared `CARD_DASHBOARD_PATHS` 
  constant used by both `handleAddCardClick` and `onAddMore`

---

### Changes Made

- [x] Fixed `onAddMore` handler in `Sidebar.tsx` to navigate to home with 
      `?customizeSidebar=true` when not on a dashboard page, instead of 
      calling `openAddCardModal` directly
- [x] Extracted `CARD_DASHBOARD_PATHS` constant to remove duplicated array 
      between `handleAddCardClick` and `onAddMore`
- [x] Refactored `handleAddCardClick` to use the new shared constant

---

### Checklist

- [ ] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo (N/A)
- [ ] isDemoData is wired correctly (N/A — no cards changed)
- [ ] I have written unit tests for the changes (if applicable)
- [x] ] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

