### PR TITLE
test: coverage batch 12 — helm, workloads, buildpacks, sseClient

### DIFF
--- a/web/src/hooks/mcp/__tests__/buildpacks-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-pure.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+const mod = await import('../buildpacks')
+const {
+  getDemoBuildpackImages,
+  loadFromStorage,
+  saveToStorage,
+  BUILDPACK_CACHE_KEY,
+  BUILDPACK_CACHE_TTL_MS,
+  BUILDPACK_REFRESH_INTERVAL_MS,
+} = mod.__buildpacksTestables
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('getDemoBuildpackImages', () => {
+  it('returns a non-empty array', () => {
+    expect(getDemoBuildpackImages().length).toBeGreaterThan(0)
+  })
+
+  it('each image has required fields', () => {
+    for (const img of getDemoBuildpackImages()) {
+      expect(typeof img.name).toBe('string')
+      expect(typeof img.namespace).toBe('string')
+      expect(typeof img.builder).toBe('string')
+      expect(typeof img.image).toBe('string')
+      expect(typeof img.status).toBe('string')
+      expect(typeof img.updated).toBe('string')
+      expect(typeof img.cluster).toBe('string')
+    }
+  })
+
+  it('includes both succeeded and failed statuses', () => {
+    const statuses = new Set(getDemoBuildpackImages().map(img => img.status))
+    expect(statuses.has('succeeded')).toBe(true)
+    expect(statuses.has('failed')).toBe(true)
+  })
+
+  it('updated fields are valid ISO dates', () => {
+    for (const img of getDemoBuildpackImages()) {
+      expect(new Date(img.updated).getTime()).not.toBeNaN()
+    }
+  })
+})
+
+describe('loadFromStorage', () => {
+  it('returns empty data when localStorage is empty', () => {
+    const result = loadFromStorage()
+    expect(result.data).toEqual([])
+    expect(result.timestamp).toBe(0)
+  })
+
+  it('returns stored data when valid', () => {
+    const data = [{ name: 'app', namespace: 'ns', builder: 'b', image: 'i', status: 'succeeded', updated: '', cluster: 'c' }]
+    const ts = 55555
+    localStorage.setItem(BUILDPACK_CACHE_KEY, JSON.stringify({ data, timestamp: ts }))
+    const result = loadFromStorage()
+    expect(result.data).toEqual(data)
+    expect(result.timestamp).toBe(ts)
+  })
+
+  it('returns empty on corrupted JSON', () => {
+    localStorage.setItem(BUILDPACK_CACHE_KEY, 'not-json!')
+    const result = loadFromStorage()
+    expect(result.data).toEqual([])
+    expect(result.timestamp).toBe(0)
+  })
+
+  it('returns empty when data is not an array', () => {
+    localStorage.setItem(BUILDPACK_CACHE_KEY, JSON.stringify({ data: 'string' }))
+    const result = loadFromStorage()
+    expect(result.data).toEqual([])
+  })
+
+  it('defaults timestamp to 0 when missing', () => {
+    localStorage.setItem(BUILDPACK_CACHE_KEY, JSON.stringify({ data: [{ name: 'x' }] }))
+    const result = loadFromStorage()
+    expect(result.timestamp).toBe(0)
+  })
+})
+
+describe('saveToStorage', () => {
+  it('persists data and timestamp', () => {
+    const data = [{ name: 'saved', namespace: 'ns', builder: 'b', image: 'i', status: 'succeeded', updated: '', cluster: 'c' }]
+    saveToStorage(data, 77777)
+    const stored = JSON.parse(localStorage.getItem(BUILDPACK_CACHE_KEY) || '{}')
+    expect(stored.data).toEqual(data)
+    expect(stored.timestamp).toBe(77777)
+  })
+
+  it('overwrites previous data', () => {
+    saveToStorage([{ name: 'first' }] as never[], 1)
+    saveToStorage([{ name: 'second' }] as never[], 2)
+    const stored = JSON.parse(localStorage.getItem(BUILDPACK_CACHE_KEY) || '{}')
+    expect(stored.data[0].name).toBe('second')
+    expect(stored.timestamp).toBe(2)
+  })
+})
+
+describe('constants', () => {
+  it('BUILDPACK_CACHE_KEY is a non-empty string', () => {
+    expect(typeof BUILDPACK_CACHE_KEY).toBe('string')
+    expect(BUILDPACK_CACHE_KEY.length).toBeGreaterThan(0)
+  })
+
+  it('BUILDPACK_CACHE_TTL_MS is positive', () => {
+    expect(BUILDPACK_CACHE_TTL_MS).toBeGreaterThan(0)
+  })
+
+  it('BUILDPACK_REFRESH_INTERVAL_MS is larger than TTL', () => {
+    expect(BUILDPACK_REFRESH_INTERVAL_MS).toBeGreaterThan(BUILDPACK_CACHE_TTL_MS)
+  })
+})

