### PR TITLE
🐛 Replace 17 raw lazy() calls with safeLazy for chunk resilience

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1,4 +1,5 @@
-import { ReactNode, useState, useEffect, useCallback, useRef, useMemo, createContext, use, ComponentType, Suspense, lazy } from 'react'
+import { ReactNode, useState, useEffect, useCallback, useRef, useMemo, createContext, use, ComponentType, Suspense } from 'react'
+import { safeLazy } from '../../lib/safeLazy'
 import {
   Maximize2, RefreshCw, ChevronRight, ChevronDown, Bug, AlertTriangle, Info,
 } from 'lucide-react'
@@ -26,13 +27,9 @@ import { CardActionMenu } from './card-wrapper/CardActionMenu'
 import { PendingSwapNotification } from './card-wrapper/PendingSwapNotification'
 import { InstallCTAFlow } from './card-wrapper/InstallCTAFlow'
 // Lazy-load the widget export modal (~42 KB + code generator ~30 KB) — only when user exports
-const WidgetExportModal = lazy(() =>
-  import('../widgets/WidgetExportModal').then(m => ({ default: m.WidgetExportModal }))
-)
+const WidgetExportModal = safeLazy(() => import('../widgets/WidgetExportModal'), 'WidgetExportModal')
 // Lazy-load the feedback modal (~67 KB) — only loaded when user clicks bug report
-const FeatureRequestModal = lazy(() =>
-  import('../feedback/FeatureRequestModal').then(m => ({ default: m.FeatureRequestModal }))
-)
+const FeatureRequestModal = safeLazy(() => import('../feedback/FeatureRequestModal'), 'FeatureRequestModal')
 
 
 // Minimum duration to show spin animation (ensures at least one full rotation)

--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo, useEffect, useRef, lazy, Suspense, memo } from 'react'
+import { useState, useMemo, useEffect, useRef, Suspense, memo } from 'react'
+import { safeLazy } from '../../lib/safeLazy'
 import { useClusters } from '../../hooks/useMCP'
 import { CLUSTER_POLL_INTERVAL_MS } from '../../hooks/mcp/shared'
 import { Server, Clock, Layers, TrendingUp } from 'lucide-react'
@@ -107,12 +108,8 @@ interface MetricPoint {
 // Lazy-load chart components to defer the echarts vendor chunk (~1.14 MB)
 // from the critical loading path. The card itself stays eager — only the
 // chart subtrees are deferred behind React.lazy + Suspense.
-const LazyTimeSeriesChart = lazy(() =>
-  import('../charts/TimeSeriesChart').then(m => ({ default: m.TimeSeriesChart }))
-)
-const LazyMultiSeriesChart = lazy(() =>
-  import('../charts/TimeSeriesChart').then(m => ({ default: m.MultiSeriesChart }))
-)
+const LazyTimeSeriesChart = safeLazy(() => import('../charts/TimeSeriesChart'), 'TimeSeriesChart')
+const LazyMultiSeriesChart = safeLazy(() => import('../charts/TimeSeriesChart'), 'MultiSeriesChart')
 
 /** Height (px) of the chart area — used for both the chart and its Suspense fallback */
 const CHART_AREA_MIN_HEIGHT = 160

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -5,7 +5,7 @@
  *   src/components/dashboard/AddCardModal.tsx → CARD_CATALOG
  * See src/config/cards/index.ts for the full registration checklist.
  */
-import { lazy, createElement, ComponentType } from 'react'
+import { createElement, ComponentType } from 'react'
 import { safeLazy } from '../../lib/safeLazy'
 import { isDynamicCardRegistered } from '../../lib/dynamic-cards/dynamicCardRegistry'
 import { getCardConfig } from '../../config/cards'
@@ -597,9 +597,9 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   rbac_audit_dashboard: RBACAuditDashboardCard,
   session_dashboard: SessionDashboardCard,
   // Enterprise Risk Management dashboard content cards
-  risk_matrix_dashboard: lazy(() => import('../compliance/RiskMatrixDashboard').then(m => ({ default: m.RiskMatrixDashboardContent }))),
-  risk_register_dashboard: lazy(() => import('../compliance/RiskRegisterDashboard').then(m => ({ default: m.RiskRegisterDashboardContent }))),
-  risk_appetite_dashboard: lazy(() => import('../compliance/RiskAppetiteDashboard').then(m => ({ default: m.RiskAppetiteDashboardContent }))),
+  risk_matrix_dashboard: safeLazy(() => import('../compliance/RiskMatrixDashboard'), 'RiskMatrixDashboardContent'),
+  risk_register_dashboard: safeLazy(() => import('../compliance/RiskRegisterDashboard'), 'RiskRegisterDashboardContent'),
+  risk_appetite_dashboard: safeLazy(() => import('../compliance/RiskAppetiteDashboard'), 'RiskAppetiteDashboardContent'),
   // ISO 27001 audit checklist
   iso27001_audit: ISO27001Audit,
   // Cross-cluster compliance cards
@@ -905,9 +905,7 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
 }
 
 // Lazy-load UnifiedCard — keeps it out of the main bundle for fast page load
