### PR TITLE
🐛 Fix 26-route TypeError crashes and GPU Overview card visibility

### DIFF
--- a/web/src/components/cards/GPUOverview.tsx
+++ b/web/src/components/cards/GPUOverview.tsx
@@ -90,7 +90,7 @@ export function GPUOverview({ config: _config }: GPUOverviewProps) {
         .map(c => c.name)
     )
 
-  const hasReachableClusters = filteredClusters.some(c => c.reachable !== false && c.nodeCount !== undefined && c.nodeCount > 0)
+  const hasReachableClusters = filteredClusters.some(c => c.reachable !== false) || (isDemoMode || isDemoFallback)
 
   // Apply GPU type filter on top of useCardData filtered nodes
   // Also filter out nodes from unreachable clusters

--- a/web/src/components/compliance/GxPDashboard.tsx
+++ b/web/src/components/compliance/GxPDashboard.tsx
@@ -64,10 +64,15 @@ export const GxPDashboardContent = memo(function GxPDashboardContent() {
         authFetch('/api/compliance/gxp/chain/verify'),
       ])
       if (!smRes.ok || !recRes.ok || !sigRes.ok || !chainRes.ok) throw new Error('Failed to load GxP data')
-      setSummary(await smRes.json())
-      setRecords(await recRes.json())
-      setSignatures(await sigRes.json())
-      setChainStatus(await chainRes.json())
+      const smData = await smRes.json()
+      // Guard against non-object responses (e.g. catch-all mock returning [])
+      setSummary(smData && typeof smData === 'object' && !Array.isArray(smData) && 'config' in smData ? smData : null)
+      const recData = await recRes.json()
+      setRecords(Array.isArray(recData) ? recData : [])
+      const sigData = await sigRes.json()
+      setSignatures(Array.isArray(sigData) ? sigData : [])
+      const chainData = await chainRes.json()
+      setChainStatus(chainData && typeof chainData === 'object' && !Array.isArray(chainData) ? chainData : null)
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load GxP data')
     } finally {
@@ -120,11 +125,11 @@ export const GxPDashboardContent = memo(function GxPDashboardContent() {
         <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
           <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4">
             <div className="text-sm text-gray-400 mb-1">GxP Mode</div>
-            <div className={`text-xl font-bold ${summary.config.enabled ? 'text-emerald-400' : 'text-gray-500'}`}>
-              {summary.config.enabled ? '● ENABLED' : '○ DISABLED'}
+            <div className={`text-xl font-bold ${summary.config?.enabled ? 'text-emerald-400' : 'text-gray-500'}`}>
+              {summary.config?.enabled ? '● ENABLED' : '○ DISABLED'}
             </div>
             <div className="text-xs text-gray-500 mt-1">
-              {summary.config.append_only ? 'Append-only' : 'Standard'} mode
+              {summary.config?.append_only ? 'Append-only' : 'Standard'} mode
             </div>
           </div>
           <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4">
@@ -163,7 +168,7 @@ export const GxPDashboardContent = memo(function GxPDashboardContent() {
             </div>
             <div className="text-xs text-gray-500 mt-0.5">
               {chainStatus.verified_records}/{chainStatus.total_records} records verified
-              {' · '}Algorithm: {summary?.config.hash_algorithm || 'SHA-256'}
+              {' · '}Algorithm: {summary?.config?.hash_algorithm || 'SHA-256'}
               {' · '}Verified: {new Date(chainStatus.verified_at).toLocaleString()}
             </div>
           </div>
@@ -194,12 +199,12 @@ export const GxPDashboardContent = memo(function GxPDashboardContent() {
           </h2>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
             {[
-              { label: 'Mode', value: summary.config.enabled ? 'Enabled' : 'Disabled' },
-              { label: 'Enabled At', value: new Date(summary.config.enabled_at).toLocaleString() },
-              { label: 'Enabled By', value: summary.config.enabled_by },
-              { label: 'Append Only', value: summary.config.append_only ? 'Yes' : 'No' },
-              { label: 'Require Signature', value: summary.config.require_signature ? 'Yes' : 'No' },
-              { label: 'Hash Algorithm', value: summary.config.hash_algorithm },
+              { label: 'Mode', value: summary.config?.enabled ? 'Enabled' : 'Disabled' },
+              { label: 'Enabled At', value: summary.config?.enabled_at ? new Date(summary.config.enabled_at).toLocaleString() : '—' },
+              { label: 'Enabled By', value: summary.config?.enabled_by ?? '—' },
+              { label: 'Append Only', value: summary.config?.append_only ? 'Yes' : 'No' },
+              { label: 'Require Signature', value: summary.config?.require_signature ? 'Yes' : 'No' },
+              { label: 'Hash Algorithm', value: summary.config?.hash_algorithm ?? '—' },
             ].map(({ label, value }) => (
               <div key={label} className="p-3 bg-gray-900/50 rounded-lg">
                 <div className="text-xs text-gray-400">{label}</div>

--- a/web/src/components/compliance/RiskRegisterDashboard.tsx
+++ b/web/src/components/compliance/RiskRegisterDashboard.tsx
@@ -99,9 +99,13 @@ export const RiskRegisterDashboardContent = memo(function RiskRegisterDashboardC
         authFetch('/api/v1/compliance/erm/risk-register/summary'),
       ])
       if (!rRes.ok || !cRes.ok || !sRes.ok) throw new Error('Failed to fetch risk register data')
-      setRisks(await rRes.json())
-      setCategories(await cRes.json())
-      setSummary(await sRes.json())
+      const rData = await rRes.json()
+      setRisks(Array.isArray(rData) ? rData : [])
+      const cData = await cRes.json()
+      setCategories(Array.isArray(cData) ? cData : [])
+      const sData = await sRes.json()
+      // Guard against non-object responses (e.g. catch-all mock returning [])
+      setSummary(sData && typeof sData === 'object' && !Array.isArray(sData) && 'total_risks' in sData ? sData : null)
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
@@ -170,7 +174,7 @@ export const RiskRegisterDashboardContent = memo(function RiskRegisterDashboardC
           </div>
           <div className="bg-gray-800/50 rounded-lg p-4 border border-gray-700">
             <p className="text-sm text-gray-400">Avg Risk Score</p>
-            <p className="text-2xl font-bold text-orange-400">{summary.avg_risk_score.toFixed(1)}</p>
+            <p className="text-2xl font-bold text-orange-400">{(summary.avg_risk_score ?? 0).toFixed(1)}</p>
           </div>
         </div>
       )}
@@ -188,7 +192,7 @@ export const RiskRegisterDashboardContent = memo(function RiskRegisterDashboardC
             >
               <p className="text-xs text-gray-400 truncate">{cat.category}</p>
               <p className="text-lg font-bold text-white">{cat.count}</p>
-              <p className="text-xs text-gray-500">{cat.open} open · avg {cat.avg_score.toFixed(1)}</p>
+              <p className="text-xs text-gray-500">{cat.open} open · avg {(cat.avg_score ?? 0).toFixed(1)}</p>
             </button>
           ))}
         </div>

--- a/web/src/components/compliance/SBOMDashboard.tsx
+++ b/web/src/components/compliance/SBOMDashboard.tsx
@@ -95,9 +95,13 @@ export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
         authFetch('/api/v1/compliance/sbom/summary'),
       ])
       if (!pRes.ok || !vRes.ok || !sRes.ok) throw new Error('Failed to fetch SBOM data')
-      setPackages(await pRes.json())
-      setVulnerabilities(await vRes.json())
-      setSummary(await sRes.json())
+      const pData = await pRes.json()
+      setPackages(Array.isArray(pData) ? pData : [])
+      const vData = await vRes.json()
+      setVulnerabilities(Array.isArray(vData) ? vData : [])
+      const sData = await sRes.json()
+      // Guard against non-object responses (e.g. catch-all mock returning [])
+      setSummary(sData && typeof sData === 'object' && !Array.isArray(sData) && 'scan_status' in sData ? sData : null)
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
@@ -162,7 +166,7 @@ export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
               {summary.scan_status === 'completed' && <CheckCircle2 className="w-5 h-5 text-green-400" />}
               {summary.scan_status === 'in_progress' && <Loader2 className="w-5 h-5 text-blue-400 animate-spin" />}
               {summary.scan_status === 'failed' && <XCircle className="w-5 h-5 text-red-400" />}
-              <span className="text-lg font-semibold text-white capitalize">{summary.scan_status.replace('_', ' ')}</span>
+              <span className="text-lg font-semibold text-white capitalize">{(summary.scan_status ?? '').replace('_', ' ')}</span>
             </div>
           </div>
         </div>

--- a/web/src/components/settings/sections/ThemeSection.tsx
+++ b/web/src/components/settings/sections/ThemeSection.tsx
@@ -368,7 +368,7 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
             </StatusBadge>
           )}
           <span className="px-2 py-1 text-xs rounded bg-secondary text-muted-foreground">
-            Font: {currentTheme.font.family.split(',')[0].replace(/'/g, '')}
+            Font: {currentTheme.font?.family?.split(',')[0]?.replace(/'/g, '') ?? 'System'}
           </span>
         </div>
       </div>

--- a/web/src/hooks/useCachedOpenfeature.ts
+++ b/web/src/hooks/useCachedOpenfeature.ts
@@ -72,7 +72,7 @@ function rollupFlagStats(flags: OpenFeatureFlag[]): OpenFeatureFlagStats {
   let enabled = 0
   let disabled = 0
   for (const flag of flags ?? []) {
-    if (flag.enabled) {
+    if (flag?.enabled) {
       enabled++
     } else {
       disabled++
@@ -89,7 +89,7 @@ function rollupFlagStats(flags: OpenFeatureFlag[]): OpenFeatureFlagStats {
 function sumProviderEvaluations(providers: OpenFeatureProvider[]): number {
   let total = 0
   for (const provider of providers ?? []) {
-    total += provider.evaluations
+    total += provider?.evaluations ?? 0
   }
   return total
 }

--- a/web/src/hooks/useMetricsHistory.ts
+++ b/web/src/hooks/useMetricsHistory.ts
@@ -473,8 +473,8 @@ export function getMetricsHistoryContext(): string {
     }).filter((v): v is { cpu: number; mem: number } => v !== null)
 
     if (values.length > 0) {
-      const cpuTrend = values.map(v => `${v.cpu.toFixed(0)}%`).join(' → ')
-      const memTrend = values.map(v => `${v.mem.toFixed(0)}%`).join(' → ')
+      const cpuTrend = values.map(v => `${(v.cpu ?? 0).toFixed(0)}%`).join(' → ')
+      const memTrend = values.map(v => `${(v.mem ?? 0).toFixed(0)}%`).join(' → ')
       context += `${name}:\n  CPU: ${cpuTrend}\n  Memory: ${memTrend}\n`
     }
   })


### PR DESCRIPTION
Fixes #11030
Fixes #11031

## Root cause

The catch-all API mock in `liveMocks.ts` returns `[]` (empty array) for unmocked endpoints. Three compliance dashboards (GxPDashboard, RiskRegisterDashboard, SBOMDashboard) set this array as their `summary` state. Since arrays are truthy, the `{summary && (...)}` guards pass, but accessing `.config.enabled`, `.avg_risk_score.toFixed()`, and `.scan_status.replace()` on an array crashes with TypeError.

## Changes

- **GxPDashboard**: Validate response is a proper object with `config` key before setting state; add `?.` on all `summary.config.*` accesses
- **RiskRegisterDashboard**: Validate response shape; guard `.toFixed()` with `?? 0`
- **SBOMDashboard**: Validate response shape; guard `.replace()` with `?? ''`
- **useMetricsHistory**: Guard `.toFixed()` on potentially undefined `cpu`/`mem` values
- **ThemeSection**: Guard `.replace()` on potentially undefined `font.family`
- **useCachedOpenfeature**: Add null-safe access for flag/provider items
- **GPUOverview**: Relax `hasReachableClusters` check to work in demo/mock mode (fixes card not visible on /gpu-reservations)