### PR TITLE
🐛 fix(fetch): add AbortSignal.timeout to unguarded fetch calls

### DIFF
--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { AlertTriangle, Loader2, Database } from 'lucide-react'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
 import { getDynamicCard } from '../../lib/dynamic-cards/dynamicCardRegistry'
 import { compileCardCode, createCardComponent } from '../../lib/dynamic-cards/compiler'
 import { Skeleton } from '../ui/Skeleton'
@@ -144,6 +145,7 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
       const token = localStorage.getItem(STORAGE_KEY_TOKEN)
       const res = await fetch(apiEndpoint, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const json = await res.json()

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useImperativeHandle, memo, type Ref } from 'react'
 import { GitPullRequest, GitBranch, Star, Users, Package, TrendingUp, AlertCircle, Clock, CheckCircle, XCircle, GitMerge, Settings, X, Plus, Check } from 'lucide-react'
 import { MS_PER_HOUR, MS_PER_DAY } from '../../lib/constants/time'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
 import { formatTimeAgo } from '../../lib/formatters'
 import { Button } from '../ui/Button'
 import { Skeleton } from '../ui/Skeleton'
@@ -246,7 +247,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
       const fetchOptions = { headers }
 
       // Fetch repository info
-      const repoResponse = await fetch(`/api/github/repos/${targetRepo}`, fetchOptions)
+      const repoResponse = await fetch(`/api/github/repos/${targetRepo}`, { ...fetchOptions, signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!repoResponse.ok) throw await githubFetchError(repoResponse, 'Failed to fetch repo')
       const repoData = await repoResponse.json().catch(() => null)
       if (!repoData) throw new Error('Failed to parse GitHub repo response: invalid JSON')
@@ -291,13 +292,13 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
       const filteredIssues = issuesData.filter((issue: GitHubIssue & { pull_request?: unknown }) => !issue.pull_request)
 
       // Fetch Releases
-      const releasesResponse = await fetch(`/api/github/repos/${targetRepo}/releases?per_page=10`, fetchOptions)
+      const releasesResponse = await fetch(`/api/github/repos/${targetRepo}/releases?per_page=10`, { ...fetchOptions, signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!releasesResponse.ok) throw await githubFetchError(releasesResponse, 'Failed to fetch releases')
       const releasesData = await releasesResponse.json().catch(() => null)
       if (!releasesData) throw new Error('Failed to parse GitHub releases response: invalid JSON')
 
       // Fetch Contributors
-      const contributorsResponse = await fetch(`/api/github/repos/${targetRepo}/contributors?per_page=20`, fetchOptions)
+      const contributorsResponse = await fetch(`/api/github/repos/${targetRepo}/contributors?per_page=20`, { ...fetchOptions, signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!contributorsResponse.ok) throw await githubFetchError(contributorsResponse, 'Failed to fetch contributors')
       const contributorsData = await contributorsResponse.json().catch(() => null)
       if (!contributorsData) throw new Error('Failed to parse GitHub contributors response: invalid JSON')


### PR DESCRIPTION
Fixes #10354
Fixes #11218
Fixes #11219

Add `FETCH_DEFAULT_TIMEOUT_MS` signal to fetch calls in `DynamicCard` and `GitHubActivity` that were missing timeout/signal options, causing the `consistency-test` Phase 5 check to fail and the nightly test suite to go RED.