### PR TITLE
test: coverage batch 10 — cache internals, shared distribution, auth, lastRoute

### DIFF
--- a/web/src/hooks/__tests__/useLastRoute.test.ts
+++ b/web/src/hooks/__tests__/useLastRoute.test.ts
@@ -294,3 +294,48 @@ describe('setRememberPosition', () => {
     expect(() => setRememberPosition('/x', true)).not.toThrow()
   })
 })
+
+// ── __testables: getFirstDashboardRoute ──
+
+const SIDEBAR_CONFIG_KEY = 'kubestellar-sidebar-config-v5'
+
+describe('getFirstDashboardRoute', () => {
+  it('returns "/" when no sidebar config exists', async () => {
+    const { __testables } = await importFresh()
+    expect(__testables.getFirstDashboardRoute()).toBe('/')
+  })
+
+  it('returns first primaryNav href', async () => {
+    localStorage.setItem(SIDEBAR_CONFIG_KEY, JSON.stringify({
+      primaryNav: [{ href: '/clusters', label: 'Clusters' }, { href: '/pods', label: 'Pods' }],
+    }))
+    const { __testables } = await importFresh()
+    expect(__testables.getFirstDashboardRoute()).toBe('/clusters')
+  })
+
+  it('returns "/" when primaryNav is empty', async () => {
+    localStorage.setItem(SIDEBAR_CONFIG_KEY, JSON.stringify({ primaryNav: [] }))
+    const { __testables } = await importFresh()
+    expect(__testables.getFirstDashboardRoute()).toBe('/')
+  })
+
+  it('returns "/" when first nav item has no href', async () => {
+    localStorage.setItem(SIDEBAR_CONFIG_KEY, JSON.stringify({
+      primaryNav: [{ label: 'No Href' }],
+    }))
+    const { __testables } = await importFresh()
+    expect(__testables.getFirstDashboardRoute()).toBe('/')
+  })
+
+  it('returns "/" when sidebar config is invalid JSON', async () => {
+    localStorage.setItem(SIDEBAR_CONFIG_KEY, 'not-json{{{')
+    const { __testables } = await importFresh()
+    expect(__testables.getFirstDashboardRoute()).toBe('/')
+  })
+
+  it('returns "/" when sidebar config has no primaryNav', async () => {
+    localStorage.setItem(SIDEBAR_CONFIG_KEY, JSON.stringify({ version: 5 }))
+    const { __testables } = await importFresh()
+    expect(__testables.getFirstDashboardRoute()).toBe('/')
+  })
+})

