### PR TITLE
✨ Add microphone and file attachment buttons to AI Missions chat input

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -21,8 +21,7 @@ import {
   StopCircle,
   ListChecks,
   Loader2,
-  ArrowDown,
-  Paperclip } from 'lucide-react'
+  ArrowDown } from 'lucide-react'
 import { useMissions, type Mission } from '../../../hooks/useMissions'
 import { useAuth } from '../../../lib/auth'
 import { useDemoMode } from '../../../hooks/useDemoMode'

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -21,7 +21,8 @@ import {
   StopCircle,
   ListChecks,
   Loader2,
-  ArrowDown } from 'lucide-react'
+  ArrowDown,
+  Paperclip } from 'lucide-react'
 import { useMissions, type Mission } from '../../../hooks/useMissions'
 import { useAuth } from '../../../lib/auth'
 import { useDemoMode } from '../../../hooks/useDemoMode'
@@ -40,6 +41,7 @@ import { OrbitSetupOffer } from '../../missions/OrbitSetupOffer'
 import { OrbitMonitorOffer } from '../../missions/OrbitMonitorOffer'
 import type { OrbitResourceFilter } from '../../../lib/missions/types'
 import { MicrophoneButton } from '../../ui/MicrophoneButton'
+import { FileAttachmentButton } from '../../ui/FileAttachmentButton'
 /** Pixels from the bottom edge within which the chat is considered "at bottom" */
 const SCROLL_BOTTOM_THRESHOLD_PX = 50
 /** Duration in ms for the scroll-to-bottom button fade animation */
@@ -998,6 +1000,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 placeholder={t('missionChat.askFollowUp', { defaultValue: 'Ask a follow-up question...' })}
                 className="flex-1 min-w-0 px-3 py-2 text-sm rounded-lg border border-border bg-secondary/50 focus:bg-secondary focus:outline-hidden focus:ring-1 focus:ring-primary"
               />
+              <FileAttachmentButton compact />
               <MicrophoneButton onTranscript={handleMicrophoneTranscript} compact />
               <button
                 onClick={handleSend}
@@ -1062,6 +1065,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 placeholder={t('missionChat.retryWithMessage')}
                 className="flex-1 min-w-0 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-primary"
               />
+              <FileAttachmentButton compact />
               <MicrophoneButton onTranscript={handleMicrophoneTranscript} compact />
               <button
                 onClick={handleSend}
@@ -1091,6 +1095,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 placeholder={t('missionChat.typeMessage')}
                 className="flex-1 min-w-0 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-primary"
               />
+              <FileAttachmentButton compact />
               <MicrophoneButton onTranscript={handleMicrophoneTranscript} compact />
               <button
                 onClick={handleSend}

--- a/web/src/components/ui/FileAttachmentButton.tsx
+++ b/web/src/components/ui/FileAttachmentButton.tsx
@@ -1,0 +1,102 @@
+import { Paperclip, X, AlertCircle } from 'lucide-react'
+import { useRef, useState } from 'react'
+import { cn } from '../../lib/cn'
+import { useTranslation } from 'react-i18next'
+import { useToast } from './Toast'
+
+interface FileAttachmentButtonProps {
+  /** Called with selected file when user picks one */
+  onFileSelected?: (file: File) => void
+  /** Disable the button (e.g. while agent is running) */
+  disabled?: boolean
+  /** Compact mode for inline placement next to chat inputs */
+  compact?: boolean
+}
+
+export function FileAttachmentButton({ onFileSelected, disabled = false, compact = false }: FileAttachmentButtonProps) {
+  const { t } = useTranslation('common')
+  const { showToast } = useToast()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+
+  const handleButtonClick = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      setSelectedFile(file)
+      // Placeholder: log file info and show toast
+      console.log('[FileAttachment] Selected file:', {
+        name: file.name,
+        type: file.type,
+        size: file.size,
+      })
+      showToast(
+        t('fileAttachment.comingSoon', { 
+          defaultValue: `File attachment coming soon! Selected: ${file.name}` 
+        }),
+        'info'
+      )
+      if (onFileSelected) {
+        onFileSelected(file)
+      }
+      // Reset input so the same file can be selected again
+      e.target.value = ''
+    }
+  }
+
+  const handleClearFile = () => {
+    setSelectedFile(null)
+  }
+
+  const buttonSize = compact ? 'p-2' : 'p-3'
+  const iconSize = compact ? 'w-4 h-4' : 'w-5 h-5'
+
+  return (
+    <div className="relative flex items-center">
+      {/* Selected file indicator */}
+      {selectedFile && (
+        <div className="absolute bottom-full mb-2 right-0 text-xs bg-blue-500/10 text-blue-400 px-2 py-1 rounded border border-blue-500/20 flex items-center gap-1 max-w-xs z-50">
+          <Paperclip className="w-3 h-3 shrink-0" />
+          <span className="truncate max-w-[120px]">{selectedFile.name}</span>
+          <button
+            onClick={handleClearFile}
+            className="ml-1 hover:text-blue-300"
+            title={t('fileAttachment.clearFile', { defaultValue: 'Clear file' })}
+          >
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+      )}
+
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        className="hidden"
+        onChange={handleFileChange}
+        accept="*/*"
+      />
+
+      {/* Attachment button */}
+      <button
+        onClick={handleButtonClick}
+        disabled={disabled}
+        className={cn(
+          buttonSize,
+          'rounded-lg transition-all duration-200 relative',
+          selectedFile
+            ? 'bg-blue-500/20 text-blue-400 hover:bg-blue-500/30 ring-1 ring-blue-500/30'
+            : 'bg-secondary text-muted-foreground hover:bg-secondary/80 hover:text-foreground',
+          disabled && 'opacity-50 cursor-not-allowed'
+        )}
+        title={t('fileAttachment.attachFile', { defaultValue: 'Attach file' })}
+        data-testid="file-attachment-button"
+      >
+        <Paperclip className={iconSize} />
+      </button>
+    </div>
+  )
+}

--- a/web/src/components/ui/FileAttachmentButton.tsx
+++ b/web/src/components/ui/FileAttachmentButton.tsx
@@ -1,4 +1,4 @@
-import { Paperclip, X, AlertCircle } from 'lucide-react'
+import { Paperclip, X } from 'lucide-react'
 import { useRef, useState } from 'react'
 import { cn } from '../../lib/cn'
 import { useTranslation } from 'react-i18next'


### PR DESCRIPTION
Fixes #10727

Adds microphone (voice input) and file attachment icon buttons to the AI Missions chat input area. Both buttons are visually present with placeholder functionality that can be extended with full speech-to-text and file upload support.

**Changes:**
- Created `FileAttachmentButton` component with file picker functionality
- Added file attachment button (paperclip icon) to all three chat input areas
- MicrophoneButton was already present (not added, was already in place)
- File attachment shows placeholder toast message indicating coming soon feature
- Uses Lucide React icons (`Paperclip`, `Mic`)
- Follows existing i18n patterns with default values
- Clean, responsive layout matching existing button styling