### PR TITLE
🐛 fix: extend write deadline for SSE streams to prevent 60s cutoff

### DIFF
--- a/pkg/agent/server_events_stream.go
+++ b/pkg/agent/server_events_stream.go
@@ -64,6 +64,10 @@ func (s *Server) handleEventsStreamSSE(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
+	// Override the server-level WriteTimeout for this long-lived SSE stream.
+	rc := http.NewResponseController(w)
+	rc.SetWriteDeadline(time.Now().Add(sseWatchTimeout + time.Minute))
+
 	client, err := s.k8sClient.GetClient(cluster)
 	if err != nil {
 		sseWriteError(w, flusher, fmt.Sprintf("failed to get client for cluster %s: %v", cluster, err))
@@ -94,6 +98,7 @@ func (s *Server) handleEventsStreamSSE(w http.ResponseWriter, r *http.Request) {
 		case <-heartbeat.C:
 			// Keepalive comment — ignored by SSE clients but prevents
 			// proxies/load-balancers from closing idle connections.
+			rc.SetWriteDeadline(time.Now().Add(sseWatchTimeout + time.Minute))
 			fmt.Fprintf(w, ":heartbeat\n\n")
 			flusher.Flush()
 

--- a/pkg/agent/server_http_workloads.go
+++ b/pkg/agent/server_http_workloads.go
@@ -467,6 +467,7 @@ func (s *Server) handlePodsHTTP(w http.ResponseWriter, r *http.Request) {
 // pods SSE stream handler. Each cluster fetch is capped independently so one
 // slow cluster does not block the rest of the stream.
 const podsStreamPerClusterTimeout = 15 * time.Second
+const podsStreamSSETimeout = 2 * time.Minute
 
 // handlePodsStreamSSE streams pod data per cluster via Server-Sent Events.
 // The frontend subscribes to this endpoint for progressive multi-cluster pod
@@ -506,6 +507,10 @@ func (s *Server) handlePodsStreamSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
+
+	// Override the server-level WriteTimeout for this SSE stream.
+	rc := http.NewResponseController(w)
+	rc.SetWriteDeadline(time.Now().Add(podsStreamSSETimeout))
 
 	bw := bufio.NewWriter(w)
 


### PR DESCRIPTION
### 📝 Summary of Changes

- SSE endpoints `/events/stream` and `/pods/stream` were silently killed after 60s 
  by `http.Server.WriteTimeout`- designed for 10-minute watches, heartbeats couldn't prevent it
- Go's `WriteTimeout` is a single deadline from request start, not reset by `Write()`/`Flush()`

---

### Changes Made

- [x] `server_events_stream.go`: added `http.NewResponseController(w).SetWriteDeadline()` after SSE headers to extend write deadline to match watch timeout
- [x] Reset deadline on each heartbeat tick to keep connection alive for full watch duration
- [x] `server_http_workloads.go`: same `ResponseController` pattern for pods stream
- [x] Added `podsStreamSSETimeout` constant (2 minutes) for multi-cluster pod fetches

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

N/A

---

### 👀 Reviewer Notes

two files changed- `pkg/agent/server_events_stream.go` and `pkg/agent/server_http_workloads.go`.
WebSocket endpoints unaffected- `Upgrade()` hijacks connection out of server timeout governance.
Slowloris protection preserved for all non-SSE endpoints
