### PR TITLE
🐛 Add aria-label to 4 port-forward form inputs (WCAG 1.3.1)

### DIFF
--- a/web/src/components/dashboard/cardFactoryTemplatesT2.ts
+++ b/web/src/components/dashboard/cardFactoryTemplatesT2.ts
@@ -427,16 +427,16 @@ export const T2_TEMPLATES: T2Template[] = [
 
       {adding && (
         <div className="grid grid-cols-2 gap-2 mb-3 p-2 rounded bg-secondary/20 border border-border/50">
-          <input placeholder="Namespace" value={form.namespace}
+          <input placeholder="Namespace" value={form.namespace} aria-label="Namespace"
             onChange={e => setForm(p => ({...p, namespace: e.target.value}))}
             className="text-xs px-2 py-1 rounded bg-secondary text-foreground" />
-          <input placeholder="pod/name or svc/name" value={form.resource}
+          <input placeholder="pod/name or svc/name" value={form.resource} aria-label="Kubernetes resource (pod/name or svc/name)"
             onChange={e => setForm(p => ({...p, resource: e.target.value}))}
             className="text-xs px-2 py-1 rounded bg-secondary text-foreground" />
-          <input placeholder="Local port" value={form.localPort} type="number"
+          <input placeholder="Local port" value={form.localPort} type="number" aria-label="Local port number"
             onChange={e => setForm(p => ({...p, localPort: e.target.value}))}
             className="text-xs px-2 py-1 rounded bg-secondary text-foreground" />
-          <input placeholder="Remote port" value={form.remotePort} type="number"
+          <input placeholder="Remote port" value={form.remotePort} type="number" aria-label="Remote port number"
             onChange={e => setForm(p => ({...p, remotePort: e.target.value}))}
             className="text-xs px-2 py-1 rounded bg-secondary text-foreground" />
           <button onClick={addForward}


### PR DESCRIPTION
Fixes #10868

The port-forward form in `cardFactoryTemplatesT2.ts` had 4 `<input>` fields with placeholder text but no associated `<label>` elements or `aria-label` attributes. Screen readers could not describe these fields, violating WCAG 1.3.1 Level A.

**Changes:**
- Added `aria-label` to Namespace, Resource, Local port, and Remote port inputs

**Bead note:** The original scan listed 10 images missing alt and 5 inputs missing labels. Scanning the current codebase shows all 10 images already have proper `alt` text and the Events.tsx input already has an `htmlFor`-linked label. Only these 4 port-forward inputs needed fixing.