### PR TITLE
fix: auto-build kc-agent from source in startup-oauth.sh

### DIFF
--- a/cmd/watcher/watcher_html.go
+++ b/cmd/watcher/watcher_html.go
@@ -65,6 +65,7 @@ h1{font-size:1.25rem;font-weight:500;margin-bottom:.25rem}
 
 <div class="steps" id="steps">
   <div class="step active" data-stage="watchdog"><span class="step-icon"></span>Preparing environment</div>
+  <div class="step waiting" data-stage="agent_build"><span class="step-icon"></span>Building agent</div>
   <div class="step waiting" data-stage="npm_install"><span class="step-icon"></span>Installing dependencies</div>
   <div class="step waiting" data-stage="frontend_build"><span class="step-icon"></span>Building frontend</div>
   <div class="step waiting" data-stage="backend_compiling"><span class="step-icon"></span>Compiling backend</div>
@@ -126,7 +127,7 @@ var reloading=false;
 var elapsedEl=document.getElementById('elapsed');
 
 // Stage ordering
-var STAGES=['watchdog','npm_install','frontend_build','vite_starting','backend_compiling','backend_starting','ready'];
+var STAGES=['watchdog','agent_build','npm_install','frontend_build','vite_starting','backend_compiling','backend_starting','ready'];
 
 function normalizeStage(s){
   if(s==='vite_starting') return 'frontend_build';
@@ -162,6 +163,7 @@ function updateSteps(stage){
   var subtitle=document.querySelector('.subtitle');
   var labels={
     'watchdog':'Preparing environment\u2026',
+    'agent_build':'Building agent\u2026',
     'npm_install':'Installing dependencies\u2026',
     'frontend_build':'Building frontend\u2026',
     'vite_starting':'Starting dev server\u2026',

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -274,26 +274,14 @@ cleanup() {
 }
 trap cleanup SIGINT SIGTERM EXIT
 
-# Resolve kc-agent binary path
+# Resolve kc-agent binary path (build happens later, after the loading page is up)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 KC_AGENT_BIN=""
+KC_AGENT_NEEDS_BUILD=false
 
-# Auto-build kc-agent from source when running from a dev checkout.
-# This ensures the binary always matches the checked-out code and embeds
-# the commit SHA + build time so /health and the feedback modal report it.
 if [ -f "$SCRIPT_DIR/cmd/kc-agent/main.go" ] && command -v go &>/dev/null; then
-    echo -e "${GREEN}Building kc-agent from source...${NC}"
-    AGENT_LDFLAGS="-X github.com/kubestellar/console/pkg/agent.CommitSHA=$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
-    AGENT_LDFLAGS="$AGENT_LDFLAGS -X github.com/kubestellar/console/pkg/agent.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    mkdir -p "$SCRIPT_DIR/bin"
-    if GOWORK=off go build -ldflags "$AGENT_LDFLAGS" -o "$SCRIPT_DIR/bin/kc-agent" ./cmd/kc-agent; then
-        KC_AGENT_BIN="$SCRIPT_DIR/bin/kc-agent"
-        echo -e "${GREEN}kc-agent built ($(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo dev))${NC}"
-    else
-        echo -e "${YELLOW}Warning: kc-agent build failed. Falling back to existing binary or brew.${NC}"
-    fi
+    KC_AGENT_NEEDS_BUILD=true
 elif [ -f "$SCRIPT_DIR/bin/kc-agent" ]; then
-    # Local build binary found — validate it is non-empty and executable
     if [ -s "$SCRIPT_DIR/bin/kc-agent" ] && [ -x "$SCRIPT_DIR/bin/kc-agent" ]; then
         KC_AGENT_BIN="$SCRIPT_DIR/bin/kc-agent"
     else
@@ -429,6 +417,22 @@ if [ "$USE_DEV_SERVER" = true ]; then
         "$WATCHER_BIN" $TLS_FLAG --backend-port "$BACKEND_LISTEN_PORT" &
         WATCHDOG_PID=$!
         sleep 1
+        echo -e "${CYAN}  Loading page: http://localhost:8080${NC}"
+    fi
+
+    # Build kc-agent from source if running from a dev checkout.
+    if [ "$KC_AGENT_NEEDS_BUILD" = true ]; then
+        write_stage "agent_build"
+        echo -e "${GREEN}Building kc-agent from source...${NC}"
+        AGENT_LDFLAGS="-X github.com/kubestellar/console/pkg/agent.CommitSHA=$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+        AGENT_LDFLAGS="$AGENT_LDFLAGS -X github.com/kubestellar/console/pkg/agent.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        mkdir -p "$SCRIPT_DIR/bin"
+        if GOWORK=off go build -ldflags "$AGENT_LDFLAGS" -o "$SCRIPT_DIR/bin/kc-agent" ./cmd/kc-agent; then
+            KC_AGENT_BIN="$SCRIPT_DIR/bin/kc-agent"
+            echo -e "${GREEN}kc-agent built ($(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo dev))${NC}"
+        else
+            echo -e "${YELLOW}Warning: kc-agent build failed. Falling back to existing binary or brew.${NC}"
+        fi
     fi
 
     # Always run npm install to pick up new/changed dependencies (#4405).
@@ -484,6 +488,22 @@ else
         "$WATCHER_BIN" $TLS_FLAG --backend-port "$BACKEND_LISTEN_PORT" &
         WATCHDOG_PID=$!
         sleep 1
+        echo -e "${CYAN}  Loading page: http://localhost:8080${NC}"
+    fi
+
+    # Build kc-agent from source if running from a dev checkout.
+    if [ "$KC_AGENT_NEEDS_BUILD" = true ]; then
+        write_stage "agent_build"
+        echo -e "${GREEN}Building kc-agent from source...${NC}"
+        AGENT_LDFLAGS="-X github.com/kubestellar/console/pkg/agent.CommitSHA=$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+        AGENT_LDFLAGS="$AGENT_LDFLAGS -X github.com/kubestellar/console/pkg/agent.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        mkdir -p "$SCRIPT_DIR/bin"
+        if GOWORK=off go build -ldflags "$AGENT_LDFLAGS" -o "$SCRIPT_DIR/bin/kc-agent" ./cmd/kc-agent; then
+            KC_AGENT_BIN="$SCRIPT_DIR/bin/kc-agent"
+            echo -e "${GREEN}kc-agent built ($(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo dev))${NC}"
+        else
+            echo -e "${YELLOW}Warning: kc-agent build failed. Falling back to existing binary or brew.${NC}"
+        fi
     fi
 
     # Always run npm install to pick up new/changed dependencies (#4405).

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -277,7 +277,22 @@ trap cleanup SIGINT SIGTERM EXIT
 # Resolve kc-agent binary path
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 KC_AGENT_BIN=""
-if [ -f "$SCRIPT_DIR/bin/kc-agent" ]; then
+
+# Auto-build kc-agent from source when running from a dev checkout.
+# This ensures the binary always matches the checked-out code and embeds
+# the commit SHA + build time so /health and the feedback modal report it.
+if [ -f "$SCRIPT_DIR/cmd/kc-agent/main.go" ] && command -v go &>/dev/null; then
+    echo -e "${GREEN}Building kc-agent from source...${NC}"
+    AGENT_LDFLAGS="-X github.com/kubestellar/console/pkg/agent.CommitSHA=$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    AGENT_LDFLAGS="$AGENT_LDFLAGS -X github.com/kubestellar/console/pkg/agent.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    mkdir -p "$SCRIPT_DIR/bin"
+    if GOWORK=off go build -ldflags "$AGENT_LDFLAGS" -o "$SCRIPT_DIR/bin/kc-agent" ./cmd/kc-agent; then
+        KC_AGENT_BIN="$SCRIPT_DIR/bin/kc-agent"
+        echo -e "${GREEN}kc-agent built ($(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo dev))${NC}"
+    else
+        echo -e "${YELLOW}Warning: kc-agent build failed. Falling back to existing binary or brew.${NC}"
+    fi
+elif [ -f "$SCRIPT_DIR/bin/kc-agent" ]; then
     # Local build binary found — validate it is non-empty and executable
     if [ -s "$SCRIPT_DIR/bin/kc-agent" ] && [ -x "$SCRIPT_DIR/bin/kc-agent" ]; then
         KC_AGENT_BIN="$SCRIPT_DIR/bin/kc-agent"


### PR DESCRIPTION
## Summary
- When running from a dev checkout, `startup-oauth.sh` now auto-rebuilds `kc-agent` with `-ldflags` embedding the git commit SHA and build time
- Ensures the `/health` endpoint and feedback modal always report the accurate version, preventing stale-binary debugging like we had with Ghanshyam's CORS issue
- Brew/release users are unaffected — the auto-build only triggers when `cmd/kc-agent/main.go` exists and `go` is installed

## Test plan
- [ ] Run `startup-oauth.sh` from a cloned repo — verify kc-agent is rebuilt and log shows the short SHA
- [ ] Run `curl http://127.0.0.1:8585/health` — verify `commitSHA` and `buildTime` are populated
- [ ] Verify brew-installed users are unaffected (no `cmd/kc-agent/main.go` → skips auto-build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)