### PR TITLE
fix: resolve Settings panel Save failed error

### DIFF
--- a/web/src/hooks/usePersistedSettings.ts
+++ b/web/src/hooks/usePersistedSettings.ts
@@ -70,6 +70,7 @@ export function usePersistedSettings() {
         const current = collectFromLocalStorage()
         // Retry once after a delay — transient failures are common during page
         // transitions when the agent's connection pool is saturated.
+        let lastError: unknown
         for (let attempt = 0; attempt < 2; attempt++) {
           try {
             await settingsFetch('/settings', {
@@ -80,14 +81,18 @@ export function usePersistedSettings() {
               setLastSaved(new Date())
             }
             return
-          } catch {
+          } catch (err) {
+            lastError = err
             if (attempt === 0) {
               await new Promise(r => setTimeout(r, RETRY_DELAY_MS))
             }
           }
         }
         if (mountedRef.current) {
-          setSyncStatus('error')
+          // Network/connection errors mean the agent is offline — show 'offline'
+          // rather than 'error' to stay consistent with the initial load behaviour.
+          const isNetworkError = lastError instanceof TypeError
+          setSyncStatus(isNetworkError ? 'offline' : 'error')
         }
         console.debug('[settings] failed to persist to local agent')
       } catch {


### PR DESCRIPTION
Fixes #11134

## Changes
- In `saveToBackend()`, capture the thrown error from each retry attempt
- After all retries are exhausted, check `lastError instanceof TypeError`
- Network/connection errors (kc-agent not running) now set `syncStatus` to `'offline'` instead of `'error'`
- HTTP errors from a running agent (5xx responses) still correctly set `'error'`

## Root cause
`saveToBackend()` unconditionally called `setSyncStatus('error')` after all retry attempts failed, regardless of the failure type. When the local kc-agent is not running, every `fetch()` to `http://127.0.0.1:8585/settings` throws a `TypeError` (network failure). After two such failures with a 3-second retry delay, the hook set `'error'` — surfacing a red "Save failed" indicator to users.

The initial `loadSettings()` already handled this correctly: it catches all errors from the GET request and sets `'offline'` (a neutral grey "Local only" indicator). The save path was inconsistent with the load path.

The fix makes both paths consistent: `TypeError` → `'offline'`, HTTP error → `'error'`.