### PR TITLE
🐛 fix(e2e): replace catch-all API mocks with strict endpoint handlers

### DIFF
--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -1,9 +1,42 @@
 import { test, expect } from '@playwright/test'
-import { setupDashboardTest, mockApiFallback } from './helpers/setup'
+import { setupDashboardTest } from './helpers/setup'
+import { setupStrictDemoMode, API_RESPONSES } from './helpers/api-mocks'
 
 test.describe('Dashboard Page', () => {
   test.beforeEach(async ({ page }) => {
-    await setupDashboardTest(page)
+    // Strict API mocking setup — tracks calls and logs unmocked endpoints
+    await setupStrictDemoMode(page, {
+      logUnmocked: true,
+      failOnUnmocked: false, // Gradual migration — log but don't fail
+      customHandlers: [
+        // MCP endpoints for dashboard cards
+        {
+          pattern: '**/api/mcp/**',
+          handler: async (route) => {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify(API_RESPONSES.mcp()),
+            })
+          },
+        },
+      ],
+    })
+
+    // Navigate to dashboard
+    await page.addInitScript(() => {
+      localStorage.setItem('token', 'demo-token')
+      localStorage.setItem('kc-demo-mode', 'true')
+      localStorage.setItem('kc-has-session', 'true')
+      localStorage.setItem('demo-user-onboarded', 'true')
+      localStorage.setItem('kc-backend-status', JSON.stringify({
+        available: true,
+        timestamp: Date.now(),
+      }))
+    })
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+    await page.locator('#root').waitFor({ state: 'visible', timeout: 15000 })
   })
 
   test.describe('Layout and Structure', () => {

--- a/web/e2e/UpdateSettings.spec.ts
+++ b/web/e2e/UpdateSettings.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test'
-import { mockApiFallback } from './helpers/setup'
+import { setupStrictDemoMode } from './helpers/api-mocks'
 
 /**
  * E2E tests for the Settings > System Updates section.
@@ -39,38 +39,46 @@ async function setupUpdateTest(page: Page): Promise<WsRoutes> {
 
   const wsRoutes: WsRoutes = { routes: [] }
 
-  // Catch-all API mock prevents unmocked requests hanging in webkit/firefox
-  await mockApiFallback(page)
-
-  // Mock auth
-  await page.route('**/api/me', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(MOCK_USER),
-    })
-  )
-
-  // Mock health — default to "ok" (individual tests may override after setup)
-  await page.route('**/health', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ status: 'ok', version: 'dev', oauth_configured: true }),
-    })
-  )
-
-  // Mock MCP / agent HTTP endpoints
-  await page.route('**/api/mcp/**', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ clusters: [], issues: [], events: [], nodes: [] }),
-    })
-  )
-  await page.route('http://127.0.0.1:8585/**', (route) =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
-  )
+  // Strict API mocking — logs unmocked calls instead of silently returning {}
+  await setupStrictDemoMode(page, {
+    logUnmocked: true,
+    failOnUnmocked: false,
+    customHandlers: [
+      // Mock auth with test user
+      {
+        pattern: '**/api/me',
+        handler: async (route) =>
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(MOCK_USER),
+          }),
+      },
+      // Mock health — default to "ok" (individual tests may override after setup)
+      {
+        pattern: '**/health',
+        handler: async (route) => {
+          const url = new URL(route.request().url())
+          if (url.pathname !== '/health') return route.fallback()
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ status: 'ok', version: 'dev', oauth_configured: true }),
+          })
+        },
+      },
+      // Mock MCP / agent HTTP endpoints
+      {
+        pattern: '**/api/mcp/**',
+        handler: async (route) =>
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ clusters: [], issues: [], events: [], nodes: [] }),
+          }),
+      },
+    ],
+  })
 
   // Mock the kc-agent WebSocket — capture WebSocketRoute handles from callback
   await page.routeWebSocket('ws://127.0.0.1:8585/**', (ws) => {
@@ -84,11 +92,6 @@ async function setupUpdateTest(page: Page): Promise<WsRoutes> {
       }
     })
   })
