### PR TITLE
🐛 Fix NamespaceOverview auto-select and persistence E2E tests

### DIFF
--- a/web/e2e/NamespaceOverview.spec.ts
+++ b/web/e2e/NamespaceOverview.spec.ts
@@ -55,8 +55,13 @@ async function setupDemoMode(page: Page) {
     localStorage.removeItem('kc-ns-overview-cluster')
     localStorage.removeItem('kc-ns-overview-namespace')
     localStorage.setItem(
-      'kubestellar-dashboard-cards',
-      JSON.stringify([{ id: 'namespace_overview', size: 'medium', order: 0 }])
+      'kubestellar-main-dashboard-cards',
+      JSON.stringify([{
+        id: 'namespace_overview',
+        card_type: 'namespace_overview',
+        config: {},
+        position: { x: 0, y: 0, w: 6, h: 3 },
+      }])
     )
   })
 }
@@ -104,8 +109,13 @@ async function setupLiveMode(page: Page) {
     localStorage.removeItem('kc-ns-overview-cluster')
     localStorage.removeItem('kc-ns-overview-namespace')
     localStorage.setItem(
-      'kubestellar-dashboard-cards',
-      JSON.stringify([{ id: 'namespace_overview', size: 'medium', order: 0 }])
+      'kubestellar-main-dashboard-cards',
+      JSON.stringify([{
+        id: 'namespace_overview',
+        card_type: 'namespace_overview',
+        config: {},
+        position: { x: 0, y: 0, w: 6, h: 3 },
+      }])
     )
   })
 }


### PR DESCRIPTION
Fixes #10965

Fix two issues in `NamespaceOverview.spec.ts` that prevented the card from rendering during E2E tests:

1. **Wrong localStorage key**: test used `kubestellar-dashboard-cards` but the Dashboard component reads from `kubestellar-main-dashboard-cards` (`STORAGE_KEY_MAIN_DASHBOARD_CARDS`). With the wrong key, the dashboard fell back to `DEFAULT_DASHBOARD_CARDS` which doesn't include `namespace_overview`, so the card never rendered.

2. **Wrong card format**: test stored `{ id, size, order }` but the Dashboard expects `{ id, card_type, config, position }`. Without `card_type`, the card registry lookup (`CARD_COMPONENTS[card.card_type]`) returned `undefined`, preventing the NamespaceOverview component from mounting.

The `select[title="Select a cluster to view namespace details"]` locator timed out because the card was simply not on the page.