### PR TITLE
🐛 Add missing retryFetch to all useCached* hook return objects

### DIFF
--- a/web/src/hooks/useCachedCoreWorkloads.ts
+++ b/web/src/hooks/useCachedCoreWorkloads.ts
@@ -225,7 +225,7 @@ export function useCachedPods(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 /**
@@ -266,7 +266,7 @@ export function useCachedAllPods(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 /**
@@ -362,7 +362,7 @@ export function useCachedEvents(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 /**
@@ -443,7 +443,7 @@ export function useCachedPodIssues(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 /**
@@ -530,7 +530,7 @@ export function useCachedDeploymentIssues(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 /**
@@ -611,7 +611,7 @@ export function useCachedDeployments(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 /**
@@ -651,7 +651,7 @@ export function useCachedServices(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 /**
@@ -722,7 +722,7 @@ export function useCachedSecurityIssues(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 /**
@@ -794,5 +794,5 @@ export function useCachedWorkloads(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }

--- a/web/src/hooks/useCachedGPU.ts
+++ b/web/src/hooks/useCachedGPU.ts
@@ -240,7 +240,7 @@ export function useCachedGPUNodes(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 /**
@@ -280,7 +280,7 @@ export function useCachedGPUNodeHealth(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 /**
@@ -377,7 +377,7 @@ export function useGPUHealthCronJob(cluster?: string) {
     actionInProgress,
     install,
     uninstall,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 /**
@@ -452,7 +452,7 @@ export function useCachedWarningEvents(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 // Re-export AGENT_HTTP_TIMEOUT_MS for use in the workaround in useCachedCoreWorkloads

--- a/web/src/hooks/useCachedGitOps.ts
+++ b/web/src/hooks/useCachedGitOps.ts
@@ -84,7 +84,7 @@ function createGitOpsSseHook<T extends object>(config: GitOpsSseConfig<T>) {
       isFailed: result.isFailed,
       consecutiveFailures: result.consecutiveFailures,
       lastRefresh: result.lastRefresh,
-      refetch: result.refetch,
+      refetch: result.refetch, retryFetch: result.retryFetch,
     } as CachedHookResult<T[]> & Record<string, T[]>
   }
 }
@@ -140,7 +140,7 @@ function createRbacHook<T extends object>(config: RbacConfig<T>) {
       isFailed: result.isFailed,
       consecutiveFailures: result.consecutiveFailures,
       lastRefresh: result.lastRefresh,
-      refetch: result.refetch,
+      refetch: result.refetch, retryFetch: result.retryFetch,
     } as CachedHookResult<T[]> & Record<string, T[]>
   }
 }
@@ -211,7 +211,7 @@ export function useCachedHelmHistory(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch,
+    refetch: result.refetch, retryFetch: result.retryFetch,
   }
 }
 
@@ -246,7 +246,7 @@ export function useCachedHelmValues(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch,
+    refetch: result.refetch, retryFetch: result.retryFetch,
   }
 }
 
@@ -283,7 +283,7 @@ export function useCachedGitOpsDrifts(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch,
+    refetch: result.refetch, retryFetch: result.retryFetch,
   }
 }
 
@@ -329,7 +329,7 @@ export function useCachedBuildpackImages(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch,
+    refetch: result.refetch, retryFetch: result.retryFetch,
   }
 }
 

--- a/web/src/hooks/useCachedISO27001.ts
+++ b/web/src/hooks/useCachedISO27001.ts
@@ -313,6 +313,6 @@ export function useCachedISO27001Audit(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch,
+    refetch: result.refetch, retryFetch: result.retryFetch,
   }
 }

--- a/web/src/hooks/useCachedK8sResources.ts
+++ b/web/src/hooks/useCachedK8sResources.ts
@@ -99,7 +99,7 @@ function createCachedK8sResourceHook<T extends object>(
       isFailed: result.isFailed,
       consecutiveFailures: result.consecutiveFailures,
       lastRefresh: result.lastRefresh,
-      refetch: result.refetch,
+      refetch: result.refetch, retryFetch: result.retryFetch,
     } as CachedHookResult<T[]> & Record<string, T[]>
   }
 }
@@ -244,6 +244,6 @@ export function useCachedNamespaces(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch,
+    refetch: result.refetch, retryFetch: result.retryFetch,
   }
 }

--- a/web/src/hooks/useCachedLLMd.ts
+++ b/web/src/hooks/useCachedLLMd.ts
@@ -364,7 +364,7 @@ export function useCachedLLMdServers(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch,
+    refetch: result.refetch, retryFetch: result.retryFetch,
   }
 }
 
@@ -443,6 +443,6 @@ export function useCachedLLMdModels(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch,
+    refetch: result.refetch, retryFetch: result.retryFetch,
   }
 }

--- a/web/src/hooks/useCachedNodes.ts
+++ b/web/src/hooks/useCachedNodes.ts
@@ -135,7 +135,7 @@ export function useCachedNodes(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 /**
@@ -297,7 +297,7 @@ export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & {
     // multi-cluster drill-down can explain an empty list with "lacks
     // list-nodes RBAC on cluster X" rather than a generic warning.
     clusterErrors,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }
 
 // fetches coredns pods from kube-system and builds per-cluster health info
@@ -362,5 +362,5 @@ export function useCachedCoreDNSStatus(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch }
+    refetch: result.refetch, retryFetch: result.retryFetch }
 }

--- a/web/src/hooks/useCachedProw.ts
+++ b/web/src/hooks/useCachedProw.ts
@@ -159,7 +159,7 @@ export function useCachedProwJobs(
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
-    refetch: result.refetch,
+    refetch: result.refetch, retryFetch: result.retryFetch,
     formatTimeAgo,
   }
 }


### PR DESCRIPTION
Fixes #11056
Fixes #11059
Fixes #11060
Fixes #11061
Fixes #11062

## Summary

The `CachedHookResult<T>` type requires `retryFetch` (added in PR #11043) but 8 hook files that manually construct their return objects were missing it, causing a TypeScript build failure on main.

## Changes

Added `retryFetch` pass-through to all manual return objects in:
- `useCachedCoreWorkloads.ts`
- `useCachedGPU.ts`
- `useCachedGitOps.ts`
- `useCachedISO27001.ts`
- `useCachedK8sResources.ts`
- `useCachedLLMd.ts`
- `useCachedNodes.ts`
- `useCachedProw.ts`