### PR TITLE
🐛 Fix createCachedHook stale mock and DataComplianceCards double mockClusters

### DIFF
--- a/web/src/components/cards/__tests__/DataComplianceCards.test.tsx
+++ b/web/src/components/cards/__tests__/DataComplianceCards.test.tsx
@@ -21,7 +21,10 @@ vi.mock('../../../hooks/useDemoMode', () => ({
 
 const mockClusters = vi.fn(() => [])
 vi.mock('../../../hooks/useMCP', () => ({
-  useClusters: () => ({ clusters: mockClusters(), deduplicatedClusters: mockClusters() }),
+  useClusters: () => {
+    const clusters = mockClusters()
+    return { clusters, deduplicatedClusters: clusters }
+  },
 }))
 
 const mockKubectlExec = vi.fn()

--- a/web/src/lib/cache/__tests__/createCachedHook.test.ts
+++ b/web/src/lib/cache/__tests__/createCachedHook.test.ts
@@ -38,6 +38,7 @@ const defaultCacheResult = {
   consecutiveFailures: 0,
   lastRefresh: null,
   refetch: vi.fn(),
+  retryFetch: vi.fn(),
   clearAndRefetch: vi.fn(),
 }
 
@@ -208,5 +209,25 @@ describe('createCachedHook', () => {
         demoData: undefined,
       })
     )
+  })
+
+  it('exposes retryFetch from useCache result', () => {
+    const retryFn = vi.fn()
+    mockUseCache.mockReturnValue({
+      ...defaultCacheResult,
+      retryFetch: retryFn,
+    })
+
+    const hook = createCachedHook<TestData>({
+      key: 'retry-test',
+      initialData: INITIAL_DATA,
+      fetcher: vi.fn(),
+    })
+
+    const { result } = renderHook(() => hook())
+    expect(result.current.retryFetch).toBe(retryFn)
+
+    result.current.retryFetch()
+    expect(retryFn).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Fixes #11170
Fixes #11172

- Update createCachedHook tests to mock retryFetch instead of stale fetch path
- Remove duplicate mockClusters() call in DataComplianceCards test setup