### PR TITLE
🐛 Exempt /api/mcp/clusters from API rate limiter

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -773,6 +773,7 @@ func (s *Server) setupRoutes() {
 		"/api/feedback/requests": true, // feedback submission has its own feedbackLimiter
 		"/api/me":                true, // user identity — must survive for login to work
 		"/api/version":           true, // version check for update dialog
+		"/api/mcp/clusters":     true, // cluster discovery — must not be blocked by auth-retry cascades (#10925)
 	}
 	apiLimiterSkipPrefixes := []string{
 		"/api/github/", // GitHub proxy (updates dialog, contributions list) has its own per-user limiter


### PR DESCRIPTION
Fixes #10925

## Problem

When JWT auth fails (expired/invalid token), the frontend retries requests, exhausting the API rate limiter (2000 req/min). Once saturated, `/api/mcp/clusters` returns 429, making cluster discovery impossible — even though the cluster and kc-agent are healthy.

The cascade: `auth failure → frontend retry loop → rate limit exhausted → /api/clusters blocked → "No clusters configured"`

## Fix

Add `/api/mcp/clusters` to `apiLimiterSkipPaths` so cluster discovery remains functional during auth-retry cascades. The endpoint still requires JWT authentication (JWTAuth middleware) — only the rate-limit counting is bypassed.

This mirrors the existing pattern for `/api/me` and `/api/version` which are also exempt to prevent login loops and version-check failures.

## Risk

Low — the endpoint still requires valid JWT authentication. Only the per-IP rate counting is removed for this single path.