### PR TITLE
🌱 Add React.memo to 5 chart card components

### DIFF
--- a/web/src/components/cards/EventsTimeline.tsx
+++ b/web/src/components/cards/EventsTimeline.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { memo, useState, useEffect, useRef, useMemo } from 'react'
 import { Activity, AlertTriangle, CheckCircle, Clock, Server } from 'lucide-react'
 import { LazyEChart } from '../charts/LazyEChart'
 import { useClusters } from '../../hooks/useMCP'
@@ -374,10 +374,10 @@ function EventsTimelineInternal() {
   )
 }
 
-export function EventsTimeline() {
+export const EventsTimeline = memo(function EventsTimeline() {
   return (
     <DynamicCardErrorBoundary cardId="EventsTimeline">
       <EventsTimelineInternal />
     </DynamicCardErrorBoundary>
   )
-}
+})

--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from 'react'
+import { memo, useState, useMemo, useEffect, useRef } from 'react'
 import { TrendingUp, Cpu, Server, Clock } from 'lucide-react'
 import { CardClusterFilter } from '../../lib/cards/CardComponents'
 import { LazyEChart } from '../charts/LazyEChart'
@@ -73,7 +73,7 @@ const TIME_RANGE_OPTIONS: { value: TimeRange; label: string; points: number; int
   { value: '24h', label: '24 hours', points: 24, intervalMs: MS_PER_HOUR },
 ]
 
-export function GPUUsageTrend() {
+const GPUUsageTrend = memo(function GPUUsageTrend() {
   const { t } = useTranslation()
   const {
     nodes: gpuNodes,
@@ -533,4 +533,7 @@ export function GPUUsageTrend() {
       )}
     </div>
   )
-}
+})
+
+
+export { GPUUsageTrend }

--- a/web/src/components/cards/GPUUtilization.tsx
+++ b/web/src/components/cards/GPUUtilization.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect, useRef } from 'react'
+import { memo, useMemo, useState, useEffect, useRef } from 'react'
 import { TrendingUp, Clock, Server } from 'lucide-react'
 import { CardClusterFilter } from '../../lib/cards/CardComponents'
 import { useGPUTaintFilter, GPUTaintFilterControl } from './GPUTaintFilter'
@@ -48,7 +48,7 @@ const TIME_RANGE_OPTIONS: { value: TimeRange; label: string }[] = [
   { value: '24h', label: '24 hours' },
 ]
 
-export function GPUUtilization() {
+const GPUUtilization = memo(function GPUUtilization() {
   const { t } = useTranslation()
   const {
     nodes: gpuNodes,
@@ -406,4 +406,7 @@ export function GPUUtilization() {
       })()}
     </div>
   )
-}
+})
+
+
+export { GPUUtilization }

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -8,7 +8,7 @@
  * Falls back to demo data when in demo mode.
  */
 
-import { useState, useMemo, useEffect, useCallback, useRef } from 'react'
+import { memo, useState, useMemo, useEffect, useCallback, useRef } from 'react'
 import { LazyEChart } from '../charts/LazyEChart'
 import type ReactEChartsType from 'echarts-for-react'
 import { Calendar, RefreshCw, GitPullRequest } from 'lucide-react'
@@ -311,7 +311,7 @@ async function fetchIssueStats(
 
 // ── Component ───────────────────────────────────────────────────────────────
 
-export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
+const IssueActivityChart = memo(function IssueActivityChart(props: { config?: IssueActivityConfig }) {
   const { t } = useTranslation('cards')
   const { isDemoMode } = useDemoMode()
   const { showToast } = useToast()
@@ -688,6 +688,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
       </div>
     </div>
   )
-}
+})
 
 export default IssueActivityChart
+export { IssueActivityChart }

--- a/web/src/components/cards/PodHealthTrend.tsx
+++ b/web/src/components/cards/PodHealthTrend.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect, useRef } from 'react'
+import { memo, useMemo, useState, useEffect, useRef } from 'react'
 import { CheckCircle, AlertTriangle, Clock, Server } from 'lucide-react'
 import { LazyEChart } from '../charts/LazyEChart'
 import { useClusters } from '../../hooks/useMCP'
@@ -50,7 +50,7 @@ const TIME_RANGE_OPTIONS: { value: TimeRange; label: string; points: number }[] 
   { value: '24h', label: '24 hours', points: TIME_RANGE_MAX_POINTS['24h'] },
 ]
 
-export function PodHealthTrend() {
+const PodHealthTrend = memo(function PodHealthTrend() {
   const { t } = useTranslation(['common', 'cards'])
   const { deduplicatedClusters: clusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed: clustersFailed, consecutiveFailures: clustersFailures } = useClusters()
   const { issues, isLoading: issuesLoading, isRefreshing: issuesRefreshing, isDemoFallback, isFailed: issuesFailed, consecutiveFailures: issuesFailures } = useCachedPodIssues()
@@ -457,4 +457,7 @@ export function PodHealthTrend() {
       </div>
     </div>
   )
-}
+})
+
+
+export { PodHealthTrend }


### PR DESCRIPTION
Fixes #8695

Wrap 5 chart card components in `React.memo()` to prevent unnecessary re-renders when parent state changes without affecting these components' props.

### Files changed:
- **GPUUsageTrend.tsx** — wrapped in `memo()`, added named export
- **PodHealthTrend.tsx** — wrapped in `memo()`, added named export
- **EventsTimeline.tsx** — wrapped outer component in `memo()`
- **IssueActivityChart.tsx** — wrapped in `memo()`, added named export alongside default
- **GPUUtilization.tsx** — wrapped in `memo()`, added named export

### Pattern applied:
```tsx
// Before
export function Foo() { ... }

// After
const Foo = memo(function Foo() { ... })
export { Foo }
```

No logic changes — only memo wrapping. Build and lint pass.