### PR TITLE
🐛 Fix Playwright nightly firefox+webkit failures

### DIFF
--- a/web/e2e/Clusters.spec.ts
+++ b/web/e2e/Clusters.spec.ts
@@ -90,6 +90,12 @@ async function setupClustersTest(page: Page) {
     // Clear the IndexedDB cache so stale data from previous tests doesn't bleed in.
     // Tests run against the same origin so cache entries are shared across tests.
     indexedDB.deleteDatabase('kc_cache')
+    // Clear sessionStorage snapshots so the SWR cache layer cannot rehydrate
+    // stale cluster data from a previous navigation/test. sessionStorage
+    // survives page.reload() and on webkit/firefox the sync rehydration
+    // outraces the async IndexedDB delete, causing filter tests to render
+    // clusters from the beforeEach mock alongside the test-specific mock. (#10828)
+    sessionStorage.clear()
     // Clear stale backend-status cache so checkBackendAvailability() makes a
     // fresh health check instead of returning a cached "unavailable" result
     // from a previous test. (#10784)
@@ -276,8 +282,11 @@ test.describe('Clusters Page', () => {
       // Unhealthy clusters must NOT appear in the Healthy tab
       // Scoped to clusters-page so sidebar cluster status widget doesn't cause
       // false positives. Use .first() for strict-mode safety.
-      await expect(clustersPage.getByText('unhealthy-with-nodes').first()).not.toBeVisible()
-      await expect(clustersPage.getByText('truly-unhealthy').first()).not.toBeVisible()
+      // Webkit/Firefox need extra time for the filter DOM update after
+      // sessionStorage-based SWR rehydration is replaced by fresh API data. (#10828)
+      const FILTER_HIDDEN_TIMEOUT_MS = 20_000
+      await expect(clustersPage.getByText('unhealthy-with-nodes').first()).not.toBeVisible({ timeout: FILTER_HIDDEN_TIMEOUT_MS })
+      await expect(clustersPage.getByText('truly-unhealthy').first()).not.toBeVisible({ timeout: FILTER_HIDDEN_TIMEOUT_MS })
     })
 
     test('Unhealthy stat count matches clusters shown after clicking Unhealthy tab', async ({ page }) => {
@@ -321,7 +330,10 @@ test.describe('Clusters Page', () => {
       // widget which shows all cluster names regardless of the active filter. #10790
       const clustersPage = page.getByTestId('clusters-page')
       await expect(clustersPage.getByText('unhealthy-no-nodes').first()).toBeVisible({ timeout: 5000 })
-      await expect(clustersPage.getByText('healthy-cluster').first()).not.toBeVisible()
+      // Webkit/Firefox need extra time for the filter DOM update after
+      // sessionStorage-based SWR rehydration is replaced by fresh API data. (#10828)
+      const FILTER_HIDDEN_TIMEOUT_MS = 20_000
+      await expect(clustersPage.getByText('healthy-cluster').first()).not.toBeVisible({ timeout: FILTER_HIDDEN_TIMEOUT_MS })
     })
   })
 })

--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -448,6 +448,12 @@ test.describe('Dashboard Data Accuracy (#6459)', () => {
       // makes a fresh health check instead of returning a cached
       // "unavailable" result from a previous test. (#10784)
       localStorage.removeItem('kc-backend-status')
+      // Clear sessionStorage snapshots so the SWR cache layer cannot
+      // rehydrate stale cluster data from a previous test. sessionStorage
+      // survives page.reload() and on webkit/firefox the sync rehydration
+      // outraces the async IndexedDB delete, causing row-count
+      // mismatches. (#10828)
+      sessionStorage.clear()
       localStorage.setItem('token', 'test-token')
       localStorage.setItem('demo-user-onboarded', 'true')
       localStorage.setItem('kc-demo-mode', 'false')
@@ -467,9 +473,16 @@ test.describe('Dashboard Data Accuracy (#6459)', () => {
     await page.goto('/clusters')
     await page.waitForLoadState('domcontentloaded')
 
-    // Wait for clusters page to fully render — Firefox may need extra time
+    // Wait for clusters page to fully render — Firefox/webkit may need extra time
     const PAGE_RENDER_TIMEOUT_MS = 30_000
-    await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: PAGE_RENDER_TIMEOUT_MS }).catch(() => {})
+    await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: PAGE_RENDER_TIMEOUT_MS })
+
+    // Wait for cluster data to actually render before counting rows.
+    // On webkit/firefox the SWR cache hydrates slower than Chromium, so
+    // the container can be visible before any cluster rows appear. (#10828)
+    const DATA_RENDER_TIMEOUT_MS = 20_000
+    const firstClusterName = page.getByText('accuracy-cluster-1').first()
+    await expect(firstClusterName).toBeVisible({ timeout: DATA_RENDER_TIMEOUT_MS }).catch(() => {})
 
     // The clusters page renders a row per cluster. We count any element
     // whose data-testid matches the cluster-row pattern. If the test

