### PR TITLE
🐛 Fix GA4 anomalies: agent_token_failure trending + ksc_error spike

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -50,6 +50,8 @@ const AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'
 const AGENT_TOKEN_FETCH_TIMEOUT_MS = 5000
 
 let agentTokenPromise: Promise<string> | null = null
+/** Session-level dedup: only emit one agent_token_failure per page load */
+let agentTokenFailureEmitted = false
 
 /**
  * Lazily fetch the kc-agent token from the backend. The token is cached
@@ -75,14 +77,18 @@ function getAgentToken(): Promise<string> {
         const token = data.token || ''
         if (token) {
           localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, token)
-        } else {
+        } else if (!agentTokenFailureEmitted) {
+          agentTokenFailureEmitted = true
           emitAgentTokenFailure('empty token from /api/agent/token')
         }
         agentTokenPromise = null
         return token
       })
       .catch((err) => {
-        emitAgentTokenFailure(err?.message || 'network error')
+        if (!agentTokenFailureEmitted) {
+          agentTokenFailureEmitted = true
+          emitAgentTokenFailure(err?.message || 'network error')
+        }
         agentTokenPromise = null
         return ''
       })

--- a/web/src/lib/__tests__/analytics-events.test.ts
+++ b/web/src/lib/__tests__/analytics-events.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 vi.mock('../analytics-core', () => ({
   send: vi.fn(),
   setAnalyticsUserProperties: vi.fn(),
+  emitError: vi.fn(),
 }))
 
 vi.mock('../demoMode', () => ({
@@ -19,7 +20,7 @@ vi.mock('../analytics-session', () => ({
   getDeploymentType: vi.fn(() => 'localhost'),
 }))
 
-import { send, setAnalyticsUserProperties } from '../analytics-core'
+import { send, setAnalyticsUserProperties, emitError } from '../analytics-core'
 import { isDemoMode } from '../demoMode'
 import { getDeploymentType } from '../analytics-session'
 import { CAPABILITY_TOOL_EXEC, CAPABILITY_CHAT } from '../analytics-types'
@@ -203,6 +204,7 @@ import {
 
 const mockSend = vi.mocked(send)
 const mockSetProps = vi.mocked(setAnalyticsUserProperties)
+const mockEmitError = vi.mocked(emitError)
 const mockIsDemoMode = vi.mocked(isDemoMode)
 const mockGetDeploymentType = vi.mocked(getDeploymentType)
 
@@ -210,6 +212,7 @@ describe('analytics-events', () => {
   beforeEach(() => {
     mockSend.mockClear()
     mockSetProps.mockClear()
+    mockEmitError.mockClear()
     mockIsDemoMode.mockClear()
     mockGetDeploymentType.mockClear()
     mockIsDemoMode.mockReturnValue(false)
@@ -681,54 +684,54 @@ describe('analytics-events', () => {
   })
 
   describe('Auth / Connection Failure Detection', () => {
-    it('emitAgentTokenFailure sends ksc_error with agent_token_failure category', () => {
+    it('emitAgentTokenFailure delegates to throttled emitError with agent_token_failure category', () => {
       emitAgentTokenFailure('empty token from /api/agent/token')
-      expect(mockSend).toHaveBeenCalledWith('ksc_error', expect.objectContaining({
-        error_category: 'agent_token_failure',
-        error_detail: 'empty token from /api/agent/token',
-      }))
+      expect(mockEmitError).toHaveBeenCalledWith(
+        'agent_token_failure',
+        'empty token from /api/agent/token',
+      )
     })
 
     it('emitAgentTokenFailure truncates reason to 100 characters', () => {
       const longReason = 'x'.repeat(150)
       emitAgentTokenFailure(longReason)
-      expect(mockSend).toHaveBeenCalledWith('ksc_error', expect.objectContaining({
-        error_category: 'agent_token_failure',
-        error_detail: 'x'.repeat(100),
-      }))
+      expect(mockEmitError).toHaveBeenCalledWith(
+        'agent_token_failure',
+        'x'.repeat(100),
+      )
     })
 
-    it('emitWsAuthMissing sends ksc_error with ws_auth_missing category and strips host', () => {
+    it('emitWsAuthMissing delegates to throttled emitError with ws_auth_missing category and strips host', () => {
       emitWsAuthMissing('ws://127.0.0.1:8585/ws')
-      expect(mockSend).toHaveBeenCalledWith('ksc_error', expect.objectContaining({
-        error_category: 'ws_auth_missing',
-        error_detail: '/ws',
-      }))
+      expect(mockEmitError).toHaveBeenCalledWith(
+        'ws_auth_missing',
+        '/ws',
+      )
     })
 
-    it('emitSseAuthFailure sends ksc_error with sse_auth_failure category and strips host', () => {
+    it('emitSseAuthFailure delegates to throttled emitError with sse_auth_failure category and strips host', () => {
       emitSseAuthFailure('http://127.0.0.1:8585/pods/stream?cluster=test')
-      expect(mockSend).toHaveBeenCalledWith('ksc_error', expect.objectContaining({
-        error_category: 'sse_auth_failure',
-        error_detail: '/pods/stream?cluster=test',
-      }))
+      expect(mockEmitError).toHaveBeenCalledWith(
+        'sse_auth_failure',
+        '/pods/stream?cluster=test',
+      )
     })
 
-    it('emitSessionRefreshFailure sends ksc_error with session_refresh_failure category', () => {
+    it('emitSessionRefreshFailure delegates to throttled emitError with session_refresh_failure category', () => {
       emitSessionRefreshFailure('network error')
-      expect(mockSend).toHaveBeenCalledWith('ksc_error', expect.objectContaining({
-        error_category: 'session_refresh_failure',
-        error_detail: 'network error',
-      }))
+      expect(mockEmitError).toHaveBeenCalledWith(
+        'session_refresh_failure',
+        'network error',
+      )
     })
 
     it('emitSessionRefreshFailure truncates reason to 100 characters', () => {
       const longReason = 'a]'.repeat(75)
       emitSessionRefreshFailure(longReason)
-      expect(mockSend).toHaveBeenCalledWith('ksc_error', expect.objectContaining({
-        error_category: 'session_refresh_failure',
-        error_detail: longReason.slice(0, 100),
-      }))
+      expect(mockEmitError).toHaveBeenCalledWith(
+        'session_refresh_failure',
+        longReason.slice(0, 100),
+      )
     })
   })
 

--- a/web/src/lib/analytics-events.ts
+++ b/web/src/lib/analytics-events.ts
@@ -6,7 +6,7 @@
  * in the original analytics.ts.
  */
 
