### PR TITLE
🐛 log WebSocket close frame errors for consistency

### DIFF
--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -596,8 +596,10 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 				// from the writer goroutine (single-writer semantics) and exit.
 				if msg == nil {
 					client.writeMu.Lock()
-					_ = conn.WriteMessage(websocket.CloseMessage,
-						websocket.FormatCloseMessage(websocket.CloseNormalClosure, "session invalidated"))
+					if err := conn.WriteMessage(websocket.CloseMessage,
+						websocket.FormatCloseMessage(websocket.CloseNormalClosure, "session invalidated")); err != nil {
+						slog.Error("[WebSocket] close frame error", "error", err)
+					}
 					client.writeMu.Unlock()
 					return
 				}


### PR DESCRIPTION
Improves error logging consistency by capturing WebSocket close frame write errors.

Changes:
- Log close frame WriteMessage errors (previously silently ignored)
- Matches existing pattern for regular message write errors
- Improves observability for connection closure issues

Note: Many _ = err patterns in codebase are intentionally non-fatal with
inline comments explaining why (e.g., errgroup.Wait() where errors are
collected separately). This PR focuses on logging gaps where errors
deserve observability without changing intentional non-critical patterns.