### PR TITLE
fix(useMissions): add unmount guard to preflight promise handlers

### DIFF
--- a/web/src/hooks/useMissions.provider.tsx
+++ b/web/src/hooks/useMissions.provider.tsx
@@ -1887,6 +1887,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         : Promise.resolve({ ok: true } as PreflightResult)
 
     preflightPromise.then(preflight => {
+      if (unmountedRef.current) return
       if (!preflight.ok && 'error' in preflight && preflight.error) {
         // Preflight failed — block the mission with a structured error
         setMissions(prev => prev.map(m =>
@@ -1928,6 +1929,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
       // Preflight passed — proceed to send to agent
       executeMission(missionId, enhancedPrompt, params)
     }).catch((err) => {
+      if (unmountedRef.current) return
       // Preflight itself threw unexpectedly — block the mission instead of
       // fail-open to prevent executing without validation (#5846)
       setMissions(prev => prev.map(m =>


### PR DESCRIPTION
Add unmountedRef.current checks at the start of both .then() and .catch() handlers in preflightAndExecute() to prevent setState calls on unmounted components.

Without these guards, if a mission preflight is in-flight when the provider unmounts (e.g. user navigates away), the promise resolution will still fire and attempt to update component state after unmount, causing memory leaks and React warnings.

Part of P1 architect fixes from comprehensive refactor/perf scan.