### PR TITLE
🐛 Fix 151 test failures: add missing agentFetch mock to shared module mocks

### DIFF
--- a/web/src/hooks/mcp/__tests__/clusters.dedup.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.dedup.test.ts
@@ -76,6 +76,7 @@ vi.mock('../shared', async () => {
     fetchSingleClusterHealth: mockFetchSingleClusterHealth,
     fullFetchClusters: mockFullFetchClusters,
     connectSharedWebSocket: mockConnectSharedWebSocket,
+    agentFetch: m.agentFetch,
   }
 })
 

--- a/web/src/hooks/mcp/__tests__/clusters.health.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.health.test.ts
@@ -76,6 +76,7 @@ vi.mock('../shared', async () => {
     fetchSingleClusterHealth: mockFetchSingleClusterHealth,
     fullFetchClusters: mockFullFetchClusters,
     connectSharedWebSocket: mockConnectSharedWebSocket,
+    agentFetch: m.agentFetch,
   }
 })
 

--- a/web/src/hooks/mcp/__tests__/clusters.list.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.list.test.ts
@@ -76,6 +76,7 @@ vi.mock('../shared', async () => {
     fetchSingleClusterHealth: mockFetchSingleClusterHealth,
     fullFetchClusters: mockFullFetchClusters,
     connectSharedWebSocket: mockConnectSharedWebSocket,
+    agentFetch: m.agentFetch,
   }
 })
 

--- a/web/src/hooks/mcp/__tests__/operators-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/operators-pure.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../../lib/constants', () => ({
 vi.mock('../shared', () => ({
   clusterCacheRef: { current: new Map() },
   subscribeClusterCache: vi.fn(),
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 const mod = await import('../operators')

--- a/web/src/hooks/mcp/__tests__/operators.test.ts
+++ b/web/src/hooks/mcp/__tests__/operators.test.ts
@@ -55,6 +55,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../shared', () => ({
   clusterCacheRef: mockClusterCacheRef,
   subscribeClusterCache: (...args: unknown[]) => mockSubscribeClusterCache(...args),
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 vi.mock('../../../lib/constants', async (importOriginal) => {

--- a/web/src/lib/__tests__/auth-coverage.test.tsx
+++ b/web/src/lib/__tests__/auth-coverage.test.tsx
@@ -74,6 +74,7 @@ vi.mock('../sseClient', () => ({
 
 vi.mock('../../hooks/mcp/shared', () => ({
   clearClusterCacheOnLogout: vi.fn(),
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/__tests__/auth-expand.test.ts
+++ b/web/src/lib/__tests__/auth-expand.test.ts
@@ -76,6 +76,7 @@ vi.mock('../sseClient', () => ({
 
 vi.mock('../../hooks/mcp/shared', () => ({
   clearClusterCacheOnLogout: vi.fn(),
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/__tests__/auth-session-expiry.test.ts
+++ b/web/src/lib/__tests__/auth-session-expiry.test.ts
@@ -74,6 +74,7 @@ vi.mock('../sseClient', () => ({
 
 vi.mock('../../hooks/mcp/shared', () => ({
   clearClusterCacheOnLogout: vi.fn(),
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 // ── Constants ──────────────────────────────────────────────────────────────

--- a/web/src/lib/__tests__/auth.test.ts
+++ b/web/src/lib/__tests__/auth.test.ts
@@ -70,6 +70,7 @@ vi.mock('../sseClient', () => ({
 
 vi.mock('../../hooks/mcp/shared', () => ({
   clearClusterCacheOnLogout: vi.fn(),
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/cache/__tests__/fetcherUtils.test.ts
+++ b/web/src/lib/cache/__tests__/fetcherUtils.test.ts
@@ -9,6 +9,7 @@ vi.mock('../../sseClient', () => ({
 }))
 vi.mock('../../../hooks/mcp/shared', () => ({
   clusterCacheRef: { clusters: [] },
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 vi.mock('../../constants', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',


### PR DESCRIPTION
Fixes #11117

The `agentFetch` export was added to `hooks/mcp/shared.ts` but test files that mock this module did not include it. Vitest's strict mock checking throws when code under test accesses the missing export.

**Fix:** Add `agentFetch: vi.fn().mockResolvedValue(new Response(...))` to all test mocks of the shared module that were missing it.

**Files fixed (10):**
- `src/hooks/mcp/__tests__/clusters.dedup.test.ts` — forward `agentFetch` from actual module
- `src/hooks/mcp/__tests__/clusters.health.test.ts` — forward `agentFetch` from actual module
- `src/hooks/mcp/__tests__/clusters.list.test.ts` — forward `agentFetch` from actual module
- `src/hooks/mcp/__tests__/operators-pure.test.ts` — add mock stub
- `src/hooks/mcp/__tests__/operators.test.ts` — add mock stub
- `src/lib/__tests__/auth-coverage.test.tsx` — add mock stub
- `src/lib/__tests__/auth-expand.test.ts` — add mock stub
- `src/lib/__tests__/auth-session-expiry.test.ts` — add mock stub
- `src/lib/__tests__/auth.test.ts` — add mock stub
- `src/lib/cache/__tests__/fetcherUtils.test.ts` — add mock stub