### PR TITLE
🐛 fix(e2e): restore {} destructuring in compliance spec test functions

### DIFF
--- a/web/e2e/compliance/card-loading-compliance.spec.ts
+++ b/web/e2e/compliance/card-loading-compliance.spec.ts
@@ -928,7 +928,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
     }
   })
 
-  test('setup — mocks + warmup + manifest', async (_fixtures, testInfo) => {
+  test('setup — mocks + warmup + manifest', async ({}, testInfo) => {
     testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
 
     await setupAuth(sharedPage)
@@ -965,7 +965,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
   // beyond the actual manifest size short-circuit (Playwright requires test
   // declarations at load time, so we can't size this dynamically).
   for (let batchIdx = 0; batchIdx < MAX_EXPECTED_BATCHES; batchIdx++) {
-    test(`cold — batch ${batchIdx + 1}`, async (_fixtures, testInfo) => {
+    test(`cold — batch ${batchIdx + 1}`, async ({}, testInfo) => {
       testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
       if (!complianceState.setupDone) {
         test.skip(true, 'setup did not complete')
@@ -978,7 +978,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
     })
   }
 
-  test('navigate away — between cold and warm phases', async (_fixtures, testInfo) => {
+  test('navigate away — between cold and warm phases', async ({}, testInfo) => {
     testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
     if (!complianceState.setupDone) test.skip(true, 'setup did not complete')
     console.log('[Compliance] Phase 3: Navigate away')
@@ -987,7 +987,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
   })
 
   for (let batchIdx = 0; batchIdx < MAX_EXPECTED_BATCHES; batchIdx++) {
-    test(`warm — batch ${batchIdx + 1}`, async (_fixtures, testInfo) => {
+    test(`warm — batch ${batchIdx + 1}`, async ({}, testInfo) => {
       testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
       if (!complianceState.setupDone) {
         test.skip(true, 'setup did not complete')
@@ -1004,7 +1004,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
     })
   }
 
-  test('aggregate report + cross-batch assertions', async (_fixtures, testInfo) => {
+  test('aggregate report + cross-batch assertions', async ({}, testInfo) => {
     testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
     if (!complianceState.setupDone) test.skip(true, 'setup did not complete')
 


### PR DESCRIPTION
Fixes #11210 regression

PR #11210 accidentally changed `async ({}, testInfo)` → `async (_fixtures, testInfo)` in `card-loading-compliance.spec.ts`. Playwright requires the fixtures argument to use object destructuring — a plain identifier is rejected at parse time with:

```
First argument must use the object destructuring pattern: _fixtures
```

This caused **all 5 compliance test functions** in the Mobile Browser Tests job to fail immediately, making the nightly Playwright run RED.

### Fix
Revert the 5 affected signatures back to `{}`.