### PR TITLE
🐛 Add confirmation dialogs for destructive delete actions

### DIFF
--- a/web/src/components/workloads/Workloads.tsx
+++ b/web/src/components/workloads/Workloads.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ChevronRight, Plus, Rocket, RefreshCw, Trash2, Terminal } from 'lucide-react'
 import { useDeploymentIssues, usePodIssues, useClusters, useDeployments } from '../../hooks/useMCP'
@@ -20,6 +20,7 @@ import { useTranslation } from 'react-i18next'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { useToast } from '../ui/Toast'
 import { PortalTooltip } from '../cards/llmd/shared/PortalTooltip'
+import { ConfirmDialog } from '../../lib/modals'
 
 const WORKLOADS_CARDS_KEY = 'kubestellar-workloads-cards'
 
@@ -63,6 +64,7 @@ export function Workloads() {
 
   const { drillToNamespace, drillToAllNamespaces, drillToAllDeployments, drillToAllPods, drillToDeployment } = useDrillDownActions()
   const { showToast } = useToast()
+  const [pendingDelete, setPendingDelete] = useState<{ cluster: string; namespace: string; name: string } | null>(null)
 
   // Combined states
   const isLoading = podIssuesLoading || deploymentIssuesLoading || deploymentsLoading || clustersLoading
@@ -92,9 +94,15 @@ export function Workloads() {
     }
   }
 
-  const handleDeleteDeployment = async (e: React.MouseEvent, cluster: string, namespace: string, name: string) => {
+  const handleDeleteDeployment = (e: React.MouseEvent, cluster: string, namespace: string, name: string) => {
     e.stopPropagation()
-    if (!window.confirm(t('workloads.confirmDelete', 'Are you sure you want to delete deployment {{name}}?', { name }))) return
+    setPendingDelete({ cluster, namespace, name })
+  }
+
+  const confirmDeleteDeployment = async () => {
+    if (!pendingDelete) return
+    const { cluster, namespace, name } = pendingDelete
+    setPendingDelete(null)
     try {
       showToast(t('workloads.deleting', 'Deleting deployment...'), 'info')
       await kubectlProxy.exec(['delete', 'deployment', name, '-n', namespace], { context: cluster })
@@ -470,6 +478,16 @@ export function Workloads() {
           )}
         </div>
       </div>
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== null}
+        onClose={() => setPendingDelete(null)}
+        onConfirm={confirmDeleteDeployment}
+        title={t('workloads.deleteDeployment', 'Delete Deployment')}
+        message={t('workloads.confirmDelete', 'Are you sure you want to delete deployment {{name}}? This action cannot be undone.', { name: pendingDelete?.name ?? '' })}
+        confirmLabel={t('common:actions.delete', 'Delete')}
+        variant="danger"
+      />
     </DashboardPage>
   )
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3855,6 +3855,16 @@
   "deployments": {
     "errorLoading": "Error loading deployment data"
   },
+  "workloads": {
+    "deleteDeployment": "Delete Deployment",
+    "confirmDelete": "Are you sure you want to delete deployment {{name}}? This action cannot be undone.",
+    "deleting": "Deleting deployment...",
+    "deleteSuccess": "Deployment deleted",
+    "deleteError": "Failed to delete deployment",
+    "restarting": "Restarting deployment...",
+    "restartSuccess": "Restart triggered",
+    "restartError": "Failed to restart deployment"
+  },
   "nodeDetail": {
     "showAll": "Show all",
     "showLess": "Show less",


### PR DESCRIPTION
Fixes #10704

Replace `window.confirm()` with the themed `ConfirmDialog` component in the Workloads page for deployment deletion, matching the codebase convention established in `lib/modals/ConfirmDialog.tsx`.

### Changes
- **`web/src/components/workloads/Workloads.tsx`** — Replace browser-native `window.confirm()` with `ConfirmDialog` for delete deployment action
- **`web/src/locales/en/common.json`** — Add proper i18n keys for workload actions (`deleteDeployment`, `confirmDelete`, etc.)

### Auto-QA triage
The other findings from the auto-QA scan were verified as already addressed:
- **UserManagement.tsx:489,538** — Already uses `ConfirmDialog` (line 678)
- **ClusterGroups.tsx:285,288,377** — Already uses `ConfirmDialog` (line 255)
- **Missions.tsx:206** — `localStorage.removeItem()`, not a user-facing delete
- **WorkloadDeployment.tsx:577** — `localStorage.removeItem()`, not a user-facing delete

Size: **S** (31 insertions, 3 deletions)