### PR TITLE
🌱 coverage: add targeted tests for DashboardCustomizer and useClusterGroups

### DIFF
--- a/web/src/components/dashboard/customizer/__tests__/DashboardCustomizer.test.tsx
+++ b/web/src/components/dashboard/customizer/__tests__/DashboardCustomizer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string, d?: string) => d || k }),
@@ -49,8 +49,14 @@ vi.mock('../../../../lib/iconSuggester', () => ({
 }))
 
 vi.mock('../DashboardCustomizerSidebar', () => ({
-  DashboardCustomizerSidebar: ({ activeSection }: { activeSection: string }) =>
-    <div data-testid="sidebar" data-section={activeSection} />,
+  DashboardCustomizerSidebar: ({ activeSection, onSectionChange }: { activeSection: string; onSectionChange?: (s: string) => void }) =>
+    <div data-testid="sidebar" data-section={activeSection}>
+      <button data-testid="sidebar-go-widgets" onClick={() => onSectionChange?.('widgets')}>widgets</button>
+      <button data-testid="sidebar-go-collections" onClick={() => onSectionChange?.('collections')}>collections</button>
+      <button data-testid="sidebar-go-card-factory" onClick={() => onSectionChange?.('card-factory')}>card-factory</button>
+      <button data-testid="sidebar-go-stat-factory" onClick={() => onSectionChange?.('stat-factory')}>stat-factory</button>
+      <button data-testid="sidebar-go-create-dashboard" onClick={() => onSectionChange?.('create-dashboard')}>create-dashboard</button>
+    </div>,
 }))
 
 vi.mock('../PreviewPanel', () => ({
@@ -58,7 +64,13 @@ vi.mock('../PreviewPanel', () => ({
 }))
 
 vi.mock('../sections/UnifiedCardsSection', () => ({
-  UnifiedCardsSection: () => <div data-testid="unified-cards" />,
+  UnifiedCardsSection: ({ onAddCards }: { onAddCards?: (cards: Array<{ type: string; title: string; description: string; visualization: string; config: Record<string, unknown> }>) => void }) =>
+    <div data-testid="unified-cards">
+      <button
+        data-testid="trigger-add-cards"
+        onClick={() => onAddCards?.([{ type: 'pods', title: 'Pods', description: '', visualization: 'status', config: {} }])}
+      >add</button>
+    </div>,
 }))
 
 vi.mock('../sections/NavigationSection', () => ({
@@ -66,11 +78,33 @@ vi.mock('../sections/NavigationSection', () => ({
 }))
 
 vi.mock('../sections/TemplateGallerySection', () => ({
-  TemplateGallerySection: () => <div data-testid="template-gallery" />,
+  TemplateGallerySection: ({
+    onReplaceWithTemplate,
+    onAddTemplate,
+  }: {
+    onReplaceWithTemplate?: (tpl: unknown) => void
+    onAddTemplate?: (tpl: { cards?: Array<{ card_type: string; config?: Record<string, unknown> }> }) => void
+  }) =>
+    <div data-testid="template-gallery">
+      <button
+        data-testid="trigger-replace-template"
+        onClick={() => onReplaceWithTemplate?.({ id: 'tpl1', name: 'My Template' })}
+      >replace</button>
+      <button
+        data-testid="trigger-add-template"
+        onClick={() => onAddTemplate?.({ cards: [{ card_type: 'pods', config: {} }] })}
+      >add template</button>
+    </div>,
 }))
 
 vi.mock('../../CardFactoryModal', () => ({
-  CardFactoryModal: () => <div data-testid="card-factory" />,
+  CardFactoryModal: ({ onCardCreated }: { onCardCreated?: (cardId: string) => void }) =>
+    <div data-testid="card-factory">
+      <button
+        data-testid="trigger-card-created"
+        onClick={() => onCardCreated?.('my-new-card-id')}
+      >created</button>
+    </div>,
 }))
 
 vi.mock('../../StatBlockFactoryModal', () => ({
@@ -156,6 +190,225 @@ describe('DashboardCustomizer', () => {
       />
     )
     expect(screen.getByTestId('base-modal')).toBeTruthy()
+  })
+
+  it('renders WidgetExportModal when initialSection=widgets', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(<DashboardCustomizer {...DEFAULT_PROPS} initialSection="widgets" />)
+    expect(screen.getByTestId('widget-export')).toBeTruthy()
+  })
+
+  it('renders CreateDashboardModal when initialSection=create-dashboard', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(<DashboardCustomizer {...DEFAULT_PROPS} initialSection="create-dashboard" />)
+    expect(screen.getByTestId('create-dashboard')).toBeTruthy()
+  })
+
+  it('renders CardFactoryModal when initialSection=card-factory', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(<DashboardCustomizer {...DEFAULT_PROPS} initialSection="card-factory" />)
+    expect(screen.getByTestId('card-factory')).toBeTruthy()
+  })
+
+  it('renders StatBlockFactoryModal when initialSection=stat-factory', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(<DashboardCustomizer {...DEFAULT_PROPS} initialSection="stat-factory" />)
+    expect(screen.getByTestId('stat-factory')).toBeTruthy()
+  })
+
+  it('renders TemplateGallerySection when initialSection=collections and onApplyTemplate provided', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(
+      <DashboardCustomizer
+        {...DEFAULT_PROPS}
+        initialSection="collections"
+        onApplyTemplate={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('template-gallery')).toBeTruthy()
+  })
+
+  it('does NOT render TemplateGallerySection when initialSection=collections but onApplyTemplate is absent', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(<DashboardCustomizer {...DEFAULT_PROPS} initialSection="collections" />)
+    expect(screen.queryByTestId('template-gallery')).toBeNull()
+  })
+
+  it('renders Reset Dashboard button when isCustomized=true and onReset provided', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(
+      <DashboardCustomizer
+        {...DEFAULT_PROPS}
+        isCustomized={true}
+        onReset={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Reset Dashboard')).toBeTruthy()
+  })
+
+  it('calls onReset when Reset Dashboard button is clicked', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    const onReset = vi.fn()
+    render(
+      <DashboardCustomizer
+        {...DEFAULT_PROPS}
+        isCustomized={true}
+        onReset={onReset}
+      />
+    )
+    fireEvent.click(screen.getByText('Reset Dashboard'))
+    expect(onReset).toHaveBeenCalledOnce()
+  })
+
+  it('shows preview panel for cards section (SECTIONS_WITH_PREVIEW)', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(<DashboardCustomizer {...DEFAULT_PROPS} initialSection="cards" />)
+    expect(screen.getByTestId('preview-panel')).toBeTruthy()
+  })
+
+  it('shows preview panel for collections section (SECTIONS_WITH_PREVIEW)', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(
+      <DashboardCustomizer
+        {...DEFAULT_PROPS}
+        initialSection="collections"
+        onApplyTemplate={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('preview-panel')).toBeTruthy()
+  })
+
+  it('does NOT show preview panel for widgets section', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(<DashboardCustomizer {...DEFAULT_PROPS} initialSection="widgets" />)
+    expect(screen.queryByTestId('preview-panel')).toBeNull()
+  })
+
+  it('handleAddCards calls onAddCards and onClose when UnifiedCardsSection triggers', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    const onAddCards = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <DashboardCustomizer
+        isOpen={true}
+        onClose={onClose}
+        onAddCards={onAddCards}
+        initialSection="cards"
+      />
+    )
+    fireEvent.click(screen.getByTestId('trigger-add-cards'))
+    expect(onAddCards).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining({ type: 'pods' })]))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('handleApplyTemplate calls onApplyTemplate and onClose when TemplateGallerySection triggers replace', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    const onApplyTemplate = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <DashboardCustomizer
+        isOpen={true}
+        onClose={onClose}
+        onAddCards={vi.fn()}
+        onApplyTemplate={onApplyTemplate}
+        initialSection="collections"
+      />
+    )
+    fireEvent.click(screen.getByTestId('trigger-replace-template'))
+    expect(onApplyTemplate).toHaveBeenCalledWith(expect.objectContaining({ id: 'tpl1' }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('onAddTemplate converts template cards to CardSuggestion and calls handleAddCards', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    const onAddCards = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <DashboardCustomizer
+        isOpen={true}
+        onClose={onClose}
+        onAddCards={onAddCards}
+        onApplyTemplate={vi.fn()}
+        initialSection="collections"
+      />
+    )
+    fireEvent.click(screen.getByTestId('trigger-add-template'))
+    expect(onAddCards).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'pods', visualization: 'status' }),
+      ])
+    )
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('onCardCreated adds a dynamic_card CardSuggestion and changes section to cards', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    const onAddCards = vi.fn()
+    render(
+      <DashboardCustomizer
+        isOpen={true}
+        onClose={vi.fn()}
+        onAddCards={onAddCards}
+        initialSection="card-factory"
+      />
+    )
+    fireEvent.click(screen.getByTestId('trigger-card-created'))
+    expect(onAddCards).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'dynamic_card', config: expect.objectContaining({ dynamicCardId: 'my-new-card-id' }) }),
+      ])
+    )
+  })
+
+  it('sidebar onSectionChange switches the active section to widgets', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(<DashboardCustomizer {...DEFAULT_PROPS} />)
+    // Default is cards
+    expect(screen.getByTestId('sidebar').getAttribute('data-section')).toBe('cards')
+    fireEvent.click(screen.getByTestId('sidebar-go-widgets'))
+    expect(screen.getByTestId('sidebar').getAttribute('data-section')).toBe('widgets')
+    expect(screen.getByTestId('widget-export')).toBeTruthy()
+  })
+
+  it('sidebar onSectionChange switches to card-factory section', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(<DashboardCustomizer {...DEFAULT_PROPS} />)
+    fireEvent.click(screen.getByTestId('sidebar-go-card-factory'))
+    expect(screen.getByTestId('card-factory')).toBeTruthy()
+  })
+
+  it('sidebar onSectionChange switches to stat-factory section', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(<DashboardCustomizer {...DEFAULT_PROPS} />)
+    fireEvent.click(screen.getByTestId('sidebar-go-stat-factory'))
+    expect(screen.getByTestId('stat-factory')).toBeTruthy()
+  })
+
+  it('sidebar onSectionChange switches to create-dashboard section', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    render(<DashboardCustomizer {...DEFAULT_PROPS} />)
+    fireEvent.click(screen.getByTestId('sidebar-go-create-dashboard'))
+    expect(screen.getByTestId('create-dashboard')).toBeTruthy()
+  })
+
+  it('Undo button calls onUndo when canUndo=true', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    const onUndo = vi.fn()
+    render(
+      <DashboardCustomizer {...DEFAULT_PROPS} onUndo={onUndo} canUndo={true} />
+    )
+    fireEvent.click(screen.getByText('Undo'))
+    expect(onUndo).toHaveBeenCalledOnce()
+  })
+
+  it('Redo button calls onRedo when canRedo=true', async () => {
+    const { DashboardCustomizer } = await import('../DashboardCustomizer')
+    const onRedo = vi.fn()
+    render(
+      <DashboardCustomizer {...DEFAULT_PROPS} onRedo={onRedo} canRedo={true} />
+    )
+    fireEvent.click(screen.getByText('Redo'))
+    expect(onRedo).toHaveBeenCalledOnce()
   })
 })
 

