### PR TITLE
Fix 6 Copilot review findings from recent PRs

### DIFF
--- a/pkg/agent/provider_copilotcli_test.go
+++ b/pkg/agent/provider_copilotcli_test.go
@@ -81,7 +81,7 @@ func TestIsAuthError(t *testing.T) {
 	}
 }
 
-func TestFreshEnv_StripsStalTokens(t *testing.T) {
+func TestFreshEnv_StripsStaleTokens(t *testing.T) {
 	t.Setenv("GH_TOKEN", "stale-gh-token")
 	t.Setenv("GITHUB_TOKEN", "stale-github-token")
 

--- a/web/src/components/cards/compliance/PolicyViolationDetailModal.tsx
+++ b/web/src/components/cards/compliance/PolicyViolationDetailModal.tsx
@@ -47,7 +47,7 @@ export function PolicyViolationDetailModal({ isOpen, onClose, violation }: Polic
   const handleFixWithAI = () => {
     if (!violation) return
     emitActionClicked('fix_with_ai', 'policy_violations', 'compliance')
-    onClose() // Close modal so mission sidebar is visible
+    handleClose() // Close modal so mission sidebar is visible
     startMission({
       title: `Fix: ${violation.policy} violations`,
       description: `${violation.count} violations from ${violation.tool} on ${(violation.clusters || []).join(', ')}`,
@@ -68,7 +68,6 @@ Please proceed step by step.`,
         clusters: violation.clusters,
         violationCount: violation.count } })
     openSidebar()
-    handleClose()
   }
 
   if (!violation) return null

--- a/web/src/components/cards/deploy/GitOpsDriftDetailModal.tsx
+++ b/web/src/components/cards/deploy/GitOpsDriftDetailModal.tsx
@@ -96,7 +96,6 @@ Please proceed step by step.`,
         driftType: drift.driftType,
         severity: drift.severity } })
     openSidebar()
-    handleClose()
   }
 
   if (!drift) return null

--- a/web/src/components/cards/deploy/HelmHistoryDetailModal.tsx
+++ b/web/src/components/cards/deploy/HelmHistoryDetailModal.tsx
@@ -57,7 +57,7 @@ export function HelmHistoryDetailModal({
   const handleRollback = () => {
     if (!entry) return
     emitActionClicked('rollback', 'helm_history', 'deploy')
-    onClose() // Close modal so mission sidebar is visible
+    handleClose() // Close modal so mission sidebar is visible
     startMission({
       title: `Rollback: ${releaseName} to rev ${entry.revision}`,
       description: `Rollback Helm release ${releaseName} in ${namespace} on ${clusterName} to revision ${entry.revision}`,
@@ -85,7 +85,6 @@ Please proceed step by step.`,
         targetRevision: entry.revision,
         currentRevision } })
     openSidebar()
-    handleClose()
   }
 
   if (!entry) return null

--- a/web/src/components/cards/insights/InsightDetailModal.tsx
+++ b/web/src/components/cards/insights/InsightDetailModal.tsx
@@ -81,7 +81,7 @@ export function InsightDetailModal({ isOpen, onClose, insight }: InsightDetailMo
   const handleCreateMission = () => {
     if (!insight) return
     emitActionClicked('create_mission', insight.category, 'insights')
-    onClose() // Close modal so mission sidebar is visible
+    handleClose() // Close modal so mission sidebar is visible
     startMission({
       title: `Fix: ${insight.title}`,
       description: insight.description,
@@ -97,7 +97,6 @@ Help me investigate and resolve this.`,
         severity: insight.severity,
         affectedClusters: insight.affectedClusters } })
     openSidebar()
-    handleClose()
   }
 
   if (!insight) return null

--- a/web/src/components/cards/trivy/TrivyDetailModal.tsx
+++ b/web/src/components/cards/trivy/TrivyDetailModal.tsx
@@ -97,7 +97,6 @@ Please proceed step by step.`,
         critical: img.critical,
         high: img.high } })
     openSidebar()
-    onClose()
   }
 
   const handleTriageCritical = () => {
@@ -134,7 +133,6 @@ Please proceed step by step.`,
         totalCritical: critical,
         imageCount: criticalImages.length } })
     openSidebar()
