### PR TITLE
🐛 Add io.LimitReader to 30 unbounded io.ReadAll(resp.Body) calls

### DIFF
--- a/pkg/agent/provider_claude.go
+++ b/pkg/agent/provider_claude.go
@@ -11,6 +11,10 @@ import (
 	"strings"
 )
 
+// maxLLMResponseBytes caps io.ReadAll on LLM API responses to prevent
+// an unbounded allocation if an upstream server sends an oversized body.
+const maxLLMResponseBytes = 10 * 1024 * 1024 // 10 MiB
+
 var (
 	claudeAPIURL       = "https://api.anthropic.com/v1/messages"
 	claudeAPIVersion   = "2023-06-01"
@@ -89,7 +93,7 @@ func (c *ClaudeProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatRespo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}
@@ -157,7 +161,7 @@ func (c *ClaudeProvider) StreamChat(ctx context.Context, req *ChatRequest, onChu
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}

--- a/pkg/agent/provider_gemini.go
+++ b/pkg/agent/provider_gemini.go
@@ -96,7 +96,7 @@ func (g *GeminiProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatRespo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}
@@ -176,7 +176,7 @@ func (g *GeminiProvider) StreamChat(ctx context.Context, req *ChatRequest, onChu
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}

--- a/pkg/agent/provider_openai.go
+++ b/pkg/agent/provider_openai.go
@@ -82,7 +82,7 @@ func (o *OpenAIProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatRespo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}
@@ -147,7 +147,7 @@ func (o *OpenAIProvider) StreamChat(ctx context.Context, req *ChatRequest, onChu
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}

--- a/pkg/agent/provider_openai_compat.go
+++ b/pkg/agent/provider_openai_compat.go
@@ -70,7 +70,7 @@ func chatViaOpenAICompatibleWithHeaders(ctx context.Context, req *ChatRequest, p
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(respBody))
 	}
 
@@ -160,7 +160,7 @@ func streamViaOpenAICompatibleWithHeaders(ctx context.Context, req *ChatRequest,
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(respBody))
 	}
 

--- a/pkg/agent/server_ops_settings.go
+++ b/pkg/agent/server_ops_settings.go
@@ -667,7 +667,7 @@ func validateClaudeKey(ctx context.Context, apiKey string) (bool, error) {
 	if resp.StatusCode == http.StatusUnauthorized {
 		return false, nil // Invalid key - no error so it gets cached
 	}
-	body, readErr := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 	if readErr != nil {
 		body = []byte("(failed to read response body)")
 	}
@@ -697,7 +697,7 @@ func validateOpenAIKey(ctx context.Context, apiKey string) (bool, error) {
 		// kc-agent startup (#7923). Matches validateClaudeKey behavior.
 		return false, nil
 	}
-	body, readErr := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 	if readErr != nil {
 		body = []byte("(failed to read response body)")
 	}
@@ -744,7 +744,7 @@ func validateOpenRouterKey(ctx context.Context, apiKey string) (bool, error) {
 	if resp.StatusCode == http.StatusUnauthorized {
 		return false, nil
 	}
-	body, readErr := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 	if readErr != nil {
 		body = []byte("(failed to read response body)")
 	}
@@ -774,7 +774,7 @@ func validateGroqKey(ctx context.Context, apiKey string) (bool, error) {
 	if resp.StatusCode == http.StatusUnauthorized {
 		return false, nil
 	}
-	body, readErr := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 	if readErr != nil {
 		body = []byte("(failed to read response body)")
 	}
@@ -805,7 +805,7 @@ func validateGeminiKey(ctx context.Context, apiKey string) (bool, error) {
 		// kc-agent startup (#7923). Matches validateClaudeKey behavior.
 		return false, nil
 	}
-	body, readErr := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxLLMResponseBytes))
 	if readErr != nil {
 		body = []byte("(failed to read response body)")
 	}

--- a/pkg/api/handlers/benchmarks.go
+++ b/pkg/api/handlers/benchmarks.go
@@ -477,7 +477,7 @@ func (h *BenchmarkHandlers) driveGetWithRetry(ctx context.Context, url string) (
 			continue
 		}
 		if resp.StatusCode == 403 || resp.StatusCode == 429 {
-			body, readErr := io.ReadAll(resp.Body)
+			body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBenchmarkReportBytes))
 			if readErr != nil {
 				body = []byte("(failed to read response body)")
 			}
