### PR TITLE
🐛 Fix Playwright RED: clusters page filter and row count assertions

### DIFF
--- a/web/e2e/Clusters.spec.ts
+++ b/web/e2e/Clusters.spec.ts
@@ -294,21 +294,18 @@ test.describe('Clusters Page', () => {
       // asserting hidden clusters — firefox/webkit may batch the DOM update. (#10956)
       await expect(healthyTab).toHaveClass(/bg-green-500/, { timeout: 5000 })
 
-      // Only healthy-cluster must be visible
-      // Scope assertions to clusters-page to exclude sidebar cluster status
-      // widget which shows all cluster names regardless of the active filter.
-      // Use .first() — cluster name can appear in both the list row and header. #10790
-      const clustersPage = page.getByTestId('clusters-page')
-      await expect(clustersPage.getByText('healthy-cluster').first()).toBeVisible({ timeout: 5000 })
+      // Only healthy-cluster must be visible in the ClusterGrid.
+      // Use cluster-row-* testids (rendered by ClusterGrid) instead of text
+      // search — the ClusterHealth card also renders cluster names inside
+      // clusters-page, and those are NOT filtered by the tab. On Chromium the
+      // card hasn't mounted by the time assertions run; on Firefox/WebKit it
+      // has, causing getByText to find unfiltered names. (#10992)
+      await expect(page.locator('[data-testid="cluster-row-healthy-cluster"]')).toBeVisible({ timeout: 10_000 })
 
-      // Unhealthy clusters must NOT appear in the Healthy tab
-      // Scoped to clusters-page so sidebar cluster status widget doesn't cause
-      // false positives. Use .first() for strict-mode safety.
-      // Webkit/Firefox need extra time for the filter DOM update after
-      // sessionStorage-based SWR rehydration is replaced by fresh API data. (#10828)
+      // Unhealthy cluster rows must NOT appear in the Healthy tab.
       const FILTER_HIDDEN_TIMEOUT_MS = 20_000
-      await expect(clustersPage.getByText('unhealthy-with-nodes').first()).not.toBeVisible({ timeout: FILTER_HIDDEN_TIMEOUT_MS })
-      await expect(clustersPage.getByText('truly-unhealthy').first()).not.toBeVisible({ timeout: FILTER_HIDDEN_TIMEOUT_MS })
+      await expect(page.locator('[data-testid="cluster-row-unhealthy-with-nodes"]')).not.toBeVisible({ timeout: FILTER_HIDDEN_TIMEOUT_MS })
+      await expect(page.locator('[data-testid="cluster-row-truly-unhealthy"]')).not.toBeVisible({ timeout: FILTER_HIDDEN_TIMEOUT_MS })
     })
 
     test('Unhealthy stat count matches clusters shown after clicking Unhealthy tab', async ({ page }) => {
@@ -359,15 +356,13 @@ test.describe('Clusters Page', () => {
       // Wait for the filter to visually activate before asserting hidden clusters. (#10956)
       await expect(unhealthyTab).toHaveClass(/bg-orange-500/, { timeout: 5000 })
 
-      // Only the truly unhealthy cluster should appear
-      // Scope assertions to clusters-page to exclude sidebar cluster status
-      // widget which shows all cluster names regardless of the active filter. #10790
-      const clustersPage = page.getByTestId('clusters-page')
-      await expect(clustersPage.getByText('unhealthy-no-nodes').first()).toBeVisible({ timeout: 5000 })
-      // Webkit/Firefox need extra time for the filter DOM update after
-      // sessionStorage-based SWR rehydration is replaced by fresh API data. (#10828)
+      // Only the truly unhealthy cluster row should appear in the ClusterGrid.
+      // Use cluster-row-* testids — the ClusterHealth card renders cluster
+      // names for ALL clusters regardless of filter tab. (#10992)
+      await expect(page.locator('[data-testid="cluster-row-unhealthy-no-nodes"]')).toBeVisible({ timeout: 10_000 })
+      // Healthy cluster row must NOT appear under the Unhealthy filter.
       const FILTER_HIDDEN_TIMEOUT_MS = 20_000
-      await expect(clustersPage.getByText('healthy-cluster').first()).not.toBeVisible({ timeout: FILTER_HIDDEN_TIMEOUT_MS })
+      await expect(page.locator('[data-testid="cluster-row-healthy-cluster"]')).not.toBeVisible({ timeout: FILTER_HIDDEN_TIMEOUT_MS })
     })
   })
 })

