### PR TITLE
🐛 Fix namespace section to use full viewport height

### DIFF
--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -377,7 +377,7 @@ export function NamespaceManager() {
   // Show loading while clusters are being fetched
   if (clustersLoading) {
     return (
-      <div className="h-full flex flex-col items-center justify-center p-6">
+      <div className="min-h-full flex flex-col items-center justify-center p-6">
         <RefreshCw className="w-16 h-16 text-blue-400 mb-4 animate-spin" />
         <h2 className="text-xl font-semibold text-white mb-2">Loading Clusters...</h2>
         <p className="text-muted-foreground text-center max-w-md">
@@ -390,7 +390,7 @@ export function NamespaceManager() {
   // Show message if no clusters are selected
   if (targetClusters.length === 0) {
     return (
-      <div className="h-full flex flex-col items-center justify-center p-6">
+      <div className="min-h-full flex flex-col items-center justify-center p-6">
         <AlertTriangle className="w-16 h-16 text-yellow-400 mb-4" />
         <h2 className="text-xl font-semibold text-white mb-2">No Clusters Selected</h2>
         <p className="text-muted-foreground text-center max-w-md">
@@ -401,7 +401,7 @@ export function NamespaceManager() {
   }
 
   return (
-    <div className="h-full flex flex-col p-6">
+    <div className="min-h-full flex flex-col p-6">
       {/* Header */}
       <DashboardHeader
         title="Namespace Manager"


### PR DESCRIPTION
Fixes #10692

The Namespace Manager section was using `h-full` on its container divs, which didn't extend to fill the available viewport height — leaving visible blank space at the bottom.

Changed all three container divs (main view, loading state, and no-clusters state) from `h-full` to `min-h-full` so they always fill at least the full available height, consistent with other sections in the console.