### PR TITLE
🐛 Fix Playwright login tests failing on mobile-safari

### DIFF
--- a/web/e2e/Login.spec.ts
+++ b/web/e2e/Login.spec.ts
@@ -119,11 +119,15 @@ test.describe('Login Page — frontend-only (mocked backend)', () => {
     })
 
     // Mock GitHub auth endpoint failure — redirect back to /login with error
-    // param, matching real OAuth error flow (backend redirects to /login?error=)
+    // param, matching real OAuth error flow (backend redirects to /login?error=).
+    // Use a 200 + client-side redirect instead of status 302 because
+    // Playwright's route.fulfill() does not support redirect status codes
+    // (3xx) on WebKit / mobile-safari. (#11019, #11028)
     await page.route('**/auth/github', (route) =>
       route.fulfill({
-        status: 302,
-        headers: { Location: '/login?error=server_error' },
+        status: 200,
+        contentType: 'text/html',
+        body: '<script>location.replace("/login?error=server_error")</script>',
       })
     )
 


### PR DESCRIPTION
Fixes #11019
Fixes #11028

Playwright's `route.fulfill()` does not support redirect status codes (3xx) on WebKit / mobile-safari, causing the login error handling test to fail with:

```
Error: route.fulfill: Cannot fulfill with redirect status: 302
```

**Fix:** Replace `route.fulfill({ status: 302, headers: { Location: ... } })` with a `200` response containing a client-side `location.replace()` redirect. This achieves the same navigation behavior without using a 3xx status code that Playwright disallows on WebKit.