### PR TITLE
🐛 Improve error logging: use console.error for storage/API failures

### DIFF
--- a/web/src/components/cards/insights/useInsightActions.ts
+++ b/web/src/components/cards/insights/useInsightActions.ts
@@ -29,7 +29,7 @@ function loadSet(storage: Storage, key: string): Set<string> {
     }
     return new Set(parsed.filter((v): v is string => typeof v === 'string'))
   } catch (err) {
-    console.warn(`[useInsightActions] Failed to load ${key} from storage:`, err)
+    console.error(`[useInsightActions] Failed to load ${key} from storage:`, err)
     return new Set()
   }
 }
@@ -40,7 +40,7 @@ function saveSet(storage: Storage, key: string, set: Set<string>, onError?: Erro
   try {
     storage.setItem(key, JSON.stringify(Array.from(set)))
   } catch (err) {
-    console.warn(`[useInsightActions] Failed to save ${key} to storage:`, err)
+    console.error(`[useInsightActions] Failed to save ${key} to storage:`, err)
     onError?.(SAVE_ERROR_MESSAGE)
   }
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -276,7 +276,7 @@ export async function checkBackendAvailability(forceCheck = false): Promise<bool
           available: backendAvailable,
           timestamp: backendLastCheckTime,
         }))
-      } catch (e) { console.warn('[api] failed to cache backend status:', e) }
+      } catch (e) { console.error('[api] failed to cache backend status:', e) }
       return backendAvailable
     } catch {
       backendAvailable = false
@@ -356,7 +356,7 @@ function markBackendFailure(): void {
   // Persisting false causes fresh page loads to inherit stale "backend down" state.
   try {
     localStorage.removeItem(BACKEND_STATUS_KEY)
-  } catch (e) { console.warn('[api] failed to clear backend status cache:', e) }
+  } catch (e) { console.error('[api] failed to clear backend status cache:', e) }
 }
 
 function markBackendSuccess(): void {
@@ -367,7 +367,7 @@ function markBackendSuccess(): void {
       available: true,
       timestamp: backendLastCheckTime,
     }))
-  } catch (e) { console.warn('[api] failed to cache backend success:', e) }
+  } catch (e) { console.error('[api] failed to cache backend success:', e) }
 }
 
 /**


### PR DESCRIPTION
Fixes #10768

Upgraded console.warn to console.error for better error visibility in DevTools error logs:

**Changes:**
- `web/src/lib/api.ts` (3 locations): backend status cache operations
- `web/src/components/cards/insights/useInsightActions.ts` (2 locations): storage load/save

This ensures errors are properly surfaced in browser error logs instead of warnings.