### PR TITLE
Restore arXiv paper reference in ACMM dashboard

### DIFF
--- a/web/src/components/acmm/ACMMIntroModal.tsx
+++ b/web/src/components/acmm/ACMMIntroModal.tsx
@@ -3,7 +3,7 @@
  *
  * Educational modal shown on first visit to /acmm. Explains what the
  * AI Codebase Maturity Model is, the 6 levels, the 4 source frameworks,
- * and links to the ACMM documentation.
+ * and links to the underlying paper and ACMM documentation.
  *
  * Key concepts introduced:
  * - Learning — how ACMM helps teams learn AI-assisted development practices
@@ -38,7 +38,7 @@ import {
 import { BaseModal } from '../../lib/modals'
 
 const STORAGE_KEY = 'kc-acmm-intro-dismissed'
-/** Live documentation — always up to date, unlike the static arXiv preprint */
+const PAPER_URL = 'https://arxiv.org/abs/2604.09388'
 const ACMM_DOCS_URL = 'https://console-docs.kubestellar.io/docs/console/acmm/acmm-dashboard'
 
 /** Level definitions for rendering the level grid */
@@ -211,8 +211,17 @@ export function ACMMIntroModal({ isOpen, onClose }: ACMMIntroModalProps) {
             </ul>
           </section>
 
-          {/* Documentation link */}
-          <section className="border-t border-border pt-3">
+          {/* Paper + documentation links */}
+          <section className="border-t border-border pt-3 flex flex-wrap gap-x-4 gap-y-1">
+            <a
+              href={PAPER_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-primary hover:underline text-xs"
+            >
+              <ExternalLink className="w-3.5 h-3.5" />
+              {t('acmmIntro.paperLink')}
+            </a>
             <a
               href={ACMM_DOCS_URL}
               target="_blank"

--- a/web/src/components/cards/ACMMLevel.tsx
+++ b/web/src/components/cards/ACMMLevel.tsx
@@ -7,8 +7,7 @@ import { acmmSource } from '../../lib/acmm/sources/acmm'
 const MAX_LEVEL = 6
 const GAUGE_SIZE = 120
 const GAUGE_STROKE = 10
-/** Live documentation — always up to date, unlike the static arXiv preprint */
-const ACMM_DOCS_URL = 'https://console-docs.kubestellar.io/docs/console/acmm/acmm-dashboard'
+const PAPER_URL = 'https://arxiv.org/abs/2604.09388'
 
 const ALL_LEVELS = acmmSource.levels ?? []
 
@@ -74,7 +73,7 @@ export function ACMMLevel() {
       <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className="text-xs text-muted-foreground font-mono truncate">{repo}</div>
         <a
-          href={ACMM_DOCS_URL}
+          href={PAPER_URL}
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-primary transition-colors shrink-0 ml-2"

--- a/web/src/lib/acmm/sources/acmm.ts
+++ b/web/src/lib/acmm/sources/acmm.ts
@@ -847,8 +847,8 @@ const CRITERIA: Criterion[] = [
 export const acmmSource: Source = {
   id: 'acmm',
   name: 'AI Codebase Maturity Model',
-  url: 'https://console-docs.kubestellar.io/docs/console/acmm/acmm-dashboard',
-  citation: 'Anderson, A. (2026). The AI Codebase Maturity Model. console-docs.kubestellar.io',
+  url: 'https://arxiv.org/abs/2604.09388',
+  citation: 'Anderson, A. (2026). The AI Codebase Maturity Model: From Assisted Coding to Fully Autonomous Systems. arXiv:2604.09388v2',
   definesLevels: true,
   levels: LEVELS,
   criteria: CRITERIA,

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3859,6 +3859,7 @@
     "actionInventory": "Browse detected vs missing criteria on the Feedback Loops Inventory card.",
     "actionAgent": "Click Ask agent for help on any missing criterion to launch an agent that adds it.",
     "actionBadge": "Generate a shields.io badge for your README — it updates as your score changes.",
+    "paperLink": "Read the paper on arXiv (2604.09388v2)",
     "docsLink": "Read the full ACMM documentation",
     "dontShowAgain": "Don't show this again",
     "gotIt": "Got it — let's go"


### PR DESCRIPTION
## Summary

The ACMM paper ([arXiv:2604.09388](https://arxiv.org/abs/2604.09388)) was updated to v2 on April 27 with:
- Extended from 5 to 6 levels (added Level 6: Fully Autonomous)
- Hive reference implementation for Level 6
- Beads for cross-agent memory continuity
- Throughput acceleration data (5x PR, 37x issue throughput L2→L6)
- Metrics updated to 100 days

PR #10321 had replaced the arXiv link with the docs URL because the paper was a static v1 preprint. Now that v2 is published and up to date, this restores the paper as the primary citation.

**Changes:**
- `ACMMIntroModal.tsx` — shows both paper link and docs link side by side
- `ACMMLevel.tsx` — "Source" link points back to arXiv paper
- `acmm.ts` — source `url` and `citation` restored to arXiv with v2 title
- `common.json` — re-added `paperLink` translation key

## Test plan
- [ ] CI build passes
- [ ] `/acmm` intro modal shows both "Read the paper" and "Read the docs" links
- [ ] ACMM Level card "Source" link opens arXiv paper

🤖 Generated with [Claude Code](https://claude.com/claude-code)