### PR TITLE
fix(workloads): catch silent multi-cluster propagation failures and unhandled rejections

### DIFF
--- a/web/src/hooks/__tests__/useWorkloads.test.ts
+++ b/web/src/hooks/__tests__/useWorkloads.test.ts
@@ -583,9 +583,9 @@ describe('useClusterCapabilities', () => {
 
 describe('useDeployWorkload', () => {
   it('sends POST request with deploy payload', async () => {
-    const deployResults = [{ success: true, cluster: 'prod', message: 'Deployed' }]
+    const deployResult = { success: true, message: 'Deployed', deployedTo: ['prod'] }
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-      new Response(JSON.stringify(deployResults), {
+      new Response(JSON.stringify(deployResult), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       })
@@ -606,7 +606,7 @@ describe('useDeployWorkload', () => {
       )
     })
 
-    expect(onSuccess).toHaveBeenCalledWith(deployResults)
+    expect(onSuccess).toHaveBeenCalledWith(deployResult)
     expect(result.current.isLoading).toBe(false)
     expect(result.current.error).toBeNull()
   })
@@ -652,6 +652,7 @@ describe('useDeployWorkload', () => {
     )
     const { useDeployWorkload } = await importFresh()
     const onError = vi.fn()
+    const onSuccess = vi.fn()
 
     const { result } = renderHook(() => useDeployWorkload())
     await act(async () => {
@@ -663,7 +664,7 @@ describe('useDeployWorkload', () => {
             sourceCluster: 'staging',
             targetClusters: ['prod'],
           },
-          { onError }
+          { onError, onSuccess }
         )
       } catch {
         // expected
@@ -671,6 +672,7 @@ describe('useDeployWorkload', () => {
     })
 
     expect(onError).toHaveBeenCalled()
+    expect(onSuccess).not.toHaveBeenCalled()
     expect(result.current.error).toBeDefined()
     expect(result.current.error!.message).toBe('Logic failure')
   })
@@ -682,9 +684,9 @@ describe('useDeployWorkload', () => {
 
 describe('useScaleWorkload', () => {
   it('sends scale request and calls onSuccess', async () => {
-    const scaleResults = [{ success: true, cluster: 'prod', message: 'Scaled to 5' }]
+    const scaleResult = { success: true, message: 'Scaled to 5' }
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-      new Response(JSON.stringify(scaleResults), {
+      new Response(JSON.stringify(scaleResult), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       })
@@ -700,7 +702,7 @@ describe('useScaleWorkload', () => {
       )
     })
 
-    expect(onSuccess).toHaveBeenCalledWith(scaleResults)
+    expect(onSuccess).toHaveBeenCalledWith(scaleResult)
     expect(result.current.isLoading).toBe(false)
   })
 
@@ -732,13 +734,14 @@ describe('useScaleWorkload', () => {
     )
     const { useScaleWorkload } = await importFresh()
     const onError = vi.fn()
+    const onSuccess = vi.fn()
 
     const { result } = renderHook(() => useScaleWorkload())
     await act(async () => {
       try {
         await result.current.mutate(
           { workloadName: 'api-server', namespace: 'production', replicas: 5 },
-          { onError }
+          { onError, onSuccess }
         )
       } catch {
         // expected
@@ -746,6 +749,7 @@ describe('useScaleWorkload', () => {
     })
 
     expect(onError).toHaveBeenCalled()
+    expect(onSuccess).not.toHaveBeenCalled()
     expect(result.current.error).toBeDefined()
     expect(result.current.error!.message).toBe('Scaling logic failure')
   })
@@ -758,7 +762,10 @@ describe('useScaleWorkload', () => {
 describe('useDeleteWorkload', () => {
   it('sends POST to kc-agent /workloads/delete and calls onSuccess', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-      new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+      new Response(JSON.stringify({ success: true, message: 'Deleted' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
     )
     const { useDeleteWorkload } = await importFresh()
     const onSuccess = vi.fn()
@@ -844,13 +851,14 @@ describe('useDeleteWorkload', () => {
     )
     const { useDeleteWorkload } = await importFresh()
     const onError = vi.fn()
+    const onSuccess = vi.fn()
 
     const { result } = renderHook(() => useDeleteWorkload())
     await act(async () => {
       try {
         await result.current.mutate(
           { cluster: 'prod', namespace: 'production', name: 'api-server' },
-          { onError }
+          { onError, onSuccess }
         )
       } catch {
         // expected
@@ -858,6 +866,7 @@ describe('useDeleteWorkload', () => {
     })
 
     expect(onError).toHaveBeenCalled()
+    expect(onSuccess).not.toHaveBeenCalled()
     expect(result.current.error).toBeDefined()
     expect(result.current.error!.message).toBe('Deletion logic failure')
   })

--- a/web/src/hooks/__tests__/useWorkloads.test.ts
+++ b/web/src/hooks/__tests__/useWorkloads.test.ts
@@ -642,6 +642,38 @@ describe('useDeployWorkload', () => {
     expect(result.current.error).toBeDefined()
     expect(result.current.error!.message).toBe('Cluster unreachable')
   })
+
+  it('throws error when response is 200 OK but success is false', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: false, error: 'Logic failure' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    const { useDeployWorkload } = await importFresh()
+    const onError = vi.fn()
+
+    const { result } = renderHook(() => useDeployWorkload())
+    await act(async () => {
+      try {
+        await result.current.mutate(
+          {
+            workloadName: 'api-server',
+            namespace: 'production',
+            sourceCluster: 'staging',
+            targetClusters: ['prod'],
+          },
+          { onError }
+        )
+      } catch {
+        // expected
+      }
+    })
+
+    expect(onError).toHaveBeenCalled()
+    expect(result.current.error).toBeDefined()
+    expect(result.current.error!.message).toBe('Logic failure')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -689,6 +721,33 @@ describe('useScaleWorkload', () => {
 
     expect(result.current.error).toBeInstanceOf(Error)
     expect(result.current.error!.message).toBe('Unknown error')
+  })
+
+  it('throws error when response is 200 OK but success is false', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: false, error: 'Scaling logic failure' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    const { useScaleWorkload } = await importFresh()
+    const onError = vi.fn()
+
+    const { result } = renderHook(() => useScaleWorkload())
+    await act(async () => {
+      try {
+        await result.current.mutate(
+          { workloadName: 'api-server', namespace: 'production', replicas: 5 },
+          { onError }
+        )
+      } catch {
+        // expected
+      }
+    })
+
+    expect(onError).toHaveBeenCalled()
+    expect(result.current.error).toBeDefined()
+    expect(result.current.error!.message).toBe('Scaling logic failure')
   })
 })
 
@@ -774,5 +833,32 @@ describe('useDeleteWorkload', () => {
     })
 
     expect(result.current.error!.message).toBe('Failed to delete workload')
+  })
+
+  it('throws error when response is 200 OK but success is false', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: false, error: 'Deletion logic failure' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    const { useDeleteWorkload } = await importFresh()
+    const onError = vi.fn()
+
+    const { result } = renderHook(() => useDeleteWorkload())
+    await act(async () => {
+      try {
+        await result.current.mutate(
+          { cluster: 'prod', namespace: 'production', name: 'api-server' },
+          { onError }
+        )
+      } catch {
+        // expected
+      }
+    })
+
+    expect(onError).toHaveBeenCalled()
+    expect(result.current.error).toBeDefined()
+    expect(result.current.error!.message).toBe('Deletion logic failure')
   })
 })

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -362,6 +362,9 @@ export function useDeployWorkload() {
         throw new Error(errorData.error || 'Failed to deploy workload')
       }
       const result = await res.json()
+      if (result.success === false) {
+        throw new Error(result.error || result.message || 'Failed to deploy workload')
+      }
       options?.onSuccess?.(result)
       return result
     } catch (err: unknown) {
@@ -412,6 +415,9 @@ export function useScaleWorkload() {
         throw new Error(errorData.error || 'Failed to scale workload')
       }
       const result = await res.json()
+      if (result.success === false) {
+        throw new Error(result.error || result.message || 'Failed to scale workload')
+      }
       options?.onSuccess?.(result)
       return result
     } catch (err: unknown) {
@@ -465,6 +471,10 @@ export function useDeleteWorkload() {
       if (!res.ok) {
         const errorData = await res.json()
         throw new Error(errorData.error || 'Failed to delete workload')
+      }
+      const result = await res.json()
+      if (result.success === false) {
+        throw new Error(result.error || result.message || 'Failed to delete workload')
       }
       options?.onSuccess?.()
     } catch (err: unknown) {

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -65,8 +65,11 @@ export interface DeployRequest {
 
 export interface DeployResult {
   success: boolean
-  cluster: string
-  message: string
+  message?: string
+  deployedTo?: string[]
+  failedClusters?: string[]
+  dependencies?: { kind: string; name: string; action: string }[]
+  warnings?: string[]
 }
 
 export function authHeaders(): Record<string, string> {
@@ -340,7 +343,7 @@ export function useDeployWorkload() {
   const mutate = async (
     request: DeployRequest,
     options?: {
-      onSuccess?: (data: DeployResult[]) => void
+      onSuccess?: (data: DeployResult) => void
       onError?: (error: Error) => void
     }
   ) => {
@@ -393,7 +396,7 @@ export function useScaleWorkload() {
       replicas: number
     },
     options?: {
-      onSuccess?: (data: DeployResult[]) => void
+      onSuccess?: (data: DeployResult) => void
       onError?: (error: Error) => void
     }
   ) => {

--- a/web/src/lib/dashboards/DashboardRuntime.tsx
+++ b/web/src/lib/dashboards/DashboardRuntime.tsx
@@ -234,7 +234,7 @@ export function DashboardRuntime({
       },
       onError: (error: Error) => {
         showToast(`Failed to deploy: ${error.message}`, 'error')
-      } })
+      } }).catch(console.error)
   }
 
   // Get stats value getter from registry or props


### PR DESCRIPTION
### 📌 Fixes

Fixes #7993 

---

### 📝 Summary of Changes

This PR fixes critical issues in workload orchestration where API failures were silently ignored and promise rejections were left unhandled, leading to misleading UI states and potential multi-cluster drift.

- Ensures frontend hooks validate logical API success (`success: false`) instead of relying solely on HTTP status
- Prevents unhandled promise rejections in dashboard runtime
- Adds comprehensive test coverage for failure scenarios

---

### Changes Made

- [x] Fixed silent API failure handling in `useDeployWorkload`, `useScaleWorkload`, and `useDeleteWorkload`
- [x] Added validation for `result.success === false` and throw appropriate errors
- [x] Prevented false-positive `onSuccess` callbacks on failed operations
- [x] Fixed unhandled promise rejection in `handleDeployWorkload` by appending `.catch(console.error)`
- [x] Added unit tests for:
  - HTTP 200 OK + `success: false` in deploy workflow
  - HTTP 200 OK + `success: false` in scale workflow
  - HTTP 200 OK + `success: false` in delete workflow

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] New cards target https://github.com/kubestellar/console-marketplace, not this repo
- [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [x] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

N/A (logic-level fix, no UI changes)

---

### 👀 Reviewer Notes

**Root Issue:**  
Frontend hooks were incorrectly treating HTTP 200 responses as success, even when the backend explicitly returned `{ success: false }` for failed multi-cluster propagation operations.

**Impact:**  
- False success notifications in UI ("Deployed successfully")
- Silent configuration drift across clusters
- Unhandled promise rejections causing instability in dashboard runtime

**Fix Highlights:**  
- Added explicit validation of `result.success` before invoking `onSuccess`
- Errors are now properly thrown and propagated to UI
- Ensured all async mutations are safely handled with `.catch(...)`

**Result:**  
Accurate error reporting, elimination of silent failures, and improved reliability of multi-cluster workload orchestration.


