### PR TITLE
🐛 Fix UserManagement container not expanding to full content height

### DIFF
--- a/web/src/pages/UserManagement.tsx
+++ b/web/src/pages/UserManagement.tsx
@@ -2,8 +2,8 @@ import { UserManagement } from '../components/cards/UserManagement'
 
 export function UserManagementPage() {
   return (
-    <div className="h-full p-6">
-      <div className="h-full rounded-xl border border-border/50 bg-card/50 p-4">
+    <div className="min-h-full p-6">
+      <div className="min-h-full rounded-xl border border-border/50 bg-card/50 p-4">
         <UserManagement />
       </div>
     </div>


### PR DESCRIPTION
Fixes #10662

## What changed

Changed `h-full` to `min-h-full` on both wrapper divs in `UserManagementPage` so the background container grows with the user list instead of clipping at viewport height.

When the user list grows beyond the viewport, the background and border now properly wrap the full content.

## Verification
- `npm run build` ✅
- `npm run lint` ✅