### PR TITLE
🐛 Fix Playwright build: pin TypeScript ~6, remove deprecated baseUrl

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -120,7 +120,7 @@
     "rimraf": "^6.1.3",
     "storybook": "^10.3.5",
     "tailwindcss": "^4.2.4",
-    "typescript": "^6.0.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.58.2",
     "vite": "^8.0.5",
     "vite-plugin-compression2": "^2.5.3",

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -16,10 +16,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary
- Pins `typescript` from `^6.0.3` to `~6.0.3` to prevent npm installing TS 7.0 in CI
- Removes deprecated `baseUrl` and `ignoreDeprecations` from `tsconfig.json` — `paths` works standalone with `moduleResolution: "bundler"` (TS 5+)
- Fixes the `TS5101: Option 'baseUrl' is deprecated` error that was breaking the Playwright E2E build step on every push to main

## Test plan
- [ ] CI build passes
- [ ] `@/*` path aliases still resolve correctly
- [ ] Playwright E2E tests can build and run on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)