### PR TITLE
🐛 Extract atomicWriteFile helper, convert 4 bare os.WriteFile sites

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/kubestellar/console/pkg/fileutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -129,8 +130,8 @@ func (cm *ConfigManager) saveLocked() error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	// Write with secure permissions
-	if err := os.WriteFile(cm.configPath, data, configFileMode); err != nil {
+	// Atomic write: temp file → fsync → rename to prevent corruption
+	if err := fileutil.AtomicWriteFile(cm.configPath, data, configFileMode); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
 	}
 

--- a/pkg/agent/server_ai_tokens.go
+++ b/pkg/agent/server_ai_tokens.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/console/pkg/agent/protocol"
+	"github.com/kubestellar/console/pkg/fileutil"
 )
 
 func (s *Server) checkClaudeAvailable() bool {
@@ -253,15 +254,10 @@ func (s *Server) saveTokenUsage() {
 		return
 	}
 
-	// Atomic write: write to a temp file then rename to avoid corruption
+	// Atomic write: temp file → fsync → rename to avoid corruption
 	// if the process is killed mid-write (#6996).
-	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, agentFileMode); err != nil {
-		slog.Warn("could not write token usage temp file", "error", err)
-		return
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		slog.Warn("could not rename token usage temp file", "error", err)
+	if err := fileutil.AtomicWriteFile(path, data, agentFileMode); err != nil {
+		slog.Warn("could not write token usage file", "error", err)
 		return
 	}
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kubestellar/console/pkg/api/audit"
 	"github.com/kubestellar/console/pkg/api/handlers"
 	"github.com/kubestellar/console/pkg/api/middleware"
+	"github.com/kubestellar/console/pkg/fileutil"
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/kagent"
 	"github.com/kubestellar/console/pkg/kagenti_provider"
@@ -1628,7 +1629,7 @@ func persistSecret(path, secret string) {
 		slog.Warn("Could not create directory for JWT secret", "dir", dir, "error", err)
 		return
 	}
-	if err := os.WriteFile(path, []byte(secret+"\n"), secretFilePerms); err != nil {
+	if err := fileutil.AtomicWriteFile(path, []byte(secret+"\n"), secretFilePerms); err != nil {
 		slog.Warn("Could not persist dev JWT secret", "path", path, "error", err)
 	} else {
 		slog.Info("Persisted dev JWT secret", "path", path)

--- a/pkg/fileutil/atomic.go
+++ b/pkg/fileutil/atomic.go
@@ -1,0 +1,47 @@
+// Package fileutil provides filesystem helpers shared across the console backend.
+package fileutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// AtomicWriteFile writes data to a file atomically by first writing to a
+// temporary file in the same directory, calling fsync, then renaming over
+// the target path. This prevents corruption if the process is killed
+// mid-write. The caller-specified perm is applied to the final file.
+func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+
+	tmp, err := os.CreateTemp(dir, ".atomic-*.tmp")
+	if err != nil {
+		return fmt.Errorf("atomic write: create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("atomic write: write temp: %w", err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("atomic write: chmod temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("atomic write: fsync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("atomic write: close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("atomic write: rename: %w", err)
+	}
+	return nil
+}

--- a/pkg/store/persistence_config.go
+++ b/pkg/store/persistence_config.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubestellar/console/pkg/fileutil"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
@@ -231,7 +232,7 @@ func (p *PersistenceStore) Save() error {
 		return fmt.Errorf("failed to marshal persistence config: %w", err)
 	}
 
-	if err := os.WriteFile(p.configPath, data, configFileMode); err != nil {
+	if err := fileutil.AtomicWriteFile(p.configPath, data, configFileMode); err != nil {
 		return fmt.Errorf("failed to write persistence config: %w", err)
 	}
 


### PR DESCRIPTION
Fixes #10867

Crash mid-write can corrupt config/token data when using bare `os.WriteFile`. The settings manager already uses atomic temp→fsync→rename; this PR extracts that pattern into `pkg/fileutil.AtomicWriteFile` and reuses it in 4 locations:

1. **pkg/agent/config.go** — `config.yaml` (bare WriteFile → atomic)
 atomic with fsync)
3. **pkg/store/persistence_config.go** — persistence config (had mutex serialization but **no atomic write** → atomic)
4. **pkg/api/server.go** — JWT secret file (bare WriteFile → atomic)

The new `fileutil.AtomicWriteFile` follows the same pattern as `settings/manager.go`: CreateTemp in same dir → Write → Chmod → Sync → Close → Rename.