### PR TITLE
🐛 Register global-teardown.ts in Playwright config

### DIFF
--- a/web/e2e/compliance/compliance.config.ts
+++ b/web/e2e/compliance/compliance.config.ts
@@ -89,6 +89,7 @@ function getWebServer() {
 const port = useDevServer ? DEV_PORT : PREVIEW_PORT
 
 export default defineConfig({
+  globalTeardown: '../global-teardown.ts',
   testDir: '.',
   // Per-test timeout (PER_TEST_TIMEOUT_MS × CI_TIMEOUT_MULTIPLIER in CI).
   // Tightened from the old 40-minute monolithic cap (Issue 9088) — each

--- a/web/e2e/global-teardown.ts
+++ b/web/e2e/global-teardown.ts
@@ -1,8 +1,11 @@
 import { execSync } from 'child_process'
 
 /**
- * Global teardown for Playwright tests.
- * Generates coverage reports if coverage collection is enabled.
+ * Playwright global teardown — generates coverage reports when VITE_COVERAGE=true.
+ *
+ * This runs automatically after all Playwright tests complete.
+ * For standalone coverage report generation, see: scripts/coverage-report.mjs
+ * (invoked by scripts/run-e2e-coverage.sh)
  */
 async function globalTeardown() {
   if (process.env.VITE_COVERAGE === 'true') {

--- a/web/e2e/visual/app-visual.config.ts
+++ b/web/e2e/visual/app-visual.config.ts
@@ -23,6 +23,7 @@ const BASE_URL = process.env.APP_VISUAL_BASE_URL || 'http://localhost:8080'
 const WEB_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 
 export default defineConfig({
+  globalTeardown: '../global-teardown.ts',
   testDir: '.',
   testMatch: 'app-*.spec.ts',
   timeout: IS_CI ? 120_000 : 60_000,

--- a/web/e2e/visual/visual.config.ts
+++ b/web/e2e/visual/visual.config.ts
@@ -21,6 +21,7 @@ const WEB_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../.
 const STORYBOOK_STATIC = path.join(WEB_DIR, 'storybook-static')
 
 export default defineConfig({
+  globalTeardown: '../global-teardown.ts',
   testDir: '.',
   timeout: IS_CI ? 120_000 : 60_000,
   expect: {

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -15,6 +15,7 @@ const isCI = Boolean(env.CI)
  * - Multi-cluster operations
  */
 export default defineConfig({
+  globalTeardown: './e2e/global-teardown.ts',
   testDir: './e2e',
 
   // Skip flaky tests until they are stabilized


### PR DESCRIPTION
Fixes #11296

Wire `e2e/global-teardown.ts` into all Playwright config files so the coverage report generator actually runs when `VITE_COVERAGE=true`.

Changes:
- Add `globalTeardown: './e2e/global-teardown.ts'` to `web/playwright.config.ts`
- Add `globalTeardown: '../global-teardown.ts'` to visual and compliance configs
- Update comment header in `global-teardown.ts` noting relationship to `scripts/coverage-report.mjs`