### PR TITLE
🌱 Add Vitest tests for 3 more card components (#4189)

### DIFF
--- a/web/src/components/cards/dapr_status/__tests__/DaprStatus.test.tsx
+++ b/web/src/components/cards/dapr_status/__tests__/DaprStatus.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { DaprStatusData } from '../demoData'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseCachedDapr = vi.fn()
+vi.mock('../../../../hooks/useCachedDapr', () => ({
+  useCachedDapr: (...args: unknown[]) => mockUseCachedDapr(...args),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+const mockUseReportCardDataState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: (opts: unknown) => mockUseReportCardDataState(opts),
+}))
+
+vi.mock('../../../../lib/formatters', () => ({
+  formatTimeAgo: () => 'just now',
+}))
+
+// Import component after mocks
+import { DaprStatus } from '../index'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeData(overrides: Partial<DaprStatusData> = {}): DaprStatusData {
+  return {
+    health: 'healthy',
+    controlPlane: [
+      {
+        name: 'operator',
+        namespace: 'dapr-system',
+        status: 'running',
+        replicasDesired: 1,
+        replicasReady: 1,
+        cluster: 'default',
+      },
+      {
+        name: 'sentry',
+        namespace: 'dapr-system',
+        status: 'running',
+        replicasDesired: 1,
+        replicasReady: 1,
+        cluster: 'default',
+      },
+    ],
+    components: [
+      {
+        name: 'orders-statestore',
+        namespace: 'orders',
+        type: 'state-store',
+        componentImpl: 'state.redis',
+        cluster: 'default',
+      },
+      {
+        name: 'checkout-pubsub',
+        namespace: 'checkout',
+        type: 'pubsub',
+        componentImpl: 'pubsub.kafka',
+        cluster: 'default',
+      },
+    ],
+    apps: { total: 10, namespaces: 3 },
+    buildingBlocks: { stateStores: 1, pubsubs: 1, bindings: 0 },
+    summary: {
+      totalControlPlanePods: 2,
+      runningControlPlanePods: 2,
+      totalComponents: 2,
+      totalDaprApps: 10,
+    },
+    lastCheckTime: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function defaultHookReturn(overrides: Record<string, unknown> = {}) {
+  return {
+    data: makeData(),
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: Date.now(),
+    showSkeleton: false,
+    showEmptyState: false,
+    error: false,
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DaprStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCachedDapr.mockReturnValue(defaultHookReturn())
+    mockUseReportCardDataState.mockReturnValue(undefined)
+  })
+
+  it('renders without crashing', () => {
+    const { container } = render(<DaprStatus />)
+    expect(container).toBeTruthy()
+  })
+
+  it('renders loading skeleton when showSkeleton is true', () => {
+    mockUseCachedDapr.mockReturnValue(
+      defaultHookReturn({ showSkeleton: true, data: makeData({ health: 'unknown' }) }),
+    )
+    const { container } = render(<DaprStatus />)
+    const skeletons = container.querySelectorAll('.animate-pulse')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('renders error state when error and showEmptyState are true', () => {
+    mockUseCachedDapr.mockReturnValue(
+      defaultHookReturn({ error: true, showEmptyState: true, isFailed: true }),
+    )
+    render(<DaprStatus />)
+    expect(screen.getByText('Unable to fetch Dapr status')).toBeTruthy()
+  })
+
+  it('renders not-installed state', () => {
+    mockUseCachedDapr.mockReturnValue(
+      defaultHookReturn({ data: makeData({ health: 'not-installed' }) }),
+    )
+    render(<DaprStatus />)
+    expect(screen.getByText('Dapr not detected')).toBeTruthy()
+  })
+
+  it('renders healthy state with green indicator', () => {
+    const { container } = render(<DaprStatus />)
+    expect(screen.getByText('Healthy')).toBeTruthy()
+    const greenElements = container.querySelectorAll('.text-green-400')
+    expect(greenElements.length).toBeGreaterThan(0)
+  })
+
+  it('renders degraded state with yellow indicator', () => {
+    mockUseCachedDapr.mockReturnValue(
+      defaultHookReturn({ data: makeData({ health: 'degraded' }) }),
+    )
+    render(<DaprStatus />)
+    expect(screen.getByText('Degraded')).toBeTruthy()
+  })
+
+  it('renders control plane pods', () => {
+    render(<DaprStatus />)
+    expect(screen.getByText('operator')).toBeTruthy()
+    expect(screen.getByText('sentry')).toBeTruthy()
+  })
+
+  it('renders component rows', () => {
+    render(<DaprStatus />)
+    expect(screen.getByText('orders-statestore')).toBeTruthy()
+    expect(screen.getByText('checkout-pubsub')).toBeTruthy()
+  })
+
+  it('renders summary metric tiles', () => {
+    render(<DaprStatus />)
+    expect(screen.getByText('2/2')).toBeTruthy()
+    expect(screen.getByText('10')).toBeTruthy()
+  })
+
+  it('handles empty controlPlane array safely', () => {
+    mockUseCachedDapr.mockReturnValue(
+      defaultHookReturn({ data: makeData({ controlPlane: [], health: 'healthy' }) }),
+    )
+    render(<DaprStatus />)
+    expect(screen.getByText('No Dapr control plane pods detected')).toBeTruthy()
+  })
+
+  it('handles empty components array safely', () => {
+    mockUseCachedDapr.mockReturnValue(
+      defaultHookReturn({ data: makeData({ components: [] }) }),
+    )
+    render(<DaprStatus />)
+    expect(screen.getByText('No Dapr components configured')).toBeTruthy()
+  })
+
+  it('reports card data state with correct arguments', () => {
+    render(<DaprStatus />)
+    expect(mockUseReportCardDataState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isFailed: false,
+        isDemoData: false,
+        isRefreshing: false,
+        hasData: true,
+      }),
+    )
+  })
+
+  it('reports isDemoData when hook returns isDemoData true', () => {
+    mockUseCachedDapr.mockReturnValue(defaultHookReturn({ isDemoData: true }))
+    render(<DaprStatus />)
+    expect(mockUseReportCardDataState).toHaveBeenCalledWith(
+      expect.objectContaining({ isDemoData: true }),
+    )
+  })
+
+  it('renders building block counts', () => {
+    render(<DaprStatus />)
+    expect(screen.getByText('State stores')).toBeTruthy()
+    expect(screen.getByText('Pub/sub')).toBeTruthy()
+    expect(screen.getByText('Bindings')).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/strimzi_status/__tests__/StrimziStatus.test.tsx
+++ b/web/src/components/cards/strimzi_status/__tests__/StrimziStatus.test.tsx
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { StrimziStatusData, StrimziKafkaCluster } from '../demoData'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseCachedStrimzi = vi.fn()
+vi.mock('../../../../hooks/useCachedStrimzi', () => ({
+  useCachedStrimzi: (...args: unknown[]) => mockUseCachedStrimzi(...args),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallbackOrOpts?: string | Record<string, unknown>) => {
+      if (typeof fallbackOrOpts === 'string') return fallbackOrOpts
+      return key
+    },
+  }),
+}))
+
+const mockUseReportCardDataState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: (opts: unknown) => mockUseReportCardDataState(opts),
+}))
+
+vi.mock('../../../../lib/formatters', () => ({
+  formatTimeAgo: () => 'just now',
+}))
+
+// Import component after mocks
+import { StrimziStatus } from '../index'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCluster(overrides: Partial<StrimziKafkaCluster> = {}): StrimziKafkaCluster {
+  return {
+    name: 'orders-kafka',
+    namespace: 'kafka',
+    cluster: 'prod-east',
+    kafkaVersion: '3.7.0',
+    health: 'healthy',
+    brokers: { ready: 3, total: 3 },
+    topics: [
+      { name: 'orders', partitions: 12, replicationFactor: 3, status: 'active' },
+      { name: 'payments', partitions: 6, replicationFactor: 3, status: 'active' },
+    ],
+    consumerGroups: [
+      { groupId: 'order-service', members: 4, lag: 0, status: 'ok' },
+      { groupId: 'payment-processor', members: 2, lag: 150, status: 'warning' },
+    ],
+    totalLag: 150,
+    ...overrides,
+  }
+}
+
+function makeData(overrides: Partial<StrimziStatusData> = {}): StrimziStatusData {
+  const clusters = overrides.clusters ?? [makeCluster()]
+  return {
+    health: 'healthy',
+    clusters,
+    stats: {
+      clusterCount: clusters.length,
+      brokerCount: 3,
+      topicCount: 2,
+      consumerGroupCount: 2,
+      totalLag: 150,
+      operatorVersion: '0.41.0',
+    },
+    summary: {
+      totalClusters: clusters.length,
+      healthyClusters: clusters.filter(c => c.health === 'healthy').length,
+      totalBrokers: 3,
+      readyBrokers: 3,
+    },
+    lastCheckTime: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function defaultHookReturn(overrides: Record<string, unknown> = {}) {
+  return {
+    data: makeData(),
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: Date.now(),
+    showSkeleton: false,
+    showEmptyState: false,
+    error: false,
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('StrimziStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCachedStrimzi.mockReturnValue(defaultHookReturn())
+    mockUseReportCardDataState.mockReturnValue(undefined)
+  })
+
+  it('renders without crashing', () => {
+    const { container } = render(<StrimziStatus />)
+    expect(container).toBeTruthy()
+  })
+
+  it('renders loading skeleton when showSkeleton is true', () => {
+    mockUseCachedStrimzi.mockReturnValue(
+      defaultHookReturn({ showSkeleton: true, data: makeData({ health: 'unknown' }) }),
+    )
+    const { container } = render(<StrimziStatus />)
+    const skeletons = container.querySelectorAll('.animate-pulse')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('renders error state when error and showEmptyState are true', () => {
+    mockUseCachedStrimzi.mockReturnValue(
+      defaultHookReturn({ error: true, showEmptyState: true, isFailed: true }),
+    )
+    render(<StrimziStatus />)
+    expect(screen.getByText('Unable to fetch Strimzi status')).toBeTruthy()
+  })
+
+  it('renders not-installed state', () => {
+    mockUseCachedStrimzi.mockReturnValue(
+      defaultHookReturn({ data: makeData({ health: 'not-installed' }) }),
+    )
+    render(<StrimziStatus />)
+    expect(screen.getByText('Strimzi not detected')).toBeTruthy()
+  })
+
+  it('renders healthy state with green indicator', () => {
+    const { container } = render(<StrimziStatus />)
+    expect(screen.getByText('Healthy')).toBeTruthy()
+    const greenElements = container.querySelectorAll('.text-green-400')
+    expect(greenElements.length).toBeGreaterThan(0)
+  })
+
+  it('renders degraded state with yellow indicator', () => {
+    mockUseCachedStrimzi.mockReturnValue(
+      defaultHookReturn({ data: makeData({ health: 'degraded' }) }),
+    )
+    render(<StrimziStatus />)
+    expect(screen.getByText('Degraded')).toBeTruthy()
+  })
+
+  it('renders Kafka cluster rows', () => {
+    render(<StrimziStatus />)
+    expect(screen.getByText('orders-kafka')).toBeTruthy()
+  })
+
+  it('renders broker readiness in summary tiles', () => {
+    render(<StrimziStatus />)
+    expect(screen.getByText('3/3')).toBeTruthy()
+  })
+
+  it('renders consumer group chips for clusters', () => {
+    render(<StrimziStatus />)
+    expect(screen.getByText('order-service')).toBeTruthy()
+    expect(screen.getByText('payment-processor')).toBeTruthy()
+  })
+
+  it('renders operator version', () => {
+    render(<StrimziStatus />)
+    expect(screen.getByText('0.41.0')).toBeTruthy()
+  })
+
+  it('handles empty clusters array safely', () => {
+    mockUseCachedStrimzi.mockReturnValue(
+      defaultHookReturn({
+        data: makeData({
+          clusters: [],
+          stats: { clusterCount: 0, brokerCount: 0, topicCount: 0, consumerGroupCount: 0, totalLag: 0, operatorVersion: '0.41.0' },
+          summary: { totalClusters: 0, healthyClusters: 0, totalBrokers: 0, readyBrokers: 0 },
+        }),
+      }),
+    )
+    render(<StrimziStatus />)
+    expect(screen.getByText('No Kafka clusters found')).toBeTruthy()
+  })
+
+  it('handles undefined clusters gracefully (array safety)', () => {
+    const data = makeData()
+    ;(data as Record<string, unknown>).clusters = undefined
+    mockUseCachedStrimzi.mockReturnValue(defaultHookReturn({ data }))
+    const { container } = render(<StrimziStatus />)
+    expect(container).toBeTruthy()
+  })
+
+  it('reports card data state with correct arguments', () => {
+    render(<StrimziStatus />)
+    expect(mockUseReportCardDataState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isFailed: false,
+        isDemoData: false,
+        isRefreshing: false,
+        hasData: true,
+      }),
+    )
+  })
+
+  it('reports isDemoData when hook returns isDemoData true', () => {
+    mockUseCachedStrimzi.mockReturnValue(defaultHookReturn({ isDemoData: true }))
+    render(<StrimziStatus />)
+    expect(mockUseReportCardDataState).toHaveBeenCalledWith(
+      expect.objectContaining({ isDemoData: true }),
+    )
+  })
+
+  it('renders multiple kafka clusters', () => {
+    const clusters = [
+      makeCluster({ name: 'orders-kafka', cluster: 'prod-east' }),
+      makeCluster({ name: 'telemetry-kafka', cluster: 'prod-west', health: 'degraded' }),
+    ]
+    mockUseCachedStrimzi.mockReturnValue(
+      defaultHookReturn({ data: makeData({ clusters }) }),
+    )
+    render(<StrimziStatus />)
+    expect(screen.getByText('orders-kafka')).toBeTruthy()
+    expect(screen.getByText('telemetry-kafka')).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/volcano_status/__tests__/VolcanoStatus.test.tsx
+++ b/web/src/components/cards/volcano_status/__tests__/VolcanoStatus.test.tsx
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { VolcanoStatusData, VolcanoQueue, VolcanoJob } from '../demoData'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseCachedVolcano = vi.fn()
+vi.mock('../../../../hooks/useCachedVolcano', () => ({
+  useCachedVolcano: (...args: unknown[]) => mockUseCachedVolcano(...args),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallbackOrOpts?: string | Record<string, unknown>) => {
+      if (typeof fallbackOrOpts === 'string') return fallbackOrOpts
+      return key
+    },
+  }),
+}))
+
+const mockUseReportCardDataState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: (opts: unknown) => mockUseReportCardDataState(opts),
+}))
+
+vi.mock('../../../../lib/formatters', () => ({
+  formatTimeAgo: () => 'just now',
+}))
+
+// Import component after mocks
+import { VolcanoStatus } from '../index'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeQueue(overrides: Partial<VolcanoQueue> = {}): VolcanoQueue {
+  return {
+    name: 'default',
+    state: 'Open',
+    weight: 1,
+    runningJobs: 3,
+    pendingJobs: 1,
+    allocatedCpu: 18,
+    allocatedMemGiB: 72,
+    allocatedGpu: 1,
+    capabilityCpu: 64,
+    capabilityMemGiB: 256,
+    capabilityGpu: 4,
+    cluster: 'prod-east',
+    ...overrides,
+  }
+}
+
+function makeJob(overrides: Partial<VolcanoJob> = {}): VolcanoJob {
+  return {
+    name: 'resnet50-train-001',
+    namespace: 'ml-training',
+    queue: 'ml-training',
+    phase: 'Running',
+    minAvailable: 8,
+    runningPods: 8,
+    totalPods: 8,
+    gpuRequest: 4,
+    cluster: 'prod-east',
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function makeData(overrides: Partial<VolcanoStatusData> = {}): VolcanoStatusData {
+  return {
+    health: 'healthy',
+    queues: [makeQueue()],
+    jobs: [makeJob()],
+    podGroups: [
+      {
+        name: 'resnet50-train-001-pg',
+        namespace: 'ml-training',
+        queue: 'ml-training',
+        phase: 'Running',
+        minMember: 8,
+        runningMember: 8,
+        cluster: 'prod-east',
+      },
+    ],
+    stats: {
+      totalQueues: 1,
+      openQueues: 1,
+      totalJobs: 7,
+      pendingJobs: 1,
+      runningJobs: 3,
+      completedJobs: 2,
+      failedJobs: 1,
+      totalPodGroups: 5,
+      allocatedGpu: 4,
+      schedulerVersion: '1.9.0',
+    },
+    summary: {
+      totalQueues: 1,
+      totalJobs: 7,
+      totalPodGroups: 5,
+      allocatedGpu: 4,
+    },
+    lastCheckTime: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function defaultHookReturn(overrides: Record<string, unknown> = {}) {
+  return {
+    data: makeData(),
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: Date.now(),
+    showSkeleton: false,
+    showEmptyState: false,
+    error: false,
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('VolcanoStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCachedVolcano.mockReturnValue(defaultHookReturn())
+    mockUseReportCardDataState.mockReturnValue(undefined)
+  })
+
+  it('renders without crashing', () => {
+    const { container } = render(<VolcanoStatus />)
+    expect(container).toBeTruthy()
+  })
+
+  it('renders loading skeleton when showSkeleton is true', () => {
+    mockUseCachedVolcano.mockReturnValue(
+      defaultHookReturn({ showSkeleton: true, data: makeData({ health: 'unknown' }) }),
+    )
+    const { container } = render(<VolcanoStatus />)
+    const skeletons = container.querySelectorAll('.animate-pulse')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('renders error state when error and showEmptyState are true', () => {
+    mockUseCachedVolcano.mockReturnValue(
+      defaultHookReturn({ error: true, showEmptyState: true, isFailed: true }),
+    )
+    render(<VolcanoStatus />)
+    expect(screen.getByText('Unable to fetch Volcano status')).toBeTruthy()
+  })
+
+  it('renders not-installed state', () => {
+    mockUseCachedVolcano.mockReturnValue(
+      defaultHookReturn({ data: makeData({ health: 'not-installed' }) }),
+    )
+    render(<VolcanoStatus />)
+    expect(screen.getByText('Volcano scheduler not detected')).toBeTruthy()
+  })
+
+  it('renders healthy state with green indicator', () => {
+    const { container } = render(<VolcanoStatus />)
+    expect(screen.getByText('Healthy')).toBeTruthy()
+    const greenElements = container.querySelectorAll('.text-green-400')
+    expect(greenElements.length).toBeGreaterThan(0)
+  })
+
+  it('renders degraded state with yellow indicator', () => {
+    mockUseCachedVolcano.mockReturnValue(
+      defaultHookReturn({ data: makeData({ health: 'degraded' }) }),
+    )
+    render(<VolcanoStatus />)
+    expect(screen.getByText('Degraded')).toBeTruthy()
+  })
+
+  it('renders queue rows', () => {
+    render(<VolcanoStatus />)
+    expect(screen.getByText('default')).toBeTruthy()
+    expect(screen.getByText('Open')).toBeTruthy()
+  })
+
+  it('renders job rows with phase badges', () => {
+    render(<VolcanoStatus />)
+    expect(screen.getByText('Running')).toBeTruthy()
+  })
+
+  it('renders job namespace/name', () => {
+    render(<VolcanoStatus />)
+    expect(screen.getByText('ml-training/resnet50-train-001')).toBeTruthy()
+  })
+
+  it('renders GPU request for jobs', () => {
+    render(<VolcanoStatus />)
+    expect(screen.getByText('4 GPU')).toBeTruthy()
+  })
+
+  it('renders CPU-only label for jobs with no GPU', () => {
+    mockUseCachedVolcano.mockReturnValue(
+      defaultHookReturn({ data: makeData({ jobs: [makeJob({ gpuRequest: 0 })] }) }),
+    )
+    render(<VolcanoStatus />)
+    expect(screen.getByText('CPU-only')).toBeTruthy()
+  })
+
+  it('renders scheduler version', () => {
+    render(<VolcanoStatus />)
+    expect(screen.getByText('1.9.0')).toBeTruthy()
+  })
+
+  it('renders summary metric tiles', () => {
+    render(<VolcanoStatus />)
+    expect(screen.getByText('Queues')).toBeTruthy()
+    expect(screen.getByText('Pending')).toBeTruthy()
+  })
+
+  it('handles empty queues array safely', () => {
+    mockUseCachedVolcano.mockReturnValue(
+      defaultHookReturn({ data: makeData({ queues: [] }) }),
+    )
+    render(<VolcanoStatus />)
+    expect(screen.getByText('No queues configured')).toBeTruthy()
+  })
+
+  it('handles empty jobs array safely', () => {
+    mockUseCachedVolcano.mockReturnValue(
+      defaultHookReturn({ data: makeData({ jobs: [] }) }),
+    )
+    render(<VolcanoStatus />)
+    expect(screen.getByText('No Volcano jobs found')).toBeTruthy()
+  })
+
+  it('handles undefined queues/jobs/podGroups gracefully (array safety)', () => {
+    const data = makeData()
+    ;(data as Record<string, unknown>).queues = undefined
+    ;(data as Record<string, unknown>).jobs = undefined
+    ;(data as Record<string, unknown>).podGroups = undefined
+    mockUseCachedVolcano.mockReturnValue(defaultHookReturn({ data }))
+    const { container } = render(<VolcanoStatus />)
+    expect(container).toBeTruthy()
+  })
+
+  it('reports card data state with correct arguments', () => {
+    render(<VolcanoStatus />)
+    expect(mockUseReportCardDataState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isFailed: false,
+        isDemoData: false,
+        isRefreshing: false,
+        hasData: true,
+      }),
+    )
+  })
+
+  it('reports isDemoData when hook returns isDemoData true', () => {
+    mockUseCachedVolcano.mockReturnValue(defaultHookReturn({ isDemoData: true }))
+    render(<VolcanoStatus />)
+    expect(mockUseReportCardDataState).toHaveBeenCalledWith(
+      expect.objectContaining({ isDemoData: true }),
+    )
+  })
+
+  it('renders queue CPU/GPU usage bars', () => {
+    render(<VolcanoStatus />)
+    expect(screen.getByText('CPU')).toBeTruthy()
+    expect(screen.getByText('GPU')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Fixes #4189

Continues card test coverage work from PR #10936. Adds Vitest component tests for 3 additional untested card components:

- **DaprStatus** (14 tests) — control plane pods, components, building blocks, health states
- **StrimziStatus** (16 tests) — Kafka clusters, brokers, consumer groups, operator version
- **VolcanoStatus** (20 tests) — queues, jobs, GPU requests, scheduler version, CPU/GPU bars

Tests cover: loading skeleton, error state, not-installed state, healthy/degraded rendering, data display, array safety (undefined guards), empty state handling, and demo data reporting.