### PR TITLE
🐛 Replace http.DefaultClient with timeout-aware clients

### DIFF
--- a/pkg/agent/server_ops_settings.go
+++ b/pkg/agent/server_ops_settings.go
@@ -581,6 +581,11 @@ func (s *Server) refreshProviderAvailability() {
 // perKeyValidationTimeout is the timeout for each individual API key validation request.
 const perKeyValidationTimeout = 15 * time.Second
 
+// apiKeyValidationClient is an HTTP client with a timeout for external API key
+// validation calls. Using http.DefaultClient would hang indefinitely if a
+// provider is slow or unresponsive.
+var apiKeyValidationClient = &http.Client{Timeout: 30 * time.Second}
+
 // maxConcurrentValidations limits how many provider keys are validated simultaneously
 // to avoid hammering all providers at once.
 const maxConcurrentValidations = 5
@@ -645,7 +650,7 @@ func validateClaudeKey(ctx context.Context, apiKey string) (bool, error) {
 	req.Header.Set("x-api-key", apiKey)
 	req.Header.Set("anthropic-version", claudeAPIVersion)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := apiKeyValidationClient.Do(req)
 	if err != nil {
 		return false, err
 	}
@@ -674,7 +679,7 @@ func validateOpenAIKey(ctx context.Context, apiKey string) (bool, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := apiKeyValidationClient.Do(req)
 	if err != nil {
 		return false, err
 	}
@@ -724,7 +729,7 @@ func validateOpenRouterKey(ctx context.Context, apiKey string) (bool, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := apiKeyValidationClient.Do(req)
 	if err != nil {
 		return false, err
 	}
@@ -754,7 +759,7 @@ func validateGroqKey(ctx context.Context, apiKey string) (bool, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := apiKeyValidationClient.Do(req)
 	if err != nil {
 		return false, err
 	}
@@ -781,7 +786,7 @@ func validateGeminiKey(ctx context.Context, apiKey string) (bool, error) {
 	}
 	req.Header.Set("x-goog-api-key", apiKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := apiKeyValidationClient.Do(req)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/api/handlers/drasi_proxy.go
+++ b/pkg/api/handlers/drasi_proxy.go
@@ -55,6 +55,10 @@ const (
 	drasiProxyDefaultTimeout = 30 * time.Second
 )
 
+// drasiProxyClient is an HTTP client with a timeout for Drasi proxy requests.
+// Using http.DefaultClient would hang indefinitely on unresponsive upstreams.
+var drasiProxyClient = &http.Client{Timeout: drasiProxyDefaultTimeout}
+
 // drasiHopByHopHeaders are removed from both directions per RFC 7230 §6.1.
 var drasiHopByHopHeaders = map[string]bool{
 	"connection":          true,
@@ -138,7 +142,7 @@ func (h *MCPHandlers) proxyDrasiServer(c *fiber.Ctx, upstreamPath string, upstre
 	if err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
-	return streamUpstream(c, http.DefaultClient, req)
+	return streamUpstream(c, drasiProxyClient, req)
 }
 
 // proxyDrasiPlatform forwards to drasi-platform's `drasi-api` Service via


### PR DESCRIPTION
Fixes #8695

Replace `http.DefaultClient` (zero timeout) with dedicated timeout-aware clients:

- **server_ops_settings.go**: `apiKeyValidationClient` (30s timeout) for 5 AI provider key validation calls (Claude, OpenAI, OpenRouter, Groq, Gemini)
- **drasi_proxy.go**: `drasiProxyClient` (30s timeout) for upstream Drasi proxy

Without timeouts, a slow or unresponsive external API hangs the handler goroutine indefinitely, eventually exhausting the goroutine pool under repeated requests.

**Note:** `missions.go` already uses `h.httpClient` with `missionsAPITimeout` (30s) — no changes needed there.