### PR TITLE
🐛 Fix e2e-assertion-audit.test.ts failed to load

### DIFF
--- a/web/src/test/e2e-assertion-audit.test.ts
+++ b/web/src/test/e2e-assertion-audit.test.ts
@@ -17,7 +17,7 @@
  * Run:   npx vitest run src/test/e2e-assertion-audit.test.ts
  */
 import { describe, it, expect } from 'vitest'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -57,8 +57,7 @@ const POSITIVE_ONLY_ASSERTION_RE =
 describe('user-flows/ assertion hygiene (#8508)', () => {
   /** All .spec.ts files in the user-flows directory */
   const specFiles = existsSync(E2E_USER_FLOWS_DIR)
-    ? fs
-        .readdirSync(E2E_USER_FLOWS_DIR)
+    ? readdirSync(E2E_USER_FLOWS_DIR)
         .filter((f) => f.endsWith('.spec.ts'))
         .map((f) => join(E2E_USER_FLOWS_DIR, f))
     : []


### PR DESCRIPTION
Fixes #10815

PR #10814 converted namespace imports to named imports but left a dangling `fs.readdirSync()` reference. This adds `readdirSync` to the named import from `node:fs` and replaces the namespace call with the direct function call.