### PR TITLE
🐛 Fix Dashboard cluster count test race condition in firefox/webkit

### DIFF
--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -504,36 +504,50 @@ test.describe('Dashboard Data Accuracy (#6459)', () => {
       'Data accuracy verified on desktop browsers.'
     )
     // 1. Visit /clusters and count the cluster rows.
+    // Wait for the mock API response to be received before inspecting the
+    // DOM — on firefox/webkit the SWR cache rehydrates stale (empty)
+    // sessionStorage data synchronously, and the async mock response
+    // arrives later. Without this guard the row count resolves to 0.
+    // (#10955)
+    const PAGE_RENDER_TIMEOUT_MS = 30_000
+    const clustersApiPromise = page.waitForResponse(
+      (resp) => resp.url().includes('/api/mcp/clusters') && resp.status() === 200
+    )
     await page.goto('/clusters')
     await page.waitForLoadState('domcontentloaded')
 
+    // Ensure the mocked /api/mcp/clusters response was delivered to the page.
+    await clustersApiPromise
+
     // Wait for clusters page to fully render — Firefox/webkit may need extra time
-    const PAGE_RENDER_TIMEOUT_MS = 30_000
     await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: PAGE_RENDER_TIMEOUT_MS })
 
     // Wait for cluster data to actually render before counting rows.
     // On webkit/firefox the SWR cache hydrates slower than Chromium, so
     // the container can be visible before any cluster rows appear. (#10828)
+    // Use a hard assertion (no .catch) so failures surface instead of
+    // silently yielding 0 rows. (#10955)
     const DATA_RENDER_TIMEOUT_MS = 20_000
     const firstClusterName = page.getByText('accuracy-cluster-1').first()
-    await expect(firstClusterName).toBeVisible({ timeout: DATA_RENDER_TIMEOUT_MS }).catch(() => {})
+    await expect(firstClusterName).toBeVisible({ timeout: DATA_RENDER_TIMEOUT_MS })
 
     // The clusters page renders a row per cluster. We count any element
     // whose data-testid matches the cluster-row pattern. If the test
     // infra doesn't expose cluster-row testids, fall back to counting
     // by name strings — both must agree with EXPECTED_CLUSTER_COUNT.
     const rowsByTestId = page.locator('[data-testid^="cluster-row-"]')
