### PR TITLE
🐛 Add 12 missing netlify.toml redirects for production API routes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -206,6 +206,78 @@
   to = "/.netlify/functions/identity-sessions-policies"
   status = 200
 
+# ACMM maturity scan API
+[[redirects]]
+  from = "/api/acmm/scan"
+  to = "/.netlify/functions/acmm-scan"
+  status = 200
+
+# ACMM maturity badge (SVG)
+[[redirects]]
+  from = "/api/acmm/badge/*"
+  to = "/.netlify/functions/acmm-badge/:splat"
+  status = 200
+
+# GitHub Actions pipelines API
+[[redirects]]
+  from = "/api/github-pipelines"
+  to = "/.netlify/functions/github-pipelines"
+  status = 200
+
+# Daily bonus points API
+[[redirects]]
+  from = "/api/rewards/bonus"
+  to = "/.netlify/functions/bonus-points"
+  status = 200
+
+# GA4 gtag.js script proxy (same-origin)
+[[redirects]]
+  from = "/api/gtag"
+  to = "/.netlify/functions/gtag-proxy"
+  status = 200
+
+# GA4 event collection proxy (base64 relay)
+[[redirects]]
+  from = "/api/m"
+  to = "/.netlify/functions/analytics-collect"
+  status = 200
+
+# Umami tracking script proxy (same-origin)
+[[redirects]]
+  from = "/api/ksc"
+  to = "/.netlify/functions/umami-script"
+  status = 200
+
+# Umami event collection proxy
+[[redirects]]
+  from = "/api/send"
+  to = "/.netlify/functions/umami-collect"
+  status = 200
+
+# GitHub contributor rewards API
+[[redirects]]
+  from = "/api/rewards/github"
+  to = "/.netlify/functions/github-rewards"
+  status = 200
+
+# NPS survey API
+[[redirects]]
+  from = "/api/nps"
+  to = "/.netlify/functions/nps"
+  status = 200
+
+# Affiliate click tracking API
+[[redirects]]
+  from = "/api/affiliate/clicks"
+  to = "/.netlify/functions/affiliate-clicks"
+  status = 200
+
+# Analytics ACMM integration
+[[redirects]]
+  from = "/api/analytics-accm"
+  to = "/.netlify/functions/analytics-accm"
+  status = 200
+
 # SPA routing - redirect all routes to index.html (only if file doesn't exist)
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Problem

12 Netlify functions had no `[[redirects]]` entry in `netlify.toml`, causing 404s on console.kubestellar.io for these API routes:

| Route | Function |
|-------|----------|
| `/api/acmm/scan` | acmm-scan |
| `/api/acmm/badge/*` | acmm-badge |
| `/api/github-pipelines` | github-pipelines |
| `/api/rewards/bonus` | bonus-points |
| `/api/rewards/github` | github-rewards |
| `/api/gtag` | gtag-proxy |
| `/api/m` | analytics-collect |
| `/api/ksc` | umami-script |
| `/api/send` | umami-collect |
| `/api/nps` | nps |
| `/api/affiliate/clicks` | affiliate-clicks |
| `/api/analytics-accm` | analytics-accm |

All 12 already had MSW passthrough rules. 9 of 12 also have matching Go backend routes.

## Fix

Added 12 `[[redirects]]` blocks before the SPA catch-all, following the existing pattern.

Bead: feature-l64