-import { send, setAnalyticsUserProperties } from './analytics-core'
+import { send, setAnalyticsUserProperties, emitError } from './analytics-core'
 import type { InstallCopySource, ProviderSummary } from './analytics-types'
 import { CAPABILITY_TOOL_EXEC, CAPABILITY_CHAT } from './analytics-types'
 import { isDemoMode } from './demoMode'
@@ -353,41 +353,28 @@ export function emitDemoModeToggled(enabled: boolean) {
 // ── Auth / Connection Failure Detection ─────────────────────────
 // These events fire when auth-dependent paths silently degrade.
 // The GA4 error monitor workflow creates issues when thresholds are hit.
+//
+// All four emitters route through emitError() so they respect the
+// per-category throttle window (ERROR_THROTTLE_MS) and the per-page
+// session budget (MAX_ERRORS_PER_PAGE_SESSION). Previously they called
+// send('ksc_error', …) directly — bypassing throttling — which caused
+// the agent_token_failure 4→17→60 trend (#10996) and the ksc_error
+// 3.6× spike (#11006) when polling hooks retried every 30-60 s.
 
 export function emitAgentTokenFailure(reason: string) {
-  send('ksc_error', {
-    error_code: 'agent_token_failure',
-    error_category: 'agent_token_failure',
-    error_detail: reason.slice(0, 100),
-    error_page: typeof window !== 'undefined' ? window.location.pathname : '',
-  })
+  emitError('agent_token_failure', reason.slice(0, 100))
 }
 
 export function emitWsAuthMissing(url: string) {
-  send('ksc_error', {
-    error_code: 'ws_auth_missing',
-    error_category: 'ws_auth_missing',
-    error_detail: url.replace(/^wss?:\/\/[^/]+/, '').slice(0, 100),
-    error_page: typeof window !== 'undefined' ? window.location.pathname : '',
-  })
+  emitError('ws_auth_missing', url.replace(/^wss?:\/\/[^/]+/, '').slice(0, 100))
 }
 
 export function emitSseAuthFailure(url: string) {
-  send('ksc_error', {
-    error_code: 'sse_auth_failure',
-    error_category: 'sse_auth_failure',
-    error_detail: url.replace(/^https?:\/\/[^/]+/, '').slice(0, 100),
-    error_page: typeof window !== 'undefined' ? window.location.pathname : '',
-  })
+  emitError('sse_auth_failure', url.replace(/^https?:\/\/[^/]+/, '').slice(0, 100))
 }
 
 export function emitSessionRefreshFailure(reason: string) {
-  send('ksc_error', {
-    error_code: 'session_refresh_failure',
-    error_category: 'session_refresh_failure',
-    error_detail: reason.slice(0, 100),
-    error_page: typeof window !== 'undefined' ? window.location.pathname : '',
-  })
+  emitError('session_refresh_failure', reason.slice(0, 100))
 }
 
 // ── kc-agent Connection ─────────────────────────────────────────


### PR DESCRIPTION
Fixes #10996
Fixes #11006

## Root Cause

The four auth failure emitters (`emitAgentTokenFailure`, `emitWsAuthMissing`, `emitSseAuthFailure`, `emitSessionRefreshFailure`) called `send('ksc_error', ...)` **directly**, bypassing the `emitError()` throttle system that all other `ksc_error` events use.

When the kc-agent backend is unreachable, polling hooks call `agentFetch()` every 30–60s. Each failure resets `agentTokenPromise = null`, causing the next call to re-attempt and fire another unthrottled `ksc_error` event — producing the 4→17→60 trend (#10996) and contributing to the 3.6× `ksc_error` spike (#11006).

## Fix

1. **Route auth emitters through `emitError()`** — subjects them to the existing per-category 60s throttle window and per-page session budget (`MAX_ERRORS_PER_PAGE_SESSION = 50`).

2. **Add session-level dedup in `shared.ts`** — only emit one `agent_token_failure` GA4 event per page load, matching the pattern `wsAuth.ts` already uses for `ws_auth_missing`.

3. **Update tests** to assert on `emitError()` delegation instead of raw `send()` calls.