### PR TITLE
🐛 Fix nightly mission index 502 errors

### DIFF
--- a/web/e2e/helpers/fetchWithRetry.ts
+++ b/web/e2e/helpers/fetchWithRetry.ts
@@ -1,0 +1,45 @@
+import type { APIRequestContext, APIResponse } from '@playwright/test'
+
+/**
+ * Fetch a URL via Playwright's request API with exponential backoff retry
+ * for transient upstream errors (5xx). Addresses flaky 502 responses from
+ * GitHub raw content CDN (#10966).
+ */
+
+/** Maximum number of retry attempts (total attempts = MAX_RETRIES + 1) */
+const MAX_RETRIES = 3
+
+/** Base delay between retries in milliseconds */
+const RETRY_BASE_DELAY_MS = 1_000
+
+/** Request timeout per attempt in milliseconds */
+const PER_ATTEMPT_TIMEOUT_MS = 30_000
+
+export async function fetchWithRetry(
+  request: APIRequestContext,
+  url: string,
+): Promise<APIResponse> {
+  let lastResp: APIResponse | null = null
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      const delay = RETRY_BASE_DELAY_MS * (1 << (attempt - 1))
+      console.log(`[fetchWithRetry] Attempt ${attempt + 1}/${MAX_RETRIES + 1} after ${delay}ms delay for ${url}`)
+      await new Promise((r) => setTimeout(r, delay))
+    }
+
+    lastResp = await request.get(url, { timeout: PER_ATTEMPT_TIMEOUT_MS })
+
+    // Don't retry client errors (4xx) — only transient 5xx
+    if (lastResp.ok() || lastResp.status() < 500) {
+      return lastResp
+    }
+
+    console.warn(
+      `[fetchWithRetry] HTTP ${lastResp.status()} on attempt ${attempt + 1}/${MAX_RETRIES + 1} for ${url}`,
+    )
+  }
+
+  // Return the last response even if it's a 5xx — let the caller decide
+  return lastResp!
+}

--- a/web/e2e/nightly/mission-deeplink.spec.ts
+++ b/web/e2e/nightly/mission-deeplink.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { mockApiFallback } from '../helpers/setup'
+import { fetchWithRetry } from '../helpers/fetchWithRetry'
 
 /**
  * Nightly Mission Deep Link Health Check
@@ -99,11 +100,11 @@ test.describe('Mission Deep Links', () => {
       }))
     })
 
-    // Fetch the missions index to get real paths
-    const response = await page.request.get('/api/missions/file?path=fixes/index.json')
+    // Fetch the missions index to get real paths (retry on transient 502s — #10966)
+    const response = await fetchWithRetry(page.request, '/api/missions/file?path=fixes/index.json')
 
-    // If the index itself fails, that's also a passthrough bug
-    expect(response.ok(), 'missions index should be accessible').toBe(true)
+    // If the index still fails after retries, that's a real problem
+    expect(response.ok(), `missions index should be accessible (got ${response.status()})`).toBe(true)
 
     const index = await response.json() as { missions?: Array<{ path: string; title?: string }> }
     const missions = (index.missions ?? []).filter((m) =>

--- a/web/e2e/nightly/mission-explorer-import.spec.ts
+++ b/web/e2e/nightly/mission-explorer-import.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
+import { fetchWithRetry } from '../helpers/fetchWithRetry'
 
 /**
  * Nightly Mission Explorer Import Check
@@ -168,9 +169,10 @@ async function setupDemoMode(page: Page) {
  * Returns the full list of index entries.
  */
 async function fetchFixesIndex(page: Page): Promise<IndexEntry[]> {
-  const resp = await page.request.get(
+  // Retry on transient 502s from GitHub raw content CDN (#10966)
+  const resp = await fetchWithRetry(
+    page.request,
     '/api/missions/file?path=fixes%2Findex.json',
-    { timeout: 30_000 }
   )
   expect(resp.ok(), `Index fetch failed: ${resp.status()}`).toBeTruthy()
   const body = await resp.json()
@@ -249,9 +251,9 @@ test.describe('Mission Explorer Import (Nightly)', () => {
     for (const entry of selected) {
       const path = entry.path
       try {
-        const fileResp = await page.request.get(
+        const fileResp = await fetchWithRetry(
+          page.request,
           `/api/missions/file?path=${encodeURIComponent(path)}`,
-          { timeout: MISSION_FETCH_TIMEOUT }
         )
 
         if (!fileResp.ok()) {
@@ -353,9 +355,9 @@ test.describe('Mission Explorer Import (Nightly)', () => {
 
     for (const entry of selected) {
       const path = entry.path
-      const fileResp = await page.request.get(
+      const fileResp = await fetchWithRetry(
+        page.request,
         `/api/missions/file?path=${encodeURIComponent(path)}`,
-        { timeout: MISSION_FETCH_TIMEOUT }
       )
       if (!fileResp.ok()) continue
 


### PR DESCRIPTION
Fixes #10966

Add test-level retry with exponential backoff for transient 502s from GitHub raw content CDN.

PR #10977 added server-side retry logic in the Go handler, Netlify function, and frontend cache, but the nightly Playwright tests still made single fetch attempts — a transient 502 would fail the test immediately.

**Changes:**
- New `web/e2e/helpers/fetchWithRetry.ts` — shared helper that retries up to 3 times with 1s/2s/4s exponential backoff for 5xx responses
- `mission-deeplink.spec.ts` — index fetch now uses `fetchWithRetry`
- `mission-explorer-import.spec.ts` — index fetch and individual mission file fetches now use `fetchWithRetry`