### PR TITLE
✨ feat(obs): add event API, fix topology typo, and expand tests

### DIFF
--- a/pkg/api/handlers/crds_test.go
+++ b/pkg/api/handlers/crds_test.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestCRDListCRDs_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewCRDHandlers(env.K8sClient)
+	env.App.Get("/api/crds", handler.ListCRDs)
+
+	// Inject dynamic objects for CRDs
+	gvrKinds := map[schema.GroupVersionResource]string{
+		{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}: "CustomResourceDefinitionList",
+	}
+	dynClient := injectDynamicCluster(env, "test-cluster", gvrKinds)
+
+	// Add a CRD
+	crd := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": "tests.example.com",
+			},
+			"spec": map[string]interface{}{
+				"group": "example.com",
+				"names": map[string]interface{}{
+					"kind": "Test",
+				},
+				"scope": "Namespaced",
+				"versions": []interface{}{
+					map[string]interface{}{
+						"name":    "v1",
+						"served":  true,
+						"storage": true,
+					},
+				},
+			},
+		},
+	}
+	_, err := dynClient.Resource(gvrKindsToGVR(gvrKinds, "CustomResourceDefinitionList")).Create(context.Background(), crd, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/crds", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result CRDListResponse
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Len(t, result.CRDs, 1)
+	assert.Equal(t, "tests", result.CRDs[0].Name)
+	assert.Equal(t, "test-cluster", result.CRDs[0].Cluster)
+}
+
+func TestCRDListCRDs_NoClient(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewCRDHandlers(nil) // No client
+	env.App.Get("/api/crds", handler.ListCRDs)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/crds", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	var result CRDListResponse
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.True(t, result.IsDemoData)
+}

--- a/pkg/api/handlers/events.go
+++ b/pkg/api/handlers/events.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"encoding/json"
+	"strconv"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
@@ -60,4 +62,42 @@ func (h *EventHandler) RecordEvent(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(fiber.Map{"status": "ok", "id": event.ID})
+}
+
+// GetEvents returns recent user events
+// GET /api/events
+func (h *EventHandler) GetEvents(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+
+	since := 24 * time.Hour
+	if s := c.Query("since"); s != "" {
+		if d, err := time.ParseDuration(s); err == nil {
+			since = d
+		}
+	}
+
+	limit := 100
+	if l := c.Query("limit"); l != "" {
+		if v, err := strconv.Atoi(l); err == nil && v > 0 {
+			limit = v
+		}
+	}
+
+	offset := 0
+	if o := c.Query("offset"); o != "" {
+		if v, err := strconv.Atoi(o); err == nil && v >= 0 {
+			offset = v
+		}
+	}
+
+	events, err := h.store.GetRecentEvents(c.UserContext(), userID, since, limit, offset)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to retrieve events")
+	}
+
+	return c.JSON(fiber.Map{
+		"events": events,
+		"limit":  limit,
+		"offset": offset,
+	})
 }

--- a/pkg/api/handlers/events_test.go
+++ b/pkg/api/handlers/events_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/kubestellar/console/pkg/models"
@@ -27,6 +28,13 @@ func (s *eventsTestStore) RecordEvent(_ context.Context, event *models.UserEvent
 		event.ID = uuid.New()
 	}
 	return s.recordErr
