### PR TITLE
🐛fix: add missing RBAC check to CallDeployTool handler

### DIFF
--- a/pkg/api/handlers/mcp_resources.go
+++ b/pkg/api/handlers/mcp_resources.go
@@ -1057,6 +1057,12 @@ func (h *MCPHandlers) CallOpsTool(c *fiber.Ctx) error {
 
 // CallDeployTool calls a kubestellar-deploy tool
 func (h *MCPHandlers) CallDeployTool(c *fiber.Ctx) error {
+	// SECURITY (#7495): tool-call endpoint can expose sensitive cluster data;
+	// require at least editor role to invoke tools.
+	if err := requireEditorOrAdmin(c, h.store); err != nil {
+		return err
+	}
+
 	if h.bridge == nil {
 		return c.Status(503).JSON(fiber.Map{"error": "MCP bridge not available"})
 	}

--- a/pkg/api/handlers/mcp_resources_test.go
+++ b/pkg/api/handlers/mcp_resources_test.go
@@ -7,6 +7,10 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -115,4 +119,71 @@ func TestCreateOrUpdateResourceQuota(t *testing.T) {
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestCallDeployTool_RBAC(t *testing.T) {
+	env := setupTestEnv(t)
+
+	makeApp := func(userID uuid.UUID) *fiber.App {
+		app := fiber.New()
+		handler := NewMCPHandlers(nil, env.K8sClient, env.Store)
+		app.Post("/api/mcp/tools/deploy", func(c *fiber.Ctx) error {
+			c.Locals("userID", userID)
+			return handler.CallDeployTool(c)
+		})
+		return app
+	}
+
+	body, _ := json.Marshal(map[string]interface{}{"name": "list_workspaces", "arguments": map[string]interface{}{}})
+
+	t.Run("viewer gets 403", func(t *testing.T) {
+		viewerID := uuid.New()
+		env.Store.(*test.MockStore).On("GetUser", viewerID).Return(&models.User{
+			ID:   viewerID,
+			Role: models.UserRoleViewer,
+		}, nil)
+
+		req, err := http.NewRequest(http.MethodPost, "/api/mcp/tools/deploy", bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := makeApp(viewerID).Test(req, 5000)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("editor is not rejected", func(t *testing.T) {
+		editorID := uuid.New()
+		env.Store.(*test.MockStore).On("GetUser", editorID).Return(&models.User{
+			ID:   editorID,
+			Role: models.UserRoleEditor,
+		}, nil)
+
+		req, err := http.NewRequest(http.MethodPost, "/api/mcp/tools/deploy", bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := makeApp(editorID).Test(req, 5000)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.NotEqual(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("admin is not rejected", func(t *testing.T) {
+		adminID := uuid.New()
+		env.Store.(*test.MockStore).On("GetUser", adminID).Return(&models.User{
+			ID:   adminID,
+			Role: models.UserRoleAdmin,
+		}, nil)
+
+		req, err := http.NewRequest(http.MethodPost, "/api/mcp/tools/deploy", bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := makeApp(adminID).Test(req, 5000)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.NotEqual(t, http.StatusForbidden, resp.StatusCode)
+	})
 }


### PR DESCRIPTION
### 📝 Summary of Changes

- `CallDeployTool` was missing the `requireEditorOrAdmin` RBAC guard that `CallOpsTool` 
  has since #7495
- viewer-role users could invoke deploy tools exposing sensitive cluster data 
  (logs, drift, pending changes)


---

### Changes Made

- [x] Added `requireEditorOrAdmin(c, h.store)` at the top of `CallDeployTool`-
  identical to the guard already in `CallOpsTool`
---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

N/A
---

### 👀 Reviewer Notes

one file changed- `pkg/api/handlers/mcp_resources.go`. one line added.
copy-paste omission from #7495 both tool-call endpoints now have identical auth requirements.
