### PR TITLE
🌱 Replace nil slice declarations with make([]T, 0) in nvidia and workloads

### DIFF
--- a/pkg/agent/server_nvidia.go
+++ b/pkg/agent/server_nvidia.go
@@ -84,7 +84,7 @@ func (s *Server) handleNvidiaOperatorsHTTP(w http.ResponseWriter, r *http.Reques
 	ctx, cancel := context.WithTimeout(r.Context(), agentDefaultTimeout)
 	defer cancel()
 
-	var results []nvidiaOperatorStatus
+	results := make([]nvidiaOperatorStatus, 0)
 
 	if cluster != "" {
 		client, err := s.k8sClient.GetClient(cluster)
@@ -131,9 +131,6 @@ func (s *Server) handleNvidiaOperatorsHTTP(w http.ResponseWriter, r *http.Reques
 		wg.Wait()
 	}
 
-	if results == nil {
-		results = make([]nvidiaOperatorStatus, 0)
-	}
 	writeJSON(w, map[string]interface{}{"operators": results})
 }
 

--- a/pkg/api/handlers/mcp_workloads.go
+++ b/pkg/api/handlers/mcp_workloads.go
@@ -837,10 +837,8 @@ func (h *MCPHandlers) GetWorkloads(c *fiber.Ctx) error {
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
-	var workloads []v1alpha1.Workload
-	if list == nil || list.Items == nil {
-		workloads = make([]v1alpha1.Workload, 0)
-	} else {
+	workloads := make([]v1alpha1.Workload, 0)
+	if list != nil && list.Items != nil {
 		workloads = list.Items
 	}
 


### PR DESCRIPTION
Supersedes #10865 (which accumulated 14 commits and lost DCO sign-off during rebases).

## Problem

Per CLAUDE.md convention, Go nil slices (`var x []T`) serialize as `null` in JSON instead of `[]`. This breaks frontend `.map()`/`.filter()` calls that expect arrays.

## Fix

Converted 2 remaining nil slice declarations:
- `pkg/agent/server_nvidia.go`: `results := make([]nvidiaOperatorStatus, 0)` + remove redundant nil guard
- `pkg/api/handlers/mcp_workloads.go`: `workloads := make([]v1alpha1.Workload, 0)` + simplify conditional

## Risk

Low — `make([]T, 0)` is semantically equivalent to `var x []T` for all operations except JSON serialization, where it correctly produces `[]` instead of `null`.