### PR TITLE
🐛 Add user notifications for silent error catch blocks

### DIFF
--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -12,6 +12,7 @@ import { useCardData } from '../../lib/cards/cardHooks'
 import { useCardLoadingState } from './CardDataContext'
 import type { SortDirection } from '../../lib/cards/cardHooks'
 import { useTranslation } from 'react-i18next'
+import { useToast } from '../ui/Toast'
 import { StatusBadge } from '../ui/StatusBadge'
 import { usePipelineFilter } from './pipelines/PipelineFilterContext'
 import { RepoSubtitle } from './pipelines/RepoSubtitle'
@@ -153,7 +154,7 @@ function getCachedData(repo: string): CachedGitHubData | null {
 }
 
 // Save data to cache
-function setCachedData(repo: string, data: Omit<CachedGitHubData, 'timestamp'>) {
+function setCachedData(repo: string, data: Omit<CachedGitHubData, 'timestamp'>, onError?: (msg: string) => void) {
   try {
     const cached: CachedGitHubData = {
       ...data,
@@ -164,6 +165,7 @@ function setCachedData(repo: string, data: Omit<CachedGitHubData, 'timestamp'>) 
     // Non-critical: localStorage may be full or disabled. The card still
     // works, it just won't persist cached data across page reloads.
     console.warn('[GitHubActivity] Failed to cache data (storage may be full):', e)
+    onError?.('[GitHubActivity] Failed to cache data. Browser storage may be full.')
   }
 }
 
@@ -256,6 +258,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
   const [openPRCount, setOpenPRCount] = useState(0)
   const [openIssueCount, setOpenIssueCount] = useState(0)
   const { isDemoMode } = useDemoMode()
+  const { showToast } = useToast()
 
   // Use configured repos or default to kubestellar/console
   const repos = config?.repos?.length ? config.repos : [DEFAULT_REPO]
@@ -415,7 +418,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
         releases: releasesData,
         contributors: contributorsData,
         openPRCount: openPRsData.length,
-        openIssueCount: calculatedOpenIssueCount })
+        openIssueCount: calculatedOpenIssueCount }, (msg) => showToast(msg, 'warning'))
 
       setLastRefresh(new Date())
     } catch (err) {

--- a/web/src/components/cards/NamespaceOverview.tsx
+++ b/web/src/components/cards/NamespaceOverview.tsx
@@ -11,6 +11,7 @@ import { ClusterBadge } from '../ui/ClusterBadge'
 import { StatusBadge } from '../ui/StatusBadge'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardLoadingState } from './CardDataContext'
