### PR TITLE
🐛 Fix KubeKart up-arrow movement and add FlappyPod start instructions

### DIFF
--- a/web/src/components/cards/FlappyPod.tsx
+++ b/web/src/components/cards/FlappyPod.tsx
@@ -272,12 +272,14 @@ export function FlappyPod(_props: CardComponentProps) {
         {/* Start overlay - only covers game area */}
         {!isPlaying && !gameOver && (
           <div
-            className="absolute inset-0 bg-background/80 flex items-center justify-center rounded-lg cursor-pointer"
+            className="absolute inset-0 bg-background/90 flex items-center justify-center rounded-lg cursor-pointer backdrop-blur-sm"
             onClick={handleClick}
           >
-            <div className="text-center">
-              <div className="text-muted-foreground mb-4">Click or press Space to fly!</div>
-              <div className="text-sm text-muted-foreground">Avoid the node walls</div>
+            <div className="text-center px-4">
+              <div className="text-2xl font-bold text-foreground mb-4">Ready to Fly?</div>
+              <div className="text-lg text-blue-400 mb-2">Click or press Space to flap</div>
+              <div className="text-sm text-muted-foreground mb-4">Keep tapping to stay airborne!</div>
+              <div className="text-xs text-yellow-400">Avoid the green pipes</div>
             </div>
           </div>
         )}

--- a/web/src/components/cards/KubeKart.tsx
+++ b/web/src/components/cards/KubeKart.tsx
@@ -209,9 +209,16 @@ export function KubeKart() {
 
     if (keys.has('arrowleft') || keys.has('a')) {
       player.angle -= TURN_SPEED * (player.speed > 0 ? 1 : -1)
-    }
-    if (keys.has('arrowright') || keys.has('d')) {
+    } else if (keys.has('arrowright') || keys.has('d')) {
       player.angle += TURN_SPEED * (player.speed > 0 ? 1 : -1)
+    } else {
+      // Auto-straighten when no turn keys pressed
+      const angleDiff = FORWARD_ANGLE - player.angle
+      if (Math.abs(angleDiff) > 0.01) {
+        player.angle += angleDiff * 0.15
+      } else {
+        player.angle = FORWARD_ANGLE
+      }
     }
 
     // Apply movement (mostly forward)


### PR DESCRIPTION
Fixes #10770
Fixes #10774

## Changes

### KubeKart (#10770)
- **Fixed:** Up arrow now accelerates the car straight forward independently of Left/Right arrows
- **Root cause:** Missing auto-straightening logic caused the car to retain its turning angle, making Up arrow move diagonally
- **Solution:** Added gradual auto-straightening to forward angle when no turn keys are pressed

### FlappyPod (#10774)
- **Fixed:** Start screen now displays clear, prominent instructions before game begins
- **Improvements:**
  - Larger, hierarchical text with "Ready to Fly?" header
  - Clearer call-to-action: "Click or press Space to flap"
  - Stronger backdrop blur for better readability
  - Color-coded instructions (blue for primary action, yellow for warning)

## Testing
- ✅ KubeKart: Pressing Up arrow alone now moves car straight forward
- ✅ FlappyPod: Start screen displays prominently with clear instructions