### PR TITLE
🐛 fix(missions): use theme-aware colors for warning/error cards

### DIFF
--- a/web/src/components/missions/PreflightFailure.tsx
+++ b/web/src/components/missions/PreflightFailure.tsx
@@ -122,7 +122,7 @@ function ActionButton({
   if (action.actionType === 'info') {
     return (
       <div className="flex items-start gap-2 text-xs text-muted-foreground">
-        <Icon size={14} className="mt-0.5 shrink-0 text-gray-400" />
+        <Icon size={14} className="mt-0.5 shrink-0 text-muted-foreground" />
         <span>{action.description}</span>
       </div>
     )
@@ -162,16 +162,16 @@ function ActionButton({
         {action.codeSnippet && (
           <button
             onClick={handleCopy}
-            className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-gray-400 transition-colors hover:bg-gray-700 hover:text-foreground"
+            className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
           >
             <Icon size={12} />
             {copied ? 'Copied' : 'Copy'}
           </button>
         )}
       </div>
-      <p className="text-xs text-gray-400">{action.description}</p>
+      <p className="text-xs text-muted-foreground">{action.description}</p>
       {action.codeSnippet && (
-        <pre className="mt-1 overflow-x-auto rounded-md bg-gray-900/70 p-2 text-xs text-muted-foreground">
+        <pre className="mt-1 overflow-x-auto rounded-md bg-secondary/70 p-2 text-xs text-muted-foreground">
           <code>{action.codeSnippet}</code>
         </pre>
       )}
@@ -197,7 +197,7 @@ export function PreflightFailure({ error, context, onRetry }: PreflightFailurePr
   return (
     <div
       className={cn(
-        'rounded-lg border border-gray-700/50 p-4',
+        'rounded-lg border border-border p-4',
         display.bgColor,
       )}
       data-testid="preflight-failure"
@@ -206,10 +206,10 @@ export function PreflightFailure({ error, context, onRetry }: PreflightFailurePr
       {/* Header */}
       <div className="mb-3 flex items-center gap-2">
         <Icon size={18} className={display.color} />
-        <h4 className="text-sm font-semibold text-gray-100">
+        <h4 className="text-sm font-semibold text-foreground">
           {display.title}
         </h4>
-        <span className="ml-auto rounded bg-gray-800/80 px-2 py-0.5 text-[10px] font-mono text-gray-500">
+        <span className="ml-auto rounded bg-secondary/80 px-2 py-0.5 text-[10px] font-mono text-muted-foreground">
           {error.code}
         </span>
       </div>
@@ -221,15 +221,15 @@ export function PreflightFailure({ error, context, onRetry }: PreflightFailurePr
 
       {/* Context info */}
       {context && (
-        <p className="mb-3 text-xs text-gray-500">
-          Cluster context: <code className="rounded bg-gray-800 px-1 py-0.5 text-gray-400">{context}</code>
+        <p className="mb-3 text-xs text-muted-foreground">
+          Cluster context: <code className="rounded bg-secondary px-1 py-0.5 text-muted-foreground">{context}</code>
         </p>
       )}
 
       {/* Remediation actions */}
       {actions.length > 0 && (
-        <div className="space-y-3 border-t border-gray-700/30 pt-3">
-          <p className="text-xs font-medium text-gray-400">How to fix:</p>
+        <div className="space-y-3 border-t border-border pt-3">
+          <p className="text-xs font-medium text-muted-foreground">How to fix:</p>
           {actions.map((action, i) => (
             <ActionButton key={i} action={action} onRetry={onRetry} />
           ))}


### PR DESCRIPTION
Fixes #11329

Replaces hardcoded dark-mode colors in AI Missions warning/error cards with semantic theme tokens for proper light/dark mode support.

**Changes:**
- Replace `border-gray-700/50` → `border-border`
- Replace `text-gray-100` → `text-foreground`
- Replace `bg-gray-800/80` → `bg-secondary/80`
- Replace `text-gray-500`, `text-gray-400` → `text-muted-foreground`
- Replace `bg-gray-800`, `bg-gray-900/70` → `bg-secondary`, `bg-secondary/70`
- Replace `border-gray-700/30` → `border-border`
- Replace `hover:bg-gray-700` → `hover:bg-secondary`

These theme-aware semantic classes will automatically adapt to both light and dark modes, resolving the poor contrast issue reported in light mode.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>