### PR TITLE
🐛 Remove stale dedup CAUTION comments (fixed by #11156)

### DIFF
--- a/web/src/hooks/useIntoto.ts
+++ b/web/src/hooks/useIntoto.ts
@@ -355,9 +355,8 @@ async function fetchSingleCluster(cluster: string): Promise<IntotoClusterStatus>
 
 export function useIntoto() {
   const { isDemoMode } = useDemoMode()
-  // ⚠️  CAUTION: deduplicatedClusters aggregates reachability across aliases but keeps the primary context name.
-  // If primary context is unreachable/unauthorized but an alias works, this may still include the primary context
-  // in scans. For kubectl-based operations, verify selected context is actually reachable before execution.
+  // (#11156) deduplicateClustersByServer now sorts reachable contexts first and uses the primary's reachable
+  // flag authoritatively, so deduplicatedClusters is safe to use for kubectl-based operations.
   const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
 
   // Snapshot ref value to avoid reading ref during render

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -235,9 +235,8 @@ async function fetchSingleCluster(cluster: string): Promise<TrivyClusterStatus> 
 
 export function useTrivy() {
   const { isDemoMode } = useDemoMode()
-  // ⚠️  CAUTION: deduplicatedClusters aggregates reachability across aliases but keeps the primary context name.
-  // If primary context is unreachable/unauthorized but an alias works, this may still include the primary context
-  // in scans. For kubectl-based operations, verify selected context is actually reachable before execution.
+  // (#11156) deduplicateClustersByServer now sorts reachable contexts first and uses the primary's reachable
+  // flag authoritatively, so deduplicatedClusters is safe to use for kubectl-based operations.
   const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
 
   // Snapshot ref value to avoid reading ref during render


### PR DESCRIPTION
Fixes the HIGH Copilot findings from PR #11045 (useIntoto:358, useTrivy:238).

The ⚠️ CAUTION warnings saying `deduplicatedClusters aggregates reachability across aliases` were added in #11045. They became inaccurate after #11156 fixed `deduplicateClustersByServer` to:
- Sort reachable contexts first when picking the primary
- Use `primary.reachable` authoritatively (not aggregated across aliases)

Replace with a concise comment pointing to #11156 so future readers understand the history.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>