### PR TITLE
fix(websocket): add eviction for unbounded demoSessions map

### DIFF
--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -48,6 +48,9 @@ const (
 	// is a safe upper bound for a single instance; scale horizontally for higher capacity.
 	// Configurable via WS_MAX_CONNECTIONS environment variable.
 	defaultMaxWebSocketConnections = 1000
+	// wsEvictionInterval is how often to evict stale demo sessions from the hub map.
+	// Prevents unbounded memory growth in long-running servers.
+	wsEvictionInterval = 5 * time.Minute
 )
 
 // Message represents a WebSocket message
@@ -177,6 +180,9 @@ func (h *Hub) config() (jwtSecret string, devMode bool) {
 
 // Run starts the hub
 func (h *Hub) Run() {
+	evictionTicker := time.NewTicker(wsEvictionInterval)
+	defer evictionTicker.Stop()
+
 	for {
 		select {
 		case client := <-h.register:
@@ -238,6 +244,17 @@ func (h *Hub) Run() {
 					}(client)
 				}
 			}
+
+		case <-evictionTicker.C:
+			// Periodically evict stale demo sessions to prevent unbounded map growth
+			h.mu.Lock()
+			cutoff := time.Now().Add(-wsInactiveCutoff)
+			for id, lastSeen := range h.demoSessions {
+				if !lastSeen.After(cutoff) {
+					delete(h.demoSessions, id)
+				}
+			}
+			h.mu.Unlock()
 
 		case <-h.done:
 			return


### PR DESCRIPTION
Adds periodic background eviction of stale demo sessions to prevent unbounded memory growth in long-running servers.

The demoSessions map can accumulate entries from unauthed demo connections indefinitely without a cleanup mechanism. This fix:
- Creates a background ticker (5 minute interval) in Hub.Run()
- Periodically scans and deletes stale entries using wsInactiveCutoff (60s) as TTL
- Safely guarded by mu.Lock/Unlock during cleanup
- Mirrors the pattern used in sse.go:193-242

Part of P0 architect fixes from comprehensive refactor/perf scan.