### PR TITLE
🌱 : add unit tests for mission control layout, codec, and approval body generation

### DIFF
--- a/web/src/components/mission-control/__tests__/BlueprintLayout.test.ts
+++ b/web/src/components/mission-control/__tests__/BlueprintLayout.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import { computeLayout, INTEGRATION_LABELS } from '../BlueprintLayout'
+import type { MissionControlState } from '../types'
+
+describe('BlueprintLayout', () => {
+  const mockState: MissionControlState = {
+    title: 'Test Layout',
+    description: 'Test Description',
+    projects: [
+      {
+        name: 'prometheus',
+        displayName: 'Prometheus',
+        category: 'Monitoring',
+        priority: 'P1',
+        reason: 'Essential',
+        dependencies: [],
+      },
+      {
+        name: 'grafana',
+        displayName: 'Grafana',
+        category: 'Visualization',
+        priority: 'P1',
+        reason: 'Essential',
+        dependencies: ['prometheus'],
+      },
+    ],
+    assignments: [
+      {
+        clusterName: 'cluster-1',
+        provider: 'kind',
+        projectNames: ['prometheus', 'grafana'],
+        clusterContext: 'cluster-1',
+        warnings: [],
+        readiness: { cpuHeadroomPercent: 0, memHeadroomPercent: 0, storageHeadroomPercent: 0, overallScore: 0 },
+      },
+    ],
+    phases: [],
+    deployMode: 'phased',
+    phase: 'blueprint',
+  }
+
+  it('computes layout for a simple single-cluster mission', () => {
+    const layout = computeLayout(mockState)
+    
+    expect(layout.viewBox.width).toBe(560)
+    expect(layout.viewBox.height).toBeGreaterThanOrEqual(360)
+    
+    expect(layout.clusterRects.has('cluster-1')).toBe(true)
+    const rect = layout.clusterRects.get('cluster-1')!
+    expect(rect.width).toBeGreaterThan(0)
+    expect(rect.height).toBeGreaterThan(0)
+
+    // Positions for projects
+    expect(layout.projectPositions.has('cluster-1/prometheus')).toBe(true)
+    expect(layout.projectPositions.has('cluster-1/grafana')).toBe(true)
+    
+    const posProm = layout.projectPositions.get('cluster-1/prometheus')!
+    const posGraf = layout.projectPositions.get('cluster-1/grafana')!
+    
+    // They should be different
+    expect(posProm.cx).not.toBe(posGraf.cx)
+  })
+
+  it('identifies explicit dependencies as edges', () => {
+    const layout = computeLayout(mockState)
+    
+    const edge = layout.dependencyEdges.find(e => e.from === 'grafana' && e.to === 'prometheus')
+    expect(edge).toBeDefined()
+    expect(edge?.crossCluster).toBe(false)
+  })
+
+  it('identifies implicit integrations from INTEGRATION_LABELS', () => {
+    // Add a project that has an implicit integration with prometheus but no explicit dep
+    const stateWithImplicit = {
+      ...mockState,
+      projects: [
+        ...mockState.projects,
+        {
+          name: 'cilium',
+          displayName: 'Cilium',
+          category: 'Network',
+          priority: 'P1',
+          reason: 'Network',
+          dependencies: [],
+        }
+      ],
+      assignments: [
+        {
+          ...mockState.assignments[0],
+          projectNames: ['prometheus', 'grafana', 'cilium']
+        }
+      ]
+    }
+    
+    const layout = computeLayout(stateWithImplicit)
+    
+    // prometheus -> cilium integration should exist in INTEGRATION_LABELS
+    expect(INTEGRATION_LABELS['prometheus']?.['cilium']).toBe('network metrics')
+    
+    const edge = layout.dependencyEdges.find(e => 
+      (e.from === 'prometheus' && e.to === 'cilium') || 
+      (e.from === 'cilium' && e.to === 'prometheus')
+    )
+    expect(edge).toBeDefined()
+    expect(edge?.label).toBe('network metrics')
+  })
+
+  it('handles multiple clusters and identifies cross-cluster edges', () => {
+    const multiClusterState: MissionControlState = {
+      ...mockState,
+      assignments: [
+        {
+          clusterName: 'cluster-1',
+          provider: 'kind',
+          projectNames: ['prometheus'],
+          clusterContext: 'cluster-1',
+          warnings: [],
+          readiness: { cpuHeadroomPercent: 0, memHeadroomPercent: 0, storageHeadroomPercent: 0, overallScore: 0 },
+        },
+        {
+          clusterName: 'cluster-2',
+          provider: 'kind',
+          projectNames: ['grafana'],
+          clusterContext: 'cluster-2',
+          warnings: [],
+          readiness: { cpuHeadroomPercent: 0, memHeadroomPercent: 0, storageHeadroomPercent: 0, overallScore: 0 },
+        }
+      ]
+    }
+    
+    const layout = computeLayout(multiClusterState)
+    
+    expect(layout.clusterRects.size).toBe(2)
+    const edge = layout.dependencyEdges.find(e => e.from === 'grafana' && e.to === 'prometheus')
+    expect(edge).toBeDefined()
+    expect(edge?.crossCluster).toBe(true)
+  })
+})

