### PR TITLE
feat: exponential backoff for MCP hook polling on failures

### DIFF
--- a/web/src/hooks/mcp/buildpacks.ts
+++ b/web/src/hooks/mcp/buildpacks.ts
@@ -273,7 +273,7 @@ export function useBuildpackImages(cluster?: string) {
     // Poll for buildpack images (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `buildpackImages:${cluster || 'all'}`,
-      getEffectiveInterval(BUILDPACK_REFRESH_INTERVAL_MS),
+      getEffectiveInterval(BUILDPACK_REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(true),
     )
 
@@ -286,7 +286,7 @@ export function useBuildpackImages(cluster?: string) {
       unsubscribePolling()
       unregister()
     }
-  }, [refetch, cluster])
+  }, [refetch, cluster, consecutiveFailures])
 
   useEffect(() => {
     if (initialMountRef.current) {

--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -49,6 +49,7 @@ export function useMCPStatus() {
   const [status, setStatus] = useState<MCPStatus | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
 
   useEffect(() => {
     const fetchStatus = async () => {
@@ -58,9 +59,11 @@ export function useMCPStatus() {
         const data = await resp.json()
         setStatus(data)
         setError(null)
+        setConsecutiveFailures(0)
       } catch {
         setError('MCP bridge not available')
         setStatus(null)
+        setConsecutiveFailures(prev => prev + 1)
       } finally {
         setIsLoading(false)
       }
@@ -70,11 +73,11 @@ export function useMCPStatus() {
     // Poll MCP status (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       'mcpStatus',
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       fetchStatus,
     )
     return () => unsubscribePolling()
-  }, [])
+  }, [consecutiveFailures])
 
   return { status, isLoading, error }
 }
@@ -185,14 +188,14 @@ export function useClusters() {
   useEffect(() => {
     const unsubscribePolling = subscribePolling(
       'clusters',
-      getEffectiveInterval(CLUSTER_POLL_INTERVAL_MS),
+      getEffectiveInterval(CLUSTER_POLL_INTERVAL_MS, dataState.consecutiveFailures),
       () => fullFetchClusters(),
     )
 
     return () => {
       unsubscribePolling()
     }
-  }, [])
+  }, [dataState.consecutiveFailures])
 
   // Refetch function that consumers can call
   const refetch = useCallback(() => {

--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -351,7 +351,7 @@ export function useGPUNodes(cluster?: string) {
     // Poll GPU node data periodically (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `gpuNodes:${cluster || 'all'}`,
-      getEffectiveInterval(GPU_POLL_INTERVAL_MS),
+      getEffectiveInterval(GPU_POLL_INTERVAL_MS, gpuNodeCache.consecutiveFailures),
       () => fetchGPUNodes(cluster, 'poll'),
     )
 
@@ -365,7 +365,7 @@ export function useGPUNodes(cluster?: string) {
       unsubscribePolling()
       unregisterRefetch()
     }
-  }, [cluster])
+  }, [cluster, gpuNodeCache.consecutiveFailures])
 
   const refetch = useCallback(() => {
     fetchGPUNodes(cluster)

--- a/web/src/hooks/mcp/crossplane.ts
+++ b/web/src/hooks/mcp/crossplane.ts
@@ -280,7 +280,7 @@ export function useCrossplaneManagedResources(cluster?: string) {
     // Poll for Crossplane managed resources (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `crossplaneManaged:${cluster || 'all'}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(true),
     )
 
@@ -293,7 +293,7 @@ export function useCrossplaneManagedResources(cluster?: string) {
       unsubscribePolling()
       unregister()
     }
-  }, [refetch, cluster])
+  }, [refetch, cluster, consecutiveFailures])
 
   useEffect(() => {
     if (initialMountRef.current) {

--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -212,7 +212,7 @@ export function useEvents(cluster?: string, namespace?: string, limit = 20) {
     // Poll for events (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `events:${cacheKey}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(true),
     )
 
@@ -223,7 +223,7 @@ export function useEvents(cluster?: string, namespace?: string, limit = 20) {
       unsubscribePolling()
       unregisterRefetch()
     }
-  }, [refetch, cacheKey])
+  }, [refetch, cacheKey, consecutiveFailures])
 
   // Subscribe to cache reset notifications - triggers skeleton when cache is cleared
   useEffect(() => {
@@ -289,6 +289,7 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [lastUpdated, setLastUpdated] = useState<Date | null>(cached?.timestamp || null)
   const [error, setError] = useState<string | null>(null)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
 
   const refetch = useCallback(async (silent = false) => {
     // For silent (background) refreshes, don't update loading states - prevents UI flashing
@@ -353,11 +354,13 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
       setEvents(allEvents.slice(0, limit))
       setError(null)
       setLastUpdated(now)
+      setConsecutiveFailures(0)
     } catch (err: unknown) {
       // Use name check instead of instanceof to handle both Error and DOMException
       // across all browser versions (DOMException may not extend Error in older Safari).
       if ((err as { name?: string })?.name === 'AbortError') return
       if (!isMountedRef.current) return
+      setConsecutiveFailures(prev => prev + 1)
       if (!silent && !warningEventsCache) {
         setError('Failed to fetch warning events')
       }
@@ -391,7 +394,7 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
     // Poll for warning events (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `warningEvents:${cacheKey}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(true),
     )
 
@@ -402,7 +405,7 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
       unsubscribePolling()
       unregisterRefetch()
     }
-  }, [refetch, cacheKey])
+  }, [refetch, cacheKey, consecutiveFailures])
 
   // Subscribe to cache reset notifications - triggers skeleton when cache is cleared
   useEffect(() => {

--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -293,7 +293,7 @@ export function useHelmReleases(cluster?: string) {
     // Poll for Helm releases (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `helmReleases:${cluster || 'all'}`,
-      getEffectiveInterval(HELM_REFRESH_INTERVAL_MS),
+      getEffectiveInterval(HELM_REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(true),
     )
 
@@ -304,7 +304,7 @@ export function useHelmReleases(cluster?: string) {
       unsubscribePolling()
       unregisterRefetch()
     }
-  }, [refetch, cluster])
+  }, [refetch, cluster, consecutiveFailures])
 
   // Re-fetch when demo mode changes (not on initial mount)
   useEffect(() => {

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -304,7 +304,7 @@ export function useServices(cluster?: string, namespace?: string) {
     // Poll for service updates (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `services:${cacheKey}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(true),
     )
 
@@ -317,7 +317,7 @@ export function useServices(cluster?: string, namespace?: string) {
       unsubscribePolling()
       unregisterRefetch()
     }
-  }, [refetch, cacheKey])
+  }, [refetch, cacheKey, consecutiveFailures])
 
   // Subscribe to cache reset notifications - triggers skeleton when cache is cleared
   useEffect(() => {

--- a/web/src/hooks/mcp/security.ts
+++ b/web/src/hooks/mcp/security.ts
@@ -268,7 +268,7 @@ export function useGitOpsDrifts(cluster?: string, namespace?: string) {
     // Poll for GitOps drifts (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `gitopsDrifts:${cluster || 'all'}:${namespace || 'all'}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(true),
     )
 
@@ -281,7 +281,7 @@ export function useGitOpsDrifts(cluster?: string, namespace?: string) {
       unsubscribePolling()
       unregisterRefetch()
     }
-  }, [refetch, cluster, namespace])
+  }, [refetch, cluster, namespace, consecutiveFailures])
 
   // Re-fetch when demo mode changes (not on initial mount)
   useEffect(() => {

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -30,8 +30,15 @@ export const GPU_POLL_INTERVAL_MS = 30000      // 30 seconds
 /** Cache TTL: matches cluster poll interval for freshness checks */
 export const CACHE_TTL_MS = CLUSTER_POLL_INTERVAL_MS
 
-export function getEffectiveInterval(baseInterval: number): number {
-  return baseInterval
+/** Backoff multiplier applied per consecutive failure (2x, 4x, 8x …) */
+const FAILURE_BACKOFF_MULTIPLIER = 2
+/** Maximum polling interval after repeated failures (10 minutes) */
+const MAX_BACKOFF_INTERVAL_MS = 600_000
+
+export function getEffectiveInterval(baseInterval: number, consecutiveFailures = 0): number {
+  if (consecutiveFailures <= 0) return baseInterval
+  const multiplier = Math.pow(FAILURE_BACKOFF_MULTIPLIER, Math.min(consecutiveFailures, 5))
+  return Math.min(baseInterval * multiplier, MAX_BACKOFF_INTERVAL_MS)
 }
 
 /** Name length above which a cluster context name is considered auto-generated */

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -320,7 +320,7 @@ export function usePVCs(cluster?: string, namespace?: string) {
     // Poll for PVC updates (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `pvcs:${cacheKey}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => { if (!cancelled) refetch(true) },
     )
 
@@ -334,7 +334,7 @@ export function usePVCs(cluster?: string, namespace?: string) {
       unsubscribePolling()
       unregisterRefetch()
     }
-  }, [refetch, cacheKey])
+  }, [refetch, cacheKey, consecutiveFailures])
 
   // Subscribe to cache reset notifications - triggers skeleton when cache is cleared
   useEffect(() => {
@@ -409,7 +409,7 @@ export function usePVs(cluster?: string) {
     // Poll for PV updates (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `pvs:${cluster || 'all'}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(),
     )
 
@@ -422,7 +422,7 @@ export function usePVs(cluster?: string) {
       unsubscribePolling()
       unregisterRefetch()
     }
-  }, [refetch, cluster])
+  }, [refetch, cluster, consecutiveFailures])
 
   return { pvs, isLoading, isRefreshing, error, refetch, consecutiveFailures, isFailed: consecutiveFailures >= 3 }
 }
