### PR TITLE
🐛 Fix kagenti test expectations after error message improvements

### DIFF
--- a/web/src/hooks/mcp/__tests__/kagenti.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagenti.test.ts
@@ -792,9 +792,9 @@ describe('useKagentiAgents — fetcher callback', () => {
     })
 
     renderHook(() => useKagentiAgents())
-    // agentFetch now throws on non-ok response; when all clusters fail,
-    // agentFetchAllClusters re-throws with an aggregate error
-    await expect(capturedFetcher!()).rejects.toThrow('All kagenti fetches failed')
+    // agentFetch now throws a classified error; when all clusters fail,
+    // agentFetchAllClusters re-throws with the classified message
+    await expect(capturedFetcher!()).rejects.toThrow(/Agent returned HTTP 500/)
 
     globalThis.fetch = originalFetch
   })
@@ -819,9 +819,9 @@ describe('useKagentiAgents — fetcher callback', () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'))
 
     renderHook(() => useKagentiAgents())
-    // agentFetch now throws on network error; when all clusters fail,
-    // agentFetchAllClusters re-throws with an aggregate error
-    await expect(capturedFetcher!()).rejects.toThrow('All kagenti fetches failed')
+    // agentFetch now throws a classified error; when all clusters fail,
+    // agentFetchAllClusters re-throws with the classified message
+    await expect(capturedFetcher!()).rejects.toThrow('ECONNREFUSED')
 
     globalThis.fetch = originalFetch
   })


### PR DESCRIPTION
Fixes #10848

PR #10847 improved kagenti error messages with contextual guidance but didn't update two tests that asserted the old generic error string `'All kagenti fetches failed'`. This updates the test expectations to match the new classified error format:

- **HTTP 500 test**: now expects `/Agent returned HTTP 500/` (regex match)
- **Network error test**: now expects `'ECONNREFUSED'` (the classified error message)