### PR TITLE
🐛 Add helpful error message when frontend build fails in startup-oauth.sh

### DIFF
--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -478,7 +478,22 @@ else
 
     write_stage "frontend_build"
     echo -e "${GREEN}Building frontend...${NC}"
-    (cd web && npm run build)
+    if ! (cd web && npm run build); then
+        echo ""
+        echo -e "${RED}========================================${NC}"
+        echo -e "${RED}  Frontend build failed.${NC}"
+        echo -e "${RED}========================================${NC}"
+        echo ""
+        echo "  This often happens after pulling new changes."
+        echo "  Try:"
+        echo "    1. git pull origin main"
+        echo "    2. cd web && npm install"
+        echo "    3. Re-run ./startup-oauth.sh"
+        echo ""
+        echo "  If the error persists, check the build output above for details."
+        echo ""
+        exit 1
+    fi
     echo -e "${GREEN}Frontend built successfully${NC}"
 
     # Start backend on port 8081 — watchdog on 8080 proxies to it


### PR DESCRIPTION
Fixes #11248

When `startup-oauth.sh` runs in production mode and the frontend build fails (commonly TS5101 from stale checkouts), the script now prints clear remediation steps instead of exiting with only the raw TypeScript error.

### Changes
- Wrap `npm run build` in startup-oauth.sh production mode with error handling
- Print actionable guidance: git pull + npm install + re-run
- Dev mode (`--dev`) uses Vite dev server and has no build step, so no change needed there

Supersedes #11249 (which has merge conflicts and missing DCO sign-off).