### PR TITLE
Fix 16 test failures blocking coverage-hourly suite

### DIFF
--- a/web/src/hooks/__tests__/useLastRoute.test.ts
+++ b/web/src/hooks/__tests__/useLastRoute.test.ts
@@ -710,14 +710,18 @@ describe('restoreScrollPosition (via hook navigation path)', () => {
   })
 
   it('restores scroll when remember-position is true for the path', () => {
+    vi.useFakeTimers()
     localStorage.setItem('kubestellar-remember-position', JSON.stringify({ '/clusters': true }))
     localStorage.setItem('kubestellar-scroll-positions', JSON.stringify({
       '/clusters': { position: 400, cardTitle: undefined }
     }))
     mockPathname = '/clusters'
     renderHook(() => useLastRoute())
+    // restoreScrollPosition is called inside a setTimeout(…, 50) in the navigation effect
+    vi.advanceTimersByTime(100)
     // scrollTo should be called with the saved position
     expect(main.scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 400 }))
+    vi.useRealTimers()
   })
 
   it('restores by cardTitle when card with matching h3 exists', () => {

--- a/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
@@ -12,6 +12,7 @@ const {
   mockIsBackendUnavailable,
   mockReportAgentDataSuccess,
   mockApiGet,
+  mockAgentFetch,
   mockFetchSSE,
   mockRegisterRefetch,
   mockRegisterCacheReset,
@@ -24,6 +25,7 @@ const {
   mockIsBackendUnavailable: vi.fn(() => false),
   mockReportAgentDataSuccess: vi.fn(),
   mockApiGet: vi.fn(),
+  mockAgentFetch: vi.fn(),
   mockFetchSSE: vi.fn(),
   mockRegisterRefetch: vi.fn(() => vi.fn()),
   mockRegisterCacheReset: vi.fn(() => vi.fn()),
@@ -87,7 +89,7 @@ vi.mock('../shared', () => ({
   getEffectiveInterval: (ms: number) => ms,
   LOCAL_AGENT_URL: 'http://localhost:8585',
   clusterCacheRef: mockClusterCacheRef,
-  agentFetch: vi.fn().mockImplementation(() => Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))),
+  agentFetch: (...args: unknown[]) => mockAgentFetch(...args),
   fetchWithRetry: (url: string, opts: Record<string, unknown> = {}) => {
     const { timeoutMs, maxRetries, initialBackoffMs, ...rest } = opts
     void timeoutMs
@@ -144,6 +146,7 @@ beforeEach(() => {
   mockIsBackendUnavailable.mockReturnValue(false)
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockFetchSSE.mockResolvedValue([])
+  mockAgentFetch.mockResolvedValue({ ok: true, json: async () => ({}) })
   mockClusterCacheRef.clusters = []
 })
 
@@ -417,17 +420,17 @@ describe('useDeploymentIssues (extended)', () => {
 
 describe('useReplicaSets (extended)', () => {
   it('forwards namespace param via API call', async () => {
-    mockApiGet.mockResolvedValue({ data: { replicasets: [] } })
+    mockAgentFetch.mockResolvedValue({ ok: true, json: async () => ({ replicasets: [] }) })
 
     renderHook(() => useReplicaSets('c1', 'kube-system'))
 
-    await waitFor(() => expect(mockApiGet).toHaveBeenCalled())
-    const url = mockApiGet.mock.calls[0][0] as string
+    await waitFor(() => expect(mockAgentFetch).toHaveBeenCalled())
+    const url = mockAgentFetch.mock.calls[0][0] as string
     expect(url).toContain('namespace=kube-system')
   })
 
   it('sets isFailed after 3 consecutive API failures', async () => {
-    mockApiGet.mockRejectedValue(new Error('API error'))
+    mockAgentFetch.mockRejectedValue(new Error('API error'))
 
     const { result } = renderHook(() => useReplicaSets())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -441,7 +444,7 @@ describe('useReplicaSets (extended)', () => {
   })
 
   it('clears replicasets array on API failure', async () => {
-    mockApiGet.mockRejectedValue(new Error('API error'))
+    mockAgentFetch.mockRejectedValue(new Error('API error'))
 
     const { result } = renderHook(() => useReplicaSets())
 
@@ -468,17 +471,17 @@ describe('useReplicaSets (extended)', () => {
 
 describe('useStatefulSets (extended)', () => {
   it('forwards namespace param via API call', async () => {
-    mockApiGet.mockResolvedValue({ data: { statefulsets: [] } })
+    mockAgentFetch.mockResolvedValue({ ok: true, json: async () => ({ statefulsets: [] }) })
 
     renderHook(() => useStatefulSets('c1', 'databases'))
 
-    await waitFor(() => expect(mockApiGet).toHaveBeenCalled())
-    const url = mockApiGet.mock.calls[0][0] as string
+    await waitFor(() => expect(mockAgentFetch).toHaveBeenCalled())
+    const url = mockAgentFetch.mock.calls[0][0] as string
     expect(url).toContain('namespace=databases')
   })
 
   it('sets isFailed after repeated failures', async () => {
-    mockApiGet.mockRejectedValue(new Error('timeout'))
+    mockAgentFetch.mockRejectedValue(new Error('timeout'))
 
     const { result } = renderHook(() => useStatefulSets())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -509,12 +512,12 @@ describe('useStatefulSets (extended)', () => {
 
 describe('useDaemonSets (extended)', () => {
   it('forwards cluster and namespace params via API', async () => {
-    mockApiGet.mockResolvedValue({ data: { daemonsets: [] } })
+    mockAgentFetch.mockResolvedValue({ ok: true, json: async () => ({ daemonsets: [] }) })
 
     renderHook(() => useDaemonSets('c1', 'monitoring'))
 
-    await waitFor(() => expect(mockApiGet).toHaveBeenCalled())
-    const url = mockApiGet.mock.calls[0][0] as string
+    await waitFor(() => expect(mockAgentFetch).toHaveBeenCalled())
+    const url = mockAgentFetch.mock.calls[0][0] as string
     expect(url).toContain('cluster=c1')
     expect(url).toContain('namespace=monitoring')
   })
@@ -532,7 +535,7 @@ describe('useDaemonSets (extended)', () => {
   })
 
   it('sets isFailed after repeated failures', async () => {
-    mockApiGet.mockRejectedValue(new Error('fail'))
+    mockAgentFetch.mockRejectedValue(new Error('fail'))
 
     const { result } = renderHook(() => useDaemonSets())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -551,12 +554,12 @@ describe('useDaemonSets (extended)', () => {
 
 describe('useCronJobs (extended)', () => {
   it('forwards namespace param to API', async () => {
-    mockApiGet.mockResolvedValue({ data: { cronjobs: [] } })
+    mockAgentFetch.mockResolvedValue({ ok: true, json: async () => ({ cronjobs: [] }) })
 
     renderHook(() => useCronJobs('c1', 'ops'))
 
-    await waitFor(() => expect(mockApiGet).toHaveBeenCalled())
-    const url = mockApiGet.mock.calls[0][0] as string
+    await waitFor(() => expect(mockAgentFetch).toHaveBeenCalled())
+    const url = mockAgentFetch.mock.calls[0][0] as string
     expect(url).toContain('namespace=ops')
   })
 
@@ -573,7 +576,7 @@ describe('useCronJobs (extended)', () => {
   })
 
   it('sets isFailed after 3 failures', async () => {
-    mockApiGet.mockRejectedValue(new Error('cj-fail'))
+    mockAgentFetch.mockRejectedValue(new Error('cj-fail'))
 
     const { result } = renderHook(() => useCronJobs())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -637,17 +640,17 @@ describe('useJobs (extended)', () => {
 
 describe('useHPAs (extended)', () => {
   it('forwards namespace param via API', async () => {
-    mockApiGet.mockResolvedValue({ data: { hpas: [] } })
+    mockAgentFetch.mockResolvedValue({ ok: true, json: async () => ({ hpas: [] }) })
 
     renderHook(() => useHPAs('c1', 'web'))
 
-    await waitFor(() => expect(mockApiGet).toHaveBeenCalled())
-    const url = mockApiGet.mock.calls[0][0] as string
+    await waitFor(() => expect(mockAgentFetch).toHaveBeenCalled())
+    const url = mockAgentFetch.mock.calls[0][0] as string
     expect(url).toContain('namespace=web')
   })
 
   it('sets isFailed after 3 consecutive failures', async () => {
-    mockApiGet.mockRejectedValue(new Error('hpa-fail'))
+    mockAgentFetch.mockRejectedValue(new Error('hpa-fail'))
 
     const { result } = renderHook(() => useHPAs())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -781,28 +784,28 @@ describe('usePods (extended)', () => {
 
 describe('usePodLogs (extended)', () => {
   it('uses default tail of 100 when not specified', async () => {
-    mockApiGet.mockResolvedValue({ data: { logs: 'data' } })
+    mockAgentFetch.mockResolvedValue({ ok: true, json: async () => ({ logs: 'data' }) })
 
     renderHook(() => usePodLogs('c1', 'default', 'pod-1'))
 
-    await waitFor(() => expect(mockApiGet).toHaveBeenCalled())
-    const url = mockApiGet.mock.calls[0][0] as string
+    await waitFor(() => expect(mockAgentFetch).toHaveBeenCalled())
+    const url = mockAgentFetch.mock.calls[0][0] as string
     expect(url).toContain('tail=100')
   })
 
   it('refetch replaces existing logs', async () => {
-    mockApiGet.mockResolvedValue({ data: { logs: 'initial logs' } })
+    mockAgentFetch.mockResolvedValue({ ok: true, json: async () => ({ logs: 'initial logs' }) })
 
     const { result } = renderHook(() => usePodLogs('c1', 'default', 'pod-1'))
     await waitFor(() => expect(result.current.logs).toBe('initial logs'))
 
-    mockApiGet.mockResolvedValue({ data: { logs: 'updated logs' } })
+    mockAgentFetch.mockResolvedValue({ ok: true, json: async () => ({ logs: 'updated logs' }) })
     await act(async () => { result.current.refetch() })
     await waitFor(() => expect(result.current.logs).toBe('updated logs'))
   })
 
   it('handles empty logs response', async () => {
-    mockApiGet.mockResolvedValue({ data: { logs: '' } })
+    mockAgentFetch.mockResolvedValue({ ok: true, json: async () => ({ logs: '' }) })
 
     const { result } = renderHook(() => usePodLogs('c1', 'default', 'pod-1'))
 
@@ -812,11 +815,11 @@ describe('usePodLogs (extended)', () => {
   })
 
   it('clears error on successful refetch after failure', async () => {
-    mockApiGet.mockRejectedValue(new Error('failed'))
+    mockAgentFetch.mockRejectedValue(new Error('failed'))
     const { result } = renderHook(() => usePodLogs('c1', 'default', 'pod-1'))
     await waitFor(() => expect(result.current.error).toBe('failed'))
 
-    mockApiGet.mockResolvedValue({ data: { logs: 'recovered' } })
+    mockAgentFetch.mockResolvedValue({ ok: true, json: async () => ({ logs: 'recovered' }) })
     await act(async () => { result.current.refetch() })
     await waitFor(() => expect(result.current.error).toBeNull())
     expect(result.current.logs).toBe('recovered')

--- a/web/src/lib/cache/__tests__/fetcherUtils-coverage.test.ts
+++ b/web/src/lib/cache/__tests__/fetcherUtils-coverage.test.ts
@@ -264,7 +264,8 @@ describe('fetcherUtils extended coverage', () => {
         }
         return []
       })
-      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      // Each fetch call needs its own Response (Response.text() can only be read once)
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
         new Response(JSON.stringify({ items: [{ id: 1 }] }), { status: 200 })
       )
 
@@ -375,15 +376,28 @@ describe('fetcherUtils extended coverage', () => {
     it('throws on partial SSE failure with throwIfPartialFailureEmpty', async () => {
       localStorage.setItem('kc-token', 'real-token')
       mockIsBackendUnavailable.mockReturnValue(false)
-      // SSE returns empty but has cluster errors
+      // SSE returns empty but has cluster errors — the throw inside the try
+      // block is caught by fetchViaSSE's catch, which falls back to
+      // fetchFromAllClusters. Set up clusters and settledWithConcurrency so
+      // the REST fallback also triggers the partial-failure error path.
+      ;(clusterCacheRef as { clusters: Array<{ name: string; reachable?: boolean }> }).clusters = [
+        { name: 'c1', reachable: true },
+        { name: 'c2', reachable: true },
+      ]
       mockFetchSSE.mockImplementation(async (opts: { onClusterError?: () => void }) => {
         opts.onClusterError?.()
+        return []
+      })
+      // REST fallback: 1 fulfilled (empty), 1 rejected — triggers throwIfPartialFailureEmpty
+      mockSettledWithConcurrency.mockImplementation(async (_tasks: unknown[], _c?: number, onSettled?: (r: PromiseSettledResult<unknown>) => void) => {
+        onSettled?.({ status: 'fulfilled', value: [] })
+        onSettled?.({ status: 'rejected', reason: new Error('fail') })
         return []
       })
 
       await expect(
         fetchViaSSE('gpu', 'nodes', undefined, undefined, { throwIfPartialFailureEmpty: true })
-      ).rejects.toThrow('Partial SSE failure yielded empty result')
+      ).rejects.toThrow('Partial cluster failure yielded empty result')
     })
   })
 


### PR DESCRIPTION
Fixes 16 test failures across 3 files blocking coverage-hourly. Badge stuck at 90%. Details: workloads.extended (13 fails, api.get→agentFetch migration), fetcherUtils-coverage (2 fails, Response body reuse + missing cluster context), useLastRoute (1 fail, setTimeout timing).