### PR TITLE
🐛 Fix TS2345 build break: replace strict TFunction with loose TranslateFn

### DIFF
--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -15,7 +15,7 @@ import { SEVERITY_COLORS, SeverityLevel } from '../../lib/accessibility'
 import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 /** Loose translation function type for helper functions that use dynamic keys */
-type TranslateFn = (key: string, options?: Record<string, unknown>) => string
+type TranslateFn = (key: string, ...rest: unknown[]) => string
 
 // Demo security issues data for demo mode
 function getDemoSecurityIssues(): SecurityIssue[] {

--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -14,7 +14,8 @@ import { CardClusterFilter, CardSearchInput, CardAIActions } from '../../lib/car
 import { SEVERITY_COLORS, SeverityLevel } from '../../lib/accessibility'
 import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
-import type { TFunction } from 'i18next'
+/** Loose translation function type for helper functions that use dynamic keys */
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
 
 // Demo security issues data for demo mode
 function getDemoSecurityIssues(): SecurityIssue[] {
@@ -76,7 +77,7 @@ interface SecurityIssuesProps {
   config?: Record<string, unknown>
 }
 
-const getIssueIcon = (issue: string | undefined, t: TFunction): { icon: typeof Shield; tooltip: string } => {
+const getIssueIcon = (issue: string | undefined, t: TranslateFn): { icon: typeof Shield; tooltip: string } => {
   const s = issue || ''
   if (s.includes('Privileged')) return { icon: Shield, tooltip: t('securityIssues.privilegedContainer') }
   if (s.includes('root')) return { icon: User, tooltip: t('securityIssues.runningAsRoot') }

--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -15,7 +15,7 @@ import { SEVERITY_COLORS, SeverityLevel } from '../../lib/accessibility'
 import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 /** Loose translation function type for helper functions that use dynamic keys */
-type TranslateFn = (key: string, ...rest: unknown[]) => string
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
 
 // Demo security issues data for demo mode
 function getDemoSecurityIssues(): SecurityIssue[] {
@@ -302,7 +302,7 @@ function SecurityIssuesInternal({ config }: SecurityIssuesProps) {
           card within standard card height when rendered at lg grid size. */}
       <div ref={containerRef} className="flex-1 space-y-2 overflow-y-auto min-h-card-content" style={containerStyle}>
         {issues.map((issue: SecurityIssue, idx: number) => {
-          const { icon: Icon, tooltip: iconTooltip } = getIssueIcon(issue.issue, t)
+          const { icon: Icon, tooltip: iconTooltip } = getIssueIcon(issue.issue, t as unknown as TranslateFn)
           const colors = getSeverityColor(issue.severity)
 
           return (

--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -18,13 +18,14 @@ import type { ConsoleUser, UserRole, OpenShiftUser } from '../../types/users'
 import { Skeleton } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
-/** Loose translation function type for helper functions that use dynamic keys */
-type TranslateFn = (key: string, options?: Record<string, unknown>) => string
 import { StatusBadge } from '../ui/StatusBadge'
 import { useToast } from '../ui/Toast'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { emitUserRoleChanged, emitUserRemoved } from '../../lib/analytics'
 import { ConfirmDialog } from '../../lib/modals'
+
+/** Loose translation function type for helper functions that use dynamic keys */
+type TranslateFn = (key: string, ...rest: unknown[]) => string
 
 const MAX_VISIBLE_GROUPS = 3
 

--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -18,7 +18,8 @@ import type { ConsoleUser, UserRole, OpenShiftUser } from '../../types/users'
 import { Skeleton } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
-import type { TFunction } from 'i18next'
+/** Loose translation function type for helper functions that use dynamic keys */
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
 import { StatusBadge } from '../ui/StatusBadge'
 import { useToast } from '../ui/Toast'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -37,7 +38,7 @@ type OpenShiftUserSortBy = 'name' | 'kind'
 type SASortBy = 'name' | 'namespace'
 
 // Sort options defined in component to access t()
-function getConsoleUserSortOptions(t: TFunction) {
+function getConsoleUserSortOptions(t: TranslateFn) {
   return [
     { value: 'name' as const, label: t('common:common.name') },
     { value: 'role' as const, label: t('common:common.role') },
@@ -45,14 +46,14 @@ function getConsoleUserSortOptions(t: TFunction) {
   ]
 }
 
-function getOpenShiftUserSortOptions(t: TFunction) {
+function getOpenShiftUserSortOptions(t: TranslateFn) {
   return [
     { value: 'name' as const, label: t('userManagement.username') },
     { value: 'kind' as const, label: t('userManagement.fullName') },
   ]
 }
 
-function getSASortOptions(t: TFunction) {
+function getSASortOptions(t: TranslateFn) {
   return [
     { value: 'name' as const, label: t('common:common.name') },
     { value: 'namespace' as const, label: t('common:common.namespace') },

--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -25,7 +25,7 @@ import { emitUserRoleChanged, emitUserRemoved } from '../../lib/analytics'
 import { ConfirmDialog } from '../../lib/modals'
 
 /** Loose translation function type for helper functions that use dynamic keys */
-type TranslateFn = (key: string, ...rest: unknown[]) => string
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
 
 const MAX_VISIBLE_GROUPS = 3
 
@@ -259,9 +259,9 @@ export function UserManagement({ config: _config }: UserManagementProps) {
     : activeTab === 'serviceAccounts' ? setSaItemsPerPage
     : setConsoleUserItemsPerPage
 
-  const activeSortOptions = activeTab === 'clusterUsers' ? getOpenShiftUserSortOptions(t)
-    : activeTab === 'serviceAccounts' ? getSASortOptions(t)
-    : getConsoleUserSortOptions(t)
+  const activeSortOptions = activeTab === 'clusterUsers' ? getOpenShiftUserSortOptions(t as unknown as TranslateFn)
+    : activeTab === 'serviceAccounts' ? getSASortOptions(t as unknown as TranslateFn)
+    : getConsoleUserSortOptions(t as unknown as TranslateFn)
 
   const isAdmin = currentUser?.role === 'admin'
 

--- a/web/src/components/cards/llmd/LLMdAIInsights.tsx
+++ b/web/src/components/cards/llmd/LLMdAIInsights.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from 'react-i18next'
 import { PROGRESS_SIMULATION_MS } from '../../../lib/constants/network'
 
 /** Loose translation function type for helper functions that use dynamic keys */
-type TranslateFn = (key: string, ...rest: unknown[]) => string
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
 
 const INSIGHT_ICONS = {
   optimization: Lightbulb,
@@ -321,7 +321,7 @@ export function LLMdAIInsights() {
     }
 
     if (stackContext?.selectedStack) {
-      return generateStackInsights(stackContext.selectedStack, t)
+      return generateStackInsights(stackContext.selectedStack, t as unknown as TranslateFn)
     }
 
     return []

--- a/web/src/components/cards/llmd/LLMdAIInsights.tsx
+++ b/web/src/components/cards/llmd/LLMdAIInsights.tsx
@@ -14,9 +14,10 @@ import { useCardExpanded } from '../CardWrapper'
 import { generateAIInsights, type AIInsight } from '../../../lib/llmd/mockData'
 import type { LLMdStack } from '../../../hooks/useStackDiscovery'
 import { useTranslation } from 'react-i18next'
-/** Loose translation function type for helper functions that use dynamic keys */
-type TranslateFn = (key: string, options?: Record<string, unknown>) => string
 import { PROGRESS_SIMULATION_MS } from '../../../lib/constants/network'
+
+/** Loose translation function type for helper functions that use dynamic keys */
+type TranslateFn = (key: string, ...rest: unknown[]) => string
 
 const INSIGHT_ICONS = {
   optimization: Lightbulb,

--- a/web/src/components/cards/llmd/LLMdAIInsights.tsx
+++ b/web/src/components/cards/llmd/LLMdAIInsights.tsx
@@ -14,7 +14,8 @@ import { useCardExpanded } from '../CardWrapper'
 import { generateAIInsights, type AIInsight } from '../../../lib/llmd/mockData'
 import type { LLMdStack } from '../../../hooks/useStackDiscovery'
 import { useTranslation } from 'react-i18next'
-import type { TFunction } from 'i18next'
+/** Loose translation function type for helper functions that use dynamic keys */
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
 import { PROGRESS_SIMULATION_MS } from '../../../lib/constants/network'
 
 const INSIGHT_ICONS = {
@@ -112,7 +113,7 @@ function InsightCard({ insight, isExpanded, onToggle }: InsightCardProps) {
 /**
  * Generate real insights based on the selected stack's state
  */
-function generateStackInsights(stack: LLMdStack, t?: TFunction): AIInsight[] {
+function generateStackInsights(stack: LLMdStack, t?: TranslateFn): AIInsight[] {
   const insights: AIInsight[] = []
   const now = new Date()
 


### PR DESCRIPTION
Fixes #10915

## Problem
PR #10902 replaced `(t as any)()` double-casts with a strict `TFunction` type import from i18next. With strict `CustomTypeOptions` enabled, this rejects dynamic translation keys like `t('userManagement.email')` — causing TS2345 build errors on main.

## Fix
Replace the `TFunction` import with a local `TranslateFn` type alias: `(key: string, options?: Record<string, unknown>) => string`. This matches the existing pattern used in 8+ other files (AddCardModal, DashboardCustomizer, RBACExplorer, formatters, etc.).

## Files changed
- `UserManagement.tsx` — 3 helper functions
- `SecurityIssues.tsx` — `getIssueIcon` helper
- `LLMdAIInsights.tsx` — `generateStackInsights` helper