-const LazyUnifiedCard = lazy(() =>
-  import('../../lib/unified/card/UnifiedCard').then(m => ({ default: m.UnifiedCard })),
-)
+const LazyUnifiedCard = safeLazy(() => import('../../lib/unified/card/UnifiedCard'), 'UnifiedCard')
 
 /** Supported unified content types that the adapter can render */
 const _UNIFIED_CONTENT_TYPES = ['list', 'table', 'chart', 'status-grid']

--- a/web/src/components/enterprise/EnterpriseLayout.tsx
+++ b/web/src/components/enterprise/EnterpriseLayout.tsx
@@ -9,7 +9,8 @@
  * content area needs an explicit left margin to clear it — mirroring the
  * approach used by the primary Layout component.
  */
-import { lazy, Suspense, useCallback, useMemo } from 'react'
+import { Suspense, useCallback, useMemo } from 'react'
+import { safeLazy } from '../../lib/safeLazy'
 import { Outlet, useLocation } from 'react-router-dom'
 import EnterpriseSidebar from './EnterpriseSidebar'
 import { VersionCheckProvider } from '../../hooks/useVersionCheck'
@@ -90,14 +91,8 @@ function readExistingPlacements(storageKey: string): DashboardCardPlacement[] {
   return []
 }
 
-const MissionSidebar = lazy(() =>
-  import('../layout/mission-sidebar').then((m) => ({ default: m.MissionSidebar })),
-)
-const MissionSidebarToggle = lazy(() =>
-  import('../layout/mission-sidebar').then((m) => ({
-    default: m.MissionSidebarToggle,
-  })),
-)
+const MissionSidebar = safeLazy(() => import('../layout/mission-sidebar'), 'MissionSidebar')
+const MissionSidebarToggle = safeLazy(() => import('../layout/mission-sidebar'), 'MissionSidebarToggle')
 
 export default function EnterpriseLayout() {
   const { config } = useSidebarConfig()

--- a/web/src/components/feedback/FeatureRequestButton.tsx
+++ b/web/src/components/feedback/FeatureRequestButton.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, lazy, Suspense } from 'react'
+import { useEffect, useState, Suspense } from 'react'
+import { safeLazy } from '../../lib/safeLazy'
 import { Bug, Loader2 } from 'lucide-react'
 import { useFeatureRequests } from '../../hooks/useFeatureRequests'
 import type { RequestType } from '../../hooks/useFeatureRequests'
@@ -7,9 +8,7 @@ import { useTranslation } from 'react-i18next'
 import { cn } from '../../lib/cn'
 
 // Lazy-load the modal (~67 KB) — only needed when the user clicks the bug icon
-const FeatureRequestModal = lazy(() =>
-  import('./FeatureRequestModal').then(m => ({ default: m.FeatureRequestModal }))
-)
+const FeatureRequestModal = safeLazy(() => import('./FeatureRequestModal'), 'FeatureRequestModal')
 
 /** Badge displays "99+" for counts above this threshold. */
 const MAX_BADGE_DISPLAY = 99

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,4 +1,5 @@
-import { ReactNode, Suspense, lazy, useState, useEffect, useRef } from 'react'
+import { ReactNode, Suspense, useState, useEffect, useRef } from 'react'
+import { safeLazy } from '../../lib/safeLazy'
 import { useTranslation } from 'react-i18next'
 import { Link, useLocation } from 'react-router-dom'
 import {
@@ -59,14 +60,8 @@ import { copyToClipboard } from '../../lib/clipboard'
 
 // Lazy-load the AI mission sidebar so react-markdown and remark plugins are
 // not part of the initial bundle — they only load when the sidebar is first rendered.
-const MissionSidebar = lazy(() =>
-  import('./mission-sidebar').then((m) => ({ default: m.MissionSidebar })),
-)
-const MissionSidebarToggle = lazy(() =>
-  import('./mission-sidebar').then((m) => ({
-    default: m.MissionSidebarToggle,
-  })),
-)
+const MissionSidebar = safeLazy(() => import('./mission-sidebar'), 'MissionSidebar')
+const MissionSidebarToggle = safeLazy(() => import('./mission-sidebar'), 'MissionSidebarToggle')
 
 // Module-level constant — computed once, never changes on re-render.
 // Prevents star field from flickering when Layout re-renders due to hooks.

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect, lazy, Suspense } from 'react'
+import { useState, useRef, useEffect, Suspense } from 'react'
+import { safeLazy } from '../../lib/safeLazy'
 import { Tooltip } from '../ui/Tooltip'
 import { useModalState } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'
