### PR TITLE
🐛 Fix 177 test failures: add missing preflightCheck mock exports

### DIFF
--- a/web/src/hooks/__tests__/useMissions.provider.test.ts
+++ b/web/src/hooks/__tests__/useMissions.provider.test.ts
@@ -118,6 +118,10 @@ vi.mock('../../lib/constants/time', () => ({
 
 vi.mock('../../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn(async () => ({ ok: true, checks: [] })),
+  classifyKubectlError: vi.fn(),
+  getRemediationActions: vi.fn(() => []),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
 }))
 
 vi.mock('../../lib/kubectlProxy', () => ({

--- a/web/src/hooks/useMissions.analytics-agents.test.tsx
+++ b/web/src/hooks/useMissions.analytics-agents.test.tsx
@@ -65,6 +65,8 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.edgecases.test.tsx
+++ b/web/src/hooks/useMissions.edgecases.test.tsx
@@ -65,6 +65,8 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.messages-stream.test.tsx
+++ b/web/src/hooks/useMissions.messages-stream.test.tsx
@@ -65,6 +65,8 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.preflight-agents.test.tsx
+++ b/web/src/hooks/useMissions.preflight-agents.test.tsx
@@ -66,6 +66,8 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.provider-start.test.tsx
+++ b/web/src/hooks/useMissions.provider-start.test.tsx
@@ -65,6 +65,8 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.save-run.test.tsx
+++ b/web/src/hooks/useMissions.save-run.test.tsx
@@ -65,6 +65,8 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.state-persist.test.tsx
+++ b/web/src/hooks/useMissions.state-persist.test.tsx
@@ -65,6 +65,8 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.websocket-reconnect.test.tsx
+++ b/web/src/hooks/useMissions.websocket-reconnect.test.tsx
@@ -65,6 +65,8 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({


### PR DESCRIPTION
Fixes #11111

All 177 test failures were caused by the `resolveRequiredTools` and `runToolPreflightCheck` exports missing from test mocks of `../lib/missions/preflightCheck`. These were added in PR #11091 but test mocks weren't updated.

This PR adds the missing mock exports to all 9 affected test files.