### PR TITLE
🌱 Replace magic number timeouts in AbortSignal.timeout with named constants

### DIFF
--- a/web/src/hooks/usePersistedSettings.ts
+++ b/web/src/hooks/usePersistedSettings.ts
@@ -8,7 +8,7 @@ import {
   SETTINGS_CHANGED_EVENT } from '../lib/settingsSync'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { agentFetch } from './mcp/shared'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS, FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
 import { isNetlifyDeployment } from '../lib/demoMode'
 import { safeRevokeObjectURL } from '../lib/download'
 
@@ -27,7 +27,7 @@ async function settingsFetch<T>(path: string, options?: RequestInit): Promise<T>
       'Content-Type': 'application/json',
       'X-Requested-With': 'XMLHttpRequest', // #10000 CSRF defence-in-depth
       ...options?.headers },
-    signal: options?.signal ?? AbortSignal.timeout(15000) })
+    signal: options?.signal ?? AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
   if (!response.ok) throw new Error(`HTTP ${response.status}`)
   // Use .catch() on .json() to prevent Firefox from firing unhandledrejection
   // before the caller's try/catch processes the rejection (microtask timing issue).
@@ -129,7 +129,7 @@ export function usePersistedSettings() {
       await settingsFetch('/settings/import', {
         method: 'PUT',
         body: text,
-        signal: AbortSignal.timeout(10000) })
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       // Reload settings from backend after import
       const data = await settingsFetch<AllSettings>('/settings')
       if (data) {

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -8,7 +8,7 @@ import type {
   UpdateProgress } from '../types/updates'
 import { emitSessionContext } from '../lib/analytics'
 import { UPDATE_STORAGE_KEYS } from '../types/updates'
-import { FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS, FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
 import { MS_PER_MINUTE } from '../lib/constants/time'
 import { useLocalAgent } from './useLocalAgent'
 
@@ -132,7 +132,7 @@ function useVersionCheckCore() {
       console.debug('[version-check] Fetching auto-update status from kc-agent...')
       const resp = await fetch('/api/agent/auto-update/status', {
         credentials: 'include',
-        signal: AbortSignal.timeout(10000) })
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (resp.ok) {
         const data = await safeJsonParse<AutoUpdateStatus>(resp, 'Auto-update status')
         console.debug('[version-check] Auto-update status:', data)
@@ -247,7 +247,7 @@ function useVersionCheckCore() {
       console.debug('[version-check] Fetching commits:', currentSHA.slice(0, 7), '→', latestSHA.slice(0, 7))
       const resp = await fetch(
         `/api/github/repos/kubestellar/console/compare/${currentSHA}...${latestSHA}`,
-        { headers, signal: AbortSignal.timeout(10000) }
+        { headers, signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) }
       )
       if (resp.ok) {
         const data = await safeJsonParse<{ commits?: Array<{ sha: string; commit: { message: string; author: { name: string; date: string } } }> }>(resp, 'GitHub compare')


### PR DESCRIPTION
Fixes #3400

Replaces 4 hardcoded timeout values in AbortSignal.timeout() calls with named constants:

- usePersistedSettings.ts: 2 occurrences
  - Line 30: 15000 → FETCH_EXTERNAL_TIMEOUT_MS
  - Line 132: 10000 → FETCH_DEFAULT_TIMEOUT_MS
- useVersionCheck.tsx: 2 occurrences  
  - Line 135: 10000 → FETCH_DEFAULT_TIMEOUT_MS
  - Line 250: 10000 → FETCH_DEFAULT_TIMEOUT_MS

Follows project convention: no magic numbers (see CLAUDE.md).