### PR TITLE
test: coverage batch 13 — sweep across 7 modules (+114 tests)

### DIFF
--- a/web/src/hooks/__tests__/useAIPredictions-pure.test.ts
+++ b/web/src/hooks/__tests__/useAIPredictions-pure.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, STORAGE_KEY_TOKEN: 'kc-auth-token', LOCAL_AGENT_HTTP_URL: 'http://localhost:4201', LOCAL_AGENT_WS_URL: 'ws://localhost:4201' }
+})
+
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual }
+})
+
+vi.mock('../../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: vi.fn((url: string) => url),
+}))
+
+const mod = await import('../useAIPredictions')
+const {
+  aiPredictionToRisk,
+  DEMO_AI_PREDICTIONS,
+  DEGRADED_RECONNECT_INTERVAL_MS,
+  POLL_INTERVAL_MS,
+  ANALYSIS_POLL_INTERVAL_MS,
+  ANALYSIS_MAX_TIMEOUT_MS,
+} = mod.__testables
+
+describe('aiPredictionToRisk', () => {
+  it('converts a prediction to PredictedRisk format', () => {
+    const prediction = {
+      id: 'pred-1',
+      category: 'resource-trend',
+      severity: 'warning',
+      name: 'test-pod',
+      cluster: 'test-cluster',
+      namespace: 'default',
+      reason: 'High CPU usage',
+      reasonDetailed: 'Details here',
+      confidence: 85,
+      generatedAt: '2026-01-01T00:00:00Z',
+      provider: 'claude',
+      trend: 'worsening',
+    }
+    const risk = aiPredictionToRisk(prediction as never)
+    expect(risk.id).toBe('pred-1')
+    expect(risk.type).toBe('resource-trend')
+    expect(risk.severity).toBe('warning')
+    expect(risk.name).toBe('test-pod')
+    expect(risk.cluster).toBe('test-cluster')
+    expect(risk.namespace).toBe('default')
+    expect(risk.reason).toBe('High CPU usage')
+    expect(risk.source).toBe('ai')
+    expect(risk.confidence).toBe(85)
+    expect(risk.provider).toBe('claude')
+    expect(risk.trend).toBe('worsening')
+    expect(risk.generatedAt).toBeInstanceOf(Date)
+  })
+
+  it('handles missing optional fields', () => {
+    const prediction = {
+      id: 'pred-2',
+      category: 'anomaly',
+      severity: 'info',
+      name: 'pod-x',
+      cluster: 'c1',
+      reason: 'Minor issue',
+      confidence: 50,
+      generatedAt: '2026-01-01T00:00:00Z',
+      provider: 'test',
+    }
+    const risk = aiPredictionToRisk(prediction as never)
+    expect(risk.id).toBe('pred-2')
+    expect(risk.namespace).toBeUndefined()
+    expect(risk.trend).toBeUndefined()
+  })
+})
+
+describe('DEMO_AI_PREDICTIONS', () => {
+  it('is a non-empty array', () => {
+    expect(DEMO_AI_PREDICTIONS.length).toBeGreaterThan(0)
+  })
+
+  it('each prediction has required fields', () => {
+    for (const p of DEMO_AI_PREDICTIONS) {
+      expect(typeof p.id).toBe('string')
+      expect(typeof p.category).toBe('string')
+      expect(typeof p.severity).toBe('string')
+      expect(typeof p.name).toBe('string')
+      expect(typeof p.cluster).toBe('string')
+      expect(typeof p.reason).toBe('string')
+      expect(typeof p.confidence).toBe('number')
+      expect(typeof p.generatedAt).toBe('string')
+      expect(typeof p.provider).toBe('string')
+    }
+  })
+
+  it('confidence values are between 0 and 100', () => {
+    for (const p of DEMO_AI_PREDICTIONS) {
+      expect(p.confidence).toBeGreaterThanOrEqual(0)
+      expect(p.confidence).toBeLessThanOrEqual(100)
+    }
+  })
+})
+
+describe('constants', () => {
+  it('DEGRADED_RECONNECT_INTERVAL_MS is 60 seconds', () => {
+    expect(DEGRADED_RECONNECT_INTERVAL_MS).toBe(60_000)
+  })
+
+  it('POLL_INTERVAL_MS is 30 seconds', () => {
+    expect(POLL_INTERVAL_MS).toBe(30_000)
+  })
+
+  it('ANALYSIS_POLL_INTERVAL_MS is 4 seconds', () => {
+    expect(ANALYSIS_POLL_INTERVAL_MS).toBe(4_000)
+  })
+
+  it('ANALYSIS_MAX_TIMEOUT_MS is 60 seconds', () => {
+    expect(ANALYSIS_MAX_TIMEOUT_MS).toBe(60_000)
+  })
+
+  it('ANALYSIS_MAX_TIMEOUT_MS > ANALYSIS_POLL_INTERVAL_MS', () => {
+    expect(ANALYSIS_MAX_TIMEOUT_MS).toBeGreaterThan(ANALYSIS_POLL_INTERVAL_MS)
+  })
+})

