### PR TITLE
🐛 Fix vacuous test assertions in useLastRoute, useActiveUsers, useWorkloads

### DIFF
--- a/web/src/hooks/__tests__/useActiveUsers.test.ts
+++ b/web/src/hooks/__tests__/useActiveUsers.test.ts
@@ -435,6 +435,13 @@ describe('useActiveUsers', () => {
         (url as string).includes('/api/active-users') && (opts as RequestInit)?.method === 'POST'
       )
       expect(postCalls.length).toBeGreaterThanOrEqual(1)
+      // Verify the POST body includes a sessionId
+      const firstPostBody = (postCalls[0][1] as RequestInit)?.body
+      expect(firstPostBody).toBeDefined()
+      const parsed = JSON.parse(firstPostBody as string)
+      expect(parsed.sessionId).toBeDefined()
+      expect(typeof parsed.sessionId).toBe('string')
+      expect(parsed.sessionId.length).toBeGreaterThan(0)
       unmount()
     })
 
@@ -470,7 +477,9 @@ describe('useActiveUsers', () => {
           await vi.advanceTimersByTimeAsync(10_100)
         })
       }
-      expect(result.current.activeUsers).toBeGreaterThanOrEqual(0)
+      expect(result.current.activeUsers).toBeGreaterThanOrEqual(2)
+      // Smoothed count should be the max of the counts seen so far
+      expect(result.current.activeUsers).toBeLessThanOrEqual(8)
     })
   })
 
@@ -528,7 +537,7 @@ describe('useActiveUsers', () => {
       await act(async () => {
         await vi.advanceTimersByTimeAsync(100)
       })
-      expect(fetchSpy.mock.calls.length).toBeGreaterThanOrEqual(callsBefore)
+      expect(fetchSpy.mock.calls.length).toBeGreaterThan(callsBefore)
       unmount()
     })
   })

--- a/web/src/hooks/__tests__/useActiveUsers.test.ts
+++ b/web/src/hooks/__tests__/useActiveUsers.test.ts
@@ -222,8 +222,9 @@ describe('useActiveUsers', () => {
         await vi.advanceTimersByTimeAsync(100)
       })
       const id = sessionStorage.getItem('kc-session-id')
-      expect(id).toBeTruthy()
+      expect(id).not.toBeNull()
       expect(typeof id).toBe('string')
+      expect(id!.length).toBeGreaterThan(0)
     })
 
     it('reuses existing session ID from sessionStorage', async () => {
@@ -434,7 +435,7 @@ describe('useActiveUsers', () => {
       const postCalls = fetchSpy.mock.calls.filter(([url, opts]) =>
         (url as string).includes('/api/active-users') && (opts as RequestInit)?.method === 'POST'
       )
-      expect(postCalls.length).toBeGreaterThanOrEqual(1)
+      expect(postCalls.length).toBe(1)
       // Verify the POST body includes a sessionId
       const firstPostBody = (postCalls[0][1] as RequestInit)?.body
       expect(firstPostBody).toBeDefined()
@@ -477,9 +478,8 @@ describe('useActiveUsers', () => {
           await vi.advanceTimersByTimeAsync(10_100)
         })
       }
-      expect(result.current.activeUsers).toBeGreaterThanOrEqual(2)
-      // Smoothed count should be the max of the counts seen so far
-      expect(result.current.activeUsers).toBeLessThanOrEqual(8)
+      // Smoothed count should be the max of the recent window (max of [3,5,2,8,4,3] = 8)
+      expect(result.current.activeUsers).toBe(8)
     })
   })
 

--- a/web/src/hooks/__tests__/useLastRoute.test.ts
+++ b/web/src/hooks/__tests__/useLastRoute.test.ts
@@ -575,9 +575,12 @@ describe('saveScrollPositionNow (via scroll+beforeunload with main DOM)', () => 
     renderHook(() => useLastRoute())
     window.dispatchEvent(new Event('beforeunload'))
     const stored = localStorage.getItem(SCROLL_POSITIONS_KEY)
+    // Either nothing was written, or the entry for this path is absent
     if (stored) {
       const positions = JSON.parse(stored)
       expect(positions['/clusters']).toBeUndefined()
+    } else {
+      expect(stored).toBeNull()
     }
   })
 
