### PR TITLE
🐛 Fix agentFetch retry: reuse signal and add missing tests

### DIFF
--- a/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
@@ -297,6 +297,54 @@ describe('agentFetch — 401 retry with stale token', () => {
     expect(mockFetch.mock.calls.length).toBeLessThanOrEqual(2)
   })
 
+  it('returns 401 without infinite retry loop when retry also fails', async () => {
+    localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, 'stale-token')
+    const mockFetch = vi.fn()
+    // First call: 401 with stale token
+    mockFetch.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+    // Token endpoint returns a fresh token
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ token: 'fresh-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    // Retry also returns 401
+    mockFetch.mockResolvedValueOnce(new Response('Still Unauthorized', { status: 401 }))
+    globalThis.fetch = mockFetch
+
+    const result = await agentFetch('http://localhost:8090/clusters')
+
+    // The retry 401 is returned as-is (no second retry / infinite loop)
+    expect(result.status).toBe(401)
+    // Exactly 3 calls: original request, token fetch, single retry
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('retry reuses original signal instead of creating a fresh timeout', async () => {
+    localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, 'stale-token')
+    const callerSignal = AbortSignal.timeout(12345)
+    const mockFetch = vi.fn()
+    // First call: 401
+    mockFetch.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+    // Token endpoint returns a fresh token
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ token: 'fresh-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    // Retry succeeds
+    mockFetch.mockResolvedValueOnce(new Response('ok', { status: 200 }))
+    globalThis.fetch = mockFetch
+
+    await agentFetch('http://localhost:8090/clusters', { signal: callerSignal })
+
+    // The retry (3rd fetch call) must reuse the caller-provided signal
+    const retryInit = mockFetch.mock.calls[2][1]
+    expect(retryInit.signal).toBe(callerSignal)
+  })
+
   it('returns the 401 when fresh token is the same as the stale one', async () => {
     localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, 'same-token')
     const mockFetch = vi.fn()

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -154,8 +154,7 @@ export async function agentFetch(input: RequestInfo | URL, init?: RequestInit): 
       if (!retryHeaders.has('X-Requested-With')) {
         retryHeaders.set('X-Requested-With', 'XMLHttpRequest')
       }
-      const retrySignal = init?.signal ?? AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS)
-      return fetch(input, { ...init, headers: retryHeaders, signal: retrySignal })
+      return fetch(input, { ...init, headers: retryHeaders, signal })
     }
   }
 


### PR DESCRIPTION
Fixes #11199
Fixes #11200
Fixes #11201

## Changes

### Signal reuse (#11201)
The 401 retry path previously created a fresh `AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS)` for the retry request, meaning the total elapsed time could reach 2× the intended timeout budget. Now the retry reuses the original signal computed at the start of `agentFetch`, keeping the overall operation within `MCP_HOOK_TIMEOUT_MS`.

### Caller-auth guard confirmed (#11199)
The `weInjectedToken` check at line 145 already correctly prevents the retry path from triggering when the caller supplies their own `Authorization` header. Existing test confirms this behavior.

### Additional test coverage (#11200)
- Added test: retry also returns 401 → returned without infinite loop
- Added test: retry reuses original signal (no fresh timeout created)