### PR TITLE
🐛 fix: guard MCP stdin close with sync.Once to prevent double-close race

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -32,10 +32,11 @@ type Client struct {
 	// int64 — a type mismatch that caused every call() to block until the
 	// context deadline fired (#6622).
 	pending  map[string]chan *Response
-	tools    []Tool
-	ready    atomic.Bool // protected via atomic to avoid data races (#6942)
-	done     chan struct{}
-	stopOnce sync.Once
+	tools         []Tool
+	ready         atomic.Bool // protected via atomic to avoid data races (#6942)
+	done          chan struct{}
+	stopOnce      sync.Once
+	stdinCloseOnce sync.Once
 }
 
 // idKey converts a JSON-RPC request/response ID of any supported shape
@@ -272,9 +273,7 @@ func (c *Client) Stop() error {
 		c.mu.Unlock()
 
 		// Close stdin pipe to send EOF to the server process
-		if c.stdin != nil {
-			c.stdin.Close()
-		}
+		c.closeStdin()
 
 		if c.cmd != nil && c.cmd.Process != nil {
 			// Kill the process, then Wait() to reap it and release OS resources
@@ -424,6 +423,14 @@ func (c *Client) notify(method string, params interface{}) error {
 	return c.send(req)
 }
 
+func (c *Client) closeStdin() {
+	c.stdinCloseOnce.Do(func() {
+		if c.stdin != nil {
+			c.stdin.Close()
+		}
+	})
+}
+
 // stdinWriteTimeout is how long send() waits for a stdin write before
 // giving up. If the child process stops consuming stdin the OS pipe
 // buffer fills and Write blocks; this timeout prevents holding the
@@ -463,9 +470,7 @@ func (c *Client) send(req Request) error {
 	case <-time.After(stdinWriteTimeout):
 		// Close stdin to unblock the stuck Write goroutine — this causes
 		// Write to return with an error, releasing writeMu via defer.
-		if c.stdin != nil {
-			c.stdin.Close()
-		}
+		c.closeStdin()
 		return fmt.Errorf("stdin write timed out after %s (child process may have stopped)", stdinWriteTimeout)
 	case <-c.done:
 		return fmt.Errorf("client stopped while writing to stdin")

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -134,6 +136,34 @@ func TestClient_RPC_Error(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("timed out waiting for response")
 	}
+}
+
+type countingCloser struct {
+	closes atomic.Int32
+}
+
+func (c *countingCloser) Write(p []byte) (int, error) { return len(p), nil }
+func (c *countingCloser) Close() error                { c.closes.Add(1); return nil }
+
+func TestCloseStdin_CalledOnlyOnce(t *testing.T) {
+	stub := &countingCloser{}
+	c := &Client{
+		stdin: stub,
+		done:  make(chan struct{}),
+	}
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			c.closeStdin()
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), stub.closes.Load(), "Close() must be called exactly once")
 }
 
 func TestClient_Stop_FailsPending(t *testing.T) {


### PR DESCRIPTION
### 📝 Summary of Changes

- `send()` in `pkg/mcp/client.go` called `c.stdin.Close()` on timeout with no synchronization
- concurrent timeouts or `Stop()` racing with a timing-out `send()` could double-close 
  the same `os.File` pipe silently corrupting unrelated FDs on Linux with no error trace

---

### Changes Made

- [x] Added `stdinCloseOnce sync.Once` field to `Client` struct
- [x] Added `closeStdin()` method wrapping `c.stdin.Close()` inside the `Once`
- [x] Replaced both raw `c.stdin.Close()` call sites in `send()` and `Stop()` with `c.closeStdin()`

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

N/A

---

### 👀 Reviewer Notes

one file changed- `pkg/mcp/client.go`. minimal change sync.Once guard around 
stdin close. no logic changes, no new dependencies. fixes a silent FD corruption 
risk that would be nearly impossible to debug in production.
