### PR TITLE
🐛 Add missing clusterErrors, WorkloadList, and MCSClusterError frontend types

### DIFF
--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -15,6 +15,7 @@ export interface Workload {
   targetClusters?: string[]
   replicas: number
   readyReplicas: number
+  updatedReplicas?: number
   status: 'Running' | 'Degraded' | 'Failed' | 'Pending'
   image: string
   labels?: Record<string, string>
@@ -25,7 +26,22 @@ export interface Workload {
     readyReplicas: number
     lastUpdated: string
   }>
+  reason?: string
+  message?: string
   createdAt: string
+  updatedAt?: string
+}
+
+export interface WorkloadClusterError {
+  cluster: string
+  errorType: string
+  message: string
+}
+
+export interface WorkloadList {
+  items: Workload[]
+  totalCount: number
+  clusterErrors?: WorkloadClusterError[]
 }
 
 export interface ClusterCapability {

--- a/web/src/types/mcs.ts
+++ b/web/src/types/mcs.ts
@@ -70,11 +70,23 @@ export interface ServiceImport {
 }
 
 /**
+ * MCSClusterError reports an error from a specific cluster during MCS queries.
+ */
+export interface MCSClusterError {
+  cluster: string
+  errorType?: string
+  message: string
+}
+
+/**
  * ServiceExportList is a paginated list of ServiceExports.
  */
 export interface ServiceExportList {
   items: ServiceExport[]
   totalCount: number
+  clusterErrors?: MCSClusterError[]
+  /** Present only on single-cluster queries (?cluster=X). */
+  cluster?: string
 }
 
 /**
@@ -83,6 +95,9 @@ export interface ServiceExportList {
 export interface ServiceImportList {
   items: ServiceImport[]
   totalCount: number
+  clusterErrors?: MCSClusterError[]
+  /** Present only on single-cluster queries (?cluster=X). */
+  cluster?: string
 }
 
 /**


### PR DESCRIPTION
## Problem

Go backend returns `clusterErrors` in `ServiceExportList`, `ServiceImportList`, and `WorkloadList` responses. Frontend TypeScript types lack these fields entirely — cluster error data is silently dropped. Additionally, the `Workload` interface was missing `updatedReplicas`, `reason`, `message`, and `updatedAt`.

## Fix

| Type | Change |
|------|--------|
| `Workload` | Added `updatedReplicas?`, `reason?`, `message?`, `updatedAt?` |
| `WorkloadList` | **New** — `items`, `totalCount`, `clusterErrors?` |
| `WorkloadClusterError` | **New** — matches Go struct |
| `ServiceExportList` | Added `clusterErrors?`, `cluster?` |
| `ServiceImportList` | Added `clusterErrors?`, `cluster?` |
| `MCSClusterError` | **New** — matches Go struct |

## Risk

Type-only additions — all new fields are optional (`?`). No runtime behavior changes.

Bead: feature-aiq