### PR TITLE
🐛 Fix compute-deep E2E test failures

### DIFF
--- a/web/e2e/helpers/setup.ts
+++ b/web/e2e/helpers/setup.ts
@@ -207,11 +207,16 @@ export async function mockApiFallback(page: Page) {
   // cache probes http://127.0.0.1:8585/clusters before falling back to demo
   // data. Without this mock the probe hangs in CI (nobody on port 8585),
   // keeping isLoading=true and blocking page render.
+  //
+  // Return 503 (not 200 with empty data) so fetchClusterListFromAgent()
+  // returns null and fullFetchClusters() falls through to the demo-data
+  // fallback path. A 200 with { clusters: [] } is truthy and short-circuits
+  // the demo fallback, leaving stats/sublabels empty (#compute-deep failures).
   await page.route('http://127.0.0.1:8585/**', (route) =>
     route.fulfill({
-      status: 200,
+      status: 503,
       contentType: 'application/json',
-      body: JSON.stringify({ clusters: [], issues: [], events: [], nodes: [], pods: [] }),
+      body: JSON.stringify({ error: 'Service unavailable (test mock)' }),
     })
   )
 }

--- a/web/src/components/cards/__tests__/DeploymentRiskScore.test.tsx
+++ b/web/src/components/cards/__tests__/DeploymentRiskScore.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+
+// Standard mocks
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => mockUseDemoMode(),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
+}))
+
+vi.mock('../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
+}))
+
+import { DeploymentRiskScore } from '../DeploymentRiskScore'
+
+describe('DeploymentRiskScore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
+  })
+
+  it('exports a function component', () => {
+    expect(typeof DeploymentRiskScore).toBe('function')
+  })
+
+  it('renders without crashing', () => {
+    const { container } = render(<DeploymentRiskScore />)
+    expect(container).toBeTruthy()
+  })
+
+  // TODO: Test risk score calculation (0-100 index) with mock Argo CD / Kyverno data
+  // TODO: Test namespace-level breakdown rendering
+  // TODO: Test loading and empty states
+  // TODO: Test demo mode fallback with isDemoData badge
+})

--- a/web/src/components/cards/__tests__/EventSummary.test.tsx
+++ b/web/src/components/cards/__tests__/EventSummary.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+
+// Standard mocks
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => mockUseDemoMode(),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
+}))
+
+vi.mock('../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
+}))
+
+vi.mock('../../../hooks/useCachedData', () => ({
+  useCachedEvents: vi.fn(() => ({
+    events: [],
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+  })),
+}))
+
+vi.mock('../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({ selectedClusters: [], isAllClustersSelected: true }),
+}))
+
+import { EventSummary } from '../EventSummary'
+
+describe('EventSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
+  })
+
+  it('exports a function component', () => {
+    expect(typeof EventSummary).toBe('function')
+  })
+
+  it('renders without crashing', () => {
+    const { container } = render(<EventSummary />)
+    expect(container).toBeTruthy()
+  })
+
+  // TODO: Test event grouping by type (Warning, Normal)
+  // TODO: Test event count display and severity breakdown
+  // TODO: Test cluster filter integration
+  // TODO: Test loading skeleton and empty state
+})

--- a/web/src/components/cards/__tests__/HardwareHealthCard.test.tsx
+++ b/web/src/components/cards/__tests__/HardwareHealthCard.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+
+// Standard mocks
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => mockUseDemoMode(),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
+}))
+
+vi.mock('../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
+}))
+
+import { HardwareHealthCard } from '../HardwareHealthCard'
+
+describe('HardwareHealthCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
+  })
+
+  it('exports a function component', () => {
+    expect(typeof HardwareHealthCard).toBe('function')
+  })
+
+  it('renders without crashing', () => {
+    const { container } = render(<HardwareHealthCard />)
+    expect(container).toBeTruthy()
+  })
+
+  // TODO: Test hardware component status rendering (CPU, memory, disk, network)
+  // TODO: Test alert/warning indicators for degraded hardware
+  // TODO: Test snooze functionality for hardware alerts
+  // TODO: Test loading skeleton and empty state
+  // TODO: Test search/filter and pagination controls
+})

