### PR TITLE
🌱 ci: fix Scorecard TokenPermissions + PinnedDependencies alerts

### DIFF
--- a/.github/workflows/acmm-level-monitor.yml
+++ b/.github/workflows/acmm-level-monitor.yml
@@ -11,6 +11,9 @@ on:
         required: false
         default: '5'
 
+permissions:
+  contents: read
+
 jobs:
   check-acmm-level:
     runs-on: ubuntu-latest

--- a/.github/workflows/kb-nightly-validation.yml
+++ b/.github/workflows/kb-nightly-validation.yml
@@ -4,11 +4,14 @@ on:
     - cron: '0 4 * * *'  # 4 AM UTC daily
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-kb:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
 
       - name: Validate mission structure
         run: |
@@ -35,7 +38,7 @@ jobs:
 
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: kb-validation-reports
           path: |

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   analysis:
-    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main  # internal org ref — intentional
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - Backend
-FROM golang:1.26-alpine AS backend-builder
+FROM golang:1.26-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS backend-builder
 
 WORKDIR /app
 

--- a/cmd/kc-agent/Dockerfile
+++ b/cmd/kc-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the kc-agent binary
-FROM golang:1.25-alpine AS builder
+FROM golang:1.25-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS builder
 
 WORKDIR /src
 
@@ -11,7 +11,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /kc-agent ./cmd/kc-agent
 
 # Stage 2: Minimal runtime image
-FROM alpine:3.21
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Fixes #11042

## Changes

- `kb-nightly-validation.yml`: add `permissions: contents: read` + pin action SHAs (`checkout@v4.2.2`, `upload-artifact@v4.3.3`)
- `acmm-level-monitor.yml`: add top-level `permissions: contents: read`
- `pr-verifier.yml`: pin `docker/login-action` to SHA (v4.1.0)
- `scorecard.yml`: add comment on intentional internal org ref `@main`
- `Dockerfile`: pin `golang:1.26-alpine` to digest
- `cmd/kc-agent/Dockerfile`: pin `golang:1.25-alpine` + `alpine:3.21` to digests

*Dispatched by reviewer agent — Pass 79*