### PR TITLE
✨ feat(feedback): support video uploads in bug report/feature request modal

### DIFF
--- a/web/src/components/feedback/FeatureRequestTypes.ts
+++ b/web/src/components/feedback/FeatureRequestTypes.ts
@@ -56,7 +56,15 @@ export interface PreviewResult {
 export interface ScreenshotItem {
   file: File
   preview: string
+  /** Whether this attachment is a video or image */
+  mediaType?: 'image' | 'video'
 }
+
+/** Maximum video file size in bytes (10 MB) */
+export const MAX_VIDEO_SIZE_BYTES = 10 * 1024 * 1024
+
+/** Accepted media types for file input */
+export const ACCEPTED_MEDIA_TYPES = 'image/*,video/mp4,video/webm,video/quicktime'
 
 // ── Utility functions ──
 

--- a/web/src/components/feedback/FeedbackDialogs.tsx
+++ b/web/src/components/feedback/FeedbackDialogs.tsx
@@ -265,6 +265,7 @@ interface ScreenshotPreviewOverlayProps {
 
 export function ScreenshotPreviewOverlay({ src, onClose }: ScreenshotPreviewOverlayProps) {
   const overlayRef = useRef<HTMLDivElement>(null)
+  const isVideo = src.startsWith('data:video/')
 
   // Auto-focus the overlay so it can receive keyboard events (e.g. Escape)
   useEffect(() => {
@@ -288,29 +289,37 @@ export function ScreenshotPreviewOverlay({ src, onClose }: ScreenshotPreviewOver
       }}
       role="dialog"
       aria-modal="true"
-      aria-label="Screenshot preview"
+      aria-label={isVideo ? 'Video preview' : 'Screenshot preview'}
     >
       <div className="relative max-w-[90vw] max-h-[85vh] bg-background border border-border rounded-xl shadow-2xl flex flex-col">
         <div className="flex items-center justify-between px-5 py-3 border-b border-border">
           <div className="flex items-center gap-2 text-sm font-medium text-foreground">
             <Maximize2 className="w-4 h-4" />
-            Screenshot Preview
+            {isVideo ? 'Video Preview' : 'Screenshot Preview'}
           </div>
           <button
             type="button"
             onClick={onClose}
             className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary/80 transition-colors"
-            aria-label="Close screenshot preview"
+            aria-label="Close preview"
           >
             <X className="w-4 h-4" />
           </button>
         </div>
         <div className="flex-1 overflow-auto p-4 flex items-center justify-center">
-          <img
-            src={src}
-            alt="Screenshot preview"
-            className="max-w-full max-h-[75vh] object-contain rounded-lg"
-          />
+          {isVideo ? (
+            <video
+              src={src}
+              controls
+              className="max-w-full max-h-[75vh] rounded-lg"
+            />
+          ) : (
+            <img
+              src={src}
+              alt="Screenshot preview"
+              className="max-w-full max-h-[75vh] object-contain rounded-lg"
+            />
+          )}
         </div>
       </div>
     </div>

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -12,7 +12,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { createPortal } from 'react-dom'
-import { X, Bug, Lightbulb, Send, CheckCircle2, ExternalLink, ImagePlus, Trash2, Copy, Check, AlertTriangle, Loader2 } from 'lucide-react'
+import { X, Bug, Lightbulb, Send, CheckCircle2, ExternalLink, ImagePlus, Trash2, Copy, Check, AlertTriangle, Loader2, Film } from 'lucide-react'
 import { Linkedin } from '@/lib/icons'
 import { ConfirmDialog } from '../../lib/modals'
 import { StatusBadge } from '../ui/StatusBadge'
@@ -26,6 +26,7 @@ import { FEEDBACK_UPLOAD_TIMEOUT_MS } from '../../lib/constants/network'
 import { compressScreenshot } from '../../lib/imageCompression'
 import { useFeatureRequests } from '../../hooks/useFeatureRequests'
 import { useAuth } from '../../lib/auth'
+import { MAX_VIDEO_SIZE_BYTES, ACCEPTED_MEDIA_TYPES } from './FeatureRequestTypes'
 
 type FeedbackType = 'bug' | 'feature'
 
@@ -57,7 +58,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [validationErrors, setValidationErrors] = useState<{ title?: string; description?: string }>({})
   const { awardCoins } = useRewards()
-  const [screenshots, setScreenshots] = useState<{ file: File; preview: string }[]>([])
+  const [screenshots, setScreenshots] = useState<{ file: File; preview: string; mediaType?: 'image' | 'video' }[]>([])
   const [isDragOver, setIsDragOver] = useState(false)
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null)
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
@@ -66,17 +67,22 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
   const handleScreenshotFiles = (files: FileList | null) => {
     if (!files) return
     const allFiles = Array.from(files)
-    const imageFiles = allFiles.filter(f => f.type.startsWith('image/'))
-    if (imageFiles.length === 0) return
-    imageFiles.forEach(file => {
+    const mediaFiles = allFiles.filter(f => f.type.startsWith('image/') || f.type.startsWith('video/'))
+    if (mediaFiles.length === 0) return
+    mediaFiles.forEach(file => {
+      const isVideo = file.type.startsWith('video/')
+      if (isVideo && file.size > MAX_VIDEO_SIZE_BYTES) {
+        showToast(`Video "${file.name}" exceeds 10 MB limit. Please use a shorter or lower-resolution recording.`, 'error')
+        return
+      }
       const reader = new FileReader()
       reader.onload = (e) => {
         const dataUri = e.target?.result as string
-        setScreenshots(prev => [...prev, { file, preview: dataUri }])
+        setScreenshots(prev => [...prev, { file, preview: dataUri, mediaType: isVideo ? 'video' : 'image' }])
       }
       reader.onerror = (err) => {
-        console.error(`[Screenshot] FileReader failed for ${file.name}:`, err)
-        showToast(`Failed to read screenshot "${file.name}". Try a different image.`, 'error')
+        console.error(`[Attachment] FileReader failed for ${file.name}:`, err)
+        showToast(`Failed to read file "${file.name}". Try a different file.`, 'error')
       }
       reader.readAsDataURL(file)
     })
@@ -90,8 +96,8 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault()
     setIsDragOver(false)
-    const imageCount = Array.from(e.dataTransfer.files).filter(f => f.type.startsWith('image/')).length
-    if (imageCount > 0) emitScreenshotAttached('drop', imageCount)
+    const mediaCount = Array.from(e.dataTransfer.files).filter(f => f.type.startsWith('image/') || f.type.startsWith('video/')).length
+    if (mediaCount > 0) emitScreenshotAttached('drop', mediaCount)
     handleScreenshotFiles(e.dataTransfer.files)
   }
 
@@ -194,10 +200,15 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
       // Compress screenshots to fit within GitHub's 65K issue body limit.
       // Images are embedded as base64 and processed into rendered images
       // by a GitHub Actions workflow after the issue is created.
+      // Videos are passed through without compression.
       const screenshotDataURIs: string[] = []
       for (const s of screenshots) {
-        const compressed = await compressScreenshot(s.preview)
-        if (compressed) screenshotDataURIs.push(compressed)
+        if (s.mediaType === 'video') {
+          screenshotDataURIs.push(s.preview)
+        } else {
+          const compressed = await compressScreenshot(s.preview)
+          if (compressed) screenshotDataURIs.push(compressed)
+        }
       }
 
       // Submit via backend API — creates GitHub issue directly using the
@@ -524,12 +535,16 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                           : 'border-border hover:border-muted-foreground'
                       }`}
                     >
-                      <ImagePlus className="w-5 h-5 text-muted-foreground" />
-                      <span className="text-xs text-muted-foreground text-center">Drop screenshots here or click to browse</span>
+                      <div className="flex items-center gap-2">
+                        <ImagePlus className="w-5 h-5 text-muted-foreground" />
+                        <Film className="w-4 h-4 text-muted-foreground" />
+                      </div>
+                      <span className="text-xs text-muted-foreground text-center">Drop images or videos here, or click to browse</span>
+                      <span className="text-2xs text-muted-foreground/70">Videos: mp4, webm, mov (max 10 MB)</span>
                       <input
                         ref={fileInputRef}
                         type="file"
-                        accept="image/*"
+                        accept={ACCEPTED_MEDIA_TYPES}
                         multiple
                         onChange={e => {
                           const files = e.target.files
@@ -543,25 +558,34 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                       <div className="mt-2 flex flex-wrap gap-2">
                         {screenshots.map((s, i) => (
                           <div key={i} className="relative group w-20 h-20 shrink-0">
-                            <img
-                              src={s.preview}
-                              alt={`Screenshot ${i + 1}`}
-                              className="w-20 h-20 object-cover rounded-lg border border-border"
-                            />
+                            {s.mediaType === 'video' ? (
+                              <div className="w-20 h-20 rounded-lg border border-border bg-black flex items-center justify-center overflow-hidden">
+                                <video src={s.preview} className="w-full h-full object-cover" muted playsInline />
+                                <Film className="absolute w-5 h-5 text-white/80 drop-shadow-md" />
+                              </div>
+                            ) : (
+                              <img
+                                src={s.preview}
+                                alt={`Attachment ${i + 1}`}
+                                className="w-20 h-20 object-cover rounded-lg border border-border"
+                              />
+                            )}
                             <div className="absolute inset-0 flex items-center justify-center gap-1 opacity-0 group-hover:opacity-100 bg-black/60 rounded-lg transition-opacity">
-                              <button
-                                type="button"
-                                onClick={e => { e.stopPropagation(); void copyScreenshotToClipboard(s.preview, i) }}
-                                className="p-1.5 rounded-md bg-secondary/80 text-foreground hover:bg-secondary transition-colors"
-                                title="Copy to clipboard"
-                              >
-                                {copiedIndex === i ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
-                              </button>
+                              {s.mediaType !== 'video' && (
+                                <button
+                                  type="button"
+                                  onClick={e => { e.stopPropagation(); void copyScreenshotToClipboard(s.preview, i) }}
+                                  className="p-1.5 rounded-md bg-secondary/80 text-foreground hover:bg-secondary transition-colors"
+                                  title="Copy to clipboard"
+                                >
+                                  {copiedIndex === i ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
+                                </button>
+                              )}
                               <button
                                 type="button"
                                 onClick={e => { e.stopPropagation(); removeScreenshot(i) }}
                                 className="p-1.5 rounded-md bg-secondary/80 text-red-400 hover:bg-red-500/20 transition-colors"
-                                title="Remove screenshot"
+                                title="Remove attachment"
                               >
                                 <Trash2 className="w-3.5 h-3.5" />
                               </button>

--- a/web/src/components/feedback/SubmitTab.tsx
+++ b/web/src/components/feedback/SubmitTab.tsx
@@ -3,6 +3,7 @@ import {
   Bug, Sparkles, Loader2, ExternalLink, Bell,
   Check, Eye, Pencil, Settings, Maximize2,
   ImagePlus, Trash2, Copy, AlertTriangle, Monitor, BookOpen, FileText, Save, Lock,
+  Film,
 } from 'lucide-react'
 import { Github } from '@/lib/icons'
 import { Button } from '../ui/Button'
@@ -25,6 +26,8 @@ import {
   MIN_DESCRIPTION_LENGTH,
   MIN_DESCRIPTION_WORDS,
   MAX_TITLE_LENGTH,
+  MAX_VIDEO_SIZE_BYTES,
+  ACCEPTED_MEDIA_TYPES,
 } from './FeatureRequestTypes'
 
 // ── Success View (shown after successful submission) ──
@@ -72,13 +75,13 @@ export function SuccessView({ success, screenshots, onViewUpdates }: SuccessView
         </button>
       </div>
 
-      {/* Screenshot status */}
+      {/* Attachment status */}
       {screenshots.length > 0 && (success.screenshotsUploaded ?? 0) > 0 && (
         <div className="mt-4 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
           <p className="text-xs text-green-400 font-medium">
             {(success.screenshotsUploaded ?? 0) === 1
-              ? 'Screenshot attached to the issue. It will render as an image shortly.'
-              : `${success.screenshotsUploaded} screenshots attached to the issue. They will render as images shortly.`}
+              ? 'Attachment uploaded to the issue successfully.'
+              : `${success.screenshotsUploaded} attachments uploaded to the issue successfully.`}
           </p>
         </div>
       )}
@@ -86,8 +89,8 @@ export function SuccessView({ success, screenshots, onViewUpdates }: SuccessView
         <div className="mt-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
           <p className="text-xs text-yellow-400 font-medium">
             {success.screenshotsFailed === 1
-              ? 'Screenshot could not be attached — invalid image format.'
-              : `${success.screenshotsFailed} screenshots could not be attached — invalid image format.`}
+              ? 'Attachment could not be uploaded — unsupported format or too large.'
+              : `${success.screenshotsFailed} attachments could not be uploaded — unsupported format or too large.`}
           </p>
         </div>
       )}
@@ -187,11 +190,11 @@ export function SubmitForm({
       if (file) {
         const reader = new FileReader()
         reader.onload = (ev) => {
-          setScreenshots(prev => [...prev, { file, preview: ev.target?.result as string }])
+          setScreenshots(prev => [...prev, { file, preview: ev.target?.result as string, mediaType: 'image' }])
         }
         reader.onerror = (err) => {
-          console.error('[Screenshot] Paste FileReader failed:', err)
-          showToast('Failed to read pasted screenshot. Try attaching the image instead.', 'error')
+          console.error('[Attachment] Paste FileReader failed:', err)
+          showToast('Failed to read pasted image. Try attaching the file instead.', 'error')
         }
         reader.readAsDataURL(file)
       }
@@ -201,15 +204,26 @@ export function SubmitForm({
 
   const handleScreenshotFiles = (files: FileList | null) => {
     if (!files) return
-    const imageFiles = Array.from(files).filter(f => f.type.startsWith('image/'))
-    imageFiles.forEach(file => {
+    const mediaFiles = Array.from(files).filter(f =>
+      f.type.startsWith('image/') || f.type.startsWith('video/')
+    )
+    mediaFiles.forEach(file => {
+      const isVideo = file.type.startsWith('video/')
+      if (isVideo && file.size > MAX_VIDEO_SIZE_BYTES) {
+        showToast(`Video "${file.name}" exceeds 10 MB limit. Please use a shorter or lower-resolution recording.`, 'error')
+        return
+      }
       const reader = new FileReader()
       reader.onload = (ev) => {
-        setScreenshots(prev => [...prev, { file, preview: ev.target?.result as string }])
+        setScreenshots(prev => [...prev, {
+          file,
+          preview: ev.target?.result as string,
+          mediaType: isVideo ? 'video' : 'image',
+        }])
       }
       reader.onerror = (err) => {
-        console.error(`[Screenshot] FileReader failed for ${file.name}:`, err)
-        showToast(`Failed to read screenshot "${file.name}". Try a different image.`, 'error')
+        console.error(`[Attachment] FileReader failed for ${file.name}:`, err)
+        showToast(`Failed to read file "${file.name}". Try a different file.`, 'error')
       }
       reader.readAsDataURL(file)
     })
@@ -275,8 +289,13 @@ export function SubmitForm({
 
     const screenshotDataURIs: string[] = []
     for (const s of screenshots) {
-      const compressed = await compressScreenshot(s.preview)
-      if (compressed) screenshotDataURIs.push(compressed)
+      if (s.mediaType === 'video') {
+        // Videos are passed through without compression
+        screenshotDataURIs.push(s.preview)
+      } else {
+        const compressed = await compressScreenshot(s.preview)
+        if (compressed) screenshotDataURIs.push(compressed)
+      }
     }
 
     try {
@@ -575,10 +594,10 @@ export function SubmitForm({
           </p>
         </div>
 
-        {/* Screenshot Upload */}
+        {/* Attachment Upload (images & videos) */}
         <div>
           <label className="block text-xs font-medium text-muted-foreground mb-1.5">
-            Screenshots <span className="font-normal">(optional)</span>
+            Attachments <span className="font-normal">(optional — images &amp; videos)</span>
           </label>
           <div
             onDragOver={inputsDisabled ? undefined : handleScreenshotDragOver}
@@ -594,12 +613,16 @@ export function SubmitForm({
                   : 'border-border hover:border-muted-foreground'}`
             }`}
           >
-            <ImagePlus className="w-5 h-5 text-muted-foreground" />
-            <span className="text-xs text-muted-foreground text-center">Drop screenshots here or click to browse</span>
+            <div className="flex items-center gap-2">
+              <ImagePlus className="w-5 h-5 text-muted-foreground" />
+              <Film className="w-4 h-4 text-muted-foreground" />
+            </div>
+            <span className="text-xs text-muted-foreground text-center">Drop images or videos here, or click to browse</span>
+            <span className="text-2xs text-muted-foreground/70">Videos: mp4, webm, mov (max 10 MB)</span>
             <input
               ref={screenshotInputRef}
               type="file"
-              accept="image/*"
+              accept={ACCEPTED_MEDIA_TYPES}
               multiple
               disabled={inputsDisabled}
               onChange={e => handleScreenshotFiles(e.target.files)}
@@ -610,34 +633,48 @@ export function SubmitForm({
             <div className="mt-2 flex flex-wrap gap-2">
               {screenshots.map((s, i) => (
                 <div key={i} className="relative group w-20 h-20 shrink-0">
-                  <img
-                    src={s.preview}
-                    alt={`Screenshot ${i + 1}`}
-                    className="w-20 h-20 object-cover rounded-lg border border-border"
-                  />
+                  {s.mediaType === 'video' ? (
+                    <div className="w-20 h-20 rounded-lg border border-border bg-black flex items-center justify-center overflow-hidden">
+                      <video
+                        src={s.preview}
+                        className="w-full h-full object-cover"
+                        muted
+                        playsInline
+                      />
+                      <Film className="absolute w-5 h-5 text-white/80 drop-shadow-md" />
+                    </div>
+                  ) : (
+                    <img
+                      src={s.preview}
+                      alt={`Attachment ${i + 1}`}
+                      className="w-20 h-20 object-cover rounded-lg border border-border"
+                    />
+                  )}
                   <div className="absolute inset-0 flex items-center justify-center gap-1 opacity-0 group-hover:opacity-100 bg-black/60 rounded-lg transition-opacity">
                     <button
                       type="button"
                       onClick={e => { e.stopPropagation(); setPreviewImageSrc(s.preview) }}
                       className="p-1.5 rounded-md bg-secondary/80 text-foreground hover:bg-secondary transition-colors"
-                      title="Preview screenshot"
-                      aria-label="Preview screenshot"
+                      title={s.mediaType === 'video' ? 'Preview video' : 'Preview image'}
+                      aria-label={s.mediaType === 'video' ? 'Preview video' : 'Preview image'}
                     >
                       <Eye className="w-3.5 h-3.5" />
                     </button>
-                    <button
-                      type="button"
-                      onClick={e => { e.stopPropagation(); void copyScreenshotToClipboard(s.preview, i) }}
-                      className="p-1.5 rounded-md bg-secondary/80 text-foreground hover:bg-secondary transition-colors"
-                      title="Copy to clipboard"
-                    >
-                      {copiedIndex === i ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
-                    </button>
+                    {s.mediaType !== 'video' && (
+                      <button
+                        type="button"
+                        onClick={e => { e.stopPropagation(); void copyScreenshotToClipboard(s.preview, i) }}
+                        className="p-1.5 rounded-md bg-secondary/80 text-foreground hover:bg-secondary transition-colors"
+                        title="Copy to clipboard"
+                      >
+                        {copiedIndex === i ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
+                      </button>
+                    )}
                     <button
                       type="button"
                       onClick={e => { e.stopPropagation(); removeScreenshot(i) }}
                       className="p-1.5 rounded-md bg-secondary/80 text-red-400 hover:bg-red-500/20 transition-colors"
-                      title="Remove screenshot"
+                      title="Remove attachment"
                     >
                       <Trash2 className="w-3.5 h-3.5" />
                     </button>
@@ -648,7 +685,7 @@ export function SubmitForm({
           )}
           {screenshots.length > 0 && (
             <p className="text-2xs text-muted-foreground mt-1">
-              Screenshots will be uploaded and embedded directly in the GitHub issue.
+              Attachments will be uploaded and embedded directly in the GitHub issue.
             </p>
           )}
         </div>


### PR DESCRIPTION
Fixes #11345

## Summary

Extends the attachment section (formerly 'Screenshots') in the Contribute modal to accept video file uploads alongside images. This addresses user feedback that video recordings are more effective for demonstrating UI/UX issues.

## Changes

- **FeatureRequestTypes.ts**: Added `mediaType` field to `ScreenshotItem`, plus `MAX_VIDEO_SIZE_BYTES` (10 MB) and `ACCEPTED_MEDIA_TYPES` constants
- **SubmitTab.tsx**: Accept video files (mp4, webm, mov), show video previews with film icon overlay, skip image compression for videos, renamed section to 'Attachments'
- **FeedbackModal.tsx**: Same video support for the legacy feedback modal
- **FeedbackDialogs.tsx**: `ScreenshotPreviewOverlay` renders a playable `<video>` element for video attachments

## Features

- ✅ Video file uploads (.mp4, .webm, .mov)
- ✅ 10 MB size limit with user-friendly error message
- ✅ Video thumbnail preview with film icon overlay
- ✅ Full-screen video playback in preview dialog
- ✅ Mixed uploads (images + videos together)
- ✅ Drag & drop support for videos
- ✅ Copy-to-clipboard hidden for video items (not supported)