### PR TITLE
🐛 Fix DynamicCard test load failure

### DIFF
--- a/web/src/components/cards/__tests__/DynamicCard.test.tsx
+++ b/web/src/components/cards/__tests__/DynamicCard.test.tsx
@@ -27,9 +27,10 @@ vi.mock('../../../lib/dynamic-cards/compiler', () => ({
   createCardComponent: (...args: unknown[]) => mockCreateCardComponent(...args),
 }))
 
-vi.mock('../../../lib/constants', () => ({
-  STORAGE_KEY_TOKEN: 'kc_token',
-}))
+vi.mock('../../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/constants')>()
+  return { ...actual, STORAGE_KEY_TOKEN: 'kc_token' }
+})
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k }),


### PR DESCRIPTION
Fixes #11115

Fix the DynamicCard test that fails to load due to incomplete `lib/constants` mock.

The test mocked `lib/constants` with only `STORAGE_KEY_TOKEN`, but the transitive import chain (`DynamicCard → useCache → lib/cache → demoMode`) requires `STORAGE_KEY_DEMO_MODE` and `DEMO_TOKEN_VALUE` from the same module. Vitest's strict mock checking threw:

```
Error: No "STORAGE_KEY_DEMO_MODE" export is defined on the "../../../lib/constants" mock
```

**Fix:** Use `importOriginal` to spread all actual constants into the mock, only overriding `STORAGE_KEY_TOKEN`.