### PR TITLE
🐛 fix: prevent SaveToken/DeleteToken from clobbering settings on GetAll…

### DIFF
--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -299,7 +299,10 @@ func (h *GitHubProxyHandler) SaveToken(c *fiber.Ctx) error {
 
 	all, err := sm.GetAll()
 	if err != nil {
-		all = &settings.AllSettings{}
+		slog.Error("[GitHubProxy] failed to read settings", "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to read current settings",
+		})
 	}
 	all.FeedbackGitHubToken = body.Token
 	all.FeedbackGitHubTokenSource = settings.GitHubTokenSourceSettings
@@ -333,7 +336,10 @@ func (h *GitHubProxyHandler) DeleteToken(c *fiber.Ctx) error {
 
 	all, err := sm.GetAll()
 	if err != nil {
-		return c.JSON(fiber.Map{"success": true}) // Nothing to delete
+		slog.Error("[GitHubProxy] failed to read settings", "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to read current settings",
+		})
 	}
 	all.FeedbackGitHubToken = ""
 	all.FeedbackGitHubTokenSource = ""


### PR DESCRIPTION
### 📝 Summary of Changes

- `SaveToken` in `pkg/api/handlers/github_proxy.go` was silently destroying all encrypted 
  secrets (AI keys, notifications) when `GetAll()` failed during a GitHub PAT save
- `DeleteToken` was returning success even when `GetAll()` failed

---

### Changes Made

- [x] `SaveToken`: return HTTP 500 on `GetAll()` failure instead of proceeding with destructive write
- [x] `DeleteToken`: return HTTP 500 on `GetAll()` failure instead of false success

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

N/A

---

### 👀 Reviewer Notes

one file changed- `pkg/api/handlers/github_proxy.go`. both handlers follow a 
read-modify-write pattern- fix ensures the write only happens when the read succeeds.
no new dependencies, no logic changes outside the error path.
