### PR TITLE
🐛 fix(test): update useDeployMissions mocks for Running status + updatedReplicas

### DIFF
--- a/web/src/hooks/__tests__/useDeployMissions.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions.test.ts
@@ -442,7 +442,7 @@ describe('useDeployMissions', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({
-        deployments: [{ name: 'nginx', replicas: 2, readyReplicas: 2 }],
+        deployments: [{ name: 'nginx', replicas: 2, readyReplicas: 2, updatedReplicas: 2, status: 'Running' }],
       }),
     })
     mockKubectlExec.mockResolvedValue({ exitCode: 1, output: '' })
@@ -512,7 +512,7 @@ describe('useDeployMissions', () => {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({
-            deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1 }],
+            deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1, updatedReplicas: 1, status: 'Running' }],
           }),
         })
       }
@@ -548,7 +548,7 @@ describe('useDeployMissions', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({
-        deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1 }],
+        deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1, updatedReplicas: 1, status: 'Running' }],
       }),
     })
     mockKubectlExec.mockResolvedValue({ exitCode: 1, output: '' })
@@ -1005,7 +1005,7 @@ describe('useDeployMissions', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({
-        deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1 }],
+        deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1, updatedReplicas: 1, status: 'Running' }],
       }),
     })
 
@@ -1304,7 +1304,7 @@ describe('useDeployMissions', () => {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({
-            deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1 }],
+            deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1, updatedReplicas: 1, status: 'Running' }],
           }),
         })
       }


### PR DESCRIPTION
Fixes #11226

PR #11213 tightened the agent-path verification in useDeployMissions to require `status: Running` and `updatedReplicas >= replicas` (mirroring the REST path). Five tests mocked agent responses without these fields, causing them to fail.

This PR updates those 5 test mocks to include `status: "Running"` and `updatedReplicas` in the deployment objects where success is expected.