### PR TITLE
🐛 Show labels in navbar overflow toggle menu

### DIFF
--- a/web/src/components/feedback/FeatureRequestButton.tsx
+++ b/web/src/components/feedback/FeatureRequestButton.tsx
@@ -4,6 +4,7 @@ import { useFeatureRequests } from '../../hooks/useFeatureRequests'
 import type { RequestType } from '../../hooks/useFeatureRequests'
 import { useModalState } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'
+import { cn } from '../../lib/cn'
 
 // Lazy-load the modal (~67 KB) — only needed when the user clicks the bug icon
 const FeatureRequestModal = lazy(() =>
@@ -13,7 +14,12 @@ const FeatureRequestModal = lazy(() =>
 /** Badge displays "99+" for counts above this threshold. */
 const MAX_BADGE_DISPLAY = 99
 
-export function FeatureRequestButton() {
+interface FeatureRequestButtonProps {
+  /** Force label text to be visible (used in overflow menu) */
+  showLabel?: boolean
+}
+
+export function FeatureRequestButton({ showLabel = false }: FeatureRequestButtonProps) {
   const { t } = useTranslation()
   const { isOpen: isModalOpen, open: openModal, close: closeModal } = useModalState()
   const [initialRequestType, setInitialRequestType] = useState<RequestType | undefined>()
@@ -42,9 +48,11 @@ export function FeatureRequestButton() {
       <button
         onClick={openModal}
         data-tour="feedback"
-        className={`relative p-2 w-9 h-9 flex items-center justify-center rounded-lg hover:bg-secondary/50 transition-colors ${
+        className={cn(
+          'relative flex items-center rounded-lg hover:bg-secondary/50 transition-colors',
+          showLabel ? 'gap-2 px-3 py-1.5 h-9' : 'p-2 w-9 h-9 justify-center',
           summariesError ? 'text-red-400' : requestCount > 0 ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
-        }`}
+        )}
         title={
           summariesError
             ? t('feedback.couldNotLoadStatus', { error: summariesError })
@@ -53,7 +61,10 @@ export function FeatureRequestButton() {
               : t('feedback.reportBugOrFeature')
         }
       >
-        {summariesLoading ? <Loader2 className="w-5 h-5 animate-spin" /> : <Bug className="w-5 h-5" />}
+        {summariesLoading ? <Loader2 className="w-5 h-5 animate-spin" /> : <Bug className="w-5 h-5 shrink-0" />}
+        {showLabel && (
+          <span className="text-sm font-medium">{t('feedback.feedback')}</span>
+        )}
         {!summariesLoading && requestCount > 0 && (
           <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] flex items-center justify-center text-2xs font-bold text-white rounded-full bg-purple-500">
             {requestCount > MAX_BADGE_DISPLAY ? `${MAX_BADGE_DISPLAY}+` : requestCount}

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -25,7 +25,12 @@ import type { AgentInfo } from '../../../types/agent'
 
 const CONNECTING_DEBOUNCE_MS = 300
 
-export function AgentStatusIndicator() {
+interface AgentStatusIndicatorProps {
+  /** Force label text to be visible (used in overflow menu) */
+  showLabel?: boolean
+}
+
+export function AgentStatusIndicator({ showLabel = false }: AgentStatusIndicatorProps) {
   const { t } = useTranslation(['common'])
   const {
     status: agentStatus,
@@ -323,7 +328,7 @@ export function AgentStatusIndicator() {
         title={pillStyle.title}
       >
         <pillStyle.Icon className="w-4 h-4" />
-        <span className="text-sm font-medium hidden sm:inline whitespace-nowrap">
+        <span className={cn("text-sm font-medium whitespace-nowrap", showLabel ? 'inline' : 'hidden sm:inline')}>
           {pillStyle.label}
         </span>
         <span

--- a/web/src/components/layout/navbar/ClusterFilterPanel.tsx
+++ b/web/src/components/layout/navbar/ClusterFilterPanel.tsx
@@ -79,7 +79,12 @@ function FilterSection<T extends string>({
   )
 }
 
-export function ClusterFilterPanel() {
+interface ClusterFilterPanelProps {
+  /** Force label text to be visible (used in overflow menu) */
+  showLabel?: boolean
+}
+
+export function ClusterFilterPanel({ showLabel = false }: ClusterFilterPanelProps) {
   const { t } = useTranslation()
   const {
     selectedClusters,
@@ -176,14 +181,18 @@ export function ClusterFilterPanel() {
           <button
             onClick={() => toggleDropdown()}
             className={cn(
-              'relative flex items-center justify-center w-9 h-9 rounded-lg transition-colors',
+              'relative flex items-center rounded-lg transition-colors',
+              showLabel ? 'gap-2 px-3 py-1.5 h-9' : 'justify-center w-9 h-9',
               isFiltered
                 ? 'bg-purple-500/20 text-purple-400 shadow-[0_0_6px_rgba(139,92,246,0.2)]'
                 : 'bg-secondary/50 text-muted-foreground hover:text-foreground'
             )}
             aria-label={isFiltered ? t('layout.navbar.filtersActive') : t('layout.navbar.noFilters')}
           >
-            <Filter className="w-4 h-4" />
+            <Filter className="w-4 h-4 shrink-0" />
+            {showLabel && (
+              <span className="text-sm font-medium">{t('navbar.clusterFilter')}</span>
+            )}
             {/* Color dot from active filter set, or generic purple dot */}
             {isFiltered && (
               <span

--- a/web/src/components/layout/navbar/LearnDropdown.tsx
+++ b/web/src/components/layout/navbar/LearnDropdown.tsx
@@ -47,7 +47,12 @@ function getDropdownPosition(triggerRect: DOMRect, isMobile: boolean) {
 /** Tailwind `sm` breakpoint — below this we use mobile layout */
 const SM_BREAKPOINT_PX = 640
 
-export function LearnDropdown() {
+interface LearnDropdownProps {
+  /** Force label text to be visible (used in overflow menu) */
+  showLabel?: boolean
+}
+
+export function LearnDropdown({ showLabel = false }: LearnDropdownProps) {
   const { isOpen, close, toggle } = useModalState()
   const triggerRef = useRef<HTMLButtonElement>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -145,7 +150,7 @@ export function LearnDropdown() {
         title={t('layout.navbar.learn.title')}
       >
         <BookOpen className="w-4 h-4" />
-        <span className="hidden xl:inline">{t('layout.navbar.learn.title')}</span>
+        <span className={cn(showLabel ? 'inline' : 'hidden xl:inline')}>{t('layout.navbar.learn.title')}</span>
       </button>
 
       {/* Dropdown — portaled to document.body to escape navbar overflow clipping (#10319) */}

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -229,10 +229,10 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
                   {/* Items only hidden at <md (768px): filter, agent status, agent selector */}
                   <div className="md:hidden">
                     <div className="px-3 py-2">
-                      <ClusterFilterPanel />
+                      <ClusterFilterPanel showLabel />
                     </div>
                     <div className="px-3 py-2">
-                      <AgentStatusIndicator />
+                      <AgentStatusIndicator showLabel />
                     </div>
                     <div className="px-3 py-2">
                       <Suspense fallback={null}><AgentSelector compact /></Suspense>
@@ -259,16 +259,16 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
                     </div>
                   )}
                   <div className="px-3 py-2">
-                    <UpdateIndicator />
+                    <UpdateIndicator showLabel />
                   </div>
                   <div className="px-3 py-2">
-                    <TokenUsageWidget />
+                    <TokenUsageWidget showLabel />
                   </div>
                   <div className="px-3 py-2">
-                    <FeatureRequestButton />
+                    <FeatureRequestButton showLabel />
                   </div>
                   <div className="px-3 py-2">
-                    <LearnDropdown />
+                    <LearnDropdown showLabel />
                   </div>
                 </div>
               </div>

--- a/web/src/components/layout/navbar/TokenUsageWidget.tsx
+++ b/web/src/components/layout/navbar/TokenUsageWidget.tsx
@@ -16,7 +16,12 @@ const CATEGORY_CONFIG: Record<TokenCategory, { label: string; icon: React.Compon
   other: { label: 'Other', icon: MoreHorizontal, color: 'bg-muted-foreground' },
 }
 
-export function TokenUsageWidget() {
+interface TokenUsageWidgetProps {
+  /** Force label text to be visible (used in overflow menu) */
+  showLabel?: boolean
+}
+
+export function TokenUsageWidget({ showLabel = false }: TokenUsageWidgetProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { usage, alertLevel, percentage, remaining, isDemoData } = useTokenUsage()
@@ -69,8 +74,8 @@ export function TokenUsageWidget() {
         {isDemoData && (
           <StatusBadge color="yellow" role="img" aria-label={t('layout.navbar.demoModeActive')}>{t('layout.demo')}</StatusBadge>
         )}
-        <span className="text-xs font-medium hidden sm:inline">{percentage.toFixed(0)}%</span>
-        <div className="w-12 h-1.5 bg-secondary rounded-full overflow-hidden hidden sm:block">
+        <span className={cn("text-xs font-medium", showLabel ? 'inline' : 'hidden sm:inline')}>{percentage.toFixed(0)}%</span>
+        <div className={cn("w-12 h-1.5 bg-secondary rounded-full overflow-hidden", showLabel ? 'block' : 'hidden sm:block')}>
           <div
             className={`h-full transition-all ${
               isDemoData

--- a/web/src/components/layout/navbar/UpdateIndicator.tsx
+++ b/web/src/components/layout/navbar/UpdateIndicator.tsx
@@ -20,7 +20,12 @@ const ICON_SIZE = 'w-4 h-4'
 /** Dot indicator size class */
 const DOT_SIZE = 'w-2 h-2'
 
-export function UpdateIndicator() {
+interface UpdateIndicatorProps {
+  /** Force label text to be visible (used in overflow menu) */
+  showLabel?: boolean
+}
+
+export function UpdateIndicator({ showLabel = false }: UpdateIndicatorProps) {
   const { t } = useTranslation()
   const { showToast } = useToast()
   const { hasUpdate, latestRelease, channel, autoUpdateStatus, latestMainSHA } = useVersionCheck()
@@ -110,6 +115,9 @@ export function UpdateIndicator() {
           )}
           {!isUpgrading && !isUpgradeComplete && !isUpgradeError && (
             <span className={cn(DOT_SIZE, 'bg-green-400 rounded-full animate-pulse')} />
+          )}
+          {showLabel && (
+            <span className="text-sm font-medium">{t('update.available')}</span>
           )}
         </button>
 

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1901,7 +1901,8 @@
     "goHome": "Go to home dashboard",
     "themeToggle": "Theme: {{theme}} (click to toggle)",
     "moreOptions": "More options",
-    "viewDocs": "View documentation"
+    "viewDocs": "View documentation",
+    "clusterFilter": "Cluster Filter"
   },
   "missionSidebar": {
     "expandSidebar": "Expand sidebar",


### PR DESCRIPTION
Fixes #10654

When the viewport width is reduced, navbar items collapse into the overflow/toggle menu. Previously, only icons were displayed in this menu because responsive Tailwind classes (`hidden sm:inline`, `hidden xl:inline`) kept labels hidden even inside the overflow menu. Icon-only components (FeatureRequestButton, ClusterFilterPanel, UpdateIndicator) had no label at all.

**Fix:** Added a `showLabel` prop to six navbar components (LearnDropdown, TokenUsageWidget, AgentStatusIndicator, UpdateIndicator, FeatureRequestButton, ClusterFilterPanel). When `showLabel` is passed in the overflow menu, labels display alongside icons. The prop defaults to `false` so the normal navbar behavior is unchanged.

**Files changed:**
- `web/src/components/layout/navbar/Navbar.tsx` — pass `showLabel` to components in overflow menu
- `web/src/components/layout/navbar/LearnDropdown.tsx` — add `showLabel` prop
- `web/src/components/layout/navbar/TokenUsageWidget.tsx` — add `showLabel` prop
- `web/src/components/layout/navbar/AgentStatusIndicator.tsx` — add `showLabel` prop
- `web/src/components/layout/navbar/UpdateIndicator.tsx` — add `showLabel` prop
- `web/src/components/layout/navbar/ClusterFilterPanel.tsx` — add `showLabel` prop
- `web/src/components/feedback/FeatureRequestButton.tsx` — add `showLabel` prop
- `web/src/locales/en/common.json` — add `navbar.clusterFilter` i18n key