### PR TITLE
🐛 Fix Playwright cross-browser failures: strict locators, health filters, demo mode

### DIFF
--- a/web/e2e/Clusters.spec.ts
+++ b/web/e2e/Clusters.spec.ts
@@ -229,13 +229,17 @@ test.describe('Clusters Page', () => {
       await healthyTab.click()
 
       // Only healthy-cluster must be visible
-      // Use .first() — cluster name can appear in both the list row and sidebar
-      // cluster status widget, triggering a strict-mode violation on webkit.
-      await expect(page.getByText('healthy-cluster').first()).toBeVisible({ timeout: 5000 })
+      // Scope assertions to clusters-page to exclude sidebar cluster status
+      // widget which shows all cluster names regardless of the active filter.
+      // Use .first() — cluster name can appear in both the list row and header. #10790
+      const clustersPage = page.getByTestId('clusters-page')
+      await expect(clustersPage.getByText('healthy-cluster').first()).toBeVisible({ timeout: 5000 })
 
       // Unhealthy clusters must NOT appear in the Healthy tab
-      await expect(page.getByText('unhealthy-with-nodes').first()).not.toBeVisible()
-      await expect(page.getByText('truly-unhealthy').first()).not.toBeVisible()
+      // Scoped to clusters-page so sidebar cluster status widget doesn't cause
+      // false positives. Use .first() for strict-mode safety.
+      await expect(clustersPage.getByText('unhealthy-with-nodes').first()).not.toBeVisible()
+      await expect(clustersPage.getByText('truly-unhealthy').first()).not.toBeVisible()
     })
 
     test('Unhealthy stat count matches clusters shown after clicking Unhealthy tab', async ({ page }) => {
@@ -275,9 +279,11 @@ test.describe('Clusters Page', () => {
       await unhealthyTab.click()
 
       // Only the truly unhealthy cluster should appear
-      // Use .first() — name may appear in both list row and sidebar cluster status widget.
-      await expect(page.getByText('unhealthy-no-nodes').first()).toBeVisible({ timeout: 5000 })
-      await expect(page.getByText('healthy-cluster').first()).not.toBeVisible()
+      // Scope assertions to clusters-page to exclude sidebar cluster status
+      // widget which shows all cluster names regardless of the active filter. #10790
+      const clustersPage = page.getByTestId('clusters-page')
+      await expect(clustersPage.getByText('unhealthy-no-nodes').first()).toBeVisible({ timeout: 5000 })
+      await expect(clustersPage.getByText('healthy-cluster').first()).not.toBeVisible()
     })
   })
 })

--- a/web/e2e/Login.spec.ts
+++ b/web/e2e/Login.spec.ts
@@ -175,6 +175,18 @@ test.describe('Login Page — frontend-only (mocked backend)', () => {
   })
 
   test('detects demo mode vs OAuth mode behavior', async ({ page }) => {
+    // Mock /health so the app doesn't redirect to /auth/github on
+    // webkit/firefox where the redirect fires before JS can intercept. #10790
+    await page.route('**/health', (route) => {
+      const url = new URL(route.request().url())
+      if (url.pathname !== '/health') return route.fallback()
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'dev', oauth_configured: false }),
+      })
+    })
+
     // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
     await page.route('**/api/**', (route) =>
       route.fulfill({

--- a/web/e2e/cluster-admin-cards.spec.ts
+++ b/web/e2e/cluster-admin-cards.spec.ts
@@ -364,7 +364,9 @@ test.describe('Cluster Admin Cards — EtcdStatus, DNSHealth, AdmissionWebhooks'
 
       // Wait for data to render — should show cluster names from mock data
       // The card groups etcd pods by cluster — expect to see "prod-east" or "staging"
-      await expect(card.getByText('prod-east').or(card.getByText('staging'))).toBeVisible({ timeout: 10000 })
+      // Use .first() to avoid strict-mode violations when multiple cluster names
+      // appear inside the card (e.g. grouped rows + summary). #10790
+      await expect(card.getByText('prod-east').or(card.getByText('staging')).first()).toBeVisible({ timeout: 10000 })
     })
 
     test('EtcdStatus shows health status indicators', async ({ page }) => {
@@ -391,7 +393,9 @@ test.describe('Cluster Admin Cards — EtcdStatus, DNSHealth, AdmissionWebhooks'
       await expect(card).toBeVisible({ timeout: 15000 })
 
       // Should show cluster names from coredns mock pods
-      await expect(card.getByText('prod-east').or(card.getByText('staging'))).toBeVisible({ timeout: 10000 })
+      // Use .first() to avoid strict-mode violations when multiple cluster names
+      // appear inside the card (e.g. grouped rows + summary). #10790
+      await expect(card.getByText('prod-east').or(card.getByText('staging')).first()).toBeVisible({ timeout: 10000 })
     })
 
     test('DNSHealth shows health status indicators for DNS pods', async ({ page }) => {


### PR DESCRIPTION
Fixes #10790

- Replace ambiguous `.or()` selectors with `.first()` to prevent strict mode violations in cluster-admin-cards tests
- Scope cluster health filter `not.toBeVisible()` assertions to `clusters-page` testid so sidebar cluster status widget doesn't cause false positives
- Mock `/health` with `oauth_configured: false` in Login spec's demo-mode detection test to prevent OAuth redirect on webkit/firefox