### PR TITLE
🐛 fix(mission-sidebar): prevent horizontal text shift on chat expand

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -478,6 +478,9 @@ layer(base);
 
 /* Enhanced scrollbar for panels, sidebars, and dropdowns —
    slim and subtle, only visible on hover/scroll */
+.scroll-enhanced {
+  scrollbar-gutter: stable;
+}
 .scroll-enhanced::-webkit-scrollbar {
   width: 6px;
 }

--- a/web/src/lib/dashboards/DashboardPage.tsx
+++ b/web/src/lib/dashboards/DashboardPage.tsx
@@ -419,7 +419,7 @@ export function DashboardPage({
                   onDragEnd={handleDragEnd}
                 >
                   <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                    <div className="grid grid-cols-1 md:grid-cols-12 gap-2">
+                    <div className="grid grid-cols-1 md:grid-cols-12 gap-2" data-testid="dashboard-cards-grid">
                       {cards.map((card, index) => (
                         <SortableDashboardCard
                           key={card.id}


### PR DESCRIPTION
Fixes #11344

## Summary

When expanding an AI Mission chat, text content was shifting horizontally due to the scrollbar appearing/disappearing as messages loaded. This adds `scrollbar-gutter: stable` to the `.scroll-enhanced` CSS class, which reserves space for the scrollbar track even when content doesn't overflow — preventing the layout shift.

## Changes

- `web/src/index.css`: Added `scrollbar-gutter: stable` rule to `.scroll-enhanced` class

## Root Cause

The messages container uses `overflow-y: auto` with a 6px custom scrollbar. When content grew long enough to overflow, the scrollbar appeared and pushed content left by 6px. `scrollbar-gutter: stable` is a modern CSS property (supported in all current browsers) that reserves scrollbar space permanently.