### PR TITLE
🐛 Fix test failures: app roundtrip + coverage suite

### DIFF
--- a/.github/workflows/console-app-roundtrip.yml
+++ b/.github/workflows/console-app-roundtrip.yml
@@ -313,18 +313,24 @@ jobs:
           # 5. Clean up FIRST so a verify failure still closes the issue.
           #    Use || true so cleanup failures don't mask the attribution result.
           echo "Closing + locking test issue #$ISSUE_NUMBER..."
-          curl -sS -X PATCH \
+          CLOSE_HTTP=$(curl -sS -o /dev/null -w "%{http_code}" -X PATCH \
             -H "Authorization: Bearer $TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -d '{"state":"closed","state_reason":"not_planned"}' \
-            "https://api.github.com/repos/${TEST_REPO_OWNER}/${TEST_REPO_NAME}/issues/${ISSUE_NUMBER}" \
-            > /dev/null || echo "::warning::Failed to close test issue #$ISSUE_NUMBER (curl exit $?)"
-          curl -sS -X PUT \
+            "https://api.github.com/repos/${TEST_REPO_OWNER}/${TEST_REPO_NAME}/issues/${ISSUE_NUMBER}") \
+            || echo "::warning::curl failed closing test issue #$ISSUE_NUMBER (exit $?)"
+          if [ "$CLOSE_HTTP" != "200" ]; then
+            echo "::warning::Failed to close test issue #$ISSUE_NUMBER — HTTP $CLOSE_HTTP"
+          fi
+          LOCK_HTTP=$(curl -sS -o /dev/null -w "%{http_code}" -X PUT \
             -H "Authorization: Bearer $TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -d '{"lock_reason":"resolved"}' \
-            "https://api.github.com/repos/${TEST_REPO_OWNER}/${TEST_REPO_NAME}/issues/${ISSUE_NUMBER}/lock" \
-            > /dev/null || echo "::warning::Failed to lock test issue #$ISSUE_NUMBER (curl exit $?)"
+            "https://api.github.com/repos/${TEST_REPO_OWNER}/${TEST_REPO_NAME}/issues/${ISSUE_NUMBER}/lock") \
+            || echo "::warning::curl failed locking test issue #$ISSUE_NUMBER (exit $?)"
+          if [ "$LOCK_HTTP" != "204" ] && [ "$LOCK_HTTP" != "200" ]; then
+            echo "::warning::Failed to lock test issue #$ISSUE_NUMBER — HTTP $LOCK_HTTP"
+          fi
 
           # 6a. PRIMARY assertion — the issue.user.login must match the
           #     App's bot login. GitHub stamps this from the auth token

--- a/web/src/hooks/__tests__/useSelfUpgrade.test.ts
+++ b/web/src/hooks/__tests__/useSelfUpgrade.test.ts
@@ -29,6 +29,9 @@ describe('useSelfUpgrade', () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.restoreAllMocks()
+    // Ensure stubGlobal('location', ...) from pollForRestart tests is always cleaned up,
+    // even if the test fails before reaching vi.unstubAllGlobals() inline.
+    vi.unstubAllGlobals()
   })
 
   it('starts with null status and not loading', () => {
@@ -475,8 +478,6 @@ describe('useSelfUpgrade', () => {
       expect(result.current.restartComplete).toBe(true)
       expect(result.current.isRestarting).toBe(false)
     })
-
-    vi.unstubAllGlobals()
   })
 
   it('pollForRestart sets restartError after max poll time exceeded', async () => {


### PR DESCRIPTION
Fixes #11007
Fixes #11027

### Changes

**useSelfUpgrade test** (#11027): The `pollForRestart completes when /health returns 200` test failed with `TypeError: Cannot redefine property: reload` because `vi.spyOn(window.location, 'reload')` doesn't work in jsdom. A prior commit fixed this with `vi.stubGlobal`, but the cleanup (`vi.unstubAllGlobals()`) was inline in the test body — if the test fails before reaching cleanup, the stub leaks to subsequent tests. Moved cleanup to `afterEach` for robustness.

**App roundtrip workflow** (#11007): The close/lock API calls discarded HTTP responses via `> /dev/null`, so HTTP errors (403, 422) were silently swallowed and test issues were left open. Now captures HTTP status codes and emits warnings on failure.