### PR TITLE
feat: add agent diagnostics to health endpoint and feedback issues

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,8 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/kubestellar/console/pkg/agent.Version={{.Version}}
+      - -X github.com/kubestellar/console/pkg/agent.CommitSHA={{.FullCommit}}
+      - -X github.com/kubestellar/console/pkg/agent.BuildTime={{.Date}}
 
   - id: console
     main: ./cmd/console

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ pull:
 build:
 	cd web && npm install --prefer-offline && npm run build
 	mkdir -p bin
-	go build -o bin/kc-agent ./cmd/kc-agent
+	go build -ldflags "-X github.com/kubestellar/console/pkg/agent.CommitSHA=$$(git rev-parse HEAD) -X github.com/kubestellar/console/pkg/agent.BuildTime=$$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o bin/kc-agent ./cmd/kc-agent
 	go build -o bin/console ./cmd/console
 	go build -o bin/kc-watcher ./cmd/watcher
 	@# Update Homebrew kc-agent if installed

--- a/cmd/kc-agent/main.go
+++ b/cmd/kc-agent/main.go
@@ -32,11 +32,11 @@ func main() {
 	flag.Parse()
 
 	if *version {
-		fmt.Printf("kc-agent version %s\n", agent.Version)
+		fmt.Printf("kc-agent version %s (commit: %s, built: %s)\n", agent.Version, agent.CommitSHA, agent.BuildTime)
 		os.Exit(0)
 	}
 
-	slog.Info("KubeStellar Console - Local Agent starting", "version", agent.Version)
+	slog.Info("KubeStellar Console - Local Agent starting", "version", agent.Version, "commit", agent.CommitSHA, "built", agent.BuildTime)
 
 	// Parse comma-separated allowed origins from flag
 	var origins []string

--- a/pkg/agent/endpoint_auth_test.go
+++ b/pkg/agent/endpoint_auth_test.go
@@ -463,6 +463,11 @@ func TestEndpointAuth_HealthDoesNotLeakSecrets(t *testing.T) {
 	allowedFields := map[string]bool{
 		"status":             true,
 		"version":            true,
+		"commitSHA":          true,
+		"buildTime":          true,
+		"goVersion":          true,
+		"os":                 true,
+		"arch":               true,
 		"clusters":           true,
 		"hasClaude":          true,
 		"claude":             true,

--- a/pkg/agent/protocol/messages.go
+++ b/pkg/agent/protocol/messages.go
@@ -41,6 +41,11 @@ type Message struct {
 type HealthPayload struct {
 	Status             string            `json:"status"`
 	Version            string            `json:"version"`
+	CommitSHA          string            `json:"commitSHA,omitempty"`
+	BuildTime          string            `json:"buildTime,omitempty"`
+	GoVersion          string            `json:"goVersion,omitempty"`
+	OS                 string            `json:"os"`
+	Arch               string            `json:"arch"`
 	Clusters           int               `json:"clusters"`
 	HasClaude          bool              `json:"hasClaude"`
 	Claude             *ClaudeInfo       `json:"claude,omitempty"`

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -106,6 +107,12 @@ var missionExecutionTimeout = defaultMissionExecutionTimeout
 
 // Version is set by ldflags during build
 var Version = "dev"
+
+// CommitSHA is set by ldflags during build (git commit hash)
+var CommitSHA = "unknown"
+
+// BuildTime is set by ldflags during build (ISO 8601 timestamp)
+var BuildTime = "unknown"
 
 // Config holds agent configuration
 type Config struct {
@@ -807,6 +814,11 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	payload := protocol.HealthPayload{
 		Status:             "ok",
 		Version:            Version,
+		CommitSHA:          CommitSHA,
+		BuildTime:          BuildTime,
+		GoVersion:          runtime.Version(),
+		OS:                 runtime.GOOS,
+		Arch:               runtime.GOARCH,
 		Clusters:           len(clusters),
 		HasClaude:          hasClaude,
 		Claude:             s.getClaudeInfo(),

--- a/pkg/api/handlers/feedback_github.go
+++ b/pkg/api/handlers/feedback_github.go
@@ -491,7 +491,7 @@ type screenshotUploadResult struct {
 // upload, synchronous result counts, error). #9898: screenshot uploads are
 // decoupled from this path — callers launch uploadScreenshotCommentsAsync
 // on the returned slice from a background goroutine.
-func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *models.FeatureRequest, user *models.User, repoOwner, repoName string, screenshots []string, consoleErrors []models.ConsoleError, clientAuth string) (int, string, []string, screenshotUploadResult, error) {
+func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *models.FeatureRequest, user *models.User, repoOwner, repoName string, screenshots []string, consoleErrors []models.ConsoleError, diagnostics *models.DiagnosticInfo, clientAuth string) (int, string, []string, screenshotUploadResult, error) {
 	// Determine labels based on request type and target repo
 	var labels []string
 	isDocs := request.TargetRepo == models.TargetRepoDocs
@@ -570,6 +570,48 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *
 		consoleErrorBlock = fmt.Sprintf("\n<details>\n<summary>Browser Console Errors (%d captured)</summary>\n\n%s\n</details>\n", len(consoleErrors), errLines.String())
 	}
 
+	diagnosticsBlock := ""
+	if diagnostics != nil {
+		var diag strings.Builder
+		diag.WriteString("\n<details>\n<summary>Diagnostics</summary>\n\n")
+		diag.WriteString("| Field | Value |\n|-------|-------|\n")
+		if diagnostics.AgentVersion != "" {
+			diag.WriteString(fmt.Sprintf("| Agent Version | %s |\n", diagnostics.AgentVersion))
+		}
+		if diagnostics.CommitSHA != "" {
+			diag.WriteString(fmt.Sprintf("| Commit SHA | `%s` |\n", diagnostics.CommitSHA))
+		}
+		if diagnostics.BuildTime != "" {
+			diag.WriteString(fmt.Sprintf("| Build Time | %s |\n", diagnostics.BuildTime))
+		}
+		if diagnostics.GoVersion != "" {
+			diag.WriteString(fmt.Sprintf("| Go Version | %s |\n", diagnostics.GoVersion))
+		}
+		if diagnostics.AgentOS != "" {
+			diag.WriteString(fmt.Sprintf("| Agent OS | %s |\n", diagnostics.AgentOS))
+		}
+		if diagnostics.AgentArch != "" {
+			diag.WriteString(fmt.Sprintf("| Agent Arch | %s |\n", diagnostics.AgentArch))
+		}
+		if diagnostics.InstallMethod != "" {
+			diag.WriteString(fmt.Sprintf("| Install Method | %s |\n", diagnostics.InstallMethod))
+		}
+		if diagnostics.Clusters > 0 {
+			diag.WriteString(fmt.Sprintf("| Clusters | %d |\n", diagnostics.Clusters))
+		}
+		if diagnostics.BrowserUA != "" {
+			diag.WriteString(fmt.Sprintf("| Browser UA | %s |\n", diagnostics.BrowserUA))
+		}
+		if diagnostics.BrowserPlatform != "" {
+			diag.WriteString(fmt.Sprintf("| Browser Platform | %s |\n", diagnostics.BrowserPlatform))
+		}
+		if diagnostics.BrowserLanguage != "" {
+			diag.WriteString(fmt.Sprintf("| Browser Language | %s |\n", diagnostics.BrowserLanguage))
+		}
+		diag.WriteString("\n</details>\n")
+		diagnosticsBlock = diag.String()
+	}
+
 	issueBody := fmt.Sprintf(`## User Request
 
 **Type:** %s
@@ -580,10 +622,10 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *
 ## Description
 
 %s
-%s%s
+%s%s%s
 ---
 *This issue was automatically created from the KubeStellar Console.*
-`, request.RequestType, repoLabel, user.GitHubLogin, request.ID.String(), request.Description, shaLine, consoleErrorBlock)
+`, request.RequestType, repoLabel, user.GitHubLogin, request.ID.String(), request.Description, shaLine, consoleErrorBlock, diagnosticsBlock)
 
 	// First attempt: create issue with labels
 	number, htmlURL, err := h.postGitHubIssue(ctx, repoOwner, repoName, request.Title, issueBody, labels, clientAuth)

--- a/pkg/api/handlers/feedback_requests.go
+++ b/pkg/api/handlers/feedback_requests.go
@@ -91,7 +91,7 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 	// created synchronously so the client receives the issue number/URL in
 	// the response; screenshot comments are uploaded asynchronously below
 	// (#9898) so slow GitHub responses do not block Fiber workers.
-	issueNumber, _, validScreenshots, ssResult, err := h.createGitHubIssueInRepo(c.UserContext(), request, user, h.repoOwner, targetRepoName, input.Screenshots, input.ConsoleErrors, clientAuth)
+	issueNumber, _, validScreenshots, ssResult, err := h.createGitHubIssueInRepo(c.UserContext(), request, user, h.repoOwner, targetRepoName, input.Screenshots, input.ConsoleErrors, input.Diagnostics, clientAuth)
 	if err != nil {
 		slog.Error("[Feedback] failed to create GitHub issue", "error", err)
 		// Clean up the orphaned database record. Log but don't fail the

--- a/pkg/models/feedback.go
+++ b/pkg/models/feedback.go
@@ -114,6 +114,22 @@ type ConsoleError struct {
 	Source    string `json:"source,omitempty"`
 }
 
+// DiagnosticInfo contains environment details collected from the agent and browser
+// to help debug issues (e.g. CORS mismatches from old agent builds).
+type DiagnosticInfo struct {
+	AgentVersion    string `json:"agent_version,omitempty"`
+	CommitSHA       string `json:"commit_sha,omitempty"`
+	BuildTime       string `json:"build_time,omitempty"`
+	GoVersion       string `json:"go_version,omitempty"`
+	AgentOS         string `json:"agent_os,omitempty"`
+	AgentArch       string `json:"agent_arch,omitempty"`
+	InstallMethod   string `json:"install_method,omitempty"`
+	Clusters        int    `json:"clusters,omitempty"`
+	BrowserUA       string `json:"browser_user_agent,omitempty"`
+	BrowserPlatform string `json:"browser_platform,omitempty"`
+	BrowserLanguage string `json:"browser_language,omitempty"`
+}
+
 // CreateFeatureRequestInput is the input for creating a feature request
 type CreateFeatureRequestInput struct {
 	Title       string      `json:"title" validate:"required,min=10,max=200"`
@@ -126,6 +142,8 @@ type CreateFeatureRequestInput struct {
 	// ConsoleErrors contains recent browser console errors captured automatically.
 	// Only populated for bug reports. Rendered as a collapsible section in the issue body.
 	ConsoleErrors []ConsoleError `json:"console_errors,omitempty"`
+	// Diagnostics contains agent and browser environment info for debugging.
+	Diagnostics *DiagnosticInfo `json:"diagnostics,omitempty"`
 }
 
 // SubmitFeedbackInput is the input for submitting PR feedback

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -24,7 +24,8 @@ import { useBranding } from '../../hooks/useBranding'
 import { FETCH_DEFAULT_TIMEOUT_MS, COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
 import { FEEDBACK_UPLOAD_TIMEOUT_MS } from '../../lib/constants/network'
 import { compressScreenshot } from '../../lib/imageCompression'
-import { useFeatureRequests } from '../../hooks/useFeatureRequests'
+import { useFeatureRequests, DiagnosticInfo } from '../../hooks/useFeatureRequests'
+import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { useAuth } from '../../lib/auth'
 
 type FeedbackType = 'bug' | 'feature'
@@ -49,6 +50,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
   const branding = useBranding()
   const { user } = useAuth()
   const { createRequest } = useFeatureRequests(user?.github_login || '')
+  const { health: agentHealth } = useLocalAgent()
   const [type, setType] = useState<FeedbackType>(initialType)
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
@@ -200,6 +202,21 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
         if (compressed) screenshotDataURIs.push(compressed)
       }
 
+      // Gather agent and browser diagnostics to help debug reported issues
+      const diagnostics: DiagnosticInfo = {
+        agent_version: agentHealth?.version,
+        commit_sha: agentHealth?.commitSHA,
+        build_time: agentHealth?.buildTime,
+        go_version: agentHealth?.goVersion,
+        agent_os: agentHealth?.os,
+        agent_arch: agentHealth?.arch,
+        install_method: agentHealth?.install_method,
+        clusters: agentHealth?.clusters,
+        browser_user_agent: navigator.userAgent,
+        browser_platform: navigator.platform,
+        browser_language: navigator.language,
+      }
+
       // Submit via backend API — creates GitHub issue directly using the
       // server-side token. No GitHub login required from the user.
       // Screenshots are uploaded server-side and embedded as images.
@@ -209,6 +226,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
         description: description.trim(),
         request_type: type,
         target_repo: 'console',
+        diagnostics,
         ...(hasScreenshots && { screenshots: screenshotDataURIs }) }, hasScreenshots ? { timeout: FEEDBACK_UPLOAD_TIMEOUT_MS } : undefined)
       if (hasScreenshots) emitScreenshotUploadSuccess(screenshotDataURIs.length)
 

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -90,6 +90,20 @@ export interface ConsoleError {
   source?: string
 }
 
+export interface DiagnosticInfo {
+  agent_version?: string
+  commit_sha?: string
+  build_time?: string
+  go_version?: string
+  agent_os?: string
+  agent_arch?: string
+  install_method?: string
+  clusters?: number
+  browser_user_agent?: string
+  browser_platform?: string
+  browser_language?: string
+}
+
 export interface CreateFeatureRequestInput {
   title: string
   description: string
@@ -99,6 +113,8 @@ export interface CreateFeatureRequestInput {
   screenshots?: string[]
   /** Recent browser console errors captured automatically for bug reports */
   console_errors?: ConsoleError[]
+  /** Agent and browser diagnostics for debugging */
+  diagnostics?: DiagnosticInfo
 }
 
 export interface SubmitFeedbackInput {

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -15,6 +15,11 @@ export interface ProviderSummary {
 export interface AgentHealth {
   status: string
   version: string
+  commitSHA?: string
+  buildTime?: string
+  goVersion?: string
+  os?: string
+  arch?: string
   clusters: number
   hasClaude: boolean
   install_method?: string


### PR DESCRIPTION
## Summary

- Adds `commitSHA`, `buildTime`, `goVersion`, `os`, and `arch` fields to kc-agent's `/health` endpoint response
- Wires ldflags in `.goreleaser.yaml` and `Makefile` to inject commit SHA and build time at compile time
- Collects agent diagnostics + browser environment (UA, platform, language) in the feedback modal
- Renders a collapsible **Diagnostics** section (markdown table) in created GitHub issues

This helps debug user-reported issues where the root cause is a stale agent build (e.g. CORS mismatches from agents built before origin-allowlist changes).

## Test plan

- [ ] Run `make build` and verify `bin/kc-agent` reports correct commit/build time on `/health`
- [ ] Submit a bug report via the feedback modal and confirm the GitHub issue contains a Diagnostics section
- [ ] Verify existing health checks still pass (no breaking changes to existing fields)