### PR TITLE
🐛 fix: address Copilot review issues in mcp_query, stig_test, supply_chain_test

### DIFF
--- a/pkg/api/handlers/mcp_query.go
+++ b/pkg/api/handlers/mcp_query.go
@@ -32,7 +32,7 @@ func queryAllClusters[T any](
 ) ([]T, *clusterErrorTracker) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	var results []T
+	results := make([]T, 0)
 	errTracker := &clusterErrorTracker{}
 
 	clusterCtx, clusterCancel := context.WithCancel(ctx)

--- a/pkg/api/handlers/stig_test.go
+++ b/pkg/api/handlers/stig_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kubestellar/console/pkg/compliance/stig"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSTIGHandlers(t *testing.T) {
@@ -16,33 +17,36 @@ func TestSTIGHandlers(t *testing.T) {
 
 	t.Run("listBenchmarks", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/compliance/stig/benchmarks", nil)
-		resp, _ := env.App.Test(req)
+		resp, err := env.App.Test(req)
+		require.NoError(t, err)
 
 		assert.Equal(t, 200, resp.StatusCode)
 		var benchmarks []stig.Benchmark
-		err := json.NewDecoder(resp.Body).Decode(&benchmarks)
+		err = json.NewDecoder(resp.Body).Decode(&benchmarks)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, benchmarks)
 	})
 
 	t.Run("listFindings", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/compliance/stig/findings", nil)
-		resp, _ := env.App.Test(req)
+		resp, err := env.App.Test(req)
+		require.NoError(t, err)
 
 		assert.Equal(t, 200, resp.StatusCode)
 		var findings []stig.Finding
-		err := json.NewDecoder(resp.Body).Decode(&findings)
+		err = json.NewDecoder(resp.Body).Decode(&findings)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, findings)
 	})
 
 	t.Run("getSummary", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/compliance/stig/summary", nil)
-		resp, _ := env.App.Test(req)
+		resp, err := env.App.Test(req)
+		require.NoError(t, err)
 
 		assert.Equal(t, 200, resp.StatusCode)
 		var summary stig.Summary
-		err := json.NewDecoder(resp.Body).Decode(&summary)
+		err = json.NewDecoder(resp.Body).Decode(&summary)
 		assert.NoError(t, err)
 		assert.Greater(t, summary.TotalFindings, 0)
 		assert.NotEmpty(t, summary.EvaluatedAt)

--- a/pkg/api/handlers/supply_chain_test.go
+++ b/pkg/api/handlers/supply_chain_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubestellar/console/pkg/compliance/signing"
 	"github.com/kubestellar/console/pkg/compliance/slsa"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSupplyChainHandlers(t *testing.T) {
@@ -21,20 +22,22 @@ func TestSupplyChainHandlers(t *testing.T) {
 
 		t.Run("getSummary", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/supply-chain/sbom/summary", nil)
-			resp, _ := env.App.Test(req)
+			resp, err := env.App.Test(req)
+			require.NoError(t, err)
 			assert.Equal(t, 200, resp.StatusCode)
 			var summary sbom.Summary
-			err := json.NewDecoder(resp.Body).Decode(&summary)
+			err = json.NewDecoder(resp.Body).Decode(&summary)
 			assert.NoError(t, err)
 			assert.Greater(t, summary.TotalWorkloads, 0)
 		})
 
 		t.Run("listDocuments", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/supply-chain/sbom/documents", nil)
-			resp, _ := env.App.Test(req)
+			resp, err := env.App.Test(req)
+			require.NoError(t, err)
 			assert.Equal(t, 200, resp.StatusCode)
 			var documents []sbom.Document
-			err := json.NewDecoder(resp.Body).Decode(&documents)
+			err = json.NewDecoder(resp.Body).Decode(&documents)
 			assert.NoError(t, err)
 		})
 	})
@@ -45,28 +48,31 @@ func TestSupplyChainHandlers(t *testing.T) {
 
 		t.Run("getSummary", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/supply-chain/signing/summary", nil)
-			resp, _ := env.App.Test(req)
+			resp, err := env.App.Test(req)
+			require.NoError(t, err)
 			assert.Equal(t, 200, resp.StatusCode)
 			var summary signing.Summary
-			err := json.NewDecoder(resp.Body).Decode(&summary)
+			err = json.NewDecoder(resp.Body).Decode(&summary)
 			assert.NoError(t, err)
 		})
 
 		t.Run("listImages", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/supply-chain/signing/images", nil)
-			resp, _ := env.App.Test(req)
+			resp, err := env.App.Test(req)
+			require.NoError(t, err)
 			assert.Equal(t, 200, resp.StatusCode)
 			var images []signing.Image
-			err := json.NewDecoder(resp.Body).Decode(&images)
+			err = json.NewDecoder(resp.Body).Decode(&images)
 			assert.NoError(t, err)
 		})
 
 		t.Run("listPolicies", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/supply-chain/signing/policies", nil)
-			resp, _ := env.App.Test(req)
+			resp, err := env.App.Test(req)
+			require.NoError(t, err)
 			assert.Equal(t, 200, resp.StatusCode)
 			var policies []signing.Policy
-			err := json.NewDecoder(resp.Body).Decode(&policies)
+			err = json.NewDecoder(resp.Body).Decode(&policies)
 			assert.NoError(t, err)
 		})
 	})
