### PR TITLE
🐛 Add isDemoMode checks to cards + dashboard handlers

### DIFF
--- a/pkg/api/handlers/cards.go
+++ b/pkg/api/handlers/cards.go
@@ -75,6 +75,9 @@ func isValidCardType(t models.CardType) bool {
 
 // ListCards returns all cards for a dashboard
 func (h *CardHandler) ListCards(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON([]models.Card{})
+	}
 	userID := middleware.GetUserID(c)
 	dashboardID, err := uuid.Parse(c.Params("id"))
 	if err != nil {
@@ -99,6 +102,9 @@ func (h *CardHandler) ListCards(c *fiber.Ctx) error {
 
 // CreateCard creates a new card
 func (h *CardHandler) CreateCard(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.Status(fiber.StatusCreated).JSON(fiber.Map{"status": "ok", "source": "demo"})
+	}
 	// Role check must run before any data access (#5999). Viewers cannot
 	// create cards; only editors and admins may.
 	if err := h.requireEditorOrAdmin(c); err != nil {
@@ -168,6 +174,9 @@ func (h *CardHandler) CreateCard(c *fiber.Ctx) error {
 
 // UpdateCard updates a card
 func (h *CardHandler) UpdateCard(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(fiber.Map{"status": "ok", "source": "demo"})
+	}
 	// Role check must run before any data access (#5999).
 	if err := h.requireEditorOrAdmin(c); err != nil {
 		return err
@@ -242,6 +251,9 @@ func (h *CardHandler) UpdateCard(c *fiber.Ctx) error {
 
 // DeleteCard deletes a card
 func (h *CardHandler) DeleteCard(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.SendStatus(fiber.StatusNoContent)
+	}
 	// Role check must run before any data access (#5999).
 	if err := h.requireEditorOrAdmin(c); err != nil {
 		return err
@@ -281,6 +293,9 @@ func (h *CardHandler) DeleteCard(c *fiber.Ctx) error {
 
 // RecordFocus records a card focus event
 func (h *CardHandler) RecordFocus(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(fiber.Map{"status": "ok", "source": "demo"})
+	}
 	// Role check: RecordFocus writes to card_focus and the event log, so
 	// it is a mutating operation that must be restricted to editors/admins,
 	// consistent with CreateCard, UpdateCard, DeleteCard, MoveCard (#7011).
@@ -336,11 +351,17 @@ func (h *CardHandler) RecordFocus(c *fiber.Ctx) error {
 
 // GetCardTypes returns available card types
 func (h *CardHandler) GetCardTypes(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return demoResponse(c, "card_types", models.GetCardTypes())
+	}
 	return c.JSON(models.GetCardTypes())
 }
 
 // GetHistory returns the user's card history
 func (h *CardHandler) GetHistory(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON([]models.CardHistory{})
+	}
 	userID := middleware.GetUserID(c)
 
 	limit := 50
@@ -361,6 +382,9 @@ func (h *CardHandler) GetHistory(c *fiber.Ctx) error {
 
 // MoveCard moves a card to a different dashboard
 func (h *CardHandler) MoveCard(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(fiber.Map{"status": "ok", "source": "demo"})
+	}
 	// Role check must run before any data access (#5999).
 	if err := h.requireEditorOrAdmin(c); err != nil {
 		return err

--- a/pkg/api/handlers/dashboard.go
+++ b/pkg/api/handlers/dashboard.go
@@ -53,6 +53,9 @@ func NewDashboardHandler(s store.Store) *DashboardHandler {
 // Supports limit/offset query params via parsePageParams (#6596); a response
 // may therefore be a partial page. Absent limit yields the store default.
 func (h *DashboardHandler) ListDashboards(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON([]models.Dashboard{})
+	}
 	userID := middleware.GetUserID(c)
 	// #6596: bound the read. Same limit/offset contract as the feedback list
 	// endpoints — absent limit → store default, malformed/oversized → 400.
@@ -73,6 +76,12 @@ func (h *DashboardHandler) ListDashboards(c *fiber.Ctx) error {
 
 // GetDashboard returns a dashboard with its cards
 func (h *DashboardHandler) GetDashboard(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(models.DashboardWithCards{
+			Dashboard: models.Dashboard{Name: "Demo Dashboard"},
+			Cards:     []models.Card{},
+		})
+	}
 	userID := middleware.GetUserID(c)
 	dashboardID, err := uuid.Parse(c.Params("id"))
 	if err != nil {
@@ -104,6 +113,9 @@ func (h *DashboardHandler) GetDashboard(c *fiber.Ctx) error {
 
 // CreateDashboard creates a new dashboard
 func (h *DashboardHandler) CreateDashboard(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.Status(fiber.StatusCreated).JSON(fiber.Map{"status": "ok", "source": "demo"})
+	}
 	userID := middleware.GetUserID(c)
 
 	var input struct {
@@ -143,6 +155,9 @@ func (h *DashboardHandler) CreateDashboard(c *fiber.Ctx) error {
 
 // UpdateDashboard updates a dashboard
 func (h *DashboardHandler) UpdateDashboard(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(fiber.Map{"status": "ok", "source": "demo"})
+	}
 	userID := middleware.GetUserID(c)
 	dashboardID, err := uuid.Parse(c.Params("id"))
 	if err != nil {
@@ -187,6 +202,9 @@ func (h *DashboardHandler) UpdateDashboard(c *fiber.Ctx) error {
 
 // DeleteDashboard deletes a dashboard
 func (h *DashboardHandler) DeleteDashboard(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.SendStatus(fiber.StatusNoContent)
+	}
 	userID := middleware.GetUserID(c)
 	dashboardID, err := uuid.Parse(c.Params("id"))
 	if err != nil {
@@ -214,6 +232,14 @@ func (h *DashboardHandler) DeleteDashboard(c *fiber.Ctx) error {
 // ExportDashboard returns a self-contained JSON blob with the dashboard and
 // all its cards in a portable format that can be shared or re-imported.
 func (h *DashboardHandler) ExportDashboard(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(DashboardExport{
+			Format:     "kc-dashboard-v1",
+			Name:       "Demo Dashboard",
+			ExportedAt: time.Now().UTC(),
+			Cards:      []CardExport{},
+		})
+	}
 	userID := middleware.GetUserID(c)
 	dashboardID, err := uuid.Parse(c.Params("id"))
 	if err != nil {
@@ -258,6 +284,9 @@ func (h *DashboardHandler) ExportDashboard(c *fiber.Ctx) error {
 
 // ImportDashboard creates a new dashboard from a portable export JSON blob.
 func (h *DashboardHandler) ImportDashboard(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.Status(fiber.StatusCreated).JSON(fiber.Map{"status": "ok", "source": "demo"})
+	}
 	userID := middleware.GetUserID(c)
 
 	var input DashboardExport


### PR DESCRIPTION
Fixes #8695

Add demo mode guards to all 16 handlers in `cards.go` (8 handlers) and `dashboard.go` (7 handlers) that were missing `isDemoMode` checks.

**cards.go handlers:** ListCards, CreateCard, UpdateCard, DeleteCard, RecordFocus, GetCardTypes, GetHistory, MoveCard

**dashboard.go handlers:** ListDashboards, GetDashboard, CreateDashboard, UpdateDashboard, DeleteDashboard, ExportDashboard, ImportDashboard

Read handlers return empty/demo data. Write handlers return success no-ops. Follows the same pattern established in `workloads.go` and `data_residency.go` (PR #10655).

**CLAUDE.md rule:** Every data-returning endpoint MUST check demo mode.