### PR TITLE
🐛 Fix demoData test assertions (kubevela, volcano, wasmcloud) — coverage RED fix

### DIFF
--- a/web/src/components/cards/__tests__/kubevela_status.test.ts
+++ b/web/src/components/cards/__tests__/kubevela_status.test.ts
@@ -26,20 +26,20 @@ describe('KUBEVELA_DEMO_DATA', () => {
       expect(typeof app.name).toBe('string')
       expect(typeof app.namespace).toBe('string')
       expect(typeof app.cluster).toBe('string')
-      const validStatuses: KubeVelaAppStatus[] = ['running', 'workflow-failed', 'workflow-suspended', 'deleting', 'rendering', 'runningWorkflow', 'workflowTerminated', 'workflowFinished', 'unknown']
+      const validStatuses: KubeVelaAppStatus[] = ['running', 'workflowSuspending', 'workflowTerminated', 'workflowFailed', 'unhealthy', 'deleting']
       expect(validStatuses).toContain(app.status)
     }
   })
 
-  it('each application has components', () => {
+  it('each application has component count', () => {
     for (const app of KUBEVELA_DEMO_DATA.applications) {
-      expect(Array.isArray(app.components)).toBe(true)
       expect(typeof app.componentCount).toBe('number')
+      expect(typeof app.traitCount).toBe('number')
     }
   })
 
   it('application workflows have valid step phases', () => {
-    const validPhases: WorkflowStepPhase[] = ['succeeded', 'failed', 'skipped', 'running', 'pending', 'stopped']
+    const validPhases: WorkflowStepPhase[] = ['succeeded', 'failed', 'skipped', 'running', 'pending', 'suspending']
     for (const app of KUBEVELA_DEMO_DATA.applications) {
       if (app.workflowSteps) {
         for (const step of app.workflowSteps) {
@@ -57,7 +57,8 @@ describe('KUBEVELA_DEMO_DATA', () => {
   it('each controller pod has required fields', () => {
     for (const pod of KUBEVELA_DEMO_DATA.controllerPods) {
       expect(typeof pod.name).toBe('string')
-      expect(typeof pod.ready).toBe('boolean')
+      const validStatuses = ['running', 'pending', 'failed']
+      expect(validStatuses).toContain(pod.status)
     }
   })
 
@@ -69,8 +70,7 @@ describe('KUBEVELA_DEMO_DATA', () => {
     expect(typeof KUBEVELA_DEMO_DATA.stats.totalTraits).toBe('number')
   })
 
-  it('has summary with controllerVersion', () => {
-    expect(typeof KUBEVELA_DEMO_DATA.summary.controllerVersion).toBe('string')
-    expect(typeof KUBEVELA_DEMO_DATA.summary.velaCLIVersion).toBe('string')
+  it('has stats with controllerVersion', () => {
+    expect(typeof KUBEVELA_DEMO_DATA.stats.controllerVersion).toBe('string')
   })
 })

--- a/web/src/components/cards/__tests__/volcano_status.test.ts
+++ b/web/src/components/cards/__tests__/volcano_status.test.ts
@@ -58,8 +58,8 @@ describe('VOLCANO_DEMO_DATA', () => {
   })
 
   it('has summary with schedulerVersion', () => {
-    expect(typeof VOLCANO_DEMO_DATA.summary.schedulerVersion).toBe('string')
-    expect(typeof VOLCANO_DEMO_DATA.summary.totalScheduledJobs).toBe('number')
+    expect(typeof VOLCANO_DEMO_DATA.stats.schedulerVersion).toBe('string')
+    expect(typeof VOLCANO_DEMO_DATA.stats.totalJobs).toBe('number')
   })
 
   it('stats counts are non-negative', () => {

--- a/web/src/components/cards/__tests__/wasmcloud_status.test.ts
+++ b/web/src/components/cards/__tests__/wasmcloud_status.test.ts
@@ -24,7 +24,7 @@ describe('WASMCLOUD_DEMO_DATA', () => {
 
   it('each host has required fields', () => {
     for (const host of WASMCLOUD_DEMO_DATA.hosts) {
-      expect(typeof host.id).toBe('string')
+      expect(typeof host.hostId).toBe('string')
       expect(typeof host.cluster).toBe('string')
       const validStatuses: WasmcloudHostStatus[] = ['ready', 'starting', 'unreachable']
       expect(validStatuses).toContain(host.status)
@@ -37,9 +37,9 @@ describe('WASMCLOUD_DEMO_DATA', () => {
 
   it('each actor has required fields', () => {
     for (const actor of WASMCLOUD_DEMO_DATA.actors) {
-      expect(typeof actor.id).toBe('string')
+      expect(typeof actor.actorId).toBe('string')
       expect(typeof actor.name).toBe('string')
-      expect(typeof actor.instances).toBe('number')
+      expect(typeof actor.instanceCount).toBe('number')
     }
   })
 
@@ -66,14 +66,13 @@ describe('WASMCLOUD_DEMO_DATA', () => {
   })
 
   it('has stats with required numeric fields', () => {
-    expect(typeof WASMCLOUD_DEMO_DATA.stats.totalHosts).toBe('number')
-    expect(typeof WASMCLOUD_DEMO_DATA.stats.readyHosts).toBe('number')
-    expect(typeof WASMCLOUD_DEMO_DATA.stats.totalActors).toBe('number')
-    expect(typeof WASMCLOUD_DEMO_DATA.stats.totalProviders).toBe('number')
-    expect(typeof WASMCLOUD_DEMO_DATA.stats.totalLinks).toBe('number')
+    expect(typeof WASMCLOUD_DEMO_DATA.stats.hostCount).toBe('number')
+    expect(typeof WASMCLOUD_DEMO_DATA.stats.actorCount).toBe('number')
+    expect(typeof WASMCLOUD_DEMO_DATA.stats.providerCount).toBe('number')
+    expect(typeof WASMCLOUD_DEMO_DATA.stats.linkCount).toBe('number')
   })
 
-  it('has summary with latticeVersion', () => {
-    expect(typeof WASMCLOUD_DEMO_DATA.summary.latticeVersion).toBe('string')
+  it('has stats with latticeVersion', () => {
+    expect(typeof WASMCLOUD_DEMO_DATA.stats.latticeVersion).toBe('string')
   })
 })


### PR DESCRIPTION
Fixes test failures in the coverage suite causing coverage RED (89% < 91%).

Three test files had assertions written against an incorrect/stale interface design that didn't match the actual demoData source:

**kubevela_status.test.ts**
- `KubeVelaAppStatus` values were kebab-case (`workflow-failed`) — actual source uses camelCase (`workflowFailed`, `workflowSuspending`)
- Tested non-existent `app.components` array — source uses `componentCount`/`traitCount` numbers
 `'suspending'` (matches actual type union)
- `pod.ready` (boolean) → `pod.status` (string union) per `KubeVelaControllerPod` interface
- `summary.controllerVersion` → `stats.controllerVersion` (summary has no version field)

**volcano_status.test.ts**
- `summary.schedulerVersion` → `stats.schedulerVersion`
- `summary.totalScheduledJobs` → `stats.totalJobs`

**wasmcloud_status.test.ts**
- `host.id` → `host.hostId`, `actor.id` → `actor.actorId`, `actor.instances` → `actor.instanceCount`
- Stats: `totalHosts` → `hostCount`, removed non-existent `readyHosts`, `totalActors` → `actorCount`, `totalProviders` → `providerCount`, `totalLinks` → `linkCount`
- `summary.latticeVersion` → `stats.latticeVersion`

These 10 test failures were preventing the coverage suite from completing successfully, which caused the coverage metric to read below the 91% gate.