-    const rowCountByTestId = await rowsByTestId.count().catch(() => 0)
+    const rowCountByTestId = await rowsByTestId.count()
 
     let clustersPageCount = rowCountByTestId
     if (clustersPageCount === 0) {
       // Fallback: count unique cluster-name text occurrences.
-      const NAME_CHECK_TIMEOUT_MS = 5_000
+      // Each name was already confirmed present (firstClusterName wait
+      // above succeeded), so use a reasonable timeout per name.
+      const NAME_CHECK_TIMEOUT_MS = 10_000
       let found = 0
       for (let i = 1; i <= EXPECTED_CLUSTER_COUNT; i++) {
-        const hasName = await page
-          .getByText(`accuracy-cluster-${i}`)
-          .first()
+        const nameLocator = page.getByText(`accuracy-cluster-${i}`).first()
+        const hasName = await nameLocator
           .isVisible({ timeout: NAME_CHECK_TIMEOUT_MS })
           .catch(() => false)
         if (hasName) found++

--- a/web/src/components/cards/__tests__/artifact_hub_status.test.ts
+++ b/web/src/components/cards/__tests__/artifact_hub_status.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ARTIFACT_HUB_DEMO_DATA,
+  type ArtifactHubDemoData,
+} from '../artifact_hub_status/demoData'
+
+describe('ARTIFACT_HUB_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(ARTIFACT_HUB_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid: ArtifactHubDemoData['health'][] = ['healthy', 'degraded']
+    expect(valid).toContain(ARTIFACT_HUB_DEMO_DATA.health)
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(ARTIFACT_HUB_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  it('packages count is positive', () => {
+    expect(ARTIFACT_HUB_DEMO_DATA.packages).toBeGreaterThan(0)
+  })
+
+  it('repositories count is positive', () => {
+    expect(ARTIFACT_HUB_DEMO_DATA.repositories).toBeGreaterThan(0)
+  })
+
+  it('organizations count is positive', () => {
+    expect(ARTIFACT_HUB_DEMO_DATA.organizations).toBeGreaterThan(0)
+  })
+
+  it('users count is positive', () => {
+    expect(ARTIFACT_HUB_DEMO_DATA.users).toBeGreaterThan(0)
+  })
+
+  it('repositories < packages (hub scale)', () => {
+    expect(ARTIFACT_HUB_DEMO_DATA.repositories).toBeLessThan(ARTIFACT_HUB_DEMO_DATA.packages)
+  })
+
+  it('organizations < users (org scale)', () => {
+    expect(ARTIFACT_HUB_DEMO_DATA.organizations).toBeLessThan(ARTIFACT_HUB_DEMO_DATA.users)
+  })
+})

--- a/web/src/components/cards/__tests__/change_timeline.test.ts
+++ b/web/src/components/cards/__tests__/change_timeline.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getDemoTimelineEvents,
+  type TimelineEvent,
+  type TimelineEventType,
+} from '../change_timeline/demoData'
+
+describe('getDemoTimelineEvents', () => {
+  let events: TimelineEvent[]
+
+  beforeEach(() => {
+    events = getDemoTimelineEvents()
+  })
+
+  it('returns a non-empty array', () => {
+    expect(Array.isArray(events)).toBe(true)
+    expect(events.length).toBeGreaterThan(0)
+  })
+
+  it('each event has required fields', () => {
+    const validTypes: TimelineEventType[] = [
+      'Created', 'Modified', 'Deleted', 'Scaled', 'Restarted', 'Failed', 'Warning',
+    ]
+    for (const evt of events) {
+      expect(typeof evt.id).toBe('string')
+      expect(evt.id.length).toBeGreaterThan(0)
+      expect(typeof evt.cluster).toBe('string')
+      expect(typeof evt.namespace).toBe('string')
+      expect(typeof evt.resource).toBe('string')
+      expect(validTypes).toContain(evt.eventType)
+      expect(typeof evt.timestamp).toBe('string')
+      expect(new Date(evt.timestamp).getTime()).toBeGreaterThan(0)
+      expect(typeof evt.message).toBe('string')
+    }
+  })
+
+  it('timestamps are within the last 24 hours', () => {
+    const now = Date.now()
+    const msInDay = 24 * 60 * 60 * 1000
+    for (const evt of events) {
+      const ts = new Date(evt.timestamp).getTime()
+      expect(ts).toBeGreaterThan(now - msInDay * 2)
+      expect(ts).toBeLessThanOrEqual(now + 1000)
+    }
+  })
+
+  it('covers multiple event types', () => {
+    const types = new Set(events.map(e => e.eventType))
+    expect(types.size).toBeGreaterThan(1)
+  })
+
+  it('covers multiple clusters', () => {
+    const clusters = new Set(events.map(e => e.cluster))
+    expect(clusters.size).toBeGreaterThan(1)
+  })
+
+  it('all event IDs are unique', () => {
+    const ids = events.map(e => e.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('calling twice returns consistent shape', () => {
+    const events2 = getDemoTimelineEvents()
+    expect(events2.length).toBe(events.length)
+    expect(events2[0].cluster).toBe(events[0].cluster)
+  })
+})

--- a/web/src/components/cards/__tests__/cloudevents_status.test.ts
+++ b/web/src/components/cards/__tests__/cloudevents_status.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { CLOUDEVENTS_DEMO_DATA, type CloudEventsDemoData } from '../cloudevents_status/demoData'
+
+describe('CLOUDEVENTS_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(CLOUDEVENTS_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid: CloudEventsDemoData['health'][] = ['healthy', 'degraded', 'not-installed']
+    expect(valid).toContain(CLOUDEVENTS_DEMO_DATA.health)
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(CLOUDEVENTS_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  describe('brokers', () => {
+    it('has non-negative counts', () => {
+      const { brokers } = CLOUDEVENTS_DEMO_DATA
+      expect(brokers.total).toBeGreaterThanOrEqual(0)
+      expect(brokers.ready).toBeGreaterThanOrEqual(0)
+      expect(brokers.notReady).toBeGreaterThanOrEqual(0)
+    })
+
+    it('ready + notReady equals total', () => {
+      const { brokers } = CLOUDEVENTS_DEMO_DATA
+      expect(brokers.ready + brokers.notReady).toBe(brokers.total)
+    })
+  })
+
+  describe('triggers', () => {
+    it('has non-negative counts', () => {
+      const { triggers } = CLOUDEVENTS_DEMO_DATA
+      expect(triggers.total).toBeGreaterThanOrEqual(0)
+      expect(triggers.ready).toBeGreaterThanOrEqual(0)
+      expect(triggers.notReady).toBeGreaterThanOrEqual(0)
+    })
+
+    it('ready + notReady equals total', () => {
+      const { triggers } = CLOUDEVENTS_DEMO_DATA
+      expect(triggers.ready + triggers.notReady).toBe(triggers.total)
+    })
+  })
+
+  describe('eventSources', () => {
+    it('has non-negative counts', () => {
+      const { eventSources } = CLOUDEVENTS_DEMO_DATA
+      expect(eventSources.total).toBeGreaterThanOrEqual(0)
+      expect(eventSources.ready).toBeGreaterThanOrEqual(0)
+      expect(eventSources.failed).toBeGreaterThanOrEqual(0)
+    })
+
+    it('ready + failed does not exceed total', () => {
+      const { eventSources } = CLOUDEVENTS_DEMO_DATA
+      expect(eventSources.ready + eventSources.failed).toBeLessThanOrEqual(eventSources.total)
+    })
+  })
+
+  describe('deliveries', () => {
+    it('all delivery counts are non-negative', () => {
+      const { deliveries } = CLOUDEVENTS_DEMO_DATA
+      expect(deliveries.successful).toBeGreaterThanOrEqual(0)
+      expect(deliveries.failed).toBeGreaterThanOrEqual(0)
+      expect(deliveries.unknown).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  describe('resources', () => {
+    it('is an array', () => {
+      expect(Array.isArray(CLOUDEVENTS_DEMO_DATA.resources)).toBe(true)
+    })
+
+    it('each resource has required fields', () => {
+      for (const res of CLOUDEVENTS_DEMO_DATA.resources) {
+        expect(typeof res.name).toBe('string')
+        expect(typeof res.namespace).toBe('string')
+        expect(typeof res.cluster).toBe('string')
+        expect(typeof res.kind).toBe('string')
+        expect(['ready', 'degraded', 'error']).toContain(res.state)
+        expect(typeof res.sink).toBe('string')
+        expect(typeof res.lastSeen).toBe('string')
+      }
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/contour_status.test.ts
+++ b/web/src/components/cards/__tests__/contour_status.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { CONTOUR_DEMO_DATA, type ContourStatusData } from '../contour_status/demoData'
+
+describe('CONTOUR_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(CONTOUR_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid: ContourStatusData['health'][] = ['healthy', 'degraded', 'not-installed']
+    expect(valid).toContain(CONTOUR_DEMO_DATA.health)
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(CONTOUR_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  describe('proxies', () => {
+    it('is an array', () => {
+      expect(Array.isArray(CONTOUR_DEMO_DATA.proxies)).toBe(true)
+    })
+
+    it('each proxy has required fields', () => {
+      for (const proxy of CONTOUR_DEMO_DATA.proxies) {
+        expect(typeof proxy.name).toBe('string')
+        expect(proxy.name.length).toBeGreaterThan(0)
+        expect(typeof proxy.namespace).toBe('string')
+        expect(typeof proxy.cluster).toBe('string')
+        expect(typeof proxy.fqdn).toBe('string')
+        expect(['Valid', 'Invalid']).toContain(proxy.status)
+        expect(Array.isArray(proxy.conditions)).toBe(true)
+      }
+    })
+
+    it('covers Valid and Invalid statuses', () => {
+      const statuses = new Set(CONTOUR_DEMO_DATA.proxies.map(p => p.status))
+      expect(statuses.has('Valid')).toBe(true)
+      expect(statuses.has('Invalid')).toBe(true)
+    })
+  })
+
+  describe('envoyFleet', () => {
+    it('has non-negative counts', () => {
+      const { envoyFleet } = CONTOUR_DEMO_DATA
+      expect(envoyFleet.total).toBeGreaterThanOrEqual(0)
+      expect(envoyFleet.ready).toBeGreaterThanOrEqual(0)
+      expect(envoyFleet.notReady).toBeGreaterThanOrEqual(0)
+    })
+
+    it('ready + notReady equals total', () => {
+      const { envoyFleet } = CONTOUR_DEMO_DATA
+      expect(envoyFleet.ready + envoyFleet.notReady).toBe(envoyFleet.total)
+    })
+  })
+
+  describe('summary', () => {
+    it('matches proxy array counts', () => {
+      const total = CONTOUR_DEMO_DATA.proxies.length
+      const valid = CONTOUR_DEMO_DATA.proxies.filter(p => p.status === 'Valid').length
+      const invalid = CONTOUR_DEMO_DATA.proxies.filter(p => p.status === 'Invalid').length
+      expect(CONTOUR_DEMO_DATA.summary.totalProxies).toBe(total)
+      expect(CONTOUR_DEMO_DATA.summary.validProxies).toBe(valid)
+      expect(CONTOUR_DEMO_DATA.summary.invalidProxies).toBe(invalid)
+    })
+
+    it('validProxies + invalidProxies equals totalProxies', () => {
+      const { summary } = CONTOUR_DEMO_DATA
+      expect(summary.validProxies + summary.invalidProxies).toBe(summary.totalProxies)
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/crio_status.test.ts
+++ b/web/src/components/cards/__tests__/crio_status.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CRIO_DEMO_DATA,
+  type CrioStatusDemoData,
+} from '../crio_status/demoData'
+
+describe('CRIO_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(CRIO_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid: CrioStatusDemoData['health'][] = ['healthy', 'degraded', 'not-installed']
+    expect(valid).toContain(CRIO_DEMO_DATA.health)
+  })
+
+  it('detected is boolean', () => {
+    expect(typeof CRIO_DEMO_DATA.detected).toBe('boolean')
+  })
+
+  it('totalNodes is positive', () => {
+    expect(CRIO_DEMO_DATA.totalNodes).toBeGreaterThan(0)
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(CRIO_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  describe('versions', () => {
+    it('is an object', () => {
+      expect(typeof CRIO_DEMO_DATA.versions).toBe('object')
+    })
+
+    it('version values are positive numbers', () => {
+      for (const [ver, count] of Object.entries(CRIO_DEMO_DATA.versions)) {
+        expect(typeof ver).toBe('string')
+        expect(count).toBeGreaterThan(0)
+      }
+    })
+
+    it('sum of version counts matches totalNodes', () => {
+      const total = Object.values(CRIO_DEMO_DATA.versions).reduce((a, b) => a + b, 0)
+      expect(total).toBe(CRIO_DEMO_DATA.totalNodes)
+    })
+  })
+
+  describe('runtimeMetrics', () => {
+    it('has non-negative container counts', () => {
+      const { runtimeMetrics } = CRIO_DEMO_DATA
+      expect(runtimeMetrics.runningContainers).toBeGreaterThanOrEqual(0)
+      expect(runtimeMetrics.pausedContainers).toBeGreaterThanOrEqual(0)
+      expect(runtimeMetrics.stoppedContainers).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  describe('imagePulls', () => {
+    it('successful + failed does not exceed total', () => {
+      const { imagePulls } = CRIO_DEMO_DATA
+      expect(imagePulls.successful + imagePulls.failed).toBeLessThanOrEqual(imagePulls.total)
+    })
+
+    it('all counts are non-negative', () => {
+      expect(CRIO_DEMO_DATA.imagePulls.total).toBeGreaterThanOrEqual(0)
+      expect(CRIO_DEMO_DATA.imagePulls.successful).toBeGreaterThanOrEqual(0)
+      expect(CRIO_DEMO_DATA.imagePulls.failed).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  describe('podSandboxes', () => {
+    it('ready + notReady equals total', () => {
+      const { podSandboxes } = CRIO_DEMO_DATA
+      expect(podSandboxes.ready + podSandboxes.notReady).toBe(podSandboxes.total)
+    })
+
+    it('all counts are non-negative', () => {
+      expect(CRIO_DEMO_DATA.podSandboxes.ready).toBeGreaterThanOrEqual(0)
+      expect(CRIO_DEMO_DATA.podSandboxes.notReady).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  describe('recentImagePulls', () => {
+    it('is an array', () => {
+      expect(Array.isArray(CRIO_DEMO_DATA.recentImagePulls)).toBe(true)
+    })
+
+    it('each pull has image and status', () => {
+      for (const pull of CRIO_DEMO_DATA.recentImagePulls) {
+        expect(typeof pull.image).toBe('string')
+        expect(pull.image.length).toBeGreaterThan(0)
+        expect(['success', 'failed']).toContain(pull.status)
+        expect(typeof pull.time).toBe('string')
+      }
+    })
+
+    it('covers success and failed statuses', () => {
+      const statuses = new Set(CRIO_DEMO_DATA.recentImagePulls.map(p => p.status))
+      expect(statuses.has('success')).toBe(true)
+      expect(statuses.has('failed')).toBe(true)
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/cubefs_status.test.ts
+++ b/web/src/components/cards/__tests__/cubefs_status.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CUBEFS_DEMO_DATA,
+  type CubefsVolumeStatus,
+  type CubefsNodeStatus,
+} from '../cubefs_status/demoData'
+
+describe('CUBEFS_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(CUBEFS_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth = ['healthy', 'degraded', 'not-installed']
+    expect(validHealth).toContain(CUBEFS_DEMO_DATA.health)
+  })
+
+  it('has clusterName string', () => {
+    expect(typeof CUBEFS_DEMO_DATA.clusterName).toBe('string')
+    expect(CUBEFS_DEMO_DATA.clusterName.length).toBeGreaterThan(0)
+  })
+
+  it('has masterLeader string', () => {
+    expect(typeof CUBEFS_DEMO_DATA.masterLeader).toBe('string')
+  })
+
+  it('has volumes array with entries', () => {
+    expect(Array.isArray(CUBEFS_DEMO_DATA.volumes)).toBe(true)
+    expect(CUBEFS_DEMO_DATA.volumes.length).toBeGreaterThan(0)
+  })
+
+  it('each volume has required fields', () => {
+    const validStatus: CubefsVolumeStatus[] = ['active', 'inactive', 'read-only', 'unknown']
+    for (const vol of CUBEFS_DEMO_DATA.volumes) {
+      expect(typeof vol.name).toBe('string')
+      expect(typeof vol.owner).toBe('string')
+      expect(validStatus).toContain(vol.status)
+      expect(typeof vol.capacity).toBe('string')
+      expect(typeof vol.usedSize).toBe('string')
+      expect(typeof vol.usagePercent).toBe('number')
+      expect(vol.usagePercent).toBeGreaterThanOrEqual(0)
+      expect(vol.usagePercent).toBeLessThanOrEqual(100)
+    }
+  })
+
+  it('has nodes array with entries', () => {
+    expect(Array.isArray(CUBEFS_DEMO_DATA.nodes)).toBe(true)
+    expect(CUBEFS_DEMO_DATA.nodes.length).toBeGreaterThan(0)
+  })
+
+  it('each node has required fields', () => {
+    const validStatus: CubefsNodeStatus[] = ['active', 'inactive', 'unknown']
+    const validRoles = ['master', 'meta', 'data'] as const
+    for (const node of CUBEFS_DEMO_DATA.nodes) {
+      expect(typeof node.address).toBe('string')
+      expect(validRoles).toContain(node.role)
+      expect(validStatus).toContain(node.status)
+      expect(typeof node.totalDisk).toBe('string')
+      expect(typeof node.usedDisk).toBe('string')
+      expect(typeof node.diskUsagePercent).toBe('number')
+    }
+  })
+
+  it('disk usage percent is between 0 and 100', () => {
+    for (const node of CUBEFS_DEMO_DATA.nodes) {
+      expect(node.diskUsagePercent).toBeGreaterThanOrEqual(0)
+      expect(node.diskUsagePercent).toBeLessThanOrEqual(100)
+    }
+  })
+})

--- a/web/src/components/cards/__tests__/dapr_status.test.ts
+++ b/web/src/components/cards/__tests__/dapr_status.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DAPR_DEMO_DATA,
+  type DaprHealth,
+  type DaprControlPlanePodStatus,
+  type DaprComponentType,
+} from '../dapr_status/demoData'
+
+describe('DAPR_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(DAPR_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth: DaprHealth[] = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(validHealth).toContain(DAPR_DEMO_DATA.health)
+  })
+
+  it('has controlPlane array with entries', () => {
+    expect(Array.isArray(DAPR_DEMO_DATA.controlPlane)).toBe(true)
+    expect(DAPR_DEMO_DATA.controlPlane.length).toBeGreaterThan(0)
+  })
+
+  it('each control plane pod has required fields', () => {
+    const validStatuses: DaprControlPlanePodStatus[] = ['running', 'pending', 'failed', 'unknown']
+    for (const pod of DAPR_DEMO_DATA.controlPlane) {
+      expect(typeof pod.name).toBe('string')
+      expect(typeof pod.namespace).toBe('string')
+      expect(validStatuses).toContain(pod.status)
+    }
+  })
+
+  it('has components array', () => {
+    expect(Array.isArray(DAPR_DEMO_DATA.components)).toBe(true)
+  })
+
+  it('each component has valid type', () => {
+    const validTypes: DaprComponentType[] = ['state-store', 'pubsub', 'binding']
+    for (const comp of DAPR_DEMO_DATA.components) {
+      expect(typeof comp.name).toBe('string')
+      expect(validTypes).toContain(comp.type)
+    }
+  })
+
+  it('has apps sidecar with total and namespaces counts', () => {
+    expect(typeof DAPR_DEMO_DATA.apps.total).toBe('number')
+    expect(typeof DAPR_DEMO_DATA.apps.namespaces).toBe('number')
+    expect(DAPR_DEMO_DATA.apps.total).toBeGreaterThan(0)
+  })
+
+  it('has buildingBlocks with required fields', () => {
+    expect(typeof DAPR_DEMO_DATA.buildingBlocks.stateStores).toBe('number')
+    expect(typeof DAPR_DEMO_DATA.buildingBlocks.pubsubs).toBe('number')
+  })
+
+  it('has summary with required fields', () => {
+    expect(typeof DAPR_DEMO_DATA.summary.totalControlPlanePods).toBe('number')
+    expect(typeof DAPR_DEMO_DATA.summary.runningControlPlanePods).toBe('number')
+    expect(typeof DAPR_DEMO_DATA.summary.totalComponents).toBe('number')
+    expect(typeof DAPR_DEMO_DATA.summary.totalDaprApps).toBe('number')
+  })
+
+  it('summary running pods <= total pods', () => {
+    expect(DAPR_DEMO_DATA.summary.runningControlPlanePods).toBeLessThanOrEqual(
+      DAPR_DEMO_DATA.summary.totalControlPlanePods
+    )
+  })
+})

--- a/web/src/components/cards/__tests__/envoy_status.test.ts
+++ b/web/src/components/cards/__tests__/envoy_status.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ENVOY_DEMO_DATA,
+  type EnvoyHealth,
+  type EnvoyListenerStatus,
+  type EnvoyClusterHealth,
+} from '../envoy_status/demoData'
+
+describe('ENVOY_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(ENVOY_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth: EnvoyHealth[] = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(validHealth).toContain(ENVOY_DEMO_DATA.health)
+  })
+
+  it('has listeners array with entries', () => {
+    expect(Array.isArray(ENVOY_DEMO_DATA.listeners)).toBe(true)
+    expect(ENVOY_DEMO_DATA.listeners.length).toBeGreaterThan(0)
+  })
+
+  it('each listener has required fields', () => {
+    const validStatus: EnvoyListenerStatus[] = ['active', 'draining', 'warming']
+    for (const l of ENVOY_DEMO_DATA.listeners) {
+      expect(typeof l.name).toBe('string')
+      expect(typeof l.address).toBe('string')
+      expect(typeof l.port).toBe('number')
+      expect(validStatus).toContain(l.status)
+      expect(typeof l.cluster).toBe('string')
+    }
+  })
+
+  it('has clusters array with entries', () => {
+    expect(Array.isArray(ENVOY_DEMO_DATA.clusters)).toBe(true)
+    expect(ENVOY_DEMO_DATA.clusters.length).toBeGreaterThan(0)
+  })
+
+  it('each upstream cluster has required fields', () => {
+    for (const c of ENVOY_DEMO_DATA.clusters) {
+      expect(typeof c.name).toBe('string')
+      expect(typeof c.upstream).toBe('string')
+      expect(typeof c.endpointsTotal).toBe('number')
+      expect(typeof c.endpointsHealthy).toBe('number')
+      expect(c.endpointsHealthy).toBeLessThanOrEqual(c.endpointsTotal)
+    }
+  })
+
+  it('has stats with required numeric fields', () => {
+    expect(typeof ENVOY_DEMO_DATA.stats.requestsPerSecond).toBe('number')
+    expect(typeof ENVOY_DEMO_DATA.stats.activeConnections).toBe('number')
+    expect(typeof ENVOY_DEMO_DATA.stats.totalRequests).toBe('number')
+    expect(typeof ENVOY_DEMO_DATA.stats.http5xxRate).toBe('number')
+  })
+
+  it('has summary with required counts', () => {
+    expect(typeof ENVOY_DEMO_DATA.summary.totalListeners).toBe('number')
+    expect(typeof ENVOY_DEMO_DATA.summary.activeListeners).toBe('number')
+    expect(typeof ENVOY_DEMO_DATA.summary.totalClusters).toBe('number')
+    expect(typeof ENVOY_DEMO_DATA.summary.healthyClusters).toBe('number')
+  })
+
+  it('activeListeners <= totalListeners', () => {
+    expect(ENVOY_DEMO_DATA.summary.activeListeners).toBeLessThanOrEqual(ENVOY_DEMO_DATA.summary.totalListeners)
+  })
+})

--- a/web/src/components/cards/__tests__/failover_timeline.test.ts
+++ b/web/src/components/cards/__tests__/failover_timeline.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FAILOVER_TIMELINE_DEMO_DATA,
+  type FailoverTimelineData,
+  type FailoverEventType,
+  type FailoverSeverity,
+} from '../failover_timeline/demoData'
+
+describe('FAILOVER_TIMELINE_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(FAILOVER_TIMELINE_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(FAILOVER_TIMELINE_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  it('activeClusters is non-negative', () => {
+    expect(FAILOVER_TIMELINE_DEMO_DATA.activeClusters).toBeGreaterThanOrEqual(0)
+  })
+
+  it('totalClusters is positive', () => {
+    expect(FAILOVER_TIMELINE_DEMO_DATA.totalClusters).toBeGreaterThan(0)
+  })
+
+  it('activeClusters does not exceed totalClusters', () => {
+    expect(FAILOVER_TIMELINE_DEMO_DATA.activeClusters).toBeLessThanOrEqual(
+      FAILOVER_TIMELINE_DEMO_DATA.totalClusters,
+    )
+  })
+
+  it('lastFailover is a valid ISO string or null', () => {
+    const { lastFailover } = FAILOVER_TIMELINE_DEMO_DATA
+    if (lastFailover !== null) {
+      expect(new Date(lastFailover).getTime()).toBeGreaterThan(0)
+    }
+  })
+
+  describe('events', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(FAILOVER_TIMELINE_DEMO_DATA.events)).toBe(true)
+      expect(FAILOVER_TIMELINE_DEMO_DATA.events.length).toBeGreaterThan(0)
+    })
+
+    it('each event has required fields', () => {
+      const validTypes: FailoverEventType[] = [
+        'cluster_down', 'binding_reschedule', 'cluster_recovery', 'replica_rebalance',
+      ]
+      const validSeverities: FailoverSeverity[] = ['critical', 'warning', 'info']
+      for (const evt of FAILOVER_TIMELINE_DEMO_DATA.events) {
+        expect(typeof evt.timestamp).toBe('string')
+        expect(new Date(evt.timestamp).getTime()).toBeGreaterThan(0)
+        expect(validTypes).toContain(evt.eventType)
+        expect(typeof evt.cluster).toBe('string')
+        expect(typeof evt.workload).toBe('string')
+        expect(typeof evt.details).toBe('string')
+        expect(validSeverities).toContain(evt.severity)
+      }
+    })
+
+    it('covers multiple event types', () => {
+      const types = new Set(FAILOVER_TIMELINE_DEMO_DATA.events.map(e => e.eventType))
+      expect(types.size).toBeGreaterThan(1)
+    })
+
+    it('covers multiple severity levels', () => {
+      const severities = new Set(FAILOVER_TIMELINE_DEMO_DATA.events.map(e => e.severity))
+      expect(severities.size).toBeGreaterThan(1)
+    })
+
+    it('has at least one cluster_down event', () => {
+      const hasDown = FAILOVER_TIMELINE_DEMO_DATA.events.some(e => e.eventType === 'cluster_down')
+      expect(hasDown).toBe(true)
+    })
+
+    it('has at least one cluster_recovery event', () => {
+      const hasRecovery = FAILOVER_TIMELINE_DEMO_DATA.events.some(
+        e => e.eventType === 'cluster_recovery',
+      )
+      expect(hasRecovery).toBe(true)
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/fluentd_status.test.ts
+++ b/web/src/components/cards/__tests__/fluentd_status.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { FLUENTD_DEMO_DATA, type FluentdDemoData } from '../fluentd_status/demoData'
+
+describe('FLUENTD_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(FLUENTD_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid: FluentdDemoData['health'][] = ['healthy', 'degraded', 'not-installed']
+    expect(valid).toContain(FLUENTD_DEMO_DATA.health)
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(FLUENTD_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  describe('pods', () => {
+    it('has ready and total', () => {
+      expect(typeof FLUENTD_DEMO_DATA.pods.ready).toBe('number')
+      expect(typeof FLUENTD_DEMO_DATA.pods.total).toBe('number')
+    })
+
+    it('ready does not exceed total', () => {
+      expect(FLUENTD_DEMO_DATA.pods.ready).toBeLessThanOrEqual(FLUENTD_DEMO_DATA.pods.total)
+    })
+
+    it('both counts are positive', () => {
+      expect(FLUENTD_DEMO_DATA.pods.total).toBeGreaterThan(0)
+    })
+  })
+
+  describe('buffer utilization', () => {
+    it('is between 0 and 100', () => {
+      expect(FLUENTD_DEMO_DATA.bufferUtilization).toBeGreaterThanOrEqual(0)
+      expect(FLUENTD_DEMO_DATA.bufferUtilization).toBeLessThanOrEqual(100)
+    })
+  })
+
+  describe('eventsPerSecond', () => {
+    it('is non-negative', () => {
+      expect(FLUENTD_DEMO_DATA.eventsPerSecond).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  describe('retryCount', () => {
+    it('is non-negative', () => {
+      expect(FLUENTD_DEMO_DATA.retryCount).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  describe('outputPlugins', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(FLUENTD_DEMO_DATA.outputPlugins)).toBe(true)
+      expect(FLUENTD_DEMO_DATA.outputPlugins.length).toBeGreaterThan(0)
+    })
+
+    it('each plugin has required fields', () => {
+      for (const plugin of FLUENTD_DEMO_DATA.outputPlugins) {
+        expect(typeof plugin.name).toBe('string')
+        expect(plugin.name.length).toBeGreaterThan(0)
+        expect(typeof plugin.type).toBe('string')
+        expect(['healthy', 'degraded', 'error']).toContain(plugin.status)
+        expect(typeof plugin.emitCount).toBe('number')
+        expect(typeof plugin.errorCount).toBe('number')
+        expect(plugin.emitCount).toBeGreaterThanOrEqual(0)
+        expect(plugin.errorCount).toBeGreaterThanOrEqual(0)
+      }
+    })
+
+    it('covers multiple status variants', () => {
+      const statuses = new Set(FLUENTD_DEMO_DATA.outputPlugins.map(p => p.status))
+      expect(statuses.size).toBeGreaterThan(1)
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/fluid_status.test.ts
+++ b/web/src/components/cards/__tests__/fluid_status.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FLUID_DEMO_DATA,
+  type FluidDatasetStatus,
+  type FluidRuntimeStatus,
+} from '../fluid_status/demoData'
+
+describe('FLUID_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(FLUID_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth = ['healthy', 'degraded', 'not-installed']
+    expect(validHealth).toContain(FLUID_DEMO_DATA.health)
+  })
+
+  it('has controllerPods with ready/total counts', () => {
+    expect(typeof FLUID_DEMO_DATA.controllerPods.ready).toBe('number')
+    expect(typeof FLUID_DEMO_DATA.controllerPods.total).toBe('number')
+    expect(FLUID_DEMO_DATA.controllerPods.ready).toBeLessThanOrEqual(FLUID_DEMO_DATA.controllerPods.total)
+  })
+
+  it('has datasets array with entries', () => {
+    expect(Array.isArray(FLUID_DEMO_DATA.datasets)).toBe(true)
+    expect(FLUID_DEMO_DATA.datasets.length).toBeGreaterThan(0)
+  })
+
+  it('each dataset has required fields', () => {
+    const validStatus: FluidDatasetStatus[] = ['bound', 'not-bound', 'unknown']
+    for (const ds of FLUID_DEMO_DATA.datasets) {
+      expect(typeof ds.name).toBe('string')
+      expect(typeof ds.namespace).toBe('string')
+      expect(validStatus).toContain(ds.status)
+      expect(typeof ds.source).toBe('string')
+      expect(typeof ds.cachedPercentage).toBe('number')
+      expect(ds.cachedPercentage).toBeGreaterThanOrEqual(0)
+      expect(ds.cachedPercentage).toBeLessThanOrEqual(100)
+    }
+  })
+
+  it('has runtimes array', () => {
+    expect(Array.isArray(FLUID_DEMO_DATA.runtimes)).toBe(true)
+  })
+
+  it('each runtime has required fields', () => {
+    const validRuntimeStatus: FluidRuntimeStatus[] = ['ready', 'not-ready', 'unknown']
+    for (const rt of FLUID_DEMO_DATA.runtimes) {
+      expect(typeof rt.type).toBe('string')
+      expect(validRuntimeStatus).toContain(rt.status)
+    }
+  })
+
+  it('has dataLoads array', () => {
+    expect(Array.isArray(FLUID_DEMO_DATA.dataLoads)).toBe(true)
+  })
+})

--- a/web/src/components/cards/__tests__/flux_status.test.ts
+++ b/web/src/components/cards/__tests__/flux_status.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FLUX_DEMO_DATA,
+  type FluxStatusData,
+  type FluxResourceKind,
+  type FluxResourceStatus,
+  type FluxResourceSummary,
+} from '../flux_status/demoData'
+
+describe('FLUX_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(FLUX_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid: FluxStatusData['health'][] = ['healthy', 'degraded', 'not-installed']
+    expect(valid).toContain(FLUX_DEMO_DATA.health)
+  })
+
+  it('has valid lastCheckTime ISO string', () => {
+    expect(() => new Date(FLUX_DEMO_DATA.lastCheckTime)).not.toThrow()
+    expect(new Date(FLUX_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  describe('sources summary', () => {
+    it('has numeric totals', () => {
+      const { sources } = FLUX_DEMO_DATA
+      expect(typeof sources.total).toBe('number')
+      expect(typeof sources.ready).toBe('number')
+      expect(typeof sources.notReady).toBe('number')
+    })
+
+    it('ready + notReady equals total', () => {
+      const { sources } = FLUX_DEMO_DATA
+      expect(sources.ready + sources.notReady).toBe(sources.total)
+    })
+
+    it('ready and notReady are non-negative', () => {
+      expect(FLUX_DEMO_DATA.sources.ready).toBeGreaterThanOrEqual(0)
+      expect(FLUX_DEMO_DATA.sources.notReady).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  describe('kustomizations summary', () => {
+    it('has numeric totals', () => {
+      const { kustomizations } = FLUX_DEMO_DATA
+      expect(typeof kustomizations.total).toBe('number')
+      expect(typeof kustomizations.ready).toBe('number')
+      expect(typeof kustomizations.notReady).toBe('number')
+    })
+
+    it('ready + notReady equals total', () => {
+      const { kustomizations } = FLUX_DEMO_DATA
+      expect(kustomizations.ready + kustomizations.notReady).toBe(kustomizations.total)
+    })
+  })
+
+  describe('helmReleases summary', () => {
+    it('has numeric totals', () => {
+      const { helmReleases } = FLUX_DEMO_DATA
+      expect(typeof helmReleases.total).toBe('number')
+      expect(typeof helmReleases.ready).toBe('number')
+      expect(typeof helmReleases.notReady).toBe('number')
+    })
+
+    it('ready + notReady equals total', () => {
+      const { helmReleases } = FLUX_DEMO_DATA
+      expect(helmReleases.ready + helmReleases.notReady).toBe(helmReleases.total)
+    })
+  })
+
+  describe('resources.sources', () => {
+    it('is an array', () => {
+      expect(Array.isArray(FLUX_DEMO_DATA.resources.sources)).toBe(true)
+    })
+
+    it('count matches sources.total', () => {
+      expect(FLUX_DEMO_DATA.resources.sources.length).toBe(FLUX_DEMO_DATA.sources.total)
+    })
+
+    it('each source has required fields', () => {
+      const validKinds: FluxResourceKind[] = ['GitRepository', 'Kustomization', 'HelmRelease']
+      for (const src of FLUX_DEMO_DATA.resources.sources) {
+        expect(validKinds).toContain(src.kind)
+        expect(typeof src.name).toBe('string')
+        expect(src.name.length).toBeGreaterThan(0)
+        expect(typeof src.namespace).toBe('string')
+        expect(typeof src.cluster).toBe('string')
+        expect(typeof src.ready).toBe('boolean')
+      }
+    })
+
+    it('not-ready sources have a reason', () => {
+      for (const src of FLUX_DEMO_DATA.resources.sources) {
+        if (!src.ready) {
+          expect(typeof src.reason).toBe('string')
+        }
+      }
+    })
+  })
+
+  describe('resources.kustomizations', () => {
+    it('count matches kustomizations.total', () => {
+      expect(FLUX_DEMO_DATA.resources.kustomizations.length).toBe(
+        FLUX_DEMO_DATA.kustomizations.total,
+      )
+    })
+
+    it('each kustomization has kind Kustomization', () => {
+      for (const k of FLUX_DEMO_DATA.resources.kustomizations) {
+        expect(k.kind).toBe('Kustomization')
+      }
+    })
+  })
+
+  describe('resources.helmReleases', () => {
+    it('count matches helmReleases.total', () => {
+      expect(FLUX_DEMO_DATA.resources.helmReleases.length).toBe(
+        FLUX_DEMO_DATA.helmReleases.total,
+      )
+    })
+
+    it('each release has kind HelmRelease', () => {
+      for (const hr of FLUX_DEMO_DATA.resources.helmReleases) {
+        expect(hr.kind).toBe('HelmRelease')
+      }
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/grpc_status.test.ts
+++ b/web/src/components/cards/__tests__/grpc_status.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import {
+  GRPC_DEMO_DATA,
+  type GrpcHealth,
+  type GrpcServingStatus,
+} from '../grpc_status/demoData'
+
+describe('GRPC_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(GRPC_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth: GrpcHealth[] = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(validHealth).toContain(GRPC_DEMO_DATA.health)
+  })
+
+  it('has services array with entries', () => {
+    expect(Array.isArray(GRPC_DEMO_DATA.services)).toBe(true)
+    expect(GRPC_DEMO_DATA.services.length).toBeGreaterThan(0)
+  })
+
+  it('each service has required fields', () => {
+    const validStatus: GrpcServingStatus[] = ['serving', 'not-serving', 'unknown']
+    for (const svc of GRPC_DEMO_DATA.services) {
+      expect(typeof svc.name).toBe('string')
+      expect(typeof svc.namespace).toBe('string')
+      expect(typeof svc.endpoints).toBe('number')
+      expect(typeof svc.rps).toBe('number')
+      expect(typeof svc.latencyP99Ms).toBe('number')
+      expect(typeof svc.errorRatePct).toBe('number')
+      expect(validStatus).toContain(svc.status)
+      expect(typeof svc.cluster).toBe('string')
+    }
+  })
+
+  it('has stats with required numeric fields', () => {
+    expect(typeof GRPC_DEMO_DATA.stats.totalRps).toBe('number')
+    expect(typeof GRPC_DEMO_DATA.stats.avgLatencyP99Ms).toBe('number')
+    expect(typeof GRPC_DEMO_DATA.stats.avgErrorRatePct).toBe('number')
+    expect(typeof GRPC_DEMO_DATA.stats.reflectionEnabled).toBe('number')
+  })
+
+  it('has summary with required counts', () => {
+    expect(typeof GRPC_DEMO_DATA.summary.totalServices).toBe('number')
+    expect(typeof GRPC_DEMO_DATA.summary.servingServices).toBe('number')
+    expect(typeof GRPC_DEMO_DATA.summary.totalEndpoints).toBe('number')
+  })
+
+  it('servingServices <= totalServices', () => {
+    expect(GRPC_DEMO_DATA.summary.servingServices).toBeLessThanOrEqual(GRPC_DEMO_DATA.summary.totalServices)
+  })
+})

--- a/web/src/components/cards/__tests__/harbor_status.test.ts
+++ b/web/src/components/cards/__tests__/harbor_status.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import {
+  HARBOR_DEMO_DATA,
+  type HarborProjectStatus,
+} from '../harbor_status/demoData'
+
+describe('HARBOR_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(HARBOR_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth = ['healthy', 'degraded', 'not-installed']
+    expect(validHealth).toContain(HARBOR_DEMO_DATA.health)
+  })
+
+  it('has instanceName string', () => {
+    expect(typeof HARBOR_DEMO_DATA.instanceName).toBe('string')
+    expect(HARBOR_DEMO_DATA.instanceName.length).toBeGreaterThan(0)
+  })
+
+  it('has version string', () => {
+    expect(typeof HARBOR_DEMO_DATA.version).toBe('string')
+    expect(HARBOR_DEMO_DATA.version.length).toBeGreaterThan(0)
+  })
+
+  it('has projects array with entries', () => {
+    expect(Array.isArray(HARBOR_DEMO_DATA.projects)).toBe(true)
+    expect(HARBOR_DEMO_DATA.projects.length).toBeGreaterThan(0)
+  })
+
+  it('each project has required fields', () => {
+    for (const proj of HARBOR_DEMO_DATA.projects) {
+      expect(typeof proj.name).toBe('string')
+      expect(typeof proj.repoCount).toBe('number')
+      expect(typeof proj.isPublic).toBe('boolean')
+      expect(typeof proj.pullCount).toBe('number')
+    }
+  })
+
+  it('has repositories array', () => {
+    expect(Array.isArray(HARBOR_DEMO_DATA.repositories)).toBe(true)
+  })
+
+  it('each repository has required fields', () => {
+    for (const repo of HARBOR_DEMO_DATA.repositories) {
+      expect(typeof repo.name).toBe('string')
+      expect(typeof repo.artifactCount).toBe('number')
+      expect(typeof repo.pullCount).toBe('number')
+    }
+  })
+})

--- a/web/src/components/cards/__tests__/k3s_status.test.ts
+++ b/web/src/components/cards/__tests__/k3s_status.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { K3S_DEMO_DATA, type K3sStatusDemoData } from '../multi-tenancy/k3s-status/demoData'
+
+describe('K3S_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(K3S_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(valid).toContain(K3S_DEMO_DATA.health)
+  })
+
+  it('detected is a boolean', () => {
+    expect(typeof K3S_DEMO_DATA.detected).toBe('boolean')
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(K3S_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  describe('pod counts', () => {
+    it('healthyPods + unhealthyPods equals podCount', () => {
+      expect(K3S_DEMO_DATA.healthyPods + K3S_DEMO_DATA.unhealthyPods).toBe(K3S_DEMO_DATA.podCount)
+    })
+
+    it('all counts are positive', () => {
+      expect(K3S_DEMO_DATA.podCount).toBeGreaterThan(0)
+      expect(K3S_DEMO_DATA.healthyPods).toBeGreaterThanOrEqual(0)
+      expect(K3S_DEMO_DATA.unhealthyPods).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  describe('serverPods', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(K3S_DEMO_DATA.serverPods)).toBe(true)
+      expect(K3S_DEMO_DATA.serverPods.length).toBeGreaterThan(0)
+    })
+
+    it('each server pod has required fields', () => {
+      const validStatuses = ['running', 'pending', 'failed']
+      for (const pod of K3S_DEMO_DATA.serverPods) {
+        expect(typeof pod.name).toBe('string')
+        expect(pod.name.length).toBeGreaterThan(0)
+        expect(typeof pod.namespace).toBe('string')
+        expect(typeof pod.version).toBe('string')
+        expect(validStatuses).toContain(pod.status)
+      }
+    })
+
+    it('server pod count is less than or equal to podCount', () => {
+      expect(K3S_DEMO_DATA.serverPods.length).toBeLessThanOrEqual(K3S_DEMO_DATA.podCount)
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/karmada_status.test.ts
+++ b/web/src/components/cards/__tests__/karmada_status.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import {
+  KARMADA_DEMO_DATA,
+  type KarmadaHealth,
+  type KarmadaClusterStatus,
+  type KarmadaBindingStatus,
+} from '../karmada_status/demoData'
+
+describe('KARMADA_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(KARMADA_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth: KarmadaHealth[] = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(validHealth).toContain(KARMADA_DEMO_DATA.health)
+  })
+
+  it('has memberClusters array with entries', () => {
+    expect(Array.isArray(KARMADA_DEMO_DATA.memberClusters)).toBe(true)
+    expect(KARMADA_DEMO_DATA.memberClusters.length).toBeGreaterThan(0)
+  })
+
+  it('each member cluster has required fields', () => {
+    const validStatus: KarmadaClusterStatus[] = ['Ready', 'NotReady', 'Unknown']
+    for (const cluster of KARMADA_DEMO_DATA.memberClusters) {
+      expect(typeof cluster.name).toBe('string')
+      expect(validStatus).toContain(cluster.status)
+      expect(typeof cluster.nodeCount).toBe('number')
+      expect(typeof cluster.kubernetesVersion).toBe('string')
+    }
+  })
+
+  it('has propagationPolicies array', () => {
+    expect(Array.isArray(KARMADA_DEMO_DATA.propagationPolicies)).toBe(true)
+  })
+
+  it('each propagation policy has required fields', () => {
+    for (const policy of KARMADA_DEMO_DATA.propagationPolicies) {
+      expect(typeof policy.name).toBe('string')
+      expect(typeof policy.namespace).toBe('string')
+    }
+  })
+
+  it('has controllerPods with ready/total counts', () => {
+    expect(typeof KARMADA_DEMO_DATA.controllerPods.ready).toBe('number')
+    expect(typeof KARMADA_DEMO_DATA.controllerPods.total).toBe('number')
+    expect(KARMADA_DEMO_DATA.controllerPods.ready).toBeLessThanOrEqual(KARMADA_DEMO_DATA.controllerPods.total)
+  })
+
+  it('has clusterPoliciesCount and overridePoliciesCount', () => {
+    expect(typeof KARMADA_DEMO_DATA.clusterPoliciesCount).toBe('number')
+    expect(typeof KARMADA_DEMO_DATA.overridePoliciesCount).toBe('number')
+  })
+
+  it('has resourceBindings array', () => {
+    expect(Array.isArray(KARMADA_DEMO_DATA.resourceBindings)).toBe(true)
+  })
+})

--- a/web/src/components/cards/__tests__/keda_status.test.ts
+++ b/web/src/components/cards/__tests__/keda_status.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import {
+  KEDA_DEMO_DATA,
+  type KedaScaledObjectStatus,
+  type KedaTriggerType,
+} from '../keda_status/demoData'
+
+describe('KEDA_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(KEDA_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth = ['healthy', 'degraded', 'not-installed']
+    expect(validHealth).toContain(KEDA_DEMO_DATA.health)
+  })
+
+  it('has operatorPods with ready/total counts', () => {
+    expect(typeof KEDA_DEMO_DATA.operatorPods.ready).toBe('number')
+    expect(typeof KEDA_DEMO_DATA.operatorPods.total).toBe('number')
+    expect(KEDA_DEMO_DATA.operatorPods.ready).toBeLessThanOrEqual(KEDA_DEMO_DATA.operatorPods.total)
+  })
+
+  it('has scaledObjects array with entries', () => {
+    expect(Array.isArray(KEDA_DEMO_DATA.scaledObjects)).toBe(true)
+    expect(KEDA_DEMO_DATA.scaledObjects.length).toBeGreaterThan(0)
+  })
+
+  it('each scaledObject has required fields', () => {
+    const validStatus: KedaScaledObjectStatus[] = ['ready', 'degraded', 'paused', 'error']
+    for (const so of KEDA_DEMO_DATA.scaledObjects) {
+      expect(typeof so.name).toBe('string')
+      expect(typeof so.namespace).toBe('string')
+      expect(validStatus).toContain(so.status)
+      expect(typeof so.target).toBe('string')
+      expect(typeof so.currentReplicas).toBe('number')
+      expect(typeof so.desiredReplicas).toBe('number')
+      expect(typeof so.minReplicas).toBe('number')
+      expect(typeof so.maxReplicas).toBe('number')
+    }
+  })
+
+  it('each scaledObject has triggers array', () => {
+    const validTypes: KedaTriggerType[] = ['kafka', 'prometheus', 'rabbitmq', 'aws-sqs-queue', 'azure-servicebus', 'redis', 'cron', 'cpu', 'memory', 'external']
+    for (const so of KEDA_DEMO_DATA.scaledObjects) {
+      expect(Array.isArray(so.triggers)).toBe(true)
+      for (const trigger of so.triggers) {
+        expect(validTypes).toContain(trigger.type)
+        expect(typeof trigger.source).toBe('string')
+        expect(typeof trigger.currentValue).toBe('number')
+        expect(typeof trigger.targetValue).toBe('number')
+      }
+    }
+  })
+
+  it('has totalScaledJobs count', () => {
+    expect(typeof KEDA_DEMO_DATA.totalScaledJobs).toBe('number')
+    expect(KEDA_DEMO_DATA.totalScaledJobs).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/web/src/components/cards/__tests__/keycloak_status.test.ts
+++ b/web/src/components/cards/__tests__/keycloak_status.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import {
+  KEYCLOAK_DEMO_DATA,
+  type KeycloakDemoData,
+  type KeycloakRealmStatus,
+} from '../keycloak_status/demoData'
+
+describe('KEYCLOAK_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(KEYCLOAK_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid: KeycloakDemoData['health'][] = ['healthy', 'degraded', 'not-installed']
+    expect(valid).toContain(KEYCLOAK_DEMO_DATA.health)
+  })
+
+  it('has valid lastCheckTime ISO string', () => {
+    const t = new Date(KEYCLOAK_DEMO_DATA.lastCheckTime).getTime()
+    expect(t).toBeGreaterThan(0)
+  })
+
+  describe('operatorPods', () => {
+    it('has ready and total counts', () => {
+      expect(typeof KEYCLOAK_DEMO_DATA.operatorPods.ready).toBe('number')
+      expect(typeof KEYCLOAK_DEMO_DATA.operatorPods.total).toBe('number')
+    })
+
+    it('ready does not exceed total', () => {
+      expect(KEYCLOAK_DEMO_DATA.operatorPods.ready).toBeLessThanOrEqual(
+        KEYCLOAK_DEMO_DATA.operatorPods.total,
+      )
+    })
+  })
+
+  describe('realms', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(KEYCLOAK_DEMO_DATA.realms)).toBe(true)
+      expect(KEYCLOAK_DEMO_DATA.realms.length).toBeGreaterThan(0)
+    })
+
+    it('each realm has required string fields', () => {
+      for (const realm of KEYCLOAK_DEMO_DATA.realms) {
+        expect(typeof realm.name).toBe('string')
+        expect(realm.name.length).toBeGreaterThan(0)
+        expect(typeof realm.namespace).toBe('string')
+        expect(typeof realm.cluster).toBe('string')
+      }
+    })
+
+    it('each realm has valid status', () => {
+      const valid: KeycloakRealmStatus[] = ['ready', 'provisioning', 'degraded', 'error']
+      for (const realm of KEYCLOAK_DEMO_DATA.realms) {
+        expect(valid).toContain(realm.status)
+      }
+    })
+
+    it('each realm has non-negative numeric counters', () => {
+      for (const realm of KEYCLOAK_DEMO_DATA.realms) {
+        expect(realm.clients).toBeGreaterThanOrEqual(0)
+        expect(realm.users).toBeGreaterThanOrEqual(0)
+        expect(realm.activeSessions).toBeGreaterThanOrEqual(0)
+        expect(typeof realm.enabled).toBe('boolean')
+      }
+    })
+
+    it('covers all four status variants', () => {
+      const statuses = new Set(KEYCLOAK_DEMO_DATA.realms.map(r => r.status))
+      expect(statuses.has('ready')).toBe(true)
+      expect(statuses.has('degraded')).toBe(true)
+      expect(statuses.has('provisioning')).toBe(true)
+      expect(statuses.has('error')).toBe(true)
+    })
+  })
+
+  describe('totals', () => {
+    it('totalClients matches sum of realm clients', () => {
+      const sum = KEYCLOAK_DEMO_DATA.realms.reduce((acc, r) => acc + r.clients, 0)
+      expect(KEYCLOAK_DEMO_DATA.totalClients).toBe(sum)
+    })
+
+    it('totalUsers matches sum of realm users', () => {
+      const sum = KEYCLOAK_DEMO_DATA.realms.reduce((acc, r) => acc + r.users, 0)
+      expect(KEYCLOAK_DEMO_DATA.totalUsers).toBe(sum)
+    })
+
+    it('totalActiveSessions matches sum of realm activeSessions', () => {
+      const sum = KEYCLOAK_DEMO_DATA.realms.reduce((acc, r) => acc + r.activeSessions, 0)
+      expect(KEYCLOAK_DEMO_DATA.totalActiveSessions).toBe(sum)
+    })
+
+    it('all totals are positive', () => {
+      expect(KEYCLOAK_DEMO_DATA.totalClients).toBeGreaterThan(0)
+      expect(KEYCLOAK_DEMO_DATA.totalUsers).toBeGreaterThan(0)
+      expect(KEYCLOAK_DEMO_DATA.totalActiveSessions).toBeGreaterThan(0)
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/knative_status.test.ts
+++ b/web/src/components/cards/__tests__/knative_status.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import {
+  KNATIVE_DEMO_DATA,
+  type KnativeServiceStatus,
+  type KnativeBrokerStatus,
+} from '../knative_status/demoData'
+
+describe('KNATIVE_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(KNATIVE_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth = ['healthy', 'degraded', 'not-installed']
+    expect(validHealth).toContain(KNATIVE_DEMO_DATA.health)
+  })
+
+  it('has servingControllerPods with ready/total', () => {
+    expect(typeof KNATIVE_DEMO_DATA.servingControllerPods.ready).toBe('number')
+    expect(typeof KNATIVE_DEMO_DATA.servingControllerPods.total).toBe('number')
+    expect(KNATIVE_DEMO_DATA.servingControllerPods.ready).toBeLessThanOrEqual(
+      KNATIVE_DEMO_DATA.servingControllerPods.total
+    )
+  })
+
+  it('has eventingControllerPods with ready/total', () => {
+    expect(typeof KNATIVE_DEMO_DATA.eventingControllerPods.ready).toBe('number')
+    expect(typeof KNATIVE_DEMO_DATA.eventingControllerPods.total).toBe('number')
+  })
+
+  it('has services array with entries', () => {
+    expect(Array.isArray(KNATIVE_DEMO_DATA.services)).toBe(true)
+    expect(KNATIVE_DEMO_DATA.services.length).toBeGreaterThan(0)
+  })
+
+  it('each service has required fields', () => {
+    const validStatus: KnativeServiceStatus[] = ['ready', 'not-ready', 'unknown']
+    for (const svc of KNATIVE_DEMO_DATA.services) {
+      expect(typeof svc.name).toBe('string')
+      expect(typeof svc.namespace).toBe('string')
+      expect(validStatus).toContain(svc.status)
+    }
+  })
+
+  it('has revisions array', () => {
+    expect(Array.isArray(KNATIVE_DEMO_DATA.revisions)).toBe(true)
+  })
+
+  it('has brokers array', () => {
+    expect(Array.isArray(KNATIVE_DEMO_DATA.brokers)).toBe(true)
+    const validBrokerStatus: KnativeBrokerStatus[] = ['ready', 'not-ready', 'unknown']
+    for (const broker of KNATIVE_DEMO_DATA.brokers) {
+      expect(typeof broker.name).toBe('string')
+      expect(validBrokerStatus).toContain(broker.status)
+    }
+  })
+})

--- a/web/src/components/cards/__tests__/kubeflex_status.test.ts
+++ b/web/src/components/cards/__tests__/kubeflex_status.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import {
+  KUBEFLEX_DEMO_DATA,
+  type KubeFlexStatusDemoData,
+} from '../multi-tenancy/kubeflex-status/demoData'
+
+describe('KUBEFLEX_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(KUBEFLEX_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(valid).toContain(KUBEFLEX_DEMO_DATA.health)
+  })
+
+  it('detected is a boolean', () => {
+    expect(typeof KUBEFLEX_DEMO_DATA.detected).toBe('boolean')
+  })
+
+  it('controllerHealthy is a boolean', () => {
+    expect(typeof KUBEFLEX_DEMO_DATA.controllerHealthy).toBe('boolean')
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(KUBEFLEX_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  describe('controlPlanes', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(KUBEFLEX_DEMO_DATA.controlPlanes)).toBe(true)
+      expect(KUBEFLEX_DEMO_DATA.controlPlanes.length).toBeGreaterThan(0)
+    })
+
+    it('each control plane has name and healthy fields', () => {
+      for (const cp of KUBEFLEX_DEMO_DATA.controlPlanes) {
+        expect(typeof cp.name).toBe('string')
+        expect(cp.name.length).toBeGreaterThan(0)
+        expect(typeof cp.healthy).toBe('boolean')
+      }
+    })
+
+    it('tenantCount matches controlPlanes length', () => {
+      expect(KUBEFLEX_DEMO_DATA.tenantCount).toBe(KUBEFLEX_DEMO_DATA.controlPlanes.length)
+    })
+  })
+
+  it('all control planes are healthy in demo data', () => {
+    expect(KUBEFLEX_DEMO_DATA.controlPlanes.every(cp => cp.healthy)).toBe(true)
+  })
+})

--- a/web/src/components/cards/__tests__/kuberay_fleet.test.ts
+++ b/web/src/components/cards/__tests__/kuberay_fleet.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import {
+  KUBERAY_FLEET_DEMO_DATA,
+  type RayClusterState,
+  type RayJobStatus,
+  type RayServiceStatus,
+} from '../kuberay_fleet/demoData'
+
+describe('KUBERAY_FLEET_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(KUBERAY_FLEET_DEMO_DATA).toBeDefined()
+  })
+
+  it('detected field is boolean', () => {
+    expect(typeof KUBERAY_FLEET_DEMO_DATA.detected).toBe('boolean')
+  })
+
+  it('has rayClusters array with entries', () => {
+    expect(Array.isArray(KUBERAY_FLEET_DEMO_DATA.rayClusters)).toBe(true)
+    expect(KUBERAY_FLEET_DEMO_DATA.rayClusters.length).toBeGreaterThan(0)
+  })
+
+  it('each rayCluster has required fields', () => {
+    const validStates: RayClusterState[] = ['ready', 'unhealthy', 'suspended', 'unknown']
+    for (const cluster of KUBERAY_FLEET_DEMO_DATA.rayClusters) {
+      expect(typeof cluster.name).toBe('string')
+      expect(typeof cluster.namespace).toBe('string')
+      expect(typeof cluster.cluster).toBe('string')
+      expect(validStates).toContain(cluster.state)
+      expect(typeof cluster.desiredWorkers).toBe('number')
+      expect(typeof cluster.availableWorkers).toBe('number')
+      expect(typeof cluster.gpuCount).toBe('number')
+    }
+  })
+
+  it('availableWorkers <= desiredWorkers per cluster', () => {
+    for (const cluster of KUBERAY_FLEET_DEMO_DATA.rayClusters) {
+      expect(cluster.availableWorkers).toBeLessThanOrEqual(cluster.desiredWorkers)
+    }
+  })
+
+  it('has rayJobs array', () => {
+    expect(Array.isArray(KUBERAY_FLEET_DEMO_DATA.rayJobs)).toBe(true)
+  })
+
+  it('each rayJob has required fields', () => {
+    const validStatuses: RayJobStatus[] = ['RUNNING', 'SUCCEEDED', 'FAILED', 'PENDING', 'STOPPED']
+    for (const job of KUBERAY_FLEET_DEMO_DATA.rayJobs) {
+      expect(typeof job.name).toBe('string')
+      expect(typeof job.namespace).toBe('string')
+      expect(validStatuses).toContain(job.jobStatus)
+    }
+  })
+
+  it('has rayServices array', () => {
+    expect(Array.isArray(KUBERAY_FLEET_DEMO_DATA.rayServices)).toBe(true)
+  })
+
+  it('each rayService has required fields', () => {
+    const validStatuses: RayServiceStatus[] = ['Running', 'Deploying', 'FailedToGetOrCreateRayCluster', 'WaitForServeDeploymentReady', 'Unknown']
+    for (const svc of KUBERAY_FLEET_DEMO_DATA.rayServices) {
+      expect(typeof svc.name).toBe('string')
+      expect(validStatuses).toContain(svc.status)
+    }
+  })
+
+  it('has totalGPUs count', () => {
+    expect(typeof KUBERAY_FLEET_DEMO_DATA.totalGPUs).toBe('number')
+    expect(KUBERAY_FLEET_DEMO_DATA.totalGPUs).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/web/src/components/cards/__tests__/kubevela_status.test.ts
+++ b/web/src/components/cards/__tests__/kubevela_status.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  KUBEVELA_DEMO_DATA,
+  type KubeVelaHealth,
+  type KubeVelaAppStatus,
+  type WorkflowStepPhase,
+} from '../kubevela_status/demoData'
+
+describe('KUBEVELA_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(KUBEVELA_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth: KubeVelaHealth[] = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(validHealth).toContain(KUBEVELA_DEMO_DATA.health)
+  })
+
+  it('has applications array with entries', () => {
+    expect(Array.isArray(KUBEVELA_DEMO_DATA.applications)).toBe(true)
+    expect(KUBEVELA_DEMO_DATA.applications.length).toBeGreaterThan(0)
+  })
+
+  it('each application has required fields', () => {
+    for (const app of KUBEVELA_DEMO_DATA.applications) {
+      expect(typeof app.name).toBe('string')
+      expect(typeof app.namespace).toBe('string')
+      expect(typeof app.cluster).toBe('string')
+      const validStatuses: KubeVelaAppStatus[] = ['running', 'workflow-failed', 'workflow-suspended', 'deleting', 'rendering', 'runningWorkflow', 'workflowTerminated', 'workflowFinished', 'unknown']
+      expect(validStatuses).toContain(app.status)
+    }
+  })
+
+  it('each application has components', () => {
+    for (const app of KUBEVELA_DEMO_DATA.applications) {
+      expect(Array.isArray(app.components)).toBe(true)
+      expect(typeof app.componentCount).toBe('number')
+    }
+  })
+
+  it('application workflows have valid step phases', () => {
+    const validPhases: WorkflowStepPhase[] = ['succeeded', 'failed', 'skipped', 'running', 'pending', 'stopped']
+    for (const app of KUBEVELA_DEMO_DATA.applications) {
+      if (app.workflowSteps) {
+        for (const step of app.workflowSteps) {
+          expect(validPhases).toContain(step.phase)
+        }
+      }
+    }
+  })
+
+  it('has controllerPods array', () => {
+    expect(Array.isArray(KUBEVELA_DEMO_DATA.controllerPods)).toBe(true)
+    expect(KUBEVELA_DEMO_DATA.controllerPods.length).toBeGreaterThan(0)
+  })
+
+  it('each controller pod has required fields', () => {
+    for (const pod of KUBEVELA_DEMO_DATA.controllerPods) {
+      expect(typeof pod.name).toBe('string')
+      expect(typeof pod.ready).toBe('boolean')
+    }
+  })
+
+  it('has stats with required numeric fields', () => {
+    expect(typeof KUBEVELA_DEMO_DATA.stats.totalApplications).toBe('number')
+    expect(typeof KUBEVELA_DEMO_DATA.stats.runningApplications).toBe('number')
+    expect(typeof KUBEVELA_DEMO_DATA.stats.failedApplications).toBe('number')
+    expect(typeof KUBEVELA_DEMO_DATA.stats.totalComponents).toBe('number')
+    expect(typeof KUBEVELA_DEMO_DATA.stats.totalTraits).toBe('number')
+  })
+
+  it('has summary with controllerVersion', () => {
+    expect(typeof KUBEVELA_DEMO_DATA.summary.controllerVersion).toBe('string')
+    expect(typeof KUBEVELA_DEMO_DATA.summary.velaCLIVersion).toBe('string')
+  })
+})

--- a/web/src/components/cards/__tests__/kubevirt_status.test.ts
+++ b/web/src/components/cards/__tests__/kubevirt_status.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import {
+  KUBEVIRT_DEMO_DATA,
+  type KubevirtStatusDemoData,
+  type VmInfo,
+} from '../multi-tenancy/kubevirt-status/demoData'
+
+describe('KUBEVIRT_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(KUBEVIRT_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(valid).toContain(KUBEVIRT_DEMO_DATA.health)
+  })
+
+  it('detected is a boolean', () => {
+    expect(typeof KUBEVIRT_DEMO_DATA.detected).toBe('boolean')
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(KUBEVIRT_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  describe('pod counts', () => {
+    it('healthyPods + unhealthyPods equals podCount', () => {
+      const { podCount, healthyPods, unhealthyPods } = KUBEVIRT_DEMO_DATA
+      expect(healthyPods + unhealthyPods).toBe(podCount)
+    })
+
+    it('all counts are non-negative', () => {
+      expect(KUBEVIRT_DEMO_DATA.podCount).toBeGreaterThanOrEqual(0)
+      expect(KUBEVIRT_DEMO_DATA.healthyPods).toBeGreaterThanOrEqual(0)
+      expect(KUBEVIRT_DEMO_DATA.unhealthyPods).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  describe('vms', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(KUBEVIRT_DEMO_DATA.vms)).toBe(true)
+      expect(KUBEVIRT_DEMO_DATA.vms.length).toBeGreaterThan(0)
+    })
+
+    it('each VM has required fields', () => {
+      const validStates = ['running', 'stopped', 'paused', 'migrating', 'pending', 'failed', 'unknown']
+      for (const vm of KUBEVIRT_DEMO_DATA.vms) {
+        expect(typeof vm.name).toBe('string')
+        expect(vm.name.length).toBeGreaterThan(0)
+        expect(typeof vm.namespace).toBe('string')
+        expect(typeof vm.cluster).toBe('string')
+        expect(validStates).toContain(vm.state)
+      }
+    })
+
+    it('covers multiple VM states', () => {
+      const states = new Set(KUBEVIRT_DEMO_DATA.vms.map(v => v.state))
+      expect(states.size).toBeGreaterThan(1)
+    })
+  })
+
+  describe('clusters', () => {
+    it('is a non-empty array', () => {
+      expect(KUBEVIRT_DEMO_DATA.clusters.length).toBeGreaterThan(0)
+    })
+
+    it('each cluster has valid fields', () => {
+      const validHealth = ['healthy', 'degraded', 'not-installed', 'unknown']
+      for (const cl of KUBEVIRT_DEMO_DATA.clusters) {
+        expect(typeof cl.cluster).toBe('string')
+        expect(typeof cl.installed).toBe('boolean')
+        expect(cl.vmCount).toBeGreaterThanOrEqual(0)
+        expect(cl.runningCount).toBeGreaterThanOrEqual(0)
+        expect(cl.runningCount).toBeLessThanOrEqual(cl.vmCount)
+        expect(cl.infraPods).toBeGreaterThanOrEqual(0)
+        expect(validHealth).toContain(cl.health)
+      }
+    })
+
+    it('sum of cluster vmCounts equals vm array length', () => {
+      const sum = KUBEVIRT_DEMO_DATA.clusters.reduce((a, c) => a + c.vmCount, 0)
+      expect(sum).toBe(KUBEVIRT_DEMO_DATA.vms.length)
+    })
+  })
+
+  it('tenantCount matches unique tenant namespaces in vms', () => {
+    const namespaces = new Set(KUBEVIRT_DEMO_DATA.vms.map(v => v.namespace))
+    expect(KUBEVIRT_DEMO_DATA.tenantCount).toBe(namespaces.size)
+  })
+})

--- a/web/src/components/cards/__tests__/lima_status.test.ts
+++ b/web/src/components/cards/__tests__/lima_status.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { LIMA_DEMO_DATA, type LimaDemoData } from '../lima_status/demoData'
+
+describe('LIMA_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(LIMA_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid: LimaDemoData['health'][] = ['healthy', 'degraded', 'not-detected']
+    expect(valid).toContain(LIMA_DEMO_DATA.health)
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(LIMA_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  describe('instances', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(LIMA_DEMO_DATA.instances)).toBe(true)
+      expect(LIMA_DEMO_DATA.instances.length).toBeGreaterThan(0)
+    })
+
+    it('each instance has required fields', () => {
+      for (const inst of LIMA_DEMO_DATA.instances) {
+        expect(typeof inst.name).toBe('string')
+        expect(inst.name.length).toBeGreaterThan(0)
+        expect(['running', 'stopped', 'broken']).toContain(inst.status)
+        expect(inst.cpuCores).toBeGreaterThan(0)
+        expect(inst.memoryGB).toBeGreaterThan(0)
+        expect(inst.diskGB).toBeGreaterThan(0)
+        expect(typeof inst.arch).toBe('string')
+        expect(typeof inst.os).toBe('string')
+        expect(typeof inst.limaVersion).toBe('string')
+        expect(typeof inst.lastSeen).toBe('string')
+      }
+    })
+
+    it('covers multiple status variants', () => {
+      const statuses = new Set(LIMA_DEMO_DATA.instances.map(i => i.status))
+      expect(statuses.size).toBeGreaterThan(1)
+    })
+  })
+
+  describe('node totals', () => {
+    it('totalNodes matches instance count', () => {
+      expect(LIMA_DEMO_DATA.totalNodes).toBe(LIMA_DEMO_DATA.instances.length)
+    })
+
+    it('runningNodes + stoppedNodes + brokenNodes equals totalNodes', () => {
+      const { runningNodes, stoppedNodes, brokenNodes, totalNodes } = LIMA_DEMO_DATA
+      expect(runningNodes + stoppedNodes + brokenNodes).toBe(totalNodes)
+    })
+
+    it('running count matches instances with running status', () => {
+      const count = LIMA_DEMO_DATA.instances.filter(i => i.status === 'running').length
+      expect(LIMA_DEMO_DATA.runningNodes).toBe(count)
+    })
+
+    it('stopped count matches instances with stopped status', () => {
+      const count = LIMA_DEMO_DATA.instances.filter(i => i.status === 'stopped').length
+      expect(LIMA_DEMO_DATA.stoppedNodes).toBe(count)
+    })
+  })
+
+  describe('resource totals', () => {
+    it('totalCpuCores equals sum of instance cpuCores', () => {
+      const sum = LIMA_DEMO_DATA.instances.reduce((a, i) => a + i.cpuCores, 0)
+      expect(LIMA_DEMO_DATA.totalCpuCores).toBe(sum)
+    })
+
+    it('totalMemoryGB equals sum of instance memoryGB', () => {
+      const sum = LIMA_DEMO_DATA.instances.reduce((a, i) => a + i.memoryGB, 0)
+      expect(LIMA_DEMO_DATA.totalMemoryGB).toBe(sum)
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/linkerd_status.test.ts
+++ b/web/src/components/cards/__tests__/linkerd_status.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import {
+  LINKERD_DEMO_DATA,
+  type LinkerdHealth,
+  type LinkerdPodStatus,
+} from '../linkerd_status/demoData'
+
+describe('LINKERD_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(LINKERD_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth: LinkerdHealth[] = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(validHealth).toContain(LINKERD_DEMO_DATA.health)
+  })
+
+  it('has deployments array with entries', () => {
+    expect(Array.isArray(LINKERD_DEMO_DATA.deployments)).toBe(true)
+    expect(LINKERD_DEMO_DATA.deployments.length).toBeGreaterThan(0)
+  })
+
+  it('each deployment has required fields', () => {
+    const validStatus: LinkerdPodStatus[] = ['meshed', 'partial', 'unmeshed']
+    for (const dep of LINKERD_DEMO_DATA.deployments) {
+      expect(typeof dep.namespace).toBe('string')
+      expect(typeof dep.deployment).toBe('string')
+      expect(typeof dep.meshedPods).toBe('number')
+      expect(typeof dep.totalPods).toBe('number')
+      expect(typeof dep.successRatePct).toBe('number')
+      expect(typeof dep.requestsPerSecond).toBe('number')
+      expect(typeof dep.p99LatencyMs).toBe('number')
+      expect(validStatus).toContain(dep.status)
+      expect(typeof dep.cluster).toBe('string')
+    }
+  })
+
+  it('meshedPods <= totalPods per deployment', () => {
+    for (const dep of LINKERD_DEMO_DATA.deployments) {
+      expect(dep.meshedPods).toBeLessThanOrEqual(dep.totalPods)
+    }
+  })
+
+  it('has stats with required fields', () => {
+    expect(typeof LINKERD_DEMO_DATA.stats.totalRps).toBe('number')
+    expect(typeof LINKERD_DEMO_DATA.stats.avgSuccessRatePct).toBe('number')
+    expect(typeof LINKERD_DEMO_DATA.stats.avgP99LatencyMs).toBe('number')
+    expect(typeof LINKERD_DEMO_DATA.stats.controlPlaneVersion).toBe('string')
+  })
+
+  it('has summary with required fields', () => {
+    expect(typeof LINKERD_DEMO_DATA.summary.totalDeployments).toBe('number')
+    expect(typeof LINKERD_DEMO_DATA.summary.fullyMeshedDeployments).toBe('number')
+    expect(typeof LINKERD_DEMO_DATA.summary.totalMeshedPods).toBe('number')
+    expect(typeof LINKERD_DEMO_DATA.summary.totalPods).toBe('number')
+  })
+})

--- a/web/src/components/cards/__tests__/multi_tenancy_overview.test.ts
+++ b/web/src/components/cards/__tests__/multi_tenancy_overview.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DEMO_MULTI_TENANCY_OVERVIEW,
+} from '../multi-tenancy/multi-tenancy-overview/demoData'
+
+describe('DEMO_MULTI_TENANCY_OVERVIEW', () => {
+  it('is defined', () => {
+    expect(DEMO_MULTI_TENANCY_OVERVIEW).toBeDefined()
+  })
+
+  it('tenantCount is positive', () => {
+    expect(DEMO_MULTI_TENANCY_OVERVIEW.tenantCount).toBeGreaterThan(0)
+  })
+
+  it('overallScore does not exceed totalLevels', () => {
+    expect(DEMO_MULTI_TENANCY_OVERVIEW.overallScore).toBeLessThanOrEqual(
+      DEMO_MULTI_TENANCY_OVERVIEW.totalLevels,
+    )
+  })
+
+  it('overallScore equals totalLevels in healthy demo state', () => {
+    expect(DEMO_MULTI_TENANCY_OVERVIEW.overallScore).toBe(
+      DEMO_MULTI_TENANCY_OVERVIEW.totalLevels,
+    )
+  })
+
+  it('isDemoData is true', () => {
+    expect(DEMO_MULTI_TENANCY_OVERVIEW.isDemoData).toBe(true)
+  })
+
+  it('isFailed is false in demo', () => {
+    expect(DEMO_MULTI_TENANCY_OVERVIEW.isFailed).toBe(false)
+  })
+
+  describe('components', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(DEMO_MULTI_TENANCY_OVERVIEW.components)).toBe(true)
+      expect(DEMO_MULTI_TENANCY_OVERVIEW.components.length).toBeGreaterThan(0)
+    })
+
+    it('each component has required fields', () => {
+      const validHealth = ['healthy', 'degraded', 'not-installed', 'unknown']
+      for (const comp of DEMO_MULTI_TENANCY_OVERVIEW.components) {
+        expect(typeof comp.name).toBe('string')
+        expect(comp.name.length).toBeGreaterThan(0)
+        expect(typeof comp.detected).toBe('boolean')
+        expect(validHealth).toContain(comp.health)
+        expect(typeof comp.icon).toBe('string')
+      }
+    })
+
+    it('all 4 expected components are present', () => {
+      const names = DEMO_MULTI_TENANCY_OVERVIEW.components.map(c => c.name)
+      expect(names).toContain('OVN-K8s')
+      expect(names).toContain('KubeFlex')
+      expect(names).toContain('K3s')
+      expect(names).toContain('KubeVirt')
+    })
+  })
+
+  describe('isolationLevels', () => {
+    it('is a non-empty array matching totalLevels', () => {
+      expect(Array.isArray(DEMO_MULTI_TENANCY_OVERVIEW.isolationLevels)).toBe(true)
+      expect(DEMO_MULTI_TENANCY_OVERVIEW.isolationLevels.length).toBe(
+        DEMO_MULTI_TENANCY_OVERVIEW.totalLevels,
+      )
+    })
+
+    it('each level has type, status, and provider fields', () => {
+      const validStatuses = ['ready', 'missing', 'degraded']
+      for (const level of DEMO_MULTI_TENANCY_OVERVIEW.isolationLevels) {
+        expect(typeof level.type).toBe('string')
+        expect(validStatuses).toContain(level.status)
+        expect(typeof level.provider).toBe('string')
+      }
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/nats_status.test.ts
+++ b/web/src/components/cards/__tests__/nats_status.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { NATS_DEMO_DATA, type NatsServerState } from '../nats_status/demoData'
+
+describe('NATS_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(NATS_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth = ['healthy', 'degraded', 'not-installed']
+    expect(validHealth).toContain(NATS_DEMO_DATA.health)
+  })
+
+  it('has servers object with counts', () => {
+    expect(typeof NATS_DEMO_DATA.servers.total).toBe('number')
+    expect(typeof NATS_DEMO_DATA.servers.ok).toBe('number')
+    expect(typeof NATS_DEMO_DATA.servers.warning).toBe('number')
+    expect(typeof NATS_DEMO_DATA.servers.error).toBe('number')
+  })
+
+  it('has messaging object with required fields', () => {
+    expect(typeof NATS_DEMO_DATA.messaging.totalConnections).toBe('number')
+    expect(typeof NATS_DEMO_DATA.messaging.inMsgsPerSec).toBe('number')
+    expect(typeof NATS_DEMO_DATA.messaging.outMsgsPerSec).toBe('number')
+    expect(typeof NATS_DEMO_DATA.messaging.totalSubscriptions).toBe('number')
+  })
+
+  it('has jetstream with enabled flag and counts', () => {
+    expect(typeof NATS_DEMO_DATA.jetstream.enabled).toBe('boolean')
+    expect(typeof NATS_DEMO_DATA.jetstream.streams).toBe('number')
+    expect(typeof NATS_DEMO_DATA.jetstream.totalMessages).toBe('number')
+    expect(typeof NATS_DEMO_DATA.jetstream.totalConsumers).toBe('number')
+  })
+
+  it('has serverList array', () => {
+    expect(Array.isArray(NATS_DEMO_DATA.serverList)).toBe(true)
+  })
+
+  it('each server has required fields', () => {
+    const validStates: NatsServerState[] = ['ok', 'warning', 'error']
+    for (const srv of NATS_DEMO_DATA.serverList) {
+      expect(typeof srv.name).toBe('string')
+      expect(typeof srv.cluster).toBe('string')
+      expect(validStates).toContain(srv.state)
+    }
+  })
+
+  it('has streamList array', () => {
+    expect(Array.isArray(NATS_DEMO_DATA.streamList)).toBe(true)
+  })
+
+  it('each stream has required fields', () => {
+    for (const stream of NATS_DEMO_DATA.streamList) {
+      expect(typeof stream.name).toBe('string')
+      expect(typeof stream.consumers).toBe('number')
+      expect(typeof stream.messages).toBe('number')
+    }
+  })
+})

--- a/web/src/components/cards/__tests__/openfeature_status.test.ts
+++ b/web/src/components/cards/__tests__/openfeature_status.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import {
+  OPENFEATURE_DEMO_DATA,
+  type OpenFeatureHealth,
+  type OpenFeatureProviderStatus,
+  type OpenFeatureFlagType,
+} from '../openfeature_status/demoData'
+
+describe('OPENFEATURE_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(OPENFEATURE_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth: OpenFeatureHealth[] = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(validHealth).toContain(OPENFEATURE_DEMO_DATA.health)
+  })
+
+  it('has providers array with entries', () => {
+    expect(Array.isArray(OPENFEATURE_DEMO_DATA.providers)).toBe(true)
+    expect(OPENFEATURE_DEMO_DATA.providers.length).toBeGreaterThan(0)
+  })
+
+  it('each provider has required fields', () => {
+    const validStatus: OpenFeatureProviderStatus[] = ['healthy', 'degraded', 'unhealthy']
+    for (const prov of OPENFEATURE_DEMO_DATA.providers) {
+      expect(typeof prov.name).toBe('string')
+      expect(validStatus).toContain(prov.status)
+      expect(typeof prov.evaluations).toBe('number')
+      expect(typeof prov.cacheHitRate).toBe('number')
+    }
+  })
+
+  it('has flags array with entries', () => {
+    expect(Array.isArray(OPENFEATURE_DEMO_DATA.flags)).toBe(true)
+    expect(OPENFEATURE_DEMO_DATA.flags.length).toBeGreaterThan(0)
+  })
+
+  it('each flag has required fields', () => {
+    const validTypes: OpenFeatureFlagType[] = ['boolean', 'string', 'number', 'json']
+    for (const flag of OPENFEATURE_DEMO_DATA.flags) {
+      expect(typeof flag.key).toBe('string')
+      expect(validTypes).toContain(flag.type)
+      expect(typeof flag.enabled).toBe('boolean')
+      expect(typeof flag.defaultVariant).toBe('string')
+      expect(typeof flag.variants).toBe('number')
+      expect(typeof flag.evaluations).toBe('number')
+    }
+  })
+
+  it('has featureFlags stats with required fields', () => {
+    expect(typeof OPENFEATURE_DEMO_DATA.featureFlags.total).toBe('number')
+    expect(typeof OPENFEATURE_DEMO_DATA.featureFlags.enabled).toBe('number')
+    expect(typeof OPENFEATURE_DEMO_DATA.featureFlags.disabled).toBe('number')
+    expect(typeof OPENFEATURE_DEMO_DATA.featureFlags.errorRate).toBe('number')
+  })
+
+  it('featureFlags enabled + disabled <= total', () => {
+    const { total, enabled, disabled } = OPENFEATURE_DEMO_DATA.featureFlags
+    expect(enabled + disabled).toBeLessThanOrEqual(total)
+  })
+
+  it('has totalEvaluations count', () => {
+    expect(typeof OPENFEATURE_DEMO_DATA.totalEvaluations).toBe('number')
+    expect(OPENFEATURE_DEMO_DATA.totalEvaluations).toBeGreaterThan(0)
+  })
+})

--- a/web/src/components/cards/__tests__/openfga_status.test.ts
+++ b/web/src/components/cards/__tests__/openfga_status.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  OPENFGA_DEMO_DATA,
+  type OpenfgaHealth,
+  type OpenfgaStoreStatus,
+} from '../openfga_status/demoData'
+
+describe('OPENFGA_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(OPENFGA_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth: OpenfgaHealth[] = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(validHealth).toContain(OPENFGA_DEMO_DATA.health)
+  })
+
+  it('has stores array with entries', () => {
+    expect(Array.isArray(OPENFGA_DEMO_DATA.stores)).toBe(true)
+    expect(OPENFGA_DEMO_DATA.stores.length).toBeGreaterThan(0)
+  })
+
+  it('each store has required fields', () => {
+    const validStatus: OpenfgaStoreStatus[] = ['active', 'paused', 'draining']
+    for (const store of OPENFGA_DEMO_DATA.stores) {
+      expect(typeof store.id).toBe('string')
+      expect(typeof store.name).toBe('string')
+      expect(typeof store.tupleCount).toBe('number')
+      expect(typeof store.modelCount).toBe('number')
+      expect(validStatus).toContain(store.status)
+    }
+  })
+
+  it('has models array with entries', () => {
+    expect(Array.isArray(OPENFGA_DEMO_DATA.models)).toBe(true)
+    expect(OPENFGA_DEMO_DATA.models.length).toBeGreaterThan(0)
+  })
+
+  it('each model has required fields', () => {
+    for (const model of OPENFGA_DEMO_DATA.models) {
+      expect(typeof model.id).toBe('string')
+      expect(typeof model.storeName).toBe('string')
+      expect(typeof model.schemaVersion).toBe('string')
+      expect(typeof model.typeCount).toBe('number')
+    }
+  })
+
+  it('has stats with required numeric fields', () => {
+    expect(typeof OPENFGA_DEMO_DATA.stats.totalTuples).toBe('number')
+    expect(typeof OPENFGA_DEMO_DATA.stats.totalStores).toBe('number')
+    expect(typeof OPENFGA_DEMO_DATA.stats.totalModels).toBe('number')
+    expect(typeof OPENFGA_DEMO_DATA.stats.serverVersion).toBe('string')
+  })
+
+  it('has stats.rps with api rates', () => {
+    expect(typeof OPENFGA_DEMO_DATA.stats.rps.check).toBe('number')
+    expect(typeof OPENFGA_DEMO_DATA.stats.rps.expand).toBe('number')
+    expect(typeof OPENFGA_DEMO_DATA.stats.rps.listObjects).toBe('number')
+  })
+
+  it('has stats.latency with percentiles', () => {
+    const { p50, p95, p99 } = OPENFGA_DEMO_DATA.stats.latency
+    expect(typeof p50).toBe('number')
+    expect(typeof p95).toBe('number')
+    expect(typeof p99).toBe('number')
+    expect(p50).toBeLessThanOrEqual(p95)
+    expect(p95).toBeLessThanOrEqual(p99)
+  })
+
+  it('has summary with required fields', () => {
+    expect(typeof OPENFGA_DEMO_DATA.summary.endpoint).toBe('string')
+    expect(typeof OPENFGA_DEMO_DATA.summary.totalTuples).toBe('number')
+    expect(typeof OPENFGA_DEMO_DATA.summary.totalStores).toBe('number')
+    expect(typeof OPENFGA_DEMO_DATA.summary.totalModels).toBe('number')
+  })
+})

--- a/web/src/components/cards/__tests__/openkruise_status.test.ts
+++ b/web/src/components/cards/__tests__/openkruise_status.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import {
+  OPENKRUISE_DEMO_DATA,
+  type OpenKruiseDemoCloneSet,
+  type OpenKruiseDemoAdvancedStatefulSet,
+} from '../openkruise_status/demoData'
+
+describe('OPENKRUISE_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(OPENKRUISE_DEMO_DATA).toBeDefined()
+  })
+
+  it('has cloneSets array with entries', () => {
+    expect(Array.isArray(OPENKRUISE_DEMO_DATA.cloneSets)).toBe(true)
+    expect(OPENKRUISE_DEMO_DATA.cloneSets.length).toBeGreaterThan(0)
+  })
+
+  it('each cloneSet has required fields', () => {
+    const validStatuses = ['healthy', 'updating', 'degraded', 'failed'] as const
+    const validStrategies = ['ReCreate', 'InPlaceIfPossible', 'InPlaceOnly'] as const
+    for (const cs of OPENKRUISE_DEMO_DATA.cloneSets) {
+      expect(typeof cs.name).toBe('string')
+      expect(typeof cs.namespace).toBe('string')
+      expect(typeof cs.cluster).toBe('string')
+      expect(typeof cs.replicas).toBe('number')
+      expect(typeof cs.readyReplicas).toBe('number')
+      expect(validStatuses).toContain(cs.status)
+      expect(validStrategies).toContain(cs.updateStrategy)
+    }
+  })
+
+  it('cloneSet readyReplicas <= replicas', () => {
+    for (const cs of OPENKRUISE_DEMO_DATA.cloneSets) {
+      expect(cs.readyReplicas).toBeLessThanOrEqual(cs.replicas)
+    }
+  })
+
+  it('has advancedStatefulSets array', () => {
+    expect(Array.isArray(OPENKRUISE_DEMO_DATA.advancedStatefulSets)).toBe(true)
+  })
+
+  it('each advancedStatefulSet has required fields', () => {
+    for (const ss of OPENKRUISE_DEMO_DATA.advancedStatefulSets) {
+      expect(typeof ss.name).toBe('string')
+      expect(typeof ss.namespace).toBe('string')
+      expect(typeof ss.cluster).toBe('string')
+      expect(typeof ss.replicas).toBe('number')
+      expect(typeof ss.readyReplicas).toBe('number')
+    }
+  })
+
+  it('has advancedDaemonSets array', () => {
+    expect(Array.isArray(OPENKRUISE_DEMO_DATA.advancedDaemonSets)).toBe(true)
+  })
+
+  it('has sidecarSets array', () => {
+    expect(Array.isArray(OPENKRUISE_DEMO_DATA.sidecarSets)).toBe(true)
+  })
+
+  it('has broadcastJobs array', () => {
+    expect(Array.isArray(OPENKRUISE_DEMO_DATA.broadcastJobs)).toBe(true)
+  })
+
+  it('has advancedCronJobs array', () => {
+    expect(Array.isArray(OPENKRUISE_DEMO_DATA.advancedCronJobs)).toBe(true)
+  })
+
+  it('has controllerVersion string', () => {
+    expect(typeof OPENKRUISE_DEMO_DATA.controllerVersion).toBe('string')
+    expect(OPENKRUISE_DEMO_DATA.controllerVersion.length).toBeGreaterThan(0)
+  })
+
+  it('has totalInjectedPods count', () => {
+    expect(typeof OPENKRUISE_DEMO_DATA.totalInjectedPods).toBe('number')
+    expect(OPENKRUISE_DEMO_DATA.totalInjectedPods).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/web/src/components/cards/__tests__/openyurt_status.test.ts
+++ b/web/src/components/cards/__tests__/openyurt_status.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import {
+  OPENYURT_DEMO_DATA,
+  type OpenYurtDemoData,
+  type NodePoolType,
+  type NodePoolStatus,
+  type GatewayStatus,
+} from '../openyurt_status/demoData'
+
+describe('OPENYURT_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(OPENYURT_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid: OpenYurtDemoData['health'][] = ['healthy', 'degraded', 'not-installed']
+    expect(valid).toContain(OPENYURT_DEMO_DATA.health)
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(OPENYURT_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  describe('controllerPods', () => {
+    it('has ready and total', () => {
+      expect(typeof OPENYURT_DEMO_DATA.controllerPods.ready).toBe('number')
+      expect(typeof OPENYURT_DEMO_DATA.controllerPods.total).toBe('number')
+    })
+
+    it('ready does not exceed total', () => {
+      expect(OPENYURT_DEMO_DATA.controllerPods.ready).toBeLessThanOrEqual(
+        OPENYURT_DEMO_DATA.controllerPods.total,
+      )
+    })
+  })
+
+  describe('nodePools', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(OPENYURT_DEMO_DATA.nodePools)).toBe(true)
+      expect(OPENYURT_DEMO_DATA.nodePools.length).toBeGreaterThan(0)
+    })
+
+    it('each pool has valid type', () => {
+      const validTypes: NodePoolType[] = ['edge', 'cloud']
+      for (const pool of OPENYURT_DEMO_DATA.nodePools) {
+        expect(validTypes).toContain(pool.type)
+      }
+    })
+
+    it('each pool has valid status', () => {
+      const validStatuses: NodePoolStatus[] = ['ready', 'degraded', 'not-ready']
+      for (const pool of OPENYURT_DEMO_DATA.nodePools) {
+        expect(validStatuses).toContain(pool.status)
+      }
+    })
+
+    it('each pool has valid node counts', () => {
+      for (const pool of OPENYURT_DEMO_DATA.nodePools) {
+        expect(pool.nodeCount).toBeGreaterThan(0)
+        expect(pool.readyNodes).toBeGreaterThanOrEqual(0)
+        expect(pool.readyNodes).toBeLessThanOrEqual(pool.nodeCount)
+        expect(typeof pool.autonomyEnabled).toBe('boolean')
+      }
+    })
+
+    it('covers edge and cloud types', () => {
+      const types = new Set(OPENYURT_DEMO_DATA.nodePools.map(p => p.type))
+      expect(types.has('edge')).toBe(true)
+      expect(types.has('cloud')).toBe(true)
+    })
+
+    it('covers multiple status variants', () => {
+      const statuses = new Set(OPENYURT_DEMO_DATA.nodePools.map(p => p.status))
+      expect(statuses.size).toBeGreaterThan(1)
+    })
+  })
+
+  describe('gateways', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(OPENYURT_DEMO_DATA.gateways)).toBe(true)
+      expect(OPENYURT_DEMO_DATA.gateways.length).toBeGreaterThan(0)
+    })
+
+    it('each gateway has valid status', () => {
+      const valid: GatewayStatus[] = ['connected', 'disconnected', 'pending']
+      for (const gw of OPENYURT_DEMO_DATA.gateways) {
+        expect(valid).toContain(gw.status)
+        expect(typeof gw.name).toBe('string')
+        expect(typeof gw.nodePool).toBe('string')
+        expect(typeof gw.endpoint).toBe('string')
+      }
+    })
+
+    it('covers connected and disconnected states', () => {
+      const statuses = new Set(OPENYURT_DEMO_DATA.gateways.map(g => g.status))
+      expect(statuses.has('connected')).toBe(true)
+      expect(statuses.has('disconnected')).toBe(true)
+    })
+  })
+
+  describe('node totals', () => {
+    it('totalNodes is positive', () => {
+      expect(OPENYURT_DEMO_DATA.totalNodes).toBeGreaterThan(0)
+    })
+
+    it('autonomousNodes does not exceed totalNodes', () => {
+      expect(OPENYURT_DEMO_DATA.autonomousNodes).toBeLessThanOrEqual(
+        OPENYURT_DEMO_DATA.totalNodes,
+      )
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/ovn_status.test.ts
+++ b/web/src/components/cards/__tests__/ovn_status.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { OVN_DEMO_DATA, type OvnStatusDemoData } from '../multi-tenancy/ovn-status/demoData'
+
+describe('OVN_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(OVN_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const valid = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(valid).toContain(OVN_DEMO_DATA.health)
+  })
+
+  it('detected is a boolean', () => {
+    expect(typeof OVN_DEMO_DATA.detected).toBe('boolean')
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(OVN_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  describe('pod counts', () => {
+    it('healthyPods + unhealthyPods equals podCount', () => {
+      expect(OVN_DEMO_DATA.healthyPods + OVN_DEMO_DATA.unhealthyPods).toBe(OVN_DEMO_DATA.podCount)
+    })
+
+    it('all counts are non-negative', () => {
+      expect(OVN_DEMO_DATA.podCount).toBeGreaterThanOrEqual(0)
+      expect(OVN_DEMO_DATA.healthyPods).toBeGreaterThanOrEqual(0)
+      expect(OVN_DEMO_DATA.unhealthyPods).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  describe('udns', () => {
+    it('is an array', () => {
+      expect(Array.isArray(OVN_DEMO_DATA.udns)).toBe(true)
+    })
+
+    it('each UDN has required fields', () => {
+      const validNetworkTypes = ['layer2', 'layer3', 'localnet']
+      const validRoles = ['primary', 'secondary']
+      for (const udn of OVN_DEMO_DATA.udns) {
+        expect(typeof udn.name).toBe('string')
+        expect(udn.name.length).toBeGreaterThan(0)
+        expect(validNetworkTypes).toContain(udn.networkType)
+        expect(validRoles).toContain(udn.role)
+      }
+    })
+
+    it('covers both primary and secondary roles', () => {
+      const roles = new Set(OVN_DEMO_DATA.udns.map(u => u.role))
+      expect(roles.has('primary')).toBe(true)
+      expect(roles.has('secondary')).toBe(true)
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/slo_compliance.test.ts
+++ b/web/src/components/cards/__tests__/slo_compliance.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { SLO_COMPLIANCE_DEMO_DATA, type SLOComplianceData } from '../slo_compliance/demoData'
+
+describe('SLO_COMPLIANCE_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(SLO_COMPLIANCE_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(SLO_COMPLIANCE_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  it('overallBudgetRemaining is between 0 and 100', () => {
+    expect(SLO_COMPLIANCE_DEMO_DATA.overallBudgetRemaining).toBeGreaterThanOrEqual(0)
+    expect(SLO_COMPLIANCE_DEMO_DATA.overallBudgetRemaining).toBeLessThanOrEqual(100)
+  })
+
+  describe('targets', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(SLO_COMPLIANCE_DEMO_DATA.targets)).toBe(true)
+      expect(SLO_COMPLIANCE_DEMO_DATA.targets.length).toBeGreaterThan(0)
+    })
+
+    it('each target has required string fields', () => {
+      for (const target of SLO_COMPLIANCE_DEMO_DATA.targets) {
+        expect(typeof target.name).toBe('string')
+        expect(target.name.length).toBeGreaterThan(0)
+        expect(typeof target.metric).toBe('string')
+        expect(typeof target.unit).toBe('string')
+        expect(typeof target.window).toBe('string')
+      }
+    })
+
+    it('each target has positive threshold', () => {
+      for (const target of SLO_COMPLIANCE_DEMO_DATA.targets) {
+        expect(target.threshold).toBeGreaterThan(0)
+      }
+    })
+
+    it('compliance is between 0 and 100', () => {
+      for (const target of SLO_COMPLIANCE_DEMO_DATA.targets) {
+        expect(target.currentCompliance).toBeGreaterThanOrEqual(0)
+        expect(target.currentCompliance).toBeLessThanOrEqual(100)
+      }
+    })
+
+    it('all target names are unique', () => {
+      const names = SLO_COMPLIANCE_DEMO_DATA.targets.map(t => t.name)
+      expect(new Set(names).size).toBe(names.length)
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/spiffe_status.test.ts
+++ b/web/src/components/cards/__tests__/spiffe_status.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SPIFFE_DEMO_DATA,
+  type SpiffeHealth,
+  type SvidType,
+  type FederationStatus,
+} from '../spiffe_status/demoData'
+
+describe('SPIFFE_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(SPIFFE_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth: SpiffeHealth[] = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(validHealth).toContain(SPIFFE_DEMO_DATA.health)
+  })
+
+  it('has entries array with entries', () => {
+    expect(Array.isArray(SPIFFE_DEMO_DATA.entries)).toBe(true)
+    expect(SPIFFE_DEMO_DATA.entries.length).toBeGreaterThan(0)
+  })
+
+  it('each registration entry has required fields', () => {
+    const validSvidTypes: SvidType[] = ['x509', 'jwt']
+    for (const entry of SPIFFE_DEMO_DATA.entries) {
+      expect(typeof entry.spiffeId).toBe('string')
+      expect(entry.spiffeId).toMatch(/^spiffe:\/\//)
+      expect(typeof entry.parentId).toBe('string')
+      expect(typeof entry.selector).toBe('string')
+      expect(validSvidTypes).toContain(entry.svidType)
+      expect(typeof entry.ttlSeconds).toBe('number')
+      expect(entry.ttlSeconds).toBeGreaterThan(0)
+      expect(typeof entry.cluster).toBe('string')
+    }
+  })
+
+  it('has federatedDomains array', () => {
+    expect(Array.isArray(SPIFFE_DEMO_DATA.federatedDomains)).toBe(true)
+  })
+
+  it('each federated domain has required fields', () => {
+    const validStatus: FederationStatus[] = ['active', 'pending', 'failed']
+    for (const domain of SPIFFE_DEMO_DATA.federatedDomains) {
+      expect(typeof domain.trustDomain).toBe('string')
+      expect(typeof domain.bundleEndpoint).toBe('string')
+      expect(validStatus).toContain(domain.status)
+    }
+  })
+
+  it('has stats with required fields', () => {
+    expect(typeof SPIFFE_DEMO_DATA.stats.x509SvidCount).toBe('number')
+    expect(typeof SPIFFE_DEMO_DATA.stats.jwtSvidCount).toBe('number')
+    expect(typeof SPIFFE_DEMO_DATA.stats.registrationEntryCount).toBe('number')
+    expect(typeof SPIFFE_DEMO_DATA.stats.agentCount).toBe('number')
+    expect(typeof SPIFFE_DEMO_DATA.stats.serverVersion).toBe('string')
+  })
+
+  it('has summary with required fields', () => {
+    expect(typeof SPIFFE_DEMO_DATA.summary.trustDomain).toBe('string')
+    expect(typeof SPIFFE_DEMO_DATA.summary.totalSvids).toBe('number')
+    expect(typeof SPIFFE_DEMO_DATA.summary.totalFederatedDomains).toBe('number')
+    expect(typeof SPIFFE_DEMO_DATA.summary.totalEntries).toBe('number')
+  })
+})

--- a/web/src/components/cards/__tests__/strimzi_status.test.ts
+++ b/web/src/components/cards/__tests__/strimzi_status.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+  STRIMZI_DEMO_DATA,
+  type StrimziHealth,
+  type ClusterHealth,
+  type TopicStatus,
+  type ConsumerGroupStatus,
+} from '../strimzi_status/demoData'
+
+describe('STRIMZI_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(STRIMZI_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth: StrimziHealth[] = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(validHealth).toContain(STRIMZI_DEMO_DATA.health)
+  })
+
+  it('has clusters array with entries', () => {
+    expect(Array.isArray(STRIMZI_DEMO_DATA.clusters)).toBe(true)
+    expect(STRIMZI_DEMO_DATA.clusters.length).toBeGreaterThan(0)
+  })
+
+  it('each cluster has required fields', () => {
+    const validClusterHealth: ClusterHealth[] = ['healthy', 'degraded', 'unavailable']
+    for (const kc of STRIMZI_DEMO_DATA.clusters) {
+      expect(typeof kc.name).toBe('string')
+      expect(typeof kc.namespace).toBe('string')
+      expect(typeof kc.cluster).toBe('string')
+      expect(typeof kc.kafkaVersion).toBe('string')
+      expect(validClusterHealth).toContain(kc.health)
+      expect(typeof kc.brokers.ready).toBe('number')
+      expect(typeof kc.brokers.total).toBe('number')
+      expect(kc.brokers.ready).toBeLessThanOrEqual(kc.brokers.total)
+    }
+  })
+
+  it('each cluster has topics array', () => {
+    const validTopicStatus: TopicStatus[] = ['active', 'inactive', 'error']
+    for (const kc of STRIMZI_DEMO_DATA.clusters) {
+      expect(Array.isArray(kc.topics)).toBe(true)
+      for (const topic of kc.topics) {
+        expect(typeof topic.name).toBe('string')
+        expect(typeof topic.partitions).toBe('number')
+        expect(typeof topic.replicationFactor).toBe('number')
+        expect(validTopicStatus).toContain(topic.status)
+      }
+    }
+  })
+
+  it('each cluster has consumerGroups array', () => {
+    const validCgStatus: ConsumerGroupStatus[] = ['ok', 'warning', 'error']
+    for (const kc of STRIMZI_DEMO_DATA.clusters) {
+      expect(Array.isArray(kc.consumerGroups)).toBe(true)
+      for (const cg of kc.consumerGroups) {
+        expect(typeof cg.groupId).toBe('string')
+        expect(typeof cg.members).toBe('number')
+        expect(typeof cg.lag).toBe('number')
+        expect(validCgStatus).toContain(cg.status)
+      }
+    }
+  })
+
+  it('has stats with required numeric fields', () => {
+    expect(typeof STRIMZI_DEMO_DATA.stats.clusterCount).toBe('number')
+    expect(typeof STRIMZI_DEMO_DATA.stats.brokerCount).toBe('number')
+    expect(typeof STRIMZI_DEMO_DATA.stats.topicCount).toBe('number')
+    expect(typeof STRIMZI_DEMO_DATA.stats.consumerGroupCount).toBe('number')
+    expect(typeof STRIMZI_DEMO_DATA.stats.totalLag).toBe('number')
+    expect(typeof STRIMZI_DEMO_DATA.stats.operatorVersion).toBe('string')
+  })
+
+  it('has summary with required fields', () => {
+    expect(typeof STRIMZI_DEMO_DATA.summary.totalClusters).toBe('number')
+    expect(typeof STRIMZI_DEMO_DATA.summary.healthyClusters).toBe('number')
+    expect(typeof STRIMZI_DEMO_DATA.summary.totalBrokers).toBe('number')
+    expect(typeof STRIMZI_DEMO_DATA.summary.readyBrokers).toBe('number')
+  })
+})

--- a/web/src/components/cards/__tests__/tenant_topology.test.ts
+++ b/web/src/components/cards/__tests__/tenant_topology.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { DEMO_TENANT_TOPOLOGY } from '../multi-tenancy/tenant-topology/demoData'
+
+describe('DEMO_TENANT_TOPOLOGY', () => {
+  it('is defined', () => {
+    expect(DEMO_TENANT_TOPOLOGY).toBeDefined()
+  })
+
+  it('isDemoData is true', () => {
+    expect(DEMO_TENANT_TOPOLOGY.isDemoData).toBe(true)
+  })
+
+  it('isLoading is false in demo', () => {
+    expect(DEMO_TENANT_TOPOLOGY.isLoading).toBe(false)
+  })
+
+  it('all component detected flags are boolean', () => {
+    expect(typeof DEMO_TENANT_TOPOLOGY.ovnDetected).toBe('boolean')
+    expect(typeof DEMO_TENANT_TOPOLOGY.kubeflexDetected).toBe('boolean')
+    expect(typeof DEMO_TENANT_TOPOLOGY.k3sDetected).toBe('boolean')
+    expect(typeof DEMO_TENANT_TOPOLOGY.kubevirtDetected).toBe('boolean')
+  })
+
+  it('all component healthy flags are boolean', () => {
+    expect(typeof DEMO_TENANT_TOPOLOGY.ovnHealthy).toBe('boolean')
+    expect(typeof DEMO_TENANT_TOPOLOGY.kubeflexHealthy).toBe('boolean')
+    expect(typeof DEMO_TENANT_TOPOLOGY.k3sHealthy).toBe('boolean')
+    expect(typeof DEMO_TENANT_TOPOLOGY.kubevirtHealthy).toBe('boolean')
+  })
+
+  it('all detected components are healthy in demo', () => {
+    if (DEMO_TENANT_TOPOLOGY.ovnDetected) expect(DEMO_TENANT_TOPOLOGY.ovnHealthy).toBe(true)
+    if (DEMO_TENANT_TOPOLOGY.kubeflexDetected) expect(DEMO_TENANT_TOPOLOGY.kubeflexHealthy).toBe(true)
+    if (DEMO_TENANT_TOPOLOGY.k3sDetected) expect(DEMO_TENANT_TOPOLOGY.k3sHealthy).toBe(true)
+    if (DEMO_TENANT_TOPOLOGY.kubevirtDetected) expect(DEMO_TENANT_TOPOLOGY.kubevirtHealthy).toBe(true)
+  })
+
+  describe('network rates', () => {
+    it('kvEth0Rate equals kvEth0Rx + kvEth0Tx', () => {
+      expect(DEMO_TENANT_TOPOLOGY.kvEth0Rate).toBe(
+        DEMO_TENANT_TOPOLOGY.kvEth0Rx + DEMO_TENANT_TOPOLOGY.kvEth0Tx,
+      )
+    })
+
+    it('kvEth1Rate equals kvEth1Rx + kvEth1Tx', () => {
+      expect(DEMO_TENANT_TOPOLOGY.kvEth1Rate).toBe(
+        DEMO_TENANT_TOPOLOGY.kvEth1Rx + DEMO_TENANT_TOPOLOGY.kvEth1Tx,
+      )
+    })
+
+    it('k3sEth0Rate equals k3sEth0Rx + k3sEth0Tx', () => {
+      expect(DEMO_TENANT_TOPOLOGY.k3sEth0Rate).toBe(
+        DEMO_TENANT_TOPOLOGY.k3sEth0Rx + DEMO_TENANT_TOPOLOGY.k3sEth0Tx,
+      )
+    })
+
+    it('k3sEth1Rate equals k3sEth1Rx + k3sEth1Tx', () => {
+      expect(DEMO_TENANT_TOPOLOGY.k3sEth1Rate).toBe(
+        DEMO_TENANT_TOPOLOGY.k3sEth1Rx + DEMO_TENANT_TOPOLOGY.k3sEth1Tx,
+      )
+    })
+
+    it('all rates are non-negative', () => {
+      expect(DEMO_TENANT_TOPOLOGY.kvEth0Rate).toBeGreaterThanOrEqual(0)
+      expect(DEMO_TENANT_TOPOLOGY.kvEth1Rate).toBeGreaterThanOrEqual(0)
+      expect(DEMO_TENANT_TOPOLOGY.k3sEth0Rate).toBeGreaterThanOrEqual(0)
+      expect(DEMO_TENANT_TOPOLOGY.k3sEth1Rate).toBeGreaterThanOrEqual(0)
+    })
+
+    it('rx and tx values are non-negative', () => {
+      const fields = [
+        'kvEth0Rx', 'kvEth0Tx', 'kvEth1Rx', 'kvEth1Tx',
+        'k3sEth0Rx', 'k3sEth0Tx', 'k3sEth1Rx', 'k3sEth1Tx',
+      ] as const
+      for (const field of fields) {
+        expect(DEMO_TENANT_TOPOLOGY[field]).toBeGreaterThanOrEqual(0)
+      }
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/trino_gateway.test.ts
+++ b/web/src/components/cards/__tests__/trino_gateway.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import {
+  TRINO_GATEWAY_DEMO_DATA,
+  type TrinoGatewayData,
+  type TrinoGatewayStatus,
+} from '../trino_gateway/demoData'
+
+describe('TRINO_GATEWAY_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(TRINO_GATEWAY_DEMO_DATA).toBeDefined()
+  })
+
+  it('detected is boolean', () => {
+    expect(typeof TRINO_GATEWAY_DEMO_DATA.detected).toBe('boolean')
+  })
+
+  it('has valid lastCheckTime', () => {
+    expect(new Date(TRINO_GATEWAY_DEMO_DATA.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+
+  it('totalWorkers is positive', () => {
+    expect(TRINO_GATEWAY_DEMO_DATA.totalWorkers).toBeGreaterThan(0)
+  })
+
+  it('totalActiveQueries is non-negative', () => {
+    expect(TRINO_GATEWAY_DEMO_DATA.totalActiveQueries).toBeGreaterThanOrEqual(0)
+  })
+
+  describe('trinoClusters', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(TRINO_GATEWAY_DEMO_DATA.trinoClusters)).toBe(true)
+      expect(TRINO_GATEWAY_DEMO_DATA.trinoClusters.length).toBeGreaterThan(0)
+    })
+
+    it('each cluster has required fields', () => {
+      for (const cluster of TRINO_GATEWAY_DEMO_DATA.trinoClusters) {
+        expect(typeof cluster.name).toBe('string')
+        expect(cluster.name.length).toBeGreaterThan(0)
+        expect(typeof cluster.cluster).toBe('string')
+        expect(typeof cluster.namespace).toBe('string')
+        expect(typeof cluster.coordinatorReady).toBe('boolean')
+        expect(cluster.workerCount).toBeGreaterThanOrEqual(0)
+        expect(cluster.activeQueries).toBeGreaterThanOrEqual(0)
+        expect(cluster.queuedQueries).toBeGreaterThanOrEqual(0)
+      }
+    })
+
+    it('totalWorkers matches sum of cluster workerCounts', () => {
+      const sum = TRINO_GATEWAY_DEMO_DATA.trinoClusters.reduce(
+        (acc, c) => acc + c.workerCount,
+        0,
+      )
+      expect(TRINO_GATEWAY_DEMO_DATA.totalWorkers).toBe(sum)
+    })
+
+    it('totalActiveQueries matches sum of cluster activeQueries', () => {
+      const sum = TRINO_GATEWAY_DEMO_DATA.trinoClusters.reduce(
+        (acc, c) => acc + c.activeQueries,
+        0,
+      )
+      expect(TRINO_GATEWAY_DEMO_DATA.totalActiveQueries).toBe(sum)
+    })
+  })
+
+  describe('gateways', () => {
+    it('is an array', () => {
+      expect(Array.isArray(TRINO_GATEWAY_DEMO_DATA.gateways)).toBe(true)
+    })
+
+    it('each gateway has valid status', () => {
+      const valid: TrinoGatewayStatus[] = ['healthy', 'degraded', 'down']
+      for (const gw of TRINO_GATEWAY_DEMO_DATA.gateways) {
+        expect(valid).toContain(gw.status)
+        expect(typeof gw.name).toBe('string')
+        expect(typeof gw.cluster).toBe('string')
+        expect(typeof gw.namespace).toBe('string')
+        expect(Array.isArray(gw.backends)).toBe(true)
+      }
+    })
+
+    it('each backend has required fields', () => {
+      for (const gw of TRINO_GATEWAY_DEMO_DATA.gateways) {
+        for (const be of gw.backends) {
+          expect(typeof be.name).toBe('string')
+          expect(typeof be.cluster).toBe('string')
+          expect(typeof be.active).toBe('boolean')
+          expect(typeof be.draining).toBe('boolean')
+        }
+      }
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/volcano_status.test.ts
+++ b/web/src/components/cards/__tests__/volcano_status.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import {
+  VOLCANO_DEMO_DATA,
+  type VolcanoHealth,
+  type VolcanoJobPhase,
+  type QueueState,
+} from '../volcano_status/demoData'
+
+describe('VOLCANO_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(VOLCANO_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth: VolcanoHealth[] = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(validHealth).toContain(VOLCANO_DEMO_DATA.health)
+  })
+
+  it('has jobs array with entries', () => {
+    expect(Array.isArray(VOLCANO_DEMO_DATA.jobs)).toBe(true)
+    expect(VOLCANO_DEMO_DATA.jobs.length).toBeGreaterThan(0)
+  })
+
+  it('each job has required fields', () => {
+    for (const job of VOLCANO_DEMO_DATA.jobs) {
+      expect(typeof job.name).toBe('string')
+      expect(typeof job.namespace).toBe('string')
+      expect(typeof job.cluster).toBe('string')
+      expect(typeof job.minAvailable).toBe('number')
+    }
+  })
+
+  it('each job has a valid phase', () => {
+    const validPhases: VolcanoJobPhase[] = ['Pending', 'Running', 'Completing', 'Completed', 'Terminating', 'Terminated', 'Aborting', 'Aborted', 'Failed', 'Unknown']
+    for (const job of VOLCANO_DEMO_DATA.jobs) {
+      expect(validPhases).toContain(job.phase)
+    }
+  })
+
+  it('has queues array', () => {
+    expect(Array.isArray(VOLCANO_DEMO_DATA.queues)).toBe(true)
+  })
+
+  it('each queue has required fields', () => {
+    for (const queue of VOLCANO_DEMO_DATA.queues) {
+      expect(typeof queue.name).toBe('string')
+      const validStates: QueueState[] = ['Open', 'Closed', 'Closing']
+      expect(validStates).toContain(queue.state)
+    }
+  })
+
+  it('has stats with required numeric fields', () => {
+    expect(typeof VOLCANO_DEMO_DATA.stats.totalJobs).toBe('number')
+    expect(typeof VOLCANO_DEMO_DATA.stats.runningJobs).toBe('number')
+    expect(typeof VOLCANO_DEMO_DATA.stats.completedJobs).toBe('number')
+    expect(typeof VOLCANO_DEMO_DATA.stats.failedJobs).toBe('number')
+    expect(typeof VOLCANO_DEMO_DATA.stats.totalQueues).toBe('number')
+  })
+
+  it('has summary with schedulerVersion', () => {
+    expect(typeof VOLCANO_DEMO_DATA.summary.schedulerVersion).toBe('string')
+    expect(typeof VOLCANO_DEMO_DATA.summary.totalScheduledJobs).toBe('number')
+  })
+
+  it('stats counts are non-negative', () => {
+    expect(VOLCANO_DEMO_DATA.stats.totalJobs).toBeGreaterThanOrEqual(0)
+    expect(VOLCANO_DEMO_DATA.stats.runningJobs).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/web/src/components/cards/__tests__/wasmcloud_status.test.ts
+++ b/web/src/components/cards/__tests__/wasmcloud_status.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import {
+  WASMCLOUD_DEMO_DATA,
+  type WasmcloudHealth,
+  type WasmcloudHostStatus,
+  type WasmcloudProviderStatus,
+  type WasmcloudLinkStatus,
+} from '../wasmcloud_status/demoData'
+
+describe('WASMCLOUD_DEMO_DATA', () => {
+  it('is defined', () => {
+    expect(WASMCLOUD_DEMO_DATA).toBeDefined()
+  })
+
+  it('has valid health status', () => {
+    const validHealth: WasmcloudHealth[] = ['healthy', 'degraded', 'not-installed', 'unknown']
+    expect(validHealth).toContain(WASMCLOUD_DEMO_DATA.health)
+  })
+
+  it('has hosts array with entries', () => {
+    expect(Array.isArray(WASMCLOUD_DEMO_DATA.hosts)).toBe(true)
+    expect(WASMCLOUD_DEMO_DATA.hosts.length).toBeGreaterThan(0)
+  })
+
+  it('each host has required fields', () => {
+    for (const host of WASMCLOUD_DEMO_DATA.hosts) {
+      expect(typeof host.id).toBe('string')
+      expect(typeof host.cluster).toBe('string')
+      const validStatuses: WasmcloudHostStatus[] = ['ready', 'starting', 'unreachable']
+      expect(validStatuses).toContain(host.status)
+    }
+  })
+
+  it('has actors array', () => {
+    expect(Array.isArray(WASMCLOUD_DEMO_DATA.actors)).toBe(true)
+  })
+
+  it('each actor has required fields', () => {
+    for (const actor of WASMCLOUD_DEMO_DATA.actors) {
+      expect(typeof actor.id).toBe('string')
+      expect(typeof actor.name).toBe('string')
+      expect(typeof actor.instances).toBe('number')
+    }
+  })
+
+  it('has providers array', () => {
+    expect(Array.isArray(WASMCLOUD_DEMO_DATA.providers)).toBe(true)
+  })
+
+  it('each provider has valid status', () => {
+    const validStatuses: WasmcloudProviderStatus[] = ['running', 'starting', 'failed']
+    for (const provider of WASMCLOUD_DEMO_DATA.providers) {
+      expect(validStatuses).toContain(provider.status)
+    }
+  })
+
+  it('has links array', () => {
+    expect(Array.isArray(WASMCLOUD_DEMO_DATA.links)).toBe(true)
+  })
+
+  it('each link has valid status', () => {
+    const validStatuses: WasmcloudLinkStatus[] = ['active', 'pending', 'failed']
+    for (const link of WASMCLOUD_DEMO_DATA.links) {
+      expect(validStatuses).toContain(link.status)
+    }
+  })
+
+  it('has stats with required numeric fields', () => {
+    expect(typeof WASMCLOUD_DEMO_DATA.stats.totalHosts).toBe('number')
+    expect(typeof WASMCLOUD_DEMO_DATA.stats.readyHosts).toBe('number')
+    expect(typeof WASMCLOUD_DEMO_DATA.stats.totalActors).toBe('number')
+    expect(typeof WASMCLOUD_DEMO_DATA.stats.totalProviders).toBe('number')
+    expect(typeof WASMCLOUD_DEMO_DATA.stats.totalLinks).toBe('number')
+  })
+
+  it('has summary with latticeVersion', () => {
+    expect(typeof WASMCLOUD_DEMO_DATA.summary.latticeVersion).toBe('string')
+  })
+})


### PR DESCRIPTION
Fixes #10955

The E2E test 'cluster count in dashboard header matches /clusters page row count' fails in firefox/webkit because the SWR cache rehydrates empty sessionStorage data synchronously before the mock API response arrives.

### Changes
- **Add `page.waitForResponse()`** for `/api/mcp/clusters` before navigating, ensuring the mock response is delivered before row counting begins
- **Remove `.catch(() => {})`** on the `firstClusterName` visibility assertion — failures now surface immediately instead of silently yielding 0 rows
- **Remove `.catch(() => 0)`** on `rowsByTestId.count()` — this method never throws
- **Increase fallback `NAME_CHECK_TIMEOUT_MS`** from 5s to 10s for slower browser engines