### PR TITLE
fix(e2e): add mockApiFallback, kc-demo-mode, and addInitScript to 14 test files

### DIFF
--- a/web/e2e/Login.spec.ts
+++ b/web/e2e/Login.spec.ts
@@ -116,6 +116,17 @@ test.describe('Login Page — frontend-only (mocked backend)', () => {
   })
 
   test('handles login errors gracefully', async ({ page }) => {
+    // Mock /health so the app doesn't hang waiting for backend
+    await page.route('**/health', (route) => {
+      const url = new URL(route.request().url())
+      if (url.pathname !== '/health') return route.fallback()
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'dev', oauth_configured: true }),
+      })
+    })
+
     // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
     await page.route('**/api/**', (route) =>
       route.fulfill({

--- a/web/e2e/Missions.spec.ts
+++ b/web/e2e/Missions.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test'
+import { mockApiFallback } from './helpers/setup'
 
 /**
  * Missions.spec.ts — E2E coverage for the AI Missions (Mission Control) feature.
@@ -27,6 +28,9 @@ const DIALOG_VISIBLE_TIMEOUT_MS = 10_000 // dialogs open async after route hydra
 const CONTROL_VISIBLE_TIMEOUT_MS = 5_000 // interactive controls render after dialog open
 
 async function setupMissionsTest(page: Page) {
+  // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+  await mockApiFallback(page)
+
   // Mock authentication
   await page.route('**/api/me', (route) =>
     route.fulfill({
@@ -106,10 +110,10 @@ async function setupMissionsTest(page: Page) {
     })
   )
 
-  // Seed auth token + onboarded flag so the app doesn't bounce to /login.
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed auth token + onboarded flag BEFORE any page script runs
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
+    localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
   })
 }

--- a/web/e2e/NamespaceOverview.spec.ts
+++ b/web/e2e/NamespaceOverview.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test'
+import { mockApiFallback } from './helpers/setup'
 
 /**
  * NamespaceOverview Card E2E Tests
@@ -18,6 +19,8 @@ const DEMO_CLUSTERS = ['prod-us-east', 'prod-eu-west', 'staging']
 const _DEMO_NAMESPACES = ['default', 'kube-system', 'monitoring']
 
 async function setupDemoMode(page: Page) {
+  await mockApiFallback(page)
+
   await page.route('**/api/me', route =>
     route.fulfill({
       status: 200,
@@ -37,12 +40,10 @@ async function setupDemoMode(page: Page) {
     })
   )
 