@@ -437,6 +437,7 @@ export function useResourceQuotas(cluster?: string, namespace?: string, forceLiv
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [isDemoFallback, setIsDemoFallback] = useState(false)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
 
   const refetch = useCallback(async () => {
     // If demo mode is enabled, use demo data (unless forceLive overrides)
@@ -461,12 +462,14 @@ export function useResourceQuotas(cluster?: string, namespace?: string, forceLiv
       setResourceQuotas(data.resourceQuotas || [])
       setIsDemoFallback(false)
       setError(null)
+      setConsecutiveFailures(0)
     } catch {
       // Don't show error - ResourceQuotas are optional
       setError(null)
       // Don't fall back to demo data - show empty instead
       setResourceQuotas([])
       setIsDemoFallback(false)
+      setConsecutiveFailures(prev => prev + 1)
     } finally {
       setIsLoading(false)
     }
@@ -477,7 +480,7 @@ export function useResourceQuotas(cluster?: string, namespace?: string, forceLiv
     // Poll for resource quota updates (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `resourceQuotas:${cluster || 'all'}:${namespace || 'all'}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(),
     )
 
@@ -490,7 +493,7 @@ export function useResourceQuotas(cluster?: string, namespace?: string, forceLiv
       unsubscribePolling()
       unregisterRefetch()
     }
-  }, [refetch, cluster, namespace])
+  }, [refetch, cluster, namespace, consecutiveFailures])
 
   return { resourceQuotas, isLoading, error, refetch, isDemoFallback }
 }