@@ -589,8 +592,11 @@ describe('saveScrollPositionNow (via scroll+beforeunload with main DOM)', () => 
     } as DOMRect)
     renderHook(() => useLastRoute())
     window.dispatchEvent(new Event('beforeunload'))
-    // No exception thrown is the main assertion
-    expect(true).toBe(true)
+    const stored = localStorage.getItem(SCROLL_POSITIONS_KEY)
+    expect(stored).not.toBeNull()
+    const positions = JSON.parse(stored!)
+    expect(positions['/clusters']).toBeDefined()
+    expect(positions['/clusters'].position).toBe(500)
   })
 
   it('saves position with card elements present (card-finding path)', () => {
@@ -615,13 +621,11 @@ describe('saveScrollPositionNow (via scroll+beforeunload with main DOM)', () => 
     window.dispatchEvent(new Event('beforeunload'))
 
     const stored = localStorage.getItem(SCROLL_POSITIONS_KEY)
-    if (stored) {
-      const positions = JSON.parse(stored)
-      if (positions['/clusters'] && typeof positions['/clusters'] === 'object') {
-        expect(typeof positions['/clusters'].position).toBe('number')
-      }
-    }
-    expect(true).toBe(true)
+    expect(stored).not.toBeNull()
+    const positions = JSON.parse(stored!)
+    expect(positions['/clusters']).toBeDefined()
+    expect(typeof positions['/clusters'].position).toBe('number')
+    expect(positions['/clusters'].cardTitle).toBe('My Card')
   })
 
   it('handles cards with zero-size getBoundingClientRect (hidden/KeepAlive)', () => {
@@ -646,7 +650,13 @@ describe('saveScrollPositionNow (via scroll+beforeunload with main DOM)', () => 
     renderHook(() => useLastRoute())
     window.dispatchEvent(new Event('beforeunload'))
 
-    expect(true).toBe(true)
+    // Zero-size card should be skipped — position saved without cardTitle from hidden card
+    const stored = localStorage.getItem(SCROLL_POSITIONS_KEY)
+    expect(stored).not.toBeNull()
+    const positions = JSON.parse(stored!)
+    expect(positions['/clusters']).toBeDefined()
+    expect(positions['/clusters'].position).toBe(200)
+    // cardTitle should not reference the zero-size card (no h3 text available)
   })
 
   it('scroll event triggers position save via debounce', () => {
@@ -662,9 +672,15 @@ describe('saveScrollPositionNow (via scroll+beforeunload with main DOM)', () => 
     main.dispatchEvent(new Event('scroll'))
     vi.advanceTimersByTime(2500)
 
+    // After debounce fires, localStorage should have been updated
+    const stored = localStorage.getItem(SCROLL_POSITIONS_KEY)
+    expect(stored).not.toBeNull()
+    const positions = JSON.parse(stored!)
+    expect(positions['/clusters']).toBeDefined()
+    expect(positions['/clusters'].position).toBe(150)
+
     unmount()
     vi.useRealTimers()
-    expect(true).toBe(true)
   })
 })
 
@@ -700,7 +716,8 @@ describe('restoreScrollPosition (via hook navigation path)', () => {
     }))
     mockPathname = '/clusters'
     renderHook(() => useLastRoute())
-    expect(true).toBe(true)
+    // scrollTo should be called with the saved position
+    expect(main.scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 400 }))
   })
 
   it('restores by cardTitle when card with matching h3 exists', () => {
@@ -731,8 +748,13 @@ describe('restoreScrollPosition (via hook navigation path)', () => {
     renderHook(() => useLastRoute())
 
     vi.advanceTimersByTime(200)
+    // Should attempt to scroll to the card's position relative to the container
+    expect(main.scrollTo).toHaveBeenCalled()
+    const scrollCall = (main.scrollTo as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call) => call[0]?.top !== undefined && call[0].top > 0
+    )
+    expect(scrollCall).toBeDefined()
     vi.useRealTimers()
-    expect(true).toBe(true)
   })
 })
 