+}
+
+func (s *eventsTestStore) GetRecentEvents(_ context.Context, userID uuid.UUID, since time.Duration, limit, offset int) ([]models.UserEvent, error) {
+	if s.recordErr != nil {
+		return nil, s.recordErr
+	}
+	return []models.UserEvent{{ID: uuid.New(), UserID: userID, EventType: models.EventTypePageView}}, nil
 }
 
 func TestEventRecordEvent_Success(t *testing.T) {
@@ -124,4 +132,25 @@ func TestEventRecordEvent_StoreError(t *testing.T) {
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+func TestEventGetEvents_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	store := &eventsTestStore{}
+	handler := NewEventHandler(store)
+	env.App.Get("/api/events", handler.GetEvents)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/events", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result struct {
+		Events []models.UserEvent `json:"events"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Len(t, result.Events, 1)
+	assert.Equal(t, testAdminUserID, result.Events[0].UserID)
 }

--- a/pkg/api/handlers/setup_test.go
+++ b/pkg/api/handlers/setup_test.go
@@ -111,6 +111,16 @@ func setupTestEnv(t *testing.T) *testEnv {
 	}
 }
 
+// gvrKindsToGVR is a helper to find the GVR for a given list kind
+func gvrKindsToGVR(gvrKinds map[schema.GroupVersionResource]string, listKind string) schema.GroupVersionResource {
+	for gvr, kind := range gvrKinds {
+		if kind == listKind {
+			return gvr
+		}
+	}
+	return schema.GroupVersionResource{}
+}
+
 // injectDynamicCluster creates a fake dynamic client with custom list kinds (for CRD resources
 // like Gateway, HTTPRoute, ServiceExport, etc.) and injects both dynamic and typed clients
 // into the test environment for the given cluster name.

--- a/pkg/api/handlers/timeline_test.go
+++ b/pkg/api/handlers/timeline_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/kubestellar/console/pkg/store"
+	"github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimelineGetTimeline_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	mockStore := env.Store.(*test.MockStore)
+
+	handler := NewTimelineHandler(env.Store, env.K8sClient)
+	env.App.Get("/api/timeline", handler.GetTimeline)
+
+	expectedEvents := []store.ClusterEvent{
+		{
+			ClusterName: "test-cluster",
+			Namespace:   "default",
+			EventType:   "Normal",
+			Reason:      "Scheduled",
+			Message:     "Successfully assigned default/pod to node-1",
+		},
+	}
+
+	mockStore.On("QueryTimeline", mock.Anything).Return(expectedEvents, nil)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/timeline?cluster=test-cluster", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result []store.ClusterEvent
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "test-cluster", result[0].ClusterName)
+}
+
+func TestTimelineGetTimeline_Error(t *testing.T) {
+	env := setupTestEnv(t)
+	mockStore := env.Store.(*test.MockStore)
+
+	handler := NewTimelineHandler(env.Store, env.K8sClient)
+	env.App.Get("/api/timeline", handler.GetTimeline)
+
+	mockStore.On("QueryTimeline", mock.Anything).Return(nil, assert.AnError)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/timeline", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}

--- a/pkg/api/handlers/topology.go
+++ b/pkg/api/handlers/topology.go
@@ -201,9 +201,9 @@ func (h *TopologyHandlers) buildTopologyGraph(
 					Cluster:   exp.Cluster,
 					Namespace: exp.Namespace,
 					Metadata: map[string]interface{}{
-						"status":    string(exp.Status),
-						"exported":  true,
-						"serviceNa": exp.ServiceName,
+						"status":      string(exp.Status),
+						"exported":    true,
+						"serviceName": exp.ServiceName,
 					},
 					Health: health,
 				})

--- a/pkg/api/handlers/topology_test.go
+++ b/pkg/api/handlers/topology_test.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/kubestellar/console/pkg/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestTopologyGetTopology_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewTopologyHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/topology", handler.GetTopology)
+
+	// Inject dynamic objects for MCS and Gateway API
+	gvrKinds := map[schema.GroupVersionResource]string{
+		{Group: "multicluster.x-k8s.io", Version: "v1alpha1", Resource: "serviceexports"}: "ServiceExportList",
+		{Group: "multicluster.x-k8s.io", Version: "v1alpha1", Resource: "serviceimports"}: "ServiceImportList",
+		{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}:          "GatewayList",
+		{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}:        "HTTPRouteList",
+	}
+	dynClient := injectDynamicCluster(env, "test-cluster", gvrKinds)
+
+	// Add a ServiceExport
+	se := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "multicluster.x-k8s.io/v1alpha1",
+			"kind":       "ServiceExport",
+			"metadata": map[string]interface{}{
+				"name":      "test-svc",
+				"namespace": "default",
+			},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   string(v1alpha1.ServiceExportStatusReady),
+						"status": "True",
+					},
+				},
+			},
+		},
+	}
+	_, err := dynClient.Resource(gvrKindsToGVR(gvrKinds, "ServiceExportList")).Namespace("default").Create(context.Background(), se, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/topology", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+
+	graph := result["graph"].(map[string]interface{})
+	nodes := graph["nodes"].([]interface{})
+
+	// Verify graph contains the service and cluster nodes
+	foundService := false
+	foundCluster := false
+	for _, n := range nodes {
+		node := n.(map[string]interface{})
+		if node["type"] == "service" && node["label"] == "test-svc" {
+			foundService = true
+			assert.Equal(t, "default", node["namespace"])
+			assert.Equal(t, "test-cluster", node["cluster"])
+		}
+		if node["type"] == "cluster" && node["label"] == "test-cluster" {
+			foundCluster = true
+		}
+	}
+	assert.True(t, foundService, "Service node should be present")
+	assert.True(t, foundCluster, "Cluster node should be present")
+}
+
+func TestTopologyGetTopology_NoClusters(t *testing.T) {
+	env := setupTestEnv(t)
+	// Clear clusters
+	env.K8sClient.SetRawConfig(&k8sapi.Config{})
+	
+	handler := NewTopologyHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/topology", handler.GetTopology)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/topology", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	graph := result["graph"].(map[string]interface{})
+	assert.Empty(t, graph["nodes"])
+}
+

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1021,6 +1021,7 @@ func (s *Server) setupRoutes() {
 	// Events (anonymous product feedback)
 	events := handlers.NewEventHandler(s.store)
 	api.Post("/events", events.RecordEvent)
+	api.Get("/events", events.GetEvents)
 
 	// RBAC and User Management routes
 	rbac := handlers.NewRBACHandler(s.store, s.k8sClient)


### PR DESCRIPTION
### 📝 Summary of Changes

This PR completes the audit and implementation of backend observability and topology test coverage. It fixes a critical typo in topology metadata, implements a missing event retrieval endpoint, and adds comprehensive unit tests for several core handlers.

---

### Changes Made

- **Topology Fix**: Corrected typo `serviceNa` → `serviceName` in `pkg/api/handlers/topology.go` metadata to match frontend expectations.
- **New API Endpoint**: Implemented `GET /api/events` in `pkg/api/handlers/events.go` to allow retrieval of user interaction events with support for `since`, `limit`, and `offset` filters.
- **New Unit Tests**:
    - `pkg/api/handlers/topology_test.go`: Added coverage for graph generation and MCS/Gateway API integration.
    - `pkg/api/handlers/timeline_test.go`: Added coverage for the cluster event journal and timeline queries.
    - `pkg/api/handlers/crds_test.go`: Added coverage for cross-cluster CRD discovery and parsing.
- **Improved Mocking**: Added `gvrKindsToGVR` helper to `pkg/api/handlers/setup_test.go` to facilitate dynamic client mocking across multiple test suites.
- **API Server**: Registered the new events retrieval route in `pkg/api/server.go`.

---

### Checklist

- [x] I used a coding agent (Antigravity) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] I have written unit tests for the changes
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

**Test Execution Results:**
```bash
=== RUN   TestCRDListCRDs_Success
--- PASS: TestCRDListCRDs_Success (0.00s)
=== RUN   TestEventGetEvents_Success
--- PASS: TestEventGetEvents_Success (0.00s)
=== RUN   TestTimelineGetTimeline_Success
--- PASS: TestTimelineGetTimeline_Success (0.00s)
=== RUN   TestTopologyGetTopology_Success
--- PASS: TestTopologyGetTopology_Success (0.00s)
PASS
ok  	github.com/kubestellar/console/pkg/api/handlers	0.032s
