### PR TITLE
🐛 Cluster dedup phase 2: fix 20 files double-counting clusters (#11093)

### DIFF
--- a/web/src/components/cards/MaintenanceWindows.tsx
+++ b/web/src/components/cards/MaintenanceWindows.tsx
@@ -39,7 +39,7 @@ function saveWindows(windows: MaintenanceWindow[]) {
 
 export function MaintenanceWindows() {
   const { t } = useTranslation(['common', 'cards'])
-  const { clusters } = useClusters()
+  const { deduplicatedClusters: clusters } = useClusters()
   const [windows, setWindows] = useState<MaintenanceWindow[]>(loadWindows)
   const [showForm, setShowForm] = useState(false)
   const [timeError, setTimeError] = useState('')

--- a/web/src/components/compliance/Compliance.tsx
+++ b/web/src/components/compliance/Compliance.tsx
@@ -28,7 +28,7 @@ const MOCK_GATEKEEPER_PER_CLUSTER = 3.2
 const MOCK_FALCO_PER_CLUSTER = 1.5
 
 export function Compliance() {
-  const { clusters, isLoading, refetch, lastUpdated, isRefreshing: dataRefreshing, error } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, refetch, lastUpdated, isRefreshing: dataRefreshing, error } = useClusters()
   const { drillToAllSecurity, drillToCompliance } = useDrillDownActions()
   const { selectedClusters: globalSelectedClusters, isAllClustersSelected } = useGlobalFilters()
 

--- a/web/src/components/cost/Cost.tsx
+++ b/web/src/components/cost/Cost.tsx
@@ -22,7 +22,7 @@ const STORAGE_COST_PER_GB_MONTH = 0.10
 const DEFAULT_COST_CARDS = getDefaultCards('cost')
 
 export function Cost() {
-  const { clusters, isLoading, refetch, lastUpdated, isRefreshing: dataRefreshing, error } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, refetch, lastUpdated, isRefreshing: dataRefreshing, error } = useClusters()
   const { nodes: gpuNodes } = useGPUNodes()
   const { drillToCost } = useDrillDownActions()
   const { selectedClusters: globalSelectedClusters, isAllClustersSelected } = useGlobalFilters()

--- a/web/src/components/dashboard/ConfigureCardModal.tsx
+++ b/web/src/components/dashboard/ConfigureCardModal.tsx
@@ -522,7 +522,7 @@ export function ConfigureCardModal({ isOpen, card, onClose, onSave, onCreateCard
   const [activeTab, setActiveTab] = useState<'settings' | 'behaviors' | 'ai'>('settings')
   const [aiChanges, setAiChanges] = useState<string[]>([])
   const [aiError, setAiError] = useState<string | null>(null)
-  const { clusters } = useClusters()
+  const { deduplicatedClusters: clusters } = useClusters()
   const { addTokens } = useTokenUsage()
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isMountedRef = useRef(true)

--- a/web/src/components/helm/HelmReleases.tsx
+++ b/web/src/components/helm/HelmReleases.tsx
@@ -13,7 +13,7 @@ const HELM_CARDS_KEY = 'kubestellar-helm-cards'
 const DEFAULT_HELM_CARDS = getDefaultCards('helm')
 
 export function HelmReleases() {
-  const { clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error } = useClusters()
   const { drillToAllHelm, drillToAllClusters } = useDrillDownActions()
   const { selectedClusters: globalSelectedClusters, isAllClustersSelected } = useGlobalFilters()
 

--- a/web/src/components/insights/Insights.tsx
+++ b/web/src/components/insights/Insights.tsx
@@ -10,7 +10,7 @@ const INSIGHTS_CARDS_KEY = 'kubestellar-insights-cards'
 const DEFAULT_INSIGHTS_CARDS = getDefaultCards('insights')
 
 export function Insights() {
-  const { clusters, isLoading: clustersLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error } = useClusters()
   const { insights, isLoading: insightsLoading, isDemoData } = useMultiClusterInsights()
 
   const reachableClusters = clusters.filter(c => c.reachable !== false)

--- a/web/src/components/karmada-ops/KarmadaOps.tsx
+++ b/web/src/components/karmada-ops/KarmadaOps.tsx
@@ -14,7 +14,7 @@ const KARMADA_OPS_CARDS_KEY = 'kubestellar-karmada-ops-cards'
 const DEFAULT_KARMADA_OPS_CARDS = getDefaultCards('karmada-ops')
 
 export function KarmadaOps() {
-  const { clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error } = useClusters()
 
   const reachableClusters = clusters.filter(c => c.reachable !== false)
   const hasRealData = reachableClusters.length > 0

--- a/web/src/components/logs/Logs.tsx
+++ b/web/src/components/logs/Logs.tsx
@@ -24,7 +24,7 @@ const DEFAULT_LOGS_CARDS = [
 ]
 
 export function Logs() {
-  const { clusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, refetch: refetchClusters } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, refetch: refetchClusters } = useClusters()
   const { events, isLoading: eventsLoading, isRefreshing: eventsRefreshing, lastRefresh, refetch: refetchEvents } = useCachedEvents()
   const warningEvents = events.filter(e => e.type === 'Warning')
   const lastUpdated = lastRefresh ? new Date(lastRefresh) : null

--- a/web/src/components/mission-control/FlightPlanBlueprint.tsx
+++ b/web/src/components/mission-control/FlightPlanBlueprint.tsx
@@ -138,7 +138,7 @@ export function FlightPlanBlueprint({
   onMoveProject,
   installedProjects = new Set() }: FlightPlanBlueprintProps) {
   const svgId = useId().replace(/:/g, '')
-  const { clusters, error: clustersError } = useClusters()
+  const { deduplicatedClusters: clusters, error: clustersError } = useClusters()
 
   // Filter out explicitly unhealthy clusters and redistribute orphaned projects to healthy ones.
   // Also scope to state.targetClusters when set — without this, assignments from

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -522,7 +522,7 @@ export function useMissionControl() {
   )
   const { startMission, sendMessage, missions, dismissMission } = useMissions()
   const { releases: helmReleases } = useHelmReleases()
-  const { clusters, isLoading: clustersLoading, lastUpdated: clustersLastUpdated } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading, lastUpdated: clustersLastUpdated } = useClusters()
   const lastParsedContentRef = useRef('')
   // #9496 — Track whether the AI suggestion request timed out. When the
   // AI_SUGGEST_TIMEOUT_MS safety net fires, we set this ref so the parse

--- a/web/src/components/missions/ClusterSelectionDialog.tsx
+++ b/web/src/components/missions/ClusterSelectionDialog.tsx
@@ -22,7 +22,7 @@ interface ClusterSelectionDialogProps {
 }
 
 export function ClusterSelectionDialog({ open, missionTitle, onSelect, onCancel }: ClusterSelectionDialogProps) {
-  const { clusters, isLoading } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading } = useClusters()
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [search, setSearch] = useState('')
 

--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -165,7 +165,7 @@ function formReducer(state: FormState, action: FormAction): FormState {
 
 export function CanIChecker() {
   const { t } = useTranslation('common')
-  const { clusters: rawClusters } = useClusters()
+  const { deduplicatedClusters: rawClusters } = useClusters()
   const clusters = rawClusters.map(c => c.name)
   const { checkPermission, checking, result, error, reset } = useCanI()
 

--- a/web/src/components/services/Services.tsx
+++ b/web/src/components/services/Services.tsx
@@ -17,7 +17,7 @@ const DEFAULT_SERVICES_CARDS = getDefaultCards('services')
 
 export function Services() {
   const navigate = useNavigate()
-  const { clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error: clustersError } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error: clustersError } = useClusters()
   const { services, error: servicesError } = useServices()
   const { ingresses } = useIngresses()
   const error = clustersError || servicesError

--- a/web/src/components/settings/sections/LocalClustersSection.tsx
+++ b/web/src/components/settings/sections/LocalClustersSection.tsx
@@ -146,7 +146,7 @@ export function LocalClustersSection() {
   const [deleteClusterConfirm, setDeleteClusterConfirm] = useState<{ tool: string; name: string } | null>(null)
   const [deleteVClusterConfirm, setDeleteVClusterConfirm] = useState<{ name: string; namespace: string } | null>(null)
 
-  const { clusters: connectedClusters } = useClusters()
+  const { deduplicatedClusters: connectedClusters } = useClusters()
   const healthyClusters = (connectedClusters || []).filter(c => c.healthy !== false)
 
   const hasVClusterTool = installedTools.some(t => t.name === 'vcluster')

--- a/web/src/components/settings/sections/PersistenceSection.tsx
+++ b/web/src/components/settings/sections/PersistenceSection.tsx
@@ -24,7 +24,7 @@ export function PersistenceSection() {
     isActive,
   } = usePersistence()
 
-  const { clusters } = useClusters()
+  const { deduplicatedClusters: clusters } = useClusters()
   const [localConfig, setLocalConfig] = useState<PersistenceConfig>(config)
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<{ cluster: string; success: boolean } | null>(null)

--- a/web/src/components/workloads/Workloads.tsx
+++ b/web/src/components/workloads/Workloads.tsx
@@ -57,7 +57,7 @@ export function Workloads() {
   const { issues: podIssues, isLoading: podIssuesLoading, isRefreshing: podIssuesRefreshing, lastUpdated, refetch: refetchPodIssues } = usePodIssues()
   const { issues: deploymentIssues, isLoading: deploymentIssuesLoading, isRefreshing: deploymentIssuesRefreshing, refetch: refetchDeploymentIssues } = useDeploymentIssues()
   const { deployments: allDeployments, isLoading: deploymentsLoading, isRefreshing: deploymentsRefreshing, refetch: refetchDeployments } = useDeployments()
-  const { clusters, isLoading: clustersLoading, refetch: refetchClusters } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading, refetch: refetchClusters } = useClusters()
   const { status: agentStatus } = useLocalAgent()
   const { isDemoMode } = useDemoMode()
   const isModeSwitching = useIsModeSwitching()

--- a/web/src/hooks/useCardRecommendations.ts
+++ b/web/src/hooks/useCardRecommendations.ts
@@ -46,7 +46,7 @@ export function useCardRecommendations(currentCardTypes: string[]) {
   const { issues: deploymentIssues } = useDeploymentIssues()
   const { events: warningEvents } = useWarningEvents()
   const { nodes: gpuNodes } = useGPUNodes()
-  const { clusters } = useClusters()
+  const { deduplicatedClusters: clusters } = useClusters()
   const { issues: securityIssues } = useSecurityIssues()
 
   // Analyze cluster state and generate recommendations

--- a/web/src/hooks/useClusterFilter.tsx
+++ b/web/src/hooks/useClusterFilter.tsx
@@ -17,7 +17,7 @@ const ClusterFilterContext = createContext<ClusterFilterContextType | null>(null
 const STORAGE_KEY = 'clusterFilter'
 
 export function ClusterFilterProvider({ children }: { children: ReactNode }) {
-  const { clusters } = useClusters()
+  const { deduplicatedClusters: clusters } = useClusters()
   const availableClusters = clusters.map(c => c.name)
 
   // Initialize from localStorage or default to all clusters (empty array means all)

--- a/web/src/hooks/useMissionSuggestions.ts
+++ b/web/src/hooks/useMissionSuggestions.ts
@@ -61,7 +61,7 @@ export function useMissionSuggestions() {
   const { issues: podIssues } = usePodIssues()
   const { issues: deploymentIssues } = useDeploymentIssues()
   const { issues: securityIssues } = useSecurityIssues()
-  const { clusters } = useClusters()
+  const { deduplicatedClusters: clusters } = useClusters()
   const { nodes } = useNodes()
   const { pods } = usePods()
 

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -372,7 +372,7 @@ function matchesQuery(item: SearchItem, query: string): boolean {
 // --- Hook ---
 
 export function useSearchIndex(query: string) {
-  const { clusters } = useClusters()
+  const { deduplicatedClusters: clusters } = useClusters()
   const { deployments } = useDeployments()
   // Search should index all available pods, not just a small subset (#7217).
   const SEARCH_POD_LIMIT = 500


### PR DESCRIPTION
Fixes #11093

## Changes
Replace `{ clusters }` with `{ deduplicatedClusters: clusters }` in 20 files that were still using raw cluster lists from `useClusters()`, causing double-counting when multiple kubeconfig contexts alias the same physical cluster.

### Files changed (20)
- **Cards:** `MaintenanceWindows.tsx`
- **Pages:** `HelmReleases.tsx`, `Services.tsx`, `Compliance.tsx`, `Cost.tsx`, `Insights.tsx`, `KarmadaOps.tsx`, `Logs.tsx`, `Workloads.tsx`
- **Mission control:** `FlightPlanBlueprint.tsx`, `useMissionControl.ts`
- **Dashboard:** `ConfigureCardModal.tsx`, `ClusterSelectionDialog.tsx`
- **Settings:** `LocalClustersSection.tsx`, `PersistenceSection.tsx`
- **RBAC:** `CanIChecker.tsx`
- **Hooks:** `useClusterFilter.tsx`, `useCardRecommendations.ts`, `useSearchIndex.ts`, `useMissionSuggestions.ts`

This is a mechanical find/replace — the destructured alias means no other code in each file needs changing.