### PR TITLE
🐛 Snapshot subscriber Sets before iteration to prevent mutation-during-forEach races

### DIFF
--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -84,7 +84,7 @@ export let gpuNodeCache: GPUNodeCache = loadGPUCacheFromStorage()
 export const gpuNodeSubscribers = new Set<(cache: GPUNodeCache) => void>()
 
 export function notifyGPUNodeSubscribers() {
-  gpuNodeSubscribers.forEach(subscriber => subscriber(gpuNodeCache))
+  Array.from(gpuNodeSubscribers).forEach(subscriber => subscriber(gpuNodeCache))
 }
 
 // Register with mode transition coordinator for unified cache clearing

--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -28,7 +28,7 @@ type EventsSubscriber = (state: EventsSharedState) => void
 const eventsSubscribers = new Set<EventsSubscriber>()
 
 function notifyEventsSubscribers() {
-  eventsSubscribers.forEach(subscriber => subscriber(eventsSharedState))
+  Array.from(eventsSubscribers).forEach(subscriber => subscriber(eventsSharedState))
 }
 
 export function subscribeEventsCache(callback: EventsSubscriber): () => void {

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -30,7 +30,7 @@ type NetworkingSubscriber = (state: NetworkingSharedState) => void
 const networkingSubscribers = new Set<NetworkingSubscriber>()
 
 function notifyNetworkingSubscribers() {
-  networkingSubscribers.forEach(subscriber => subscriber(networkingSharedState))
+  Array.from(networkingSubscribers).forEach(subscriber => subscriber(networkingSharedState))
 }
 
 export function subscribeNetworkingCache(callback: NetworkingSubscriber): () => void {

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -371,14 +371,14 @@ export const clusterSubscribers: Set<ClusterSubscriber> = new Set<ClusterSubscri
 export function notifyClusterDataSubscribers() {
   const snapshot = clusterCache
   startTransition(() => {
-    dataSubscribers.forEach(subscriber => subscriber(snapshot))
+    Array.from(dataSubscribers).forEach(subscriber => subscriber(snapshot))
   })
 }
 
 /** Notify only UI subscribers, urgently (outside startTransition). */
 export function notifyClusterUISubscribers() {
   const snapshot = clusterCache
-  uiSubscribers.forEach(subscriber => subscriber(snapshot))
+  Array.from(uiSubscribers).forEach(subscriber => subscriber(snapshot))
 }
 
 /**
@@ -397,11 +397,11 @@ export function notifyClusterUISubscribers() {
 export function notifyClusterSubscribers() {
   const snapshot = clusterCache
   // Urgent leg — UI subscribers + legacy (merged) subscribers.
-  uiSubscribers.forEach(subscriber => subscriber(snapshot))
-  clusterSubscribers.forEach(subscriber => subscriber(snapshot))
+  Array.from(uiSubscribers).forEach(subscriber => subscriber(snapshot))
+  Array.from(clusterSubscribers).forEach(subscriber => subscriber(snapshot))
   // Interruptible leg — only the heavy-data subscribers.
   startTransition(() => {
-    dataSubscribers.forEach(subscriber => subscriber(snapshot))
+    Array.from(dataSubscribers).forEach(subscriber => subscriber(snapshot))
   })
 }
 
@@ -513,7 +513,7 @@ export function notifyClusterSubscribersDebounced() {
   }
   notifyTimeout = setTimeout(() => {
     const snapshot = clusterCache
-    clusterSubscribers.forEach(subscriber => subscriber(snapshot))
+    Array.from(clusterSubscribers).forEach(subscriber => subscriber(snapshot))
     notifyClusterDataSubscribers()
     notifyTimeout = null
   }, CLUSTER_NOTIFY_DEBOUNCE_MS)
@@ -552,7 +552,7 @@ export function updateClusterCache(updates: Partial<ClusterCache>) {
   // call so the pre-split contract (one notify per update) is preserved.
   if (touchesUI || touchesData) {
     const snapshot = clusterCache
-    clusterSubscribers.forEach(subscriber => subscriber(snapshot))
+    Array.from(clusterSubscribers).forEach(subscriber => subscriber(snapshot))
   } else {
     // If the updates somehow touch neither slice, fall back to notifying
     // every subscriber so nothing gets silently dropped.

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -28,7 +28,7 @@ type StorageSubscriber = (state: StorageSharedState) => void
 const storageSubscribers = new Set<StorageSubscriber>()
 
 function notifyStorageSubscribers() {
-  storageSubscribers.forEach(subscriber => subscriber(storageSharedState))
+  Array.from(storageSubscribers).forEach(subscriber => subscriber(storageSharedState))
 }
 
 export function subscribeStorageCache(callback: StorageSubscriber): () => void {

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -44,7 +44,7 @@ const workloadsSubscribers = new Set<WorkloadsSubscriber>()
 
 // Notify all subscribers of cache reset
 function notifyWorkloadsSubscribers() {
-  workloadsSubscribers.forEach(subscriber => subscriber(workloadsSharedState))
+  Array.from(workloadsSubscribers).forEach(subscriber => subscriber(workloadsSharedState))
 }
 
 // Subscribe to workloads cache changes (for hooks that need reactive updates)


### PR DESCRIPTION
## Problem

All 12 subscriber notification loops across 6 MCP hook files iterate a `Set` using `.forEach()` while subscriber callbacks may trigger `.add()` or `.delete()` on the same Set. This can skip notifications or throw at runtime.

**Affected files:** `shared.ts` (7 sites), `events.ts`, `workloads.ts`, `storage.ts`, `networking.ts`, `compute.ts` (1 each).

## Fix

Wrap every subscriber iteration with `Array.from(subscriberSet).forEach(...)` to snapshot the Set before iteration. This is the standard fix for mutation-during-iteration on JS Sets.

## Risk

Minimal — `Array.from()` is a shallow copy with negligible overhead for the subscriber set sizes involved (typically <50 entries). No behavioral change for correctly-behaving subscribers.

Bead: feature-642