### PR TITLE
🐛 fix(tests): update MCP hook tests for exponential backoff behavior

### DIFF
--- a/web/src/hooks/mcp/__tests__/clusters.health.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.health.test.ts
@@ -607,6 +607,7 @@ describe('useMCPStatus — additional branches', () => {
     const { result } = renderHook(() => useMCPStatus())
     await act(async () => { await Promise.resolve() })
     expect(result.current.status).toEqual(initialStatus)
+    expect(result.current.consecutiveFailures).toBe(0)
 
     // Subsequent poll errors
     mockAgentFetch.mockRejectedValue(new Error('Network error'))
@@ -614,6 +615,7 @@ describe('useMCPStatus — additional branches', () => {
     await act(async () => { await Promise.resolve() })
     expect(result.current.error).toBe('MCP bridge not available')
     expect(result.current.status).toBeNull()
+    expect(result.current.consecutiveFailures).toBe(1)
     vi.useRealTimers()
   })
 
@@ -624,17 +626,19 @@ describe('useMCPStatus — additional branches', () => {
     const { result } = renderHook(() => useMCPStatus())
     await act(async () => { await Promise.resolve() })
     expect(result.current.error).toBe('MCP bridge not available')
+    expect(result.current.consecutiveFailures).toBe(1)
 
-    // Now succeed
+    // Now succeed - need to advance by backoff interval (2x = 240s after 1 failure)
     const good: MCPStatus = {
       opsClient: { available: true, toolCount: 1 },
       deployClient: { available: false, toolCount: 0 },
     }
     mockAgentFetch.mockImplementation(() => Promise.resolve(new Response(JSON.stringify(good), { status: 200 })))
-    await act(async () => { vi.advanceTimersByTime(REFRESH_INTERVAL_MS) })
+    await act(async () => { vi.advanceTimersByTime(REFRESH_INTERVAL_MS * 2) })
     await act(async () => { await Promise.resolve() })
     expect(result.current.error).toBeNull()
     expect(result.current.status).toEqual(good)
+    expect(result.current.consecutiveFailures).toBe(0)
     vi.useRealTimers()
   })
 })

--- a/web/src/hooks/mcp/__tests__/events.test.ts
+++ b/web/src/hooks/mcp/__tests__/events.test.ts
@@ -63,7 +63,11 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
-  getEffectiveInterval: (ms: number) => ms,
+  getEffectiveInterval: (ms: number, consecutiveFailures = 0) => {
+    if (consecutiveFailures <= 0) return ms
+    const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
+    return Math.min(ms * multiplier, 600_000)
+  },
   LOCAL_AGENT_URL: 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
 }))

--- a/web/src/hooks/mcp/__tests__/helm.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm.test.ts
@@ -50,7 +50,11 @@ vi.mock('../../../lib/modeTransition', () => ({
 
 vi.mock('../shared', () => ({
   MIN_REFRESH_INDICATOR_MS: 500,
-  getEffectiveInterval: (ms: number) => ms,
+  getEffectiveInterval: (ms: number, consecutiveFailures = 0) => {
+    if (consecutiveFailures <= 0) return ms
+    const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
+    return Math.min(ms * multiplier, 600_000)
+  },
   agentFetch: vi.fn().mockImplementation(() => Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))),
 }))
 

--- a/web/src/hooks/mcp/__tests__/networking.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking.test.ts
@@ -71,7 +71,11 @@ vi.mock('../../../lib/kubectlProxy', () => ({
 vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
-  getEffectiveInterval: (ms: number) => ms,
+  getEffectiveInterval: (ms: number, consecutiveFailures = 0) => {
+    if (consecutiveFailures <= 0) return ms
+    const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
+    return Math.min(ms * multiplier, 600_000)
+  },
   LOCAL_AGENT_URL: 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
   clusterCacheRef: mockClusterCacheRef,

--- a/web/src/hooks/mcp/__tests__/storage.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage.test.ts
@@ -79,7 +79,11 @@ vi.mock('../../../lib/kubectlProxy', () => ({
 vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
-  getEffectiveInterval: (ms: number) => ms,
+  getEffectiveInterval: (ms: number, consecutiveFailures = 0) => {
+    if (consecutiveFailures <= 0) return ms
+    const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
+    return Math.min(ms * multiplier, 600_000)
+  },
   LOCAL_AGENT_URL: 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
   clusterCacheRef: mockClusterCacheRef,

--- a/web/src/hooks/mcp/__tests__/workloads.core.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.core.test.ts
@@ -84,7 +84,11 @@ vi.mock('../../../lib/kubectlProxy', () => ({
 vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
-  getEffectiveInterval: (ms: number) => ms,
+  getEffectiveInterval: (ms: number, consecutiveFailures = 0) => {
+    if (consecutiveFailures <= 0) return ms
+    const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
+    return Math.min(ms * multiplier, 600_000)
+  },
   clusterCacheRef: mockClusterCacheRef,
   agentFetch: vi.fn().mockImplementation(async (...args: unknown[]) => {
     const result = await mockApiGet(...args)

--- a/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
@@ -86,7 +86,11 @@ vi.mock('../../../lib/kubectlProxy', () => ({
 vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
-  getEffectiveInterval: (ms: number) => ms,
+  getEffectiveInterval: (ms: number, consecutiveFailures = 0) => {
+    if (consecutiveFailures <= 0) return ms
+    const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
+    return Math.min(ms * multiplier, 600_000)
+  },
   LOCAL_AGENT_URL: 'http://localhost:8585',
   clusterCacheRef: mockClusterCacheRef,
   agentFetch: (...args: unknown[]) => mockAgentFetch(...args),


### PR DESCRIPTION
Fixes #11337

Updates 14 failing MCP hook tests to account for the exponential backoff behavior introduced in #11330.

## Changes
- Updated `getEffectiveInterval` mock in 7 test files to accept `consecutiveFailures` parameter
- Implemented exponential backoff formula in test mocks (2x per failure, capped at 600s)
- Added `consecutiveFailures` assertions in clusters.health.test.ts
- Fixed timer advancement in clusters.health.test.ts to account for backoff (240s after first failure)

## Root Cause
PR #11330 added exponential backoff to MCP hook polling by passing `consecutiveFailures` to `getEffectiveInterval()`. The test mocks still used the old signature `(ms: number) => ms`, causing the backoff logic to be ignored and timing issues in tests.

## Test Files Updated
- `web/src/hooks/mcp/__tests__/clusters.health.test.ts`
- `web/src/hooks/mcp/__tests__/events.test.ts`
- `web/src/hooks/mcp/__tests__/helm.test.ts`
- `web/src/hooks/mcp/__tests__/networking.test.ts`
- `web/src/hooks/mcp/__tests__/storage.test.ts`
- `web/src/hooks/mcp/__tests__/workloads.core.test.ts`
- `web/src/hooks/mcp/__tests__/workloads.extended.test.ts`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>