### PR TITLE
🐛 fix: guard useLastRoute return against localStorage.getItem throwing

### DIFF
--- a/web/src/hooks/useLastRoute.ts
+++ b/web/src/hooks/useLastRoute.ts
@@ -359,8 +359,14 @@ export function useLastRoute() {
     }
   }, [location.pathname, restoreScrollPosition])
 
+  let lastRouteValue: string | null = null
+  try {
+    lastRouteValue = localStorage.getItem(LAST_ROUTE_KEY)
+  } catch {
+    // Ignore localStorage errors
+  }
   return {
-    lastRoute: localStorage.getItem(LAST_ROUTE_KEY),
+    lastRoute: lastRouteValue,
     scrollPositions: getScrollPositions(),
   }
 }


### PR DESCRIPTION
Fixes #11023

## Problem
Coverage Suite shard-6 RED: `useLastRoute.test.ts > useLastRoute hook > does not throw when localStorage throws on redirect read`

The hook's return statement called `localStorage.getItem(LAST_ROUTE_KEY)` directly, outside any try-catch. When localStorage throws (corrupt storage, quota exceeded, private-browsing restrictions), the hook threw an unhandled exception up through `renderHook`.

## Fix
Wrap the return-time `getItem` in a try-catch, returning `null` on error — consistent with all other localStorage accesses in this hook.

```ts
// before
return { lastRoute: localStorage.getItem(LAST_ROUTE_KEY), ... }

// after
let lastRouteValue: string | null = null
try { lastRouteValue = localStorage.getItem(LAST_ROUTE_KEY) } catch { /* ignore */ }
return { lastRoute: lastRouteValue, ... }
```

## Root cause
Test in #11021 correctly identified real missing guard. The test was right; the impl was wrong.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>