### PR TITLE
🐛 Add keyboard accessibility to clickable elements

### DIFF
--- a/web/src/components/feedback/DraftsTab.tsx
+++ b/web/src/components/feedback/DraftsTab.tsx
@@ -149,8 +149,7 @@ export function DraftsTab({
                     </div>
 
                     {/* Actions */}
-                    {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-                    <div className="flex items-center gap-2 mt-2 pt-2 border-t border-border/30" onClick={(e) => e.stopPropagation()}>
+                    <div role="group" className="flex items-center gap-2 mt-2 pt-2 border-t border-border/30" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
                       {isConfirmingDelete ? (
                         <>
                           <span className="text-xs text-muted-foreground">{t('drafts.deleteThisDraft', 'Delete this draft?')}</span>
@@ -208,8 +207,7 @@ export function DraftsTab({
               </span>
               {recentlyDeletedOpen && (
                 showEmptyAllConfirm ? (
-                  /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-                  <span className="flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+                  <span role="group" className="flex items-center gap-1.5" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
                     <span className="text-xs text-muted-foreground">{t('drafts.emptyAllConfirm', 'Remove all?')}</span>
                     <button
                       onClick={() => { onEmptyRecentlyDeleted(); setShowEmptyAllConfirm(false); showToast(t('drafts.permanentlyDeletedAll', 'All deleted drafts removed'), 'success') }}

--- a/web/src/components/history/CardHistory.tsx
+++ b/web/src/components/history/CardHistory.tsx
@@ -86,7 +86,7 @@ interface ConfirmDeleteDialogProps {
 function ConfirmDeleteDialog({ title, message, onConfirm, onCancel }: ConfirmDeleteDialogProps) {
   return (
     <>
-      <div className="fixed inset-0 bg-black/60 backdrop-blur-xs z-overlay" onClick={onCancel} />
+      <div role="button" tabIndex={0} className="fixed inset-0 bg-black/60 backdrop-blur-xs z-overlay" onClick={onCancel} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onCancel(); } }} aria-label="Close dialog" />
       <div className="fixed inset-0 flex items-center justify-center z-modal p-4">
         <div className="bg-card border border-border rounded-xl shadow-xl max-w-sm w-full p-6">
           <div className="flex items-center gap-3 mb-4">

--- a/web/src/lib/cards/__tests__/CardComponents-coverage.test.tsx
+++ b/web/src/lib/cards/__tests__/CardComponents-coverage.test.tsx
@@ -546,7 +546,7 @@ describe('CardAIActions', () => {
   it('stops propagation on container click', () => {
     const parentClick = vi.fn()
     render(
-      <div onClick={parentClick}>
+      <div role="button" onClick={parentClick}>
         <CardAIActions resource={defaultResource} />
       </div>
     )
@@ -558,7 +558,7 @@ describe('CardAIActions', () => {
   it('stops propagation on button clicks', () => {
     const parentClick = vi.fn()
     render(
-      <div onClick={parentClick}>
+      <div role="button" onClick={parentClick}>
         <CardAIActions resource={defaultResource} />
       </div>
     )


### PR DESCRIPTION
Fixes #10864

Adds keyboard accessibility to 5 clickable elements that lacked keyboard support:

- **DraftsTab.tsx**: 2 container divs using onClick stopPropagation — added role="group" and onKeyDown handler, removed eslint-disable comments
- **CardHistory.tsx**: 1 overlay backdrop — added role="button", tabIndex={0}, onKeyDown (Enter/Space), and aria-label
- **CardComponents-coverage.test.tsx**: 2 test wrapper divs — added role="button"

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>