### PR TITLE
🐛 Fix Firefox/mobile nightly Playwright failures

### DIFF
--- a/web/e2e/Clusters.spec.ts
+++ b/web/e2e/Clusters.spec.ts
@@ -63,8 +63,9 @@ async function setupClustersTest(page: Page) {
   // Webkit is significantly slower to stabilize the DOM after
   // domcontentloaded — wait for the root element to be visible so
   // assertions in beforeEach don't time out (#10433).
-  const ROOT_VISIBLE_TIMEOUT_MS = 15_000
-  await page.locator('#root').waitFor({ state: 'visible', timeout: ROOT_VISIBLE_TIMEOUT_MS })
+  // Wait for clusters-page testid (not #root which is always in DOM before React renders)
+  const ROOT_VISIBLE_TIMEOUT_MS = 20_000
+  await page.getByTestId('clusters-page').waitFor({ state: 'visible', timeout: ROOT_VISIBLE_TIMEOUT_MS })
 }
 
 test.describe('Clusters Page', () => {

--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -202,7 +202,7 @@ test.describe('Dashboard Page', () => {
       await page.waitForLoadState('domcontentloaded')
 
       // Dashboard page should be visible even during loading
-      const PAGE_VISIBLE_TIMEOUT_MS = 15_000
+      const PAGE_VISIBLE_TIMEOUT_MS = 30_000
       await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: PAGE_VISIBLE_TIMEOUT_MS })
     })
 
@@ -242,7 +242,7 @@ test.describe('Dashboard Page', () => {
       await page.waitForLoadState('domcontentloaded')
 
       // Dashboard should still render (not crash)
-      const PAGE_VISIBLE_TIMEOUT_MS = 15_000
+      const PAGE_VISIBLE_TIMEOUT_MS = 30_000
       await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: PAGE_VISIBLE_TIMEOUT_MS })
     })
 
@@ -424,7 +424,7 @@ test.describe('Dashboard Data Accuracy (#6459)', () => {
     await page.waitForLoadState('domcontentloaded')
 
     // Wait for clusters page to fully render — Firefox may need extra time
-    const PAGE_RENDER_TIMEOUT_MS = 15_000
+    const PAGE_RENDER_TIMEOUT_MS = 30_000
     await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: PAGE_RENDER_TIMEOUT_MS }).catch(() => {})
 
     // The clusters page renders a row per cluster. We count any element

--- a/web/e2e/Login.spec.ts
+++ b/web/e2e/Login.spec.ts
@@ -188,8 +188,8 @@ test.describe('Login Page — frontend-only (mocked backend)', () => {
       await expect(loginPage).toBeVisible()
       await expect(page.getByTestId('github-login-button')).toBeVisible()
     } else {
-      // OAuth/authenticated mode — dashboard sidebar should be visible
-      await expect(page.getByTestId('sidebar-primary-nav')).toBeVisible()
+      // OAuth/authenticated mode — check dashboard-page (sidebar-primary-nav is hidden on mobile)
+      await expect(page.getByTestId('dashboard-page')).toBeVisible()
     }
   })
 })