--- a/web/src/components/mission-control/__tests__/BlueprintReport.test.ts
+++ b/web/src/components/mission-control/__tests__/BlueprintReport.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { shortenClusterName, exportFullReport } from '../BlueprintReport'
+import type { MissionControlState } from '../types'
+
+describe('BlueprintReport', () => {
+  describe('shortenClusterName', () => {
+    it('strips context prefix', () => {
+      expect(shortenClusterName('default/my-cluster')).toBe('my-cluster')
+      expect(shortenClusterName('kind-kind/cluster-1')).toBe('cluster-1')
+    })
+
+    it('shortens very long names by taking segments', () => {
+      const longName = 'default/api-fmaas-platform-eval-fmaas-res-2024'
+      // Expected: api-fmaas-platform (first 3 segments)
+      expect(shortenClusterName(longName)).toBe('api-fmaas-platform')
+    })
+
+    it('truncates with ellipsis if no segments are found', () => {
+      const longUnderscoreName = 'default/thisisareallylongclusternamewithoutanysegments'
+      expect(shortenClusterName(longUnderscoreName)).toBe('thisisareallylongclust…')
+    })
+
+    it('returns original name if it is short enough', () => {
+      expect(shortenClusterName('my-cluster')).toBe('my-cluster')
+    })
+  })
+
+  describe('exportFullReport', () => {
+    const mockState: MissionControlState = {
+      title: 'Report Mission',
+      description: 'Desc',
+      projects: [],
+      assignments: [],
+      phases: [],
+      deployMode: 'phased',
+      phase: 'blueprint',
+    }
+
+    beforeEach(() => {
+      vi.spyOn(window, 'open').mockReturnValue({
+        document: {
+          write: vi.fn(),
+          close: vi.fn(),
+        },
+      } as any)
+
+      // Mock XMLSerializer which might not be in all environments
+      vi.stubGlobal('XMLSerializer', class {
+        serializeToString = vi.fn().mockReturnValue('<svg></svg>')
+      })
+    })
+
+    it('calls window.open and writes HTML', () => {
+      const svgRef = { current: document.createElement('div') } as any
+      
+      exportFullReport(mockState, mockState, new Set(), null, svgRef)
+      
+      expect(window.open).toHaveBeenCalledWith('', '_blank')
+      const openedWindow = (window.open as any).mock.results[0].value
+      expect(openedWindow.document.write).toHaveBeenCalledWith(expect.stringContaining('Report Mission'))
+      expect(openedWindow.document.write).toHaveBeenCalledWith(expect.stringContaining('<h1>Flight Plan: Report Mission</h1>'))
+    })
+  })
+})

