### PR TITLE
🧪 Coverage batch 3: analytics-core and useSearchIndex tests

### DIFF
--- a/web/src/hooks/__tests__/useSearchIndex.test.ts
+++ b/web/src/hooks/__tests__/useSearchIndex.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock all hook dependencies so the module loads without React context
+// ---------------------------------------------------------------------------
+
+vi.mock('../../components/cards/cardMetadata', () => ({
+  CARD_TITLES: { gpu_overview: 'GPU Overview', cluster_health: 'Cluster Health' },
+  CARD_DESCRIPTIONS: { gpu_overview: 'GPU metrics' },
+}))
+
+vi.mock('../../components/ui/StatsBlockDefinitions', () => ({
+  getDefaultStatBlocks: vi.fn(() => []),
+}))
+
+vi.mock('../mcp/clusters', () => ({ useClusters: vi.fn(() => ({ clusters: [] })) }))
+vi.mock('../mcp/workloads', () => ({
+  useDeployments: vi.fn(() => ({ deployments: [] })),
+  usePods: vi.fn(() => ({ pods: [] })),
+}))
+vi.mock('../mcp/networking', () => ({ useServices: vi.fn(() => ({ services: [] })) }))
+vi.mock('../mcp/compute', () => ({ useNodes: vi.fn(() => ({ nodes: [] })) }))
+vi.mock('../mcp/helm', () => ({ useHelmReleases: vi.fn(() => ({ releases: [] })) }))
+vi.mock('../useMissions', () => ({ useMissions: vi.fn(() => ({ missions: [] })) }))
+vi.mock('../useDashboards', () => ({ useDashboards: vi.fn(() => ({ dashboards: [] })) }))
+vi.mock('../../config/dashboards', () => ({
+  DASHBOARD_CONFIGS: {
+    main: { storageKey: 'kubestellar-main-dashboard-cards', route: '/', name: 'Main' },
+    clusters: { storageKey: 'kubestellar-clusters-cards', route: '/clusters', name: 'Clusters' },
+  },
+}))
+
+import { __testables } from '../useSearchIndex'
+import type { SearchItem } from '../useSearchIndex'
+
+const { matchesQuery, buildDashboardStorage, scanPlacedCards } = __testables
+
+const store = new Map<string, string>()
+
+beforeEach(() => {
+  store.clear()
+  vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => store.get(key) ?? null)
+  vi.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => { store.set(key, value) })
+  vi.restoreAllMocks
+})
+
+// ---------------------------------------------------------------------------
+// matchesQuery
+// ---------------------------------------------------------------------------
+
+describe('matchesQuery', () => {
+  const item: SearchItem = {
+    id: 'test-1',
+    name: 'GPU Overview',
+    description: 'Shows GPU metrics',
+    category: 'card',
+    keywords: ['gpu', 'nvidia'],
+    meta: 'compute accelerator',
+  }
+
+  it('matches by name (case-insensitive)', () => {
+    expect(matchesQuery(item, 'gpu')).toBe(true)
+    expect(matchesQuery(item, 'GPU')).toBe(true)
+  })
+
+  it('matches by description', () => {
+    expect(matchesQuery(item, 'metrics')).toBe(true)
+  })
+
+  it('matches by keyword', () => {
+    expect(matchesQuery(item, 'nvidia')).toBe(true)
+  })
+
+  it('matches by meta', () => {
+    expect(matchesQuery(item, 'accelerator')).toBe(true)
+  })
+
+  it('returns false for non-matching query', () => {
+    expect(matchesQuery(item, 'kubernetes')).toBe(false)
+  })
+
+  it('handles item with no optional fields', () => {
+    const minimal: SearchItem = { id: 'x', name: 'Test', category: 'page' }
+    expect(matchesQuery(minimal, 'test')).toBe(true)
+    expect(matchesQuery(minimal, 'xyz')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildDashboardStorage
+// ---------------------------------------------------------------------------
+
+describe('buildDashboardStorage', () => {
+  it('returns entries from DASHBOARD_CONFIGS', () => {
+    const entries = buildDashboardStorage()
+    expect(entries.length).toBeGreaterThan(0)
+    const main = entries.find(e => e.route === '/')
+    expect(main).toBeDefined()
+    expect(main!.name).toBe('Main')
+  })
+
+  it('does not duplicate keys', () => {
+    const entries = buildDashboardStorage()
+    const keys = entries.map(e => e.key)
+    const unique = new Set(keys)
+    expect(unique.size).toBe(keys.length)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// scanPlacedCards
+// ---------------------------------------------------------------------------
+
+describe('scanPlacedCards', () => {
+  beforeEach(() => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => store.get(key) ?? null)
+  })
+
+  it('returns empty array when no cards in localStorage', () => {
+    const result = scanPlacedCards([])
+    expect(result).toEqual([])
+  })
+
+  it('finds cards placed on built-in dashboards', () => {
+    store.set('kubestellar-main-dashboard-cards', JSON.stringify([
+      { card_type: 'gpu_overview', title: 'GPU Overview' },
+      { card_type: 'cluster_health' },
+    ]))
+    const result = scanPlacedCards([])
+    expect(result.length).toBe(2)
+    expect(result[0].name).toBe('GPU Overview')
+    expect(result[0].category).toBe('card')
+    expect(result[0].href).toBe('/')
+  })
+
+  it('finds cards on custom dashboards', () => {
+    store.set('kubestellar-custom-dashboard-abc-cards', JSON.stringify([
+      { card_type: 'gpu_overview' },
+    ]))
+    const result = scanPlacedCards([{ id: 'abc', name: 'My Dashboard' }])
+    expect(result.length).toBe(1)
+    expect(result[0].description).toContain('My Dashboard')
+    expect(result[0].href).toBe('/custom-dashboard/abc')
+  })
+
+  it('handles malformed JSON gracefully', () => {
+    store.set('kubestellar-main-dashboard-cards', 'not json')
+    expect(() => scanPlacedCards([])).not.toThrow()
+    expect(scanPlacedCards([])).toEqual([])
+  })
+
+  it('skips cards without card_type', () => {
+    store.set('kubestellar-main-dashboard-cards', JSON.stringify([
+      { title: 'No Type' },
+      { card_type: 'gpu_overview' },
+    ]))
+    const result = scanPlacedCards([])
+    expect(result.length).toBe(1)
+  })
+})

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -557,3 +557,10 @@ export function useSearchIndex(query: string) {
 
   return { results, totalCount }
 }
+
+export const __testables = {
+  matchesQuery,
+  buildDashboardStorage,
+  scanPlacedCards,
+  scanPlacedStats,
+}

--- a/web/src/lib/__tests__/analytics-core.test.ts
+++ b/web/src/lib/__tests__/analytics-core.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock all external dependencies so the module loads cleanly
+// ---------------------------------------------------------------------------
+
+vi.mock('../demoMode', () => ({
+  isDemoMode: vi.fn(() => false),
+  isNetlifyDeployment: false,
+}))
+
+vi.mock('../chunkErrors', () => ({
+  CHUNK_RELOAD_TS_KEY: 'kc-chunk-reload-ts',
+  isChunkLoadMessage: vi.fn(() => false),
+}))
+
+vi.mock('../constants', () => ({
+  STORAGE_KEY_ANALYTICS_OPT_OUT: 'kc-analytics-opt-out',
+}))
+
+vi.mock('../analytics-session', () => ({
+  isAutomatedEnvironment: vi.fn(() => false),
+  isOptedOut: vi.fn(() => false),
+  getDeploymentType: vi.fn(() => 'development'),
+  getClientId: vi.fn(() => 'test-client-id'),
+  getSession: vi.fn(() => ({ sid: 'test-sid', sc: 'start', seq: 1, pages: 1, engaged: false })),
+  peekEngagementMs: vi.fn(() => 0),
+  peekSessionEngagementMs: vi.fn(() => 0),
+  getAndResetEngagementMs: vi.fn(() => 0),
+  resetSessionEngagement: vi.fn(),
+  incrementSessionPageViewCount: vi.fn(),
+  getSessionPageViewCount: vi.fn(() => 1),
+  startEngagementTracking: vi.fn(),
+  stopEngagementTracking: vi.fn(),
+  hashUserId: vi.fn((id: string) => `hashed-${id}`),
+  getOrCreateAnonymousId: vi.fn(() => 'anon-id'),
+  _loadUtmParams: vi.fn(),
+  getUtmParams: vi.fn(() => ({})),
+  rand: vi.fn(() => 'rand123'),
+  CID_KEY: 'kc-cid',
+  SID_KEY: 'kc-sid',
+  SC_KEY: 'kc-sc',
+  LAST_KEY: 'kc-last',
+}))
+
+import {
+  __testables,
+  _resetErrorThrottles,
+  _resetAnalyticsState,
+  markErrorReported,
+} from '../analytics-core'
+
+const {
+  inferErrorType,
+  inferComponentName,
+  isBrowserExtensionNoise,
+  isBareNetworkNoise,
+  isErrorThrottled,
+  wasAlreadyReported,
+} = __testables
+
+beforeEach(() => {
+  _resetErrorThrottles()
+  _resetAnalyticsState()
+})
+
+// ---------------------------------------------------------------------------
+// inferErrorType
+// ---------------------------------------------------------------------------
+
+describe('inferErrorType', () => {
+  it('extracts error.name from Error object', () => {
+    const err = new TypeError('something broke')
+    expect(inferErrorType('something broke', err)).toBe('TypeError')
+  })
+
+  it('ignores generic "Error" name', () => {
+    const err = new Error('something')
+    expect(inferErrorType('something', err)).toBe('Unknown')
+  })
+
+  it('extracts error type from message prefix pattern', () => {
+    expect(inferErrorType('SyntaxError: unexpected token')).toBe('SyntaxError')
+  })
+
+  it('detects network errors from message fragments', () => {
+    expect(inferErrorType('Failed to fetch resource')).toBe('NetworkError')
+    expect(inferErrorType('net::ERR_CONNECTION_REFUSED')).toBe('NetworkError')
+    expect(inferErrorType('Load failed')).toBe('NetworkError')
+  })
+
+  it('returns Unknown for unrecognized messages', () => {
+    expect(inferErrorType('something went wrong')).toBe('Unknown')
+  })
+
+  it('truncates long error names', () => {
+    const err = { name: 'A'.repeat(100) }
+    const result = inferErrorType('msg', err)
+    expect(result.length).toBeLessThanOrEqual(40)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// inferComponentName
+// ---------------------------------------------------------------------------
+
+describe('inferComponentName', () => {
+  it('uses cardId when provided', () => {
+    expect(inferComponentName('gpu_overview')).toBe('gpu_overview')
+  })
+
+  it('extracts component from React componentStack', () => {
+    const stack = '\n    in MyComponent (created by App)\n    in div'
+    expect(inferComponentName(undefined, stack)).toBe('MyComponent')
+  })
+
+  it('extracts filename from error stack (Chromium format)', () => {
+    const err = { stack: 'Error\n    at fn (https://host/path/Dashboard.tsx:12:3)' }
+    expect(inferComponentName(undefined, undefined, err)).toBe('Dashboard')
+  })
+
+  it('returns "unknown" when no info available', () => {
+    expect(inferComponentName()).toBe('unknown')
+  })
+
+  it('truncates long cardIds', () => {
+    const long = 'x'.repeat(200)
+    expect(inferComponentName(long)!.length).toBeLessThanOrEqual(60)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isBrowserExtensionNoise
+// ---------------------------------------------------------------------------
+
+describe('isBrowserExtensionNoise', () => {
+  it('detects MetaMask errors', () => {
+    expect(isBrowserExtensionNoise('MetaMask: something failed', undefined)).toBe(true)
+  })
+
+  it('detects ethereum errors', () => {
+    expect(isBrowserExtensionNoise('ethereum provider not found', undefined)).toBe(true)
+  })
+
+  it('detects chrome-extension stack frames', () => {
+    const reason = { stack: 'Error\n    at chrome-extension://abc/script.js:1:1' }
+    expect(isBrowserExtensionNoise('unknown', reason)).toBe(true)
+  })
+
+  it('detects moz-extension stack frames', () => {
+    const reason = { stack: 'Error\n    at moz-extension://abc/script.js:1:1' }
+    expect(isBrowserExtensionNoise('unknown', reason)).toBe(true)
+  })
+
+  it('returns false for app errors', () => {
+    expect(isBrowserExtensionNoise('Cannot read property x', { stack: 'at App.tsx:1' })).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isBareNetworkNoise
+// ---------------------------------------------------------------------------
+
+describe('isBareNetworkNoise', () => {
+  it('filters bare "Failed to fetch"', () => {
+    expect(isBareNetworkNoise('Failed to fetch')).toBe(true)
+  })
+
+  it('filters bare "NetworkError"', () => {
+    expect(isBareNetworkNoise('NetworkError when attempting to fetch resource')).toBe(true)
+  })
+
+  it('does NOT filter chunk-load failures containing strict chunk indicators', () => {
+    expect(isBareNetworkNoise('Failed to fetch dynamically imported module: /assets/Foo.js')).toBe(false)
+  })
+
+  it('returns false for non-network messages', () => {
+    expect(isBareNetworkNoise('TypeError: Cannot read property')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isErrorThrottled
+// ---------------------------------------------------------------------------
+
+describe('isErrorThrottled', () => {
+  it('allows the first error emission', () => {
+    expect(isErrorThrottled('runtime', '/dashboard')).toBe(false)
+  })
+
+  it('throttles duplicate category+page within window', () => {
+    isErrorThrottled('runtime', '/dashboard')
+    expect(isErrorThrottled('runtime', '/dashboard')).toBe(true)
+  })
+
+  it('allows different categories on same page', () => {
+    isErrorThrottled('runtime', '/dashboard')
+    expect(isErrorThrottled('card_render', '/dashboard')).toBe(false)
+  })
+
+  it('allows same category on different pages', () => {
+    isErrorThrottled('runtime', '/dashboard')
+    expect(isErrorThrottled('runtime', '/clusters')).toBe(false)
+  })
+
+  it('distinguishes by cardId', () => {
+    isErrorThrottled('card_render', '/dashboard', 'gpu_overview')
+    expect(isErrorThrottled('card_render', '/dashboard', 'cluster_health')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// markErrorReported / wasAlreadyReported
+// ---------------------------------------------------------------------------
+
+describe('markErrorReported / wasAlreadyReported', () => {
+  it('marks and detects reported errors', () => {
+    markErrorReported('test error message')
+    expect(wasAlreadyReported('test error message')).toBe(true)
+  })
+
+  it('returns false for unreported errors', () => {
+    expect(wasAlreadyReported('never seen this')).toBe(false)
+  })
+})

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -1127,3 +1127,13 @@ export function startGlobalErrorTracking() {
     }
   })
 }
+
+export const __testables = {
+  inferErrorType,
+  inferComponentName,
+  isBrowserExtensionNoise,
+  isBareNetworkNoise,
+  isErrorThrottled,
+  markErrorReported,
+  wasAlreadyReported,
+}


### PR DESCRIPTION
## Summary
Replaces closed #10897 (was closed due to pre-existing TS2367 build errors on main, now fixed).

- **analytics-core** (6 test suites, ~30 assertions): `inferErrorType`, `inferComponentName`, `isBrowserExtensionNoise`, `isBareNetworkNoise`, `isErrorThrottled`, `markErrorReported`/`wasAlreadyReported`
- **useSearchIndex** (4 test suites, ~20 assertions): `matchesQuery`, `buildDashboardStorage`, `scanPlacedCards` — localStorage mocking, malformed JSON handling

Both files export `__testables` for direct pure-function testing.

## Test plan
- [x] `npx vitest run src/lib/__tests__/analytics-core.test.ts` — all pass
- [x] `npx vitest run src/hooks/__tests__/useSearchIndex.test.ts` — all pass
- [ ] CI build passes (TS2367 fix now on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)