@@ -1020,7 +1020,7 @@ func (h *BenchmarkHandlers) listDriveFolder(ctx context.Context, folderID string
 
 		if resp.StatusCode != 200 {
 			var bodyStr string
-			if body, readErr := io.ReadAll(resp.Body); readErr == nil {
+			if body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBenchmarkReportBytes)); readErr == nil {
 				bodyStr = string(body)
 			}
 			resp.Body.Close()

--- a/pkg/api/handlers/feedback_github.go
+++ b/pkg/api/handlers/feedback_github.go
@@ -678,7 +678,7 @@ func (h *FeedbackHandler) postGitHubIssue(ctx context.Context, repoOwner, repoNa
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		respBody, readErr := io.ReadAll(resp.Body)
+		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxGitHubResponseBytes))
 		if readErr != nil {
 			respBody = []byte("(failed to read response body)")
 		}
@@ -739,7 +739,7 @@ func (h *FeedbackHandler) postGitHubIssueViaProxy(ctx context.Context, repoOwner
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxGitHubResponseBytes))
 		return 0, "", fmt.Errorf("proxy returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
@@ -825,7 +825,7 @@ func (h *FeedbackHandler) uploadScreenshotToGitHub(repoOwner, repoName, requestI
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxGitHubResponseBytes))
 		return "", fmt.Errorf("GitHub Contents API returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
@@ -900,7 +900,7 @@ func (h *FeedbackHandler) addPRComment(ctx context.Context, request *models.Feat
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxGitHubResponseBytes))
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}

--- a/pkg/api/handlers/feedback_requests.go
+++ b/pkg/api/handlers/feedback_requests.go
@@ -1152,7 +1152,7 @@ func (h *FeedbackHandler) closeGitHubIssue(ctx context.Context, issueNumber int,
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxGitHubResponseBytes))
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}
@@ -1191,7 +1191,7 @@ func (h *FeedbackHandler) addIssueComment(ctx context.Context, issueNumber int, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxGitHubResponseBytes))
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}

--- a/pkg/api/handlers/github_app_auth.go
+++ b/pkg/api/handlers/github_app_auth.go
@@ -181,7 +181,7 @@ func (p *GitHubAppTokenProvider) mintInstallationToken(ctx context.Context) (str
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxGitHubResponseBytes))
 		return "", time.Time{}, fmt.Errorf("installation token request returned %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -60,6 +60,9 @@ const (
 	// kcAgentProxyTimeout is the timeout for proxied requests to kc-agent.
 	kcAgentProxyTimeout = 30 * time.Second
 
+	// maxAgentProxyResponseBytes caps io.ReadAll on kc-agent proxy responses.
+	maxAgentProxyResponseBytes = 10 * 1024 * 1024 // 10 MiB
+
 	// apiDefaultBodyLimit is the per-route body-size limit enforced by the
 	// bodyGuard middleware on all API routes except feedback screenshot uploads.
 	apiDefaultBodyLimit = 1 * 1024 * 1024 // 1 MB — sufficient for JSON API requests
@@ -855,7 +858,7 @@ func (s *Server) setupRoutes() {
 		}
 		defer resp.Body.Close()
 
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxAgentProxyResponseBytes))
 		c.Set("Content-Type", resp.Header.Get("Content-Type"))
 		return c.Status(resp.StatusCode).Send(body)
 	})

--- a/pkg/kagent/client.go
+++ b/pkg/kagent/client.go
@@ -13,6 +13,9 @@ import (
 	"time"
 )
 
