### PR TITLE
🐛 fix: remove stale config reload after key save to prevent lost-update…

### DIFF
--- a/pkg/agent/server_ops_settings.go
+++ b/pkg/agent/server_ops_settings.go
@@ -572,10 +572,10 @@ func (s *Server) validateAPIKeyValue(provider, apiKey string) (bool, error) {
 
 // refreshProviderAvailability updates provider availability after key changes
 func (s *Server) refreshProviderAvailability() {
-	// Re-initialize providers to pick up new keys
-	// This is a simple approach - providers check availability on each request anyway
-	// For now, we just reload the config
-	GetConfigManager().Load()
+	// In-memory config is already authoritative after SetAPIKey/SetModel/RemoveAPIKey.
+	// Calling Load() here would re-read a potentially stale disk file and overwrite
+	// concurrent in-memory writes, causing silent API key loss under concurrent requests.
+	// Providers check availability on each request, so no explicit reload is needed.
 }
 
 // perKeyValidationTimeout is the timeout for each individual API key validation request.

--- a/pkg/agent/server_ops_settings.go
+++ b/pkg/agent/server_ops_settings.go
@@ -570,12 +570,12 @@ func (s *Server) validateAPIKeyValue(provider, apiKey string) (bool, error) {
 	}
 }
 
-// refreshProviderAvailability updates provider availability after key changes
+// refreshProviderAvailability is intentionally a no-op after config mutations.
+// In-memory config is already authoritative after SetAPIKey/SetModel/RemoveAPIKey/SetBaseURL/RemoveBaseURL.
+// Calling Load() would re-read a potentially stale disk file and overwrite
+// concurrent in-memory writes, causing silent API key loss under concurrent requests.
+// Providers check availability on each request, so no explicit reload is needed.
 func (s *Server) refreshProviderAvailability() {
-	// In-memory config is already authoritative after SetAPIKey/SetModel/RemoveAPIKey.
-	// Calling Load() here would re-read a potentially stale disk file and overwrite
-	// concurrent in-memory writes, causing silent API key loss under concurrent requests.
-	// Providers check availability on each request, so no explicit reload is needed.
 }
 
 // perKeyValidationTimeout is the timeout for each individual API key validation request.


### PR DESCRIPTION
### 📝 Summary of Changes

- `refreshProviderAvailability()` called `Load()` after every key save/delete, 
  re-reading disk and replacing in-memory config- creating a lost-update race 
  under concurrent requests that silently dropped just-saved API keys

---

### Changes Made

- [x] Removed `GetConfigManager().Load()` from `refreshProviderAvailability()`
- [x] In-memory config is already authoritative after the lock-protected mutate+save cycle reload was redundant and dangerous

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

N/A

---

### 👀 Reviewer Notes

one file changed- `pkg/agent/server_ops_settings.go`. purely a removal, 
no new logic. providers check availability on each request anyway so 
nothing functional changes.