### PR TITLE
⚡ Wrap ClusterComparison in React.memo

### DIFF
--- a/web/src/components/cards/ClusterComparison.tsx
+++ b/web/src/components/cards/ClusterComparison.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from 'react'
+import { useState, useMemo, useEffect, useRef, memo } from 'react'
 import { Server, Activity, Box, Cpu, ChevronRight } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedGPUNodes } from '../../hooks/useCachedData'
@@ -268,10 +268,10 @@ function ClusterComparisonInternal({ config }: ClusterComparisonProps) {
   )
 }
 
-export function ClusterComparison(props: ClusterComparisonProps) {
+export const ClusterComparison = memo(function ClusterComparison(props: ClusterComparisonProps) {
   return (
     <DynamicCardErrorBoundary cardId="ClusterComparison">
       <ClusterComparisonInternal {...props} />
     </DynamicCardErrorBoundary>
   )
-}
+})


### PR DESCRIPTION
Fixes #10887

ClusterComparison was the only chart card not wrapped in `React.memo()` — sibling cards ResourceUsage and ClusterMetrics already use it. The component receives stable props from the dashboard parent but re-rendered on every unrelated state change.

**Impact:** Single file, pure perf optimization, no behavioral change.