### PR TITLE
🐛 Fix Vitest fake timer cleanup and module-level state leak

### DIFF
--- a/web/src/hooks/__tests__/useNightlyE2EData-funcs.test.ts
+++ b/web/src/hooks/__tests__/useNightlyE2EData-funcs.test.ts
@@ -78,9 +78,13 @@ describe('loadCachedData', () => {
   it('returns empty guides when localStorage has invalid JSON', () => {
     localStorage.setItem(LS_CACHE_KEY, '{not valid json')
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const result = loadCachedData()
-    expect(result).toEqual({ guides: [], isDemo: false })
-    expect(warnSpy).toHaveBeenCalledOnce()
+    try {
+      const result = loadCachedData()
+      expect(result).toEqual({ guides: [], isDemo: false })
+      expect(warnSpy).toHaveBeenCalledOnce()
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it('returns empty guides when cached data has no guides property', () => {

--- a/web/src/hooks/__tests__/useTokenUsage-funcs.test.ts
+++ b/web/src/hooks/__tests__/useTokenUsage-funcs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { __testables } from '../useTokenUsage'
 
 const {
@@ -196,6 +196,10 @@ describe('persistUsage', () => {
 })
 
 describe('getNextResetDate', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('returns a valid ISO date string', () => {
     const result = getNextResetDate()
     expect(() => new Date(result)).not.toThrow()
@@ -232,7 +236,6 @@ describe('getNextResetDate', () => {
     expect(parsed.getFullYear()).toBe(2026)
     expect(parsed.getMonth()).toBe(0)
     expect(parsed.getDate()).toBe(1)
-    vi.useRealTimers()
   })
 
   it('handles January correctly', () => {
@@ -243,7 +246,6 @@ describe('getNextResetDate', () => {
     expect(parsed.getFullYear()).toBe(2025)
     expect(parsed.getMonth()).toBe(1)
     expect(parsed.getDate()).toBe(1)
-    vi.useRealTimers()
   })
 
   it('handles last day of month', () => {
@@ -254,7 +256,6 @@ describe('getNextResetDate', () => {
     expect(parsed.getFullYear()).toBe(2025)
     expect(parsed.getMonth()).toBe(3)
     expect(parsed.getDate()).toBe(1)
-    vi.useRealTimers()
   })
 
   it('handles first day of month', () => {
@@ -265,6 +266,5 @@ describe('getNextResetDate', () => {
     expect(parsed.getFullYear()).toBe(2025)
     expect(parsed.getMonth()).toBe(6)
     expect(parsed.getDate()).toBe(1)
-    vi.useRealTimers()
   })
 })

--- a/web/src/hooks/mcp/__tests__/shared-cache-fetch.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-cache-fetch.test.ts
@@ -103,6 +103,7 @@ import {
   clearClusterFailure,
   clusterDisplayName,
   fetchWithRetry,
+  _resetAgentTokenState,
   // Async functions
   fullFetchClusters,
   refreshSingleCluster,
@@ -631,6 +632,7 @@ describe('fetchSingleClusterHealth', () => {
   const originalFetch = globalThis.fetch
 
   beforeEach(() => {
+    _resetAgentTokenState()
     mockIsAgentUnavailable.mockReturnValue(false)
     mockIsNetlifyDeployment.value = false
     mockIsDemoToken.mockReturnValue(false)
@@ -640,6 +642,7 @@ describe('fetchSingleClusterHealth', () => {
   afterEach(() => {
     globalThis.fetch = originalFetch
     vi.restoreAllMocks()
+    _resetAgentTokenState()
   })
 
   it('returns health data from agent HTTP endpoint', async () => {

--- a/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
@@ -233,6 +233,7 @@ describe('getAgentToken — emits GA4 on failure', () => {
     globalThis.fetch = originalFetch
     localStorage.clear()
     mockEmitAgentTokenFailure.mockClear()
+    _resetAgentTokenState()
   })
 
   it('emits emitAgentTokenFailure when /api/agent/token returns non-OK', async () => {


### PR DESCRIPTION
Fixes #11164
Fixes #11166

- Ensure fake timers and spies are cleaned up in afterEach/try-finally blocks
- Reset module-level agentTokenFailureEmitted between tests to prevent cross-test leaks