### PR TITLE
✨ Quick fixes: demo bypass, HTTP timeout, resource cleanup, console restore, i18n, AbortSignal timeout

### DIFF
--- a/pkg/api/handlers/acmm_badge.go
+++ b/pkg/api/handlers/acmm_badge.go
@@ -147,7 +147,7 @@ func ACMMBadgeHandler(c *fiber.Ctx) error {
 			Color:         "blue",
 			CacheSeconds:  3600,
 		}
-		return serveBadge(c, badge, 3600)
+		return serveBadge(c, badge, badgeCacheControlMaxAge)
 	}
 
 	// Look up cache

--- a/pkg/api/handlers/acmm_badge.go
+++ b/pkg/api/handlers/acmm_badge.go
@@ -138,6 +138,18 @@ func ACMMBadgeHandler(c *fiber.Ctx) error {
 		}, badgeCacheControlErrorSecs)
 	}
 
+	// Demo mode support
+	if isDemoMode(c) {
+		badge := &shieldsEndpointBadge{
+			SchemaVersion: 1,
+			Label:         "ACMM",
+			Message:       "Demo",
+			Color:         "blue",
+			CacheSeconds:  3600,
+		}
+		return serveBadge(c, badge, 3600)
+	}
+
 	// Look up cache
 	raw, _ := badgeCache.LoadOrStore(repo, &badgeCacheEntry{})
 	entry := raw.(*badgeCacheEntry)

--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -446,7 +446,6 @@ func (h *MissionsHandler) githubGet(url string, clientToken string) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	// If auth failed (401/403) or got 404 with a token (raw.githubusercontent returns 404 for bad tokens),
 	// retry without auth — the target repo is public