--- a/web/src/hooks/__tests__/useNightlyE2EData-pure.test.ts
+++ b/web/src/hooks/__tests__/useNightlyE2EData-pure.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, STORAGE_KEY_TOKEN: 'kc-auth-token' }
+})
+
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual }
+})
+
+vi.mock('../../lib/cache', () => ({
+  useCache: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('../../lib/demoMode', () => ({
+  isNetlifyDeployment: vi.fn(() => false),
+}))
+
+const mod = await import('../useNightlyE2EData')
+const {
+  loadCachedData,
+  saveCachedData,
+  getAuthHeaders,
+  REFRESH_IDLE_MS,
+  REFRESH_ACTIVE_MS,
+  LS_CACHE_KEY,
+} = mod.__testables
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('loadCachedData', () => {
+  it('returns empty guides when localStorage is empty', () => {
+    const result = loadCachedData()
+    expect(result.guides).toEqual([])
+    expect(result.isDemo).toBe(false)
+  })
+
+  it('returns stored data when valid', () => {
+    const data = { guides: [{ name: 'test', status: 'passed' }], isDemo: false }
+    localStorage.setItem(LS_CACHE_KEY, JSON.stringify(data))
+    const result = loadCachedData()
+    expect(result.guides).toHaveLength(1)
+  })
+
+  it('returns empty on corrupted JSON', () => {
+    localStorage.setItem(LS_CACHE_KEY, 'bad{json')
+    const result = loadCachedData()
+    expect(result.guides).toEqual([])
+  })
+
+  it('rejects demo data from cache', () => {
+    const data = { guides: [{ name: 'test' }], isDemo: true }
+    localStorage.setItem(LS_CACHE_KEY, JSON.stringify(data))
+    const result = loadCachedData()
+    expect(result.guides).toEqual([])
+  })
+
+  it('rejects empty guides array', () => {
+    const data = { guides: [], isDemo: false }
+    localStorage.setItem(LS_CACHE_KEY, JSON.stringify(data))
+    const result = loadCachedData()
+    expect(result.guides).toEqual([])
+  })
+})
+
+describe('saveCachedData', () => {
+  it('persists data to localStorage', () => {
+    const data = { guides: [{ name: 'g1' }], isDemo: false }
+    saveCachedData(data as never)
+    const stored = JSON.parse(localStorage.getItem(LS_CACHE_KEY) || '{}')
+    expect(stored.guides).toHaveLength(1)
+  })
+})
+
+describe('getAuthHeaders', () => {
+  it('returns empty object when no token', () => {
+    expect(getAuthHeaders()).toEqual({})
+  })
+
+  it('returns Authorization header when token exists', () => {
+    localStorage.setItem('kc-auth-token', 'jwt-xyz')
+    const headers = getAuthHeaders()
+    expect(headers.Authorization).toBe('Bearer jwt-xyz')
+  })
+})
+
+describe('constants', () => {
+  it('REFRESH_IDLE_MS is 5 minutes', () => {
+    expect(REFRESH_IDLE_MS).toBe(300_000)
+  })
+
+  it('REFRESH_ACTIVE_MS is 2 minutes', () => {
+    expect(REFRESH_ACTIVE_MS).toBe(120_000)
+  })
+
+  it('REFRESH_ACTIVE_MS is less than REFRESH_IDLE_MS', () => {
+    expect(REFRESH_ACTIVE_MS).toBeLessThan(REFRESH_IDLE_MS)
+  })
+
+  it('LS_CACHE_KEY is a non-empty string', () => {
+    expect(typeof LS_CACHE_KEY).toBe('string')
+    expect(LS_CACHE_KEY.length).toBeGreaterThan(0)
+  })
+})

--- a/web/src/hooks/__tests__/useRewards-pure.test.ts
+++ b/web/src/hooks/__tests__/useRewards-pure.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const { mockGetDemoMode } = vi.hoisted(() => ({
+  mockGetDemoMode: vi.fn(() => false),
+}))
+
+vi.mock('../../lib/demoMode', () => ({
+  getDemoMode: mockGetDemoMode,
+  isDemoMode: mockGetDemoMode,
+  isNetlifyDeployment: vi.fn(() => false),
+}))
+
+vi.mock('../useDemoMode', () => ({
+  getDemoMode: mockGetDemoMode,
+  useDemoMode: () => ({ isDemoMode: false }),
+}))
+
+vi.mock('../../lib/auth', () => ({
+  useAuth: () => ({ user: null }),
+}))
+
+vi.mock('../useGitHubRewards', () => ({
+  useGitHubRewards: () => ({ githubRewards: null, githubPoints: 0, refresh: vi.fn() }),
+}))
+
+vi.mock('../useBonusPoints', () => ({
+  useBonusPoints: () => ({ bonusPoints: 0 }),
+}))
+
+vi.mock('../../lib/rewardsApi', () => ({
+  fetchGitHubRewards: vi.fn(),
+  fetchBonusPoints: vi.fn(),
+  incrementCoins: vi.fn(),
+  RewardsUnauthenticatedError: class extends Error {},
+}))
+
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, STORAGE_KEY_TOKEN: 'kc-auth-token' }
+})
+
+const mod = await import('../useRewards')
+const {
+  generateId,
+  loadRewards,
+  saveRewards,
+  createInitialRewards,
+  resolveRewardsUserId,
+  checkAchievements,
+  REWARDS_STORAGE_KEY,
+  MAX_REWARD_EVENTS,
+  RECENT_EVENTS_LIMIT,
+  DEMO_REWARDS_USER_ID,
+} = mod.__testables
+
+beforeEach(() => {
+  localStorage.clear()
+  mockGetDemoMode.mockReturnValue(false)
+})
+
+describe('generateId', () => {
+  it('returns a non-empty string', () => {
+    const id = generateId()
+    expect(typeof id).toBe('string')
+    expect(id.length).toBeGreaterThan(0)
+  })
+
+  it('generates unique IDs', () => {
+    const ids = new Set(Array.from({ length: 10 }, () => generateId()))
+    expect(ids.size).toBe(10)
+  })
+})
+
+describe('loadRewards', () => {
+  it('returns null when localStorage is empty', () => {
+    expect(loadRewards('user-1')).toBeNull()
+  })
+
+  it('returns null for unknown user', () => {
+    localStorage.setItem(REWARDS_STORAGE_KEY, JSON.stringify({ 'user-2': { userId: 'user-2', totalCoins: 5 } }))
+    expect(loadRewards('user-1')).toBeNull()
+  })
+
+  it('returns stored rewards for matching user', () => {
+    const rewards = { userId: 'user-1', totalCoins: 42, lifetimeCoins: 42, events: [], achievements: [] }
+    localStorage.setItem(REWARDS_STORAGE_KEY, JSON.stringify({ 'user-1': rewards }))
+    const result = loadRewards('user-1')
+    expect(result).not.toBeNull()
+    expect(result!.totalCoins).toBe(42)
+  })
+
+  it('handles corrupted JSON gracefully', () => {
+    localStorage.setItem(REWARDS_STORAGE_KEY, 'not-json!!!')
+    expect(loadRewards('user-1')).toBeNull()
+  })
+})
+
+describe('saveRewards', () => {
+  it('persists rewards for a user', () => {
+    const rewards = { userId: 'u1', totalCoins: 10, lifetimeCoins: 10, events: [], achievements: [], lastUpdated: '' }
+    saveRewards('u1', rewards as never)
+    const stored = JSON.parse(localStorage.getItem(REWARDS_STORAGE_KEY) || '{}')
+    expect(stored['u1'].totalCoins).toBe(10)
+  })
+
+  it('preserves other users when saving', () => {
+    const r1 = { userId: 'u1', totalCoins: 5 }
+    const r2 = { userId: 'u2', totalCoins: 99 }
+    localStorage.setItem(REWARDS_STORAGE_KEY, JSON.stringify({ u1: r1 }))
+    saveRewards('u2', r2 as never)
+    const stored = JSON.parse(localStorage.getItem(REWARDS_STORAGE_KEY) || '{}')
+    expect(stored['u1'].totalCoins).toBe(5)
+    expect(stored['u2'].totalCoins).toBe(99)
+  })
+})
+
+describe('createInitialRewards', () => {
+  it('creates rewards with zero coins', () => {
+    const r = createInitialRewards('new-user')
+    expect(r.userId).toBe('new-user')
+    expect(r.totalCoins).toBe(0)
+    expect(r.lifetimeCoins).toBe(0)
+    expect(r.events).toEqual([])
+    expect(r.achievements).toEqual([])
+  })
+
+  it('has a valid lastUpdated ISO string', () => {
+    const r = createInitialRewards('u')
+    expect(new Date(r.lastUpdated).getTime()).not.toBeNaN()
+  })
+})
+
+describe('resolveRewardsUserId', () => {
+  it('returns null for undefined', () => {
+    expect(resolveRewardsUserId(undefined)).toBeNull()
+  })
+
+  it('returns demo user ID in demo mode', () => {
+    mockGetDemoMode.mockReturnValue(true)
+    expect(resolveRewardsUserId('any-user')).toBe(DEMO_REWARDS_USER_ID)
+  })
+
+  it('returns the actual user ID when not in demo mode', () => {
+    mockGetDemoMode.mockReturnValue(false)
+    expect(resolveRewardsUserId('real-user-123')).toBe('real-user-123')
+  })
+
+  it('returns demo user ID when userId is demo-user', () => {
+    mockGetDemoMode.mockReturnValue(false)
+    expect(resolveRewardsUserId(DEMO_REWARDS_USER_ID)).toBe(DEMO_REWARDS_USER_ID)
+  })
+})
+
+describe('checkAchievements', () => {
+  it('returns empty array for fresh user', () => {
+    const rewards = createInitialRewards('u')
+    expect(checkAchievements(rewards)).toEqual([])
+  })
+})
+
+describe('constants', () => {
+  it('MAX_REWARD_EVENTS is 100', () => {
+    expect(MAX_REWARD_EVENTS).toBe(100)
+  })
+
+  it('RECENT_EVENTS_LIMIT is 10', () => {
+    expect(RECENT_EVENTS_LIMIT).toBe(10)
+  })
+
+  it('DEMO_REWARDS_USER_ID is a non-empty string', () => {
+    expect(typeof DEMO_REWARDS_USER_ID).toBe('string')
+    expect(DEMO_REWARDS_USER_ID.length).toBeGreaterThan(0)
+  })
+
+  it('REWARDS_STORAGE_KEY is a non-empty string', () => {
+    expect(typeof REWARDS_STORAGE_KEY).toBe('string')
+    expect(REWARDS_STORAGE_KEY.length).toBeGreaterThan(0)
+  })
+})

