### PR TITLE
🐛 Add missing array safety guards for undefined data

### DIFF
--- a/web/src/components/cards/rss/storage.ts
+++ b/web/src/components/cards/rss/storage.ts
@@ -31,7 +31,7 @@ export function getCachedFeed(url: string, ignoreExpiry = false): { items: FeedI
     // Return cache if not expired, or if we want stale data
     if (!isStale || ignoreExpiry) {
       return {
-        items: data.items.map((item: FeedItem) => ({
+        items: (data.items || []).map((item: FeedItem) => ({
           ...item,
           pubDate: item.pubDate ? new Date(item.pubDate) : undefined,
         })),

--- a/web/src/hooks/useClusterContext.ts
+++ b/web/src/hooks/useClusterContext.ts
@@ -35,7 +35,7 @@ export function useClusterContext(): {
   const isLoading = clustersLoading || operatorsLoading || helmLoading || podLoading || securityLoading
 
   const clusterContext = useMemo(() => {
-    const healthyClusters = deduplicatedClusters.filter(c => c.healthy)
+    const healthyClusters = (deduplicatedClusters || []).filter(c => c.healthy)
     if (healthyClusters.length === 0) return null
 
     // Pick primary cluster (current context or first healthy)

--- a/web/src/hooks/useGlobalFilters.tsx
+++ b/web/src/hooks/useGlobalFilters.tsx
@@ -156,7 +156,8 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
       if (stored) {
         const parsed = JSON.parse(stored)
         // null means all clusters
-        return parsed === null ? [] : parsed
+        if (parsed === null) return []
+        if (Array.isArray(parsed)) return parsed
       }
     } catch {
       // Ignore parse errors
@@ -170,7 +171,8 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
       const stored = localStorage.getItem(SEVERITY_STORAGE_KEY)
       if (stored) {
         const parsed = JSON.parse(stored)
-        return parsed === null ? [] : parsed
+        if (parsed === null) return []
+        if (Array.isArray(parsed)) return parsed
       }
     } catch {
       // Ignore parse errors
@@ -184,7 +186,10 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
     try {
       const stored = localStorage.getItem(GROUPS_STORAGE_KEY)
       if (stored) {
-        groups = JSON.parse(stored)
+        const parsed = JSON.parse(stored)
+        if (Array.isArray(parsed)) {
+          groups = parsed
+        }
       }
     } catch {
       // Ignore parse errors

--- a/web/src/hooks/useMetricsHistory.ts
+++ b/web/src/hooks/useMetricsHistory.ts
@@ -42,10 +42,13 @@ if (typeof window !== 'undefined') {
   const stored = localStorage.getItem(STORAGE_KEY)
   if (stored) {
     try {
-      snapshots = JSON.parse(stored)
-      // Remove snapshots older than 7 days
-      const cutoff = Date.now() - CACHE_TTL_MS
-      snapshots = snapshots.filter(s => new Date(s.timestamp).getTime() > cutoff)
+      const parsed = JSON.parse(stored)
+      if (Array.isArray(parsed)) {
+        snapshots = parsed
+        // Remove snapshots older than 7 days
+        const cutoff = Date.now() - CACHE_TTL_MS
+        snapshots = snapshots.filter(s => new Date(s.timestamp).getTime() > cutoff)
+      }
     } catch {
       // Invalid JSON, use empty array
     }

--- a/web/src/hooks/useNavigationHistory.ts
+++ b/web/src/hooks/useNavigationHistory.ts
@@ -35,7 +35,10 @@ export function useNavigationHistory() {
 export function getNavigationBehavior() {
   let history: string[] = []
   try {
-    history = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]')
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]')
+    if (Array.isArray(parsed)) {
+      history = parsed
+    }
   } catch {
     // Corrupted data — reset
   }

--- a/web/src/hooks/usePredictionFeedback.ts
+++ b/web/src/hooks/usePredictionFeedback.ts
@@ -20,8 +20,10 @@ if (typeof window !== 'undefined') {
   const stored = localStorage.getItem(STORAGE_KEY)
   if (stored) {
     try {
-      const parsed: StoredFeedback[] = JSON.parse(stored)
-      feedbackMap = new Map(parsed.map(f => [f.predictionId, f]))
+      const parsed = JSON.parse(stored)
+      if (Array.isArray(parsed)) {
+        feedbackMap = new Map(parsed.map((f: StoredFeedback) => [f.predictionId, f]))
+      }
     } catch {
       // Invalid JSON, use empty map
     }
@@ -73,9 +75,11 @@ export function usePredictionFeedback() {
       const stored = localStorage.getItem(STORAGE_KEY)
       if (stored) {
         try {
-          const parsed: StoredFeedback[] = JSON.parse(stored)
-          feedbackMap = new Map(parsed.map(f => [f.predictionId, f]))
-          notifySubscribers()
+          const parsed = JSON.parse(stored)
+          if (Array.isArray(parsed)) {
+            feedbackMap = new Map(parsed.map((f: StoredFeedback) => [f.predictionId, f]))
+            notifySubscribers()
+          }
         } catch {
           // Invalid JSON, ignore
         }


### PR DESCRIPTION
Fixes #4190

## Summary

Adds `Array.isArray()` checks and `|| []` guards to prevent runtime crashes when localStorage data is corrupted or API responses have unexpected shapes. Per CLAUDE.md: *"NEVER call .join(), .map(), .filter(), .forEach(), or for...of on values that might be undefined."*

## Changes

| File | Bug | Fix |
|------|-----|-----|
| `useMetricsHistory.ts` | `JSON.parse()` result used as array without validation, then `.filter()` called | Added `Array.isArray()` check |
| `useNavigationHistory.ts` | `JSON.parse()` result used as array without validation, then `.forEach()` called | Added `Array.isArray()` check |
| `useGlobalFilters.tsx` | `selectedClusters`, `selectedSeverities`, `clusterGroups` from `JSON.parse()` used without array validation — corrupted localStorage could crash the app | Added `Array.isArray()` checks for all three |
| `usePredictionFeedback.ts` | `JSON.parse()` result typed as array but could be anything at runtime, then `.map()` called | Added `Array.isArray()` check (both init and event handler) |
| `useClusterContext.ts` | `deduplicatedClusters.filter()` without guard, inconsistent with neighboring `(operators \|\| []).forEach()` pattern | Added `\|\| []` guard |
| `rss/storage.ts` | `data.items.map()` where `items` could be undefined from corrupted localStorage cache | Added `\|\| []` guard |

## Risk

Low — all changes are defensive guards that are no-ops when data is already valid. No behavioral changes for correct data paths.