### PR TITLE
🐛 Fix cni_status loading skeleton test

### DIFF
--- a/web/src/components/cards/cni_status/cni_status.test.tsx
+++ b/web/src/components/cards/cni_status/cni_status.test.tsx
@@ -45,7 +45,37 @@ describe('CniStatus', () => {
   })
 
   it('renders loading skeleton when isLoading is true', () => {
-    setup({ showSkeleton: true })
+    setup({
+      isLoading: true,
+      showSkeleton: true,
+      data: {
+        health: 'healthy',
+        nodes: [],
+        stats: {
+          activePlugin: 'unknown',
+          pluginVersion: 'unknown',
+          podNetworkCidr: '',
+          serviceNetworkCidr: '',
+          nodeCount: 0,
+          nodesCniReady: 0,
+          networkPolicyCount: 0,
+          servicesWithNetworkPolicy: 0,
+          totalServices: 0,
+          podsWithIp: 0,
+          totalPods: 0,
+        },
+        summary: {
+          activePlugin: 'unknown',
+          pluginVersion: 'unknown',
+          podNetworkCidr: '',
+          nodesCniReady: 0,
+          nodeCount: 0,
+          networkPolicyCount: 0,
+          servicesWithNetworkPolicy: 0,
+        },
+        lastCheckTime: new Date().toISOString(),
+      },
+    })
     render(<CniStatus />)
 
     expect(screen.getByTestId('skeleton')).toBeTruthy()


### PR DESCRIPTION
Fixes #10798

Align cni_status test mock with actual hook return shape so loading skeleton renders correctly.

The test was setting `showSkeleton: true` directly, but the component reads this computed value from `useCachedCni()`. For `showSkeleton` to be true in the real hook, `hasAnyData` must be false, which requires:
- Empty nodes array (`data.nodes = []`)
- Health state that is NOT 'not-installed'

Updated the test to provide `isLoading: true`, `showSkeleton: true`, and empty data matching this contract.