### PR TITLE
🌱 Replace explicit any types in Workloads and formatters

### DIFF
--- a/web/src/components/workloads/Workloads.tsx
+++ b/web/src/components/workloads/Workloads.tsx
@@ -8,7 +8,7 @@ import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useIsModeSwitching } from '../../lib/unified/demo'
-import { StatusIndicator } from '../charts/StatusIndicator'
+import { StatusIndicator, type Status } from '../charts/StatusIndicator'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { Skeleton } from '../ui/Skeleton'
 import { StatBlockValue } from '../ui/StatsOverview'
@@ -363,7 +363,7 @@ export function Workloads() {
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-4">
-                    <StatusIndicator status={status as any} size="lg" />
+                    <StatusIndicator status={status as Status} size="lg" />
                     <div>
                       <h3 className="font-semibold text-foreground">{isDeployment ? deploy.name : app.namespace}</h3>
                       <div className="flex items-center gap-2">

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -245,17 +245,19 @@ export function createCardSyncFormatter(
   keys: string | CardSyncKeys,
 ): (isoString: string) => string {
   const k = typeof keys === 'string' ? cardSyncKeys(keys) : keys
+  // Cast to loose signature — sync keys are computed at runtime from card prefixes
+  const tDynamic = t as (key: string, options?: Record<string, unknown>) => string
 
   return (isoString: string): string => {
     const parsed = new Date(isoString).getTime()
-    if (!isoString || isNaN(parsed)) return t(k.justNow)
+    if (!isoString || isNaN(parsed)) return tDynamic(k.justNow)
 
     const diff = Date.now() - parsed
-    if (diff < 0) return t(k.justNow)
+    if (diff < 0) return tDynamic(k.justNow)
 
-    if (diff < MS_PER_MINUTE) return t(k.justNow)
-    if (diff < MS_PER_HOUR) return t(k.minutesAgo, { count: Math.floor(diff / MS_PER_MINUTE) })
-    if (diff < MS_PER_DAY) return t(k.hoursAgo, { count: Math.floor(diff / MS_PER_HOUR) })
-    return t(k.daysAgo, { count: Math.floor(diff / MS_PER_DAY) })
+    if (diff < MS_PER_MINUTE) return tDynamic(k.justNow)
+    if (diff < MS_PER_HOUR) return tDynamic(k.minutesAgo, { count: Math.floor(diff / MS_PER_MINUTE) })
+    if (diff < MS_PER_DAY) return tDynamic(k.hoursAgo, { count: Math.floor(diff / MS_PER_HOUR) })
+    return tDynamic(k.daysAgo, { count: Math.floor(diff / MS_PER_DAY) })
   }
 }

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -240,8 +240,7 @@ function cardSyncKeys(prefix: string): CardSyncKeys {
  * or an explicit {@link CardSyncKeys} object for non-standard cards.
  */
 export function createCardSyncFormatter(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  t: (key: any, options?: any) => string,
+  t: (key: string, options?: Record<string, unknown>) => string,
   keys: string | CardSyncKeys,
 ): (isoString: string) => string {
   const k = typeof keys === 'string' ? cardSyncKeys(keys) : keys

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -2,6 +2,7 @@
  * Utility functions for formatting values for display
  */
 
+import type { TFunction } from 'i18next'
 import { MS_PER_SECOND, MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY, MS_PER_MONTH, MS_PER_YEAR, SECONDS_PER_MINUTE, MINUTES_PER_HOUR } from './constants/time'
 
 /**
@@ -240,7 +241,7 @@ function cardSyncKeys(prefix: string): CardSyncKeys {
  * or an explicit {@link CardSyncKeys} object for non-standard cards.
  */
 export function createCardSyncFormatter(
-  t: (key: string, options?: Record<string, unknown>) => string,
+  t: TFunction<'cards'>,
   keys: string | CardSyncKeys,
 ): (isoString: string) => string {
   const k = typeof keys === 'string' ? cardSyncKeys(keys) : keys


### PR DESCRIPTION
Fixes #3400

Replaces 2 explicit `any` type annotations with proper types:

- **Workloads.tsx**: Replace `status as any` with `status as Status` (imported from StatusIndicator)
- **formatters.ts**: Replace `any` in translation function params with `string` and `Record<string, unknown>`, removing the eslint-disable comment

Follows project convention: no explicit `any` types (CLAUDE.md).