### PR TITLE
🐛 Fix coverage test regressions introduced by #10991 and #10990

### DIFF
--- a/web/src/components/dashboard/customizer/__tests__/DashboardCustomizer.test.tsx
+++ b/web/src/components/dashboard/customizer/__tests__/DashboardCustomizer.test.tsx
@@ -86,6 +86,7 @@ vi.mock('../../../widgets/WidgetExportModal', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
+  LayoutGrid: () => null,
   Palette: () => null,
   Undo2: () => null,
   Redo2: () => null,

--- a/web/src/hooks/__tests__/useDeployMissions-pure.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions-pure.test.ts
@@ -151,7 +151,7 @@ describe('loadMissions', () => {
   })
 
   it('returns missions from primary storage key', () => {
-    const missions = [{ id: 'm1', status: 'orbit', workload: 'test', clusterStatuses: [] }]
+    const missions = [{ id: 'm1', status: 'orbit', workload: 'test', targetClusters: [], clusterStatuses: [] }]
     localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
     expect(loadMissions()).toEqual(missions)
   })


### PR DESCRIPTION
Fixes #10987

## Root cause
Two test regressions introduced by recent merges caused coverage-hourly to fail with 10 failing tests, keeping coverage at 89% (below the 91% target).

### 1. DashboardCustomizer.test.tsx — missing `LayoutGrid` in lucide-react mock
`customizerNav.ts` (imported by `DashboardCustomizer.tsx`) imports `LayoutGrid` from `lucide-react`. The vitest mock for `lucide-react` in this test file only listed `Palette`, `Undo2`, `Redo2`, `RotateCcw`. Vitest's strict mock mode errored: _No "LayoutGrid" export is defined on the "lucide-react" mock_ — all 9 DashboardCustomizer tests crashed before running.

**Fix**: add `LayoutGrid: () => null` to the `vi.mock('lucide-react')` block.

### 2. useDeployMissions-pure.test.ts — missing `targetClusters` in test fixture
PR #10990 patched `loadMissions()` to normalize stored missions with `targetClusters: []` for null-safety. The test fixture `{ id: 'm1', status: 'orbit', workload: 'test', clusterStatuses: [] }` (4 keys) was missing `targetClusters`, so `loadMissions()` returned a 5-key object causing the deep-equality assertion to fail.

**Fix**: add `targetClusters: []` to the test fixture.

## Impact
- Unblocks all 10 failing tests in coverage-hourly shard 9
- Restores coverage to ≥91% (the 9 DashboardCustomizer tests now contribute to coverage)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>