-
-  // Catch-all for any remaining /api/** endpoints
-  await page.route('**/api/**', (route) =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
-  )
 
   // Set auth token + skip onboarding/tour BEFORE navigation
   await page.addInitScript(() => {

--- a/web/e2e/helpers/api-mocks.ts
+++ b/web/e2e/helpers/api-mocks.ts
@@ -1,0 +1,359 @@
+import { type Page, type Route } from '@playwright/test'
+
+/**
+ * E2E Strict API Mocking Helper
+ *
+ * Replaces catch-all `page.route('/api/**')` patterns with explicit endpoint
+ * handlers that:
+ *   1. Track which endpoints were called
+ *   2. Log unexpected/unmocked API calls instead of silently returning {}
+ *   3. Provide properly-shaped response data for known endpoints
+ *   4. Fail tests when unexpected endpoints are hit (optional)
+ *
+ * See Issue #11225 — broad catch-all mocks prevent detection of real backend
+ * issues like missing endpoints, broken routes, or malformed responses.
+ *
+ * Usage:
+ *   const apiTracker = await strictApiMocking(page, { failOnUnmocked: false })
+ *   // ... run test ...
+ *   expect(apiTracker.called('/api/me')).toBe(true)
+ *   expect(apiTracker.unmockedCalls).toHaveLength(0)
+ */
+
+// ---------------------------------------------------------------------------
+// Response shape factories — properly typed data for common endpoints
+// ---------------------------------------------------------------------------
+
+export const API_RESPONSES = {
+  /** /api/me — authenticated user */
+  me: () => ({
+    id: '1',
+    github_id: '99999',
+    github_login: 'demo-user',
+    email: 'demo@kubestellar.io',
+    onboarded: true,
+    role: 'admin',
+  }),
+
+  /** /health — backend health check */
+  health: () => ({
+    status: 'ok',
+    version: 'dev',
+    oauth_configured: false,
+    in_cluster: false,
+    no_local_agent: true,
+    install_method: 'dev',
+  }),
+
+  /** /api/active-users — presence tracking */
+  activeUsers: () => ({
+    activeUsers: 1,
+    totalConnections: 1,
+  }),
+
+  /** /api/dashboards — dashboard list */
+  dashboards: () => [],
+
+  /** /api/cards — card list */
+  cards: () => [],
+
+  /** /api/settings — user settings */
+  settings: () => ({}),
+
+  /** /api/mcp/** — MCP/agent endpoints return empty arrays for clusters/issues/events */
+  mcp: () => ({
+    clusters: [],
+    issues: [],
+    events: [],
+    nodes: [],
+    pods: [],
+    deployments: [],
+    services: [],
+    namespaces: [],
+  }),
+
+  /** kc-agent HTTP endpoint — 503 to trigger demo fallback */
+  kcAgentHttp: () => ({
+    status: 503,
+    body: { error: 'Service unavailable (test mock)' },
+  }),
+
+  /** /api/missions/browse — mission catalog */
+  missionsBrowse: () => [],
+
+  /** /api/missions/scores — mission leaderboard */
+  missionsScores: () => ({
+    topScores: [],
+    userScore: null,
+  }),
+
+  /** /api/rewards/github — GitHub contributor rewards */
+  rewardsGithub: () => ({
+    topContributors: [],
+    recentActivity: [],
+  }),
+
+  /** /api/youtube/playlist — YouTube feed */
+  youtubePlaylist: () => ({
+    items: [],
+  }),
+
+  /** /api/medium/blog — Medium blog posts */
+  mediumBlog: () => ({
+    items: [],
+  }),
+
+  /** /api/issue-stats — GitHub issue statistics */
+  issueStats: () => ({
+    open: 0,
+    closed: 0,
+    totalComments: 0,
+  }),
+
+  /** /api/github-pipelines — CI/CD pipeline status */
+  githubPipelines: () => ({
+    workflows: [],
+  }),
+} as const
+
+// ---------------------------------------------------------------------------
+// API call tracker — records which endpoints were hit during the test
+// ---------------------------------------------------------------------------
+
+export interface ApiCallTracker {
+  /** All API calls made during the test (successful mocks + unmocked) */
+  allCalls: string[]
+  /** API calls that had no explicit mock handler */
+  unmockedCalls: string[]
+  /** Check if a specific endpoint was called */
+  called: (endpoint: string) => boolean
+  /** Get call count for an endpoint */
+  callCount: (endpoint: string) => number
+}
+
+function createApiCallTracker(): ApiCallTracker {
+  const allCalls: string[] = []
+  const unmockedCalls: string[] = []
+
+  return {
+    allCalls,
+    unmockedCalls,
+    called: (endpoint: string) => allCalls.some(call => call.includes(endpoint)),
+    callCount: (endpoint: string) => allCalls.filter(call => call.includes(endpoint)).length,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Strict API mocking — explicit handlers with unmocked call tracking
+// ---------------------------------------------------------------------------
+
+export interface StrictApiMockingOptions {
+  /**
+   * If true, unmocked API calls will cause route.abort() (test will see
+   * failed fetch). If false (default), unmocked calls are logged but still
+   * return 200 with {} so existing tests don't break immediately.
+   */
+  failOnUnmocked?: boolean
+
+  /**
+   * If true, console.error will be called for unmocked endpoints so they
+   * appear in test output. Default: true.
+   */
+  logUnmocked?: boolean
+
+  /**
+   * Additional explicit route handlers to register. Called AFTER the
+   * built-in handlers, so they can override defaults if needed.
+   */
+  customHandlers?: Array<{
+    pattern: string | RegExp
+    handler: (route: Route) => Promise<void>
+  }>
+}
+
+/**
+ * Set up strict API mocking with explicit handlers for known endpoints.
+ * Replaces catch-all page.route('/api/**') patterns.
+ *
+ * Returns an ApiCallTracker for asserting on which endpoints were called.
+ */
+export async function strictApiMocking(
+  page: Page,
+  options: StrictApiMockingOptions = {}
+): Promise<ApiCallTracker> {
+  const {
+    failOnUnmocked = false,
+    logUnmocked = true,
+    customHandlers = [],
+  } = options
+
+  const tracker = createApiCallTracker()
+
+  // Helper: standard JSON response
+  const jsonResponse = (data: unknown, status = 200) => ({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(data),
+  })
+
+  // ---------------------------------------------------------------------------
+  // Explicit endpoint handlers (highest priority — registered last)
+  // ---------------------------------------------------------------------------
+
+  // /api/me
+  await page.route('**/api/me', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.me()))
+  })
+
+  // /health (root-level only, not /api/health)
+  await page.route('**/health', async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname !== '/health') {
+      return route.fallback()
+    }
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.health()))
+  })
+
+  // /api/active-users
+  await page.route('**/api/active-users*', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.activeUsers()))
+  })
+
+  // /api/dashboards
+  await page.route('**/api/dashboards*', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.dashboards()))
+  })
+
+  // /api/cards
+  await page.route('**/api/cards*', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.cards()))
+  })
+
+  // /api/settings
+  await page.route('**/api/settings*', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.settings()))
+  })
+
+  // /api/mcp/**
+  await page.route('**/api/mcp/**', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.mcp()))
+  })
+
+  // /api/missions/browse
+  await page.route('**/api/missions/browse*', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.missionsBrowse()))
+  })
+
+  // /api/missions/scores
+  await page.route('**/api/missions/scores*', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.missionsScores()))
+  })
+
+  // /api/rewards/github
+  await page.route('**/api/rewards/github*', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.rewardsGithub()))
+  })
+
+  // /api/youtube/playlist
+  await page.route('**/api/youtube/playlist*', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.youtubePlaylist()))
+  })
+
+  // /api/medium/blog
+  await page.route('**/api/medium/blog*', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.mediumBlog()))
+  })
+
+  // /api/issue-stats
+  await page.route('**/api/issue-stats*', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.issueStats()))
+  })
+
+  // /api/github-pipelines
+  await page.route('**/api/github-pipelines*', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    await route.fulfill(jsonResponse(API_RESPONSES.githubPipelines()))
+  })
+
+  // kc-agent HTTP endpoint (http://127.0.0.1:8585/**)
+  await page.route('http://127.0.0.1:8585/**', async (route) => {
+    tracker.allCalls.push(route.request().url())
+    const { status, body } = API_RESPONSES.kcAgentHttp()
+    await route.fulfill(jsonResponse(body, status))
+  })
+
+  // ---------------------------------------------------------------------------
+  // Custom handlers (if provided)
+  // ---------------------------------------------------------------------------
+
+  for (const { pattern, handler } of customHandlers) {
+    await page.route(pattern, handler)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Catch-all for unmocked /api/** — logs/fails instead of silent {}
+  // ---------------------------------------------------------------------------
+
+  await page.route('**/api/**', async (route) => {
+    const url = route.request().url()
+    tracker.allCalls.push(url)
+    tracker.unmockedCalls.push(url)
+
+    if (logUnmocked) {
+      // eslint-disable-next-line no-console
+      console.error(`[strict-api-mocking] Unmocked API call: ${url}`)
+    }
+
+    if (failOnUnmocked) {
+      // Abort the request — test will see a network error
+      await route.abort('failed')
+    } else {
+      // Return empty object but log the issue
+      await route.fulfill(jsonResponse({}))
+    }
+  })
+
+  return tracker
+}
+
+// ---------------------------------------------------------------------------
+// Helper: setup strict mocking + demo mode localStorage
+// ---------------------------------------------------------------------------
+
+/**
+ * Combined setup: strict API mocking + demo mode localStorage.
+ * Replacement for setupDemoMode() that uses strict mocking.
+ */
+export async function setupStrictDemoMode(
+  page: Page,
+  options: StrictApiMockingOptions = {}
+): Promise<ApiCallTracker> {
+  // Set localStorage before page loads
+  await page.addInitScript(() => {
+    localStorage.setItem('token', 'demo-token')
+    localStorage.setItem('kc-demo-mode', 'true')
+    localStorage.setItem('kc-has-session', 'true')
+    localStorage.setItem('demo-user-onboarded', 'true')
+    localStorage.setItem('kc-backend-status', JSON.stringify({
+      available: true,
+      timestamp: Date.now(),
+    }))
+    localStorage.setItem('kc-agent-setup-dismissed', 'true')
+  })
+
+  // Set up strict API mocking
+  return strictApiMocking(page, options)
+}

--- a/web/e2e/helpers/setup.ts
+++ b/web/e2e/helpers/setup.ts
@@ -175,13 +175,18 @@ export async function mockApiFallback(page: Page) {
   // overrides it. Previously the catch-all was registered last and intercepted /api/active-users
   // before the specific mock, returning {} → Number.isFinite(undefined)=false → error/retry
   // re-render cycles in Firefox/webkit causing DOM instability.
-  await page.route('**/api/**', (route) =>
+  //
+  // STRICT MOCKING: Log unmocked API calls to help detect missing endpoints (#11225)
+  await page.route('**/api/**', (route) => {
+    const url = route.request().url()
+    // eslint-disable-next-line no-console
+    console.error(`[mockApiFallback] Unmocked API call: ${url}`)
     route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({}),
     })
-  )
+  })
 
   // Registered AFTER the catch-all → higher priority. Trailing * matches query params too.
   // Returns valid data so useActiveUsers stays stable (no error state / re-renders).

