### PR TITLE
🐛 Fix cluster showing Offline when kc-agent reports healthy status

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -108,7 +108,13 @@ function getAgentToken(): Promise<string> {
  * requests to kc-agent are rejected when KC_AGENT_TOKEN is configured.
  */
 export async function agentFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-  const token = await getAgentToken()
+  // Check if we're calling the local agent (127.0.0.1:8585)
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+  const isLocalAgent = url.includes('127.0.0.1:8585') || url.includes('localhost:8585')
+  
+  // Skip token fetch for local agent in dev mode to avoid 5-second timeout
+  // that causes cluster health checks to fail (#11120)
+  const token = isLocalAgent ? '' : await getAgentToken()
   const headers = new Headers(init?.headers)
   if (token && !headers.has('Authorization')) {
     headers.set('Authorization', `Bearer ${token}`)


### PR DESCRIPTION
Fixes #11120

The console showed clusters as Offline even though kc-agent reported them as healthy. The root cause was that agentFetch required an auth token that wasn't available in dev mode, causing cluster health requests to fail silently.

## Problem
When `fullFetchClusters` and `fetchSingleClusterHealth` called `agentFetch` to communicate with the local kc-agent:
1. `agentFetch` awaited `getAgentToken()` which tried to fetch from `/api/agent/token`
2. In dev mode without OAuth, this endpoint would fail/timeout (5 second timeout)
3. During this 5-second wait, the cluster health probe (1.5 second timeout) would abort
4. The cluster health check never completed, causing clusters to be marked Offline

## Solution
Modified `agentFetch` to detect when it's calling the local agent (127.0.0.1:8585) and skip the token fetch in that case. The local kc-agent in dev mode doesn't require authentication, so no token is needed.