### PR TITLE
🐛 Fix nil slice JSON serialization in handlers

### DIFF
--- a/pkg/api/handlers/acmm_scan.go
+++ b/pkg/api/handlers/acmm_scan.go
@@ -386,7 +386,7 @@ func fetchACMMWeeklyActivity(ctx context.Context, repo, token string) []acmmWeek
 
 func lastNWeeks(n int) []string {
 	seen := make(map[string]bool)
-	var weeks []string
+	weeks := make([]string, 0)
 	now := time.Now().UTC()
 	for i := n - 1; i >= 0; i-- {
 		d := now.AddDate(0, 0, -i*7)

--- a/pkg/api/handlers/demo_data.go
+++ b/pkg/api/handlers/demo_data.go
@@ -109,7 +109,7 @@ func getDemoEvents() []k8s.Event {
 // Demo warning events (filtered from events)
 func getDemoWarningEvents() []k8s.Event {
 	events := getDemoEvents()
-	var warnings []k8s.Event
+	warnings := make([]k8s.Event, 0)
 	for _, e := range events {
 		if e.Type == "Warning" {
 			warnings = append(warnings, e)
@@ -477,7 +477,7 @@ func getDemoPodLogs() string {
 // getDemoAllClusterHealth returns health for all demo clusters
 func getDemoAllClusterHealth() []k8s.ClusterHealth {
 	clusters := getDemoClusters()
-	var health []k8s.ClusterHealth
+	health := make([]k8s.ClusterHealth, 0)
 	for _, c := range clusters {
 		h := getDemoClusterHealth(c.Name)
 		health = append(health, *h)


### PR DESCRIPTION
Replace nil slice declarations with make([]T, 0) to ensure empty responses serialize as [] instead of null in JSON.

Affected functions:
- **getDemoWarningEvents** (demo_data.go:112): warnings []k8s.Event
- **getDemoAllClusterHealth** (demo_data.go:480): health []k8s.ClusterHealth  
- **lastNWeeks** (acmm_scan.go:389): weeks []string

All three return data that reaches c.JSON() responses. Without this fix, empty results appear as null in the frontend API contract instead of empty arrays.

**Impact**: Prevents frontend parse errors and maintains API contract consistency.