### PR TITLE
🐛 Add 'unknown' to 15 Health type unions — fixes TS2367 build errors

### DIFF
--- a/web/src/components/cards/chaos_mesh_status/demoData.ts
+++ b/web/src/components/cards/chaos_mesh_status/demoData.ts
@@ -24,7 +24,7 @@ export interface ChaosMeshSummary {
   failed: number
 }
 
-export type ChaosMeshHealth = 'healthy' | 'degraded' | 'not-installed'
+export type ChaosMeshHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export interface ChaosMeshStatusData {
   experiments: ChaosMeshExperiment[]

--- a/web/src/components/cards/karmada_status/demoData.ts
+++ b/web/src/components/cards/karmada_status/demoData.ts
@@ -16,7 +16,7 @@
 const DEMO_LAST_CHECK_OFFSET_MS = 30_000
 
 /** Number of demo member cluster entries */
-export type KarmadaHealth = 'healthy' | 'degraded' | 'not-installed'
+export type KarmadaHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export type KarmadaClusterStatus = 'Ready' | 'NotReady' | 'Unknown'
 

--- a/web/src/components/cards/spiffe_status/demoData.ts
+++ b/web/src/components/cards/spiffe_status/demoData.ts
@@ -24,7 +24,7 @@ import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_D
 // Types
 // ---------------------------------------------------------------------------
 
-export type SpiffeHealth = 'healthy' | 'degraded' | 'not-installed'
+export type SpiffeHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 export type SvidType = 'x509' | 'jwt'
 export type FederationStatus = 'active' | 'pending' | 'failed'
 

--- a/web/src/components/cards/strimzi_status/demoData.ts
+++ b/web/src/components/cards/strimzi_status/demoData.ts
@@ -20,7 +20,7 @@
 // Types
 // ---------------------------------------------------------------------------
 
-export type StrimziHealth = 'healthy' | 'degraded' | 'not-installed'
+export type StrimziHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 export type ClusterHealth = 'healthy' | 'degraded' | 'unavailable'
 export type TopicStatus = 'active' | 'inactive' | 'error'
 export type ConsumerGroupStatus = 'ok' | 'warning' | 'error'

--- a/web/src/components/cards/volcano_status/demoData.ts
+++ b/web/src/components/cards/volcano_status/demoData.ts
@@ -24,7 +24,7 @@ import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../../lib/constants/t
 // Types
 // ---------------------------------------------------------------------------
 
-export type VolcanoHealth = 'healthy' | 'degraded' | 'not-installed'
+export type VolcanoHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 export type VolcanoJobPhase =
   | 'Pending'
   | 'Running'

--- a/web/src/components/cards/wasmcloud_status/demoData.ts
+++ b/web/src/components/cards/wasmcloud_status/demoData.ts
@@ -24,7 +24,7 @@
 // Types
 // ---------------------------------------------------------------------------
 
-export type WasmcloudHealth = 'healthy' | 'degraded' | 'not-installed'
+export type WasmcloudHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 export type WasmcloudHostStatus = 'ready' | 'starting' | 'unreachable'
 export type WasmcloudProviderStatus = 'running' | 'starting' | 'failed'
 export type WasmcloudLinkStatus = 'active' | 'pending' | 'failed'

--- a/web/src/lib/demo/backstage.ts
+++ b/web/src/lib/demo/backstage.ts
@@ -15,7 +15,7 @@ import { MS_PER_MINUTE, MS_PER_HOUR } from '../constants/time'
 // ---------------------------------------------------------------------------
 
 /** Overall health roll-up for the Backstage instance. */
-export type BackstageHealth = 'healthy' | 'degraded' | 'not-installed'
+export type BackstageHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 /** Status of a single Backstage plugin install. */
 export type BackstagePluginStatus = 'enabled' | 'disabled' | 'error'

--- a/web/src/lib/demo/cloud-custodian.ts
+++ b/web/src/lib/demo/cloud-custodian.ts
@@ -71,7 +71,7 @@ export interface CustodianSummary {
   dryRunPolicies: number
 }
 
-export type CustodianHealth = 'healthy' | 'degraded' | 'not-installed'
+export type CustodianHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export interface CloudCustodianStatusData {
   health: CustodianHealth

--- a/web/src/lib/demo/dragonfly.ts
+++ b/web/src/lib/demo/dragonfly.ts
@@ -23,7 +23,7 @@ import { BYTES_PER_GIB } from '../constants/units'
 // Types
 // ---------------------------------------------------------------------------
 
-export type DragonflyHealth = 'healthy' | 'degraded' | 'not-installed'
+export type DragonflyHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export type DragonflyComponent = 'manager' | 'scheduler' | 'seed-peer' | 'dfdaemon'
 

--- a/web/src/lib/demo/flatcar.ts
+++ b/web/src/lib/demo/flatcar.ts
@@ -25,7 +25,7 @@ import { MS_PER_MINUTE, MS_PER_HOUR } from '../constants/time'
 // Types
 // ---------------------------------------------------------------------------
 
-export type FlatcarHealth = 'healthy' | 'degraded' | 'not-installed'
+export type FlatcarHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 export type FlatcarChannel = 'stable' | 'beta' | 'alpha' | 'lts'
 export type FlatcarNodeState =
   | 'up-to-date'

--- a/web/src/lib/demo/longhorn.ts
+++ b/web/src/lib/demo/longhorn.ts
@@ -20,7 +20,7 @@ import { BYTES_PER_GIB, BYTES_PER_TIB } from '../constants/units'
 // Types
 // ---------------------------------------------------------------------------
 
-export type LonghornInstallHealth = 'healthy' | 'degraded' | 'not-installed'
+export type LonghornInstallHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 /**
  * Volume operational state as reported by `volume.status.state`.

--- a/web/src/lib/demo/rook.ts
+++ b/web/src/lib/demo/rook.ts
@@ -20,7 +20,7 @@ import { BYTES_PER_GIB, BYTES_PER_TIB } from '../constants/units'
 // ---------------------------------------------------------------------------
 
 export type RookCephHealth = 'HEALTH_OK' | 'HEALTH_WARN' | 'HEALTH_ERR'
-export type RookInstallHealth = 'healthy' | 'degraded' | 'not-installed'
+export type RookInstallHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export interface RookCephCluster {
   /** Namespace/name of the CephCluster custom resource. */

--- a/web/src/lib/demo/spire.ts
+++ b/web/src/lib/demo/spire.ts
@@ -20,7 +20,7 @@ import { MS_PER_HOUR, MS_PER_DAY } from '../constants/time'
 // Types
 // ---------------------------------------------------------------------------
 
-export type SpireHealth = 'healthy' | 'degraded' | 'not-installed'
+export type SpireHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export type SpirePodPhase =
   | 'Running'

--- a/web/src/lib/demo/tuf.ts
+++ b/web/src/lib/demo/tuf.ts
@@ -41,7 +41,7 @@ export interface TufSummary {
   expiringSoonRoles: number
 }
 
-export type TufHealth = 'healthy' | 'degraded' | 'not-installed'
+export type TufHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export interface TufStatusData {
   health: TufHealth

--- a/web/src/lib/demo/vitess.ts
+++ b/web/src/lib/demo/vitess.ts
@@ -18,7 +18,7 @@
 
 export type VitessTabletType = 'PRIMARY' | 'REPLICA' | 'RDONLY'
 export type VitessTabletState = 'SERVING' | 'NOT_SERVING' | 'UNKNOWN'
-export type VitessHealth = 'healthy' | 'degraded' | 'not-installed'
+export type VitessHealth = 'healthy' | 'degraded' | 'not-installed' | 'unknown'
 
 export interface VitessTablet {
   alias: string


### PR DESCRIPTION
Fixes #3400

## Summary

4 Health type unions (Strimzi, Volcano, Wasmcloud, Spiffe) caused TS2367 errors because their card components compare `data.health !== 'unknown'` but the types didn't include `'unknown'`. This broke the CI build (`npm run build`) for **all open PRs**.

Also added `'unknown'` to the remaining 11 Health types for consistency — they all follow the same `'healthy' | 'degraded' | 'not-installed'` pattern and will need `'unknown'` when `useReportCardDataState` is wired.

## Files changed (15)

**Build-error fixes (4):**
- `strimzi_status/demoData.ts` — `StrimziHealth`
- `volcano_status/demoData.ts` — `VolcanoHealth`
- `wasmcloud_status/demoData.ts` — `WasmcloudHealth`
- `spiffe_status/demoData.ts` — `SpiffeHealth`

**Consistency alignment (11):**
- `chaos_mesh_status/demoData.ts`, `karmada_status/demoData.ts`
- `lib/demo/backstage.ts`, `dragonfly.ts`, `spire.ts`, `cloud-custodian.ts`, `tuf.ts`, `rook.ts`, `flatcar.ts`, `longhorn.ts`, `vitess.ts`

## Risk

**None** — adds a valid variant to union types. No runtime behavior change. Types that already had `'unknown'` (DaprHealth, OpenFeatureHealth, LinkerdHealth, etc.) are unchanged.