### PR TITLE
🐛 Add missing title icon to Dashboard page

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -20,6 +20,7 @@ import {
   sortableKeyboardCoordinates,
   rectSortingStrategy } from '@dnd-kit/sortable'
 import { useTranslation } from 'react-i18next'
+import { LayoutDashboard } from 'lucide-react'
 import { api, BackendUnavailableError, UnauthenticatedError } from '../../lib/api'
 import { safeRevokeObjectURL } from '../../lib/download'
 import { emitCardAdded, emitCardRemoved, emitCardDragged, emitCardConfigured } from '../../lib/analytics'
@@ -981,6 +982,7 @@ export function Dashboard() {
       <DashboardHeader
         title={t('dashboard.title')}
         subtitle={t('dashboard.subtitle')}
+        icon={<LayoutDashboard className="w-6 h-6 text-purple-400" />}
         isFetching={isFetching}
         onRefresh={() => triggerRefresh()}
         autoRefresh={autoRefresh}


### PR DESCRIPTION
Fixes #11314

The Dashboard page was missing a title icon unlike other pages (My Clusters, Compliance, Cluster Admin). Added a LayoutDashboard icon to match the visual pattern used across other pages.