### PR TITLE
🐛 Fix build: change savedCards/sharedDashboards from const to let

### DIFF
--- a/web/src/mocks/handlers.fixtures.ts
+++ b/web/src/mocks/handlers.fixtures.ts
@@ -346,8 +346,8 @@ export function getDefaultUser() {
 // Capped to prevent unbounded memory growth in long-running sessions (#7418).
 /** Maximum number of entries in each in-memory share registry */
 export const MAX_SHARE_REGISTRY_ENTRIES = 500
-export const savedCards: Record<string, unknown> = {}
-export const sharedDashboards: Record<string, unknown> = {}
+export let savedCards: Record<string, unknown> = {}
+export let sharedDashboards: Record<string, unknown> = {}
 
 // ---------------------------------------------------------------------------
 // Demo time-offset constants — used in Date.now() ± N for realistic timestamps


### PR DESCRIPTION
Fixes #11193

PR #11191 changed `resetShareRegistries()` to reassign `savedCards` and `sharedDashboards` instead of clearing their properties, but left the declarations as `export const`, causing a TypeScript compilation error (cannot assign to const).

**Fix:** Change declarations from `export const` to `export let` so they can be reassigned in `resetShareRegistries()`.