### PR TITLE
🌱 Replace explicit any types in demoData.ts and GPUInventoryHistory.tsx

### DIFF
--- a/web/src/components/cards/GPUInventoryHistory.tsx
+++ b/web/src/components/cards/GPUInventoryHistory.tsx
@@ -192,13 +192,14 @@ function getTypeColor(index: number): string {
 // Component
 // ---------------------------------------------------------------------------
 
+type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
+
 /** Extracted chart sub-component to keep the main component readable */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function GPUInventoryChart({ displayChartData, chartMode, chartGPUTypes, t }: {
   displayChartData: GPUHistoryDataPoint[]
   chartMode: ChartMode
   chartGPUTypes: string[]
-  t: any
+  t: TranslateFn
 }) {
   const chartOption = useMemo(() => {
     const timeData = (displayChartData || []).map(d => d.time)
@@ -983,7 +984,7 @@ export function GPUInventoryHistory() {
                   displayChartData={displayChartData}
                   chartMode={chartMode}
                   chartGPUTypes={chartGPUTypes}
-                  t={t}
+                  t={t as unknown as TranslateFn}
                 />
               </div>
             )}

--- a/web/src/hooks/useCachedData/demoData.ts
+++ b/web/src/hooks/useCachedData/demoData.ts
@@ -42,6 +42,7 @@ import type {
 } from '../useMCP'
 import type { Workload } from '../useWorkloads'
 import type { CiliumStatus } from '../../types/cilium'
+import type { JaegerStatus } from '../../types/jaeger'
 
 // ---------------------------------------------------------------------------
 // Local type stubs used only by demo data — avoid circular import with
@@ -503,7 +504,7 @@ export const getDemoCiliumStatus = (): CiliumStatus => ({
 // Jaeger demo data
 // ============================================================================
 
-export const getDemoJaegerStatus = (): any => ({
+export const getDemoJaegerStatus = (): JaegerStatus => ({
   status: 'Healthy',
   version: '1.57.0',
   collectors: {


### PR DESCRIPTION
Supersedes #10863 (which accumulated 354 changed files and merge conflicts during rebases).

## Problem

Two `any` type annotations violate the codebase convention of explicit types:
1. `getDemoJaegerStatus(): any` in `demoData.ts`
2. `t: any` in `GPUInventoryHistory.tsx`

## Fix

- Replace `: any` return type on `getDemoJaegerStatus` with the existing `JaegerStatus` interface from `types/jaeger.ts`
- Replace `t: any` with `TranslateFn` type alias matching the established codebase pattern (used in Events.tsx, SecurityIssues.tsx, UserManagement.tsx, LLMdAIInsights.tsx)
- Add `as unknown as TranslateFn` cast at the call site per the i18next TFunction contravariance workaround

## Risk

Low — type-only changes, no runtime behavior change.