### PR TITLE
🐛 Return error when SetModel fails instead of sending success

### DIFF
--- a/pkg/agent/server_ops_settings.go
+++ b/pkg/agent/server_ops_settings.go
@@ -499,6 +499,9 @@ func (s *Server) handleSetKey(w http.ResponseWriter, r *http.Request) {
 	if req.Model != "" {
 		if err := cm.SetModel(req.Provider, req.Model); err != nil {
 			slog.Error("failed to save model preference", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "save_failed", Message: "failed to save model preference"})
+			return
 		}
 	}
 


### PR DESCRIPTION
Fixes #10884

`handleConfigureProvider` in `server_ops_settings.go` logged the `SetModel` error but continued execution, sending `{success: true}` to the client. This means the frontend shows a success toast even when model persistence fails.

**Fix:** Add `return` with HTTP 500 + `ErrorPayload` after logging the error, matching the pattern used by adjacent `SetAPIKey` and `SetBaseURL` error handlers.

**Impact:** Single Go handler file. No frontend changes needed — the frontend already handles error responses from this endpoint.