--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -522,35 +522,31 @@ test.describe('Dashboard Data Accuracy (#6459)', () => {
     // Wait for clusters page to fully render — Firefox/webkit may need extra time
     await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: PAGE_RENDER_TIMEOUT_MS })
 
-    // Wait for cluster data to actually render before counting rows.
-    // On webkit/firefox the SWR cache hydrates slower than Chromium, so
-    // the container can be visible before any cluster rows appear. (#10828)
-    // Use a hard assertion (no .catch) so failures surface instead of
-    // silently yielding 0 rows. (#10955)
+    // Wait for cluster data to actually render in the ClusterGrid before
+    // counting rows. Use cluster-row-* testids instead of text search —
+    // the ClusterHealth card also renders cluster.name as text inside
+    // clusters-page, and on Firefox/WebKit it can appear before ClusterGrid
+    // rows mount, causing getByText to resolve against the card rather than
+    // the grid. (#10828, #10993)
     const DATA_RENDER_TIMEOUT_MS = 20_000
-    const firstClusterName = page.getByText('accuracy-cluster-1').first()
-    await expect(firstClusterName).toBeVisible({ timeout: DATA_RENDER_TIMEOUT_MS })
+    const firstClusterRow = page.locator('[data-testid="cluster-row-accuracy-cluster-1"]')
+    await expect(firstClusterRow).toBeVisible({ timeout: DATA_RENDER_TIMEOUT_MS })
 
     // The clusters page renders a row per cluster. We count any element
-    // whose data-testid matches the cluster-row pattern. If the test
-    // infra doesn't expose cluster-row testids, fall back to counting
-    // by name strings — both must agree with EXPECTED_CLUSTER_COUNT.
+    // whose data-testid matches the cluster-row pattern.
     const rowsByTestId = page.locator('[data-testid^="cluster-row-"]')
     const rowCountByTestId = await rowsByTestId.count()
 
     let clustersPageCount = rowCountByTestId
     if (clustersPageCount === 0) {
-      // Fallback: count unique cluster-name text occurrences.
-      // Each name was already confirmed present (firstClusterName wait
-      // above succeeded), so use a reasonable timeout per name.
-      const NAME_CHECK_TIMEOUT_MS = 10_000
+      // Fallback: count unique cluster-row testids per cluster name.
       let found = 0
       for (let i = 1; i <= EXPECTED_CLUSTER_COUNT; i++) {
-        const nameLocator = page.getByText(`accuracy-cluster-${i}`).first()
-        const hasName = await nameLocator
-          .isVisible({ timeout: NAME_CHECK_TIMEOUT_MS })
+        const rowLocator = page.locator(`[data-testid="cluster-row-accuracy-cluster-${i}"]`)
+        const hasRow = await rowLocator
+          .isVisible({ timeout: DATA_RENDER_TIMEOUT_MS })
           .catch(() => false)
-        if (hasName) found++
+        if (hasRow) found++
       }
       clustersPageCount = found
     }


### PR DESCRIPTION
Fixes #10992
Fixes #10993

## Problem

Both Clusters page filter tests and Dashboard row count test fail on Firefox/WebKit (pass on Chromium).

**Root cause:** The `ClusterHealth` card (`web/src/components/cards/ClusterHealth.tsx:366`) renders `cluster.name` as visible text for ALL clusters inside the `clusters-page` test ID wrapper, regardless of the active filter tab. On Firefox/WebKit, this card mounts before or alongside ClusterGrid, so `getByText()` matches unfiltered cluster names in the card rather than the filtered grid.

## Fix

- **Clusters.spec.ts**: Replace `getByText()` assertions with `data-testid="cluster-row-*"` locators that target ClusterGrid rows exclusively. These testids only exist on grid items and respect the filter.
- **Dashboard.spec.ts**: Wait for `cluster-row-accuracy-cluster-1` testid (not text) before counting rows. Fallback also uses testid-based locators.

## Why this works

`cluster-row-{name}` testids are rendered by `SortableClusterItem` in ClusterGrid only — the ClusterHealth card has no such testids. By targeting these, assertions are immune to unfiltered cluster names appearing elsewhere in the page.