### PR TITLE
🌱 Add explicit unknown type to 441 catch blocks

### DIFF
--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -186,7 +186,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
       setKeysStatus(data.keys)
       setRegisteredProviders(data.registeredProviders || [])
       setConfigPath(data.configPath)
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : t('agent.failedToConnect'))
     } finally {
       setLoading(false)
@@ -224,7 +224,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
       setBaseURLSaved(prev => new Set(prev).add(provider))
       // Refresh status so the row reflects the new resolved value.
       await fetchKeysStatus()
-    } catch (err) {
+    } catch (err: unknown) {
       setBaseURLError(e => ({ ...e, [provider]: err instanceof Error ? err.message : t('agent.failedToSaveKey') }))
     } finally {
       setSaving(false)
@@ -276,7 +276,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
       await fetchKeysStatus()
       emitApiKeyConfigured(provider)
       emitConversionStep(5, 'api_key', { provider })
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : t('agent.failedToSaveKey'))
     } finally {
       setSaving(false)
@@ -304,7 +304,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
 
       await fetchKeysStatus()
       emitApiKeyRemoved(provider)
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : t('agent.failedToDeleteKey'))
     } finally {
       setSaving(false)

--- a/web/src/components/cards/ClusterLocations.tsx
+++ b/web/src/components/cards/ClusterLocations.tsx
@@ -267,7 +267,7 @@ export function ClusterLocations({ config: _config }: ClusterLocationsProps) {
         setMapSvg(DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } }))
         setMapLoading(false)
       })
