### PR TITLE
🐛 Fix 14 test failures in OperatorStatus and RecentEvents (#10940)

### DIFF
--- a/web/src/components/cards/__tests__/OperatorStatus.test.tsx
+++ b/web/src/components/cards/__tests__/OperatorStatus.test.tsx
@@ -85,6 +85,81 @@ vi.mock('../../../hooks/useTokenUsage', () => ({
   },
 }))
 
+// Mock useCardData and useCardFilters from cardHooks
+vi.mock('../../../lib/cards/cardHooks', () => ({
+  useCardData: (items: unknown[]) => ({
+    items,
+    allFilteredItems: items,
+    totalItems: (items as unknown[]).length,
+    currentPage: 1,
+    totalPages: 1,
+    itemsPerPage: 5,
+    goToPage: vi.fn(),
+    needsPagination: false,
+    setItemsPerPage: vi.fn(),
+    filters: {
+      search: '',
+      setSearch: vi.fn(),
+      localClusterFilter: [],
+      toggleClusterFilter: vi.fn(),
+      clearClusterFilter: vi.fn(),
+      availableClusters: [{ name: 'cluster-1' }],
+      showClusterFilter: false,
+      setShowClusterFilter: vi.fn(),
+      clusterFilterRef: { current: null },
+    },
+    sorting: {
+      sortBy: 'status',
+      setSortBy: vi.fn(),
+      sortDirection: 'asc',
+      setSortDirection: vi.fn(),
+    },
+    containerRef: { current: null },
+    containerStyle: {},
+  }),
+  useCardFilters: (items: unknown[]) => ({
+    filtered: items,
+    search: '',
+    setSearch: vi.fn(),
+    localClusterFilter: [],
+    toggleClusterFilter: vi.fn(),
+    clearClusterFilter: vi.fn(),
+    availableClusters: [],
+    showClusterFilter: false,
+    setShowClusterFilter: vi.fn(),
+    clusterFilterRef: { current: null },
+  }),
+  commonComparators: {
+    string: () => () => 0,
+    number: () => () => 0,
+    date: () => () => 0,
+  },
+}))
+
+// Mock card UI components
+vi.mock('../../../lib/cards/CardComponents', () => ({
+  CardSearchInput: () => <input data-testid="search" />,
+  CardControlsRow: () => <div data-testid="controls-row" />,
+  CardPaginationFooter: () => <div data-testid="pagination" />,
+  CardAIActions: () => <div data-testid="ai-actions" />,
+}))
+
+vi.mock('../../ui/Skeleton', () => ({
+  Skeleton: () => <div data-testid="skeleton" className="animate-pulse" />,
+}))
+
+vi.mock('../../ui/ClusterBadge', () => ({
+  ClusterBadge: ({ cluster }: { cluster: string }) => <span>{cluster}</span>,
+}))
+
+vi.mock('../../ui/StatusBadge', () => ({
+  StatusBadge: ({ children }: { children: React.ReactNode }) => <span data-testid="status-badge">{children}</span>,
+}))
+
+vi.mock('../DynamicCardErrorBoundary', () => ({
+  DynamicCardErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
 // Import component after mocks
 import { OperatorStatus } from '../OperatorStatus'
 
@@ -164,10 +239,8 @@ describe('OperatorStatus', () => {
     })
     mockUseCachedOperators.mockReturnValue(defaultHookResult({ operators: [], isLoading: true }))
 
-    const { container } = render(<OperatorStatus />)
-    // Skeleton renders animate-pulse elements
-    const skeletons = container.querySelectorAll('.animate-pulse')
-    expect(skeletons.length).toBeGreaterThan(0)
+    render(<OperatorStatus />)
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0)
   })
 
   it('shows empty state when no operators', () => {

--- a/web/src/components/cards/__tests__/RecentEvents.test.tsx
+++ b/web/src/components/cards/__tests__/RecentEvents.test.tsx
@@ -79,6 +79,61 @@ vi.mock('../../../hooks/useTokenUsage', () => ({
   },
 }))
 
+// Mock useCardData from cardHooks
+vi.mock('../../../lib/cards/cardHooks', () => ({
+  useCardData: (items: unknown[]) => ({
+    items,
+    allFilteredItems: items,
+    totalItems: (items as unknown[]).length,
+    currentPage: 1,
+    totalPages: 1,
+    itemsPerPage: 5,
+    goToPage: vi.fn(),
+    needsPagination: false,
+    setItemsPerPage: vi.fn(),
+    filters: {
+      search: '',
+      setSearch: vi.fn(),
+      localClusterFilter: [],
+      toggleClusterFilter: vi.fn(),
+      clearClusterFilter: vi.fn(),
+      availableClusters: [{ name: 'test-cluster' }],
+      showClusterFilter: false,
+      setShowClusterFilter: vi.fn(),
+      clusterFilterRef: { current: null },
+    },
+    sorting: {
+      sortBy: 'time',
+      setSortBy: vi.fn(),
+      sortDirection: 'desc',
+      setSortDirection: vi.fn(),
+    },
+    containerRef: { current: null },
+    containerStyle: {},
+  }),
+  commonComparators: {
+    string: () => () => 0,
+    number: () => () => 0,
+    date: () => () => 0,
+  },
+}))
+
+// Mock card UI components
+vi.mock('../../../lib/cards/CardComponents', () => ({
+  CardSearchInput: () => <input data-testid="search" />,
+  CardControlsRow: () => <div data-testid="controls-row" />,
+  CardPaginationFooter: () => <div data-testid="pagination" />,
+  CardSkeleton: () => <div data-testid="card-skeleton" />,
+}))
+
+vi.mock('../../ui/ClusterBadge', () => ({
+  ClusterBadge: ({ cluster }: { cluster: string }) => <span>{cluster}</span>,
+}))
+
+vi.mock('../../ui/RefreshIndicator', () => ({
+  RefreshButton: () => <button data-testid="refresh-button">Refresh</button>,
+}))
+
 // Import component after mocks
 import { RecentEvents } from '../RecentEvents'
 import type { ClusterEvent } from '../../../hooks/useMCP'
@@ -158,9 +213,8 @@ describe('RecentEvents', () => {
     })
     mockUseCachedEvents.mockReturnValue(defaultHookResult({ events: [], isLoading: true }))
 
-    const { container } = render(<RecentEvents />)
-    // CardSkeleton renders animated loading indicators
-    expect(container.innerHTML.length).toBeGreaterThan(0)
+    render(<RecentEvents />)
+    expect(screen.getByTestId('card-skeleton')).toBeTruthy()
   })
 
   it('shows empty state when no events and showEmptyState is true', () => {


### PR DESCRIPTION
Fixes #10940

Fixes 14 failing Vitest tests introduced in PR #10936. Tests were not matching actual component implementation.

Changes:
- Added missing mocks for `useCardData`, `useCardFilters`, and `commonComparators` from `cardHooks`
- Added missing mocks for `CardComponents` (`CardSearchInput`, `CardControlsRow`, `CardPaginationFooter`, `CardSkeleton`, `CardAIActions`)
- Added missing mocks for UI components (`Skeleton`, `ClusterBadge`, `StatusBadge`, `RefreshButton`, `DynamicCardErrorBoundary`)
- Updated skeleton test assertion to use `data-testid` instead of CSS class selector
- Follows the established mock pattern from other passing card tests (e.g., HelmReleaseStatus)