### PR TITLE
🐛 fix: add retryFetch to createCachedHook factory return value

### DIFF
--- a/web/src/lib/cache/createCachedHook.ts
+++ b/web/src/lib/cache/createCachedHook.ts
@@ -82,6 +82,7 @@ export function createCachedHook<T>(
       consecutiveFailures: result.consecutiveFailures,
       lastRefresh: result.lastRefresh,
       refetch: result.refetch,
+      retryFetch: result.retryFetch,
     }
   }
 }


### PR DESCRIPTION
Fixes #11056

## Problem
PR #11043 added `retryFetch` to `UseCacheResult<T>` and therefore to `CachedHookResult<T>` (which is `Omit<UseCacheResult<T>, 'clearAndRefetch'>`). However, the `createCachedHook` factory was not updated to include `retryFetch` in its return object, causing this TypeScript build error:

```
Property 'retryFetch' is missing in type '{ data: T; isLoading: boolean; ... }'
but required in type 'CachedHookResult<T>'
```

## Fix
Add `retryFetch: result.retryFetch` to the factory's return object so it satisfies the full `CachedHookResult<T>` contract.