### PR TITLE
🐛 Reset triggerGuardRef and cancelState on success in UpdateSettings

### DIFF
--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -663,6 +663,8 @@ export function UpdateSettings() {
                 if (!result.success) {
                   setCancelState('error')
                   setCancelError(result.error ?? t('settings.updates.cancelFailed'))
+                } else {
+                  setCancelState('idle')
                 }
               }}
               disabled={!canCancel || cancelState === 'pending'}
@@ -867,6 +869,8 @@ export function UpdateSettings() {
               if (!result.success) {
                 setTriggerState('error')
                 setTriggerError(result.error ?? 'Unknown error')
+                triggerGuardRef.current = false
+              } else {
                 triggerGuardRef.current = false
               }
             }}


### PR DESCRIPTION
## Problem

In `UpdateSettings.tsx`:
1. `triggerGuardRef.current` set to `true` before async `triggerUpdate()`, only reset on error — success leaves ref `true` forever, permanently disabling the update button.
2. `cancelState` set to `'pending'` but never reset to `'idle'` on success — cancel button permanently disabled after first successful cancel.

## Fix

Two-line fix: add `else` branches to reset `triggerGuardRef.current = false` and `setCancelState('idle')` on success.

Bead: feature-0g6