### PR TITLE
🐛 Suppress noisy GA4 error emits for expected auth states

### DIFF
--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -206,7 +206,7 @@ function OPAPoliciesInternal({ config: _config }: OPAPoliciesProps) {
       .then(data => {
         if (controller.signal.aborted) return
         if (data.clusters) {
-          setAgentClusters(data.clusters.map((c: { name: string }) => ({ name: c.name, healthy: true })))
+          setAgentClusters((data.clusters || []).map((c: { name: string }) => ({ name: c.name, healthy: true })))
         }
       })
       .catch(() => { /* agent not available or request aborted */ })

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -16,7 +16,7 @@ import {
   DEFAULT_REFRESH_INTERVAL_MS,
 } from '../../lib/constants'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants/storage'
-import { MCP_PROBE_TIMEOUT_MS, FOCUS_DELAY_MS, KUBECTL_MAX_TIMEOUT_MS } from '../../lib/constants/network'
+import { MCP_PROBE_TIMEOUT_MS, FOCUS_DELAY_MS, KUBECTL_MAX_TIMEOUT_MS, isLocalAgentSuppressed } from '../../lib/constants/network'
 import type { ClusterInfo, ClusterHealth } from './types'
 
 // Re-export canonical constant under the name used by MCP hooks
@@ -59,7 +59,7 @@ let agentTokenPromise: Promise<string> | null = null
  * (#10643, root cause of the 48-hour blank dashboard in #10398).
  */
 function getAgentToken(): Promise<string> {
-  if (isDemoMode() || isNetlifyDeployment) return Promise.resolve('')
+  if (isDemoMode() || isNetlifyDeployment || isLocalAgentSuppressed()) return Promise.resolve('')
 
   const cached = localStorage.getItem(AGENT_TOKEN_STORAGE_KEY)
   if (cached) return Promise.resolve(cached)

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -512,7 +512,7 @@ export function useSearchIndex(query: string) {
     }
 
     // Scan placed cards from localStorage (fast synchronous read)
-    const customDashboardList = dashboards
+    const customDashboardList = (dashboards || [])
       .filter(d => !d.is_default)
       .map(d => ({ id: d.id, name: d.name }))
     const placedCards = scanPlacedCards(customDashboardList)

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -372,7 +372,7 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
           // Don't retry on auth (401) or service unavailable (503) — expected in demo mode
           const is401 = err.message?.includes('401')
           const isNonRetryable = is401 || err.message?.includes('503')
-          if (is401) {
+          if (is401 && currentToken) {
             emitSseAuthFailure(fullUrl)
           }
           if (isNonRetryable) {

--- a/web/src/lib/utils/wsAuth.ts
+++ b/web/src/lib/utils/wsAuth.ts
@@ -5,6 +5,8 @@
  * so we pass the token as a query parameter instead.
  */
 import { emitWsAuthMissing } from '../analytics'
+import { isLocalAgentSuppressed } from '../constants/network'
+import { isDemoMode } from '../demoMode'
 
 /** localStorage key for the kc-agent shared secret */
 const AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'
@@ -23,7 +25,7 @@ let wsAuthMissingEmitted = false
 export function appendWsAuthToken(url: string): string {
   const token = localStorage.getItem(AGENT_TOKEN_STORAGE_KEY)
   if (!token) {
-    if (!wsAuthMissingEmitted) {
+    if (!wsAuthMissingEmitted && !isLocalAgentSuppressed() && !isDemoMode()) {
       wsAuthMissingEmitted = true
       emitWsAuthMissing(url)
     }


### PR DESCRIPTION
## Summary

GA4 error analysis (past 10 days) showed ~100+ spurious `ksc_error` events from expected auth states — unauthenticated users, suppressed agents, and demo mode. These fixes suppress the noise so the error stream surfaces only real issues.

- **agent_token_failure (55 events):** `getAgentToken()` now skips fetch when `isLocalAgentSuppressed()` — covers in-cluster deployments where BrandingProvider dynamically suppresses the agent
- **sse_auth_failure (42 events):** Only emit when a token was actually sent (`currentToken` truthy) — unauthenticated 401s are expected, not errors
- **ws_auth_missing (6 events):** Skip emit in demo mode or when agent is suppressed — the `/disabled` sentinel URL is intentional
- **OPAPolicies:** Guard `.map()` on `data.clusters` with `|| []` fallback
- **useSearchIndex:** Guard `.filter()` on `dashboards` with `|| []` fallback (matches existing guard on line 494)

## Test plan

- [ ] CI build passes
- [ ] CI lint passes
- [ ] Verify GA4 error counts drop over next 24hrs