### PR TITLE
♿ Fix 5 WCAG accessibility violations caught by Playwright

### DIFF
--- a/web/e2e/Sidebar.spec.ts
+++ b/web/e2e/Sidebar.spec.ts
@@ -311,7 +311,8 @@ test.describe('Sidebar Navigation', () => {
     })
 
     test('navigation links are keyboard navigable', async ({ page }) => {
-      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: 10000 })
+      const sidebar = page.getByTestId('sidebar')
+      await sidebar.waitFor({ state: 'visible', timeout: 15_000 })
 
       // Tab into sidebar navigation
       await page.keyboard.press('Tab')
@@ -324,9 +325,10 @@ test.describe('Sidebar Navigation', () => {
     })
 
     test('collapse button is keyboard accessible', async ({ page }) => {
-      await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: 10000 })
+      await page.getByTestId('sidebar').waitFor({ state: 'visible', timeout: 15_000 })
 
       const collapseToggle = page.getByTestId('sidebar-collapse-toggle')
+      await collapseToggle.waitFor({ state: 'visible', timeout: 15_000 })
 
       // Focus the button
       await collapseToggle.focus()

--- a/web/src/components/dashboard/DemoToLocalCTA.tsx
+++ b/web/src/components/dashboard/DemoToLocalCTA.tsx
@@ -103,9 +103,9 @@ export function DemoToLocalCTA() {
           <div className="flex items-center gap-2">
             <KeyRound className="w-4 h-4 text-purple-400" />
             <div>
-              <h3 className="text-sm font-semibold text-foreground">
+              <p className="text-sm font-semibold text-foreground">
                 Set up GitHub OAuth to sign in
-              </h3>
+              </p>
               <p className="text-xs text-muted-foreground mt-0.5">
                 You&apos;re viewing demo data &mdash; configure GitHub OAuth to authenticate and connect your clusters
               </p>
@@ -143,9 +143,9 @@ export function DemoToLocalCTA() {
         <div className="flex items-center gap-2">
           <Terminal className="w-4 h-4 text-blue-400" />
           <div>
-            <h3 className="text-sm font-semibold text-foreground">
+            <p className="text-sm font-semibold text-foreground">
               Install KubeStellar Console locally to connect your clusters
-            </h3>
+            </p>
             <p className="text-xs text-muted-foreground mt-0.5">
               You&apos;re viewing demo data &mdash; install locally to monitor your real clusters
             </p>

--- a/web/src/components/dashboard/DiscoverCardsPlaceholder.tsx
+++ b/web/src/components/dashboard/DiscoverCardsPlaceholder.tsx
@@ -73,6 +73,7 @@ export function DiscoverCardsPlaceholder({
             <button
               onClick={() => setCurrentIndex(prev => (prev - 1 + available.length) % available.length)}
               className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover:opacity-100"
+              aria-label="Previous card"
             >
               <ChevronLeft className="w-4 h-4" />
             </button>
@@ -89,6 +90,7 @@ export function DiscoverCardsPlaceholder({
             <button
               onClick={() => setCurrentIndex(prev => (prev + 1) % available.length)}
               className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover:opacity-100"
+              aria-label="Next card"
             >
               <ChevronRight className="w-4 h-4" />
             </button>

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -89,7 +89,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
           type="button"
           onClick={() => navigate(ROUTES.HOME)}
           className="hidden lg:flex flex-col leading-tight justify-center min-h-[44px] hover:opacity-80 transition-opacity text-left cursor-pointer"
-          aria-label={t('navbar.goHome')}
+          title={t('navbar.goHome')}
         >
           <span className="text-base md:text-lg font-semibold text-foreground">{branding.appName}</span>
           <RotatingTagline />


### PR DESCRIPTION
## Summary

Fixes 5 accessibility test failures in the Playwright E2E suite by fixing the actual UI components:

- **heading-order** (DemoToLocalCTA.tsx): `<h3>` tags skipped heading levels — changed to `<p>` since these are banner titles, not document headings
- **button-name** (DiscoverCardsPlaceholder.tsx): Carousel chevron buttons had no accessible name — added `aria-label="Previous card"` / `aria-label="Next card"`
- **label-content-name-mismatch** (Navbar.tsx): Text button had `aria-label="Go to home dashboard"` but visible text was the app name + tagline — replaced `aria-label` with `title` to avoid the mismatch
- **Sidebar keyboard tests** (Sidebar.spec.ts): Increased timeouts and added explicit `waitFor` for collapse toggle visibility in CI

## Test plan

- [ ] CI build/lint passes
- [ ] Playwright a11y.spec.ts: headings, buttons, label-content-name-mismatch tests pass
- [ ] Playwright Sidebar.spec.ts: keyboard navigation and collapse tests more stable