### PR TITLE
fix: correct test expectations in batch 1/2 coverage tests

### DIFF
--- a/web/src/hooks/__tests__/useCachedContainerd.test.ts
+++ b/web/src/hooks/__tests__/useCachedContainerd.test.ts
@@ -164,33 +164,37 @@ describe('mapContainerState', () => {
     expect(mapContainerState('running')).toBe('running')
   })
 
-  it('maps waiting to created', () => {
-    expect(mapContainerState('waiting')).toBe('created')
+  it('maps waiting to paused', () => {
+    expect(mapContainerState('waiting')).toBe('paused')
   })
 
   it('maps terminated to stopped', () => {
     expect(mapContainerState('terminated')).toBe('stopped')
   })
 
-  it('maps undefined to unknown', () => {
-    expect(mapContainerState(undefined)).toBe('unknown')
+  it('maps undefined to stopped', () => {
+    expect(mapContainerState(undefined)).toBe('stopped')
   })
 })
 
 describe('formatUptime', () => {
-  it('returns "0s" for undefined startedAt', () => {
-    expect(formatUptime(undefined)).toBe('unknown')
+  it('returns "0s" for non-running state', () => {
+    expect(formatUptime(undefined, 'stopped')).toBe('0s')
+  })
+
+  it('returns "unknown" for running state with undefined startedAt', () => {
+    expect(formatUptime(undefined, 'running')).toBe('unknown')
   })
 
   it('formats recent uptime as seconds', () => {
     const tenSecondsAgo = new Date(Date.now() - 10_000).toISOString()
-    const result = formatUptime(tenSecondsAgo)
+    const result = formatUptime(tenSecondsAgo, 'running')
     expect(result).toMatch(/\d+s/)
   })
 
   it('formats hours when uptime > 1 hour', () => {
     const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString()
-    const result = formatUptime(twoHoursAgo)
+    const result = formatUptime(twoHoursAgo, 'running')
     expect(result).toMatch(/\d+h/)
   })
 })

--- a/web/src/hooks/__tests__/useCachedDragonfly.test.ts
+++ b/web/src/hooks/__tests__/useCachedDragonfly.test.ts
@@ -110,53 +110,53 @@ describe('useCachedDragonfly hook', () => {
 // ---------------------------------------------------------------------------
 
 describe('podIsReady', () => {
-  it('returns true when all containers are ready', () => {
-    expect(podIsReady({ status: { containerStatuses: [{ ready: true }, { ready: true }] } })).toBe(true)
+  it('returns true when all containers are ready and phase is Running', () => {
+    expect(podIsReady({ name: 'p', status: { phase: 'Running', containerStatuses: [{ ready: true }, { ready: true }] } })).toBe(true)
   })
 
   it('returns false when any container is not ready', () => {
-    expect(podIsReady({ status: { containerStatuses: [{ ready: true }, { ready: false }] } })).toBe(false)
+    expect(podIsReady({ name: 'p', status: { phase: 'Running', containerStatuses: [{ ready: true }, { ready: false }] } })).toBe(false)
   })
 
   it('returns false when no container statuses exist', () => {
-    expect(podIsReady({})).toBe(false)
+    expect(podIsReady({ name: 'p' })).toBe(false)
   })
 })
 
 describe('parseVersion', () => {
   it('extracts version from image tag', () => {
-    expect(parseVersion([{ image: 'dragonflyoss/manager:v2.1.0' }])).toBe('v2.1.0')
+    expect(parseVersion({ name: 'p', status: { containerStatuses: [{ image: 'dragonflyoss/manager:v2.1.0' }] } })).toBe('v2.1.0')
   })
 
-  it('returns unknown for empty containers', () => {
-    expect(parseVersion([])).toBe('unknown')
+  it('returns empty string for empty containers', () => {
+    expect(parseVersion({ name: 'p', status: { containerStatuses: [] } })).toBe('')
   })
 
-  it('returns unknown when no image tag', () => {
-    expect(parseVersion([{ image: 'dragonflyoss/manager' }])).toBe('unknown')
+  it('returns empty string when no image tag', () => {
+    expect(parseVersion({ name: 'p', status: { containerStatuses: [{ image: 'dragonflyoss/manager' }] } })).toBe('')
   })
 })
 
 describe('buildStatus', () => {
-  it('returns not-installed for empty components', () => {
+  it('returns not-installed for empty pods', () => {
     const result = buildStatus([])
     expect(result.health).toBe('not-installed')
     expect(result.components).toEqual([])
   })
 
-  it('returns healthy when all components have ready replicas', () => {
-    const components = [
-      { component: 'manager' as const, ready: 1, desired: 1, version: 'v2.1.0', pods: [] },
+  it('returns healthy when all dragonfly pods are ready', () => {
+    const pods = [
+      { name: 'dragonfly-manager-0', status: { phase: 'Running', containerStatuses: [{ ready: true, image: 'dragonflyoss/manager:v2.1.0' }] } },
     ]
-    const result = buildStatus(components)
+    const result = buildStatus(pods)
     expect(result.health).toBe('healthy')
   })
 
-  it('returns degraded when some replicas are not ready', () => {
-    const components = [
-      { component: 'manager' as const, ready: 0, desired: 1, version: 'v2.1.0', pods: [] },
+  it('returns degraded when some pods are not ready', () => {
+    const pods = [
+      { name: 'dragonfly-manager-0', status: { phase: 'Pending', containerStatuses: [{ ready: false, image: 'dragonflyoss/manager:v2.1.0' }] } },
     ]
-    const result = buildStatus(components)
+    const result = buildStatus(pods)
     expect(result.health).toBe('degraded')
   })
 })

--- a/web/src/hooks/__tests__/useCachedLonghorn.test.ts
+++ b/web/src/hooks/__tests__/useCachedLonghorn.test.ts
@@ -116,12 +116,12 @@ describe('normalizeVolumeState', () => {
     expect(normalizeVolumeState('attaching')).toBe('attaching')
   })
 
-  it('returns "unknown" for invalid state', () => {
-    expect(normalizeVolumeState('bogus')).toBe('unknown')
+  it('returns "detached" for invalid state', () => {
+    expect(normalizeVolumeState('bogus')).toBe('detached')
   })
 
-  it('returns "unknown" for undefined', () => {
-    expect(normalizeVolumeState(undefined)).toBe('unknown')
+  it('returns "detached" for undefined', () => {
+    expect(normalizeVolumeState(undefined)).toBe('detached')
   })
 })
 
@@ -147,9 +147,9 @@ describe('summarize', () => {
 
   it('counts volume health states correctly', () => {
     const volumes = [
-      { name: 'v1', state: 'attached' as const, robustness: 'healthy' as const, size: 1073741824, numberOfReplicas: 3, replicas: [] },
-      { name: 'v2', state: 'attached' as const, robustness: 'degraded' as const, size: 1073741824, numberOfReplicas: 3, replicas: [] },
-      { name: 'v3', state: 'detached' as const, robustness: 'faulted' as const, size: 1073741824, numberOfReplicas: 3, replicas: [] },
+      { name: 'v1', namespace: 'default', state: 'attached' as const, robustness: 'healthy' as const, replicasDesired: 3, replicasHealthy: 3, sizeBytes: 1073741824, actualSizeBytes: 0, nodeAttached: 'n1', cluster: '' },
+      { name: 'v2', namespace: 'default', state: 'attached' as const, robustness: 'degraded' as const, replicasDesired: 3, replicasHealthy: 1, sizeBytes: 1073741824, actualSizeBytes: 0, nodeAttached: 'n1', cluster: '' },
+      { name: 'v3', namespace: 'default', state: 'detached' as const, robustness: 'faulted' as const, replicasDesired: 3, replicasHealthy: 0, sizeBytes: 1073741824, actualSizeBytes: 0, nodeAttached: '', cluster: '' },
     ]
     const result = summarize(volumes, [])
     expect(result.totalVolumes).toBe(3)
@@ -160,8 +160,8 @@ describe('summarize', () => {
 
   it('counts node readiness correctly', () => {
     const nodes = [
-      { name: 'n1', ready: true, schedulable: true, disks: {}, storageCapacity: 0, storageUsed: 0 },
-      { name: 'n2', ready: false, schedulable: true, disks: {}, storageCapacity: 0, storageUsed: 0 },
+      { name: 'n1', ready: true, schedulable: true, storageTotalBytes: 0, storageUsedBytes: 0, replicaCount: 0, cluster: '' },
+      { name: 'n2', ready: false, schedulable: true, storageTotalBytes: 0, storageUsedBytes: 0, replicaCount: 0, cluster: '' },
     ]
     const result = summarize([], nodes)
     expect(result.totalNodes).toBe(2)
@@ -170,51 +170,51 @@ describe('summarize', () => {
 })
 
 describe('deriveHealth', () => {
-  it('returns not-installed for empty summary', () => {
-    const summary = {
-      totalVolumes: 0, healthyVolumes: 0, degradedVolumes: 0, faultedVolumes: 0,
-      totalNodes: 0, readyNodes: 0, schedulableNodes: 0,
-      totalCapacityBytes: 0, totalUsedBytes: 0,
-    }
-    expect(deriveHealth(summary)).toBe('not-installed')
+  it('returns not-installed for empty volumes and nodes', () => {
+    expect(deriveHealth([], [])).toBe('not-installed')
   })
 
-  it('returns healthy when all volumes are healthy', () => {
-    const summary = {
-      totalVolumes: 3, healthyVolumes: 3, degradedVolumes: 0, faultedVolumes: 0,
-      totalNodes: 2, readyNodes: 2, schedulableNodes: 2,
-      totalCapacityBytes: 100, totalUsedBytes: 50,
-    }
-    expect(deriveHealth(summary)).toBe('healthy')
+  it('returns healthy when all volumes are healthy and nodes ready', () => {
+    const volumes = [
+      { name: 'v1', state: 'attached' as const, robustness: 'healthy' as const, replicasDesired: 3, replicasHealthy: 3, sizeBytes: 100, actualSizeBytes: 50, nodeAttached: 'n1', namespace: 'default', cluster: '' },
+      { name: 'v2', state: 'attached' as const, robustness: 'healthy' as const, replicasDesired: 3, replicasHealthy: 3, sizeBytes: 100, actualSizeBytes: 50, nodeAttached: 'n1', namespace: 'default', cluster: '' },
+    ]
+    const nodes = [
+      { name: 'n1', ready: true, schedulable: true, storageTotalBytes: 100, storageUsedBytes: 50, replicaCount: 2, cluster: '' },
+    ]
+    expect(deriveHealth(volumes, nodes)).toBe('healthy')
   })
 
   it('returns degraded when some volumes are degraded', () => {
-    const summary = {
-      totalVolumes: 3, healthyVolumes: 2, degradedVolumes: 1, faultedVolumes: 0,
-      totalNodes: 2, readyNodes: 2, schedulableNodes: 2,
-      totalCapacityBytes: 100, totalUsedBytes: 50,
-    }
-    expect(deriveHealth(summary)).toBe('degraded')
+    const volumes = [
+      { name: 'v1', state: 'attached' as const, robustness: 'healthy' as const, replicasDesired: 3, replicasHealthy: 3, sizeBytes: 100, actualSizeBytes: 50, nodeAttached: 'n1', namespace: 'default', cluster: '' },
+      { name: 'v2', state: 'attached' as const, robustness: 'degraded' as const, replicasDesired: 3, replicasHealthy: 1, sizeBytes: 100, actualSizeBytes: 50, nodeAttached: 'n1', namespace: 'default', cluster: '' },
+    ]
+    const nodes = [
+      { name: 'n1', ready: true, schedulable: true, storageTotalBytes: 100, storageUsedBytes: 50, replicaCount: 2, cluster: '' },
+    ]
+    expect(deriveHealth(volumes, nodes)).toBe('degraded')
   })
 
-  it('returns critical when volumes are faulted', () => {
-    const summary = {
-      totalVolumes: 3, healthyVolumes: 1, degradedVolumes: 1, faultedVolumes: 1,
-      totalNodes: 2, readyNodes: 2, schedulableNodes: 2,
-      totalCapacityBytes: 100, totalUsedBytes: 50,
-    }
-    expect(deriveHealth(summary)).toBe('critical')
+  it('returns degraded when volumes are faulted', () => {
+    const volumes = [
+      { name: 'v1', state: 'attached' as const, robustness: 'faulted' as const, replicasDesired: 3, replicasHealthy: 0, sizeBytes: 100, actualSizeBytes: 50, nodeAttached: 'n1', namespace: 'default', cluster: '' },
+    ]
+    const nodes = [
+      { name: 'n1', ready: true, schedulable: true, storageTotalBytes: 100, storageUsedBytes: 50, replicaCount: 1, cluster: '' },
+    ]
+    expect(deriveHealth(volumes, nodes)).toBe('degraded')
   })
 })
 
 describe('buildStatus', () => {
-  it('returns not-installed for null response', () => {
-    const result = buildStatus(null)
+  it('returns not-installed for empty arrays', () => {
+    const result = buildStatus([], [])
     expect(result.health).toBe('not-installed')
   })
 
-  it('returns not-installed for empty response', () => {
-    const result = buildStatus({ volumes: [], nodes: [] })
+  it('returns not-installed for empty volumes and nodes', () => {
+    const result = buildStatus([], [])
     expect(result.health).toBe('not-installed')
   })
 })

--- a/web/src/hooks/__tests__/useCachedOtel.test.ts
+++ b/web/src/hooks/__tests__/useCachedOtel.test.ts
@@ -169,32 +169,32 @@ describe('normalizeSignal', () => {
     expect(normalizeSignal('logs')).toBe('logs')
   })
 
-  it('returns the input for unknown signals', () => {
-    expect(normalizeSignal('custom')).toBe('custom')
+  it('returns traces for unknown signals', () => {
+    expect(normalizeSignal('custom')).toBe('traces')
   })
 })
 
 describe('deriveCollectorState', () => {
-  it('returns running for Running phase with ready containers', () => {
-    expect(deriveCollectorState('Running', [{ ready: true }])).toBe('running')
+  it('returns Running for Running phase with ready containers', () => {
+    expect(deriveCollectorState({ name: 'p', status: { phase: 'Running', containerStatuses: [{ ready: true }] } })).toBe('Running')
   })
 
-  it('returns degraded for Running phase with unready containers', () => {
-    expect(deriveCollectorState('Running', [{ ready: false }])).toBe('degraded')
+  it('returns Degraded for Running phase with unready containers', () => {
+    expect(deriveCollectorState({ name: 'p', status: { phase: 'Running', containerStatuses: [{ ready: false }] } })).toBe('Degraded')
   })
 
-  it('returns stopped for non-Running phase', () => {
-    expect(deriveCollectorState('Failed', [])).toBe('stopped')
+  it('returns Failed for non-Running phase', () => {
+    expect(deriveCollectorState({ name: 'p', status: { phase: 'Failed' } })).toBe('Failed')
   })
 })
 
 describe('parseVersion', () => {
   it('extracts version from image tag', () => {
-    expect(parseVersion([{ image: 'otel/opentelemetry-collector:0.90.0' }])).toBe('0.90.0')
+    expect(parseVersion({ name: 'p', status: { containerStatuses: [{ image: 'otel/opentelemetry-collector:0.90.0' }] } })).toBe('0.90.0')
   })
 
-  it('returns unknown for no containers', () => {
-    expect(parseVersion([])).toBe('unknown')
+  it('returns empty string for no containers', () => {
+    expect(parseVersion({ name: 'p', status: { containerStatuses: [] } })).toBe('')
   })
 })
 
@@ -212,7 +212,7 @@ describe('summarize', () => {
       name: 'test',
       namespace: 'default',
       cluster: 'c1',
-      state: 'running' as const,
+      state: 'Running' as const,
       version: '0.90.0',
       mode: 'deployment',
       pipelines: [],

--- a/web/src/hooks/__tests__/versionUtils.test.ts
+++ b/web/src/hooks/__tests__/versionUtils.test.ts
@@ -33,15 +33,11 @@ import {
 import type { GitHubRelease, ParsedRelease } from '../../types/updates'
 
 // ---------------------------------------------------------------------------
-// localStorage mock
+// localStorage helpers
 // ---------------------------------------------------------------------------
 
-const store = new Map<string, string>()
-
 beforeEach(() => {
-  store.clear()
-  vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => store.get(key) ?? null)
-  vi.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => { store.set(key, value) })
+  localStorage.clear()
 })
 
 afterEach(() => {
@@ -87,7 +83,7 @@ describe('safeJsonParse', () => {
       status: 502,
     })
     await expect(safeJsonParse(response, 'proxy')).rejects.toThrow(
-      'proxy: expected JSON response but received unknown content type (status 502)'
+      'proxy: expected JSON response but received text/plain;charset=UTF-8 (status 502)'
     )
   })
 
@@ -296,13 +292,13 @@ describe('loadCache', () => {
 
   it('returns parsed cache when valid JSON exists', () => {
     const cache = { data: [], timestamp: Date.now(), etag: 'abc' }
-    store.set('kc-releases-cache', JSON.stringify(cache))
+    localStorage.setItem('kc-releases-cache', JSON.stringify(cache))
     const result = loadCache()
     expect(result).toEqual(cache)
   })
 
   it('returns null on malformed JSON', () => {
-    store.set('kc-releases-cache', 'not json')
+    localStorage.setItem('kc-releases-cache', 'not json')
     expect(loadCache()).toBeNull()
   })
 })
@@ -313,7 +309,7 @@ describe('saveCache', () => {
       { tag_name: 'v1.0.0', published_at: '2025-01-01T00:00:00Z', body: '', html_url: '', prerelease: false },
     ]
     saveCache(data, 'etag-123')
-    const stored = store.get('kc-releases-cache')
+    const stored = localStorage.getItem('kc-releases-cache')
     expect(stored).toBeDefined()
     const parsed = JSON.parse(stored!)
     expect(parsed.data).toEqual(data)
@@ -323,7 +319,7 @@ describe('saveCache', () => {
 
   it('handles null etag', () => {
     saveCache([], null)
-    const parsed = JSON.parse(store.get('kc-releases-cache')!)
+    const parsed = JSON.parse(localStorage.getItem('kc-releases-cache')!)
     expect(parsed.etag).toBeNull()
   })
 })
@@ -345,12 +341,12 @@ describe('isCacheValid', () => {
 
 describe('loadChannel', () => {
   it('returns stored channel when valid', () => {
-    store.set('kc-update-channel', 'unstable')
+    localStorage.setItem('kc-update-channel', 'unstable')
     expect(loadChannel()).toBe('unstable')
   })
 
   it('returns stored "stable" channel', () => {
-    store.set('kc-update-channel', 'stable')
+    localStorage.setItem('kc-update-channel', 'stable')
     expect(loadChannel()).toBe('stable')
   })
 
@@ -359,7 +355,7 @@ describe('loadChannel', () => {
   })
 
   it('ignores invalid stored values and falls back', () => {
-    store.set('kc-update-channel', 'invalid')
+    localStorage.setItem('kc-update-channel', 'invalid')
     expect(loadChannel()).toBe('developer')
   })
 })
@@ -370,7 +366,7 @@ describe('loadChannel', () => {
 
 describe('loadAutoUpdateEnabled', () => {
   it('returns true when enabled', () => {
-    store.set('kc-auto-update-enabled', 'true')
+    localStorage.setItem('kc-auto-update-enabled', 'true')
     expect(loadAutoUpdateEnabled()).toBe(true)
   })
 
@@ -379,7 +375,7 @@ describe('loadAutoUpdateEnabled', () => {
   })
 
   it('returns false for non-"true" values', () => {
-    store.set('kc-auto-update-enabled', 'false')
+    localStorage.setItem('kc-auto-update-enabled', 'false')
     expect(loadAutoUpdateEnabled()).toBe(false)
   })
 })
@@ -394,12 +390,12 @@ describe('loadSkippedVersions', () => {
   })
 
   it('returns parsed array of versions', () => {
-    store.set('kc-skipped-versions', JSON.stringify(['v1.0.0', 'v1.1.0']))
+    localStorage.setItem('kc-skipped-versions', JSON.stringify(['v1.0.0', 'v1.1.0']))
     expect(loadSkippedVersions()).toEqual(['v1.0.0', 'v1.1.0'])
   })
 
   it('returns empty array on malformed JSON', () => {
-    store.set('kc-skipped-versions', 'bad json')
+    localStorage.setItem('kc-skipped-versions', 'bad json')
     expect(loadSkippedVersions()).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- Fixes 30+ failing tests across 5 files from coverage PRs #10893 and #10895
- versionUtils: use global localStorage mock instead of Storage.prototype spy (same fix as #10920)
- useCachedContainerd, useCachedOtel, useCachedDragonfly, useCachedLonghorn: correct expected values to match actual function signatures and return values

## Test plan
- [x] All 131 tests pass locally across all 5 files
- [ ] Wait for all CI shards to pass before merging