### PR TITLE
🐛 Fix Playwright cross-browser: Firefox/WebKit test failures

### DIFF
--- a/web/e2e/Clusters.spec.ts
+++ b/web/e2e/Clusters.spec.ts
@@ -265,12 +265,12 @@ test.describe('Clusters Page', () => {
         }
       })
 
-      // Clear sessionStorage before reload so the SWR cache layer cannot
-      // sync-rehydrate stale cluster data from the beforeEach mock. The
-      // addInitScript also clears it, but on firefox/webkit the browser may
-      // restore sessionStorage from its page cache before addInitScript runs,
-      // causing a brief render with stale data that outraces the filter. (#10956)
-      await page.evaluate(() => sessionStorage.clear())
+      // sessionStorage is already cleared by the addInitScript registered in
+      // setupClustersTest (which runs on every navigation including reload).
+      // Previously we had a page.evaluate(() => sessionStorage.clear()) here,
+      // but on Firefox/WebKit the page can be mid-navigation when evaluate()
+      // runs, causing "Execution context was destroyed" errors. Removing the
+      // redundant evaluate avoids this race entirely. (#11003)
 
       // Reload and wait for the test-specific mock API response to arrive so
       // the component renders with the correct cluster set before we interact.
@@ -280,6 +280,12 @@ test.describe('Clusters Page', () => {
       ])
       await page.waitForLoadState('domcontentloaded')
       await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 20_000 })
+
+      // Wait for the cluster grid to stabilize — on Firefox/WebKit the SWR
+      // cache can trigger a secondary render after domcontentloaded that
+      // briefly restores stale data. Waiting for the expected row ensures
+      // the test-specific mock data has fully propagated. (#11003)
+      await expect(page.locator('[data-testid="cluster-row-healthy-cluster"]')).toBeVisible({ timeout: 20_000 })
 
       // The Healthy filter button should show count 1 (only healthy-cluster with healthy: true)
       // Webkit/Firefox render filter tabs slightly later — use generous timeout
@@ -332,9 +338,9 @@ test.describe('Clusters Page', () => {
         }
       })
 
-      // Clear sessionStorage before reload so the SWR cache layer cannot
-      // sync-rehydrate stale cluster data from the beforeEach mock. (#10956)
-      await page.evaluate(() => sessionStorage.clear())
+      // sessionStorage is already cleared by the addInitScript registered in
+      // setupClustersTest (which runs on every navigation including reload).
+      // See the Healthy filter test above for why page.evaluate was removed. (#11003)
 
       // Reload and wait for the test-specific mock API response to arrive so
       // the component renders with the correct cluster set before we interact.
@@ -344,6 +350,9 @@ test.describe('Clusters Page', () => {
       ])
       await page.waitForLoadState('domcontentloaded')
       await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 20_000 })
+
+      // Wait for the cluster grid to stabilize with the test-specific mock data. (#11003)
+      await expect(page.locator('[data-testid="cluster-row-unhealthy-no-nodes"]')).toBeVisible({ timeout: 20_000 })
 
       // The Unhealthy tab must show count 1
       const FILTER_TAB_TIMEOUT_MS = 20_000

--- a/web/e2e/Events.spec.ts
+++ b/web/e2e/Events.spec.ts
@@ -55,8 +55,13 @@ async function setupEventsTest(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('kc-demo-mode', 'true')
+    localStorage.setItem('kc-has-session', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
     localStorage.setItem('kc-agent-setup-dismissed', 'true')
+    localStorage.setItem('kc-backend-status', JSON.stringify({
+      available: true,
+      timestamp: Date.now(),
+    }))
   })
 
   await page.goto('/events')

--- a/web/e2e/Settings.spec.ts
+++ b/web/e2e/Settings.spec.ts
@@ -1,9 +1,15 @@
 import { test, expect, Page } from '@playwright/test'
