### PR TITLE
🐛 Fix test failure in Coverage Suite

### DIFF
--- a/web/src/lib/cache/__tests__/cache-coverage.test.ts
+++ b/web/src/lib/cache/__tests__/cache-coverage.test.ts
@@ -1025,7 +1025,7 @@ describe('worker-active IndexedDB mirror write', () => {
     // (vi.resetModules clears pending doMock registrations, so ordering matters.)
     vi.resetModules()
     vi.doMock('../workerRpc', () => ({
-      CacheWorkerRpc: vi.fn().mockImplementation(() => mockRpc),
+      CacheWorkerRpc: vi.fn().mockImplementation(function () { return mockRpc }),
     }))
 
     const mod = await import('../index')


### PR DESCRIPTION
Fixes #11073

## Changes
- Fix the failing test in `cache-coverage.test.ts` (`worker-active IndexedDB mirror write > mirrors data to _idbStorage.set when workerRpc is active`)
- The `CacheWorkerRpc` mock used an arrow function in `mockImplementation()`, but arrow functions cannot be used as constructors (`new`). Changed to a regular function expression.