### PR TITLE
🐛 Fix failing cni_status and vitess_status tests

### DIFF
--- a/web/src/components/cards/cni_status/cni_status.test.tsx
+++ b/web/src/components/cards/cni_status/cni_status.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import React from 'react'
 import { CniStatus } from './index'
+import { CNI_DEMO_DATA } from '../../../lib/demo/cni'
 
 const mockUseCachedCni = vi.fn()
 
@@ -23,12 +24,16 @@ vi.mock('../../ui/Skeleton', () => ({
 
 function setup(overrides?: Record<string, unknown>) {
   mockUseCachedCni.mockReturnValue({
-    plugin: null,
-    nodeStatus: [],
+    data: CNI_DEMO_DATA,
     isLoading: false,
     isRefreshing: false,
     isDemoData: false,
     isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: Date.now(),
+    showSkeleton: false,
+    showEmptyState: false,
+    error: false,
     refetch: vi.fn(),
     ...overrides,
   })
@@ -40,14 +45,42 @@ describe('CniStatus', () => {
   })
 
   it('renders loading skeleton when isLoading is true', () => {
-    setup({ isLoading: true })
+    setup({ showSkeleton: true })
     render(<CniStatus />)
 
     expect(screen.getByTestId('skeleton')).toBeTruthy()
   })
 
   it('renders with empty state when no CNI plugin found', () => {
-    setup({ plugin: null, nodeStatus: [] })
+    setup({
+      data: {
+        health: 'not-installed',
+        nodes: [],
+        stats: {
+          activePlugin: 'unknown',
+          pluginVersion: 'unknown',
+          podNetworkCidr: '',
+          serviceNetworkCidr: '',
+          nodeCount: 0,
+          nodesCniReady: 0,
+          networkPolicyCount: 0,
+          servicesWithNetworkPolicy: 0,
+          totalServices: 0,
+          podsWithIp: 0,
+          totalPods: 0,
+        },
+        summary: {
+          activePlugin: 'unknown',
+          pluginVersion: 'unknown',
+          podNetworkCidr: '',
+          nodesCniReady: 0,
+          nodeCount: 0,
+          networkPolicyCount: 0,
+          servicesWithNetworkPolicy: 0,
+        },
+        lastCheckTime: new Date().toISOString(),
+      },
+    })
     render(<CniStatus />)
 
     // Component should render without error

--- a/web/src/components/cards/vitess_status/vitess_status.test.tsx
+++ b/web/src/components/cards/vitess_status/vitess_status.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../../../hooks/useCachedVitess', () => ({
   useCachedVitess: (...args: unknown[]) => mockUseCachedVitess(...args),
 }))
 
-vi.mock('./CardDataContext', () => ({
+vi.mock('../CardDataContext', () => ({
   useCardLoadingState: (opts: Record<string, unknown>) => mockUseCardLoadingState(opts),
 }))
 
@@ -30,16 +30,30 @@ vi.mock('../../ui/EmptyState', () => ({
 
 function setup(overrides?: Record<string, unknown>) {
   mockUseCachedVitess.mockReturnValue({
-    keyspaces: [],
+    data: {
+      health: 'healthy',
+      summary: {
+        totalKeyspaces: 0,
+        totalShards: 0,
+        totalTablets: 0,
+        servingTablets: 0,
+        primaryTablets: 0,
+        maxReplicationLagSeconds: 0,
+      },
+      keyspaces: [],
+      tablets: [],
+      vitessVersion: 'v0.0.0',
+    },
     isLoading: false,
     isRefreshing: false,
-    isDemoData: false,
+    isDemoFallback: false,
     isFailed: false,
     consecutiveFailures: 0,
+    lastRefresh: Date.now(),
     refetch: vi.fn(),
     ...overrides,
   })
-  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
 }
 
 describe('VitessStatus', () => {
@@ -49,14 +63,30 @@ describe('VitessStatus', () => {
 
   it('renders skeleton when loading', () => {
     setup({ isLoading: true })
-    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false })
     render(<VitessStatus />)
 
     expect(screen.getByTestId('skeleton')).toBeTruthy()
   })
 
   it('renders empty state when no keyspaces', () => {
-    setup({ keyspaces: [] })
+    setup({
+      data: {
+        health: 'not-installed',
+        summary: {
+          totalKeyspaces: 0,
+          totalShards: 0,
+          totalTablets: 0,
+          servingTablets: 0,
+          primaryTablets: 0,
+          maxReplicationLagSeconds: 0,
+        },
+        keyspaces: [],
+        tablets: [],
+        vitessVersion: 'v0.0.0',
+      },
+    })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: true })
     render(<VitessStatus />)
 
     expect(screen.getByTestId('empty')).toBeTruthy()


### PR DESCRIPTION
Fixes #10785

Fix 4 test failures in cni_status and vitess_status test suites by aligning test expectations with actual component rendering behavior.

## Changes

### CniStatus Tests
- Fixed mock to match useCachedCni hook's actual return structure
- Added showSkeleton and showEmptyState flags returned by the hook
- Imported CNI_DEMO_DATA for proper data structure
- Updated empty state test to mock data.health = 'not-installed'

### VitessStatus Tests  
- Fixed empty state test to mock data.health = 'not-installed'
- Updated useCardLoadingState mock to return showEmptyState: true
- Ensured proper data structure with all required fields

## Root Cause

PR #10779 added these tests with expectations that didn't match the actual hook implementations. The hooks use useCardLoadingState internally to compute showSkeleton/showEmptyState flags, which weren't being properly mocked in the tests.
