### PR TITLE
🐛 Improve namespace error handling for agent connectivity failures

### DIFF
--- a/pkg/agent/server_http_resources.go
+++ b/pkg/agent/server_http_resources.go
@@ -310,7 +310,9 @@ func (s *Server) handleNamespacesHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), agentExtendedTimeout)
+	// Use context.Background() so the cluster query completes even if the
+	// browser disconnects (prevents noisy "context canceled" log entries).
+	ctx, cancel := context.WithTimeout(context.Background(), agentExtendedTimeout)
 	defer cancel()
 
 	namespaces, err := s.k8sClient.ListNamespacesWithDetails(ctx, cluster)

--- a/web/src/components/namespaces/CreateNamespaceModal.tsx
+++ b/web/src/components/namespaces/CreateNamespaceModal.tsx
@@ -54,7 +54,14 @@ export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNam
       }
       onCreated(cluster)
     } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to create namespace'
+      let errorMessage: string
+      if (err instanceof TypeError) {
+        errorMessage = t('namespaces.errors.agentNotReachable')
+      } else if (err instanceof Error) {
+        errorMessage = err.message
+      } else {
+        errorMessage = t('namespaces.errors.createFailed')
+      }
       setError(errorMessage)
     } finally {
       setCreating(false)

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -159,7 +159,12 @@ export function NamespaceManager() {
               }))
             }
           }
-        } catch {
+        } catch (err: unknown) {
+          if (err instanceof DOMException && err.name === 'AbortError') {
+            console.warn(`[NamespaceManager] ${t('namespaces.errors.requestTimedOut')}`, cluster)
+          } else if (err instanceof TypeError) {
+            console.warn(`[NamespaceManager] ${t('namespaces.errors.agentNotReachable')}`, cluster)
+          }
           // Local agent failed, will fall back to API
         }
 

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -275,8 +275,8 @@ export const QUICK_ABORT_TIMEOUT_MS = 3_000
 /** Abort timeout for AI prediction requests (5 seconds) */
 export const AI_PREDICTION_TIMEOUT_MS = 5_000
 
-/** Abort timeout for namespace management operations (8 seconds) */
-export const NAMESPACE_ABORT_TIMEOUT_MS = 8_000
+/** Abort timeout for namespace management operations (15 seconds — matches nsDefaultTimeout in Go backend) */
+export const NAMESPACE_ABORT_TIMEOUT_MS = 15_000
 
 /** Abort timeout for deploy mission operations (10 seconds) */
 export const DEPLOY_ABORT_TIMEOUT_MS = 10_000

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3091,7 +3091,12 @@
     "adminAccessRequired": "Admin access required to view namespace details",
     "fetchAccessFailed": "Failed to fetch namespace access",
     "adminRequiredForAccess": "Admin access required to view role bindings",
-    "noRoleBindings": "No role bindings found"
+    "noRoleBindings": "No role bindings found",
+    "errors": {
+      "agentNotReachable": "Local agent is not reachable. Make sure kc-agent is running on port 8585.",
+      "requestTimedOut": "Request timed out. The cluster may be slow to respond.",
+      "createFailed": "Failed to create namespace"
+    }
   },
   "cluster": {
     "subtitle": "Manage your Kubernetes clusters",


### PR DESCRIPTION
Fixes #10840

Also fixes #10841

## Changes

- **CreateNamespaceModal**: Detect `TypeError` (network errors) and show i18n "agent not reachable" message instead of generic failure
- **NamespaceManager**: Differentiate `AbortError` (timeout) vs `TypeError` (network) in fetch catch blocks with descriptive log messages
- **network.ts**: Increase `NAMESPACE_ABORT_TIMEOUT_MS` from 8s to 15s to match Go backend's `nsDefaultTimeout`
- **server_http_resources.go**: Use `context.Background()` for namespace GET handler so cluster queries complete even if the browser disconnects (eliminates noisy "context canceled" logs)
- **common.json**: Add i18n keys for new error messages under `namespaces.errors`