--- a/web/src/components/cards/__tests__/KyvernoPolicies.test.tsx
+++ b/web/src/components/cards/__tests__/KyvernoPolicies.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+
+// Standard mocks
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => mockUseDemoMode(),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
+}))
+
+vi.mock('../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
+}))
+
+vi.mock('../../../hooks/useKyverno', () => ({
+  useKyverno: vi.fn(() => ({
+    policies: [],
+    violations: [],
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+  })),
+}))
+
+vi.mock('../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({ selectedClusters: [], isAllClustersSelected: true }),
+}))
+
+import { KyvernoPolicies } from '../KyvernoPolicies'
+
+describe('KyvernoPolicies', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
+  })
+
+  it('exports a function component', () => {
+    expect(typeof KyvernoPolicies).toBe('function')
+  })
+
+  it('renders without crashing', () => {
+    const { container } = render(<KyvernoPolicies config={{}} />)
+    expect(container).toBeTruthy()
+  })
+
+  // TODO: Test policy list rendering with mock Kyverno data
+  // TODO: Test violation count and severity indicators
+  // TODO: Test per-cluster Kyverno CRD detection fallback
+  // TODO: Test demo data fallback when Kyverno is not installed
+  // TODO: Test loading skeleton and empty state
+})

--- a/web/src/components/cards/__tests__/NamespaceQuotas.test.tsx
+++ b/web/src/components/cards/__tests__/NamespaceQuotas.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+
+// Standard mocks
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => mockUseDemoMode(),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
+}))
+
+vi.mock('../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
+}))
+
+vi.mock('../../../hooks/useCachedData', () => ({
+  useCachedNamespaceQuotas: vi.fn(() => ({
+    quotas: [],
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+  })),
+}))
+
+vi.mock('../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({ selectedClusters: [], isAllClustersSelected: true }),
+}))
+
+import { NamespaceQuotas } from '../NamespaceQuotas'
+
+describe('NamespaceQuotas', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
+  })
+
+  it('exports a function component', () => {
+    expect(typeof NamespaceQuotas).toBe('function')
+  })
+
+  it('renders without crashing', () => {
+    const { container } = render(<NamespaceQuotas config={{}} />)
+    expect(container).toBeTruthy()
+  })
+
+  // TODO: Test quota usage bars (CPU, memory, storage) with mock data
+  // TODO: Test over-quota warning indicators
+  // TODO: Test create/edit/delete quota modal interactions
+  // TODO: Test loading skeleton and empty state
+  // TODO: Test cluster filter integration
+})


### PR DESCRIPTION
Fix 4 failing Playwright E2E tests in `compute-deep.spec.ts` caused by the kc-agent mock in `setupDemoMode()` returning HTTP 200 with empty clusters instead of 503.

## Root cause

The shared agent mock at `http://127.0.0.1:8585/**` returned `{ clusters: [] }` with status 200. This made `fetchClusterListFromAgent()` return `[]` (truthy), causing `fullFetchClusters()` to short-circuit before reaching the demo-data fallback path. Result: empty clusters, no stats, sublabels not visible.

## Fix

Return 503 from the agent mock so `fetchClusterListFromAgent()` returns `null`, allowing the `isDemoMode() && isDemoToken()` fallback to populate demo clusters with full metrics (`nodeCount`, `podCount`, `cpuCores`, etc.).

## Tests fixed
- `displays CPU cores stat` — expects "cores allocatable" visible
- `displays memory stat with unit formatting` — expects "allocatable" visible
- `displays pod count stat` — expects "running pods" visible
- `expanding comparison shows cluster list` — expects cluster list after toggle