### PR TITLE
🐛 Add timeouts to 2 fetch calls that could hang indefinitely

### DIFF
--- a/web/src/components/cards/ClusterLocations.tsx
+++ b/web/src/components/cards/ClusterLocations.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next'
 import { useToast } from '../ui/Toast'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { CLUSTER_MARKER_FONT_SIZE } from '../../lib/constants'
+import { FETCH_EXTERNAL_TIMEOUT_MS } from '../../lib/constants/network'
 
 /** Search input debounce delay (#6213). */
 const SEARCH_DEBOUNCE_MS = 250
@@ -256,7 +257,7 @@ export function ClusterLocations({ config: _config }: ClusterLocationsProps) {
     setMapLoading(true)
     setMapError(false)
     
-    fetch(WorldMapSvgUrl, { signal: controller.signal })
+    fetch(WorldMapSvgUrl, { signal: AbortSignal.any([controller.signal, AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS)]) })
       .then(res => {
         if (!res.ok) throw new Error('Failed to load map')
         return res.text()

--- a/web/src/hooks/useBenchmarkData.ts
+++ b/web/src/hooks/useBenchmarkData.ts
@@ -105,11 +105,17 @@ function startGlobalStream(since: string) {
   const token = localStorage.getItem(STORAGE_KEY_TOKEN)
   abortController = new AbortController()
 
+  // Connection timeout: abort if the server doesn't respond within the default timeout.
+  // Once the response arrives (stream connected), the timer is cleared so the
+  // long-lived SSE stream can run indefinitely until done or manually aborted.
+  const connectTimer = setTimeout(() => abortController?.abort(), FETCH_DEFAULT_TIMEOUT_MS)
+
   fetch(`/api/benchmarks/reports/stream?since=${encodeURIComponent(since)}`, {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
     signal: abortController.signal,
   })
     .then(async (res) => {
+      clearTimeout(connectTimer)
       if (!res.ok || !res.body) {
         streamState = { ...streamState, isStreaming: false, isDone: true, error: `Stream error: ${res.status}` }
         notifySubscribers()
@@ -179,6 +185,7 @@ function startGlobalStream(since: string) {
       notifySubscribers()
     })
     .catch((err) => {
+      clearTimeout(connectTimer)
       if (err.name !== 'AbortError') {
         streamState = { ...streamState, error: err.message, isStreaming: false, isDone: true }
         notifySubscribers()


### PR DESCRIPTION
Fixes #10866

Two fetch calls lacked timeouts, allowing requests to hang indefinitely if the backend is slow or unresponsive:

1. **ClusterLocations.tsx** — SVG map fetch had an AbortController for unmount cleanup but no timeout. Added `AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS)` via `AbortSignal.any()` so the fetch aborts after 15s even if the server never responds.

2. **useBenchmarkData.ts** — SSE stream fetch had no connection timeout. Added a `setTimeout` that aborts the controller after `FETCH_DEFAULT_TIMEOUT_MS` (10s) if the server hasn't responded. The timer is cleared once the response arrives so the long-lived stream can run normally.

Note: The bead mentioned useMarketplace.ts lines 298/310, but those already have `AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS)` — no changes needed there.