### PR TITLE
🌱 Add local fullstack E2E runner and mission integration tests

### DIFF
--- a/scripts/run-fullstack-e2e.sh
+++ b/scripts/run-fullstack-e2e.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# run-fullstack-e2e.sh — Run fullstack E2E tests locally against the Go backend.
+#
+# Mirrors .github/workflows/fullstack-e2e.yml so developers can run the same
+# smoke tests without pushing to CI (fixes kubestellar/console#10688).
+#
+# Usage:
+#   bash scripts/run-fullstack-e2e.sh
+#   # or via npm:
+#   cd web && npm run test:e2e:fullstack
+
+set -euo pipefail
+
+# ── Named constants (no magic numbers per CLAUDE.md) ─────────────────────────
+readonly BACKEND_PORT=8080
+readonly HEALTH_TIMEOUT_S=60
+readonly HEALTH_POLL_INTERVAL_S=1
+readonly DEV_JWT_SECRET='local-fullstack-e2e-jwt-secret-placeholder-not-a-real-key'
+
+# ── Repo root ────────────────────────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+readonly REPO_ROOT
+readonly BINARY_PATH="${REPO_ROOT}/console-binary-e2e"
+readonly LOG_PATH="${REPO_ROOT}/console-e2e.log"
+
+BACKEND_PID=""
+
+# ── Cleanup on exit / error ──────────────────────────────────────────────────
+cleanup() {
+  echo ""
+  echo "── cleanup ──"
+  if [ -n "${BACKEND_PID}" ] && kill -0 "${BACKEND_PID}" 2>/dev/null; then
+    echo "Stopping backend (PID ${BACKEND_PID})…"
+    kill "${BACKEND_PID}" || true
+    wait "${BACKEND_PID}" 2>/dev/null || true
+  fi
+  if [ -f "${BINARY_PATH}" ]; then
+    rm -f "${BINARY_PATH}"
+    echo "Removed ${BINARY_PATH}"
+  fi
+  if [ -f "${LOG_PATH}" ]; then
+    echo "Backend log kept at ${LOG_PATH}"
+  fi
+}
+trap cleanup EXIT
+
+# ── Step 1: Build Go backend ────────────────────────────────────────────────
+echo "── Building Go backend ──"
+cd "${REPO_ROOT}"
+go build -o "${BINARY_PATH}" ./cmd/console
+
+# ── Step 2: Build frontend ──────────────────────────────────────────────────
+echo "── Building frontend ──"
+cd "${REPO_ROOT}/web"
+npm run build
+
+# ── Step 3: Start Go backend ────────────────────────────────────────────────
+echo "── Starting backend on port ${BACKEND_PORT} ──"
+cd "${REPO_ROOT}"
+JWT_SECRET="${DEV_JWT_SECRET}" PORT="${BACKEND_PORT}" "${BINARY_PATH}" > "${LOG_PATH}" 2>&1 &
+BACKEND_PID=$!
+echo "Backend PID: ${BACKEND_PID}"
+
+# ── Step 4: Wait for /healthz ────────────────────────────────────────────────
+echo "── Waiting for /healthz (up to ${HEALTH_TIMEOUT_S}s) ──"
+for i in $(seq 1 "${HEALTH_TIMEOUT_S}"); do
+  if curl -sf "http://localhost:${BACKEND_PORT}/healthz" > /dev/null 2>&1; then
+    echo "Backend healthy after ${i}s"
+    break
+  fi
+  if [ "${i}" -eq "${HEALTH_TIMEOUT_S}" ]; then
+    echo "ERROR: Backend did not become healthy in ${HEALTH_TIMEOUT_S}s"
+    echo "── console-e2e.log ──"
+    cat "${LOG_PATH}" || true
+    exit 1
+  fi
+  sleep "${HEALTH_POLL_INTERVAL_S}"
+done
+
+# ── Step 5: Run fullstack E2E specs ─────────────────────────────────────────
+echo "── Running fullstack E2E tests ──"
+cd "${REPO_ROOT}/web"
+FULLSTACK_SMOKE=1 \
+PLAYWRIGHT_BASE_URL="http://localhost:${BACKEND_PORT}" \
+  npx playwright test \
+    e2e/fullstack-smoke.spec.ts \
+    e2e/mission-integration.spec.ts \
+    --project=chromium
+
+echo "── All fullstack E2E tests passed ──"

--- a/web/e2e/fullstack-smoke.spec.ts
+++ b/web/e2e/fullstack-smoke.spec.ts
@@ -18,6 +18,9 @@ import { test, expect } from '@playwright/test'
  *
  * Driven from .github/workflows/fullstack-e2e.yml, which spins up the Go
  * binary with minimal env and points PLAYWRIGHT_BASE_URL at port 8080.
+ *
+ * Local runner: scripts/run-fullstack-e2e.sh (or `npm run test:e2e:fullstack`)
+ * builds Go + frontend, starts the backend, and runs this spec automatically.
  */
 
 // The Go backend serves both API and built frontend on port 8080 when
