### PR TITLE
⚡ Memoize StockMarketTicker mock data + fix cascading re-renders

### DIFF
--- a/web/src/components/cards/StockMarketTicker.tsx
+++ b/web/src/components/cards/StockMarketTicker.tsx
@@ -553,7 +553,8 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
 
   // Stock data via useCache (persists across navigation)
   const symbolsKey = [...activeSymbols].sort().join(',')
-  const demoStockData = generateMockStockData(activeSymbols)
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- symbolsKey is the stable string derived from activeSymbols
+  const demoStockData = useMemo(() => generateMockStockData(activeSymbols), [symbolsKey])
 
   const { data: stockData, isLoading: isLoadingData, isRefreshing: stockRefreshing } = useCache<StockData[]>({
     key: `stocks:${symbolsKey}:${useLiveData ? 'live' : 'demo'}`,
@@ -573,10 +574,18 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
   // Update saved stocks when data changes
   useEffect(() => {
     if (stockData.length > 0) {
-      setSavedStocks(prev => prev.map(saved => {
-        const stock = stockData.find(s => s.symbol === saved.symbol)
-        return stock ? { ...saved, price: stock.price, changePercent: stock.changePercent } : saved
-      }))
+      setSavedStocks(prev => {
+        let changed = false
+        const next = prev.map(saved => {
+          const stock = stockData.find(s => s.symbol === saved.symbol)
+          if (stock && (saved.price !== stock.price || saved.changePercent !== stock.changePercent)) {
+            changed = true
+            return { ...saved, price: stock.price, changePercent: stock.changePercent }
+          }
+          return saved
+        })
+        return changed ? next : prev
+      })
     }
   }, [stockData])
 


### PR DESCRIPTION
Fixes #10671

## What changed

1. **Memoized `generateMockStockData()`** — wrapped with `useMemo` keyed on `symbolsKey` to avoid re-creating 20-point sparkline arrays with Math operations on every render.

2. **Fixed cascading re-renders in `setSavedStocks`** — the `useEffect` updater now checks whether prices actually changed before returning a new array. Previously it always created new objects for every saved stock, causing unnecessary child re-renders.

## Blast radius
StockMarketTicker card only — no other components affected.

## Verification
- `npm run build` ✅
- `npm run lint` ✅ (no new warnings)