### PR TITLE
🐛 Fix CORS and auth token mismatch blocking cluster data

### DIFF
--- a/pkg/agent/kagent_crds.go
+++ b/pkg/agent/kagent_crds.go
@@ -115,7 +115,7 @@ func (s *Server) handleKagentCRDAgents(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -218,7 +218,7 @@ func (s *Server) handleKagentCRDTools(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -351,7 +351,7 @@ func (s *Server) handleKagentCRDModels(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -477,7 +477,7 @@ func (s *Server) handleKagentCRDMemories(w http.ResponseWriter, r *http.Request)
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -549,7 +549,7 @@ func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) 
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/kagenti.go
+++ b/pkg/agent/kagenti.go
@@ -143,7 +143,7 @@ func (s *Server) handleKagentiAgents(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -237,7 +237,7 @@ func (s *Server) handleKagentiBuilds(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -322,7 +322,7 @@ func (s *Server) handleKagentiCards(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -405,7 +405,7 @@ func (s *Server) handleKagentiTools(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -482,7 +482,7 @@ func (s *Server) handleKagentiSummary(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/prometheus.go
+++ b/pkg/agent/prometheus.go
@@ -59,7 +59,7 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -670,16 +670,9 @@ func (s *Server) Start() error {
 	// browser's allowed methods. Per-handler setCORSHeaders() calls still
 	// narrow this to the exact methods each endpoint accepts.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		origin := r.Header.Get("Origin")
-		if s.isAllowedOrigin(origin) {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-		}
-		w.Header().Set("Access-Control-Allow-Methods", catchallCORSAllowedMethods)
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
-		w.Header().Set("Access-Control-Allow-Credentials", "true")
-		w.Header().Set("Access-Control-Allow-Private-Network", "true")
+		s.setCORSHeaders(w, r, catchallCORSAllowedMethods)
 		if r.Method == "OPTIONS" {
-			w.WriteHeader(http.StatusOK)
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 		http.NotFound(w, r)
@@ -771,20 +764,12 @@ func (s *Server) Start() error {
 
 // handleHealth handles HTTP health checks
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	// CORS headers - only allow configured origins
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Credentials", "true")
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
+	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 
 	// Handle preflight
 	if r.Method == "OPTIONS" {
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Requested-With")
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -820,18 +805,11 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 // handleProviderCheck runs a readiness handshake for a specific provider.
 // GET /provider/check?name=antigravity
 func (s *Server) handleProviderCheck(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Credentials", "true")
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
+	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Requested-With")
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_ai_chat.go
+++ b/pkg/agent/server_ai_chat.go
@@ -512,17 +512,10 @@ func (s *Server) cancelAllChatsForConn(conn *websocket.Conn) {
 // handleCancelChatHTTP is the HTTP fallback for cancelling in-progress chat sessions.
 // Used when the WebSocket connection is unavailable (e.g., disconnected during long agent runs).
 func (s *Server) handleCancelChatHTTP(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
-	w.Header().Set("Access-Control-Allow-Credentials", "true")
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	if r.Method != "POST" {

--- a/pkg/agent/server_ai_websocket.go
+++ b/pkg/agent/server_ai_websocket.go
@@ -52,15 +52,10 @@ const maxPromptChars = 100_000
 func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Handle CORS preflight for Private Network Access (required by Chrome 104+)
 	if r.Method == http.MethodOptions {
-		origin := r.Header.Get("Origin")
-		if s.isAllowedOrigin(origin) {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-		}
-		w.Header().Set("Access-Control-Allow-Credentials", "true")
-		w.Header().Set("Access-Control-Allow-Private-Network", "true")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Requested-With, Upgrade, Connection, Sec-WebSocket-Key, Sec-WebSocket-Version, Sec-WebSocket-Protocol")
-		w.WriteHeader(http.StatusOK)
+		s.setCORSHeaders(w, r, http.MethodGet, http.MethodOptions)
+		// WebSocket upgrades need additional headers beyond what setCORSHeaders provides
+		w.Header().Add("Access-Control-Allow-Headers", "Upgrade, Connection, Sec-WebSocket-Key, Sec-WebSocket-Version, Sec-WebSocket-Protocol")
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_argocd.go
+++ b/pkg/agent/server_argocd.go
@@ -55,7 +55,7 @@ func (s *Server) handleArgoCDSync(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	if !s.validateToken(r) {

--- a/pkg/agent/server_cilium.go
+++ b/pkg/agent/server_cilium.go
@@ -86,7 +86,7 @@ func (s *Server) handleCiliumStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_exec.go
+++ b/pkg/agent/server_exec.go
@@ -238,15 +238,10 @@ func (q *agentTerminalSizeQueue) Next() *remotecommand.TerminalSize {
 func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 	// CORS + Private Network Access preflight (same pattern as handleWebSocket).
 	if r.Method == http.MethodOptions {
-		origin := r.Header.Get("Origin")
-		if s.isAllowedOrigin(origin) {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-		}
-		w.Header().Set("Access-Control-Allow-Credentials", "true")
-		w.Header().Set("Access-Control-Allow-Private-Network", "true")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Requested-With, Upgrade, Connection, Sec-WebSocket-Key, Sec-WebSocket-Version, Sec-WebSocket-Protocol")
-		w.WriteHeader(http.StatusOK)
+		s.setCORSHeaders(w, r, http.MethodGet, http.MethodOptions)
+		// WebSocket upgrades need additional headers beyond what setCORSHeaders provides
+		w.Header().Add("Access-Control-Allow-Headers", "Upgrade, Connection, Sec-WebSocket-Key, Sec-WebSocket-Version, Sec-WebSocket-Protocol")
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_exec_test.go
+++ b/pkg/agent/server_exec_test.go
@@ -1097,8 +1097,8 @@ func TestHandleExec_OPTIONSPreflight(t *testing.T) {
 	s.handleExec(w, req)
 
 	resp := w.Result()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("status = %d; want %d", resp.StatusCode, http.StatusOK)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("status = %d; want %d", resp.StatusCode, http.StatusNoContent)
 	}
 
 	acao := resp.Header.Get("Access-Control-Allow-Origin")

--- a/pkg/agent/server_gitops.go
+++ b/pkg/agent/server_gitops.go
@@ -338,7 +338,7 @@ func (s *Server) handleDetectDrift(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	if !s.validateToken(r) {
@@ -461,7 +461,7 @@ func (s *Server) handleGitopsSync(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	if !s.validateToken(r) {

--- a/pkg/agent/server_gitops_test.go
+++ b/pkg/agent/server_gitops_test.go
@@ -25,8 +25,8 @@ func TestGitopsHandlers(t *testing.T) {
 		req := httptest.NewRequest(http.MethodOptions, "/api/gitops/detect-drift", nil)
 		w := httptest.NewRecorder()
 		server.handleDetectDrift(w, req)
-		if w.Code != http.StatusOK {
-			t.Errorf("Expected status 200 for OPTIONS, got %d", w.Code)
+		if w.Code != http.StatusNoContent {
+			t.Errorf("Expected status 204 for OPTIONS, got %d", w.Code)
 		}
 	})
 

--- a/pkg/agent/server_gpu_health.go
+++ b/pkg/agent/server_gpu_health.go
@@ -63,7 +63,7 @@ func (s *Server) handleGPUHealthCronJob(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	if !s.validateToken(r) {

--- a/pkg/agent/server_helm.go
+++ b/pkg/agent/server_helm.go
@@ -144,7 +144,7 @@ func (s *Server) handleHelmRollback(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	if !s.validateToken(r) {
@@ -222,7 +222,7 @@ func (s *Server) handleHelmUninstall(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	if !s.validateToken(r) {
@@ -295,7 +295,7 @@ func (s *Server) handleHelmUpgrade(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	if !s.validateToken(r) {

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -199,7 +199,7 @@ func (s *Server) handleRestartBackend(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -435,7 +435,7 @@ func (s *Server) handleAutoUpdateConfig(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -517,7 +517,7 @@ func (s *Server) handleAutoUpdateStatus(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -542,7 +542,7 @@ func (s *Server) handleAutoUpdateTrigger(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -593,7 +593,7 @@ func (s *Server) handleAutoUpdateCancel(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_http_kubeconfig.go
+++ b/pkg/agent/server_http_kubeconfig.go
@@ -10,17 +10,11 @@ import (
 
 // handleRenameContextHTTP renames a kubeconfig context
 func (s *Server) handleRenameContextHTTP(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -80,17 +74,11 @@ type kubeconfigPreviewResponse struct {
 
 // handleKubeconfigPreviewHTTP returns a dry-run preview of which contexts would be imported
 func (s *Server) handleKubeconfigPreviewHTTP(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -131,17 +119,11 @@ func (s *Server) handleKubeconfigPreviewHTTP(w http.ResponseWriter, r *http.Requ
 
 // handleKubeconfigImportHTTP merges new contexts from a kubeconfig YAML into the local kubeconfig
 func (s *Server) handleKubeconfigImportHTTP(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -194,7 +176,7 @@ func (s *Server) handleKubeconfigRemoveHTTP(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -237,17 +219,11 @@ func (s *Server) handleKubeconfigRemoveHTTP(w http.ResponseWriter, r *http.Reque
 
 // handleKubeconfigAddHTTP adds a cluster from structured form fields
 func (s *Server) handleKubeconfigAddHTTP(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -282,17 +258,11 @@ func (s *Server) handleKubeconfigAddHTTP(w http.ResponseWriter, r *http.Request)
 
 // handleKubeconfigTestHTTP tests a connection to a Kubernetes API server
 func (s *Server) handleKubeconfigTestHTTP(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_http_resources.go
+++ b/pkg/agent/server_http_resources.go
@@ -20,7 +20,7 @@ func (s *Server) handleClustersHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -44,7 +44,7 @@ func (s *Server) handleGPUNodesHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -119,7 +119,7 @@ func (s *Server) handleNodesHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -191,7 +191,7 @@ func (s *Server) handleEventsHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -279,7 +279,7 @@ func (s *Server) handleNamespacesHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -401,7 +401,7 @@ func (s *Server) handleDeploymentsHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -443,7 +443,7 @@ func (s *Server) handleReplicaSetsHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token when configured (#7000)
@@ -477,7 +477,7 @@ func (s *Server) handleStatefulSetsHTTP(w http.ResponseWriter, r *http.Request) 
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token when configured (#7000)
@@ -511,7 +511,7 @@ func (s *Server) handleDaemonSetsHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token when configured (#7000)
@@ -545,7 +545,7 @@ func (s *Server) handleCronJobsHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token when configured (#7000)
@@ -579,7 +579,7 @@ func (s *Server) handleIngressesHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token when configured (#7000)
@@ -613,7 +613,7 @@ func (s *Server) handleNetworkPoliciesHTTP(w http.ResponseWriter, r *http.Reques
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token when configured (#7000)
@@ -647,7 +647,7 @@ func (s *Server) handleServicesHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token when configured (#7000)
@@ -681,7 +681,7 @@ func (s *Server) handleConfigMapsHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token when configured (#7000)
@@ -715,7 +715,7 @@ func (s *Server) handleSecretsHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -757,7 +757,7 @@ func (s *Server) handleServiceAccountsHTTP(w http.ResponseWriter, r *http.Reques
 	s.setCORSHeaders(w, r, http.MethodGet, http.MethodPost, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token when configured (#7000)
@@ -869,7 +869,7 @@ func (s *Server) handleServiceExportsHTTP(w http.ResponseWriter, r *http.Request
 	s.setCORSHeaders(w, r, http.MethodPost, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	if !s.validateToken(r) {
@@ -965,7 +965,7 @@ func (s *Server) handleJobsHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token when configured (#7000)
@@ -999,7 +999,7 @@ func (s *Server) handleHPAsHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token for HPAs endpoint
@@ -1033,7 +1033,7 @@ func (s *Server) handlePVCsHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token for PVCs endpoint
@@ -1067,7 +1067,7 @@ func (s *Server) handleRolesHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token for Roles endpoint
@@ -1107,7 +1107,7 @@ func (s *Server) handleRoleBindingsHTTP(w http.ResponseWriter, r *http.Request) 
 	s.setCORSHeaders(w, r, http.MethodGet, http.MethodPost, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token for RoleBindings endpoint
@@ -1286,7 +1286,7 @@ func (s *Server) handleResourceQuotasHTTP(w http.ResponseWriter, r *http.Request
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token for ResourceQuotas endpoint
@@ -1320,7 +1320,7 @@ func (s *Server) handleLimitRangesHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token for LimitRanges endpoint
@@ -1355,7 +1355,7 @@ func (s *Server) handleResolveDepsHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	// SECURITY: Validate token for ResolveDeps endpoint

--- a/pkg/agent/server_http_workloads.go
+++ b/pkg/agent/server_http_workloads.go
@@ -23,7 +23,7 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -180,7 +180,7 @@ func (s *Server) handleDeployWorkloadHTTP(w http.ResponseWriter, r *http.Request
 	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -329,7 +329,7 @@ func (s *Server) handleDeleteWorkloadHTTP(w http.ResponseWriter, r *http.Request
 	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -429,7 +429,7 @@ func (s *Server) handlePodsHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -584,7 +584,7 @@ func (s *Server) handleClusterHealthHTTP(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_jaeger.go
+++ b/pkg/agent/server_jaeger.go
@@ -61,7 +61,7 @@ func (s *Server) handleJaegerStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_nvidia.go
+++ b/pkg/agent/server_nvidia.go
@@ -66,7 +66,7 @@ func (s *Server) handleNvidiaOperatorsHTTP(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_ops_clusters.go
+++ b/pkg/agent/server_ops_clusters.go
@@ -15,7 +15,7 @@ func (s *Server) handleCloudCLIStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -68,7 +68,7 @@ func (s *Server) handleLocalClusterTools(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -90,7 +90,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -256,7 +256,7 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -351,7 +351,7 @@ func (s *Server) handleVClusterList(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -379,7 +379,7 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -461,7 +461,7 @@ func (s *Server) handleVClusterConnect(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -519,7 +519,7 @@ func (s *Server) handleVClusterDisconnect(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -577,7 +577,7 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_ops_insights.go
+++ b/pkg/agent/server_ops_insights.go
@@ -9,17 +9,11 @@ import (
 
 // handleInsightsEnrich accepts heuristic insight summaries and returns AI enrichments
 func (s *Server) handleInsightsEnrich(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -64,17 +58,11 @@ func (s *Server) handleInsightsEnrich(w http.ResponseWriter, r *http.Request) {
 
 // handleInsightsAI returns cached AI enrichments
 func (s *Server) handleInsightsAI(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -106,7 +94,7 @@ func (s *Server) handleVClusterCheck(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_ops_predictions.go
+++ b/pkg/agent/server_ops_predictions.go
@@ -217,7 +217,7 @@ func (s *Server) handleDeviceAlerts(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -249,7 +249,7 @@ func (s *Server) handleDeviceAlertsClear(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -292,7 +292,7 @@ func (s *Server) handleDeviceInventory(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_ops_predictions.go
+++ b/pkg/agent/server_ops_predictions.go
@@ -17,17 +17,11 @@ import (
 
 // handlePredictionsAI returns current AI predictions
 func (s *Server) handlePredictionsAI(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -54,17 +48,11 @@ func (s *Server) handlePredictionsAI(w http.ResponseWriter, r *http.Request) {
 
 // handlePredictionsAnalyze triggers a manual AI analysis
 func (s *Server) handlePredictionsAnalyze(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -122,17 +110,11 @@ type PredictionFeedbackRequest struct {
 
 // handlePredictionsFeedback handles prediction feedback submissions
 func (s *Server) handlePredictionsFeedback(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -168,17 +150,11 @@ func (s *Server) handlePredictionsFeedback(w http.ResponseWriter, r *http.Reques
 
 // handlePredictionsStats returns prediction accuracy statistics
 func (s *Server) handlePredictionsStats(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -205,17 +181,11 @@ func (s *Server) handlePredictionsStats(w http.ResponseWriter, r *http.Request) 
 
 // handleMetricsHistory returns historical metrics for trend analysis
 func (s *Server) handleMetricsHistory(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_ops_settings.go
+++ b/pkg/agent/server_ops_settings.go
@@ -17,17 +17,11 @@ import (
 )
 
 func (s *Server) handleSettingsKeys(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodGet, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -50,17 +44,11 @@ func (s *Server) handleSettingsKeys(w http.ResponseWriter, r *http.Request) {
 
 // handleSettingsKeyByProvider handles DELETE for /settings/keys/:provider
 func (s *Server) handleSettingsKeyByProvider(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "DELETE, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -115,17 +103,11 @@ func (s *Server) handleSettingsKeyByProvider(w http.ResponseWriter, r *http.Requ
 
 // handleSettingsAll handles GET and PUT for /settings (persists to ~/.kc/settings.json)
 func (s *Server) handleSettingsAll(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodGet, http.MethodPut, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -181,16 +163,10 @@ func (s *Server) handleSettingsAll(w http.ResponseWriter, r *http.Request) {
 
 // handleSettingsExport handles POST for /settings/export (returns encrypted backup)
 func (s *Server) handleSettingsExport(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -225,17 +201,11 @@ func (s *Server) handleSettingsExport(w http.ResponseWriter, r *http.Request) {
 
 // handleSettingsImport handles PUT/POST for /settings/import (imports encrypted backup)
 func (s *Server) handleSettingsImport(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "PUT, POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r, http.MethodPut, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -841,17 +811,11 @@ type ProvidersHealthResponse struct {
 }
 
 func (s *Server) handleProvidersHealth(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if s.isAllowedOrigin(origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/agent/server_test.go
+++ b/pkg/agent/server_test.go
@@ -880,8 +880,8 @@ func TestServer_HandleClustersHTTP_OPTIONS(t *testing.T) {
 
 	server.handleClustersHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 	if w.Header().Get("Access-Control-Allow-Origin") != "http://allowed.com" {
 		t.Error("CORS origin header not set for OPTIONS")
@@ -938,8 +938,8 @@ func TestServer_HandleGPUNodesHTTP_OPTIONS(t *testing.T) {
 
 	server.handleGPUNodesHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1034,8 +1034,8 @@ func TestServer_HandleEventsHTTP_OPTIONS(t *testing.T) {
 
 	server.handleEventsHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1160,8 +1160,8 @@ func TestServer_HandleRestartBackend_OPTIONS(t *testing.T) {
 
 	server.handleRestartBackend(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1380,8 +1380,8 @@ func TestServer_HandleRenameContextHTTP_OPTIONS(t *testing.T) {
 
 	server.handleRenameContextHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1396,8 +1396,8 @@ func TestServer_HandleSettingsKeyByProvider_OPTIONS(t *testing.T) {
 
 	server.handleSettingsKeyByProvider(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1457,8 +1457,8 @@ func TestServer_HandleSettingsAll_OPTIONS(t *testing.T) {
 
 	server.handleSettingsAll(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1512,8 +1512,8 @@ func TestServer_HandleSettingsKeys_OPTIONS(t *testing.T) {
 
 	server.handleSettingsKeys(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1528,8 +1528,8 @@ func TestServer_HandleProvidersHealth_OPTIONS(t *testing.T) {
 
 	server.handleProvidersHealth(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1559,8 +1559,8 @@ func TestServer_HandleMetricsHistory_OPTIONS(t *testing.T) {
 
 	server.handleMetricsHistory(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1612,8 +1612,8 @@ func TestServer_HandleDeviceAlerts_OPTIONS(t *testing.T) {
 
 	server.handleDeviceAlerts(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1665,8 +1665,8 @@ func TestServer_HandleDeviceAlertsClear_OPTIONS(t *testing.T) {
 
 	server.handleDeviceAlertsClear(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1744,8 +1744,8 @@ func TestServer_HandleDeviceInventory_OPTIONS(t *testing.T) {
 
 	server.handleDeviceInventory(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1797,8 +1797,8 @@ func TestServer_HandlePredictionsAI_OPTIONS(t *testing.T) {
 
 	server.handlePredictionsAI(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1844,8 +1844,8 @@ func TestServer_HandlePredictionsStats_OPTIONS(t *testing.T) {
 
 	server.handlePredictionsStats(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -1982,8 +1982,8 @@ func TestServer_HandleHealth_OPTIONS(t *testing.T) {
 
 	server.handleHealth(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 	if w.Header().Get("Access-Control-Allow-Methods") != "GET, OPTIONS" {
 		t.Error("Missing Allow-Methods header for OPTIONS")
@@ -2001,8 +2001,8 @@ func TestServer_HandleSettingsExport_OPTIONS(t *testing.T) {
 
 	server.handleSettingsExport(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -2032,8 +2032,8 @@ func TestServer_HandleSettingsImport_OPTIONS(t *testing.T) {
 
 	server.handleSettingsImport(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -2063,8 +2063,8 @@ func TestServer_HandlePredictionsAnalyze_OPTIONS(t *testing.T) {
 
 	server.handlePredictionsAnalyze(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -2094,8 +2094,8 @@ func TestServer_HandlePredictionsFeedback_OPTIONS(t *testing.T) {
 
 	server.handlePredictionsFeedback(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -2298,8 +2298,8 @@ func TestServer_HandleWebSocket_OPTIONS(t *testing.T) {
 
 	server.handleWebSocket(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 	if w.Header().Get("Access-Control-Allow-Private-Network") != "true" {
 		t.Error("Missing Private-Network header")
@@ -2337,8 +2337,8 @@ func TestServer_HandleLocalClusterTools_OPTIONS(t *testing.T) {
 
 	server.handleLocalClusterTools(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -2353,8 +2353,8 @@ func TestServer_HandleLocalClusters_OPTIONS(t *testing.T) {
 
 	server.handleLocalClusters(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS, got %d", w.Code)
 	}
 }
 
@@ -2376,8 +2376,8 @@ func TestHandleLocalClusters_CORSAdvertisesDELETE(t *testing.T) {
 
 	server.handleLocalClusters(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected 200 for OPTIONS preflight, got %d", w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204 for OPTIONS preflight, got %d", w.Code)
 	}
 
 	methods := w.Header().Get("Access-Control-Allow-Methods")

--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
-import { api } from '../../lib/api'
 import { useDemoMode } from '../useDemoMode'
 import { isDemoMode } from '../../lib/demoMode'
 import { triggerAggressiveDetection } from '../useLocalAgent'
@@ -27,6 +26,7 @@ import {
 import type { ClusterInfo } from './types'
 import { subscribePolling } from './pollingManager'
 import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
+import { agentFetch } from './shared'
 
 /** Data slice returned by useClusters — heavy, arrives via startTransition. */
 interface ClusterDataSlice {
@@ -53,7 +53,9 @@ export function useMCPStatus() {
   useEffect(() => {
     const fetchStatus = async () => {
       try {
-        const { data } = await api.get<MCPStatus>(`${LOCAL_AGENT_HTTP_URL}/status`)
+        const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/status`)
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+        const data = await resp.json()
         setStatus(data)
         setError(null)
       } catch {

--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { api } from '../../lib/api'
 import { fetchSSE } from '../../lib/sseClient'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode } from '../../lib/demoMode'
@@ -212,7 +211,9 @@ async function fetchGPUNodes(cluster?: string, _source?: string) {
       } catch {
         // SSE failed, try REST fallback
         try {
-          const { data } = await api.get<{ nodes: GPUNode[] }>(`${LOCAL_AGENT_HTTP_URL}/gpu-nodes?${params}`)
+          const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/gpu-nodes?${params}`)
+          if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+          const data = await resp.json()
           newNodes = data.nodes || []
           fetchSucceeded = true
         } catch {
@@ -638,7 +639,9 @@ export function useNVIDIAOperators(cluster?: string) {
       // REST fallback
       const urlParams = new URLSearchParams()
       if (cluster) urlParams.append('cluster', cluster)
-      const { data } = await api.get<{ operators?: NVIDIAOperatorStatus[], operator?: NVIDIAOperatorStatus }>(`${LOCAL_AGENT_HTTP_URL}/nvidia-operators?${urlParams}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/nvidia-operators?${urlParams}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       if (data.operators) {
         setOperators(data.operators)
       } else if (data.operator) {

--- a/web/src/hooks/mcp/config.ts
+++ b/web/src/hooks/mcp/config.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { api } from '../../lib/api'
 import { fetchSSE } from '../../lib/sseClient'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode } from '../../lib/demoMode'
@@ -80,7 +79,9 @@ export function useConfigMaps(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ configmaps: ConfigMap[] }>(`${LOCAL_AGENT_HTTP_URL}/configmaps?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/configmaps?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       setConfigMaps(data.configmaps || [])
       setError(null)
     } catch {
@@ -183,7 +184,9 @@ export function useSecrets(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ secrets: Secret[] }>(`${LOCAL_AGENT_HTTP_URL}/secrets?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/secrets?${params}`)
+      if (!resp.ok) throw new Error(`secrets fetch failed: ${resp.status}`)
+      const data = await resp.json() as { secrets: Secret[] }
       setSecrets(data.secrets || [])
       setError(null)
     } catch {
@@ -260,7 +263,9 @@ export function useServiceAccounts(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ serviceAccounts: ServiceAccount[] }>(`${LOCAL_AGENT_HTTP_URL}/serviceaccounts?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/serviceaccounts?${params}`)
+      if (!resp.ok) throw new Error(`serviceaccounts fetch failed: ${resp.status}`)
+      const data = await resp.json() as { serviceAccounts: ServiceAccount[] }
       setServiceAccounts(data.serviceAccounts || [])
       setError(null)
     } catch {

--- a/web/src/hooks/mcp/namespaces.ts
+++ b/web/src/hooks/mcp/namespaces.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { api } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { isDemoMode } from '../../lib/demoMode'
@@ -143,7 +142,9 @@ export function useNamespaces(cluster?: string, forceLive = false) {
     try {
       const podNs: string[] = []
       try {
-        const { data } = await api.get<{ pods: PodInfo[] }>(`${LOCAL_AGENT_HTTP_URL}/pods?cluster=${encodeURIComponent(cluster)}`)
+        const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/pods?cluster=${encodeURIComponent(cluster)}`)
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+        const data = await resp.json()
         for (const pod of (data.pods || [])) {
           if (pod.namespace) podNs.push(pod.namespace)
         }
@@ -194,11 +195,13 @@ export function useNamespaceStats(cluster?: string) {
     setIsLoading(true)
     try {
       // Fetch all pods for the cluster (no limit)
-      const { data } = await api.get<{ pods: PodInfo[] }>(`${LOCAL_AGENT_HTTP_URL}/pods?cluster=${encodeURIComponent(cluster)}&limit=1000`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/pods?cluster=${encodeURIComponent(cluster)}&limit=1000`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
 
       // Group pods by namespace and calculate stats
       const nsMap: Record<string, NamespaceStats> = {}
-      data.pods?.forEach(pod => {
+      data.pods?.forEach((pod: PodInfo) => {
         const ns = pod.namespace || 'default'
         if (!nsMap[ns]) {
           nsMap[ns] = { name: ns, podCount: 0, runningPods: 0, pendingPods: 0, failedPods: 0 }

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { api } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode } from '../../lib/demoMode'
 import { useDemoMode } from '../useDemoMode'
@@ -425,7 +424,9 @@ export function useIngresses(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ ingresses: Ingress[] }>(`${LOCAL_AGENT_HTTP_URL}/ingresses?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/ingresses?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       setIngresses(data.ingresses || [])
       setIsDemoFallback(false)
       setError(null)
@@ -508,7 +509,9 @@ export function useNetworkPolicies(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ networkpolicies: NetworkPolicy[] }>(`${LOCAL_AGENT_HTTP_URL}/networkpolicies?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/networkpolicies?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       setNetworkPolicies(data.networkpolicies || [])
       setError(null)
       setConsecutiveFailures(0)

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { api } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode } from '../../lib/demoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
@@ -266,7 +265,9 @@ export function usePVCs(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ pvcs: PVC[] }>(`${LOCAL_AGENT_HTTP_URL}/pvcs?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/pvcs?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       const newData = data.pvcs || []
       const now = new Date()
 
@@ -377,7 +378,9 @@ export function usePVs(cluster?: string) {
     try {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
-      const { data } = await api.get<{ pvs: PV[] }>(`${LOCAL_AGENT_HTTP_URL}/pvs?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/pvs?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       if (!isMountedRef.current) return
       setPVs(data.pvs || [])
       setError(null)
@@ -447,7 +450,9 @@ export function useResourceQuotas(cluster?: string, namespace?: string, forceLiv
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ resourceQuotas: ResourceQuota[] }>(`${LOCAL_AGENT_HTTP_URL}/resourcequotas?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/resourcequotas?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       setResourceQuotas(data.resourceQuotas || [])
       setIsDemoFallback(false)
       setError(null)
@@ -507,7 +512,9 @@ export function useLimitRanges(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ limitRanges: LimitRange[] }>(`${LOCAL_AGENT_HTTP_URL}/limitranges?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/limitranges?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       setLimitRanges(data.limitRanges || [])
       setError(null)
     } catch {
@@ -545,13 +552,22 @@ export function useLimitRanges(cluster?: string, namespace?: string) {
 
 // Create or update a ResourceQuota
 export async function createOrUpdateResourceQuota(spec: ResourceQuotaSpec): Promise<ResourceQuota> {
-  const { data } = await api.post<{ resourceQuota: ResourceQuota }>(`${LOCAL_AGENT_HTTP_URL}/resourcequotas`, spec)
+  const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/resourcequotas`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(spec),
+  })
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+  const data = await resp.json()
   return data.resourceQuota
 }
 
 // Delete a ResourceQuota
 export async function deleteResourceQuota(cluster: string, namespace: string, name: string): Promise<void> {
-  await api.delete(`${LOCAL_AGENT_HTTP_URL}/resourcequotas?cluster=${cluster}&namespace=${namespace}&name=${name}`)
+  const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/resourcequotas?cluster=${cluster}&namespace=${namespace}&name=${name}`, {
+    method: 'DELETE',
+  })
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
 }
 
 // Common GPU resource types for quotas

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -1,11 +1,11 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { api, isBackendUnavailable } from '../../lib/api'
+import { isBackendUnavailable } from '../../lib/api'
 import { fetchSSE } from '../../lib/sseClient'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode } from '../../lib/demoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { kubectlProxy } from '../../lib/kubectlProxy'
-import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef, fetchWithRetry } from './shared'
+import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef, fetchWithRetry, agentFetch } from './shared'
 import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { PodInfo, PodIssue, Deployment, DeploymentIssue, Job, HPA, ReplicaSet, StatefulSet, DaemonSet, CronJob } from './types'
@@ -1471,7 +1471,9 @@ export function useHPAs(cluster?: string, namespace?: string): UseHPAsResult {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ hpas: HPA[] }>(`${LOCAL_AGENT_HTTP_URL}/hpas?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/hpas?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       setHPAs(data.hpas || [])
       setError(null)
       setConsecutiveFailures(0)
@@ -1536,7 +1538,9 @@ export function useReplicaSets(cluster?: string, namespace?: string): UseReplica
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ replicasets: ReplicaSet[] }>(`${LOCAL_AGENT_HTTP_URL}/replicasets?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/replicasets?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       setReplicaSets(data.replicasets || [])
       setError(null)
       setConsecutiveFailures(0)
@@ -1599,7 +1603,9 @@ export function useStatefulSets(cluster?: string, namespace?: string): UseStatef
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ statefulsets: StatefulSet[] }>(`${LOCAL_AGENT_HTTP_URL}/statefulsets?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/statefulsets?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       setStatefulSets(data.statefulsets || [])
       setError(null)
       setConsecutiveFailures(0)
@@ -1662,7 +1668,9 @@ export function useDaemonSets(cluster?: string, namespace?: string): UseDaemonSe
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ daemonsets: DaemonSet[] }>(`${LOCAL_AGENT_HTTP_URL}/daemonsets?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/daemonsets?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       setDaemonSets(data.daemonsets || [])
       setError(null)
       setConsecutiveFailures(0)
@@ -1725,7 +1733,9 @@ export function useCronJobs(cluster?: string, namespace?: string): UseCronJobsRe
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ cronjobs: CronJob[] }>(`${LOCAL_AGENT_HTTP_URL}/cronjobs?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/cronjobs?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       setCronJobs(data.cronjobs || [])
       setError(null)
       setConsecutiveFailures(0)
@@ -1778,7 +1788,9 @@ export function usePodLogs(cluster: string, namespace: string, pod: string, cont
       params.append('pod', pod)
       if (container) params.append('container', container)
       params.append('tail', tail.toString())
-      const { data } = await api.get<{ logs: string }>(`${LOCAL_AGENT_HTTP_URL}/pods/logs?${params}`)
+      const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/pods/logs?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
       setLogs(data.logs || '')
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to fetch logs')


### PR DESCRIPTION
## Summary
- **CORS fix (backend):** 12+ kc-agent handlers were manually setting CORS headers without `Access-Control-Allow-Credentials: true`, causing browsers to block cross-origin requests containing the `X-Requested-With` header. All handlers now use the centralized `setCORSHeaders()` method which includes credentials, private network access, and consistent preflight responses.
- **Auth token fix (frontend):** 22 fetch calls in MCP hooks were using `api.get()` (which sends the console JWT) against kc-agent URLs instead of `agentFetch()` (which sends the kc-agent token). This caused 401 Unauthorized errors on workloads, storage, networking, compute, config, clusters, and namespaces endpoints.

### Backend files (8):
`server.go`, `server_ai_chat.go`, `server_ai_websocket.go`, `server_exec.go`, `server_http_kubeconfig.go`, `server_ops_insights.go`, `server_ops_predictions.go`, `server_ops_settings.go`

### Frontend files (7):
`clusters.ts`, `compute.ts`, `config.ts`, `namespaces.ts`, `networking.ts`, `storage.ts`, `workloads.ts`

Fixes #11102

## Test plan
- [ ] Console starts without errors (`bash startup-oauth.sh`)
- [ ] Clusters page shows cluster data (no "Agent connected — no cluster data available")
- [ ] Dashboard cards load workloads, storage, networking data
- [ ] Browser console shows no CORS errors on kc-agent requests
- [ ] No 401 errors on kc-agent endpoints in browser network tab