@@ -77,19 +83,21 @@ func TestSupplyChainHandlers(t *testing.T) {
 
 		t.Run("getSummary", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/supply-chain/slsa/summary", nil)
-			resp, _ := env.App.Test(req)
+			resp, err := env.App.Test(req)
+			require.NoError(t, err)
 			assert.Equal(t, 200, resp.StatusCode)
 			var summary slsa.Summary
-			err := json.NewDecoder(resp.Body).Decode(&summary)
+			err = json.NewDecoder(resp.Body).Decode(&summary)
 			assert.NoError(t, err)
 		})
 
 		t.Run("listWorkloads", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/supply-chain/slsa/workloads", nil)
-			resp, _ := env.App.Test(req)
+			resp, err := env.App.Test(req)
+			require.NoError(t, err)
 			assert.Equal(t, 200, resp.StatusCode)
 			var workloads []slsa.Workload
-			err := json.NewDecoder(resp.Body).Decode(&workloads)
+			err = json.NewDecoder(resp.Body).Decode(&workloads)
 			assert.NoError(t, err)
 		})
 	})
@@ -100,28 +108,31 @@ func TestSupplyChainHandlers(t *testing.T) {
 
 		t.Run("getSummary", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/supply-chain/licenses/summary", nil)
-			resp, _ := env.App.Test(req)
+			resp, err := env.App.Test(req)
+			require.NoError(t, err)
 			assert.Equal(t, 200, resp.StatusCode)
 			var summary licenses.Summary
-			err := json.NewDecoder(resp.Body).Decode(&summary)
+			err = json.NewDecoder(resp.Body).Decode(&summary)
 			assert.NoError(t, err)
 		})
 
 		t.Run("listPackages", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/supply-chain/licenses/packages", nil)
-			resp, _ := env.App.Test(req)
+			resp, err := env.App.Test(req)
+			require.NoError(t, err)
 			assert.Equal(t, 200, resp.StatusCode)
 			var pkgs []licenses.Package
-			err := json.NewDecoder(resp.Body).Decode(&pkgs)
+			err = json.NewDecoder(resp.Body).Decode(&pkgs)
 			assert.NoError(t, err)
 		})
 
 		t.Run("listCategories", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/supply-chain/licenses/categories", nil)
-			resp, _ := env.App.Test(req)
+			resp, err := env.App.Test(req)
+			require.NoError(t, err)
 			assert.Equal(t, 200, resp.StatusCode)
 			var categories []licenses.Category
-			err := json.NewDecoder(resp.Body).Decode(&categories)
+			err = json.NewDecoder(resp.Body).Decode(&categories)
 			assert.NoError(t, err)
 		})
 	})

--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -1,5 +1,46 @@
 # Reviewer Log
 
+## Pass 91 — 2026-05-01T18:47–19:00 UTC
+
+### Trigger
+KICK — CI=0%, nightlyPlaywright=RED. 166 unaddressed Copilot comments (4 HIGH). GA4 nominal.
+
+### Pre-flight
+- Branch: `fix/copilot-review-batch-2`, rebased on upstream/main `19ea7cda6`
+- GA4: **NOMINAL, 0 anomalies** ✅
+- merge-eligible.json: 1 PR eligible (#11312)
+
+### RED Analysis
+
+**CI=0%**: No actionable RED on main branch identified (the 0% refers to PR-level CI, not a broken main). The prior nightly re-trigger from pass 90 addressed consistency issues.
+
+**nightlyPlaywright=RED**: Scanner-owned (not file issues). No action.
+
+### Actions Taken
+
+| Action | Detail |
+|--------|--------|
+| Merged PR #11312 | `feat: add agent diagnostics to health endpoint and feedback issues` — CI=pass, merge-eligible ✅ |
+| Created PR #11317 | `fix/copilot-review-batch-2` — addresses HIGH/MEDIUM Copilot comments on #11306 and #11308 |
+| Noted PR #11313 | CI=fail (TTFI Hard Gate, Visual Regression, build failures) — not eligible, not merged |
+
+### Copilot Comments Addressed
+
+| Comment | PR | File | Fix |
+|---------|-----|------|-----|
+| HIGH #3173438592 | #11279 | missions.go:449 | Already correct in main (no defer resp.Body.Close()) |
+| HIGH #3173336903 | #11269 | missions.go:475 | Already correct in main |
+| HIGH #3173318616 | #11254 | missions.go:449 | Already correct in main |
+| MEDIUM #3174216097 | #11306 | mcp_query.go:35 | Fixed: `var results []T` → `make([]T, 0)` in PR #11317 |
+| MEDIUM #3174216063 | #11306 | mcp_query.go:60 | Already fixed (returns `*clusterErrorTracker` pointer) |
+| MEDIUM #3174322323/356 | #11308 | stig_test.go:25,36,47 | Fixed: `require.NoError` on App.Test() in PR #11317 |
+| MEDIUM #3174322377+ | #11308 | supply_chain_test.go | Fixed: `require.NoError` on all 9 App.Test() calls in PR #11317 |
+
+### Note on PR #11313 (ci=fail)
+PR #11313 only modifies `web/src/components/feedback/FeatureRequestModal.tsx`. CI failures include TTFI Hard Gate, Visual Regression, and build failures — likely a TTFI regression from the tab count fix. Not merged; needs investigation by author.
+
+---
+
 ## Pass 90 — 2026-05-01T09:38–09:55 UTC
 
 ### Trigger


### PR DESCRIPTION
Fixes #11306
Fixes #11308

## Changes

- **mcp_query.go**: Initialize `results` with `make([]T, 0)` so an empty result encodes as JSON `[]` instead of `null`, consistent with all other handlers
- **stig_test.go**: Use `require.NoError(t, err)` on `App.Test()` return to prevent nil dereference and surface failures cleanly; reuse `err` variable with `=` to avoid redeclaration compile error
- **supply_chain_test.go**: Same fix for all 9 `App.Test()` call sites

Addresses HIGH and MEDIUM Copilot review comments on PRs #11306 and #11308.