### PR TITLE
🌱 Replace 5 unsafe t() double-casts with TFunction type

### DIFF
--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -14,6 +14,7 @@ import { CardClusterFilter, CardSearchInput, CardAIActions } from '../../lib/car
 import { SEVERITY_COLORS, SeverityLevel } from '../../lib/accessibility'
 import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
 
 // Demo security issues data for demo mode
 function getDemoSecurityIssues(): SecurityIssue[] {
@@ -75,7 +76,7 @@ interface SecurityIssuesProps {
   config?: Record<string, unknown>
 }
 
-const getIssueIcon = (issue: string | undefined, t: (key: string) => string): { icon: typeof Shield; tooltip: string } => {
+const getIssueIcon = (issue: string | undefined, t: TFunction): { icon: typeof Shield; tooltip: string } => {
   const s = issue || ''
   if (s.includes('Privileged')) return { icon: Shield, tooltip: t('securityIssues.privilegedContainer') }
   if (s.includes('root')) return { icon: User, tooltip: t('securityIssues.runningAsRoot') }
@@ -300,7 +301,7 @@ function SecurityIssuesInternal({ config }: SecurityIssuesProps) {
           card within standard card height when rendered at lg grid size. */}
       <div ref={containerRef} className="flex-1 space-y-2 overflow-y-auto min-h-card-content" style={containerStyle}>
         {issues.map((issue: SecurityIssue, idx: number) => {
-          const { icon: Icon, tooltip: iconTooltip } = getIssueIcon(issue.issue, t as unknown as (key: string) => string)
+          const { icon: Icon, tooltip: iconTooltip } = getIssueIcon(issue.issue, t)
           const colors = getSeverityColor(issue.severity)
 
           return (

--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -18,6 +18,7 @@ import type { ConsoleUser, UserRole, OpenShiftUser } from '../../types/users'
 import { Skeleton } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useToast } from '../ui/Toast'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -36,7 +37,7 @@ type OpenShiftUserSortBy = 'name' | 'kind'
 type SASortBy = 'name' | 'namespace'
 
 // Sort options defined in component to access t()
-function getConsoleUserSortOptions(t: (key: string) => string) {
+function getConsoleUserSortOptions(t: TFunction) {
   return [
     { value: 'name' as const, label: t('common:common.name') },
     { value: 'role' as const, label: t('common:common.role') },
@@ -44,14 +45,14 @@ function getConsoleUserSortOptions(t: (key: string) => string) {
   ]
 }
 
-function getOpenShiftUserSortOptions(t: (key: string) => string) {
+function getOpenShiftUserSortOptions(t: TFunction) {
   return [
     { value: 'name' as const, label: t('userManagement.username') },
     { value: 'kind' as const, label: t('userManagement.fullName') },
   ]
 }
 
-function getSASortOptions(t: (key: string) => string) {
+function getSASortOptions(t: TFunction) {
   return [
     { value: 'name' as const, label: t('common:common.name') },
     { value: 'namespace' as const, label: t('common:common.namespace') },
@@ -256,9 +257,9 @@ export function UserManagement({ config: _config }: UserManagementProps) {
     : activeTab === 'serviceAccounts' ? setSaItemsPerPage
     : setConsoleUserItemsPerPage
 
-  const activeSortOptions = activeTab === 'clusterUsers' ? getOpenShiftUserSortOptions(t as unknown as (key: string) => string)
-    : activeTab === 'serviceAccounts' ? getSASortOptions(t as unknown as (key: string) => string)
-    : getConsoleUserSortOptions(t as unknown as (key: string) => string)
+  const activeSortOptions = activeTab === 'clusterUsers' ? getOpenShiftUserSortOptions(t)
+    : activeTab === 'serviceAccounts' ? getSASortOptions(t)
+    : getConsoleUserSortOptions(t)
 
   const isAdmin = currentUser?.role === 'admin'
 

--- a/web/src/components/cards/llmd/LLMdAIInsights.tsx
+++ b/web/src/components/cards/llmd/LLMdAIInsights.tsx
@@ -14,6 +14,7 @@ import { useCardExpanded } from '../CardWrapper'
 import { generateAIInsights, type AIInsight } from '../../../lib/llmd/mockData'
 import type { LLMdStack } from '../../../hooks/useStackDiscovery'
 import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
 import { PROGRESS_SIMULATION_MS } from '../../../lib/constants/network'
 
 const INSIGHT_ICONS = {
@@ -111,7 +112,7 @@ function InsightCard({ insight, isExpanded, onToggle }: InsightCardProps) {
 /**
  * Generate real insights based on the selected stack's state
  */
-function generateStackInsights(stack: LLMdStack, t?: (key: string, options?: Record<string, unknown>) => string): AIInsight[] {
+function generateStackInsights(stack: LLMdStack, t?: TFunction): AIInsight[] {
   const insights: AIInsight[] = []
   const now = new Date()
 
@@ -318,7 +319,7 @@ export function LLMdAIInsights() {
     }
 
     if (stackContext?.selectedStack) {
-      return generateStackInsights(stackContext.selectedStack, t as unknown as (key: string, options?: Record<string, unknown>) => string)
+      return generateStackInsights(stackContext.selectedStack, t)
     }
 
     return []


### PR DESCRIPTION
Fixes #3400

## Summary

Helper functions accepting i18next's `t()` used `(key: string) => string` as the parameter type, forcing callers to double-cast via `t as unknown as (key: string) => string`. This bypasses TypeScript's type safety.

**Fix:** Change parameter types to `TFunction` from `'i18next'`, which is the actual type returned by `useTranslation()`. Removes all 5 double-casts across 3 files.

## Files changed

| File | Change |
|------|--------|
| `SecurityIssues.tsx` | `getIssueIcon()` param: `(key: string) => string` → `TFunction` |
| `UserManagement.tsx` | 3 sort option helpers: same param fix |
| `llmd/LLMdAIInsights.tsx` | `generateStackInsights()` param: same fix |

## Risk

**Minimal** — `TFunction` is a superset of `(key: string) => string`, so all existing call sites are compatible without any behavioral change.