--- a/web/src/hooks/__tests__/useClusterGroups.test.ts
+++ b/web/src/hooks/__tests__/useClusterGroups.test.ts
@@ -817,4 +817,91 @@ describe('useClusterGroups', () => {
     expect(typeof result.current.isLoading).toBe('boolean')
     unmount()
   })
+
+  // =========================================================================
+  // 14. Edge cases — uncovered branches
+  // =========================================================================
+
+  it('updateGroup in localStorage mode does nothing when group name is not found', async () => {
+    // No groups seeded — localGroups.find returns undefined → backend sync skipped
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+    const { result, unmount } = renderHook(() => useClusterGroups())
+
+    await act(async () => {
+      await result.current.updateGroup('ghost-group', { color: 'red' })
+    })
+
+    // No groups exist, still empty
+    expect(result.current.groups).toHaveLength(0)
+    // fetch should NOT have been called (no group to sync)
+    expect(global.fetch).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('CR mode: createGroup with a dynamic group sends dynamicFilters in spec', async () => {
+    mockUsePersistence.mockReturnValue({ isEnabled: true, isActive: true })
+    const { result, unmount } = renderHook(() => useClusterGroups())
+
+    await act(async () => {
+      await result.current.createGroup({
+        name: 'dyn-cr',
+        kind: 'dynamic',
+        clusters: [],
+        query: { filters: [{ field: 'healthy', operator: 'eq', value: 'true' }] },
+      })
+    })
+
+    expect(mockCreateCRGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { name: 'dyn-cr' },
+        spec: expect.objectContaining({
+          dynamicFilters: [{ field: 'healthy', operator: 'eq', value: 'true' }],
+          staticMembers: undefined,
+        }),
+      })
+    )
+    unmount()
+  })
+
+  it('CR mode: updateGroup with a dynamic group sends dynamicFilters', async () => {
+    mockUsePersistence.mockReturnValue({ isEnabled: true, isActive: true })
+    mockCRGroups.push({
+      metadata: { name: 'existing-dyn' },
+      spec: {
+        dynamicFilters: [{ field: 'healthy', operator: 'eq', value: 'true' }],
+      },
+      status: { matchedClusters: ['c1'] },
+    })
+
+    const { result, unmount } = renderHook(() => useClusterGroups())
+
+    await act(async () => {
+      await result.current.updateGroup('existing-dyn', { color: 'purple' })
+    })
+
+    expect(mockUpdateCRGroup).toHaveBeenCalledWith(
+      'existing-dyn',
+      expect.objectContaining({
+        spec: expect.objectContaining({
+          dynamicFilters: expect.arrayContaining([{ field: 'healthy', operator: 'eq', value: 'true' }]),
+          color: 'purple',
+        }),
+      })
+    )
+    unmount()
+  })
+
+  it('evaluateGroup: dynamic group with no query returns existing clusters', async () => {
+    // group.kind === 'dynamic' but group.query is undefined → returns group.clusters
+    seedGroups([{ name: 'dyn-no-query', kind: 'dynamic', clusters: ['fallback-c1'] }])
+    const { result, unmount } = renderHook(() => useClusterGroups())
+
+    let evaluated: string[] = []
+    await act(async () => {
+      evaluated = await result.current.evaluateGroup('dyn-no-query')
+    })
+
+    expect(evaluated).toEqual(['fallback-c1'])
+    unmount()
+  })
 })


