### PR TITLE
🐛 Fix 5 test failures: use getAllByText for multi-match elements (#10947)

### DIFF
--- a/web/src/components/cards/__tests__/OperatorStatus.test.tsx
+++ b/web/src/components/cards/__tests__/OperatorStatus.test.tsx
@@ -270,7 +270,7 @@ describe('OperatorStatus', () => {
     )
 
     render(<OperatorStatus />)
-    expect(screen.getByText(/operatorStatus.errorLoading/)).toBeTruthy()
+    expect(screen.getAllByText(/operatorStatus.errorLoading/)[0]).toBeInTheDocument()
   })
 
   it('handles empty operators array gracefully', () => {

--- a/web/src/components/cards/dapr_status/__tests__/DaprStatus.test.tsx
+++ b/web/src/components/cards/dapr_status/__tests__/DaprStatus.test.tsx
@@ -212,8 +212,8 @@ describe('DaprStatus', () => {
 
   it('renders building block counts', () => {
     render(<DaprStatus />)
-    expect(screen.getByText('State stores')).toBeTruthy()
-    expect(screen.getByText('Pub/sub')).toBeTruthy()
-    expect(screen.getByText('Bindings')).toBeTruthy()
+    expect(screen.getAllByText('State stores')[0]).toBeInTheDocument()
+    expect(screen.getAllByText('Pub/sub')[0]).toBeInTheDocument()
+    expect(screen.getAllByText('Bindings')[0]).toBeInTheDocument()
   })
 })

--- a/web/src/components/cards/strimzi_status/__tests__/StrimziStatus.test.tsx
+++ b/web/src/components/cards/strimzi_status/__tests__/StrimziStatus.test.tsx
@@ -161,7 +161,7 @@ describe('StrimziStatus', () => {
 
   it('renders broker readiness in summary tiles', () => {
     render(<StrimziStatus />)
-    expect(screen.getByText('3/3')).toBeTruthy()
+    expect(screen.getAllByText('3/3')[0]).toBeInTheDocument()
   })
 
   it('renders consumer group chips for clusters', () => {

--- a/web/src/components/cards/volcano_status/__tests__/VolcanoStatus.test.tsx
+++ b/web/src/components/cards/volcano_status/__tests__/VolcanoStatus.test.tsx
@@ -190,7 +190,7 @@ describe('VolcanoStatus', () => {
 
   it('renders job rows with phase badges', () => {
     render(<VolcanoStatus />)
-    expect(screen.getByText('Running')).toBeTruthy()
+    expect(screen.getAllByText('Running')[0]).toBeInTheDocument()
   })
 
   it('renders job namespace/name', () => {
@@ -218,8 +218,8 @@ describe('VolcanoStatus', () => {
 
   it('renders summary metric tiles', () => {
     render(<VolcanoStatus />)
-    expect(screen.getByText('Queues')).toBeTruthy()
-    expect(screen.getByText('Pending')).toBeTruthy()
+    expect(screen.getAllByText('Queues')[0]).toBeInTheDocument()
+    expect(screen.getAllByText('Pending')[0]).toBeInTheDocument()
   })
 
   it('handles empty queues array safely', () => {


### PR DESCRIPTION
Fixes #10947

All 5 failures were caused by `screen.getByText()` finding multiple matching elements. Components render the same text in multiple places (labels, tooltips, values). Fixed by using `getAllByText()[0]` for precise single-element assertions.

Affected tests:
- DaprStatus: building block counts
- StrimziStatus: broker readiness tiles
- VolcanoStatus: job phases + summary metrics
- OperatorStatus: error state