--- a/web/src/hooks/mcp/__tests__/shared-distribution.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-distribution.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: vi.fn().mockReturnValue(false),
+  isDemoToken: vi.fn().mockReturnValue(false),
+  isNetlifyDeployment: false,
+  subscribeDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitClusterDiscovery: vi.fn(),
+}))
+
+vi.mock('../../../lib/kubectlProxy', () => ({
+  kubectlProxy: { exec: vi.fn(), isConnected: vi.fn().mockReturnValue(false) },
+}))
+
+vi.mock('../../../lib/api', () => ({
+  fetchWithAuth: vi.fn(),
+}))
+
+vi.mock('../../../lib/modeTransition', () => ({
+  registerCacheReset: vi.fn(),
+  registerRefetch: vi.fn(),
+}))
+
+vi.mock('../../../lib/cache', () => ({
+  useCache: vi.fn().mockReturnValue({
+    data: [], isLoading: false, isRefreshing: false,
+    error: null, isFailed: false, consecutiveFailures: 0,
+    lastRefresh: null, refetch: vi.fn(), clearAndRefetch: vi.fn(),
+    isDemoFallback: false,
+  }),
+  REFRESH_RATES: { clusters: 60_000, default: 120_000 },
+}))
+
+vi.mock('../clusterCacheRef', () => ({
+  clusterCacheRef: { current: new Map() },
+  setClusterCacheRefClusters: vi.fn(),
+}))
+
+const mod = await import('../shared')
+const {
+  detectDistributionFromNamespaces,
+  detectDistributionFromServer,
+  updatesTouchData,
+  updatesTouchUI,
+} = mod.__testables
+
+// ── detectDistributionFromNamespaces ──
+
+describe('detectDistributionFromNamespaces', () => {
+  it('detects OpenShift from openshift- prefix', () => {
+    expect(detectDistributionFromNamespaces(['kube-system', 'openshift-monitoring', 'default'])).toBe('openshift')
+  })
+
+  it('detects OpenShift from bare openshift namespace', () => {
+    expect(detectDistributionFromNamespaces(['kube-system', 'openshift'])).toBe('openshift')
+  })
+
+  it('detects GKE from gke- prefix', () => {
+    expect(detectDistributionFromNamespaces(['kube-system', 'gke-managed-system'])).toBe('gke')
+  })
+
+  it('detects GKE from config-management-system', () => {
+    expect(detectDistributionFromNamespaces(['config-management-system', 'kube-system'])).toBe('gke')
+  })
+
+  it('detects EKS from aws- prefix', () => {
+    expect(detectDistributionFromNamespaces(['kube-system', 'aws-observability'])).toBe('eks')
+  })
+
+  it('detects EKS from amazon- prefix', () => {
+    expect(detectDistributionFromNamespaces(['amazon-vpc-cni', 'kube-system'])).toBe('eks')
+  })
+
+  it('detects AKS from azure- prefix', () => {
+    expect(detectDistributionFromNamespaces(['kube-system', 'azure-extensions'])).toBe('aks')
+  })
+
+  it('detects AKS from azure-arc namespace', () => {
+    expect(detectDistributionFromNamespaces(['azure-arc', 'kube-system'])).toBe('aks')
+  })
+
+  it('detects Rancher from cattle-system', () => {
+    expect(detectDistributionFromNamespaces(['cattle-system', 'kube-system'])).toBe('rancher')
+  })
+
+  it('detects Rancher from cattle- prefix', () => {
+    expect(detectDistributionFromNamespaces(['cattle-fleet-system', 'kube-system'])).toBe('rancher')
+  })
+
+  it('returns undefined for vanilla K8s namespaces', () => {
+    expect(detectDistributionFromNamespaces(['kube-system', 'default', 'kube-public'])).toBeUndefined()
+  })
+
+  it('returns undefined for empty array', () => {
+    expect(detectDistributionFromNamespaces([])).toBeUndefined()
+  })
+
+  it('prioritizes OpenShift over other distributions', () => {
+    expect(detectDistributionFromNamespaces(['openshift-monitoring', 'aws-observability'])).toBe('openshift')
+  })
+})
+
+// ── detectDistributionFromServer ──
+
+describe('detectDistributionFromServer', () => {
+  it('returns undefined for undefined server', () => {
+    expect(detectDistributionFromServer(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for empty string', () => {
+    expect(detectDistributionFromServer('')).toBeUndefined()
+  })
+
+  it('detects OpenShift from openshiftapps.com', () => {
+    expect(detectDistributionFromServer('https://api.cluster1.openshiftapps.com:6443')).toBe('openshift')
+  })
+
+  it('detects OpenShift from openshift.com', () => {
+    expect(detectDistributionFromServer('https://api.cluster.openshift.com:6443')).toBe('openshift')
+  })
+
+  it('detects OpenShift from fmaas pattern', () => {
+    expect(detectDistributionFromServer('https://api.fmaas-prod.fmaas.res.ibm.com:6443')).toBe('openshift')
+  })
+
+  it('detects OpenShift from generic api:6443 pattern', () => {
+    expect(detectDistributionFromServer('https://api.mycluster.example.com:6443')).toBe('openshift')
+  })
+
+  it('does not detect OpenShift for EKS on port 6443', () => {
+    expect(detectDistributionFromServer('https://api.cluster.eks.amazonaws.com:6443')).not.toBe('openshift')
+  })
+
+  it('does not detect OpenShift for AKS on port 6443', () => {
+    expect(detectDistributionFromServer('https://api.cluster.azmk8s.io:6443')).not.toBe('openshift')
+  })
+
+  it('detects EKS from eks.amazonaws.com', () => {
+    expect(detectDistributionFromServer('https://ABCDEF.eks.amazonaws.com')).toBe('eks')
+  })
+
+  it('detects GKE from container.googleapis.com', () => {
+    expect(detectDistributionFromServer('https://34.1.2.3/apis/container.googleapis.com')).toBeUndefined()
+    expect(detectDistributionFromServer('https://cluster.container.googleapis.com')).toBe('gke')
+  })
+
+  it('detects AKS from azmk8s.io', () => {
+    expect(detectDistributionFromServer('https://mycluster.azmk8s.io')).toBe('aks')
+  })
+
+  it('detects OCI from oraclecloud.com', () => {
+    expect(detectDistributionFromServer('https://cluster.oraclecloud.com')).toBe('oci')
+  })
+
+  it('detects DigitalOcean from k8s.ondigitalocean.com', () => {
+    expect(detectDistributionFromServer('https://cluster.k8s.ondigitalocean.com')).toBe('digitalocean')
+  })
+
+  it('detects DigitalOcean from digitalocean.com', () => {
+    expect(detectDistributionFromServer('https://api.digitalocean.com/v2/clusters')).toBe('digitalocean')
+  })
+
+  it('returns undefined for localhost', () => {
+    expect(detectDistributionFromServer('https://localhost:6443')).toBeUndefined()
+  })
+
+  it('returns undefined for plain IP', () => {
+    expect(detectDistributionFromServer('https://192.168.1.1:6443')).toBeUndefined()
+  })
+})
+
+// ── updatesTouchData / updatesTouchUI ──
+
+describe('updatesTouchData', () => {
+  it('returns true for clusters field', () => {
+    expect(updatesTouchData({ clusters: [] } as Record<string, unknown>)).toBe(true)
+  })
+
+  it('returns true for lastUpdated', () => {
+    expect(updatesTouchData({ lastUpdated: Date.now() } as Record<string, unknown>)).toBe(true)
+  })
+
+  it('returns true for consecutiveFailures', () => {
+    expect(updatesTouchData({ consecutiveFailures: 3 } as Record<string, unknown>)).toBe(true)
+  })
+
+  it('returns true for isFailed', () => {
+    expect(updatesTouchData({ isFailed: true } as Record<string, unknown>)).toBe(true)
+  })
+
+  it('returns false for UI-only fields', () => {
+    expect(updatesTouchData({ isLoading: true } as Record<string, unknown>)).toBe(false)
+  })
+
+  it('returns false for empty updates', () => {
+    expect(updatesTouchData({} as Record<string, unknown>)).toBe(false)
+  })
+
+  it('returns false for unrelated fields', () => {
+    expect(updatesTouchData({ someRandom: 'value' } as Record<string, unknown>)).toBe(false)
+  })
+})
+
+describe('updatesTouchUI', () => {
+  it('returns true for isLoading', () => {
+    expect(updatesTouchUI({ isLoading: true } as Record<string, unknown>)).toBe(true)
+  })
+
+  it('returns true for isRefreshing', () => {
+    expect(updatesTouchUI({ isRefreshing: false } as Record<string, unknown>)).toBe(true)
+  })
+
+  it('returns true for error', () => {
+    expect(updatesTouchUI({ error: 'timeout' } as Record<string, unknown>)).toBe(true)
+  })
+
+  it('returns true for lastRefresh', () => {
+    expect(updatesTouchUI({ lastRefresh: Date.now() } as Record<string, unknown>)).toBe(true)
+  })
+
+  it('returns false for data-only fields', () => {
+    expect(updatesTouchUI({ clusters: [] } as Record<string, unknown>)).toBe(false)
+  })
+
+  it('returns false for empty updates', () => {
+    expect(updatesTouchUI({} as Record<string, unknown>)).toBe(false)
+  })
+})
+
+// ── clusterDisplayName ──
+
+describe('clusterDisplayName', () => {
+  it('returns base name for simple names', () => {
+    expect(mod.clusterDisplayName('my-cluster')).toBe('my-cluster')
+  })
+
+  it('strips context prefix', () => {
+    expect(mod.clusterDisplayName('ctx/my-cluster')).toBe('my-cluster')
+  })
+
+  it('truncates long names with segments', () => {
+    const long = 'very-long-cluster-name-that-exceeds-limit'
+    const result = mod.clusterDisplayName(long)
+    expect(result.length).toBeLessThanOrEqual(25)
+  })
+
+  it('truncates long names without enough segments', () => {
+    const long = 'a'.repeat(30)
+    const result = mod.clusterDisplayName(long)
+    expect(result).toBe(long.slice(0, 22) + '…')
+  })
+
+  it('handles names exactly at 24 chars', () => {
+    const exact = 'a'.repeat(24)
+    expect(mod.clusterDisplayName(exact)).toBe(exact)
+  })
+
+  it('handles empty string', () => {
+    expect(mod.clusterDisplayName('')).toBe('')
+  })
+
+  it('handles names with dots', () => {
+    const long = 'api.cluster.prod.region.cloud.example.com'
+    const result = mod.clusterDisplayName(long)
+    expect(result.length).toBeLessThanOrEqual(25)
+  })
+})
+
+// ── getEffectiveInterval ──
+
+describe('getEffectiveInterval', () => {
+  it('returns base interval unchanged', () => {
+    expect(mod.getEffectiveInterval(60_000)).toBe(60_000)
+  })
+})
+
+// ── shouldMarkOffline ──
+
+describe('shouldMarkOffline', () => {
+  it('returns false for unknown cluster', () => {
+    expect(mod.shouldMarkOffline('nonexistent-cluster')).toBe(false)
+  })
+})

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -2009,3 +2009,11 @@ export function clusterDisplayName(name: string): string {
   }
   return base
 }
+
+export const __testables = {
+  detectDistributionFromNamespaces,
+  detectDistributionFromServer,
+  updatesTouchData,
+  updatesTouchUI,
+  applyDistributionCache,
+}

--- a/web/src/hooks/useLastRoute.ts
+++ b/web/src/hooks/useLastRoute.ts
@@ -421,3 +421,12 @@ export function setRememberPosition(path: string, enabled: boolean): void {
     // Ignore localStorage errors
   }
 }
