### PR TITLE
🐛 Auto-refresh Copilot auth tokens at runtime (#11079)

### DIFF
--- a/pkg/agent/provider_copilotcli.go
+++ b/pkg/agent/provider_copilotcli.go
@@ -8,14 +8,23 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 )
+
+// authRefreshCooldown prevents hammering `gh auth token` on repeated failures.
+const authRefreshCooldown = 30 * time.Second
 
 // CopilotCLIProvider implements the AIProvider and StreamingProvider interfaces
 // for GitHub Copilot CLI, providing real-time streaming responses.
 type CopilotCLIProvider struct {
 	cliPath string
 	version string
+
+	// Token refresh state — guarded by authMu.
+	authMu            sync.Mutex
+	lastAuthRefresh   time.Time
+	lastAuthRefreshOK bool
 }
 
 func NewCopilotCLIProvider() *CopilotCLIProvider {
@@ -81,6 +90,73 @@ func (c *CopilotCLIProvider) Refresh() {
 	c.detectCLI()
 }
 
+// isAuthError returns true when the error text indicates an expired or invalid
+// GitHub / Copilot auth token.
+func isAuthError(text string) bool {
+	lower := strings.ToLower(text)
+	return strings.Contains(lower, "login") ||
+		strings.Contains(lower, "auth") ||
+		strings.Contains(lower, "sign in") ||
+		strings.Contains(lower, "token") ||
+		strings.Contains(lower, "authenticate") ||
+		strings.Contains(lower, "401") ||
+		strings.Contains(lower, "403")
+}
+
+// refreshGitHubAuth attempts to obtain a fresh GitHub token by invoking
+// `gh auth token`.  If the command succeeds the token file/keyring was
+// already refreshed by the user (e.g. `gh auth refresh`) and subsequent
+// copilot CLI invocations will pick it up automatically.
+//
+// The method is rate-limited by authRefreshCooldown so we don't spam the
+// gh CLI on repeated failures.  Returns true when the refresh looks healthy.
+func (c *CopilotCLIProvider) refreshGitHubAuth() bool {
+	c.authMu.Lock()
+	defer c.authMu.Unlock()
+
+	if time.Since(c.lastAuthRefresh) < authRefreshCooldown {
+		return c.lastAuthRefreshOK
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "gh", "auth", "token").Output()
+	c.lastAuthRefresh = time.Now()
+	if err != nil {
+		slog.Warn("[CopilotCLI] gh auth token failed — token may still be expired", "error", err)
+		c.lastAuthRefreshOK = false
+		return false
+	}
+	tok := strings.TrimSpace(string(out))
+	if tok == "" {
+		slog.Warn("[CopilotCLI] gh auth token returned empty output")
+		c.lastAuthRefreshOK = false
+		return false
+	}
+	slog.Info("[CopilotCLI] gh auth token succeeded — fresh token available")
+	c.lastAuthRefreshOK = true
+	return true
+}
+
+// freshEnv returns a copy of the current process environment with any stale
+// GH_TOKEN / GITHUB_TOKEN entries removed, plus NO_COLOR=1.  Removing these
+// vars forces the copilot CLI to read the freshly-refreshed token from gh's
+// config/keyring rather than using a stale value inherited from the kc-agent
+// process environment at startup.
+func freshEnv() []string {
+	env := os.Environ()
+	filtered := make([]string, 0, len(env)+1)
+	for _, e := range env {
+		upper := strings.ToUpper(e)
+		if strings.HasPrefix(upper, "GH_TOKEN=") || strings.HasPrefix(upper, "GITHUB_TOKEN=") {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return append(filtered, "NO_COLOR=1")
+}
+
 func (c *CopilotCLIProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
 	var result strings.Builder
 	resp, err := c.StreamChatWithProgress(ctx, req, func(chunk string) {
@@ -100,7 +176,21 @@ func (c *CopilotCLIProvider) StreamChat(ctx context.Context, req *ChatRequest, o
 }
 
 // StreamChatWithProgress implements StreamingProvider for real-time streaming.
+// On auth errors it attempts one automatic token refresh and retry (#11079).
 func (c *CopilotCLIProvider) StreamChatWithProgress(ctx context.Context, req *ChatRequest, onChunk func(chunk string), onProgress func(event StreamEvent)) (*ChatResponse, error) {
+	resp, err := c.doStreamChat(ctx, req, onChunk, onProgress)
+	if err != nil && isAuthError(err.Error()) {
+		slog.Info("[CopilotCLI] auth error detected — attempting token refresh", "error", err)
+		if c.refreshGitHubAuth() {
+			slog.Info("[CopilotCLI] retrying after token refresh")
+			resp, err = c.doStreamChat(ctx, req, onChunk, onProgress)
+		}
+	}
+	return resp, err
+}
+
+// doStreamChat performs a single invocation of the copilot CLI.
+func (c *CopilotCLIProvider) doStreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string), onProgress func(event StreamEvent)) (*ChatResponse, error) {
 	if c.cliPath == "" {
 		return nil, fmt.Errorf("copilot CLI not found")
 	}
@@ -120,7 +210,7 @@ func (c *CopilotCLIProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 	// --allow-all-tools: allow tool execution without confirmation (required for non-interactive mode)
 	// --allow-all-paths: allow access to any file path for kubectl/helm operations
 	cmd := exec.CommandContext(ctx, c.cliPath, "-p", prompt, "--silent", "--no-ask-user", "--no-color", "--allow-all-tools", "--allow-all-paths")
-	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	cmd.Env = freshEnv()
 	configureProcessGroup(cmd) // #9442: kill entire process tree on timeout
 
 	stdout, err := cmd.StdoutPipe()

--- a/pkg/agent/provider_copilotcli_test.go
+++ b/pkg/agent/provider_copilotcli_test.go
@@ -1,7 +1,10 @@
 package agent
 
 import (
+	"os"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestCopilotCLIProvider_Basics(t *testing.T) {
@@ -54,4 +57,115 @@ func TestCopilotCLIProvider_DescriptionWithVersion(t *testing.T) {
 
 func TestCopilotCLIProvider_Interface(t *testing.T) {
 	var _ AIProvider = &CopilotCLIProvider{}
+}
+
+func TestIsAuthError(t *testing.T) {
+	cases := []struct {
+		text string
+		want bool
+	}{
+		{"copilot CLI requires authentication", true},
+		{"please login first", true},
+		{"token has expired", true},
+		{"HTTP 401 Unauthorized", true},
+		{"HTTP 403 Forbidden", true},
+		{"sign in to continue", true},
+		{"rate limit exceeded", false},
+		{"network timeout", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isAuthError(tc.text); got != tc.want {
+			t.Errorf("isAuthError(%q) = %v, want %v", tc.text, got, tc.want)
+		}
+	}
+}
+
+func TestFreshEnv_StripsStalTokens(t *testing.T) {
+	t.Setenv("GH_TOKEN", "stale-gh-token")
+	t.Setenv("GITHUB_TOKEN", "stale-github-token")
+
+	env := freshEnv()
+
+	for _, e := range env {
+		upper := strings.ToUpper(e)
+		if strings.HasPrefix(upper, "GH_TOKEN=") {
+			t.Error("freshEnv should strip GH_TOKEN")
+		}
+		if strings.HasPrefix(upper, "GITHUB_TOKEN=") {
+			t.Error("freshEnv should strip GITHUB_TOKEN")
+		}
+	}
+
+	found := false
+	for _, e := range env {
+		if e == "NO_COLOR=1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("freshEnv should include NO_COLOR=1")
+	}
+}
+
+func TestFreshEnv_PreservesOtherVars(t *testing.T) {
+	t.Setenv("MY_CUSTOM_VAR", "keepme")
+
+	env := freshEnv()
+	found := false
+	for _, e := range env {
+		if e == "MY_CUSTOM_VAR=keepme" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("freshEnv should preserve non-token env vars")
+	}
+}
+
+func TestRefreshGitHubAuth_Cooldown(t *testing.T) {
+	p := &CopilotCLIProvider{}
+
+	// Force a recent refresh so the cooldown prevents another attempt.
+	p.authMu.Lock()
+	p.lastAuthRefresh = time.Now()
+	p.lastAuthRefreshOK = true
+	p.authMu.Unlock()
+
+	// Should return cached result without invoking gh.
+	got := p.refreshGitHubAuth()
+	if !got {
+		t.Error("Expected cached true from cooldown period")
+	}
+
+	// With lastAuthRefreshOK=false, cooldown should return false.
+	p.authMu.Lock()
+	p.lastAuthRefreshOK = false
+	p.lastAuthRefresh = time.Now()
+	p.authMu.Unlock()
+
+	got = p.refreshGitHubAuth()
+	if got {
+		t.Error("Expected cached false from cooldown period")
+	}
+}
+
+func TestRefreshGitHubAuth_GhNotInstalled(t *testing.T) {
+	p := &CopilotCLIProvider{}
+
+	// Ensure cooldown is expired so it actually runs gh.
+	p.authMu.Lock()
+	p.lastAuthRefresh = time.Time{}
+	p.authMu.Unlock()
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", "/nonexistent")
+	defer os.Setenv("PATH", origPath)
+
+	got := p.refreshGitHubAuth()
+	if got {
+		t.Error("Expected false when gh is not on PATH")
+	}
 }


### PR DESCRIPTION
Fixes #11079

## Changes

- Add token expiry detection and auto-refresh for Copilot auth in `provider_copilotcli.go`
- On auth error, automatically invoke `gh auth token` to check for refreshed credentials, then retry once
- Strip stale `GH_TOKEN`/`GITHUB_TOKEN` from subprocess environment so the copilot CLI reads fresh tokens from gh's config/keyring
- Rate-limit refresh attempts with a 30s cooldown to avoid hammering gh CLI
- Add comprehensive tests: auth error detection, env filtering, cooldown behavior