### PR TITLE
🐛 Break circular import cycle between lib/cache and hooks/mcp/shared

### DIFF
--- a/web/src/hooks/mcp/clusterCacheRef.ts
+++ b/web/src/hooks/mcp/clusterCacheRef.ts
@@ -1,0 +1,27 @@
+/**
+ * Standalone cluster-cache reference that breaks the circular dependency
+ * between lib/cache and hooks/mcp/shared.
+ *
+ * hooks/mcp/shared.ts populates `_clusters` at init time; consumers
+ * read via the exported getter without importing shared.ts.
+ */
+
+import type { ClusterInfo } from './types'
+
+let _clusters: ClusterInfo[] = []
+
+/**
+ * Lightweight read-only reference to the current cluster list.
+ * Used by lib/cache/fetcherUtils.ts to resolve clusters without
+ * importing the full MCP shared module (which would create a cycle).
+ */
+export const clusterCacheRef = {
+  get clusters(): ClusterInfo[] {
+    return _clusters
+  },
+}
+
+/** Called by hooks/mcp/shared.ts whenever the cluster cache changes. */
+export function setClusterCacheRefClusters(clusters: ClusterInfo[]): void {
+  _clusters = clusters
+}

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -5,6 +5,7 @@ import { isDemoMode, isNetlifyDeployment, isDemoToken, subscribeDemoMode } from 
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { registerCacheReset, triggerAllRefetches } from '../../lib/modeTransition'
 import { resetFailuresForCluster, resetAllCacheFailures } from '../../lib/cache'
+import { clusterCacheRef, setClusterCacheRefClusters } from './clusterCacheRef'
 import { hostnameEndsWith, hostnameContainsLabel } from '../../lib/utils/urlHostname'
 import { appendWsAuthToken } from '../../lib/utils/wsAuth'
 import { emitAgentTokenFailure } from '../../lib/analytics'
@@ -348,6 +349,9 @@ export let clusterCache: ClusterCache = {
   lastRefresh: storedClusters.length > 0 ? new Date() : null,
 }
 
+// Seed the standalone clusterCacheRef at module init
+setClusterCacheRefClusters(storedClusters)
+
 // Subscribers that get notified when cluster state changes.
 // Split into two sets (#7865):
 //  - dataSubscribers: notified inside React.startTransition(), so navigation
@@ -535,6 +539,11 @@ export function updateClusterCache(updates: Partial<ClusterCache>) {
   // `clusterCache` object sees the update (ESM live-binding of `let` exports
   // is not preserved by all bundlers / test runners).
   Object.assign(clusterCache, updates)
+
+  // Keep the standalone clusterCacheRef in sync (breaks circular import)
+  if (updates.clusters) {
+    setClusterCacheRefClusters(clusterCache.clusters)
+  }
 
   // Route notifications based on which slice the updates touch (#7865).
   // UI fires first (urgent) so spinner on/off commits immediately, then
@@ -1844,13 +1853,8 @@ function getDemoClusters(): ClusterInfo[] {
   ]
 }
 
-// Lightweight reference to cluster cache for domain modules
-// Modules that don't need the full singleton can import this
-export const clusterCacheRef = {
-  get clusters(): ClusterInfo[] {
-    return clusterCache.clusters
-  },
-}
+// Re-exported from clusterCacheRef.ts for backward compatibility
+export { clusterCacheRef }
 
 // Subscribe to cluster cache changes (for modules that need reactive updates).
 // Back-compat API: receives BOTH data and UI updates. Prefer the split

--- a/web/src/lib/cache/fetcherUtils.ts
+++ b/web/src/lib/cache/fetcherUtils.ts
@@ -7,7 +7,7 @@
 
 import { isBackendUnavailable } from '../api'
 import { fetchSSE } from '../sseClient'
-import { clusterCacheRef } from '../../hooks/mcp/shared'
+import { clusterCacheRef } from '../../hooks/mcp/clusterCacheRef'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../constants/network'
 import { settledWithConcurrency } from '../utils/concurrency'


### PR DESCRIPTION
Fixes #10877

`lib/cache/fetcherUtils.ts` imported `clusterCacheRef` from `hooks/mcp/shared`, which imported `resetFailuresForCluster` from `lib/cache` — creating a cycle: `lib/cache → hooks/mcp/shared → lib/cache`. This could cause undefined exports during module initialization depending on bundler load order.

**Fix:** Extract `clusterCacheRef` to `hooks/mcp/clusterCacheRef.ts` — a tiny standalone module with no dependencies on `lib/cache`:
- Exports `clusterCacheRef` (getter) and `setClusterCacheRefClusters` (setter)
- `shared.ts` seeds the ref at module init and calls the setter in `updateClusterCache()`
- `fetcherUtils.ts` now imports from `clusterCacheRef.ts` instead of `shared.ts`
- `shared.ts` re-exports `clusterCacheRef` for backward compatibility (50+ consumers)