-      .catch(err => {
+      .catch((err: unknown) => {
         if (err.name !== 'AbortError') {
           console.error('Failed to load world map:', err)
           showToast('Failed to load world map', 'error')

--- a/web/src/components/cards/ClusterLocations.tsx
+++ b/web/src/components/cards/ClusterLocations.tsx
@@ -268,12 +268,11 @@ export function ClusterLocations({ config: _config }: ClusterLocationsProps) {
         setMapLoading(false)
       })
       .catch((err: unknown) => {
-        if (err.name !== 'AbortError') {
-          console.error('Failed to load world map:', err)
-          showToast('Failed to load world map', 'error')
-          setMapError(true)
-          setMapLoading(false)
-        }
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        console.error('Failed to load world map:', err)
+        showToast('Failed to load world map', 'error')
+        setMapError(true)
+        setMapLoading(false)
       })
     
     return () => controller.abort()

--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -164,7 +164,7 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
         setApiData(Array.isArray(json) ? json : json.items || json.data || [json])
         setApiLoading(false)
       })
-      .catch(err => {
+      .catch((err: unknown) => {
         if (cancelled) return
         setApiError(err.message)
         setApiLoading(false)
@@ -434,7 +434,7 @@ export function Tier2CardRuntime({ definition, config }: Tier2Props) {
         cleanupRef.current = componentResult.cleanup
         setCardComponent(() => componentResult.component)
         setCompiling(false)
-      } catch (err) {
+      } catch (err: unknown) {
         if (cancelled) return
         const message = err instanceof Error ? err.message : String(err)
         // Message is already surfaced to the user via setError below (#8816)

--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -166,7 +166,7 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
       })
       .catch((err: unknown) => {
         if (cancelled) return
-        setApiError(err.message)
+        setApiError(err instanceof Error ? err.message : String(err))
         setApiLoading(false)
       })
 

--- a/web/src/components/cards/EnterpriseComplianceCards.tsx
+++ b/web/src/components/cards/EnterpriseComplianceCards.tsx
@@ -72,7 +72,7 @@ export function HIPAACard() {
     authFetch('/api/compliance/hipaa/summary')
       .then(r => r.ok ? safeJson<Record<string, number>>(r) : null)
       .then(setData)
-      .catch(err => { setError(err?.message || 'Failed to load'); console.error(err) })
+      .catch((err: unknown) => { setError(err?.message || 'Failed to load'); console.error(err) })
       .finally(() => setIsLoading(false))
   }, [])
   return (
@@ -110,7 +110,7 @@ export function GxPCard() {
     authFetch('/api/compliance/gxp/summary')
       .then(r => r.ok ? safeJson<Record<string, unknown>>(r) : null)
       .then(setData)
-      .catch(err => { setError(err?.message || 'Failed to load'); console.error(err) })
+      .catch((err: unknown) => { setError(err?.message || 'Failed to load'); console.error(err) })
       .finally(() => setIsLoading(false))
   }, [])
   return (
@@ -152,7 +152,7 @@ export function BAACard() {
     authFetch('/api/compliance/baa/summary')
       .then(r => r.ok ? safeJson<Record<string, number>>(r) : null)
       .then(setData)
-      .catch(err => { setError(err?.message || 'Failed to load'); console.error(err) })
+      .catch((err: unknown) => { setError(err?.message || 'Failed to load'); console.error(err) })
       .finally(() => setIsLoading(false))
   }, [])
   return (

--- a/web/src/components/cards/EnterpriseComplianceCards.tsx
+++ b/web/src/components/cards/EnterpriseComplianceCards.tsx
@@ -72,7 +72,7 @@ export function HIPAACard() {
     authFetch('/api/compliance/hipaa/summary')
       .then(r => r.ok ? safeJson<Record<string, number>>(r) : null)
       .then(setData)
-      .catch((err: unknown) => { setError(err?.message || 'Failed to load'); console.error(err) })
+      .catch((err: unknown) => { setError(err instanceof Error ? err.message : 'Failed to load'); console.error(err) })
       .finally(() => setIsLoading(false))
   }, [])
   return (
@@ -110,7 +110,7 @@ export function GxPCard() {
     authFetch('/api/compliance/gxp/summary')
       .then(r => r.ok ? safeJson<Record<string, unknown>>(r) : null)
       .then(setData)
-      .catch((err: unknown) => { setError(err?.message || 'Failed to load'); console.error(err) })
+      .catch((err: unknown) => { setError(err instanceof Error ? err.message : 'Failed to load'); console.error(err) })
       .finally(() => setIsLoading(false))
   }, [])
   return (
@@ -152,7 +152,7 @@ export function BAACard() {
     authFetch('/api/compliance/baa/summary')
       .then(r => r.ok ? safeJson<Record<string, number>>(r) : null)
       .then(setData)
-      .catch((err: unknown) => { setError(err?.message || 'Failed to load'); console.error(err) })
+      .catch((err: unknown) => { setError(err instanceof Error ? err.message : 'Failed to load'); console.error(err) })
       .finally(() => setIsLoading(false))
   }, [])
   return (

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -161,7 +161,7 @@ function setCachedData(repo: string, data: Omit<CachedGitHubData, 'timestamp'>, 
       timestamp: Date.now()
     }
     localStorage.setItem(CACHE_KEY_PREFIX + repo.replace('/', '_'), JSON.stringify(cached))
-  } catch (e) {
+  } catch (e: unknown) {
     // Non-critical: localStorage may be full or disabled. The card still
     // works, it just won't persist cached data across page reloads.
     console.warn('[GitHubActivity] Failed to cache data (storage may be full):', e)
@@ -421,7 +421,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
         openIssueCount: calculatedOpenIssueCount }, (msg) => showToast(msg, 'warning'))
 
       setLastRefresh(new Date())
-    } catch (err) {
+    } catch (err: unknown) {
       // Abort errors are expected during cleanup — do not treat as failures
       if (err instanceof DOMException && err.name === 'AbortError') return
       if (signal?.aborted) return

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -362,7 +362,7 @@ const IssueActivityChart = memo(function IssueActivityChart(props: { config?: Is
       setStats(data)
       setIsDemoFallback(false)
       setCachedStats(repo, lookbackDays, data)
-    } catch (err) {
+    } catch (err: unknown) {
       if (signal?.aborted) return
       const message = err instanceof Error ? err.message : 'Failed to fetch issue data'
       setError(message)

--- a/web/src/components/cards/Kubectl.tsx
+++ b/web/src/components/cards/Kubectl.tsx
@@ -152,7 +152,7 @@ export function Kubectl() {
 
       setYamlError(null)
       return true
-    } catch (err) {
+    } catch (err: unknown) {
       setYamlError(err instanceof Error ? err.message : 'Invalid YAML')
       return false
     }
@@ -204,7 +204,7 @@ export function Kubectl() {
 
       setCommand('')
       setHistoryIndex(-1)
-    } catch (err) {
+    } catch (err: unknown) {
       const errorMsg = err instanceof Error ? err.message : 'Command failed'
       setOutput(prev => [
         ...prev,
@@ -277,7 +277,7 @@ export function Kubectl() {
       setAiPrompt('')
       setShowAI(false)
       commandInputRef.current?.focus()
-    } catch (err) {
+    } catch (err: unknown) {
       setOutput(prev => [
         ...prev,
         `AI Error: ${err instanceof Error ? err.message : 'Failed to generate command'}`,
@@ -365,7 +365,7 @@ data:
       setShowYAMLEditor(true)
       setShowAI(false)
       setAiPrompt('')
-    } catch (err) {
+    } catch (err: unknown) {
       setOutput(prev => [
         ...prev,
         `AI Error: ${err instanceof Error ? err.message : 'Failed to generate YAML'}`,
@@ -420,7 +420,7 @@ data:
         setYamlContent('')
         setShowYAMLEditor(false)
       }
-    } catch (err) {
+    } catch (err: unknown) {
       setOutput(prev => [
         ...prev,
         `Error applying YAML: ${err instanceof Error ? err.message : 'Unknown error'}`,

--- a/web/src/components/cards/NamespaceOverview.tsx
+++ b/web/src/components/cards/NamespaceOverview.tsx
@@ -63,12 +63,12 @@ export function NamespaceOverview({ config }: NamespaceOverviewProps) {
 
   // Persist cluster selection so it survives page navigation (#3115)
   useEffect(() => {
-    try { localStorage.setItem(STORAGE_KEY_NS_OVERVIEW_CLUSTER, selectedCluster) } catch (e) { console.warn('[NamespaceOverview] failed to persist cluster selection:', e); showToast(t('errors.storagePersistFailed'), 'warning') }
+    try { localStorage.setItem(STORAGE_KEY_NS_OVERVIEW_CLUSTER, selectedCluster) } catch (e: unknown) { console.warn('[NamespaceOverview] failed to persist cluster selection:', e); showToast(t('errors.storagePersistFailed'), 'warning') }
   }, [selectedCluster, showToast, t])
 
   // Persist namespace selection so it survives page navigation (#3115)
   useEffect(() => {
-    try { localStorage.setItem(STORAGE_KEY_NS_OVERVIEW_NAMESPACE, selectedNamespace) } catch (e) { console.warn('[NamespaceOverview] failed to persist namespace selection:', e); showToast(t('errors.storagePersistFailed'), 'warning') }
+    try { localStorage.setItem(STORAGE_KEY_NS_OVERVIEW_NAMESPACE, selectedNamespace) } catch (e: unknown) { console.warn('[NamespaceOverview] failed to persist namespace selection:', e); showToast(t('errors.storagePersistFailed'), 'warning') }
   }, [selectedNamespace, showToast, t])
 
   // Auto-select first available cluster when none is selected (#3113 — works in both demo and live mode)

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -154,7 +154,7 @@ function QuotaModal({
     try {
       await onSave({ cluster, namespace, name, hard })
       onClose()
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to save quota')
     }
   }

--- a/web/src/components/cards/NetworkUtils.tsx
+++ b/web/src/components/cards/NetworkUtils.tsx
@@ -175,7 +175,7 @@ export function NetworkUtils() {
         timestamp: new Date(),
         statusCode: data.statusCode,
         error: data.error || undefined }
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof Error && error.name === 'AbortError') {
         return {
           host,

--- a/web/src/components/cards/NodeConditions.tsx
+++ b/web/src/components/cards/NodeConditions.tsx
@@ -85,7 +85,7 @@ export function NodeConditions() {
     setActionError(null)
     try {
       await execute(cluster, [action, nodeName])
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : `Failed to ${action} node`
       setActionError(`${action} ${nodeName}: ${message}`)
     } finally {

--- a/web/src/components/cards/NodeDebug.tsx
+++ b/web/src/components/cards/NodeDebug.tsx
@@ -143,7 +143,7 @@ export function NodeDebug() {
       setOutput(`$ ${cmdStr}\n\n${text}`)
       setWasTruncated(truncated)
       showToast(t('nodeDebug.commandCompleted'), 'success')
-    } catch (err) {
+    } catch (err: unknown) {
       setOutput(`$ ${cmdStr}\n\nError: ${err instanceof Error ? err.message : String(err)}`)
       setWasTruncated(false)
     } finally {
@@ -173,7 +173,7 @@ export function NodeDebug() {
       setOutput(`$ ${cmdStr}\n\n${text}`)
       setWasTruncated(truncated)
       showToast(t('nodeDebug.commandCompleted'), 'success')
-    } catch (err) {
+    } catch (err: unknown) {
       setOutput(`$ ${cmdStr}\n\nError: ${err instanceof Error ? err.message : String(err)}`)
       setWasTruncated(false)
     } finally {

--- a/web/src/components/cards/SudokuGame.tsx
+++ b/web/src/components/cards/SudokuGame.tsx
@@ -247,7 +247,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
               notes: new Set(Array.isArray(cell.notes) ? cell.notes : []) }))
           )
           setGameState(parsed)
-        } catch (e) {
+        } catch (e: unknown) {
           console.error('Failed to load saved game:', e)
           showToast(t('sudoku.errors.loadFailed', 'Could not load saved game — starting fresh.'), 'warning')
         }
@@ -257,7 +257,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
       if (savedBestTimes) {
         try {
           setBestTimes(JSON.parse(savedBestTimes) as BestTimes)
-        } catch (e) {
+        } catch (e: unknown) {
           console.error('Failed to load best times:', e)
           showToast(t('sudoku.errors.bestTimesFailed', 'Could not load best times.'), 'warning')
         }

--- a/web/src/components/cards/WorkloadDeployment.tsx
+++ b/web/src/components/cards/WorkloadDeployment.tsx
@@ -303,7 +303,7 @@ function DraggableWorkloadItem({ workload, isSelected, onSelect, onScaled }: Dra
         } else {
           setScaleError(failures.map(r => `${r.cluster}: ${r.message || 'Scale failed'}`).join('; '))
         }
-      } catch (agentErr) {
+      } catch (agentErr: unknown) {
         if (
           agentErr &&
           typeof agentErr === 'object' &&

--- a/web/src/components/cards/WorkloadImportDialog.tsx
+++ b/web/src/components/cards/WorkloadImportDialog.tsx
@@ -105,7 +105,7 @@ function parseYamlDocuments(text: string): { resources: ParsedResource[]; errors
 
       resources.push({ kind, name, namespace, image })
     }
-  } catch (err) {
+  } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err)
     errors.push(`YAML parse error: ${message}`)
   }

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -191,7 +191,7 @@ async function fetchAllNodes(): Promise<NodeData[]> {
       nodesFetchError = null
       notifyNodesSubscribers()
     }
-  } catch (error) {
+  } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Unknown error'
     console.error('[OfflineDetection] Error fetching nodes:', error)
     nodesFetchError = message

--- a/web/src/components/cards/insights/useInsightActions.ts
+++ b/web/src/components/cards/insights/useInsightActions.ts
@@ -28,7 +28,7 @@ function loadSet(storage: Storage, key: string): Set<string> {
       return new Set()
     }
     return new Set(parsed.filter((v): v is string => typeof v === 'string'))
-  } catch (err) {
+  } catch (err: unknown) {
     console.error(`[useInsightActions] Failed to load ${key} from storage:`, err)
     return new Set()
   }
@@ -39,7 +39,7 @@ type ErrorCallback = (message: string) => void
 function saveSet(storage: Storage, key: string, set: Set<string>, onError?: ErrorCallback): void {
   try {
     storage.setItem(key, JSON.stringify(Array.from(set)))
-  } catch (err) {
+  } catch (err: unknown) {
     console.error(`[useInsightActions] Failed to save ${key} to storage:`, err)
     onError?.(SAVE_ERROR_MESSAGE)
   }

--- a/web/src/components/cards/llmd/StackSelector.tsx
+++ b/web/src/components/cards/llmd/StackSelector.tsx
@@ -309,7 +309,7 @@ export function StackSelector() {
     setFetchError(null)
     try {
       await refetch?.()
-    } catch (err) {
+    } catch (err: unknown) {
       setFetchError(err instanceof Error ? err.message : 'Failed to refresh stacks')
     }
   }

--- a/web/src/components/cards/opa/ClusterOPAModal.tsx
+++ b/web/src/components/cards/opa/ClusterOPAModal.tsx
@@ -154,7 +154,7 @@ What would you like to modify about this policy?`,
       } else {
         setYamlContent('# No YAML returned from cluster\n# You can write new YAML here')
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('[OPA] Failed to fetch policy YAML:', err)
       setYamlContent(`# Failed to fetch policy YAML\n# Error: ${err}\n\n# You can write new YAML here`)
     }
@@ -199,7 +199,7 @@ Please proceed with applying this policy.`,
       )
       showToast('Policy mode updated successfully', 'success')
       onRefresh()
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Failed to toggle mode:', err)
       showToast('Failed to toggle policy mode', 'error')
     }
@@ -215,7 +215,7 @@ Please proceed with applying this policy.`,
       setDeleteConfirm(null)
       showToast('Policy deleted successfully', 'success')
       onRefresh()
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Failed to delete policy:', err)
       showToast('Failed to delete policy', 'error')
     }

--- a/web/src/components/cards/opa/CreatePolicyModal.tsx
+++ b/web/src/components/cards/opa/CreatePolicyModal.tsx
@@ -149,7 +149,7 @@ Based on this analysis:
 Start with the highest-priority policy.`,
         context: { cluster: selectedCluster },
       })
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('[OPA] Failed to analyze cluster:', err)
       if (mountedRef.current) showToast('Failed to gather cluster data', 'error')
     } finally {

--- a/web/src/components/cards/rss/RSSFeed.tsx
+++ b/web/src/components/cards/rss/RSSFeed.tsx
@@ -437,7 +437,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
       const sourceCount = activeFeed.isAggregate ? ` from ${activeFeed.sourceUrls?.length || 0} sources` : ''
       setFetchSuccess(`Fetched ${feedItems.length} items${sourceCount}`)
       cacheFeed(cacheKey, feedItems)
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to load feed'
 
       // Try to use stale cache - if we have cached items, don't show error

--- a/web/src/components/cards/weather/Weather.tsx
+++ b/web/src/components/cards/weather/Weather.tsx
@@ -237,7 +237,7 @@ export function Weather({ config }: { config?: WeatherConfig }) {
         setCitySearchResults([])
         setShowCityDropdown(false)
       }
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('City search error:', error)
       showToast(t('errors.citySearchFailed', 'City search failed. Please try again.'), 'error')
       setCitySearchResults([])

--- a/web/src/components/clusters/AddClusterDialog.tsx
+++ b/web/src/components/clusters/AddClusterDialog.tsx
@@ -104,7 +104,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
       const data = await res.json()
       setPreviewContexts(data.contexts || [])
       setImportState('previewed')
-    } catch (err) {
+    } catch (err: unknown) {
       setErrorMessage(err instanceof Error ? err.message : String(err))
       setImportState('error')
     }
@@ -132,7 +132,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
         resetImportState()
         onClose()
       }, 1500)
-    } catch (err) {
+    } catch (err: unknown) {
       setErrorMessage(err instanceof Error ? err.message : String(err))
       setImportState('error')
     }
@@ -158,7 +158,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
       const data = await res.json()
       setTestResult(data)
       setConnectState('tested')
-    } catch (err) {
+    } catch (err: unknown) {
       setConnectError(err instanceof Error ? err.message : String(err))
       setConnectState('error')
     }
@@ -194,7 +194,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
         resetConnectState()
         onClose()
       }, 1500)
-    } catch (err) {
+    } catch (err: unknown) {
       setConnectError(err instanceof Error ? err.message : String(err))
       setConnectState('error')
     }

--- a/web/src/components/clusters/components/RemoveClusterDialog.tsx
+++ b/web/src/components/clusters/components/RemoveClusterDialog.tsx
@@ -38,7 +38,7 @@ export function RemoveClusterDialog({
     try {
       await onConfirm(contextName)
       onClose()
-    } catch (err) {
+    } catch (err: unknown) {
       setStatus({
         removing: false,
         error: err instanceof Error ? err.message : t('cluster.removeClusterError') })

--- a/web/src/components/clusters/components/RenameModal.tsx
+++ b/web/src/components/clusters/components/RenameModal.tsx
@@ -46,7 +46,7 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
       // the label does not flip back to "Rename" while the modal fades out.
       setPhase('success')
       onClose()
-    } catch (err) {
+    } catch (err: unknown) {
       setPhase('idle')
       setError(err instanceof Error ? err.message : t('cluster.renameContext.errorFailed'))
     }

--- a/web/src/components/compliance/AirGapDashboard.tsx
+++ b/web/src/components/compliance/AirGapDashboard.tsx
@@ -89,7 +89,7 @@ export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
       setRequirements(await rRes.json())
       setClusters(await cRes.json())
       setSummary(await sRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/BAADashboard.tsx
+++ b/web/src/components/compliance/BAADashboard.tsx
@@ -58,7 +58,7 @@ export const BAADashboardContent = memo(function BAADashboardContent() {
       setAgreements(await agRes.json())
       setAlerts(await alRes.json())
       setSummary(await smRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load BAA data')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -92,7 +92,7 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
       setChanges(Array.isArray(cData) ? cData : [])
       setViolations(Array.isArray(vData) ? vData : [])
       setPolicies(Array.isArray(pData) ? pData : [])
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to load data')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/ComplianceReports.tsx
+++ b/web/src/components/compliance/ComplianceReports.tsx
@@ -79,7 +79,7 @@ export const ComplianceReportsContent = memo(function ComplianceReportsContent()
       document.body.removeChild(a)
 
       setSuccess(`Report downloaded: ${filename}`)
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Report generation failed')
     } finally {
       setGenerating(false)

--- a/web/src/components/compliance/DataResidency.tsx
+++ b/web/src/components/compliance/DataResidency.tsx
@@ -118,7 +118,7 @@ export const DataResidencyContent = memo(function DataResidencyContent() {
       setRules(Array.isArray(rulesData) ? rulesData : [])
       setClusters(Array.isArray(clustersData) ? clustersData : [])
       setViolations(Array.isArray(violationsData) ? violationsData : [])
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to load data')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/FedRAMPDashboard.tsx
+++ b/web/src/components/compliance/FedRAMPDashboard.tsx
@@ -102,7 +102,7 @@ export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
       setControls(await cRes.json())
       setPOAMs(await pRes.json())
       setScore(await sRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/GxPDashboard.tsx
+++ b/web/src/components/compliance/GxPDashboard.tsx
@@ -68,7 +68,7 @@ export const GxPDashboardContent = memo(function GxPDashboardContent() {
       setRecords(await recRes.json())
       setSignatures(await sigRes.json())
       setChainStatus(await chainRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load GxP data')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/HIPAADashboard.tsx
+++ b/web/src/components/compliance/HIPAADashboard.tsx
@@ -72,7 +72,7 @@ export const HIPAADashboardContent = memo(function HIPAADashboardContent() {
       setPHINamespaces(await nsRes.json())
       setDataFlows(await flRes.json())
       setSummary(await smRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load HIPAA data')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/IncidentResponseDashboard.tsx
+++ b/web/src/components/compliance/IncidentResponseDashboard.tsx
@@ -97,7 +97,7 @@ const IncidentResponseDashboard = memo(function IncidentResponseDashboard() {
       setIncidents(await iRes.json())
       setMetrics(await mRes.json())
       setPlaybooks(await pRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/LicenseComplianceDashboard.tsx
+++ b/web/src/components/compliance/LicenseComplianceDashboard.tsx
@@ -82,7 +82,7 @@ export default function LicenseComplianceDashboard() {
       setPackages(await pkgRes.json())
       setCategories(await catRes.json())
       setSummary(await sumRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load license data')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/NISTDashboard.tsx
+++ b/web/src/components/compliance/NISTDashboard.tsx
@@ -97,7 +97,7 @@ export const NISTDashboardContent = memo(function NISTDashboardContent() {
       setFamilies(Array.isArray(familiesData) ? familiesData : [])
       setMappings(Array.isArray(mappingsData) ? mappingsData : [])
       setSummary(summaryData ?? null)
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/OIDCDashboard.tsx
+++ b/web/src/components/compliance/OIDCDashboard.tsx
@@ -56,7 +56,7 @@ export const OIDCDashboardContent = memo(function OIDCDashboardContent() {
       setSummary(await smRes.json())
       setProviders(await pRes.json())
       setSessions(await sRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load OIDC data')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/RBACAuditDashboard.tsx
+++ b/web/src/components/compliance/RBACAuditDashboard.tsx
@@ -67,7 +67,7 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
       setSummary(await smRes.json())
       setBindings(await bRes.json())
       setFindings(await fRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load RBAC data')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/RiskAppetiteDashboard.tsx
+++ b/web/src/components/compliance/RiskAppetiteDashboard.tsx
@@ -86,7 +86,7 @@ export const RiskAppetiteDashboardContent = memo(function RiskAppetiteDashboardC
       setThresholds(await tRes.json())
       setKRIs(await kRes.json())
       setSummary(await sRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/RiskMatrixDashboard.tsx
+++ b/web/src/components/compliance/RiskMatrixDashboard.tsx
@@ -88,7 +88,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
       setRisks(await rRes.json())
       setHeatmap(await hRes.json())
       setSummary(await sRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/RiskRegisterDashboard.tsx
+++ b/web/src/components/compliance/RiskRegisterDashboard.tsx
@@ -102,7 +102,7 @@ export const RiskRegisterDashboardContent = memo(function RiskRegisterDashboardC
       setRisks(await rRes.json())
       setCategories(await cRes.json())
       setSummary(await sRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/SBOMDashboard.tsx
+++ b/web/src/components/compliance/SBOMDashboard.tsx
@@ -98,7 +98,7 @@ export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
       setPackages(await pRes.json())
       setVulnerabilities(await vRes.json())
       setSummary(await sRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/SIEMDashboard.tsx
+++ b/web/src/components/compliance/SIEMDashboard.tsx
@@ -89,7 +89,7 @@ const SIEMDashboard = memo(function SIEMDashboard() {
       setEvents(await eRes.json())
       setAlerts(await aRes.json())
       setSummary(await sRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/SLSADashboard.tsx
+++ b/web/src/components/compliance/SLSADashboard.tsx
@@ -119,7 +119,7 @@ export const SLSADashboardContent = memo(function SLSADashboardContent() {
       setAttestations(Array.isArray(aData) ? aData : [])
       setProvenance(Array.isArray(pData) ? pData : [])
       setSummary(sData ?? null)
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/STIGDashboard.tsx
+++ b/web/src/components/compliance/STIGDashboard.tsx
@@ -93,7 +93,7 @@ export const STIGDashboardContent = memo(function STIGDashboardContent() {
       setBenchmarks(await bRes.json())
       setFindings(await fRes.json())
       setSummary(await sRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -74,7 +74,7 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
       setRules(await rRes.json())
       setPrincipals(await pRes.json())
       setViolations(await vRes.json())
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to load data')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/SessionDashboard.tsx
+++ b/web/src/components/compliance/SessionDashboard.tsx
@@ -56,7 +56,7 @@ export const SessionDashboardContent = memo(function SessionDashboardContent() {
       setSummary(await smRes.json())
       setSessions(await sRes.json())
       setPolicies(await pRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load session data')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/SigningStatusDashboard.tsx
+++ b/web/src/components/compliance/SigningStatusDashboard.tsx
@@ -80,7 +80,7 @@ export default function SigningStatusDashboard() {
       setImages(await imgRes.json())
       setPolicies(await polRes.json())
       setSummary(await sumRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load signing data')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/SigstoreDashboard.tsx
+++ b/web/src/components/compliance/SigstoreDashboard.tsx
@@ -105,7 +105,7 @@ export const SigstoreDashboardContent = memo(function SigstoreDashboardContent()
       setSignatures(await sigRes.json())
       setVerifications(await verRes.json())
       setSummary(await sumRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/compliance/ThreatIntelDashboard.tsx
+++ b/web/src/components/compliance/ThreatIntelDashboard.tsx
@@ -120,7 +120,7 @@ const ThreatIntelDashboard = memo(function ThreatIntelDashboard() {
       setFeeds(await fRes.json())
       setIOCs(await iRes.json())
       setSummary(await sRes.json())
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -291,7 +291,7 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
     try {
       didAddCards.current = cardsToAdd.length > 0
       onAddCards(cardsToAdd)
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Error adding cards:', error)
       showToast(t('dashboard.addCard.failedToAdd'), 'error')
     }

--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -354,7 +354,7 @@ export function CustomDashboard() {
         }
       }
       setLastUpdated(new Date())
-    } catch (error) {
+    } catch (error: unknown) {
       // Discard errors from stale requests
       if (thisRequestId !== requestIdRef.current) return
 
@@ -439,7 +439,7 @@ export function CustomDashboard() {
       for (const card of cardsToAdd) {
         try {
           await api.post(`/api/dashboards/${id}/cards`, card)
-        } catch (error) {
+        } catch (error: unknown) {
           console.error('Failed to persist card:', error)
           showToast('Failed to persist card to backend', 'error')
         }
@@ -457,7 +457,7 @@ export function CustomDashboard() {
     if (id) {
       try {
         await api.delete(`/api/dashboards/${id}/cards/${cardId}`)
-      } catch (error) {
+      } catch (error: unknown) {
         // Card is already removed from UI state above — backend failure is
         // non-critical. Log for debugging but don't alarm the user. (#8564)
         console.debug('Backend card deletion failed (card already removed from UI):', error)
@@ -511,7 +511,7 @@ export function CustomDashboard() {
       for (const card of templateCards) {
         try {
           await api.post(`/api/dashboards/${id}/cards`, card)
-        } catch (error) {
+        } catch (error: unknown) {
           console.error('Failed to persist template card:', error)
           showToast('Failed to persist template card', 'error')
         }

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -403,7 +403,7 @@ export function Dashboard() {
           setLocalCards((items) => items.filter((item) => item.id !== active.id))
           // Show success toast
           showToast(`Card moved to "${targetDashboardName}"`, 'success')
-        } catch (error) {
+        } catch (error: unknown) {
           console.error('Failed to move card:', error)
           showToast('Failed to move card', 'error')
         }
@@ -421,7 +421,7 @@ export function Dashboard() {
           setLocalCards((items) => items.filter((item) => item.id !== active.id))
           showToast(`Card moved to "${newDash.name || 'New Dashboard'}"`, 'success')
         }
-      } catch (error) {
+      } catch (error: unknown) {
         console.error('Failed to create dashboard and move card:', error)
         showToast('Failed to create dashboard', 'error')
       }
@@ -500,7 +500,7 @@ export function Dashboard() {
                 warnings: resp.warnings } })
           }
         } })
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Deploy failed:', err)
       showToast(
         `Deploy failed: ${err instanceof Error ? err.message : 'Unknown error'}`,
@@ -636,7 +636,7 @@ export function Dashboard() {
         // Update cache with demo cards
         dashboardCache = { dashboard: null, cards, timestamp: Date.now() }
       }
-    } catch (error) {
+    } catch (error: unknown) {
       // Don't log expected failures (backend unavailable or timeout)
       const isExpectedFailure = error instanceof BackendUnavailableError ||
         error instanceof UnauthenticatedError ||
@@ -711,7 +711,7 @@ export function Dashboard() {
       for (const card of newCards) {
         try {
           await api.post(`/api/dashboards/${dashboard.id}/cards`, card)
-        } catch (error) {
+        } catch (error: unknown) {
           console.error('Failed to persist card:', error)
           showToast('Failed to persist card to backend', 'error')
         }
@@ -741,7 +741,7 @@ export function Dashboard() {
     if (dashboard?.id) {
       try {
         await api.delete(`/api/cards/${cardId}`)
-      } catch (error) {
+      } catch (error: unknown) {
         // Card is already removed from UI state above — backend failure is
         // non-critical. Log for debugging but don't alarm the user. (#8564)
         console.debug('Backend card deletion failed (card already removed from UI):', error)
@@ -773,7 +773,7 @@ export function Dashboard() {
             position: { ...(card.position || { w: 4, h: 2 }), w: newWidth }
           })
         }
-      } catch (error) {
+      } catch (error: unknown) {
         console.error('Failed to update card width:', error)
         showToast('Failed to update card width', 'error')
       }
@@ -799,7 +799,7 @@ export function Dashboard() {
             position: { ...(card.position || { x: 0, y: 0, w: 4, h: 2 }), h: newHeight }
           })
         }
-      } catch (error) {
+      } catch (error: unknown) {
         console.error('Failed to update card height:', error)
         showToast('Failed to update card height', 'error')
       }
@@ -834,7 +834,7 @@ export function Dashboard() {
     if (dashboard?.id && !cardId.startsWith('demo-') && !cardId.startsWith('new-') && !cardId.startsWith('rec-') && !cardId.startsWith('template-') && !cardId.startsWith('restored-') && !cardId.startsWith('ai-')) {
       try {
         await api.put(`/api/cards/${cardId}`, { config: newConfig, title: newTitle })
-      } catch (error) {
+      } catch (error: unknown) {
         console.error('Failed to update card configuration:', error)
         showToast('Failed to update card configuration', 'error')
       }

--- a/web/src/components/dashboard/cardFactoryTemplatesT2.ts
+++ b/web/src/components/dashboard/cardFactoryTemplatesT2.ts
@@ -373,7 +373,7 @@ export const T2_TEMPLATES: T2Template[] = [
 
   // Persist forwards
   useEffect(() => {
-    try { window?.localStorage?.setItem?.(STORAGE_KEY, JSON.stringify(forwards)) } catch (e) { console.warn('[CardFactoryModal] failed to persist port-forwards:', e) }
+    try { window?.localStorage?.setItem?.(STORAGE_KEY, JSON.stringify(forwards)) } catch (e: unknown) { console.warn('[CardFactoryModal] failed to persist port-forwards:', e) }
   }, [forwards])
 
   const addForward = () => {

--- a/web/src/components/dashboard/customizer/sections/CardCatalogSection.tsx
+++ b/web/src/components/dashboard/customizer/sections/CardCatalogSection.tsx
@@ -200,7 +200,7 @@ export function CardCatalogSection({
     }
     try {
       onAddCards(cardsToAdd)
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Error adding cards:', error)
       showToast(t('dashboard.addCard.failedToAdd'), 'error')
     }

--- a/web/src/components/dashboard/customizer/sections/UnifiedCardsSection.tsx
+++ b/web/src/components/dashboard/customizer/sections/UnifiedCardsSection.tsx
@@ -180,7 +180,7 @@ export function UnifiedCardsSection({
         }
       }
     }
-    try { onAddCards(cardsToAdd) } catch (error) {
+    try { onAddCards(cardsToAdd) } catch (error: unknown) {
       console.error('Error adding cards:', error)
       showToast(t('dashboard.addCard.failedToAdd'), 'error')
     }

--- a/web/src/components/deploy/Deploy.tsx
+++ b/web/src/components/deploy/Deploy.tsx
@@ -113,7 +113,7 @@ export function Deploy() {
             targetGroupRef: groupName ? { name: groupName } : undefined,
             targetClusters: groupName ? undefined : targetClusters,
             strategy: 'RollingUpdate' } })
-      } catch (err) {
+      } catch (err: unknown) {
         console.error('Failed to create persistence CRs:', err)
         showToast('Failed to create deployment tracking records', 'warning')
         // Continue with deploy even if CR creation fails
@@ -149,7 +149,7 @@ export function Deploy() {
                 warnings: resp.warnings } })
           }
         } })
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Deploy failed:', err)
       const errorMessage = (err instanceof Error && err.message.trim()) ? err.message.trim() : 'Deploy failed'
       showToast(errorMessage, 'error')

--- a/web/src/components/drilldown/RemediationConsole.tsx
+++ b/web/src/components/drilldown/RemediationConsole.tsx
@@ -306,7 +306,7 @@ export function RemediationConsole({
         type: 'output',
         message: output,
       })
-    } catch (error) {
+    } catch (error: unknown) {
       // Fall back to simulated output when backend is unavailable
       const message = error instanceof Error ? error.message : 'Connection failed'
       setShellError(`MCP bridge unavailable: ${message}`)

--- a/web/src/components/drilldown/views/BuildpackDrillDown.tsx
+++ b/web/src/components/drilldown/views/BuildpackDrillDown.tsx
@@ -197,7 +197,7 @@ export function BuildpackDrillDown({ data }: Props) {
         const parsed = JSON.parse(output)
         setImageInfo(parsed)
       }
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Failed to fetch image info:', error)
       showToast('Failed to fetch image info', 'error')
     }
@@ -242,7 +242,7 @@ export function BuildpackDrillDown({ data }: Props) {
         const parsed = JSON.parse(output)
         setBuilds(parsed.items || [])
       }
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Failed to fetch builds:', error)
       showToast('Failed to fetch builds', 'error')
       setBuilds([])
@@ -297,7 +297,7 @@ export function BuildpackDrillDown({ data }: Props) {
       } else {
         setLogs('No builds found for this image')
       }
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Failed to fetch logs:', error)
       showToast('Failed to fetch logs', 'error')
       setLogs('Error fetching logs')

--- a/web/src/components/drilldown/views/DeploymentDrillDown.tsx
+++ b/web/src/components/drilldown/views/DeploymentDrillDown.tsx
@@ -366,7 +366,7 @@ export function DeploymentDrillDown({ data }: Props) {
         // Issue 9284: don't leak raw kubectl stderr — map to a friendly message.
         setScaleError(t(classifyScaleError(output)))
       }
-    } catch (err) {
+    } catch (err: unknown) {
       // Issue 9284: don't leak raw stack traces; map through the same helper.
       setScaleError(t(classifyScaleError(err instanceof Error ? err.message : '')))
     } finally {

--- a/web/src/components/drilldown/views/EventsDrillDown.tsx
+++ b/web/src/components/drilldown/views/EventsDrillDown.tsx
@@ -103,7 +103,7 @@ export function EventsDrillDown({ data }: Props) {
       } else {
         setError('Failed to fetch events')
       }
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to fetch events')
     } finally {
       setIsLoading(false)

--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -604,7 +604,7 @@ Be specific and reference actual values from the data. Keep response to 3-4 sent
         setAiAnalysisLoading(false)
         ws.close()
       }
-    } catch (err) {
+    } catch (err: unknown) {
       // #5945 — Unexpected errors (kubectl failures, network issues, etc.)
       // must also be surfaced so the failure is not silent.
       const errMsg = `Failed to perform AI analysis: ${err instanceof Error ? err.message : String(err)}`
@@ -846,7 +846,7 @@ Please:
         setDeletingPod(false)
         ws.close()
       }
-    } catch (err) {
+    } catch (err: unknown) {
       setDeleteError(err instanceof Error ? err.message : 'Unknown error')
       setDeletingPod(false)
     }
@@ -961,7 +961,7 @@ Please:
       setPendingLabelChanges({})
       setNewLabelKey('')
       setNewLabelValue('')
-    } catch (err) {
+    } catch (err: unknown) {
       setLabelError(`Failed to save: ${err}`)
     } finally {
       setLabelSaving(false)
@@ -1098,7 +1098,7 @@ Please:
       setPendingAnnotationChanges({})
       setNewAnnotationKey('')
       setNewAnnotationValue('')
-    } catch (err) {
+    } catch (err: unknown) {
       setAnnotationError(`Failed to save: ${err}`)
     } finally {
       setAnnotationSaving(false)

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -224,7 +224,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
         issueUrl: result.github_issue_url,
         screenshotsUploaded: result.screenshots_uploaded,
         screenshotsFailed: result.screenshots_failed })
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('[Screenshot] Failed to submit feedback:', err)
       const message = err instanceof Error ? err.message : 'Failed to submit feedback'
       if (screenshots.length > 0) emitScreenshotUploadFailed(message, screenshots.length)

--- a/web/src/components/feedback/SubmitTab.tsx
+++ b/web/src/components/feedback/SubmitTab.tsx
@@ -296,7 +296,7 @@ export function SubmitForm({
         screenshotsUploaded: result.screenshots_uploaded,
         screenshotsFailed: result.screenshots_failed,
       })
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : ''
       try {
         const parsed = JSON.parse(message)

--- a/web/src/components/gitops/GitOps.tsx
+++ b/web/src/components/gitops/GitOps.tsx
@@ -230,7 +230,7 @@ export function GitOps() {
               status: 'ok' as const,
               drifted: data.drifted,
               resources: data.resources || [] } satisfies DriftResult }
-        } catch (e) {
+        } catch (e: unknown) {
           // #6156 — Failed drift checks MUST NOT be coerced to
           // `drifted: false` — that rendered as "synced + healthy" (false
           // green). Return status: 'error' so the UI can render a distinct

--- a/web/src/components/gitops/SyncDialog.tsx
+++ b/web/src/components/gitops/SyncDialog.tsx
@@ -185,7 +185,7 @@ export function SyncDialog({
       }
 
       setPhase('plan')
-    } catch (err) {
+    } catch (err: unknown) {
       // Error states should be shown immediately (not deferred with startTransition)
       updateLastLog('error')
       const message = err instanceof Error ? err.message : 'Detection failed'
@@ -283,7 +283,7 @@ export function SyncDialog({
         addLog(`Sync failed: ${data.message}`, 'error')
         setError(data.message)
       }
-    } catch (err) {
+    } catch (err: unknown) {
       updateLastLog('error')
       const message = err instanceof Error ? err.message : 'Sync failed'
       addLog(`Error: ${message}`, 'error')

--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -473,7 +473,7 @@ export function GPUReservations() {
     try {
       await apiDeleteReservation(deleteConfirmId)
       showToast('GPU reservation deleted', 'success')
-    } catch (err) {
+    } catch (err: unknown) {
       showToast(`Failed to delete: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error')
     } finally {
       setIsDeleting(false)

--- a/web/src/components/gpu/ReservationFormModal.tsx
+++ b/web/src/components/gpu/ReservationFormModal.tsx
@@ -398,7 +398,7 @@ export function ReservationFormModal({
 
       onSaved()
       onClose()
-    } catch (err) {
+    } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : t('gpuReservations.form.errors.saveFailed')
       setError(msg)
       onError(msg)

--- a/web/src/components/mission-control/LaunchSequence.tsx
+++ b/web/src/components/mission-control/LaunchSequence.tsx
@@ -248,7 +248,7 @@ export function LaunchSequence({
               : p
           )
         )
-      } catch (err) {
+      } catch (err: unknown) {
         // #7143 — Capture the full error message. When `err` is an array
         // (e.g. from Promise.all rejections or grouped validation errors),
         // stringify each element individually to avoid losing detail.

--- a/web/src/components/mission-control/RequestApprovalModal.tsx
+++ b/web/src/components/mission-control/RequestApprovalModal.tsx
@@ -93,7 +93,7 @@ export function RequestApprovalModal({
       const data = await res.json() as { html_url: string }
       setIssueUrl(data.html_url)
       showToast('Approval request created on GitHub', 'success')
-    } catch (err) {
+    } catch (err: unknown) {
       showToast(`Network error: ${err instanceof Error ? err.message : 'unknown'}`, 'error')
     } finally {
       setSubmitting(false)

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -267,7 +267,7 @@ function persistState(state: MissionControlState) {
       savedAt: Date.now(),
       schemaVersion: PERSISTED_SCHEMA_VERSION }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(entry))
-  } catch (e) {
+  } catch (e: unknown) {
     // #6665 — Do not silently swallow quota errors. Log a warning naming
     // the wizard so the user can see which draft was at risk, and surface
     // an ephemeral flag in sessionStorage so the Mission Control dialog
@@ -1099,7 +1099,7 @@ Include real CNCF projects only. Consider dependencies between projects.`
           sendMessage(missionId, prompt)
           setState((prev) => ({ ...prev, aiStreaming: true }))
         }
-      } catch (err) {
+      } catch (err: unknown) {
         aiRequestInFlightRef.current = false
         console.error('[MissionControl] #6811 — askAIForSuggestions failed:', err)
         showToast('AI suggestion request failed — please try again', 'error')
@@ -1264,7 +1264,7 @@ Order phases by dependency — prerequisites first. Each phase completes before 
           sendMessage(missionId, prompt)
           setState((prev) => ({ ...prev, aiStreaming: true }))
         }
-      } catch (err) {
+      } catch (err: unknown) {
         aiRequestInFlightRef.current = false
         console.error('[MissionControl] #7117 — askAIForAssignments failed:', err)
         showToast('AI assignment request failed — please try again', 'error')

--- a/web/src/components/missions/SaveResolutionDialog.tsx
+++ b/web/src/components/missions/SaveResolutionDialog.tsx
@@ -202,7 +202,7 @@ Return ONLY valid JSON, no markdown code blocks or explanation.`
             sessionId: `resolution-${mission.id}`,
             agent: mission.agent || undefined }
         }))
-      } catch (err) {
+      } catch (err: unknown) {
         settle(() => {
           ws.close()
           reject(err instanceof Error ? err : new Error('Failed to send AI summary request'))
@@ -370,7 +370,7 @@ export function SaveResolutionDialog({
       setSummary(`**Problem:** ${aiSummary.problem}\n\n**Solution:** ${aiSummary.solution}`)
       setSteps(aiSummary.steps.length > 0 ? aiSummary.steps : [''])
       setYaml(aiSummary.yaml || '')
-    } catch (err) {
+    } catch (err: unknown) {
       setAiError(err instanceof Error ? err.message : 'Failed to generate summary')
       // Fall back to basic extraction
       setTitle(currentMission.title)
@@ -457,7 +457,7 @@ export function SaveResolutionDialog({
 
       onSaved?.()
       onClose()
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : t('dashboard.missions.failedToSave'))
     } finally {
       setIsSaving(false)

--- a/web/src/components/missions/browser/missionCache.ts
+++ b/web/src/components/missions/browser/missionCache.ts
@@ -227,7 +227,7 @@ async function fetchAllFromIndex() {
     missionCache.fetchedAt = Date.now()
     missionCache.fetchError = null
     persistCacheToStorage()
-  } catch (err) {
+  } catch (err: unknown) {
     console.warn('[MissionBrowser] Failed to fetch index:', err)
     missionCache.fetchError = err instanceof Error ? err.message : 'Failed to load missions. Please try again.'
   } finally {

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -254,7 +254,7 @@ export function NamespaceManager() {
     try {
       const response = await api.get<{ bindings: typeof accessEntries }>(`/api/namespaces/${encodeURIComponent(namespace.name)}/access?cluster=${encodeURIComponent(namespace.cluster)}`)
       setAccessEntries(response.data?.bindings || [])
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Failed to fetch access:', err)
       setAccessEntries([])
       const message = err instanceof Error && err.message?.includes('403')
@@ -341,7 +341,7 @@ export function NamespaceManager() {
         setSelectedNamespace(null)
       }
       setNamespaceToDelete(null)
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Failed to delete namespace:', err)
       setError('Failed to delete namespace')
       showToast('Failed to delete namespace', 'error')
@@ -379,7 +379,7 @@ export function NamespaceManager() {
         throw new Error(errorData.error || 'Failed to revoke access')
       }
       fetchAccess(selectedNamespace)
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Failed to revoke access:', err)
       setError('Failed to revoke access')
       showToast('Failed to revoke access', 'error')

--- a/web/src/components/onboarding/Onboarding.tsx
+++ b/web/src/components/onboarding/Onboarding.tsx
@@ -159,7 +159,7 @@ export function Onboarding() {
       await refreshUser()
 
       navigate(ROUTES.HOME)
-    } catch (err) {
+    } catch (err: unknown) {
       // For demo mode, still allow navigation even if there's an error
       const token = safeGetItem(STORAGE_KEY_TOKEN)
       if (token === DEMO_TOKEN_VALUE) {

--- a/web/src/components/pods/Pods.tsx
+++ b/web/src/components/pods/Pods.tsx
@@ -83,7 +83,7 @@ export function Pods() {
       await kubectlProxy.exec(['delete', 'pod', name, '-n', namespace], { context: cluster })
       showToast(t('pods.restartSuccess', 'Pod deletion triggered (it will restart if managed)'), 'success')
       refetchPodIssues()
-    } catch (err) {
+    } catch (err: unknown) {
       const detail = err instanceof Error ? err.message : String(err)
       showToast(t('pods.restartErrorDetail', 'Failed to restart pod: {{detail}}', { detail }), 'error')
     }
@@ -106,7 +106,7 @@ export function Pods() {
       await kubectlProxy.exec(['delete', 'pod', target.name, '-n', target.namespace], { context: target.cluster })
       showToast(t('pods.deleteSuccess', 'Pod deleted'), 'success')
       refetchPodIssues()
-    } catch (err) {
+    } catch (err: unknown) {
       const detail = err instanceof Error ? err.message : String(err)
       showToast(t('pods.deleteErrorDetail', 'Failed to delete pod: {{detail}}', { detail }), 'error')
     } finally {

--- a/web/src/components/rewards/GitHubInvite.tsx
+++ b/web/src/components/rewards/GitHubInvite.tsx
@@ -85,7 +85,7 @@ export function GitHubInviteModal({ isOpen, onClose }: GitHubInviteProps) {
       }
 
       setUsername('')
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to send invite')
     } finally {
       setIsSubmitting(false)

--- a/web/src/components/security/Security.tsx
+++ b/web/src/components/security/Security.tsx
@@ -80,7 +80,7 @@ export function Security() {
       // For now, just simulate a refresh
       await new Promise(resolve => setTimeout(resolve, SHORT_DELAY_MS))
       setLastUpdated(new Date())
-    } catch (error) {
+    } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Failed to refresh security data'
       setRefreshError(message)
     } finally {

--- a/web/src/components/settings/sections/EmailNotificationSettings.tsx
+++ b/web/src/components/settings/sections/EmailNotificationSettings.tsx
@@ -78,7 +78,7 @@ export function EmailNotificationSettings({
         emailPassword: config.emailPassword,
       })
       setTestResult({ type: 'email', success: true, message: t('settings.notifications.email.testSuccess') })
-    } catch (error) {
+    } catch (error: unknown) {
       setTestResult({
         type: 'email',
         success: false,

--- a/web/src/components/settings/sections/GitHubTokenSection.tsx
+++ b/web/src/components/settings/sections/GitHubTokenSection.tsx
@@ -150,7 +150,7 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
         reset: new Date(data.rate.reset * 1000),
       })
       return true
-    } catch (err) {
+    } catch (err: unknown) {
       setTokenError(err instanceof Error ? err.message : 'Failed to validate token')
       setRateLimit(null)
       return false
@@ -203,7 +203,7 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
         // Trigger system updates check with the new token
         forceVersionCheck()
       }
-    } catch (err) {
+    } catch (err: unknown) {
       setTokenError(err instanceof Error ? err.message : 'Failed to save token')
     } finally {
       setTokenTesting(false)

--- a/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
+++ b/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
@@ -38,7 +38,7 @@ export function OpsGenieNotificationSettings({
         opsgenieApiKey: config.opsgenieApiKey,
       })
       setTestResult({ type: 'opsgenie', success: true, message: t('settings.notifications.opsgenie.testSuccess') })
-    } catch (error) {
+    } catch (error: unknown) {
       setTestResult({
         type: 'opsgenie',
         success: false,

--- a/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
+++ b/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
@@ -38,7 +38,7 @@ export function PagerDutyNotificationSettings({
         pagerdutyRoutingKey: config.pagerdutyRoutingKey,
       })
       setTestResult({ type: 'pagerduty', success: true, message: t('settings.notifications.pagerduty.testSuccess') })
-    } catch (error) {
+    } catch (error: unknown) {
       setTestResult({
         type: 'pagerduty',
         success: false,

--- a/web/src/components/settings/sections/ProfileSection.tsx
+++ b/web/src/components/settings/sections/ProfileSection.tsx
@@ -137,7 +137,7 @@ export function ProfileSection({ initialEmail, initialSlackId, githubLogin, refr
       setIsRefreshing(false)
       setProfileSaved(true)
       timeoutRef.current = window.setTimeout(() => setProfileSaved(false), UI_FEEDBACK_TIMEOUT_MS)
-    } catch (error) {
+    } catch (error: unknown) {
       const message = error instanceof Error ? error.message : t('settings.profile.saveFailed')
       setError(message)
       setIsRefreshing(false)

--- a/web/src/components/settings/sections/SlackNotificationSettings.tsx
+++ b/web/src/components/settings/sections/SlackNotificationSettings.tsx
@@ -61,7 +61,7 @@ export function SlackNotificationSettings({
         slackChannel: config.slackChannel,
       })
       setTestResult({ type: 'slack', success: true, message: t('settings.notifications.slack.testSuccess') })
-    } catch (error) {
+    } catch (error: unknown) {
       setTestResult({
         type: 'slack',
         success: false,

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -128,7 +128,7 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
             merged_at: pr.merged_at!,
           }))
         setRecentPRs(merged)
-      } catch (err) {
+      } catch (err: unknown) {
         if (cancelled) return
         if (err instanceof RateLimitError) {
           setPrsError('GitHub API rate limit reached — data will refresh automatically. Try again in a moment.')
@@ -172,7 +172,7 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
       emitWhatsNewUpdateClicked(latestRelease?.tag ?? '', installMethod ?? 'unknown')
       showToast('Update running in background', 'info')
       onClose()
-    } catch (err) {
+    } catch (err: unknown) {
       showToast(err instanceof Error ? err.message : 'Update failed', 'error')
     } finally {
       setUpdating(false)

--- a/web/src/components/widgets/WidgetExportModal.tsx
+++ b/web/src/components/widgets/WidgetExportModal.tsx
@@ -104,7 +104,7 @@ export function WidgetExportModal({ isOpen, onClose, cardType, mode: _mode = 'pi
     if (!exportConfig) return ''
     try {
       return generateWidget(exportConfig)
-    } catch (err) {
+    } catch (err: unknown) {
       return `// Error generating widget: ${err}`
     }
   }, [exportConfig])

--- a/web/src/components/workloads/Workloads.tsx
+++ b/web/src/components/workloads/Workloads.tsx
@@ -89,7 +89,7 @@ export function Workloads() {
       await kubectlProxy.exec(['rollout', 'restart', 'deployment', name, '-n', namespace], { context: cluster })
       showToast(t('workloads.restartSuccess', 'Restart triggered'), 'success')
       refetchDeployments()
-    } catch (err) {
+    } catch (err: unknown) {
       showToast(t('workloads.restartError', 'Failed to restart deployment'), 'error')
     }
   }
@@ -108,7 +108,7 @@ export function Workloads() {
       await kubectlProxy.exec(['delete', 'deployment', name, '-n', namespace], { context: cluster })
       showToast(t('workloads.deleteSuccess', 'Deployment deleted'), 'success')
       refetchDeployments()
-    } catch (err) {
+    } catch (err: unknown) {
       showToast(t('workloads.deleteError', 'Failed to delete deployment'), 'error')
     }
   }

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -383,7 +383,7 @@ function loadFromStorage<T>(key: string, defaultValue: T): T {
 function saveToStorage<T>(key: string, value: T): void {
   try {
     localStorage.setItem(key, JSON.stringify(value))
-  } catch (e) {
+  } catch (e: unknown) {
     console.error(`Failed to save ${key} to localStorage:`, e)
   }
 }
@@ -406,7 +406,7 @@ function saveAlerts(alerts: Alert[]): void {
   // QuotaExceededError propagates to our own catch block (#7576).
   try {
     localStorage.setItem(ALERTS_KEY, JSON.stringify(toSave))
-  } catch (e) {
+  } catch (e: unknown) {
     // QuotaExceededError: DOMException with name 'QuotaExceededError', or legacy
     // browsers that use numeric code 22 instead of the named exception.
     // Pattern matches useMissions/useMetricsHistory for consistency across the codebase.
@@ -422,7 +422,7 @@ function saveAlerts(alerts: Alert[]): void {
       const pruned = [...firing, ...resolved]
       try {
         localStorage.setItem(ALERTS_KEY, JSON.stringify(pruned))
-      } catch (retryError) {
+      } catch (retryError: unknown) {
         console.error('[Alerts] localStorage still full after pruning, clearing alerts', retryError)
         safeRemove(ALERTS_KEY)
       }
@@ -1028,7 +1028,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
         const data = await response.json().catch(() => ({}))
         throw new Error(data.message || 'Failed to send notifications')
       }
-    } catch (error) {
+    } catch (error: unknown) {
       // Silent failure - notifications are best-effort
       // Only log unexpected errors (not network issues)
       if (error instanceof Error && !error.message.includes('fetch')) {

--- a/web/src/hooks/__tests__/useCachedNodes.test.ts
+++ b/web/src/hooks/__tests__/useCachedNodes.test.ts
@@ -209,7 +209,7 @@ describe('useCachedAllNodes — Issue 9355 clusterErrors surfacing', () => {
             const res: PromiseSettledResult<unknown> = { status: 'fulfilled', value }
             results.push(res)
             if (handleSettled) await handleSettled(res as PromiseSettledResult<never>)
-          } catch (reason) {
+          } catch (reason: unknown) {
             const res: PromiseSettledResult<unknown> = { status: 'rejected', reason }
             results.push(res)
             if (handleSettled) await handleSettled(res as PromiseSettledResult<never>)

--- a/web/src/hooks/__tests__/useDataCompliance.test.ts
+++ b/web/src/hooks/__tests__/useDataCompliance.test.ts
@@ -64,7 +64,7 @@ vi.mock('../../lib/utils/concurrency', () => ({
         try {
           const value = await task()
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }

--- a/web/src/hooks/__tests__/useIntoto-hook.test.tsx
+++ b/web/src/hooks/__tests__/useIntoto-hook.test.tsx
@@ -24,7 +24,7 @@ const {
   mockUseClusters: vi.fn(),
   mockKubectlExec: vi.fn(),
   mockSettledWithConcurrency: vi.fn(async (tasks: (() => Promise<unknown>)[]) => {
-    return Promise.all(tasks.map(t => t().then(v => ({ status: 'fulfilled' as const, value: v })).catch(e => ({ status: 'rejected' as const, reason: e }))))
+    return Promise.all(tasks.map(t => t().then(v => ({ status: 'fulfilled' as const, value: v })).catch((e: unknown) => ({ status: 'rejected' as const, reason: e }))))
   }),
   mockRegisterCacheReset: vi.fn(),
   mockRegisterRefetch: vi.fn(() => vi.fn()),

--- a/web/src/hooks/__tests__/useKyverno.test.ts
+++ b/web/src/hooks/__tests__/useKyverno.test.ts
@@ -49,7 +49,7 @@ vi.mock('../../lib/utils/concurrency', () => ({
         try {
           const value = await task()
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }

--- a/web/src/hooks/__tests__/useNPSSurvey.test.ts
+++ b/web/src/hooks/__tests__/useNPSSurvey.test.ts
@@ -126,7 +126,7 @@ describe('useNPSSurvey', () => {
     await act(async () => {
       try {
         await result.current.submitResponse(3)
-      } catch (err) {
+      } catch (err: unknown) {
         caught = err
       }
     })

--- a/web/src/hooks/__tests__/useNotificationAPI.test.ts
+++ b/web/src/hooks/__tests__/useNotificationAPI.test.ts
@@ -62,7 +62,7 @@ describe('useNotificationAPI', () => {
     await act(async () => {
       try {
         await result.current.testNotification('slack', {})
-      } catch (e) {
+      } catch (e: unknown) {
         caughtError = e
       }
     })
@@ -90,7 +90,7 @@ describe('useNotificationAPI', () => {
     await act(async () => {
       try {
         await result.current.testNotification('email', {})
-      } catch (e) {
+      } catch (e: unknown) {
         caughtError = e
       }
     })

--- a/web/src/hooks/__tests__/useRBACFindings.test.ts
+++ b/web/src/hooks/__tests__/useRBACFindings.test.ts
@@ -49,7 +49,7 @@ vi.mock('../../lib/utils/concurrency', () => ({
         try {
           const value = await task()
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }

--- a/web/src/hooks/__tests__/useTrestle-expand.test.ts
+++ b/web/src/hooks/__tests__/useTrestle-expand.test.ts
@@ -39,7 +39,7 @@ vi.mock('../../lib/utils/concurrency', () => ({
         try {
           const value = await task()
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }

--- a/web/src/hooks/__tests__/useTrestle.test.ts
+++ b/web/src/hooks/__tests__/useTrestle.test.ts
@@ -44,7 +44,7 @@ vi.mock('../../lib/utils/concurrency', () => ({
         try {
           const value = await task()
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }

--- a/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
@@ -447,7 +447,7 @@ describe('fetcher callback — agentFetchAllClusters', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }
@@ -538,7 +538,7 @@ describe('fetcher callback — agentFetchAllClusters', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }
@@ -582,7 +582,7 @@ describe('fetcher callback — agentFetchAllClusters', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }
@@ -712,7 +712,7 @@ describe('fetcher callback — agentFetchAllClusters', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }
@@ -763,7 +763,7 @@ describe('fetcher callback — agentFetchAllClusters', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }
@@ -805,7 +805,7 @@ describe('fetcher callback — agentFetchAllClusters', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }
@@ -953,7 +953,7 @@ describe('agentFetch — namespace parameter handling', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }
@@ -1005,7 +1005,7 @@ describe('agentFetch — namespace parameter handling', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }
@@ -1055,7 +1055,7 @@ describe('agentFetch — missing data key fallback', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }
@@ -1105,7 +1105,7 @@ describe('agentFetch — abort timeout behavior', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }
@@ -1151,7 +1151,7 @@ describe('agentFetch — abort timeout behavior', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }
@@ -1337,7 +1337,7 @@ describe('agentFetchAllClusters — cluster context fallback', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }
@@ -1387,7 +1387,7 @@ describe('agentFetchAllClusters — items annotated with cluster name', () => {
         try {
           const value = await fn(items[i], i)
           results.push({ status: 'fulfilled', value })
-        } catch (reason) {
+        } catch (reason: unknown) {
           results.push({ status: 'rejected', reason })
         }
       }

--- a/web/src/hooks/mcp/buildpacks.ts
+++ b/web/src/hooks/mcp/buildpacks.ts
@@ -69,7 +69,7 @@ function loadFromStorage(): { data: BuildpackImage[]; timestamp: number } {
         return { data: parsed.data, timestamp: parsed.timestamp || 0 }
       }
     }
-  } catch (err) {
+  } catch (err: unknown) {
     console.debug('[Buildpacks] Failed to load from storage:', err)
   }
   return { data: [], timestamp: 0 }
@@ -81,7 +81,7 @@ function saveToStorage(data: BuildpackImage[], timestamp: number) {
       BUILDPACK_CACHE_KEY,
       JSON.stringify({ data, timestamp })
     )
-  } catch (err) {
+  } catch (err: unknown) {
     console.debug('[Buildpacks] Failed to save to storage:', err)
   }
 }
@@ -228,7 +228,7 @@ export function useBuildpackImages(cluster?: string) {
         setConsecutiveFailures(0)
         setLastRefresh(Date.now())
         setIsDemoData(false)
-      } catch (err) {
+      } catch (err: unknown) {
         const message =
           err instanceof Error
             ? err.message
@@ -313,7 +313,7 @@ if (typeof window !== 'undefined') {
   registerCacheReset('buildpack-images', () => {
     try {
       localStorage.removeItem(BUILDPACK_CACHE_KEY)
-    } catch (err) {
+    } catch (err: unknown) {
       console.debug('[Buildpacks] Failed to remove cache from storage:', err)
     }
 

--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -515,7 +515,7 @@ export function useNodes(cluster?: string) {
             return
           }
         }
-      } catch (err) {
+      } catch (err: unknown) {
         console.error(`[useNodes] Local agent failed for ${cluster}:`, err)
       }
     }

--- a/web/src/hooks/mcp/crossplane.ts
+++ b/web/src/hooks/mcp/crossplane.ts
@@ -84,7 +84,7 @@ function loadFromStorage() {
           timestamp: parsed.timestamp || 0 }
       }
     }
-  } catch (err) {
+  } catch (err: unknown) {
     console.debug('[Crossplane] Failed to load cache:', err)
   }
 
@@ -100,7 +100,7 @@ function saveToStorage(
       CACHE_KEY,
       JSON.stringify({ data, timestamp })
     )
-  } catch (err) {
+  } catch (err: unknown) {
     console.debug('[Crossplane] Failed to save cache:', err)
   }
 }
@@ -233,7 +233,7 @@ export function useCrossplaneManagedResources(cluster?: string) {
         setConsecutiveFailures(0)
         setLastRefresh(Date.now())
         setIsDemoData(false)
-      } catch (err) {
+      } catch (err: unknown) {
         const message =
           err instanceof Error
             ? err.message
@@ -320,7 +320,7 @@ if (typeof window !== 'undefined') {
   registerCacheReset('crossplane-managed', () => {
     try {
       localStorage.removeItem(CACHE_KEY)
-    } catch (err) {
+    } catch (err: unknown) {
       console.debug('[Crossplane] Failed to clear cache:', err)
     }
 

--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -141,7 +141,7 @@ export function useEvents(cluster?: string, namespace?: string, limit = 20) {
           reportAgentDataSuccess()
           return
         }
-      } catch (err) {
+      } catch (err: unknown) {
         console.error(`[useEvents] Local agent failed for ${cluster}:`, err)
       }
     }
@@ -172,7 +172,7 @@ export function useEvents(cluster?: string, namespace?: string, limit = 20) {
       setLastUpdated(now)
       setConsecutiveFailures(0)
       setLastRefresh(now)
-    } catch (err) {
+    } catch (err: unknown) {
       // Use name check instead of instanceof to handle both Error and DOMException
       // across all browser versions (DOMException may not extend Error in older Safari).
       if ((err as { name?: string })?.name === 'AbortError') return
@@ -353,7 +353,7 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
       setEvents(allEvents.slice(0, limit))
       setError(null)
       setLastUpdated(now)
-    } catch (err) {
+    } catch (err: unknown) {
       // Use name check instead of instanceof to handle both Error and DOMException
       // across all browser versions (DOMException may not extend Error in older Safari).
       if ((err as { name?: string })?.name === 'AbortError') return

--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -253,7 +253,7 @@ export function useHelmReleases(cluster?: string) {
         setConsecutiveFailures(0)
         setLastRefresh(Date.now())
       }
-    } catch (err) {
+    } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to fetch Helm releases'
 
       // Increment failure count
@@ -426,7 +426,7 @@ export function useHelmHistory(cluster?: string, release?: string, namespace?: s
         })
         saveHelmHistoryToStorage(helmHistoryCache)
       }
-    } catch (err) {
+    } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to fetch Helm history'
       setError(errorMessage)
       setConsecutiveFailures(prev => prev + 1)
@@ -581,7 +581,7 @@ export function useHelmValues(cluster?: string, release?: string, namespace?: st
           consecutiveFailures: 0
         })
       }
-    } catch (err) {
+    } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to fetch Helm values'
       setError(errorMessage)
       setConsecutiveFailures(prev => prev + 1)
@@ -692,7 +692,7 @@ export function useHelmValues(cluster?: string, release?: string, namespace?: st
             timestamp: Date.now(),
             consecutiveFailures: 0
           })
-        } catch (err) {
+        } catch (err: unknown) {
           const errorMessage = err instanceof Error ? err.message : 'Failed to fetch Helm values'
           setError(errorMessage)
           setConsecutiveFailures(prev => prev + 1)

--- a/web/src/hooks/mcp/kagent_crds.ts
+++ b/web/src/hooks/mcp/kagent_crds.ts
@@ -76,7 +76,7 @@ async function agentFetch<T>(path: string, cluster: string, namespace?: string):
     clearTimeout(tid)
     if (!res.ok) throw new Error(`Agent returned ${res.status} for ${path} (cluster: ${cluster})`)
     return await res.json()
-  } catch (err) {
+  } catch (err: unknown) {
     clearTimeout(tid)
     // Log the error so it is visible in the console
     console.warn(`[kagent_crds] fetch failed for ${path} (cluster: ${cluster}):`, err)

--- a/web/src/hooks/mcp/kagenti.ts
+++ b/web/src/hooks/mcp/kagenti.ts
@@ -156,7 +156,7 @@ async function agentFetch<T>(path: string, cluster: string, namespace?: string):
       throw new Error(classified)
     }
     return await res.json()
-  } catch (err) {
+  } catch (err: unknown) {
     clearTimeout(tid)
     console.warn(`[kagenti] fetch failed for ${path} (cluster: ${cluster}):`, err)
     // If already classified (from !res.ok branch), re-throw as-is

--- a/web/src/hooks/mcp/namespaces.ts
+++ b/web/src/hooks/mcp/namespaces.ts
@@ -104,7 +104,7 @@ export function useNamespaces(cluster?: string, forceLive = false) {
             return
           }
         }
-      } catch (err) {
+      } catch (err: unknown) {
         console.error(`[useNamespaces] Local agent failed for ${cluster}:`, err)
       }
     }
@@ -132,7 +132,7 @@ export function useNamespaces(cluster?: string, forceLive = false) {
           setIsLoading(false)
           return
         }
-      } catch (err) {
+      } catch (err: unknown) {
         if (timerId !== null) clearTimeout(timerId)
         console.error(`[useNamespaces] kubectl proxy failed for ${cluster}:`, err)
       }

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -239,7 +239,7 @@ export function useServices(cluster?: string, namespace?: string) {
           }
           return
         }
-      } catch (err) {
+      } catch (err: unknown) {
         console.error(`[useServices] kubectl proxy failed for ${cluster}:`, err)
       }
     }

--- a/web/src/hooks/mcp/operators.ts
+++ b/web/src/hooks/mcp/operators.ts
@@ -206,7 +206,7 @@ export function useOperators(cluster?: string) {
           setConsecutiveFailures(0)
           setLastRefresh(Date.now())
         }
-      } catch (err) {
+      } catch (err: unknown) {
         if (!controller.signal.aborted) {
           // #7547: Surface the error message so the UI can show it instead
           // of silently displaying an empty state.
@@ -374,7 +374,7 @@ export function useOperatorSubscriptions(cluster?: string) {
           setConsecutiveFailures(0)
           setLastRefresh(Date.now())
         }
-      } catch (err) {
+      } catch (err: unknown) {
         if (!controller.signal.aborted) {
           // #7547: Surface the error message so the UI can show it instead
           // of silently displaying an empty state.

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1977,7 +1977,7 @@ export async function fetchWithRetry(
       }
 
       return response
-    } catch (err) {
+    } catch (err: unknown) {
       clearTimeout(timeoutId)
       lastError = err
       // Only retry on transient errors

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -486,7 +486,7 @@ export function usePods(cluster?: string, namespace?: string, sortBy: 'restarts'
       setLastUpdated(now)
       setConsecutiveFailures(0)
       setLastRefresh(now)
-    } catch (err) {
+    } catch (err: unknown) {
       // Ignore AbortError — expected when cluster/namespace changes during a fetch
       if (err instanceof DOMException && err.name === 'AbortError') return
       // Keep stale data on error — only fall back to demo data when demo mode is active
@@ -657,7 +657,7 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
       setError(null)
       setClusterErrors(collectedErrors)
       setLastUpdated(now)
-    } catch (err) {
+    } catch (err: unknown) {
       if (err instanceof DOMException && err.name === 'AbortError') return
       const message = err instanceof Error ? err.message : 'Failed to fetch pods'
       console.warn('[useAllPods] Fetch failed:', message)
@@ -831,7 +831,7 @@ export function usePodIssues(cluster?: string, namespace?: string): UsePodIssues
           setIsRefreshing(false)
         }
         return
-      } catch (proxyErr) {
+      } catch (proxyErr: unknown) {
         // kubectl proxy failed, fall through to SSE
         console.debug('[usePodIssues] kubectl proxy failed, falling back to SSE:', proxyErr)
       }
@@ -867,7 +867,7 @@ export function usePodIssues(cluster?: string, namespace?: string): UsePodIssues
       setLastUpdated(now)
       setConsecutiveFailures(0)
       setLastRefresh(now)
-    } catch (err) {
+    } catch (err: unknown) {
       if (err instanceof DOMException && err.name === 'AbortError') return
       const message = err instanceof Error ? err.message : 'Failed to fetch pod issues'
       console.warn('[usePodIssues] Fetch failed:', message)
@@ -1030,7 +1030,7 @@ export function useDeploymentIssues(cluster?: string, namespace?: string): UseDe
       setLastUpdated(now)
       setConsecutiveFailures(0)
       setLastRefresh(now)
-    } catch (err) {
+    } catch (err: unknown) {
       if (err instanceof DOMException && err.name === 'AbortError') return
       setConsecutiveFailures(prev => prev + 1)
       setLastRefresh(new Date())
@@ -1209,7 +1209,7 @@ export function useDeployments(cluster?: string, namespace?: string): UseDeploym
           reportAgentDataSuccess()
           return
         }
-      } catch (agentErr) {
+      } catch (agentErr: unknown) {
         // Agent unavailable — fall through to kubectl proxy
         console.debug('[useDeployments] Agent fetch failed, falling back to kubectl proxy:', agentErr)
       }
@@ -1244,7 +1244,7 @@ export function useDeployments(cluster?: string, namespace?: string): UseDeploym
           }
           return
         }
-      } catch (proxyErr) {
+      } catch (proxyErr: unknown) {
         // kubectl proxy unavailable — fall through to REST API
         console.debug('[useDeployments] kubectl proxy failed, falling back to REST API:', proxyErr)
       }
@@ -1284,7 +1284,7 @@ export function useDeployments(cluster?: string, namespace?: string): UseDeploym
       setConsecutiveFailures(0)
       setLastRefresh(now)
       deploymentsCache = { data: newDeployments, timestamp: now, key: cacheKey }
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to fetch deployments'
       console.error('[useDeployments] All fetch sources failed:', message, err)
       setConsecutiveFailures(prev => prev + 1)
@@ -1380,7 +1380,7 @@ export function useJobs(cluster?: string, namespace?: string): UseJobsResult {
           reportAgentDataSuccess()
           return
         }
-      } catch (agentErr) {
+      } catch (agentErr: unknown) {
         // Agent failed — fall through to SSE
         console.debug('[useJobs] Agent fetch failed, falling back to SSE:', agentErr)
       }
@@ -1409,7 +1409,7 @@ export function useJobs(cluster?: string, namespace?: string): UseJobsResult {
       setJobs(result)
       setError(null)
       setConsecutiveFailures(0)
-    } catch (err) {
+    } catch (err: unknown) {
       if (err instanceof DOMException && err.name === 'AbortError') return
       const message = err instanceof Error ? err.message : 'Failed to fetch jobs'
       console.warn('[useJobs] Fetch failed:', message)
@@ -1462,7 +1462,7 @@ export function useHPAs(cluster?: string, namespace?: string): UseHPAsResult {
           reportAgentDataSuccess()
           return
         }
-      } catch (agentErr) {
+      } catch (agentErr: unknown) {
         // Agent failed — fall through to REST API
         console.debug('[useHPAs] Agent fetch failed, falling back to REST API:', agentErr)
       }
@@ -1475,7 +1475,7 @@ export function useHPAs(cluster?: string, namespace?: string): UseHPAsResult {
       setHPAs(data.hpas || [])
       setError(null)
       setConsecutiveFailures(0)
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to fetch HPAs'
       if (err instanceof Error && err.name === 'UnauthenticatedError') { console.debug('[useHPAs] Skipped — no auth token') } else { console.error('[useHPAs] Fetch failed:', message, err) }
       setError(message)
@@ -1527,7 +1527,7 @@ export function useReplicaSets(cluster?: string, namespace?: string): UseReplica
           reportAgentDataSuccess()
           return
         }
-      } catch (agentErr) {
+      } catch (agentErr: unknown) {
         // Agent failed — fall through to REST API
         console.debug('[useReplicaSets] Agent fetch failed, falling back to REST API:', agentErr)
       }
@@ -1540,7 +1540,7 @@ export function useReplicaSets(cluster?: string, namespace?: string): UseReplica
       setReplicaSets(data.replicasets || [])
       setError(null)
       setConsecutiveFailures(0)
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to fetch ReplicaSets'
       if (err instanceof Error && err.name === 'UnauthenticatedError') { console.debug('[useReplicaSets] Skipped — no auth token') } else { console.error('[useReplicaSets] Fetch failed:', message, err) }
       setError(message)
@@ -1590,7 +1590,7 @@ export function useStatefulSets(cluster?: string, namespace?: string): UseStatef
           reportAgentDataSuccess()
           return
         }
-      } catch (agentErr) {
+      } catch (agentErr: unknown) {
         // Agent failed — fall through to REST API
         console.debug('[useStatefulSets] Agent fetch failed, falling back to REST API:', agentErr)
       }
@@ -1603,7 +1603,7 @@ export function useStatefulSets(cluster?: string, namespace?: string): UseStatef
       setStatefulSets(data.statefulsets || [])
       setError(null)
       setConsecutiveFailures(0)
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to fetch StatefulSets'
       if (err instanceof Error && err.name === 'UnauthenticatedError') { console.debug('[useStatefulSets] Skipped — no auth token') } else { console.error('[useStatefulSets] Fetch failed:', message, err) }
       setError(message)
@@ -1653,7 +1653,7 @@ export function useDaemonSets(cluster?: string, namespace?: string): UseDaemonSe
           reportAgentDataSuccess()
           return
         }
-      } catch (agentErr) {
+      } catch (agentErr: unknown) {
         // Agent failed — fall through to REST API
         console.debug('[useDaemonSets] Agent fetch failed, falling back to REST API:', agentErr)
       }
@@ -1666,7 +1666,7 @@ export function useDaemonSets(cluster?: string, namespace?: string): UseDaemonSe
       setDaemonSets(data.daemonsets || [])
       setError(null)
       setConsecutiveFailures(0)
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to fetch DaemonSets'
       if (err instanceof Error && err.name === 'UnauthenticatedError') { console.debug('[useDaemonSets] Skipped — no auth token') } else { console.error('[useDaemonSets] Fetch failed:', message, err) }
       setError(message)
@@ -1716,7 +1716,7 @@ export function useCronJobs(cluster?: string, namespace?: string): UseCronJobsRe
           reportAgentDataSuccess()
           return
         }
-      } catch (agentErr) {
+      } catch (agentErr: unknown) {
         // Agent failed — fall through to REST API
         console.debug('[useCronJobs] Agent fetch failed, falling back to REST API:', agentErr)
       }
@@ -1729,7 +1729,7 @@ export function useCronJobs(cluster?: string, namespace?: string): UseCronJobsRe
       setCronJobs(data.cronjobs || [])
       setError(null)
       setConsecutiveFailures(0)
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to fetch CronJobs'
       if (err instanceof Error && err.name === 'UnauthenticatedError') { console.debug('[useCronJobs] Skipped — no auth token') } else { console.error('[useCronJobs] Fetch failed:', message, err) }
       setError(message)
@@ -1780,7 +1780,7 @@ export function usePodLogs(cluster: string, namespace: string, pod: string, cont
       params.append('tail', tail.toString())
       const { data } = await api.get<{ logs: string }>(`${LOCAL_AGENT_HTTP_URL}/pods/logs?${params}`)
       setLogs(data.logs || '')
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to fetch logs')
       setLogs('')
     } finally {

--- a/web/src/hooks/useAIPredictions.ts
+++ b/web/src/hooks/useAIPredictions.ts
@@ -210,7 +210,7 @@ async function fetchAIPredictions(): Promise<void> {
       isStale = true
       notifySubscribers()
     }
-  } catch (error) {
+  } catch (error: unknown) {
     // Network error, timeout, or AbortError — backend is unreachable. Mark
     // predictions stale and notify subscribers so the UI updates immediately
     // rather than continuing to show data as if it were fresh (#5937, #5938).

--- a/web/src/hooks/useAlerts.ts
+++ b/web/src/hooks/useAlerts.ts
@@ -25,7 +25,7 @@ function loadFromStorage<T>(key: string, defaultValue: T): T {
     if (stored) {
       return JSON.parse(stored)
     }
-  } catch (e) {
+  } catch (e: unknown) {
     console.error(`Failed to load ${key} from localStorage:`, e)
   }
   return defaultValue
@@ -35,7 +35,7 @@ function loadFromStorage<T>(key: string, defaultValue: T): T {
 function saveToStorage<T>(key: string, value: T): void {
   try {
     localStorage.setItem(key, JSON.stringify(value))
-  } catch (e) {
+  } catch (e: unknown) {
     console.error(`Failed to save ${key} to localStorage:`, e)
   }
 }
@@ -231,7 +231,7 @@ export function useSlackNotification() {
           throw new Error(`Notification send failed (${response.status}): ${errText}`)
         }
         return true
-      } catch (error) {
+      } catch (error: unknown) {
         console.error('Failed to send Slack notification:', error)
         throw error
       }

--- a/web/src/hooks/useArgoCD.ts
+++ b/web/src/hooks/useArgoCD.ts
@@ -892,7 +892,7 @@ export function useArgoApplicationSets(): UseArgoApplicationSetsResult {
 
       // API explicitly indicated demo data — fall through to mock
       throw new Error('No ArgoCD ApplicationSet data available')
-    } catch (err) {
+    } catch (err: unknown) {
       const errorMsg = err instanceof Error ? err.message : 'Failed to fetch ApplicationSets'
       console.error('[ArgoCD] ApplicationSets fetch failed:', errorMsg)
       setError(errorMsg)

--- a/web/src/hooks/useCachedCoreWorkloads.ts
+++ b/web/src/hooks/useCachedCoreWorkloads.ts
@@ -677,7 +677,7 @@ export function useCachedSecurityIssues(
         try {
           const issues = await fetchSecurityIssuesViaKubectl(cluster, namespace)
           if (issues.length > 0) return issues
-        } catch (err) {
+        } catch (err: unknown) {
           console.error('[useCachedSecurityIssues] kubectl fetch failed:', err)
         }
       }
@@ -689,7 +689,7 @@ export function useCachedSecurityIssues(
         try {
           const data = await fetchBackendAPI<{ issues: SecurityIssue[] }>('security-issues', { cluster, namespace })
           if (data?.issues && data.issues.length > 0) return data.issues
-        } catch (err) {
+        } catch (err: unknown) {
           console.error('[useCachedSecurityIssues] API fetch failed:', err)
         }
       }
@@ -703,7 +703,7 @@ export function useCachedSecurityIssues(
         try {
           const issues = await fetchSecurityIssuesViaKubectl(cluster, namespace, onProgress)
           if (issues.length > 0) return issues
-        } catch (err) {
+        } catch (err: unknown) {
           console.error('[useCachedSecurityIssues] progressive kubectl fetch failed:', err)
         }
       }

--- a/web/src/hooks/useCachedData/__tests__/agentFetchers.test.ts
+++ b/web/src/hooks/useCachedData/__tests__/agentFetchers.test.ts
@@ -61,7 +61,7 @@ vi.mock('../../../lib/utils/concurrency', () => ({
       try {
         const value = await task()
         onSettled({ status: 'fulfilled', value })
-      } catch (reason) {
+      } catch (reason: unknown) {
         onSettled({ status: 'rejected', reason })
       }
     }

--- a/web/src/hooks/useCachedGPU.ts
+++ b/web/src/hooks/useCachedGPU.ts
@@ -138,7 +138,7 @@ async function fetchHardwareHealth(): Promise<HardwareHealthData> {
     }
 
     return result
-  } catch (e) {
+  } catch (e: unknown) {
     clearTimeout(timeoutId)
     throw e
   }
@@ -332,7 +332,7 @@ export function useGPUHealthCronJob(cluster?: string) {
         throw new Error(text || `Install failed: ${response.status}`)
       }
       await result.refetch()
-    } catch (err) {
+    } catch (err: unknown) {
       setActionError(err instanceof Error ? err.message : 'Failed to install CronJob')
     } finally {
       setActionInProgress(null)
@@ -363,7 +363,7 @@ export function useGPUHealthCronJob(cluster?: string) {
         throw new Error(text || `Uninstall failed: ${response.status}`)
       }
       await result.refetch()
-    } catch (err) {
+    } catch (err: unknown) {
       setActionError(err instanceof Error ? err.message : 'Failed to uninstall CronJob')
     } finally {
       setActionInProgress(null)

--- a/web/src/hooks/useCachedGitOps.ts
+++ b/web/src/hooks/useCachedGitOps.ts
@@ -307,7 +307,7 @@ export function useCachedBuildpackImages(
       try {
         const data = await fetchGitOpsAPI<{ images: BuildpackImage[] }>('buildpack-images', cluster ? { cluster } : undefined)
         return data.images || []
-      } catch (err) {
+      } catch (err: unknown) {
         // When no buildpacks CRDs exist on any cluster, the API returns 404.
         // Treat this as an empty result rather than an error so the card
         // settles into its empty state instead of retrying indefinitely.

--- a/web/src/hooks/useCachedISO27001.ts
+++ b/web/src/hooks/useCachedISO27001.ts
@@ -256,7 +256,7 @@ async function fetchISO27001AuditViaKubectl(
     .map(({ name, context }) => async () => {
       try {
         return await runISO27001ChecksForCluster(name, context || name)
-      } catch (err) {
+      } catch (err: unknown) {
         console.error(`[ISO27001] Audit failed for cluster ${name}:`, err)
         return []
       }

--- a/web/src/hooks/useCachedLLMd.ts
+++ b/web/src/hooks/useCachedLLMd.ts
@@ -302,7 +302,7 @@ export async function fetchLLMdServers(
   const tasks = clusters.map((cluster) => async () => {
     try {
       return await fetchLLMdServersForCluster(cluster)
-    } catch (err) {
+    } catch (err: unknown) {
       // Suppress demo mode errors - they're expected when agent is unavailable
       const errMsg = err instanceof Error ? err.message : String(err)
       if (!errMsg.includes('demo mode')) {
@@ -395,7 +395,7 @@ export async function fetchLLMdModels(
         })
       }
       return clusterModels
-    } catch (err) {
+    } catch (err: unknown) {
       // Suppress demo mode errors - they're expected when agent is unavailable
       const errMsg = err instanceof Error ? err.message : String(err)
       if (!errMsg.includes('demo mode')) {

--- a/web/src/hooks/useCachedNodes.ts
+++ b/web/src/hooks/useCachedNodes.ts
@@ -227,7 +227,7 @@ export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & {
             nodes: (data.nodes || []).map((n) => ({ ...n, cluster: cluster.name })),
             error: null,
           }
-        } catch (err) {
+        } catch (err: unknown) {
           // Per-cluster failure: tolerate it so a single unreachable cluster
           // doesn't wipe the whole aggregate. Accumulated nodes from other
           // clusters still render.  Issue 9355 — classify the error (auth /

--- a/web/src/hooks/useCertManager.ts
+++ b/web/src/hooks/useCertManager.ts
@@ -342,7 +342,7 @@ export function useCertManager() {
                 certificateCount: 0 })
             }
           }
-        } catch (err) {
+        } catch (err: unknown) {
           // Silence expected errors in demo mode (agent unavailable)
           const isDemoError = err instanceof Error && err.message.includes('demo mode')
           if (!isDemoError) {
@@ -370,7 +370,7 @@ export function useCertManager() {
 
       // Save to localStorage cache
       saveToCache(allCertificates, allIssuers, certManagerFound)
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('[useCertManager] Error:', err)
       setError(err instanceof Error ? err.message : 'Failed to fetch cert-manager data')
       setConsecutiveFailures(prev => prev + 1)

--- a/web/src/hooks/useComplianceFrameworks.ts
+++ b/web/src/hooks/useComplianceFrameworks.ts
@@ -84,7 +84,7 @@ export function useComplianceFrameworks() {
       setFrameworks(data)
       saveCache(data)
       setError(null)
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to load frameworks')
     } finally {
       setIsLoading(false)
@@ -112,7 +112,7 @@ export function useFrameworkEvaluation() {
         { cluster },
       )
       setResult(data)
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Evaluation failed')
       setResult(null)
     } finally {

--- a/web/src/hooks/useConsoleCRs.ts
+++ b/web/src/hooks/useConsoleCRs.ts
@@ -234,7 +234,7 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
       } else {
         throw new Error('Failed to fetch')
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error(`[useConsoleCR] Failed to fetch ${resourceType}:`, err)
       if (isMounted.current) {
         setError(`Failed to load ${resourceType}`)
@@ -256,7 +256,7 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
       if (response.ok) {
         return await response.json()
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error(`[useConsoleCR] Failed to get ${resourceType} ${name}:`, err)
     }
     return null
@@ -282,7 +282,7 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
         setItems(prev => [...prev, created])
         return created
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error(`[useConsoleCR] Failed to create ${resourceType}:`, err)
     }
     return null
@@ -308,7 +308,7 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
         setItems(prev => prev.map(i => i.metadata.name === name ? updated : i))
         return updated
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error(`[useConsoleCR] Failed to update ${resourceType} ${name}:`, err)
     }
     return null
@@ -332,7 +332,7 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
         setItems(prev => prev.filter(i => i.metadata.name !== name))
         return true
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error(`[useConsoleCR] Failed to delete ${resourceType} ${name}:`, err)
     }
     return false
@@ -401,7 +401,7 @@ export function useWorkloadDeployments() {
       if (response.ok) {
         return await response.json()
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error(`[useWorkloadDeployments] Failed to update status for ${name}:`, err)
     }
     return null

--- a/web/src/hooks/useDataCompliance.ts
+++ b/web/src/hooks/useDataCompliance.ts
@@ -301,7 +301,7 @@ export function useDataCompliance() {
         setError(null)
       }
       initialLoadDone.current = true
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to fetch compliance data')
     } finally {
       setIsLoading(false)

--- a/web/src/hooks/useDependencies.ts
+++ b/web/src/hooks/useDependencies.ts
@@ -143,7 +143,7 @@ export function useResolveDependencies() {
         const result: DependencyResolution = await res.json()
         setData(result)
         return result
-      } catch (restErr) {
+      } catch (restErr: unknown) {
         restError = restErr
         console.error('[useDependencies] REST API failed, trying agent:', restErr)
       }
@@ -156,7 +156,7 @@ export function useResolveDependencies() {
           setData(agentResult)
           return agentResult
         }
-      } catch (agentErr) {
+      } catch (agentErr: unknown) {
         agentError = agentErr
         console.error('[useDependencies] Agent resolve-deps failed:', agentErr)
       }

--- a/web/src/hooks/useDrasiResources.ts
+++ b/web/src/hooks/useDrasiResources.ts
@@ -375,7 +375,7 @@ export function useDrasiResources(): UseDrasiResourcesResult {
       }
       setData(next)
       setError(null)
-    } catch (e) {
+    } catch (e: unknown) {
       if ((e as Error).name !== 'AbortError') {
         setError((e as Error).message || 'Failed to fetch Drasi resources')
         setData(null)

--- a/web/src/hooks/useExecSession.ts
+++ b/web/src/hooks/useExecSession.ts
@@ -238,7 +238,7 @@ export function useExecSession(): UseExecSessionResult {
     let ws: WebSocket
     try {
       ws = new WebSocket(appendWsAuthToken(wsUrl))
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to create WebSocket connection'
       updateStatus(
         'error',

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -360,7 +360,7 @@ export function useFeatureRequests(currentUserId?: string, options?: UseFeatureR
       const { data } = await api.post<FeatureRequest>('/api/feedback/requests', input, mergedOpts)
       setRequests(prev => [data, ...prev])
       return data
-    } catch (err) {
+    } catch (err: unknown) {
       if (err instanceof RateLimitError) {
         throw new Error('Too many requests — please wait a moment and try again.')
       }

--- a/web/src/hooks/useGPUReservations.ts
+++ b/web/src/hooks/useGPUReservations.ts
@@ -192,7 +192,7 @@ export function useGPUReservations(onlyMine = false) {
         setReservations(safeData)
       }
       setError(null)
-    } catch (err) {
+    } catch (err: unknown) {
       // API unreachable — fall back to demo data when in demo mode
       if (effectiveDemo) {
         setReservations(DEMO_RESERVATIONS)

--- a/web/src/hooks/useGitHubPipelines.ts
+++ b/web/src/hooks/useGitHubPipelines.ts
@@ -517,7 +517,7 @@ export function usePipelineMutations() {
           error: body.error,
           status: res.status,
         }
-      } catch (err) {
+      } catch (err: unknown) {
         return { ok: false, error: (err as Error).message, status: 0 }
       }
     },
@@ -548,7 +548,7 @@ export async function fetchPipelineLog(
       lines: body.lines ?? 0,
       truncatedFrom: body.truncatedFrom ?? 0,
     }
-  } catch (err) {
+  } catch (err: unknown) {
     return { error: (err as Error).message }
   }
 }

--- a/web/src/hooks/useGitHubRewards.ts
+++ b/web/src/hooks/useGitHubRewards.ts
@@ -197,7 +197,7 @@ export function useGitHubRewards() {
       setData(merged)
       saveCache(githubLogin, merged)
       setError(null)
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Unknown error')
       const cached = loadCache(githubLogin)
       if (!cached) {

--- a/web/src/hooks/useHelmActions.ts
+++ b/web/src/hooks/useHelmActions.ts
@@ -105,7 +105,7 @@ export function useHelmActions(): UseHelmActionsResult {
         output: data.output }
       setLastResult(result)
       return result
-    } catch (err) {
+    } catch (err: unknown) {
       const result: HelmActionResult = {
         success: false,
         message: err instanceof Error ? err.message : 'Network error' }

--- a/web/src/hooks/useIntoto.ts
+++ b/web/src/hooks/useIntoto.ts
@@ -339,7 +339,7 @@ async function fetchSingleCluster(cluster: string): Promise<IntotoClusterStatus>
       layouts,
       ...stats,
     }
-  } catch (err) {
+  } catch (err: unknown) {
     const isDemoError = err instanceof Error && err.message.includes('demo mode')
     if (!isDemoError) {
       console.error(`[useIntoto] Error fetching from ${cluster}:`, err)

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -287,7 +287,7 @@ async function fetchSingleCluster(cluster: string): Promise<KubescapeClusterStat
       passedControls,
       failedControls,
       controls }
-  } catch (err) {
+  } catch (err: unknown) {
     const isDemoError = err instanceof Error && err.message.includes('demo mode')
     if (!isDemoError) {
       console.error(`[useKubescape] Error fetching from ${cluster}:`, err)

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -307,7 +307,7 @@ async function fetchSingleCluster(cluster: string): Promise<KyvernoClusterStatus
       totalViolations,
       enforcingCount: policies.filter(p => p.status === 'enforcing').length,
       auditCount: policies.filter(p => p.status === 'audit').length }
-  } catch (err) {
+  } catch (err: unknown) {
     const isDemoError = err instanceof Error && err.message.includes('demo mode')
     if (!isDemoError) {
       console.error(`[useKyverno] Error fetching from ${cluster}:`, err)

--- a/web/src/hooks/useLLMd.ts
+++ b/web/src/hooks/useLLMd.ts
@@ -248,7 +248,7 @@ export function useLLMdServers(clusters: string[] = ['vllm-d', 'platform-eval'])
               const items = data.items || []
               allDeployments.push(...items)
             }
-          } catch (err) {
+          } catch (err: unknown) {
             // Suppress demo mode errors - they're expected when agent is unavailable
             const errMsg = err instanceof Error ? err.message : String(err)
             if (!errMsg.includes('demo mode')) {
@@ -405,7 +405,7 @@ export function useLLMdServers(clusters: string[] = ['vllm-d', 'platform-eval'])
               initialLoadDone.current = true
             }
           }
-        } catch (err) {
+        } catch (err: unknown) {
           // Suppress demo mode errors - they're expected when agent is unavailable
           const errMsg = err instanceof Error ? err.message : String(err)
           if (!errMsg.includes('demo mode')) {
@@ -418,7 +418,7 @@ export function useLLMdServers(clusters: string[] = ['vllm-d', 'platform-eval'])
       setConsecutiveFailures(0)
       setLastRefresh(new Date())
       initialLoadDone.current = true
-    } catch (err) {
+    } catch (err: unknown) {
       // Suppress demo mode errors
       const errMsg = err instanceof Error ? err.message : String(err)
       if (!errMsg.includes('demo mode')) {
@@ -438,7 +438,7 @@ export function useLLMdServers(clusters: string[] = ['vllm-d', 'platform-eval'])
   }
 
   useEffect(() => {
-    refetch(false).catch(err => {
+    refetch(false).catch((err: unknown) => {
       console.error('[useLLMdServers] Initial fetch error:', err)
     })
     const interval = setInterval(() => refetch(true), REFRESH_INTERVAL_MS)
@@ -550,7 +550,7 @@ export function useLLMdModels(clusters: string[] = ['vllm-d', 'platform-eval']) 
               initialLoadDone.current = true
             }
           }
-        } catch (err) {
+        } catch (err: unknown) {
           // Suppress demo mode errors - they're expected when agent is unavailable
           const errMsg = err instanceof Error ? err.message : String(err)
           if (!errMsg.includes('demo mode')) {
@@ -563,7 +563,7 @@ export function useLLMdModels(clusters: string[] = ['vllm-d', 'platform-eval']) 
       setConsecutiveFailures(0)
       setLastRefresh(new Date())
       initialLoadDone.current = true
-    } catch (err) {
+    } catch (err: unknown) {
       setConsecutiveFailures(prev => prev + 1)
       setLastRefresh(new Date())
       if (!silent) {

--- a/web/src/hooks/useLocalClusterTools.ts
+++ b/web/src/hooks/useLocalClusterTools.ts
@@ -116,7 +116,7 @@ export function useLocalClusterTools() {
         setTools(data.tools || [])
         setError(null)
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Failed to fetch local cluster tools:', err)
       setError('Failed to fetch cluster tools')
     }
@@ -145,7 +145,7 @@ export function useLocalClusterTools() {
         setClusters(data.clusters || [])
         setError(null)
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Failed to fetch local clusters:', err)
       setError('Failed to fetch clusters')
     } finally {
@@ -191,7 +191,7 @@ export function useLocalClusterTools() {
         const text = await response.text()
         return { status: 'error', message: text }
       }
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to create cluster'
       setError(message)
       return { status: 'error', message }
@@ -231,7 +231,7 @@ export function useLocalClusterTools() {
         setError(text)
         return false
       }
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : `Failed to ${action} cluster`
       setError(message)
       return false
@@ -276,7 +276,7 @@ export function useLocalClusterTools() {
         setError(text)
         return false
       }
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to delete cluster'
       setError(message)
       return false
@@ -322,7 +322,7 @@ export function useLocalClusterTools() {
         setVclusterInstances([])
         setVClustersError(message)
       }
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to fetch vCluster instances'
       console.error('Failed to fetch vCluster instances:', err)
       setVclusterInstances([])
@@ -348,7 +348,7 @@ export function useLocalClusterTools() {
           return [...filtered, data]
         })
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error(`Failed to check vCluster on ${context}:`, err)
     }
   }
@@ -398,7 +398,7 @@ export function useLocalClusterTools() {
         const text = await response.text()
         return { status: 'error', message: text }
       }
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to create vCluster'
       setError(message)
       return { status: 'error', message }
@@ -443,7 +443,7 @@ export function useLocalClusterTools() {
         setError(text)
         return false
       }
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to connect to vCluster'
       setError(message)
       return false
@@ -488,7 +488,7 @@ export function useLocalClusterTools() {
         setError(text)
         return false
       }
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to disconnect from vCluster'
       setError(message)
       return false
@@ -533,7 +533,7 @@ export function useLocalClusterTools() {
         setError(text)
         return false
       }
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to delete vCluster'
       setError(message)
       return false

--- a/web/src/hooks/useMCS.ts
+++ b/web/src/hooks/useMCS.ts
@@ -70,7 +70,7 @@ export function useMCSStatus() {
         error: null,
         lastUpdated: Date.now(),
       })
-    } catch (err) {
+    } catch (err: unknown) {
       if (err instanceof BackendUnavailableError) {
         setState((prev) => ({
           ...prev,
@@ -148,7 +148,7 @@ export function useServiceExports(cluster?: string, namespace?: string) {
         error: null,
         lastUpdated: Date.now(),
       })
-    } catch (err) {
+    } catch (err: unknown) {
       if (err instanceof BackendUnavailableError) {
         setState((prev) => ({
           ...prev,
@@ -240,7 +240,7 @@ export function useServiceImports(cluster?: string, namespace?: string) {
         error: null,
         lastUpdated: Date.now(),
       })
-    } catch (err) {
+    } catch (err: unknown) {
       if (err instanceof BackendUnavailableError) {
         setState((prev) => ({
           ...prev,
@@ -323,7 +323,7 @@ export function useServiceExport(cluster: string, namespace: string, name: strin
         error: null,
         lastUpdated: Date.now(),
       })
-    } catch (err) {
+    } catch (err: unknown) {
       if (err instanceof BackendUnavailableError) {
         setState((prev) => ({
           ...prev,
@@ -388,7 +388,7 @@ export function useServiceImport(cluster: string, namespace: string, name: strin
         error: null,
         lastUpdated: Date.now(),
       })
-    } catch (err) {
+    } catch (err: unknown) {
       if (err instanceof BackendUnavailableError) {
         setState((prev) => ({
           ...prev,

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -253,7 +253,7 @@ export function useMarketplace() {
       } catch {
         // Cache write failed — non-critical
       }
-    } catch (err) {
+    } catch (err: unknown) {
       // #7543: On fetch failure, keep cached/current items with a stale indicator
       // instead of clearing to empty which falsely implies no items exist.
       const staleMsg = err instanceof Error ? err.message : 'Failed to load marketplace'
@@ -328,7 +328,7 @@ export function useMarketplace() {
     try {
       response = await fetch(item.downloadUrl, {
         signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
-    } catch (e) {
+    } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : 'network error'
       emitMarketplaceInstallFailed(item.type, item.name, msg)
       throw e
@@ -377,7 +377,7 @@ export function useMarketplace() {
           throw new Error('no dashboard available to install card-preset into')
         }
         await api.post(`/api/dashboards/${target.id}/cards`, newCard)
-      } catch (e) {
+      } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : 'backend persist failed'
         emitMarketplaceInstallFailed(item.type, item.name, msg)
         throw e

--- a/web/src/hooks/useMetricsHistory.ts
+++ b/web/src/hooks/useMetricsHistory.ts
@@ -70,7 +70,7 @@ function persistSnapshots() {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshots))
     window.dispatchEvent(new Event(HISTORY_CHANGED_EVENT))
-  } catch (e) {
+  } catch (e: unknown) {
     // QuotaExceededError - try to free up space
     if (e instanceof DOMException && (e.name === 'QuotaExceededError' || e.code === 22)) {
       console.warn('[MetricsHistory] Storage quota exceeded, cleaning up old data...')

--- a/web/src/hooks/useMicrophoneInput.ts
+++ b/web/src/hooks/useMicrophoneInput.ts
@@ -174,7 +174,7 @@ export function useMicrophoneInput(): UseMicrophoneInputReturn {
       }
 
       recognition.start()
-    } catch (err) {
+    } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to access microphone'
       setError(errorMessage)
       setIsRecording(false)
@@ -184,7 +184,7 @@ export function useMicrophoneInput(): UseMicrophoneInputReturn {
   const stopRecording = useCallback(async () => {
     try {
       await stopRecordingInternal()
-    } catch (err) {
+    } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to stop recording'
       setError(errorMessage)
     }

--- a/web/src/hooks/useMissionStorage.ts
+++ b/web/src/hooks/useMissionStorage.ts
@@ -47,7 +47,7 @@ export function loadMissions(): Mission[] {
       let parsed: unknown
       try {
         parsed = JSON.parse(stored)
-      } catch (parseErr) {
+      } catch (parseErr: unknown) {
         console.error('[Missions] Corrupted localStorage JSON — clearing:', parseErr)
         localStorage.removeItem(MISSIONS_STORAGE_KEY)
         return getDemoMode() ? DEMO_MISSIONS_AS_MISSIONS : []
@@ -127,7 +127,7 @@ export function loadMissions(): Mission[] {
         return mission
       })
     }
-  } catch (e) {
+  } catch (e: unknown) {
     // issue 6437 — If the persisted payload is unparseable (the previous
     // saveMissions pass may have been interrupted mid-write, or quota
     // pressure corrupted it), fully clear the key instead of leaving a
@@ -153,7 +153,7 @@ export function loadMissions(): Mission[] {
 export function saveMissions(missions: Mission[]) {
   try {
     localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
-  } catch (e) {
+  } catch (e: unknown) {
     // QuotaExceededError: DOMException with name 'QuotaExceededError', or legacy
     // browsers that use numeric code 22 instead of the named exception.
     // Pattern matches useMetricsHistory for consistency across the codebase.
@@ -208,7 +208,7 @@ export function loadUnreadMissionIds(): Set<string> {
       if (!Array.isArray(parsed)) return new Set()
       return new Set(parsed)
     }
-  } catch (e) {
+  } catch (e: unknown) {
     console.error('Failed to load unread missions from localStorage:', e)
   }
   return new Set()
@@ -218,7 +218,7 @@ export function loadUnreadMissionIds(): Set<string> {
 export function saveUnreadMissionIds(ids: Set<string>) {
   try {
     localStorage.setItem(UNREAD_MISSIONS_KEY, JSON.stringify([...ids]))
-  } catch (e) {
+  } catch (e: unknown) {
     console.error('Failed to save unread missions to localStorage:', e)
   }
 }

--- a/web/src/hooks/useMissions.provider.tsx
+++ b/web/src/hooks/useMissions.provider.tsx
@@ -460,7 +460,7 @@ export function MissionProvider({ children }: { children: ReactNode }) {
             }
           }
           missionStatusTimers.current.clear()
-        } catch (err) {
+        } catch (err: unknown) {
           // #6767 — Message is issue-agnostic; this branch now covers
           // #6758, #6762, and #6767 follow-ups.
           console.warn('[Missions] Cross-tab remote reset detected — failed to clear local mission state to match:', err)
@@ -485,7 +485,7 @@ export function MissionProvider({ children }: { children: ReactNode }) {
           const next = new Set([...prev].filter(id => reloadedIds.has(id)))
           return next.size === prev.size ? prev : next
         })
-      } catch (err) {
+      } catch (err: unknown) {
         console.warn('[Missions] issue 6668 — failed to reload from cross-tab write:', err)
       }
     }
@@ -957,7 +957,7 @@ export function MissionProvider({ children }: { children: ReactNode }) {
           try {
             const message = JSON.parse(event.data)
             handleAgentMessageRef.current(message)
-          } catch (e) {
+          } catch (e: unknown) {
             console.error('[Missions] Failed to parse message:', e)
           }
         }
@@ -1157,7 +1157,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           setAgentsLoading(false)
           reject(new Error('CONNECTION_FAILED'))
         }
-      } catch (err) {
+      } catch (err: unknown) {
         clearTimeout(timeout)
         reject(err)
       }
@@ -2896,7 +2896,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       }), () => {
         console.error('[Missions] Failed to send agent selection after retries')
       })
-    }).catch(err => {
+    }).catch((err: unknown) => {
       selectAgentPending.current = null
       console.error('[Missions] Failed to select agent:', err)
     })
@@ -2908,7 +2908,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     // connection requests (e.g. clicking "Reconnect" after giveup).
     // Moved from ensureConnection so auto-reconnect preserves backoff.
     wsReconnectAttempts.current = 0
-    ensureConnection().catch(err => {
+    ensureConnection().catch((err: unknown) => {
       console.error('[Missions] Failed to connect to agent:', err)
     })
   }

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -549,7 +549,7 @@ export function MissionProvider({ children }: { children: ReactNode }) {
             }
           }
           missionStatusTimers.current.clear()
-        } catch (err) {
+        } catch (err: unknown) {
           // #6767 — Message is issue-agnostic; this branch now covers
           // #6758, #6762, and #6767 follow-ups.
           console.warn('[Missions] Cross-tab remote reset detected — failed to clear local mission state to match:', err)
@@ -574,7 +574,7 @@ export function MissionProvider({ children }: { children: ReactNode }) {
           const next = new Set([...prev].filter(id => reloadedIds.has(id)))
           return next.size === prev.size ? prev : next
         })
-      } catch (err) {
+      } catch (err: unknown) {
         console.warn('[Missions] issue 6668 — failed to reload from cross-tab write:', err)
       }
     }
@@ -1046,7 +1046,7 @@ export function MissionProvider({ children }: { children: ReactNode }) {
           try {
             const message = JSON.parse(event.data)
             handleAgentMessageRef.current(message)
-          } catch (e) {
+          } catch (e: unknown) {
             console.error('[Missions] Failed to parse message:', e)
           }
         }
@@ -1246,7 +1246,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           setAgentsLoading(false)
           reject(new Error('CONNECTION_FAILED'))
         }
-      } catch (err) {
+      } catch (err: unknown) {
         clearTimeout(timeout)
         reject(err)
       }
@@ -2985,7 +2985,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       }), () => {
         console.error('[Missions] Failed to send agent selection after retries')
       })
-    }).catch(err => {
+    }).catch((err: unknown) => {
       selectAgentPending.current = null
       console.error('[Missions] Failed to select agent:', err)
     })
@@ -2997,7 +2997,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     // connection requests (e.g. clicking "Reconnect" after giveup).
     // Moved from ensureConnection so auto-reconnect preserves backoff.
     wsReconnectAttempts.current = 0
-    ensureConnection().catch(err => {
+    ensureConnection().catch((err: unknown) => {
       console.error('[Missions] Failed to connect to agent:', err)
     })
   }

--- a/web/src/hooks/useNPSSurvey.ts
+++ b/web/src/hooks/useNPSSurvey.ts
@@ -132,7 +132,7 @@ export function useNPSSurvey(): NPSSurveyState {
         // 5xx / 400 / 401 / 403 — real server failure, surface to the user.
         throw new Error(`NPS submit failed: ${resp.status} ${resp.statusText}`)
       }
-    } catch (err) {
+    } catch (err: unknown) {
       // Re-throw only if this wasn't a 404/405 we already swallowed above.
       // Network errors (DNS failure, connection refused, timeout) still
       // propagate so the user sees a failure toast and can retry.

--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -41,7 +41,7 @@ function loadCachedData(): NightlyE2EData {
       const parsed = JSON.parse(raw) as NightlyE2EData
       if (parsed.guides?.length > 0 && !parsed.isDemo) return parsed
     }
-  } catch (e) { console.warn('[useNightlyE2EData] failed to read cached nightly data:', e) }
+  } catch (e: unknown) { console.warn('[useNightlyE2EData] failed to read cached nightly data:', e) }
   return { guides: [], isDemo: false }
 }
 

--- a/web/src/hooks/useNotificationAPI.ts
+++ b/web/src/hooks/useNotificationAPI.ts
@@ -45,7 +45,7 @@ export function useNotificationAPI() {
         }
 
         return data
-      } catch (err) {
+      } catch (err: unknown) {
         const message = err instanceof Error ? err.message : 'Failed to test notification'
         setError(message)
         throw err
@@ -72,7 +72,7 @@ export function useNotificationAPI() {
         }
 
         return data
-      } catch (err) {
+      } catch (err: unknown) {
         const message = err instanceof Error ? err.message : 'Failed to send notification'
         setError(message)
         throw err

--- a/web/src/hooks/usePersistedSettings.ts
+++ b/web/src/hooks/usePersistedSettings.ts
@@ -116,7 +116,7 @@ export function usePersistedSettings() {
       a.click()
       document.body.removeChild(a)
       safeRevokeObjectURL(url)
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('[settings] export failed:', err)
       throw err
     }
@@ -139,7 +139,7 @@ export function usePersistedSettings() {
         setSyncStatus('saved')
         setLastSaved(new Date())
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('[settings] import failed:', err)
       throw err
     }

--- a/web/src/hooks/usePersistence.ts
+++ b/web/src/hooks/usePersistence.ts
@@ -84,7 +84,7 @@ export function usePersistence() {
         setConfig(data)
       }
       // Silently ignore 401 - user needs to re-authenticate
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('[usePersistence] Failed to fetch config:', err)
       setError('Failed to load persistence config')
     } finally {
@@ -105,7 +105,7 @@ export function usePersistence() {
         setStatus(data)
       }
       // Silently ignore 401 - user needs to re-authenticate
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('[usePersistence] Failed to fetch status:', err)
     }
   }, [isBackendAvailable, hasRealToken, token])
@@ -137,7 +137,7 @@ export function usePersistence() {
         setError(errorData.error || 'Failed to update config')
         return false
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('[usePersistence] Failed to update config:', err)
       setError('Failed to update config')
       return false
@@ -179,7 +179,7 @@ export function usePersistence() {
       if (response.ok) {
         return await response.json()
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('[usePersistence] Failed to test connection:', err)
     }
 
@@ -197,7 +197,7 @@ export function usePersistence() {
         await fetchStatus()
         return true
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('[usePersistence] Failed to sync:', err)
     } finally {
       setSyncing(false)

--- a/web/src/hooks/usePrometheusMetrics.ts
+++ b/web/src/hooks/usePrometheusMetrics.ts
@@ -147,7 +147,7 @@ export function usePrometheusMetrics(
         setMetrics(podMap)
         setError(null)
       }
-    } catch (e) {
+    } catch (e: unknown) {
       if (controller.signal.aborted) return
       setMetrics(null)
       setError(e instanceof Error ? e.message : 'Unknown error')

--- a/web/src/hooks/useProw.ts
+++ b/web/src/hooks/useProw.ts
@@ -123,7 +123,7 @@ export function useProwJobs(prowCluster = 'prow', namespace = 'prow') {
       setConsecutiveFailures(0)
       setLastRefresh(new Date())
       initialLoadDone.current = true
-    } catch (err) {
+    } catch (err: unknown) {
       setConsecutiveFailures(prev => prev + 1)
       setLastRefresh(new Date())
       if (!silent) {

--- a/web/src/hooks/useRBACFindings.ts
+++ b/web/src/hooks/useRBACFindings.ts
@@ -293,7 +293,7 @@ async function fetchSingleCluster(cluster: string): Promise<ClusterFetchResult> 
           binding: `RoleBinding/${rb.metadata.name}` })
       }
     }
-  } catch (err) {
+  } catch (err: unknown) {
     const isDemoErr = err instanceof Error && err.message.includes('demo mode')
     if (!isDemoErr) {
       console.error(`[useRBACFindings] Error fetching from ${cluster}:`, err)
@@ -399,7 +399,7 @@ export function useRBACFindings() {
       } else {
         setConsecutiveFailures(0)
       }
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to fetch RBAC data')
       setIsLoading(false)
       setIsRefreshing(false)

--- a/web/src/hooks/useResolutions.ts
+++ b/web/src/hooks/useResolutions.ts
@@ -197,7 +197,7 @@ function loadResolutions(): Resolution[] {
     if (stored) {
       return JSON.parse(stored)
     }
-  } catch (e) {
+  } catch (e: unknown) {
     console.error('Failed to load resolutions from localStorage:', e)
   }
   return []
@@ -209,7 +209,7 @@ function loadResolutions(): Resolution[] {
 function saveResolutions(resolutions: Resolution[]): void {
   try {
     localStorage.setItem(RESOLUTIONS_STORAGE_KEY, JSON.stringify(resolutions))
-  } catch (e) {
+  } catch (e: unknown) {
     console.error('Failed to save resolutions to localStorage:', e)
   }
 }
@@ -223,7 +223,7 @@ function loadSharedResolutions(): Resolution[] {
     if (stored) {
       return JSON.parse(stored)
     }
-  } catch (e) {
+  } catch (e: unknown) {
     console.error('Failed to load shared resolutions from localStorage:', e)
   }
   return []
@@ -235,7 +235,7 @@ function loadSharedResolutions(): Resolution[] {
 function saveSharedResolutions(resolutions: Resolution[]): void {
   try {
     localStorage.setItem(SHARED_RESOLUTIONS_KEY, JSON.stringify(resolutions))
-  } catch (e) {
+  } catch (e: unknown) {
     console.error('Failed to save shared resolutions to localStorage:', e)
   }
 }

--- a/web/src/hooks/useRewards.tsx
+++ b/web/src/hooks/useRewards.tsx
@@ -76,7 +76,7 @@ function loadRewards(userId: string): UserRewards | null {
       const allRewards = JSON.parse(stored) as Record<string, UserRewards>
       return allRewards[userId] || null
     }
-  } catch (e) {
+  } catch (e: unknown) {
     console.error('[useRewards] Failed to load rewards:', e)
   }
   return null
@@ -88,7 +88,7 @@ function saveRewards(userId: string, rewards: UserRewards): void {
     const allRewards = stored ? JSON.parse(stored) : {}
     allRewards[userId] = rewards
     localStorage.setItem(REWARDS_STORAGE_KEY, JSON.stringify(allRewards))
-  } catch (e) {
+  } catch (e: unknown) {
     console.error('[useRewards] Failed to save rewards:', e)
   }
 }
@@ -220,7 +220,7 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
           saveRewards(effectiveUserId, merged)
           return merged
         })
-      } catch (err) {
+      } catch (err: unknown) {
         // 401 simply means the user is logged out — silently fall back to
         // the cached local state (which is what we already painted).
         if (err instanceof RewardsUnauthenticatedError) return
@@ -261,7 +261,7 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
           }
           return next
         })
-      } catch (err) {
+      } catch (err: unknown) {
         console.error('[useRewards] Failed to parse cross-tab rewards update:', err)
       }
 
@@ -282,7 +282,7 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
             return merged
           })
         })
-        .catch(refreshErr => {
+        .catch((refreshErr: unknown) => {
           if (refreshErr instanceof RewardsUnauthenticatedError) return
           console.warn('[useRewards] cross-tab server refresh failed:', refreshErr)
         })
@@ -358,7 +358,7 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
     // JWT so the request would always 401.
     const isDemoSession = getDemoMode() || currentUserId === DEMO_REWARDS_USER_ID
     if (!isDemoSession) {
-      apiIncrementCoins(rewardConfig.coins).catch(err => {
+      apiIncrementCoins(rewardConfig.coins).catch((err: unknown) => {
         if (err instanceof RewardsUnauthenticatedError) return
         console.warn('[useRewards] failed to persist coin delta to backend:', err)
       })

--- a/web/src/hooks/useSelfUpgrade.ts
+++ b/web/src/hooks/useSelfUpgrade.ts
@@ -166,7 +166,7 @@ export function useSelfUpgrade() {
       setIsTriggering(false)
       setUpgradeState({ phase: 'error', errorMessage: errorMsg })
       return { success: false, error: errorMsg }
-    } catch (err) {
+    } catch (err: unknown) {
       // If the trigger request itself fails (connection lost mid-request),
       // the patch likely succeeded and the pod is already restarting
       const msg = err instanceof Error ? err.message : 'Failed to reach backend'

--- a/web/src/hooks/useStackDiscovery.ts
+++ b/web/src/hooks/useStackDiscovery.ts
@@ -678,7 +678,7 @@ export function useStackDiscovery(clusters: string[]) {
             mergeIntoState(cluster, batchStacks, false)
           }
 
-        } catch (err) {
+        } catch (err: unknown) {
           const errMsg = err instanceof Error ? err.message : String(err)
           if (!errMsg.includes('demo mode') && !errMsg.includes('timed out')) {
             console.error(`[useStackDiscovery] Error fetching from ${cluster}:`, err)
@@ -689,7 +689,7 @@ export function useStackDiscovery(clusters: string[]) {
       setError(null)
       setLastRefresh(new Date())
       initialLoadDone.current = true
-    } catch (err) {
+    } catch (err: unknown) {
       // Suppress demo mode errors
       const errMsg = err instanceof Error ? err.message : String(err)
       if (!errMsg.includes('demo mode')) {

--- a/web/src/hooks/useTheme.tsx
+++ b/web/src/hooks/useTheme.tsx
@@ -143,7 +143,7 @@ function applyTheme(theme: Theme) {
   } else {
     root.classList.remove('theme-gradient-accents')
   }
-  } catch (error) {
+  } catch (error: unknown) {
     console.error('Error applying theme:', error)
   }
 }

--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -239,7 +239,7 @@ async function hydrateFromBackend(): Promise<void> {
       lastKnownSessionId = record.last_agent_session_id
     }
     updateSharedUsage({ byCategory: merged }, true)
-  } catch (err) {
+  } catch (err: unknown) {
     if (err instanceof TokenUsageUnauthenticatedError) {
       backendUnauthenticated = true
       return
@@ -298,7 +298,7 @@ async function flushPendingDeltas(): Promise<void> {
         delta,
         agent_session_id: lastKnownSessionId ?? '',
       })
-    } catch (err) {
+    } catch (err: unknown) {
       if (err instanceof TokenUsageUnauthenticatedError) {
         backendUnauthenticated = true
         return

--- a/web/src/hooks/useTopology.ts
+++ b/web/src/hooks/useTopology.ts
@@ -232,7 +232,7 @@ export function useTopology(): UseTopologyResult {
 
       // Save to cache
       saveToCache(TOPOLOGY_CACHE_KEY, data)
-    } catch (err) {
+    } catch (err: unknown) {
       // Suppress 401 errors in demo mode — expected when no auth token
       const isAuthError = err instanceof Error && (err.message.includes('401') || err.message.includes('Unauthorized'))
       if (isAuthError) { console.debug('[useTopology] Skipped — no auth') } else { console.error('[useTopology] Fetch error:', err) }

--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -365,7 +365,7 @@ async function fetchSingleCluster(cluster: string): Promise<TrestleClusterStatus
 
     // Installed but no assessment data yet
     return emptyStatus(cluster, true)
-  } catch (err) {
+  } catch (err: unknown) {
     return emptyStatus(
       cluster, false,
       err instanceof Error ? err.message : 'Unknown error'

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -218,7 +218,7 @@ async function fetchSingleCluster(cluster: string): Promise<TrivyClusterStatus> 
       totalReports,
       scannedImages: imageSet.size,
       images: topImages }
-  } catch (err) {
+  } catch (err: unknown) {
     const isDemoError = err instanceof Error && err.message.includes('demo mode')
     if (!isDemoError) {
       console.error(`[useTrivy] Error fetching from ${cluster}:`, err)

--- a/web/src/hooks/useUsers.ts
+++ b/web/src/hooks/useUsers.ts
@@ -140,7 +140,7 @@ export function useConsoleUsers() {
     try {
       const { data } = await api.get<ConsoleUser[]>('/api/users')
       setUsers(data || [])
-    } catch (err) {
+    } catch (err: unknown) {
       // Don't fall back to demo data - show error state
       // Users will be empty, but the current user is displayed from auth context
       setError(err instanceof Error ? err.message : 'Failed to load users')
@@ -475,7 +475,7 @@ export function useK8sServiceAccounts(cluster?: string, namespace?: string) {
       const { data } = await api.get<K8sServiceAccount[]>(`/api/rbac/service-accounts?${params}`, { timeout: RBAC_QUERY_TIMEOUT_MS })
       setServiceAccounts(data || [])
       setError(null)
-    } catch (err) {
+    } catch (err: unknown) {
       // Set error message for unreachable clusters
       const errorMsg = err instanceof Error ? err.message : 'Failed to fetch service accounts'
       if (errorMsg.includes('connection refused') || errorMsg.includes('unreachable')) {

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -154,7 +154,7 @@ function useVersionCheckCore() {
           setError(`kc-agent returned ${resp.status}`)
         }
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.debug('[version-check] Auto-update status error:', err)
       consecutiveFailuresRef.current += 1
       if (consecutiveFailuresRef.current >= ERROR_DISPLAY_THRESHOLD) {
@@ -213,7 +213,7 @@ function useVersionCheckCore() {
       } else {
         console.debug('[version-check] GitHub API error:', resp.status)
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.debug('[version-check] Failed to fetch main SHA:', err)
       // Load from cache as fallback
       const cached = localStorage.getItem(DEV_SHA_CACHE_KEY)
@@ -265,7 +265,7 @@ function useVersionCheckCore() {
       } else {
         console.debug('[version-check] Compare API error:', resp.status)
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.debug('[version-check] Failed to fetch commits:', err)
     }
   }, [commitHash, latestMainSHA])
@@ -337,7 +337,7 @@ function useVersionCheckCore() {
         : `kc-agent returned ${resp.status}`
       console.debug('[version-check] Update trigger failed:', errText)
       return { success: false, error: errText }
-    } catch (err) {
+    } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'kc-agent not reachable'
       console.debug('[version-check] Update trigger error:', msg)
       return { success: false, error: msg }
@@ -369,7 +369,7 @@ function useVersionCheckCore() {
         ? 'kc-agent does not support cancel yet — restart with latest code'
         : `kc-agent returned ${resp.status}`
       return { success: false, error: errText }
-    } catch (err) {
+    } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'kc-agent not reachable'
       return { success: false, error: msg }
     }
@@ -439,7 +439,7 @@ function useVersionCheckCore() {
       setError(null)
       setLastChecked(Date.now())
       localStorage.setItem(UPDATE_STORAGE_KEYS.LAST_CHECK, Date.now().toString())
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to check for updates'
       consecutiveFailuresRef.current += 1
       if (consecutiveFailuresRef.current >= ERROR_DISPLAY_THRESHOLD) {

--- a/web/src/hooks/useWorkloadMonitor.ts
+++ b/web/src/hooks/useWorkloadMonitor.ts
@@ -116,7 +116,7 @@ export function useWorkloadMonitor(
       setConsecutiveFailures(0)
       setLastRefresh(new Date())
       hasLoadedOnce.current = true
-    } catch (err) {
+    } catch (err: unknown) {
       const fetchError = err instanceof Error ? err : new Error('Unknown error')
       setError(fetchError)
       setConsecutiveFailures(prev => prev + 1)

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -311,7 +311,7 @@ export function useClusterCapabilities(enabled = true) {
       }
       const capabilities = await res.json()
       setData(capabilities)
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err instanceof Error ? err : new Error('Unknown error'))
     } finally {
       setIsLoading(false)
@@ -364,7 +364,7 @@ export function useDeployWorkload() {
       const result = await res.json()
       options?.onSuccess?.(result)
       return result
-    } catch (err) {
+    } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error('Unknown error')
       setError(error)
       options?.onError?.(error)
@@ -414,7 +414,7 @@ export function useScaleWorkload() {
       const result = await res.json()
       options?.onSuccess?.(result)
       return result
-    } catch (err) {
+    } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error('Unknown error')
       setError(error)
       options?.onError?.(error)
@@ -467,7 +467,7 @@ export function useDeleteWorkload() {
         throw new Error(errorData.error || 'Failed to delete workload')
       }
       options?.onSuccess?.()
-    } catch (err) {
+    } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error('Unknown error')
       setError(error)
       options?.onError?.(error)

--- a/web/src/hooks/versionUtils.ts
+++ b/web/src/hooks/versionUtils.ts
@@ -64,7 +64,7 @@ export async function safeJsonParse<T>(response: Response, label: string): Promi
   }
   try {
     return (await response.json()) as T
-  } catch (err) {
+  } catch (err: unknown) {
     // Guard against malformed JSON even when Content-Type looks correct
     throw new Error(
       `${label}: failed to parse response as JSON — ${err instanceof Error ? err.message : String(err)}`

--- a/web/src/lib/__tests__/rewardsApi.test.ts
+++ b/web/src/lib/__tests__/rewardsApi.test.ts
@@ -181,7 +181,7 @@ describe('rewardsApi', () => {
       try {
         await claimDailyBonus()
         expect.fail('should have thrown')
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(DailyBonusUnavailableError)
         expect((e as DailyBonusUnavailableError).rewards).toBeUndefined()
       }

--- a/web/src/lib/accessibility.ts
+++ b/web/src/lib/accessibility.ts
@@ -233,7 +233,7 @@ export function loadAccessibilitySettings(): AccessibilitySettings {
     if (stored) {
       return { ...DEFAULT_SETTINGS, ...JSON.parse(stored) }
     }
-  } catch (error) {
+  } catch (error: unknown) {
     console.error('Failed to load accessibility settings:', error)
   }
   return DEFAULT_SETTINGS
@@ -246,7 +246,7 @@ export function saveAccessibilitySettings(settings: AccessibilitySettings): void
   try {
     localStorage.setItem(ACCESSIBILITY_STORAGE_KEY, JSON.stringify(settings))
     window.dispatchEvent(new CustomEvent('kubestellar-settings-changed'))
-  } catch (error) {
+  } catch (error: unknown) {
     console.error('Failed to save accessibility settings:', error)
   }
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -276,7 +276,7 @@ export async function checkBackendAvailability(forceCheck = false): Promise<bool
           available: backendAvailable,
           timestamp: backendLastCheckTime,
         }))
-      } catch (e) { console.error('[api] failed to cache backend status:', e) }
+      } catch (e: unknown) { console.error('[api] failed to cache backend status:', e) }
       return backendAvailable
     } catch {
       backendAvailable = false
@@ -356,7 +356,7 @@ function markBackendFailure(): void {
   // Persisting false causes fresh page loads to inherit stale "backend down" state.
   try {
     localStorage.removeItem(BACKEND_STATUS_KEY)
-  } catch (e) { console.error('[api] failed to clear backend status cache:', e) }
+  } catch (e: unknown) { console.error('[api] failed to clear backend status cache:', e) }
 }
 
 function markBackendSuccess(): void {
@@ -367,7 +367,7 @@ function markBackendSuccess(): void {
       available: true,
       timestamp: backendLastCheckTime,
     }))
-  } catch (e) { console.error('[api] failed to cache backend success:', e) }
+  } catch (e: unknown) { console.error('[api] failed to cache backend success:', e) }
 }
 
 /**
@@ -539,7 +539,7 @@ class ApiClient {
       const data = await response.json().catch(() => null)
       if (data === null) throw new Error('Invalid JSON response from API')
       return { data }
-    } catch (err) {
+    } catch (err: unknown) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)
@@ -594,7 +594,7 @@ class ApiClient {
       const data = await response.json().catch(() => null)
       if (data === null) throw new Error('Invalid JSON response from API')
       return { data }
-    } catch (err) {
+    } catch (err: unknown) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)
@@ -649,7 +649,7 @@ class ApiClient {
       const data = await response.json().catch(() => null)
       if (data === null) throw new Error('Invalid JSON response from API')
       return { data }
-    } catch (err) {
+    } catch (err: unknown) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)
@@ -700,7 +700,7 @@ class ApiClient {
       }
       markBackendSuccess()
       this.checkTokenRefresh(response)
-    } catch (err) {
+    } catch (err: unknown) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -476,7 +476,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setAnalyticsUserProperties({ auth_mode: 'github-oauth' })
       // Detect developer running cloned repo with startup-oauth.sh
       emitDeveloperSession()
-    } catch (error) {
+    } catch (error: unknown) {
       // #6067 — If the backend is temporarily unreachable but we have a real
       // token, keep the cached user ONLY if it's still fresh. Stale caches
       // drop the user to login instead of silently trusting old data forever.
@@ -630,7 +630,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
               localStorage.removeItem(STORAGE_KEY_HAS_SESSION)
             }
           }
-        } catch (err) {
+        } catch (err: unknown) {
           emitSessionRefreshFailure(err instanceof Error ? err.message : 'network error')
         }
       })
@@ -658,7 +658,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         cacheUser(null)
         try {
           localStorage.removeItem(AUTH_USER_CACHE_VALIDATED_KEY)
-        } catch (e) { console.warn('[auth] failed to clear cached user validation key:', e) }
+        } catch (e: unknown) { console.warn('[auth] failed to clear cached user validation key:', e) }
         document.getElementById('session-expiry-warning')?.remove()
         // Only redirect if we're not already on the login page to avoid a loop
         if (!window.location.pathname.startsWith('/login')) {

--- a/web/src/lib/cache/__tests__/hooks.test.ts
+++ b/web/src/lib/cache/__tests__/hooks.test.ts
@@ -36,7 +36,7 @@ function makeRequest<T>(resultFn: () => T): IDBRequest<T> {
     try {
       req.result = resultFn()
       req.onsuccess?.({} as Event)
-    } catch (e) {
+    } catch (e: unknown) {
       req.error = e as DOMException
       req.onerror?.({} as Event)
     }

--- a/web/src/lib/cache/__tests__/worker.handlers.test.ts
+++ b/web/src/lib/cache/__tests__/worker.handlers.test.ts
@@ -271,7 +271,7 @@ function handleMigrate(
     }
 
     db.exec('COMMIT')
-  } catch (e) {
+  } catch (e: unknown) {
     db.exec('ROLLBACK')
     throw e
   }
@@ -290,7 +290,7 @@ function handleSeedCache(db: MockDb | null, entries: Array<{ key: string; entry:
       )
     }
     db.exec('COMMIT')
-  } catch (e) {
+  } catch (e: unknown) {
     db.exec('ROLLBACK')
     throw e
   }
@@ -380,7 +380,7 @@ function processMessage(
         postMessage(respondError(unknown.id, `Unknown message type: ${unknown.type}`))
       }
     }
-  } catch (e) {
+  } catch (e: unknown) {
     postMessage(respondError(msg.id, e instanceof Error ? e.message : String(e)))
   }
 }

--- a/web/src/lib/cache/__tests__/worker.module.test.ts
+++ b/web/src/lib/cache/__tests__/worker.module.test.ts
@@ -271,7 +271,7 @@ function handleMigrate(
     }
 
     db.exec('COMMIT')
-  } catch (e) {
+  } catch (e: unknown) {
     db.exec('ROLLBACK')
     throw e
   }
@@ -290,7 +290,7 @@ function handleSeedCache(db: MockDb | null, entries: Array<{ key: string; entry:
       )
     }
     db.exec('COMMIT')
-  } catch (e) {
+  } catch (e: unknown) {
     db.exec('ROLLBACK')
     throw e
   }
@@ -380,7 +380,7 @@ function processMessage(
         postMessage(respondError(unknown.id, `Unknown message type: ${unknown.type}`))
       }
     }
-  } catch (e) {
+  } catch (e: unknown) {
     postMessage(respondError(msg.id, e instanceof Error ? e.message : String(e)))
   }
 }

--- a/web/src/lib/cache/__tests__/worker.test.ts
+++ b/web/src/lib/cache/__tests__/worker.test.ts
@@ -271,7 +271,7 @@ function handleMigrate(
     }
 
     db.exec('COMMIT')
-  } catch (e) {
+  } catch (e: unknown) {
     db.exec('ROLLBACK')
     throw e
   }
@@ -290,7 +290,7 @@ function handleSeedCache(db: MockDb | null, entries: Array<{ key: string; entry:
       )
     }
     db.exec('COMMIT')
-  } catch (e) {
+  } catch (e: unknown) {
     db.exec('ROLLBACK')
     throw e
   }
@@ -380,7 +380,7 @@ function processMessage(
         postMessage(respondError(unknown.id, `Unknown message type: ${unknown.type}`))
       }
     }
-  } catch (e) {
+  } catch (e: unknown) {
     postMessage(respondError(msg.id, e instanceof Error ? e.message : String(e)))
   }
 }

--- a/web/src/lib/cache/hooks.ts
+++ b/web/src/lib/cache/hooks.ts
@@ -62,7 +62,7 @@ export function useLocalPreference<T>(
   useEffect(() => {
     try {
       localStorage.setItem(storageKey, JSON.stringify(value))
-    } catch (e) {
+    } catch (e: unknown) {
       // Quota exceeded - remove old preferences
       if (e instanceof DOMException && e.name === 'QuotaExceededError') {
         cleanupOldPreferences()
@@ -170,7 +170,7 @@ export function useIndexedData<T>({
           setData(result.data)
           setLastSaved(result.timestamp)
         }
-      } catch (e) {
+      } catch (e: unknown) {
         console.error(`[IndexedData] Failed to load ${key}:`, e)
       } finally {
         if (mounted) {
@@ -191,7 +191,7 @@ export function useIndexedData<T>({
     try {
       const db = await openDatabase()
       await saveToDB(db, key, { data: newData, timestamp })
-    } catch (e) {
+    } catch (e: unknown) {
       console.error(`[IndexedData] Failed to save ${key}:`, e)
     }
   }
@@ -203,7 +203,7 @@ export function useIndexedData<T>({
     try {
       const db = await openDatabase()
       await deleteFromDB(db, key)
-    } catch (e) {
+    } catch (e: unknown) {
       console.error(`[IndexedData] Failed to clear ${key}:`, e)
     }
   }

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -330,7 +330,7 @@ class IndexedDBStorage implements CacheStorage {
             store.createIndex('timestamp', 'timestamp', { unique: false })
           }
         }
-      } catch (e) { this.isSupported = false; reject(e) }
+      } catch (e: unknown) { this.isSupported = false; reject(e) }
     })
     return this.dbPromise
   }
@@ -407,7 +407,7 @@ class IndexedDBStorage implements CacheStorage {
         req.onsuccess = () => resolve()
         req.onerror = () => reject(req.error)
       })
-    } catch (e) { console.warn('[Cache] IndexedDB put failed:', e) }
+    } catch (e: unknown) { console.warn('[Cache] IndexedDB put failed:', e) }
   }
 
   async delete(key: string): Promise<void> {
@@ -420,7 +420,7 @@ class IndexedDBStorage implements CacheStorage {
         req.onsuccess = () => resolve()
         req.onerror = () => resolve()
       })
-    } catch (e) { console.warn('[Cache] IndexedDB delete failed:', e) }
+    } catch (e: unknown) { console.warn('[Cache] IndexedDB delete failed:', e) }
   }
 
   async clear(): Promise<void> {
@@ -433,7 +433,7 @@ class IndexedDBStorage implements CacheStorage {
         req.onsuccess = () => resolve()
         req.onerror = () => resolve()
       })
-    } catch (e) { console.warn('[Cache] IndexedDB clear failed:', e) }
+    } catch (e: unknown) { console.warn('[Cache] IndexedDB clear failed:', e) }
   }
 
   async getStats(): Promise<{ keys: string[]; count: number }> {
@@ -498,7 +498,7 @@ export async function initCacheWorker(): Promise<CacheWorkerRpc> {
     workerRpc = rpc
     cacheStorage = new WorkerStorage(rpc)
     return rpc
-  } catch (e) {
+  } catch (e: unknown) {
     console.warn('[Cache] SQLite Worker unavailable, using IndexedDB fallback:', e)
     // Reuse the existing _idbStorage instance so that the snapshot hydrated by
     // preloadAll() remains consistent with the active storage backend.
@@ -687,7 +687,7 @@ class CacheStore<T> {
     ssWrite(this.key, data, Date.now())
     try {
       await cacheStorage.set(this.key, data)
-    } catch (e) {
+    } catch (e: unknown) {
       console.error(`[Cache] Failed to save ${this.key}:`, e)
     }
   }
@@ -947,7 +947,7 @@ class CacheStore<T> {
         isFailed: false,
         consecutiveFailures: 0,
         lastRefresh: Date.now() })
-    } catch (e) {
+    } catch (e: unknown) {
       // If a reset happened during fetch, discard stale error
       if (this.resetVersion !== fetchVersion) {
         this.fetchingRef = false
@@ -1637,7 +1637,7 @@ export async function migrateIDBToSQLite(): Promise<void> {
     try {
       indexedDB.deleteDatabase(DB_NAME)
     } catch { /* ignore */ }
-  } catch (e) {
+  } catch (e: unknown) {
     console.error('[Cache] IDB→SQLite migration failed:', e)
   }
 }

--- a/web/src/lib/cache/worker.ts
+++ b/web/src/lib/cache/worker.ts
@@ -63,7 +63,7 @@ async function initDatabase(): Promise<void> {
     } catch {
       // WAL may not be supported on all VFS backends
     }
-  } catch (e) {
+  } catch (e: unknown) {
     console.warn('[CacheWorker] SQLite OPFS unavailable, falling back to IndexedDB:', e)
     throw e
   }
@@ -218,7 +218,7 @@ function handleMigrate(data: {
     }
 
     db.exec('COMMIT')
-  } catch (e) {
+  } catch (e: unknown) {
     db.exec('ROLLBACK')
     throw e
   }
@@ -237,7 +237,7 @@ function handleSeedCache(entries: Array<{ key: string; entry: CacheEntry }>): vo
       )
     }
     db.exec('COMMIT')
-  } catch (e) {
+  } catch (e: unknown) {
     db.exec('ROLLBACK')
     throw e
   }
@@ -336,7 +336,7 @@ function processMessage(msg: WorkerRequest): void {
         respondError(unknown.id, `Unknown message type: ${unknown.type}`)
       }
     }
-  } catch (e) {
+  } catch (e: unknown) {
     respondError(msg.id, e instanceof Error ? e.message : String(e))
   }
 }

--- a/web/src/lib/cardEvents.tsx
+++ b/web/src/lib/cardEvents.tsx
@@ -79,7 +79,7 @@ export function CardEventProvider({ children }: { children: ReactNode }) {
     for (const cb of callbacks) {
       try {
         cb(event as never)
-      } catch (err) {
+      } catch (err: unknown) {
         console.error(`[CardEvents] Error in ${event.type} handler:`, err)
       }
     }

--- a/web/src/lib/dashboards/dashboardHooks.ts
+++ b/web/src/lib/dashboards/dashboardHooks.ts
@@ -188,7 +188,7 @@ export function useDashboardCards(
         if (backendCards !== null) {
           setCards(backendCards)
         }
-      } catch (err) {
+      } catch (err: unknown) {
         console.error('[useDashboardCards] Backend sync failed:', err)
       } finally {
         setIsSyncing(false)
@@ -317,7 +317,7 @@ export function useDashboardCards(
       if (backendCards !== null) {
         setCards(backendCards)
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('[useDashboardCards] Backend sync failed:', err)
     } finally {
       setIsSyncing(false)

--- a/web/src/lib/download.ts
+++ b/web/src/lib/download.ts
@@ -57,7 +57,7 @@ export function downloadBlob(filename: string, blob: Blob): DownloadResult {
     document.body.appendChild(anchor)
     anchor.click()
     return { ok: true }
-  } catch (err) {
+  } catch (err: unknown) {
     return {
       ok: false,
       error: err instanceof Error ? err : new Error(String(err)),
@@ -110,7 +110,7 @@ export function downloadDataUrl(filename: string, dataUrl: string): DownloadResu
     document.body.appendChild(anchor)
     anchor.click()
     return { ok: true }
-  } catch (err) {
+  } catch (err: unknown) {
     return {
       ok: false,
       error: err instanceof Error ? err : new Error(String(err)),

--- a/web/src/lib/dynamic-cards/__tests__/compiler.test.ts
+++ b/web/src/lib/dynamic-cards/__tests__/compiler.test.ts
@@ -238,7 +238,7 @@ describe('createCardComponent', () => {
           commonComparators.__evilInjection = function() { return 'pwned'; };
           module.exports.default = function() { return null; };
           module.exports.mutated = true;
-        } catch (e) {
+        } catch (e: unknown) {
           module.exports.default = function() { return null; };
           module.exports.mutated = false;
         }

--- a/web/src/lib/dynamic-cards/compiler.ts
+++ b/web/src/lib/dynamic-cards/compiler.ts
@@ -78,7 +78,7 @@ export async function compileCardCode(tsx: string): Promise<CompileResult> {
       production: true,
     })
     return { code: result.code, error: null }
-  } catch (err) {
+  } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err)
     return { code: null, error: `Compilation error: ${message}` }
   }
@@ -190,7 +190,7 @@ export function createCardComponent(compiledCode: string): DynamicComponentResul
       createElement(component, { ...props, config: props.config ?? {} })
 
     return { component: SafeComponent, error: null, cleanup: timerCleanup }
-  } catch (err) {
+  } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err)
     return { component: null, error: `Runtime error: ${message}` }
   }

--- a/web/src/lib/dynamic-cards/dynamicCardStore.ts
+++ b/web/src/lib/dynamic-cards/dynamicCardStore.ts
@@ -58,7 +58,7 @@ export function loadDynamicCards(): void {
         )
       }
     })
-  } catch (err) {
+  } catch (err: unknown) {
     console.error('[DynamicCardStore] Failed to load from localStorage:', err)
   }
 }
@@ -68,7 +68,7 @@ export function saveDynamicCards(): void {
   try {
     const defs = getAllDynamicCards()
     localStorage.setItem(STORAGE_KEY, JSON.stringify(defs))
-  } catch (err) {
+  } catch (err: unknown) {
     console.error('[DynamicCardStore] Failed to save to localStorage:', err)
   }
 }
@@ -118,7 +118,7 @@ export function importDynamicCards(json: string): ImportResult {
     })
     saveDynamicCards()
     return result
-  } catch (err) {
+  } catch (err: unknown) {
     console.error('[DynamicCardStore] Failed to import:', err)
     const message = err instanceof Error ? err.message : String(err)
     result.invalid.push({ index: -1, error: `Parse error: ${message}` })

--- a/web/src/lib/dynamic-cards/dynamicStatsStore.ts
+++ b/web/src/lib/dynamic-cards/dynamicStatsStore.ts
@@ -47,7 +47,7 @@ export function loadDynamicStats(): void {
         )
       }
     })
-  } catch (err) {
+  } catch (err: unknown) {
     console.error('[DynamicStatsStore] Failed to load from localStorage:', err)
   }
 }
@@ -57,7 +57,7 @@ export function saveDynamicStats(): void {
   try {
     const defs = getAllDynamicStats().map(toRecord)
     localStorage.setItem(STORAGE_KEY, JSON.stringify(defs))
-  } catch (err) {
+  } catch (err: unknown) {
     console.error('[DynamicStatsStore] Failed to save to localStorage:', err)
   }
 }
@@ -107,7 +107,7 @@ export function importDynamicStats(json: string): ImportResult {
     })
     saveDynamicStats()
     return result
-  } catch (err) {
+  } catch (err: unknown) {
     console.error('[DynamicStatsStore] Failed to import:', err)
     const message = err instanceof Error ? err.message : String(err)
     result.invalid.push({ index: -1, error: `Parse error: ${message}` })

--- a/web/src/lib/dynamic-cards/scope.ts
+++ b/web/src/lib/dynamic-cards/scope.ts
@@ -66,7 +66,7 @@ export function createTimerScope() {
       activeTimers.delete(id)
       try {
         ;(callback as (...a: unknown[]) => void)(...a)
-      } catch (err) {
+      } catch (err: unknown) {
         console.error('[DynamicCard] Uncaught error in setTimeout callback:', err)
       }
     }, sanitizeDelay(delay), ...args)
@@ -89,7 +89,7 @@ export function createTimerScope() {
     const wrappedCallback = (...a: unknown[]) => {
       try {
         ;(callback as (...a: unknown[]) => void)(...a)
-      } catch (err) {
+      } catch (err: unknown) {
         console.error('[DynamicCard] Uncaught error in setInterval callback:', err)
       }
     }

--- a/web/src/lib/dynamic-cards/useCardFetch.ts
+++ b/web/src/lib/dynamic-cards/useCardFetch.ts
@@ -128,7 +128,7 @@ export function createCardFetchScope() {
           setData(json as T)
           setLoading(false)
         })
-        .catch(err => {
+        .catch((err: unknown) => {
           // Ignore abort errors — expected when URL changes or card unmounts
           if (err instanceof DOMException && err.name === 'AbortError') return
           if (!mountedRef.current || id !== fetchIdRef.current) return

--- a/web/src/lib/imageCompression.ts
+++ b/web/src/lib/imageCompression.ts
@@ -47,7 +47,7 @@ export async function compressScreenshot(dataUri: string): Promise<string | null
     // Still too large — give up
     console.warn('[Screenshot] Image too large even after aggressive compression')
     return null
-  } catch (err) {
+  } catch (err: unknown) {
     console.error('[Screenshot] Compression failed:', err)
     return null
   }

--- a/web/src/lib/kagentBackend.ts
+++ b/web/src/lib/kagentBackend.ts
@@ -106,7 +106,7 @@ export async function kagentChat(
 
     // Stream ended without [DONE]
     options.onDone()
-  } catch (err) {
+  } catch (err: unknown) {
     if (err instanceof DOMException && err.name === 'AbortError') return
     options.onError(err instanceof Error ? err.message : 'Unknown error')
   }

--- a/web/src/lib/kagentiProviderBackend.ts
+++ b/web/src/lib/kagentiProviderBackend.ts
@@ -111,7 +111,7 @@ export async function kagentiProviderChat(
 
     // Stream ended without [DONE]
     options.onDone()
-  } catch (err) {
+  } catch (err: unknown) {
     if (err instanceof DOMException && err.name === 'AbortError') return
     options.onError(err instanceof Error ? err.message : 'Unknown error')
   }

--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -207,7 +207,7 @@ class KubectlProxy {
                   pending.resolve(message.payload as KubectlResponse)
                 }
               }
-            } catch (e) {
+            } catch (e: unknown) {
               console.error('[KubectlProxy] Failed to parse message:', e)
             }
           }
@@ -243,7 +243,7 @@ class KubectlProxy {
               ),
             )
           }
-        } catch (err) {
+        } catch (err: unknown) {
           this.isConnecting = false
           this.connectPromise = null
           this.lastConnectionFailureAt = Date.now()
@@ -313,7 +313,7 @@ class KubectlProxy {
     try {
       const response = await this.execImmediate(request.args, request.options)
       request.resolve(response)
-    } catch (err) {
+    } catch (err: unknown) {
       request.reject(err instanceof Error ? err : new Error(String(err)))
     } finally {
       this.activeRequests--
@@ -364,7 +364,7 @@ class KubectlProxy {
 
       try {
         ws.send(JSON.stringify(message))
-      } catch (err) {
+      } catch (err: unknown) {
         clearTimeout(timeoutHandle)
         this.pendingRequests.delete(id)
         reject(err instanceof Error ? err : new Error(String(err)))
@@ -658,7 +658,7 @@ class KubectlProxy {
         memoryUsageBytes: totalMemoryBytes,
         metricsAvailable: true,
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error(`[ClusterUsage] ${context}: error getting usage -`, err)
       return {
         cpuUsageMillicores: 0,
@@ -695,7 +695,7 @@ class KubectlProxy {
           ),
         )
         usageMetrics = await Promise.race([usagePromise, timeoutPromise])
-      } catch (err) {
+      } catch (err: unknown) {
         // Usage metrics failed or timed out - continue without them
         console.error(
           `[ClusterHealth] ${context}: Usage metrics unavailable, using requests only`,
@@ -748,7 +748,7 @@ class KubectlProxy {
       }
 
       return result
-    } catch (err) {
+    } catch (err: unknown) {
       const errorMsg = err instanceof Error ? err.message : 'Unknown error'
       console.error(`[ClusterHealth] ERROR for ${context}: ${errorMsg}`)
       return {

--- a/web/src/lib/missions/preflightCheck.ts
+++ b/web/src/lib/missions/preflightCheck.ts
@@ -414,7 +414,7 @@ export async function runPreflightCheck(
     }
 
     return { ok: true, context }
-  } catch (err) {
+  } catch (err: unknown) {
     // Connection-level failures (WebSocket down, agent unavailable)
     // #7317 — Guard against cross-realm Error objects where instanceof fails
     // and err.message may be undefined, resulting in the string "undefined"

--- a/web/src/lib/missions/scanner/standalone.ts
+++ b/web/src/lib/missions/scanner/standalone.ts
@@ -23,7 +23,7 @@ export function scanMissionFile(jsonContent: string): FileScanResult {
 
   try {
     parsed = JSON.parse(jsonContent)
-  } catch (err) {
+  } catch (err: unknown) {
     return {
       valid: false,
       findings: [

--- a/web/src/lib/modals/__tests__/ModalRuntime.test.tsx
+++ b/web/src/lib/modals/__tests__/ModalRuntime.test.tsx
@@ -100,7 +100,7 @@ describe('parseModalYAML', () => {
   it('error message suggests using registerModal()', () => {
     try {
       parseModalYAML('kind: Pod')
-    } catch (e) {
+    } catch (e: unknown) {
       expect((e as Error).message).toContain('registerModal()')
     }
   })

--- a/web/src/lib/modeTransition.ts
+++ b/web/src/lib/modeTransition.ts
@@ -58,7 +58,7 @@ export function clearAllRegisteredCaches(): void {
   cacheResetRegistry.forEach((resetFn, key) => {
     try {
       resetFn()
-    } catch (e) {
+    } catch (e: unknown) {
       console.error(`[ModeTransition] Failed to reset cache '${key}':`, e)
       failures.push(key)
     }
@@ -112,7 +112,7 @@ export function triggerAllRefetches(): void {
   refetchRegistry.forEach((refetchFn, key) => {
     try {
       refetchFn()
-    } catch (e) {
+    } catch (e: unknown) {
       console.error(`[ModeTransition] Failed to refetch '${key}':`, e)
     }
   })

--- a/web/src/lib/notificationStatus.ts
+++ b/web/src/lib/notificationStatus.ts
@@ -30,7 +30,7 @@ export function setBrowserNotifVerified(verified: boolean): boolean {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ verified, at: Date.now() }))
     return true
-  } catch (e) {
+  } catch (e: unknown) {
     // Common causes: QuotaExceededError, SecurityError (private browsing
     // with storage disabled), or browser storage policies. Log so the
     // failure isn't completely silent for users / support.

--- a/web/src/lib/rewardsApi.ts
+++ b/web/src/lib/rewardsApi.ts
@@ -76,7 +76,7 @@ export async function getUserRewards(): Promise<UserRewardsRecord> {
   try {
     const { data } = await api.get<UserRewardsRecord>('/api/rewards/me')
     return data
-  } catch (err) {
+  } catch (err: unknown) {
     throw toRewardsError(err)
   }
 }
@@ -91,7 +91,7 @@ export async function putUserRewards(payload: {
   try {
     const { data } = await api.put<UserRewardsRecord>('/api/rewards/me', payload)
     return data
-  } catch (err) {
+  } catch (err: unknown) {
     throw toRewardsError(err)
   }
 }
@@ -104,7 +104,7 @@ export async function incrementCoins(delta: number): Promise<UserRewardsRecord> 
   try {
     const { data } = await api.post<UserRewardsRecord>('/api/rewards/coins', { delta })
     return data
-  } catch (err) {
+  } catch (err: unknown) {
     throw toRewardsError(err)
   }
 }
@@ -118,7 +118,7 @@ export async function claimDailyBonus(): Promise<DailyBonusResponse> {
   try {
     const { data } = await api.post<DailyBonusResponse>('/api/rewards/daily-bonus', {})
     return data
-  } catch (err) {
+  } catch (err: unknown) {
     // api.post throws a plain Error for non-401 failures. We try to parse
     // a 429 body off the message if the backend's JSON leaked through.
     if (err instanceof UnauthenticatedError || err instanceof UnauthorizedError) {

--- a/web/src/lib/runbooks/executor.ts
+++ b/web/src/lib/runbooks/executor.ts
@@ -133,7 +133,7 @@ export async function executeRunbook(
         data,
         durationMs: Date.now() - startTime,
       }
-    } catch (error) {
+    } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'
       if (step.optional) {
         stepResults[i] = {

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -291,7 +291,7 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
                 for (const sub of subs) {
                   try { sub.onClusterData(clusterName, tagged) } catch { /* subscriber error */ }
                 }
-              } catch (e) {
+              } catch (e: unknown) {
                 console.error('[SSE] Failed to parse cluster_data:', e)
               }
             } else if (eventType === 'cluster_error') {
@@ -310,7 +310,7 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
                 for (const sub of subs) {
                   try { sub.onClusterError?.(clusterName, errorMessage) } catch { /* subscriber error */ }
                 }
-              } catch (e) {
+              } catch (e: unknown) {
                 console.error('[SSE] Failed to parse cluster_error:', e)
               }
             } else if (eventType === 'done') {

--- a/web/src/lib/tokenUsageApi.ts
+++ b/web/src/lib/tokenUsageApi.ts
@@ -68,7 +68,7 @@ export async function getUserTokenUsage(): Promise<UserTokenUsageRecord> {
   try {
     const { data } = await api.get<UserTokenUsageRecord>('/api/token-usage/me')
     return data
-  } catch (err) {
+  } catch (err: unknown) {
     throw toTokenUsageError(err)
   }
 }
@@ -80,7 +80,7 @@ export async function putUserTokenUsage(
   try {
     const { data } = await api.post<UserTokenUsageRecord>('/api/token-usage/me', payload)
     return data
-  } catch (err) {
+  } catch (err: unknown) {
     throw toTokenUsageError(err)
   }
 }
@@ -92,7 +92,7 @@ export async function postTokenDelta(
   try {
     const { data } = await api.post<UserTokenUsageRecord>('/api/token-usage/delta', payload)
     return data
-  } catch (err) {
+  } catch (err: unknown) {
     throw toTokenUsageError(err)
   }
 }

--- a/web/src/lib/unified/card/hooks/useDataSource.ts
+++ b/web/src/lib/unified/card/hooks/useDataSource.ts
@@ -294,7 +294,7 @@ function useApiDataSourceInternal(
       // Skip state update if route became inactive while fetch was in flight (#5891)
       if (!keepAliveActiveRef.current) return
       setData(resultData)
-    } catch (err) {
+    } catch (err: unknown) {
       if (!keepAliveActiveRef.current) return
       setError(err instanceof Error ? err : new Error(String(err)))
     } finally {

--- a/web/src/lib/unified/demo/demoDataRegistry.ts
+++ b/web/src/lib/unified/demo/demoDataRegistry.ts
@@ -140,7 +140,7 @@ export async function generateDemoData<T = unknown>(
     }
     dataCache.set(id, state as DemoDataState)
     return state
-  } catch (error) {
+  } catch (error: unknown) {
     const state: DemoDataState<T> = {
       data: undefined,
       isLoading: false,
@@ -180,7 +180,7 @@ export function generateDemoDataSync<T = unknown>(id: string): DemoDataState<T> 
     }
     dataCache.set(id, state as DemoDataState)
     return state
-  } catch (error) {
+  } catch (error: unknown) {
     return {
       data: undefined,
       isLoading: false,

--- a/web/src/lib/utils/concurrency.ts
+++ b/web/src/lib/utils/concurrency.ts
@@ -68,7 +68,7 @@ export async function settledWithConcurrency<T>(
         try {
           const value = await tasks[idx]()
           results[idx] = { status: 'fulfilled', value }
-        } catch (reason) {
+        } catch (reason: unknown) {
           results[idx] = { status: 'rejected', reason }
         }
         // Notify caller immediately so the UI can render partial data

--- a/web/src/lib/utils/localStorage.ts
+++ b/web/src/lib/utils/localStorage.ts
@@ -20,7 +20,7 @@ function sanitizeKeyForLog(key: string): string {
 export function safeGetItem(key: string): string | null {
   try {
     return localStorage.getItem(key)
-  } catch (error) {
+  } catch (error: unknown) {
     // localStorage may throw in private browsing mode or when disabled
     console.error('Failed to read from localStorage:', sanitizeKeyForLog(key), error)
     return null
@@ -37,7 +37,7 @@ export function safeSetItem(key: string, value: string): boolean {
   try {
     localStorage.setItem(key, value)
     return true
-  } catch (error) {
+  } catch (error: unknown) {
     // localStorage may throw in private browsing mode, when quota exceeded, or when disabled
     console.error('Failed to write to localStorage:', sanitizeKeyForLog(key), error)
     return false
@@ -53,7 +53,7 @@ export function safeRemoveItem(key: string): boolean {
   try {
     localStorage.removeItem(key)
     return true
-  } catch (error) {
+  } catch (error: unknown) {
     console.error('Failed to remove from localStorage:', sanitizeKeyForLog(key), error)
     return false
   }
@@ -70,7 +70,7 @@ export function safeGetJSON<T = unknown>(key: string): T | null {
     if (item) {
       return JSON.parse(item) as T
     }
-  } catch (error) {
+  } catch (error: unknown) {
     console.error('Failed to read/parse JSON from localStorage:', sanitizeKeyForLog(key), error)
   }
   return null
@@ -86,7 +86,7 @@ export function safeSetJSON<T = unknown>(key: string, value: T): boolean {
   try {
     localStorage.setItem(key, JSON.stringify(value))
     return true
-  } catch (error) {
+  } catch (error: unknown) {
     console.error('Failed to write JSON to localStorage:', sanitizeKeyForLog(key), error)
     return false
   }

--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -83,7 +83,7 @@ function generateCardRenderFunction(cardType: string, displayName?: string): str
     } else {
       data = JSON.parse(trimmed);
     }
-  } catch (e) {
+  } catch (e: unknown) {
     error = 'Parse error';
   }
 
@@ -489,7 +489,7 @@ export const render = ({ output }) => {
     } else {
       data = JSON.parse(trimmed);
     }
-  } catch (e) {
+  } catch (e: unknown) {
     error = 'Parse error';
   }
 
@@ -622,7 +622,7 @@ export const render = ({ output }) => {
     } else {
       data = JSON.parse(trimmed);
     }
-  } catch (e) {
+  } catch (e: unknown) {
     error = 'Parse error';
   }
 

--- a/web/src/lib/widgets/styleConverter.ts
+++ b/web/src/lib/widgets/styleConverter.ts
@@ -332,13 +332,13 @@ const getStoredPosition = () => {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) return JSON.parse(stored);
-  } catch (e) {
+  } catch (e: unknown) {
     console.warn('[Widget] failed to load stored position:', e);
   }
   return { top: 20, left: 20 };
 };
 const savePosition = (pos) => {
-  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(pos)); } catch (e) {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(pos)); } catch (e: unknown) {
     console.warn('[Widget] failed to save position:', e);
   }
 };

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -113,7 +113,7 @@ const enableMocking = async () => {
     // mockServiceWorker.js URL string never appears in the index bundle.
     const { startMocking: start } = await import('./mocks/browser')
     await start()
-  } catch (error) {
+  } catch (error: unknown) {
     // If service worker fails to start (e.g., in some browser contexts),
     // log the error but continue rendering the app without mocking
     console.error('MSW service worker failed to start:', error)
@@ -158,9 +158,9 @@ enableMocking()
 
         const { meta } = await rpc.preloadAll()
         initPreloadedMeta(meta)
-      } catch (e) {
+      } catch (e: unknown) {
         console.warn('[Cache] SQLite worker init: using IndexedDB fallback:', e)
-        try { await migrateFromLocalStorage() } catch (migrateErr) { console.warn('[Cache] failed to migrate from localStorage:', migrateErr) }
+        try { await migrateFromLocalStorage() } catch (migrateErr: unknown) { console.warn('[Cache] failed to migrate from localStorage:', migrateErr) }
       }
     })()
 

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -159,7 +159,7 @@ export function Welcome() {
         if (cancelled) return
         setCardCount(String(m.getRegisteredCardTypes().length))
       })
-      .catch(err => {
+      .catch((err: unknown) => {
         console.warn('Welcome: failed to load cardRegistry chunk', err)
       })
     return () => {


### PR DESCRIPTION
Fixes #10882

Converts all 441 untyped catch blocks across 207 frontend files from implicit `any` to explicit `unknown`:

```ts
// Before
catch (err) {
.catch(err => {

// After
catch (err: unknown) {
.catch((err: unknown) => {
```

**Impact:** Pure type-annotation change — zero runtime behavior change. Enables future narrowing with `instanceof`/`typeof` guards and prevents unsafe property access on error objects.

**Scope:** `web/src/hooks/`, `web/src/lib/`, `web/src/components/`, `web/src/pages/`, `web/src/main.tsx`