### PR TITLE
🌱 Extract magic number delays to named constants in RemediationConsole

### DIFF
--- a/web/src/components/drilldown/RemediationConsole.tsx
+++ b/web/src/components/drilldown/RemediationConsole.tsx
@@ -27,52 +27,64 @@ interface RemediationConsoleProps {
   issues: string[]
 }
 
+// Animation delay constants for simulated remediation steps
+const THINKING_DELAY_MS = 800
+const ACTION_DELAY_MS = 1000
+const ACTION_LONG_DELAY_MS = 1200
+const ANALYSIS_DELAY_MS = 1500
+const INFO_DELAY_MS = 600
+const RESULT_DELAY_MS = 500
+
+// Token usage estimation constants
+const BASE_TOKEN_ESTIMATE = 1000
+const TOKENS_PER_STEP_ESTIMATE = 100
+
 // Simulated remediation steps based on issue type
 const REMEDIATION_FLOWS: Record<string, Array<{ type: LogEntry['type']; message: string; details?: string; delay: number }>> = {
   CrashLoopBackOff: [
-    { type: 'thinking', message: 'Analyzing CrashLoopBackOff issue...', delay: 800 },
-    { type: 'action', message: 'Fetching pod logs to identify root cause', delay: 1200 },
-    { type: 'info', message: 'Found error in container logs: "Error: Cannot find module \'express\'"', delay: 1500 },
-    { type: 'thinking', message: 'This appears to be a missing dependency issue. Checking if this is a code or image problem...', delay: 1000 },
-    { type: 'action', message: 'Checking deployment image and pull policy', delay: 800 },
-    { type: 'info', message: 'Image: myapp:latest, PullPolicy: Always', delay: 600 },
-    { type: 'thinking', message: 'The issue is likely in the container image. Recommending image rebuild or rollback.', delay: 1000 },
-    { type: 'result', message: 'Recommendation: Rollback to previous working image version or fix the Docker build', details: 'kubectl rollout undo deployment/myapp -n default', delay: 500 },
+    { type: 'thinking', message: 'Analyzing CrashLoopBackOff issue...', delay: THINKING_DELAY_MS },
+    { type: 'action', message: 'Fetching pod logs to identify root cause', delay: ACTION_LONG_DELAY_MS },
+    { type: 'info', message: 'Found error in container logs: "Error: Cannot find module \'express\'"', delay: ANALYSIS_DELAY_MS },
+    { type: 'thinking', message: 'This appears to be a missing dependency issue. Checking if this is a code or image problem...', delay: ACTION_DELAY_MS },
+    { type: 'action', message: 'Checking deployment image and pull policy', delay: THINKING_DELAY_MS },
+    { type: 'info', message: 'Image: myapp:latest, PullPolicy: Always', delay: INFO_DELAY_MS },
+    { type: 'thinking', message: 'The issue is likely in the container image. Recommending image rebuild or rollback.', delay: ACTION_DELAY_MS },
+    { type: 'result', message: 'Recommendation: Rollback to previous working image version or fix the Docker build', details: 'kubectl rollout undo deployment/myapp -n default', delay: RESULT_DELAY_MS },
   ],
   ImagePullBackOff: [
-    { type: 'thinking', message: 'Analyzing ImagePullBackOff issue...', delay: 800 },
-    { type: 'action', message: 'Checking image reference and pull secrets', delay: 1000 },
-    { type: 'info', message: 'Image: registry.example.com/app:v2.0', delay: 600 },
-    { type: 'action', message: 'Verifying image pull secrets in namespace', delay: 1200 },
-    { type: 'error', message: 'No valid pull secret found for registry.example.com', delay: 800 },
-    { type: 'thinking', message: 'The pod needs a pull secret to access the private registry.', delay: 1000 },
-    { type: 'result', message: 'Fix: Create or update image pull secret for the registry', details: 'kubectl create secret docker-registry regcred --docker-server=registry.example.com --docker-username=<user> --docker-password=<pass> -n default', delay: 500 },
+    { type: 'thinking', message: 'Analyzing ImagePullBackOff issue...', delay: THINKING_DELAY_MS },
+    { type: 'action', message: 'Checking image reference and pull secrets', delay: ACTION_DELAY_MS },
+    { type: 'info', message: 'Image: registry.example.com/app:v2.0', delay: INFO_DELAY_MS },
+    { type: 'action', message: 'Verifying image pull secrets in namespace', delay: ACTION_LONG_DELAY_MS },
+    { type: 'error', message: 'No valid pull secret found for registry.example.com', delay: THINKING_DELAY_MS },
+    { type: 'thinking', message: 'The pod needs a pull secret to access the private registry.', delay: ACTION_DELAY_MS },
+    { type: 'result', message: 'Fix: Create or update image pull secret for the registry', details: 'kubectl create secret docker-registry regcred --docker-server=registry.example.com --docker-username=<user> --docker-password=<pass> -n default', delay: RESULT_DELAY_MS },
   ],
   OOMKilled: [
-    { type: 'thinking', message: 'Analyzing OOMKilled issue...', delay: 800 },
-    { type: 'action', message: 'Checking container resource limits', delay: 1000 },
-    { type: 'info', message: 'Current memory limit: 256Mi, Request: 128Mi', delay: 600 },
-    { type: 'action', message: 'Analyzing memory usage patterns from metrics', delay: 1500 },
-    { type: 'info', message: 'Peak memory usage before OOM: 254Mi (99% of limit)', delay: 800 },
-    { type: 'thinking', message: 'The container is running out of memory. Need to increase limits or optimize the application.', delay: 1000 },
-    { type: 'result', message: 'Recommendation: Increase memory limit to 512Mi', details: 'kubectl patch deployment myapp -p \'{"spec":{"template":{"spec":{"containers":[{"name":"app","resources":{"limits":{"memory":"512Mi"}}}]}}}}\'', delay: 500 },
+    { type: 'thinking', message: 'Analyzing OOMKilled issue...', delay: THINKING_DELAY_MS },
+    { type: 'action', message: 'Checking container resource limits', delay: ACTION_DELAY_MS },
+    { type: 'info', message: 'Current memory limit: 256Mi, Request: 128Mi', delay: INFO_DELAY_MS },
+    { type: 'action', message: 'Analyzing memory usage patterns from metrics', delay: ANALYSIS_DELAY_MS },
+    { type: 'info', message: 'Peak memory usage before OOM: 254Mi (99% of limit)', delay: THINKING_DELAY_MS },
+    { type: 'thinking', message: 'The container is running out of memory. Need to increase limits or optimize the application.', delay: ACTION_DELAY_MS },
+    { type: 'result', message: 'Recommendation: Increase memory limit to 512Mi', details: 'kubectl patch deployment myapp -p \'{"spec":{"template":{"spec":{"containers":[{"name":"app","resources":{"limits":{"memory":"512Mi"}}}]}}}}\'', delay: RESULT_DELAY_MS },
   ],
   Pending: [
-    { type: 'thinking', message: 'Analyzing why pod is stuck in Pending state...', delay: 800 },
-    { type: 'action', message: 'Checking node resources and scheduling constraints', delay: 1200 },
-    { type: 'info', message: 'Pod requests: CPU 2, Memory 4Gi', delay: 600 },
-    { type: 'action', message: 'Checking available cluster capacity', delay: 1000 },
-    { type: 'info', message: 'Available: CPU 0.5, Memory 1Gi across all nodes', delay: 800 },
-    { type: 'thinking', message: 'Insufficient cluster resources to schedule the pod.', delay: 1000 },
-    { type: 'result', message: 'Options: Scale up cluster, reduce pod resource requests, or remove other workloads', details: 'Consider: kubectl scale deployment less-critical-app --replicas=0', delay: 500 },
+    { type: 'thinking', message: 'Analyzing why pod is stuck in Pending state...', delay: THINKING_DELAY_MS },
+    { type: 'action', message: 'Checking node resources and scheduling constraints', delay: ACTION_LONG_DELAY_MS },
+    { type: 'info', message: 'Pod requests: CPU 2, Memory 4Gi', delay: INFO_DELAY_MS },
+    { type: 'action', message: 'Checking available cluster capacity', delay: ACTION_DELAY_MS },
+    { type: 'info', message: 'Available: CPU 0.5, Memory 1Gi across all nodes', delay: THINKING_DELAY_MS },
+    { type: 'thinking', message: 'Insufficient cluster resources to schedule the pod.', delay: ACTION_DELAY_MS },
+    { type: 'result', message: 'Options: Scale up cluster, reduce pod resource requests, or remove other workloads', details: 'Consider: kubectl scale deployment less-critical-app --replicas=0', delay: RESULT_DELAY_MS },
   ],
   default: [
-    { type: 'thinking', message: 'Analyzing the issue...', delay: 800 },
-    { type: 'action', message: 'Gathering diagnostic information', delay: 1200 },
-    { type: 'action', message: 'Checking pod events and logs', delay: 1000 },
-    { type: 'action', message: 'Analyzing resource configuration', delay: 1000 },
-    { type: 'thinking', message: 'Determining best remediation approach...', delay: 1200 },
-    { type: 'result', message: 'Analysis complete. Review the gathered information above for next steps.', delay: 500 },
+    { type: 'thinking', message: 'Analyzing the issue...', delay: THINKING_DELAY_MS },
+    { type: 'action', message: 'Gathering diagnostic information', delay: ACTION_LONG_DELAY_MS },
+    { type: 'action', message: 'Checking pod events and logs', delay: ACTION_DELAY_MS },
+    { type: 'action', message: 'Analyzing resource configuration', delay: ACTION_DELAY_MS },
+    { type: 'thinking', message: 'Determining best remediation approach...', delay: ACTION_LONG_DELAY_MS },
+    { type: 'result', message: 'Analysis complete. Review the gathered information above for next steps.', delay: RESULT_DELAY_MS },
   ],
 }
 
