### PR TITLE
🐛 Fix liveMocks data shapes, namespace iterator guard, pipeline demo links

### DIFF
--- a/web/e2e/mocks/liveMocks.ts
+++ b/web/e2e/mocks/liveMocks.ts
@@ -27,9 +27,9 @@ export const mockUser = {
 export const MOCK_DATA: Record<string, Record<string, unknown[]>> = {
   clusters: {
     clusters: [
-      { name: MOCK_CLUSTER, reachable: true, status: 'Ready', provider: 'kind', version: '1.28.0', nodes: 3, pods: 12, namespaces: 4, cpuCores: 12, memoryGB: 24, nodeCount: 3, podCount: 12, storageGB: 100 },
-      { name: 'eks-prod', reachable: true, status: 'Ready', provider: 'aws', version: '1.28.0', nodes: 5, pods: 45, namespaces: 8, cpuCores: 20, memoryGB: 64, nodeCount: 5, podCount: 45, storageGB: 200 },
-      { name: 'gke-staging', reachable: true, status: 'Ready', provider: 'gcp', version: '1.28.0', nodes: 3, pods: 32, namespaces: 5, cpuCores: 12, memoryGB: 48, nodeCount: 3, podCount: 32, storageGB: 100 },
+      { name: MOCK_CLUSTER, reachable: true, status: 'Ready', provider: 'kind', version: '1.28.0', nodes: 3, pods: 12, namespaces: ["default","kube-system","kube-public","argocd"], cpuCores: 12, memoryGB: 24, nodeCount: 3, podCount: 12, storageGB: 100 },
+      { name: 'eks-prod', reachable: true, status: 'Ready', provider: 'aws', version: '1.28.0', nodes: 5, pods: 45, namespaces: ["default","kube-system","kube-public","argocd","istio-system","monitoring","cert-manager","ingress-nginx"], cpuCores: 20, memoryGB: 64, nodeCount: 5, podCount: 45, storageGB: 200 },
+      { name: 'gke-staging', reachable: true, status: 'Ready', provider: 'gcp', version: '1.28.0', nodes: 3, pods: 32, namespaces: ["default","kube-system","kube-public","argocd","monitoring"], cpuCores: 12, memoryGB: 48, nodeCount: 3, podCount: 32, storageGB: 100 },
     ],
   },
   pods: {

--- a/web/src/components/cards/pipelines/PipelineFilterBar.tsx
+++ b/web/src/components/cards/pipelines/PipelineFilterBar.tsx
@@ -120,15 +120,17 @@ export function PipelineFilterBar() {
               >
                 {short}
               </button>
-              <button
-                type="button"
-                onClick={(e) => { e.stopPropagation(); isDemo ? showInstallGate() : removeRepo(repo) }}
-                className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded-full hover:bg-red-500/20 text-muted-foreground hover:text-red-400"
-                title={LABEL_REMOVE_REPO}
-                aria-label={`${LABEL_REMOVE_REPO}: ${repo}`}
-              >
-                <X className="w-2.5 h-2.5" />
-              </button>
+              {!isDemo && (
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); removeRepo(repo) }}
+                  className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded-full hover:bg-red-500/20 text-muted-foreground hover:text-red-400"
+                  title={LABEL_REMOVE_REPO}
+                  aria-label={`${LABEL_REMOVE_REPO}: ${repo}`}
+                >
+                  <X className="w-2.5 h-2.5" />
+                </button>
+              )}
             </span>
           )
         })}

--- a/web/src/components/cards/pipelines/PipelineFlow.tsx
+++ b/web/src/components/cards/pipelines/PipelineFlow.tsx
@@ -289,15 +289,17 @@ function RunRow({ run, onCancel, canMutate, mutating }: RunRowProps) {
       {/* Actions — inline at the end of the steps column so they don't
            get clipped by the card's overflow-auto scroll container. */}
       <div className="relative z-20 flex items-center gap-1 justify-end pt-1">
-        <a
-          href={run.run.htmlUrl}
-          target="_blank"
-          rel="noreferrer noopener"
-          className="text-muted-foreground hover:text-foreground p-1 rounded hover:bg-secondary/50"
-          title={TITLE_OPEN_RUN}
-        >
-          <ExternalLink className="w-3 h-3" />
-        </a>
+        {run.run.htmlUrl && run.run.htmlUrl !== '#' && (
+          <a
+            href={run.run.htmlUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-muted-foreground hover:text-foreground p-1 rounded hover:bg-secondary/50"
+            title={TITLE_OPEN_RUN}
+          >
+            <ExternalLink className="w-3 h-3" />
+          </a>
+        )}
         {isActive(run.run.status) && (
           <button
             type="button"

--- a/web/src/hooks/mcp/namespaces.ts
+++ b/web/src/hooks/mcp/namespaces.ts
@@ -25,7 +25,7 @@ function mergeWithClusterCache(fetched: string[], cluster: string): string[] {
     if (ns) set.add(ns)
   }
   const cachedCluster = clusterCacheRef.clusters.find(c => c.name === cluster)
-  if (cachedCluster?.namespaces) {
+  if (Array.isArray(cachedCluster?.namespaces)) {
     for (const ns of cachedCluster.namespaces) {
       if (ns) set.add(ns)
     }


### PR DESCRIPTION
Fixes #11206

## Root-cause fixes for nightlyPlaywright RED failures

### liveMocks.ts — wrong data shapes caused TypeError crashes
- **Namespace integers** (4, 8, 5) changed to string arrays — `for...of number` threw TypeError crashing namespace-fetching hooks
- **kagent-crds status** was `{ phase: 'Ready' }` (object) → changed to `'Ready'` (string) to prevent React error #31 (object as React child)
- **jaeger-status** was missing `metrics` field → added full shape so `servicesCount` lookup doesn't throw undefined TypeError

### namespaces.ts — truthy check passed for integers
- `if (cachedCluster?.namespaces)` → `if (Array.isArray(cachedCluster?.namespaces))`
- Integer `4` is truthy, bypassed the check, then `for...of 4` crashed the entire dashboard via AppErrorBoundary

### PipelineFlow. bare '#' href rendered as linktsx 
- Skip `<a href>` entirely when `htmlUrl === '#'` (demo data placeholder)
- Consistent with the guard already present in NightlyReleasePulse.tsx and WorkflowMatrix.tsx

### PipelineFilterBar.tsx — demo mode showed remove button calling install gate
- Hide remove-repo button entirely when `isDemo === true` (was calling `showInstallGate()`)
- Tests in demo mode expect 0 remove buttons visible

## Validation
- `npm run build` ✅
- `npm run lint` ✅ (exit 0)