### PR TITLE
🔧 Add spec_filter input to Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,7 +6,13 @@ on:
     paths:
       - 'web/**'
       - '.github/workflows/playwright.yml'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      spec_filter:
+        description: 'Spec file to run (e.g. e2e/Sidebar.spec.ts). Leave empty for all tests.'
+        required: false
+        default: ''
+        type: string
 
 # Least-privilege: read-only by default; jobs declare write scopes individually
 permissions: read-all
@@ -94,7 +100,12 @@ jobs:
           npx wait-on http://localhost:4173 --timeout 60000
 
       - name: Run Playwright tests
-        run: npx playwright test --project=chromium --shard=${{ matrix.shard }}/4
+        run: |
+          if [ -n "${{ inputs.spec_filter }}" ]; then
+            npx playwright test --project=chromium "${{ inputs.spec_filter }}"
+          else
+            npx playwright test --project=chromium --shard=${{ matrix.shard }}/4
+          fi
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:4173
 


### PR DESCRIPTION
## Summary
- Adds `spec_filter` input to the Playwright E2E workflow's `workflow_dispatch` trigger
- When a spec file path is provided (e.g. `e2e/Sidebar.spec.ts`), only that file runs — no sharding
- When empty (default), runs the full suite with 4 shards as before

## Test plan
- [ ] Trigger workflow_dispatch with `spec_filter: e2e/Sidebar.spec.ts` — verify only sidebar tests run
- [ ] Trigger workflow_dispatch with empty `spec_filter` — verify full suite runs with shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)