--- a/web/src/hooks/mcp/__tests__/helm-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-pure.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+const mod = await import('../helm')
+const {
+  getDemoHelmReleases,
+  getDemoHelmHistory,
+  getDemoHelmValues,
+  loadHelmReleasesFromStorage,
+  saveHelmReleasesToStorage,
+  loadHelmHistoryFromStorage,
+  saveHelmHistoryToStorage,
+  HELM_RELEASES_CACHE_KEY,
+  HELM_HISTORY_CACHE_KEY,
+  HELM_CACHE_TTL_MS,
+  HELM_REFRESH_INTERVAL_MS,
+} = mod.__helmTestables
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('getDemoHelmReleases', () => {
+  it('returns a non-empty array', () => {
+    const releases = getDemoHelmReleases()
+    expect(releases.length).toBeGreaterThan(0)
+  })
+
+  it('each release has required fields', () => {
+    for (const r of getDemoHelmReleases()) {
+      expect(typeof r.name).toBe('string')
+      expect(typeof r.namespace).toBe('string')
+      expect(typeof r.revision).toBe('string')
+      expect(typeof r.updated).toBe('string')
+      expect(typeof r.status).toBe('string')
+      expect(typeof r.chart).toBe('string')
+      expect(typeof r.app_version).toBe('string')
+      expect(typeof r.cluster).toBe('string')
+    }
+  })
+
+  it('includes at least one failed release', () => {
+    const failed = getDemoHelmReleases().filter(r => r.status === 'failed')
+    expect(failed.length).toBeGreaterThan(0)
+  })
+
+  it('covers multiple clusters', () => {
+    const clusters = new Set(getDemoHelmReleases().map(r => r.cluster))
+    expect(clusters.size).toBeGreaterThanOrEqual(2)
+  })
+
+  it('returns cached result on second call', () => {
+    const a = getDemoHelmReleases()
+    const b = getDemoHelmReleases()
+    expect(a).toBe(b)
+  })
+})
+
+describe('getDemoHelmHistory', () => {
+  it('returns a non-empty array', () => {
+    expect(getDemoHelmHistory().length).toBeGreaterThan(0)
+  })
+
+  it('each entry has required fields', () => {
+    for (const h of getDemoHelmHistory()) {
+      expect(typeof h.revision).toBe('number')
+      expect(typeof h.updated).toBe('string')
+      expect(typeof h.status).toBe('string')
+      expect(typeof h.chart).toBe('string')
+      expect(typeof h.app_version).toBe('string')
+      expect(typeof h.description).toBe('string')
+    }
+  })
+
+  it('includes multiple statuses', () => {
+    const statuses = new Set(getDemoHelmHistory().map(h => h.status))
+    expect(statuses.size).toBeGreaterThanOrEqual(2)
+  })
+
+  it('revisions are in descending order', () => {
+    const history = getDemoHelmHistory()
+    for (let i = 1; i < history.length; i++) {
+      expect(history[i - 1].revision).toBeGreaterThan(history[i].revision)
+    }
+  })
+})
+
+describe('getDemoHelmValues', () => {
+  it('returns an object with replicaCount', () => {
+    const vals = getDemoHelmValues()
+    expect(typeof vals.replicaCount).toBe('number')
+  })
+
+  it('has nested image config', () => {
+    const vals = getDemoHelmValues()
+    const img = vals.image as Record<string, unknown>
+    expect(typeof img.repository).toBe('string')
+    expect(typeof img.tag).toBe('string')
+  })
+
+  it('has resources with limits and requests', () => {
+    const vals = getDemoHelmValues()
+    const res = vals.resources as Record<string, Record<string, string>>
+    expect(res.limits).toBeDefined()
+    expect(res.requests).toBeDefined()
+  })
+})
+
+describe('loadHelmReleasesFromStorage', () => {
+  it('returns empty data when localStorage is empty', () => {
+    const result = loadHelmReleasesFromStorage()
+    expect(result.data).toEqual([])
+    expect(result.timestamp).toBe(0)
+  })
+
+  it('returns stored data when valid', () => {
+    const data = [{ name: 'test', namespace: 'ns', revision: '1', updated: '', status: 'deployed', chart: 'c-1.0', app_version: '1.0' }]
+    const ts = Date.now()
+    localStorage.setItem(HELM_RELEASES_CACHE_KEY, JSON.stringify({ data, timestamp: ts }))
+    const result = loadHelmReleasesFromStorage()
+    expect(result.data).toEqual(data)
+    expect(result.timestamp).toBe(ts)
+  })
+
+  it('returns empty on corrupted JSON', () => {
+    localStorage.setItem(HELM_RELEASES_CACHE_KEY, 'not-json')
+    const result = loadHelmReleasesFromStorage()
+    expect(result.data).toEqual([])
+  })
+
+  it('returns empty when data is not an array', () => {
+    localStorage.setItem(HELM_RELEASES_CACHE_KEY, JSON.stringify({ data: 'notarray' }))
+    const result = loadHelmReleasesFromStorage()
+    expect(result.data).toEqual([])
+  })
+
+  it('defaults timestamp to 0 when missing', () => {
+    localStorage.setItem(HELM_RELEASES_CACHE_KEY, JSON.stringify({ data: [{ name: 'x' }] }))
+    const result = loadHelmReleasesFromStorage()
+    expect(result.timestamp).toBe(0)
+  })
+})
+
+describe('saveHelmReleasesToStorage', () => {
+  it('persists data to localStorage', () => {
+    const data = [{ name: 'saved', namespace: 'ns', revision: '2', updated: '', status: 'deployed', chart: 'c', app_version: '1' }]
+    const ts = 12345
+    saveHelmReleasesToStorage(data, ts)
+    const stored = JSON.parse(localStorage.getItem(HELM_RELEASES_CACHE_KEY) || '{}')
+    expect(stored.data).toEqual(data)
+    expect(stored.timestamp).toBe(ts)
+  })
+})
+
+describe('loadHelmHistoryFromStorage', () => {
+  it('returns empty Map when localStorage is empty', () => {
+    const result = loadHelmHistoryFromStorage()
+    expect(result).toBeInstanceOf(Map)
+    expect(result.size).toBe(0)
+  })
+
+  it('returns stored entries', () => {
+    const entry = { data: [{ revision: 1, updated: '', status: 'deployed', chart: 'c', app_version: '1', description: 'ok' }], timestamp: 100, consecutiveFailures: 0 }
+    localStorage.setItem(HELM_HISTORY_CACHE_KEY, JSON.stringify({ 'prod:release1': entry }))
+    const result = loadHelmHistoryFromStorage()
+    expect(result.size).toBe(1)
+    expect(result.get('prod:release1')).toEqual(entry)
+  })
+
+  it('returns empty Map on corrupted JSON', () => {
+    localStorage.setItem(HELM_HISTORY_CACHE_KEY, '{invalid')
+    const result = loadHelmHistoryFromStorage()
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('saveHelmHistoryToStorage', () => {
+  it('persists Map entries to localStorage', () => {
+    const cache = new Map()
+    cache.set('c1:r1', { data: [], timestamp: 999, consecutiveFailures: 0 })
+    saveHelmHistoryToStorage(cache)
+    const stored = JSON.parse(localStorage.getItem(HELM_HISTORY_CACHE_KEY) || '{}')
+    expect(stored['c1:r1'].timestamp).toBe(999)
+  })
+
+  it('handles empty Map', () => {
+    saveHelmHistoryToStorage(new Map())
+    const stored = JSON.parse(localStorage.getItem(HELM_HISTORY_CACHE_KEY) || '{}')
+    expect(Object.keys(stored)).toHaveLength(0)
+  })
+})
+
+describe('constants', () => {
+  it('HELM_RELEASES_CACHE_KEY is a string', () => {
+    expect(typeof HELM_RELEASES_CACHE_KEY).toBe('string')
+    expect(HELM_RELEASES_CACHE_KEY.length).toBeGreaterThan(0)
+  })
+
+  it('HELM_HISTORY_CACHE_KEY is a string', () => {
+    expect(typeof HELM_HISTORY_CACHE_KEY).toBe('string')
+  })
+
+  it('HELM_CACHE_TTL_MS is positive', () => {
+    expect(HELM_CACHE_TTL_MS).toBeGreaterThan(0)
+  })
+
+  it('HELM_REFRESH_INTERVAL_MS is positive and larger than TTL', () => {
+    expect(HELM_REFRESH_INTERVAL_MS).toBeGreaterThan(HELM_CACHE_TTL_MS)
+  })
+})

--- a/web/src/hooks/mcp/__tests__/workloads-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads-pure.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+const mod = await import('../workloads')
+const {
+  getDemoPods,
+  getDemoPodIssues,
+  getDemoDeploymentIssues,
+  getDemoDeployments,
+  getDemoAllPods,
+  loadPodsCacheFromStorage,
+  savePodsCacheToStorage,
+  PODS_CACHE_KEY,
+} = mod.__workloadsTestables
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('getDemoPods', () => {
+  it('returns 10 pods', () => {
+    expect(getDemoPods()).toHaveLength(10)
+  })
+
+  it('each pod has required fields', () => {
+    for (const pod of getDemoPods()) {
+      expect(typeof pod.name).toBe('string')
+      expect(typeof pod.namespace).toBe('string')
+      expect(typeof pod.cluster).toBe('string')
+      expect(typeof pod.status).toBe('string')
+      expect(typeof pod.ready).toBe('string')
+      expect(typeof pod.restarts).toBe('number')
+      expect(typeof pod.age).toBe('string')
+      expect(typeof pod.node).toBe('string')
+    }
+  })
+
+  it('covers multiple clusters', () => {
+    const clusters = new Set(getDemoPods().map(p => p.cluster))
+    expect(clusters.size).toBeGreaterThanOrEqual(3)
+  })
+
+  it('all pods are Running', () => {
+    for (const pod of getDemoPods()) {
+      expect(pod.status).toBe('Running')
+    }
+  })
+})
+
+describe('getDemoPodIssues', () => {
+  it('returns non-empty array', () => {
+    expect(getDemoPodIssues().length).toBeGreaterThan(0)
+  })
+
+  it('each issue has required fields', () => {
+    for (const issue of getDemoPodIssues()) {
+      expect(typeof issue.name).toBe('string')
+      expect(typeof issue.namespace).toBe('string')
+      expect(typeof issue.cluster).toBe('string')
+      expect(typeof issue.status).toBe('string')
+      expect(typeof issue.restarts).toBe('number')
+      expect(typeof issue.reason).toBe('string')
+      expect(Array.isArray(issue.issues)).toBe(true)
+    }
+  })
+
+  it('includes CrashLoopBackOff status', () => {
+    const crash = getDemoPodIssues().find(i => i.status === 'CrashLoopBackOff')
+    expect(crash).toBeDefined()
+  })
+
+  it('includes OOMKilled status', () => {
+    const oom = getDemoPodIssues().find(i => i.status === 'OOMKilled')
+    expect(oom).toBeDefined()
+  })
+
+  it('includes Pending status', () => {
+    const pending = getDemoPodIssues().find(i => i.status === 'Pending')
+    expect(pending).toBeDefined()
+  })
+})
+
+describe('getDemoDeploymentIssues', () => {
+  it('returns non-empty array', () => {
+    expect(getDemoDeploymentIssues().length).toBeGreaterThan(0)
+  })
+
+  it('each issue has required fields', () => {
+    for (const issue of getDemoDeploymentIssues()) {
+      expect(typeof issue.name).toBe('string')
+      expect(typeof issue.namespace).toBe('string')
+      expect(typeof issue.cluster).toBe('string')
+      expect(typeof issue.replicas).toBe('number')
+      expect(typeof issue.readyReplicas).toBe('number')
+      expect(typeof issue.reason).toBe('string')
+      expect(typeof issue.message).toBe('string')
+    }
+  })
+
+  it('readyReplicas is less than replicas for each issue', () => {
+    for (const issue of getDemoDeploymentIssues()) {
+      expect(issue.readyReplicas).toBeLessThan(issue.replicas)
+    }
+  })
+})
+
+describe('getDemoDeployments', () => {
+  it('returns non-empty array', () => {
+    expect(getDemoDeployments().length).toBeGreaterThan(0)
+  })
+
+  it('each deployment has required fields', () => {
+    for (const dep of getDemoDeployments()) {
+      expect(typeof dep.name).toBe('string')
+      expect(typeof dep.namespace).toBe('string')
+      expect(typeof dep.cluster).toBe('string')
+      expect(typeof dep.status).toBe('string')
+      expect(typeof dep.replicas).toBe('number')
+    }
+  })
+
+  it('includes multiple statuses', () => {
+    const statuses = new Set(getDemoDeployments().map(d => d.status))
+    expect(statuses.size).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe('getDemoAllPods', () => {
+  it('returns more pods than getDemoPods', () => {
+    expect(getDemoAllPods().length).toBeGreaterThan(getDemoPods().length)
+  })
+
+  it('includes all pods from getDemoPods', () => {
+    const allNames = new Set(getDemoAllPods().map(p => p.name))
+    for (const pod of getDemoPods()) {
+      expect(allNames.has(pod.name)).toBe(true)
+    }
+  })
+
+  it('includes GPU workload pods', () => {
+    const mlPods = getDemoAllPods().filter(p => p.namespace === 'ml')
+    expect(mlPods.length).toBeGreaterThan(0)
+  })
+})
+
+describe('loadPodsCacheFromStorage', () => {
+  it('returns null when localStorage is empty', () => {
+    expect(loadPodsCacheFromStorage('key1')).toBeNull()
+  })
+
+  it('returns null when cache key does not match', () => {
+    localStorage.setItem(PODS_CACHE_KEY, JSON.stringify({
+      key: 'other-key',
+      data: [{ name: 'pod1' }],
+      timestamp: new Date().toISOString(),
+    }))
+    expect(loadPodsCacheFromStorage('my-key')).toBeNull()
+  })
+
+  it('returns data when cache key matches', () => {
+    const data = [{ name: 'pod1', namespace: 'ns', cluster: 'c1', status: 'Running', ready: '1/1', restarts: 0, age: '1d', node: 'n1' }]
+    localStorage.setItem(PODS_CACHE_KEY, JSON.stringify({
+      key: 'match-key',
+      data,
+      timestamp: new Date().toISOString(),
+    }))
+    const result = loadPodsCacheFromStorage('match-key')
+    expect(result).not.toBeNull()
+    expect(result!.data).toEqual(data)
+    expect(result!.timestamp).toBeInstanceOf(Date)
+  })
+
+  it('returns null on corrupted JSON', () => {
+    localStorage.setItem(PODS_CACHE_KEY, 'corrupted{{{')
+    expect(loadPodsCacheFromStorage('key')).toBeNull()
+  })
+
+  it('returns null when data array is empty', () => {
+    localStorage.setItem(PODS_CACHE_KEY, JSON.stringify({
+      key: 'k',
+      data: [],
+    }))
+    expect(loadPodsCacheFromStorage('k')).toBeNull()
+  })
+
+  it('uses current date as fallback when timestamp missing', () => {
+    const data = [{ name: 'pod1' }]
+    localStorage.setItem(PODS_CACHE_KEY, JSON.stringify({
+      key: 'k',
+      data,
+    }))
+    const result = loadPodsCacheFromStorage('k')
+    expect(result).not.toBeNull()
+    expect(result!.timestamp).toBeInstanceOf(Date)
+  })
+})
+
+describe('savePodsCacheToStorage', () => {
+  it('does not throw', () => {
+    expect(() => savePodsCacheToStorage()).not.toThrow()
+  })
+})
+
+describe('constants', () => {
+  it('PODS_CACHE_KEY is a non-empty string', () => {
+    expect(typeof PODS_CACHE_KEY).toBe('string')
+    expect(PODS_CACHE_KEY.length).toBeGreaterThan(0)
+  })
+})

--- a/web/src/hooks/mcp/buildpacks.ts
+++ b/web/src/hooks/mcp/buildpacks.ts
@@ -334,3 +334,12 @@ if (typeof window !== 'undefined') {
     )
   })
 }
+
+export const __buildpacksTestables = {
+  getDemoBuildpackImages,
+  loadFromStorage,
+  saveToStorage,
+  BUILDPACK_CACHE_KEY,
+  BUILDPACK_CACHE_TTL_MS,
+  BUILDPACK_REFRESH_INTERVAL_MS,
+}

--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -752,3 +752,17 @@ if (typeof window !== 'undefined') {
     })
   })
 }
+
+export const __helmTestables = {
+  getDemoHelmReleases,
+  getDemoHelmHistory,
+  getDemoHelmValues,
+  loadHelmReleasesFromStorage,
+  saveHelmReleasesToStorage,
+  loadHelmHistoryFromStorage,
+  saveHelmHistoryToStorage,
+  HELM_RELEASES_CACHE_KEY,
+  HELM_HISTORY_CACHE_KEY,
+  HELM_CACHE_TTL_MS,
+  HELM_REFRESH_INTERVAL_MS,
+}

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -1832,3 +1832,14 @@ if (typeof window !== 'undefined') {
     }, 0)
   })
 }