--- a/web/e2e/mission-control-stress.spec.ts
+++ b/web/e2e/mission-control-stress.spec.ts
@@ -389,14 +389,19 @@ async function setupAllMocks(page: Page) {
   await setupMCPMocks(page)
   await setupMissionsFileMock(page)
 
+  // Strict catch-all — logs unmocked API calls instead of silently returning {}
+  // This helps detect when tests hit endpoints that don't have explicit mocks
   await page.route('**/api/**', (route) => {
     const url = route.request().url()
+    // Let specific mocks handle these endpoints
     if (url.includes('/api/me') || url.includes('/api/mcp') ||
         url.includes('/api/health') || url.includes('/api/github') ||
         url.includes('/api/agent') || url.includes('/api/gadget') ||
         url.includes('/api/missions')) {
       return route.fallback()
     }
+    // eslint-disable-next-line no-console
+    console.error(`[mission-control-stress] Unmocked API call: ${url}`)
     route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
   })
 


### PR DESCRIPTION
Fixes #11225

## Changes

### New: web/e2e/helpers/api-mocks.ts
- `strictApiMocking()` helper providing explicit route handlers for known endpoints
- Catch-all handler that logs unexpected API calls instead of silently returning `{}`
- Response factories for common endpoints with proper data shapes
- API call tracking for assertion in tests
- `setupStrictDemoMode()` combines strict mocking with demo mode localStorage setup

### Updated test files
- **Dashboard.spec.ts**: Replace `setupDashboardTest()` with `setupStrictDemoMode()` + explicit MCP handlers
- **UpdateSettings.spec.ts**: Replace `mockApiFallback()` + catch-all with strict mocking pattern
- **mission-control-stress.spec.ts**: Add logging to catch-all handler to surface unmocked calls
- **helpers/setup.ts**: Add logging to `mockApiFallback()` catch-all for better visibility

### Key improvements
- Unmocked endpoint calls now produce `console.error` messages in test output
- Explicit response shapes prevent `{}` from masking missing data
- API call tracking enables test assertions on which endpoints were hit
- Gradual migration path: `failOnUnmocked: false` logs warnings without breaking existing tests

## Migration path
This PR establishes the pattern and converts 3 key files. Remaining test files can be migrated incrementally using the new `strictApiMocking()` helper.

## Testing
The strict mocking helper is designed for E2E tests running in demo mode. It:
- Returns properly-shaped mock responses for known endpoints
- Logs unmocked calls without breaking tests (gradual migration)
- Provides an opt-in `failOnUnmocked: true` mode for stricter enforcement

Future PRs can:
1. Enable `failOnUnmocked: true` in test files once all endpoints are explicitly mocked
2. Add response shape validation using TypeScript types or runtime schema validation
3. Assert on `tracker.unmockedCalls.length === 0` in tests