--- a/web/src/hooks/__tests__/useTokenUsage-pure.test.ts
+++ b/web/src/hooks/__tests__/useTokenUsage-pure.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, STORAGE_KEY_TOKEN: 'kc-auth-token' }
+})
+
+vi.mock('../../lib/tokenUsageApi', () => ({
+  fetchTokenUsageFromBackend: vi.fn(),
+  postTokenDelta: vi.fn(),
+  beaconTokenDelta: vi.fn(),
+}))
+
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual }
+})
+
+const mod = await import('../useTokenUsage')
+const {
+  loadPersistedUsage,
+  persistUsage,
+  getNextResetDate,
+  MAX_SINGLE_DELTA_TOKENS,
+  MIN_STOP_THRESHOLD,
+  LAST_KNOWN_USAGE_KEY,
+  AGENT_SESSION_KEY,
+  DEFAULT_CATEGORY,
+  TOKEN_USAGE_FLUSH_INTERVAL_MS,
+  TOKEN_USAGE_FLUSH_THRESHOLD,
+  DEFAULT_SETTINGS,
+  DEFAULT_BY_CATEGORY,
+  DEMO_TOKEN_USAGE,
+  DEMO_BY_CATEGORY,
+} = mod.__testables
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('loadPersistedUsage', () => {
+  it('returns nulls when localStorage is empty', () => {
+    const result = loadPersistedUsage()
+    expect(result.lastKnown).toBeNull()
+    expect(result.sessionId).toBeNull()
+  })
+
+  it('returns stored values', () => {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, '42000')
+    localStorage.setItem(AGENT_SESSION_KEY, 'session-abc')
+    const result = loadPersistedUsage()
+    expect(result.lastKnown).toBe(42000)
+    expect(result.sessionId).toBe('session-abc')
+  })
+
+  it('returns null for non-finite lastKnown', () => {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, 'not-a-number')
+    const result = loadPersistedUsage()
+    expect(result.lastKnown).toBeNull()
+  })
+
+  it('returns null for Infinity', () => {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, 'Infinity')
+    const result = loadPersistedUsage()
+    expect(result.lastKnown).toBeNull()
+  })
+})
+
+describe('persistUsage', () => {
+  it('stores lastKnown and sessionId', () => {
+    persistUsage(12345, 'sess-1')
+    expect(localStorage.getItem(LAST_KNOWN_USAGE_KEY)).toBe('12345')
+    expect(localStorage.getItem(AGENT_SESSION_KEY)).toBe('sess-1')
+  })
+
+  it('stores lastKnown without sessionId when null', () => {
+    persistUsage(99999, null)
+    expect(localStorage.getItem(LAST_KNOWN_USAGE_KEY)).toBe('99999')
+    expect(localStorage.getItem(AGENT_SESSION_KEY)).toBeNull()
+  })
+})
+
+describe('getNextResetDate', () => {
+  it('returns a valid ISO date string', () => {
+    const result = getNextResetDate()
+    expect(new Date(result).getTime()).not.toBeNaN()
+  })
+
+  it('returns a date in the future', () => {
+    const result = new Date(getNextResetDate())
+    expect(result.getTime()).toBeGreaterThan(Date.now())
+  })
+
+  it('returns the first day of next month', () => {
+    const result = new Date(getNextResetDate())
+    expect(result.getDate()).toBe(1)
+  })
+})
+
+describe('constants', () => {
+  it('MAX_SINGLE_DELTA_TOKENS is 50000', () => {
+    expect(MAX_SINGLE_DELTA_TOKENS).toBe(50_000)
+  })
+
+  it('MIN_STOP_THRESHOLD is 0.01', () => {
+    expect(MIN_STOP_THRESHOLD).toBe(0.01)
+  })
+
+  it('DEFAULT_CATEGORY is "other"', () => {
+    expect(DEFAULT_CATEGORY).toBe('other')
+  })
+
+  it('TOKEN_USAGE_FLUSH_INTERVAL_MS is 30 seconds', () => {
+    expect(TOKEN_USAGE_FLUSH_INTERVAL_MS).toBe(30_000)
+  })
+
+  it('TOKEN_USAGE_FLUSH_THRESHOLD is 100', () => {
+    expect(TOKEN_USAGE_FLUSH_THRESHOLD).toBe(100)
+  })
+
+  it('DEFAULT_SETTINGS has required fields', () => {
+    expect(DEFAULT_SETTINGS.limit).toBeGreaterThan(0)
+    expect(DEFAULT_SETTINGS.warningThreshold).toBeGreaterThan(0)
+    expect(DEFAULT_SETTINGS.criticalThreshold).toBeGreaterThan(DEFAULT_SETTINGS.warningThreshold)
+    expect(DEFAULT_SETTINGS.stopThreshold).toBeGreaterThanOrEqual(DEFAULT_SETTINGS.criticalThreshold)
+  })
+
+  it('DEFAULT_BY_CATEGORY has all categories at zero', () => {
+    expect(DEFAULT_BY_CATEGORY.missions).toBe(0)
+    expect(DEFAULT_BY_CATEGORY.diagnose).toBe(0)
+    expect(DEFAULT_BY_CATEGORY.insights).toBe(0)
+    expect(DEFAULT_BY_CATEGORY.predictions).toBe(0)
+    expect(DEFAULT_BY_CATEGORY.other).toBe(0)
+  })
+
+  it('DEMO_TOKEN_USAGE is positive', () => {
+    expect(DEMO_TOKEN_USAGE).toBeGreaterThan(0)
+  })
+
+  it('DEMO_BY_CATEGORY sums are positive', () => {
+    const sum = DEMO_BY_CATEGORY.missions + DEMO_BY_CATEGORY.diagnose +
+                DEMO_BY_CATEGORY.insights + DEMO_BY_CATEGORY.predictions +
+                DEMO_BY_CATEGORY.other
+    expect(sum).toBeGreaterThan(0)
+  })
+
+  it('LAST_KNOWN_USAGE_KEY and AGENT_SESSION_KEY are non-empty strings', () => {
+    expect(typeof LAST_KNOWN_USAGE_KEY).toBe('string')
+    expect(LAST_KNOWN_USAGE_KEY.length).toBeGreaterThan(0)
+    expect(typeof AGENT_SESSION_KEY).toBe('string')
+    expect(AGENT_SESSION_KEY.length).toBeGreaterThan(0)
+  })
+})

