### PR TITLE
🐛 Add WaitGroup lifecycle coordination to cluster operation goroutines

### DIFF
--- a/cmd/kc-agent/main.go
+++ b/cmd/kc-agent/main.go
@@ -62,7 +62,8 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigChan
-		slog.Info("Shutting down")
+		slog.Info("Shutting down — waiting for in-flight cluster operations")
+		server.GracefulShutdown()
 		os.Exit(0)
 	}()
 

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -173,6 +173,7 @@ type Server struct {
 
 	// Local cluster management
 	localClusters *LocalClusterManager
+	clusterOpsWG  sync.WaitGroup // tracks in-flight cluster create/delete/lifecycle goroutines
 
 	// Backend process management (for restart-from-UI)
 	backendCmd *exec.Cmd
@@ -953,6 +954,27 @@ func generateRandomToken(nBytes int) (string, error) {
 		return "", fmt.Errorf("crypto/rand.Read: %w", err)
 	}
 	return hex.EncodeToString(buf), nil
+}
+
+// clusterOpsShutdownTimeout is the maximum time GracefulShutdown waits for
+// in-flight cluster create/delete/lifecycle goroutines to complete.
+const clusterOpsShutdownTimeout = 30 * time.Second
+
+// GracefulShutdown waits for all in-flight cluster operation goroutines to
+// finish (up to clusterOpsShutdownTimeout). Call this before process exit to
+// avoid orphaning background cluster create/delete operations.
+func (s *Server) GracefulShutdown() {
+	done := make(chan struct{})
+	go func() {
+		s.clusterOpsWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		slog.Info("[Server] all cluster operations completed")
+	case <-time.After(clusterOpsShutdownTimeout):
+		slog.Warn("[Server] timed out waiting for cluster operations", "timeout", clusterOpsShutdownTimeout)
+	}
 }
 
 // handleClustersHTTP returns the list of kubeconfig contexts

--- a/pkg/agent/server_ops_clusters.go
+++ b/pkg/agent/server_ops_clusters.go
@@ -130,7 +130,9 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Create cluster in background and return immediately
+		s.clusterOpsWG.Add(1)
 		go func() {
+			defer s.clusterOpsWG.Done()
 			defer func() {
 				if r := recover(); r != nil {
 					slog.Error("[LocalClusters] recovered from panic creating cluster", "cluster", req.Name, "panic", r)
@@ -193,7 +195,9 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Delete cluster in background
+		s.clusterOpsWG.Add(1)
 		go func() {
+			defer s.clusterOpsWG.Done()
 			defer func() {
 				if r := recover(); r != nil {
 					slog.Error("[LocalClusters] recovered from panic deleting cluster", "cluster", name, "panic", r)
@@ -289,7 +293,9 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	s.clusterOpsWG.Add(1)
 	go func() {
+		defer s.clusterOpsWG.Done()
 		defer func() {
 			if r := recover(); r != nil {
 				slog.Error("[LocalClusters] recovered from panic during lifecycle action", "action", req.Action, "cluster", req.Name, "panic", r)
@@ -411,7 +417,9 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create vCluster in background and return immediately
+	s.clusterOpsWG.Add(1)
 	go func() {
+		defer s.clusterOpsWG.Done()
 		defer func() {
 			if r := recover(); r != nil {
 				slog.Error("[vCluster] recovered from panic creating vcluster", "name", req.Name, "panic", r)
@@ -606,7 +614,9 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Delete vCluster in background and return immediately
+	s.clusterOpsWG.Add(1)
 	go func() {
+		defer s.clusterOpsWG.Done()
 		defer func() {
 			if r := recover(); r != nil {
 				slog.Error("[vCluster] recovered from panic deleting vcluster", "name", req.Name, "panic", r)


### PR DESCRIPTION
Fixes #8695

Add `sync.WaitGroup` tracking to the 5 background goroutines in `server_ops_clusters.go` (cluster create, delete, lifecycle, vCluster create, vCluster delete) that previously ran with no lifecycle coordination.

**Changes:**
- `server.go`: Add `clusterOpsWG sync.WaitGroup` field to Server struct
- `server.go`: Add `GracefulShutdown()` method with 30s timeout
- `server_ops_clusters.go`: Add `wg.Add(1)`/`defer wg.Done()` to all 5 goroutines
- `cmd/kc-agent/main.go`: Wire GracefulShutdown into SIGINT/SIGTERM handler

Without this, a SIGTERM during an in-flight cluster create/delete orphans the goroutine, potentially leaving infrastructure in an inconsistent state.