### PR TITLE
fix(custom-resources): validate type assertions on metadata extraction

### DIFF
--- a/pkg/api/handlers/custom_resources.go
+++ b/pkg/api/handlers/custom_resources.go
@@ -215,8 +215,22 @@ func parseCRItem(obj map[string]interface{}, clusterName string) CustomResourceI
 	item := CustomResourceItem{Cluster: clusterName}
 
 	if metadata, ok := obj["metadata"].(map[string]interface{}); ok {
-		item.Name, _ = metadata["name"].(string)
-		item.Namespace, _ = metadata["namespace"].(string)
+		if name, ok := metadata["name"].(string); ok {
+			item.Name = name
+		} else {
+			slog.Warn("custom resource metadata.name is not a string",
+				slog.String("cluster", clusterName),
+				slog.String("actual_type", fmt.Sprintf("%T", metadata["name"])))
+		}
+
+		if namespace, ok := metadata["namespace"].(string); ok {
+			item.Namespace = namespace
+		} else if metadata["namespace"] != nil {
+			slog.Warn("custom resource metadata.namespace is not a string",
+				slog.String("cluster", clusterName),
+				slog.String("actual_type", fmt.Sprintf("%T", metadata["namespace"])))
+		}
+
 		if labels, ok := metadata["labels"].(map[string]interface{}); ok {
 			item.Labels = make(map[string]string, len(labels))
 			for k, v := range labels {


### PR DESCRIPTION
Fixes #CRIT-TYPE-ASSERTIONS

## Problem
Unchecked type assertions in parseCRItem (custom_resources.go:218-219) could fail silently. If Kubernetes metadata fields were not strings (e.g., malformed resources, API version differences), the item.Name and item.Namespace would remain empty without warning. This could cause:
- Data loss when names are silently dropped
- Debugging confusion when resources appear with empty names
- Potential panic if code assumes Name is never empty

## Solution
- Replace blank-identifier type assertions with explicit ok checks
- Log warnings when metadata.name or metadata.namespace have unexpected types
- Include cluster name and actual type in structured log for debugging
- Distinguish between nil values (expected) and wrong types (error)

## Changes
- 2 unchecked type assertions replaced with validated checks
- Added structured logging for type mismatches
- More defensive parsing without breaking existing behavior

## Impact
- Prevents silent data loss from malformed Kubernetes resources
- Better observability for resource parsing issues
- No API changes - only internal validation improvements

Architect scan: CRITICAL - runtime panic risk (crit-type-assertions)
