### PR TITLE
✨ Improve AI Missions chat UX: clean up history navigation

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -1009,14 +1009,6 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 <Send className="w-4 h-4" />
               </button>
             </div>
-
-            <button
-              onClick={() => setActiveMission(null)}
-              className="flex items-center justify-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-            >
-              <ChevronLeft className="w-3 h-3" />
-              {t('missionChat.backToMissions')}
-            </button>
           </div>
         ) : mission.status === 'blocked' ? (
           <div className="flex flex-col gap-2">
@@ -1074,13 +1066,6 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 <Send className="w-4 h-4" />
               </button>
             </div>
-            <button
-              onClick={() => setActiveMission(null)}
-              className="flex items-center justify-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-            >
-              <ChevronLeft className="w-3 h-3" />
-              {t('missionChat.backToMissions')}
-            </button>
           </div>
         ) : (
           <div className="flex flex-col gap-2">
@@ -1104,13 +1089,6 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 <Send className="w-4 h-4" />
               </button>
             </div>
-            <button
-              onClick={() => setActiveMission(null)}
-              className="flex items-center justify-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-            >
-              <ChevronLeft className="w-3 h-3" />
-              {t('missionChat.backToMissions')}
-            </button>
           </div>
         )}
 


### PR DESCRIPTION
Fixes #10780

## Changes
- ✅ **Input already at bottom** - Chat input uses standard flex-col layout (header → messages → input)
- ✅ **Mic and file icons already exist** - MicrophoneButton and FileAttachmentButton already implemented with 'Coming soon' tooltips
- ✨ **Cleaned up history navigation** - Removed redundant 'Back to missions' buttons from bottom of input areas
  - Kept single navigation button at top of chat (in MissionSidebar.tsx)
  - Eliminates clutter in the input area
  - Follows standard chat UX pattern where navigation is in header, not footer

## Testing
- Tested in multiple mission states (running, completed, failed, blocked)
- Navigation button remains accessible at top of chat
- Input area is cleaner without redundant buttons

## Before/After
**Before**: 'Back to missions' button appeared at top AND bottom of chat
**After**: Single 'Back to missions' button at top only