### PR TITLE
🐛 Fix Full-Stack E2E: prevent dev-mode auto-activation in CI

### DIFF
--- a/.github/workflows/fullstack-e2e.yml
+++ b/.github/workflows/fullstack-e2e.yml
@@ -68,14 +68,21 @@ jobs:
         env:
           JWT_SECRET: ${{ env.DEV_JWT_SECRET }}
           PORT: ${{ env.BACKEND_PORT }}
+          # Provide non-empty placeholder OAuth credentials so the server does NOT
+          # auto-activate dev mode (pkg/api/server.go: auto-activates when both are
+          # absent, introduced in #10925). In dev mode the root route 307-redirects
+          # to the Vite dev server (localhost:5174) which is not running in CI,
+          # causing ERR_CONNECTION_REFUSED on page.goto('/') (#10970).
+          # These values are intentionally fake — the smoke test never exercises OAuth.
+          GITHUB_CLIENT_ID: ci-fullstack-smoke-placeholder
+          GITHUB_CLIENT_SECRET: ci-fullstack-smoke-placeholder
         run: |
           # Intentionally NOT setting DEV_MODE=true — the whole point of
           # fullstack-smoke is to exercise the production serving path where
           # the Go binary serves ./web/dist/index.html directly (see
-          # pkg/api/server.go:1221-1240). With DEV_MODE=true the root route
-          # 307-redirects to FrontendURL (Vite), which isn't running in CI,
-          # so the Playwright page.goto on '/' sees ERR_CONNECTION_REFUSED
-          # while the /healthz + /api/version tests still pass (#6362).
+          # pkg/api/server.go). With DEV_MODE=true (or auto-activated dev mode)
+          # the root route 307-redirects to FrontendURL (Vite), which isn't
+          # running in CI, so Playwright page.goto on '/' gets ERR_CONNECTION_REFUSED.
           /tmp/console-binary > /tmp/console.log 2>&1 &
           echo $! > /tmp/console.pid
           echo "Backend PID: $(cat /tmp/console.pid)"


### PR DESCRIPTION
Fixes #10970

## Problem
PR #10925 added OAuth-absent dev-mode auto-activation to prevent auth-retry cascades. But the `fullstack-e2e.yml` workflow never sets `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` — so every run auto-activates dev mode. In dev mode the root route 307-redirects to Vite (`localhost:5174`) which isn't running in CI, causing `ERR_CONNECTION_REFUSED` on `page.goto('/')` while `/healthz` and `/api/version` still pass.

Result: every PR touching Go files has a red Full-Stack E2E check (10+ consecutive failures).

## Fix
Add placeholder `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` env vars to the backend start step so the server runs in production serving mode (serves `web/dist/index.html` directly). The smoke test never exercises OAuth — it only needs static file serving + `/healthz` + `/api/version`.