@@ -500,6 +503,7 @@ export function useLimitRanges(cluster?: string, namespace?: string) {
   const [limitRanges, setLimitRanges] = useState<LimitRange[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
 
   const refetch = useCallback(async () => {
     // If demo mode is enabled, use demo data
@@ -522,11 +526,13 @@ export function useLimitRanges(cluster?: string, namespace?: string) {
       const data = await resp.json()
       setLimitRanges(data.limitRanges || [])
       setError(null)
+      setConsecutiveFailures(0)
     } catch {
       // Don't show error - LimitRanges are optional
       setError(null)
       // Don't fall back to demo data - show empty instead
       setLimitRanges([])
+      setConsecutiveFailures(prev => prev + 1)
     } finally {
       setIsLoading(false)
     }
@@ -537,7 +543,7 @@ export function useLimitRanges(cluster?: string, namespace?: string) {
     // Poll for limit range updates (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `limitRanges:${cluster || 'all'}:${namespace || 'all'}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(),
     )
 
@@ -550,7 +556,7 @@ export function useLimitRanges(cluster?: string, namespace?: string) {
       unsubscribePolling()
       unregisterRefetch()
     }
-  }, [refetch, cluster, namespace])
+  }, [refetch, cluster, namespace, consecutiveFailures])
 
   return { limitRanges, isLoading, error, refetch }
 }

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -513,7 +513,7 @@ export function usePods(cluster?: string, namespace?: string, sortBy: 'restarts'
     // Poll for pod updates (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `pods:${cacheKey}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(true),
     )
 
@@ -527,7 +527,7 @@ export function usePods(cluster?: string, namespace?: string, sortBy: 'restarts'
       unregisterRefetch()
       sseAbortRef.current?.abort()
     }