@@ -14,9 +15,7 @@ import { checkOAuthConfigured } from '../../lib/api'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
 import { DeveloperSetupDialog } from '../setup/DeveloperSetupDialog'
 // Lazy-load the feedback modal (~67 KB) — only needed when user opens it
-const FeatureRequestModal = lazy(() =>
-  import('../feedback/FeatureRequestModal').then(m => ({ default: m.FeatureRequestModal }))
-)
+const FeatureRequestModal = safeLazy(() => import('../feedback/FeatureRequestModal'), 'FeatureRequestModal')
 
 interface UserProfileDropdownProps {
   user: {

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef, lazy, Suspense } from 'react'
+import { useState, useEffect, useRef, Suspense } from 'react'
+import { safeLazy } from '../../../lib/safeLazy'
 import { isAnyModalOpen } from '../../../lib/modals'
 import {
   X,
@@ -31,9 +32,7 @@ import { StatusBadge } from '../../ui/StatusBadge'
 import { cn } from '../../../lib/cn'
 import { AgentSelector } from '../../agent/AgentSelector'
 import { LogoWithStar } from '../../ui/LogoWithStar'
-const MissionBrowser = lazy(() =>
-  import('../../missions/MissionBrowser').then(m => ({ default: m.MissionBrowser }))
-)
+const MissionBrowser = safeLazy(() => import('../../missions/MissionBrowser'), 'MissionBrowser')
 import { MissionControlDialog } from '../../mission-control/MissionControlDialog'
 import { MissionDetailView } from '../../missions/MissionDetailView'
 import type { MissionExport, OrbitResourceFilter } from '../../../lib/missions/types'

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -1486,7 +1486,7 @@ export function MissionSidebar() {
           onClose={() => setShowBrowser(false)}
           onImport={handleImportMission}
           initialMission={deepLinkMission || undefined}
-          onUseInMissionControl={(chartName) => {
+          onUseInMissionControl={(chartName: string) => {
             setShowBrowser(false)
             setPendingKubaraChart(chartName)
             setShowMissionControl(true)

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, lazy, Suspense } from 'react'
+import { useState, useEffect, Suspense } from 'react'
+import { safeLazy } from '../../../lib/safeLazy'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { Sun, Moon, Monitor, Menu, X, MoreVertical, ExternalLink, Sparkles } from 'lucide-react'
@@ -15,15 +16,11 @@ import { AlertBadge } from '../../ui/AlertBadge'
 import { FeatureRequestButton } from '../../feedback'
 // Lazy-load SearchDropdown — it imports useSearchIndex which pulls in 5 MCP
 // modules (~135 KB). The search bar appears after the chunk loads (near-instant).
-const SearchDropdown = lazy(() =>
-  import('./SearchDropdown').then(m => ({ default: m.SearchDropdown }))
-)
+const SearchDropdown = safeLazy(() => import('./SearchDropdown'), 'SearchDropdown')
 
 // Lazy-load AgentSelector — agent UI components (~41 KB) are only needed
 // when a local kc-agent is available (never on console.kubestellar.io).
-const AgentSelector = lazy(() =>
-  import('../../agent/AgentSelector').then(m => ({ default: m.AgentSelector }))
-)
+const AgentSelector = safeLazy(() => import('../../agent/AgentSelector'), 'AgentSelector')
 import { useMissions } from '../../../hooks/useMissions'
 import { TokenUsageWidget } from './TokenUsageWidget'
 import { ClusterFilterPanel } from './ClusterFilterPanel'

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -10,7 +10,8 @@
  * Phase 3: Flight Plan (SVG blueprint + deploy)
  */
 
-import { useEffect, useCallback, useRef, useState, lazy, Suspense } from 'react'
+import { useEffect, useCallback, useRef, useState, Suspense } from 'react'
+import { safeLazy } from '../../lib/safeLazy'
 import { useModalFocusTrap } from '../../lib/modals/useModalNavigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
@@ -33,9 +34,7 @@ import { ChunkErrorBoundary } from '../ChunkErrorBoundary'
 import { useMissionControl, consumePersistQuotaBanner } from './useMissionControl'
 import { FixerDefinitionPanel } from './FixerDefinitionPanel'
 import { ClusterAssignmentPanel } from './ClusterAssignmentPanel'
-const FlightPlanBlueprint = lazy(() =>
-  import('./FlightPlanBlueprint').then(m => ({ default: m.FlightPlanBlueprint }))
-)
+const FlightPlanBlueprint = safeLazy(() => import('./FlightPlanBlueprint'), 'FlightPlanBlueprint')
 import { LaunchSequence } from './LaunchSequence'
 import { RequestApprovalModal } from './RequestApprovalModal'
 import { decodePlan, planToState } from './missionPlanCodec'

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -1,4 +1,5 @@
-import { useState, memo, lazy, Suspense } from 'react'
+import { useState, memo, Suspense } from 'react'
+import { safeLazy } from '../../lib/safeLazy'
 import { useModalState } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'
 import {
@@ -15,9 +16,7 @@ import { StatBlockModePicker } from './StatBlockModePicker'
 // Lazy-load Sparkline to defer the echarts vendor chunk from the critical path.
 // The Gauge and CircularProgress components are smaller and less common, but they
 // share the same echarts import chain, so lazy-loading them too is low-cost.
-const LazySparkline = lazy(() =>
-  import('../charts/Sparkline').then(m => ({ default: m.Sparkline }))
-)
+const LazySparkline = safeLazy(() => import('../charts/Sparkline'), 'Sparkline')
 import { Gauge } from '../charts/Gauge'
 import { CircularProgress } from '../charts/ProgressBar'
 import { useLocalAgent } from '../../hooks/useLocalAgent'

--- a/web/src/lib/unified/card/UnifiedCard.tsx
+++ b/web/src/lib/unified/card/UnifiedCard.tsx
@@ -10,7 +10,8 @@
  *   <UnifiedCard config={clusterHealthConfig} title="Custom Title" />
  */
 
-import { ReactNode, useMemo, lazy, Suspense } from 'react'
+import { ReactNode, useMemo, Suspense } from 'react'
+import { safeLazy } from '../../safeLazy'
 import {
   AlertTriangle,
   Info,
@@ -31,9 +32,7 @@ import { ListVisualization } from './visualizations/ListVisualization'
 import { TableVisualization } from './visualizations/TableVisualization'
 // Lazy-load ChartVisualization to defer the echarts vendor chunk from the
 // critical loading path — it is only needed for cards with chartType content.
-const LazyChartVisualization = lazy(() =>
-  import('./visualizations/ChartVisualization').then(m => ({ default: m.ChartVisualization }))
-)
+const LazyChartVisualization = safeLazy(() => import('./visualizations/ChartVisualization'), 'ChartVisualization')
 import { StatusGridVisualization } from './visualizations/StatusGridVisualization'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useReportCardDataState } from '../../../components/cards/CardDataContext'


### PR DESCRIPTION
Fixes #3400

## Summary

Raw `React.lazy()` calls crash the app when a chunk loads stale content after a deploy — `m.Export` becomes `undefined`, causing `Cannot read properties of undefined`. The codebase already has `safeLazy()` which provides retry with exponential backoff, 8s timeout, and descriptive errors for `ChunkErrorBoundary` auto-reload recovery.

**This PR converts 17 named-export `lazy()` calls to `safeLazy()` across 12 files.**

## Files changed (12)

| File | Components converted |
|------|---------------------|
| `CardWrapper.tsx` | WidgetExportModal, FeatureRequestModal |
| `ClusterMetrics.tsx` | LazyTimeSeriesChart, LazyMultiSeriesChart |
| `cardRegistry.ts` | risk_matrix/register/appetite_dashboard, LazyUnifiedCard |
| `EnterpriseLayout.tsx` | MissionSidebar, MissionSidebarToggle |
| `FeatureRequestButton.tsx` | FeatureRequestModal |
| `Layout.tsx` | MissionSidebar, MissionSidebarToggle |
| `UserProfileDropdown.tsx` | FeatureRequestModal |
| `MissionSidebar.tsx` | MissionBrowser |
| `Navbar.tsx` | SearchDropdown, AgentSelector |
| `MissionControlDialog.tsx` | FlightPlanBlueprint |
| `StatsOverview.tsx` | LazySparkline |
| `UnifiedCard.tsx` | LazyChartVisualization |

## Not converted (6 remaining)

These use default exports or custom loaders incompatible with `safeLazy`'s named-export API:
- `Login.tsx` (GlobeAnimation — custom async loader)
- `LazyMarkdown.tsx`, `LazyEChart.tsx`, `PodDrillDown.tsx`, `AlertsContext.tsx` (default exports)
- `cardDescriptor.ts` (generic dynamic component wrapper)

## Risk

**Minimal** — `safeLazy` is a strict superset of `lazy`. Same behavior on success, better behavior on failure (retry + timeout instead of crash).