### PR TITLE
🐛 Fix TS2352 cast error breaking build after #11086

### DIFF
--- a/web/src/hooks/useMissions.provider.tsx
+++ b/web/src/hooks/useMissions.provider.tsx
@@ -1763,7 +1763,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         // 'completed', so reaching this state is the correct lifecycle end (#5479).
         // #11070 — If the backend flagged this result as an error (e.g. non-zero
         // exit code from a CLI provider), mark the mission 'failed' instead.
-        const resultIsError = !!(chatPayload as Record<string, unknown>).isError
+        const resultIsError = !!(chatPayload as unknown as Record<string, unknown>).isError
         return {
           ...m,
           status: (resultIsError ? 'failed' : 'completed') as MissionStatus,

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -1852,7 +1852,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         // 'completed', so reaching this state is the correct lifecycle end (#5479).
         // #11070 — If the backend flagged this result as an error (e.g. non-zero
         // exit code from a CLI provider), mark the mission 'failed' instead.
-        const resultIsError = !!(chatPayload as Record<string, unknown>).isError
+        const resultIsError = !!(chatPayload as unknown as Record<string, unknown>).isError
         return {
           ...m,
           status: (resultIsError ? 'failed' : 'completed') as MissionStatus,


### PR DESCRIPTION
Fixes #11087
Fixes #11088

## Problem
PR #11086 introduced a direct cast from `ChatStreamPayload` to `Record<string, unknown>` to check the `isError` field. TypeScript rejects this (TS2352) because the types don't overlap sufficiently.

## Fix
Cast through `unknown` first: `(chatPayload as unknown as Record<string, unknown>).isError`

Applied to both `useMissions.tsx` and `useMissions.provider.tsx`.