### PR TITLE
🌱 Add bug discovery infrastructure for mentorship (#4190)

### DIFF
--- a/scripts/BUG-DISCOVERY-README.md
+++ b/scripts/BUG-DISCOVERY-README.md
@@ -1,0 +1,138 @@
+# Bug Discovery Infrastructure
+
+Scripts for systematic AI-driven bug discovery in the KubeStellar Console.
+Part of **LFX Mentorship: AI-Driven Bug Discovery & Remediation Architect** ([#4190](https://github.com/kubestellar/console/issues/4190)).
+
+---
+
+## Quick Start
+
+```bash
+# Run the full anti-pattern scan (prints markdown to stdout)
+./scripts/bug-discovery.sh
+
+# Write findings to a report file
+./scripts/bug-discovery.sh --report
+
+# Scan only one category
+./scripts/bug-discovery.sh --category array-safety
+
+# Generate a bug triage report (requires `gh` CLI)
+./scripts/bug-triage-report.sh
+
+# Write triage report to file with 14-day lookback
+./scripts/bug-triage-report.sh --report --days 14
+```
+
+---
+
+## Scripts
+
+### `bug-discovery.sh` — Static Anti-Pattern Scanner
+
+Scans `web/src/` for common bug patterns documented in the project's coding standards (see `CLAUDE.md`).
+
+| Category | What It Detects |
+|----------|-----------------|
+| `array-safety` | `.map()`, `.filter()`, `.join()`, `.forEach()`, `for...of` without `\|\| []` guard |
+| `magic-numbers` | Numeric literals not assigned to named constants (excludes 0, 1, type defs) |
+| `demo-data` | Card components using `useCached*` without destructuring `isDemoData` |
+| `any-types` | Explicit `any` type annotations in TypeScript |
+| `raw-strings` | JSX string literals that appear to be English text not wrapped in `t()` |
+
+**Output:** Markdown report with file:line references and per-category counts.
+
+**Options:**
+- `--report` — write output to `scripts/bug-discovery-report.md`
+- `--category <name>` — scan only one category (`all` is default)
+
+### `bug-triage-report.sh` — Bug Triage Summary
+
+Combines GitHub issue data with static analysis results into one report.
+
+**Sections:**
+1. **Open bugs by label** — counts from `gh issue list` with `bug`/`kind/bug` labels
+2. **Recently closed bugs** — issues closed within the lookback window
+3. **Static analysis summary** — pattern frequency table from `bug-discovery.sh`
+
+**Options:**
+- `--report` — write output to `scripts/bug-triage-report.md`
+- `--days <N>` — lookback window in days (default: 30)
+
+**Prerequisites:**
+- [`gh` CLI](https://cli.github.com/) installed and authenticated
+- Run from the repo root
+
+---
+
+## Mentee Workflow
+
+### 1. Initial Assessment
+
+Run both scripts to get a baseline:
+
+```bash
+./scripts/bug-discovery.sh --report
+./scripts/bug-triage-report.sh --report
+```
+
+Review the reports to understand the current state of the codebase.
+
+### 2. Prioritize Findings
+
+Focus on findings that are most likely to cause real bugs:
+
+1. **Array safety** — missing `|| []` guards cause runtime crashes when APIs return `undefined`
+2. **Missing `isDemoData`** — cards render demo data without visual indicators
+3. **`any` types** — reduce TypeScript's ability to catch errors at compile time
+4. **Magic numbers** — make code harder to understand and maintain
+5. **Raw strings** — break internationalization for non-English users
+
+### 3. Fix and Validate
+
+For each finding:
+
+1. Verify it's a real issue (heuristic scanners produce false positives)
+2. Create a fix on a feature branch
+3. Run `cd web && npm run build && npm run lint` to validate
+4. Open a PR referencing the original issue
+
+### 4. Track Progress
+
+Re-run the scanner periodically to measure progress:
+
+```bash
+# Compare before/after
+./scripts/bug-discovery.sh 2>/dev/null | grep 'Total findings'
+```
+
+### 5. Extend the Scanner
+
+Add new categories to `bug-discovery.sh` as you discover patterns:
+
+1. Add a new `scan_<name>()` function following the existing pattern
+2. Register it in the `case` statement at the bottom
+3. Document it in this README
+
+---
+
+## Integration with AI Agents
+
+These scripts are designed to be consumed by AI coding agents:
+
+- **Output is markdown** — easily parsed by LLMs
+- **File:line references** — agents can navigate directly to findings
+- **Category flags** — agents can focus on specific anti-pattern types
+- **Exit code 0** — scripts always succeed so they can be chained in pipelines
+
+Example agent prompt:
+> Run `./scripts/bug-discovery.sh --category array-safety` and fix the top 5 findings,
+> ensuring each `.map()` / `.filter()` call has an `|| []` guard on the data source.
+
+---
+
+## Related Documentation
+
+- [`CLAUDE.md`](../CLAUDE.md) — Canonical project conventions and rules
+- [`AGENTS.md`](../AGENTS.md) — AI agent guide
+- [Issue #4190](https://github.com/kubestellar/console/issues/4190) — LFX Mentorship tracking issue

--- a/scripts/bug-discovery.sh
+++ b/scripts/bug-discovery.sh
@@ -1,0 +1,277 @@
+#!/bin/bash
+# AI-Driven Bug Discovery Scanner
+#
+# Scans web/src/ for common anti-patterns and potential bugs.
+# Part of the LFX Mentorship: AI-Driven Bug Discovery (#4190).
+#
+# Usage:
+#   ./scripts/bug-discovery.sh                # Full scan, output to stdout
+#   ./scripts/bug-discovery.sh --report       # Write markdown report to file
+#   ./scripts/bug-discovery.sh --category X   # Scan only category X
+#
+# Categories:
+#   array-safety    — .map/.filter/.join/.forEach/for...of without || [] guard
+#   magic-numbers   — numeric literals not assigned to named constants
+#   demo-data       — card components using useCached* without isDemoData
+#   any-types       — TypeScript `any` type usage
+#   raw-strings     — JSX string literals not wrapped in t() for i18n
+#   all             — run every category (default)
+#
+# Output:
+#   Markdown-formatted report with file:line references and counts.
+#
+# Exit code:
+#   0 — scan completed (findings may exist)
+#   1 — script error
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC_DIR="$REPO_ROOT/web/src"
+REPORT_FILE="$REPO_ROOT/scripts/bug-discovery-report.md"
+WRITE_REPORT=false
+CATEGORY="all"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --report) WRITE_REPORT=true; shift ;;
+    --category) CATEGORY="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+FINDINGS_COUNT=0
+
+# Write output to a staging file to avoid shell variable size limits
+STAGE_FILE="$REPO_ROOT/scripts/.bug-discovery-stage.md"
+: > "$STAGE_FILE"
+
+emit() {
+  printf '%s\n' "$1" >> "$STAGE_FILE"
+}
+
+emit_header() {
+  emit ""
+  emit "## $1"
+  emit ""
+}
+
+cleanup() { rm -f "$STAGE_FILE" "$REPO_ROOT/scripts/.bug-matches"; }
+trap cleanup EXIT
+
+# Count matches from grep; accepts a label and a grep command via args
+scan_pattern() {
+  local label="$1"
+  shift
+  local match_file="$REPO_ROOT/scripts/.bug-matches"
+  "$@" > "$match_file" 2>/dev/null || true
+  local count
+  count=$(wc -l < "$match_file" 2>/dev/null || echo 0)
+  count=$((count + 0))  # ensure numeric
+  if [[ "$count" -gt 0 ]]; then
+    FINDINGS_COUNT=$((FINDINGS_COUNT + count))
+    emit "**$label** — $count finding(s)"
+    emit ""
+    emit '```'
+    head -80 "$match_file" >> "$STAGE_FILE"
+    if [[ "$count" -gt 80 ]]; then
+      emit "... ($((count - 80)) more lines omitted)"
+    fi
+    emit '```'
+    emit ""
+  else
+    emit "**$label** — ✅ no findings"
+    emit ""
+  fi
+  rm -f "$match_file"
+}
+
+# ---------------------------------------------------------------------------
+# Category: Array Safety
+# ---------------------------------------------------------------------------
+scan_array_safety() {
+  emit_header "Array Safety — missing \`|| []\` guards"
+  emit "Detects \`.map(\`, \`.filter(\`, \`.join(\`, \`.forEach(\`, and \`for...of\`"
+  emit "on variables that may be undefined (no \`|| []\` on the same line)."
+  emit ""
+
+  # Look for array methods where the line does NOT contain '|| []'
+  local methods='\.(map|filter|join|forEach)\('
+  scan_pattern "Array method calls without \`|| []\` guard" \
+    grep -rn --include='*.tsx' --include='*.ts' \
+    -E "$methods" "$SRC_DIR" \
+    --exclude-dir='__tests__' \
+    --exclude-dir='node_modules' \
+    --exclude='*.test.*' \
+    --exclude='*.spec.*' \
+    --exclude='demoData.*'
+
+  # for...of without || []
+  scan_pattern "\`for...of\` without \`|| []\` guard" \
+    grep -rn --include='*.tsx' --include='*.ts' \
+    -E 'for\s*\(.*\bof\b' "$SRC_DIR" \
+    --exclude-dir='__tests__' \
+    --exclude-dir='node_modules' \
+    --exclude='*.test.*' \
+    --exclude='*.spec.*'
+}
+
+# ---------------------------------------------------------------------------
+# Category: Magic Numbers
+# ---------------------------------------------------------------------------
+scan_magic_numbers() {
+  emit_header "Magic Numbers"
+  emit "Numeric literals (excluding 0, 1, 2, common indices, and import/type lines)"
+  emit "that are not assigned to a named constant."
+  emit ""
+
+  # Heuristic: find lines with bare numeric literals >= 2 that are NOT
+  # part of a const/let/var assignment pattern like `const X = 42`.
+  scan_pattern "Potential magic numbers" \
+    grep -rn --include='*.tsx' --include='*.ts' \
+    -E '[\(\[,: ][0-9]{2,5}[,\)\]; ]' "$SRC_DIR" \
+    --exclude-dir='node_modules' \
+    --exclude-dir='__tests__' \
+    --exclude-dir='locales' \
+    --exclude='*.test.*' \
+    --exclude='*.spec.*' \
+    --exclude='*.d.ts' \
+    --exclude='demoData.*' \
+    --exclude='themes.ts'
+}
+
+# ---------------------------------------------------------------------------
+# Category: Missing isDemoData
+# ---------------------------------------------------------------------------
+scan_demo_data() {
+  emit_header "Missing \`isDemoData\` in Card Components"
+  emit "Card components using \`useCached*\` hooks must destructure \`isDemoData\`."
+  emit ""
+
+  # Find files that call useCached* but do NOT mention isDemoData
+  local card_dir="$SRC_DIR/components/cards"
+  if [[ ! -d "$card_dir" ]]; then
+    emit "**isDemoData wiring** — ⚠️ card directory not found at \`$card_dir\`"
+    emit ""
+    return
+  fi
+
+  local card_files
+  card_files=$(grep -rl --include='*.tsx' --include='*.ts' 'useCached' "$card_dir" 2>/dev/null || true)
+
+  if [[ -z "$card_files" ]]; then
+    emit "**isDemoData wiring** — ✅ no card files with useCached* found"
+    emit ""
+    return
+  fi
+
+  local missing=""
+  local count=0
+  while IFS= read -r f; do
+    if ! grep -q 'isDemoData\|isDemoFallback' "$f" 2>/dev/null; then
+      missing+="  $f"$'\n'
+      count=$((count + 1))
+    fi
+  done <<< "$card_files"
+
+  if [[ "$count" -gt 0 ]]; then
+    FINDINGS_COUNT=$((FINDINGS_COUNT + count))
+    emit "**isDemoData wiring** — $count file(s) missing isDemoData/isDemoFallback"
+    emit ""
+    emit '```'
+    printf '%s' "$missing" >> "$STAGE_FILE"
+    emit '```'
+  else
+    emit "**isDemoData wiring** — ✅ all card components wire isDemoData"
+  fi
+  emit ""
+}
+
+# ---------------------------------------------------------------------------
+# Category: any Types
+# ---------------------------------------------------------------------------
+scan_any_types() {
+  emit_header "TypeScript \`any\` Usage"
+  emit "Explicit \`any\` types reduce type safety."
+  emit ""
+
+  scan_pattern "\`any\` type annotations" \
+    grep -rn --include='*.tsx' --include='*.ts' \
+    -E ':\s*any\b|<any>|as any' "$SRC_DIR" \
+    --exclude-dir='node_modules' \
+    --exclude-dir='__tests__' \
+    --exclude='*.test.*' \
+    --exclude='*.spec.*' \
+    --exclude='*.d.ts' \
+    --exclude='vite-env.d.ts'
+}
+
+# ---------------------------------------------------------------------------
+# Category: Raw Strings in JSX
+# ---------------------------------------------------------------------------
+scan_raw_strings() {
+  emit_header "Raw Strings in JSX (missing i18n)"
+  emit "User-facing text should use \`t()\` from react-i18next, not raw string literals."
+  emit "This check flags JSX text content that appears to be English words (heuristic)."
+  emit ""
+
+  # Heuristic: find lines in TSX files with JSX text content
+  scan_pattern "Potential raw strings in JSX" \
+    grep -rn --include='*.tsx' \
+    -E '>[A-Z][a-z]{2,}[^<]*</' "$SRC_DIR" \
+    --exclude-dir='node_modules' \
+    --exclude-dir='__tests__' \
+    --exclude-dir='locales' \
+    --exclude='*.test.*' \
+    --exclude='*.spec.*' \
+    --exclude='*.stories.*'
+}
+
+# ---------------------------------------------------------------------------
+# Run selected categories
+# ---------------------------------------------------------------------------
+emit "# Bug Discovery Report"
+emit ""
+emit "**Generated:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+emit "**Scanned:** \`$SRC_DIR\`"
+emit "**Category:** $CATEGORY"
+
+case "$CATEGORY" in
+  array-safety)   scan_array_safety ;;
+  magic-numbers)  scan_magic_numbers ;;
+  demo-data)      scan_demo_data ;;
+  any-types)      scan_any_types ;;
+  raw-strings)    scan_raw_strings ;;
+  all)
+    scan_array_safety
+    scan_magic_numbers
+    scan_demo_data
+    scan_any_types
+    scan_raw_strings
+    ;;
+  *)
+    echo "Unknown category: $CATEGORY"
+    echo "Valid: array-safety, magic-numbers, demo-data, any-types, raw-strings, all"
+    exit 1
+    ;;
+esac
+
+emit ""
+emit "---"
+emit "**Total findings: $FINDINGS_COUNT**"
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+if $WRITE_REPORT; then
+  cp "$STAGE_FILE" "$REPORT_FILE"
+  echo "Report written to $REPORT_FILE ($FINDINGS_COUNT findings)"
+else
+  cat "$STAGE_FILE"
+fi

--- a/scripts/bug-triage-report.sh
+++ b/scripts/bug-triage-report.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# Bug Triage Report Generator
+#
+# Generates a summary of open/recently-closed bugs and cross-references
+# with static analysis findings from bug-discovery.sh.
+# Part of the LFX Mentorship: AI-Driven Bug Discovery (#4190).
+#
+# Usage:
+#   ./scripts/bug-triage-report.sh                  # Print to stdout
+#   ./scripts/bug-triage-report.sh --report          # Write to file
+#   ./scripts/bug-triage-report.sh --days 14         # Lookback window (default: 30)
+#
+# Prerequisites:
+#   - `gh` CLI authenticated with repo access
+#   - Run from repo root (or scripts/ directory)
+#
+# Output:
+#   Markdown report with:
+#     1. Open bug counts by label
+#     2. Recently closed bugs
+#     3. Pattern frequency summary from bug-discovery.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$REPO_ROOT/scripts"
+REPORT_FILE="$REPO_ROOT/scripts/bug-triage-report.md"
+WRITE_REPORT=false
+LOOKBACK_DAYS=30
+REPO="kubestellar/console"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --report) WRITE_REPORT=true; shift ;;
+    --days)   LOOKBACK_DAYS="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+SINCE_DATE=$(date -u -d "${LOOKBACK_DAYS} days ago" '+%Y-%m-%d' 2>/dev/null \
+  || date -u -v-"${LOOKBACK_DAYS}"d '+%Y-%m-%d' 2>/dev/null \
+  || echo "2024-01-01")
+
+STAGE_FILE="$REPO_ROOT/scripts/.bug-triage-stage.md"
+: > "$STAGE_FILE"
+
+emit() { printf '%s\n' "$1" >> "$STAGE_FILE"; }
+
+cleanup() { rm -f "$STAGE_FILE"; }
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Section 1 — Open bugs by label
+# ---------------------------------------------------------------------------
+emit "# Bug Triage Report"
+emit ""
+emit "**Generated:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+emit "**Repository:** $REPO"
+emit "**Lookback:** $LOOKBACK_DAYS days (since $SINCE_DATE)"
+emit ""
+
+emit "## Open Bugs by Label"
+emit ""
+
+if command -v gh &>/dev/null; then
+  # Fetch all open issues labeled 'bug' or 'kind/bug'
+  bug_issues=$(gh issue list --repo "$REPO" --state open --label bug --json number,title,labels,createdAt --limit 200 2>/dev/null || echo "[]")
+  kind_bug_issues=$(gh issue list --repo "$REPO" --state open --label kind/bug --json number,title,labels,createdAt --limit 200 2>/dev/null || echo "[]")
+
+  # Merge and deduplicate by issue number
+  all_bugs=$(echo "$bug_issues $kind_bug_issues" | jq -s 'add // [] | unique_by(.number) | sort_by(.number)')
+  total_open=$(echo "$all_bugs" | jq 'length')
+
+  emit "**Total open bugs:** $total_open"
+  emit ""
+
+  if [[ "$total_open" -gt 0 ]]; then
+    # Count by label
+    emit "| Label | Count |"
+    emit "|-------|-------|"
+    label_counts=$(echo "$all_bugs" | jq -r '
+      [.[].labels[].name] | group_by(.) | map({label: .[0], count: length})
+      | sort_by(-.count)[] | "| \(.label) | \(.count) |"
+    ' 2>/dev/null || echo "| (parse error) | - |")
+    emit "$label_counts"
+    emit ""
+
+    # List top 20
+    emit "### Open Bug List (top 20)"
+    emit ""
+    emit "| # | Title | Created |"
+    emit "|---|-------|---------|"
+    echo "$all_bugs" | jq -r '
+      .[:20][] | "| #\(.number) | \(.title[:80]) | \(.createdAt[:10]) |"
+    ' 2>/dev/null | while IFS= read -r line; do emit "$line"; done
+    emit ""
+  fi
+else
+  emit "> ⚠️ \`gh\` CLI not found — skipping GitHub issue queries."
+  emit "> Install: https://cli.github.com/"
+  emit ""
+fi
+
+# ---------------------------------------------------------------------------
+# Section 2 — Recently closed bugs
+# ---------------------------------------------------------------------------
+emit "## Recently Closed Bugs (last $LOOKBACK_DAYS days)"
+emit ""
+
+if command -v gh &>/dev/null; then
+  closed_bugs=$(gh issue list --repo "$REPO" --state closed --label bug --json number,title,closedAt --limit 100 2>/dev/null || echo "[]")
+  recent_closed=$(echo "$closed_bugs" | jq --arg since "$SINCE_DATE" '
+    [.[] | select(.closedAt >= $since)] | sort_by(.closedAt) | reverse
+  ' 2>/dev/null || echo "[]")
+  closed_count=$(echo "$recent_closed" | jq 'length')
+
+  emit "**Closed in window:** $closed_count"
+  emit ""
+
+  if [[ "$closed_count" -gt 0 ]]; then
+    emit "| # | Title | Closed |"
+    emit "|---|-------|--------|"
+    echo "$recent_closed" | jq -r '
+      .[:30][] | "| #\(.number) | \(.title[:80]) | \(.closedAt[:10]) |"
+    ' 2>/dev/null | while IFS= read -r line; do emit "$line"; done
+    emit ""
+  fi
+else
+  emit "> ⚠️ \`gh\` CLI not available."
+  emit ""
+fi
+
+# ---------------------------------------------------------------------------
+# Section 3 — Static analysis pattern frequency
+# ---------------------------------------------------------------------------
+emit "## Static Analysis Summary"
+emit ""
+
+if [[ -x "$SCRIPT_DIR/bug-discovery.sh" ]]; then
+  emit "Running \`bug-discovery.sh\` for pattern frequencies..."
+  emit ""
+
+  discovery_output=$("$SCRIPT_DIR/bug-discovery.sh" 2>&1 || true)
+
+  # Extract finding counts per category
+  emit "| Category | Findings |"
+  emit "|----------|----------|"
+
+  for category in "Array method" "for...of" "magic numbers" "isDemoData" "any.*type" "Raw strings"; do
+    count=$(echo "$discovery_output" | grep -i "$category" | grep -oE '[0-9]+ finding' | head -1 | grep -oE '[0-9]+' || echo "0")
+    emit "| $category | $count |"
+  done
+  emit ""
+
+  # Total
+  total_line=$(echo "$discovery_output" | grep -i 'Total findings' || echo "Total findings: unknown")
+  emit "**$total_line**"
+  emit ""
+else
+  emit "> ⚠️ \`bug-discovery.sh\` not found or not executable — skipping static analysis."
+  emit ""
+fi
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+emit "---"
+emit "*Report generated by \`scripts/bug-triage-report.sh\` — LFX Mentorship #4190*"
+
+if $WRITE_REPORT; then
+  cp "$STAGE_FILE" "$REPORT_FILE"
+  echo "Report written to $REPORT_FILE"
+else
+  cat "$STAGE_FILE"
+fi


### PR DESCRIPTION
Fixes #4190

Adds scripts for systematic AI-driven bug discovery:

- **`bug-discovery.sh`** — scans `web/src/` for common anti-patterns:
  - Array methods without `|| []` safety guards
  - Magic numbers not assigned to named constants
  - Card components missing `isDemoData` wiring
  - Explicit `any` type usage
  - Raw string literals in JSX (missing i18n `t()` wrapping)
- **`bug-triage-report.sh`** — generates a triage summary combining GitHub issue data with static analysis findings
- **`BUG-DISCOVERY-README.md`** — documents the mentee workflow for using these tools

Infrastructure for LFX mentee onboarding.