### PR TITLE
refactor(handlers): use c.Context() instead of context.Background()

### DIFF
--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -248,9 +248,9 @@ func (h *NightlyE2EHandler) GetRuns(c *fiber.Ctx) error {
 	h.mu.RUnlock()
 
 	// #7053 — Use singleflight to coalesce concurrent cold-cache fetches
-	// into a single fetchAll call, preventing N × 17+ goroutine fan-out.
+	// into a single fetchAllWithContext call, preventing N × 17+ goroutine fan-out.
 	v, err, _ := h.fetchGroup.Do("runs", func() (interface{}, error) {
-		return h.fetchAll()
+		return h.fetchAllWithContext(c.Context())
 	})
 	if err != nil {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{

--- a/pkg/api/handlers/self_upgrade.go
+++ b/pkg/api/handlers/self_upgrade.go
@@ -183,7 +183,7 @@ func (h *SelfUpgradeHandler) GetStatus(c *fiber.Ctx) error {
 	resp.Namespace = namespace
 	resp.ReleaseName = getReleaseName()
 
-	ctx, cancel := context.WithTimeout(context.Background(), selfUpgradeTimeout)
+	ctx, cancel := context.WithTimeout(c.Context(), selfUpgradeTimeout)
 	defer cancel()
 
 	client, err := h.getInClusterClient()
@@ -300,7 +300,7 @@ func (h *SelfUpgradeHandler) TriggerUpgrade(c *fiber.Ctx) error {
 		})
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), selfUpgradeTimeout)
+	ctx, cancel := context.WithTimeout(c.Context(), selfUpgradeTimeout)
 	defer cancel()
 
 	client, err := h.getInClusterClient()


### PR DESCRIPTION
Replace context.Background() with c.Context() in HTTP request handlers to respect request deadlines.

Changes:
- nightly_e2e.go: Pass c.Context() to fetchAllWithContext() so concurrent API calls are cancelled if HTTP request times out
- self_upgrade.go (GetStatus & TriggerUpgrade): Use c.Context() for K8s operations

This ensures in-flight sub-operations are properly cancelled when clients disconnect or HTTP request deadlines are reached, instead of continuing indefinitely.

Initial step toward resolving context propagation issues (91 context.Background() calls in pkg/api). This PR focuses on the clearest cases in HTTP handlers on the main response path.