### PR TITLE
⚡ Memoize GPU card nested maps + CardAIActions to prevent re-renders

### DIFF
--- a/web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx
+++ b/web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect } from 'react'
+import { useState, useMemo, useRef, useEffect, memo } from 'react'
 import { CheckCircle, AlertTriangle, XCircle, ChevronRight, ChevronDown, Server, Clock, Play, Trash2, Loader2, Settings2, RefreshCw, Shield } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../lib/cn'
@@ -81,6 +81,35 @@ function CheckRow({ check }: { check: GPUNodeHealthCheck }) {
     </div>
   )
 }
+
+// Memoized AI actions to avoid recreating issues/context arrays each render
+const GPUNodeAIActions = memo(function GPUNodeAIActions({ node }: { node: GPUNodeHealthStatus }) {
+  const issues = useMemo(
+    () => (node.issues || []).map((issue: string, idx: number) => ({
+      name: `Issue ${idx + 1}`,
+      message: issue })),
+    [node.issues])
+
+  const additionalContext = useMemo(
+    () => ({
+      gpuType: node.gpuType,
+      gpuCount: node.gpuCount,
+      stuckPods: node.stuckPods,
+      checks: node.checks }),
+    [node.gpuType, node.gpuCount, node.stuckPods, node.checks])
+
+  return (
+    <CardAIActions
+      resource={{
+        kind: 'Node',
+        name: node.nodeName,
+        cluster: node.cluster,
+        status: node.status }}
+      issues={issues}
+      additionalContext={additionalContext}
+    />
+  )
+})
 
 // CronJob management panel for a single cluster
 function CronJobClusterPanel({ cluster }: { cluster: string }) {
@@ -674,21 +703,7 @@ function ProactiveGPUNodeHealthMonitorInternal() {
                 <span className="text-2xs text-white/40 whitespace-nowrap">
                   {node.gpuCount} GPU{node.gpuCount !== 1 ? 's' : ''}
                 </span>
-                <CardAIActions
-                  resource={{
-                    kind: 'Node',
-                    name: node.nodeName,
-                    cluster: node.cluster,
-                    status: node.status }}
-                  issues={(node.issues || []).map((issue: string, idx: number) => ({
-                    name: `Issue ${idx + 1}`,
-                    message: issue }))}
-                  additionalContext={{
-                    gpuType: node.gpuType,
-                    gpuCount: node.gpuCount,
-                    stuckPods: node.stuckPods,
-                    checks: node.checks }}
-                />
+                <GPUNodeAIActions node={node} />
               </div>
 
               {/* Expanded detail */}


### PR DESCRIPTION
Fixes #10668

## What changed

Extracted a memoized `GPUNodeAIActions` component from `ProactiveGPUNodeHealthMonitor` using `React.memo`. The `issues` and `additionalContext` props passed to `CardAIActions` are now computed with `useMemo`, preventing new array/object references on every render.

**Before:** Triple-nested `.map()` calls + inline object creation in JSX created new references every render, forcing `CardAIActions` to re-render even when data hadn't changed.

**After:** `GPUNodeAIActions` is a `memo`-wrapped component that only re-renders when the `node` prop changes. Internal arrays are memoized on their source data.

## Blast radius
GPU card only — no other components affected.

## Verification
- `npm run build` ✅
- `npm run lint` ✅ (no new warnings)