### PR TITLE
🐛 Ensure WebSocket auth token on /clusters page connections

### DIFF
--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -22,6 +22,7 @@ const HEARTBEAT_INTERVAL = 30_000 // Heartbeat every 30 seconds
 const HEARTBEAT_JITTER = 3_000 // Jitter (0-3s) to spread heartbeats without long delays
 
 import { MAX_WS_RECONNECT_ATTEMPTS, getWsBackoffDelay } from '../lib/constants/network'
+import { appendWsAuthToken } from '../lib/utils/wsAuth'
 
 const RECOVERY_DELAY = 30_000 // Retry after circuit breaker trips
 /** Timeout for fetch() call to the active-users endpoint */
@@ -191,7 +192,7 @@ function startPresenceConnection() {
 
   function connect() {
     try {
-      presenceWs = new WebSocket(wsUrl)
+      presenceWs = new WebSocket(appendWsAuthToken(wsUrl))
     } catch {
       presenceStarted = false
       return
@@ -208,7 +209,7 @@ function startPresenceConnection() {
         if (presenceWs?.readyState === WebSocket.OPEN) {
           presenceWs.send(JSON.stringify({ type: 'ping' }))
         }
-      }, 30000)
+      }, HEARTBEAT_INTERVAL)
     }
 
     presenceWs.onmessage = (event) => {


### PR DESCRIPTION
Fixes #10675

## Problem
The presence WebSocket in `useActiveUsers.ts` was calling `new WebSocket(wsUrl)` without `appendWsAuthToken()`, causing `ws_auth_missing` errors on the `/clusters` page. GA4 detected 5 such errors.

## Fix
- Wrapped the WebSocket URL with `appendWsAuthToken()` so the `kc-agent-token` is sent as a query parameter on the handshake
- Replaced a magic number (`30000`) with the existing `HEARTBEAT_INTERVAL` constant

## Verified
- All other `new WebSocket(` call sites already use `appendWsAuthToken()`
- The auth flow (`refreshUser` in `auth.tsx` and `AuthCallback.tsx`) already fetches `/api/agent/token` and stores `kc-agent-token` in localStorage