-    onClose()
   }
 
   return (

--- a/web/src/hooks/__tests__/useMissions.provider.test.ts
+++ b/web/src/hooks/__tests__/useMissions.provider.test.ts
@@ -121,7 +121,7 @@ vi.mock('../../lib/missions/preflightCheck', () => ({
   classifyKubectlError: vi.fn(),
   getRemediationActions: vi.fn(() => []),
   resolveRequiredTools: vi.fn(() => []),
-  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
 }))
 
 vi.mock('../../lib/kubectlProxy', () => ({

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -564,7 +564,8 @@ export async function createOrUpdateResourceQuota(spec: ResourceQuotaSpec): Prom
 
 // Delete a ResourceQuota
 export async function deleteResourceQuota(cluster: string, namespace: string, name: string): Promise<void> {
-  const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/resourcequotas?cluster=${cluster}&namespace=${namespace}&name=${name}`, {
+  const params = new URLSearchParams({ cluster, namespace, name })
+  const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/resourcequotas?${params.toString()}`, {
     method: 'DELETE',
   })
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`)

--- a/web/src/hooks/useMissions.analytics-agents.test.tsx
+++ b/web/src/hooks/useMissions.analytics-agents.test.tsx
@@ -66,7 +66,7 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
   resolveRequiredTools: vi.fn(() => []),
-  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.edgecases.test.tsx
+++ b/web/src/hooks/useMissions.edgecases.test.tsx
@@ -66,7 +66,7 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
   resolveRequiredTools: vi.fn(() => []),
-  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.messages-stream.test.tsx
+++ b/web/src/hooks/useMissions.messages-stream.test.tsx
@@ -66,7 +66,7 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
   resolveRequiredTools: vi.fn(() => []),
-  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.preflight-agents.test.tsx
+++ b/web/src/hooks/useMissions.preflight-agents.test.tsx
@@ -67,7 +67,7 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
   resolveRequiredTools: vi.fn(() => []),
-  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.provider-start.test.tsx
+++ b/web/src/hooks/useMissions.provider-start.test.tsx
@@ -66,7 +66,7 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
   resolveRequiredTools: vi.fn(() => []),
-  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.provider.tsx
+++ b/web/src/hooks/useMissions.provider.tsx
@@ -1701,7 +1701,8 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         // Clear active token tracking for this mission and emit completion
         // event (#6016 — per-operation tracking keyed by missionId).
         clearActiveTokenCategory(missionId)
-        if (m.status === 'running') {
+        const resultIsError = !!chatPayload.isError
+        if (m.status === 'running' && !resultIsError) {
           // #7326 — Cap duration at 24 hours to prevent numeric overflow
           // from clock skew or backgrounded tabs.
           const rawDuration = Math.round((Date.now() - m.createdAt.getTime()) / 1000)
@@ -1712,6 +1713,8 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           window.dispatchEvent(new CustomEvent('kc-mission-completed', {
             detail: { missionId, missionType: m.type },
           }))
+        } else if (m.status === 'running' && resultIsError) {
+          emitMissionError(m.type, chatPayload.content || 'Mission failed')
         }
 
         const resultContent = chatPayload.content || (payload as { output?: string }).output || 'Task completed.'
@@ -1761,9 +1764,6 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         // is only used while streaming is in progress (stream done w/o result).
         // The UI shows a completion panel with feedback buttons when status is
         // 'completed', so reaching this state is the correct lifecycle end (#5479).
-        // #11070 — If the backend flagged this result as an error (e.g. non-zero
-        // exit code from a CLI provider), mark the mission 'failed' instead.
-        const resultIsError = !!(chatPayload as unknown as Record<string, unknown>).isError
         return {
           ...m,
           status: (resultIsError ? 'failed' : 'completed') as MissionStatus,

--- a/web/src/hooks/useMissions.save-run.test.tsx
+++ b/web/src/hooks/useMissions.save-run.test.tsx
@@ -66,7 +66,7 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
   resolveRequiredTools: vi.fn(() => []),
-  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.state-persist.test.tsx
+++ b/web/src/hooks/useMissions.state-persist.test.tsx
@@ -66,7 +66,7 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
   resolveRequiredTools: vi.fn(() => []),
-  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -1790,7 +1790,8 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         // Clear active token tracking for this mission and emit completion
         // event (#6016 — per-operation tracking keyed by missionId).
         clearActiveTokenCategory(missionId)
-        if (m.status === 'running') {
+        const resultIsError = !!chatPayload.isError
+        if (m.status === 'running' && !resultIsError) {
           // #7326 — Cap duration at 24 hours to prevent numeric overflow
           // from clock skew or backgrounded tabs.
           const rawDuration = Math.round((Date.now() - m.createdAt.getTime()) / 1000)
@@ -1801,6 +1802,8 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           window.dispatchEvent(new CustomEvent('kc-mission-completed', {
             detail: { missionId, missionType: m.type },
           }))
+        } else if (m.status === 'running' && resultIsError) {
+          emitMissionError(m.type, chatPayload.content || 'Mission failed')
         }
 
         const resultContent = chatPayload.content || (payload as { output?: string }).output || 'Task completed.'
@@ -1850,9 +1853,6 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         // is only used while streaming is in progress (stream done w/o result).
         // The UI shows a completion panel with feedback buttons when status is
         // 'completed', so reaching this state is the correct lifecycle end (#5479).
-        // #11070 — If the backend flagged this result as an error (e.g. non-zero
-        // exit code from a CLI provider), mark the mission 'failed' instead.
-        const resultIsError = !!(chatPayload as unknown as Record<string, unknown>).isError
         return {
           ...m,
           status: (resultIsError ? 'failed' : 'completed') as MissionStatus,

--- a/web/src/hooks/useMissions.websocket-reconnect.test.tsx
+++ b/web/src/hooks/useMissions.websocket-reconnect.test.tsx
@@ -66,7 +66,7 @@ vi.mock('../lib/missions/preflightCheck', () => ({
   classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
   getRemediationActions: vi.fn().mockReturnValue([]),
   resolveRequiredTools: vi.fn(() => []),
-  runToolPreflightCheck: vi.fn().mockResolvedValue({ passed: true, tools: [] }),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
 }))
 
 vi.mock('../lib/missions/scanner/malicious', () => ({

--- a/web/src/types/agent.ts
+++ b/web/src/types/agent.ts
@@ -90,7 +90,8 @@ export interface ChatStreamPayload {
   agent: string
   sessionId: string
   done: boolean
-  model?: string // Model name used for this response
+  isError?: boolean
+  model?: string
   usage?: ChatTokenUsage
 }
 


### PR DESCRIPTION
## Summary

Addresses valid findings from GitHub Copilot review comments across the past 48 hours of merged PRs.

- **ToolPreflightResult type mismatch** (9 test files): Tests used `{ passed: true }` but the actual type uses `{ ok: true }`. Fixed all 9 test files to match the real interface.
- **ChatStreamPayload missing `isError`** (`types/agent.ts`): Go backend sends `isError` field but the TypeScript interface lacked it, forcing an unsafe `as unknown as Record<string, unknown>` cast. Added the field and removed the cast.
- **Mission analytics on error** (`useMissions.tsx`, `useMissions.provider.tsx`): `emitMissionCompleted` was firing even when the mission failed with `isError: true`. Now gates on `!resultIsError` and emits `emitMissionError` for failures instead.
- **URL encoding** (`mcp/storage.ts`): `deleteResourceQuota` built DELETE URL with string interpolation — cluster context names with `/` or `:` would break the URL. Now uses `URLSearchParams`.
- **Double-close in modals** (5 files): Several detail modals called both `onClose()` (raw) and `handleClose()` (with analytics), or called close twice. Consolidated to single `handleClose()` call.
- **Test name typo** (`provider_copilotcli_test.go`): `TestFreshEnv_StripsStalTokens` → `TestFreshEnv_StripsStaleTokens`.

**Skipped:** SSE auth token mismatch (Copilot flagged `fetchSSE` sending console JWT to kc-agent endpoints). While technically correct, kc-agent doesn't validate auth on GET/stream endpoints, so this is a no-op. Fixing it would require refactoring `sseClient.ts` + 12 call sites with regression risk and no functional benefit.

## Test plan
- [ ] CI build passes
- [ ] Vitest tests pass (9 test files updated to use correct `ok` field)
- [ ] Go tests pass (renamed test function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)