--- a/web/e2e/nightly/rce-vector-scan.spec.ts
+++ b/web/e2e/nightly/rce-vector-scan.spec.ts
@@ -271,7 +271,11 @@ test('RCE vector scan — all attack surfaces', async ({ page }, testInfo) => {
 
   // Inject XSS payloads via the ReactMarkdown renderer
   // We render the markdown in the browser context to test the actual component
+  // Firefox may destroy the execution context during navigation between
+  // phases. Wrap every page.evaluate() in a try/catch so a single
+  // destroyed-context error doesn't abort the entire scan. (#10828)
   for (const payload of MARKDOWN_XSS_PAYLOADS) {
+    try {
     const result = await page.evaluate((md) => {
       // Create a temporary div and check what ReactMarkdown would render
       // by inspecting the DOM after React processes the markdown
@@ -294,6 +298,10 @@ test('RCE vector scan — all attack surfaces', async ({ page }, testInfo) => {
     addCheck('Markdown XSS', `Payload: ${payload.name}`,
       'pass', // ReactMarkdown sanitizes by default — this documents the payloads we test
       `Tested: ${payload.md.substring(0, 50)}`, 'info')
+    } catch (e) {
+      addCheck('Markdown XSS', `Payload: ${payload.name}`,
+        'warn', `Skipped — execution context destroyed (navigation): ${String(e).slice(0, 120)}`, 'info')
+    }
   }
 
   // Now test the actual React app — navigate to missions and check rendered output
@@ -487,7 +495,13 @@ test('RCE vector scan — all attack surfaces', async ({ page }, testInfo) => {
   // ══════════════════════════════════════════════════════════════════════
   console.log('[RCE] Phase 8: CSP header verification')
 
+  // Firefox/webkit may redirect '/' → '/login' which interrupts the
+  // navigation. Catch and re-navigate to settle on the final URL. (#10828)
   const response = await page.goto('/', { waitUntil: 'domcontentloaded', timeout: PAGE_LOAD_TIMEOUT_MS })
+    .catch(async () => {
+      await page.waitForLoadState('domcontentloaded').catch(() => {})
+      return null
+    })
   const csp = response?.headers()['content-security-policy'] || ''
 
   if (csp) {


### PR DESCRIPTION
Fixes #10828

## Root Cause

The Playwright nightly run (run ID 25095927208) failed on firefox and webkit jobs due to three issues:

### 1. SWR sessionStorage cache rehydrating stale cluster data
The `addInitScript` cleared IndexedDB (`indexedDB.deleteDatabase()`) but NOT `sessionStorage`. The SWR cache layer uses `sessionStorage` for synchronous rehydration across page reloads. On webkit/firefox, the sync rehydration outraces the async IndexedDB delete, causing:
- **Clusters filter tests**: Stale cluster data from `beforeEach` rendered alongside test-specific mock data, so filter tabs couldn't hide clusters
- **Dashboard accuracy test**: Cluster row count returned 0 because the page container loaded but data hadn't arrived yet

### 2. Missing try-catch in RCE vector scan Phase 3
Phase 2 already wrapped `page.evaluate()` calls in try-catch for firefox's execution-context-destroyed errors, but Phase 3 (Markdown XSS) was missing the same pattern.

### 3. Navigation redirect in RCE vector scan Phase 8
`page.goto('/')` on firefox/webkit got interrupted by the app's `/login` redirect, throwing an unhandled navigation error.

## Changes
- Add `sessionStorage.clear()` to `addInitScript` in Clusters and Dashboard tests
- Add 20s timeouts to `not.toBeVisible()` filter assertions for webkit/firefox
- Remove silent `.catch(() => {})` on clusters-page visibility; add explicit wait for cluster data render
- Wrap Phase 3 `page.evaluate()` in try-catch (matching Phase 2 pattern)
- Handle Phase 8 navigation redirect with catch + fallback