### PR TITLE
⚡ Memoize context provider values to prevent re-render storms

### DIFF
--- a/web/src/hooks/useClusterFilter.tsx
+++ b/web/src/hooks/useClusterFilter.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import { createContext, useContext, useState, useEffect, useMemo, useCallback, ReactNode } from 'react'
 import { useClusters } from './useMCP'
 
 interface ClusterFilterContextType {
@@ -42,11 +42,11 @@ export function ClusterFilterProvider({ children }: { children: ReactNode }) {
     }
   }, [selectedClusters])
 
-  const setSelectedClusters = (clusters: string[]) => {
+  const setSelectedClusters = useCallback((clusters: string[]) => {
     setSelectedClustersState(clusters)
-  }
+  }, [])
 
-  const toggleCluster = (cluster: string) => {
+  const toggleCluster = useCallback((cluster: string) => {
     setSelectedClustersState(prev => {
       // If currently "all" (empty), switch to all except this one
       if (prev.length === 0) {
@@ -68,34 +68,38 @@ export function ClusterFilterProvider({ children }: { children: ReactNode }) {
         return newSelection
       }
     })
-  }
+  }, [availableClusters])
 
-  const selectAll = () => {
+  const selectAll = useCallback(() => {
     setSelectedClustersState([])
-  }
+  }, [])
 
-  const clearAll = () => {
+  const clearAll = useCallback(() => {
     // Select just the first cluster if available
     if (availableClusters.length > 0) {
       setSelectedClustersState([availableClusters[0]])
     }
-  }
+  }, [availableClusters])
 
   // Empty array means all clusters are selected
   const isAllSelected = selectedClusters.length === 0
   const isFiltered = !isAllSelected
 
+  const effectiveSelectedClusters = isAllSelected ? availableClusters : selectedClusters
+
+  const contextValue = useMemo(() => ({
+    selectedClusters: effectiveSelectedClusters,
+    setSelectedClusters,
+    toggleCluster,
+    selectAll,
+    clearAll,
+    isAllSelected,
+    isFiltered,
+    availableClusters,
+  }), [effectiveSelectedClusters, setSelectedClusters, toggleCluster, selectAll, clearAll, isAllSelected, isFiltered, availableClusters])
+
   return (
-    <ClusterFilterContext.Provider
-      value={{
-        selectedClusters: isAllSelected ? availableClusters : selectedClusters,
-        setSelectedClusters,
-        toggleCluster,
-        selectAll,
-        clearAll,
-        isAllSelected,
-        isFiltered,
-        availableClusters }}
+    <ClusterFilterContext.Provider value={contextValue}>
     >
       {children}
     </ClusterFilterContext.Provider>

--- a/web/src/hooks/useClusterFilter.tsx
+++ b/web/src/hooks/useClusterFilter.tsx
@@ -100,7 +100,6 @@ export function ClusterFilterProvider({ children }: { children: ReactNode }) {
 
   return (
     <ClusterFilterContext.Provider value={contextValue}>
-    >
       {children}
     </ClusterFilterContext.Provider>
   )

--- a/web/src/hooks/useTour.tsx
+++ b/web/src/hooks/useTour.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import { createContext, useContext, useState, useEffect, useMemo, useCallback, ReactNode } from 'react'
 import { useMobile } from './useMobile'
 import { SETTINGS_CHANGED_EVENT, SETTINGS_RESTORED_EVENT } from '../lib/settingsSync'
 import { emitTourStarted, emitTourCompleted, emitTourSkipped } from '../lib/analytics'
@@ -117,15 +117,15 @@ export function TourProvider({ children }: { children: ReactNode }) {
 
   const currentStep = isActive ? TOUR_STEPS[currentStepIndex] : null
 
-  const startTour = () => {
+  const startTour = useCallback(() => {
     // Don't start tour on mobile devices
     if (isMobile) return
     setCurrentStepIndex(0)
     setIsActive(true)
     emitTourStarted()
-  }
+  }, [isMobile])
 
-  const nextStep = () => {
+  const nextStep = useCallback(() => {
     if (currentStepIndex < TOUR_STEPS.length - 1) {
       setCurrentStepIndex(prev => prev + 1)
     } else {
@@ -136,49 +136,51 @@ export function TourProvider({ children }: { children: ReactNode }) {
       window.dispatchEvent(new Event(SETTINGS_CHANGED_EVENT))
       emitTourCompleted(TOUR_STEPS.length)
     }
-  }
+  }, [currentStepIndex])
 
-  const prevStep = () => {
+  const prevStep = useCallback(() => {
     if (currentStepIndex > 0) {
       setCurrentStepIndex(prev => prev - 1)
     }
-  }
+  }, [currentStepIndex])
 
-  const skipTour = () => {
+  const skipTour = useCallback(() => {
     emitTourSkipped(currentStepIndex)
     setIsActive(false)
     setHasCompletedTour(true)
     localStorage.setItem(STORAGE_KEY_TOUR_COMPLETED, 'true')
     window.dispatchEvent(new Event(SETTINGS_CHANGED_EVENT))
-  }
+  }, [currentStepIndex])
 
-  const resetTour = () => {
+  const resetTour = useCallback(() => {
     localStorage.removeItem(STORAGE_KEY_TOUR_COMPLETED)
     setHasCompletedTour(false)
     window.dispatchEvent(new Event(SETTINGS_CHANGED_EVENT))
-  }
+  }, [])
 
-  const goToStep = (stepId: string) => {
+  const goToStep = useCallback((stepId: string) => {
     const index = TOUR_STEPS.findIndex(s => s.id === stepId)
     if (index >= 0) {
       setCurrentStepIndex(index)
     }
-  }
+  }, [])
+
+  const contextValue = useMemo(() => ({
+    isActive,
+    currentStep,
+    currentStepIndex,
+    totalSteps: TOUR_STEPS.length,
+    hasCompletedTour,
+    startTour,
+    nextStep,
+    prevStep,
+    skipTour,
+    resetTour,
+    goToStep,
+  }), [isActive, currentStep, currentStepIndex, hasCompletedTour, startTour, nextStep, prevStep, skipTour, resetTour, goToStep])
 
   return (
-    <TourContext.Provider
-      value={{
-        isActive,
-        currentStep,
-        currentStepIndex,
-        totalSteps: TOUR_STEPS.length,
-        hasCompletedTour,
-        startTour,
-        nextStep,
-        prevStep,
-        skipTour,
-        resetTour,
-        goToStep }}
+    <TourContext.Provider value={contextValue}>
     >
       {children}
     </TourContext.Provider>

--- a/web/src/hooks/useTour.tsx
+++ b/web/src/hooks/useTour.tsx
@@ -181,7 +181,6 @@ export function TourProvider({ children }: { children: ReactNode }) {
 
   return (
     <TourContext.Provider value={contextValue}>
-    >
       {children}
     </TourContext.Provider>
   )

--- a/web/src/lib/modals/BaseModal.tsx
+++ b/web/src/lib/modals/BaseModal.tsx
@@ -38,7 +38,7 @@
  * ```
  */
 
-import { ReactNode, createContext, useContext, useId, useRef } from 'react'
+import { ReactNode, createContext, useContext, useId, useMemo, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { X, ChevronLeft } from 'lucide-react'
 import { useModalNavigation, useModalFocusTrap } from './useModalNavigation'
@@ -124,6 +124,8 @@ export function BaseModal({
   // Trap focus within modal so Tab cannot escape to background content
   useModalFocusTrap(modalRef, isOpen)
 
+  const escapeContextValue = useMemo(() => ({ escapeEnabled: closeOnEscape }), [closeOnEscape])
+
   if (!isOpen) return null
 
   // #9165 — Outside-click detection.
@@ -190,7 +192,7 @@ export function BaseModal({
           onClick={(e) => e.stopPropagation()}
         >
           <ModalTitleIdContext.Provider value={titleId}>
-            <ModalEscapeContext.Provider value={{ escapeEnabled: closeOnEscape }}>
+            <ModalEscapeContext.Provider value={escapeContextValue}>
               {children}
             </ModalEscapeContext.Provider>
           </ModalTitleIdContext.Provider>


### PR DESCRIPTION
## Problem

Three Context providers pass un-memoized inline objects as `value`, causing all consumers to re-render on every provider render (React creates a new object reference each time).

## Fix

| File | Change |
|------|--------|
| `useTour.tsx` | `useCallback` on 6 functions, `useMemo` on provider value |
| `useClusterFilter.tsx` | `useCallback` on 4 functions, `useMemo` on provider value |
| `BaseModal.tsx` | `useMemo` on `ModalEscapeContext` value |

Reference pattern: `useVersionCheck.tsx` lines 756-780 already uses `useMemo` correctly.

## Risk

Low — pure memoization refactor. No behavioral changes. Dependencies are explicit and correct.

Bead: feature-4fb