### PR TITLE
🐛 Fix mission index 502 and add fetch resilience

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -63,6 +63,13 @@ const (
 	// when the unauthenticated rate limit (60 req/hr) is exhausted.
 	missionsCacheStaleTTL = 1 * time.Hour
 
+	// missionsMaxFetchRetries is the number of retry attempts for transient
+	// upstream errors (5xx, network timeouts) before falling back to stale
+	// cache or returning 502. Retries use exponential backoff starting at
+	// missionsFetchRetryBaseDelay. (#10966)
+	missionsMaxFetchRetries     = 2
+	missionsFetchRetryBaseDelay = 500 * time.Millisecond
+
 	// missionsCacheMaxEntries is the maximum number of entries in the response cache.
 	// Each entry stores a directory listing or file body.
 	missionsCacheMaxEntries = 256
@@ -497,33 +504,55 @@ func (h *MissionsHandler) fetchWithCache(c *fiber.Ctx, cacheKey, url, logContext
 		}, nil
 	}
 
-	resp, err := h.githubGet(url, c.Get("X-GitHub-Token"))
-	if err != nil {
-		if stale := h.cache.getStale(cacheKey, missionsCacheStaleTTL); stale != nil {
-			slog.Error("[missions] upstream error, serving stale cache "+logContext, append(logArgs, "error", err)...)
-			return &githubFetchResult{
-				Body:        stale.body,
-				StatusCode:  stale.statusCode,
-				ContentType: stale.contentType,
-				CacheStatus: cacheStatusStale,
-			}, nil
+	// Retry loop for transient upstream errors (#10966).
+	// Network failures and 5xx responses are retried with exponential backoff
+	// before falling back to stale cache or returning 502.
+	var (
+		resp *http.Response
+		err  error
+		body []byte
+	)
+	for attempt := 0; attempt <= missionsMaxFetchRetries; attempt++ {
+		if attempt > 0 {
+			delay := missionsFetchRetryBaseDelay * time.Duration(1<<(attempt-1))
+			slog.Info("[missions] retrying upstream fetch "+logContext, append(logArgs, "attempt", attempt+1, "delay", delay)...)
+			time.Sleep(delay)
 		}
-		var statusCode = http.StatusBadGateway
-		if resp != nil && resp.StatusCode > 0 {
-			statusCode = resp.StatusCode
+
+		resp, err = h.githubGet(url, c.Get("X-GitHub-Token"))
+		if err != nil {
+			continue
 		}
-		return &githubFetchResult{StatusCode: statusCode}, fmt.Errorf("upstream request failed")
-	}
-	defer resp.Body.Close()
 
-	limitedBody := io.LimitReader(resp.Body, missionsMaxBodyBytes)
-	body, ioErr := io.ReadAll(limitedBody)
-	if ioErr != nil {
-		slog.Error("[missions] failed to read response body "+logContext, append(logArgs, "error", ioErr)...)
-		return &githubFetchResult{StatusCode: http.StatusInternalServerError}, fmt.Errorf("failed to read response body")
+		limitedBody := io.LimitReader(resp.Body, missionsMaxBodyBytes)
+		body, err = io.ReadAll(limitedBody)
+		resp.Body.Close()
+		if err != nil {
+			slog.Error("[missions] failed to read response body "+logContext, append(logArgs, "error", err, "attempt", attempt+1)...)
+			continue
+		}
+
+		// Rate-limited — don't retry, fall through to stale cache
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+			break
+		}
+
+		// 5xx — retry if attempts remain
+		if resp.StatusCode >= 500 {
+			slog.Warn("[missions] upstream 5xx "+logContext, append(logArgs, "status", resp.StatusCode, "attempt", attempt+1)...)
+			continue
+		}
+
+		// Success or 4xx client error — return immediately
+		return &githubFetchResult{
+			Body:        body,
+			StatusCode:  resp.StatusCode,
+			CacheStatus: cacheStatusMiss,
+		}, nil
 	}
 
-	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+	// All retries exhausted — try stale cache before failing
+	if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests) {
 		if stale := h.cache.getStale(cacheKey, missionsCacheStaleTTL); stale != nil {
 			slog.Info("[missions] rate-limited, serving stale cache "+logContext, append(logArgs, "status", resp.StatusCode)...)
 			return &githubFetchResult{
@@ -536,11 +565,20 @@ func (h *MissionsHandler) fetchWithCache(c *fiber.Ctx, cacheKey, url, logContext
 		return &githubFetchResult{StatusCode: resp.StatusCode}, fmt.Errorf("GitHub API rate limit exceeded — no cached data available")
 	}
 
-	return &githubFetchResult{
-		Body:        body,
-		StatusCode:  resp.StatusCode,
-		CacheStatus: cacheStatusMiss,
-	}, nil
+	if stale := h.cache.getStale(cacheKey, missionsCacheStaleTTL); stale != nil {
+		slog.Error("[missions] upstream error after retries, serving stale cache "+logContext, append(logArgs, "error", err)...)
+		return &githubFetchResult{
+			Body:        stale.body,
+			StatusCode:  stale.statusCode,
+			ContentType: stale.contentType,
+			CacheStatus: cacheStatusStale,
+		}, nil
+	}
+	var statusCode = http.StatusBadGateway
+	if resp != nil && resp.StatusCode > 0 {
+		statusCode = resp.StatusCode
+	}
+	return &githubFetchResult{StatusCode: statusCode}, fmt.Errorf("upstream request failed")
 }
 
 // ---------- Browse knowledge base ----------

--- a/web/netlify/functions/missions-browse.mts
+++ b/web/netlify/functions/missions-browse.mts
@@ -22,6 +22,11 @@ const CACHE_TTL_MS = 60 * 60 * 1000;
 /** CDN edge cache: tell Netlify CDN to cache successful responses for 10 minutes */
 const CDN_CACHE_MAX_AGE_S = 600;
 
+/** Number of retry attempts for transient upstream errors (#10966) */
+const MAX_RETRIES = 2;
+/** Base delay between retries in milliseconds */
+const RETRY_BASE_DELAY_MS = 500;
+
 // See web/netlify/functions/_shared/cors.ts for allowlist rationale (#9879).
 const CORS_OPTS = {
   methods: "GET, OPTIONS",
@@ -67,12 +72,25 @@ export default async (request: Request): Promise<Response> => {
       });
     }
 
-    // Fetch from GitHub Contents API
+    // Fetch from GitHub Contents API with retry for transient errors (#10966)
     const apiUrl = `${GITHUB_API_URL}/repos/${KB_REPO}/contents/${path}?ref=${DEFAULT_REF}`;
-    const resp = await fetch(apiUrl, {
-      headers: { Accept: "application/vnd.github.v3+json" },
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
+    let resp: Response | null = null;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * (1 << (attempt - 1))));
+      }
+      resp = await fetch(apiUrl, {
+        headers: { Accept: "application/vnd.github.v3+json" },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      // Don't retry 4xx (client errors) — only transient 5xx
+      if (resp.ok || resp.status < 500) break;
+      console.warn(`[missions-browse] Upstream ${resp.status}, attempt ${attempt + 1}/${MAX_RETRIES + 1}`);
+    }
+
+    if (!resp) {
+      return jsonResponse(corsHeaders, { error: "upstream request failed" }, 502);
+    }
 
     if (!resp.ok) {
       // If GitHub fails but we have stale cache, serve it

--- a/web/netlify/functions/missions-file.mts
+++ b/web/netlify/functions/missions-file.mts
@@ -25,6 +25,11 @@ const CACHE_TTL_MS = 15 * 60 * 1000;
 /** CDN edge cache: tell Netlify CDN to cache successful responses for 10 minutes */
 const CDN_CACHE_MAX_AGE_S = 600;
 
+/** Number of retry attempts for transient upstream errors (#10966) */
+const MAX_RETRIES = 2;
+/** Base delay between retries in milliseconds */
+const RETRY_BASE_DELAY_MS = 500;
+
 // See web/netlify/functions/_shared/cors.ts for allowlist rationale (#9879).
 const CORS_OPTS = {
   methods: "GET, OPTIONS",
@@ -68,11 +73,24 @@ export default async (request: Request): Promise<Response> => {
       });
     }
 
-    // Fetch from GitHub
+    // Fetch from GitHub with retry for transient errors (#10966)
     const rawUrl = `${GITHUB_RAW_URL}/${KB_REPO}/${ref}/${path}`;
-    const resp = await fetch(rawUrl, {
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
+    let resp: Response | null = null;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * (1 << (attempt - 1))));
+      }
+      resp = await fetch(rawUrl, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      // Don't retry 4xx (client errors) — only transient 5xx
+      if (resp.ok || resp.status === 404 || resp.status < 500) break;
+      console.warn(`[missions-file] Upstream ${resp.status}, attempt ${attempt + 1}/${MAX_RETRIES + 1}`);
+    }
+
+    if (!resp) {
+      return jsonResponse(corsHeaders, { error: "upstream request failed" }, 502);
+    }
 
     if (resp.status === 404) {
       return jsonResponse(corsHeaders, { error: "file not found" }, 404);

--- a/web/src/components/missions/browser/missionCache.ts
+++ b/web/src/components/missions/browser/missionCache.ts
@@ -195,10 +195,17 @@ export async function fetchMissionContent(
 /** Request timeout for the index fetch in milliseconds */
 const INDEX_FETCH_TIMEOUT_MS = 30_000
 
+/** Maximum retry attempts for transient index fetch failures (#10966) */
+const INDEX_FETCH_MAX_RETRIES = 2
+
+/** Base delay between retry attempts in milliseconds */
+const INDEX_FETCH_RETRY_BASE_DELAY_MS = 500
+
 /**
  * Load all missions from the pre-built index in a single API call.
  * Splits results into installers and fixes, populating both caches at once.
  * Persists to localStorage for instant restore on next page load.
+ * Retries transient failures (5xx, network) with exponential backoff (#10966).
  */
 async function fetchAllFromIndex() {
   try {
@@ -206,8 +213,28 @@ async function fetchAllFromIndex() {
     // be gated by the api.get() backend-availability check (which can block when
     // the health check hasn't resolved yet on initial page load).
     const url = `/api/missions/file?path=${encodeURIComponent(FIXES_INDEX_PATH)}`
-    const response = await fetch(url, { signal: AbortSignal.timeout(INDEX_FETCH_TIMEOUT_MS) })
-    if (!response.ok) throw new Error(`Index fetch failed: ${response.status}`)
+
+    let response: Response | null = null
+    for (let attempt = 0; attempt <= INDEX_FETCH_MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await new Promise((r) => setTimeout(r, INDEX_FETCH_RETRY_BASE_DELAY_MS * (1 << (attempt - 1))))
+      }
+      try {
+        response = await fetch(url, { signal: AbortSignal.timeout(INDEX_FETCH_TIMEOUT_MS) })
+        // Success or client error (4xx) — don't retry
+        if (response.ok || response.status < 500) break
+        // 5xx — retry if attempts remain
+        console.warn(`[MissionBrowser] Index fetch returned ${response.status}, attempt ${attempt + 1}/${INDEX_FETCH_MAX_RETRIES + 1}`)
+      } catch (err) {
+        // Network error — retry if attempts remain
+        if (attempt === INDEX_FETCH_MAX_RETRIES) throw err
+        console.warn(`[MissionBrowser] Index fetch network error, attempt ${attempt + 1}/${INDEX_FETCH_MAX_RETRIES + 1}:`, err)
+      }
+    }
+
+    if (!response || !response.ok) {
+      throw new Error(`Index fetch failed: ${response?.status ?? 'no response'}`)
+    }
     const parsed = await response.json()
     const missions: IndexEntry[] = parsed?.missions || []
 

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -958,6 +958,7 @@ const BARE_NETWORK_NOISE_SUBSTRINGS = [
   'Failed to fetch',
   'NetworkError',
   'net::ERR_',
+  'Index fetch failed',
 ] as const
 
 /** True when the message is a generic network failure with no chunk context. */
@@ -1065,6 +1066,10 @@ export function startGlobalErrorTracking() {
       // these as ksc_error creates false-positive alert spikes (#9994).
       if (errorName === 'UnauthenticatedError' || errorName === 'UnauthorizedError') return
       if (msg.includes('No authentication token') || msg.includes('Token is invalid or expired')) return
+      // Skip upstream proxy errors — these are transient backend/GitHub hiccups
+      // already handled by retry logic in the fetch layer. Emitting them as
+      // ksc_error creates false-positive alert spikes (#10957).
+      if (/\b50[234]\b/.test(msg) && (msg.includes('fetch') || msg.includes('Fetch') || msg.includes('upstream'))) return
       emitError('unhandled_rejection', msg, undefined, { error: event.reason })
     } finally {
       isEmitting = false


### PR DESCRIPTION
Fixes #10966
Fixes #10957

Adds retry with exponential backoff (up to 2 retries, 500ms/1s delays) for transient upstream errors across the entire mission fetch pipeline:

**Go backend** (`pkg/api/handlers/missions.go`):
- `fetchWithCache` now retries on network errors and 5xx responses before falling back to stale cache or returning 502

**Netlify functions** (`missions-file.mts`, `missions-browse.mts`):
- GitHub raw/API fetches retry on 5xx with exponential backoff

**Frontend** (`missionCache.ts`):
- `fetchAllFromIndex` retries transient failures before setting error state

**GA4 error reduction** (`analytics-core.ts`):
- Added `Index fetch failed` to bare-network-noise filter so mission 502s don't emit `ksc_error` events
- Added upstream 5xx pattern filter to prevent cascading error event spam from transient backend hiccups