### PR TITLE
🐛 Fix Windows shell detection and permissions (#11074, #11075, #11076)

### DIFF
--- a/pkg/agent/provider.go
+++ b/pkg/agent/provider.go
@@ -157,8 +157,12 @@ type MixedModeConfig struct {
 	Enabled bool `json:"enabled"`
 }
 
-// DefaultSystemPrompt is the default system prompt for KubeStellar console
-const DefaultSystemPrompt = `You are a helpful AI assistant embedded in the KubeStellar Console.
+// DefaultSystemPrompt is the default system prompt for KubeStellar console.
+// It is a var (not const) so that init-time OS detection can be appended (#11076).
+var DefaultSystemPrompt = defaultSystemPromptBase + OSCommandHint()
+
+// defaultSystemPromptBase is the OS-independent portion of DefaultSystemPrompt.
+const defaultSystemPromptBase = `You are a helpful AI assistant embedded in the KubeStellar Console.
 Your job is to help users with:
 - Managing Kubernetes clusters and workloads
 - Creating and managing BindingPolicies for multi-cluster deployments
@@ -200,7 +204,10 @@ Only analyze and summarize this data for the user.`
 // CANNOT execute kubectl or shell commands (#10463). It avoids promising
 // command-execution capabilities that would confuse users when the provider
 // later refuses or fails to execute anything.
-const ChatOnlySystemPrompt = `You are a helpful AI assistant embedded in the KubeStellar Console.
+// Includes OS detection so suggested commands match the user's platform (#11076).
+var ChatOnlySystemPrompt = chatOnlySystemPromptBase + OSCommandHint()
+
+const chatOnlySystemPromptBase = `You are a helpful AI assistant embedded in the KubeStellar Console.
 Your job is to help users with:
 - Understanding Kubernetes clusters and workloads
 - Explaining BindingPolicies for multi-cluster deployments

--- a/pkg/agent/provider_claudecode.go
+++ b/pkg/agent/provider_claudecode.go
@@ -200,8 +200,11 @@ func (c *ClaudeCodeProvider) Capabilities() ProviderCapability {
 	return CapabilityChat | CapabilityToolExec
 }
 
-// ClaudeCodeSystemPrompt instructs Claude Code CLI to actually execute commands using tools
-const ClaudeCodeSystemPrompt = `You are an AI assistant helping manage Kubernetes clusters through the KubeStellar Console.
+// ClaudeCodeSystemPrompt instructs Claude Code CLI to actually execute commands using tools.
+// Includes OS detection so the agent uses platform-appropriate commands (#11076).
+var ClaudeCodeSystemPrompt = claudeCodeSystemPromptBase + OSCommandHint()
+
+const claudeCodeSystemPromptBase = `You are an AI assistant helping manage Kubernetes clusters through the KubeStellar Console.
 
 IMPORTANT INSTRUCTIONS:
 1. When asked to run kubectl commands, CHECK something, or ANALYZE something - you MUST actually execute the commands using the Bash tool. Do NOT just output commands as text.

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -256,7 +256,10 @@ func (s *Server) killBackendProcess() bool {
 	// Fallback: find only the LISTEN process on the resolved backend port
 	// (not connected clients). Using -sTCP:LISTEN ensures we only kill the
 	// server, not browsers/proxies.
-	// NOTE: lsof is Unix-only; on Windows this falls through to return false (#7263).
+	// lsof is Unix-only; on Windows skip to return false (#7263, #11075).
+	if isWindows() {
+		return false
+	}
 	portArg := fmt.Sprintf(":%d", resolveBackendPort())
 	out, err := exec.Command("lsof", "-ti", portArg, "-sTCP:LISTEN").Output()
 	if err != nil || len(strings.TrimSpace(string(out))) == 0 {

--- a/pkg/agent/shell.go
+++ b/pkg/agent/shell.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// errNoShellFound is returned by resolveShell when no usable shell binary
+// can be located on the system PATH.
+var errNoShellFound = errors.New("no usable shell found on PATH")
+
+// osChmod is an alias for os.Chmod, extracted so the Unix build-tagged
+// chmodIfSupported can call it without repeating the import.
+var osChmod = os.Chmod
+
+// OSContext returns a short string describing the current operating system
+// and architecture that can be injected into AI system prompts so the agent
+// emits platform-appropriate commands from the start (#11076).
+//
+// Example output: "windows/amd64" or "darwin/arm64".
+func OSContext() string {
+	return fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// OSCommandHint returns a human-readable hint telling the AI which shell and
+// package manager conventions to use. This is appended to system prompts.
+func OSCommandHint() string {
+	switch runtime.GOOS {
+	case "windows":
+		shell := "powershell.exe"
+		if _, err := resolveShell(); err == nil {
+			// resolveShell already picked the best available shell
+			shell = "the resolved PowerShell or cmd.exe"
+		}
+		return fmt.Sprintf(`
+OS DETECTION — CRITICAL:
+You are running on Windows (%s). You MUST:
+- Use PowerShell or cmd.exe syntax for all commands (NOT bash/sh).
+- Use %s as the shell.
+- Use backslashes for file paths or PowerShell path literals.
+- Use winget, choco, or scoop for package installation (NOT apt, brew, yum).
+- Do NOT use chmod, chown, or other Unix permission commands.
+- Do NOT assume /bin/sh, /bin/bash, or other Unix paths exist.
+- Use "Start-Process" or direct invocation instead of "&" background operator.
+- Use $env:VAR syntax for environment variables (NOT $VAR).`, runtime.GOARCH, shell)
+	case "darwin":
+		return fmt.Sprintf(`
+OS DETECTION:
+You are running on macOS (%s). Use:
+- bash or zsh for shell commands.
+- brew (Homebrew) for package installation.
+- Standard Unix file paths and permissions.`, runtime.GOARCH)
+	default: // linux and others
+		return fmt.Sprintf(`
+OS DETECTION:
+You are running on Linux (%s). Use:
+- bash for shell commands.
+- apt, yum, dnf, or the appropriate package manager.
+- Standard Unix file paths and permissions.`, runtime.GOARCH)
+	}
+}

--- a/pkg/agent/shell_unix.go
+++ b/pkg/agent/shell_unix.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+// Platform-specific shell resolution for Unix/macOS.
+// See shell_windows.go for the Windows equivalent (#11074, #11076).
+package agent
+
+import (
+	"os"
+	"os/exec"
+)
+
+// resolveShell returns the path to the preferred shell on this platform.
+// Unix: bash first, then sh as a fallback.
+func resolveShell() (string, error) {
+	if p, err := exec.LookPath("bash"); err == nil {
+		return p, nil
+	}
+	if p, err := exec.LookPath("sh"); err == nil {
+		return p, nil
+	}
+	return "", errNoShellFound
+}
+
+// shellFlag returns the flag used to pass an inline command string to the
+// resolved shell (e.g. "-c" for bash/sh).
+func shellFlag() string {
+	return "-c"
+}
+
+// isWindows reports whether the current OS is Windows.
+func isWindows() bool {
+	return false
+}
+
+// chmodIfSupported sets file permissions. On Unix this is a direct os.Chmod.
+func chmodIfSupported(path string, mode uint32) error {
+	return osChmod(path, os.FileMode(mode))
+}

--- a/pkg/agent/shell_windows.go
+++ b/pkg/agent/shell_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+// Platform-specific shell resolution for Windows.
+//
+// Windows ships with powershell.exe (v5.1) out of the box; pwsh.exe
+// (PowerShell Core 6+) is an optional install. The agent used to require
+// pwsh.exe and fail on stock Windows installations (#11074). This file
+// implements a fallback chain: pwsh.exe → powershell.exe → cmd.exe.
+//
+// See shell_unix.go for the Unix equivalent.
+package agent
+
+import "os/exec"
+
+// resolveShell returns the path to the preferred shell on Windows.
+// Preference order: pwsh.exe (PowerShell Core 7+) → powershell.exe
+// (Windows PowerShell 5.1, ships with every Windows 10/11) → cmd.exe.
+func resolveShell() (string, error) {
+	if p, err := exec.LookPath("pwsh.exe"); err == nil {
+		return p, nil
+	}
+	if p, err := exec.LookPath("powershell.exe"); err == nil {
+		return p, nil
+	}
+	if p, err := exec.LookPath("cmd.exe"); err == nil {
+		return p, nil
+	}
+	return "", errNoShellFound
+}
+
+// shellFlag returns the flag used to pass an inline command string to the
+// resolved shell. PowerShell uses "-Command", cmd.exe uses "/c".
+func shellFlag() string {
+	// Both pwsh.exe and powershell.exe accept -Command; cmd.exe accepts /c.
+	// Since resolveShell prefers PowerShell, default to "-Command".
+	// Callers targeting cmd.exe explicitly should use "/c" directly.
+	if _, err := exec.LookPath("pwsh.exe"); err == nil {
+		return "-Command"
+	}
+	if _, err := exec.LookPath("powershell.exe"); err == nil {
+		return "-Command"
+	}
+	return "/c"
+}
+
+// isWindows reports whether the current OS is Windows.
+func isWindows() bool {
+	return true
+}
+
+// chmodIfSupported is a no-op on Windows. Windows does not use POSIX file
+// permission bits; attempting os.Chmod can return "permission denied" or
+// silently succeed depending on the filesystem (#11075).
+func chmodIfSupported(_ string, _ uint32) error {
+	return nil
+}

--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -984,10 +984,12 @@ func (uc *UpdateChecker) executeBinaryUpdate(release *githubReleaseInfo) {
 	// Set permissions on the staged binary *before* moving it to the final
 	// location. This prevents a window where power loss leaves a non-executable
 	// binary at consolePath (#7445).
+	// On Windows, chmod is a no-op — Windows does not use POSIX permission
+	// bits and attempting to set them can return "Permission denied" (#11075).
 	stagedBinary := filepath.Join(stagingDir, "console")
 	// fileModeBinary is the permission bits for the installed console binary.
 	const fileModeBinary = 0755
-	if err := os.Chmod(stagedBinary, fileModeBinary); err != nil {
+	if err := chmodIfSupported(stagedBinary, fileModeBinary); err != nil {
 		if rbErr := renameOrCopy(backupPath, consolePath); rbErr != nil {
 			slog.Error("[AutoUpdate] backup restore failed after chmod error", "error", rbErr)
 		}


### PR DESCRIPTION
Fixes #11074
Fixes #11075
Fixes #11076

## Changes
- Add Windows OS detection before running shell commands (`isWindows()`, `OSContext()`, `OSCommandHint()`)
- Fall back to `powershell.exe` when `pwsh.exe` is unavailable on Windows via `resolveShell()` (pwsh.exe → powershell.exe → cmd.exe)
- Handle Windows permission model correctly: `chmodIfSupported()` is a no-op on Windows, preventing "Permission denied" from `os.Chmod` on NTFS
- Guard Unix-only `lsof` call in `server_http.go` with `isWindows()` early return
- Inject OS-aware hints into all AI system prompts so missions use platform-appropriate commands from the start

## Files Changed
- `pkg/agent/shell.go` — shared shell resolution utilities and OS detection
- `pkg/agent/shell_unix.go` — Unix build-tagged: bash/sh resolution, real chmod
- `pkg/agent/shell_windows.go` — Windows build-tagged: pwsh/powershell/cmd fallback, no-op chmod
- `pkg/agent/provider.go` — system prompts now include OS command hints
- `pkg/agent/provider_claudecode.go` — Claude Code prompt includes OS hints
- `pkg/agent/update_checker.go` — use `chmodIfSupported()` instead of `os.Chmod`
- `pkg/agent/server_http.go` — guard lsof with `isWindows()` check

## Testing
- `go build ./pkg/agent/...` ✅
- `go vet ./pkg/agent/...` ✅
- `go test ./pkg/agent/... -short` ✅ (all tests pass)