### PR TITLE
🐛 fix(Missions): add defaultValue fallback for t('common:searchMissions') TS type error

### DIFF
--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -426,7 +426,7 @@ Please:
       <CardSearchInput
         value={localSearch}
         onChange={setLocalSearch}
-        placeholder={t('common:searchMissions')}
+        placeholder={t('common:searchMissions', 'Search missions...')}
         className="mb-2 shrink-0"
       />
 


### PR DESCRIPTION
Follow-up to #11282 — the main build is failing with:

```
src/components/cards/Missions.tsx(429,24): error TS2345: Argument of type
'["common:searchMissions"]' is not assignable to parameter of type...
```

i18next TypeScript strict types require a `defaultValue` when the key cannot be statically verified. All other `t()` calls in `Missions.tsx` already use the two-arg form — this aligns `searchMissions` with the same pattern.

**Fix:** `t('common:searchMissions')` → `t('common:searchMissions', 'Search missions...')`