+import { useToast } from '../ui/Toast'
 import { STORAGE_KEY_NS_OVERVIEW_CLUSTER, STORAGE_KEY_NS_OVERVIEW_NAMESPACE } from '../../lib/constants/storage'
 
 interface NamespaceOverviewProps {
@@ -22,6 +23,7 @@ interface NamespaceOverviewProps {
 
 export function NamespaceOverview({ config }: NamespaceOverviewProps) {
   const { t } = useTranslation(['common', 'cards'])
+  const { showToast } = useToast()
   const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed: clustersFailed, consecutiveFailures: clustersConsecutiveFailures } = useClusters()
 
   // Initialize from config prop (card-level override) or persisted localStorage value (#3115)
@@ -61,12 +63,12 @@ export function NamespaceOverview({ config }: NamespaceOverviewProps) {
 
   // Persist cluster selection so it survives page navigation (#3115)
   useEffect(() => {
-    try { localStorage.setItem(STORAGE_KEY_NS_OVERVIEW_CLUSTER, selectedCluster) } catch (e) { console.warn('[NamespaceOverview] failed to persist cluster selection:', e) }
+    try { localStorage.setItem(STORAGE_KEY_NS_OVERVIEW_CLUSTER, selectedCluster) } catch (e) { console.warn('[NamespaceOverview] failed to persist cluster selection:', e); showToast(t('errors.storagePersistFailed'), 'warning') }
   }, [selectedCluster])
 
   // Persist namespace selection so it survives page navigation (#3115)
   useEffect(() => {
-    try { localStorage.setItem(STORAGE_KEY_NS_OVERVIEW_NAMESPACE, selectedNamespace) } catch (e) { console.warn('[NamespaceOverview] failed to persist namespace selection:', e) }
+    try { localStorage.setItem(STORAGE_KEY_NS_OVERVIEW_NAMESPACE, selectedNamespace) } catch (e) { console.warn('[NamespaceOverview] failed to persist namespace selection:', e); showToast(t('errors.storagePersistFailed'), 'warning') }
   }, [selectedNamespace])
 
   // Auto-select first available cluster when none is selected (#3113 — works in both demo and live mode)

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -15,6 +15,7 @@ import {
   Plug,
 } from 'lucide-react'
 import { Button } from '../ui/Button'
+import { useToast } from '../ui/Toast'
 import { Navbar } from './navbar/index'
 import { Sidebar } from './Sidebar'
 import {
@@ -128,6 +129,7 @@ export function Layout({ children: _children }: LayoutProps) {
   // Mission sidebar width is communicated via CSS custom property --mission-sidebar-width
   // set by MissionSidebar.tsx — no need to read sidebar state from the hook here.
   const { isDemoMode, toggleDemoMode } = useDemoMode()
+  const { showToast } = useToast()
   const { status: agentStatus } = useLocalAgent()
   const { deduplicatedClusters } = useClusters()
   const { progress: updateProgress, dismiss: dismissUpdateProgress } =
@@ -152,6 +154,13 @@ export function Layout({ children: _children }: LayoutProps) {
     window.addEventListener('open-install', handler)
     return () => window.removeEventListener('open-install', handler)
   }, [])
+
+  // Surface cache-reset failures from modeTransition.ts as user-facing toasts
+  useEffect(() => {
+    const handler = () => showToast(t('errors.cacheResetFailed'), 'warning')
+    window.addEventListener('cache-reset-error', handler)
+    return () => window.removeEventListener('cache-reset-error', handler)
+  }, [showToast, t])
 
   const [restartState, setRestartState] = useState<
     'idle' | 'restarting' | 'waiting' | 'copied'

--- a/web/src/lib/modeTransition.ts
+++ b/web/src/lib/modeTransition.ts
@@ -54,13 +54,18 @@ export function unregisterCacheReset(key: string): void {
  * Cards will then fetch appropriate data (demo or live) based on the new mode.
  */
 export function clearAllRegisteredCaches(): void {
+  const failures: string[] = []
   cacheResetRegistry.forEach((resetFn, key) => {
     try {
       resetFn()
     } catch (e) {
       console.error(`[ModeTransition] Failed to reset cache '${key}':`, e)
+      failures.push(key)
     }
   })
+  if (failures.length > 0 && typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('cache-reset-error', { detail: { keys: failures } }))
+  }
 }
 
 /**

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3874,5 +3874,11 @@
   },
   "rightSizeAdvisor": {
     "memory": "Memory"
+  },
+  "errors": {
+    "storagePersistFailed": "Failed to save your selection. Browser storage may be full.",
+    "cacheWriteFailed": "Failed to cache data. Browser storage may be full.",
+    "cardRegistryLoadFailed": "Failed to load card catalog.",
+    "cacheResetFailed": "Failed to reset some caches during mode switch."
   }
 }

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react'
 import { emitWelcomeViewed, emitWelcomeActioned } from '../lib/analytics'
 import { DEFAULT_PRIMARY_NAV, DISCOVERABLE_DASHBOARDS } from '../hooks/useSidebarConfig'
+import { useToast } from '../components/ui/Toast'
 
 /* ------------------------------------------------------------------ */
 /*  SEO / meta constants                                               */
@@ -152,6 +153,7 @@ export function Welcome() {
   const [searchParams] = useSearchParams()
   const ref = sanitizeRef(searchParams.get('ref'))
   const [cardCount, setCardCount] = useState(HERO_STATS_PLACEHOLDER)
+  const { showToast } = useToast()
 
   useEffect(() => {
     // #9835: guard against (a) setState after unmount (cancelled flag) and
@@ -165,6 +167,7 @@ export function Welcome() {
       .catch(err => {
         // Fall back to placeholder; leave cardCount as the initial hero value.
         console.warn('Welcome: failed to load cardRegistry chunk', err)
+        if (!cancelled) showToast('Failed to load card catalog.', 'warning')
       })
     return () => {
       cancelled = true


### PR DESCRIPTION
Fixes #10703

Adds user-facing toast notifications to catch blocks that previously only logged to console, ensuring users are informed when errors occur.

**Changes (6 files, 32 insertions):**
- **NamespaceOverview.tsx** — Toast on localStorage persist failure for cluster/namespace selection
- **GitHubActivity.tsx** — Toast on cache write failure via `onError` callback
- **Welcome.tsx** — Toast when card registry chunk fails to load
- **modeTransition.ts** — Dispatches `cache-reset-error` CustomEvent on cache reset failure
- **Layout.tsx** — Listens for `cache-reset-error` event and shows toast
- **common.json** — Added `errors.*` i18n keys for all new messages

**Skipped (already handled):**
- `useInsightActions.ts` — already has `useToast` for both load and save errors
- `NamespaceManager.tsx` — already calls `showToast('Failed to revoke access', 'error')`

All existing `console.warn`/`console.error` calls are preserved for debugging.