### PR TITLE
🐛 Address HIGH/MEDIUM Copilot comments in coverage tests

### DIFF
--- a/web/src/hooks/__tests__/useClusterContext-coverage.test.ts
+++ b/web/src/hooks/__tests__/useClusterContext-coverage.test.ts
@@ -11,7 +11,7 @@
  * - Fallback to first healthy cluster when none is current
  */
 
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
 vi.mock('../mcp/clusters', () => ({
@@ -57,6 +57,14 @@ import { usePodIssues } from '../mcp/workloads'
 import { useSecurityIssues } from '../mcp/security'
 
 describe('useClusterContext — additional coverage', () => {
+  beforeEach(() => {
+    vi.mocked(useClusters).mockReturnValue({ deduplicatedClusters: [], isLoading: false } as never)
+    vi.mocked(useOperators).mockReturnValue({ operators: [], isLoading: false } as never)
+    vi.mocked(useHelmReleases).mockReturnValue({ releases: [], isLoading: false } as never)
+    vi.mocked(usePodIssues).mockReturnValue({ issues: [], isLoading: false } as never)
+    vi.mocked(useSecurityIssues).mockReturnValue({ issues: [], isLoading: false } as never)
+  })
+
   it('extracts base name from operators with -operator suffix', () => {
     vi.mocked(useClusters).mockReturnValue({
       deduplicatedClusters: [

--- a/web/src/lib/missions/__tests__/preflightCheck-coverage.test.ts
+++ b/web/src/lib/missions/__tests__/preflightCheck-coverage.test.ts
@@ -276,10 +276,10 @@ describe('resolveRequiredTools', () => {
     expect(kubectlCount).toBe(EXPECTED_SINGLE_OCCURRENCE)
   })
 
-  it('returns explicit tools even if empty array', () => {
-    // Empty explicit array is falsy length, so falls through
+  it('falls back to type-based lookup when explicit tools array is empty', () => {
+    // An empty array has length 0 (falsy), so resolveRequiredTools falls
+    // through to the mission-type default tool set rather than returning [].
     const result = resolveRequiredTools('deploy', [])
-    // Empty array has length 0, so it falls through to type-based lookup
     expect(result).toContain('helm')
   })
 })
@@ -392,7 +392,8 @@ describe('runPreflightCheck — catch branch coverage', () => {
 
     const result = await runPreflightCheck(exec)
     expect(result.ok).toBe(false)
-    // Falls through to String(err) path
+    // Falls through to String(err) path → '[object Object]' classified as UNKNOWN_EXECUTION_FAILURE
+    expect(result.error?.code).toBe('UNKNOWN_EXECUTION_FAILURE')
   })
 
   it('handles non-Error thrown value (string)', async () => {
@@ -400,6 +401,8 @@ describe('runPreflightCheck — catch branch coverage', () => {
 
     const result = await runPreflightCheck(exec)
     expect(result.ok).toBe(false)
+    expect(result.error?.code).toBe('UNKNOWN_EXECUTION_FAILURE')
+    expect(result.error?.message).toBe('raw string error')
   })
 
   it('handles null thrown value', async () => {
@@ -407,6 +410,9 @@ describe('runPreflightCheck — catch branch coverage', () => {
 
     const result = await runPreflightCheck(exec)
     expect(result.ok).toBe(false)
+    // null is normalized to 'Unknown execution error' via String(null ?? 'Unknown execution error')
+    expect(result.error?.code).toBe('UNKNOWN_EXECUTION_FAILURE')
+    expect(result.error?.message).toBe('Unknown execution error')
   })
 
   it('handles "unavailable" in exception message as CLUSTER_UNREACHABLE', async () => {
@@ -431,7 +437,7 @@ describe('runPreflightCheck — catch branch coverage', () => {
 // ============================================================================
 
 describe('getRemediationActions — additional branches', () => {
-  it('includes context in MISSING_CREDENTIALS code snippet when provided', () => {
+  it('uses cloud provider login commands for MISSING_CREDENTIALS when context is provided', () => {
     const error: PreflightError = {
       code: 'MISSING_CREDENTIALS',
       message: 'No kubeconfig',


### PR DESCRIPTION
Fixes #11198

## Changes

### HIGH: Misleading test names (PR#11192)
- Renamed `'includes context in MISSING_CREDENTIALS code snippet when provided'` → `'uses cloud provider login commands for MISSING_CREDENTIALS when context is provided'` — the context is a boolean flag selecting cloud vs generic commands; the context string itself is not interpolated into the snippet
- Renamed `'returns explicit tools even if empty array'` → `'falls back to type-based lookup when explicit tools array is empty'` — accurately describes that empty arrays fall through to type-based resolution

### MEDIUM: Weak assertions in catch-branch tests (PR#11192)
- Cross-realm error (`{ message: undefined }`): added `expect(result.error?.code).toBe('UNKNOWN_EXECUTION_FAILURE')`
- Non-Error string throw: added code and message assertions (`UNKNOWN_EXECUTION_FAILURE`, `'raw string error'`)
- Null throw: added code and message assertions (`UNKNOWN_EXECUTION_FAILURE`, `'Unknown execution error'`) confirming the null-normalization path

### MEDIUM: Mock state bleed in useClusterContext tests (PR#11192)
- Added `beforeEach` that resets all mocked hook return values (`useClusters`, `useOperators`, `useHelmReleases`, `usePodIssues`, `useSecurityIssues`) to safe empty defaults, preventing state from one test leaking into subsequent tests

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>