### PR TITLE
🐛 Fix missions.go body close, Missions.tsx i18n keys, deploy status case, liveMocks shapes

### DIFF
--- a/web/e2e/mocks/liveMocks.ts
+++ b/web/e2e/mocks/liveMocks.ts
@@ -540,7 +540,7 @@ export async function setupLiveMocks(page: Page, options?: LiveMockOptions): Pro
     cronjobs: { cronjobs: [{ name: 'daily-backup', namespace: 'default', cluster: MOCK_CLUSTER, schedule: '0 2 * * *', lastSchedule: '2026-01-15T02:00:00Z', active: 0 }] },
     'gpu-nodes': { nodes: [{ name: 'gpu-node-1', cluster: MOCK_CLUSTER, gpus: [{ model: 'A100', memory: '80Gi', index: 0 }], labels: {}, allocatable: {}, capacity: {} }] },
     clusters: { clusters: [{ name: MOCK_CLUSTER, reachable: true, status: 'Ready', provider: 'kind', version: '1.28.0' }] },
-    'cluster-health': { status: 'ok', healthy: true, cluster: MOCK_CLUSTER, nodeCount: 3, readyNodes: 3, podCount: 12, cpuCores: 8, memoryGB: 16, metricsAvailable: true },
+    'cluster-health': { status: 'ok', healthy: true, reachable: true, cluster: MOCK_CLUSTER, nodeCount: 3, readyNodes: 3, podCount: 12, cpuCores: 8, memoryGB: 16, metricsAvailable: true },
     status: { status: 'ok', version: 'e2e-test', clusters: 1, hasClaude: false },
     namespaces: { namespaces: MOCK_DATA.namespaces.namespaces },
     'nvidia-operators': { operators: [] },
@@ -604,7 +604,7 @@ export async function setupLiveMocks(page: Page, options?: LiveMockOptions): Pro
 
     // Agent root health endpoint — only match /health (single segment) or /health?*
     // Nested paths like /clusters/<name>/health are served via AGENT_ENDPOINT_DATA below.
-    if ((pathParts.length === 1 && pathParts[0] === 'health') || url.includes('/health?')) {
+    if (pathParts.length === 1 && pathParts[0] === 'health') {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/web/src/hooks/__tests__/useDeployMissions-expand.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions-expand.test.ts
@@ -288,7 +288,7 @@ describe('useDeployMissions — expanded edge cases', () => {
       }
       if (url.includes('/deploy-status/')) {
         return Promise.resolve(new Response(JSON.stringify({
-          status: 'Running',
+          status: 'running',
           replicas: 2,
           readyReplicas: 2,
         }), { status: 200 }))

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -614,9 +614,9 @@ export function useDeployMissions() {
                   : safeReplicaCount(restUpdatedRaw)
                 // Zero-replica workloads are valid — treat readyReplicas >= replicas
                 // as success even when both are zero.
-                if (data.status === 'Running' && restReady >= restReplicas && restUpdated >= restReplicas) {
+                if (String(data.status).toLowerCase() === 'running' && restReady >= restReplicas && restUpdated >= restReplicas) {
                   status = 'running'
-                } else if (data.status === 'Failed') {
+                } else if (String(data.status).toLowerCase() === 'failed') {
                   // #5956 — Surface the failure reason in the mission logs
                   // instead of leaving the mission in a generic degraded state.
                   status = 'failed'


### PR DESCRIPTION
Fixes #11257
Fixes #11260
Fixes #11264

## Changes

### missions.go (#11257)
- Remove `defer resp.Body.Close()` from `githubGet` — was closing the response body before callers could read it
- Replace `defer resp.Body.Close()` inside `fetchWithCache` retry loop with explicit close after `io.ReadAll`, preventing leaked file descriptors during retries

### Missions.tsx (#11257)
- Fix i18n namespace syntax: `cards.X` → `cards:X` (colon separates namespace from key in i18next)
- Fix `common.sortBy.X` → `sortBy.X` (common is the default namespace, no prefix needed)

### useDeployMissions.ts (#11260)
- Normalise status comparison at the REST-fetch path to `String(data.status).toLowerCase() === 'running'`, matching the pattern already used at the agent-match path
- Fix test mock status from `'Running'` → `'running'` to match the lowercase API contract

### liveMocks.ts (#11264)
- Remove overly broad `url.includes('/health?')` guard that could intercept nested paths like `/clusters/<name>/health`
- Add missing `reachable: true` field to `cluster-health` mock to match the `ClusterHealth` interface