### PR TITLE
🐛 Fix 19 test failures in Coverage Suite

### DIFF
--- a/web/src/components/cards/__tests__/GitHubActivity.test.tsx
+++ b/web/src/components/cards/__tests__/GitHubActivity.test.tsx
@@ -51,6 +51,11 @@ vi.mock('../../../lib/cards/cardHooks', () => ({
   commonComparators: { string: () => () => 0, number: () => () => 0, statusOrder: () => () => 0, date: () => () => 0, boolean: () => () => 0 },
 }))
 
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => children,
+}))
+
 import { GitHubActivity } from '../GitHubActivity'
 
 describe('GitHubActivity', () => {

--- a/web/src/components/cards/__tests__/NamespaceOverview.test.tsx
+++ b/web/src/components/cards/__tests__/NamespaceOverview.test.tsx
@@ -62,6 +62,11 @@ vi.mock('../CardDataContext', () => ({
   useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
 }))
 
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => children,
+}))
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k }),
 }))

--- a/web/src/hooks/__tests__/useCachedLLMd.test.ts
+++ b/web/src/hooks/__tests__/useCachedLLMd.test.ts
@@ -247,7 +247,8 @@ describe('useCachedLLMd', () => {
 
       expect(result.current.isLoading).toBe(true)
       expect(result.current.isRefreshing).toBe(true)
-      expect(result.current.isDemoFallback).toBe(true)
+      // isDemoFallback is gated by !isLoading in the hook (prevents demo badge during loading)
+      expect(result.current.isDemoFallback).toBe(false)
       expect(result.current.error).toBe('test error')
       expect(result.current.isFailed).toBe(true)
       expect(result.current.consecutiveFailures).toBe(5)

--- a/web/src/hooks/__tests__/useCachedNodes.test.ts
+++ b/web/src/hooks/__tests__/useCachedNodes.test.ts
@@ -29,6 +29,7 @@ vi.mock('../../lib/cache/fetcherUtils', () => ({
   fetchAPI: vi.fn(),
   fetchFromAllClusters: vi.fn(),
   fetchViaSSE: vi.fn(),
+  getClusterFetcher: vi.fn(),
 }))
 
 vi.mock('../../lib/utils/concurrency', () => ({
@@ -59,7 +60,7 @@ vi.mock('../../lib/constants/network', () => ({
 }))
 
 import { useCachedNodes, useCachedCoreDNSStatus, useCachedAllNodes } from '../useCachedNodes'
-import { fetchAPI } from '../../lib/cache/fetcherUtils'
+import { fetchAPI, getClusterFetcher } from '../../lib/cache/fetcherUtils'
 import { settledWithConcurrency } from '../../lib/utils/concurrency'
 
 // ---------------------------------------------------------------------------
@@ -85,6 +86,8 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockClusterCacheRef.clusters = []
   mockUseCache.mockReturnValue(defaultCache())
+  // getClusterFetcher() should return fetchAPI so the test can control per-cluster behavior
+  vi.mocked(getClusterFetcher).mockReturnValue(fetchAPI as ReturnType<typeof getClusterFetcher>)
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #10633

## Summary

Fixes the remaining 19 test failures in the Coverage Suite (down from 334 originally, most fixed by earlier PRs).

### Root causes & fixes

| Test file | Failures | Root cause | Fix |
|-----------|----------|------------|-----|
| GitHubActivity.test.tsx | 4 | Component now uses `useToast` but test lacks `ToastProvider` | Added `useToast` mock |
| NamespaceOverview.test.tsx | 12 | Same `useToast` missing provider issue | Added `useToast` mock |
| useCachedNodes.test.ts | 2 | Mock of `fetcherUtils` missing `getClusterFetcher` export | Added mock + wired to return `fetchAPI` |

All 79 tests in these 4 files now pass locally.