### PR TITLE
🐛 fix(e2e): surface swallowed waitFor failures in visual tests; register global teardown

### DIFF
--- a/web/e2e/visual/app-visual-regression.spec.ts
+++ b/web/e2e/visual/app-visual-regression.spec.ts
@@ -24,7 +24,9 @@ async function setupAndNavigate(page: Page, path = '/') {
   await page.waitForLoadState('domcontentloaded')
   // Wait for the app shell (sidebar) to confirm React has rendered the route.
   // #root is always in the DOM before React renders — use sidebar testid instead.
-  await page.getByTestId('sidebar').waitFor({ state: 'visible', timeout: ROOT_VISIBLE_TIMEOUT_MS }).catch(() => {})
+  // #11293 — do NOT catch: sidebar absence means the app shell failed to render
+  // and the screenshot would show a blank/broken state, making the visual diff useless.
+  await page.getByTestId('sidebar').waitFor({ state: 'visible', timeout: ROOT_VISIBLE_TIMEOUT_MS })
 }
 
 test.describe('Full-app layout — desktop (1440×900)', () => {
@@ -34,7 +36,11 @@ test.describe('Full-app layout — desktop (1440×900)', () => {
     await setupAndNavigate(page)
 
     const grid = page.getByTestId('dashboard-cards-grid')
-    await grid.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch(() => {})
+    // #11293 — log rather than silence: screenshot still runs for pixel diff,
+    // but the warning surfaces that the element wasn't ready at capture time.
+    await grid.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch((e: Error) => {
+      console.warn('[visual] dashboard-cards-grid not visible before screenshot:', e.message)
+    })
 
     await expect(page).toHaveScreenshot('app-dashboard-desktop-1440.png', {
       fullPage: false,
@@ -47,7 +53,9 @@ test.describe('Full-app layout — desktop (1440×900)', () => {
     await page.getByTestId('dashboard-header').waitFor({
       state: 'visible',
       timeout: DASHBOARD_SETTLE_TIMEOUT_MS,
-    }).catch(() => {})
+    }).catch((e: Error) => {
+      console.warn('[visual] dashboard-header not visible before screenshot:', e.message)
+    })
 
     await expect(page).toHaveScreenshot('app-header-controls-desktop-1440.png', {
       fullPage: false,
@@ -62,7 +70,7 @@ test.describe('Full-app layout — laptop (1280×720)', () => {
     await setupAndNavigate(page)
 
     const grid = page.getByTestId('dashboard-cards-grid')
-    await grid.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch(() => {})
+    await grid.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch((e: Error) => { console.warn('[visual] grid not visible before screenshot:', e.message) })
 
     await expect(page).toHaveScreenshot('app-dashboard-laptop-1280.png', {
       fullPage: false,
@@ -77,7 +85,7 @@ test.describe('Full-app layout — tablet (768×1024)', () => {
     await setupAndNavigate(page)
 
     const grid = page.getByTestId('dashboard-cards-grid')
-    await grid.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch(() => {})
+    await grid.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch((e: Error) => { console.warn('[visual] grid not visible before screenshot:', e.message) })
 
     await expect(page).toHaveScreenshot('app-dashboard-tablet-768.png', {
       fullPage: false,
@@ -92,7 +100,7 @@ test.describe('Full-app layout — full page scroll', () => {
     await setupAndNavigate(page)
 
     const grid = page.getByTestId('dashboard-cards-grid')
-    await grid.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch(() => {})
+    await grid.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch((e: Error) => { console.warn('[visual] grid not visible before screenshot:', e.message) })
 
     await expect(page).toHaveScreenshot('app-dashboard-fullpage-1440.png', {
       fullPage: true,
@@ -109,10 +117,10 @@ test.describe('Clusters page — desktop (1440×900)', () => {
     await setupAndNavigate(page, '/clusters')
 
     const clustersPage = page.getByTestId('clusters-page')
-    await clustersPage.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch(() => {})
+    await clustersPage.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch((e: Error) => { console.warn('[visual] clustersPage not visible before screenshot:', e.message) })
 
     const sidebar = page.getByTestId('sidebar')
-    await sidebar.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch(() => {})
+    await sidebar.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch((e: Error) => { console.warn('[visual] sidebar not visible before screenshot:', e.message) })
 
     await expect(page).toHaveScreenshot('app-clusters-desktop-1440.png', {
       fullPage: false,
@@ -123,7 +131,7 @@ test.describe('Clusters page — desktop (1440×900)', () => {
     await setupAndNavigate(page, '/clusters')
 
     const clustersPage = page.getByTestId('clusters-page')
-    await clustersPage.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch(() => {})
+    await clustersPage.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch((e: Error) => { console.warn('[visual] clustersPage not visible before screenshot:', e.message) })
 
     await expect(page).toHaveScreenshot('app-clusters-fullpage-1440.png', {
       fullPage: true,
@@ -138,7 +146,7 @@ test.describe('Clusters page — tablet (768×1024)', () => {
     await setupAndNavigate(page, '/clusters')
 
     const clustersPage = page.getByTestId('clusters-page')
-    await clustersPage.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch(() => {})
+    await clustersPage.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch((e: Error) => { console.warn('[visual] clustersPage not visible before screenshot:', e.message) })
 
     await expect(page).toHaveScreenshot('app-clusters-tablet-768.png', {
       fullPage: false,
@@ -155,7 +163,7 @@ test.describe('Settings page — desktop (1440×900)', () => {
     await setupAndNavigate(page, '/settings')
 
     const settingsPage = page.getByTestId('settings-page')
-    await settingsPage.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch(() => {})
+    await settingsPage.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch((e: Error) => { console.warn('[visual] settingsPage not visible before screenshot:', e.message) })
 
     await expect(page).toHaveScreenshot('app-settings-desktop-1440.png', {
       fullPage: false,
@@ -166,7 +174,7 @@ test.describe('Settings page — desktop (1440×900)', () => {
     await setupAndNavigate(page, '/settings')
 
     const settingsPage = page.getByTestId('settings-page')
-    await settingsPage.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch(() => {})
+    await settingsPage.waitFor({ state: 'visible', timeout: DASHBOARD_SETTLE_TIMEOUT_MS }).catch((e: Error) => { console.warn('[visual] settingsPage not visible before screenshot:', e.message) })
 
     await expect(page).toHaveScreenshot('app-settings-fullpage-1440.png', {
       fullPage: true,

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -17,6 +17,10 @@ const isCI = Boolean(env.CI)
 export default defineConfig({
   testDir: './e2e',
 
+  // #11296 — Register the coverage teardown. It is a no-op unless
+  // VITE_COVERAGE=true, so registering it unconditionally is safe.
+  globalTeardown: './e2e/global-teardown.ts',
+
   // Skip flaky tests until they are stabilized
   // Re-enable these incrementally as they are fixed
   //


### PR DESCRIPTION
## Summary

Fixes two test infrastructure gaps found during architect scan.

### Fix 1 — Fixes #11293: Visual tests swallow element failures before screenshot

`app-visual-regression.spec.ts` used `.catch(() => {})` on 12 `waitFor` calls, silently discarding element-not-found failures before taking screenshots. Screenshots captured in a broken state would then pass pixel comparisons if the failure was consistent — masking real regressions.

**Changes:**
- `setupAndNavigate`: remove `.catch()` from the sidebar `waitFor` entirely. A missing sidebar means the app shell failed to render; proceeding produces a useless blank screenshot. The test should fail loudly.
- All other element waits (grid, header, clustersPage, settingsPage): replace `.catch(() => {})` with a logged fallback `.catch((e: Error) => console.warn('[visual] <element> not visible...', e.message))`. Visual tests are best-effort (screenshot pixel comparison is the assertion), but failures must appear in test output so they can be triaged.

### Fix 2 — Fixes #11296: `global-teardown.ts` never registered

`web/e2e/global-teardown.ts` implements Playwright coverage reporting (`npx nyc report`) when `VITE_COVERAGE=true`, but was not referenced in `playwright.config.ts`. Coverage reports were silently never generated.

**Change:** Add `globalTeardown: './e2e/global-teardown.ts'` to `playwright.config.ts`. The teardown is a no-op when `VITE_COVERAGE` is unset, so this is safe for all existing CI jobs.

## Testing

These are test-infrastructure-only changes (no production code modified). CI validates via the existing build + lint checks.