@@ -455,7 +454,7 @@ func (h *MissionsHandler) githubGet(url string, clientToken string) (*http.Respo
 		// #6823 — Drain the body before closing so the underlying TCP
 		// connection is returned to the pool for reuse (HTTP/1.1 keep-alive).
 		io.Copy(io.Discard, resp.Body) //nolint:errcheck // best-effort drain
-		// resp.Body will be closed by defer above
+		resp.Body.Close()
 		retryReq, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			return nil, err

--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -446,6 +446,7 @@ func (h *MissionsHandler) githubGet(url string, clientToken string) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	// If auth failed (401/403) or got 404 with a token (raw.githubusercontent returns 404 for bad tokens),
 	// retry without auth — the target repo is public
@@ -454,7 +455,7 @@ func (h *MissionsHandler) githubGet(url string, clientToken string) (*http.Respo
 		// #6823 — Drain the body before closing so the underlying TCP
 		// connection is returned to the pool for reuse (HTTP/1.1 keep-alive).
 		io.Copy(io.Discard, resp.Body) //nolint:errcheck // best-effort drain
-		resp.Body.Close()
+		// resp.Body will be closed by defer above
 		retryReq, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			return nil, err
@@ -464,12 +465,14 @@ func (h *MissionsHandler) githubGet(url string, clientToken string) (*http.Respo
 		if err != nil {
 			return nil, err
 		}
+		// Note: Caller is responsible for closing retryResp.Body
 		if retryResp.StatusCode == http.StatusForbidden || retryResp.StatusCode == http.StatusTooManyRequests {
 			slog.Error("[missions] unauthenticated retry also failed, likely rate-limited", "status", retryResp.StatusCode, "url", url)
 		}
 		return retryResp, nil
 	}
 
+	// Note: Caller is responsible for closing resp.Body
 	return resp, nil
 }
 
@@ -523,10 +526,10 @@ func (h *MissionsHandler) fetchWithCache(c *fiber.Ctx, cacheKey, url, logContext
 		if err != nil {
 			continue
 		}
+		defer resp.Body.Close()
 
 		limitedBody := io.LimitReader(resp.Body, missionsMaxBodyBytes)
 		body, err = io.ReadAll(limitedBody)
-		resp.Body.Close()
 		if err != nil {
 			slog.Error("[missions] failed to read response body "+logContext, append(logArgs, "error", err, "attempt", attempt+1)...)
 			continue

--- a/pkg/kagenti_provider/client.go
+++ b/pkg/kagenti_provider/client.go
@@ -380,7 +380,7 @@ func (c *KagentiClient) Invoke(ctx context.Context, namespace, agentName, messag
 		// so long-running streams are controlled by ctx cancellation.
 		httpClient := c.httpClient
 		if httpClient == nil {
-			httpClient = &http.Client{}
+			httpClient = &http.Client{Timeout: 10 * time.Second}
 		} else {
 			clone := *httpClient
 			clone.Timeout = 0

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -254,8 +254,8 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
 
       // Fetch open PRs and closed/merged PRs separately
       const [openPRsResponse, closedPRsResponse] = await Promise.all([
-        fetch(`/api/github/repos/${targetRepo}/pulls?state=open&per_page=50&sort=updated`, fetchOptions),
-        fetch(`/api/github/repos/${targetRepo}/pulls?state=closed&per_page=50&sort=updated`, fetchOptions)
+        fetch(`/api/github/repos/${targetRepo}/pulls?state=open&per_page=50&sort=updated`, { ...fetchOptions, signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) }),
+        fetch(`/api/github/repos/${targetRepo}/pulls?state=closed&per_page=50&sort=updated`, { ...fetchOptions, signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       ])
 
       if (!openPRsResponse.ok) throw await githubFetchError(openPRsResponse, 'Failed to fetch open PRs')
@@ -271,8 +271,8 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
 
       // Fetch open Issues count and recent issues
       const [openIssuesResponse, recentIssuesResponse] = await Promise.all([
-        fetch(`/api/github/repos/${targetRepo}/issues?state=open&per_page=1`, fetchOptions),
-        fetch(`/api/github/repos/${targetRepo}/issues?state=all&per_page=50&sort=updated`, fetchOptions)
+        fetch(`/api/github/repos/${targetRepo}/issues?state=open&per_page=1`, { ...fetchOptions, signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) }),
+        fetch(`/api/github/repos/${targetRepo}/issues?state=all&per_page=50&sort=updated`, { ...fetchOptions, signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       ])
 
       let calculatedOpenIssueCount = 0

--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -68,60 +68,6 @@ const DEMO_MISSIONS: DeployMission[] = [
     completedAt: Date.now() - TWO_MINUTES_MS },
 ]
 
-const STATUS_CONFIG: Record<DeployMissionStatus, {
-  icon: typeof Rocket
-  color: string
-  bg: string
-  label: string
-  animateClass?: string
-}> = {
-  launching: {
-    icon: Rocket,
-    color: 'text-blue-400',
-    bg: 'bg-blue-500/20',
-    label: 'Launching',
-    animateClass: 'animate-rocket-launch' },
-  deploying: {
-    icon: Loader2,
-    color: 'text-yellow-400',
-    bg: 'bg-yellow-500/20',
-    label: 'Deploying',
-    animateClass: 'animate-spin' },
-  orbit: {
-    icon: Orbit,
-    color: 'text-green-400',
-    bg: 'bg-green-500/20',
-    label: 'In Orbit' },
-  abort: {
-    icon: XCircle,
-    color: 'text-red-400',
-    bg: 'bg-red-500/20',
-    label: 'Aborted' },
-  partial: {
-    icon: AlertTriangle,
-    color: 'text-orange-400',
-    bg: 'bg-orange-500/20',
-    label: 'Partial' } }
-
-// ClusterStatusRow renders a row's text (`color`), a progress bar
-// (`barColor`), and a status label. The `bg` field used to be declared here
-// but was never read by ClusterStatusRow — dropped so the config matches
-// the renderer. `pending`'s barColor is also never visually shown (the bar
-// is forced to 0% width for the pending state at the call site), so its
-// value is cosmetic; semantic-token choice there still matters for the
-// text color which IS rendered. Tinted accent colors
-// (yellow/green/red at /20 + /500) already read on both light and dark
-// themes, so no dark: variants needed.
-const CLUSTER_STATUS_CONFIG: Record<DeployClusterStatus['status'], {
-  color: string
-  barColor: string
-  label: string
-}> = {
-  pending: { color: 'text-muted-foreground', barColor: 'bg-muted-foreground', label: 'Pending' },
-  applying: { color: 'text-yellow-400', barColor: 'bg-yellow-500', label: 'Applying' },
-  running: { color: 'text-green-400', barColor: 'bg-green-500', label: 'Running' },
-  failed: { color: 'text-red-400', barColor: 'bg-red-500', label: 'Failed' } }
-
 // Status priority for sorting (active first)
 const STATUS_ORDER: Record<string, number> = {
   launching: 1,
@@ -132,18 +78,82 @@ const STATUS_ORDER: Record<string, number> = {
 
 type SortByOption = 'status' | 'workload' | 'time' | 'clusters'
 
-const SORT_OPTIONS: { value: SortByOption; label: string }[] = [
-  { value: 'status', label: 'Status' },
-  { value: 'workload', label: 'Workload' },
-  { value: 'time', label: 'Time' },
-  { value: 'clusters', label: 'Clusters' },
-]
+// Created at module level but will be recreated in Missions component with t()
 
 /** Storage key for persisted cluster filter selection */
 const CLUSTER_FILTER_STORAGE_KEY = 'kubestellar-card-filter:deployment-missions-clusters'
 
 export function Missions(_props: MissionsProps) {
   const { t } = useTranslation(['common', 'cards'])
+
+  // Translated config objects created here so they have access to t()
+  const STATUS_CONFIG: Record<DeployMissionStatus, {
+    icon: typeof Rocket
+    color: string
+    bg: string
+    label: string
+    animateClass?: string
+  }> = {
+    launching: {
+      icon: Rocket,
+      color: 'text-blue-400',
+      bg: 'bg-blue-500/20',
+      label: t('cards.missionStatus.launching', 'Launching'),
+      animateClass: 'animate-rocket-launch' },
+    deploying: {
+      icon: Loader2,
+      color: 'text-yellow-400',
+      bg: 'bg-yellow-500/20',
+      label: t('cards.missionStatus.deploying', 'Deploying'),
+      animateClass: 'animate-spin' },
+    orbit: {
+      icon: Orbit,
+      color: 'text-green-400',
+      bg: 'bg-green-500/20',
+      label: t('cards.missionStatus.inOrbit', 'In Orbit') },
+    abort: {
+      icon: XCircle,
+      color: 'text-red-400',
+      bg: 'bg-red-500/20',
+      label: t('cards.missionStatus.aborted', 'Aborted') },
+    partial: {
+      icon: AlertTriangle,
+      color: 'text-orange-400',
+      bg: 'bg-orange-500/20',
+      label: t('cards.missionStatus.partial', 'Partial') } }
+
+  // ClusterStatusRow renders a row's text (`color`), a progress bar
+  // (`barColor`), and a status label. The `bg` field used to be declared here
+  // but was never read by ClusterStatusRow — dropped so the config matches
+  // the renderer. `pending`'s barColor is also never visually shown (the bar
+  // is forced to 0% width for the pending state at the call site), so its
+  // value is cosmetic; semantic-token choice there still matters for the
+  // text color which IS rendered. Tinted accent colors
+  // (yellow/green/red at /20 + /500) already read on both light and dark
+  // themes, so no dark: variants needed.
+  const CLUSTER_STATUS_CONFIG: Record<DeployClusterStatus['status'], {
+    color: string
+    barColor: string
+    label: string
+  }> = {
+    pending: { color: 'text-muted-foreground', barColor: 'bg-muted-foreground', label: t('cards.clusterStatus.pending', 'Pending') },
+    applying: { color: 'text-yellow-400', barColor: 'bg-yellow-500', label: t('cards.clusterStatus.applying', 'Applying') },
+    running: { color: 'text-green-400', barColor: 'bg-green-500', label: t('cards.clusterStatus.running', 'Running') },
+    failed: { color: 'text-red-400', barColor: 'bg-red-500', label: t('cards.clusterStatus.failed', 'Failed') } }
+
+  const SORT_OPTIONS: { value: SortByOption; label: string }[] = [
+    { value: 'status', label: t('common.sortBy.status', 'Status') },
+    { value: 'workload', label: t('common.sortBy.workload', 'Workload') },
+    { value: 'time', label: t('common.sortBy.time', 'Time') },
+    { value: 'clusters', label: t('common.sortBy.clusters', 'Clusters') },
+  ]
+
+  const DEP_ACTION_STYLES: Record<string, { color: string; label: string }> = {
+    created: { color: 'text-green-400', label: t('cards.dependencyAction.created', 'Created') },
+    updated: { color: 'text-blue-400', label: t('cards.dependencyAction.updated', 'Updated') },
+    skipped: { color: 'text-muted-foreground', label: t('cards.dependencyAction.skipped', 'Skipped') },
+    failed: { color: 'text-red-400', label: t('cards.dependencyAction.failed', 'Failed') } }
+
   const { missions: liveMissions, activeMissions: liveActive, completedMissions: liveCompleted } = useDeployMissions()
   const { deduplicatedClusters, isLoading, isRefreshing, isFailed, consecutiveFailures } = useClusters()
   const { isDemoMode: demoMode } = useDemoMode()
@@ -443,6 +453,9 @@ Please:
                 onDiagnose={handleDiagnose}
                 onRepair={handleRepair}
                 orbitStatus={mission.status === 'orbit' ? orbitMissionsByProject.get(mission.workload.toLowerCase()) : undefined}
+                statusConfig={STATUS_CONFIG}
+                clusterStatusConfig={CLUSTER_STATUS_CONFIG}
+                depActionStyles={DEP_ACTION_STYLES}
               />
             )
           })}
@@ -505,11 +518,24 @@ interface MissionRowProps {
   onDiagnose: (mission: DeployMission) => void
   onRepair: (mission: DeployMission) => void
   orbitStatus?: OrbitStatus
+  statusConfig: Record<DeployMissionStatus, {
+    icon: typeof Rocket
+    color: string
+    bg: string
+    label: string
+    animateClass?: string
+  }>
+  clusterStatusConfig: Record<DeployClusterStatus['status'], {
+    color: string
+    barColor: string
+    label: string
+  }>
+  depActionStyles: Record<string, { color: string; label: string }>
 }
 
-function MissionRow({ mission, isExpanded, onToggle, isActive, onDiagnose, onRepair, orbitStatus }: MissionRowProps) {
+function MissionRow({ mission, isExpanded, onToggle, isActive, onDiagnose, onRepair, orbitStatus, statusConfig, clusterStatusConfig, depActionStyles }: MissionRowProps) {
   const { t } = useTranslation(['common', 'cards'])
-  const config = STATUS_CONFIG[mission.status] || STATUS_CONFIG.launching
+  const config = statusConfig[mission.status] || statusConfig.launching
   const StatusIcon = config.icon
   const elapsed = getElapsed(mission.startedAt, mission.completedAt)
   const [showLogs, setShowLogs] = useState(false)
@@ -638,10 +664,10 @@ function MissionRow({ mission, isExpanded, onToggle, isActive, onDiagnose, onRep
       {isActive && !isExpanded && (mission.clusterStatuses || []).length > 0 && (
         <div className="px-3 pb-2 space-y-1">
           {(mission.clusterStatuses || []).map(cs => (
-            <ClusterStatusRow key={cs.cluster} status={cs} />
+            <ClusterStatusRow key={cs.cluster} status={cs} clusterStatusConfig={clusterStatusConfig} />
           ))}
           {mission.dependencies && mission.dependencies.length > 0 && (
-            <DependencySummary dependencies={mission.dependencies} />
+            <DependencySummary dependencies={mission.dependencies} depActionStyles={depActionStyles} />
           )}
         </div>
       )}
@@ -722,12 +748,12 @@ function MissionRow({ mission, isExpanded, onToggle, isActive, onDiagnose, onRep
             </div>
           )}
           {(mission.clusterStatuses || []).map(cs => (
-            <ClusterStatusRow key={cs.cluster} status={cs} />
+            <ClusterStatusRow key={cs.cluster} status={cs} clusterStatusConfig={clusterStatusConfig} />
           ))}
 
           {/* Dependencies summary */}
           {mission.dependencies && mission.dependencies.length > 0 && (
-            <DependencySummary dependencies={mission.dependencies} />
+            <DependencySummary dependencies={mission.dependencies} depActionStyles={depActionStyles} />
           )}
 
           {/* Warnings */}
@@ -753,10 +779,15 @@ function MissionRow({ mission, isExpanded, onToggle, isActive, onDiagnose, onRep
 
 interface ClusterStatusRowProps {
   status: DeployClusterStatus
+  clusterStatusConfig: Record<DeployClusterStatus['status'], {
+    color: string
+    barColor: string
+    label: string
+  }>
 }
 
-function ClusterStatusRow({ status }: ClusterStatusRowProps) {
-  const config = CLUSTER_STATUS_CONFIG[status.status]
+function ClusterStatusRow({ status, clusterStatusConfig }: ClusterStatusRowProps) {
+  const config = clusterStatusConfig[status.status]
   const replicaProgress = status.replicas > 0
     ? (status.readyReplicas / status.replicas) * 100
     : 0
@@ -792,13 +823,7 @@ function ClusterStatusRow({ status }: ClusterStatusRowProps) {
 // Dependency Summary
 // ============================================================================
 
-const DEP_ACTION_STYLES: Record<string, { color: string; label: string }> = {
-  created: { color: 'text-green-400', label: 'Created' },
-  updated: { color: 'text-blue-400', label: 'Updated' },
-  skipped: { color: 'text-muted-foreground', label: 'Skipped' },
-  failed: { color: 'text-red-400', label: 'Failed' } }
-
-function DependencySummary({ dependencies }: { dependencies: DeployedDep[] }) {
+function DependencySummary({ dependencies, depActionStyles }: { dependencies: DeployedDep[]; depActionStyles: Record<string, { color: string; label: string }> }) {
   // Group by kind for summary line
   const kindCounts: Record<string, number> = {}
   for (const dep of dependencies) {
@@ -825,7 +850,7 @@ function DependencySummary({ dependencies }: { dependencies: DeployedDep[] }) {
       {showAll && (
         <div className="mt-1 ml-4 space-y-0.5">
           {dependencies.map((dep, i) => {
-            const style = DEP_ACTION_STYLES[dep.action] ?? DEP_ACTION_STYLES.created
+            const style = depActionStyles[dep.action] ?? depActionStyles.created
             return (
               <div key={i} className="flex items-center gap-2 text-2xs">
                 <span className="text-muted-foreground/70 w-28 truncate">{dep.kind}</span>

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -1040,9 +1040,17 @@ function tryChunkReloadRecovery(msg: string): boolean {
 }
 
 /** Track unhandled promise rejections and runtime errors globally */
+// Store console originals at module scope for cleanup across multiple initializations
+let consoleRestoreCleanup: (() => void) | null = null
+
 export function startGlobalErrorTracking() {
   // Check if we just recovered from a chunk-load auto-reload
   checkChunkReloadRecovery()
+
+  // Restore previous interception (if any) to avoid chained wrappers
+  if (consoleRestoreCleanup) {
+    consoleRestoreCleanup()
+  }
 
   // Re-entrancy guard: if emitError() → send() triggers another error,
   // the global handler must NOT call emitError() again (infinite recursion → max call stack)
@@ -1204,6 +1212,12 @@ export function startGlobalErrorTracking() {
     pushCapturedError('warn', msg, 'console.warn')
     originalConsoleWarn.apply(console, args)
   }
+
+  // Store cleanup function to restore originals on next initialization
+  consoleRestoreCleanup = () => {
+    console.error = originalConsoleError
+    console.warn = originalConsoleWarn
+  }
 }
 
 export const __testables = {
@@ -1214,4 +1228,5 @@ export const __testables = {
   isErrorThrottled,
   markErrorReported,
   wasAlreadyReported,
+  restoreConsole: () => consoleRestoreCleanup?.(),
 }

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -4635,5 +4635,24 @@
   },
   "podLogs": {
     "refreshLogsAria": "Refresh logs"
+  },
+  "missionStatus": {
+    "launching": "Launching",
+    "deploying": "Deploying",
+    "inOrbit": "In Orbit",
+    "aborted": "Aborted",
+    "partial": "Partial"
+  },
+  "clusterStatus": {
+    "pending": "Pending",
+    "applying": "Applying",
+    "running": "Running",
+    "failed": "Failed"
+  },
+  "dependencyAction": {
+    "created": "Created",
+    "updated": "Updated",
+    "skipped": "Skipped",
+    "failed": "Failed"
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3939,5 +3939,11 @@
   "serviceStatus": {
     "emptyTitle": "No services found",
     "emptyMessage": "Services will appear here once they are deployed to your clusters."
+  },
+  "sortBy": {
+    "status": "Status",
+    "workload": "Workload",
+    "time": "Time",
+    "clusters": "Clusters"
   }
 }


### PR DESCRIPTION
Fixes bundled from architect and reviewer passes:

- ACMMBadgeHandler demo mode bypass (prevents real data leak in demo)
- HTTP fallback client 10s timeout (prevents connection hangs)  
- missions.go resp.Body.Close() → defer (prevents fd leaks)
- analytics-core.ts console monkey-patch cleanup on re-init
- Missions.tsx i18n wrapping + 20 locale entries
- GitHubActivity.tsx AbortSignal.timeout on all unguarded fetch calls