### PR TITLE
🐛 Fix inaccurate cluster inventory

### DIFF
--- a/web/src/components/cards/ControlPlaneHealth.tsx
+++ b/web/src/components/cards/ControlPlaneHealth.tsx
@@ -26,7 +26,7 @@ export function ControlPlaneHealth() {
   // Fetch from all namespaces so we catch control-plane pods in both
   // kube-system (vanilla K8s) and openshift-* namespaces (OpenShift)
   const { pods: allPods, isLoading, isRefreshing, isDemoFallback, isFailed, consecutiveFailures } = useCachedPods()
-  const { clusters } = useClusters()
+  const { deduplicatedClusters: clusters } = useClusters()
   const [selectedCluster, setSelectedCluster] = useState<string | null>(null)
 
   // Pre-filter to control-plane namespaces for efficiency

--- a/web/src/components/cards/DataComplianceCards.tsx
+++ b/web/src/components/cards/DataComplianceCards.tsx
@@ -41,7 +41,7 @@ const DEMO_VAULT: VaultStatus = {
 export function VaultSecrets({ config: _config }: CardConfig) {
   const { t } = useTranslation()
   const { isDemoMode } = useDemoMode()
-  const { clusters: allClusters } = useClusters()
+  const { deduplicatedClusters: allClusters } = useClusters()
   const [vaultStatus, setVaultStatus] = useState<VaultStatus>(DEMO_VAULT)
   const [isLoading, setIsLoading] = useState(true)
   const [secretCount, setSecretCount] = useState(0)
@@ -212,7 +212,7 @@ const DEMO_ESO: ESOStatus = {
 export function ExternalSecrets({ config: _config }: CardConfig) {
   const { t } = useTranslation()
   const { isDemoMode } = useDemoMode()
-  const { clusters: allClusters } = useClusters()
+  const { deduplicatedClusters: allClusters } = useClusters()
   const [esoStatus, setEsoStatus] = useState<ESOStatus>(DEMO_ESO)
   const [isLoading, setIsLoading] = useState(true)
 

--- a/web/src/components/compliance/ComplianceReports.tsx
+++ b/web/src/components/compliance/ComplianceReports.tsx
@@ -20,7 +20,7 @@ type ReportFormat = 'pdf' | 'json'
 
 export const ComplianceReportsContent = memo(function ComplianceReportsContent() {
   const { frameworks, isLoading: fwLoading, refetch } = useComplianceFrameworks()
-  const { clusters } = useClusters()
+  const { deduplicatedClusters: clusters } = useClusters()
   const clusterNames = useMemo(() => clusters?.map((c: { name: string }) => c.name) ?? [], [clusters])
 
   const [selectedFw, setSelectedFw] = useState<string>('')

--- a/web/src/components/gitops/GitOps.tsx
+++ b/web/src/components/gitops/GitOps.tsx
@@ -90,7 +90,7 @@ function getTimeAgo(timestamp: string | undefined, t: TFunction): string {
 
 export function GitOps() {
   const { t } = useTranslation(['common', 'cards'])
-  const { clusters, isRefreshing: dataRefreshing, refetch } = useClusters()
+  const { clusters, deduplicatedClusters, isRefreshing: dataRefreshing, refetch } = useClusters()
   const { releases: helmReleases } = useHelmReleases()
   const { subscriptions: operatorSubs } = useOperatorSubscriptions()
   const { drillToAllHelm, drillToAllOperators } = useDrillDownActions()
@@ -138,10 +138,10 @@ export function GitOps() {
     c.context || c.name.split('/').pop() || ''
   const resolveAppCluster = (preferred: string): { cluster: string; ambiguous: boolean } => {
     if (preferred) return { cluster: preferred, ambiguous: false }
-    if (clusters.length === EXACTLY_ONE_CLUSTER) {
-      return { cluster: clusterDisplayName(clusters[0]), ambiguous: false }
+    if (deduplicatedClusters.length === EXACTLY_ONE_CLUSTER) {
+      return { cluster: clusterDisplayName(deduplicatedClusters[0]), ambiguous: false }
     }
-    return { cluster: '', ambiguous: clusters.length > EXACTLY_ONE_CLUSTER }
+    return { cluster: '', ambiguous: deduplicatedClusters.length > EXACTLY_ONE_CLUSTER }
   }
 
   // #5952 — detectAllDrift is now a callable ref so the refresh button can
@@ -260,9 +260,9 @@ export function GitOps() {
     detectAllDriftRef.current = detectAllDrift
     detectAllDrift()
     return () => { cancelled = true }
-    // resolveAppCluster depends on `clusters`, which is the effective dep here.
+    // resolveAppCluster depends on `deduplicatedClusters`, which is the effective dep here.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [clusters])
+  }, [deduplicatedClusters])
 
   // Handle sync action - open the sync dialog
   const handleSync = (app: GitOpsApp) => {

--- a/web/src/hooks/useCertManager.ts
+++ b/web/src/hooks/useCertManager.ts
@@ -208,7 +208,7 @@ function getDemoIssuers(): Issuer[] {
 
 export function useCertManager() {
   const { isDemoMode: demoMode } = useDemoMode()
-  const { clusters: allClusters } = useClusters()
+  const { deduplicatedClusters: allClusters } = useClusters()
 
   // Initialize state from cache — snapshot ref value to avoid reading ref during render
   const cachedData = useRef(loadFromCache())

--- a/web/src/hooks/useDataCompliance.ts
+++ b/web/src/hooks/useDataCompliance.ts
@@ -209,7 +209,7 @@ async function fetchClusterCompliance(cluster: string): Promise<ClusterComplianc
 
 export function useDataCompliance() {
   const { isDemoMode } = useDemoMode()
-  const { clusters: allClusters, isLoading: clustersLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
   const { status: certStatus, isLoading: certLoading } = useCertManager()
 
   // Snapshot ref value to avoid reading ref during render

--- a/web/src/hooks/useIntoto.ts
+++ b/web/src/hooks/useIntoto.ts
@@ -355,7 +355,7 @@ async function fetchSingleCluster(cluster: string): Promise<IntotoClusterStatus>
 
 export function useIntoto() {
   const { isDemoMode } = useDemoMode()
-  const { clusters: allClusters, isLoading: clustersLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
 
   // Snapshot ref value to avoid reading ref during render
   const cachedData = useRef(loadFromCache())

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -303,7 +303,7 @@ async function fetchSingleCluster(cluster: string): Promise<KubescapeClusterStat
 
 export function useKubescape() {
   const { isDemoMode } = useDemoMode()
-  const { clusters: allClusters, isLoading: clustersLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
 
   // Snapshot ref value to avoid reading ref during render
   const cachedData = useRef(loadFromCache())

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -323,7 +323,7 @@ async function fetchSingleCluster(cluster: string): Promise<KyvernoClusterStatus
 
 export function useKyverno() {
   const { isDemoMode } = useDemoMode()
-  const { clusters: allClusters, isLoading: clustersLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
 
   // Snapshot ref value to avoid reading ref during render
   const cachedData = useRef(loadFromCache())

--- a/web/src/hooks/useProviderHealth.ts
+++ b/web/src/hooks/useProviderHealth.ts
@@ -250,7 +250,7 @@ async function fetchProviders(clusterSnapshot: Array<{ name: string; server?: st
  * Uses useCache for persistent caching, SWR, and demo fallback.
  */
 export function useProviderHealth() {
-  const { clusters } = useClusters()
+  const { deduplicatedClusters: clusters } = useClusters()
 
   // Always use a stable cache key — refetch when the cluster set changes
   const clustersRef = useRef(clusters)

--- a/web/src/hooks/useRBACFindings.ts
+++ b/web/src/hooks/useRBACFindings.ts
@@ -322,7 +322,7 @@ const DEMO_FINDINGS: RBACFinding[] = [
 
 export function useRBACFindings() {
   const { isDemoMode } = useDemoMode()
-  const { clusters: allClusters, isLoading: clustersLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
 
   // Snapshot ref value to avoid reading ref during render
   const cachedData = useRef(loadFromCache())

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -235,7 +235,7 @@ async function fetchSingleCluster(cluster: string): Promise<TrivyClusterStatus> 
 
 export function useTrivy() {
   const { isDemoMode } = useDemoMode()
-  const { clusters: allClusters, isLoading: clustersLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
 
   // Snapshot ref value to avoid reading ref during render
   const cachedData = useRef(loadFromCache())


### PR DESCRIPTION
Fixes #10316

Fix cluster inventory accuracy by switching 12 hooks and components from raw `clusters` to `deduplicatedClusters` from `useClusters()`.

## Problem
Multiple kubeconfig contexts can point to the same physical cluster. Hooks and components that used the raw `clusters` list (instead of `deduplicatedClusters`) were:
- Over-counting clusters in `totalClusters` stats (e.g., Trivy, Kyverno, Kubescape showed inflated counts)
- Sending redundant health probes to the same physical server from different contexts
- Making incorrect single-cluster-vs-multi-cluster decisions (GitOps)

## Fix
Changed all cluster-counting and cluster-scanning code paths to use `deduplicatedClusters`, which collapses contexts sharing the same server URL into one entry:

**Hooks (8):** useDataCompliance, useTrivy, useRBACFindings, useKyverno, useKubescape, useIntoto, useCertManager, useProviderHealth

**Components (4):** GitOps, ControlPlaneHealth, DataComplianceCards (VaultSecrets + ExternalSecrets), ComplianceReports

The raw `clusters` list is still used where appropriate (e.g., context dropdown in GitOps).