### PR TITLE
🐛 Enable backdrop click to close Console Studio modal

### DIFF
--- a/web/src/components/dashboard/customizer/DashboardCustomizer.tsx
+++ b/web/src/components/dashboard/customizer/DashboardCustomizer.tsx
@@ -92,7 +92,7 @@ export function DashboardCustomizer({
 
   return (
     <>
-    <BaseModal isOpen={isOpen} onClose={onClose} size="xl" closeOnBackdrop={false} className="max-w-[75vw]! h-[75vh]!">
+    <BaseModal isOpen={isOpen} onClose={onClose} size="xl" className="max-w-[75vw]! h-[75vh]!">
       <BaseModal.Header
         title={t('dashboard.studio.title', 'Console Studio')}
         description={t('dashboard.studio.subtitle', 'Your console is built from dashboards containing cards and stat blocks that show real-time cluster data. Browse cards, apply collections, or create custom visualizations.')}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -16,7 +16,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
Fixes #10676

## What changed
Removed `closeOnBackdrop={false}` from BaseModal in DashboardCustomizer.tsx. Default is `true`, so clicking outside Console Studio now closes it.
Also fixes tsconfig ignoreDeprecations for TS 6.0.

## Verification
- `npm run build` ✅