### PR TITLE
fix: add git fallback for SHA in feedback issues

### DIFF
--- a/pkg/api/handlers/feedback_github.go
+++ b/pkg/api/handlers/feedback_github.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os/exec"
 	"strings"
 
 	"runtime/debug"
@@ -950,15 +951,18 @@ func (h *FeedbackHandler) createNotification(ctx context.Context, userID uuid.UU
 
 func vcsRevision() string {
 	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return ""
-	}
-	for _, s := range info.Settings {
-		if s.Key == "vcs.revision" {
-			return s.Value
+	if ok {
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" {
+				return s.Value
+			}
 		}
 	}
-	return ""
+	out, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // extractFeatureRequestID extracts the feature request ID from a PR body


### PR DESCRIPTION
## Summary

- `vcsRevision()` only read from `debug.ReadBuildInfo()`, which is empty for local `go build` / `go run` builds without VCS stamping
- Added `git rev-parse HEAD` fallback (same pattern used by `/api/version` endpoint)
- Without this fix, SHA was missing from feedback-created GitHub issues on local dev builds

Fixes #11099

Follow-up to #11049.

## Test plan

- [ ] `go build ./cmd/console` compiles
- [ ] Restart console, submit a test feedback issue, verify SHA appears in the GitHub issue body

🤖 Generated with [Claude Code](https://claude.com/claude-code)