### PR TITLE
🐛 Fix auth smoke test failure

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -379,15 +379,6 @@ func (s *Server) validateToken(r *http.Request) bool {
 		return true
 	}
 
-	// Exempt read-only GET/HEAD requests from localhost that carry no Origin
-	// header. This allows desktop widgets (Übersicht, etc.) to query the agent
-	// via curl without an auth token. The agent only binds to 127.0.0.1 so all
-	// requests are local; the Origin check ensures browser-based CSRF attacks
-	// (which always include an Origin header) are still blocked.
-	if (r.Method == "GET" || r.Method == "HEAD") && r.Header.Get("Origin") == "" {
-		return true
-	}
-
 	// Check Authorization header (preferred for all requests)
 	authHeader := r.Header.Get("Authorization")
 	if strings.HasPrefix(authHeader, "Bearer ") {

--- a/pkg/agent/server_test.go
+++ b/pkg/agent/server_test.go
@@ -634,11 +634,11 @@ func TestServer_ValidateToken(t *testing.T) {
 			expectResult: true,
 		},
 		{
-			name:         "Read-only GET without Origin exempted (widget/curl)",
+			name:         "GET without token rejected even without Origin",
 			agentToken:   "secret123",
 			authHeader:   "",
 			queryToken:   "",
-			expectResult: true, // localhost widget requests have no Origin header
+			expectResult: false, // all requests require token when configured
 		},
 		{
 			name:         "GET with Origin header still requires token",


### PR DESCRIPTION
Fixes #10792

Remove the read-only GET/HEAD localhost exemption from `validateToken()` in kc-agent. This exemption was intended for desktop widgets (Übersicht, curl) but allowed any unauthenticated GET request without an Origin header to bypass `KC_AGENT_TOKEN` authentication — returning 200 instead of the expected 401.

**Root cause:** `validateToken()` had a shortcut that returned `true` for GET/HEAD requests lacking an Origin header, regardless of whether a Bearer token was present. The auth smoke test sends `curl GET /deployments` without a token and expects 401.

**Fix:** Removed the exemption so all requests require a valid Bearer token when `KC_AGENT_TOKEN` is configured. Updated the corresponding unit test expectation.