### PR TITLE
🐛 Fix CORS policy for kc-agent namespace endpoints

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -688,7 +688,13 @@ func (s *Server) Start() error {
 	// DELETE, PATCH) must include the X-Requested-With: XMLHttpRequest header.
 	// GET/HEAD/OPTIONS pass through unconditionally. This mirrors the Fiber
 	// middleware in pkg/api/middleware/csrf.go. See #10000.
-	handler := requireCSRF(mux)
+	//
+	// #10699: corsMiddleware runs outermost so that CORS headers are present
+	// on every response, including CSRF rejections. Without this layer the
+	// browser reports an opaque CORS error instead of showing the 403.
+	// corsMiddleware also short-circuits OPTIONS preflight so it never
+	// reaches requireCSRF (preflight must not carry X-Requested-With).
+	handler := s.corsMiddleware(requireCSRF(mux))
 
 	addr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	slog.Info("KC Agent starting", "version", Version, "addr", addr)

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -81,6 +81,12 @@ const defaultCORSAllowedMethods = "GET, OPTIONS"
 // real route.
 const catchallCORSAllowedMethods = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
 
+// corsPreflightMaxAge is sent as Access-Control-Max-Age so browsers cache
+// preflight responses instead of re-issuing OPTIONS on every request.
+// 600 s (10 min) balances responsiveness during development with reduced
+// network overhead in normal use.
+const corsPreflightMaxAge = "600"
+
 // setCORSHeaders sets common CORS headers for HTTP endpoints. An optional
 // list of HTTP methods may be supplied to override the default
 // Access-Control-Allow-Methods value — this is required for POST/PUT/DELETE
@@ -107,6 +113,40 @@ func (s *Server) setCORSHeaders(w http.ResponseWriter, r *http.Request, methods 
 	// #10461: Credentialed requests (Authorization header) require this header
 	// or browsers block the response even when the origin is allowed.
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
+	w.Header().Set("Access-Control-Max-Age", corsPreflightMaxAge)
+}
+
+// corsMiddleware returns an http.Handler that sets baseline CORS headers on
+// every response — including error responses produced by downstream
+// middleware (e.g. requireCSRF). Without this outer wrapper the CSRF
+// middleware's 403 response lacks Access-Control-Allow-Origin and browsers
+// report a CORS failure instead of surfacing the actual error (#10699).
+//
+// The middleware also short-circuits OPTIONS preflight requests so they
+// never reach requireCSRF (which would otherwise demand the
+// X-Requested-With header that browsers intentionally omit from
+// preflight).
+func (s *Server) corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if s.isAllowedOrigin(origin) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+		}
+		w.Header().Set("Access-Control-Allow-Private-Network", "true")
+		w.Header().Set("Access-Control-Allow-Methods", catchallCORSAllowedMethods)
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Requested-With")
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Max-Age", corsPreflightMaxAge)
+
+		// Short-circuit preflight: respond immediately so OPTIONS never
+		// reaches requireCSRF or any handler.
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }
 
 // watchdogPidFileStat is indirected through a package variable so unit tests

--- a/web/src/components/namespaces/CreateNamespaceModal.tsx
+++ b/web/src/components/namespaces/CreateNamespaceModal.tsx
@@ -4,7 +4,7 @@ import { Button } from '../ui/Button'
 import { BaseModal, ConfirmDialog } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'
 import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
