### PR TITLE
test: pure function tests for 7 hooks (coverage batch 14)

### DIFF
--- a/web/src/components/cards/envoy_status/__tests__/useCachedEnvoy-pure.test.ts
+++ b/web/src/components/cards/envoy_status/__tests__/useCachedEnvoy-pure.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest'
+import { __testables } from '../useCachedEnvoy'
+import type { EnvoyListener, EnvoyUpstreamCluster } from '../demoData'
+
+const { summarize, deriveHealth, buildEnvoyStatus } = __testables
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns zero counts for empty arrays', () => {
+    const result = summarize([], [])
+    expect(result).toEqual({
+      totalListeners: 0,
+      activeListeners: 0,
+      totalClusters: 0,
+      healthyClusters: 0,
+    })
+  })
+
+  it('counts active listeners', () => {
+    const listeners: EnvoyListener[] = [
+      { name: 'l1', address: '0.0.0.0', port: 80, status: 'active', routeCount: 2 },
+      { name: 'l2', address: '0.0.0.0', port: 443, status: 'draining', routeCount: 1 },
+      { name: 'l3', address: '0.0.0.0', port: 8080, status: 'active', routeCount: 3 },
+    ]
+    const result = summarize(listeners, [])
+    expect(result.totalListeners).toBe(3)
+    expect(result.activeListeners).toBe(2)
+  })
+
+  it('counts healthy clusters (all endpoints healthy)', () => {
+    const clusters: EnvoyUpstreamCluster[] = [
+      { name: 'c1', type: 'EDS', endpointsTotal: 3, endpointsHealthy: 3, status: 'healthy' },
+      { name: 'c2', type: 'EDS', endpointsTotal: 2, endpointsHealthy: 1, status: 'degraded' },
+      { name: 'c3', type: 'STATIC', endpointsTotal: 1, endpointsHealthy: 1, status: 'healthy' },
+    ]
+    const result = summarize([], clusters)
+    expect(result.totalClusters).toBe(3)
+    expect(result.healthyClusters).toBe(2)
+  })
+
+  it('does not count clusters with zero total endpoints as healthy', () => {
+    const clusters: EnvoyUpstreamCluster[] = [
+      { name: 'c1', type: 'EDS', endpointsTotal: 0, endpointsHealthy: 0, status: 'unknown' },
+    ]
+    const result = summarize([], clusters)
+    expect(result.healthyClusters).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveHealth', () => {
+  it('returns not-installed when both arrays are empty', () => {
+    expect(deriveHealth([], [])).toBe('not-installed')
+  })
+
+  it('returns healthy when all listeners active and all clusters fully healthy', () => {
+    const listeners: EnvoyListener[] = [
+      { name: 'l1', address: '0.0.0.0', port: 80, status: 'active', routeCount: 2 },
+    ]
+    const clusters: EnvoyUpstreamCluster[] = [
+      { name: 'c1', type: 'EDS', endpointsTotal: 3, endpointsHealthy: 3, status: 'healthy' },
+    ]
+    expect(deriveHealth(listeners, clusters)).toBe('healthy')
+  })
+
+  it('returns degraded when a cluster has unhealthy endpoints', () => {
+    const listeners: EnvoyListener[] = [
+      { name: 'l1', address: '0.0.0.0', port: 80, status: 'active', routeCount: 2 },
+    ]
+    const clusters: EnvoyUpstreamCluster[] = [
+      { name: 'c1', type: 'EDS', endpointsTotal: 3, endpointsHealthy: 2, status: 'degraded' },
+    ]
+    expect(deriveHealth(listeners, clusters)).toBe('degraded')
+  })
+
+  it('returns degraded when a listener is inactive', () => {
+    const listeners: EnvoyListener[] = [
+      { name: 'l1', address: '0.0.0.0', port: 80, status: 'draining', routeCount: 1 },
+    ]
+    const clusters: EnvoyUpstreamCluster[] = [
+      { name: 'c1', type: 'EDS', endpointsTotal: 3, endpointsHealthy: 3, status: 'healthy' },
+    ]
+    expect(deriveHealth(listeners, clusters)).toBe('degraded')
+  })
+
+  it('returns healthy when cluster has zero total endpoints (not considered unhealthy)', () => {
+    const listeners: EnvoyListener[] = [
+      { name: 'l1', address: '0.0.0.0', port: 80, status: 'active', routeCount: 2 },
+    ]
+    const clusters: EnvoyUpstreamCluster[] = [
+      { name: 'c1', type: 'EDS', endpointsTotal: 0, endpointsHealthy: 0, status: 'unknown' },
+    ]
+    expect(deriveHealth(listeners, clusters)).toBe('healthy')
+  })
+
+  it('returns healthy with only listeners and no clusters', () => {
+    const listeners: EnvoyListener[] = [
+      { name: 'l1', address: '0.0.0.0', port: 80, status: 'active', routeCount: 2 },
+    ]
+    expect(deriveHealth(listeners, [])).toBe('healthy')
+  })
+
+  it('returns healthy with only clusters and no listeners', () => {
+    const clusters: EnvoyUpstreamCluster[] = [
+      { name: 'c1', type: 'EDS', endpointsTotal: 1, endpointsHealthy: 1, status: 'healthy' },
+    ]
+    expect(deriveHealth([], clusters)).toBe('healthy')
+  })
+
+  it('returns degraded when listener status is warming', () => {
+    const listeners: EnvoyListener[] = [
+      { name: 'l1', address: '0.0.0.0', port: 80, status: 'warming', routeCount: 0 },
+    ]
+    expect(deriveHealth(listeners, [])).toBe('degraded')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildEnvoyStatus
+// ---------------------------------------------------------------------------
+
+describe('buildEnvoyStatus', () => {
+  const stats = {
+    requestsPerSecond: 100,
+    activeConnections: 50,
+    totalRequests: 10000,
+    http5xxRate: 0.01,
+  }
+
+  it('builds a complete status object', () => {
+    const listeners: EnvoyListener[] = [
+      { name: 'l1', address: '0.0.0.0', port: 80, status: 'active', routeCount: 2 },
+    ]
+    const clusters: EnvoyUpstreamCluster[] = [
+      { name: 'c1', type: 'EDS', endpointsTotal: 3, endpointsHealthy: 3, status: 'healthy' },
+    ]
+    const result = buildEnvoyStatus(listeners, clusters, stats)
+
+    expect(result.health).toBe('healthy')
+    expect(result.listeners).toBe(listeners)
+    expect(result.clusters).toBe(clusters)
+    expect(result.stats).toBe(stats)
+    expect(result.summary.totalListeners).toBe(1)
+    expect(result.summary.activeListeners).toBe(1)
+    expect(result.summary.totalClusters).toBe(1)
+    expect(result.summary.healthyClusters).toBe(1)
+    expect(result.lastCheckTime).toBeTruthy()
+  })
+
+  it('derives degraded health when applicable', () => {
+    const listeners: EnvoyListener[] = [
+      { name: 'l1', address: '0.0.0.0', port: 80, status: 'draining', routeCount: 1 },
+    ]
+    const result = buildEnvoyStatus(listeners, [], stats)
+    expect(result.health).toBe('degraded')
+  })
+
+  it('derives not-installed health for empty arrays', () => {
+    const result = buildEnvoyStatus([], [], stats)
+    expect(result.health).toBe('not-installed')
+  })
+
+  it('includes lastCheckTime as ISO string', () => {
+    const result = buildEnvoyStatus([], [], stats)
+    expect(() => new Date(result.lastCheckTime)).not.toThrow()
+    expect(new Date(result.lastCheckTime).getTime()).toBeGreaterThan(0)
+  })
+})

--- a/web/src/hooks/__tests__/useDeployMissions-funcs.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions-funcs.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { __testables } from '../useDeployMissions'
+
+const {
+  safeReplicaCount,
+  isTerminalStatus,
+  authHeaders,
+  loadMissions,
+  saveMissions,
+  runWithConcurrency,
+  MISSIONS_STORAGE_KEY,
+  MAX_MISSIONS,
+  MAX_STATUS_FAILURES,
+  MAX_NETWORK_FAILURES,
+  MIN_ACTIVE_MS,
+  LOG_RECOVERY_EXTRA_POLLS,
+  DEPLOY_POLL_MAX_CONCURRENCY,
+} = __testables
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('constants', () => {
+  it('MISSIONS_STORAGE_KEY is a non-empty string', () => {
+    expect(typeof MISSIONS_STORAGE_KEY).toBe('string')
+    expect(MISSIONS_STORAGE_KEY.length).toBeGreaterThan(0)
+  })
+
+  it('MAX_MISSIONS is a positive integer', () => {
+    expect(Number.isInteger(MAX_MISSIONS)).toBe(true)
+    expect(MAX_MISSIONS).toBeGreaterThan(0)
+  })
+
+  it('MAX_STATUS_FAILURES is a positive integer', () => {
+    expect(Number.isInteger(MAX_STATUS_FAILURES)).toBe(true)
+    expect(MAX_STATUS_FAILURES).toBeGreaterThan(0)
+  })
+
+  it('MAX_NETWORK_FAILURES is greater than MAX_STATUS_FAILURES', () => {
+    expect(MAX_NETWORK_FAILURES).toBeGreaterThan(MAX_STATUS_FAILURES)
+  })
+
+  it('MIN_ACTIVE_MS is a positive number', () => {
+    expect(MIN_ACTIVE_MS).toBeGreaterThan(0)
+  })
+
+  it('LOG_RECOVERY_EXTRA_POLLS is a non-negative integer', () => {
+    expect(Number.isInteger(LOG_RECOVERY_EXTRA_POLLS)).toBe(true)
+    expect(LOG_RECOVERY_EXTRA_POLLS).toBeGreaterThanOrEqual(0)
+  })
+
+  it('DEPLOY_POLL_MAX_CONCURRENCY is a positive integer', () => {
+    expect(Number.isInteger(DEPLOY_POLL_MAX_CONCURRENCY)).toBe(true)
+    expect(DEPLOY_POLL_MAX_CONCURRENCY).toBeGreaterThan(0)
+  })
+})
+
+describe('safeReplicaCount', () => {
+  it('returns a valid number as-is', () => {
+    expect(safeReplicaCount(3)).toBe(3)
+    expect(safeReplicaCount(0)).toBe(0)
+  })
+
+  it('parses numeric strings', () => {
+    expect(safeReplicaCount('5')).toBe(5)
+    expect(safeReplicaCount('0')).toBe(0)
+  })
+
+  it('returns fallback for NaN inputs', () => {
+    expect(safeReplicaCount('not-a-number')).toBe(0)
+    expect(safeReplicaCount('not-a-number', 1)).toBe(1)
+  })
+
+  it('returns fallback for null and undefined', () => {
+    expect(safeReplicaCount(null)).toBe(0)
+    expect(safeReplicaCount(undefined)).toBe(0)
+  })
+
+  it('returns fallback for Infinity and -Infinity', () => {
+    expect(safeReplicaCount(Infinity)).toBe(0)
+    expect(safeReplicaCount(-Infinity)).toBe(0)
+    expect(safeReplicaCount(Infinity, 2)).toBe(2)
+  })
+
+  it('returns fallback for negative numbers', () => {
+    expect(safeReplicaCount(-1)).toBe(0)
+    expect(safeReplicaCount(-100, 5)).toBe(5)
+  })
+
+  it('handles objects and arrays by returning fallback', () => {
+    expect(safeReplicaCount({})).toBe(0)
+    expect(safeReplicaCount([])).toBe(0)
+  })
+
+  it('uses custom fallback when provided', () => {
+    expect(safeReplicaCount(NaN, 42)).toBe(42)
+  })
+})
+
+describe('isTerminalStatus', () => {
+  it('returns true for orbit', () => {
+    expect(isTerminalStatus('orbit')).toBe(true)
+  })
+
+  it('returns true for abort', () => {
+    expect(isTerminalStatus('abort')).toBe(true)
+  })
+
+  it('returns true for partial', () => {
+    expect(isTerminalStatus('partial')).toBe(true)
+  })
+
+  it('returns false for launching', () => {
+    expect(isTerminalStatus('launching')).toBe(false)
+  })
+
+  it('returns false for deploying', () => {
+    expect(isTerminalStatus('deploying')).toBe(false)
+  })
+})
+
+describe('authHeaders', () => {
+  it('returns Authorization header when token exists', () => {
+    localStorage.setItem('token', 'my-secret-token')
+    const headers = authHeaders()
+    expect(headers).toEqual({ Authorization: 'Bearer my-secret-token' })
+  })
+
+  it('returns empty object when no token', () => {
+    expect(authHeaders()).toEqual({})
+  })
+
+  it('returns empty object when token is removed', () => {
+    localStorage.setItem('token', 'abc')
+    localStorage.removeItem('token')
+    expect(authHeaders()).toEqual({})
+  })
+})
+
+function makeMission(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'test-1',
+    workload: 'nginx',
+    namespace: 'default',
+    sourceCluster: 'cluster-a',
+    targetClusters: ['cluster-b'],
+    status: 'deploying',
+    clusterStatuses: [
+      { cluster: 'cluster-b', status: 'applying', replicas: 1, readyReplicas: 0 },
+    ],
+    startedAt: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('loadMissions', () => {
+  it('returns empty array when nothing stored', () => {
+    expect(loadMissions()).toEqual([])
+  })
+
+  it('loads missions from the primary storage key', () => {
+    const missions = [makeMission()]
+    localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
+    const loaded = loadMissions()
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0].id).toBe('test-1')
+  })
+
+  it('migrates from old split keys', () => {
+    const active = [makeMission({ id: 'active-1' })]
+    const history = [makeMission({ id: 'history-1', status: 'orbit' })]
+    localStorage.setItem('kubestellar-missions-active', JSON.stringify(active))
+    localStorage.setItem('kubestellar-missions-history', JSON.stringify(history))
+
+    const loaded = loadMissions()
+    expect(loaded).toHaveLength(2)
+    expect(loaded.map((m: { id: string }) => m.id)).toContain('active-1')
+    expect(loaded.map((m: { id: string }) => m.id)).toContain('history-1')
+
+    expect(localStorage.getItem('kubestellar-missions-active')).toBeNull()
+    expect(localStorage.getItem('kubestellar-missions-history')).toBeNull()
+    expect(localStorage.getItem(MISSIONS_STORAGE_KEY)).not.toBeNull()
+  })
+
+  it('limits migrated missions to MAX_MISSIONS', () => {
+    const many = Array.from({ length: MAX_MISSIONS + 10 }, (_, i) =>
+      makeMission({ id: `m-${i}` }),
+    )
+    localStorage.setItem('kubestellar-missions-active', JSON.stringify(many))
+
+    const loaded = loadMissions()
+    expect(loaded).toHaveLength(MAX_MISSIONS)
+  })
+
+  it('returns empty array on corrupt JSON', () => {
+    localStorage.setItem(MISSIONS_STORAGE_KEY, '{not valid json')
+    expect(loadMissions()).toEqual([])
+  })
+
+  it('returns empty array when old keys have empty arrays', () => {
+    localStorage.setItem('kubestellar-missions-active', JSON.stringify([]))
+    localStorage.setItem('kubestellar-missions-history', JSON.stringify([]))
+    const loaded = loadMissions()
+    expect(loaded).toEqual([])
+  })
+})
+
+describe('saveMissions', () => {
+  it('saves missions to localStorage', () => {
+    const missions = [makeMission()] as any[]
+    saveMissions(missions)
+    const stored = JSON.parse(localStorage.getItem(MISSIONS_STORAGE_KEY)!)
+    expect(stored).toHaveLength(1)
+    expect(stored[0].id).toBe('test-1')
+  })
+
+  it('truncates to MAX_MISSIONS', () => {
+    const many = Array.from({ length: MAX_MISSIONS + 10 }, (_, i) =>
+      makeMission({ id: `m-${i}` }),
+    ) as any[]
+    saveMissions(many)
+    const stored = JSON.parse(localStorage.getItem(MISSIONS_STORAGE_KEY)!)
+    expect(stored).toHaveLength(MAX_MISSIONS)
+  })
+
+  it('strips logs from active (non-terminal) missions', () => {
+    const missions = [
+      makeMission({
+        status: 'deploying',
+        clusterStatuses: [
+          { cluster: 'c1', status: 'applying', replicas: 1, readyReplicas: 0, logs: ['line1'] },
+        ],
+      }),
+    ] as any[]
+    saveMissions(missions)
+    const stored = JSON.parse(localStorage.getItem(MISSIONS_STORAGE_KEY)!)
+    expect(stored[0].clusterStatuses[0].logs).toBeUndefined()
+  })
+
+  it('preserves logs for terminal missions', () => {
+    const missions = [
+      makeMission({
+        status: 'orbit',
+        clusterStatuses: [
+          { cluster: 'c1', status: 'running', replicas: 1, readyReplicas: 1, logs: ['line1'] },
+        ],
+      }),
+    ] as any[]
+    saveMissions(missions)
+    const stored = JSON.parse(localStorage.getItem(MISSIONS_STORAGE_KEY)!)
+    expect(stored[0].clusterStatuses[0].logs).toEqual(['line1'])
+  })
+
+  it('preserves logs for abort status', () => {
+    const missions = [
+      makeMission({
+        status: 'abort',
+        clusterStatuses: [
+          { cluster: 'c1', status: 'failed', replicas: 0, readyReplicas: 0, logs: ['error'] },
+        ],
+      }),
+    ] as any[]
+    saveMissions(missions)
+    const stored = JSON.parse(localStorage.getItem(MISSIONS_STORAGE_KEY)!)
+    expect(stored[0].clusterStatuses[0].logs).toEqual(['error'])
+  })
+
+  it('preserves logs for partial status', () => {
+    const missions = [
+      makeMission({
+        status: 'partial',
+        clusterStatuses: [
+          { cluster: 'c1', status: 'running', replicas: 1, readyReplicas: 1, logs: ['ok'] },
+        ],
+      }),
+    ] as any[]
+    saveMissions(missions)
+    const stored = JSON.parse(localStorage.getItem(MISSIONS_STORAGE_KEY)!)
+    expect(stored[0].clusterStatuses[0].logs).toEqual(['ok'])
+  })
+})
+
+describe('runWithConcurrency', () => {
+  it('returns results in order', async () => {
+    const tasks = [
+      () => Promise.resolve('a'),
+      () => Promise.resolve('b'),
+      () => Promise.resolve('c'),
+    ]
+    const results = await runWithConcurrency(tasks, 2)
+    expect(results).toEqual(['a', 'b', 'c'])
+  })
+
+  it('handles empty task array', async () => {
+    const results = await runWithConcurrency([], 3)
+    expect(results).toEqual([])
+  })
+
+  it('handles single task', async () => {
+    const results = await runWithConcurrency([() => Promise.resolve(42)], 1)
+    expect(results).toEqual([42])
+  })
+
+  it('respects concurrency limit', async () => {
+    let maxConcurrent = 0
+    let currentConcurrent = 0
+    const CONCURRENCY_LIMIT = 2
+    const TASK_COUNT = 6
+
+    const tasks = Array.from({ length: TASK_COUNT }, () => async () => {
+      currentConcurrent++
+      maxConcurrent = Math.max(maxConcurrent, currentConcurrent)
+      await new Promise(r => setTimeout(r, 10))
+      currentConcurrent--
+      return maxConcurrent
+    })
+
+    await runWithConcurrency(tasks, CONCURRENCY_LIMIT)
+    expect(maxConcurrent).toBeLessThanOrEqual(CONCURRENCY_LIMIT)
+  })
+
+  it('handles limit larger than task count', async () => {
+    const tasks = [() => Promise.resolve(1), () => Promise.resolve(2)]
+    const results = await runWithConcurrency(tasks, 100)
+    expect(results).toEqual([1, 2])
+  })
+
+  it('handles limit of zero by using at least 1 worker', async () => {
+    const tasks = [() => Promise.resolve('x')]
+    const results = await runWithConcurrency(tasks, 0)
+    expect(results).toEqual(['x'])
+  })
+
+  it('propagates rejections', async () => {
+    const tasks = [
+      () => Promise.resolve('ok'),
+      () => Promise.reject(new Error('boom')),
+    ]
+    await expect(runWithConcurrency(tasks, 2)).rejects.toThrow('boom')
+  })
+
+  it('preserves result types', async () => {
+    const tasks = [
+      () => Promise.resolve({ name: 'a', count: 1 }),
+      () => Promise.resolve({ name: 'b', count: 2 }),
+    ]
+    const results = await runWithConcurrency(tasks, 2)
+    expect(results[0].name).toBe('a')
+    expect(results[1].count).toBe(2)
+  })
+})

--- a/web/src/hooks/__tests__/useMultiClusterInsights-pure.test.ts
+++ b/web/src/hooks/__tests__/useMultiClusterInsights-pure.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from 'vitest'
+import { __testables } from '../useMultiClusterInsights'
+import type { ClusterEvent } from '../mcp/types'
+
+const {
+  workloadPrefix,
+  isCausallyRelated,
+  getDemoInsights,
+  REASON_FAMILIES,
+  REASON_TO_FAMILY,
+  SEVERITY_RANK,
+  MAX_TOP_INSIGHTS,
+  RESOURCE_IMBALANCE_THRESHOLD_PCT,
+  DELTA_SIGNIFICANCE_HIGH_PCT,
+  DELTA_SIGNIFICANCE_MEDIUM_PCT,
+  INFRA_ISSUE_MIN_WORKLOADS,
+  APP_BUG_MIN_CLUSTERS,
+  ROLLOUT_STATUS_IN_PROGRESS,
+  ROLLOUT_STATUS_COMPLETE,
+  ROLLOUT_STATUS_FAILED,
+  FULL_PROGRESS,
+  PARTIAL_PROGRESS,
+} = __testables
+
+// ---------------------------------------------------------------------------
+// workloadPrefix
+// ---------------------------------------------------------------------------
+
+describe('workloadPrefix', () => {
+  it('strips pod prefix and both RS + pod hash suffixes', () => {
+    expect(workloadPrefix('pod/api-server-7d9f8b6c4f-x2k4q')).toBe('api-server')
+  })
+
+  it('strips pod prefix and single hash suffix', () => {
+    expect(workloadPrefix('pod/api-server-abc12')).toBe('api-server')
+  })
+
+  it('strips deployment prefix', () => {
+    expect(workloadPrefix('deployment/api-server')).toBe('api-server')
+  })
+
+  it('strips replicaset prefix and hash', () => {
+    expect(workloadPrefix('replicaset/api-server-7d9f8b6c4f')).toBe('api-server')
+  })
+
+  it('strips statefulset prefix', () => {
+    expect(workloadPrefix('statefulset/redis-master')).toBe('redis-master')
+  })
+
+  it('strips daemonset prefix', () => {
+    expect(workloadPrefix('daemonset/fluentd')).toBe('fluentd')
+  })
+
+  it('strips job prefix', () => {
+    expect(workloadPrefix('job/backup-12345')).toBe('backup')
+  })
+
+  it('keeps non-workload refs as-is (node)', () => {
+    expect(workloadPrefix('node/worker-3')).toBe('node/worker-3')
+  })
+
+  it('keeps non-workload refs as-is (service)', () => {
+    expect(workloadPrefix('service/api-gateway')).toBe('service/api-gateway')
+  })
+
+  it('handles pod name without hash suffix', () => {
+    expect(workloadPrefix('pod/simple-name')).toBe('simple-name')
+  })
+
+  it('handles double-hash suffix pattern', () => {
+    expect(workloadPrefix('pod/frontend-app-6b8c9d7e5f-a3b2c')).toBe('frontend-app')
+  })
+
+  it('handles name with multiple dashes before hash', () => {
+    expect(workloadPrefix('pod/my-long-service-name-8b6c4f2d1e-z9y8x')).toBe('my-long-service-name')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isCausallyRelated
+// ---------------------------------------------------------------------------
+
+describe('isCausallyRelated', () => {
+  function makeEvent(reason: string, object: string): ClusterEvent {
+    return {
+      type: 'Warning',
+      reason,
+      object,
+      message: 'test',
+      count: 1,
+      firstSeen: '2024-01-01T00:00:00Z',
+      lastSeen: '2024-01-01T00:00:00Z',
+      cluster: 'cluster-a',
+      namespace: 'default',
+    }
+  }
+
+  it('returns true for events in the same reason family (container lifecycle)', () => {
+    const a = makeEvent('BackOff', 'pod/x-abc12-xyz')
+    const b = makeEvent('CrashLoopBackOff', 'pod/y-def34-uvw')
+    expect(isCausallyRelated(a, b)).toBe(true)
+  })
+
+  it('returns true for events in the same reason family (image issues)', () => {
+    const a = makeEvent('ImagePullBackOff', 'pod/x-abc12-xyz')
+    const b = makeEvent('ErrImagePull', 'pod/y-def34-uvw')
+    expect(isCausallyRelated(a, b)).toBe(true)
+  })
+
+  it('returns true for events in the same reason family (scheduling)', () => {
+    const a = makeEvent('FailedScheduling', 'pod/x-abc12-xyz')
+    const b = makeEvent('Unschedulable', 'pod/y-def34-uvw')
+    expect(isCausallyRelated(a, b)).toBe(true)
+  })
+
+  it('returns true for events in the same reason family (node health)', () => {
+    const a = makeEvent('NodeNotReady', 'pod/x-abc12-xyz')
+    const b = makeEvent('NodeUnreachable', 'pod/y-def34-uvw')
+    expect(isCausallyRelated(a, b)).toBe(true)
+  })
+
+  it('returns true for events in the same reason family (mount/volume)', () => {
+    const a = makeEvent('FailedMount', 'pod/x-abc12-xyz')
+    const b = makeEvent('FailedAttachVolume', 'pod/y-def34-uvw')
+    expect(isCausallyRelated(a, b)).toBe(true)
+  })
+
+  it('returns true for events in the same reason family (probe failures)', () => {
+    const a = makeEvent('Unhealthy', 'pod/x-abc12-xyz')
+    const b = makeEvent('LivenessProbe', 'pod/y-def34-uvw')
+    expect(isCausallyRelated(a, b)).toBe(true)
+  })
+
+  it('returns true for events in the same reason family (network)', () => {
+    const a = makeEvent('NetworkNotReady', 'pod/x-abc12-xyz')
+    const b = makeEvent('FailedToUpdateEndpoint', 'pod/y-def34-uvw')
+    expect(isCausallyRelated(a, b)).toBe(true)
+  })
+
+  it('returns true when events share the same workload prefix', () => {
+    const a = makeEvent('Unhealthy', 'pod/api-server-7d9f8-x2k4q')
+    const b = makeEvent('FailedScheduling', 'pod/api-server-8b6c4-y3m5r')
+    expect(isCausallyRelated(a, b)).toBe(true)
+  })
+
+  it('returns false for unrelated events (different families, different workloads)', () => {
+    const a = makeEvent('BackOff', 'pod/api-abc12-xyz')
+    const b = makeEvent('FailedMount', 'pod/storage-def34-uvw')
+    expect(isCausallyRelated(a, b)).toBe(false)
+  })
+
+  it('returns false for unknown reasons with different workloads', () => {
+    const a = makeEvent('CustomReason1', 'pod/service-a-abc12-xyz')
+    const b = makeEvent('CustomReason2', 'pod/service-b-def34-uvw')
+    expect(isCausallyRelated(a, b)).toBe(false)
+  })
+
+  it('returns true when one reason is unknown but workload prefix matches', () => {
+    const a = makeEvent('CustomReason', 'pod/api-server-7d9f8b6c4f-x2k4q')
+    const b = makeEvent('AnotherReason', 'pod/api-server-8b6c4f2d1e-y3m5r')
+    expect(isCausallyRelated(a, b)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getDemoInsights
+// ---------------------------------------------------------------------------
+
+describe('getDemoInsights', () => {
+  it('returns an array of demo insights', () => {
+    const insights = getDemoInsights()
+    expect(Array.isArray(insights)).toBe(true)
+    expect(insights.length).toBeGreaterThan(0)
+  })
+
+  it('includes all 7 insight categories', () => {
+    const insights = getDemoInsights()
+    const categories = new Set(insights.map(i => i.category))
+    expect(categories.has('event-correlation')).toBe(true)
+    expect(categories.has('resource-imbalance')).toBe(true)
+    expect(categories.has('restart-correlation')).toBe(true)
+    expect(categories.has('cascade-impact')).toBe(true)
+    expect(categories.has('config-drift')).toBe(true)
+    expect(categories.has('cluster-delta')).toBe(true)
+    expect(categories.has('rollout-tracker')).toBe(true)
+  })
+
+  it('each insight has required fields', () => {
+    const insights = getDemoInsights()
+    for (const insight of insights) {
+      expect(insight.id).toBeTruthy()
+      expect(insight.category).toBeTruthy()
+      expect(insight.source).toBeTruthy()
+      expect(insight.severity).toBeTruthy()
+      expect(insight.title).toBeTruthy()
+      expect(insight.description).toBeTruthy()
+      expect(insight.affectedClusters.length).toBeGreaterThan(0)
+      expect(insight.detectedAt).toBeTruthy()
+    }
+  })
+
+  it('demo timestamps are in the past', () => {
+    const insights = getDemoInsights()
+    const now = Date.now()
+    for (const insight of insights) {
+      const ts = new Date(insight.detectedAt).getTime()
+      expect(ts).toBeLessThan(now)
+    }
+  })
+
+  it('includes chain data for cascade insights', () => {
+    const insights = getDemoInsights()
+    const cascade = insights.find(i => i.category === 'cascade-impact')
+    expect(cascade?.chain).toBeDefined()
+    expect(cascade!.chain!.length).toBeGreaterThan(0)
+  })
+
+  it('includes metrics for resource-imbalance insights', () => {
+    const insights = getDemoInsights()
+    const imbalance = insights.find(i => i.category === 'resource-imbalance')
+    expect(imbalance?.metrics).toBeDefined()
+    expect(Object.keys(imbalance!.metrics!).length).toBeGreaterThan(0)
+  })
+
+  it('includes deltas for cluster-delta insights', () => {
+    const insights = getDemoInsights()
+    const delta = insights.find(i => i.category === 'cluster-delta')
+    expect(delta?.deltas).toBeDefined()
+    expect(delta!.deltas!.length).toBeGreaterThan(0)
+  })
+
+  it('includes metrics for rollout-tracker insights', () => {
+    const insights = getDemoInsights()
+    const rollout = insights.find(i => i.category === 'rollout-tracker')
+    expect(rollout?.metrics).toBeDefined()
+    expect(rollout!.metrics!.total).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Constants validation
+// ---------------------------------------------------------------------------
+
+describe('constants', () => {
+  it('REASON_FAMILIES has 7 families', () => {
+    expect(REASON_FAMILIES.length).toBe(7)
+  })
+
+  it('REASON_TO_FAMILY maps all reasons from all families', () => {
+    let totalReasons = 0
+    for (const family of REASON_FAMILIES) {
+      totalReasons += family.length
+    }
+    expect(REASON_TO_FAMILY.size).toBe(totalReasons)
+  })
+
+  it('REASON_TO_FAMILY maps each reason to its correct family index', () => {
+    for (let i = 0; i < REASON_FAMILIES.length; i++) {
+      for (const reason of REASON_FAMILIES[i]) {
+        expect(REASON_TO_FAMILY.get(reason)).toBe(i)
+      }
+    }
+  })
+
+  it('SEVERITY_RANK orders critical > warning > info', () => {
+    expect(SEVERITY_RANK.critical).toBeGreaterThan(SEVERITY_RANK.warning)
+    expect(SEVERITY_RANK.warning).toBeGreaterThan(SEVERITY_RANK.info)
+  })
+
+  it('MAX_TOP_INSIGHTS is a positive number', () => {
+    expect(MAX_TOP_INSIGHTS).toBeGreaterThan(0)
+  })
+
+  it('threshold constants are positive numbers', () => {
+    expect(RESOURCE_IMBALANCE_THRESHOLD_PCT).toBeGreaterThan(0)
+    expect(DELTA_SIGNIFICANCE_HIGH_PCT).toBeGreaterThan(0)
+    expect(DELTA_SIGNIFICANCE_MEDIUM_PCT).toBeGreaterThan(0)
+    expect(INFRA_ISSUE_MIN_WORKLOADS).toBeGreaterThan(0)
+    expect(APP_BUG_MIN_CLUSTERS).toBeGreaterThan(0)
+  })
+
+  it('significance thresholds are ordered high > medium', () => {
+    expect(DELTA_SIGNIFICANCE_HIGH_PCT).toBeGreaterThan(DELTA_SIGNIFICANCE_MEDIUM_PCT)
+  })
+
+  it('rollout status constants are distinct', () => {
+    const statuses = new Set([ROLLOUT_STATUS_IN_PROGRESS, ROLLOUT_STATUS_COMPLETE, ROLLOUT_STATUS_FAILED])
+    expect(statuses.size).toBe(3)
+  })
+
+  it('FULL_PROGRESS is 100 and PARTIAL_PROGRESS is less', () => {
+    expect(FULL_PROGRESS).toBe(100)
+    expect(PARTIAL_PROGRESS).toBeLessThan(FULL_PROGRESS)
+    expect(PARTIAL_PROGRESS).toBeGreaterThan(0)
+  })
+})

--- a/web/src/hooks/__tests__/useNightlyE2EData-funcs.test.ts
+++ b/web/src/hooks/__tests__/useNightlyE2EData-funcs.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { __testables } from '../useNightlyE2EData'
+
+const {
+  loadCachedData,
+  saveCachedData,
+  getAuthHeaders,
+  REFRESH_IDLE_MS,
+  REFRESH_ACTIVE_MS,
+  LS_CACHE_KEY,
+} = __testables
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe('constants', () => {
+  it('REFRESH_IDLE_MS is 5 minutes', () => {
+    const FIVE_MINUTES_MS = 300_000
+    expect(REFRESH_IDLE_MS).toBe(FIVE_MINUTES_MS)
+  })
+
+  it('REFRESH_ACTIVE_MS is 2 minutes', () => {
+    const TWO_MINUTES_MS = 120_000
+    expect(REFRESH_ACTIVE_MS).toBe(TWO_MINUTES_MS)
+  })
+
+  it('REFRESH_ACTIVE_MS is less than REFRESH_IDLE_MS', () => {
+    expect(REFRESH_ACTIVE_MS).toBeLessThan(REFRESH_IDLE_MS)
+  })
+
+  it('LS_CACHE_KEY is a non-empty string', () => {
+    expect(typeof LS_CACHE_KEY).toBe('string')
+    expect(LS_CACHE_KEY.length).toBeGreaterThan(0)
+  })
+
+  it('LS_CACHE_KEY equals nightly-e2e-cache', () => {
+    expect(LS_CACHE_KEY).toBe('nightly-e2e-cache')
+  })
+})
+
+describe('loadCachedData', () => {
+  it('returns empty guides when localStorage has no data', () => {
+    const result = loadCachedData()
+    expect(result).toEqual({ guides: [], isDemo: false })
+  })
+
+  it('returns cached data when localStorage has valid live data', () => {
+    const cached = {
+      guides: [{ guide: 'test-guide', runs: [] }],
+      isDemo: false,
+    }
+    localStorage.setItem(LS_CACHE_KEY, JSON.stringify(cached))
+    const result = loadCachedData()
+    expect(result.guides).toHaveLength(1)
+    expect(result.guides[0].guide).toBe('test-guide')
+    expect(result.isDemo).toBe(false)
+  })
+
+  it('returns empty guides when cached data has isDemo=true', () => {
+    const cached = {
+      guides: [{ guide: 'demo-guide', runs: [] }],
+      isDemo: true,
+    }
+    localStorage.setItem(LS_CACHE_KEY, JSON.stringify(cached))
+    const result = loadCachedData()
+    expect(result).toEqual({ guides: [], isDemo: false })
+  })
+
+  it('returns empty guides when cached data has empty guides array', () => {
+    const cached = { guides: [], isDemo: false }
+    localStorage.setItem(LS_CACHE_KEY, JSON.stringify(cached))
+    const result = loadCachedData()
+    expect(result).toEqual({ guides: [], isDemo: false })
+  })
+
+  it('returns empty guides when localStorage has invalid JSON', () => {
+    localStorage.setItem(LS_CACHE_KEY, '{not valid json')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = loadCachedData()
+    expect(result).toEqual({ guides: [], isDemo: false })
+    expect(warnSpy).toHaveBeenCalledOnce()
+  })
+
+  it('returns empty guides when cached data has no guides property', () => {
+    localStorage.setItem(LS_CACHE_KEY, JSON.stringify({ isDemo: false }))
+    const result = loadCachedData()
+    expect(result).toEqual({ guides: [], isDemo: false })
+  })
+
+  it('returns data with multiple guides', () => {
+    const cached = {
+      guides: [
+        { guide: 'guide-a', runs: [{ id: 1 }] },
+        { guide: 'guide-b', runs: [{ id: 2 }] },
+      ],
+      isDemo: false,
+    }
+    localStorage.setItem(LS_CACHE_KEY, JSON.stringify(cached))
+    const result = loadCachedData()
+    expect(result.guides).toHaveLength(2)
+  })
+})
+
+describe('saveCachedData', () => {
+  it('saves data to localStorage under the cache key', () => {
+    const data = {
+      guides: [{ guide: 'saved-guide', runs: [] }],
+      isDemo: false,
+    }
+    saveCachedData(data)
+    const stored = localStorage.getItem(LS_CACHE_KEY)
+    expect(stored).not.toBeNull()
+    expect(JSON.parse(stored!)).toEqual(data)
+  })
+
+  it('overwrites previously cached data', () => {
+    const first = { guides: [{ guide: 'first' }], isDemo: false }
+    const second = { guides: [{ guide: 'second' }], isDemo: false }
+    saveCachedData(first as any)
+    saveCachedData(second as any)
+    const stored = JSON.parse(localStorage.getItem(LS_CACHE_KEY)!)
+    expect(stored.guides[0].guide).toBe('second')
+  })
+
+  it('saves empty guides array without error', () => {
+    const data = { guides: [], isDemo: false }
+    saveCachedData(data)
+    const stored = JSON.parse(localStorage.getItem(LS_CACHE_KEY)!)
+    expect(stored.guides).toEqual([])
+  })
+
+  it('saves data with isDemo=true', () => {
+    const data = { guides: [{ guide: 'demo' }], isDemo: true } as any
+    saveCachedData(data)
+    const stored = JSON.parse(localStorage.getItem(LS_CACHE_KEY)!)
+    expect(stored.isDemo).toBe(true)
+  })
+})
+
+describe('getAuthHeaders', () => {
+  it('returns empty object when no token in localStorage', () => {
+    const headers = getAuthHeaders()
+    expect(headers).toEqual({})
+  })
+
+  it('returns Authorization header when token exists', () => {
+    localStorage.setItem('token', 'my-jwt-token')
+    const headers = getAuthHeaders()
+    expect(headers).toEqual({ Authorization: 'Bearer my-jwt-token' })
+  })
+
+  it('includes Bearer prefix in Authorization header', () => {
+    localStorage.setItem('token', 'abc123')
+    const headers = getAuthHeaders()
+    expect(headers.Authorization).toMatch(/^Bearer /)
+  })
+
+  it('returns empty object after token is removed', () => {
+    localStorage.setItem('token', 'temp-token')
+    localStorage.removeItem('token')
+    const headers = getAuthHeaders()
+    expect(headers).toEqual({})
+  })
+
+  it('uses the current token value', () => {
+    localStorage.setItem('token', 'first-token')
+    expect(getAuthHeaders().Authorization).toBe('Bearer first-token')
+    localStorage.setItem('token', 'second-token')
+    expect(getAuthHeaders().Authorization).toBe('Bearer second-token')
+  })
+})

--- a/web/src/hooks/__tests__/useRewards-funcs.test.ts
+++ b/web/src/hooks/__tests__/useRewards-funcs.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../lib/demoMode', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/demoMode')>()
+  return {
+    ...actual,
+    getDemoMode: vi.fn(() => false),
+  }
+})
+
+import { __testables } from '../useRewards'
+import { getDemoMode } from '../../lib/demoMode'
+import type { UserRewards } from '../../types/rewards'
+
+const {
+  generateId,
+  loadRewards,
+  saveRewards,
+  createInitialRewards,
+  resolveRewardsUserId,
+  checkAchievements,
+  REWARDS_STORAGE_KEY,
+  MAX_REWARD_EVENTS,
+  RECENT_EVENTS_LIMIT,
+  DEMO_REWARDS_USER_ID,
+} = __testables
+
+function makeRewards(overrides: Partial<UserRewards> = {}): UserRewards {
+  return {
+    userId: 'test-user',
+    totalCoins: 0,
+    lifetimeCoins: 0,
+    events: [],
+    achievements: [],
+    lastUpdated: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.mocked(getDemoMode).mockReturnValue(false)
+})
+
+describe('constants', () => {
+  it('REWARDS_STORAGE_KEY is a non-empty string', () => {
+    expect(typeof REWARDS_STORAGE_KEY).toBe('string')
+    expect(REWARDS_STORAGE_KEY.length).toBeGreaterThan(0)
+  })
+
+  it('MAX_REWARD_EVENTS is a positive integer', () => {
+    expect(Number.isInteger(MAX_REWARD_EVENTS)).toBe(true)
+    expect(MAX_REWARD_EVENTS).toBeGreaterThan(0)
+  })
+
+  it('RECENT_EVENTS_LIMIT is a positive integer less than MAX_REWARD_EVENTS', () => {
+    expect(Number.isInteger(RECENT_EVENTS_LIMIT)).toBe(true)
+    expect(RECENT_EVENTS_LIMIT).toBeGreaterThan(0)
+    expect(RECENT_EVENTS_LIMIT).toBeLessThanOrEqual(MAX_REWARD_EVENTS)
+  })
+
+  it('DEMO_REWARDS_USER_ID is a non-empty string', () => {
+    expect(typeof DEMO_REWARDS_USER_ID).toBe('string')
+    expect(DEMO_REWARDS_USER_ID.length).toBeGreaterThan(0)
+  })
+})
+
+describe('generateId', () => {
+  it('returns a string containing a timestamp prefix and random suffix', () => {
+    const id = generateId()
+    expect(typeof id).toBe('string')
+    expect(id).toContain('-')
+    const [timestampPart] = id.split('-')
+    expect(Number(timestampPart)).toBeGreaterThan(0)
+  })
+
+  it('generates unique ids on successive calls', () => {
+    const ids = new Set(Array.from({ length: 50 }, () => generateId()))
+    expect(ids.size).toBe(50)
+  })
+})
+
+describe('loadRewards', () => {
+  it('returns null when localStorage is empty', () => {
+    expect(loadRewards('user-1')).toBeNull()
+  })
+
+  it('returns null when the key exists but the user is not present', () => {
+    localStorage.setItem(REWARDS_STORAGE_KEY, JSON.stringify({ 'other-user': makeRewards({ userId: 'other-user' }) }))
+    expect(loadRewards('user-1')).toBeNull()
+  })
+
+  it('returns the stored rewards for the matching user', () => {
+    const rewards = makeRewards({ userId: 'user-1', totalCoins: 42 })
+    localStorage.setItem(REWARDS_STORAGE_KEY, JSON.stringify({ 'user-1': rewards }))
+    const loaded = loadRewards('user-1')
+    expect(loaded).not.toBeNull()
+    expect(loaded!.totalCoins).toBe(42)
+    expect(loaded!.userId).toBe('user-1')
+  })
+
+  it('returns null and logs error when localStorage contains invalid JSON', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    localStorage.setItem(REWARDS_STORAGE_KEY, '{bad json')
+    expect(loadRewards('user-1')).toBeNull()
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
+  })
+})
+
+describe('saveRewards', () => {
+  it('saves rewards for a user into localStorage', () => {
+    const rewards = makeRewards({ userId: 'user-1', totalCoins: 100 })
+    saveRewards('user-1', rewards)
+    const stored = JSON.parse(localStorage.getItem(REWARDS_STORAGE_KEY)!)
+    expect(stored['user-1'].totalCoins).toBe(100)
+  })
+
+  it('preserves existing users when saving a new user', () => {
+    const r1 = makeRewards({ userId: 'user-1', totalCoins: 10 })
+    const r2 = makeRewards({ userId: 'user-2', totalCoins: 20 })
+    saveRewards('user-1', r1)
+    saveRewards('user-2', r2)
+    const stored = JSON.parse(localStorage.getItem(REWARDS_STORAGE_KEY)!)
+    expect(stored['user-1'].totalCoins).toBe(10)
+    expect(stored['user-2'].totalCoins).toBe(20)
+  })
+
+  it('overwrites rewards for an existing user', () => {
+    saveRewards('user-1', makeRewards({ userId: 'user-1', totalCoins: 10 }))
+    saveRewards('user-1', makeRewards({ userId: 'user-1', totalCoins: 99 }))
+    const stored = JSON.parse(localStorage.getItem(REWARDS_STORAGE_KEY)!)
+    expect(stored['user-1'].totalCoins).toBe(99)
+  })
+
+  it('handles corrupt existing data gracefully', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    // setItem with invalid JSON so getItem inside saveRewards throws on parse
+    localStorage.setItem(REWARDS_STORAGE_KEY, '{corrupt')
+    saveRewards('user-1', makeRewards({ userId: 'user-1' }))
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
+  })
+})
+
+describe('createInitialRewards', () => {
+  it('creates a rewards object with the given userId', () => {
+    const rewards = createInitialRewards('new-user')
+    expect(rewards.userId).toBe('new-user')
+  })
+
+  it('starts with zero coins and empty collections', () => {
+    const rewards = createInitialRewards('new-user')
+    expect(rewards.totalCoins).toBe(0)
+    expect(rewards.lifetimeCoins).toBe(0)
+    expect(rewards.events).toEqual([])
+    expect(rewards.achievements).toEqual([])
+  })
+
+  it('sets lastUpdated to a valid ISO timestamp', () => {
+    const before = new Date().toISOString()
+    const rewards = createInitialRewards('new-user')
+    const after = new Date().toISOString()
+    expect(rewards.lastUpdated >= before).toBe(true)
+    expect(rewards.lastUpdated <= after).toBe(true)
+  })
+})
+
+describe('resolveRewardsUserId', () => {
+  it('returns null for undefined input', () => {
+    expect(resolveRewardsUserId(undefined)).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(resolveRewardsUserId('')).toBeNull()
+  })
+
+  it('returns the userId as-is for non-demo authenticated sessions', () => {
+    vi.mocked(getDemoMode).mockReturnValue(false)
+    expect(resolveRewardsUserId('real-user-123')).toBe('real-user-123')
+  })
+
+  it('returns DEMO_REWARDS_USER_ID when getDemoMode returns true', () => {
+    vi.mocked(getDemoMode).mockReturnValue(true)
+    expect(resolveRewardsUserId('any-user')).toBe(DEMO_REWARDS_USER_ID)
+  })
+
+  it('returns DEMO_REWARDS_USER_ID when userId matches DEMO_REWARDS_USER_ID', () => {
+    vi.mocked(getDemoMode).mockReturnValue(false)
+    expect(resolveRewardsUserId(DEMO_REWARDS_USER_ID)).toBe(DEMO_REWARDS_USER_ID)
+  })
+})
+
+describe('checkAchievements', () => {
+  it('returns empty array for fresh user with no coins or events', () => {
+    const rewards = makeRewards()
+    expect(checkAchievements(rewards)).toEqual([])
+  })
+
+  it('awards coin-based achievements when lifetimeCoins meets the threshold', () => {
+    const rewards = makeRewards({ lifetimeCoins: 1000 })
+    const result = checkAchievements(rewards)
+    expect(result).toContain('coin_collector')
+  })
+
+  it('awards higher coin-based achievements at higher thresholds', () => {
+    const rewards = makeRewards({ lifetimeCoins: 5000 })
+    const result = checkAchievements(rewards)
+    expect(result).toContain('coin_collector')
+    expect(result).toContain('treasure_hunter')
+  })
+
+  it('awards action-based achievement with default requiredCount of 1', () => {
+    const rewards = makeRewards({
+      events: [
+        { id: '1', userId: 'test', action: 'bug_report', coins: 300, timestamp: new Date().toISOString() },
+      ],
+    })
+    const result = checkAchievements(rewards)
+    expect(result).toContain('bug_hunter')
+  })
+
+  it('awards action-based achievement when requiredCount is met', () => {
+    const events = Array.from({ length: 5 }, (_, i) => ({
+      id: String(i),
+      userId: 'test',
+      action: 'feature_suggestion' as const,
+      coins: 100,
+      timestamp: new Date().toISOString(),
+    }))
+    const rewards = makeRewards({ events })
+    const result = checkAchievements(rewards)
+    expect(result).toContain('idea_machine')
+  })
+
+  it('does not award action-based achievement when count is below requiredCount', () => {
+    const events = Array.from({ length: 4 }, (_, i) => ({
+      id: String(i),
+      userId: 'test',
+      action: 'feature_suggestion' as const,
+      coins: 100,
+      timestamp: new Date().toISOString(),
+    }))
+    const rewards = makeRewards({ events })
+    const result = checkAchievements(rewards)
+    expect(result).not.toContain('idea_machine')
+  })
+
+  it('skips achievements the user already has', () => {
+    const rewards = makeRewards({
+      lifetimeCoins: 1000,
+      achievements: ['coin_collector'],
+    })
+    const result = checkAchievements(rewards)
+    expect(result).not.toContain('coin_collector')
+  })
+
+  it('can return multiple new achievements at once', () => {
+    const rewards = makeRewards({
+      lifetimeCoins: 5000,
+      events: [
+        { id: '1', userId: 'test', action: 'complete_onboarding', coins: 100, timestamp: new Date().toISOString() },
+        { id: '2', userId: 'test', action: 'bug_report', coins: 300, timestamp: new Date().toISOString() },
+        { id: '3', userId: 'test', action: 'github_invite', coins: 500, timestamp: new Date().toISOString() },
+        { id: '4', userId: 'test', action: 'linkedin_share', coins: 200, timestamp: new Date().toISOString() },
+      ],
+    })
+    const result = checkAchievements(rewards)
+    expect(result).toContain('first_steps')
+    expect(result).toContain('bug_hunter')
+    expect(result).toContain('coin_collector')
+    expect(result).toContain('treasure_hunter')
+    expect(result).toContain('community_champion')
+    expect(result).toContain('social_butterfly')
+  })
+})

--- a/web/src/hooks/__tests__/useSelfUpgrade-funcs.test.ts
+++ b/web/src/hooks/__tests__/useSelfUpgrade-funcs.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { __testables } from '../useSelfUpgrade'
+
+const {
+  getToken,
+  SELF_UPGRADE_TIMEOUT_MS,
+  RESTART_POLL_INTERVAL_MS,
+  RESTART_POLL_MAX_MS,
+  RESTART_HEALTH_TIMEOUT_MS,
+  RELOAD_DELAY_MS,
+} = __testables
+
+describe('useSelfUpgrade __testables', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('getToken', () => {
+    it('returns null when no token is stored', () => {
+      expect(getToken()).toBeNull()
+    })
+
+    it('returns the stored token value', () => {
+      localStorage.setItem('token', 'my-jwt-token-123')
+      expect(getToken()).toBe('my-jwt-token-123')
+    })
+
+    it('returns updated value after token changes', () => {
+      localStorage.setItem('token', 'first-token')
+      expect(getToken()).toBe('first-token')
+
+      localStorage.setItem('token', 'second-token')
+      expect(getToken()).toBe('second-token')
+    })
+
+    it('returns null after token is removed', () => {
+      localStorage.setItem('token', 'temp-token')
+      expect(getToken()).toBe('temp-token')
+
+      localStorage.removeItem('token')
+      expect(getToken()).toBeNull()
+    })
+
+    it('returns empty string when token is set to empty', () => {
+      localStorage.setItem('token', '')
+      expect(getToken()).toBe('')
+    })
+  })
+
+  describe('constants', () => {
+    it('SELF_UPGRADE_TIMEOUT_MS is 15 seconds', () => {
+      expect(SELF_UPGRADE_TIMEOUT_MS).toBe(15_000)
+    })
+
+    it('RESTART_POLL_INTERVAL_MS is 3 seconds', () => {
+      expect(RESTART_POLL_INTERVAL_MS).toBe(3_000)
+    })
+
+    it('RESTART_POLL_MAX_MS is 120 seconds', () => {
+      expect(RESTART_POLL_MAX_MS).toBe(120_000)
+    })
+
+    it('RESTART_HEALTH_TIMEOUT_MS is 3 seconds', () => {
+      expect(RESTART_HEALTH_TIMEOUT_MS).toBe(3_000)
+    })
+
+    it('RELOAD_DELAY_MS is 1.5 seconds', () => {
+      expect(RELOAD_DELAY_MS).toBe(1_500)
+    })
+
+    it('all constants are positive numbers', () => {
+      const constants = [
+        SELF_UPGRADE_TIMEOUT_MS,
+        RESTART_POLL_INTERVAL_MS,
+        RESTART_POLL_MAX_MS,
+        RESTART_HEALTH_TIMEOUT_MS,
+        RELOAD_DELAY_MS,
+      ]
+      for (const c of constants) {
+        expect(typeof c).toBe('number')
+        expect(c).toBeGreaterThan(0)
+      }
+    })
+
+    it('poll interval is less than poll max', () => {
+      expect(RESTART_POLL_INTERVAL_MS).toBeLessThan(RESTART_POLL_MAX_MS)
+    })
+
+    it('health timeout does not exceed poll interval', () => {
+      expect(RESTART_HEALTH_TIMEOUT_MS).toBeLessThanOrEqual(RESTART_POLL_INTERVAL_MS)
+    })
+
+    it('reload delay is less than upgrade timeout', () => {
+      expect(RELOAD_DELAY_MS).toBeLessThan(SELF_UPGRADE_TIMEOUT_MS)
+    })
+  })
+})

--- a/web/src/hooks/__tests__/useTokenUsage-funcs.test.ts
+++ b/web/src/hooks/__tests__/useTokenUsage-funcs.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { __testables } from '../useTokenUsage'
+
+const {
+  loadPersistedUsage,
+  persistUsage,
+  getNextResetDate,
+  MAX_SINGLE_DELTA_TOKENS,
+  MIN_STOP_THRESHOLD,
+  LAST_KNOWN_USAGE_KEY,
+  AGENT_SESSION_KEY,
+  DEFAULT_CATEGORY,
+  TOKEN_USAGE_FLUSH_INTERVAL_MS,
+  TOKEN_USAGE_FLUSH_THRESHOLD,
+  DEFAULT_SETTINGS,
+  DEFAULT_BY_CATEGORY,
+  DEMO_TOKEN_USAGE,
+  DEMO_BY_CATEGORY,
+} = __testables
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('constants', () => {
+  it('MAX_SINGLE_DELTA_TOKENS is a positive number', () => {
+    expect(MAX_SINGLE_DELTA_TOKENS).toBe(50_000)
+    expect(typeof MAX_SINGLE_DELTA_TOKENS).toBe('number')
+  })
+
+  it('MIN_STOP_THRESHOLD is a small positive fraction', () => {
+    expect(MIN_STOP_THRESHOLD).toBe(0.01)
+    expect(MIN_STOP_THRESHOLD).toBeGreaterThan(0)
+    expect(MIN_STOP_THRESHOLD).toBeLessThan(1)
+  })
+
+  it('localStorage keys are namespaced strings', () => {
+    expect(LAST_KNOWN_USAGE_KEY).toBe('kc:tokenUsage:lastKnown')
+    expect(AGENT_SESSION_KEY).toBe('kc:tokenUsage:agentSession')
+  })
+
+  it('DEFAULT_CATEGORY is "other"', () => {
+    expect(DEFAULT_CATEGORY).toBe('other')
+  })
+
+  it('TOKEN_USAGE_FLUSH_INTERVAL_MS is 30 seconds', () => {
+    expect(TOKEN_USAGE_FLUSH_INTERVAL_MS).toBe(30_000)
+  })
+
+  it('TOKEN_USAGE_FLUSH_THRESHOLD is 100', () => {
+    expect(TOKEN_USAGE_FLUSH_THRESHOLD).toBe(100)
+  })
+
+  it('DEFAULT_SETTINGS has correct shape and values', () => {
+    expect(DEFAULT_SETTINGS).toEqual({
+      limit: 500_000_000,
+      warningThreshold: 0.7,
+      criticalThreshold: 0.9,
+      stopThreshold: 1.0,
+    })
+  })
+
+  it('DEFAULT_BY_CATEGORY has all zero categories', () => {
+    expect(DEFAULT_BY_CATEGORY).toEqual({
+      missions: 0,
+      diagnose: 0,
+      insights: 0,
+      predictions: 0,
+      other: 0,
+    })
+  })
+
+  it('DEMO_TOKEN_USAGE is a realistic number', () => {
+    expect(DEMO_TOKEN_USAGE).toBe(1_247_832)
+    expect(DEMO_TOKEN_USAGE).toBeGreaterThan(0)
+  })
+
+  it('DEMO_BY_CATEGORY sums to DEMO_TOKEN_USAGE', () => {
+    const sum =
+      DEMO_BY_CATEGORY.missions +
+      DEMO_BY_CATEGORY.diagnose +
+      DEMO_BY_CATEGORY.insights +
+      DEMO_BY_CATEGORY.predictions +
+      DEMO_BY_CATEGORY.other
+    expect(sum).toBe(DEMO_TOKEN_USAGE)
+  })
+
+  it('DEMO_BY_CATEGORY has expected values', () => {
+    expect(DEMO_BY_CATEGORY).toEqual({
+      missions: 523_000,
+      diagnose: 312_000,
+      insights: 245_832,
+      predictions: 167_000,
+      other: 0,
+    })
+  })
+})
+
+describe('loadPersistedUsage', () => {
+  it('returns nulls when localStorage is empty', () => {
+    const result = loadPersistedUsage()
+    expect(result).toEqual({ lastKnown: null, sessionId: null })
+  })
+
+  it('loads a valid numeric lastKnown value', () => {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, '42000')
+    const result = loadPersistedUsage()
+    expect(result.lastKnown).toBe(42_000)
+  })
+
+  it('loads sessionId from localStorage', () => {
+    localStorage.setItem(AGENT_SESSION_KEY, 'session-abc-123')
+    const result = loadPersistedUsage()
+    expect(result.sessionId).toBe('session-abc-123')
+  })
+
+  it('loads both lastKnown and sessionId together', () => {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, '99999')
+    localStorage.setItem(AGENT_SESSION_KEY, 'sess-xyz')
+    const result = loadPersistedUsage()
+    expect(result).toEqual({ lastKnown: 99_999, sessionId: 'sess-xyz' })
+  })
+
+  it('returns null lastKnown for non-numeric stored value', () => {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, 'not-a-number')
+    const result = loadPersistedUsage()
+    expect(result.lastKnown).toBeNull()
+  })
+
+  it('returns null lastKnown for NaN stored value', () => {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, 'NaN')
+    const result = loadPersistedUsage()
+    expect(result.lastKnown).toBeNull()
+  })
+
+  it('returns null lastKnown for Infinity stored value', () => {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, 'Infinity')
+    const result = loadPersistedUsage()
+    expect(result.lastKnown).toBeNull()
+  })
+
+  it('handles zero as a valid lastKnown', () => {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, '0')
+    const result = loadPersistedUsage()
+    expect(result.lastKnown).toBe(0)
+  })
+
+  it('handles negative numbers as valid lastKnown', () => {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, '-100')
+    const result = loadPersistedUsage()
+    expect(result.lastKnown).toBe(-100)
+  })
+
+  it('handles floating point lastKnown', () => {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, '3.14')
+    const result = loadPersistedUsage()
+    expect(result.lastKnown).toBe(3.14)
+  })
+})
+
+describe('persistUsage', () => {
+  it('stores lastKnown in localStorage', () => {
+    persistUsage(12345, null)
+    expect(localStorage.getItem(LAST_KNOWN_USAGE_KEY)).toBe('12345')
+  })
+
+  it('stores sessionId when provided', () => {
+    persistUsage(100, 'session-1')
+    expect(localStorage.getItem(LAST_KNOWN_USAGE_KEY)).toBe('100')
+    expect(localStorage.getItem(AGENT_SESSION_KEY)).toBe('session-1')
+  })
+
+  it('does not write sessionId when null', () => {
+    localStorage.setItem(AGENT_SESSION_KEY, 'old-session')
+    persistUsage(200, null)
+    expect(localStorage.getItem(AGENT_SESSION_KEY)).toBe('old-session')
+  })
+
+  it('overwrites previous values', () => {
+    persistUsage(100, 'first')
+    persistUsage(200, 'second')
+    expect(localStorage.getItem(LAST_KNOWN_USAGE_KEY)).toBe('200')
+    expect(localStorage.getItem(AGENT_SESSION_KEY)).toBe('second')
+  })
+
+  it('stores zero as lastKnown', () => {
+    persistUsage(0, 'sess')
+    expect(localStorage.getItem(LAST_KNOWN_USAGE_KEY)).toBe('0')
+  })
+
+  it('round-trips with loadPersistedUsage', () => {
+    persistUsage(77777, 'round-trip-session')
+    const result = loadPersistedUsage()
+    expect(result).toEqual({ lastKnown: 77_777, sessionId: 'round-trip-session' })
+  })
+})
+
+describe('getNextResetDate', () => {
+  it('returns a valid ISO date string', () => {
+    const result = getNextResetDate()
+    expect(() => new Date(result)).not.toThrow()
+    const parsed = new Date(result)
+    expect(parsed.getTime()).not.toBeNaN()
+  })
+
+  it('returns first day of next month', () => {
+    const result = getNextResetDate()
+    const parsed = new Date(result)
+    expect(parsed.getDate()).toBe(1)
+  })
+
+  it('returns a date in the future', () => {
+    const result = getNextResetDate()
+    const parsed = new Date(result)
+    const now = new Date()
+    expect(parsed.getTime()).toBeGreaterThan(now.getTime())
+  })
+
+  it('returns the correct next month', () => {
+    const result = getNextResetDate()
+    const parsed = new Date(result)
+    const now = new Date()
+    const expectedMonth = (now.getMonth() + 1) % 12
+    expect(parsed.getMonth()).toBe(expectedMonth)
+  })
+
+  it('rolls over year boundary correctly when mocked to December', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2025, 11, 15))
+    const result = getNextResetDate()
+    const parsed = new Date(result)
+    expect(parsed.getFullYear()).toBe(2026)
+    expect(parsed.getMonth()).toBe(0)
+    expect(parsed.getDate()).toBe(1)
+    vi.useRealTimers()
+  })
+
+  it('handles January correctly', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2025, 0, 20))
+    const result = getNextResetDate()
+    const parsed = new Date(result)
+    expect(parsed.getFullYear()).toBe(2025)
+    expect(parsed.getMonth()).toBe(1)
+    expect(parsed.getDate()).toBe(1)
+    vi.useRealTimers()
+  })
+
+  it('handles last day of month', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2025, 2, 31))
+    const result = getNextResetDate()
+    const parsed = new Date(result)
+    expect(parsed.getFullYear()).toBe(2025)
+    expect(parsed.getMonth()).toBe(3)
+    expect(parsed.getDate()).toBe(1)
+    vi.useRealTimers()
+  })
+
+  it('handles first day of month', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2025, 5, 1))
+    const result = getNextResetDate()
+    const parsed = new Date(result)
+    expect(parsed.getFullYear()).toBe(2025)
+    expect(parsed.getMonth()).toBe(6)
+    expect(parsed.getDate()).toBe(1)
+    vi.useRealTimers()
+  })
+})

