### PR TITLE
🐛 Fix TS7006: add explicit string type to chartName callback in MissionSidebar

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -1487,7 +1487,7 @@ export function MissionSidebar() {
           onClose={() => setShowBrowser(false)}
           onImport={handleImportMission}
           initialMission={deepLinkMission || undefined}
-          onUseInMissionControl={(chartName) => {
+          onUseInMissionControl={(chartName: string) => {
             setShowBrowser(false)
             setPendingKubaraChart(chartName)
             setShowMissionControl(true)


### PR DESCRIPTION
Fixes CI build failure.

## Problem
`MissionSidebar.tsx` line 1490: the `onUseInMissionControl` callback parameter `chartName` had implicit `any` type, causing TS7006 error under strict mode. This blocks CI on all PRs.

## Fix
Added explicit `: string` type annotation to match the `MissionBrowserProps.onUseInMissionControl` signature `(chartName: string) => void`.

## Testing
CI will validate — no local build per policy.