### PR TITLE
🐛 Fix marketplace grid responsiveness when sidebar is open

### DIFF
--- a/web/src/components/marketplace/Marketplace.tsx
+++ b/web/src/components/marketplace/Marketplace.tsx
@@ -902,7 +902,7 @@ export function Marketplace() {
                   ))}
                 </div>
               ) : (
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))' }}>
                   {categoryItems.map(item => (
                     <MarketplaceCard
                       key={item.id}
@@ -930,7 +930,7 @@ export function Marketplace() {
           ))}
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))' }}>
           {sortedItems.map(item => (
             <MarketplaceCard
               key={item.id}


### PR DESCRIPTION
Fixes #10729

Updates the Marketplace grid layout to use responsive auto-fit columns that properly adjust when the AI Missions sidebar is open, preventing cramped card layouts.

## Changes
- Replaced fixed breakpoint grid columns with CSS Grid `auto-fit` pattern
- Grid uses `repeat(auto-fit, minmax(280px, 1fr))` for responsive column count
- Cards maintain 280px minimum width and fill available space equally
- Grid automatically adjusts when sidebar opens/closes or resizes (480-800px width)

## Testing
The grid now properly adapts to:
- Sidebar closed (full width)
- Sidebar open at default width (480px)
- Sidebar resized to max width (800px)
- All standard viewport sizes with and without sidebar