### PR TITLE
🐛 fix DashboardCustomizer test: add Layout+LayoutDashboard to lucide-react mock

### DIFF
--- a/web/src/components/dashboard/customizer/__tests__/DashboardCustomizer.test.tsx
+++ b/web/src/components/dashboard/customizer/__tests__/DashboardCustomizer.test.tsx
@@ -86,7 +86,9 @@ vi.mock('../../../widgets/WidgetExportModal', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
+  Layout: () => null,
   LayoutGrid: () => null,
+  LayoutDashboard: () => null,
   Palette: () => null,
   Undo2: () => null,
   Redo2: () => null,


### PR DESCRIPTION
Fixes coverage RED: DashboardCustomizer.test.tsx failing because customizerNav.ts imports `Layout` and `LayoutDashboard` from lucide-react but the vi.mock only exported `LayoutGrid`.

Root cause: vitest error `No "Layout" export is defined on the "lucide-react" mock`.

**Fix**: Add `Layout: () => null` and `LayoutDashboard: () => null` to the existing lucide-react mock.

Coverage impact: restores 9 DashboardCustomizer tests → expected coverage ≥91% again.