### PR TITLE
Fix settings save failure after kc-agent restart

### DIFF
--- a/pkg/api/handlers/feedback_github.go
+++ b/pkg/api/handlers/feedback_github.go
@@ -552,7 +552,7 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *
 	consoleErrorBlock := ""
 	if len(consoleErrors) > 0 {
 		var errLines strings.Builder
-		const maxConsoleErrors = 20
+		const maxConsoleErrors = 50
 		shown := len(consoleErrors)
 		if shown > maxConsoleErrors {
 			shown = maxConsoleErrors

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -137,7 +137,27 @@ export async function agentFetch(input: RequestInfo | URL, init?: RequestInit): 
   }
   // Use caller-provided signal, or fall back to a default timeout
   const signal = init?.signal ?? AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS)
-  return fetch(input, { ...init, headers, signal })
+  const response = await fetch(input, { ...init, headers, signal })
+
+  // kc-agent generates a new token on each restart. If we get 401 with a
+  // cached token, clear it and retry once with a fresh token from the backend.
+  if (response.status === 401 && token) {
+    localStorage.removeItem(AGENT_TOKEN_STORAGE_KEY)
+    agentTokenPromise = null
+    agentTokenNegativeCacheUntil = 0
+    const freshToken = await getAgentToken()
+    if (freshToken && freshToken !== token) {
+      const retryHeaders = new Headers(init?.headers)
+      retryHeaders.set('Authorization', `Bearer ${freshToken}`)
+      if (!retryHeaders.has('X-Requested-With')) {
+        retryHeaders.set('X-Requested-With', 'XMLHttpRequest')
+      }
+      const retrySignal = init?.signal ?? AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS)
+      return fetch(input, { ...init, headers: retryHeaders, signal: retrySignal })
+    }
+  }
+
+  return response
 }
 
 // ============================================================================

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -791,7 +791,7 @@ function isBrowserExtensionNoise(msg: string, reason: unknown): boolean {
 // ── Browser error ring buffer (for feedback modal) ────────────────────
 // Stores recent console errors so the feedback modal can attach them to
 // GitHub issues automatically. Keeps the last N entries; oldest evicted.
-const ERROR_RING_BUFFER_SIZE = 30
+const ERROR_RING_BUFFER_SIZE = 50
 
 interface CapturedError {
   timestamp: string


### PR DESCRIPTION
## Summary
- **Settings "Save failed" bug**: `agentFetch` now detects 401 from a stale cached kc-agent token, clears it from localStorage, fetches a fresh token from `/api/agent/token`, and retries — fixing the persistent "Save failed" state after kc-agent restarts
- **Error capture limits**: Increased browser error ring buffer from 30→50 entries and GitHub issue display cap from 20→50 so all captured errors are shown without truncation

## Test plan
- [ ] Restart kc-agent (via `startup-oauth.sh`), verify settings save works without manual page reload
- [ ] Submit a bug report with >20 console errors, verify all are shown in the issue body
- [ ] Verify normal settings save/restore still works when token is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)