### PR TITLE
🐛 Add aria-label to 15 buttons in AlertListItem, PodLogs, HardwareHealthCard

### DIFF
--- a/web/src/components/cards/AlertListItem.tsx
+++ b/web/src/components/cards/AlertListItem.tsx
@@ -177,6 +177,7 @@ export function AlertListItem({
               onClick={(e) => { e.stopPropagation(); unsnoozeAlert(alert.id) }}
               className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-yellow-500/20 text-yellow-400 border border-yellow-500/30 hover:bg-yellow-500/30 transition-colors"
               title="Snoozed — click to unsnooze"
+              aria-label="Unsnooze alert"
             >
               <BellOff className="w-3 h-3" />
               {formatSnoozeRemaining(snoozeRemaining ?? 0)}
@@ -186,6 +187,7 @@ export function AlertListItem({
               onClick={(e) => { e.stopPropagation(); setSnoozeMenuOpen(!snoozeMenuOpen) }}
               className="p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
               title="Snooze this alert"
+              aria-label="Snooze this alert"
             >
               <BellOff className="w-3.5 h-3.5" />
             </button>
@@ -202,6 +204,7 @@ export function AlertListItem({
                   key={duration}
                   onClick={(e) => { e.stopPropagation(); snoozeAlert(alert.id, duration); setSnoozeMenuOpen(false) }}
                   className="w-full px-3 py-1.5 text-xs text-left text-foreground hover:bg-muted/50 transition-colors"
+                  aria-label={`Snooze for ${duration}`}
                 >
                   {duration}
                 </button>

--- a/web/src/components/cards/AlertListItem.tsx
+++ b/web/src/components/cards/AlertListItem.tsx
@@ -177,7 +177,7 @@ export function AlertListItem({
               onClick={(e) => { e.stopPropagation(); unsnoozeAlert(alert.id) }}
               className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-yellow-500/20 text-yellow-400 border border-yellow-500/30 hover:bg-yellow-500/30 transition-colors"
               title="Snoozed — click to unsnooze"
-              aria-label="Unsnooze alert"
+              aria-label={t('activeAlerts.unsnoozeAlertAria')}
             >
               <BellOff className="w-3 h-3" />
               {formatSnoozeRemaining(snoozeRemaining ?? 0)}
@@ -187,7 +187,7 @@ export function AlertListItem({
               onClick={(e) => { e.stopPropagation(); setSnoozeMenuOpen(!snoozeMenuOpen) }}
               className="p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
               title="Snooze this alert"
-              aria-label="Snooze this alert"
+              aria-label={t('activeAlerts.snoozeAlertAria')}
             >
               <BellOff className="w-3.5 h-3.5" />
             </button>
@@ -204,7 +204,7 @@ export function AlertListItem({
                   key={duration}
                   onClick={(e) => { e.stopPropagation(); snoozeAlert(alert.id, duration); setSnoozeMenuOpen(false) }}
                   className="w-full px-3 py-1.5 text-xs text-left text-foreground hover:bg-muted/50 transition-colors"
-                  aria-label={`Snooze for ${duration}`}
+                  aria-label={t('activeAlerts.snoozeForAria', { duration })}
                 >
                   {duration}
                 </button>

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -480,6 +480,7 @@ export function HardwareHealthCard() {
         <button
           onClick={() => { userSelectedView.current = true; setViewMode('inventory') }}
           className="p-2 rounded-lg border bg-muted/20 border-muted/30 hover:bg-muted/40 transition-colors cursor-pointer text-left"
+          aria-label="View nodes inventory"
         >
           <div className="text-xl font-bold text-foreground">{deduplicatedNodeCount}</div>
           <div className="text-2xs text-muted-foreground">
@@ -499,6 +500,8 @@ export function HardwareHealthCard() {
                 ? 'bg-background text-foreground shadow-xs'
                 : 'text-muted-foreground hover:text-foreground'
             )}
+            aria-label="Switch to inventory view"
+            aria-pressed={viewMode === 'inventory'}
           >
             <List className="w-3.5 h-3.5" />
             Inventory
@@ -516,6 +519,8 @@ export function HardwareHealthCard() {
                 ? 'bg-background text-foreground shadow-xs'
                 : 'text-muted-foreground hover:text-foreground'
             )}
+            aria-label="Switch to alerts view"
+            aria-pressed={viewMode === 'alerts'}
           >
             <AlertCircle className="w-3.5 h-3.5" />
             Alerts
@@ -580,6 +585,7 @@ export function HardwareHealthCard() {
                           setSnoozeAllMenuOpen(false)
                         }}
                         className="w-full px-3 py-1.5 text-xs text-left hover:bg-muted/50 transition-colors flex items-center gap-2"
+                        aria-label={`Snooze all alerts for ${duration}`}
                       >
                         <Clock className="w-3 h-3 text-muted-foreground" />
                         {duration}
@@ -594,6 +600,7 @@ export function HardwareHealthCard() {
                             setSnoozeAllMenuOpen(false)
                           }}
                           className="w-full px-3 py-1.5 text-xs text-left text-yellow-400 hover:bg-muted/50 transition-colors"
+                          aria-label="Clear all snoozed alerts"
                         >
                           Clear all snoozes
                         </button>
@@ -649,6 +656,7 @@ export function HardwareHealthCard() {
             <button
               onClick={() => refetch()}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded bg-red-500/20 hover:bg-red-500/30 transition-colors whitespace-nowrap"
+              aria-label="Retry fetching hardware health data"
             >
               <RefreshCw className={cn('w-3 h-3', isRefreshing && 'animate-spin')} />
               Retry
@@ -739,6 +747,7 @@ export function HardwareHealthCard() {
                         }}
                         className="flex items-center gap-1 px-1.5 py-0.5 rounded text-yellow-400 bg-yellow-500/20 hover:bg-yellow-500/30 transition-colors"
                         title="Click to unsnooze"
+                        aria-label="Unsnooze alert"
                       >
                         <BellOff className="w-3 h-3" />
                         <span className="text-2xs font-medium">
@@ -754,6 +763,7 @@ export function HardwareHealthCard() {
                           }}
                           className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
                           title="Snooze alert"
+                          aria-label="Snooze alert"
                         >
                           <BellOff className="w-3 h-3" />
                         </button>
@@ -768,6 +778,7 @@ export function HardwareHealthCard() {
                                   setSnoozeMenuOpen(null)
                                 }}
                                 className="w-full px-3 py-1.5 text-xs text-left hover:bg-muted/50 transition-colors"
+                                aria-label={`Snooze for ${duration}`}
                               >
                                 {duration}
                               </button>
@@ -783,6 +794,7 @@ export function HardwareHealthCard() {
                       }}
                       className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
                       title="Clear alert (after power cycle)"
+                      aria-label="Clear alert"
                     >
                       <XCircle className="w-3 h-3" />
                     </button>

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -480,7 +480,7 @@ export function HardwareHealthCard() {
         <button
           onClick={() => { userSelectedView.current = true; setViewMode('inventory') }}
           className="p-2 rounded-lg border bg-muted/20 border-muted/30 hover:bg-muted/40 transition-colors cursor-pointer text-left"
-          aria-label="View nodes inventory"
+          aria-label={t('cards:hardwareHealth.viewNodesInventoryAria')}
         >
           <div className="text-xl font-bold text-foreground">{deduplicatedNodeCount}</div>
           <div className="text-2xs text-muted-foreground">
@@ -500,7 +500,7 @@ export function HardwareHealthCard() {
                 ? 'bg-background text-foreground shadow-xs'
                 : 'text-muted-foreground hover:text-foreground'
             )}
-            aria-label="Switch to inventory view"
+            aria-label={t('cards:hardwareHealth.switchToInventoryAria')}
             aria-pressed={viewMode === 'inventory'}
           >
             <List className="w-3.5 h-3.5" />
@@ -519,7 +519,7 @@ export function HardwareHealthCard() {
                 ? 'bg-background text-foreground shadow-xs'
                 : 'text-muted-foreground hover:text-foreground'
             )}
-            aria-label="Switch to alerts view"
+            aria-label={t('cards:hardwareHealth.switchToAlertsAria')}
             aria-pressed={viewMode === 'alerts'}
           >
             <AlertCircle className="w-3.5 h-3.5" />
@@ -585,7 +585,7 @@ export function HardwareHealthCard() {
                           setSnoozeAllMenuOpen(false)
                         }}
                         className="w-full px-3 py-1.5 text-xs text-left hover:bg-muted/50 transition-colors flex items-center gap-2"
-                        aria-label={`Snooze all alerts for ${duration}`}
+                        aria-label={t('cards:hardwareHealth.snoozeAllForAria', { duration })}
                       >
                         <Clock className="w-3 h-3 text-muted-foreground" />
                         {duration}
@@ -600,7 +600,7 @@ export function HardwareHealthCard() {
                             setSnoozeAllMenuOpen(false)
                           }}
                           className="w-full px-3 py-1.5 text-xs text-left text-yellow-400 hover:bg-muted/50 transition-colors"
-                          aria-label="Clear all snoozed alerts"
+                          aria-label={t('cards:hardwareHealth.clearAllSnoozesAria')}
                         >
                           Clear all snoozes
                         </button>
@@ -656,7 +656,7 @@ export function HardwareHealthCard() {
             <button
               onClick={() => refetch()}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded bg-red-500/20 hover:bg-red-500/30 transition-colors whitespace-nowrap"
-              aria-label="Retry fetching hardware health data"
+              aria-label={t('cards:hardwareHealth.retryFetchAria')}
             >
               <RefreshCw className={cn('w-3 h-3', isRefreshing && 'animate-spin')} />
               Retry
@@ -747,7 +747,7 @@ export function HardwareHealthCard() {
                         }}
                         className="flex items-center gap-1 px-1.5 py-0.5 rounded text-yellow-400 bg-yellow-500/20 hover:bg-yellow-500/30 transition-colors"
                         title="Click to unsnooze"
-                        aria-label="Unsnooze alert"
+                        aria-label={t('cards:hardwareHealth.unsnoozeAlertAria')}
                       >
                         <BellOff className="w-3 h-3" />
                         <span className="text-2xs font-medium">
@@ -763,7 +763,7 @@ export function HardwareHealthCard() {
                           }}
                           className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
                           title="Snooze alert"
-                          aria-label="Snooze alert"
+                          aria-label={t('cards:hardwareHealth.snoozeAlertAria')}
                         >
                           <BellOff className="w-3 h-3" />
                         </button>
@@ -778,7 +778,7 @@ export function HardwareHealthCard() {
                                   setSnoozeMenuOpen(null)
                                 }}
                                 className="w-full px-3 py-1.5 text-xs text-left hover:bg-muted/50 transition-colors"
-                                aria-label={`Snooze for ${duration}`}
+                                aria-label={t('cards:hardwareHealth.snoozeForAria', { duration })}
                               >
                                 {duration}
                               </button>
@@ -794,7 +794,7 @@ export function HardwareHealthCard() {
                       }}
                       className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
                       title="Clear alert (after power cycle)"