--- a/web/src/hooks/__tests__/useUsers-pure.test.ts
+++ b/web/src/hooks/__tests__/useUsers-pure.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../useDemoMode', () => ({
+  getDemoMode: vi.fn(() => true),
+  isDemoModeForced: false,
+  useDemoMode: () => ({ isDemoMode: true }),
+}))
+
+vi.mock('../../lib/demoMode', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, getDemoMode: vi.fn(() => true), isDemoMode: vi.fn(() => true) }
+})
+
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, STORAGE_KEY_TOKEN: 'kc-auth-token', LOCAL_AGENT_HTTP_URL: 'http://localhost:4201' }
+})
+
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual }
+})
+
+vi.mock('../mcp/shared', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, agentFetch: vi.fn() }
+})
+
+const mod = await import('../useUsers')
+const {
+  agentAuthHeaders,
+  getDemoConsoleUsers,
+  getDemoUserManagementSummary,
+} = mod.__testables
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('agentAuthHeaders', () => {
+  it('returns empty object when no token', () => {
+    expect(agentAuthHeaders()).toEqual({})
+  })
+
+  it('returns Authorization header when token exists', () => {
+    localStorage.setItem('kc-auth-token', 'my-jwt-token')
+    const headers = agentAuthHeaders()
+    expect(headers.Authorization).toBe('Bearer my-jwt-token')
+  })
+})
+
+describe('getDemoConsoleUsers', () => {
+  it('returns a non-empty array', () => {
+    const users = getDemoConsoleUsers()
+    expect(users.length).toBeGreaterThan(0)
+  })
+
+  it('each user has required fields', () => {
+    for (const user of getDemoConsoleUsers()) {
+      expect(typeof user.id).toBe('string')
+      expect(typeof user.github_login).toBe('string')
+      expect(typeof user.email).toBe('string')
+      expect(typeof user.role).toBe('string')
+      expect(typeof user.onboarded).toBe('boolean')
+      expect(typeof user.created_at).toBe('string')
+      expect(typeof user.last_login).toBe('string')
+    }
+  })
+
+  it('includes admin role', () => {
+    const admins = getDemoConsoleUsers().filter(u => u.role === 'admin')
+    expect(admins.length).toBeGreaterThan(0)
+  })
+
+  it('includes editor role', () => {
+    const editors = getDemoConsoleUsers().filter(u => u.role === 'editor')
+    expect(editors.length).toBeGreaterThan(0)
+  })
+
+  it('includes viewer role', () => {
+    const viewers = getDemoConsoleUsers().filter(u => u.role === 'viewer')
+    expect(viewers.length).toBeGreaterThan(0)
+  })
+
+  it('created_at dates are valid ISO dates', () => {
+    for (const user of getDemoConsoleUsers()) {
+      expect(new Date(user.created_at).getTime()).not.toBeNaN()
+    }
+  })
+})
+
+describe('getDemoUserManagementSummary', () => {
+  it('returns a summary with consoleUsers', () => {
+    const summary = getDemoUserManagementSummary()
+    expect(summary.consoleUsers.total).toBeGreaterThan(0)
+    expect(summary.consoleUsers.admins).toBeGreaterThan(0)
+  })
+
+  it('user counts add up to total', () => {
+    const { consoleUsers } = getDemoUserManagementSummary()
+    expect(consoleUsers.admins + consoleUsers.editors + consoleUsers.viewers).toBe(consoleUsers.total)
+  })
+
+  it('has k8sServiceAccounts info', () => {
+    const summary = getDemoUserManagementSummary()
+    expect(summary.k8sServiceAccounts.total).toBeGreaterThan(0)
+    expect(summary.k8sServiceAccounts.clusters.length).toBeGreaterThan(0)
+  })
+
+  it('has currentUserPermissions for multiple clusters', () => {
+    const summary = getDemoUserManagementSummary()
+    expect(summary.currentUserPermissions.length).toBeGreaterThan(0)
+    for (const perm of summary.currentUserPermissions) {
+      expect(typeof perm.cluster).toBe('string')
+      expect(typeof perm.isClusterAdmin).toBe('boolean')
+    }
+  })
+})

