### PR TITLE
🐛 Fix 4 failing tests: agent token state, IDB mirror mock, toggle click

### DIFF
--- a/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
@@ -107,6 +107,7 @@ vi.mock('../../../lib/analytics', () => ({
 // ---------------------------------------------------------------------------
 import {
   agentFetch,
+  _resetAgentTokenState,
   clearClusterCacheOnLogout,
   clusterCache,
   clusterSubscribers,
@@ -223,6 +224,10 @@ describe('agentFetch — token injection and signal fallback', () => {
 // ============================================================================
 describe('getAgentToken — emits GA4 on failure', () => {
   const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    _resetAgentTokenState()
+  })
 
   afterEach(() => {
     globalThis.fetch = originalFetch

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -53,6 +53,12 @@ let agentTokenPromise: Promise<string> | null = null
 /** Session-level dedup: only emit one agent_token_failure per page load */
 let agentTokenFailureEmitted = false
 
+/** Reset internal getAgentToken state — exposed for tests only. */
+export function _resetAgentTokenState(): void {
+  agentTokenPromise = null
+  agentTokenFailureEmitted = false
+}
+
 /**
  * Lazily fetch the kc-agent token from the backend. The token is cached
  * in localStorage so subsequent calls (and page reloads) don't re-fetch.

--- a/web/src/lib/cache/__tests__/cache-coverage.test.ts
+++ b/web/src/lib/cache/__tests__/cache-coverage.test.ts
@@ -1021,13 +1021,14 @@ describe('worker-active IndexedDB mirror write', () => {
       migrate: vi.fn().mockResolvedValue(undefined),
     }
 
-    // Must register doMock BEFORE importFresh() resets modules, so the fresh
-    // cache/index.ts import picks up the mocked CacheWorkerRpc constructor.
+    // resetModules first, THEN register doMock so the fresh import picks it up.
+    // (vi.resetModules clears pending doMock registrations, so ordering matters.)
+    vi.resetModules()
     vi.doMock('../workerRpc', () => ({
       CacheWorkerRpc: vi.fn().mockImplementation(() => mockRpc),
     }))
 
-    const mod = await importFresh()
+    const mod = await import('../index')
     const { useCache, initCacheWorker, isSQLiteWorkerActive, __testables: testables } = mod
 
     // Activate the SQLite worker path

--- a/web/src/lib/unified/card/hooks/__tests__/useCardFiltering-controls.test.tsx
+++ b/web/src/lib/unified/card/hooks/__tests__/useCardFiltering-controls.test.tsx
@@ -137,7 +137,9 @@ describe('FilterControl – toggle type', () => {
     const { result, container } = renderControls(filters, data)
 
     const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement
-    fireEvent.change(checkbox, { target: { checked: true } })
+    act(() => {
+      fireEvent.click(checkbox)
+    })
 
     expect(result.current.filteredData).toHaveLength(1)
   })


### PR DESCRIPTION
Fixes #11068

Fix 4 failing unit tests:

1. **shared-coverage.test.ts (getAgentToken GA4 tests)**: `agentTokenFailureEmitted` persisted across tests because the module-level flag was never reset. Added `_resetAgentTokenState()` export to `shared.ts` and call it in `beforeEach`.

2. **cache-coverage.test.ts (worker-active IDB mirror)**: `vi.doMock` was registered before `importFresh()` which internally calls `vi.resetModules()`, clearing the doMock registration. Fixed by calling `vi.resetModules()` first, then `vi.doMock`, then `import('../index')`.

3. **useCardFiltering-controls.test.tsx (toggle onChange)**: `fireEvent.change` on a checkbox doesn't reliably trigger React's `onChange` across separate render trees. Switched to `fireEvent.click` wrapped in `act()` to properly toggle the checkbox and flush state updates.