### PR TITLE
fix(e2e): set kc-has-session for mission-control-e2e API calls

### DIFF
--- a/web/e2e/mission-control-e2e.spec.ts
+++ b/web/e2e/mission-control-e2e.spec.ts
@@ -347,6 +347,7 @@ async function navigateToConsole(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem('token', 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
+    localStorage.setItem('kc-has-session', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
   })
   await page.goto('/')


### PR DESCRIPTION
## Summary
- Add `kc-has-session=true` to localStorage in mission-control-e2e test setup
- Root cause: `api.get()` checks `hasToken()` which returns false for `demo-token` (treated as `DEMO_TOKEN_VALUE` sentinel). Without `kc-has-session`, fetches to `/api/github/repos/.../contents` throw `UnauthenticatedError` before Playwright route mocks can intercept them

## Test plan
- [ ] Trigger CI with `spec_filter=e2e/mission-control-e2e.spec.ts` and verify the 9 `expandSampleRunbooks` tests pass