### PR TITLE
🐛 Fix repair action not closing current panel

### DIFF
--- a/web/src/components/cards/compliance/PolicyViolationDetailModal.tsx
+++ b/web/src/components/cards/compliance/PolicyViolationDetailModal.tsx
@@ -47,6 +47,7 @@ export function PolicyViolationDetailModal({ isOpen, onClose, violation }: Polic
   const handleFixWithAI = () => {
     if (!violation) return
     emitActionClicked('fix_with_ai', 'policy_violations', 'compliance')
+    onClose() // Close modal so mission sidebar is visible
     startMission({
       title: `Fix: ${violation.policy} violations`,
       description: `${violation.count} violations from ${violation.tool} on ${(violation.clusters || []).join(', ')}`,

--- a/web/src/components/cards/deploy/GitOpsDriftDetailModal.tsx
+++ b/web/src/components/cards/deploy/GitOpsDriftDetailModal.tsx
@@ -68,6 +68,7 @@ export function GitOpsDriftDetailModal({ isOpen, onClose, drift }: GitOpsDriftDe
   const handleSyncWithAI = () => {
     if (!drift) return
     emitActionClicked('sync', 'gitops_drift', 'deploy')
+    handleClose() // Close modal so mission sidebar is visible
     startMission({
       title: `Sync: ${drift.resource} drift`,
       description: `${drift.driftType} drift on ${drift.kind}/${drift.resource} in ${drift.namespace} on ${drift.cluster}`,

--- a/web/src/components/cards/deploy/HelmHistoryDetailModal.tsx
+++ b/web/src/components/cards/deploy/HelmHistoryDetailModal.tsx
@@ -57,6 +57,7 @@ export function HelmHistoryDetailModal({
   const handleRollback = () => {
     if (!entry) return
     emitActionClicked('rollback', 'helm_history', 'deploy')
+    onClose() // Close modal so mission sidebar is visible
     startMission({
       title: `Rollback: ${releaseName} to rev ${entry.revision}`,
       description: `Rollback Helm release ${releaseName} in ${namespace} on ${clusterName} to revision ${entry.revision}`,

--- a/web/src/components/cards/insights/InsightDetailModal.tsx
+++ b/web/src/components/cards/insights/InsightDetailModal.tsx
@@ -81,6 +81,7 @@ export function InsightDetailModal({ isOpen, onClose, insight }: InsightDetailMo
   const handleCreateMission = () => {
     if (!insight) return
     emitActionClicked('create_mission', insight.category, 'insights')
+    onClose() // Close modal so mission sidebar is visible
     startMission({
       title: `Fix: ${insight.title}`,
       description: insight.description,

--- a/web/src/components/cards/trivy/TrivyDetailModal.tsx
+++ b/web/src/components/cards/trivy/TrivyDetailModal.tsx
@@ -70,6 +70,7 @@ export function TrivyDetailModal({
 
   const handleFixImage = (img: { image: string; tag: string; namespace: string; critical: number; high: number; medium: number; low: number }) => {
     emitActionClicked('fix_vulns', 'trivy_scan', 'compliance')
+    onClose() // Close modal so mission sidebar is visible
     startMission({
       title: `Fix vulns: ${img.image}:${img.tag}`,
       description: `${img.critical}C/${img.high}H vulnerabilities in ${img.image}:${img.tag} (ns: ${img.namespace}) on ${clusterName}`,
@@ -109,6 +110,7 @@ Please proceed step by step.`,
       .map(img => `- ${img.image}:${img.tag} (ns: ${img.namespace}) — ${img.critical} critical`)
       .join('\n')
 
+    onClose() // Close modal so mission sidebar is visible
     startMission({
       title: `Triage: ${critical} critical vulns on ${clusterName}`,
       description: `${criticalImages.length} images with critical vulnerabilities on ${clusterName}`,

--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -177,6 +177,7 @@ export function ClusterDetailModal({ clusterName, clusterUser, onClose, onRename
       ...clusterDeploymentIssues.map(d => `Deployment ${d.name} in ${d.namespace}: ${d.readyReplicas}/${d.replicas} ready`)
     ].slice(0, 10).join('\n')
 
+    onClose() // Close modal so mission sidebar is visible
     startMission({
       title: t('cluster.diagnoseMissionTitle', { cluster: clusterName.split('/').pop() }),
       description: t('cluster.diagnoseMissionDescription'),
@@ -205,7 +206,6 @@ Please analyze this cluster and provide:
         podIssuesCount: podIssues.length,
         deploymentIssuesCount: clusterDeploymentIssues.length }
     })
-    onClose()
   }
 
   const handleRepair = () => {
@@ -215,6 +215,7 @@ Please analyze this cluster and provide:
       ...clusterDeploymentIssues.slice(0, 5).map(d => `- Deployment "${d.name}" in namespace "${d.namespace}": ${d.readyReplicas}/${d.replicas} ready - ${d.reason || 'Unknown reason'}`)
     ].join('\n')
 
+    onClose() // Close modal so mission sidebar is visible
     startMission({
       title: t('cluster.repairMissionTitle', { cluster: clusterName.split('/').pop() }),
       description: t('cluster.repairMissionDescription'),
@@ -237,7 +238,6 @@ After I approve, help me execute the repairs step by step.`,
         podIssues: podIssues.slice(0, 10),
         deploymentIssues: clusterDeploymentIssues.slice(0, 10) }
     })
-    onClose()
   }
 
   // Determine cluster status using the SAME shared helpers as the list view
@@ -442,6 +442,7 @@ After I approve, help me execute the repairs step by step.`,
               size="sm"
               onClick={() => {
                 emitClusterAction('ask', clusterName)
+                onClose() // Close modal so mission sidebar is visible
                 startMission({
                   title: `Ask about ${clusterName.split('/').pop()}`,
                   description: 'Custom question about the cluster',
@@ -450,7 +451,6 @@ After I approve, help me execute the repairs step by step.`,
                   initialPrompt: `I have a question about Kubernetes cluster "${clusterName}". The cluster currently has ${health?.nodeCount || 0} nodes, ${health?.podCount || 0} pods, ${health?.cpuCores || 0} CPU cores, and ${health?.memoryGB || 0} GB memory. How can I help you?`,
                   context: { clusterName, health }
                 })
-                onClose()
               }}
               disabled={isUnreachable}
               icon={<Wand2 className="w-3.5 h-3.5" />}

--- a/web/src/components/clusters/NodeDetailPanel.tsx
+++ b/web/src/components/clusters/NodeDetailPanel.tsx
@@ -36,6 +36,7 @@ export function NodeDetailPanel({ node, clusterName, onClose }: NodeDetailPanelP
     }
     const issueConditions = getConditionIssuesSummary(node.conditions)
 
+    onClose?.() // Close panel so mission sidebar is visible
     startMission({
       title: `Repair Node ${node.name}`,
       description: `Diagnose and repair node issues: ${issueConditions}`,

--- a/web/src/components/drilldown/views/AlertDrillDown.tsx
+++ b/web/src/components/drilldown/views/AlertDrillDown.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useMissions } from '../../../hooks/useMissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import {
@@ -74,6 +74,7 @@ export function AlertDrillDown({ data }: Props) {
 
   const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster, drillToPod, drillToDeployment, drillToAlertRule } = useDrillDownActions()
+  const { close: closeDrillDown } = useDrillDown()
   const { startMission } = useMissions()
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
@@ -216,6 +217,7 @@ Please:
    - "Should I silence this alert or set up a preventive rule?"
    - "All done"`
 
+    closeDrillDown() // Close panel so mission sidebar is visible
     startMission({
       title: `Diagnose Alert: ${alertName}`,
       description: `Analyze ${alertSeverity} alert and provide remediation guidance`,

--- a/web/src/components/drilldown/views/ArgoAppDrillDown.tsx
+++ b/web/src/components/drilldown/views/ArgoAppDrillDown.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useMissions } from '../../../hooks/useMissions'
 import { useArgoCDTriggerSync } from '../../../hooks/useArgoCD'
 import { ClusterBadge } from '../../ui/ClusterBadge'
@@ -112,6 +112,7 @@ export function ArgoAppDrillDown({ data }: Props) {
 
   const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster, drillToPod, drillToDeployment, drillToService } = useDrillDownActions()
+  const { close: closeDrillDown } = useDrillDown()
   const { startMission } = useMissions()
   const { triggerSync, isSyncing, lastResult: syncResult } = useArgoCDTriggerSync()
 
@@ -305,6 +306,7 @@ Please:
    - "Should I check other ArgoCD apps?"
    - "All done"`
 
+    closeDrillDown() // Close panel so mission sidebar is visible
     startMission({
       title: `Diagnose ArgoApp: ${appName}`,
       description: `Analyze ArgoCD application health and sync status`,

--- a/web/src/components/drilldown/views/BuildpackDrillDown.tsx
+++ b/web/src/components/drilldown/views/BuildpackDrillDown.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useMissions } from '../../../hooks/useMissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import type { BuildpackStatus } from '../../cards/buildpacks-status/BuildpacksStatus'
@@ -106,6 +106,7 @@ export function BuildpackDrillDown({ data }: Props) {
 
   const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster } = useDrillDownActions()
+  const { close: closeDrillDown } = useDrillDown()
   const { startMission } = useMissions()
   const { showToast } = useToast()
 
@@ -333,6 +334,7 @@ export function BuildpackDrillDown({ data }: Props) {
   // 3. Including the fetch functions would cause infinite loops
   // 4. Including the data (imageYAML, logs) would trigger unwanted re-fetches
   const handleDiagnose = () => {
+    closeDrillDown() // Close panel so mission sidebar is visible
     startMission({
       title: `Diagnose Buildpack: ${name}`,
       description: `Analyze buildpack health`,

--- a/web/src/components/drilldown/views/CRDDrillDown.tsx
+++ b/web/src/components/drilldown/views/CRDDrillDown.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useMissions } from '../../../hooks/useMissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import {
@@ -97,6 +97,7 @@ export function CRDDrillDown({ data }: Props) {
 
   const { isConnected: agentConnected } = useLocalAgent()
   const { drillToCluster, drillToNamespace } = useDrillDownActions()
+  const { close: closeDrillDown } = useDrillDown()
   const { startMission } = useMissions()
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
@@ -312,6 +313,7 @@ Please:
    - "Should I check related CRDs?"
    - "All done"`
 
+    closeDrillDown() // Close panel so mission sidebar is visible
     startMission({
       title: `Diagnose CRD: ${crdName}`,
       description: `Analyze CustomResourceDefinition health and versions`,

--- a/web/src/components/drilldown/views/DriftDrillDown.tsx
+++ b/web/src/components/drilldown/views/DriftDrillDown.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useMissions } from '../../../hooks/useMissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import {
@@ -86,6 +86,7 @@ export function DriftDrillDown({ data }: Props) {
 
   const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster, drillToPod, drillToDeployment } = useDrillDownActions()
+  const { close: closeDrillDown } = useDrillDown()
   const { startMission } = useMissions()
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
@@ -291,6 +292,7 @@ Please:
    - "Should I check for drift in other namespaces?"
    - "All done"`
 
+    closeDrillDown() // Close panel so mission sidebar is visible
     startMission({
       title: `Analyze GitOps Drift: ${cluster}`,
       description: `Investigate configuration drift between Git and cluster`,

--- a/web/src/components/drilldown/views/HelmReleaseDrillDown.tsx
+++ b/web/src/components/drilldown/views/HelmReleaseDrillDown.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
 import { appendWsAuthToken } from '../../../lib/utils/wsAuth'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useMissions } from '../../../hooks/useMissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import {
@@ -87,6 +87,7 @@ export function HelmReleaseDrillDown({ data }: Props) {
 
   const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster, drillToDeployment, drillToService } = useDrillDownActions()
+  const { close: closeDrillDown } = useDrillDown()
   const { startMission } = useMissions()
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
@@ -321,6 +322,7 @@ Please:
    - "Should I check other Helm releases?"
    - "All done"`
 
+    closeDrillDown() // Close panel so mission sidebar is visible
     startMission({
       title: `Diagnose Helm: ${releaseName}`,
       description: `Analyze Helm release health and configuration`,

--- a/web/src/components/drilldown/views/KustomizationDrillDown.tsx
+++ b/web/src/components/drilldown/views/KustomizationDrillDown.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import type { Condition } from '../../../types/mcs'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useMissions } from '../../../hooks/useMissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import {
@@ -74,6 +74,7 @@ export function KustomizationDrillDown({ data }: Props) {
 
   const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster, drillToPod, drillToDeployment } = useDrillDownActions()
+  const { close: closeDrillDown } = useDrillDown()
   const { startMission } = useMissions()
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
@@ -245,6 +246,7 @@ Please:
    - "Should I check related Flux resources?"
    - "All done"`
 
+    closeDrillDown() // Close panel so mission sidebar is visible
     startMission({
       title: `Diagnose Kustomization: ${kustomizationName}`,
       description: `Analyze Flux Kustomization health and sync status`,

--- a/web/src/components/drilldown/views/OperatorDrillDown.tsx
+++ b/web/src/components/drilldown/views/OperatorDrillDown.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useMissions } from '../../../hooks/useMissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import {
@@ -88,6 +88,7 @@ export function OperatorDrillDown({ data }: Props) {
 
   const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster, drillToCRD } = useDrillDownActions()
+  const { close: closeDrillDown } = useDrillDown()
   const { startMission } = useMissions()
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
@@ -279,6 +280,7 @@ Please:
    - "Should I check other operators on this cluster?"
    - "All done"`
 
+    closeDrillDown() // Close panel so mission sidebar is visible
     startMission({
       title: `Diagnose Operator: ${operatorName}`,
       description: `Analyze OLM operator health and configuration`,

--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -748,6 +748,7 @@ Be specific and reference actual values from the data. Keep response to 3-4 sent
   }, [cluster, namespace, podName, describeOutput, logsOutput, eventsOutput, yamlOutput, podStatusOutput, aiAnalysis, labels, annotations, configMaps, secrets, pvcs, serviceAccount, ownerChain])
 
   const handleRepairPod = () => {
+    closeDrillDown() // Close panel so mission sidebar is visible
     startMission({
       title: `Repair Pod ${podName}`,
       description: `Diagnose and fix issues with pod ${podName}`,

--- a/web/src/components/drilldown/views/PolicyDrillDown.tsx
+++ b/web/src/components/drilldown/views/PolicyDrillDown.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useMissions } from '../../../hooks/useMissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import {
@@ -85,6 +85,7 @@ export function PolicyDrillDown({ data }: Props) {
 
   const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster, drillToPod } = useDrillDownActions()
+  const { close: closeDrillDown } = useDrillDown()
   const { startMission } = useMissions()
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
@@ -283,6 +284,7 @@ Please:
    - "Should I check related policies?"
    - "All done"`
 
+    closeDrillDown() // Close panel so mission sidebar is visible
     startMission({
       title: `Diagnose Policy: ${policyName}`,
       description: `Analyze ${policyType === 'kyverno' ? 'Kyverno' : 'OPA'} policy and violations`,


### PR DESCRIPTION
Fixes #11106

Fixed all drill-down views and detail modals to close the current panel/modal before launching an AI Mission via `startMission()`. Previously, clicking Repair/Diagnose would start the mission but leave the workload panel open, causing overlapping UI states.

**Changes:**
- 9 drill-down views now call `closeDrillDown()` before `startMission()` (matching the existing pattern in `NodeDrillDown`)
- 5 detail modals now call `onClose()` before `startMission()`
- `ClusterDetailModal` reordered to close before starting mission
- `NodeDetailPanel` added `onClose()` call before repair mission