### PR TITLE
🐛 Wire isDemoData + useReportCardDataState in 14 status cards

### DIFF
--- a/web/src/components/cards/cni_status/index.tsx
+++ b/web/src/components/cards/cni_status/index.tsx
@@ -26,6 +26,7 @@ import { useTranslation } from 'react-i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedCni } from '../../../hooks/useCachedCni'
+import { useReportCardDataState } from '../CardDataContext'
 import type { CniNodeState, CniNodeStatus } from '../../../lib/demo/cni'
 import { formatTimeAgo } from '../../../lib/formatters'
 
@@ -93,7 +94,9 @@ function NodeRow({ node }: { node: CniNodeStatus }) {
 
 export function CniStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedCni()
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } = useCachedCni()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const isHealthy = data.health === 'healthy'
   const nodes = data.nodes ?? []

--- a/web/src/components/cards/cortex_status/index.tsx
+++ b/web/src/components/cards/cortex_status/index.tsx
@@ -31,6 +31,7 @@ import type { TFunction } from 'i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedCortex } from '../../../hooks/useCachedCortex'
+import { useReportCardDataState } from '../CardDataContext'
 import type {
   CortexComponentName,
   CortexComponentPod,
@@ -156,8 +157,10 @@ function ComponentRow({
 
 export function CortexStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } =
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } =
     useCachedCortex()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const isHealthy = data.health === 'healthy'
   const components = data.components ?? []

--- a/web/src/components/cards/dapr_status/demoData.ts
+++ b/web/src/components/cards/dapr_status/demoData.ts
@@ -16,7 +16,7 @@
 
 export type DaprControlPlanePodStatus = 'running' | 'pending' | 'failed' | 'unknown'
 export type DaprComponentType = 'state-store' | 'pubsub' | 'binding'
-export type DaprHealth = 'healthy' | 'degraded' | 'not-installed'
+export type DaprHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export interface DaprControlPlanePod {
   /** Logical name of the control plane component. */

--- a/web/src/components/cards/dapr_status/index.tsx
+++ b/web/src/components/cards/dapr_status/index.tsx
@@ -30,6 +30,7 @@ import type { TFunction } from 'i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedDapr } from '../../../hooks/useCachedDapr'
+import { useReportCardDataState } from '../CardDataContext'
 import type {
   DaprComponent,
   DaprComponentType,
@@ -143,7 +144,9 @@ function ComponentRow({
 
 export function DaprStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedDapr()
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } = useCachedDapr()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const isHealthy = data.health === 'healthy'
 

--- a/web/src/components/cards/envoy_status/demoData.ts
+++ b/web/src/components/cards/envoy_status/demoData.ts
@@ -15,7 +15,7 @@
 
 export type EnvoyListenerStatus = 'active' | 'draining' | 'warming'
 export type EnvoyClusterHealth = 'healthy' | 'degraded' | 'unhealthy'
-export type EnvoyHealth = 'healthy' | 'degraded' | 'not-installed'
+export type EnvoyHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export interface EnvoyListener {
   name: string

--- a/web/src/components/cards/envoy_status/index.tsx
+++ b/web/src/components/cards/envoy_status/index.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from 'react-i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedEnvoy } from './useCachedEnvoy'
+import { useReportCardDataState } from '../CardDataContext'
 import type { EnvoyListener, EnvoyUpstreamCluster } from './demoData'
 import { formatTimeAgo } from '../../../lib/formatters'
 import { formatThroughput } from '../../../lib/cards/formatters'
@@ -102,7 +103,9 @@ function ClusterRow({ cluster }: { cluster: EnvoyUpstreamCluster }) {
 
 export function EnvoyStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedEnvoy()
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } = useCachedEnvoy()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const isHealthy = data.health === 'healthy'
 

--- a/web/src/components/cards/grpc_status/demoData.ts
+++ b/web/src/components/cards/grpc_status/demoData.ts
@@ -15,7 +15,7 @@
 // ---------------------------------------------------------------------------
 
 export type GrpcServingStatus = 'serving' | 'not-serving' | 'unknown'
-export type GrpcHealth = 'healthy' | 'degraded' | 'not-installed'
+export type GrpcHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export interface GrpcService {
   name: string

--- a/web/src/components/cards/grpc_status/index.tsx
+++ b/web/src/components/cards/grpc_status/index.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from 'react-i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedGrpc } from '../../../hooks/useCachedGrpc'
+import { useReportCardDataState } from '../CardDataContext'
 import type { GrpcService } from './demoData'
 import { formatTimeAgo } from '../../../lib/formatters'
 import { formatThroughput } from '../../../lib/cards/formatters'
@@ -106,7 +107,9 @@ function ServiceRow({ service }: { service: GrpcService }) {
 
 export function GrpcStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedGrpc()
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } = useCachedGrpc()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const isHealthy = data.health === 'healthy'
 

--- a/web/src/components/cards/kserve_status/index.tsx
+++ b/web/src/components/cards/kserve_status/index.tsx
@@ -33,6 +33,7 @@ import type { TFunction } from 'i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedKserve } from '../../../hooks/useCachedKserve'
+import { useReportCardDataState } from '../CardDataContext'
 import { cn } from '../../../lib/cn'
 import type {
   KServeService,

--- a/web/src/components/cards/kserve_status/index.tsx
+++ b/web/src/components/cards/kserve_status/index.tsx
@@ -168,11 +168,15 @@ export function KServeStatus() {
   const {
     data,
     isRefreshing,
+    isDemoData,
+    isFailed,
+    consecutiveFailures,
     error,
     showSkeleton,
     showEmptyState,
-    isDemoData,
   } = useCachedKserve()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   if (showSkeleton) {
     return (

--- a/web/src/components/cards/kubevela_status/demoData.ts
+++ b/web/src/components/cards/kubevela_status/demoData.ts
@@ -23,7 +23,7 @@
 // Types
 // ---------------------------------------------------------------------------
 
-export type KubeVelaHealth = 'healthy' | 'degraded' | 'not-installed'
+export type KubeVelaHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export type KubeVelaAppStatus =
   | 'running'

--- a/web/src/components/cards/kubevela_status/index.tsx
+++ b/web/src/components/cards/kubevela_status/index.tsx
@@ -32,6 +32,7 @@ import { useTranslation } from 'react-i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedKubevela } from '../../../hooks/useCachedKubevela'
+import { useReportCardDataState } from '../CardDataContext'
 import type {
   KubeVelaApplication,
   KubeVelaAppStatus,
@@ -263,8 +264,10 @@ function ApplicationRow({
 
 export function KubeVelaStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } =
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } =
     useCachedKubevela()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const applications = data.applications ?? []
   const displayedApps = applications.slice(0, MAX_APPS_DISPLAYED)

--- a/web/src/components/cards/linkerd_status/demoData.ts
+++ b/web/src/components/cards/linkerd_status/demoData.ts
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------------
 
 export type LinkerdPodStatus = 'meshed' | 'partial' | 'unmeshed'
-export type LinkerdHealth = 'healthy' | 'degraded' | 'not-installed'
+export type LinkerdHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export interface LinkerdMeshedDeployment {
   namespace: string

--- a/web/src/components/cards/linkerd_status/index.tsx
+++ b/web/src/components/cards/linkerd_status/index.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from 'react-i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedLinkerd } from '../../../hooks/useCachedLinkerd'
+import { useReportCardDataState } from '../CardDataContext'
 import type { LinkerdMeshedDeployment } from './demoData'
 import { formatTimeAgo } from '../../../lib/formatters'
 import { formatThroughput } from '../../../lib/cards/formatters'
@@ -109,7 +110,9 @@ function DeploymentRow({ deployment }: { deployment: LinkerdMeshedDeployment }) 
 
 export function LinkerdStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedLinkerd()
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } = useCachedLinkerd()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const isHealthy = data.health === 'healthy'
 

--- a/web/src/components/cards/openfeature_status/demoData.ts
+++ b/web/src/components/cards/openfeature_status/demoData.ts
@@ -20,7 +20,7 @@
 // Types
 // ---------------------------------------------------------------------------
 
-export type OpenFeatureHealth = 'healthy' | 'degraded' | 'not-installed'
+export type OpenFeatureHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 export type OpenFeatureProviderStatus = 'healthy' | 'degraded' | 'unhealthy'
 export type OpenFeatureFlagType = 'boolean' | 'string' | 'number' | 'json'
 

--- a/web/src/components/cards/openfeature_status/index.tsx
+++ b/web/src/components/cards/openfeature_status/index.tsx
@@ -32,6 +32,7 @@ import { useTranslation } from 'react-i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedOpenfeature } from '../../../hooks/useCachedOpenfeature'
+import { useReportCardDataState } from '../CardDataContext'
 import type {
   OpenFeatureFlag,
   OpenFeatureFlagType,
@@ -174,8 +175,10 @@ function FlagRow({
 
 export function OpenFeatureStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } =
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } =
     useCachedOpenfeature()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const isHealthy = data.health === 'healthy'
   const providers = data.providers ?? []

--- a/web/src/components/cards/openfga_status/demoData.ts
+++ b/web/src/components/cards/openfga_status/demoData.ts
@@ -26,7 +26,7 @@ import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../../lib/constants/t
 // Types
 // ---------------------------------------------------------------------------
 
-export type OpenfgaHealth = 'healthy' | 'degraded' | 'not-installed'
+export type OpenfgaHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 export type OpenfgaStoreStatus = 'active' | 'paused' | 'draining'
 
 export interface OpenfgaStore {

--- a/web/src/components/cards/openfga_status/index.tsx
+++ b/web/src/components/cards/openfga_status/index.tsx
@@ -29,6 +29,7 @@ import { useTranslation } from 'react-i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedOpenfga } from '../../../hooks/useCachedOpenfga'
+import { useReportCardDataState } from '../CardDataContext'
 import type {
   OpenfgaAuthorizationModel,
   OpenfgaStore,
@@ -132,8 +133,10 @@ function ModelRow({ model }: { model: OpenfgaAuthorizationModel }) {
 
 export function OpenfgaStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } =
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } =
     useCachedOpenfga()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const isHealthy = data.health === 'healthy'
   const stores = data.stores ?? []

--- a/web/src/components/cards/spiffe_status/index.tsx
+++ b/web/src/components/cards/spiffe_status/index.tsx
@@ -28,6 +28,7 @@ import { useTranslation } from 'react-i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedSpiffe } from '../../../hooks/useCachedSpiffe'
+import { useReportCardDataState } from '../CardDataContext'
 import type {
   SpiffeFederatedDomain,
   SpiffeRegistrationEntry,
@@ -121,7 +122,9 @@ function FederatedRow({ domain }: { domain: SpiffeFederatedDomain }) {
 
 export function SpiffeStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedSpiffe()
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } = useCachedSpiffe()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const isHealthy = data.health === 'healthy'
   const entries = data.entries ?? []

--- a/web/src/components/cards/strimzi_status/index.tsx
+++ b/web/src/components/cards/strimzi_status/index.tsx
@@ -30,6 +30,7 @@ import { useTranslation } from 'react-i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedStrimzi } from '../../../hooks/useCachedStrimzi'
+import { useReportCardDataState } from '../CardDataContext'
 import type {
   ClusterHealth,
   StrimziConsumerGroup,
@@ -177,7 +178,9 @@ function ClusterRow({ cluster }: { cluster: StrimziKafkaCluster }) {
 
 export function StrimziStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedStrimzi()
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } = useCachedStrimzi()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const isHealthy = data.health === 'healthy'
   const clusters = data.clusters ?? []

--- a/web/src/components/cards/volcano_status/index.tsx
+++ b/web/src/components/cards/volcano_status/index.tsx
@@ -33,6 +33,7 @@ import { useTranslation } from 'react-i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedVolcano } from '../../../hooks/useCachedVolcano'
+import { useReportCardDataState } from '../CardDataContext'
 import type {
   QueueState,
   VolcanoJob,
@@ -181,8 +182,10 @@ function JobRow({ job }: { job: VolcanoJob }) {
 
 export function VolcanoStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } =
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } =
     useCachedVolcano()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const isHealthy = data.health === 'healthy'
   const queues = data.queues ?? []

--- a/web/src/components/cards/wasmcloud_status/index.tsx
+++ b/web/src/components/cards/wasmcloud_status/index.tsx
@@ -28,6 +28,7 @@ import type { TFunction } from 'i18next'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedWasmcloud } from '../../../hooks/useCachedWasmcloud'
+import { useReportCardDataState } from '../CardDataContext'
 import type {
   WasmcloudHost,
   WasmcloudLink,
@@ -171,7 +172,9 @@ function LinkRow({ link }: { link: WasmcloudLink }) {
 
 export function WasmcloudStatus() {
   const { t } = useTranslation('cards')
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedWasmcloud()
+  const { data, isRefreshing, isDemoData, isFailed, consecutiveFailures, error, showSkeleton, showEmptyState } = useCachedWasmcloud()
+
+  useReportCardDataState({ isFailed, consecutiveFailures, isDemoData, isRefreshing, hasData: data.health !== 'unknown' })
 
   const isHealthy = data.health === 'healthy'
   const hosts = data.hosts ?? []

--- a/web/src/lib/demo/cni.ts
+++ b/web/src/lib/demo/cni.ts
@@ -21,7 +21,7 @@
 // Types
 // ---------------------------------------------------------------------------
 
-export type CniHealth = 'healthy' | 'degraded' | 'not-installed'
+export type CniHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 export type CniPlugin =
   | 'cilium'
   | 'calico'

--- a/web/src/lib/demo/cortex.ts
+++ b/web/src/lib/demo/cortex.ts
@@ -34,7 +34,7 @@ export type CortexComponentName =
   | 'ruler'
   | 'alertmanager'
 
-export type CortexHealth = 'healthy' | 'degraded' | 'not-installed'
+export type CortexHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export interface CortexComponentPod {
   /** Cortex microservice component this pod belongs to. */

--- a/web/src/lib/demo/kserve.ts
+++ b/web/src/lib/demo/kserve.ts
@@ -22,7 +22,7 @@ import { MS_PER_MINUTE } from '../constants/time'
 // Types
 // ---------------------------------------------------------------------------
 
-export type KServeHealth = 'healthy' | 'degraded' | 'not-installed'
+export type KServeHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 export type KServeServiceStatus = 'ready' | 'not-ready' | 'unknown'
 
 export interface KServeControllerPods {


### PR DESCRIPTION
Fixes #10878

14 status card components used `useCached*` hooks but never reported `isDemoData` or `isFailed`/`consecutiveFailures` to `CardWrapper` via `useReportCardDataState`. Result: Demo badge + yellow outline never shown in demo mode; CardWrapper couldn't track failure state.

**Fixed cards:** openfga, cni, cortex, dapr, envoy, grpc, kserve, kubevela, linkerd, openfeature, spiffe, strimzi, volcano, wasmcloud.

Each card now:
1. Destructures `isDemoData`, `isFailed`, `consecutiveFailures` from its `useCached*` hook
2. Calls `useReportCardDataState()` to report state to CardWrapper

This follows the pattern documented in CLAUDE.md ("Card Development Rules" section 1).