### PR TITLE
🐛 Fix 47 test failures: add missing wsAuth/demoMode mocks

### DIFF
--- a/web/src/hooks/__tests__/useUpdateProgress.test.ts
+++ b/web/src/hooks/__tests__/useUpdateProgress.test.ts
@@ -71,6 +71,11 @@ vi.mock('../../lib/constants/network', async (importOriginal) => {
 
 vi.mock('../../lib/demoMode', () => ({
   isNetlifyDeployment: false,
+  isDemoMode: () => false,
+}))
+
+vi.mock('../../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: (url: string) => url,
 }))
 
 // Assign mock to global before importing the hook

--- a/web/src/lib/__tests__/kubectlProxy.quantity.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy.quantity.test.ts
@@ -23,9 +23,14 @@ let mockIsNetlify = false
 
 vi.mock('../demoMode', () => ({
   isDemoModeForced: false,
+  isDemoMode: () => false,
   get isNetlifyDeployment() {
     return mockIsNetlify
   },
+}))
+
+vi.mock('../utils/wsAuth', () => ({
+  appendWsAuthToken: (url: string) => url,
 }))
 
 vi.mock('../../hooks/useBackendHealth', () => ({

--- a/web/src/lib/__tests__/sseClient-expand.test.ts
+++ b/web/src/lib/__tests__/sseClient-expand.test.ts
@@ -746,6 +746,8 @@ describe('sseClient expanded', () => {
 
   describe('SSE auth failure GA4 emit', () => {
     it('emits emitSseAuthFailure on 401 response', async () => {
+      // emitSseAuthFailure only fires when a token is present (real auth failure)
+      localStorage.setItem('token', 'fake-token')
       vi.mocked(fetch).mockResolvedValue(new Response('Unauthorized', { status: 401 }))
 
       const result = await fetchSSE({
@@ -757,6 +759,7 @@ describe('sseClient expanded', () => {
       expect(mockEmitSseAuth).toHaveBeenCalledTimes(1)
       expect(mockEmitSseAuth).toHaveBeenCalledWith(expect.stringContaining('/api/sse-401-'))
       expect(result).toEqual([])
+      localStorage.removeItem('token')
     })
 
     it('does not emit emitSseAuthFailure on 503 response', async () => {


### PR DESCRIPTION
Fixes #10754

## Root Cause

Three separate mock gaps causing 47 test failures in the nightly coverage suite:

### useUpdateProgress.test.ts (32 failures)
The `demoMode` mock only exported `isNetlifyDeployment` but not `isDemoMode()`. When `appendWsAuthToken()` (from `wsAuth.ts`) called `isDemoMode()`, it was `undefined`, throwing a TypeError caught by `connect()`'s catch block. No WebSocket was ever created, so `wsInstances[0]` was undefined.

### kubectlProxy.quantity.test.ts (14 failures)
Missing `wsAuth` mock — all other kubectlProxy split test files have it, but this one was missed (created in #9287, wsAuth added later in #10196).

### sseClient-expand.test.ts (1 failure)
`emitSseAuthFailure` now requires a stored token to fire (#10746 change). Test needed `localStorage.setItem('token', ...)` before the 401 scenario.

## Changes
- Add `isDemoMode` and `wsAuth` mocks to useUpdateProgress test
- Add `wsAuth` mock to kubectlProxy.quantity test (matching sibling files)
- Set localStorage token in sseClient-expand 401 test