### PR TITLE
🐛 Wire MISSION_FETCH_TIMEOUT through fetchWithRetry options

### DIFF
--- a/web/e2e/helpers/fetchWithRetry.ts
+++ b/web/e2e/helpers/fetchWithRetry.ts
@@ -12,13 +12,20 @@ const MAX_RETRIES = 3
 /** Base delay between retries in milliseconds */
 const RETRY_BASE_DELAY_MS = 1_000
 
-/** Request timeout per attempt in milliseconds */
-const PER_ATTEMPT_TIMEOUT_MS = 30_000
+/** Default request timeout per attempt in milliseconds */
+const DEFAULT_PER_ATTEMPT_TIMEOUT_MS = 30_000
+
+export interface FetchWithRetryOptions {
+  /** Per-attempt timeout in milliseconds (default: 30 000) */
+  timeout?: number
+}
 
 export async function fetchWithRetry(
   request: APIRequestContext,
   url: string,
+  options?: FetchWithRetryOptions,
 ): Promise<APIResponse> {
+  const perAttemptTimeout = options?.timeout ?? DEFAULT_PER_ATTEMPT_TIMEOUT_MS
   let lastResp: APIResponse | null = null
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -28,7 +35,7 @@ export async function fetchWithRetry(
       await new Promise((r) => setTimeout(r, delay))
     }
 
-    lastResp = await request.get(url, { timeout: PER_ATTEMPT_TIMEOUT_MS })
+    lastResp = await request.get(url, { timeout: perAttemptTimeout })
 
     // Don't retry client errors (4xx) — only transient 5xx
     if (lastResp.ok() || lastResp.status() < 500) {

--- a/web/e2e/nightly/mission-explorer-import.spec.ts
+++ b/web/e2e/nightly/mission-explorer-import.spec.ts
@@ -173,6 +173,7 @@ async function fetchFixesIndex(page: Page): Promise<IndexEntry[]> {
   const resp = await fetchWithRetry(
     page.request,
     '/api/missions/file?path=fixes%2Findex.json',
+    { timeout: MISSION_FETCH_TIMEOUT },
   )
   expect(resp.ok(), `Index fetch failed: ${resp.status()}`).toBeTruthy()
   const body = await resp.json()
@@ -254,6 +255,7 @@ test.describe('Mission Explorer Import (Nightly)', () => {
         const fileResp = await fetchWithRetry(
           page.request,
           `/api/missions/file?path=${encodeURIComponent(path)}`,
+          { timeout: MISSION_FETCH_TIMEOUT },
         )
 
         if (!fileResp.ok()) {
@@ -358,6 +360,7 @@ test.describe('Mission Explorer Import (Nightly)', () => {
       const fileResp = await fetchWithRetry(
         page.request,
         `/api/missions/file?path=${encodeURIComponent(path)}`,
+        { timeout: MISSION_FETCH_TIMEOUT },
       )
       if (!fileResp.ok()) continue
 


### PR DESCRIPTION
Fixes #11001

Add optional `timeout` parameter to `fetchWithRetry()` so callers can override the default 30s per-attempt timeout. Wire `MISSION_FETCH_TIMEOUT` (15s) at all three call sites in `mission-explorer-import.spec.ts`.

### Problem
After PR #10988 migrated to `fetchWithRetry`, the `MISSION_FETCH_TIMEOUT` constant became unused dead code. The per-request timeout silently changed from 15s to 30s (hardcoded in `fetchWithRetry`), inflating worst-case suite runtime.

### Changes
- **`web/e2e/helpers/fetchWithRetry.ts`**: Accept optional `FetchWithRetryOptions` with `timeout` field; default to 30s when not specified (backward-compatible).
- **`web/e2e/nightly/mission-explorer-import.spec.ts`**: Pass `{ timeout: MISSION_FETCH_TIMEOUT }` at all three `fetchWithRetry` call sites.