+
+export const __workloadsTestables = {
+  getDemoPods,
+  getDemoPodIssues,
+  getDemoDeploymentIssues,
+  getDemoDeployments,
+  getDemoAllPods,
+  loadPodsCacheFromStorage,
+  savePodsCacheToStorage,
+  PODS_CACHE_KEY,
+}

--- a/web/src/lib/__tests__/sseClient-pure.test.ts
+++ b/web/src/lib/__tests__/sseClient-pure.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    STORAGE_KEY_TOKEN: 'kc-auth-token',
+  }
+})
+
+vi.mock('../analytics', () => ({
+  emitSseAuthFailure: vi.fn(),
+}))
+
+const mod = await import('../sseClient')
+const {
+  parseSSEChunk,
+  SSE_TIMEOUT_MS,
+  SSE_RECONNECT_BASE_MS,
+  SSE_RECONNECT_MAX_MS,
+  SSE_RECONNECT_BACKOFF_FACTOR,
+  SSE_MAX_RECONNECT_ATTEMPTS,
+  RESULT_CACHE_TTL_MS,
+} = mod.__testables
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('parseSSEChunk', () => {
+  it('parses a complete cluster_data event', () => {
+    const events: Array<{ type: string; data: string }> = []
+    const buffer = 'event: cluster_data\ndata: {"cluster":"c1","pods":[1,2]}\n\n'
+    const remaining = parseSSEChunk(buffer, (type, data) => {
+      events.push({ type, data })
+    })
+    expect(events).toHaveLength(1)
+    expect(events[0].type).toBe('cluster_data')
+    expect(JSON.parse(events[0].data).cluster).toBe('c1')
+    expect(remaining).toBe('')
+  })
+
+  it('defaults event type to "message" when no event line', () => {
+    const events: Array<{ type: string; data: string }> = []
+    const buffer = 'data: hello\n\n'
+    parseSSEChunk(buffer, (type, data) => {
+      events.push({ type, data })
+    })
+    expect(events).toHaveLength(1)
+    expect(events[0].type).toBe('message')
+    expect(events[0].data).toBe('hello')
+  })
+
+  it('returns incomplete data as remaining buffer', () => {
+    const events: Array<{ type: string; data: string }> = []
+    const buffer = 'event: cluster_data\ndata: {"cluster":"c1"}\n\nevent: done\ndata: '
+    const remaining = parseSSEChunk(buffer, (type, data) => {
+      events.push({ type, data })
+    })
+    expect(events).toHaveLength(1)
+    expect(remaining).toBe('event: done\ndata: ')
+  })
+
+  it('parses multiple events in one chunk', () => {
+    const events: Array<{ type: string; data: string }> = []
+    const buffer = 'event: cluster_data\ndata: {"a":1}\n\nevent: done\ndata: {"ok":true}\n\n'
+    parseSSEChunk(buffer, (type, data) => {
+      events.push({ type, data })
+    })
+    expect(events).toHaveLength(2)
+    expect(events[0].type).toBe('cluster_data')
+    expect(events[1].type).toBe('done')
+  })
+
+  it('skips empty parts between double newlines', () => {
+    const events: Array<{ type: string; data: string }> = []
+    const buffer = '\n\ndata: test\n\n'
+    parseSSEChunk(buffer, (type, data) => {
+      events.push({ type, data })
+    })
+    expect(events).toHaveLength(1)
+  })
+
+  it('skips events with no data line', () => {
+    const events: Array<{ type: string; data: string }> = []
+    const buffer = 'event: heartbeat\n\n'
+    parseSSEChunk(buffer, (type, data) => {
+      events.push({ type, data })
+    })
+    expect(events).toHaveLength(0)
+  })
+
+  it('handles empty buffer', () => {
+    const events: Array<{ type: string; data: string }> = []
+    const remaining = parseSSEChunk('', (type, data) => {
+      events.push({ type, data })
+    })
+    expect(events).toHaveLength(0)
+    expect(remaining).toBe('')
+  })
+
+  it('trims whitespace from event type and data', () => {
+    const events: Array<{ type: string; data: string }> = []
+    const buffer = 'event:  cluster_error  \ndata:  {"error":"fail"}  \n\n'
+    parseSSEChunk(buffer, (type, data) => {
+      events.push({ type, data })
+    })
+    expect(events[0].type).toBe('cluster_error')
+    expect(JSON.parse(events[0].data).error).toBe('fail')
+  })
+})
+
+describe('clearSSECache', () => {
+  it('does not throw when called', () => {
+    expect(() => mod.clearSSECache()).not.toThrow()
+  })
+
+  it('can be called multiple times', () => {
+    mod.clearSSECache()
+    mod.clearSSECache()
+    expect(true).toBe(true)
+  })
+})
+
+describe('constants', () => {
+  it('SSE_TIMEOUT_MS is 60 seconds', () => {
+    expect(SSE_TIMEOUT_MS).toBe(60_000)
+  })
+
+  it('SSE_RECONNECT_BASE_MS is 1 second', () => {
+    expect(SSE_RECONNECT_BASE_MS).toBe(1_000)
+  })
+
+  it('SSE_RECONNECT_MAX_MS is 30 seconds', () => {
+    expect(SSE_RECONNECT_MAX_MS).toBe(30_000)
+  })
+
+  it('SSE_RECONNECT_BACKOFF_FACTOR is 2', () => {
+    expect(SSE_RECONNECT_BACKOFF_FACTOR).toBe(2)
+  })
+
+  it('SSE_MAX_RECONNECT_ATTEMPTS is 5', () => {
+    expect(SSE_MAX_RECONNECT_ATTEMPTS).toBe(5)
+  })
+
+  it('RESULT_CACHE_TTL_MS is 10 seconds', () => {
+    expect(RESULT_CACHE_TTL_MS).toBe(10_000)
+  })
+
+  it('reconnect max is greater than base', () => {
+    expect(SSE_RECONNECT_MAX_MS).toBeGreaterThan(SSE_RECONNECT_BASE_MS)
+  })
+
+  it('timeout is greater than reconnect max', () => {
+    expect(SSE_TIMEOUT_MS).toBeGreaterThan(SSE_RECONNECT_MAX_MS)
+  })
+})

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -435,3 +435,13 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
   inflightRequests.set(cacheKey, promise as Promise<unknown[]>)
   return promise
 }
+
+export const __testables = {
+  parseSSEChunk,
+  SSE_TIMEOUT_MS,
+  SSE_RECONNECT_BASE_MS,
+  SSE_RECONNECT_MAX_MS,
+  SSE_RECONNECT_BACKOFF_FACTOR,
+  SSE_MAX_RECONNECT_ATTEMPTS,
+  RESULT_CACHE_TTL_MS,
+}


### PR DESCRIPTION
## Summary
- Exposes pure functions via `__helmTestables`, `__workloadsTestables`, `__buildpacksTestables`, and `__testables` (sseClient) exports for testing
- Uses module-specific export names in mcp/ to avoid barrel re-export name conflicts
- Adds 85 new tests across 4 test files covering:
  - **helm.ts**: demo data generators, release/history cache load/save, constants
  - **workloads.ts**: demo pods/issues/deployments, cache load/save, pod issue statuses
  - **buildpacks.ts**: demo images, localStorage cache load/save, constants
  - **sseClient.ts**: SSE chunk parser (complete events, partial buffers, multiple events, edge cases), clearSSECache, reconnect/timeout constants

## Test plan
- [x] All 85 tests pass locally (`npx vitest run`)
- [ ] CI build passes (no barrel export conflicts)
- [ ] Coverage gate passes