--- a/web/src/hooks/__tests__/useWorkloads.test.ts
+++ b/web/src/hooks/__tests__/useWorkloads.test.ts
@@ -906,9 +906,11 @@ describe('useWorkloads via agent with clusters', () => {
     const { result } = renderHook(() => useWorkloads())
 
     await waitFor(() => {
-      expect(result.current.data).toBeDefined()
       expect(result.current.isLoading).toBe(false)
     })
+    expect(result.current.data).toBeDefined()
+    // Verify the agent concurrency path was actually invoked
+    expect(mapSettledMock).toHaveBeenCalled()
   })
 
   it('falls back to REST when agent returns null (no clusters)', async () => {
@@ -916,7 +918,7 @@ describe('useWorkloads via agent with clusters', () => {
     const mockWorkloads = [
       { name: 'web', namespace: 'default', type: 'Deployment', replicas: 1, readyReplicas: 1, status: 'Running', image: 'web:v2', createdAt: '2025-01-01T00:00:00Z' },
     ]
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ items: mockWorkloads }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -926,9 +928,13 @@ describe('useWorkloads via agent with clusters', () => {
     const { result } = renderHook(() => useWorkloads())
 
     await waitFor(() => {
-      expect(result.current.data).toBeDefined()
       expect(result.current.isLoading).toBe(false)
     })
+    // Verify it fell back to REST API fetch (not agent path)
+    expect(fetchSpy).toHaveBeenCalled()
+    const fetchUrl = fetchSpy.mock.calls[0][0] as string
+    expect(fetchUrl).toContain('/api/')
+    expect(result.current.data).toBeDefined()
   })
 
   it('authHeaders returns empty object when no token stored', async () => {

--- a/web/src/hooks/__tests__/useWorkloads.test.ts
+++ b/web/src/hooks/__tests__/useWorkloads.test.ts
@@ -82,18 +82,21 @@ describe('getDemoWorkloads', () => {
     const { getDemoWorkloads } = await importFresh()
     const workloads = getDemoWorkloads()
 
-    expect(workloads.length).toBeGreaterThan(0)
-    // Every workload must have required fields
+    expect(workloads.length).toBe(7)
+    // Every workload must have required fields with correct types
     for (const w of workloads) {
-      expect(w.name).toBeTruthy()
-      expect(w.namespace).toBeTruthy()
-      expect(w.type).toBeTruthy()
-      expect(w.cluster).toBeTruthy()
-      expect(w.replicas).toBeGreaterThanOrEqual(0)
-      expect(w.readyReplicas).toBeGreaterThanOrEqual(0)
-      expect(w.status).toBeTruthy()
-      expect(w.image).toBeTruthy()
-      expect(w.createdAt).toBeTruthy()
+      expect(typeof w.name).toBe('string')
+      expect(w.name.length).toBeGreaterThan(0)
+      expect(typeof w.namespace).toBe('string')
+      expect(w.namespace.length).toBeGreaterThan(0)
+      expect(['Deployment', 'StatefulSet', 'DaemonSet']).toContain(w.type)
+      expect(typeof w.cluster).toBe('string')
+      expect(w.cluster!.length).toBeGreaterThan(0)
+      expect(typeof w.replicas).toBe('number')
+      expect(w.readyReplicas).toBeLessThanOrEqual(w.replicas)
+      expect(['Running', 'Degraded', 'Failed', 'Pending']).toContain(w.status)
+      expect(w.image).toMatch(/:/)
+      expect(new Date(w.createdAt).getTime()).not.toBeNaN()
     }
   })
 


### PR DESCRIPTION
Fixes #11152

Replaces vacuous assertions (expect(true).toBe(true), toBeGreaterThanOrEqual(0), etc.) with meaningful assertions that verify actual behavior including localStorage state, request bodies, and timer-based effects.

### Changes:
- **useLastRoute**: Assert localStorage contains saved scroll positions after beforeunload/scroll events; assert scrollTo is called with correct position during restore
- **useActiveUsers**: Assert POST body contains sessionId; assert smoothed count within expected range; assert visibility change triggers additional fetch
- **useWorkloads**: Assert agent concurrency mock was invoked; assert REST fallback fetch URL