### PR TITLE
🐛 Fix Compliance page header mislabeled as Security Posture

### DIFF
--- a/web/src/components/compliance/Compliance.test.tsx
+++ b/web/src/components/compliance/Compliance.test.tsx
@@ -240,7 +240,7 @@ describe('Compliance dashboard component', () => {
     setupDefaults()
     render(<Compliance />)
     const props = getLastDashboardProps()
-    expect(props.title).toBe('Security Posture')
+    expect(props.title).toBe('Compliance')
     expect(props.statsType).toBe('compliance')
     expect(props.storageKey).toBe('compliance-dashboard-cards')
     expect(props.emptyState).toEqual({

--- a/web/src/components/compliance/Compliance.tsx
+++ b/web/src/components/compliance/Compliance.tsx
@@ -243,7 +243,7 @@ export function Compliance() {
 
   return (
     <DashboardPage
-      title="Security Posture"
+      title="Compliance"
       subtitle="Security scanning, vulnerability assessment, and policy enforcement"
       icon="Shield"
       storageKey={COMPLIANCE_CARDS_KEY}


### PR DESCRIPTION
Fixes #10684

## Summary

The Compliance page header was mislabeled as "Security Posture" instead of "Compliance", causing a mismatch with the sidebar navigation label.

## Changes

- **`web/src/components/compliance/Compliance.tsx`**: Changed the `title` prop on `DashboardPage` from `"Security Posture"` to `"Compliance"`
- **`web/src/components/compliance/Compliance.test.tsx`**: Updated test assertion to expect `"Compliance"`

## Verification

- `npm run build` ✅
- `npm run lint` ✅