### PR TITLE
added tests for ClusterChangeLog.tsx, CLusterComparison.tsx anddd CLu…

### DIFF
--- a/web/src/components/cards/ClusterChangelog.test.tsx
+++ b/web/src/components/cards/ClusterChangelog.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import type { ReactNode } from 'react'
+import { ClusterChangelog } from './ClusterChangelog'
+
+const mockUseCachedEvents = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+const mockRefetch = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (key.endsWith('minutesAgo')) return `${opts?.count}m ago`
+      if (key.endsWith('hoursAgo')) return `${opts?.count}h ago`
+      if (key.endsWith('daysAgo')) return `${opts?.count}d ago`
+      if (key.endsWith('justNow')) return 'just now'
+      if (key.endsWith('noChanges')) return 'No changes'
+      if (key.endsWith('retry')) return 'Retry'
+      if (key.endsWith('errorLoading')) return 'Error loading'
+      if (key.endsWith('fetchFailed')) return `Failed ${opts?.count ?? 0}`
+      return key
+    },
+  }),
+}))
+
+vi.mock('../../hooks/useCachedData', () => ({
+  useCachedEvents: (...args: unknown[]) => mockUseCachedEvents(...args),
+}))
+
+vi.mock('./CardDataContext', () => ({
+  useCardLoadingState: (opts: Record<string, unknown>) => mockUseCardLoadingState(opts),
+}))
+
+vi.mock('../ui/StatusBadge', () => ({
+  StatusBadge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock('../ui/RefreshIndicator', () => ({
+  RefreshIndicator: () => <div data-testid="refresh-indicator" />,
+}))
+
+function setup(events: Array<Record<string, unknown>>, overrides?: Record<string, unknown>) {
+  mockUseCachedEvents.mockReturnValue({
+    events,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    refetch: mockRefetch,
+    lastRefresh: Date.now(),
+    ...overrides,
+  })
+  mockUseCardLoadingState.mockReturnValue({
+    showSkeleton: false,
+  })
+}
+
+describe('ClusterChangelog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T12:00:00.000Z'))
+  })
+
+  it('renders skeleton state when showSkeleton is true', () => {
+    setup([], { isLoading: true })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true })
+    render(<ClusterChangelog />)
+
+    expect(screen.getAllByRole('generic').length).toBeGreaterThan(0)
+  })
+
+  it('renders filtered change events and excludes non-change reasons', () => {
+    setup([
+      {
+        reason: 'SuccessfulCreate',
+        object: 'deploy/app',
+        message: 'created',
+        cluster: 'c1',
+        lastSeen: '2026-01-01T11:55:00.000Z',
+      },
+      {
+        reason: 'UnrelatedReason',
+        object: 'pod/x',
+        message: 'ignored',
+        cluster: 'c2',
+        lastSeen: '2026-01-01T11:50:00.000Z',
+      },
+    ])
+    render(<ClusterChangelog />)
+
+    expect(screen.getByText('SuccessfulCreate')).toBeTruthy()
+    expect(screen.queryByText('UnrelatedReason')).toBeNull()
+    expect(screen.getByText(/deploy\/app/)).toBeTruthy()
+  })
+
+  it('shows error state and retries', async () => {
+    setup([], { isFailed: true, consecutiveFailures: 3 })
+    render(<ClusterChangelog />)
+
+    expect(screen.getByText('Error loading')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(mockRefetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/components/cards/ClusterComparison.test.tsx
+++ b/web/src/components/cards/ClusterComparison.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import type { ReactNode, ButtonHTMLAttributes } from 'react'
+import { ClusterComparison } from './ClusterComparison'
+
+const mockUseClusters = vi.fn()
+const mockUseCachedGPUNodes = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+const mockDrillToCluster = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('.').pop() ?? key,
+  }),
+}))
+
+vi.mock('../../hooks/useMCP', () => ({
+  useClusters: () => mockUseClusters(),
+}))
+
+vi.mock('../../hooks/useCachedData', () => ({
+  useCachedGPUNodes: () => mockUseCachedGPUNodes(),
+}))
+
+vi.mock('./CardDataContext', () => ({
+  useCardLoadingState: (opts: Record<string, unknown>) => mockUseCardLoadingState(opts),
+}))
+
+vi.mock('../../hooks/useDrillDown', () => ({
+  useDrillDownActions: () => ({ drillToCluster: mockDrillToCluster }),
+}))
+
+vi.mock('../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({
+    selectedClusters: [],
+    isAllClustersSelected: true,
+    customFilter: '',
+  }),
+}))
+
+vi.mock('../../hooks/useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+}))
+
+vi.mock('../ui/Skeleton', () => ({
+  Skeleton: () => <div data-testid="skeleton" />,
+}))
+
+vi.mock('../ui/RefreshIndicator', () => ({
+  RefreshIndicator: () => <div data-testid="refresh-indicator" />,
+}))
+
+vi.mock('./DynamicCardErrorBoundary', () => ({
+  DynamicCardErrorBoundary: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../ui/Button', () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}))
+
+describe('ClusterComparison', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseClusters.mockReturnValue({
+      deduplicatedClusters: [],
+      isLoading: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+    })
+    mockUseCachedGPUNodes.mockReturnValue({
+      nodes: [],
+      isDemoFallback: false,
+      isRefreshing: false,
+      lastRefresh: Date.now(),
+    })
+    mockUseCardLoadingState.mockReturnValue({
+      showSkeleton: false,
+      showEmptyState: true,
+    })
+  })
+
+  it('renders empty-state message when no clusters available', () => {
+    render(<ClusterComparison />)
+    expect(screen.getByText('noClustersSelected')).toBeTruthy()
+  })
+
+  it('drills down when clicking a cluster header button', async () => {
+    mockUseClusters.mockReturnValue({
+      deduplicatedClusters: [
+        { name: 'cluster-a', healthy: true, nodeCount: 3, podCount: 10, cpuCores: 8 },
+        { name: 'cluster-b', healthy: false, nodeCount: 2, podCount: 6, cpuCores: 4 },
+      ],
+      isLoading: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+    })
+    mockUseCardLoadingState.mockReturnValue({
+      showSkeleton: false,
+      showEmptyState: false,
+    })
+
+    render(<ClusterComparison />)
+    const clusterAButtons = screen.getAllByRole('button', { name: /cluster-a/i })
+    await userEvent.click(clusterAButtons[clusterAButtons.length - 1])
+    expect(mockDrillToCluster).toHaveBeenCalledWith(
+      'cluster-a',
+      expect.objectContaining({ nodeCount: 3, podCount: 10, cpuCores: 8 }),
+    )
+  })
+})

--- a/web/src/components/cards/ClusterCosts.test.tsx
+++ b/web/src/components/cards/ClusterCosts.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import type { ReactNode } from 'react'
+import { ClusterCosts } from './ClusterCosts'
+
+const mockUseClusters = vi.fn()
+const mockUseCachedGPUNodes = vi.fn()
+const mockUseCardData = vi.fn()
+const mockDrillToCost = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (key.endsWith('clusterCount')) return `${opts?.count ?? 0} clusters`
+      return key.split('.').pop() ?? key
+    },
+  }),
+}))
+
+vi.mock('../../hooks/useMCP', () => ({
+  useClusters: () => mockUseClusters(),
+}))
+
+vi.mock('../../hooks/useCachedData', () => ({
+  useCachedGPUNodes: () => mockUseCachedGPUNodes(),
+}))
+
+vi.mock('../../hooks/useDrillDown', () => ({
+  useDrillDownActions: () => ({ drillToCost: mockDrillToCost }),
+}))
+
+vi.mock('../../hooks/useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false }),
+}))
+
+vi.mock('./CardDataContext', () => ({
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('../../lib/cards/cardHooks', () => ({
+  useCardData: (...args: unknown[]) => mockUseCardData(...args),
+  commonComparators: {
+    number: () => () => 0,
+    string: () => () => 0,
+  },
+}))
+
+vi.mock('../../lib/cards/CardComponents', () => ({
+  CardSearchInput: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <input aria-label="search" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+  CardControlsRow: () => <div data-testid="controls" />,
+  CardPaginationFooter: () => <div data-testid="pagination" />,
+}))
+
+vi.mock('../ui/Skeleton', () => ({
+  Skeleton: () => <div data-testid="skeleton" />,
+}))
+
+vi.mock('../ui/CloudProviderIcon', () => ({
+  CloudProviderIcon: () => <span data-testid="provider-icon" />,
+}))
+
+vi.mock('../ui/StatusBadge', () => ({
+  StatusBadge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}))
+
+describe('ClusterCosts', () => {
+  const baseCardData = {
+    items: [] as Array<Record<string, unknown>>,
+    totalItems: 0,
+    currentPage: 1,
+    totalPages: 1,
+    itemsPerPage: 5,
+    goToPage: vi.fn(),
+    needsPagination: false,
+    setItemsPerPage: vi.fn(),
+    filters: {
+      search: '',
+      setSearch: vi.fn(),
+      localClusterFilter: [] as string[],
+      toggleClusterFilter: vi.fn(),
+      clearClusterFilter: vi.fn(),
+      availableClusters: [] as Array<{ name: string }>,
+      showClusterFilter: false,
+      setShowClusterFilter: vi.fn(),
+      clusterFilterRef: { current: null },
+    },
+    sorting: {
+      sortBy: 'cost',
+      setSortBy: vi.fn(),
+      sortDirection: 'desc',
+      setSortDirection: vi.fn(),
+    },
+    containerRef: { current: null },
+    containerStyle: {},
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseClusters.mockReturnValue({
+      deduplicatedClusters: [],
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+    })
+    mockUseCachedGPUNodes.mockReturnValue({
+      nodes: [],
+      isRefreshing: false,
+      isDemoFallback: false,
+    })
+    mockUseCardData.mockReturnValue(baseCardData)
+  })
+
+  it('renders loading skeleton when initial cluster fetch is loading', () => {
+    mockUseClusters.mockReturnValue({
+      deduplicatedClusters: [],
+      isLoading: true,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+    })
+    render(<ClusterCosts />)
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0)
+  })
+
+  it('renders cluster costs and drills down on row click', async () => {
+    const items = [
+      { cluster: 'prod', name: 'prod', healthy: true, cpus: 8, memory: 96, gpus: 1, hourly: 2, daily: 48, monthly: 1440, provider: 'aws' },
+    ]
+    mockUseClusters.mockReturnValue({
+      deduplicatedClusters: [
+        { name: 'prod', healthy: true, cpuCores: 8, nodeCount: 3, context: 'eks-prod' },
+      ],
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+    })
+    mockUseCardData.mockReturnValue({ ...baseCardData, items, totalItems: 1 })
+
+    render(<ClusterCosts />)
+    expect(screen.getByText('prod')).toBeTruthy()
+    await userEvent.click(screen.getByText('prod'))
+    expect(mockDrillToCost).toHaveBeenCalledWith(
+      'prod',
+      expect.objectContaining({ monthly: 1440, cpus: 8 }),
+    )
+  })
+})


### PR DESCRIPTION
…sterCosts.tsx

> **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.

> **New CNCF project card?** New cards go in [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo. PRs adding new cards here will be redirected.

> **Use a coding agent.** This repo is primarily developed with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Opus 4.5/4.6). It knows all codebase patterns (isDemoData, useCardLoadingState, locale strings, DCO). Manual PRs that miss required patterns will be sent back.

### 📌 Fixes

N/A

---

### 📝 Summary of Changes

Added targeted unit tests for three existing cluster card components to improve coverage and prevent regressions in card rendering and interactions:

ClusterChangelog
ClusterComparison
ClusterCosts

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

 Added web/src/components/cards/ClusterChangelog.test.tsx

 Added web/src/components/cards/ClusterComparison.test.tsx

 Added web/src/components/cards/ClusterCosts.test.tsx

 Covered key render paths (loading/empty/data/error states where relevant)

 Added interaction assertions (retry/refetch, drill-down actions, row/button behavior)

 Verified tests pass locally for the new test files
 
---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [x] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [ ] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
