### PR TITLE
🐛 Fix 287 test failures in coverage suite

### DIFF
--- a/web/src/components/alerts/Alerts.test.tsx
+++ b/web/src/components/alerts/Alerts.test.tsx
@@ -25,7 +25,7 @@ vi.mock('../../hooks/useAlerts', () => ({
 
 vi.mock('../../hooks/useMCP', () => ({
   useClusters: () => ({
-    isRefreshing: false, refetch: vi.fn(), error: null,
+    deduplicatedClusters: [], isRefreshing: false, refetch: vi.fn(), error: null,
   }),
 }))
 

--- a/web/src/components/cards/__tests__/HelmReleaseStatus.test.tsx
+++ b/web/src/components/cards/__tests__/HelmReleaseStatus.test.tsx
@@ -21,7 +21,7 @@ const mockDrillToHelm = vi.fn()
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 vi.mock('../../../hooks/useMCP', () => ({
-  useClusters: () => ({ isLoading: false }),
+  useClusters: () => ({ isLoading: false, deduplicatedClusters: [] }),
 }))
 
 vi.mock('../../../hooks/useCachedData', () => ({

--- a/web/src/components/cards/__tests__/OperatorStatus.test.tsx
+++ b/web/src/components/cards/__tests__/OperatorStatus.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../../../hooks/useCachedData', () => ({
 vi.mock('../../../hooks/useMCP', () => ({
   useClusters: () => ({
     clusters: [{ name: 'cluster-1' }],
+    deduplicatedClusters: [{ name: 'cluster-1' }],
     isLoading: false,
   }),
 }))

--- a/web/src/components/cards/buildpacks-status/__tests__/BuildpacksStatus.test.tsx
+++ b/web/src/components/cards/buildpacks-status/__tests__/BuildpacksStatus.test.tsx
@@ -33,7 +33,7 @@ vi.mock('react-i18next', () => ({
 }))
 
 vi.mock('../../../../hooks/useMCP', () => ({
-  useClusters: () => ({ isLoading: false }),
+  useClusters: () => ({ isLoading: false, deduplicatedClusters: [] }),
 }))
 
 vi.mock('../../../../hooks/useCachedData', () => ({

--- a/web/src/components/cards/openkruise_status/__tests__/OpenKruiseStatus.test.tsx
+++ b/web/src/components/cards/openkruise_status/__tests__/OpenKruiseStatus.test.tsx
@@ -67,7 +67,7 @@ vi.mock('../../CardDataContext', () => ({
 }))
 
 vi.mock('../../../../hooks/useMCP', () => ({
-  useClusters: () => ({ isLoading: false, clusters: [] }),
+  useClusters: () => ({ isLoading: false, clusters: [], deduplicatedClusters: [] }),
 }))
 
 vi.mock('../../../../hooks/useGlobalFilters', () => ({

--- a/web/src/components/compliance/Compliance.test.tsx
+++ b/web/src/components/compliance/Compliance.test.tsx
@@ -99,6 +99,10 @@ function defaultClustersReturn() {
       { name: 'cluster-a', reachable: true },
       { name: 'cluster-b', reachable: true },
     ],
+    deduplicatedClusters: [
+      { name: 'cluster-a', reachable: true },
+      { name: 'cluster-b', reachable: true },
+    ],
     isLoading: false,
     refetch: vi.fn(),
     lastUpdated: Date.now(),
@@ -270,7 +274,7 @@ describe('Compliance dashboard component', () => {
 
   it('hasData reflects tool installation', () => {
     setupDefaults({
-      clusters: { ...defaultClustersReturn(), clusters: [] },
+      clusters: { ...defaultClustersReturn(), clusters: [], deduplicatedClusters: [] },
     })
     render(<Compliance />)
     const props = getLastDashboardProps()

--- a/web/src/components/compliance/ComplianceReports.test.tsx
+++ b/web/src/components/compliance/ComplianceReports.test.tsx
@@ -29,6 +29,10 @@ vi.mock('../../hooks/useMCP', () => ({
       { name: 'prod-cluster' },
       { name: 'staging-cluster' },
     ],
+    deduplicatedClusters: [
+      { name: 'prod-cluster' },
+      { name: 'staging-cluster' },
+    ],
   }),
 }))
 

--- a/web/src/components/deployments/__tests__/Deployments.test.tsx
+++ b/web/src/components/deployments/__tests__/Deployments.test.tsx
@@ -9,7 +9,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('../../../hooks/useMCP', () => ({
   useClusters: () => ({
-    clusters: [], isLoading: false, isRefreshing: false,
+    clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false,
     lastUpdated: null, refetch: vi.fn(), error: null,
   }),
 }))

--- a/web/src/components/gpu/__tests__/GPUReservations.test.tsx
+++ b/web/src/components/gpu/__tests__/GPUReservations.test.tsx
@@ -49,7 +49,7 @@ vi.mock('../../../lib/dashboards/DashboardPage', () => ({
 
 vi.mock('../../../hooks/useMCP', () => ({
   useClusters: () => ({
-    clusters: [], isLoading: false, isRefreshing: false, refetch: vi.fn(), error: null,
+    clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, refetch: vi.fn(), error: null,
   }),
   useGPUNodes: vi.fn(() => ({ nodes: [], isLoading: false, refetch: vi.fn() })),
   useResourceQuotas: () => ({ resourceQuotas: [] }),

--- a/web/src/components/helm/__tests__/HelmReleases.test.tsx
+++ b/web/src/components/helm/__tests__/HelmReleases.test.tsx
@@ -9,7 +9,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('../../../hooks/useMCP', () => ({
   useClusters: () => ({
-    clusters: [], isLoading: false, isRefreshing: false,
+    clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false,
     lastUpdated: null, refetch: vi.fn(), error: null,
   }),
 }))

--- a/web/src/components/logs/Logs.test.tsx
+++ b/web/src/components/logs/Logs.test.tsx
@@ -31,7 +31,7 @@ vi.mock('../../lib/dashboards/DashboardPage', () => ({
 
 vi.mock('../../hooks/useMCP', () => ({
   useClusters: () => ({
-    clusters: [], isLoading: false, isRefreshing: false, refetch: vi.fn(),
+    clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, refetch: vi.fn(),
   }),
 }))
 

--- a/web/src/components/mission-control/__tests__/useMissionControl.hook.test.tsx
+++ b/web/src/components/mission-control/__tests__/useMissionControl.hook.test.tsx
@@ -32,7 +32,7 @@ describe('useMissionControl hook', () => {
       missions: [],
     } as any)
     vi.spyOn(useClustersModule, 'useClusters').mockReturnValue({
-      clusters: [],
+      clusters: [], deduplicatedClusters: [],
       isLoading: false,
       lastUpdated: new Date(),
     } as any)
@@ -201,6 +201,7 @@ describe('useMissionControl hook', () => {
     // Live clusters list doesn't have 'stale-cluster'
     vi.spyOn(useClustersModule, 'useClusters').mockReturnValue({
       clusters: [{ name: 'active-cluster', context: 'active-cluster' }],
+      deduplicatedClusters: [{ name: 'active-cluster', context: 'active-cluster' }],
       isLoading: false,
       lastUpdated: new Date(),
     } as any)

--- a/web/src/components/missions/__tests__/ClusterSelectionDialog.test.tsx
+++ b/web/src/components/missions/__tests__/ClusterSelectionDialog.test.tsx
@@ -32,7 +32,7 @@ vi.mock('../../../lib/cn', () => ({
 }))
 
 vi.mock('../../../hooks/mcp/clusters', () => ({
-  useClusters: () => ({ clusters: [], isLoading: false }),
+  useClusters: () => ({ clusters: [], deduplicatedClusters: [], isLoading: false }),
 }))
 
 import { ClusterSelectionDialog } from '../ClusterSelectionDialog'

--- a/web/src/components/rbac/__tests__/CanIChecker.test.tsx
+++ b/web/src/components/rbac/__tests__/CanIChecker.test.tsx
@@ -21,6 +21,7 @@ vi.mock('../../../hooks/usePermissions', () => ({
 vi.mock('../../../hooks/useMCP', () => ({
   useClusters: () => ({
     clusters: [{ name: 'cluster-a' }, { name: 'cluster-b' }],
+    deduplicatedClusters: [{ name: 'cluster-a' }, { name: 'cluster-b' }],
   }),
   useNamespaces: () => ({
     namespaces: ['default', 'kube-system'],
@@ -144,7 +145,7 @@ describe('CanIChecker — no clusters', () => {
     // Re-mock useClusters with empty array
     const useMCPModule = await import('../../../hooks/useMCP')
     vi.spyOn(useMCPModule, 'useClusters').mockReturnValue({
-      clusters: [],
+      clusters: [], deduplicatedClusters: [],
       isLoading: false,
       error: null,
     } as ReturnType<typeof useMCPModule.useClusters>)

--- a/web/src/components/services/Services.test.tsx
+++ b/web/src/components/services/Services.test.tsx
@@ -55,7 +55,7 @@ vi.mock('../../lib/dashboards/DashboardPage', () => ({
 
 vi.mock('../../hooks/useMCP', () => ({
   useClusters: () => ({
-    clusters: [], isLoading: false, isRefreshing: false,
+    clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false,
     lastUpdated: null, refetch: vi.fn(), error: null,
   }),
   useServices: () => ({ services: [], error: null }),
@@ -111,7 +111,7 @@ describe('Services Component', () => {
   // #6423 (Copilot review comment on Services.tsx:111) — when there are
   // no reachable clusters, the empty state must surface a "Connect a
   // cluster" secondary action so the user has a clear next step. The
-  // useClusters mock above returns `clusters: []`, which produces
+  // useClusters mock above returns `clusters: [], deduplicatedClusters: []`, which produces
   // `reachableClusters.length === 0` inside the component.
   it('renders the "Connect a cluster" CTA when no reachable clusters exist', () => {
     renderServices()

--- a/web/src/components/settings/sections/__tests__/PersistenceSection.test.tsx
+++ b/web/src/components/settings/sections/__tests__/PersistenceSection.test.tsx
@@ -37,7 +37,7 @@ vi.mock('../../../../hooks/usePersistence', () => ({
 }))
 
 vi.mock('../../../../hooks/mcp/clusters', () => ({
-  useClusters: () => ({ clusters: [] }),
+  useClusters: () => ({ clusters: [], deduplicatedClusters: [] }),
 }))
 
 import { PersistenceSection } from '../PersistenceSection'

--- a/web/src/components/workloads/__tests__/Workloads.test.tsx
+++ b/web/src/components/workloads/__tests__/Workloads.test.tsx
@@ -49,7 +49,7 @@ vi.mock('../../../hooks/useMCP', () => ({
     usePodIssues: () => ({ issues: mockPodIssues, isLoading: false, isRefreshing: false, refetch: vi.fn() }),
     useDeploymentIssues: () => ({ issues: mockDeploymentIssues, isLoading: false, isRefreshing: false, refetch: vi.fn() }),
     useDeployments: () => ({ deployments: mockDeployments, isLoading: false, isRefreshing: false, refetch: vi.fn() }),
-    useClusters: () => ({ clusters: mockClusters, isLoading: false, lastUpdated: null, refetch: vi.fn() }),
+    useClusters: () => ({ clusters: mockClusters, deduplicatedClusters: mockClusters, isLoading: false, lastUpdated: null, refetch: vi.fn() }),
 }))
 
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'

--- a/web/src/hooks/__tests__/useCardRecommendations.test.ts
+++ b/web/src/hooks/__tests__/useCardRecommendations.test.ts
@@ -48,7 +48,7 @@ function setDefaults(overrides: Record<string, unknown> = {}) {
   mockUseDeploymentIssues.mockReturnValue({ issues: overrides.deploymentIssues ?? [] })
   mockUseWarningEvents.mockReturnValue({ events: overrides.warningEvents ?? [] })
   mockUseGPUNodes.mockReturnValue({ nodes: overrides.gpuNodes ?? [] })
-  mockUseClusters.mockReturnValue({ clusters: overrides.clusters ?? [] })
+  mockUseClusters.mockReturnValue({ clusters: overrides.clusters ?? [], deduplicatedClusters: overrides.clusters ?? [] })
   mockUseSecurityIssues.mockReturnValue({ issues: overrides.securityIssues ?? [] })
   mockUseAIMode.mockReturnValue({ shouldProactivelySuggest: overrides.shouldProactivelySuggest ?? true })
 }
@@ -357,7 +357,7 @@ describe('useCardRecommendations', () => {
     mockUseDeploymentIssues.mockReturnValue({ issues: undefined })
     mockUseWarningEvents.mockReturnValue({ events: undefined })
     mockUseGPUNodes.mockReturnValue({ nodes: undefined })
-    mockUseClusters.mockReturnValue({ clusters: undefined })
+    mockUseClusters.mockReturnValue({ clusters: undefined, deduplicatedClusters: undefined })
     mockUseSecurityIssues.mockReturnValue({ issues: undefined })
 
     const { result } = renderHook(() => useCardRecommendations(NO_CARDS))

--- a/web/src/hooks/__tests__/useClusterFilter.test.tsx
+++ b/web/src/hooks/__tests__/useClusterFilter.test.tsx
@@ -12,6 +12,11 @@ const mockUseClusters = vi.hoisted(() =>
       { name: 'cluster-b', context: 'cluster-b', server: 'https://b.example.com' },
       { name: 'cluster-c', context: 'cluster-c', server: 'https://c.example.com' },
     ],
+    deduplicatedClusters: [
+      { name: 'cluster-a', context: 'cluster-a', server: 'https://a.example.com' },
+      { name: 'cluster-b', context: 'cluster-b', server: 'https://b.example.com' },
+      { name: 'cluster-c', context: 'cluster-c', server: 'https://c.example.com' },
+    ],
     isLoading: false,
     error: null,
   }),
@@ -44,6 +49,11 @@ beforeEach(() => {
   localStorage.clear()
   mockUseClusters.mockReturnValue({
     clusters: DEFAULT_CLUSTERS.map((name) => ({
+      name,
+      context: name,
+      server: `https://${name}.example.com`,
+    })),
+    deduplicatedClusters: DEFAULT_CLUSTERS.map((name) => ({
       name,
       context: name,
       server: `https://${name}.example.com`,
@@ -260,6 +270,7 @@ describe('selectAll and clearAll', () => {
   it('clearAll is a no-op when no clusters are available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [],
+      deduplicatedClusters: [],
       isLoading: false,
       error: null,
     })
@@ -360,6 +371,7 @@ describe('edge cases', () => {
   it('handles empty available clusters gracefully', () => {
     mockUseClusters.mockReturnValue({
       clusters: [],
+      deduplicatedClusters: [],
       isLoading: false,
       error: null,
     })
@@ -416,6 +428,9 @@ describe('edge cases', () => {
   it('handles single-cluster environment correctly', () => {
     mockUseClusters.mockReturnValue({
       clusters: [
+        { name: 'only-cluster', context: 'only-cluster', server: 'https://only.example.com' },
+      ],
+      deduplicatedClusters: [
         { name: 'only-cluster', context: 'only-cluster', server: 'https://only.example.com' },
       ],
       isLoading: false,

--- a/web/src/hooks/__tests__/useComplianceFrameworks.test.ts
+++ b/web/src/hooks/__tests__/useComplianceFrameworks.test.ts
@@ -23,6 +23,10 @@ vi.mock('../useMCP', () => ({
       { name: 'cluster-a', reachable: true },
       { name: 'cluster-b', reachable: true },
     ],
+    deduplicatedClusters: [
+      { name: 'cluster-a', reachable: true },
+      { name: 'cluster-b', reachable: true },
+    ],
     isLoading: false,
     refetch: vi.fn(),
     lastUpdated: null,

--- a/web/src/hooks/__tests__/useMissionSuggestions.test.ts
+++ b/web/src/hooks/__tests__/useMissionSuggestions.test.ts
@@ -8,7 +8,7 @@ import { renderHook, act } from '@testing-library/react'
 const mockPodIssues = vi.fn(() => ({ issues: [] }))
 const mockDeploymentIssues = vi.fn(() => ({ issues: [] }))
 const mockSecurityIssues = vi.fn(() => ({ issues: [] }))
-const mockClusters = vi.fn(() => ({ clusters: [] }))
+const mockClusters = vi.fn(() => ({ clusters: [], deduplicatedClusters: [] }))
 const mockNodes = vi.fn(() => ({ nodes: [] }))
 const mockPods = vi.fn(() => ({ pods: [] }))
 
@@ -120,7 +120,7 @@ describe('useMissionSuggestions', () => {
     mockPodIssues.mockReturnValue({ issues: [] })
     mockDeploymentIssues.mockReturnValue({ issues: [] })
     mockSecurityIssues.mockReturnValue({ issues: [] })
-    mockClusters.mockReturnValue({ clusters: [] })
+    mockClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [] })
     mockNodes.mockReturnValue({ nodes: [] })
     mockPods.mockReturnValue({ pods: [] })
     // Reset snooze/dismiss mocks
@@ -247,6 +247,7 @@ describe('useMissionSuggestions', () => {
   it('generates a health mission for unreachable clusters', () => {
     mockClusters.mockReturnValue({
       clusters: [makeCluster({ name: 'prod', reachable: false, errorMessage: 'timeout' })],
+      deduplicatedClusters: [makeCluster({ name: 'prod', reachable: false, errorMessage: 'timeout' })],
     })
     const { result } = renderHook(() => useMissionSuggestions())
 
@@ -259,6 +260,7 @@ describe('useMissionSuggestions', () => {
   it('generates a health mission for unhealthy clusters (healthy=false)', () => {
     mockClusters.mockReturnValue({
       clusters: [makeCluster({ name: 'staging', healthy: false })],
+      deduplicatedClusters: [makeCluster({ name: 'staging', healthy: false })],
     })
     const { result } = renderHook(() => useMissionSuggestions())
     expect(result.current.suggestions.find(s => s.type === 'health')).toBeDefined()
@@ -267,6 +269,7 @@ describe('useMissionSuggestions', () => {
   it('does not generate a health mission for healthy clusters', () => {
     mockClusters.mockReturnValue({
       clusters: [makeCluster({ reachable: true, healthy: true })],
+      deduplicatedClusters: [makeCluster({ reachable: true, healthy: true })],
     })
     const { result } = renderHook(() => useMissionSuggestions())
     expect(result.current.suggestions.find(s => s.type === 'health')).toBeUndefined()
@@ -384,6 +387,7 @@ describe('useMissionSuggestions', () => {
     })
     mockClusters.mockReturnValue({
       clusters: [makeCluster({ reachable: false })], // critical
+      deduplicatedClusters: [makeCluster({ reachable: false })], // critical
     })
     mockDeploymentIssues.mockReturnValue({
       issues: [makeDeploymentIssue({ replicas: 3, readyReplicas: 0 })], // high
@@ -520,6 +524,7 @@ describe('useMissionSuggestions', () => {
   it('hasSuggestions is true when there are visible suggestions', () => {
     mockClusters.mockReturnValue({
       clusters: [makeCluster({ reachable: false })],
+      deduplicatedClusters: [makeCluster({ reachable: false })],
     })
     const { result } = renderHook(() => useMissionSuggestions())
     expect(result.current.hasSuggestions).toBe(true)
@@ -580,6 +585,7 @@ describe('useMissionSuggestions', () => {
     })
     mockClusters.mockReturnValue({
       clusters: [makeCluster({ reachable: false })],
+      deduplicatedClusters: [makeCluster({ reachable: false })],
     })
     mockNodes.mockReturnValue({
       nodes: [makeNode({ conditions: [{ type: 'MemoryPressure', status: 'True' }] })],

--- a/web/src/hooks/__tests__/useSearchIndex.categories.test.ts
+++ b/web/src/hooks/__tests__/useSearchIndex.categories.test.ts
@@ -101,7 +101,7 @@ function resultCategories(results: Map<SearchCategory, SearchItem[]>): SearchCat
 describe('useSearchIndex', () => {
   beforeEach(() => {
     // Reset all hook mocks to empty data
-    mockClusters.mockReturnValue({ clusters: [] })
+    mockClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [] })
     mockDeployments.mockReturnValue({ deployments: [] })
     mockPods.mockReturnValue({ pods: [] })
     mockServices.mockReturnValue({ services: [] })
@@ -192,6 +192,10 @@ describe('useSearchIndex', () => {
   it('includes cluster items from the useClusters hook', () => {
     mockClusters.mockReturnValue({
       clusters: [
+        { name: 'prod-east', context: 'prod-east', server: 'https://k8s.prod.com', healthy: true },
+        { name: 'staging-west', context: 'staging-ctx', server: 'https://k8s.staging.com', healthy: false },
+      ],
+      deduplicatedClusters: [
         { name: 'prod-east', context: 'prod-east', server: 'https://k8s.prod.com', healthy: true },
         { name: 'staging-west', context: 'staging-ctx', server: 'https://k8s.staging.com', healthy: false },
       ],
@@ -332,6 +336,7 @@ describe('useSearchIndex', () => {
     // Provide data for multiple categories that all match 'prod'
     mockClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', context: 'prod-cluster', healthy: true }],
+      deduplicatedClusters: [{ name: 'prod-cluster', context: 'prod-cluster', healthy: true }],
     })
     mockDeployments.mockReturnValue({
       deployments: [{ name: 'prod-api', cluster: 'prod', namespace: 'default', status: 'Running' }],
@@ -357,6 +362,7 @@ describe('useSearchIndex', () => {
   it('places page results before cluster results', () => {
     mockClusters.mockReturnValue({
       clusters: [{ name: 'my-cluster', context: 'my-cluster', healthy: true }],
+      deduplicatedClusters: [{ name: 'my-cluster', context: 'my-cluster', healthy: true }],
     })
 
     // 'cluster' matches both page items and the cluster itself
@@ -430,7 +436,7 @@ describe('useSearchIndex', () => {
     mockDeployments.mockReturnValue({ deployments: manyDeployments })
     mockPods.mockReturnValue({ pods: manyPods })
     mockServices.mockReturnValue({ services: manyServices })
-    mockClusters.mockReturnValue({ clusters: manyClusters })
+    mockClusters.mockReturnValue({ clusters: manyClusters, deduplicatedClusters: manyClusters })
     mockNodes.mockReturnValue({ nodes: manyNodes })
     mockHelmReleases.mockReturnValue({ releases: manyHelm })
 
@@ -524,6 +530,7 @@ describe('useSearchIndex', () => {
   it('matches items via the meta field', () => {
     mockClusters.mockReturnValue({
       clusters: [{ name: 'silent-cluster', context: 'silent-cluster', healthy: false }],
+      deduplicatedClusters: [{ name: 'silent-cluster', context: 'silent-cluster', healthy: false }],
     })
 
     // meta for unhealthy cluster is 'unhealthy'
@@ -565,6 +572,7 @@ describe('useSearchIndex', () => {
   it('matches partial substrings in item names', () => {
     mockClusters.mockReturnValue({
       clusters: [{ name: 'production-us-east', context: 'production-us-east', healthy: true }],
+      deduplicatedClusters: [{ name: 'production-us-east', context: 'production-us-east', healthy: true }],
     })
 
     const { result } = renderHook(() => useSearchIndex('prod'))
@@ -685,6 +693,7 @@ describe('useSearchIndex', () => {
   it('shows context in cluster description when different from name', () => {
     mockClusters.mockReturnValue({
       clusters: [{ name: 'prod', context: 'arn:aws:eks:us-east-1:123:cluster/prod', healthy: true }],
+      deduplicatedClusters: [{ name: 'prod', context: 'arn:aws:eks:us-east-1:123:cluster/prod', healthy: true }],
     })
     const { result } = renderHook(() => useSearchIndex('prod'))
     const flat = flattenResults(result.current.results)
@@ -697,6 +706,7 @@ describe('useSearchIndex', () => {
   it('omits context from cluster description when same as name', () => {
     mockClusters.mockReturnValue({
       clusters: [{ name: 'kind-local', context: 'kind-local', healthy: false }],
+      deduplicatedClusters: [{ name: 'kind-local', context: 'kind-local', healthy: false }],
     })
     const { result } = renderHook(() => useSearchIndex('kind-local'))
     const flat = flattenResults(result.current.results)
@@ -770,7 +780,7 @@ describe('useSearchIndex', () => {
   // ── 42. Empty null/undefined hook data doesn't crash ───────────────────
 
   it('handles null-ish hook data without crashing', () => {
-    mockClusters.mockReturnValue({ clusters: undefined })
+    mockClusters.mockReturnValue({ clusters: undefined, deduplicatedClusters: undefined })
     mockDeployments.mockReturnValue({ deployments: null })
     mockPods.mockReturnValue({ pods: undefined })
     mockServices.mockReturnValue({ services: null })
@@ -816,6 +826,7 @@ describe('useSearchIndex', () => {
   it('returns results for a single-character query', () => {
     mockClusters.mockReturnValue({
       clusters: [{ name: 'a-cluster', context: 'a-cluster', healthy: true }],
+      deduplicatedClusters: [{ name: 'a-cluster', context: 'a-cluster', healthy: true }],
     })
     const { result } = renderHook(() => useSearchIndex('a'))
     // 'a' appears in many page names/descriptions, and in 'a-cluster'
@@ -991,6 +1002,7 @@ describe('useSearchIndex', () => {
   it('matches clusters via server URL keyword', () => {
     mockClusters.mockReturnValue({
       clusters: [{ name: 'eks-prod', context: 'eks-prod', server: 'https://ABCDEF.gr7.us-east-1.eks.amazonaws.com', healthy: true }],
+      deduplicatedClusters: [{ name: 'eks-prod', context: 'eks-prod', server: 'https://ABCDEF.gr7.us-east-1.eks.amazonaws.com', healthy: true }],
     })
     const { result } = renderHook(() => useSearchIndex('ABCDEF'))
     const flat = flattenResults(result.current.results)

--- a/web/src/hooks/__tests__/useSearchIndex.results.test.ts
+++ b/web/src/hooks/__tests__/useSearchIndex.results.test.ts
@@ -101,7 +101,7 @@ function resultCategories(results: Map<SearchCategory, SearchItem[]>): SearchCat
 describe('useSearchIndex', () => {
   beforeEach(() => {
     // Reset all hook mocks to empty data
-    mockClusters.mockReturnValue({ clusters: [] })
+    mockClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [] })
     mockDeployments.mockReturnValue({ deployments: [] })
     mockPods.mockReturnValue({ pods: [] })
     mockServices.mockReturnValue({ services: [] })
@@ -128,6 +128,7 @@ describe('useSearchIndex', () => {
     // Only clusters and settings match — nothing in between
     mockClusters.mockReturnValue({
       clusters: [{ name: 'zzz-unique-cluster', context: 'zzz-unique-cluster', healthy: true }],
+      deduplicatedClusters: [{ name: 'zzz-unique-cluster', context: 'zzz-unique-cluster', healthy: true }],
     })
     const { result } = renderHook(() => useSearchIndex('zzz-unique'))
     const categories = resultCategories(result.current.results)
@@ -185,6 +186,7 @@ describe('useSearchIndex', () => {
   it('returns results across multiple categories for a broad query', () => {
     mockClusters.mockReturnValue({
       clusters: [{ name: 'test-cluster', context: 'test-cluster', healthy: true }],
+      deduplicatedClusters: [{ name: 'test-cluster', context: 'test-cluster', healthy: true }],
     })
     mockDeployments.mockReturnValue({
       deployments: [{ name: 'test-deploy', cluster: 'c', namespace: 'ns', status: 'Running' }],
@@ -393,6 +395,7 @@ describe('useSearchIndex', () => {
   it('cluster items have correctly encoded href', () => {
     mockClusters.mockReturnValue({
       clusters: [{ name: 'my cluster', context: 'my cluster', healthy: true }],
+      deduplicatedClusters: [{ name: 'my cluster', context: 'my cluster', healthy: true }],
     })
     const { result } = renderHook(() => useSearchIndex('my cluster'))
     const flat = flattenResults(result.current.results)

--- a/web/src/hooks/__tests__/useSearchIndex.test.ts
+++ b/web/src/hooks/__tests__/useSearchIndex.test.ts
@@ -13,7 +13,7 @@ vi.mock('../../components/ui/StatsBlockDefinitions', () => ({
   getDefaultStatBlocks: vi.fn(() => []),
 }))
 
-vi.mock('../mcp/clusters', () => ({ useClusters: vi.fn(() => ({ clusters: [] })) }))
+vi.mock('../mcp/clusters', () => ({ useClusters: vi.fn(() => ({ clusters: [], deduplicatedClusters: [] })) }))
 vi.mock('../mcp/workloads', () => ({
   useDeployments: vi.fn(() => ({ deployments: [] })),
   usePods: vi.fn(() => ({ pods: [] })),

--- a/web/src/lib/unified/__tests__/index.test.ts
+++ b/web/src/lib/unified/__tests__/index.test.ts
@@ -110,7 +110,7 @@ const _stubHook = () => ({ data: [], isLoading: false, error: null, refetch: vi.
 const _namedResult = (name: string) => ({ [name]: [], isLoading: false, error: null, refetch: vi.fn() })
 
 vi.mock('../../../hooks/mcp', () => ({
-  useClusters: vi.fn().mockReturnValue({ clusters: [], isLoading: false, error: null, refetch: vi.fn() }),
+  useClusters: vi.fn().mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, error: null, refetch: vi.fn() }),
   usePVCs: vi.fn().mockReturnValue({ pvcs: [], isLoading: false, error: null, refetch: vi.fn() }),
   useServices: vi.fn().mockReturnValue({ services: [], isLoading: false, error: null, refetch: vi.fn() }),
   useOperators: vi.fn().mockReturnValue({ operators: [], isLoading: false, error: null, refetch: vi.fn() }),
@@ -137,7 +137,7 @@ vi.mock('../../../hooks/mcp', () => ({
 }))
 
 vi.mock('../../hooks/mcp', () => ({
-  useClusters: vi.fn().mockReturnValue({ clusters: [], isLoading: false, error: null, refetch: vi.fn() }),
+  useClusters: vi.fn().mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, error: null, refetch: vi.fn() }),
   usePVCs: vi.fn().mockReturnValue({ pvcs: [], isLoading: false, error: null, refetch: vi.fn() }),
   useServices: vi.fn().mockReturnValue({ services: [], isLoading: false, error: null, refetch: vi.fn() }),
   useOperators: vi.fn().mockReturnValue({ operators: [], isLoading: false, error: null, refetch: vi.fn() }),

--- a/web/src/lib/unified/__tests__/registerHooks-coverage.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-coverage.test.ts
@@ -52,7 +52,7 @@ const {
   mockUseCachedEvents: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUseCachedDeployments: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUseCachedDeploymentIssues: vi.fn().mockReturnValue({ issues: [], isLoading: false, error: null, refetch: vi.fn() }),
-  mockUseClusters: vi.fn().mockReturnValue({ clusters: [], isLoading: false, error: null, refetch: vi.fn() }),
+  mockUseClusters: vi.fn().mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUsePVCs: vi.fn().mockReturnValue({ pvcs: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUseServices: vi.fn().mockReturnValue({ services: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUseOperators: vi.fn().mockReturnValue({ operators: [], isLoading: false, error: null, refetch: vi.fn() }),

--- a/web/src/lib/unified/__tests__/registerHooks-deep.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-deep.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../../hooks/useCachedData', () => ({
 }))
 
 vi.mock('../../../hooks/mcp', () => ({
-  useClusters: vi.fn().mockReturnValue({ clusters: [], isLoading: false, error: null, refetch: vi.fn() }),
+  useClusters: vi.fn().mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, error: null, refetch: vi.fn() }),
   usePVCs: vi.fn().mockReturnValue({ pvcs: [], isLoading: false, error: null, refetch: vi.fn() }),
   useServices: vi.fn().mockReturnValue({ services: [], isLoading: false, error: null, refetch: vi.fn() }),
   useOperators: vi.fn().mockReturnValue({ operators: [], isLoading: false, error: null, refetch: vi.fn() }),

--- a/web/src/lib/unified/__tests__/registerHooks-expand2.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-expand2.test.ts
@@ -54,7 +54,7 @@ const {
   mockEvents: vi.fn(() => ({ data: [], isLoading: false, error: null, refetch: vi.fn() })),
   mockDeployments: vi.fn(() => ({ data: [], isLoading: false, error: null, refetch: vi.fn() })),
   mockDeploymentIssues: vi.fn(() => ({ issues: [], isLoading: false, error: null, refetch: vi.fn() })),
-  mockClusters: vi.fn(() => ({ clusters: [], isLoading: false, error: null, refetch: vi.fn() })),
+  mockClusters: vi.fn(() => ({ clusters: [], deduplicatedClusters: [], isLoading: false, error: null, refetch: vi.fn() })),
   mockPVCs: vi.fn(() => ({ pvcs: [], isLoading: false, error: null, refetch: vi.fn() })),
   mockServices: vi.fn(() => ({ services: [], isLoading: false, error: null, refetch: vi.fn() })),
   mockOperators: vi.fn(() => ({ operators: [], isLoading: false, error: null, refetch: vi.fn() })),

--- a/web/src/lib/unified/__tests__/registerHooks-hooks.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-hooks.test.ts
@@ -59,7 +59,7 @@ const {
     mockUseCachedEvents: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),
     mockUseCachedDeployments: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),
     mockUseCachedDeploymentIssues: vi.fn().mockReturnValue({ issues: [], isLoading: false, error: null, refetch: vi.fn() }),
-    mockUseClusters: vi.fn().mockReturnValue({ clusters: [], isLoading: false, error: null, refetch: vi.fn() }),
+    mockUseClusters: vi.fn().mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, error: null, refetch: vi.fn() }),
     mockUsePVCs: vi.fn().mockReturnValue({ pvcs: [], isLoading: false, error: null, refetch: vi.fn() }),
     mockUseServices: vi.fn().mockReturnValue({ services: [], isLoading: false, error: null, refetch: vi.fn() }),
     mockUseOperators: vi.fn().mockReturnValue({ operators: [], isLoading: false, error: null, refetch: vi.fn() }),
@@ -214,6 +214,7 @@ describe('useUnifiedClusters via renderHook', () => {
   it('maps clusters to data and wraps error', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'c1' }],
+      deduplicatedClusters: [{ name: 'c1' }],
       isLoading: true,
       error: 'cluster err',
       refetch: vi.fn(),

--- a/web/src/lib/unified/__tests__/registerHooks-wrappers.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-wrappers.test.ts
@@ -52,7 +52,7 @@ const {
   mockUseCachedEvents: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUseCachedDeployments: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUseCachedDeploymentIssues: vi.fn().mockReturnValue({ issues: [], isLoading: false, error: null, refetch: vi.fn() }),
-  mockUseClusters: vi.fn().mockReturnValue({ clusters: [], isLoading: false, error: null, refetch: vi.fn() }),
+  mockUseClusters: vi.fn().mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUsePVCs: vi.fn().mockReturnValue({ pvcs: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUseServices: vi.fn().mockReturnValue({ services: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUseOperators: vi.fn().mockReturnValue({ operators: [], isLoading: false, error: null, refetch: vi.fn() }),
@@ -253,6 +253,7 @@ describe('Unified wrapper hooks — interface normalization', () => {
       const clusters = [{ name: 'prod', reachable: true }]
       mockUseClusters.mockReturnValue({
         clusters,
+        deduplicatedClusters: clusters,
         isLoading: false,
         error: null,
         refetch: vi.fn(),

--- a/web/src/lib/unified/__tests__/registerHooks.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks.test.ts
@@ -40,7 +40,7 @@ vi.mock('../../../hooks/useCachedData', () => ({
 }))
 
 vi.mock('../../../hooks/mcp', () => ({
-  useClusters: vi.fn().mockReturnValue({ clusters: [], isLoading: false, error: null, refetch: vi.fn() }),
+  useClusters: vi.fn().mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, error: null, refetch: vi.fn() }),
   usePVCs: vi.fn().mockReturnValue({ pvcs: [], isLoading: false, error: null, refetch: vi.fn() }),
   useServices: vi.fn().mockReturnValue({ services: [], isLoading: false, error: null, refetch: vi.fn() }),
   useOperators: vi.fn().mockReturnValue({ operators: [], isLoading: false, error: null, refetch: vi.fn() }),


### PR DESCRIPTION
Fixes #11100

## Root Cause

PR #11096 (cluster dedup phase 2) changed 20 source files to destructure `deduplicatedClusters` from `useClusters()` instead of `clusters`, but test mocks were not updated to include `deduplicatedClusters` in their return values. Components received `undefined` for `deduplicatedClusters`, causing 287 test failures.

## Fix

Added `deduplicatedClusters` to all `useClusters` mock return values across 31 test files, matching the updated hook return shape. The `deduplicatedClusters` mock value mirrors the `clusters` value in each test since tests don't need actual deduplication logic.