### PR TITLE
🐛 Fix Mission Control E2E test failures

### DIFF
--- a/web/e2e/mission-control-e2e.spec.ts
+++ b/web/e2e/mission-control-e2e.spec.ts
@@ -393,6 +393,19 @@ async function navigateToConsole(page: Page) {
 }
 
 async function openMissionControl(page: Page) {
+  // First open the sidebar so the "Mission Control" button is accessible
+  const toggled = await page.evaluate(() => {
+    const toggle = document.querySelector('[data-testid="mission-sidebar-toggle"]') as HTMLElement
+      || document.querySelector('[data-tour="ai-missions-toggle"]') as HTMLElement
+    if (toggle) { toggle.click(); return true }
+    return false
+  })
+
+  if (toggled) {
+    // Wait for sidebar animation
+    await page.waitForTimeout(500)
+  }
+
   const mcButton = page.getByText('Mission Control', { exact: false }).first()
   if (await mcButton.isVisible({ timeout: 5000 }).catch(() => false)) {
     await mcButton.click()

--- a/web/e2e/mission-control-stress.spec.ts
+++ b/web/e2e/mission-control-stress.spec.ts
@@ -515,23 +515,26 @@ async function ensureDashboard(page: Page) {
 async function openMC(page: Page) {
   await ensureDashboard(page)
 
-  // The Mission Control button is in a fixed sidebar — Playwright can't scroll
-  // to it reliably. Use JS click to trigger the React state change.
+  // Strategy: first try the deep-link (most reliable), then fall back to
+  // finding the Mission Control button inside the sidebar.
   const clicked = await page.evaluate(() => {
-    // Try the titled button first (sidebar icon)
-    const titledBtn = document.querySelector('button[title*="Mission Control"]') as HTMLElement
-    if (titledBtn) { titledBtn.click(); return true }
-    // Try text-based fallback
+    // 1. Try the sidebar toggle first — open the sidebar so buttons are interactive
+    const toggleBtn = document.querySelector('[data-testid="mission-sidebar-toggle"]') as HTMLElement
+      || document.querySelector('[data-tour="ai-missions-toggle"]') as HTMLElement
+    if (toggleBtn) toggleBtn.click()
+
+    // 2. Find the "Mission Control" button (inside the sidebar empty-state or add menu)
     const buttons = Array.from(document.querySelectorAll('button'))
-    const mcBtn = buttons.find(b => b.textContent?.includes('Mission Control'))
+    const mcBtn = buttons.find(b => b.textContent?.trim() === 'Mission Control')
+      || buttons.find(b => b.textContent?.includes('Mission Control'))
     if (mcBtn) { (mcBtn as HTMLElement).click(); return true }
     return false
   })
 
   if (!clicked) {
-    // Final fallback — click via Playwright with force
-    const btn = page.locator('button', { hasText: 'Mission Control' }).first()
-    await btn.click({ force: true, timeout: 5000 }).catch(() => {})
+    // Final fallback — use the deep-link URL param
+    await page.goto('/?mission-control=open')
+    await page.waitForLoadState('domcontentloaded', { timeout: DIALOG_TIMEOUT_MS })
   }
 
   // Wait for the wizard dialog to render — look for phase stepper text

--- a/web/e2e/mission-control.spec.ts
+++ b/web/e2e/mission-control.spec.ts
@@ -1,32 +1,103 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
+import { mockApiFallback } from './helpers/setup'
+
+/**
+ * Mission Control Pipeline — smoke tests for sidebar, mission list, and
+ * deep-link detail page. Uses relative URLs so they resolve against the
+ * Playwright baseURL (defaulting to http://localhost:8080).
+ */
+
+const VISIBLE_TIMEOUT_MS = 10_000
+
+async function setupMissionControlTest(page: Page) {
+  await mockApiFallback(page)
+
+  await page.route('**/api/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1', github_id: '12345', github_login: 'testuser',
+        email: 'test@example.com', onboarded: true,
+      }),
+    })
+  )
+
+  await page.route('**/api/mcp/**', (route) => {
+    const url = route.request().url()
+    if (url.includes('/clusters')) {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          clusters: [{ name: 'prod-cluster', healthy: true, nodeCount: 5, podCount: 50 }],
+        }),
+      })
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ issues: [], events: [], nodes: [] }),
+      })
+    }
+  })
+
+  await page.route('**/127.0.0.1:8585/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ events: [], clusters: [], health: { hasClaude: true, hasBob: false } }),
+    })
+  )
+
+  await page.addInitScript(() => {
+    localStorage.setItem('token', 'test-token')
+    localStorage.setItem('kc-demo-mode', 'true')
+    localStorage.setItem('demo-user-onboarded', 'true')
+    localStorage.setItem('kc-has-session', 'true')
+    localStorage.setItem('kc-agent-setup-dismissed', 'true')
+    localStorage.setItem('kc-backend-status', JSON.stringify({
+      available: true,
+      timestamp: Date.now(),
+    }))
+  })
+}
 
 test.describe('Mission Control Pipeline', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to mission control in demo mode
-    await page.goto('http://localhost:5174/?demo=true')
+    await setupMissionControlTest(page)
   })
 
   test('mission sidebar opens on click', async ({ page }) => {
-    const trigger = page.getByTestId('mission-sidebar-toggle').or(page.getByRole('button', { name: /mission/i }))
-    if (await trigger.isVisible()) {
-      await trigger.click()
-      await expect(page.getByTestId('mission-sidebar').or(page.locator('[class*="mission"]'))).toBeVisible({ timeout: 5000 })
+    await page.goto('/?demo=true')
+    await page.waitForLoadState('domcontentloaded')
+
+    const trigger = page.getByTestId('mission-sidebar-toggle')
+      .or(page.getByRole('button', { name: /mission/i }))
+    if (await trigger.first().isVisible({ timeout: VISIBLE_TIMEOUT_MS }).catch(() => false)) {
+      await trigger.first().click()
+      await expect(
+        page.getByTestId('mission-sidebar')
+          .or(page.locator('[data-tour="ai-missions"]'))
+      ).toBeVisible({ timeout: VISIBLE_TIMEOUT_MS })
     }
   })
 
   test('mission list loads available missions', async ({ page }) => {
-    // Navigate to missions browse
-    await page.goto('http://localhost:5174/?browse=missions&demo=true')
-    // Should show mission cards
-    const missionItems = page.locator('[data-testid*="mission"]').or(page.locator('[class*="mission-card"]'))
-    await expect(missionItems.first()).toBeVisible({ timeout: 10000 })
+    await page.goto('/?browse=missions&demo=true')
+    await page.waitForLoadState('domcontentloaded')
+
+    const missionItems = page.locator('[data-testid*="mission"]')
+      .or(page.locator('[data-tour*="mission"]'))
+    await expect(missionItems.first()).toBeVisible({ timeout: VISIBLE_TIMEOUT_MS })
   })
 
   test('mission detail page shows steps', async ({ page }) => {
-    await page.goto('http://localhost:5174/missions/install-opencost?demo=true')
-    // Should render mission steps or content
+    await page.goto('/missions/install-opencost?demo=true')
+    await page.waitForLoadState('domcontentloaded')
+
     const content = page.locator('main, [role="main"], #root')
-    await expect(content).toBeVisible({ timeout: 10000 })
+    await expect(content).toBeVisible({ timeout: VISIBLE_TIMEOUT_MS })
   })
 
   test.describe('KB Query Pipeline (scaffold)', () => {

--- a/web/e2e/mission-journey.spec.ts
+++ b/web/e2e/mission-journey.spec.ts
@@ -336,15 +336,23 @@ async function navigateToDashboard(page: Page) {
 
 async function openMissionSidebar(page: Page) {
   const clicked = await page.evaluate(() => {
+    // Prefer the dedicated sidebar toggle button
+    const toggle = document.querySelector('[data-testid="mission-sidebar-toggle"]') as HTMLElement
+      || document.querySelector('[data-tour="ai-missions-toggle"]') as HTMLElement
+    if (toggle) { toggle.click(); return true }
+    // Fallback: any button with "Mission" in its title
     const btn = document.querySelector('button[title*="Mission"]') as HTMLElement
     if (btn) { btn.click(); return true }
+    // Fallback: any button with "Mission" in its text
     const buttons = Array.from(document.querySelectorAll('button'))
     const mcBtn = buttons.find(b => b.textContent?.includes('Mission'))
     if (mcBtn) { (mcBtn as HTMLElement).click(); return true }
     return false
   })
   if (!clicked) {
-    await page.locator('button', { hasText: /Mission/i }).first().click({ force: true, timeout: 5000 }).catch(() => {})
+    await page.locator('[data-testid="mission-sidebar-toggle"]')
+      .or(page.locator('button', { hasText: /Mission/i }))
+      .first().click({ force: true, timeout: 5000 }).catch(() => {})
   }
   // Wait for sidebar to appear
   await page.waitForTimeout(UI_ANIMATION_SETTLE_MS)

--- a/web/e2e/mission-regression.spec.ts
+++ b/web/e2e/mission-regression.spec.ts
@@ -144,6 +144,7 @@ test.describe('Mission System Regression Tests', () => {
       // Open mission sidebar if present
       const missionToggle = page.locator('[data-testid="mission-sidebar-toggle"]')
         .or(page.locator('button[aria-label*="mission" i]'))
+        .or(page.locator('[data-tour="ai-missions-toggle"]'))
         .or(page.locator('button:has-text("Missions")'))
 
       if (await missionToggle.first().isVisible({ timeout: 5000 }).catch(() => false)) {
@@ -158,12 +159,12 @@ test.describe('Mission System Regression Tests', () => {
 
           // Wait for mission content to load in the sidebar
           const missionSidebar = page.locator('[data-testid="mission-sidebar"]')
-            .or(page.locator('[class*="mission"][class*="sidebar"]'))
+            .or(page.locator('[data-tour="ai-missions"]'))
             .first()
           await expect(missionSidebar).toBeVisible({ timeout: 5000 })
 
           const sidebarContent = await page.locator('[data-testid="mission-sidebar"]')
-            .or(page.locator('[class*="mission"][class*="sidebar"]'))
+            .or(page.locator('[data-tour="ai-missions"]'))
             .first()
             .textContent()
             .catch(() => '')

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -705,6 +705,7 @@ export function MissionSidebar() {
 
       <div
         data-tour="ai-missions"
+        data-testid="mission-sidebar"
         className={cn(
           "fixed bg-card border-border flex flex-col overflow-hidden shadow-2xl",
           isMobile ? "z-modal" : "z-sidebar",
@@ -1572,6 +1573,7 @@ export function MissionSidebarToggle() {
     <button
       onClick={openSidebar}
       data-tour="ai-missions-toggle"
+      data-testid="mission-sidebar-toggle"
       className={cn(
         'fixed flex items-center gap-2 rounded-full shadow-lg transition-all z-50',
         // Mobile: smaller padding, bottom right

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -975,6 +975,8 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUs
     // overlaps the modal header (issue #9150).
     <div className="fixed inset-0 z-modal bg-black/60 backdrop-blur-xs">
     <div
+      role="dialog"
+      aria-label="Mission browser"
       data-testid="mission-browser"
       className="fixed bg-background rounded-xl shadow-2xl border border-border flex flex-col overflow-hidden"
       style={{


### PR DESCRIPTION
Fixes #10964

Fixes 12+ Mission Control Playwright tests across 6 spec files that broke due to missing testid attributes, hardcoded ports, missing API mocks, and stale sidebar selectors.

### Root causes
1. **Missing data-testid attributes**: MissionSidebarToggle and MissionSidebar lacked testids expected by tests
2. **Hardcoded port in mission-control.spec.ts**: Used http://localhost:5174 instead of relative URLs
3. **No API mocking in mission-control.spec.ts**: Scaffold test navigated without mocking endpoints
4. **Missing role=dialog on MissionBrowser**: Missions.spec.ts used getByRole(dialog) but MissionBrowser had no dialog role
5. **Stale sidebar selectors**: Stress/journey/e2e tests searched for buttons by title/text that did not match the actual toggle component

### Changes
- **MissionSidebar.tsx**: Add data-testid=mission-sidebar and data-testid=mission-sidebar-toggle
- **MissionBrowser.tsx**: Add role=dialog + aria-label
- **mission-control.spec.ts**: Rewrite with relative URLs, API mocks, and robust selectors
- **mission-regression.spec.ts**: Use data-tour fallback selectors
- **mission-control-stress.spec.ts**: Open sidebar toggle before finding MC button; deep-link fallback
- **mission-control-e2e.spec.ts**: Open sidebar toggle before searching for MC button
- **mission-journey.spec.ts**: Prefer data-testid toggle selector