### PR TITLE
🐛 Fix cni_status skeleton test: getByTestId → getAllByTestId

### DIFF
--- a/web/src/components/cards/cni_status/cni_status.test.tsx
+++ b/web/src/components/cards/cni_status/cni_status.test.tsx
@@ -78,7 +78,7 @@ describe('CniStatus', () => {
     })
     render(<CniStatus />)
 
-    expect(screen.getByTestId('skeleton')).toBeTruthy()
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0)
   })
 
   it('renders with empty state when no CNI plugin found', () => {


### PR DESCRIPTION
Fixes #10809

## Problem

The `cni_status.test.tsx` loading skeleton test has been failing repeatedly across Coverage Suite runs (#1721–#1726). PR #10799 attempted to fix it by adjusting mock data shapes, but the root cause was different:

The component renders **multiple** `<Skeleton>` elements (title + badge + SkeletonStats + SkeletonList). The mock maps all Skeleton variants to `<div data-testid="skeleton" />`, so `getByTestId('skeleton')` throws `TestingLibraryElementError: Found multiple elements`.

## Fix

Replace `getByTestId('skeleton')` with `getAllByTestId('skeleton')` and assert length > 0.

## Verified

Test passes locally with `npx vitest run src/components/cards/cni_status/cni_status.test.tsx` — 2/2 passing.