-  await page.goto('/login')
-  await page.evaluate(() => {
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
-    // Remove any stale persisted selections
     localStorage.removeItem('kc-ns-overview-cluster')
     localStorage.removeItem('kc-ns-overview-namespace')
     localStorage.setItem(
@@ -57,6 +58,8 @@ async function setupLiveMode(page: Page) {
     { name: 'live-cluster-1', healthy: true, reachable: true, nodeCount: 3, podCount: 20 },
     { name: 'live-cluster-2', healthy: true, reachable: true, nodeCount: 2, podCount: 10 },
   ]
+
+  await mockApiFallback(page)
 
   await page.route('**/api/me', route =>
     route.fulfill({
@@ -85,8 +88,7 @@ async function setupLiveMode(page: Page) {
     })
   )
 
-  await page.goto('/login')
-  await page.evaluate(() => {
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.removeItem('kc-demo-mode')
     localStorage.setItem('demo-user-onboarded', 'true')

--- a/web/e2e/UpdateSettings.spec.ts
+++ b/web/e2e/UpdateSettings.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test'
+import { mockApiFallback } from './helpers/setup'
 
 /**
  * E2E tests for the Settings > System Updates section.
@@ -37,6 +38,9 @@ async function setupUpdateTest(page: Page): Promise<WsRoutes> {
   page.on('console', () => {})
 
   const wsRoutes: WsRoutes = { routes: [] }
+
+  // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+  await mockApiFallback(page)
 
   // Mock auth
   await page.route('**/api/me', (route) =>
@@ -89,6 +93,7 @@ async function setupUpdateTest(page: Page): Promise<WsRoutes> {
   // Set auth token + skip onboarding/tour BEFORE navigation
   await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
+    localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
     localStorage.setItem('kubestellar-console-tour-completed', 'true')
   })

--- a/web/e2e/cluster-admin-cards.spec.ts
+++ b/web/e2e/cluster-admin-cards.spec.ts
@@ -158,6 +158,7 @@ async function setupClusterAdminTest(page: Page) {
   await page.addInitScript(
     ({ storageKey, cards }: { storageKey: string; cards: typeof CARDS_UNDER_TEST }) => {
       localStorage.setItem('token', 'test-token')
+      localStorage.setItem('kc-demo-mode', 'true')
       localStorage.setItem('demo-user-onboarded', 'true')
       localStorage.setItem(storageKey, JSON.stringify(cards))
     },
@@ -211,6 +212,7 @@ async function setupWithLoadingDelay(page: Page) {
   await page.addInitScript(
     ({ storageKey, cards }: { storageKey: string; cards: typeof CARDS_UNDER_TEST }) => {
       localStorage.setItem('token', 'test-token')
+      localStorage.setItem('kc-demo-mode', 'true')
       localStorage.setItem('demo-user-onboarded', 'true')
       localStorage.setItem(storageKey, JSON.stringify(cards))
     },
@@ -277,6 +279,7 @@ async function setupWithErrors(page: Page) {
   await page.addInitScript(
     ({ storageKey, cards }: { storageKey: string; cards: typeof CARDS_UNDER_TEST }) => {
       localStorage.setItem('token', 'test-token')
+      localStorage.setItem('kc-demo-mode', 'true')
       localStorage.setItem('demo-user-onboarded', 'true')
       localStorage.setItem(storageKey, JSON.stringify(cards))
     },

--- a/web/e2e/hourglass-audit.spec.ts
+++ b/web/e2e/hourglass-audit.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { mockApiFallback } from './helpers/setup'
 
 // Dashboards that should have refresh controls (hourglass, auto checkbox, refresh button)
 const DASHBOARDS_WITH_REFRESH = [
@@ -27,6 +28,9 @@ const DASHBOARDS_WITH_REFRESH = [
 
 test.describe('Hourglass & Refresh Controls Audit', () => {
   test.beforeEach(async ({ page }) => {
+    // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+    await mockApiFallback(page)
+
     // Mock authentication
     await page.route('**/api/me', (route) =>
       route.fulfill({
@@ -54,13 +58,12 @@ test.describe('Hourglass & Refresh Controls Audit', () => {
       route.fulfill({ status: 200, json: { dashboards: [] } })
     )
 
-    // Set auth token
-    await page.goto('/login')
-    await page.evaluate(() => {
+    // Seed localStorage BEFORE any page script runs
+    await page.addInitScript(() => {
       localStorage.setItem('token', 'test-token')
+      localStorage.setItem('kc-demo-mode', 'true')
       localStorage.setItem('demo-user-onboarded', 'true')
     })
-    await page.waitForLoadState('domcontentloaded')
   })
 
   for (const dashboard of DASHBOARDS_WITH_REFRESH) {

--- a/web/e2e/mission-control-dry-run.spec.ts
+++ b/web/e2e/mission-control-dry-run.spec.ts
@@ -125,7 +125,7 @@ async function seedAndOpenMC(page: Page, overrides: Record<string, unknown>) {
   await page.evaluate(
     ({ mc, mcKey }) => {
       localStorage.setItem('token', 'demo-token')
-      localStorage.setItem('kc_demo_mode', 'true')
+      localStorage.setItem('kc-demo-mode', 'true')
       localStorage.setItem('kc_onboarded', 'true')
       localStorage.setItem('kc_user_cache', JSON.stringify({
         id: 'demo-user', github_id: '12345', github_login: 'demo-user',
@@ -169,7 +169,7 @@ async function navigateTo(page: Page) {
   await page.waitForLoadState('domcontentloaded')
   await page.evaluate(() => {
     localStorage.setItem('token', 'demo-token')
-    localStorage.setItem('kc_demo_mode', 'true')
+    localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('kc_onboarded', 'true')
     localStorage.setItem('kc_user_cache', JSON.stringify({
       id: 'demo-user', github_id: '12345', github_login: 'demo-user',

--- a/web/e2e/mission-control-e2e.spec.ts
+++ b/web/e2e/mission-control-e2e.spec.ts
@@ -345,11 +345,11 @@ async function navigateToConsole(page: Page) {
   await setupGitHubMocks(page)
   await setupAIMocks(page)
 
-  // Set demo auth token to bypass OAuth login screen
-  await page.goto('/login')
-  await page.waitForLoadState('domcontentloaded')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'demo-token')
+    localStorage.setItem('kc-demo-mode', 'true')
+    localStorage.setItem('demo-user-onboarded', 'true')
   })
   await page.goto('/')
   await page.waitForLoadState('domcontentloaded', { timeout: DIALOG_RENDER_TIMEOUT_MS })

--- a/web/e2e/mission-control-stress.spec.ts
+++ b/web/e2e/mission-control-stress.spec.ts
@@ -393,7 +393,7 @@ async function navigateTo(page: Page) {
   await page.waitForLoadState('domcontentloaded')
   await page.evaluate(() => {
     localStorage.setItem('token', 'demo-token')
-    localStorage.setItem('kc_demo_mode', 'true')
+    localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('kc_onboarded', 'true')
     localStorage.setItem('kc_user_cache', JSON.stringify({
       id: 'demo-user', github_id: '12345', github_login: 'demo-user',
@@ -447,7 +447,7 @@ async function seedAndOpenMC(page: Page, overrides: Record<string, unknown>) {
   await page.evaluate(
     ({ mc, mcKey }) => {
       localStorage.setItem('token', 'demo-token')
-      localStorage.setItem('kc_demo_mode', 'true')
+      localStorage.setItem('kc-demo-mode', 'true')
       localStorage.setItem('kc_onboarded', 'true')
       localStorage.setItem('kc_user_cache', JSON.stringify({
         id: 'demo-user', github_id: '12345', github_login: 'demo-user',
@@ -482,7 +482,7 @@ async function ensureDashboard(page: Page) {
     if (!onLogin) return // Dashboard loaded
     await page.evaluate(() => {
     localStorage.setItem('token', 'demo-token')
-    localStorage.setItem('kc_demo_mode', 'true')
+    localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('kc_onboarded', 'true')
     localStorage.setItem('kc_user_cache', JSON.stringify({
       id: 'demo-user', github_id: '12345', github_login: 'demo-user',

--- a/web/e2e/mission-journey.spec.ts
+++ b/web/e2e/mission-journey.spec.ts
@@ -300,7 +300,7 @@ async function setupHTTPMocks(page: Page, overrides?: {
 async function seedAuth(page: Page) {
   await page.evaluate(() => {
     localStorage.setItem('token', 'demo-token')
-    localStorage.setItem('kc_demo_mode', 'true')
+    localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('kc_onboarded', 'true')
     localStorage.setItem('kc_tour_completed', 'true')
     localStorage.setItem('kc_user_cache', JSON.stringify({

--- a/web/e2e/mission-regression.spec.ts
+++ b/web/e2e/mission-regression.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test'
+import { mockApiFallback } from './helpers/setup'
 
 /**
  * Mission System Regression Tests
@@ -14,6 +15,9 @@ import { test, expect, Page } from '@playwright/test'
  */
 
 async function setupMissionTest(page: Page) {
+  // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+  await mockApiFallback(page)
+
   // Mock authentication
   await page.route('**/api/me', (route) =>
     route.fulfill({
@@ -94,10 +98,10 @@ async function setupMissionTest(page: Page) {
     }
   })
 
-  // Set auth token and navigate
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed auth token + onboarded flag BEFORE any page script runs
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
+    localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
   })
 }

--- a/web/e2e/nightly/dashboard-health.spec.ts
+++ b/web/e2e/nightly/dashboard-health.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page, type ConsoleMessage } from '@playwright/test'
+import { mockApiFallback } from '../helpers/setup'
 
 /**
  * Nightly Dashboard Health Check
@@ -148,8 +149,28 @@ function setupErrorCollector(page: Page): { errors: string[]; pageErrors: string
 }
 
 async function setupDemoMode(page: Page) {
-  await page.goto('/login')
-  await page.evaluate(() => {
+  await mockApiFallback(page)
+
+  await page.route('**/api/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1', github_id: '12345', github_login: 'testuser',
+        email: 'test@example.com', onboarded: true,
+      }),
+    })
+  )
+
+  await page.route('**/api/mcp/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ clusters: [], issues: [], events: [], nodes: [] }),
+    })
+  )
+
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')

--- a/web/e2e/nightly/mission-deeplink.spec.ts
+++ b/web/e2e/nightly/mission-deeplink.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { mockApiFallback } from '../helpers/setup'
 
 /**
  * Nightly Mission Deep Link Health Check
@@ -36,6 +37,25 @@ const INDEX_SAMPLE_SIZE = 3
 test.describe('Mission Deep Links', () => {
   for (const slug of MISSION_SLUGS) {
     test(`/missions/${slug} loads mission content`, async ({ page }) => {
+      await mockApiFallback(page)
+
+      await page.route('**/api/me', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: '1', github_id: '12345', github_login: 'testuser',
+            email: 'test@example.com', onboarded: true,
+          }),
+        })
+      )
+
+      await page.addInitScript(() => {
+        localStorage.setItem('token', 'demo-token')
+        localStorage.setItem('kc-demo-mode', 'true')
+        localStorage.setItem('demo-user-onboarded', 'true')
+      })
+
       await page.goto(`/missions/${slug}`, { waitUntil: 'networkidle' })
 
       // The "Mission not found" error text should NOT be visible
@@ -54,6 +74,25 @@ test.describe('Mission Deep Links', () => {
   }
 
   test('random missions from index resolve correctly', async ({ page }) => {
+    await mockApiFallback(page)
+
+    await page.route('**/api/me', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: '1', github_id: '12345', github_login: 'testuser',
+          email: 'test@example.com', onboarded: true,
+        }),
+      })
+    )
+
+    await page.addInitScript(() => {
+      localStorage.setItem('token', 'demo-token')
+      localStorage.setItem('kc-demo-mode', 'true')
+      localStorage.setItem('demo-user-onboarded', 'true')
+    })
+
     // Fetch the missions index to get real paths
     const response = await page.request.get('/api/missions/file?path=fixes/index.json')
 

--- a/web/e2e/nightly/navigation-error-regression.spec.ts
+++ b/web/e2e/nightly/navigation-error-regression.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page, type ConsoleMessage } from '@playwright/test'
+import { mockApiFallback } from '../helpers/setup'
 
 /**
  * Navigation Error Toast Regression Test
@@ -113,8 +114,35 @@ function isExpectedError(message: string): boolean {
 
 /** Set up demo mode via localStorage so the app loads without a real backend */
 async function setupDemoMode(page: Page): Promise<void> {
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
+  await mockApiFallback(page)
+
+  // Mock authentication
+  await page.route('**/api/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1',
+        github_id: '12345',
+        github_login: 'testuser',
+        email: 'test@example.com',
+        onboarded: true,
+      }),
+    })
+  )
+
+  // Mock MCP endpoints
+  await page.route('**/api/mcp/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ clusters: [], issues: [], events: [], nodes: [] }),
+    })
+  )
+
+  // Seed localStorage BEFORE any page script runs
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')


### PR DESCRIPTION
## Summary

Fixes three systemic issues causing ~90 Playwright E2E failures across all CI shards:

- **Missing `mockApiFallback`** — 8 test files had no catch-all API mock, causing unmocked requests to hang in webkit/firefox
- **Missing `kc-demo-mode` localStorage flag** — 10 test files didn't set this flag, so the app waited for real backend data instead of demo fallback
- **Wrong localStorage key** (`kc_demo_mode` vs `kc-demo-mode`) — 3 mission test files used underscores instead of hyphens; the app ignores the underscore variant
- **`page.evaluate()` → `addInitScript`** — 8 test files seeded localStorage after page scripts already ran, too late for webkit/Safari where auth redirects fire synchronously

### Files modified (14)

| File | Fixes applied |
|------|---------------|
| `cluster-admin-cards.spec.ts` | +`kc-demo-mode` (3 setup functions) |
| `UpdateSettings.spec.ts` | +`mockApiFallback`, +`kc-demo-mode` |
| `hourglass-audit.spec.ts` | +`mockApiFallback`, +`kc-demo-mode`, evaluate→addInitScript |
| `Missions.spec.ts` | +`mockApiFallback`, +`kc-demo-mode`, evaluate→addInitScript |
| `mission-regression.spec.ts` | +`mockApiFallback`, +`kc-demo-mode`, evaluate→addInitScript |
| `mission-control-dry-run.spec.ts` | fix `kc_demo_mode` → `kc-demo-mode` |
| `mission-control-stress.spec.ts` | fix `kc_demo_mode` → `kc-demo-mode` |
| `mission-journey.spec.ts` | fix `kc_demo_mode` → `kc-demo-mode` |
| `mission-control-e2e.spec.ts` | +`kc-demo-mode`, evaluate→addInitScript |
| `NamespaceOverview.spec.ts` | +`mockApiFallback`, evaluate→addInitScript |
| `Login.spec.ts` | +`/health` mock for error handling test |
| `nightly/dashboard-health.spec.ts` | +`mockApiFallback`, +`/api/me` + `/api/mcp` mocks, evaluate→addInitScript |
| `nightly/mission-deeplink.spec.ts` | +`mockApiFallback`, +auth mocks, +`addInitScript` |
| `nightly/navigation-error-regression.spec.ts` | +`mockApiFallback`, +`/api/me` + `/api/mcp` mocks, evaluate→addInitScript |

## Test plan

- [ ] CI Playwright shards pass (chromium shards 1-4)
- [ ] Failures related to these 14 files no longer reproduce

🤖 Generated with [Claude Code](https://claude.com/claude-code)