--- a/web/src/hooks/mcp/__tests__/storage-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage-pure.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+const mod = await import('../storage')
+const {
+  getDemoPVCs,
+  getDemoResourceQuotas,
+  getDemoLimitRanges,
+  loadPVCsCacheFromStorage,
+  savePVCsCacheToStorage,
+  PVCS_CACHE_KEY,
+} = mod.__storageTestables
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('getDemoPVCs', () => {
+  it('returns a non-empty array', () => {
+    expect(getDemoPVCs().length).toBeGreaterThan(0)
+  })
+
+  it('each PVC has required fields', () => {
+    for (const pvc of getDemoPVCs()) {
+      expect(typeof pvc.name).toBe('string')
+      expect(typeof pvc.namespace).toBe('string')
+      expect(typeof pvc.cluster).toBe('string')
+      expect(typeof pvc.status).toBe('string')
+      expect(typeof pvc.capacity).toBe('string')
+      expect(Array.isArray(pvc.accessModes)).toBe(true)
+    }
+  })
+
+  it('includes Bound and Pending statuses', () => {
+    const statuses = new Set(getDemoPVCs().map(p => p.status))
+    expect(statuses.has('Bound')).toBe(true)
+    expect(statuses.has('Pending')).toBe(true)
+  })
+
+  it('covers multiple clusters', () => {
+    const clusters = new Set(getDemoPVCs().map(p => p.cluster))
+    expect(clusters.size).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe('getDemoResourceQuotas', () => {
+  it('returns a non-empty array', () => {
+    expect(getDemoResourceQuotas().length).toBeGreaterThan(0)
+  })
+
+  it('each quota has hard and used limits', () => {
+    for (const q of getDemoResourceQuotas()) {
+      expect(typeof q.name).toBe('string')
+      expect(typeof q.namespace).toBe('string')
+      expect(typeof q.cluster).toBe('string')
+      expect(typeof q.hard).toBe('object')
+      expect(typeof q.used).toBe('object')
+    }
+  })
+
+  it('includes GPU quota', () => {
+    const gpuQuota = getDemoResourceQuotas().find(q =>
+      q.hard['requests.nvidia.com/gpu'] !== undefined
+    )
+    expect(gpuQuota).toBeDefined()
+  })
+})
+
+describe('getDemoLimitRanges', () => {
+  it('returns a non-empty array', () => {
+    expect(getDemoLimitRanges().length).toBeGreaterThan(0)
+  })
+
+  it('each limit range has limits array', () => {
+    for (const lr of getDemoLimitRanges()) {
+      expect(typeof lr.name).toBe('string')
+      expect(typeof lr.namespace).toBe('string')
+      expect(typeof lr.cluster).toBe('string')
+      expect(Array.isArray(lr.limits)).toBe(true)
+      expect(lr.limits.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('includes Container type limits', () => {
+    const hasContainer = getDemoLimitRanges().some(lr =>
+      lr.limits.some(l => l.type === 'Container')
+    )
+    expect(hasContainer).toBe(true)
+  })
+})
+
+describe('loadPVCsCacheFromStorage', () => {
+  it('returns null when localStorage is empty', () => {
+    expect(loadPVCsCacheFromStorage('key1')).toBeNull()
+  })
+
+  it('returns null when cache key does not match', () => {
+    localStorage.setItem(PVCS_CACHE_KEY, JSON.stringify({
+      key: 'other',
+      data: [{ name: 'pvc1' }],
+      timestamp: new Date().toISOString(),
+    }))
+    expect(loadPVCsCacheFromStorage('my-key')).toBeNull()
+  })
+
+  it('returns data when cache key matches', () => {
+    const data = [{ name: 'pvc1', namespace: 'ns', cluster: 'c1', status: 'Bound', capacity: '10Gi' }]
+    localStorage.setItem(PVCS_CACHE_KEY, JSON.stringify({
+      key: 'match',
+      data,
+      timestamp: new Date().toISOString(),
+    }))
+    const result = loadPVCsCacheFromStorage('match')
+    expect(result).not.toBeNull()
+    expect(result!.data).toEqual(data)
+  })
+
+  it('returns null on corrupted JSON', () => {
+    localStorage.setItem(PVCS_CACHE_KEY, '{{{bad')
+    expect(loadPVCsCacheFromStorage('key')).toBeNull()
+  })
+
+  it('returns null when data array is empty', () => {
+    localStorage.setItem(PVCS_CACHE_KEY, JSON.stringify({ key: 'k', data: [] }))
+    expect(loadPVCsCacheFromStorage('k')).toBeNull()
+  })
+})
+
+describe('savePVCsCacheToStorage', () => {
+  it('does not throw when no cache exists', () => {
+    expect(() => savePVCsCacheToStorage()).not.toThrow()
+  })
+})
+
+describe('constants', () => {
+  it('PVCS_CACHE_KEY is a non-empty string', () => {
+    expect(typeof PVCS_CACHE_KEY).toBe('string')
+    expect(PVCS_CACHE_KEY.length).toBeGreaterThan(0)
+  })
+})

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -702,3 +702,12 @@ if (typeof window !== 'undefined') {
     }, 0)
   })
 }
+
+export const __storageTestables = {
+  getDemoPVCs,
+  getDemoResourceQuotas,
+  getDemoLimitRanges,
+  loadPVCsCacheFromStorage,
+  savePVCsCacheToStorage,
+  PVCS_CACHE_KEY,
+}

--- a/web/src/hooks/useAIPredictions.ts
+++ b/web/src/hooks/useAIPredictions.ts
@@ -540,3 +540,12 @@ export function syncSettingsToBackend(): void {
     }))
   }
 }