+
+export const __testables = {
+  getFirstDashboardRoute,
+  getScrollContainer,
+  LAST_ROUTE_KEY,
+  SCROLL_POSITIONS_KEY,
+  REMEMBER_POSITION_KEY,
+  SIDEBAR_CONFIG_KEY,
+}

--- a/web/src/lib/__tests__/auth.test.ts
+++ b/web/src/lib/__tests__/auth.test.ts
@@ -101,8 +101,11 @@ function makeJwt(payload: Record<string, unknown>): string {
 // behavior — any divergence in the source will break consumer tests.
 // ---------------------------------------------------------------------------
 
-// We'll test the pure logic by re-implementing and cross-checking:
-// getJwtExpiryMs
+// Import real __testables from auth module to test actual source lines
+const authMod = await import('../auth')
+const realGetJwtExpiryMs = authMod.__testables.getJwtExpiryMs
+
+// Local re-implementation for cross-checking (kept for backward compat)
 function getJwtExpiryMs(token: string): number | null {
   try {
     const parts = token.split('.')
@@ -218,6 +221,53 @@ describe('getJwtExpiryMs', () => {
     const token = makeJwt({ exp: -100 })
     const MS_PER_SECOND = 1000
     expect(getJwtExpiryMs(token)).toBe(-100 * MS_PER_SECOND)
+  })
+})
+
+// ============================================================================
+// getJwtExpiryMs — real source function via __testables
+// ============================================================================
+
+describe('getJwtExpiryMs (real source via __testables)', () => {
+  it('returns exp * 1000 for valid JWT', () => {
+    const token = makeJwt({ exp: 1700000000 })
+    expect(realGetJwtExpiryMs(token)).toBe(1700000000 * 1000)
+  })
+
+  it('returns null for no exp', () => {
+    expect(realGetJwtExpiryMs(makeJwt({ sub: 'x' }))).toBeNull()
+  })
+
+  it('returns null for non-3-part token', () => {
+    expect(realGetJwtExpiryMs('a.b')).toBeNull()
+  })
+
+  it('returns null for bad base64', () => {
+    expect(realGetJwtExpiryMs('a.!!!.c')).toBeNull()
+  })
+})
+
+// ============================================================================
+// isJWTExpired — real exported function
+// ============================================================================
+
+describe('isJWTExpired', () => {
+  it('returns true for expired token', () => {
+    const expired = makeJwt({ exp: Math.floor(Date.now() / 1000) - 3600 })
+    expect(authMod.isJWTExpired(expired)).toBe(true)
+  })
+
+  it('returns false for future token', () => {
+    const future = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 })
+    expect(authMod.isJWTExpired(future)).toBe(false)
+  })
+
+  it('returns false for non-JWT token (no exp)', () => {
+    expect(authMod.isJWTExpired('opaque-token-string')).toBe(false)
+  })
+
+  it('returns false for JWT without exp claim', () => {
+    expect(authMod.isJWTExpired(makeJwt({ sub: 'user' }))).toBe(false)
   })
 })
 

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -800,3 +800,12 @@ export function useAuth() {
   }
   return context
 }
