### PR TITLE
🐛 fix(ci): restrict pr-verifier.yml GITHUB_TOKEN permissions (TokenPermissionsID)

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -5,10 +5,7 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  checks: write
   contents: read
-  pull-requests: read
-  packages: read
 
 jobs:
   verify-pr:
@@ -16,6 +13,10 @@ jobs:
     # Skip verification for dependabot PRs — they use different title conventions
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
     steps:
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0


### PR DESCRIPTION
Fixes #11233

## Summary

CodeQL alert #666 (HIGH / TokenPermissionsID) flagged the top-level `checks: write` permission in `.github/workflows/pr-verifier.yml` as over-broad.

## Changes

- **Removed** top-level `checks: write` permission (was never used — the workflow creates no check runs)
- **Set** top-level `permissions: contents: read` as the deny-by-default baseline
- **Added** explicit job-level permissions on `verify-pr`:
  - `contents: read` — workspace access
  - `packages: read` — GHCR login/pull of the verifier image
  - `pull-requests: write` — verifier container posts PR comments via GITHUB_TOKEN

## Security impact

| Permission | Before | After |
|---|---|---|
| `checks` | `write` (top-level) | *(removed)* |
| `contents` | `read` (top-level) | `read` (job-level) |
| `packages` | `read` (top-level) | `read` (job-level) |
| `pull-requests` | `read` (top-level) | `write` (job-level, needed for verifier comments) |