### PR TITLE
🐛 Add flex-wrap to prevent button overlap in 2 card components

### DIFF
--- a/web/src/components/cards/opa/PolicyDetailModal.tsx
+++ b/web/src/components/cards/opa/PolicyDetailModal.tsx
@@ -72,7 +72,7 @@ export function PolicyDetailModal({
                 key={idx}
                 className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
               >
-                <div className="flex items-start justify-between mb-1">
+                <div className="flex flex-wrap items-start justify-between mb-1">
                   <span className="text-sm font-medium text-foreground">{violation.name}</span>
                   <span className="text-xs text-muted-foreground">{violation.kind}</span>
                 </div>

--- a/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
+++ b/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
@@ -346,7 +346,7 @@ export function NightlyReleasePulse() {
       {!shared && <StandaloneRepoInput value={standaloneRepo} onChange={setStandaloneRepo} />}
 
       <div className="p-4 flex-1 flex flex-col gap-3 min-h-0">
-        <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
               <StatusIcon size={18} className={cn('shrink-0', iconColor)} />


### PR DESCRIPTION
Fixes #8695

Add `flex-wrap` to `flex justify-between` containers in:
- `PolicyDetailModal.tsx` (OPA card violation rows)
- `NightlyReleasePulse.tsx` (pipeline card header)

Without `flex-wrap`, child elements overlap when sidebars expand and reduce the card's available width. Part of #8695 Phase 3b — these were the 2 P1 flex-wrap files identified in the RFC.