### PR TITLE
🐛 fix nilaway violations in missions & github_proxy handlers

### DIFF
--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -116,6 +116,7 @@ func getGitHubProxyLimiter(userID string) *rate.Limiter {
 // startGitHubProxyLimiterEvictor periodically removes idle rate limiters
 // (no requests for >10 minutes) to prevent unbounded map growth.
 // Exits when ctx is cancelled.
+//nolint:nilaway // ctx is always non-nil (created by context.WithCancel)
 func startGitHubProxyLimiterEvictor(ctx context.Context) {
 	ticker := time.NewTicker(githubProxyEvictionInterval)
 	defer ticker.Stop()

--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -521,7 +521,7 @@ func (h *MissionsHandler) fetchWithCache(c *fiber.Ctx, cacheKey, url, logContext
 			// Monitor context cancellation to avoid orphaned goroutines on client disconnect
 			select {
 			case <-c.Context().Done():
-				return nil, c.Context().Err()
+				return &githubFetchResult{StatusCode: http.StatusServiceUnavailable}, c.Context().Err()
 			case <-time.After(delay):
 				// Continue to retry
 			}
@@ -608,14 +608,18 @@ func (h *MissionsHandler) BrowseConsoleKB(c *fiber.Ctx) error {
 
 	res, err := h.fetchWithCache(c, cacheKey, url, "(browse)", "path", path)
 	if err != nil {
-		if res.StatusCode == http.StatusForbidden || res.StatusCode == http.StatusTooManyRequests {
+		if res != nil && (res.StatusCode == http.StatusForbidden || res.StatusCode == http.StatusTooManyRequests) {
 			return c.Status(res.StatusCode).JSON(fiber.Map{
 				"error":  err.Error(),
 				"status": res.StatusCode,
 				"code":   "rate_limited",
 			})
 		}
-		return c.Status(res.StatusCode).JSON(fiber.Map{"error": err.Error()})
+		status := http.StatusBadGateway
+		if res != nil && res.StatusCode > 0 {
+			status = res.StatusCode
+		}
+		return c.Status(status).JSON(fiber.Map{"error": err.Error()})
 	}
 
 	if res.CacheStatus != cacheStatusMiss {
@@ -742,14 +746,18 @@ func (h *MissionsHandler) GetMissionFile(c *fiber.Ctx) error {
 
 	res, err := h.fetchWithCache(c, cacheKey, url, "(file)", "ref", ref, "path", path)
 	if err != nil {
-		if res.StatusCode == http.StatusForbidden || res.StatusCode == http.StatusTooManyRequests {
+		if res != nil && (res.StatusCode == http.StatusForbidden || res.StatusCode == http.StatusTooManyRequests) {
 			return c.Status(res.StatusCode).JSON(fiber.Map{
 				"error":  err.Error(),
 				"status": res.StatusCode,
 				"code":   "rate_limited",
 			})
 		}
-		return c.Status(res.StatusCode).JSON(fiber.Map{"error": err.Error()})
+		status := http.StatusBadGateway
+		if res != nil && res.StatusCode > 0 {
+			status = res.StatusCode
+		}
+		return c.Status(status).JSON(fiber.Map{"error": err.Error()})
 	}
 
 	if res.CacheStatus != cacheStatusMiss {


### PR DESCRIPTION
Fixes #11291

Resolves nilaway CI failures on PR #11291 by:

1. **fetchWithCache context cancellation**: Returns a non-nil `githubFetchResult` (with `StatusServiceUnavailable`) instead of `nil` when context is cancelled, matching the convention of all other error return paths in the function.

2. **Caller nil guards**: Adds nil checks on `res` before accessing `res.StatusCode` in `BrowseConsoleKB` and `GetMissionFile` — defensive coding in case `fetchWithCache` ever returns `nil` on error.

3. **False-positive suppression**: Adds `//nolint:nilaway` to `startGitHubProxyLimiterEvictor` where `ctx` is always non-nil (created by `context.WithCancel(context.Background())`).