### PR TITLE
🐛 Fix Run mission button showing raw unicode escape instead of ↵ symbol

### DIFF
--- a/web/src/components/missions/ConfirmMissionPromptDialog.tsx
+++ b/web/src/components/missions/ConfirmMissionPromptDialog.tsx
@@ -149,7 +149,7 @@ export function ConfirmMissionPromptDialog({
         >
           {t('confirmMissionPrompt.confirm', 'Run mission')}
           <kbd className="hidden sm:inline-flex px-1.5 py-0.5 rounded bg-white/10 text-[10px] font-mono leading-none">
-            {isMac ? '\u2318' : 'Ctrl'}\u21b5
+            {isMac ? '\u2318' : 'Ctrl'}↵
           </kbd>
         </Button>
       </BaseModal.Footer>


### PR DESCRIPTION
Fixes #11118

The keyboard shortcut label on the Run mission button displayed `Ctrl\u21b5` as literal text instead of rendering the ↵ (return/enter) character. Fixed by using the actual Unicode character directly.