### PR TITLE
fix(github_pipelines): add error handling for repos JSON marshal

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -520,7 +520,10 @@ func (h *GitHubPipelinesHandler) serveCached(c *fiber.Ctx, key string, build fun
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "marshal failed"})
 	}
 	// Build merged JSON: { ...payload, "repos": [...] }
-	reposJSON, _ := json.Marshal(ghpRepos)
+	reposJSON, err := json.Marshal(ghpRepos)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "repos marshal failed"})
+	}
 	var body []byte
 	if len(inner) > 2 && inner[0] == '{' {
 		// Merge repos into existing object.


### PR DESCRIPTION
Fixes silent failure when repos JSON marshaling fails.

- Check json.Marshal error for reposJSON at line 523
- Return HTTP 500 with error message if marshal fails
- Prevents invalid JSON from being cached or served to frontend

Fixes P0 issue: Missing error handling in JSON marshal