### PR TITLE
🐛 Improve Kagenti error messages with contextual guidance

### DIFF
--- a/web/src/components/aiagents/AIAgents.tsx
+++ b/web/src/components/aiagents/AIAgents.tsx
@@ -140,7 +140,12 @@ export function AIAgents() {
       {error && (
         <div className="mb-4 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400">
           <div className="font-medium">{t('aiAgents.errorLoading')}</div>
-          <div className="text-sm text-muted-foreground">{error}</div>
+          <div className="text-sm text-muted-foreground mt-1">{String(error)}</div>
+          {/not connected|not reachable|timed out|not found/i.test(String(error)) && (
+            <div className="text-sm text-muted-foreground mt-2">
+              {t('aiAgents.notConnectedHint')}
+            </div>
+          )}
         </div>
       )}
     </DashboardPage>

--- a/web/src/hooks/mcp/kagenti.ts
+++ b/web/src/hooks/mcp/kagenti.ts
@@ -116,6 +116,27 @@ function getDemoTools(): KagentiTool[] {
 
 const AGENT_TIMEOUT = 15000
 
+/** Classify a caught error into a user-friendly message. */
+function classifyFetchError(err: unknown, path: string, cluster: string, status?: number): string {
+  if (err instanceof DOMException && err.name === 'AbortError') {
+    return 'Kagenti request timed out'
+  }
+  if (err instanceof TypeError && /failed to fetch|networkerror|network request failed/i.test(err.message)) {
+    return 'Kagenti agent not connected'
+  }
+  if (status === 401 || status === 403) {
+    return `Authentication failed (${status}) for ${path}`
+  }
+  if (status === 404) {
+    return `Kagenti endpoints not found (${path})`
+  }
+  if (status) {
+    return `Agent returned HTTP ${status} for ${path} (cluster: ${cluster})`
+  }
+  const msg = err instanceof Error ? err.message : String(err)
+  return msg || 'Unknown kagenti error'
+}
+
 async function agentFetch<T>(path: string, cluster: string, namespace?: string): Promise<T | null> {
   if (isAgentUnavailable()) return null
 
@@ -130,14 +151,20 @@ async function agentFetch<T>(path: string, cluster: string, namespace?: string):
       signal: ctrl.signal,
       headers: { Accept: 'application/json' } })
     clearTimeout(tid)
-    if (!res.ok) throw new Error(`Agent returned ${res.status} for ${path} (cluster: ${cluster})`)
+    if (!res.ok) {
+      const classified = classifyFetchError(null, path, cluster, res.status)
+      throw new Error(classified)
+    }
     return await res.json()
   } catch (err) {
     clearTimeout(tid)
-    // Log the error so it is visible in the console
     console.warn(`[kagenti] fetch failed for ${path} (cluster: ${cluster}):`, err)
-    // Re-throw so callers can surface the error to the UI
-    throw err
+    // If already classified (from !res.ok branch), re-throw as-is
+    if (err instanceof Error && !(/^TypeError/.test(err.constructor.name) || err.name === 'AbortError')) {
+      throw err
+    }
+    // Classify network/abort errors into friendly messages
+    throw new Error(classifyFetchError(err, path, cluster))
   }
 }
 
@@ -176,9 +203,12 @@ async function agentFetchAllClusters<T>(
     else errors.push(r.reason?.message || 'unknown error')
   }
 
-  // If every cluster failed, throw so the error reaches the UI
+  // If every cluster failed, deduplicate errors and throw a concise message
   if (items.length === 0 && errors.length > 0) {
-    throw new Error(`All kagenti fetches failed: ${errors.join('; ')}`)
+    const uniqueErrors = [...new Set(errors)]
+    const clusterCount = errors.length
+    const suffix = clusterCount > 1 ? ` (all ${clusterCount} clusters failed)` : ''
+    throw new Error(`${uniqueErrors.join('; ')}${suffix}`)
   }
 
   return items

--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -2845,7 +2845,8 @@
     "subtitle": "Kagenti agent platform — deploy, secure, and manage AI agents",
     "emptyStateTitle": "AI Agents Dashboard",
     "emptyStateDescription": "Add cards to monitor kagenti agents, MCP tools, build pipelines, and security posture across your clusters.",