+
+export const __testables = {
+  aiPredictionToRisk,
+  DEMO_AI_PREDICTIONS,
+  DEGRADED_RECONNECT_INTERVAL_MS,
+  POLL_INTERVAL_MS,
+  ANALYSIS_POLL_INTERVAL_MS,
+  ANALYSIS_MAX_TIMEOUT_MS,
+}

--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -174,3 +174,12 @@ export function useNightlyE2EData() {
     refetch: cacheResult.refetch,
   }
 }
+
+export const __testables = {
+  loadCachedData,
+  saveCachedData,
+  getAuthHeaders,
+  REFRESH_IDLE_MS,
+  REFRESH_ACTIVE_MS,
+  LS_CACHE_KEY,
+}

--- a/web/src/hooks/useRewards.tsx
+++ b/web/src/hooks/useRewards.tsx
@@ -480,3 +480,16 @@ export function useRewards() {
 
 // Export for components that need action info
 export { REWARD_ACTIONS, ACHIEVEMENTS }
+
+export const __testables = {
+  generateId,
+  loadRewards,
+  saveRewards,
+  createInitialRewards,
+  resolveRewardsUserId,
+  checkAchievements,
+  REWARDS_STORAGE_KEY,
+  MAX_REWARD_EVENTS,
+  RECENT_EVENTS_LIMIT,
+  DEMO_REWARDS_USER_ID,
+}

--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -711,3 +711,20 @@ export function addCategoryTokens(tokens: number, category: TokenCategory = 'oth
     used: sharedUsage.used + tokens,
     byCategory: newByCategory })
 }
