### PR TITLE
🐛 Fix LOCAL_AGENT_URL const-snapshot, fixtures let→const, dead-code cleanup

### DIFF
--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -1,5 +1,39 @@
 # Reviewer Log
 
+## Pass 84 — 2026-05-01T07:10 UTC
+
+### Trigger
+KICK — RED: nightlyPlaywright=RED, nightlyRel=RED. 62 unaddressed Copilot comments.
+
+### Pre-flight
+- `git pull /tmp/hive` — skipped (divergent branches, unrelated repo)
+- Branch: `fix/11210-medium-comments` (4 commits ahead of origin/main)
+- GA4: **NOMINAL, 0 anomalies** ✅
+
+### RED Analysis
+- **nightlyPlaywright=RED**: Scanner owns (issue #10433). No file action.
+- **nightlyRel=RED**: Release run #139 `in_progress` — Docker multi-arch build still building (started 06:05 UTC). Not a code failure; 0 failed jobs. Previous runs 135–138 all success. Monitoring.
+
+### Copilot Comments
+All 6 HIGH source-file comments verified addressed (passes 78–81). No regressions.
+
+| PR | Comment | Status |
+|----|---------|--------|
+| #11209 | workloads.ts:1543,1612,1681,1750 LOCAL_AGENT_URL stale const | ✅ Fixed in d6b9563e0 |
+| #11209 | workloads.ts:1262 useHPAs/useDeployments guard after fetch | ✅ Fixed in d6b9563e0 |
+
+Verified: workloads.ts now uses `LOCAL_AGENT_HTTP_URL` (live ref) with guard `&& LOCAL_AGENT_HTTP_URL` in every agent-fetch block. No `LOCAL_AGENT_URL` (stale const) in workloads.ts. Build ✅, lint clean in changed file ✅.
+
+### PR #11210 Status
+- All non-blocking checks passing (coverage-gate, ts-null-safety, pr-check, attribute, classify)
+- 9 checks still in_progress (build, visual, TTFI, smoke)
+- 0 failures
+
+### Status
+Monitoring PR #11210 CI. Will merge on green.
+
+---
+
 ## Pass 79 — 2026-05-01T05:10–05:25 UTC
 
 **Trigger:** KICK — RED: nightlyPlaywright=RED; 54 unaddressed Copilot comments

--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -604,3 +604,29 @@ All 6 HIGH comments addressed. 0 remaining HIGH in source files.
   - Source fix committed: `playwright.config.ts` excludes unsupported nightly tests
 
 **Status: BLOCKED on PR creation (rate limit). Branch pushed, ready to merge once PR is open.**
+
+---
+
+## Pass 82 — 2026-05-01
+
+### RED Indicators
+- **nightlyRel=RED**: GoReleaser GitHub API secondary rate limit (run #134, 2026-04-27). Transient infrastructure issue — not a code fix.
+- **nightlyPlaywright=RED**: Ongoing; scanner owns E2E test fixes. Root cause (workloads infinite loading) addressed via source fix below.
+
+### Source File Fixes (PR #11210)
+
+| File | Issue | Fix |
+|------|-------|-----|
+| `workloads.ts` | `LOCAL_AGENT_URL` const-snapshot not updated by `suppressLocalAgent()` (MEDIUM #11209 ×6) | Replace with `LOCAL_AGENT_HTTP_URL` directly; add guard before each agent fetch |
+| `workloads-coverage.test.ts` | Unused `LOCAL_AGENT_URL` in shared mock (MEDIUM #11184) | Remove it; add explicit `LOCAL_AGENT_HTTP_URL` to network mock |
+| `workloads.core.test.ts` | Same | Same |
+| `handlers.fixtures.ts` | `let savedCards/sharedDashboards` + reassignment-based reset (MEDIUM #11186) | `const` + deletion-based reset; preserves object identity |
+| `useMetricsHistory.ts` | Dead `!= null` checks after type predicate (MEDIUM #11176) | Remove redundant ternaries |
+| `card-loading-compliance.spec.ts` | `{}` empty destructure (lint) | `_fixtures` |
+| `card-cache-compliance.spec.ts` | `let totalCards` pre-declared then assigned (lint) | `const` at point of assignment |
+
+### PR Created
+- PR #11210 → `fix/11210-medium-comments` → main
+
+### HIGH Copilot Comments
+All 6 HIGH source-file comments remain addressed from passes 78–81. No new HIGH comments.

--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -630,3 +630,46 @@ All 6 HIGH comments addressed. 0 remaining HIGH in source files.
 
 ### HIGH Copilot Comments
 All 6 HIGH source-file comments remain addressed from passes 78–81. No new HIGH comments.
+
+---
+
+## Pass 83 — 2026-05-01T06:23–07:05 UTC
+
+### Trigger
+KICK — RED indicators: nightlyPlaywright=RED, nightlyRel=RED. 62 unaddressed Copilot comments.
+
+### RED Indicator Analysis
+
+**nightlyRel=RED**: Release workflow run #25204538900 started at 06:05 UTC. Docker multi-platform build (linux/amd64 + linux/arm64) in progress — not a code failure. Previous nightlyRel RED (per pass 82) was GoReleaser GitHub API secondary rate limit — transient infrastructure issue. No code fix possible; monitoring.
+
+**nightlyPlaywright=RED**: Nightly cross-browser failures on webkit/firefox/mobile-safari. Source root causes addressed:
+- `workloads.ts` loading guards (merged in #11209)
+- `playwright.config.ts` nightly spec exclusions (merged in #11209)
+Scanner owns E2E test fixes for remaining webkit/firefox/mobile failures.
+
+### Source File Fixes (committed to `fix/11210-medium-comments`)
+
+| File | Issue | Fix |
+|------|-------|-----|
+| `card-cache-compliance.spec.ts` lines 117,129,141,559 | `!!process.env.CI` redundant double negation (`no-extra-boolean-cast`) | Remove `!!` — ternary already coerces to boolean |
+
+These 4 errors were missed in pass 82 (which fixed `totalCards` and `_fixtures` in the same file).
+
+### Commit
+`ae47e1b75` — 🐛 fix: remove redundant double negation in card-cache-compliance
+
+### PR Status
+- PR #11210 (`fix/11210-medium-comments`) — open, CI running
+- No merge-eligible PRs (CI in_progress)
+
+### HIGH Copilot Comments
+All 6 HIGH source-file comments remain addressed from passes 78–81:
+- `shared.ts` 401 retry ✅ (PR #11203)
+- `preflightCheck-coverage.test.ts` misleading test name ✅ (PR #11205)
+- E2E HIGH comments (Login.spec.ts, mission-control-stress.spec.ts) → scanner-owned
+
+### Outstanding
+- nightlyRel: monitoring Docker build completion
+- nightlyPlaywright: waiting for next nightly run post-source-fixes
+
+**Status:** Source fixes committed; PR #11210 in CI. Monitoring nightlyRel completion.

--- a/web/e2e/compliance/card-cache-compliance.spec.ts
+++ b/web/e2e/compliance/card-cache-compliance.spec.ts
@@ -114,7 +114,7 @@ const BATCH_LOAD_TIMEOUT_MS = 30_000
  * CPU contention.  5s gives the async loadFromStorage() path enough headroom
  * after a full page navigation fallback.
  */
-const WARM_RETURN_WAIT_MS = !!process.env.CI ? 5_000 : 3_000
+const WARM_RETURN_WAIT_MS = process.env.CI ? 5_000 : 3_000
 /** Polling interval (ms) for the resilient warm-snapshot capture loop. */
 const WARM_POLL_INTERVAL_MS = 200
 /** Max retry attempts for page.evaluate calls that may race with navigation */
@@ -126,7 +126,7 @@ const EVALUATE_RETRY_DELAY_MS = 500
  * preview servers under load. 20s default is too tight when the server is
  * already serving other suites (#9101).
  */
-const BATCH_NAV_TIMEOUT_MS = !!process.env.CI ? 90_000 : 45_000
+const BATCH_NAV_TIMEOUT_MS = process.env.CI ? 90_000 : 45_000
 /**
  * Overall test timeout (ms). 300s base × 2 CI multiplier = 600s, matching
  * the suite wall-clock cap in run-all-tests.sh (#9101).
@@ -138,7 +138,7 @@ const CI_TIMEOUT_MULTIPLIER = 2
  * CI shared runners exhibit 2-3× slower React hydration due to CPU
  * contention and virtualisation overhead, so we apply a multiplier.
  */
-const WARM_TTC_THRESHOLD_MS = !!process.env.CI ? 1_000 : 500
+const WARM_TTC_THRESHOLD_MS = process.env.CI ? 1_000 : 500
 
 
 // Mock data, setupAuth, setupLiveMocks, setLiveColdMode, navigateToBatch,
@@ -556,7 +556,7 @@ test('card cache compliance — storage and retrieval', async ({ page }, testInf
   // run-all-tests.sh. No testInfo.setTimeout was set before (#9101), so the
   // test ran against the global config timeout (1200s) which meant timeout
   // errors only surfaced as wall-clock kills.
-  testInfo.setTimeout(!!process.env.CI ? CACHE_TEST_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : CACHE_TEST_TIMEOUT_MS)
+  testInfo.setTimeout(process.env.CI ? CACHE_TEST_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : CACHE_TEST_TIMEOUT_MS)
 
   const allBatchResults: Array<{ batchIndex: number; cards: CardCacheResult[] }> = []
   const coldSnapshots: Map<string, ColdLoadSnapshot> = new Map()

--- a/web/e2e/compliance/card-cache-compliance.spec.ts
+++ b/web/e2e/compliance/card-cache-compliance.spec.ts
@@ -560,7 +560,6 @@ test('card cache compliance — storage and retrieval', async ({ page }, testInf
 
   const allBatchResults: Array<{ batchIndex: number; cards: CardCacheResult[] }> = []
   const coldSnapshots: Map<string, ColdLoadSnapshot> = new Map()
-  let totalCards = 0
 
   page.on('console', (msg) => {
     if (msg.type() === 'error') console.log(`[Browser ERROR] ${msg.text()}`)
@@ -591,7 +590,7 @@ test('card cache compliance — storage and retrieval', async ({ page }, testInf
   // ── Phase 2: Warmup — prime Vite module cache ──────────────────────────
   console.log('[CacheTest] Phase 2: Warmup — priming module cache')
   const warmupManifest = await navigateToBatch(page, 0, 180_000)
-  totalCards = warmupManifest.totalCards
+  const totalCards = warmupManifest.totalCards
   const totalBatches = Math.ceil(totalCards / BATCH_SIZE)
   console.log(`[CacheTest] Total cards: ${totalCards}, batches: ${totalBatches}`)
   // Wait for warmup batch to fully load

--- a/web/e2e/compliance/card-loading-compliance.spec.ts
+++ b/web/e2e/compliance/card-loading-compliance.spec.ts
@@ -928,7 +928,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
     }
   })
 
-  test('setup — mocks + warmup + manifest', async ({}, testInfo) => {
+  test('setup — mocks + warmup + manifest', async (_fixtures, testInfo) => {
     testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
 
     await setupAuth(sharedPage)
@@ -965,7 +965,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
   // beyond the actual manifest size short-circuit (Playwright requires test
   // declarations at load time, so we can't size this dynamically).
   for (let batchIdx = 0; batchIdx < MAX_EXPECTED_BATCHES; batchIdx++) {
-    test(`cold — batch ${batchIdx + 1}`, async ({}, testInfo) => {
+    test(`cold — batch ${batchIdx + 1}`, async (_fixtures, testInfo) => {
       testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
       if (!complianceState.setupDone) {
         test.skip(true, 'setup did not complete')
@@ -978,7 +978,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
     })
   }
 
-  test('navigate away — between cold and warm phases', async ({}, testInfo) => {
+  test('navigate away — between cold and warm phases', async (_fixtures, testInfo) => {
     testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
     if (!complianceState.setupDone) test.skip(true, 'setup did not complete')
     console.log('[Compliance] Phase 3: Navigate away')
@@ -987,7 +987,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
   })
 
   for (let batchIdx = 0; batchIdx < MAX_EXPECTED_BATCHES; batchIdx++) {
-    test(`warm — batch ${batchIdx + 1}`, async ({}, testInfo) => {
+    test(`warm — batch ${batchIdx + 1}`, async (_fixtures, testInfo) => {
       testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
       if (!complianceState.setupDone) {
         test.skip(true, 'setup did not complete')
@@ -1004,7 +1004,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
     })
   }
 
-  test('aggregate report + cross-batch assertions', async ({}, testInfo) => {
+  test('aggregate report + cross-batch assertions', async (_fixtures, testInfo) => {
     testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
     if (!complianceState.setupDone) test.skip(true, 'setup did not complete')
 

--- a/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
@@ -81,7 +81,6 @@ vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
   getEffectiveInterval: (ms: number) => ms,
-  LOCAL_AGENT_URL: 'http://localhost:8585',
   clusterCacheRef: mockClusterCacheRef,
   agentFetch: vi.fn().mockImplementation(async (...args: unknown[]) => {
     const result = await mockApiGet(...args)
@@ -96,7 +95,7 @@ vi.mock('../shared', () => ({
 
 vi.mock('../../../lib/constants/network', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
-  return { ...actual, MCP_HOOK_TIMEOUT_MS: 5_000 }
+  return { ...actual, MCP_HOOK_TIMEOUT_MS: 5_000, LOCAL_AGENT_HTTP_URL: 'http://127.0.0.1:8585' }
 })
 
 vi.mock('../../../lib/constants', async (importOriginal) => {

--- a/web/src/hooks/mcp/__tests__/workloads.core.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.core.test.ts
@@ -85,7 +85,6 @@ vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
   getEffectiveInterval: (ms: number) => ms,
-  LOCAL_AGENT_URL: 'http://localhost:8585',
   clusterCacheRef: mockClusterCacheRef,
   agentFetch: vi.fn().mockImplementation(async (...args: unknown[]) => {
     const result = await mockApiGet(...args)
@@ -102,9 +101,8 @@ vi.mock('../shared', () => ({
 
 vi.mock('../../../lib/constants/network', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
-  return { ...actual,
-  MCP_HOOK_TIMEOUT_MS: 5_000,
-} })
+  return { ...actual, MCP_HOOK_TIMEOUT_MS: 5_000, LOCAL_AGENT_HTTP_URL: 'http://127.0.0.1:8585' }
+})
 
 vi.mock('../../../lib/constants', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -5,7 +5,7 @@ import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode } from '../../lib/demoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { kubectlProxy } from '../../lib/kubectlProxy'
-import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef, fetchWithRetry, agentFetch } from './shared'
+import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, clusterCacheRef, fetchWithRetry, agentFetch } from './shared'
 import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { PodInfo, PodIssue, Deployment, DeploymentIssue, Job, HPA, ReplicaSet, StatefulSet, DaemonSet, CronJob } from './types'
@@ -1179,12 +1179,12 @@ export function useDeployments(cluster?: string, namespace?: string): UseDeploym
     }
 
     // Try local agent HTTP endpoint first (works without backend)
-    if (cluster && !isAgentUnavailable()) {
+    if (cluster && !isAgentUnavailable() && LOCAL_AGENT_HTTP_URL) {
       try {
         const params = new URLSearchParams()
         params.append('cluster', cluster)
         if (namespace) params.append('namespace', namespace)
-        const response = await fetchWithRetry(`${LOCAL_AGENT_URL}/deployments?${params}`, {
+        const response = await fetchWithRetry(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
           headers: { 'Accept': 'application/json' },
           timeoutMs: MCP_HOOK_TIMEOUT_MS,
         })
@@ -1362,12 +1362,12 @@ export function useJobs(cluster?: string, namespace?: string): UseJobsResult {
 
   const refetch = useCallback(async () => {
     setIsLoading(true)
-    if (cluster && !isAgentUnavailable()) {
+    if (cluster && !isAgentUnavailable() && LOCAL_AGENT_HTTP_URL) {
       try {
         const params = new URLSearchParams()
         params.append('cluster', cluster)
         if (namespace) params.append('namespace', namespace)
-        const response = await fetchWithRetry(`${LOCAL_AGENT_URL}/jobs?${params}`, {
+        const response = await fetchWithRetry(`${LOCAL_AGENT_HTTP_URL}/jobs?${params}`, {
           headers: { 'Accept': 'application/json' },
           timeoutMs: MCP_HOOK_TIMEOUT_MS,
         })
@@ -1444,12 +1444,12 @@ export function useHPAs(cluster?: string, namespace?: string): UseHPAsResult {
 
   const refetch = useCallback(async () => {
     setIsLoading(true)
-    if (cluster && !isAgentUnavailable()) {
+    if (cluster && !isAgentUnavailable() && LOCAL_AGENT_HTTP_URL) {
       try {
         const params = new URLSearchParams()
         params.append('cluster', cluster)
         if (namespace) params.append('namespace', namespace)
-        const response = await fetchWithRetry(`${LOCAL_AGENT_URL}/hpas?${params}`, {
+        const response = await fetchWithRetry(`${LOCAL_AGENT_HTTP_URL}/hpas?${params}`, {
           headers: { 'Accept': 'application/json' },
           timeoutMs: MCP_HOOK_TIMEOUT_MS,
         })
@@ -1515,12 +1515,12 @@ export function useReplicaSets(cluster?: string, namespace?: string): UseReplica
   const refetch = useCallback(async () => {
     setIsLoading(true)
     // Try local agent first
-    if (cluster && !isAgentUnavailable()) {
+    if (cluster && !isAgentUnavailable() && LOCAL_AGENT_HTTP_URL) {
       try {
         const params = new URLSearchParams()
         params.append('cluster', cluster)
         if (namespace) params.append('namespace', namespace)
-        const response = await fetchWithRetry(`${LOCAL_AGENT_URL}/replicasets?${params}`, {
+        const response = await fetchWithRetry(`${LOCAL_AGENT_HTTP_URL}/replicasets?${params}`, {
           headers: { 'Accept': 'application/json' },
           timeoutMs: MCP_HOOK_TIMEOUT_MS,
         })
@@ -1584,12 +1584,12 @@ export function useStatefulSets(cluster?: string, namespace?: string): UseStatef
 
   const refetch = useCallback(async () => {
     setIsLoading(true)
-    if (cluster && !isAgentUnavailable()) {
+    if (cluster && !isAgentUnavailable() && LOCAL_AGENT_HTTP_URL) {
       try {
         const params = new URLSearchParams()
         params.append('cluster', cluster)
         if (namespace) params.append('namespace', namespace)
-        const response = await fetchWithRetry(`${LOCAL_AGENT_URL}/statefulsets?${params}`, {
+        const response = await fetchWithRetry(`${LOCAL_AGENT_HTTP_URL}/statefulsets?${params}`, {
           headers: { 'Accept': 'application/json' },
           timeoutMs: MCP_HOOK_TIMEOUT_MS,
         })
@@ -1653,12 +1653,12 @@ export function useDaemonSets(cluster?: string, namespace?: string): UseDaemonSe
 
   const refetch = useCallback(async () => {
     setIsLoading(true)
-    if (cluster && !isAgentUnavailable()) {
+    if (cluster && !isAgentUnavailable() && LOCAL_AGENT_HTTP_URL) {
       try {
         const params = new URLSearchParams()
         params.append('cluster', cluster)
         if (namespace) params.append('namespace', namespace)
-        const response = await fetchWithRetry(`${LOCAL_AGENT_URL}/daemonsets?${params}`, {
+        const response = await fetchWithRetry(`${LOCAL_AGENT_HTTP_URL}/daemonsets?${params}`, {
           headers: { 'Accept': 'application/json' },
           timeoutMs: MCP_HOOK_TIMEOUT_MS,
         })
@@ -1722,12 +1722,12 @@ export function useCronJobs(cluster?: string, namespace?: string): UseCronJobsRe
 
   const refetch = useCallback(async () => {
     setIsLoading(true)
-    if (cluster && !isAgentUnavailable()) {
+    if (cluster && !isAgentUnavailable() && LOCAL_AGENT_HTTP_URL) {
       try {
         const params = new URLSearchParams()
         params.append('cluster', cluster)
         if (namespace) params.append('namespace', namespace)
-        const response = await fetchWithRetry(`${LOCAL_AGENT_URL}/cronjobs?${params}`, {
+        const response = await fetchWithRetry(`${LOCAL_AGENT_HTTP_URL}/cronjobs?${params}`, {
           headers: { 'Accept': 'application/json' },
           timeoutMs: MCP_HOOK_TIMEOUT_MS,
         })

--- a/web/src/hooks/useMetricsHistory.ts
+++ b/web/src/hooks/useMetricsHistory.ts
@@ -473,8 +473,8 @@ export function getMetricsHistoryContext(): string {
     }).filter((v): v is { cpu: number; mem: number } => v !== null)
 
     if (values.length > 0) {
-      const cpuTrend = values.map(v => v.cpu != null ? `${v.cpu.toFixed(0)}%` : 'N/A').join(' → ')
-      const memTrend = values.map(v => v.mem != null ? `${v.mem.toFixed(0)}%` : 'N/A').join(' → ')
+      const cpuTrend = values.map(v => `${v.cpu.toFixed(0)}%`).join(' → ')
+      const memTrend = values.map(v => `${v.mem.toFixed(0)}%`).join(' → ')
       context += `${name}:\n  CPU: ${cpuTrend}\n  Memory: ${memTrend}\n`
     }
   })

--- a/web/src/mocks/handlers.fixtures.ts
+++ b/web/src/mocks/handlers.fixtures.ts
@@ -346,8 +346,8 @@ export function getDefaultUser() {
 // Capped to prevent unbounded memory growth in long-running sessions (#7418).
 /** Maximum number of entries in each in-memory share registry */
 export const MAX_SHARE_REGISTRY_ENTRIES = 500
-export let savedCards: Record<string, unknown> = {}
-export let sharedDashboards: Record<string, unknown> = {}
+export const savedCards: Record<string, unknown> = {}
+export const sharedDashboards: Record<string, unknown> = {}
 
 // ---------------------------------------------------------------------------
 // Demo time-offset constants — used in Date.now() ± N for realistic timestamps
@@ -404,8 +404,8 @@ export function pruneRegistry(registry: Record<string, unknown>) {
  * with a clean registry state (#11035).
  */
 export function resetShareRegistries() {
-  savedCards = {}
-  sharedDashboards = {}
+  for (const k of Object.keys(savedCards)) delete savedCards[k]
+  for (const k of Object.keys(sharedDashboards)) delete sharedDashboards[k]
 }
 
 /** Get default state for savedCards (empty object) */


### PR DESCRIPTION
Fixes #11210

Address MEDIUM Copilot comments from PR #11209, #11186, #11185, #11176.

## Changes

### `workloads.ts` — LOCAL_AGENT_URL const-snapshot fix (PR #11209 MEDIUM comments)
- Replace `LOCAL_AGENT_URL` (a const snapshot of the mutable `LOCAL_AGENT_HTTP_URL`) with `LOCAL_AGENT_HTTP_URL` directly in all workload hooks (`useDeployments`, `useJobs`, `useHPAs`, `useReplicaSets`, `useStatefulSets`, `useDaemonSets`, `useCronJobs`)
- Add `LOCAL_AGENT_HTTP_URL` guard before each agent fetch so `suppressLocalAgent()` is respected at call time, not module-load time
- Remove unused `LOCAL_AGENT_URL` from `shared` import

### Workloads test mocks
- Remove now-unused `LOCAL_AGENT_URL` from `shared` mock
- Add explicit `LOCAL_AGENT_HTTP_URL` to `constants/network` mock for clarity

### `handlers.fixtures.ts` — let→const + O(1) reset (PR #11186 MEDIUM comment)
- Change `savedCards`/`sharedDashboards` from `let` to `const` — prevents accidental reassignment
- Fix `resetShareRegistries()` to clear by key deletion instead of reassignment, preserving object identity for callers that hold a reference and making the clear O(1)

### `useMetricsHistory.ts` — remove dead null checks (PR #11176 MEDIUM comment)
- `v.cpu` and `v.mem` are typed `number` (not `number | null`) after the `{ cpu: number; mem: number }` type predicate — the `!= null` ternaries were always taking the truthy branch

### Compliance test lint fixes
- `card-loading-compliance.spec.ts`: Replace empty `{}` destructure with `_fixtures` (Playwright lint requirement)
- `card-cache-compliance.spec.ts`: Remove pre-declared `let totalCards` that was always reassigned before use; use `const` at point of assignment