-import { authFetch } from '../../lib/api'
+import { agentFetch } from '../../hooks/mcp/shared'
 
 interface CreateNamespaceModalProps {
   clusters: string[]
@@ -36,10 +36,10 @@ export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNam
       // #7993 Phase 2: POST to kc-agent so the operation runs under the
       // user's kubeconfig. kc-agent does not accept an initialAccess field —
       // grants flow through GrantAccessModal's POST /rolebindings call once
-      // the namespace exists. #8034 Copilot followup: switched the hand-rolled
-      // agentAuthHeaders() helper to authFetch() which handles token injection
-      // and the default fetch timeout.
-      const res = await authFetch(`${LOCAL_AGENT_HTTP_URL}/namespaces`, {
+      // the namespace exists. #10699: switched from authFetch (backend JWT)
+      // to agentFetch (kc-agent token) so the request authenticates correctly
+      // against kc-agent and carries the right CORS headers.
+      const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/namespaces`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/web/src/components/namespaces/__tests__/CreateNamespaceModal.test.tsx
+++ b/web/src/components/namespaces/__tests__/CreateNamespaceModal.test.tsx
@@ -16,9 +16,9 @@ const MOCK_LATENCY_MS = 200
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
-const mockAuthFetch = vi.fn()
-vi.mock('../../../lib/api', () => ({
-  authFetch: vi.fn((...args) => mockAuthFetch(...args)),
+const mockAgentFetch = vi.fn()
+vi.mock('../../../hooks/mcp/shared', () => ({
+  agentFetch: vi.fn((...args) => mockAgentFetch(...args)),
 }))
 
 const mockTranslation = vi.fn((key: string) => key)
@@ -32,7 +32,7 @@ vi.mock('react-i18next', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockAuthFetch.mockReset()
+  mockAgentFetch.mockReset()
 })
 
 afterEach(() => {
@@ -109,7 +109,7 @@ describe('CreateNamespaceModal', () => {
 
   it('successfully creates namespace with POST to kc-agent', async () => {
     const user = userEvent.setup()
-    mockAuthFetch.mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+    mockAgentFetch.mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
 
     render(
       <CreateNamespaceModal
@@ -128,7 +128,7 @@ describe('CreateNamespaceModal', () => {
     await user.click(createBtn)
 
     await waitFor(() => {
-      expect(mockAuthFetch).toHaveBeenCalledWith(
+      expect(mockAgentFetch).toHaveBeenCalledWith(
         expect.stringContaining('/namespaces'),
         expect.any(Object)
       )
@@ -137,7 +137,7 @@ describe('CreateNamespaceModal', () => {
 
   it('displays error when creation fails', async () => {
     const user = userEvent.setup()
-    mockAuthFetch.mockResolvedValueOnce(
+    mockAgentFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ error: 'Namespace already exists' }), { status: 409 })
     )
 
@@ -214,7 +214,7 @@ describe('CreateNamespaceModal', () => {
 
   it('includes team label in POST body when provided', async () => {
     const user = userEvent.setup()
-    mockAuthFetch.mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+    mockAgentFetch.mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
 
     render(
       <CreateNamespaceModal
@@ -233,14 +233,14 @@ describe('CreateNamespaceModal', () => {
     await user.click(createBtn)
 
     await waitFor(() => {
-      const callBody = mockAuthFetch.mock.calls[0]?.[1]?.body as string
+      const callBody = mockAgentFetch.mock.calls[0]?.[1]?.body as string
       expect(callBody).toContain('"team":"platform-team"')
     })
   })
 
   it('disables create button while creation is in progress', async () => {
     const user = userEvent.setup()
-    mockAuthFetch.mockImplementationOnce(
+    mockAgentFetch.mockImplementationOnce(
       () => new Promise(resolve => setTimeout(() => resolve(new Response(JSON.stringify({}), { status: 200 })), MOCK_LATENCY_MS))
     )
 


### PR DESCRIPTION
Fixes #10699
Fixes #10698

## Problem

Namespace creation fails with `Failed to fetch` / `net::ERR_FAILED` when the frontend POSTs to `http://127.0.0.1:8585/namespaces`. The browser reports a CORS error because:

1. The `requireCSRF` middleware rejects requests before the handler sets CORS headers, so error responses lack `Access-Control-Allow-Origin` and the browser reports an opaque CORS failure instead of the real HTTP error.
2. `CreateNamespaceModal` used `authFetch` (backend JWT token) instead of `agentFetch` (kc-agent token), sending the wrong credentials.

## Fix

**Backend** (`pkg/agent/server_http.go`, `server.go`):
- Add `corsMiddleware` that wraps the outermost handler chain (`cors → csrf → mux`), ensuring CORS headers are present on **every** response — including CSRF 403 rejections.
- The middleware short-circuits OPTIONS preflight so it never reaches `requireCSRF` (browsers intentionally omit `X-Requested-With` from preflight).
- Add `Access-Control-Max-Age: 600` to reduce redundant preflight requests.

**Frontend** (`CreateNamespaceModal.tsx`):
- Switch from `authFetch` to `agentFetch` for proper kc-agent authentication.
- Update tests to match.
