### PR TITLE
🐛 fix: remove racy time.AfterFunc kill in kubectl proxy

### DIFF
--- a/pkg/agent/kubectl.go
+++ b/pkg/agent/kubectl.go
@@ -23,8 +23,8 @@ import (
 
 const (
 	// kubectlExecTimeout bounds how long any kubectl subprocess can run
-	// before it is killed. Prevents goroutine/FD leaks from hung apiservers. (#7258)
-	kubectlExecTimeout = 60 * time.Second
+	// before it is killed. Prevents goroutine/FD leaks from hung apiservers. (#7258, #7206)
+	kubectlExecTimeout = 30 * time.Second
 
 	// kubectlRenameTimeout bounds the kubectl config rename-context command. (#7279)
 	kubectlRenameTimeout = 30 * time.Second
@@ -132,21 +132,11 @@ func (k *KubectlProxy) ExecuteWithContext(parent context.Context, ctxName, names
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	// kubectlCommandTimeout prevents a hung kubectl call from blocking
-	// the handler indefinitely (e.g. unreachable apiserver) (#7206).
-	const kubectlCommandTimeout = 30 * time.Second
-	timer := time.AfterFunc(kubectlCommandTimeout, func() {
-		if cmd.Process != nil {
-			cmd.Process.Kill()
-		}
-	})
-
 	err := cmd.Run()
-	timedOut := !timer.Stop()
 	exitCode := 0
 	if err != nil {
-		if timedOut {
-			return protocol.KubectlResponse{ExitCode: 1, Error: fmt.Sprintf("kubectl timed out after %s", kubectlCommandTimeout)}
+		if ctx.Err() == context.DeadlineExceeded {
+			return protocol.KubectlResponse{ExitCode: 1, Error: fmt.Sprintf("kubectl timed out after %s", kubectlExecTimeout)}
 		}
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()


### PR DESCRIPTION
### 📝 Summary of Changes

- removed `time.AfterFunc` kill mechanism in `pkg/agent/kubectl.go` that raced with `cmd.Run()` on `cmd.Process`
- could cause agent panics or SIGKILL to unrelated processes via PID reuse on kubectl timeout

---

### Changes Made

- [x] Removed `time.AfterFunc` block- raced with `cmd.Run()` on unsynchronized `cmd.Process`
- [x] Rely solely on `exec.CommandContext` for process killing (already synchronizes internally)
- [x] Lowered `kubectlExecTimeout` from 60s → 30s to preserve intended timeout behavior
- [x] Timeout detection changed from `!timer.Stop()` to `ctx.Err() == context.DeadlineExceeded`

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

N/A

---

### 👀 Reviewer Notes
one file changed- `pkg/agent/kubectl.go`. the `time.AfterFunc` was added before 
`exec.CommandContext` existed in the codebase. now that context handles killing safely, 
the timer is just a redundant race. go race detector passes clean after removal.