### PR DESCRIPTION
Fixes #10978

## Summary

Adds 24 new targeted unit tests to push coverage from 90.27% → 91%+.

### DashboardCustomizer.test.tsx (+20 tests)
- All `initialSection` variants: `widgets`, `create-dashboard`, `card-factory`, `stat-factory`, `collections`
- `SECTIONS_WITH_PREVIEW` logic: preview panel shown for `cards` and `collections`, hidden for `widgets`
- Collections section: renders `TemplateGallerySection` only when `onApplyTemplate` is provided
- Footer Reset Dashboard button (rendered when `isCustomized=true` + `onReset`)
- `handleAddCards` and `handleApplyTemplate` callback wiring
- `onAddTemplate` converting template cards to `CardSuggestion` format
- `onCardCreated` inline callback in card-factory section
- Sidebar `onSectionChange` switching between sections
- Undo/Redo button click handlers
- Updated mocks: `DashboardCustomizerSidebar`, `UnifiedCardsSection`, `TemplateGallerySection`, `CardFactoryModal` now expose trigger buttons for callback testing

### useClusterGroups.test.ts (+4 tests)
- `updateGroup` in localStorage mode when group name not found → skips backend sync fetch
- `localGroupToCR` dynamic group path: `dynamicFilters` populated, `staticMembers` undefined
- CR mode `updateGroup` with dynamic group sends `dynamicFilters` correctly
- `evaluateGroup` with dynamic group missing `query` → returns existing clusters