### PR TITLE
🐛 Fix nightly Playwright E2E failures: missing API catch-all mocks

### DIFF
--- a/web/e2e/mission-control-e2e.spec.ts
+++ b/web/e2e/mission-control-e2e.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect, Page} from '@playwright/test'
-import { setupAuth } from './mocks/liveMocks'
+import { setupAuth } from './helpers/setup'
 
 // Mission Control requires an admin-role user to see all phases of the wizard.
-// The shared `setupAuth` (from ./mocks/liveMocks) accepts a custom user override.
+// The shared `setupAuth` (from ./helpers/setup) includes mockApiFallback catch-all.
 const MISSION_CONTROL_ADMIN_USER = {
   id: '1',
   github_id: '12345',

--- a/web/e2e/mission-control-stress.spec.ts
+++ b/web/e2e/mission-control-stress.spec.ts
@@ -412,12 +412,13 @@ async function setupAllMocks(page: Page) {
 async function navigateTo(page: Page) {
   await setupAllMocks(page)
 
-  await page.goto('/login')
-  await page.waitForLoadState('domcontentloaded')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs — prevents the app from
+  // briefly rendering the /login screen and firing auth redirects (#11179).
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('kc-has-session', 'true')
+    localStorage.setItem('demo-user-onboarded', 'true')
     localStorage.setItem('kc-backend-status', JSON.stringify({
       available: true,
       timestamp: Date.now(),
@@ -430,8 +431,8 @@ async function navigateTo(page: Page) {
     }))
   })
   await page.goto('/')
-  await page.waitForLoadState('networkidle', { timeout: DIALOG_TIMEOUT_MS })
-  await expect(page.locator('body')).not.toBeEmpty({ timeout: DIALOG_TIMEOUT_MS })
+  await page.waitForLoadState('domcontentloaded', { timeout: DIALOG_TIMEOUT_MS })
+  await page.locator('#root').waitFor({ state: 'visible', timeout: DIALOG_TIMEOUT_MS })
 }
 
 async function seedMCState(page: Page, overrides: Record<string, unknown> = {}) {

--- a/web/e2e/mission-journey.spec.ts
+++ b/web/e2e/mission-journey.spec.ts
@@ -291,6 +291,17 @@ async function setupHTTPMocks(page: Page, overrides?: {
     }
     route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
   })
+
+  // Mock the local kc-agent HTTP endpoint. The cluster cache probes
+  // http://127.0.0.1:8585/clusters before falling back to demo data.
+  // Without this mock, the probe hangs in CI (#11179).
+  await page.route('http://127.0.0.1:8585/**', (route) =>
+    route.fulfill({
+      status: 503,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'Service unavailable (test mock)' }),
+    })
+  )
 }
 
 // ---------------------------------------------------------------------------

--- a/web/e2e/nightly/mission-deeplink.spec.ts
+++ b/web/e2e/nightly/mission-deeplink.spec.ts
@@ -55,6 +55,12 @@ test.describe('Mission Deep Links', () => {
         localStorage.setItem('token', 'demo-token')
         localStorage.setItem('kc-demo-mode', 'true')
         localStorage.setItem('demo-user-onboarded', 'true')
+        localStorage.setItem('kc-has-session', 'true')
+        localStorage.setItem('kc-agent-setup-dismissed', 'true')
+        localStorage.setItem('kc-backend-status', JSON.stringify({
+          available: true,
+          timestamp: Date.now(),
+        }))
       })
 
       await page.goto(`/missions/${slug}`, { waitUntil: 'networkidle' })

--- a/web/e2e/nightly/mission-explorer-import.spec.ts
+++ b/web/e2e/nightly/mission-explorer-import.spec.ts
@@ -109,6 +109,18 @@ interface MissionResult {
 // ---------------------------------------------------------------------------
 
 async function setupDemoMode(page: Page) {
+  // Catch-all for any /api/** route not explicitly mocked below.
+  // Registered FIRST (lowest priority in Playwright's reverse-order matching)
+  // so specific mocks below override it. Without this, unmocked API calls
+  // hit the real network and fail with ERR_FAILED in CI (#11179).
+  await page.route('**/api/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    })
+  )
+
   // Mock authentication — same pattern as mission-import.spec.ts
   await page.route('**/api/me', (route) =>
     route.fulfill({
@@ -146,21 +158,26 @@ async function setupDemoMode(page: Page) {
     }
   })
 
-  // Mock local agent
-  await page.route('**/127.0.0.1:8585/**', (route) =>
+  // Mock local agent HTTP endpoint
+  await page.route('http://127.0.0.1:8585/**', (route) =>
     route.fulfill({
-      status: 200,
+      status: 503,
       contentType: 'application/json',
-      body: JSON.stringify({ events: [], health: { hasClaude: true, hasBob: false } }),
+      body: JSON.stringify({ error: 'Service unavailable (test mock)' }),
     })
   )
 
-  // Set up demo mode auth
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Set up demo mode auth via localStorage before page scripts run
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
+    localStorage.setItem('kc-has-session', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')
+    localStorage.setItem('kc-agent-setup-dismissed', 'true')
+    localStorage.setItem('kc-backend-status', JSON.stringify({
+      available: true,
+      timestamp: Date.now(),
+    }))
   })
 }
 


### PR DESCRIPTION
Fixes #11179

Fix multiple Playwright E2E test failures caused by missing API route mocks and incorrect localStorage initialization patterns that cause `ERR_FAILED` network errors and dialog overlays blocking interactions in CI.

### Changes

- **mission-control-e2e.spec.ts**: Switch `setupAuth` import from `./mocks/liveMocks` (only mocks `/api/me`) to `./helpers/setup` (includes `mockApiFallback` catch-all) so unmocked API calls don't hit real network in CI

- **nightly/mission-explorer-import.spec.ts**: Add `**/api/**` catch-all mock, switch from `page.goto('/login') + page.evaluate()` to `page.addInitScript()` for localStorage seeding, add missing keys (`kc-has-session`, `kc-agent-setup-dismissed`, `kc-backend-status`)

- **mission-journey.spec.ts**: Add `http://127.0.0.1:8585/**` HTTP mock to `setupHTTPMocks()` so kc-agent cluster probe doesn't hang in CI

- **mission-control-stress.spec.ts**: Replace unreliable double-navigation pattern (`goto /login` → `evaluate` → `goto /`) with canonical `addInitScript` + single navigation to prevent race conditions and avoid `networkidle` timeout

- **nightly/mission-deeplink.spec.ts**: Add missing localStorage keys to per-slug tests so AgentSetupDialog doesn't appear and block page interactions

### Root Cause

The 57 failures in nightly run #25193641660 had multiple causes:
1. Some were already fixed by #11160, #11161, #11173
2. The remaining persistent failures stem from specs missing `mockApiFallback` catch-all (network errors) or incorrect localStorage initialization (blocking dialogs/redirects)