### PR TITLE
🐛 Fix 5 failing unit tests causing coverage RED (89%<91%)

### DIFF
--- a/web/src/components/cards/__tests__/ControlPlaneHealth.test.tsx
+++ b/web/src/components/cards/__tests__/ControlPlaneHealth.test.tsx
@@ -30,6 +30,7 @@ vi.mock('../../../hooks/useCachedData', () => ({
 vi.mock('../../../hooks/useMCP', () => ({
   useClusters: () => ({
     clusters: [{ name: 'cluster-1' }],
+    deduplicatedClusters: [{ name: 'cluster-1' }],
     isLoading: false,
   }),
 }))

--- a/web/src/components/gitops/GitOps.test.tsx
+++ b/web/src/components/gitops/GitOps.test.tsx
@@ -38,7 +38,7 @@ let mockClusters: Array<{ name: string; context?: string }> = []
 const stableRefetch = vi.fn()
 vi.mock('../../hooks/useMCP', () => ({
   useClusters: () => ({
-    clusters: mockClusters, isRefreshing: false, refetch: stableRefetch,
+    clusters: mockClusters, deduplicatedClusters: mockClusters, isRefreshing: false, refetch: stableRefetch,
   }),
   useHelmReleases: () => ({ releases: [] }),
   useOperatorSubscriptions: () => ({ subscriptions: [] }),

--- a/web/src/hooks/__tests__/useCertManager.test.ts
+++ b/web/src/hooks/__tests__/useCertManager.test.ts
@@ -17,6 +17,7 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false }))
 const mockUseClusters = vi.fn(() => ({
   clusters: [],
+  deduplicatedClusters: [],
   isLoading: false,
 }))
 const mockKubectlProxy = { exec: vi.fn() }
@@ -120,6 +121,7 @@ function mockExecJson(items: unknown[], exitCode = 0) {
 function setClusters(...names: string[]) {
   mockUseClusters.mockReturnValue({
     clusters: names.map(name => ({ name, reachable: true })),
+    deduplicatedClusters: names.map(name => ({ name, reachable: true })),
     isLoading: false,
   })
 }
@@ -245,7 +247,7 @@ describe('useCertManager', () => {
 
   describe('no clusters', () => {
     it('stops loading when clusters list is empty', async () => {
-      mockUseClusters.mockReturnValue({ clusters: [], isLoading: false })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false })
 
       const { useCertManager } = await loadModule()
       const { result } = renderHook(() => useCertManager())
@@ -1020,6 +1022,11 @@ describe('useCertManager', () => {
     it('filters out non-reachable clusters', async () => {
       mockUseClusters.mockReturnValue({
         clusters: [
+          { name: 'reachable-1', reachable: true },
+          { name: 'unreachable-1', reachable: false },
+          { name: 'reachable-2', reachable: true },
+        ],
+        deduplicatedClusters: [
           { name: 'reachable-1', reachable: true },
           { name: 'unreachable-1', reachable: false },
           { name: 'reachable-2', reachable: true },

--- a/web/src/hooks/__tests__/useProviderHealth-coverage.test.ts
+++ b/web/src/hooks/__tests__/useProviderHealth-coverage.test.ts
@@ -26,7 +26,6 @@ const mockCacheResult = {
 // ---------------------------------------------------------------------------
 
 vi.mock('../mcp/shared', () => ({
-    createCachedHook: vi.fn(),
   agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
   clusterCacheRef: { clusters: [] },
   REFRESH_INTERVAL_MS: 120_000,
@@ -34,7 +33,6 @@ vi.mock('../mcp/shared', () => ({
 }))
 
 vi.mock('../useDemoMode', () => ({
-    createCachedHook: vi.fn(),
   getDemoMode: () => mockDemoMode,
   useDemoMode: () => ({ isDemoMode: mockDemoMode }),
 }))
@@ -56,12 +54,10 @@ vi.mock('../../lib/constants/network', async (importOriginal) => {
 })
 
 vi.mock('../mcp/clusters', () => ({
-    createCachedHook: vi.fn(),
   useClusters: () => ({ clusters: mockClusters }),
 }))
 
 vi.mock('../../lib/cache', () => ({
-    createCachedHook: vi.fn(),
   useCache: (opts: { fetcher: () => Promise<unknown>; demoData?: unknown[] }) => {
     capturedFetcher = opts.fetcher
     return {
@@ -72,7 +68,6 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 vi.mock('../../components/ui/CloudProviderIcon', () => ({
-    createCachedHook: vi.fn(),
   detectCloudProvider: (name: string, server?: string) => {
     if (name.includes('eks') || (server && server.includes('amazonaws'))) return 'eks'
     if (name.includes('gke') || (server && server.includes('googleapis'))) return 'gke'
@@ -95,7 +90,6 @@ vi.mock('../../components/ui/CloudProviderIcon', () => ({
 }))
 
 vi.mock('../useLocalAgent', () => ({
-    createCachedHook: vi.fn(),
   isAgentUnavailable: vi.fn(() => true),
   reportAgentDataSuccess: vi.fn(),
   reportAgentDataError: vi.fn(),

--- a/web/src/lib/cache/__tests__/cache-coverage.test.ts
+++ b/web/src/lib/cache/__tests__/cache-coverage.test.ts
@@ -1009,8 +1009,6 @@ describe('worker-active IndexedDB mirror write', () => {
     const originalWorker = globalThis.Worker
     globalThis.Worker = vi.fn() as unknown as typeof Worker
 
-    // Make CacheWorkerRpc constructor return a mock with the required methods
-    const { CacheWorkerRpc } = await import('../workerRpc')
     const mockRpc = {
       waitForReady: vi.fn().mockResolvedValue(undefined),
       set: vi.fn(),
@@ -1022,7 +1020,12 @@ describe('worker-active IndexedDB mirror write', () => {
       getMeta: vi.fn().mockResolvedValue(null),
       migrate: vi.fn().mockResolvedValue(undefined),
     }
-    vi.mocked(CacheWorkerRpc).mockImplementation(() => mockRpc as unknown as InstanceType<typeof CacheWorkerRpc>)
+
+    // Must register doMock BEFORE importFresh() resets modules, so the fresh
+    // cache/index.ts import picks up the mocked CacheWorkerRpc constructor.
+    vi.doMock('../workerRpc', () => ({
+      CacheWorkerRpc: vi.fn().mockImplementation(() => mockRpc),
+    }))
 
     const mod = await importFresh()
     const { useCache, initCacheWorker, isSQLiteWorkerActive, __testables: testables } = mod


### PR DESCRIPTION
Fixes the coverage RED indicator (89% < 91% threshold) by repairing 5 failing test files.

## Root Causes & Fixes

### 1. `useProviderHealth-coverage.test.ts`
Spurious `createCachedHook: vi.fn()` entries were present in 6 `vi.mock` factory objects. `createCachedHook` is not exported by these modules, causing Vitest to throw on all tests in the file. **Fix:** removed the invalid export lines.

### 2. `ControlPlaneHealth.test.tsx` & `GitOps.test.tsx`
Both components destructure `deduplicatedClusters` from `useClusters()`, but the test mocks only returned `clusters`. This caused a `TypeError: Cannot read properties of undefined (reading 'length')` at render time. **Fix:** added `deduplicatedClusters` to both mocks.

### 3. `useCertManager.test.ts`
`useCertManager.ts` uses `deduplicatedClusters.filter()` at line 231, but every `mockReturnValue` call in the test omitted `deduplicatedClusters`. **Fix:** added `deduplicatedClusters` to the default mock factory, the `setClusters()` helper, and the two inline `mockReturnValue` calls.

### 4. `cache-coverage.test.ts` (worker-active IDB mirror test)
The test set `vi.mocked(CacheWorkerRpc).mockImplementation(...)` on the old mock instance, then called `importFresh()` which runs `vi.resetModules()`. This invalidated the old module instance — `initCacheWorker()` in the fresh module used a new `vi.fn()` with no implementation, so it returned `undefined` instead of `mockRpc`. **Fix:** replaced the stale-instance approach with `vi.doMock('../workerRpc', ...)` registered _before_ `importFresh()` so the fresh module import picks up the correct constructor.