### PR TITLE
🐛 Fix dashboardChunks test after empty state handling merge

### DIFF
--- a/web/src/lib/__tests__/dashboardChunks.test.ts
+++ b/web/src/lib/__tests__/dashboardChunks.test.ts
@@ -25,19 +25,22 @@ describe('DASHBOARD_CHUNKS', () => {
   })
 
   it('every loader returns a Promise when invoked', async () => {
-    for (const [key, loader] of Object.entries(DASHBOARD_CHUNKS)) {
-      const result = loader()
-      expect(result).toBeInstanceOf(Promise)
-      // Await to exercise the import path; catch errors from missing modules
-      try {
-        await result
-      } catch {
-        // Dynamic import may fail in test env — that's fine,
-        // we just need the loader function itself to be exercised
-      }
-      expect(key).toBeTruthy()
-    }
-  })
+    const entries = Object.entries(DASHBOARD_CHUNKS)
+    // Resolve all chunk imports in parallel to avoid serial timeout accumulation
+    await Promise.all(
+      entries.map(async ([key, loader]) => {
+        const result = loader()
+        expect(result).toBeInstanceOf(Promise)
+        try {
+          await result
+        } catch {
+          // Dynamic import may fail in test env — that's fine,
+          // we just need the loader function itself to be exercised
+        }
+        expect(key).toBeTruthy()
+      }),
+    )
+  }, 15_000)
 
   it('does not have unknown keys', () => {
     expect(DASHBOARD_CHUNKS['nonexistent']).toBeUndefined()


### PR DESCRIPTION
Fixes #10829

The `dashboardChunks.test.ts` test was timing out at the default 5000ms because PR #10827 added new imports (lucide-react icons, CardEmptyState) to card components, making the dynamic import chain heavier when resolving sequentially.

**Fix:** Resolve all chunk imports in `Promise.all` (parallel) instead of a serial `for` loop, and set an explicit 15s timeout to accommodate the growing import tree.