### PR TITLE
fix(e2e): add /health mock and diagnostic debugging for mission-control tests

### DIFF
--- a/web/e2e/mission-control-e2e.spec.ts
+++ b/web/e2e/mission-control-e2e.spec.ts
@@ -270,6 +270,24 @@ async function setupClusterMocks(page: Page) {
     })
   )
 
+  // checkBackendAvailability() fetches /health (without /api prefix)
+  await page.route('**/health', (route) => {
+    const url = route.request().url()
+    if (url.includes('/api/health')) {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', oauth_configured: true, in_cluster: false, install_method: 'dev' }),
+      })
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok' }),
+      })
+    }
+  })
+
   await page.route('**/api/mcp/**', (route) => {
     const url = route.request().url()
     if (url.includes('/clusters')) return
@@ -349,6 +367,10 @@ async function navigateToConsole(page: Page) {
     localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('kc-has-session', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
+    localStorage.setItem('kc-backend-status', JSON.stringify({
+      available: true,
+      timestamp: Date.now(),
+    }))
   })
   await page.goto('/')
   await page.waitForLoadState('domcontentloaded', { timeout: DIALOG_RENDER_TIMEOUT_MS })
@@ -382,27 +404,27 @@ async function expandSampleRunbooks(page: Page) {
   await page.reload({ waitUntil: 'domcontentloaded' })
   await page.waitForLoadState('networkidle', { timeout: DIALOG_RENDER_TIMEOUT_MS })
 
-  // Debug: log all github API requests to see if mocks are intercepting
-  const githubRequests: string[] = []
+  // Track all requests/responses for debugging CI failures
+  const allRequests: string[] = []
+  const browserErrors: string[] = []
   page.on('request', (req) => {
-    if (req.url().includes('/api/github/')) {
-      githubRequests.push(`[REQ] ${req.url()}`)
+    if (req.url().includes('/api/')) {
+      allRequests.push(`[REQ] ${req.method()} ${req.url()}`)
     }
   })
   page.on('response', (res) => {
-    if (res.url().includes('/api/github/')) {
-      githubRequests.push(`[RES] ${res.url()} -> ${res.status()}`)
+    if (res.url().includes('/api/')) {
+      allRequests.push(`[RES] ${res.status()} ${res.url()}`)
     }
   })
-
-  // Debug: check auth state before browsing
-  const authState = await page.evaluate(() => ({
-    token: localStorage.getItem('token'),
-    demoMode: localStorage.getItem('kc-demo-mode'),
-    hasSession: localStorage.getItem('kc-has-session'),
-    watchedRepos: localStorage.getItem('kc_mission_watched_repos'),
-  }))
-  console.log('[expandSampleRunbooks] Auth state:', JSON.stringify(authState))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      browserErrors.push(msg.text())
+    }
+  })
+  page.on('pageerror', (err) => {
+    browserErrors.push(`PAGE_ERROR: ${err.message}`)
+  })
 
   await openMissionBrowser(page)
 
@@ -418,31 +440,38 @@ async function expandSampleRunbooks(page: Page) {
   await expect(repoNode).toBeVisible({ timeout: DIALOG_RENDER_TIMEOUT_MS })
   await repoNode.click()
 
-  // Wait a moment and check console errors
-  await page.waitForTimeout(2000)
+  // Wait for the fetch to complete
+  await page.waitForTimeout(3000)
 
-  // Debug: check for JS errors on the page
-  const consoleErrors = await page.evaluate(() => {
-    return (window as unknown as { __consoleErrors?: string[] }).__consoleErrors || []
+  // Collect diagnostic info
+  const diagnostics = await page.evaluate(() => {
+    const token = localStorage.getItem('token')
+    const hasSession = localStorage.getItem('kc-has-session')
+    const backendStatus = localStorage.getItem('kc-backend-status')
+    const demoMode = localStorage.getItem('kc-demo-mode')
+    const watchedRepos = localStorage.getItem('kc_mission_watched_repos')
+    const treeText = document.querySelector('[class*="mission"]')?.textContent?.substring(0, 500) || 'NO_MISSION_ELEMENT'
+    const bodySnippet = document.body.innerText.substring(0, 1000)
+    return { token, hasSession, backendStatus, demoMode, watchedRepos, treeText, bodySnippet }
   })
-  console.log('[expandSampleRunbooks] Console errors:', JSON.stringify(consoleErrors))
-  console.log('[expandSampleRunbooks] GitHub requests:', JSON.stringify(githubRequests))
-
-  // Debug: check page content for clues
-  const bodyText = await page.evaluate(() => document.body.innerText.substring(0, 2000))
-  console.log('[expandSampleRunbooks] Page text (first 2000 chars):', bodyText)
 
   // If files aren't visible yet, click again (first click may have only toggled expand)
-  const fileVisible = await page.getByText('argocd-application', { exact: false }).isVisible({ timeout: GITHUB_FETCH_TIMEOUT_MS }).catch(() => false)
+  const fileVisible = await page.getByText('argocd-application', { exact: false }).isVisible().catch(() => false)
   if (!fileVisible) {
-    // Click again to trigger selectNode (first click was toggleNode)
     await repoNode.click()
-    await page.waitForTimeout(2000)
-    console.log('[expandSampleRunbooks] After second click, GitHub requests:', JSON.stringify(githubRequests))
+    await page.waitForTimeout(3000)
   }
 
-  // Wait for files to appear in either the tree or the directory listing
-  await expect(page.getByText('argocd-application', { exact: false })).toBeVisible({ timeout: GITHUB_FETCH_TIMEOUT_MS })
+  // Final check with full diagnostic dump on failure
+  const isVisible = await page.getByText('argocd-application', { exact: false }).isVisible().catch(() => false)
+  if (!isVisible) {
+    const debugDump = [
+      `DIAGNOSTICS: ${JSON.stringify(diagnostics)}`,
+      `API_REQUESTS: ${JSON.stringify(allRequests)}`,
+      `BROWSER_ERRORS: ${JSON.stringify(browserErrors)}`,
+    ].join('\n')
+    throw new Error(`argocd-application not visible after expanding sample-runbooks.\n${debugDump}`)
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add route mock for `/health` (without `/api` prefix) — `checkBackendAvailability()` fetches `/health`, not `/api/health`
- Seed `kc-backend-status` in localStorage via `addInitScript` to pre-cache backend as available
- Replace `console.log` debugging (invisible in CI logs) with throw-on-failure diagnostic dump that appears in CI annotations
- Track all API requests and browser errors

## Context
Mission-control-e2e tests pass locally but fail in CI. The debug logging from PR #10801 didn't appear in CI output because Playwright doesn't surface `console.log` in workflow logs. This PR adds:
1. A potential fix (health endpoint mock mismatch)
2. Better diagnostics that WILL appear in CI error output

## Test plan
- [ ] Run in CI with `spec_filter=mission-control-e2e`
- [ ] If tests still fail, error annotations will contain full diagnostic dump