### PR TITLE
🐛 Fix Worker mock leak in cache-coverage.test.ts

### DIFF
--- a/web/src/lib/cache/__tests__/cache-coverage.test.ts
+++ b/web/src/lib/cache/__tests__/cache-coverage.test.ts
@@ -1004,69 +1004,68 @@ describe('saveMeta localStorage fallback', () => {
 // ============================================================================
 
 describe('worker-active IndexedDB mirror write', () => {
-  let originalWorker: typeof Worker
-
   afterEach(() => {
-    // Always restore Worker and reset modules to prevent mock leakage into subsequent tests.
-    // This is critical because globalThis.Worker is a global singleton — if not restored,
-    // subsequent tests will get the mocked version. See #11039.
-    if (originalWorker) {
-      globalThis.Worker = originalWorker
-    }
+    // Reset modules to prevent mock leakage into subsequent tests. See #11039.
     vi.resetModules()
     vi.doUnmock('../workerRpc')
   })
 
   it('mirrors data to _idbStorage.set when workerRpc is active', async () => {
-    // Mock the Worker constructor so initCacheWorker() doesn't try to spawn a real worker
-    originalWorker = globalThis.Worker
-    globalThis.Worker = vi.fn() as unknown as typeof Worker
+    // Save and restore Worker in a try/finally to guarantee cleanup even if assertions throw.
+    const originalWorker = globalThis.Worker
+    try {
+      // Mock the Worker constructor so initCacheWorker() doesn't try to spawn a real worker
+      globalThis.Worker = vi.fn() as unknown as typeof Worker
 
-    const mockRpc = {
-      waitForReady: vi.fn().mockResolvedValue(undefined),
-      set: vi.fn(),
-      get: vi.fn().mockResolvedValue(null),
-      getStats: vi.fn().mockResolvedValue({ keys: [], count: 0 }),
-      deleteKey: vi.fn(),
-      clear: vi.fn().mockResolvedValue(undefined),
-      setMeta: vi.fn(),
-      getMeta: vi.fn().mockResolvedValue(null),
-      migrate: vi.fn().mockResolvedValue(undefined),
+      const mockRpc = {
+        waitForReady: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn(),
+        get: vi.fn().mockResolvedValue(null),
+        getStats: vi.fn().mockResolvedValue({ keys: [], count: 0 }),
+        deleteKey: vi.fn(),
+        clear: vi.fn().mockResolvedValue(undefined),
+        setMeta: vi.fn(),
+        getMeta: vi.fn().mockResolvedValue(null),
+        migrate: vi.fn().mockResolvedValue(undefined),
+      }
+
+      // resetModules first, THEN register doMock so the fresh import picks it up.
+      // (vi.resetModules clears pending doMock registrations, so ordering matters.)
+      vi.resetModules()
+      vi.doMock('../workerRpc', () => ({
+        CacheWorkerRpc: vi.fn().mockImplementation(function () { return mockRpc }),
+      }))
+
+      const mod = await import('../index')
+      const { useCache, initCacheWorker, isSQLiteWorkerActive, __testables: testables } = mod
+
+      // Activate the SQLite worker path
+      await initCacheWorker()
+      expect(isSQLiteWorkerActive()).toBe(true)
+
+      // Spy on the IndexedDB storage mirror target
+      const idbSetSpy = vi.spyOn(testables._idbStorage, 'set').mockResolvedValue(undefined)
+
+      const testData = [1, 2, 3]
+      const { result } = renderHook(() => useCache({
+        key: 'idb-mirror-test',
+        fetcher: () => Promise.resolve(testData),
+        initialData: [] as number[],
+        autoRefresh: false,
+      }))
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      // The mirror write should have been called with the correct key and data
+      expect(idbSetSpy).toHaveBeenCalledWith('idb-mirror-test', testData)
+
+      idbSetSpy.mockRestore()
+    } finally {
+      // Always restore the original Worker — even if an assertion above throws.
+      globalThis.Worker = originalWorker
     }
-
-    // resetModules first, THEN register doMock so the fresh import picks it up.
-    // (vi.resetModules clears pending doMock registrations, so ordering matters.)
-    vi.resetModules()
-    vi.doMock('../workerRpc', () => ({
-      CacheWorkerRpc: vi.fn().mockImplementation(function () { return mockRpc }),
-    }))
-
-    const mod = await import('../index')
-    const { useCache, initCacheWorker, isSQLiteWorkerActive, __testables: testables } = mod
-
-    // Activate the SQLite worker path
-    await initCacheWorker()
-    expect(isSQLiteWorkerActive()).toBe(true)
-
-    // Spy on the IndexedDB storage mirror target
-    const idbSetSpy = vi.spyOn(testables._idbStorage, 'set').mockResolvedValue(undefined)
-
-    const testData = [1, 2, 3]
-    const { result } = renderHook(() => useCache({
-      key: 'idb-mirror-test',
-      fetcher: () => Promise.resolve(testData),
-      initialData: [] as number[],
-      autoRefresh: false,
-    }))
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false)
-    })
-
-    // The mirror write should have been called with the correct key and data
-    expect(idbSetSpy).toHaveBeenCalledWith('idb-mirror-test', testData)
-
-    idbSetSpy.mockRestore()
   })
 
   it('does not mirror to IDB when workerRpc is null (fallback mode)', async () => {


### PR DESCRIPTION
Wraps `globalThis.Worker` reassignment in `try/finally` to prevent mock leak when assertions throw.

Previously the describe-level `originalWorker` variable was restored via `afterEach` only when truthy, leaving a window where a falsy `Worker` (e.g. `undefined` in jsdom) would not be restored. The `try/finally` guarantees cleanup unconditionally.

Changes:
- Move `originalWorker` into a `const` local to the test body
- Wrap all Worker-dependent code in `try/finally` for guaranteed cleanup
- Simplify `afterEach` to only reset modules (Worker restore is now in-test)

Fixes #11150

Copilot review finding from PR #11039.