+
+export const __testables = {
+  loadPersistedUsage,
+  persistUsage,
+  getNextResetDate,
+  MAX_SINGLE_DELTA_TOKENS,
+  MIN_STOP_THRESHOLD,
+  LAST_KNOWN_USAGE_KEY,
+  AGENT_SESSION_KEY,
+  DEFAULT_CATEGORY,
+  TOKEN_USAGE_FLUSH_INTERVAL_MS,
+  TOKEN_USAGE_FLUSH_THRESHOLD,
+  DEFAULT_SETTINGS,
+  DEFAULT_BY_CATEGORY,
+  DEMO_TOKEN_USAGE,
+  DEMO_BY_CATEGORY,
+}

--- a/web/src/hooks/useUsers.ts
+++ b/web/src/hooks/useUsers.ts
@@ -727,3 +727,9 @@ export function useClusterPermissions(cluster?: string) {
 
   return { permissions, isLoading, error, refetch: fetchPermissions }
 }
+
+export const __testables = {
+  agentAuthHeaders,
+  getDemoConsoleUsers,
+  getDemoUserManagementSummary,
+}

--- a/web/src/lib/__tests__/kubectlProxy-pure.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy-pure.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, STORAGE_KEY_TOKEN: 'kc-auth-token' }
+})
+
+vi.mock('../constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual }
+})
+
+const mod = await import('../kubectlProxy')
+const {
+  parseResourceQuantity,
+  parseResourceQuantityMillicores,
+} = mod.__testables
+
+describe('parseResourceQuantity', () => {
+  it('returns 0 for undefined', () => {
+    expect(parseResourceQuantity(undefined)).toBe(0)
+  })
+
+  it('returns 0 for empty string', () => {
+    expect(parseResourceQuantity('')).toBe(0)
+  })
+
+  it('parses plain numbers', () => {
+    expect(parseResourceQuantity('1024')).toBe(1024)
+  })
+
+  it('parses Ki suffix (kibibytes)', () => {
+    expect(parseResourceQuantity('1Ki')).toBe(1024)
+  })
+
+  it('parses Mi suffix (mebibytes)', () => {
+    expect(parseResourceQuantity('1Mi')).toBe(1024 * 1024)
+  })
+
+  it('parses Gi suffix (gibibytes)', () => {
+    expect(parseResourceQuantity('1Gi')).toBe(1024 * 1024 * 1024)
+  })
+
+  it('parses Ti suffix (tebibytes)', () => {
+    expect(parseResourceQuantity('1Ti')).toBe(1024 * 1024 * 1024 * 1024)
+  })
+
+  it('parses K suffix (kilobytes)', () => {
+    expect(parseResourceQuantity('1K')).toBe(1000)
+  })
+
+  it('parses M suffix (megabytes)', () => {
+    expect(parseResourceQuantity('1M')).toBe(1_000_000)
+  })
+
+  it('parses G suffix (gigabytes)', () => {
+    expect(parseResourceQuantity('1G')).toBe(1_000_000_000)
+  })
+
+  it('parses T suffix (terabytes)', () => {
+    expect(parseResourceQuantity('1T')).toBe(1_000_000_000_000)
+  })
+
+  it('parses m suffix (millicores)', () => {
+    expect(parseResourceQuantity('500m')).toBe(0.5)
+  })
+
+  it('parses decimal values', () => {
+    expect(parseResourceQuantity('2.5Gi')).toBe(2.5 * 1024 * 1024 * 1024)
+  })
+
+  it('returns 0 for unparseable string', () => {
+    expect(parseResourceQuantity('abc')).toBe(0)
+  })
+
+  it('parses "0" as zero', () => {
+    expect(parseResourceQuantity('0')).toBe(0)
+  })
+})
+
+describe('parseResourceQuantityMillicores', () => {
+  it('returns 0 for undefined', () => {
+    expect(parseResourceQuantityMillicores(undefined)).toBe(0)
+  })
+
+  it('returns 0 for empty string', () => {
+    expect(parseResourceQuantityMillicores('')).toBe(0)
+  })
+
+  it('parses millicores suffix', () => {
+    expect(parseResourceQuantityMillicores('100m')).toBe(100)
+  })
+
+  it('parses 500m as 500 millicores', () => {
+    expect(parseResourceQuantityMillicores('500m')).toBe(500)
+  })
+
+  it('parses whole cores to millicores', () => {
+    expect(parseResourceQuantityMillicores('1')).toBe(1000)
+  })
+
+  it('parses fractional cores to millicores', () => {
+    expect(parseResourceQuantityMillicores('0.5')).toBe(500)
+  })
+
+  it('parses 2.5 cores to 2500 millicores', () => {
+    expect(parseResourceQuantityMillicores('2.5')).toBe(2500)
+  })
+
+  it('returns 0 for non-numeric string', () => {
+    expect(parseResourceQuantityMillicores('abc')).toBe(0)
+  })
+
+  it('returns 0 for "abcm" (non-numeric millicores)', () => {
+    expect(parseResourceQuantityMillicores('abcm')).toBe(0)
+  })
+
+  it('trims whitespace', () => {
+    expect(parseResourceQuantityMillicores('  200m  ')).toBe(200)
+  })
+})

