### PR TITLE
🐛 Add createCachedHook to remaining 9 cache mock files

### DIFF
--- a/web/src/components/dashboard/__tests__/Dashboard.test.tsx
+++ b/web/src/components/dashboard/__tests__/Dashboard.test.tsx
@@ -169,7 +169,7 @@ vi.mock('../../../hooks/useCardGridNavigation', () => ({
 vi.mock('../../../lib/modals', () => ({
   useModalState: () => ({ isOpen: false, open: vi.fn(), close: vi.fn() }),
 }))
-vi.mock('../../../lib/cache', () => ({ setAutoRefreshPaused: vi.fn() }))
+vi.mock('../../../lib/cache', () => ({ setAutoRefreshPaused: vi.fn(), createCachedHook: vi.fn((_config: unknown) => () => ({})) }))
 vi.mock('../../../hooks/useRefreshIndicator', () => ({
   useRefreshIndicator: (fn: () => void) => ({ showIndicator: false, triggerRefresh: fn }),
 }))

--- a/web/src/hooks/mcp/__tests__/clusterDedup-regression.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusterDedup-regression.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../../../lib/cache', () => ({
   resetFailuresForCluster: mockResetFailuresForCluster,
   resetAllCacheFailures: mockResetAllCacheFailures,
+  createCachedHook: vi.fn((_config: unknown) => () => ({})),
 }))
 
 vi.mock('../../../lib/kubectlProxy', () => ({

--- a/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
@@ -47,6 +47,7 @@ vi.mock('../shared', () => ({
 vi.mock('../../../lib/cache', () => ({
   useCache: (opts: { key: string; initialData: unknown; demoData: unknown; fetcher?: () => Promise<unknown>; enabled?: boolean }) => mockUseCache(opts),
   resetFailuresForCluster: vi.fn(),
+  createCachedHook: vi.fn((_config: unknown) => () => ({})),
 }))
 
 vi.mock('../../../lib/utils/concurrency', () => ({

--- a/web/src/hooks/mcp/__tests__/kagenti.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagenti.test.ts
@@ -45,6 +45,7 @@ vi.mock('../shared', () => ({
 vi.mock('../../../lib/cache', () => ({
   useCache: (opts: { key: string; initialData: unknown; demoData: unknown }) => mockUseCache(opts),
   resetFailuresForCluster: vi.fn(),
+  createCachedHook: vi.fn((_config: unknown) => () => ({})),
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/hooks/mcp/__tests__/shared-cache-fetch.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-cache-fetch.test.ts
@@ -63,6 +63,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../../../lib/cache', () => ({
   resetFailuresForCluster: mockResetFailuresForCluster,
   resetAllCacheFailures: mockResetAllCacheFailures,
+  createCachedHook: vi.fn((_config: unknown) => () => ({})),
 }))
 
 vi.mock('../../../lib/kubectlProxy', () => ({

--- a/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
@@ -80,6 +80,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../../../lib/cache', () => ({
   resetFailuresForCluster: mockResetFailuresForCluster,
   resetAllCacheFailures: mockResetAllCacheFailures,
+  createCachedHook: vi.fn((_config: unknown) => () => ({})),
 }))
 
 vi.mock('../../../lib/kubectlProxy', () => ({

--- a/web/src/hooks/mcp/__tests__/shared-pure-funcs.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-pure-funcs.test.ts
@@ -63,6 +63,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../../../lib/cache', () => ({
   resetFailuresForCluster: mockResetFailuresForCluster,
   resetAllCacheFailures: mockResetAllCacheFailures,
+  createCachedHook: vi.fn((_config: unknown) => () => ({})),
 }))
 
 vi.mock('../../../lib/kubectlProxy', () => ({

--- a/web/src/hooks/mcp/__tests__/shared-websocket-detect.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-websocket-detect.test.ts
@@ -63,6 +63,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../../../lib/cache', () => ({
   resetFailuresForCluster: mockResetFailuresForCluster,
   resetAllCacheFailures: mockResetAllCacheFailures,
+  createCachedHook: vi.fn((_config: unknown) => () => ({})),
 }))
 
 vi.mock('../../../lib/kubectlProxy', () => ({

--- a/web/src/hooks/useCachedJaegerStatus.test.ts
+++ b/web/src/hooks/useCachedJaegerStatus.test.ts
@@ -5,6 +5,7 @@ import { renderHook } from '@testing-library/react'
 const mockUseCache = vi.fn()
 vi.mock('../lib/cache', () => ({
     useCache: (options: any) => mockUseCache(options),
+    createCachedHook: vi.fn((_config: unknown) => () => mockUseCache(_config)),
 }))
 
 // Mock useDemoMode — the hook actually imports `useDemoMode` from `./useDemoMode`,


### PR DESCRIPTION
Fixes #8695

Add `createCachedHook` to the last 9 test files that mock `lib/cache` without including it. Since `lib/cache/index.ts` re-exports `createCachedHook`, any transitive import of a factory-based hook gets `undefined` when the mock omits it.

**Files fixed (9):**
- `useCachedJaegerStatus.test.ts`
- `kagenti.test.ts`, `kagent_crds.test.ts`
- `clusterDedup-regression.test.ts`
- `shared-coverage.test.ts`, `shared-websocket-detect.test.ts`
- `shared-cache-fetch.test.ts`, `shared-pure-funcs.test.ts`
- `Dashboard.test.tsx`

This completes the fix started in PR #10645 (78 files). All 89 test files mocking `lib/cache` now include `createCachedHook`.