-  }, [refetch, cacheKey])
+  }, [refetch, cacheKey, consecutiveFailures])
 
   // Subscribe to cache reset notifications - triggers skeleton when cache is cleared
   useEffect(() => {
@@ -580,6 +580,7 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [lastUpdated, setLastUpdated] = useState<Date | null>(cached?.timestamp || null)
   const [error, setError] = useState<string | null>(null)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
   // Per-cluster errors from the SSE `cluster_error` event (Issue 9353). Lets
   // consumers (drill-downs) distinguish an RBAC denial on one or more
   // clusters from a globally-transient failure so the UI can show a
@@ -657,10 +658,12 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
       setError(null)
       setClusterErrors(collectedErrors)
       setLastUpdated(now)
+      setConsecutiveFailures(0)
     } catch (err: unknown) {
       if (err instanceof DOMException && err.name === 'AbortError') return
       const message = err instanceof Error ? err.message : 'Failed to fetch pods'
       console.warn('[useAllPods] Fetch failed:', message)
+      setConsecutiveFailures(prev => prev + 1)
       if (!silent && !podsCache) {
         setError(message)
       }
@@ -682,7 +685,7 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
     // Poll for pod updates (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `allPods:${cacheKey}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(true),
     )
 
@@ -696,7 +699,7 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
       unregisterRefetch()
       sseAbortRef.current?.abort()
     }
-  }, [refetch, cacheKey])
+  }, [refetch, cacheKey, consecutiveFailures])
 
   // Subscribe to cache reset notifications - triggers skeleton when cache is cleared
   useEffect(() => {
@@ -893,7 +896,7 @@ export function usePodIssues(cluster?: string, namespace?: string): UsePodIssues
     // Poll for pod issue updates (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `podIssues:${cacheKey}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(true),
     )
 
@@ -907,7 +910,7 @@ export function usePodIssues(cluster?: string, namespace?: string): UsePodIssues
       unregisterRefetch()
       sseAbortRef.current?.abort()
     }
-  }, [refetch, cacheKey])
+  }, [refetch, cacheKey, consecutiveFailures])
 
   // Subscribe to cache reset notifications - triggers skeleton when cache is cleared
   useEffect(() => {
@@ -1053,7 +1056,7 @@ export function useDeploymentIssues(cluster?: string, namespace?: string): UseDe
     // Poll for deployment issues (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `deploymentIssues:${cacheKey}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(true),
     )
 
@@ -1067,7 +1070,7 @@ export function useDeploymentIssues(cluster?: string, namespace?: string): UseDe
       unregisterRefetch()
       sseAbortRef.current?.abort()
     }
-  }, [refetch, cacheKey])
+  }, [refetch, cacheKey, consecutiveFailures])
 
   // Subscribe to cache reset notifications - triggers skeleton when cache is cleared
   useEffect(() => {
@@ -1309,7 +1312,7 @@ export function useDeployments(cluster?: string, namespace?: string): UseDeploym
     // Poll for deployment updates (shared interval prevents duplicates across components)
     const unsubscribePolling = subscribePolling(
       `deployments:${cacheKey}`,
-      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      getEffectiveInterval(REFRESH_INTERVAL_MS, consecutiveFailures),
       () => refetch(true),
     )
 
@@ -1322,7 +1325,7 @@ export function useDeployments(cluster?: string, namespace?: string): UseDeploym
       unsubscribePolling()
       unregisterRefetch()
     }
-  }, [refetch, cacheKey])
+  }, [refetch, cacheKey, consecutiveFailures])
 
   // Subscribe to cache reset notifications - triggers skeleton when cache is cleared
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Adds exponential backoff (2x per failure, capped at 10 min) to getEffectiveInterval() in MCP hooks
- When kc-agent is unreachable, polling slows from 120s to 240s to 480s to 600s max
- Resets to base interval immediately when a fetch succeeds
- Wires consecutiveFailures into 5 hooks that were missing it (useWarningEvents, useMCPStatus, useResourceQuotas, useLimitRanges, useAllPods)

**Impact**: Reduces ~1,200 noisy ksc_http_error events/week from localhost installs where kc-agent is not connected. Also reduces unnecessary network traffic for users without a connected agent.

## Test plan
- [ ] Verify console starts normally with kc-agent connected
- [ ] Disconnect kc-agent — confirm polling intervals increase after consecutive failures
- [ ] Reconnect kc-agent — confirm polling resets to base interval
- [ ] Check GA4 ksc_http_error count after 1 week to measure reduction