### PR TITLE
🐛 Fix SpeechRecognition handler leak in useMicrophoneInput

### DIFF
--- a/web/src/hooks/useMicrophoneInput.ts
+++ b/web/src/hooks/useMicrophoneInput.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 
 interface SpeechRecognitionEvent extends Event {
   resultIndex: number
@@ -95,6 +95,16 @@ export function useMicrophoneInput(): UseMicrophoneInputReturn {
       recordingTimeoutRef.current = null
     }
 
+    // Abort recognition and clear handlers to prevent stale callbacks
+    if (recognitionRef.current) {
+      recognitionRef.current.onstart = null
+      recognitionRef.current.onresult = null
+      recognitionRef.current.onerror = null
+      recognitionRef.current.onend = null
+      try { recognitionRef.current.abort() } catch { /* already stopped */ }
+      recognitionRef.current = null
+    }
+
     if (mediaStreamRef.current) {
       for (const track of mediaStreamRef.current.getTracks()) {
         track.stop()
@@ -103,6 +113,7 @@ export function useMicrophoneInput(): UseMicrophoneInputReturn {
     }
 
     setIsRecording(false)
+    setIsTranscribing(false)
   }, [])
 
   const startRecording = useCallback(async () => {
@@ -172,14 +183,16 @@ export function useMicrophoneInput(): UseMicrophoneInputReturn {
 
   const stopRecording = useCallback(async () => {
     try {
-      if (recognitionRef.current) {
-        recognitionRef.current.stop()
-      }
       await stopRecordingInternal()
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to stop recording'
       setError(errorMessage)
     }
+  }, [stopRecordingInternal])
+
+  // Cleanup on unmount — abort any active recognition and release media stream
+  useEffect(() => {
+    return () => { stopRecordingInternal() }
   }, [stopRecordingInternal])
 
   return {


### PR DESCRIPTION
## Problem

`useMicrophoneInput` hook has a memory leak: `stopRecordingInternal` stops media tracks but never aborts the SpeechRecognition instance or clears its event handlers. Repeated start/stop cycles accumulate stale `onstart`, `onresult`, `onerror`, and `onend` handlers causing duplicate state updates. No cleanup runs on component unmount either.

## Fix

1. **Abort recognition** — call `recognition.abort()` in `stopRecordingInternal` and null the ref
2. **Clear all handlers** — null out `onstart`, `onresult`, `onerror`, `onend` before aborting
3. **Reset `isTranscribing`** — set to false in cleanup (was only set in `onend` which won't fire after abort)
4. **Unmount cleanup** — added `useEffect` with cleanup callback that calls `stopRecordingInternal`
5. **Simplify `stopRecording`** — removed redundant `recognition.stop()` call since `stopRecordingInternal` now handles abort

Build and lint pass.