### PR TITLE
feat: enrich ksc_http_error with status code and endpoint

### DIFF
--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -635,6 +635,11 @@ const COMPONENT_NAME_MAX_LEN = 60
 // short (TypeError, RangeError, etc.), so 40 chars is plenty.
 const ERROR_TYPE_MAX_LEN = 40
 
+// Maximum length for the HTTP endpoint dimension. API paths are short
+// (/api/clusters, /api/mcp/pod-issues/stream, etc.) but query strings
+// can bloat them, so truncate at 120 chars.
+const HTTP_ENDPOINT_MAX_LEN = 120
+
 /** Fallback when no error type can be inferred from the message or Error.name */
 const ERROR_TYPE_UNKNOWN = 'Unknown'
 
@@ -916,6 +921,26 @@ export function emitError(
   })
 }
 
+/**
+ * Emit a structured HTTP error event with status code and endpoint path.
+ * Called from api.get()/api.post() so every non-2xx response is tracked
+ * with enough context to diagnose without digging through error_detail.
+ */
+export function emitHttpError(
+  status: number | string,
+  endpoint: string,
+  detail?: string,
+) {
+  const page = window.location.pathname
+  if (isErrorThrottled(`http_${status}`, page)) return
+  send('ksc_http_error', {
+    http_status: String(status),
+    http_endpoint: endpoint.slice(0, HTTP_ENDPOINT_MAX_LEN),
+    error_detail: (detail || `HTTP ${status}`).slice(0, ERROR_DETAIL_MAX_LEN),
+    error_page: page,
+  })
+}
+
 /** Emit when auto-reload failed to fix stale chunks (user sees manual reload UI) */
 export function emitChunkReloadRecoveryFailed(errorDetail: string) {
   send('ksc_chunk_reload_recovery', {
@@ -1112,18 +1137,18 @@ export function startGlobalErrorTracking() {
       // these as ksc_error creates false-positive alert spikes (#9994).
       if (errorName === 'UnauthenticatedError' || errorName === 'UnauthorizedError') {
         pushCapturedError('error', msg, 'auth_error')
-        send('ksc_http_error', { http_status: 'auth', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        send('ksc_http_error', { http_status: 'auth', http_endpoint: 'global', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
         return
       }
       if (msg.includes('No authentication token') || msg.includes('Token is invalid or expired')) {
         pushCapturedError('error', msg, 'auth_error')
-        send('ksc_http_error', { http_status: 'auth', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        send('ksc_http_error', { http_status: 'auth', http_endpoint: 'global', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
         return
       }
       if (/\b50[234]\b/.test(msg) && (msg.includes('fetch') || msg.includes('Fetch') || msg.includes('upstream'))) {
         const statusMatch = msg.match(/\b(50[234])\b/)
         pushCapturedError('error', msg, `http_${statusMatch?.[1] ?? '5xx'}`)
-        send('ksc_http_error', { http_status: statusMatch?.[1] ?? '5xx', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        send('ksc_http_error', { http_status: statusMatch?.[1] ?? '5xx', http_endpoint: 'global', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
         return
       }
       pushCapturedError('error', msg, 'unhandled_rejection')
@@ -1182,12 +1207,12 @@ export function startGlobalErrorTracking() {
       if (tryChunkReloadRecovery(event.message)) return
       if (event.error?.name === 'UnauthenticatedError' || event.error?.name === 'UnauthorizedError') {
         pushCapturedError('error', event.message, 'auth_error')
-        send('ksc_http_error', { http_status: 'auth', error_detail: event.message.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        send('ksc_http_error', { http_status: 'auth', http_endpoint: 'global', error_detail: event.message.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
         return
       }
       if (event.message.includes('No authentication token') || event.message.includes('Token is invalid or expired')) {
         pushCapturedError('error', event.message, 'auth_error')
-        send('ksc_http_error', { http_status: 'auth', error_detail: event.message.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        send('ksc_http_error', { http_status: 'auth', http_endpoint: 'global', error_detail: event.message.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
         return
       }
       pushCapturedError('error', event.message, 'runtime')

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -23,6 +23,7 @@ export {
   emitUserEngagement,
   startGlobalErrorTracking,
   emitError,
+  emitHttpError,
   emitChunkReloadRecoveryFailed,
   markErrorReported,
   captureUtmParams,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -7,7 +7,7 @@ import {
   DEMO_TOKEN_VALUE,
   FETCH_DEFAULT_TIMEOUT_MS,
 } from './constants'
-import { emitSessionExpired } from './analytics'
+import { emitSessionExpired, emitHttpError } from './analytics'
 
 const API_BASE = ''
 const DEFAULT_TIMEOUT = MCP_HOOK_TIMEOUT_MS
@@ -529,9 +529,7 @@ class ApiClient {
           handle429(response)
         }
         const errorText = await response.text().catch(() => '')
-        // Note: We don't mark backend as failed on 500 responses here.
-        // The health check is the source of truth for backend availability.
-        // Individual API 500s could be endpoint-specific issues, not infrastructure failure.
+        emitHttpError(response.status, path, errorText || undefined)
         throw new Error(errorText || `API error: ${response.status}`)
       }
       markBackendSuccess()
@@ -542,11 +540,12 @@ class ApiClient {
     } catch (err: unknown) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
+        emitHttpError('timeout', path, `Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s`)
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)
       }
-      // Only mark backend failure on actual network errors (fetch TypeError)
       if (err instanceof TypeError && err.message.includes('fetch')) {
         markBackendFailure()
+        emitHttpError('network', path, err.message)
       }
       throw err
     }
@@ -586,7 +585,7 @@ class ApiClient {
           handle429(response)
         }
         const errorText = await response.text().catch(() => '')
-        // Note: Don't mark backend as failed on 500s - health check is source of truth
+        emitHttpError(response.status, path, errorText || undefined)
         throw new Error(errorText || `API error: ${response.status}`)
       }
       markBackendSuccess()
@@ -597,11 +596,12 @@ class ApiClient {
     } catch (err: unknown) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
+        emitHttpError('timeout', path, `Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s`)
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)
       }
-      // Only mark backend failure on actual network errors
       if (err instanceof TypeError && err.message.includes('fetch')) {
         markBackendFailure()
+        emitHttpError('network', path, err.message)
       }
       throw err
     }
@@ -641,7 +641,7 @@ class ApiClient {
           handle429(response)
         }
         const errorText = await response.text().catch(() => '')
-        // Note: Don't mark backend as failed on 500s - health check is source of truth
+        emitHttpError(response.status, path, errorText || undefined)
         throw new Error(errorText || `API error: ${response.status}`)
       }
       markBackendSuccess()
@@ -652,11 +652,12 @@ class ApiClient {
     } catch (err: unknown) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
+        emitHttpError('timeout', path, `Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s`)
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)
       }
-      // Only mark backend failure on actual network errors
       if (err instanceof TypeError && err.message.includes('fetch')) {
         markBackendFailure()
+        emitHttpError('network', path, err.message)
       }
       throw err
     }
@@ -695,7 +696,7 @@ class ApiClient {
           handle429(response)
         }
         const errorText = await response.text().catch(() => '')
-        // Note: Don't mark backend as failed on 500s - health check is source of truth
+        emitHttpError(response.status, path, errorText || undefined)
         throw new Error(errorText || `API error: ${response.status}`)
       }
       markBackendSuccess()
@@ -703,11 +704,12 @@ class ApiClient {
     } catch (err: unknown) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
+        emitHttpError('timeout', path, `Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s`)
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)
       }
-      // Only mark backend failure on actual network errors
       if (err instanceof TypeError && err.message.includes('fetch')) {
         markBackendFailure()
+        emitHttpError('network', path, err.message)
       }
       throw err
     }


### PR DESCRIPTION
## Summary

- Adds `emitHttpError()` function that emits structured `ksc_http_error` events with `http_status`, `http_endpoint`, and `error_detail`
- Wires it into all 4 API methods (`get`, `post`, `put`, `delete`) for HTTP errors, timeouts, and network failures
- Adds `http_endpoint` dimension to existing global error handler emissions (set to `'global'` to distinguish)
- Respects existing error throttling via `isErrorThrottled()`

## Why

GA4 showed ~20K `ksc_http_error` events/week from localhost installs with `error_code: (not set)` and `error_detail: (not set)` — completely opaque. HTTP errors were bubbling up as unhandled rejections with no structured dimensions, making it impossible to tell which endpoints were failing or what status codes were returned.

## What changes

| Dimension | Before | After |
|-----------|--------|-------|
| `http_status` | `'auth'` / `'5xx'` only | Numeric status (`403`, `500`, etc.), `'timeout'`, `'network'` |
| `http_endpoint` | not sent | API path (e.g., `/api/clusters`, `/api/mcp/pod-issues/stream`) |
| `error_detail` | error message | response body or descriptive message |

## GA4 Setup Required

Register `http_endpoint` as a custom dimension in GA4:
- Admin > Custom definitions > Create custom dimension
- Dimension name: `http_endpoint`
- Scope: Event
- Event parameter: `http_endpoint`

## Test plan

- [ ] Build passes
- [ ] Verify `ksc_http_error` events appear in GA4 DebugView with all 3 dimensions populated
- [ ] Check that error throttling still works (same endpoint/status doesn't spam)