--- a/web/e2e/Sidebar.spec.ts
+++ b/web/e2e/Sidebar.spec.ts
@@ -53,17 +53,17 @@ async function setupSidebarTest(page: Page) {
   // where the auth redirect fires synchronously on script evaluation.
   // page.addInitScript() injects the snippet ahead of any page code (#9096).
   await page.addInitScript(() => {
-    localStorage.setItem('token', 'test-token')
+    // demo-token sentinel: setDemoMode() runs synchronously, no /api/me fetch needed.
+    // Auth resolves instantly on all browsers. (#nightly-playwright)
+    localStorage.setItem('token', 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
   })
 
   await page.goto('/')
   await page.waitForLoadState('domcontentloaded')
-  // Webkit and Firefox can be significantly slower to mount the sidebar after
-  // domcontentloaded. Wait for it explicitly so all tests start with the
-  // sidebar visible, preventing 10 s wait-loops in every individual test.
-  await page.getByTestId('sidebar').waitFor({ state: 'visible', timeout: 15_000 })
+  // Wait up to 20s for sidebar — Firefox/webkit are slower on CI.
+  await page.getByTestId('sidebar').waitFor({ state: 'visible', timeout: 20_000 })
 }
 
 test.describe('Sidebar Navigation', () => {

--- a/web/e2e/Tour.spec.ts
+++ b/web/e2e/Tour.spec.ts
@@ -50,7 +50,8 @@ async function setupTourTest(page: Page, tourCompleted: boolean = true) {
   // fallback rather than waiting for API data (avoids loading skeleton timeout).
   const completed = tourCompleted
   await page.addInitScript((isCompleted: boolean) => {
-    localStorage.setItem('token', 'test-token')
+    // demo-token: setDemoMode() runs synchronously, auth resolves without /api/me. (#nightly-playwright)
+    localStorage.setItem('token', 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
     if (isCompleted) {

--- a/web/e2e/navbar-responsive.spec.ts
+++ b/web/e2e/navbar-responsive.spec.ts
@@ -34,7 +34,8 @@ async function setupPage(page: Page) {
   // where the auth redirect fires synchronously on script evaluation.
   // page.addInitScript() injects the snippet ahead of any page code (#9096).
   await page.addInitScript(() => {
-    localStorage.setItem('token', 'test-token')
+    // demo-token: auth resolves instantly without /api/me. (#nightly-playwright)
+    localStorage.setItem('token', 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
   })
@@ -49,7 +50,8 @@ async function setupPage(page: Page) {
 // Breakpoints from Navbar.tsx:
 //   sm  = 640px  (search bar visible in main bar)
 //   md  = 768px  (ClusterFilterPanel, AgentStatus, AgentSelector)
-//   lg  = 1024px (UpdateIndicator, TokenUsage, FeatureRequest; overflow menu hidden)
+//   lg  = 1024px (ClusterFilterPanel, AgentStatus visible)
+//   xl  = 1280px (UpdateIndicator, TokenUsage, FeatureRequest; overflow menu hidden)
 // Minimum enforced width is ~511px (observed in issue #2999)
 const VIEWPORTS = [
   { name: 'minimum (511px)', width: 511, height: 720 },
@@ -168,26 +170,26 @@ test.describe('Navbar responsive layout', () => {
     await expect(desktopGroup).toBeVisible()
   })
 
-  test('extended item group is visible at lg+ (1024px)', async ({ page, isMobile }) => {
+  test('extended item group is visible at xl+ (1280px)', async ({ page, isMobile }) => {
     test.skip(isMobile, 'Viewport breakpoint tests are unreliable on mobile device emulation (DPR > 1)')
-    // Use 1025px — safely above the 1024px lg: boundary.
-    await page.setViewportSize({ width: 1025, height: 720 })
+    // Use 1281px — safely above the 1280px xl: boundary.
+    await page.setViewportSize({ width: 1281, height: 720 })
     await setupPage(page)
 
     const nav = page.locator('nav[data-tour="navbar"]')
-    // UpdateIndicator/TokenUsage/FeatureRequest group uses hidden lg:flex
-    const lgGroup = nav.locator('.hidden.lg\\:flex').first()
-    await expect(lgGroup).toBeVisible()
+    // UpdateIndicator/TokenUsage/FeatureRequest group uses hidden xl:flex (Navbar.tsx:139)
+    const xlGroup = nav.locator('.hidden.xl\\:flex').first()
+    await expect(xlGroup).toBeVisible()
   })
 
-  test('overflow menu button is hidden at lg+ (1024px)', async ({ page, isMobile }) => {
+  test('overflow menu button is hidden at xl+ (1280px)', async ({ page, isMobile }) => {
     test.skip(isMobile, 'Viewport breakpoint tests are unreliable on mobile device emulation (DPR > 1)')
-    await page.setViewportSize({ width: 1025, height: 720 })
+    await page.setViewportSize({ width: 1281, height: 720 })
     await setupPage(page)
 
     const nav = page.locator('nav[data-tour="navbar"]')
-    // Overflow container uses relative lg:hidden
-    const overflowContainer = nav.locator('.relative.lg\\:hidden')
+    // Overflow container uses relative xl:hidden (Navbar.tsx:200)
+    const overflowContainer = nav.locator('.relative.xl\\:hidden')
     await expect(overflowContainer).toBeHidden()
   })
 })


### PR DESCRIPTION
Fixes #10764

## Root Cause

Firefox/webkit/mobile E2E tests were failing in nightly CI because:

1. **Auth race condition**: Tests using `token='test-token'` require `refreshUser()` to call `/api/me` over the network (even mocked). Firefox CI is slower to process async network mocks — elements weren't in DOM within timeout.

   **Fix**: Use `token='demo-token'` (= `DEMO_TOKEN_VALUE`) in Sidebar, Tour, and navbar-responsive `setupXxx` functions. With this sentinel, `setDemoMode()` runs **synchronously** with no network request — auth resolves instantly on all browsers.

2. **Navbar breakpoint mismatch**: `Navbar.tsx` uses `hidden xl:flex` (1280px, moved from lg in #10001), but tests used `.hidden.lg\\:flex` at 1025px viewport — always failing.

   **Fix**: Update test viewport 1025→1281, CSS selectors `lg`→`xl` in both breakpoint tests.

3. **Mobile sidebar hidden**: `sidebar-primary-nav` has `display:none` on mobile viewports (`SidebarShell.tsx`). Login test else-branch checked for it on mobile emulation.

   **Fix**: Check `dashboard-page` instead (always rendered regardless of viewport).

4. **Setup readiness guard**: `Clusters.spec.ts` waited for `#root` which is present as soon as HTML is parsed — before React renders anything. Tests timed out inside `beforeEach` waiting for actual content.

   **Fix**: Wait for `clusters-page` testid (20s) instead of `#root`.

5. **Dashboard timeouts too short**: `kc-demo-mode=false` tests need real auth + async render on Firefox CI. 15s was not enough.

   **Fix**: Increase to 30s for affected tests.

## Changes

| File | Fix |
|------|-----|
| `Sidebar.spec.ts` | `test-token` → `demo-token`, setup wait 15s→20s |
| `Tour.spec.ts` | `test-token` → `demo-token` |
| `navbar-responsive.spec.ts` | `test-token` → `demo-token`; 1025px→1281px viewport; `lg`→`xl` class selectors |
| `Login.spec.ts` | `sidebar-primary-nav` → `dashboard-page` in mobile else-branch |
| `Clusters.spec.ts` | Wait for `clusters-page` not `#root` in setup |
| `Dashboard.spec.ts` | Timeouts 15s→30s |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>