### PR TITLE
🐛 Increase i18n compliance test timeout for CI

### DIFF
--- a/web/e2e/compliance/i18n-compliance.spec.ts
+++ b/web/e2e/compliance/i18n-compliance.spec.ts
@@ -178,6 +178,13 @@ async function setupMockServer(page: Page) {
 test.describe.configure({ mode: 'serial' })
 
 test('i18n compliance — internationalization audit', async ({ page }) => {
+  // This test navigates 13+ routes (Phase 5c spot-checks + Phase 6 multi-page)
+  // and performs DOM evaluations on each. The default 60s timeout is insufficient
+  // in CI where page loads are slower. Use 180s to match the global CI retry budget.
+  const CI_AUDIT_TIMEOUT_MS = 180_000
+  const LOCAL_AUDIT_TIMEOUT_MS = 90_000
+  test.setTimeout(IS_CI ? CI_AUDIT_TIMEOUT_MS : LOCAL_AUDIT_TIMEOUT_MS)
+
   const checks: I18nCheck[] = []
 
   function addCheck(


### PR DESCRIPTION
Fixes #10851

The `i18n compliance — internationalization audit` E2E test navigates 13+ routes across Phases 5c (spot-check routes) and 6 (multi-page navigation), performing DOM evaluations on each page. The default 60s global timeout is insufficient in CI where page loads are slower, causing consistent timeouts at the multi-page navigation phase.

**Root cause:** Test timeout of 60000ms exceeded at `page.goto` (line 691) during Phase 6 multi-page navigation. On retry, it timed out during Phase 5b `page.evaluate` (line 596).

**Fix:** Add `test.setTimeout(180_000)` in CI (90s locally) to give sufficient headroom for all navigation and evaluation phases to complete. This matches the existing CI retry budget pattern used by other compliance tests.