### PR TITLE
🐛 fix(pod-logs): align dropdown styling with theme tokens

### DIFF
--- a/web/src/components/cards/PodLogs.tsx
+++ b/web/src/components/cards/PodLogs.tsx
@@ -266,7 +266,7 @@ export function PodLogs({ config }: PodLogsProps) {
       </div>
 
       {/* Log viewer */}
-      <div className="flex-1 min-h-0 rounded-lg border border-border bg-slate-950 overflow-hidden">
+      <div className="flex-1 min-h-0 rounded-lg border border-border bg-card overflow-hidden">
         {logsError ? (
           <div className="h-full flex items-center justify-center gap-2 p-4 text-xs text-red-400">
             <AlertCircle className="w-4 h-4 shrink-0" />


### PR DESCRIPTION
Fixes #11339

Replaced hardcoded `bg-slate-950` with `bg-card` in the Pod Logs log viewer container to ensure consistent styling across light/dark themes.

**Changes:**
- PodLogs.tsx: Changed log viewer background from hardcoded `bg-slate-950` to semantic theme token `bg-card`

This ensures the log viewer properly adapts to all theme variants without hardcoded color values.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>