### PR TITLE
Auto-attach browser errors to feedback issues + GA4 ksc_http_error tracking

### DIFF
--- a/pkg/api/handlers/feedback_github.go
+++ b/pkg/api/handlers/feedback_github.go
@@ -491,7 +491,7 @@ type screenshotUploadResult struct {
 // upload, synchronous result counts, error). #9898: screenshot uploads are
 // decoupled from this path — callers launch uploadScreenshotCommentsAsync
 // on the returned slice from a background goroutine.
-func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *models.FeatureRequest, user *models.User, repoOwner, repoName string, screenshots []string, clientAuth string) (int, string, []string, screenshotUploadResult, error) {
+func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *models.FeatureRequest, user *models.User, repoOwner, repoName string, screenshots []string, consoleErrors []models.ConsoleError, clientAuth string) (int, string, []string, screenshotUploadResult, error) {
 	// Determine labels based on request type and target repo
 	var labels []string
 	isDocs := request.TargetRepo == models.TargetRepoDocs
@@ -549,6 +549,27 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *
 		shaLine = fmt.Sprintf("\nSHA: [`%s`](https://github.com/%s/%s/commit/%s)\n", shortSHA, repoOwner, repoName, fullSHA)
 	}
 
+	consoleErrorBlock := ""
+	if len(consoleErrors) > 0 {
+		var errLines strings.Builder
+		const maxConsoleErrors = 20
+		shown := len(consoleErrors)
+		if shown > maxConsoleErrors {
+			shown = maxConsoleErrors
+		}
+		for _, ce := range consoleErrors[:shown] {
+			src := ""
+			if ce.Source != "" {
+				src = fmt.Sprintf(" (%s)", ce.Source)
+			}
+			errLines.WriteString(fmt.Sprintf("- `[%s]` **%s**%s: %s\n", ce.Timestamp, ce.Level, src, ce.Message))
+		}
+		if len(consoleErrors) > maxConsoleErrors {
+			errLines.WriteString(fmt.Sprintf("\n_...and %d more errors omitted_\n", len(consoleErrors)-maxConsoleErrors))
+		}
+		consoleErrorBlock = fmt.Sprintf("\n<details>\n<summary>Browser Console Errors (%d captured)</summary>\n\n%s\n</details>\n", len(consoleErrors), errLines.String())
+	}
+
 	issueBody := fmt.Sprintf(`## User Request
 
 **Type:** %s
@@ -559,10 +580,10 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *
 ## Description
 
 %s
-%s
+%s%s
 ---
 *This issue was automatically created from the KubeStellar Console.*
-`, request.RequestType, repoLabel, user.GitHubLogin, request.ID.String(), request.Description, shaLine)
+`, request.RequestType, repoLabel, user.GitHubLogin, request.ID.String(), request.Description, shaLine, consoleErrorBlock)
 
 	// First attempt: create issue with labels
 	number, htmlURL, err := h.postGitHubIssue(ctx, repoOwner, repoName, request.Title, issueBody, labels, clientAuth)

--- a/pkg/api/handlers/feedback_requests.go
+++ b/pkg/api/handlers/feedback_requests.go
@@ -87,7 +87,7 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 	// created synchronously so the client receives the issue number/URL in
 	// the response; screenshot comments are uploaded asynchronously below
 	// (#9898) so slow GitHub responses do not block Fiber workers.
-	issueNumber, _, validScreenshots, ssResult, err := h.createGitHubIssueInRepo(c.UserContext(), request, user, h.repoOwner, targetRepoName, input.Screenshots, clientAuth)
+	issueNumber, _, validScreenshots, ssResult, err := h.createGitHubIssueInRepo(c.UserContext(), request, user, h.repoOwner, targetRepoName, input.Screenshots, input.ConsoleErrors, clientAuth)
 	if err != nil {
 		slog.Error("[Feedback] failed to create GitHub issue", "error", err)
 		// Clean up the orphaned database record. Log but don't fail the

--- a/pkg/models/feedback.go
+++ b/pkg/models/feedback.go
@@ -106,6 +106,14 @@ const (
 	TargetRepoDocs TargetRepo = "docs"
 )
 
+// ConsoleError represents a browser console error captured by the ring buffer.
+type ConsoleError struct {
+	Timestamp string `json:"timestamp"`
+	Level     string `json:"level"`
+	Message   string `json:"message"`
+	Source    string `json:"source,omitempty"`
+}
+
 // CreateFeatureRequestInput is the input for creating a feature request
 type CreateFeatureRequestInput struct {
 	Title       string      `json:"title" validate:"required,min=10,max=200"`
@@ -115,6 +123,9 @@ type CreateFeatureRequestInput struct {
 	// Screenshots contains base64-encoded data URIs (e.g. "data:image/png;base64,...")
 	// that will be uploaded to GitHub and embedded in the issue body.
 	Screenshots []string `json:"screenshots,omitempty"`
+	// ConsoleErrors contains recent browser console errors captured automatically.
+	// Only populated for bug reports. Rendered as a collapsible section in the issue body.
+	ConsoleErrors []ConsoleError `json:"console_errors,omitempty"`
 }
 
 // SubmitFeedbackInput is the input for submitting PR feedback

--- a/web/src/components/feedback/SubmitTab.tsx
+++ b/web/src/components/feedback/SubmitTab.tsx
@@ -281,6 +281,8 @@ export function SubmitForm({
 
     try {
       const hasScreenshots = screenshotDataURIs.length > 0
+      const { getRecentBrowserErrors } = await import('../../lib/analytics-core')
+      const browserErrors = requestType === 'bug' ? getRecentBrowserErrors() : []
       const result = await onSubmit(
         {
           title: extractedTitle,
@@ -288,6 +290,7 @@ export function SubmitForm({
           request_type: requestType,
           target_repo: targetRepo,
           ...(hasScreenshots && { screenshots: screenshotDataURIs }),
+          ...(browserErrors.length > 0 && { console_errors: browserErrors }),
         },
         hasScreenshots ? { timeout: FEEDBACK_UPLOAD_TIMEOUT_MS } : undefined,
       )

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -83,6 +83,13 @@ export interface Notification {
 /** Target repository for issue creation */
 export type TargetRepo = 'console' | 'docs'
 
+export interface ConsoleError {
+  timestamp: string
+  level: 'error' | 'warn'
+  message: string
+  source?: string
+}
+
 export interface CreateFeatureRequestInput {
   title: string
   description: string
@@ -90,6 +97,8 @@ export interface CreateFeatureRequestInput {
   target_repo?: TargetRepo
   /** Base64 data-URI screenshots to upload and embed in the GitHub issue */
   screenshots?: string[]
+  /** Recent browser console errors captured automatically for bug reports */
+  console_errors?: ConsoleError[]
 }
 
 export interface SubmitFeedbackInput {

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -788,6 +788,43 @@ function isBrowserExtensionNoise(msg: string, reason: unknown): boolean {
   return false
 }
 
+// ── Browser error ring buffer (for feedback modal) ────────────────────
+// Stores recent console errors so the feedback modal can attach them to
+// GitHub issues automatically. Keeps the last N entries; oldest evicted.
+const ERROR_RING_BUFFER_SIZE = 30
+
+interface CapturedError {
+  timestamp: string
+  level: 'error' | 'warn'
+  message: string
+  source?: string
+}
+
+const capturedErrors: CapturedError[] = []
+
+function pushCapturedError(level: 'error' | 'warn', message: string, source?: string) {
+  const entry: CapturedError = {
+    timestamp: new Date().toISOString(),
+    level,
+    message: message.slice(0, 500),
+    ...(source && { source }),
+  }
+  capturedErrors.push(entry)
+  if (capturedErrors.length > ERROR_RING_BUFFER_SIZE) {
+    capturedErrors.shift()
+  }
+}
+
+/** Returns recent browser errors for inclusion in feedback reports. */
+export function getRecentBrowserErrors(): CapturedError[] {
+  return [...capturedErrors]
+}
+
+/** @internal — exported for test isolation only */
+export function _resetCapturedErrors() {
+  capturedErrors.length = 0
+}
+
 // ── Per-card / per-page error throttling (#10092) ──────────────────────
 // CI/CD cards poll every 30-120s. Without throttling, a single broken card
 // generates dozens of ksc_error events per session. We cap emissions to at
@@ -827,6 +864,7 @@ export function _resetAnalyticsState() {
   pendingRecoveryEvent = null
   recentErrorEmissions.clear()
   pageErrorCounts.clear()
+  capturedErrors.length = 0
 }
 
 function isErrorThrottled(category: string, page: string, cardId?: string): boolean {
@@ -1064,12 +1102,23 @@ export function startGlobalErrorTracking() {
       // Skip auth-flow errors — UnauthenticatedError is thrown by api.get() when
       // no token is available (expected for unauthenticated visitors). Emitting
       // these as ksc_error creates false-positive alert spikes (#9994).
-      if (errorName === 'UnauthenticatedError' || errorName === 'UnauthorizedError') return
-      if (msg.includes('No authentication token') || msg.includes('Token is invalid or expired')) return
-      // Skip upstream proxy errors — these are transient backend/GitHub hiccups
-      // already handled by retry logic in the fetch layer. Emitting them as
-      // ksc_error creates false-positive alert spikes (#10957).
-      if (/\b50[234]\b/.test(msg) && (msg.includes('fetch') || msg.includes('Fetch') || msg.includes('upstream'))) return
+      if (errorName === 'UnauthenticatedError' || errorName === 'UnauthorizedError') {
+        pushCapturedError('error', msg, 'auth_error')
+        send('ksc_http_error', { http_status: 'auth', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        return
+      }
+      if (msg.includes('No authentication token') || msg.includes('Token is invalid or expired')) {
+        pushCapturedError('error', msg, 'auth_error')
+        send('ksc_http_error', { http_status: 'auth', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        return
+      }
+      if (/\b50[234]\b/.test(msg) && (msg.includes('fetch') || msg.includes('Fetch') || msg.includes('upstream'))) {
+        const statusMatch = msg.match(/\b(50[234])\b/)
+        pushCapturedError('error', msg, `http_${statusMatch?.[1] ?? '5xx'}`)
+        send('ksc_http_error', { http_status: statusMatch?.[1] ?? '5xx', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        return
+      }
+      pushCapturedError('error', msg, 'unhandled_rejection')
       emitError('unhandled_rejection', msg, undefined, { error: event.reason })
     } finally {
       isEmitting = false
@@ -1123,14 +1172,38 @@ export function startGlobalErrorTracking() {
       if (event.message.includes('Non-Error')) return
       // Stale chunks can surface as runtime errors (Safari: "Importing a module script failed")
       if (tryChunkReloadRecovery(event.message)) return
-      // Skip auth-flow errors that surface as synchronous error events (#9994).
-      if (event.error?.name === 'UnauthenticatedError' || event.error?.name === 'UnauthorizedError') return
-      if (event.message.includes('No authentication token') || event.message.includes('Token is invalid or expired')) return
+      if (event.error?.name === 'UnauthenticatedError' || event.error?.name === 'UnauthorizedError') {
+        pushCapturedError('error', event.message, 'auth_error')
+        send('ksc_http_error', { http_status: 'auth', error_detail: event.message.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        return
+      }
+      if (event.message.includes('No authentication token') || event.message.includes('Token is invalid or expired')) {
+        pushCapturedError('error', event.message, 'auth_error')
+        send('ksc_http_error', { http_status: 'auth', error_detail: event.message.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        return
+      }
+      pushCapturedError('error', event.message, 'runtime')
       emitError('runtime', event.message, undefined, { error: event.error })
     } finally {
       isEmitting = false
     }
   })
+
+  // Intercept console.error and console.warn to capture them in the ring buffer
+  const originalConsoleError = console.error
+  const originalConsoleWarn = console.warn
+  console.error = (...args: unknown[]) => {
+    const msg = args.map(a => (typeof a === 'string' ? a : String(a))).join(' ')
+    if (!isBrowserExtensionNoise(msg, null)) {
+      pushCapturedError('error', msg, 'console.error')
+    }
+    originalConsoleError.apply(console, args)
+  }
+  console.warn = (...args: unknown[]) => {
+    const msg = args.map(a => (typeof a === 'string' ? a : String(a))).join(' ')
+    pushCapturedError('warn', msg, 'console.warn')
+    originalConsoleWarn.apply(console, args)
+  }
 }
 
 export const __testables = {


### PR DESCRIPTION
## Summary

- Adds a ring buffer (last 30 entries) in `analytics-core.ts` that captures `console.error`, `console.warn`, unhandled rejections, and runtime errors
- When a user submits a **bug report** via the feedback modal, captured browser errors are automatically included in the request and rendered as a collapsible `<details>` block in the GitHub issue body
- Adds new `ksc_http_error` GA4 event for auth errors (401/403) and upstream proxy errors (502/503/504) that were previously filtered out entirely — these are now visible in GA4 Realtime and explorations
- Previously filtered errors (auth, 5xx) are still excluded from `ksc_error` to avoid alert noise, but are now captured in the ring buffer for feedback reports and tracked separately via `ksc_http_error`

Fixes the gap where browser console errors like the ones in #11102 had to be manually copied by reporters.

## Changes

| File | Change |
|------|--------|
| `web/src/lib/analytics-core.ts` | Ring buffer, console.error/warn intercept, ksc_http_error event, capture auth + 5xx errors |
| `web/src/components/feedback/SubmitTab.tsx` | Attach captured errors to bug report submissions |
| `web/src/hooks/useFeatureRequests.ts` | Add `ConsoleError` type and `console_errors` field to input interface |
| `pkg/models/feedback.go` | Add `ConsoleError` struct and field to `CreateFeatureRequestInput` |
| `pkg/api/handlers/feedback_github.go` | Render console errors as collapsible section in issue body |
| `pkg/api/handlers/feedback_requests.go` | Pass console errors through to issue creation |

## Test plan

- [ ] Submit a bug report via feedback modal — verify console errors appear in the created GitHub issue as a collapsible block
- [ ] Submit a feature request — verify no console errors are attached (only bug reports)
- [ ] Trigger a 401/503 error — verify `ksc_http_error` event appears in GA4 Realtime
- [ ] Verify ring buffer caps at 30 entries (oldest evicted)