### PR TITLE
🐛 Fix duplicate and stale exports in MSW handlers.ts breaking build

### DIFF
--- a/web/src/mocks/handlers.fixtures.ts
+++ b/web/src/mocks/handlers.fixtures.ts
@@ -346,8 +346,8 @@ export function getDefaultUser() {
 // Capped to prevent unbounded memory growth in long-running sessions (#7418).
 /** Maximum number of entries in each in-memory share registry */
 export const MAX_SHARE_REGISTRY_ENTRIES = 500
-export let savedCards: Record<string, unknown> = {}
-export let sharedDashboards: Record<string, unknown> = {}
+export const savedCards: Record<string, unknown> = {}
+export const sharedDashboards: Record<string, unknown> = {}
 
 // ---------------------------------------------------------------------------
 // Demo time-offset constants — used in Date.now() ± N for realistic timestamps

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -38,7 +38,5 @@ export {
   sharedDashboards,
   pruneRegistry,
   resetShareRegistries,
-  getDefaultSavedCards,
-  getDefaultSharedDashboards,
   MAX_SHARE_REGISTRY_ENTRIES,
 } from './handlers.fixtures'


### PR DESCRIPTION
Fixes #11188
Fixes #11189

The Docker build CI on fix/11188 has already passed (run 25198035923). This unblocks main.

Root cause: PR #11185 introduced duplicate exports and a stale currentUser reference.