+
+export const __testables = {
+  getJwtExpiryMs,
+  showExpiryWarningBanner,
+  AUTH_USER_CACHE_KEY,
+  EXPIRY_CHECK_INTERVAL_MS,
+  EXPIRY_WARNING_THRESHOLD_MS,
+  MAX_CACHED_USER_AGE_MS,
+}

--- a/web/src/lib/cache/__tests__/cache-internals.test.ts
+++ b/web/src/lib/cache/__tests__/cache-internals.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { __testables, REFRESH_RATES, isAutoRefreshPaused, setAutoRefreshPaused, subscribeAutoRefreshPaused,
+  initPreloadedMeta, isSQLiteWorkerActive, resetFailuresForCluster, resetAllCacheFailures,
+  clearAllCaches, getCacheStats, invalidateCache } = await import('../index')
+
+const {
+  ssWrite, ssRead, clearSessionSnapshots, isEquivalentToInitial,
+  getEffectiveInterval, CACHE_VERSION, SS_PREFIX, MAX_FAILURES,
+  FAILURE_BACKOFF_MULTIPLIER, MAX_BACKOFF_INTERVAL,
+} = __testables
+
+beforeEach(() => {
+  sessionStorage.clear()
+  localStorage.clear()
+  setAutoRefreshPaused(false)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ── ssWrite / ssRead ──
+
+describe('ssWrite + ssRead', () => {
+  it('round-trips data through sessionStorage', () => {
+    ssWrite('test-key', { hello: 'world' }, 1000)
+    const result = ssRead<{ hello: string }>('test-key')
+    expect(result).not.toBeNull()
+    expect(result!.data).toEqual({ hello: 'world' })
+    expect(result!.timestamp).toBe(1000)
+  })
+
+  it('returns null for missing key', () => {
+    expect(ssRead('nonexistent')).toBeNull()
+  })
+
+  it('returns null for version mismatch', () => {
+    sessionStorage.setItem(
+      SS_PREFIX + 'old-key',
+      JSON.stringify({ d: 'data', t: 100, v: CACHE_VERSION - 1 }),
+    )
+    expect(ssRead('old-key')).toBeNull()
+    expect(sessionStorage.getItem(SS_PREFIX + 'old-key')).toBeNull()
+  })
+
+  it('returns null for missing version field', () => {
+    sessionStorage.setItem(SS_PREFIX + 'no-v', JSON.stringify({ d: 'data', t: 100 }))
+    expect(ssRead('no-v')).toBeNull()
+  })
+
+  it('returns null for missing data field', () => {
+    sessionStorage.setItem(SS_PREFIX + 'no-d', JSON.stringify({ t: 100, v: CACHE_VERSION }))
+    expect(ssRead('no-d')).toBeNull()
+  })
+
+  it('returns null for missing timestamp field', () => {
+    sessionStorage.setItem(SS_PREFIX + 'no-t', JSON.stringify({ d: 'data', v: CACHE_VERSION }))
+    expect(ssRead('no-t')).toBeNull()
+  })
+
+  it('returns null for corrupted JSON', () => {
+    sessionStorage.setItem(SS_PREFIX + 'bad', 'not-json{{{')
+    expect(ssRead('bad')).toBeNull()
+  })
+
+  it('returns null for null stored value', () => {
+    sessionStorage.setItem(SS_PREFIX + 'null-val', 'null')
+    expect(ssRead('null-val')).toBeNull()
+  })
+
+  it('returns null for non-object stored value', () => {
+    sessionStorage.setItem(SS_PREFIX + 'string', '"just a string"')
+    expect(ssRead('string')).toBeNull()
+  })
+
+  it('handles array data', () => {
+    ssWrite('arr', [1, 2, 3], 500)
+    const result = ssRead<number[]>('arr')
+    expect(result!.data).toEqual([1, 2, 3])
+  })
+
+  it('handles null data', () => {
+    ssWrite('null-data', null, 999)
+    const result = ssRead<null>('null-data')
+    expect(result!.data).toBeNull()
+  })
+
+  it('silently handles QuotaExceededError on write', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota exceeded', 'QuotaExceededError')
+    })
+    expect(() => ssWrite('full', { big: 'data' }, 100)).not.toThrow()
+  })
+})
+
+// ── clearSessionSnapshots ──
+
+describe('clearSessionSnapshots', () => {
+  it('removes all kcc:-prefixed keys', () => {
+    sessionStorage.setItem(SS_PREFIX + 'a', 'data-a')
+    sessionStorage.setItem(SS_PREFIX + 'b', 'data-b')
+    sessionStorage.setItem('other-key', 'keep-me')
+
+    clearSessionSnapshots()
+
+    expect(sessionStorage.getItem(SS_PREFIX + 'a')).toBeNull()
+    expect(sessionStorage.getItem(SS_PREFIX + 'b')).toBeNull()
+    expect(sessionStorage.getItem('other-key')).toBe('keep-me')
+  })
+
+  it('handles empty sessionStorage', () => {
+    expect(() => clearSessionSnapshots()).not.toThrow()
+  })
+
+  it('handles sessionStorage errors gracefully', () => {
+    vi.spyOn(Storage.prototype, 'key').mockImplementation(() => {
+      throw new Error('access denied')
+    })
+    expect(() => clearSessionSnapshots()).not.toThrow()
+  })
+})
+
+// ── isEquivalentToInitial ──
+
+describe('isEquivalentToInitial', () => {
+  it('returns true for both null', () => {
+    expect(isEquivalentToInitial(null, null)).toBe(true)
+  })
+
+  it('returns true for both undefined', () => {
+    expect(isEquivalentToInitial(undefined, undefined)).toBe(true)
+  })
+
+  it('returns true for null and undefined', () => {
+    expect(isEquivalentToInitial(null, undefined)).toBe(true)
+  })
+
+  it('returns true for two empty arrays', () => {
+    expect(isEquivalentToInitial([], [])).toBe(true)
+  })
+
+  it('returns false for non-empty vs empty array', () => {
+    expect(isEquivalentToInitial([1], [])).toBe(false)
+  })
+
+  it('returns false for empty vs non-empty array', () => {
+    expect(isEquivalentToInitial([], [1])).toBe(false)
+  })
+
+  it('returns true for equal objects via JSON', () => {
+    expect(isEquivalentToInitial({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true)
+  })
+
+  it('returns false for different objects', () => {
+    expect(isEquivalentToInitial({ a: 1 }, { a: 2 })).toBe(false)
+  })
+
+  it('returns true for objects with empty arrays and zeros', () => {
+    const a = { alerts: [], inventory: [], nodeCount: 0 }
+    expect(isEquivalentToInitial(a, { ...a })).toBe(true)
+  })
+
+  it('returns false for non-null vs null', () => {
+    expect(isEquivalentToInitial({ a: 1 }, null)).toBe(false)
+  })
+
+  it('returns false for primitives that differ', () => {
+    expect(isEquivalentToInitial('a', 'b')).toBe(false)
+  })
+
+  it('returns false for circular reference objects', () => {
+    const obj: Record<string, unknown> = {}
+    obj.self = obj
+    expect(isEquivalentToInitial(obj, {})).toBe(false)
+  })
+})
+
+// ── getEffectiveInterval ──
+
+describe('getEffectiveInterval', () => {
+  it('returns base interval when no failures', () => {
+    expect(getEffectiveInterval(60_000, 0)).toBe(60_000)
+  })
+
+  it('doubles interval after 1 failure', () => {
+    expect(getEffectiveInterval(60_000, 1)).toBe(120_000)
+  })
+
+  it('quadruples interval after 2 failures', () => {
+    expect(getEffectiveInterval(60_000, 2)).toBe(240_000)
+  })
+
+  it('caps at MAX_BACKOFF_INTERVAL', () => {
+    expect(getEffectiveInterval(60_000, 10)).toBe(MAX_BACKOFF_INTERVAL)
+  })
+
+  it('caps exponent at 5 (2^5 = 32x)', () => {
+    const expected = Math.min(60_000 * Math.pow(FAILURE_BACKOFF_MULTIPLIER, 5), MAX_BACKOFF_INTERVAL)
+    expect(getEffectiveInterval(60_000, 5)).toBe(expected)
+    expect(getEffectiveInterval(60_000, 6)).toBe(expected)
+  })
+
+  it('handles small base interval', () => {
+    expect(getEffectiveInterval(1_000, 3)).toBe(8_000)
+  })
+})
+
+// ── REFRESH_RATES ──
+
+describe('REFRESH_RATES', () => {
+  it('contains all expected categories', () => {
+    const expectedCategories = [
+      'realtime', 'pods', 'clusters', 'deployments', 'services',
+      'metrics', 'gpu', 'helm', 'gitops', 'namespaces', 'rbac',
+      'operators', 'costs', 'ai-ml', 'default',
+    ]
+    for (const cat of expectedCategories) {
+      expect(REFRESH_RATES).toHaveProperty(cat)
+      expect(typeof (REFRESH_RATES as Record<string, number>)[cat]).toBe('number')
+    }
+  })
+
+  it('realtime is the shortest interval', () => {
+    const values = Object.values(REFRESH_RATES) as number[]
+    expect(REFRESH_RATES.realtime).toBe(Math.min(...values))
+  })
+
+  it('costs is the longest interval', () => {
+    const values = Object.values(REFRESH_RATES) as number[]
+    expect(REFRESH_RATES.costs).toBe(Math.max(...values))
+  })
+})
+
+// ── Auto-refresh pause ──
+
+describe('auto-refresh pause', () => {
+  it('defaults to not paused', () => {
+    expect(isAutoRefreshPaused()).toBe(false)
+  })
+
+  it('can be paused', () => {
+    setAutoRefreshPaused(true)
+    expect(isAutoRefreshPaused()).toBe(true)
+  })
+
+  it('can be resumed', () => {
+    setAutoRefreshPaused(true)
+    setAutoRefreshPaused(false)
+    expect(isAutoRefreshPaused()).toBe(false)
+  })
+
+  it('notifies subscribers on change', () => {
+    const cb = vi.fn()
+    const unsub = subscribeAutoRefreshPaused(cb)
+
+    setAutoRefreshPaused(true)
+    expect(cb).toHaveBeenCalledWith(true)
+
+    setAutoRefreshPaused(false)
+    expect(cb).toHaveBeenCalledWith(false)
+
+    unsub()
+  })
+
+  it('does not notify when setting same value', () => {
+    const cb = vi.fn()
+    const unsub = subscribeAutoRefreshPaused(cb)
+
+    setAutoRefreshPaused(false)
+    expect(cb).not.toHaveBeenCalled()
+
+    unsub()
+  })
+
+  it('unsubscribe stops notifications', () => {
+    const cb = vi.fn()
+    const unsub = subscribeAutoRefreshPaused(cb)
+    unsub()
+
+    setAutoRefreshPaused(true)
+    expect(cb).not.toHaveBeenCalled()
+  })
+})
+
+// ── isSQLiteWorkerActive ──
+
+describe('isSQLiteWorkerActive', () => {
+  it('returns false when no worker initialized', () => {
+    expect(isSQLiteWorkerActive()).toBe(false)
+  })
+})
+
+// ── Constants ──
+
+describe('cache constants', () => {
+  it('CACHE_VERSION is a positive integer', () => {
+    expect(Number.isInteger(CACHE_VERSION)).toBe(true)
+    expect(CACHE_VERSION).toBeGreaterThan(0)
+  })
+
+  it('MAX_FAILURES is a positive integer', () => {
+    expect(Number.isInteger(MAX_FAILURES)).toBe(true)
+    expect(MAX_FAILURES).toBeGreaterThan(0)
+  })
+
+  it('SS_PREFIX is a non-empty string', () => {
+    expect(typeof SS_PREFIX).toBe('string')
+    expect(SS_PREFIX.length).toBeGreaterThan(0)
+  })
+})

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -1679,3 +1679,17 @@ export {
 // Re-export hook factory
 export { createCachedHook } from './createCachedHook'
 export type { CreateCachedHookConfig } from './createCachedHook'
+
+export const __testables = {
+  ssWrite,
+  ssRead,
+  clearSessionSnapshots,
+  isEquivalentToInitial,
+  getEffectiveInterval,
+  CACHE_VERSION,
+  SS_PREFIX,
+  META_PREFIX,
+  MAX_FAILURES,
+  FAILURE_BACKOFF_MULTIPLIER,
+  MAX_BACKOFF_INTERVAL,
+}


### PR DESCRIPTION
## Summary
- Add `__testables` exports to 4 source files (`cache/index.ts`, `mcp/shared.ts`, `auth.tsx`, `useLastRoute.ts`) exposing private pure functions for unit testing
- New test file: `cache-internals.test.ts` (46 tests) — ssWrite/ssRead round-trips, version mismatch, clearSessionSnapshots, isEquivalentToInitial, getEffectiveInterval backoff, REFRESH_RATES validation, auto-refresh pause
- New test file: `shared-distribution.test.ts` (51 tests) — detectDistributionFromNamespaces (OpenShift/GKE/EKS/AKS/Rancher), detectDistributionFromServer (URL pattern matching), updatesTouchData/updatesTouchUI, clusterDisplayName, shouldMarkOffline
- Expanded `auth.test.ts` (+8 tests) — getJwtExpiryMs and isJWTExpired via `__testables`
- Expanded `useLastRoute.test.ts` (+6 tests) — getFirstDashboardRoute sidebar config parsing

## Test plan
- [ ] All 204 tests pass across 4 test files
- [ ] No source logic changes — only `__testables` exports added
- [ ] CI coverage report shows improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)