@@ -28,7 +31,7 @@ const FULLSTACK_BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8080
 // This test is ONLY meaningful when pointed at the Go binary.
 test.skip(
   () => !process.env.FULLSTACK_SMOKE,
-  'fullstack-smoke only runs in the dedicated fullstack-e2e workflow',
+  'Set FULLSTACK_SMOKE=1 or use npm run test:e2e:fullstack (see scripts/run-fullstack-e2e.sh)',
 )
 
 test.describe('full-stack smoke (#6362)', () => {

--- a/web/e2e/mission-integration.spec.ts
+++ b/web/e2e/mission-integration.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Mission integration tests — kubestellar/console#10683
+ *
+ * Validates real mission API endpoints against the running Go backend.
+ * Unlike web/e2e/Missions.spec.ts (which mocks all backend interactions),
+ * these tests hit the actual /api/missions/* routes to verify handler wiring,
+ * response shapes, and end-to-end data flow.
+ *
+ * Run locally:
+ *   npm run test:e2e:fullstack          (builds + starts backend automatically)
+ *   # or manually:
+ *   FULLSTACK_SMOKE=1 PLAYWRIGHT_BASE_URL=http://localhost:8080 \
+ *     npx playwright test e2e/mission-integration.spec.ts --project=chromium
+ */
+
+// ── Named constants (no magic numbers per CLAUDE.md) ────────────────────────
+const API_REQUEST_TIMEOUT_MS = 15_000
+const EXPECTED_HTTP_OK = 200
+const EXPECTED_HTTP_BAD_REQUEST = 400
+
+const FULLSTACK_BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8080'
+
+// Only run against the real Go backend — skip in default Vite dev server mode.
+test.skip(
+  () => !process.env.FULLSTACK_SMOKE,
+  'Set FULLSTACK_SMOKE=1 or use npm run test:e2e:fullstack (see scripts/run-fullstack-e2e.sh)',
+)
+
+test.describe('mission integration (real backend)', () => {
+  test('GET /api/missions/browse returns mission catalog', async ({ request }) => {
+    const res = await request.get(`${FULLSTACK_BASE}/api/missions/browse`, {
+      timeout: API_REQUEST_TIMEOUT_MS,
+    })
+    // The route must exist and be wired. GitHub API may return data or an
+    // error, but a 404 means the route itself is missing from Go routing.
+    expect(res.status()).not.toBe(404)
+
+    if (res.status() === EXPECTED_HTTP_OK) {
+      const body = await res.json()
+      // The browse endpoint returns an array of mission entries
+      expect(Array.isArray(body)).toBe(true)
+    }
+  })
+
+  test('GET /api/missions/scores returns KB scores', async ({ request }) => {
+    const res = await request.get(`${FULLSTACK_BASE}/api/missions/scores`, {
+      timeout: API_REQUEST_TIMEOUT_MS,
+    })
+    expect(res.status()).not.toBe(404)
+
+    if (res.status() === EXPECTED_HTTP_OK) {
+      const body = await res.json()
+      // Scores endpoint returns an object (map of project scores)
+      expect(typeof body).toBe('object')
+      expect(body).not.toBeNull()
+    }
+  })
+
+  test('POST /api/missions/validate accepts or rejects a payload', async ({ request }) => {
+    const minimalPayload = { title: 'test-mission', steps: [] }
+
+    const res = await request.post(`${FULLSTACK_BASE}/api/missions/validate`, {
+      data: minimalPayload,
+      timeout: API_REQUEST_TIMEOUT_MS,
+    })
+    // The validate endpoint should return 200 (valid) or 400 (invalid).
+    // A 404 means the route is missing; 401/403 means auth middleware
+    // is blocking a route that should be reachable in this test config.
+    const acceptableStatuses = [EXPECTED_HTTP_OK, EXPECTED_HTTP_BAD_REQUEST]
+    expect(acceptableStatuses).toContain(res.status())
+  })
+
+  test('GET /api/health returns health with oauth_configured field', async ({ request }) => {
+    const res = await request.get(`${FULLSTACK_BASE}/api/health`, {
+      timeout: API_REQUEST_TIMEOUT_MS,
+    })
+    expect(res.status()).toBe(EXPECTED_HTTP_OK)
+
+    const body = await res.json()
+    expect(body).toHaveProperty('oauth_configured')
+  })
+
+  test('GET /api/version is accessible', async ({ request }) => {
+    const res = await request.get(`${FULLSTACK_BASE}/api/version`, {
+      timeout: API_REQUEST_TIMEOUT_MS,
+    })
+    expect(res.status()).toBe(EXPECTED_HTTP_OK)
+  })
+})

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "playwright test --debug",
+    "test:e2e:fullstack": "cd .. && bash scripts/run-fullstack-e2e.sh",
     "test:e2e:chromium": "playwright test --project=chromium",
     "test:e2e:ux-sweep": "PLAYWRIGHT_BASE_URL=http://localhost:8080 PLAYWRIGHT_STORAGE_STATE=auth.json playwright test --config=e2e/user-flows/ux-scan.config.ts",
     "test:e2e:firefox": "playwright test --project=firefox",


### PR DESCRIPTION
Fixes #10688
Fixes #10683

## What changed

### Local fullstack E2E runner (fixes #10688)
- **`scripts/run-fullstack-e2e.sh`** — self-contained script that builds the Go binary + frontend, starts the backend, waits for /healthz, runs fullstack specs, and cleans up on exit. Mirrors `.github/workflows/fullstack-e2e.yml` for local use.
- **`npm run test:e2e:fullstack`** — one-command entry point in web/package.json.
- Updated skip message in `fullstack-smoke.spec.ts` to hint at the local runner.

### Mission integration tests (fixes #10683)
- **`web/e2e/mission-integration.spec.ts`** — validates real mission API endpoints (`/api/missions/browse`, `/scores`, `/validate`, `/api/health`, `/api/version`) against the running Go backend. No mocking — tests hit actual handlers and assert response shapes.
- Integrated into the fullstack runner so both specs run together.