### PR TITLE
🐛 Fix nightly validation pass rate check grep pattern mismatch

### DIFF
--- a/.github/workflows/kb-nightly-validation.yml
+++ b/.github/workflows/kb-nightly-validation.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Check for regressions
         run: |
           # Fail if mission pass rate drops below 90%
-          if grep -q "pass rate" validation-results.txt; then
-            RATE=$(grep -oP '\d+%' validation-results.txt | head -1 | tr -d '%')
+          if grep -q "PASS_RATE=" validation-results.txt; then
+            RATE=$(grep -oP 'PASS_RATE=\K\d+' validation-results.txt | head -1)
             if [ "${RATE:-100}" -lt 90 ]; then
               echo "::error::Mission validation pass rate dropped below 90% (currently ${RATE}%)"
               exit 1

--- a/scripts/validate-missions.sh
+++ b/scripts/validate-missions.sh
@@ -348,8 +348,10 @@ echo -e "  Total missions validated:  ${BOLD}${total}${RESET}"
 if [[ $total -gt 0 ]]; then
   pass_pct=$((passed * 100 / total))
   echo -e "  Passed (no critical issues): ${GREEN}${passed}${RESET} (${pass_pct}%)"
+  echo "PASS_RATE=${pass_pct}%"
 else
   echo -e "  Passed: ${GREEN}0${RESET}"
+  echo "PASS_RATE=0%"
 fi
 
 echo -e "  Critical issues:           ${RED}${critical}${RESET}"


### PR DESCRIPTION
Fixes #11246

## Problem

The KB nightly validation workflow grepped for `"pass rate"` in `validation-results.txt`, but `scripts/validate-missions.sh` actually outputs `"Passed (no critical issues): N (XX%)"`. The grep never matched, making the <90% threshold check dead code — CI always exited 0 regardless of actual pass rate.

## Fix

- Added a machine-parseable `PASS_RATE=XX%` line to `validate-missions.sh` output
- Updated `.github/workflows/kb-nightly-validation.yml` to grep for `PASS_RATE=` and extract the numeric value with `grep -oP 'PASS_RATE=\K\d+'`
- Hard-fails when pass rate < 90% as originally intended