### PR TITLE
⚡ Memoize expensive reduce/filter chains in render body

### DIFF
--- a/web/src/components/cards/GPUInventoryHistory.tsx
+++ b/web/src/components/cards/GPUInventoryHistory.tsx
@@ -627,6 +627,12 @@ export function GPUInventoryHistory() {
     return { arrivalRate, departureRate, avgDurationIntervals }
   }, [history, showDemo, filterGPUNodes, chartData])
 
+  const meanAllocatedGPUs = useMemo(() => {
+    const safeData = chartData || []
+    if (safeData.length === 0) return 0
+    return Math.round(safeData.reduce((s, d) => s + d.allocated, 0) / safeData.length)
+  }, [chartData])
+
   // ── Snapshot interval (computed from history timestamps) ────────────
   /** Median interval between consecutive snapshots in minutes, used to display churn metrics in real time units */
   const snapshotIntervalMin = (() => {
@@ -1077,7 +1083,7 @@ export function GPUInventoryHistory() {
           <span>
             {t('cards:gpuInventoryHistory.avgUsage', 'Avg')}:{' '}
             <span className="text-foreground font-medium">
-              {Math.round((chartData || []).reduce((s, d) => s + d.allocated, 0) / (chartData || []).length)} GPUs
+              {meanAllocatedGPUs} GPUs
             </span>
           </span>
           {churnMetrics && (

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -578,10 +578,14 @@ Please:
       context: { clusterName } })
   }
 
-  const installedCount = Object.values(statuses).filter(s => s.installed).length
-  const totalViolations = Object.values(statuses)
-    .filter(s => s.installed)
-    .reduce((sum, s) => sum + (s.violationCount || 0), 0)
+  const { installedCount, totalViolations, activePolicies } = useMemo(() => {
+    const installed = Object.values(statuses).filter(s => s.installed)
+    return {
+      installedCount: installed.length,
+      totalViolations: installed.reduce((sum, s) => sum + (s.violationCount || 0), 0),
+      activePolicies: installed.reduce((sum, s) => sum + (s.policyCount || 0), 0),
+    }
+  }, [statuses])
 
   const handleShowViolations = (clusterName: string) => {
     setSelectedClusterForViolations(clusterName)
@@ -708,7 +712,7 @@ Please:
           <div className="p-2 rounded-lg bg-orange-500/10 border border-orange-500/20">
             <p className="text-2xs text-orange-400">Policies Active</p>
             <p className="text-lg font-bold text-foreground">
-              {Object.values(statuses).filter(s => s.installed).reduce((sum, s) => sum + (s.policyCount || 0), 0)}
+              {activePolicies}
             </p>
           </div>
           <div className="p-2 rounded-lg bg-red-500/10 border border-red-500/20">


### PR DESCRIPTION
Fixes #10870

Multiple card components ran expensive array operations on every render without `useMemo`:

**GPUInventoryHistory.tsx** — Inline `.reduce()` in JSX computed average GPU allocation on every render. Extracted to `meanAllocatedGPUs` useMemo.

**OPAPolicies.tsx** — Three separate `Object.values(statuses).filter(s => s.installed)` chains (installedCount, totalViolations, and an inline policyCount reduce in JSX) iterated the statuses map independently on every render. Consolidated into a single useMemo that iterates once.

**Not changed (already optimized):**
- ComplianceCards.tsx — reduces are already inside useMemo
- IssueActivityChart.tsx — reduces are already inside useMemo
- ConsoleOfflineDetectionCard.tsx — filter/map chains are inside an event handler (`doStartAnalysis`), not in render body