### PR TITLE
🐛 Fix Hardware Health: CORS auth for device inventory + retry recovery

### DIFF
--- a/pkg/agent/server_ops_predictions.go
+++ b/pkg/agent/server_ops_predictions.go
@@ -243,13 +243,7 @@ func (s *Server) handleMetricsHistory(w http.ResponseWriter, r *http.Request) {
 
 // handleDeviceAlerts returns current hardware device alerts
 func (s *Server) handleDeviceAlerts(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -281,13 +275,7 @@ func (s *Server) handleDeviceAlerts(w http.ResponseWriter, r *http.Request) {
 
 // handleDeviceAlertsClear clears a specific device alert
 func (s *Server) handleDeviceAlertsClear(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -330,13 +318,7 @@ func (s *Server) handleDeviceAlertsClear(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleDeviceInventory(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -107,7 +107,8 @@ export function HardwareHealthCard() {
     consecutiveFailures,
     isDemoFallback,
     error: fetchError,
-    refetch } = useCachedHardwareHealth()
+    refetch,
+    retryFetch } = useCachedHardwareHealth()
 
   const alerts = hwData.alerts
   const inventory = hwData.inventory
@@ -654,12 +655,12 @@ export function HardwareHealthCard() {
               <span>{fetchError}</span>
             </div>
             <button
-              onClick={() => refetch()}
+              onClick={() => retryFetch()}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded bg-red-500/20 hover:bg-red-500/30 transition-colors whitespace-nowrap"
               aria-label={t('cards:hardwareHealth.retryFetchAria')}
             >
               <RefreshCw className={cn('w-3 h-3', isRefreshing && 'animate-spin')} />
-              Retry
+              {t('common:common.retry', 'Retry')}
             </button>
           </div>
         </div>

--- a/web/src/components/cards/__tests__/HardwareHealthCard.test.tsx
+++ b/web/src/components/cards/__tests__/HardwareHealthCard.test.tsx
@@ -50,6 +50,7 @@ vi.mock('../../../hooks/useCachedData', () => ({
     consecutiveFailures: 0,
     error: null,
     refetch: vi.fn(),
+    retryFetch: vi.fn(),
   })),
 }))
 

--- a/web/src/hooks/__tests__/useCachedGPU.test.ts
+++ b/web/src/hooks/__tests__/useCachedGPU.test.ts
@@ -75,6 +75,7 @@ function defaultCache(overrides = {}) {
     consecutiveFailures: 0,
     lastRefresh: null,
     refetch: vi.fn(),
+    retryFetch: vi.fn(),
     ...overrides,
   }
 }

--- a/web/src/hooks/useCachedGPU.ts
+++ b/web/src/hooks/useCachedGPU.ts
@@ -384,7 +384,7 @@ export function useGPUHealthCronJob(cluster?: string) {
  * Hook for fetching hardware health data (device alerts + inventory) with caching.
  * Uses IndexedDB persistence so data survives navigation.
  */
-export function useCachedHardwareHealth(): CachedHookResult<HardwareHealthData> {
+export function useCachedHardwareHealth(): CachedHookResult<HardwareHealthData> & { retryFetch: () => Promise<void> } {
   const result = useCache({
     key: 'hardware-health',
     category: 'pods', // 30-second refresh
@@ -405,7 +405,8 @@ export function useCachedHardwareHealth(): CachedHookResult<HardwareHealthData> 
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch,
+    retryFetch: result.retryFetch }
 }
 
 /**

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -1119,6 +1119,8 @@ export interface UseCacheResult<T> {
   lastRefresh: number | null
   /** Manually trigger a refresh */
   refetch: () => Promise<void>
+  /** Reset failure counters and refetch — for explicit user retries */
+  retryFetch: () => Promise<void>
   /** Clear cache and refetch */
   clearAndRefetch: () => Promise<void>
   /** Whether demoWhenEmpty fallback is active (live data returned empty, showing demo data) */
@@ -1215,6 +1217,14 @@ export function useCache<T>({
   progressiveFetcherRef.current = progressiveFetcher
 
   const refetch = useCallback(async () => {
+    if (!effectiveEnabled || !keepAliveActive) return
+    await store.fetch(() => fetcherRef.current(), mergeRef.current, progressiveFetcherRef.current)
+  }, [effectiveEnabled, keepAliveActive, store])
+
+  /** Reset failure counters then refetch — use for explicit user-triggered retries
+   *  so backoff is cleared and the fetch runs immediately. */
+  const retryFetch = useCallback(async () => {
+    store.resetFailures()
     if (!effectiveEnabled || !keepAliveActive) return
     await store.fetch(() => fetcherRef.current(), mergeRef.current, progressiveFetcherRef.current)
   }, [effectiveEnabled, keepAliveActive, store])
@@ -1389,6 +1399,7 @@ export function useCache<T>({
     lastRefresh: state.lastRefresh,
     isDemoFallback: shouldFallbackToDemo || !effectiveEnabled || showOptimisticDemo,
     refetch,
+    retryFetch,
     clearAndRefetch }
 }
 


### PR DESCRIPTION
Fixes #10998
Fixes #10999

## Changes

**CORS fix (backend):** Refactored device handlers (`handleDeviceAlerts`, `handleDeviceAlertsClear`, `handleDeviceInventory`) to use `setCORSHeaders()` instead of manually setting CORS headers. The manual headers were missing `Access-Control-Allow-Credentials: true` and `Access-Control-Max-Age`, causing browsers to block credentialed requests (with `Authorization` header) — the handler's `Set()` calls overwrote the middleware-set values without including all required CORS response headers.

**Retry fix (frontend):** Added `retryFetch()` to `useCache` that calls `store.resetFailures()` before fetching, clearing the backoff state so the fetch runs immediately. The Retry button in HardwareHealthCard now uses `retryFetch()` instead of `refetch()`, which was silently keeping the exponential backoff growing and leaving the UI stuck after `MAX_FAILURES`.

Also internationalized the Retry button label via `t()`.