### PR TITLE
🐛 fix: persist target_repo field in feature_requests to fix cross-repo

### DIFF
--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -377,6 +377,7 @@ func (s *SQLiteStore) migrate() error {
 		title TEXT NOT NULL,
 		description TEXT NOT NULL,
 		request_type TEXT NOT NULL,
+		target_repo TEXT NOT NULL DEFAULT 'console',
 		github_issue_number INTEGER,
 		-- NOTE: github_issue_url was removed (#7735) — it was never
 		-- populated or read by any INSERT/SELECT/UPDATE query.  The

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -573,6 +573,10 @@ func (s *SQLiteStore) migrate() error {
 		// continue to read meaningful values, and pre-migration rows are
 		// transparently promoted to a one-element list on read.
 		"ALTER TABLE gpu_reservations ADD COLUMN gpu_types TEXT NOT NULL DEFAULT ''",
+		// target_repo was declared in the FeatureRequest model but never
+		// persisted — the column, INSERT, and SELECT all omitted it, causing
+		// webhook/close/update operations to route docs issues to the wrong repo.
+		"ALTER TABLE feature_requests ADD COLUMN target_repo TEXT NOT NULL DEFAULT 'console'",
 	}
 	for i, migration := range migrations {
 		if _, err := s.db.ExecContext(ctx, migration); err != nil {

--- a/pkg/store/sqlite_features.go
+++ b/pkg/store/sqlite_features.go
@@ -20,6 +20,9 @@ func (s *SQLiteStore) CreateFeatureRequest(ctx context.Context, request *models.
 	if request.Status == "" {
 		request.Status = models.RequestStatusOpen
 	}
+	if request.TargetRepo != models.TargetRepoConsole && request.TargetRepo != models.TargetRepoDocs {
+		request.TargetRepo = models.TargetRepoConsole
+	}
 
 	_, err := s.db.ExecContext(ctx, `INSERT INTO feature_requests (id, user_id, title, description, request_type, target_repo, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		request.ID.String(), request.UserID.String(), request.Title, request.Description, string(request.RequestType),

--- a/pkg/store/sqlite_features.go
+++ b/pkg/store/sqlite_features.go
@@ -21,25 +21,25 @@ func (s *SQLiteStore) CreateFeatureRequest(ctx context.Context, request *models.
 		request.Status = models.RequestStatusOpen
 	}
 
-	_, err := s.db.ExecContext(ctx, `INSERT INTO feature_requests (id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	_, err := s.db.ExecContext(ctx, `INSERT INTO feature_requests (id, user_id, title, description, request_type, target_repo, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		request.ID.String(), request.UserID.String(), request.Title, request.Description, string(request.RequestType),
-		request.GitHubIssueNumber, string(request.Status),
+		string(request.TargetRepo), request.GitHubIssueNumber, string(request.Status),
 		request.PRNumber, nullString(request.PRURL), nullString(request.CopilotSessionURL), nullString(request.NetlifyPreviewURL), request.CreatedAt)
 	return err
 }
 
 func (s *SQLiteStore) GetFeatureRequest(ctx context.Context, id uuid.UUID) (*models.FeatureRequest, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE id = ?`, id.String())
+	row := s.db.QueryRowContext(ctx, `SELECT id, user_id, title, description, request_type, target_repo, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE id = ?`, id.String())
 	return s.scanFeatureRequest(row)
 }
 
 func (s *SQLiteStore) GetFeatureRequestByIssueNumber(ctx context.Context, issueNumber int) (*models.FeatureRequest, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE github_issue_number = ?`, issueNumber)
+	row := s.db.QueryRowContext(ctx, `SELECT id, user_id, title, description, request_type, target_repo, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE github_issue_number = ?`, issueNumber)
 	return s.scanFeatureRequest(row)
 }
 
 func (s *SQLiteStore) GetFeatureRequestByPRNumber(ctx context.Context, prNumber int) (*models.FeatureRequest, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE pr_number = ?`, prNumber)
+	row := s.db.QueryRowContext(ctx, `SELECT id, user_id, title, description, request_type, target_repo, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE pr_number = ?`, prNumber)
 	return s.scanFeatureRequest(row)
 }
 
@@ -51,7 +51,7 @@ func (s *SQLiteStore) GetFeatureRequestByPRNumber(ctx context.Context, prNumber 
 func (s *SQLiteStore) GetUserFeatureRequests(ctx context.Context, userID uuid.UUID, limit, offset int) ([]models.FeatureRequest, error) {
 	lim := resolvePageLimit(limit, defaultPageLimit)
 	off := resolvePageOffset(offset)
-	rows, err := s.db.QueryContext(ctx, `SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE user_id = ? ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`, userID.String(), lim, off)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, user_id, title, description, request_type, target_repo, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE user_id = ? ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`, userID.String(), lim, off)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (s *SQLiteStore) CountUserPendingFeatureRequests(ctx context.Context, userI
 func (s *SQLiteStore) GetAllFeatureRequests(ctx context.Context, limit, offset int) ([]models.FeatureRequest, error) {
 	lim := resolvePageLimit(limit, defaultAdminPageLimit)
 	off := resolvePageOffset(offset)
-	rows, err := s.db.QueryContext(ctx, `SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`, lim, off)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, user_id, title, description, request_type, target_repo, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`, lim, off)
 	if err != nil {
 		return nil, err
 	}
@@ -111,13 +111,13 @@ func (s *SQLiteStore) GetAllFeatureRequests(ctx context.Context, limit, offset i
 func (s *SQLiteStore) scanFeatureRequest(row *sql.Row) (*models.FeatureRequest, error) {
 	var r models.FeatureRequest
 	var idStr, userIDStr string
-	var requestType, status string
+	var requestType, status, targetRepo string
 	var issueNumber, prNumber sql.NullInt64
 	var prURL, copilotSessionURL, previewURL, latestComment sql.NullString
 	var closedByUser sql.NullInt64
 	var updatedAt sql.NullTime
 
-	err := row.Scan(&idStr, &userIDStr, &r.Title, &r.Description, &requestType, &issueNumber, &status, &prNumber, &prURL, &copilotSessionURL, &previewURL, &closedByUser, &latestComment, &r.CreatedAt, &updatedAt)
+	err := row.Scan(&idStr, &userIDStr, &r.Title, &r.Description, &requestType, &targetRepo, &issueNumber, &status, &prNumber, &prURL, &copilotSessionURL, &previewURL, &closedByUser, &latestComment, &r.CreatedAt, &updatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -128,6 +128,7 @@ func (s *SQLiteStore) scanFeatureRequest(row *sql.Row) (*models.FeatureRequest, 
 	r.ID = parseUUID(idStr, "r.ID")
 	r.UserID = parseUUID(userIDStr, "r.UserID")
 	r.RequestType = models.RequestType(requestType)
+	r.TargetRepo = models.TargetRepo(targetRepo)
 	r.Status = models.RequestStatus(status)
 	if issueNumber.Valid {
 		num := int(issueNumber.Int64)
@@ -161,13 +162,13 @@ func (s *SQLiteStore) scanFeatureRequest(row *sql.Row) (*models.FeatureRequest, 
 func (s *SQLiteStore) scanFeatureRequestRow(ctx context.Context, rows *sql.Rows) (*models.FeatureRequest, error) {
 	var r models.FeatureRequest
 	var idStr, userIDStr string
-	var requestType, status string
+	var requestType, status, targetRepo string
 	var issueNumber, prNumber sql.NullInt64
 	var prURL, copilotSessionURL, previewURL, latestComment sql.NullString
 	var closedByUser sql.NullInt64
 	var updatedAt sql.NullTime
 
-	err := rows.Scan(&idStr, &userIDStr, &r.Title, &r.Description, &requestType, &issueNumber, &status, &prNumber, &prURL, &copilotSessionURL, &previewURL, &closedByUser, &latestComment, &r.CreatedAt, &updatedAt)
+	err := rows.Scan(&idStr, &userIDStr, &r.Title, &r.Description, &requestType, &targetRepo, &issueNumber, &status, &prNumber, &prURL, &copilotSessionURL, &previewURL, &closedByUser, &latestComment, &r.CreatedAt, &updatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -175,6 +176,7 @@ func (s *SQLiteStore) scanFeatureRequestRow(ctx context.Context, rows *sql.Rows)
 	r.ID = parseUUID(idStr, "r.ID")
 	r.UserID = parseUUID(userIDStr, "r.UserID")
 	r.RequestType = models.RequestType(requestType)
+	r.TargetRepo = models.TargetRepo(targetRepo)
 	r.Status = models.RequestStatus(status)
 	if issueNumber.Valid {
 		num := int(issueNumber.Int64)


### PR DESCRIPTION
### 📝 Summary of Changes

- `TargetRepo` on `FeatureRequest` was never persisted- no DB column, no INSERT, no SELECT
- every read returned `""`, so webhook, close, and update ops on docs-repo issues 
  always routed to `kubestellar/console` instead of `kubestellar/docs`
---

### Changes Made

- [x] Added migration: `ALTER TABLE feature_requests ADD COLUMN target_repo TEXT NOT NULL DEFAULT 'console'`
- [x] Added `target_repo` to INSERT in `CreateFeatureRequest`
- [x] Added `target_repo` to all SELECT queries across `sqlite_features.go`
- [x] Added `target_repo` scan + assignment in `scanFeatureRequest` and `scanFeatureRequestRow`

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

N/A

---

### 👀 Reviewer Notes

two files changed- `pkg/store/sqlite.go` and `pkg/store/sqlite_features.go`.
existing rows default to `'console'` which is correct for all pre-existing data.
no breaking changes, no new dependencies.