--- a/web/src/components/mission-control/__tests__/buildApprovalIssueBody.test.ts
+++ b/web/src/components/mission-control/__tests__/buildApprovalIssueBody.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest'
+import { buildApprovalIssueBody } from '../buildApprovalIssueBody'
+import type { MissionControlState } from '../types'
+
+describe('buildApprovalIssueBody', () => {
+  const mockState: MissionControlState = {
+    title: 'Test Plan',
+    description: 'Test Mission Description',
+    projects: [
+      {
+        name: 'proj-1',
+        displayName: 'Project 1',
+        category: 'Monitoring',
+        priority: 'P1',
+        reason: 'Essential',
+        dependencies: [],
+      },
+    ],
+    assignments: [
+      {
+        clusterName: 'cluster-alpha',
+        provider: 'kind',
+        projectNames: ['proj-1'],
+        clusterContext: 'cluster-alpha',
+        warnings: [],
+        readiness: { cpuHeadroomPercent: 0, memHeadroomPercent: 0, storageHeadroomPercent: 0, overallScore: 0 },
+      },
+    ],
+    phases: [
+      {
+        phase: 1,
+        name: 'Initial Phase',
+        projectNames: ['proj-1'],
+        estimatedSeconds: 120,
+      },
+    ],
+    deployMode: 'phased',
+    phase: 'blueprint',
+  }
+
+  it('builds a correct markdown body with all sections', () => {
+    const installedProjects = new Set(['proj-existing'])
+    const notes = 'Urgent deployment'
+    const reviewUrl = 'https://console.example.com/plan/123'
+
+    const body = buildApprovalIssueBody(mockState, installedProjects, notes, reviewUrl)
+
+    expect(body).toContain('## Mission Control — Deployment Approval Request')
+    expect(body).toContain('Test Mission Description')
+    expect(body).toContain('### Notes from Requester')
+    expect(body).toContain('Urgent deployment')
+    expect(body).toContain('[View this plan interactively in KubeStellar Console](https://console.example.com/plan/123)')
+    
+    // Project table
+    expect(body).toContain('| Project | Category | Priority | Status | Reason |')
+    expect(body).toContain('| Project 1 | Monitoring | P1 | Needs Deploy | Essential |')
+
+    // Cluster table
+    expect(body).toContain('| Cluster | Projects | Assignments |')
+    expect(body).toContain('| cluster-alpha | 1 | proj-1 |')
+
+    // Phase table
+    expect(body).toContain('| Phase | Estimate | Projects |')
+    expect(body).toContain('| 1. Initial Phase | 2 min | proj-1 |')
+    
+    expect(body).toContain('### Approval Checklist')
+  })
+
+  it('handles empty phases by generating defaults', () => {
+    const stateWithNoPhases = { ...mockState, phases: [] }
+    const body = buildApprovalIssueBody(stateWithNoPhases, new Set())
+    
+    // Should contain Phase 1 (default)
+    expect(body).toContain('| 1. ')
+  })
+
+  it('marks already installed projects with a checkmark', () => {
+    const installedProjects = new Set(['proj-1'])
+    const body = buildApprovalIssueBody(mockState, installedProjects)
+    
+    expect(body).toContain('proj-1 ✅')
+    expect(body).toContain('Installed')
+  })
+
+  it('handles missing description and notes', () => {
+    const minimalisticState = { ...mockState, description: '' }
+    const body = buildApprovalIssueBody(minimalisticState, new Set())
+    
+    expect(body).toContain('_No description provided_')
+    expect(body).not.toContain('### Notes from Requester')
+  })
+})

