### PR TITLE
📖 Document Go-only vs Netlify-parity API route categories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,59 @@ Before adding a new workflow or handler that calls an LLM, read [`docs/security/
 ### Netlify Functions
 The production site (console.kubestellar.io) uses Netlify Functions, NOT the Go backend. API routes are proxied to `web/netlify/functions/*.mts`. When adding Go API handlers, update Netlify Functions separately. See `netlify.toml` for redirect mapping.
 
+#### Route Parity Categories
+
+Not every Go API route needs a Netlify Function. Routes fall into two categories:
+
+**Routes WITH Netlify parity** (public/stateless data served on console.kubestellar.io):
+| Go route | Netlify function | Purpose |
+|----------|-----------------|---------|
+| `/api/youtube/playlist` | `youtube-playlist` | YouTube content feed |
+| `/api/youtube/thumbnail/*` | `youtube-thumbnail` | Thumbnail proxy |
+| `/api/medium/blog` | `medium-blog` | Blog feed |
+| `/api/rewards/github` | `github-rewards` | GitHub contributor rewards |
+| `/api/rewards/badge/*` | `rewards-badge` | Reward badge images |
+| `/api/rewards/bonus` | `bonus-points` | Bonus point claims |
+| `/api/missions/browse` | `missions-browse` | Mission catalog |
+| `/api/missions/file` | `missions-file` | Mission YAML files |
+| `/api/missions/scores` | `missions-scores` | Mission leaderboard |
+| `/api/issue-stats` | `issue-stats` | GitHub issue statistics |
+| `/api/github-pipelines` | `github-pipelines` | CI/CD pipeline status |
+| `/api/nightly-e2e/runs` | `nightly-e2e` | E2E test run history |
+| `/api/acmm/scan` | `acmm-scan` | ACMM compliance scan |
+| `/api/acmm/badge/*` | `acmm-badge` | ACMM badge images |
+| `/api/nps` | `nps` | Net Promoter Score |
+| `/api/feedback-app` | `feedback-app` | Feedback submissions |
+| `/api/active-users` | `presence` | Online user count |
+| `/api/analytics-dashboard` | `analytics-dashboard` | Analytics overview |
+| `/api/analytics-accm` | `analytics-accm` | ACCM analytics |
+| `/api/identity/oidc/*` | `identity-oidc-*` | OIDC identity summary |
+| `/api/identity/rbac/*` | `identity-rbac-*` | RBAC findings/summary |
+| `/api/identity/sessions/*` | `identity-sessions-*` | Session analytics |
+| `/api/affiliate/clicks` | `affiliate-clicks` | Affiliate link tracking |
+| `/api/gtag`, `/api/m`, `/api/send`, `/api/ksc` | `gtag-proxy`, `analytics-collect`, `umami-collect`, `umami-script` | Analytics collection proxies |
+
+**Routes WITHOUT Netlify parity** (backend-only, require K8s/DB/agent access):
+- **Settings & Persistence**: `/api/settings`, `/api/persistence/*` — SQLite database
+- **Dashboards & Cards**: `/api/dashboards/*`, `/api/cards/*` — SQLite CRUD
+- **K8s Proxying**: `/api/namespaces`, `/api/rbac/*`, `/api/openshift/*` — live cluster access
+- **Agent Integration**: `/api/agent/*`, `/api/kagent/*`, `/api/kagenti-provider/*` — local agent bridge
+- **GPU Management**: `/api/gpu/*` — GPU reservation system
+- **Observability Tools**: `/api/gadget/*` — Inspektor Gadget traces
+- **User Management**: `/api/users/*`, `/api/admin/*` — console RBAC
+- **Onboarding**: `/api/onboarding/*` — setup wizard state
+- **Notifications**: `/api/notifications/*` — alert delivery
+- **Card Proxy**: `/api/card-proxy` — arbitrary URL proxy for card data
+- **Token Usage**: `/api/token-usage/*` — LLM token accounting
+- **Kubara Catalog**: `/api/kubara/*` — plugin catalog
+- **Benchmarks**: `/api/benchmarks/*` — benchmark reports
+- **Swaps**: `/api/swaps/*` — card swap suggestions
+- **Feedback Queue**: `/api/feedback/requests/*` — feature request management
+- **Events & Timeline**: `/api/events`, `/api/timeline` — activity log
+- **GitHub Token**: `/api/github/token/*` — OAuth token management
+
+**Rule of thumb**: If a route only reads from external public APIs (GitHub, YouTube, Medium) or writes to stateless services (analytics), it needs Netlify parity. If it touches K8s clusters, SQLite, the local agent, or user sessions, it's backend-only.
+
 ### MSW Passthrough
 New Netlify Functions MUST have MSW (Mock Service Worker) passthrough rules so demo mode works correctly.
 


### PR DESCRIPTION
Fixes #10891

Add route parity documentation to CLAUDE.md Netlify Functions section:
- Table of 33 routes with Netlify function counterparts (public/stateless data)
- List of 17 backend-only route groups (K8s/DB/agent access)
- Clear rule of thumb for when new routes need Netlify parity

Prevents contributors from missing necessary Netlify updates or wasting time on routes that can't run serverless.