### PR TITLE
fix(analytics): add missing error_code to auth error emitters

### DIFF
--- a/web/src/lib/analytics-events.ts
+++ b/web/src/lib/analytics-events.ts
@@ -356,6 +356,7 @@ export function emitDemoModeToggled(enabled: boolean) {
 
 export function emitAgentTokenFailure(reason: string) {
   send('ksc_error', {
+    error_code: 'agent_token_failure',
     error_category: 'agent_token_failure',
     error_detail: reason.slice(0, 100),
     error_page: typeof window !== 'undefined' ? window.location.pathname : '',
@@ -364,6 +365,7 @@ export function emitAgentTokenFailure(reason: string) {
 
 export function emitWsAuthMissing(url: string) {
   send('ksc_error', {
+    error_code: 'ws_auth_missing',
     error_category: 'ws_auth_missing',
     error_detail: url.replace(/^wss?:\/\/[^/]+/, '').slice(0, 100),
     error_page: typeof window !== 'undefined' ? window.location.pathname : '',
@@ -372,6 +374,7 @@ export function emitWsAuthMissing(url: string) {
 
 export function emitSseAuthFailure(url: string) {
   send('ksc_error', {
+    error_code: 'sse_auth_failure',
     error_category: 'sse_auth_failure',
     error_detail: url.replace(/^https?:\/\/[^/]+/, '').slice(0, 100),
     error_page: typeof window !== 'undefined' ? window.location.pathname : '',
@@ -380,6 +383,7 @@ export function emitSseAuthFailure(url: string) {
 
 export function emitSessionRefreshFailure(reason: string) {
   send('ksc_error', {
+    error_code: 'session_refresh_failure',
     error_category: 'session_refresh_failure',
     error_detail: reason.slice(0, 100),
     error_page: typeof window !== 'undefined' ? window.location.pathname : '',


### PR DESCRIPTION
## Summary
- Four auth-related emit functions (`emitAgentTokenFailure`, `emitWsAuthMissing`, `emitSseAuthFailure`, `emitSessionRefreshFailure`) sent `ksc_error` events with `error_category` but no `error_code` field
- GA4 reported these as `(not set)` in error_code dimension, making it impossible to filter or diagnose them in reports
- Added `error_code` field matching the existing `error_category` value to all four functions

## Context
GA4 analysis showed 390+ `(not set)` error_code events on `/clusters` in 48 hours. These auth emitters bypass the main `emitError()` function (which correctly sets `error_code`) and call `send()` directly — missing the field.

## Test plan
- [ ] Verify `ksc_error` events from these functions now include `error_code` in GA4 DebugView
- [ ] Confirm no regression in existing error tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)