--- a/web/src/hooks/useMultiClusterInsights.ts
+++ b/web/src/hooks/useMultiClusterInsights.ts
@@ -851,3 +851,24 @@ export function useMultiClusterInsights(): UseMultiClusterInsightsResult {
     insightsByCategory,
     topInsights }
 }
+
+// ── Exported testables — private functions for unit testing ──────────
+export const __testables = {
+  workloadPrefix,
+  isCausallyRelated,
+  getDemoInsights,
+  REASON_FAMILIES,
+  REASON_TO_FAMILY,
+  SEVERITY_RANK,
+  MAX_TOP_INSIGHTS,
+  RESOURCE_IMBALANCE_THRESHOLD_PCT,
+  DELTA_SIGNIFICANCE_HIGH_PCT,
+  DELTA_SIGNIFICANCE_MEDIUM_PCT,
+  INFRA_ISSUE_MIN_WORKLOADS,
+  APP_BUG_MIN_CLUSTERS,
+  ROLLOUT_STATUS_IN_PROGRESS,
+  ROLLOUT_STATUS_COMPLETE,
+  ROLLOUT_STATUS_FAILED,
+  FULL_PROGRESS,
+  PARTIAL_PROGRESS,
+}


### PR DESCRIPTION
## Summary
- Adds 199 new tests across 7 test files targeting private/pure functions via `__testables` exports
- Covers `useMultiClusterInsights` (12 algorithm helpers + constants), `useCachedEnvoy` (3 pure helpers), `useDeployMissions` (6 functions + constants), `useTokenUsage` (3 functions + constants), `useRewards` (6 functions + constants), `useNightlyE2EData` (3 functions + constants), `useSelfUpgrade` (1 function + constants)
- Adds `__testables` export to `useMultiClusterInsights.ts` for private functions (`workloadPrefix`, `isCausallyRelated`, `getDemoInsights`) and internal constants

## Test plan
- [x] All 199 tests pass locally via `npx vitest run`
- [x] No existing tests broken
- [ ] CI build/lint passes
- [ ] Coverage-hourly CI confirms statement coverage increase