### PR TITLE
🐛 Fix 150 test failures: add missing agentFetch mock to shared module mocks

### DIFF
--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
@@ -54,6 +54,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../shared', () => ({
   MIN_REFRESH_INDICATOR_MS: 0,
   getEffectiveInterval: (ms: number) => ms,
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 vi.mock('../pollingManager', () => ({

--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage2.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage2.test.ts
@@ -38,7 +38,7 @@ vi.mock('../../../lib/modeTransition', () => ({
   registerRefetch: (...args: unknown[]) => mockRegisterRefetch(...args),
   registerCacheReset: (...args: unknown[]) => mockRegisterCacheReset(...args),
 }))
-vi.mock('../shared', () => ({ MIN_REFRESH_INDICATOR_MS: 0, getEffectiveInterval: (ms: number) => ms }))
+vi.mock('../shared', () => ({ MIN_REFRESH_INDICATOR_MS: 0, getEffectiveInterval: (ms: number) => ms, agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })) }))
 vi.mock('../pollingManager', () => ({ subscribePolling: (...args: unknown[]) => mockSubscribePolling(...args) }))
 vi.mock('../../../lib/constants/network', async (i) => ({ ...(await i() as Record<string, unknown>), MCP_HOOK_TIMEOUT_MS: 5_000 }))
 vi.mock('../../../lib/constants', async (i) => ({ ...(await i() as Record<string, unknown>), STORAGE_KEY_TOKEN: 'token' }))

--- a/web/src/hooks/mcp/__tests__/buildpacks.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks.test.ts
@@ -43,6 +43,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../shared', () => ({
   MIN_REFRESH_INDICATOR_MS: 500,
   getEffectiveInterval: (ms: number) => ms,
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 vi.mock('../../../lib/constants/network', async (importOriginal) => {

--- a/web/src/hooks/mcp/__tests__/crossplane-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/crossplane-coverage.test.ts
@@ -45,6 +45,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../shared', () => ({
   MIN_REFRESH_INDICATOR_MS: 0,
   getEffectiveInterval: (ms: number) => ms,
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 vi.mock('../pollingManager', () => ({

--- a/web/src/hooks/mcp/__tests__/crossplane.test.ts
+++ b/web/src/hooks/mcp/__tests__/crossplane.test.ts
@@ -43,6 +43,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../shared', () => ({
   MIN_REFRESH_INDICATOR_MS: 500,
   getEffectiveInterval: (ms: number) => ms,
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 vi.mock('../../../lib/constants/network', async (importOriginal) => {

--- a/web/src/hooks/mcp/__tests__/helm-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-coverage.test.ts
@@ -51,6 +51,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../shared', () => ({
   MIN_REFRESH_INDICATOR_MS: 500,
   getEffectiveInterval: (ms: number) => ms,
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 vi.mock('../pollingManager', () => ({

--- a/web/src/hooks/mcp/__tests__/helm.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm.test.ts
@@ -51,6 +51,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../shared', () => ({
   MIN_REFRESH_INDICATOR_MS: 500,
   getEffectiveInterval: (ms: number) => ms,
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 vi.mock('../pollingManager', () => ({

--- a/web/src/hooks/mcp/__tests__/security.test.ts
+++ b/web/src/hooks/mcp/__tests__/security.test.ts
@@ -48,6 +48,7 @@ vi.mock('../shared', () => ({
   MIN_REFRESH_INDICATOR_MS: 500,
   REFRESH_INTERVAL_MS: 120_000,
   getEffectiveInterval: (ms: number) => ms,
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
 }))
 
 vi.mock('../pollingManager', () => ({

--- a/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
@@ -83,6 +83,7 @@ vi.mock('../shared', () => ({
   getEffectiveInterval: (ms: number) => ms,
   LOCAL_AGENT_URL: 'http://localhost:8585',
   clusterCacheRef: mockClusterCacheRef,
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
   fetchWithRetry: (url: string, opts: Record<string, unknown> = {}) => {
     const { timeoutMs, maxRetries, initialBackoffMs, ...rest } = opts
     void timeoutMs; void maxRetries; void initialBackoffMs

--- a/web/src/hooks/mcp/__tests__/workloads.branches.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.branches.test.ts
@@ -87,6 +87,7 @@ vi.mock('../shared', () => ({
   getEffectiveInterval: (ms: number) => ms,
   LOCAL_AGENT_URL: 'http://localhost:8585',
   clusterCacheRef: mockClusterCacheRef,
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
   fetchWithRetry: (url: string, opts: Record<string, unknown> = {}) => {
     const { timeoutMs, maxRetries, initialBackoffMs, ...rest } = opts
     void timeoutMs

--- a/web/src/hooks/mcp/__tests__/workloads.core.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.core.test.ts
@@ -87,6 +87,7 @@ vi.mock('../shared', () => ({
   getEffectiveInterval: (ms: number) => ms,
   LOCAL_AGENT_URL: 'http://localhost:8585',
   clusterCacheRef: mockClusterCacheRef,
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
   fetchWithRetry: (url: string, opts: Record<string, unknown> = {}) => {
     const { timeoutMs, maxRetries, initialBackoffMs, ...rest } = opts
     void timeoutMs

--- a/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
@@ -87,6 +87,7 @@ vi.mock('../shared', () => ({
   getEffectiveInterval: (ms: number) => ms,
   LOCAL_AGENT_URL: 'http://localhost:8585',
   clusterCacheRef: mockClusterCacheRef,
+  agentFetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
   fetchWithRetry: (url: string, opts: Record<string, unknown> = {}) => {
     const { timeoutMs, maxRetries, initialBackoffMs, ...rest } = opts
     void timeoutMs


### PR DESCRIPTION
Fixes #11125

The agentFetch export was added to hooks/mcp/shared.ts but 12 test files
that mock this module did not include it. Vitest strict mock checking
throws when code under test tries to access the missing export.

This is the same root cause as #11119 but covers the remaining files that
were missed in that fix.

Fix: Add agentFetch mock to all test files that mock hooks/mcp/shared.