--- a/web/src/components/mission-control/__tests__/missionPlanCodec.test.ts
+++ b/web/src/components/mission-control/__tests__/missionPlanCodec.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { encodePlan, decodePlan, planToState } from '../missionPlanCodec'
+import type { MissionControlState } from '../types'
+
+describe('missionPlanCodec', () => {
+  const mockState: MissionControlState = {
+    title: 'Test Plan',
+    description: 'Test Description',
+    projects: [
+      {
+        name: 'proj-1',
+        displayName: 'Project 1',
+        category: 'cat-1',
+        priority: 'P1',
+        reason: 'reason-1',
+        dependencies: [],
+      },
+    ],
+    assignments: [
+      {
+        clusterName: 'cluster-1',
+        provider: 'kind',
+        projectNames: ['proj-1'],
+        clusterContext: 'cluster-1',
+        warnings: [],
+        readiness: { cpuHeadroomPercent: 0, memHeadroomPercent: 0, storageHeadroomPercent: 0, overallScore: 0 },
+      },
+    ],
+    phases: [
+      {
+        phase: 1,
+        name: 'Phase 1',
+        projectNames: ['proj-1'],
+        estimatedSeconds: 60,
+      },
+    ],
+    deployMode: 'phased',
+    phase: 'blueprint',
+  }
+
+  it('encodes and decodes a plan correctly', () => {
+    const encoded = encodePlan(mockState, 'Test Notes')
+    expect(typeof encoded).toBe('string')
+
+    const decoded = decodePlan(encoded)
+    expect(decoded).not.toBeNull()
+    expect(decoded?.title).toBe(mockState.title)
+    expect(decoded?.description).toBe(mockState.description)
+    expect(decoded?.notes).toBe('Test Notes')
+    expect(decoded?.projects).toHaveLength(1)
+    expect(decoded?.projects[0].name).toBe('proj-1')
+    expect(decoded?.assignments).toHaveLength(1)
+    expect(decoded?.assignments[0].clusterName).toBe('cluster-1')
+  })
+
+  it('handles empty notes in encodePlan', () => {
+    const encoded = encodePlan(mockState)
+    const decoded = decodePlan(encoded)
+    expect(decoded?.notes).toBeUndefined()
+  })
+
+  it('returns null for invalid encoded strings', () => {
+    expect(decodePlan('invalid-base64')).toBeNull()
+    expect(decodePlan(btoa('{}'))).toBeNull() // Missing version and title
+  })
+
+  it('converts a plan back to a partial state', () => {
+    const encoded = encodePlan(mockState)
+    const decoded = decodePlan(encoded)!
+    const state = planToState(decoded)
+
+    expect(state.title).toBe(mockState.title)
+    expect(state.description).toBe(mockState.description)
+    expect(state.projects).toHaveLength(1)
+    expect(state.projects![0].name).toBe('proj-1')
+    expect(state.assignments).toHaveLength(1)
+    expect(state.assignments![0].clusterName).toBe('cluster-1')
+    expect(state.assignments![0].clusterContext).toBe('cluster-1')
+    expect(state.phase).toBe('blueprint')
+  })
+})


### PR DESCRIPTION
### 📝 Summary of Changes

This PR introduces a comprehensive suite of unit tests for the **Mission Control** core logic and utilities. It ensures that the "pure logic" foundation of the feature—including plan serialization, markdown generation, and SVG layout math—is robust and regression-proof.

---

### Changes Made

- [x] Added tests for `missionPlanCodec.ts`: Validates Base64/JSON encoding/decoding and state restoration.
- [x] Added tests for `buildApprovalIssueBody.ts`: Verifies the generation of formatted markdown for GitHub deployment approvals.
- [x] Added tests for `BlueprintLayout.ts`: Ensures deterministic SVG layout calculations for cluster zones, project nodes, and dependency edges.
- [x] Added tests for `BlueprintReport.ts`: Covers cluster name shortening utilities and HTML/PDF report generation logic.

---

### Checklist

- [x] I used a coding agent to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] I have written unit tests for the changes
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

```text
 ✓ src/components/mission-control/__tests__/missionPlanCodec.test.ts (4 tests)
 ✓ src/components/mission-control/__tests__/buildApprovalIssueBody.test.ts (4 tests)
 ✓ src/components/mission-control/__tests__/BlueprintReport.test.ts (5 tests)
 ✓ src/components/mission-control/__tests__/BlueprintLayout.test.ts (4 tests)
