### PR TITLE
🐛 Fix preflight check failing with .filter is not a function

### DIFF
--- a/web/src/lib/missions/preflightCheck.ts
+++ b/web/src/lib/missions/preflightCheck.ts
@@ -449,11 +449,16 @@ export async function runToolPreflightCheck(
         tools: [],
       }
     }
-    const detected: ToolCheckResult[] = await resp.json()
+    const responseData = await resp.json()
+    const detected: ToolCheckResult[] = Array.isArray(responseData)
+      ? responseData
+      : Array.isArray(responseData?.tools)
+        ? responseData.tools
+        : []
 
     // Build a lookup of installed tools
     const installedSet = new Set(
-      (detected || [])
+      detected
         .filter((t: ToolCheckResult) => t.installed)
         .map((t: ToolCheckResult) => t.name.toLowerCase()),
     )
@@ -467,7 +472,7 @@ export async function runToolPreflightCheck(
 
     // Merge required tools into the result so the UI can show a full checklist
     const toolResults: ToolCheckResult[] = requiredTools.map(name => {
-      const match = (detected || []).find(
+      const match = detected.find(
         (d: ToolCheckResult) => d.name.toLowerCase() === name.toLowerCase(),
       )
       return match || { name, installed: installedSet.has(name.toLowerCase()) }


### PR DESCRIPTION
Fixes #11121

The pre-flight tool check failed because `.filter()` was called on a value that was truthy but not an array. The API returns `{ tools: [...] }` but the code expected the array directly. The `(r || [])` guard only protects against null/undefined, not non-array truthy values.

Fixed by extracting the `tools` property from the response and using `Array.isArray()` to properly validate before calling array methods.