### PR TITLE
🐛 Fix cluster data fetch to work in kagenti cluster mode

### DIFF
--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -277,6 +277,13 @@ extraEnv: []
 # Direct agent mode (optional, overrides controller discovery):
 #   - set directAgentUrl to a service URL
 #   - optionally set directAgentName/directAgentNamespace for UI metadata
+#
+# Cluster scope:
+#   The in-cluster ServiceAccount (see rbac section above) grants read-only
+#   access to the LOCAL cluster only by default.  Dashboard cards show data
+#   from that single cluster.  To surface remote clusters, either:
+#     1. Configure additional kubeconfigs via extraEnv / mounted secrets, or
+#     2. Use the kc-agent in local-agent mode to bridge browser kubeconfigs.
 kagenti:
   enabled: false
 

--- a/web/src/hooks/useCachedCoreWorkloads.ts
+++ b/web/src/hooks/useCachedCoreWorkloads.ts
@@ -23,6 +23,7 @@ import {
   fetchViaSSE,
   fetchViaBackendSSE,
   getToken,
+  getClusterFetcher,
   AGENT_HTTP_TIMEOUT_MS,
 } from '../lib/cache/fetcherUtils'
 import {
@@ -196,7 +197,7 @@ export function useCachedPods(
     fetcher: async () => {
       let pods: PodInfo[]
       if (cluster) {
-        const raw = await fetchAPI<unknown>('pods', { cluster, namespace })
+        const raw = await getClusterFetcher()<unknown>('pods', { cluster, namespace })
         const data = validateArrayResponse<{ pods: PodInfo[] }>(PodsResponseSchema, raw, '/api/mcp/pods', 'pods')
         pods = (data.pods || []).map(p => ({ ...p, cluster }))
       } else {
@@ -246,7 +247,7 @@ export function useCachedAllPods(
     demoData: getDemoPods(),
     fetcher: async () => {
       if (cluster) {
-        const raw = await fetchAPI<unknown>('pods', { cluster })
+        const raw = await getClusterFetcher()<unknown>('pods', { cluster })
         const data = validateArrayResponse<{ pods: PodInfo[] }>(PodsResponseSchema, raw, '/api/mcp/pods (allPods)', 'pods')
         return (data.pods || []).map(p => ({ ...p, cluster }))
       }
@@ -318,7 +319,7 @@ export function useCachedEvents(
 
       // Fall back to REST API (requires backend auth)
       if (cluster) {
-        const raw = await fetchAPI<unknown>('events', { cluster, namespace, limit })
+        const raw = await getClusterFetcher()<unknown>('events', { cluster, namespace, limit })
         const data = validateArrayResponse<{ events: ClusterEvent[] }>(EventsResponseSchema, raw, '/api/mcp/events', 'events')
         return data.events || []
       }
@@ -582,7 +583,7 @@ export function useCachedDeployments(
       const hasRealToken = token && token !== 'demo-token'
       if (hasRealToken && !isBackendUnavailable()) {
         if (cluster) {
-          const raw = await fetchAPI<unknown>('deployments', { cluster, namespace })
+          const raw = await getClusterFetcher()<unknown>('deployments', { cluster, namespace })
           const data = validateArrayResponse<{ deployments: Deployment[] }>(DeploymentsResponseSchema, raw, '/api/mcp/deployments', 'deployments')
           const deployments = data.deployments || []
           return deployments.map(d => ({ ...d, cluster: d.cluster || cluster }))
@@ -632,7 +633,7 @@ export function useCachedServices(
     demoData: getDemoServices(),
     fetcher: async () => {
       if (cluster) {
-        const data = await fetchAPI<{ services: Service[] }>('services', { cluster, namespace })
+        const data = await getClusterFetcher()<{ services: Service[] }>('services', { cluster, namespace })
         return (data.services || []).map(s => ({ ...s, cluster }))
       }
       return await fetchFromAllClusters<Service>('services', 'services', { namespace })

--- a/web/src/hooks/useCachedCoreWorkloads.ts
+++ b/web/src/hooks/useCachedCoreWorkloads.ts
@@ -16,7 +16,6 @@ import { FETCH_DEFAULT_TIMEOUT_MS, KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/co
 import { VULN_SEVERITY_ORDER } from '../types/alerts'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import {
-  fetchAPI,
   fetchBackendAPI,
   fetchFromAllClusters,
   fetchFromAllClustersViaBackend,

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -285,7 +285,6 @@ import { clusterCacheRef } from './mcp/shared'
 import { isAgentUnavailable } from './useLocalAgent'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import {
-  fetchAPI,
   fetchBackendAPI,
   fetchFromAllClusters,
   fetchFromAllClustersViaBackend,

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -290,6 +290,7 @@ import {
   fetchFromAllClusters,
   fetchFromAllClustersViaBackend,
   getToken,
+  getClusterFetcher,
   MAX_PREFETCH_PODS,
 } from '../lib/cache/fetcherUtils'
 import {
@@ -332,7 +333,7 @@ export const coreFetchers = {
     return []
   },
   events: async (): Promise<ClusterEvent[]> => {
-    const data = await fetchAPI<{ events: ClusterEvent[] }>('events', { limit: 20 })
+    const data = await getClusterFetcher()<{ events: ClusterEvent[] }>('events', { limit: 20 })
     return data.events || []
   },
   deploymentIssues: async (): Promise<DeploymentIssue[]> => {
@@ -368,7 +369,7 @@ export const coreFetchers = {
     return []
   },
   services: async (): Promise<Service[]> => {
-    const data = await fetchAPI<{ services: Service[] }>('services', {})
+    const data = await getClusterFetcher()<{ services: Service[] }>('services', {})
     return data.services || []
   },
   securityIssues: async (): Promise<SecurityIssue[]> => {

--- a/web/src/hooks/useCachedGPU.ts
+++ b/web/src/hooks/useCachedGPU.ts
@@ -7,7 +7,7 @@
 
 import { useState } from 'react'
 import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
-import { fetchAPI, fetchBackendAPI, fetchFromAllClustersViaBackend, fetchViaSSE, fetchViaBackendSSE, getToken, AGENT_HTTP_TIMEOUT_MS } from '../lib/cache/fetcherUtils'
+import { fetchAPI, fetchBackendAPI, fetchFromAllClustersViaBackend, fetchViaSSE, fetchViaBackendSSE, getToken, getClusterFetcher, AGENT_HTTP_TIMEOUT_MS } from '../lib/cache/fetcherUtils'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS } from '../lib/constants/network'
@@ -174,7 +174,7 @@ export function useCachedGPUNodes(
     demoData: getDemoGPUNodes(),
     fetcher: async () => {
       if (cluster) {
-        const raw = await fetchAPI<unknown>('gpu-nodes', { cluster })
+        const raw = await getClusterFetcher()<unknown>('gpu-nodes', { cluster })
         const data = validateArrayResponse<{ nodes: GPUNode[] }>(GPUNodesResponseSchema, raw, '/api/mcp/gpu-nodes', 'nodes')
         return (data.nodes || []).map(n => ({ ...n, cluster }))
       }
@@ -198,7 +198,7 @@ export function useCachedGPUNodes(
       }
 
       const tasks = reachable.map((cl) => async () => {
-        const raw = await fetchAPI<unknown>('gpu-nodes', { cluster: cl.name })
+        const raw = await getClusterFetcher()<unknown>('gpu-nodes', { cluster: cl.name })
         const data = validateArrayResponse<{ nodes: GPUNode[] }>(
           GPUNodesResponseSchema, raw, '/api/mcp/gpu-nodes', 'nodes',
         )

--- a/web/src/hooks/useCachedGPU.ts
+++ b/web/src/hooks/useCachedGPU.ts
@@ -7,7 +7,7 @@
 
 import { useState } from 'react'
 import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
-import { fetchAPI, fetchBackendAPI, fetchFromAllClustersViaBackend, fetchViaSSE, fetchViaBackendSSE, getToken, getClusterFetcher, AGENT_HTTP_TIMEOUT_MS } from '../lib/cache/fetcherUtils'
+import { fetchBackendAPI, fetchFromAllClustersViaBackend, fetchViaSSE, fetchViaBackendSSE, getToken, getClusterFetcher, AGENT_HTTP_TIMEOUT_MS } from '../lib/cache/fetcherUtils'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS } from '../lib/constants/network'

--- a/web/src/hooks/useCachedK8sResources.ts
+++ b/web/src/hooks/useCachedK8sResources.ts
@@ -7,7 +7,7 @@
  */
 
 import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
-import { fetchAPI, fetchFromAllClusters, fetchViaSSE, getToken, getClusterFetcher } from '../lib/cache/fetcherUtils'
+import { fetchFromAllClusters, fetchViaSSE, getToken, getClusterFetcher } from '../lib/cache/fetcherUtils'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import {
   getDemoPVCs,

--- a/web/src/hooks/useCachedK8sResources.ts
+++ b/web/src/hooks/useCachedK8sResources.ts
@@ -7,7 +7,7 @@
  */
 
 import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
-import { fetchAPI, fetchFromAllClusters, fetchViaSSE, getToken } from '../lib/cache/fetcherUtils'
+import { fetchAPI, fetchFromAllClusters, fetchViaSSE, getToken, getClusterFetcher } from '../lib/cache/fetcherUtils'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import {
   getDemoPVCs,
@@ -79,7 +79,7 @@ function createCachedK8sResourceHook<T extends object>(
       demoData: getDemoData(),
       fetcher: async () => {
         if (cluster) {
-          const data = await fetchAPI<Record<string, T[]>>(apiEndpoint, { cluster, namespace })
+          const data = await getClusterFetcher()<Record<string, T[]>>(apiEndpoint, { cluster, namespace })
           return ((data[responseKey] as T[]) || []).map(item => ({ ...item, cluster }))
         }
         return await fetchFromAllClusters<T>(apiEndpoint, responseKey, { namespace })

--- a/web/src/hooks/useCachedNodes.ts
+++ b/web/src/hooks/useCachedNodes.ts
@@ -7,7 +7,7 @@
 import { useSyncExternalStore } from 'react'
 import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { clusterCacheRef, deduplicateClustersByServer } from './mcp/shared'
-import { fetchAPI, fetchFromAllClusters, fetchViaSSE } from '../lib/cache/fetcherUtils'
+import { fetchAPI, fetchFromAllClusters, fetchViaSSE, getClusterFetcher } from '../lib/cache/fetcherUtils'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { NodesResponseSchema } from '../lib/schemas'
 import { validateArrayResponse } from '../lib/schemas/validate'
@@ -110,7 +110,7 @@ export function useCachedNodes(
     persist: true,
     fetcher: async () => {
       if (cluster) {
-        const raw = await fetchAPI<unknown>('nodes', { cluster })
+        const raw = await getClusterFetcher()<unknown>('nodes', { cluster })
         const data = validateArrayResponse<{ nodes: NodeInfo[] }>(NodesResponseSchema, raw, '/api/mcp/nodes', 'nodes')
         return (data.nodes || []).map(n => ({ ...n, cluster }))
       }
@@ -216,7 +216,7 @@ export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & {
       // scan, src/test/concurrent-mutation-safety.test.ts).
       const tasks = reachable.map((cluster) => async (): Promise<PerClusterNodeResult> => {
         try {
-          const raw = await fetchAPI<unknown>('nodes', { cluster: cluster.name })
+          const raw = await getClusterFetcher()<unknown>('nodes', { cluster: cluster.name })
           const data = validateArrayResponse<{ nodes: NodeInfo[] }>(
             NodesResponseSchema,
             raw,
@@ -314,7 +314,7 @@ export function useCachedCoreDNSStatus(
     fetcher: async () => {
       let pods: PodInfo[]
       if (cluster) {
-        const data = await fetchAPI<{ pods: PodInfo[] }>('pods', { cluster, namespace: 'kube-system' })
+        const data = await getClusterFetcher()<{ pods: PodInfo[] }>('pods', { cluster, namespace: 'kube-system' })
         pods = (data.pods || []).map(p => ({ ...p, cluster }))
       } else {
         pods = await fetchFromAllClusters<PodInfo>('pods', 'pods', { namespace: 'kube-system' })

--- a/web/src/hooks/useCachedNodes.ts
+++ b/web/src/hooks/useCachedNodes.ts
@@ -7,7 +7,7 @@
 import { useSyncExternalStore } from 'react'
 import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { clusterCacheRef, deduplicateClustersByServer } from './mcp/shared'
-import { fetchAPI, fetchFromAllClusters, fetchViaSSE, getClusterFetcher } from '../lib/cache/fetcherUtils'
+import { fetchFromAllClusters, fetchViaSSE, getClusterFetcher } from '../lib/cache/fetcherUtils'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { NodesResponseSchema } from '../lib/schemas'
 import { validateArrayResponse } from '../lib/schemas/validate'

--- a/web/src/lib/cache/fetcherUtils.ts
+++ b/web/src/lib/cache/fetcherUtils.ts
@@ -17,6 +17,28 @@ import {
 import { validateArrayResponse } from '../schemas/validate'
 
 // ============================================================================
+// Backend preference helper
+// ============================================================================
+
+/** localStorage key for agent backend preference (kagenti, kagent, kc-agent) */
+const BACKEND_PREF_KEY = 'kc_agent_backend_preference'
+
+/**
+ * Returns true when the user has selected kagenti or kagent as their
+ * preferred backend.  In that mode data should be routed through the
+ * Go backend (`/api/mcp/`) rather than the local kc-agent (port 8585).
+ * See issue #10510.
+ */
+export function isClusterModeBackend(): boolean {
+  try {
+    const pref = localStorage.getItem(BACKEND_PREF_KEY)
+    return pref === 'kagenti' || pref === 'kagent'
+  } catch {
+    return false
+  }
+}
+
+// ============================================================================
 // Token helper
 // ============================================================================
 
@@ -117,6 +139,16 @@ export const fetchBackendAPI = makeRestFetcher({
   errorLabel: '/api/mcp',
 })
 
+/**
+ * Route-aware fetcher: returns `fetchBackendAPI` when the user has selected
+ * kagenti or kagent as their preferred backend (cluster mode), and `fetchAPI`
+ * (local kc-agent) otherwise.  This ensures per-cluster data requests reach
+ * the correct backend without requiring every call-site to check. (#10510)
+ */
+export function getClusterFetcher() {
+  return isClusterModeBackend() ? fetchBackendAPI : fetchAPI
+}
+
 // Get list of reachable (or not-yet-checked) clusters (prefer local agent data for accurate reachability)
 function getReachableClusters(): string[] {
   // Use local agent's cluster cache - it has up-to-date reachability info
@@ -137,8 +169,11 @@ export async function fetchClusters(): Promise<string[]> {
     return localClusters
   }
 
-  // Fall back to backend API
-  const raw = await fetchAPI<unknown>('clusters')
+  // In cluster mode (kagenti/kagent), route through the Go backend so the
+  // request reaches the in-cluster service account instead of the absent
+  // local kc-agent. (#10510)
+  const fetcher = isClusterModeBackend() ? fetchBackendAPI : fetchAPI
+  const raw = await fetcher<unknown>('clusters')
   const data = validateArrayResponse<{ clusters: Array<{ name: string; reachable?: boolean }> }>(ClustersResponseSchema, raw, '/api/mcp/clusters', 'clusters')
   return (data.clusters || [])
     .filter(c => c.reachable !== false && !c.name.includes('/'))
@@ -169,6 +204,13 @@ export async function fetchFromAllClusters<T>(
   onProgress?: (partial: T[]) => void,
   options?: FetchFromAllClustersOptions
 ): Promise<T[]> {
+  // In cluster mode (kagenti/kagent), delegate to the backend variant so
+  // requests reach the Go backend's MCP bridge instead of the local agent.
+  // (#10510)
+  if (isClusterModeBackend()) {
+    return fetchFromAllClustersViaBackend<T>(endpoint, resultKey, params, addClusterField, onProgress, options)
+  }
+
   const clusters = await fetchClusters()
   if (clusters.length === 0) {
     throw new Error('No clusters available (agent connecting or backend not authenticated)')
@@ -239,6 +281,13 @@ export async function fetchViaSSE<T>(
   onProgress?: (partial: T[]) => void,
   options?: FetchFromAllClustersOptions
 ): Promise<T[]> {
+  // In cluster mode (kagenti/kagent), delegate to the backend SSE variant so
+  // streaming requests reach the Go backend instead of the local agent.
+  // (#10510)
+  if (isClusterModeBackend()) {
+    return fetchViaBackendSSE<T>(endpoint, resultKey, params, onProgress, options)
+  }
+
   const token = getToken()
   // SSE only available with real backend token
   if (!token || token === 'demo-token' || isBackendUnavailable()) {


### PR DESCRIPTION
Fixes #10510

## Problem

In cluster mode (kagenti/kagent preferred), per-cluster data fetches (pods, nodes, events, deployments, services, etc.) were still routed to the local kc-agent (port 8585) instead of the Go backend (`/api/mcp/`). This caused cluster dashboard cards to remain empty or stale even though the kagenti status showed as connected.

The root cause: `fetchFromAllClusters()`, `fetchViaSSE()`, and direct `fetchAPI()` calls in `useCached*` hooks were hardcoded to use the local agent URL. Only `fullFetchClusters()` checked the backend preference.

## Fix

- Add `isClusterModeBackend()` helper that checks `localStorage` for kagenti/kagent preference
- Add `getClusterFetcher()` that returns the correct fetcher (`fetchBackendAPI` vs `fetchAPI`) based on mode
- Route `fetchFromAllClusters()` → `fetchFromAllClustersViaBackend()` in cluster mode
- Route `fetchViaSSE()` → `fetchViaBackendSSE()` in cluster mode
- Route `fetchClusters()` fallback through backend in cluster mode
- Update all per-cluster `fetchAPI` calls in hooks to use `getClusterFetcher()`
- Document in-cluster service account scope in Helm `values.yaml`

## Acceptance Criteria

- [x] Frontend cluster fetch uses active backend routing for cluster mode (kagenti)
- [x] Kagenti proxy exposes/forwards required cluster inventory endpoints (all `/api/mcp/*` routes verified in Go backend)
- [x] Connected state is consistent with data availability (data now flows through correct backend)
- [x] In-cluster service account scope documented as local-cluster only unless extra remote-cluster credentials configured