### PR TITLE
🐛 fix(test): add missing mockApiFallback import in Dashboard.spec.ts

### DIFF
--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { setupDashboardTest } from './helpers/setup'
+import { setupDashboardTest, mockApiFallback } from './helpers/setup'
 import { setupStrictDemoMode, API_RESPONSES } from './helpers/api-mocks'
 
 test.describe('Dashboard Page', () => {


### PR DESCRIPTION
Fixes #11236

The Playwright Cross-Browser (Nightly) workflow fails on all browsers with `ReferenceError: mockApiFallback is not defined` in the Dashboard Data Accuracy test block. The function is called at line 583 but was never imported.

This PR adds the missing import from `./helpers/setup` so the nightly cross-browser tests pass again.