--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -1287,3 +1287,8 @@ export interface Deployment {
 
 // Singleton instance
 export const kubectlProxy = new KubectlProxy()
+
+export const __testables = {
+  parseResourceQuantity,
+  parseResourceQuantityMillicores,
+}


### PR DESCRIPTION
## Summary
- Exposes pure functions via `__testables` exports across 7 modules
- Uses module-specific names (`__storageTestables`) in mcp/ barrel to avoid name conflicts
- Adds 114 new tests covering:
  - **useTokenUsage.ts**: loadPersistedUsage, persistUsage, getNextResetDate, all constants
  - **useRewards.tsx**: generateId, loadRewards, saveRewards, createInitialRewards, resolveRewardsUserId, checkAchievements
  - **useUsers.ts**: agentAuthHeaders, getDemoConsoleUsers, getDemoUserManagementSummary
  - **mcp/storage.ts**: getDemoPVCs, getDemoResourceQuotas, getDemoLimitRanges, loadPVCsCacheFromStorage
  - **useNightlyE2EData.ts**: loadCachedData, saveCachedData, getAuthHeaders, refresh interval constants
  - **kubectlProxy.ts**: parseResourceQuantity (Ki/Mi/Gi/Ti/K/M/G/T/m suffixes), parseResourceQuantityMillicores
  - **useAIPredictions.ts**: aiPredictionToRisk converter, DEMO_AI_PREDICTIONS validation, timing constants

## Test plan
- [x] All 114 tests pass locally (`npx vitest run`)
- [ ] CI build passes
- [ ] Coverage gate passes