### PR TITLE

Add unit test covering the worker-active IndexedDB mirror write path in web/src/lib/cache/index.ts (line ~699).

### Changes
- **cache-coverage.test.ts**: New worker-active IndexedDB mirror write describe block with two tests:
  - Verifies _idbStorage.set is called with correct key/data when workerRpc is active
  - Verifies no duplicate IDB mirror call when workerRpc is null (fallback mode)
- **cache/index.ts**: Exposes _idbStorage via __testables for test spying

### DIFF
--- a/web/src/lib/cache/__tests__/cache-coverage.test.ts
+++ b/web/src/lib/cache/__tests__/cache-coverage.test.ts
@@ -1000,6 +1000,90 @@ describe('saveMeta localStorage fallback', () => {
 })
 
 // ============================================================================
+// Worker-active IndexedDB mirror write (#10985)
+// ============================================================================
+
+describe('worker-active IndexedDB mirror write', () => {
+  it('mirrors data to _idbStorage.set when workerRpc is active', async () => {
+    // Mock the Worker constructor so initCacheWorker() doesn't try to spawn a real worker
+    const originalWorker = globalThis.Worker
+    globalThis.Worker = vi.fn() as unknown as typeof Worker
+
+    // Make CacheWorkerRpc constructor return a mock with the required methods
+    const { CacheWorkerRpc } = await import('../workerRpc')
+    const mockRpc = {
+      waitForReady: vi.fn().mockResolvedValue(undefined),
+      set: vi.fn(),
+      get: vi.fn().mockResolvedValue(null),
+      getStats: vi.fn().mockResolvedValue({ keys: [], count: 0 }),
+      deleteKey: vi.fn(),
+      clear: vi.fn().mockResolvedValue(undefined),
+      setMeta: vi.fn(),
+      getMeta: vi.fn().mockResolvedValue(null),
+      migrate: vi.fn().mockResolvedValue(undefined),
+    }
+    vi.mocked(CacheWorkerRpc).mockImplementation(() => mockRpc as unknown as InstanceType<typeof CacheWorkerRpc>)
+
+    const mod = await importFresh()
+    const { useCache, initCacheWorker, isSQLiteWorkerActive, __testables: testables } = mod
+
+    // Activate the SQLite worker path
+    await initCacheWorker()
+    expect(isSQLiteWorkerActive()).toBe(true)
+
+    // Spy on the IndexedDB storage mirror target
+    const idbSetSpy = vi.spyOn(testables._idbStorage, 'set').mockResolvedValue(undefined)
+
+    const testData = [1, 2, 3]
+    const { result } = renderHook(() => useCache({
+      key: 'idb-mirror-test',
+      fetcher: () => Promise.resolve(testData),
+      initialData: [] as number[],
+      autoRefresh: false,
+    }))
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    // The mirror write should have been called with the correct key and data
+    expect(idbSetSpy).toHaveBeenCalledWith('idb-mirror-test', testData)
+
+    idbSetSpy.mockRestore()
+    globalThis.Worker = originalWorker
+  })
+
+  it('does not mirror to IDB when workerRpc is null (fallback mode)', async () => {
+    // Without calling initCacheWorker, workerRpc stays null
+    const mod = await importFresh()
+    const { useCache, isSQLiteWorkerActive, __testables: testables } = mod
+
+    expect(isSQLiteWorkerActive()).toBe(false)
+
+    const idbSetSpy = vi.spyOn(testables._idbStorage, 'set').mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useCache({
+      key: 'idb-no-mirror-test',
+      fetcher: () => Promise.resolve(['a', 'b']),
+      initialData: [] as string[],
+      autoRefresh: false,
+    }))
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    // _idbStorage.set IS called because it's the active cacheStorage backend (not mirror)
+    // but only once — no additional mirror call since workerRpc is null.
+    // The cacheStorage.set call goes through _idbStorage directly.
+    const callCount = idbSetSpy.mock.calls.filter(c => c[0] === 'idb-no-mirror-test').length
+    expect(callCount).toBe(1) // exactly one call from cacheStorage.set, no mirror duplicate
+
+    idbSetSpy.mockRestore()
+  })
+})
+
+// ============================================================================
 // clearSessionSnapshots edge cases
 // ============================================================================
 

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -1703,4 +1703,6 @@ export const __testables = {
   MAX_FAILURES,
   FAILURE_BACKOFF_MULTIPLIER,
   MAX_BACKOFF_INTERVAL,
+  /** Exposed for testing the worker→IDB mirror write path. */
+  _idbStorage,
 }


### PR DESCRIPTION
Fixes #10985

Add unit test covering the worker-active IndexedDB mirror write path in `web/src/lib/cache/index.ts` (line ~699).

### Changes
- **cache-coverage.test.ts**: New `worker-active IndexedDB mirror write` describe block with two tests:
  - Verifies `_idbStorage.set` is called with correct key/data when `workerRpc` is active
  - Verifies no duplicate IDB mirror call when `workerRpc` is null (fallback mode)
- **cache/index.ts**: Exposes `_idbStorage` via `__testables` for test spying