### PR TITLE
⚡ React perf: CardWrapper memo + useCallback handlers + useMemo filters (#11094)

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState, useEffect, useCallback, useRef, useMemo, createContext, use, ComponentType, Suspense } from 'react'
+import { ReactNode, useState, useEffect, useCallback, useRef, useMemo, memo, createContext, use, ComponentType, Suspense } from 'react'
 import { safeLazy } from '../../lib/safeLazy'
 import {
   Maximize2, RefreshCw, ChevronRight, ChevronDown, Bug, AlertTriangle, Info,
@@ -202,7 +202,7 @@ interface CardWrapperProps {
 // Re-export for backwards compatibility — data now lives in cardMetadata.ts and cardIcons.ts
 export { CARD_TITLES, CARD_DESCRIPTIONS } from './cardMetadata'
 
-export function CardWrapper({
+export const CardWrapper = memo(function CardWrapper({
   cardId,
   cardType,
   title: customTitle,
@@ -1002,4 +1002,4 @@ export function CardWrapper({
     </CardExpandedContext.Provider>
     </CardTypeContext.Provider>
   )
-}
+})

--- a/web/src/components/cards/ClusterCosts.tsx
+++ b/web/src/components/cards/ClusterCosts.tsx
@@ -259,14 +259,14 @@ export const ClusterCosts = memo(function ClusterCosts({ config }: ClusterCostsP
   const memoryCost = config?.memoryCostPerGBHour ?? pricing.memory
   const gpuCost = config?.gpuCostPerHour ?? pricing.gpu
 
-  const gpuByCluster = (() => {
+  const gpuByCluster = useMemo(() => {
     const map: Record<string, number> = {}
     gpuNodes.forEach(node => {
       const clusterKey = (node.cluster ?? '').split('/')[0]
       map[clusterKey] = (map[clusterKey] || 0) + node.gpuCount
     })
     return map
-  })()
+  }, [gpuNodes])
 
   // Get the provider for a specific cluster (memoized to prevent re-renders)
   const getClusterProvider = useCallback((clusterName: string, context?: string): CloudProvider => {
@@ -350,6 +350,20 @@ export const ClusterCosts = memo(function ClusterCosts({ config }: ClusterCostsP
 
   const totalMonthly = clusterCosts.reduce((sum, c) => sum + c.monthly, 0)
   const totalDaily = clusterCosts.reduce((sum, c) => sum + c.daily, 0)
+
+  // Memoize provider breakdown counts to avoid recomputing in render
+  const providerBreakdown = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const c of clusterCosts) {
+      counts[c.provider] = (counts[c.provider] || 0) + 1
+    }
+    return counts
+  }, [clusterCosts])
+
+  const uniqueProviders = useMemo(() =>
+    Array.from(new Set(clusterCosts.map(c => c.provider))),
+    [clusterCosts]
+  )
 
   if (isLoading && allClusters.length === 0) {
     return (
@@ -608,7 +622,7 @@ export const ClusterCosts = memo(function ClusterCosts({ config }: ClusterCostsP
                 {(Object.keys(CLOUD_PRICING) as CloudProvider[]).filter(p => p !== 'estimate').map(provider => {
                   const p = CLOUD_PRICING[provider]
                   const icon = PROVIDER_ICONS[provider]
-                  const count = clusterCosts.filter(c => c.provider === provider).length
+                  const count = providerBreakdown[provider] || 0
                   if (count === 0 && !showRatesInfo) return null
                   return (
                     <div key={provider} className={`flex items-center gap-2 p-1.5 rounded ${count > 0 ? 'bg-secondary/50' : 'opacity-50'}`}>
@@ -804,8 +818,8 @@ export const ClusterCosts = memo(function ClusterCosts({ config }: ClusterCostsP
               <>
                 <span>{t('cards:clusterCosts.mixedPricing')}</span>
                 {/* Show unique providers used */}
-                {Array.from(new Set(clusterCosts.map(c => c.provider))).map(provider => {
-                  const count = clusterCosts.filter(c => c.provider === provider).length
+                {uniqueProviders.map(provider => {
+                  const count = providerBreakdown[provider] || 0
                   const icon = PROVIDER_ICONS[provider]
                   return (
                     <span

--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -243,7 +243,7 @@ export function TrivyScan({ config: _config }: CardConfig) {
   const allChecked = clustersChecked >= totalClusters && totalClusters > 0
 
   // Filter by selected clusters
-  const filtered = (() => {
+  const filtered = useMemo(() => {
     if (selectedClusters.length === 0) return aggregated
     const agg = { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 }
     for (const [name, s] of Object.entries(statuses)) {
@@ -257,7 +257,7 @@ export function TrivyScan({ config: _config }: CardConfig) {
       agg.unknown += vuln.unknown
     }
     return agg
-  })()
+  }, [selectedClusters, aggregated, statuses])
 
   const hasData = installed || isDemoData
   // #6219: surface failure state. `hasErrors` from useTrivy means at least
@@ -460,6 +460,11 @@ export function KubescapeScan({ config: _config }: CardConfig) {
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
   const [modalCluster, setModalCluster] = useState<string | null>(null)
+
+  const installedClusters = useMemo(() =>
+    Object.keys(statuses).filter(c => statuses[c].installed),
+    [statuses]
+  )
 
   /** Whether all clusters have been checked */
   const allChecked = clustersChecked >= totalClusters && totalClusters > 0
@@ -715,7 +720,7 @@ Please proceed step by step.`,
           onClose={() => setModalCluster(null)}
           clusterName={modalCluster}
           status={statuses[modalCluster]}
-          clusters={Object.keys(statuses).filter(c => statuses[c].installed)}
+          clusters={installedClusters}
           onClusterChange={(newCluster) => setModalCluster(newCluster)}
           onRefresh={() => refetch()}
           isRefreshing={isRefreshing}

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 import { Gauge, Cpu, HardDrive, Box, ChevronRight, Plus, Pencil, Trash2, Zap } from 'lucide-react'
 import { BaseModal, useModalState } from '../../lib/modals'
 import { Button } from '../ui/Button'
@@ -400,10 +400,10 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
   }
 
   // Open edit modal for a quota
-  const openEditModal = (quota: ResourceQuota) => {
+  const openEditModal = useCallback((quota: ResourceQuota) => {
     setEditingQuota(quota)
     openModal()
-  }
+  }, [openModal])
 
   // Transform ResourceQuotas to QuotaUsage format for display (pre-filter by selectors only)
   const quotaUsages = useMemo(() => {

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, Suspense } from 'react'
+import { useState, useEffect, useRef, useCallback, Suspense } from 'react'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import {
   DndContext,
@@ -291,7 +291,7 @@ export function Dashboard() {
   // Custom collision detection: when dragging a workload, prioritize cluster-group
   // and cluster-drop droppable zones (detected via pointerWithin) over the larger
   // sortable card containers that would otherwise always win with closestCenter.
-  const collisionDetection: CollisionDetection = (args) => {
+  const collisionDetection: CollisionDetection = useCallback((args) => {
     const isWorkloadDrag = args.active.data.current?.type === 'workload'
     if (isWorkloadDrag) {
       // For workload drags, prioritize cluster-group drop targets.
@@ -335,7 +335,7 @@ export function Dashboard() {
     )
     if (dashboardDropTarget) return [dashboardDropTarget]
     return centerCollisions
-  }
+  }, [])
 
   const handleDragStart = (event: DragStartEvent) => {
     const id = event.active.id as string

--- a/web/src/components/dashboard/DashboardCards.tsx
+++ b/web/src/components/dashboard/DashboardCards.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Plus, LayoutGrid, ChevronDown, ChevronRight, Layout, AlertTriangle } from 'lucide-react'
 import { useModalState } from '../../lib/modals'
@@ -64,25 +64,25 @@ export function DashboardCards({
     return () => window.removeEventListener('kc-add-card-from-marketplace', handler)
   }, [onAddCard])
 
-  const handleAddCards = (suggestions: CardSuggestion[]) => {
+  const handleAddCards = useCallback((suggestions: CardSuggestion[]) => {
     suggestions.forEach(card => {
       onAddCard(card.type, card.config, card.title)
     })
     addCardModal.close()
-  }
+  }, [onAddCard, addCardModal])
 
-  const handleConfigureCard = (cardId: string) => {
+  const handleConfigureCard = useCallback((cardId: string) => {
     setSelectedCardId(cardId)
     configureModal.open()
-  }
+  }, [configureModal])
 
-  const handleSaveConfig = (cardId: string, config: Record<string, unknown>, _title?: string) => {
+  const handleSaveConfig = useCallback((cardId: string, config: Record<string, unknown>, _title?: string) => {
     onUpdateCardConfig(cardId, config)
     configureModal.close()
     setSelectedCardId(null)
-  }
+  }, [onUpdateCardConfig, configureModal])
 
-  const handleApplyTemplate = (template: DashboardTemplate) => {
+  const handleApplyTemplate = useCallback((template: DashboardTemplate) => {
     // Preserve per-card position (w/h) from the template definition (#7253)
     const newCards: DashboardCard[] = template.cards.map((card, idx) => ({
       id: `${card.card_type}-${Date.now()}-${idx}`,
@@ -93,7 +93,7 @@ export function DashboardCards({
     }))
     onReplaceCards(newCards)
     templatesModal.close()
-  }
+  }, [onReplaceCards, templatesModal])
 
   const selectedCard = cards.find(c => c.id === selectedCardId)
   // Transform to the Card format expected by ConfigureCardModal


### PR DESCRIPTION
Fixes #11094

## Changes
Add React performance optimizations to dashboard card rendering:

- **CardWrapper.tsx**: Wrap in `React.memo()` to skip re-renders when props unchanged
- **DashboardCards.tsx**: `useCallback()` for handler props passed to cards
- **Dashboard.tsx**: `useCallback()` for `collisionDetection` callback
- **NamespaceQuotas.tsx**: Extract memoized handlers from `.map()` loops
- **ComplianceCards.tsx**: `useMemo()` for filtered cluster computation + IIFE→useMemo for TrivyScan filter
- **ClusterCosts.tsx**: `useMemo()` for gpuByCluster, provider breakdown counts, and unique providers

These are pure performance optimizations with no behavior changes.