+import { mockApiFallback } from './helpers/setup'
 
 /**
  * Sets up authentication and MCP mocks for settings tests
  */
 async function setupSettingsTest(page: Page) {
+  // Catch-all API mock prevents unmocked requests hanging in webkit/firefox.
+  // Without this, unmocked /health requests cause Firefox/WebKit to redirect
+  // to /login before the settings page loads. (#11003)
+  await mockApiFallback(page)
+
   // Mock authentication
   await page.route('**/api/me', (route) =>
     route.fulfill({
@@ -36,12 +42,21 @@ async function setupSettingsTest(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('kc-demo-mode', 'true')
+    localStorage.setItem('kc-has-session', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
     localStorage.setItem('kc-agent-setup-dismissed', 'true')
+    localStorage.setItem('kc-backend-status', JSON.stringify({
+      available: true,
+      timestamp: Date.now(),
+    }))
   })
 
   await page.goto('/settings')
   await page.waitForLoadState('domcontentloaded')
+  // WebKit is slower to stabilize after domcontentloaded — wait for the
+  // settings page element so assertions don't time out. (#11003)
+  const SETTINGS_VISIBLE_TIMEOUT_MS = 15_000
+  await page.getByTestId('settings-page').waitFor({ state: 'visible', timeout: SETTINGS_VISIBLE_TIMEOUT_MS })
 }
 
 test.describe('Settings Page', () => {
@@ -84,6 +99,10 @@ test.describe('Settings Page', () => {
 
       await page.reload()
       await page.waitForLoadState('domcontentloaded')
+      // Wait for the settings page to fully stabilize before evaluating
+      // localStorage — on Firefox/WebKit the execution context can be
+      // destroyed if evaluate() runs mid-navigation. (#11003)
+      await expect(page.getByTestId('settings-page')).toBeVisible({ timeout: 15_000 })
 
       // Theme should be preserved in localStorage
       const storedTheme = await page.evaluate(() =>

--- a/web/e2e/custom-dashboard.spec.ts
+++ b/web/e2e/custom-dashboard.spec.ts
@@ -1,9 +1,16 @@
 import { test, expect, Page } from '@playwright/test'
+import { mockApiFallback } from './helpers/setup'
 
 /**
  * Sets up authentication and mocks for custom dashboard tests
  */
 async function setupCustomDashboardTest(page: Page) {
+  // Catch-all API mock prevents unmocked requests hanging in webkit/firefox.
+  // Must be registered BEFORE specific mocks (Playwright matches in reverse
+  // registration order). Without this, unmocked /health and /api/** requests
+  // cause Firefox/WebKit to wait indefinitely or redirect to /login. (#11003)
+  await mockApiFallback(page)
+
   // Mock authentication
   await page.route('**/api/me', (route) =>
     route.fulfill({
@@ -57,12 +64,21 @@ async function setupCustomDashboardTest(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('kc-demo-mode', 'true')
+    localStorage.setItem('kc-has-session', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
     localStorage.setItem('kc-agent-setup-dismissed', 'true')
+    localStorage.setItem('kc-backend-status', JSON.stringify({
+      available: true,
+      timestamp: Date.now(),
+    }))
   })
 
   await page.goto('/')
   await page.waitForLoadState('domcontentloaded')
+  // WebKit/Firefox are slower to stabilize the DOM — wait for the root
+  // layout to be visible so assertions in beforeEach don't time out. (#11003)
+  const ROOT_VISIBLE_TIMEOUT_MS = 15_000
+  await page.locator('#root').waitFor({ state: 'visible', timeout: ROOT_VISIBLE_TIMEOUT_MS })
 }
 
 test.describe('Custom Dashboard Creation', () => {


### PR DESCRIPTION
Fixes #11003
Fixes #11018

Fixes Playwright cross-browser test failures for cluster filter, add-card, and persist tests on Firefox and WebKit.

## Root Causes

1. **Cluster filter (Clusters.spec.ts)**: `page.evaluate(() => sessionStorage.clear())` before reload throws 'Execution context was destroyed' on Firefox/WebKit because the page navigates mid-evaluate. Removed the redundant call (addInitScript already clears sessionStorage on every navigation). Added explicit waits for cluster-row testids so mock data propagates before filter assertions.

2. **Add-card / navigation redirect (custom-dashboard.spec.ts, Settings.spec.ts)**: Missing `mockApiFallback()` and missing `kc-has-session` / `kc-backend-status` localStorage keys cause the auth guard to redirect to `/login` on Firefox/WebKit (where the redirect fires synchronously).

3. **Theme persist (Settings.spec.ts)**: `page.evaluate()` after reload races with navigation on Firefox/WebKit. Added explicit wait for settings-page visibility before evaluating localStorage.

Also fixed Events.spec.ts with the same missing localStorage keys for consistency.