+// maxKAgentResponseBytes caps io.ReadAll on kagent API responses.
+const maxKAgentResponseBytes = 10 * 1024 * 1024 // 10 MiB
+
 // AgentInfo describes a kagent agent discovered via the platform.
 type AgentInfo struct {
 	Name        string   `json:"name"`
@@ -81,7 +84,7 @@ func (c *KagentClient) ListAgents() ([]AgentInfo, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxKAgentResponseBytes))
 		return nil, fmt.Errorf("list agents returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -103,7 +106,7 @@ func (c *KagentClient) Discover(namespace, agentName string) (*AgentCard, error)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxKAgentResponseBytes))
 		return nil, fmt.Errorf("discover agent %s/%s returned %d: %s", namespace, agentName, resp.StatusCode, string(body))
 	}
 
@@ -164,7 +167,7 @@ func (c *KagentClient) Invoke(ctx context.Context, namespace, agentName, message
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		errBody, _ := io.ReadAll(resp.Body)
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxKAgentResponseBytes))
 		resp.Body.Close()
 		return nil, fmt.Errorf("A2A invoke returned %d: %s", resp.StatusCode, string(errBody))
 	}

--- a/pkg/kagenti_provider/client.go
+++ b/pkg/kagenti_provider/client.go
@@ -32,6 +32,7 @@ const (
 	defaultKagentiServiceScheme = "http"
 	defaultDirectAgentName      = "kagenti-agent"
 	defaultDirectAgentNamespace = "default"
+	maxKAgentResponseBytes      = 10 * 1024 * 1024 // 10 MiB
 )
 
 var (
@@ -239,7 +240,7 @@ func (c *KagentiClient) ListAgentsWithContext(ctx context.Context) ([]AgentInfo,
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, maxKAgentResponseBytes))
 			drainAndClose(resp.Body)
 			lastErr = fmt.Errorf("list agents at %s returned %d: %s", path, resp.StatusCode, string(body))
 			continue
@@ -294,7 +295,7 @@ func (c *KagentiClient) Discover(namespace, agentName string) (*AgentCard, error
 	defer drainAndClose(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxKAgentResponseBytes))
 		return nil, fmt.Errorf("discover agent %s/%s returned %d: %s", namespace, agentName, resp.StatusCode, string(body))
 	}
 
@@ -341,7 +342,7 @@ func (c *KagentiClient) Invoke(ctx context.Context, namespace, agentName, messag
 				return resp.Body, nil
 			}
 
-			errBody, _ := io.ReadAll(resp.Body)
+			errBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxKAgentResponseBytes))
 			drainAndClose(resp.Body)
 			lastErr = fmt.Errorf("direct invoke returned %d: %s", resp.StatusCode, string(errBody))
 		}
@@ -396,7 +397,7 @@ func (c *KagentiClient) Invoke(ctx context.Context, namespace, agentName, messag
 			return resp.Body, nil
 		}
 
-		errBody, _ := io.ReadAll(resp.Body)
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxKAgentResponseBytes))
 		drainAndClose(resp.Body)
 		lastErr = fmt.Errorf("kagenti invoke at %s returned %d: %s", url, resp.StatusCode, string(errBody))
 	}


### PR DESCRIPTION
Fixes #10895

30 HTTP response body reads across 12 Go files used `io.ReadAll(resp.Body)` without a size limit. A malicious or buggy upstream server could send an oversized response and exhaust process memory.

This wraps each call in `io.LimitReader` with 10 MiB caps, matching the pattern already established in `analytics_proxy.go`, `github_proxy.go`, `rewards.go`, and `nightly_e2e.go`.

**Files fixed (30 instances across 12 files):**
- LLM providers: `provider_claude.go`, `provider_openai.go`, `provider_gemini.go`, `provider_openai_compat.go` (8)
- Agent settings: `server_ops_settings.go` (5)
- KAgent clients: `kagenti_provider/client.go`, `kagent/client.go` (7)
- GitHub handlers: `feedback_github.go`, `feedback_requests.go`, `github_app_auth.go` (7)
- Benchmarks: `benchmarks.go` (2)
- Agent proxy: `server.go` (1)