### PR TITLE
🐛 Add null guards to fix ksc_error 3.6× spike

### DIFF
--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -523,9 +523,9 @@ function MissionRow({ mission, isExpanded, onToggle, isActive, onDiagnose, onRep
   }, [isDeploying, hasLogs])
 
   // Calculate overall progress
-  const totalClusters = mission.clusterStatuses.length
-  const readyClusters = mission.clusterStatuses.filter(s => s.status === 'running').length
-  const failedClusters = mission.clusterStatuses.filter(s => s.status === 'failed').length
+  const totalClusters = (mission.clusterStatuses || []).length
+  const readyClusters = (mission.clusterStatuses || []).filter(s => s.status === 'running').length
+  const failedClusters = (mission.clusterStatuses || []).filter(s => s.status === 'failed').length
   const progressPct = totalClusters > 0 ? ((readyClusters + failedClusters) / totalClusters) * 100 : 0
 
   return (
@@ -635,9 +635,9 @@ function MissionRow({ mission, isExpanded, onToggle, isActive, onDiagnose, onRep
       )}
 
       {/* Per-cluster progress — visible for active missions; completed missions show on expand */}
-      {isActive && !isExpanded && mission.clusterStatuses.length > 0 && (
+      {isActive && !isExpanded && (mission.clusterStatuses || []).length > 0 && (
         <div className="px-3 pb-2 space-y-1">
-          {mission.clusterStatuses.map(cs => (
+          {(mission.clusterStatuses || []).map(cs => (
             <ClusterStatusRow key={cs.cluster} status={cs} />
           ))}
           {mission.dependencies && mission.dependencies.length > 0 && (
@@ -721,7 +721,7 @@ function MissionRow({ mission, isExpanded, onToggle, isActive, onDiagnose, onRep
               Deployed by: <span className="text-muted-foreground">{mission.deployedBy}</span>
             </div>
           )}
-          {mission.clusterStatuses.map(cs => (
+          {(mission.clusterStatuses || []).map(cs => (
             <ClusterStatusRow key={cs.cluster} status={cs} />
           ))}
 

--- a/web/src/components/cards/WorkloadDeployment.tsx
+++ b/web/src/components/cards/WorkloadDeployment.tsx
@@ -280,7 +280,7 @@ function DraggableWorkloadItem({ workload, isSelected, onSelect, onScaled }: Dra
       await scaleWorkload({
         workloadName: workload.name,
         namespace: workload.namespace,
-        targetClusters: workload.targetClusters,
+        targetClusters: workload.targetClusters || [],
         replicas: desiredReplicas })
       setScaleSuccess(true)
       onScaled?.()
@@ -288,7 +288,7 @@ function DraggableWorkloadItem({ workload, isSelected, onSelect, onScaled }: Dra
     } catch {
       // Backend failed — try agent fallback for all target clusters
       try {
-        const clusters = workload.targetClusters.length > 0 ? workload.targetClusters : ['unknown']
+        const clusters = (workload.targetClusters || []).length > 0 ? workload.targetClusters : ['unknown']
         const results = await Promise.all(
           clusters.map(async c => {
             const r = await scaleViaAgent(c, workload.namespace, workload.name, desiredReplicas)
@@ -327,7 +327,7 @@ function DraggableWorkloadItem({ workload, isSelected, onSelect, onScaled }: Dra
     }
   }
   // Source cluster is the first cluster in the list (where we'll copy from)
-  const sourceCluster = workload.targetClusters[0] || 'unknown'
+  const sourceCluster = (workload.targetClusters || [])[0] || 'unknown'
 
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `workload-${sourceCluster}-${workload.namespace}-${workload.name}`,
@@ -338,7 +338,7 @@ function DraggableWorkloadItem({ workload, isSelected, onSelect, onScaled }: Dra
         namespace: workload.namespace,
         type: workload.type,
         sourceCluster,
-        currentClusters: workload.targetClusters } } })
+        currentClusters: workload.targetClusters || [] } } })
 
   // When dragging, fade the original — the DragOverlay renders the floating preview as a portal
   const style: React.CSSProperties = isDragging
@@ -420,7 +420,7 @@ function DraggableWorkloadItem({ workload, isSelected, onSelect, onScaled }: Dra
           <div className="flex flex-wrap items-center justify-between gap-y-2">
             <span className="text-xs text-muted-foreground">Target Clusters</span>
             <div className="flex gap-1">
-              {workload.targetClusters.map((c) => (
+              {(workload.targetClusters || []).map((c) => (
                 <ClusterBadge key={c} cluster={c} size="sm" />
               ))}
             </div>
@@ -672,7 +672,7 @@ export function WorkloadDeployment(_props: WorkloadDeploymentProps) {
       degradedCount: workloads.filter(w => w.status === 'Degraded').length,
       pendingCount: workloads.filter(w => w.status === 'Pending').length,
       failedCount: workloads.filter(w => w.status === 'Failed').length,
-      totalClusters: new Set(workloads.flatMap(w => w.targetClusters)).size }
+      totalClusters: new Set(workloads.flatMap(w => w.targetClusters || [])).size }
   })()
 
   // Pre-filter by type, status, and cluster before passing to useCardData
@@ -690,7 +690,7 @@ export function WorkloadDeployment(_props: WorkloadDeploymentProps) {
     const validClusterFilter = localClusterFilter.filter(c => availableClusterNames.has(c))
     if (validClusterFilter.length > 0) {
       result = result.filter(w =>
-        w.targetClusters.some(c => validClusterFilter.includes(c)),
+        (w.targetClusters || []).some(c => validClusterFilter.includes(c)),
       )
     }
     return result
@@ -718,7 +718,7 @@ export function WorkloadDeployment(_props: WorkloadDeploymentProps) {
     filter: {
       searchFields: ['name', 'namespace', 'image'] as (keyof Workload)[],
       customPredicate: (w, query) =>
-        w.targetClusters.some(c => c.toLowerCase().includes(query)),
+        (w.targetClusters || []).some(c => c.toLowerCase().includes(query)),
       storageKey: 'workload-deployment' },
     sort: {
       defaultField: 'status',

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -207,7 +207,15 @@ async function runWithConcurrency<T>(
 function loadMissions(): DeployMission[] {
   try {
     const stored = localStorage.getItem(MISSIONS_STORAGE_KEY)
-    if (stored) return JSON.parse(stored)
+    if (stored) {
+      const parsed: DeployMission[] = JSON.parse(stored)
+      // Ensure required arrays exist — older stored data or corruption may omit them
+      return (parsed || []).map(m => ({
+        ...m,
+        targetClusters: m.targetClusters || [],
+        clusterStatuses: m.clusterStatuses || [],
+      }))
+    }
     // Migrate from old split keys
     const oldActive = localStorage.getItem(STORAGE_KEY_MISSIONS_ACTIVE)
     const oldHistory = localStorage.getItem(STORAGE_KEY_MISSIONS_HISTORY)
@@ -233,7 +241,7 @@ function saveMissions(missions: DeployMission[]) {
   // Strip logs for active missions (transient data, re-fetched on each poll cycle).
   const clean = missions.slice(0, MAX_MISSIONS).map(m => ({
     ...m,
-    clusterStatuses: m.clusterStatuses.map(cs => ({
+    clusterStatuses: (m.clusterStatuses || []).map(cs => ({
       ...cs,
       logs: isTerminalStatus(m.status) ? cs.logs : undefined })) }))
   localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(clean))
@@ -275,7 +283,7 @@ export function useDeployMissions() {
         groupName: p.groupName,
         deployedBy: p.deployedBy,
         status: 'launching',
-        clusterStatuses: p.targetClusters.map(c => ({
+        clusterStatuses: (p.targetClusters || []).map(c => ({
           cluster: c,
           status: 'pending',
           replicas: 0,
@@ -328,7 +336,7 @@ export function useDeployMissions() {
       const allTerminal = current.every(m => isTerminalStatus(m.status))
       const anyNeedsRecovery = allTerminal && current.some(m => {
         if (!m.completedAt || (Date.now() - m.completedAt) <= CACHE_TTL_MS) return false
-        const hasAnyLogs = m.clusterStatuses.some(cs => cs.logs && cs.logs.length > 0)
+        const hasAnyLogs = (m.clusterStatuses || []).some(cs => cs.logs && cs.logs.length > 0)
         const recoveryPolls = m.logRecoveryPolls ?? 0
         // Still needs recovery if: has logs but under budget, OR has no logs at all
         return !hasAnyLogs || recoveryPolls < LOG_RECOVERY_EXTRA_POLLS
@@ -360,7 +368,7 @@ export function useDeployMissions() {
           let inRecoveryWindow = false
           if (isCompleted && mission.completedAt &&
               (Date.now() - mission.completedAt) > CACHE_TTL_MS) {
-            const hasAnyLogs = mission.clusterStatuses.some(cs => cs.logs && cs.logs.length > 0)
+            const hasAnyLogs = (mission.clusterStatuses || []).some(cs => cs.logs && cs.logs.length > 0)
             const recoveryPolls = mission.logRecoveryPolls ?? 0
             if (hasAnyLogs) {
               if (recoveryPolls >= LOG_RECOVERY_EXTRA_POLLS) {
@@ -380,9 +388,9 @@ export function useDeployMissions() {
           // #6640 — Bounded concurrency over clusters. Each cluster task is
           // wrapped in a thunk so runWithConcurrency can schedule them.
           const clusterTasks: Array<() => Promise<DeployClusterStatus>> =
-            mission.targetClusters.map((cluster) => async (): Promise<DeployClusterStatus> => {
+            (mission.targetClusters || []).map((cluster) => async (): Promise<DeployClusterStatus> => {
               // Track consecutive failures from previous poll cycle
-              const prevStatus = mission.clusterStatuses.find(cs => cs.cluster === cluster)
+              const prevStatus = (mission.clusterStatuses || []).find(cs => cs.cluster === cluster)
               const prevFailures = prevStatus?.consecutiveFailures ?? 0
               const prevNetworkFailures = prevStatus?.networkFailureCount ?? 0
 

--- a/web/src/hooks/useProviderHealth.ts
+++ b/web/src/hooks/useProviderHealth.ts
@@ -278,8 +278,8 @@ export function useProviderHealth() {
     }
   }, [clusters.length]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const aiProviders = cacheResult.data.filter(p => p.category === 'ai')
-  const cloudProviders = cacheResult.data.filter(p => p.category === 'cloud')
+  const aiProviders = (cacheResult.data || []).filter(p => p.category === 'ai')
+  const cloudProviders = (cacheResult.data || []).filter(p => p.category === 'cloud')
 
   // Don't signal demo fallback while still loading — card should show skeleton, not demo data
   const effectiveIsDemoFallback = cacheResult.isDemoFallback && !cacheResult.isLoading


### PR DESCRIPTION
Fixes #10957

## Root cause

The `ksc_error` GA4 event spiked 3.6× baseline (540 vs 150.1 daily avg) due to missing null guards on array properties accessed at runtime:

1. **`useDeployMissions.ts`** — Missions loaded from `localStorage` via `JSON.parse()` may have `clusterStatuses` or `targetClusters` as `undefined` (corrupted/stale data from older code versions). Six call sites accessed these with `.map()`, `.some()`, `.find()` without guards, throwing `TypeError` caught by the global error handler → `ksc_error`.

2. **`WorkloadDeployment.tsx`** — `Workload.targetClusters` is typed as optional (`string[]?`) in the interface but accessed directly with `.map()`, `.some()`, `.length`, `[0]` across 7 call sites. Any workload missing this field throws `TypeError`.

3. **`Missions.tsx`** — `mission.clusterStatuses` accessed with `.length`, `.filter()`, `.map()` without guards in the card render path — same localStorage corruption vector.

4. **`useProviderHealth.ts`** — `cacheResult.data.filter()` called without guard (defense in depth).

## Fix

- Add `(x || [])` guards before all array method calls on potentially undefined arrays
- Normalize `loadMissions()` parsed data to ensure `targetClusters` and `clusterStatuses` arrays always exist
- 4 files changed, 16 guard sites fixed