### PR TITLE
🐛 Fix nil slice serializing to null in health endpoint JSON

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -795,7 +795,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	hasClaude := s.checkClaudeAvailable()
 
 	// Build lightweight provider summaries for telemetry
-	var providerSummaries []protocol.ProviderSummary
+	providerSummaries := make([]protocol.ProviderSummary, 0)
 	for _, p := range s.registry.ListAvailable() {
 		providerSummaries = append(providerSummaries, protocol.ProviderSummary{
 			Name:         p.Name,


### PR DESCRIPTION
## Problem

`pkg/agent/server.go:798` declares `var providerSummaries []protocol.ProviderSummary` which is a nil slice. When no providers are configured, the health endpoint responds with `"providers": null` instead of `"providers": []`. Frontend code calling `.map()`/`.filter()` on this field crashes.

## Fix

Single-line change: `make([]protocol.ProviderSummary, 0)` instead of `var` declaration. This follows the project convention (CLAUDE.md): always use `make([]T, 0)` not `var x []T`.

Go build passes.