### PR TITLE
🐛 Clean up resize drag listeners on unmount in SidebarShell + MissionSidebar

### DIFF
--- a/web/src/components/layout/SidebarShell.tsx
+++ b/web/src/components/layout/SidebarShell.tsx
@@ -248,6 +248,11 @@ export function SidebarShell({
 
   // ---- Resize handle ----
   const [isResizing, setIsResizing] = useState(false)
+  const resizeCleanupRef = useRef<(() => void) | null>(null)
+
+  // Clean up resize listeners on unmount to prevent leaks if mouseup never fires
+  useEffect(() => () => { resizeCleanupRef.current?.() }, [])
+
   const handleResizeStart = (e: React.MouseEvent) => {
     e.preventDefault()
     setIsResizing(true)
@@ -268,12 +273,14 @@ export function SidebarShell({
       document.removeEventListener('mouseup', handleMouseUp)
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
+      resizeCleanupRef.current = null
     }
 
     document.body.style.cursor = 'col-resize'
     document.body.style.userSelect = 'none'
     document.addEventListener('mousemove', handleMouseMove)
     document.addEventListener('mouseup', handleMouseUp)
+    resizeCleanupRef.current = handleMouseUp
   }
 
   // ---- Inline rename state ----

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -152,6 +152,11 @@ export function MissionSidebar() {
     return () => window.removeEventListener('resize', onResize)
   }, [])
 
+  const resizeCleanupRef = useRef<(() => void) | null>(null)
+
+  // Clean up resize listeners on unmount to prevent leaks if mouseup never fires
+  useEffect(() => () => { resizeCleanupRef.current?.() }, [])
+
   const handleResizeStart = (e: React.MouseEvent) => {
     e.preventDefault()
     setIsResizing(true)
@@ -175,6 +180,7 @@ export function MissionSidebar() {
       document.removeEventListener('mouseup', onMouseUp)
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
+      resizeCleanupRef.current = null
       // Persist final width using ref to avoid state-updater side effects
       try { localStorage.setItem(SIDEBAR_WIDTH_KEY, String(latestWidthRef.current)) } catch { /* ignore */ }
     }
@@ -183,6 +189,7 @@ export function MissionSidebar() {
     document.body.style.userSelect = 'none'
     document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp)
+    resizeCleanupRef.current = onMouseUp
   }
   const [showNewMission, setShowNewMission] = useState(false)
   const [showBrowser, setShowBrowser] = useState(false)


### PR DESCRIPTION
## Problem

Both `SidebarShell.tsx` and `MissionSidebar.tsx` attach `mousemove`/`mouseup` listeners to `document` during resize drag. Cleanup relies on `mouseup` firing — if the component unmounts mid-drag (navigation, route change), listeners persist and fire on every subsequent mouse move.

## Fix

Store the `mouseup` handler (which removes both listeners) in a `resizeCleanupRef`. A `useEffect` cleanup callback invokes it on unmount. The ref is nulled after normal mouseup completion to avoid double-cleanup.

Bead: feature-4tl