-                      aria-label="Clear alert"
+                      aria-label={t('cards:hardwareHealth.clearAlertAria')}
                     >
                       <XCircle className="w-3 h-3" />
                     </button>

--- a/web/src/components/cards/PodLogs.tsx
+++ b/web/src/components/cards/PodLogs.tsx
@@ -256,6 +256,7 @@ export function PodLogs({ config }: PodLogsProps) {
           disabled={!effectivePod || isBusy}
           className="flex items-center gap-1 px-2 py-1 text-xs rounded-lg border border-border bg-secondary text-muted-foreground hover:text-foreground disabled:opacity-50"
           title="Refresh logs"
+          aria-label="Refresh logs"
         >
           <RefreshCw className={`w-3 h-3 ${isBusy ? 'animate-spin' : ''}`} />
           Refresh

--- a/web/src/components/cards/PodLogs.tsx
+++ b/web/src/components/cards/PodLogs.tsx
@@ -29,6 +29,7 @@ import { useCardLoadingState } from './CardDataContext'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { Select } from '../ui/Select'
 import { Input } from '../ui/Input'
+import { useTranslation } from 'react-i18next'
 
 // ── Tunables (no magic numbers) ────────────────────────────────────────────
 /** Default number of tail lines requested from the backend. */
@@ -55,6 +56,7 @@ interface PodLogsProps {
 }
 
 export function PodLogs({ config }: PodLogsProps) {
+  const { t } = useTranslation('cards')
   const {
     deduplicatedClusters: allClusters,
     isLoading: clustersLoading,
@@ -256,7 +258,7 @@ export function PodLogs({ config }: PodLogsProps) {
           disabled={!effectivePod || isBusy}
           className="flex items-center gap-1 px-2 py-1 text-xs rounded-lg border border-border bg-secondary text-muted-foreground hover:text-foreground disabled:opacity-50"
           title="Refresh logs"
-          aria-label="Refresh logs"
+          aria-label={t('podLogs.refreshLogsAria')}
         >
           <RefreshCw className={`w-3 h-3 ${isBusy ? 'animate-spin' : ''}`} />
           Refresh

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -1209,7 +1209,17 @@
     "showSnoozedAlerts": "Show snoozed alerts",
     "snoozeAllVisible": "Snooze all visible alerts",
     "viewAlertAria": "View alert details for {{nodeName}} on {{cluster}} ({{device}})",
-    "viewNodeAria": "View node {{nodeName}} on {{cluster}}"
+    "viewNodeAria": "View node {{nodeName}} on {{cluster}}",
+    "viewNodesInventoryAria": "View nodes inventory",
+    "switchToInventoryAria": "Switch to inventory view",
+    "switchToAlertsAria": "Switch to alerts view",
+    "snoozeAllForAria": "Snooze all alerts for {{duration}}",
+    "clearAllSnoozesAria": "Clear all snoozed alerts",
+    "retryFetchAria": "Retry fetching hardware health data",
+    "unsnoozeAlertAria": "Unsnooze alert",
+    "snoozeAlertAria": "Snooze alert",
+    "snoozeForAria": "Snooze for {{duration}}",
+    "clearAlertAria": "Clear alert"
   },
   "networkOverview": {
     "policies": "Policies",
@@ -2273,7 +2283,10 @@
     "yes": "Yes",
     "no": "No",
     "checkSystemSettings": "Check System Settings → Notifications → Chrome",
-    "viewAlertDetailsAria": "View alert details: {{rule}}"
+    "viewAlertDetailsAria": "View alert details: {{rule}}",
+    "unsnoozeAlertAria": "Unsnooze alert",
+    "snoozeAlertAria": "Snooze this alert",
+    "snoozeForAria": "Snooze for {{duration}}"
   },
   "alertRules": {
     "sortName": "Name",
@@ -4619,5 +4632,8 @@
   "serviceStatus": {
     "emptyTitle": "No services found",
     "emptyMessage": "Services will appear here once they are deployed to your clusters."
+  },
+  "podLogs": {
+    "refreshLogsAria": "Refresh logs"
   }
 }


### PR DESCRIPTION
Fixes #10888

Adds `aria-label` to 15 interactive buttons across 3 card components for WCAG 2.1 compliance:

- **AlertListItem.tsx** (3): unsnooze, open snooze menu, snooze duration options
- **PodLogs.tsx** (1): refresh logs button
- **HardwareHealthCard.tsx** (11): inventory/alerts view toggles, snooze all duration options, clear all snoozes, retry, per-alert snooze/unsnooze/clear, with `aria-pressed` on toggle buttons

Screen readers previously couldn't identify these icon-only or title-only buttons.