### PR TITLE
🐛 Fix docs feedback commit URL using wrong repo name

### DIFF
--- a/pkg/api/handlers/feedback_github.go
+++ b/pkg/api/handlers/feedback_github.go
@@ -546,7 +546,7 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *
 		if len(shortSHA) > shortSHALen {
 			shortSHA = shortSHA[:shortSHALen]
 		}
-		shaLine = fmt.Sprintf("\nSHA: [`%s`](https://github.com/%s/%s/commit/%s)\n", shortSHA, repoOwner, repoName, fullSHA)
+		shaLine = fmt.Sprintf("\nSHA: [`%s`](https://github.com/%s/%s/commit/%s)\n", shortSHA, h.repoOwner, h.repoName, fullSHA)
 	}
 
 	consoleErrorBlock := ""


### PR DESCRIPTION
Fixes #11165

- Use `h.repoOwner`/`h.repoName` (the console repo) instead of the function parameters `repoOwner`/`repoName` (the target repo) when constructing commit URLs in docs feedback handler