### PR TITLE
🐛 fix(useDeployMissions): lowercase agent deployment status check

### DIFF
--- a/web/src/hooks/__tests__/useDeployMissions.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions.test.ts
@@ -442,7 +442,7 @@ describe('useDeployMissions', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({
-        deployments: [{ name: 'nginx', replicas: 2, readyReplicas: 2, updatedReplicas: 2, status: 'Running' }],
+        deployments: [{ name: 'nginx', replicas: 2, readyReplicas: 2, updatedReplicas: 2, status: 'running' }],
       }),
     })
     mockKubectlExec.mockResolvedValue({ exitCode: 1, output: '' })
@@ -512,7 +512,7 @@ describe('useDeployMissions', () => {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({
-            deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1, updatedReplicas: 1, status: 'Running' }],
+            deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1, updatedReplicas: 1, status: 'running' }],
           }),
         })
       }
@@ -548,7 +548,7 @@ describe('useDeployMissions', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({
-        deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1, updatedReplicas: 1, status: 'Running' }],
+        deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1, updatedReplicas: 1, status: 'running' }],
       }),
     })
     mockKubectlExec.mockResolvedValue({ exitCode: 1, output: '' })
@@ -1005,7 +1005,7 @@ describe('useDeployMissions', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({
-        deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1, updatedReplicas: 1, status: 'Running' }],
+        deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1, updatedReplicas: 1, status: 'running' }],
       }),
     })
 
@@ -1304,7 +1304,7 @@ describe('useDeployMissions', () => {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({
-            deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1, updatedReplicas: 1, status: 'Running' }],
+            deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1, updatedReplicas: 1, status: 'running' }],
           }),
         })
       }

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -482,7 +482,7 @@ export function useDeployMissions() {
                       let status: DeployClusterStatus['status'] = 'applying'
                       // Zero-replica workloads are valid (e.g. scale-to-zero) — treat
                       // readyReplicas >= replicas as success even when both are zero.
-                      if (String(match.status) === 'Running'
+                      if (String(match.status) === 'running'
                           && readyReplicas >= replicas
                           && agentUpdated >= replicas) {
                         status = 'running'


### PR DESCRIPTION
Fixes Copilot MEDIUM comment on #11213 (useDeployMissions.ts:490)

## Root Cause

The kc-agent `/deployments` endpoint returns lowercase status values (`running`, `deploying`, `failed`) as documented in `pkg/k8s/client.go` Deployment type:
```go
Status string `json:"status"` // running, deploying, failed
```

The agent-path check at line 485 was comparing against `'Running'` (capital R), which never matched in production. Missions using the agent path were permanently stuck in `'applying'` state.

## Fix

- `useDeployMissions.ts:485`: `'Running'` → `'running'`
- `useDeployMissions.test.ts`: agent `deployments` mocks updated to lowercase to correctly model the wire format (REST path mocks at lines 584/729/884/916/1184 keep `'Running'` — the K8s deploy-status API uses Kubernetes-style casing)

## Testing

52 tests pass (`npx vitest run useDeployMissions.test.ts`).