### PR TITLE
🐛 Fix namespace selector in Logs & Events using correct API path

### DIFF
--- a/web/src/hooks/useCachedK8sResources.ts
+++ b/web/src/hooks/useCachedK8sResources.ts
@@ -224,7 +224,7 @@ export function useCachedNamespaces(
       if (!cluster) return getDemoNamespaces()
       const token = getToken()
       if (!token) throw new Error('No authentication token')
-      const response = await fetch(`/api/namespaces?cluster=${encodeURIComponent(cluster)}`, {
+      const response = await fetch(`/api/mcp/namespaces?cluster=${encodeURIComponent(cluster)}`, {
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })


### PR DESCRIPTION
Fixes #10843

## Problem
The namespace selector in Logs & Events was always empty ('No namespaces'), preventing users from viewing pod logs.

## Root Cause
The frontend called `/api/namespaces?cluster=XXX` but the backend registers the route at `/api/mcp/namespaces` (see `pkg/api/routes_mcp.go:79`). This caused a 404 response, so `useCachedNamespaces` returned an empty array.

## Fix
Changed the fetch URL in `web/src/hooks/useCachedK8sResources.ts` from `/api/namespaces` to `/api/mcp/namespaces` to match the backend route.