@@ -173,8 +185,7 @@ export function RemediationConsole({
         type: 'info',
         message: 'Remediation analysis complete',
       })
-      // Track token usage for AI remediation (~1000 tokens for analysis)
-      addTokens(1000 + flow.length * 100)
+      addTokens(BASE_TOKEN_ESTIMATE + flow.length * TOKENS_PER_STEP_ESTIMATE)
     }
 
     setIsRunning(false)


### PR DESCRIPTION
Fixes #11076

Replaces hardcoded delay values in `REMEDIATION_FLOWS` with named constants per codebase convention (no magic numbers).

### Constants added
| Constant | Value | Usage |
|----------|-------|-------|
| `THINKING_DELAY_MS` | 800 | Initial analysis / short thinking steps |
| `ACTION_DELAY_MS` | 1000 | Standard action / reasoning steps |
| `ACTION_LONG_DELAY_MS` | 1200 | Longer operations (fetching, verifying) |
| `ANALYSIS_DELAY_MS` | 1500 | Deep analysis steps |
| `INFO_DELAY_MS` | 600 | Quick info display |
| `RESULT_DELAY_MS` | 500 | Final result/recommendation |
| `BASE_TOKEN_ESTIMATE` | 1000 | Token usage base estimate |
| `TOKENS_PER_STEP_ESTIMATE` | 100 | Per-step token estimate |