### PR TITLE
🐛 Fix mission outcome verification in agent path for partial rollouts

### DIFF
--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -472,13 +472,22 @@ export function useDeployMissions() {
                       // Fall back to 0 for non-finite values.
                       const replicas = safeReplicaCount(match.replicas)
                       const readyReplicas = safeReplicaCount(match.readyReplicas)
+                      // #11211 — Require updatedReplicas >= replicas so a partial
+                      // rollout (old pods still ready, new pods not yet) is not
+                      // marked "running". Mirrors the REST fallback path at ~line 608.
+                      const updatedReplicasRaw = match.updatedReplicas
+                      const updatedReplicas = updatedReplicasRaw === undefined
+                        ? replicas
+                        : safeReplicaCount(updatedReplicasRaw)
                       let status: DeployClusterStatus['status'] = 'applying'
                       // Zero-replica workloads are valid (e.g. scale-to-zero) — treat
                       // readyReplicas >= replicas as success even when both are zero.
-                      if (readyReplicas >= replicas) {
+                      if (String(match.status) === 'Running' && readyReplicas >= replicas && updatedReplicas >= replicas) {
                         status = 'running'
-                      } else if (String(match.status) === 'failed') {
+                      } else if (String(match.status) === 'Failed') {
                         status = 'failed'
+                      } else if (readyReplicas > 0) {
+                        status = 'applying'
                       }
                       // Fetch K8s events via kubectlProxy
                       let logs: string[] | undefined


### PR DESCRIPTION
Fixes #11211

## Problem

The agent-path success verification in `useDeployMissions.ts` only checked `readyReplicas >= replicas` to mark a deployment as successful. This missed two critical guards that the REST fallback path already had:

1. **`status === 'Running'`** — deployment rollout phase must be complete
2. **`updatedReplicas >= replicas`** — ensures the NEW generation pods are ready, not old ones

Without these, during a rolling update the old ReplicaSet's ready pods satisfy the check, causing premature mission success while the new version hasn't started.

## Fix

Aligned the agent path (line ~478) with the REST fallback path (line ~608):
- Added `updatedReplicas` extraction with `safeReplicaCount` and undefined fallback
- Added `String(match.status) === 'Running'` gate
- Added `updatedReplicas >= replicas` gate
- Aligned failed status casing to `'Failed'` (not `'failed'`)
- Added `readyReplicas > 0` intermediate `'applying'` state