-    "errorLoading": "Error loading kagenti data"
+    "errorLoading": "Error loading kagenti data",
+    "notConnectedHint": "Install Kagenti or connect your agent to see live data. Demo data is shown below."
   },
   "aiml": {
     "title": "AI/ML",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3538,7 +3538,8 @@
     "subtitle": "Kagenti agent platform — deploy, secure, and manage AI agents",
     "emptyStateTitle": "AI Agents Dashboard",
     "emptyStateDescription": "Add cards to monitor kagenti agents, MCP tools, build pipelines, and security posture across your clusters.",
-    "errorLoading": "Error loading kagenti data"
+    "errorLoading": "Error loading kagenti data",
+    "notConnectedHint": "Install Kagenti or connect your agent to see live data. Demo data is shown below."
   },
   "aiml": {
     "title": "AI/ML",

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -2845,7 +2845,8 @@
     "subtitle": "Kagenti agent platform — deploy, secure, and manage AI agents",
     "emptyStateTitle": "AI Agents Dashboard",
     "emptyStateDescription": "Add cards to monitor kagenti agents, MCP tools, build pipelines, and security posture across your clusters.",
-    "errorLoading": "Error loading kagenti data"
+    "errorLoading": "Error loading kagenti data",
+    "notConnectedHint": "Install Kagenti or connect your agent to see live data. Demo data is shown below."
   },
   "aiml": {
     "title": "AI/ML",

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -2845,7 +2845,8 @@
     "subtitle": "Kagenti agent platform — deploy, secure, and manage AI agents",
     "emptyStateTitle": "AI Agents Dashboard",
     "emptyStateDescription": "Add cards to monitor kagenti agents, MCP tools, build pipelines, and security posture across your clusters.",
-    "errorLoading": "Error loading kagenti data"
+    "errorLoading": "Error loading kagenti data",
+    "notConnectedHint": "Install Kagenti or connect your agent to see live data. Demo data is shown below."
   },
   "aiml": {
     "title": "AI/ML",

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -2845,7 +2845,8 @@
     "subtitle": "Kagenti agent platform — deploy, secure, and manage AI agents",
     "emptyStateTitle": "AI Agents Dashboard",
     "emptyStateDescription": "Add cards to monitor kagenti agents, MCP tools, build pipelines, and security posture across your clusters.",
-    "errorLoading": "Error loading kagenti data"
+    "errorLoading": "Error loading kagenti data",
+    "notConnectedHint": "Install Kagenti or connect your agent to see live data. Demo data is shown below."
   },
   "aiml": {
     "title": "AI/ML",

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -2845,7 +2845,8 @@
     "subtitle": "Kagenti agent platform — deploy, secure, and manage AI agents",
     "emptyStateTitle": "AI Agents Dashboard",
     "emptyStateDescription": "Add cards to monitor kagenti agents, MCP tools, build pipelines, and security posture across your clusters.",
-    "errorLoading": "Error loading kagenti data"
+    "errorLoading": "Error loading kagenti data",
+    "notConnectedHint": "Install Kagenti or connect your agent to see live data. Demo data is shown below."
   },
   "aiml": {
     "title": "AI/ML",

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -2845,7 +2845,8 @@
     "subtitle": "Kagenti agent platform — deploy, secure, and manage AI agents",
     "emptyStateTitle": "AI Agents Dashboard",
     "emptyStateDescription": "Add cards to monitor kagenti agents, MCP tools, build pipelines, and security posture across your clusters.",
-    "errorLoading": "Error loading kagenti data"
+    "errorLoading": "Error loading kagenti data",
+    "notConnectedHint": "Install Kagenti or connect your agent to see live data. Demo data is shown below."
   },
   "aiml": {
     "title": "AI/ML",

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -2845,7 +2845,8 @@
     "subtitle": "Kagenti agent platform — deploy, secure, and manage AI agents",
     "emptyStateTitle": "AI Agents Dashboard",
     "emptyStateDescription": "Add cards to monitor kagenti agents, MCP tools, build pipelines, and security posture across your clusters.",
-    "errorLoading": "Error loading kagenti data"
+    "errorLoading": "Error loading kagenti data",
+    "notConnectedHint": "Install Kagenti or connect your agent to see live data. Demo data is shown below."
   },
   "aiml": {
     "title": "AI/ML",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -2845,7 +2845,8 @@
     "subtitle": "Kagenti agent platform — deploy, secure, and manage AI agents",
     "emptyStateTitle": "AI Agents Dashboard",
     "emptyStateDescription": "Add cards to monitor kagenti agents, MCP tools, build pipelines, and security posture across your clusters.",
-    "errorLoading": "Error loading kagenti data"
+    "errorLoading": "Error loading kagenti data",
+    "notConnectedHint": "Install Kagenti or connect your agent to see live data. Demo data is shown below."
   },
   "aiml": {
     "title": "AI/ML",


### PR DESCRIPTION
Fixes #10844
Fixes #10845

## Changes

### Error Classification (`kagenti.ts`)
- `agentFetch()` now classifies errors into friendly messages:
  - Network errors → "Kagenti agent not connected"
  - Abort/timeout → "Kagenti request timed out"
  - HTTP 401/403 → "Authentication failed"
  - HTTP 404 → "Kagenti endpoints not found"
  - Other HTTP → includes status code with context

### Error Deduplication (`kagenti.ts`)
- `agentFetchAllClusters()` deduplicates identical per-cluster errors
- Instead of `Failed to fetch; Failed to fetch; Failed to fetch`, shows: `Kagenti agent not connected (all 3 clusters failed)`

### UI Guidance (`AIAgents.tsx`)
- When error indicates Kagenti isn't connected/reachable, shows actionable hint: "Install Kagenti or connect your agent to see live data"

### i18n
- Added `notConnectedHint` key to all 9 locale files (en, de, es, fr, hi, it, ja, pt, zh)