### PR TITLE
🐛 Fix api.test.ts missing emitHttpError mock

### DIFF
--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -28,6 +28,7 @@ vi.mock('../constants', async (importOriginal) => {
 
 vi.mock('../analytics', () => ({
   emitError: vi.fn(),
+  emitHttpError: vi.fn(),
   emitSessionExpired: vi.fn(),
 }))
 


### PR DESCRIPTION
Fixes #11325

The analytics mock in api.test.ts was missing the emitHttpError function added in PR #11319, causing the 'handles 500 with error text' test to fail with a TypeError when the code tries to call the unmocked function.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>