### PR TITLE
🐛 Fix useMetricsHistory zero-default and UserManagement undefined guard

### DIFF
--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -111,7 +111,7 @@ export function UserManagement({ config: _config }: UserManagementProps) {
 
   // Ensure current user is always included from auth context
   const usersWithCurrent = useMemo(() => {
-    let result = [...(allUsers || [])]
+    let result = [...(Array.isArray(allUsers) ? allUsers : [])]
     if (currentUser && !result.some(u => u.github_id === currentUser.github_id)) {
       const authUser: ConsoleUser = {
         id: currentUser.id,

--- a/web/src/hooks/useMetricsHistory.ts
+++ b/web/src/hooks/useMetricsHistory.ts
@@ -473,8 +473,8 @@ export function getMetricsHistoryContext(): string {
     }).filter((v): v is { cpu: number; mem: number } => v !== null)
 
     if (values.length > 0) {
-      const cpuTrend = values.map(v => `${(v.cpu ?? 0).toFixed(0)}%`).join(' → ')
-      const memTrend = values.map(v => `${(v.mem ?? 0).toFixed(0)}%`).join(' → ')
+      const cpuTrend = values.map(v => v.cpu != null ? `${v.cpu.toFixed(0)}%` : 'N/A').join(' → ')
+      const memTrend = values.map(v => v.mem != null ? `${v.mem.toFixed(0)}%` : 'N/A').join(' → ')
       context += `${name}:\n  CPU: ${cpuTrend}\n  Memory: ${memTrend}\n`
     }
   })


### PR DESCRIPTION
Fixes #11169
Fixes #11171

- Use null check instead of `?? 0` for missing metrics data points to show 'N/A' instead of misleading zero values
- Use `Array.isArray(allUsers)` instead of `allUsers || []` to guard against truthy non-array values