### PR TITLE
feat: enhance feedback modal with full diagnostics and failed API tracking

### DIFF
--- a/pkg/api/handlers/feedback_github.go
+++ b/pkg/api/handlers/feedback_github.go
@@ -491,7 +491,7 @@ type screenshotUploadResult struct {
 // upload, synchronous result counts, error). #9898: screenshot uploads are
 // decoupled from this path — callers launch uploadScreenshotCommentsAsync
 // on the returned slice from a background goroutine.
-func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *models.FeatureRequest, user *models.User, repoOwner, repoName string, screenshots []string, consoleErrors []models.ConsoleError, diagnostics *models.DiagnosticInfo, clientAuth string) (int, string, []string, screenshotUploadResult, error) {
+func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *models.FeatureRequest, user *models.User, repoOwner, repoName string, screenshots []string, consoleErrors []models.ConsoleError, failedApiCalls []models.FailedApiCall, diagnostics *models.DiagnosticInfo, clientAuth string) (int, string, []string, screenshotUploadResult, error) {
 	// Determine labels based on request type and target repo
 	var labels []string
 	isDocs := request.TargetRepo == models.TargetRepoDocs
@@ -599,6 +599,15 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *
 		if diagnostics.Clusters > 0 {
 			diag.WriteString(fmt.Sprintf("| Clusters | %d |\n", diagnostics.Clusters))
 		}
+		if diagnostics.AgentConnectionStatus != "" {
+			diag.WriteString(fmt.Sprintf("| Agent Connection | %s |\n", diagnostics.AgentConnectionStatus))
+		}
+		if diagnostics.AgentConnectionFailures > 0 {
+			diag.WriteString(fmt.Sprintf("| Connection Failures | %d |\n", diagnostics.AgentConnectionFailures))
+		}
+		if diagnostics.AgentLastError != "" {
+			diag.WriteString(fmt.Sprintf("| Last Agent Error | %s |\n", diagnostics.AgentLastError))
+		}
 		if diagnostics.BrowserUA != "" {
 			diag.WriteString(fmt.Sprintf("| Browser UA | %s |\n", diagnostics.BrowserUA))
 		}
@@ -608,8 +617,38 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *
 		if diagnostics.BrowserLanguage != "" {
 			diag.WriteString(fmt.Sprintf("| Browser Language | %s |\n", diagnostics.BrowserLanguage))
 		}
+		if diagnostics.ScreenResolution != "" {
+			diag.WriteString(fmt.Sprintf("| Screen Resolution | %s |\n", diagnostics.ScreenResolution))
+		}
+		if diagnostics.WindowSize != "" {
+			diag.WriteString(fmt.Sprintf("| Window Size | %s |\n", diagnostics.WindowSize))
+		}
+		if diagnostics.PageURL != "" {
+			diag.WriteString(fmt.Sprintf("| Page URL | %s |\n", diagnostics.PageURL))
+		}
 		diag.WriteString("\n</details>\n")
 		diagnosticsBlock = diag.String()
+	}
+
+	failedApiBlock := ""
+	if len(failedApiCalls) > 0 {
+		var apiLines strings.Builder
+		const maxFailedApiCalls = 30
+		shown := len(failedApiCalls)
+		if shown > maxFailedApiCalls {
+			shown = maxFailedApiCalls
+		}
+		for _, call := range failedApiCalls[:shown] {
+			detail := ""
+			if call.Detail != "" {
+				detail = fmt.Sprintf(": %s", call.Detail)
+			}
+			apiLines.WriteString(fmt.Sprintf("- `[%s]` **%s** `%s`%s\n", call.Timestamp, call.Status, call.Endpoint, detail))
+		}
+		if len(failedApiCalls) > maxFailedApiCalls {
+			apiLines.WriteString(fmt.Sprintf("\n_...and %d more omitted_\n", len(failedApiCalls)-maxFailedApiCalls))
+		}
+		failedApiBlock = fmt.Sprintf("\n<details>\n<summary>Failed API Calls (%d captured)</summary>\n\n%s\n</details>\n", len(failedApiCalls), apiLines.String())
 	}
 
 	issueBody := fmt.Sprintf(`## User Request
@@ -622,10 +661,10 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *
 ## Description
 
 %s
-%s%s%s
+%s%s%s%s
 ---
 *This issue was automatically created from the KubeStellar Console.*
-`, request.RequestType, repoLabel, user.GitHubLogin, request.ID.String(), request.Description, shaLine, consoleErrorBlock, diagnosticsBlock)
+`, request.RequestType, repoLabel, user.GitHubLogin, request.ID.String(), request.Description, shaLine, consoleErrorBlock, failedApiBlock, diagnosticsBlock)
 
 	// First attempt: create issue with labels
 	number, htmlURL, err := h.postGitHubIssue(ctx, repoOwner, repoName, request.Title, issueBody, labels, clientAuth)

--- a/pkg/api/handlers/feedback_requests.go
+++ b/pkg/api/handlers/feedback_requests.go
@@ -91,7 +91,7 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 	// created synchronously so the client receives the issue number/URL in
 	// the response; screenshot comments are uploaded asynchronously below
 	// (#9898) so slow GitHub responses do not block Fiber workers.
-	issueNumber, _, validScreenshots, ssResult, err := h.createGitHubIssueInRepo(c.UserContext(), request, user, h.repoOwner, targetRepoName, input.Screenshots, input.ConsoleErrors, input.Diagnostics, clientAuth)
+	issueNumber, _, validScreenshots, ssResult, err := h.createGitHubIssueInRepo(c.UserContext(), request, user, h.repoOwner, targetRepoName, input.Screenshots, input.ConsoleErrors, input.FailedApiCalls, input.Diagnostics, clientAuth)
 	if err != nil {
 		slog.Error("[Feedback] failed to create GitHub issue", "error", err)
 		// Clean up the orphaned database record. Log but don't fail the

--- a/pkg/models/feedback.go
+++ b/pkg/models/feedback.go
@@ -117,17 +117,31 @@ type ConsoleError struct {
 // DiagnosticInfo contains environment details collected from the agent and browser
 // to help debug issues (e.g. CORS mismatches from old agent builds).
 type DiagnosticInfo struct {
-	AgentVersion    string `json:"agent_version,omitempty"`
-	CommitSHA       string `json:"commit_sha,omitempty"`
-	BuildTime       string `json:"build_time,omitempty"`
-	GoVersion       string `json:"go_version,omitempty"`
-	AgentOS         string `json:"agent_os,omitempty"`
-	AgentArch       string `json:"agent_arch,omitempty"`
-	InstallMethod   string `json:"install_method,omitempty"`
-	Clusters        int    `json:"clusters,omitempty"`
-	BrowserUA       string `json:"browser_user_agent,omitempty"`
-	BrowserPlatform string `json:"browser_platform,omitempty"`
-	BrowserLanguage string `json:"browser_language,omitempty"`
+	AgentVersion            string `json:"agent_version,omitempty"`
+	CommitSHA               string `json:"commit_sha,omitempty"`
+	BuildTime               string `json:"build_time,omitempty"`
+	GoVersion               string `json:"go_version,omitempty"`
+	AgentOS                 string `json:"agent_os,omitempty"`
+	AgentArch               string `json:"agent_arch,omitempty"`
+	InstallMethod           string `json:"install_method,omitempty"`
+	Clusters                int    `json:"clusters,omitempty"`
+	AgentConnectionStatus   string `json:"agent_connection_status,omitempty"`
+	AgentConnectionFailures int    `json:"agent_connection_failures,omitempty"`
+	AgentLastError          string `json:"agent_last_error,omitempty"`
+	BrowserUA               string `json:"browser_user_agent,omitempty"`
+	BrowserPlatform         string `json:"browser_platform,omitempty"`
+	BrowserLanguage         string `json:"browser_language,omitempty"`
+	ScreenResolution        string `json:"screen_resolution,omitempty"`
+	WindowSize              string `json:"window_size,omitempty"`
+	PageURL                 string `json:"page_url,omitempty"`
+}
+
+// FailedApiCall represents a recent failed API call captured by the ring buffer.
+type FailedApiCall struct {
+	Timestamp string `json:"timestamp"`
+	Status    string `json:"status"`
+	Endpoint  string `json:"endpoint"`
+	Detail    string `json:"detail,omitempty"`
 }
 
 // CreateFeatureRequestInput is the input for creating a feature request
@@ -142,6 +156,8 @@ type CreateFeatureRequestInput struct {
 	// ConsoleErrors contains recent browser console errors captured automatically.
 	// Only populated for bug reports. Rendered as a collapsible section in the issue body.
 	ConsoleErrors []ConsoleError `json:"console_errors,omitempty"`
+	// FailedApiCalls contains recent 4xx/5xx API responses captured automatically.
+	FailedApiCalls []FailedApiCall `json:"failed_api_calls,omitempty"`
 	// Diagnostics contains agent and browser environment info for debugging.
 	Diagnostics *DiagnosticInfo `json:"diagnostics,omitempty"`
 }

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -18,7 +18,7 @@ import { ConfirmDialog } from '../../lib/modals'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useRewards, REWARD_ACTIONS } from '../../hooks/useRewards'
 import { useToast } from '../ui/Toast'
-import { emitFeedbackSubmitted, emitLinkedInShare, emitScreenshotAttached, emitScreenshotUploadFailed, emitScreenshotUploadSuccess } from '../../lib/analytics'
+import { emitFeedbackSubmitted, emitLinkedInShare, emitScreenshotAttached, emitScreenshotUploadFailed, emitScreenshotUploadSuccess, getRecentBrowserErrors, getRecentFailedApiCalls } from '../../lib/analytics'
 import { copyBlobToClipboard } from '../../lib/clipboard'
 import { useBranding } from '../../hooks/useBranding'
 import { FETCH_DEFAULT_TIMEOUT_MS, COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
@@ -51,7 +51,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
   const branding = useBranding()
   const { user } = useAuth()
   const { createRequest } = useFeatureRequests(user?.github_login || '')
-  const { health: agentHealth } = useLocalAgent()
+  const { health: agentHealth, status: agentStatus, dataErrorCount: agentDataErrorCount, lastDataError: agentLastDataError } = useLocalAgent()
   const [type, setType] = useState<FeedbackType>(initialType)
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
@@ -223,10 +223,19 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
         agent_arch: agentHealth?.arch,
         install_method: agentHealth?.install_method,
         clusters: agentHealth?.clusters,
+        agent_connection_status: agentStatus,
+        agent_connection_failures: agentDataErrorCount,
+        agent_last_error: agentLastDataError ?? undefined,
         browser_user_agent: navigator.userAgent,
         browser_platform: navigator.platform,
         browser_language: navigator.language,
+        screen_resolution: `${screen.width}x${screen.height}`,
+        window_size: `${window.innerWidth}x${window.innerHeight}`,
+        page_url: window.location.href,
       }
+
+      const consoleErrors = getRecentBrowserErrors()
+      const failedApiCalls = getRecentFailedApiCalls()
 
       // Submit via backend API — creates GitHub issue directly using the
       // server-side token. No GitHub login required from the user.
@@ -238,6 +247,8 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
         request_type: type,
         target_repo: 'console',
         diagnostics,
+        ...(consoleErrors.length > 0 && { console_errors: consoleErrors }),
+        ...(failedApiCalls.length > 0 && { failed_api_calls: failedApiCalls }),
         ...(hasScreenshots && { screenshots: screenshotDataURIs }) }, hasScreenshots ? { timeout: FEEDBACK_UPLOAD_TIMEOUT_MS } : undefined)
       if (hasScreenshots) emitScreenshotUploadSuccess(screenshotDataURIs.length)
 

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -90,6 +90,13 @@ export interface ConsoleError {
   source?: string
 }
 
+export interface FailedApiCall {
+  timestamp: string
+  status: number | string
+  endpoint: string
+  detail?: string
+}
+
 export interface DiagnosticInfo {
   agent_version?: string
   commit_sha?: string
@@ -99,9 +106,15 @@ export interface DiagnosticInfo {
   agent_arch?: string
   install_method?: string
   clusters?: number
+  agent_connection_status?: string
+  agent_connection_failures?: number
+  agent_last_error?: string
   browser_user_agent?: string
   browser_platform?: string
   browser_language?: string
+  screen_resolution?: string
+  window_size?: string
+  page_url?: string
 }
 
 export interface CreateFeatureRequestInput {
@@ -113,6 +126,8 @@ export interface CreateFeatureRequestInput {
   screenshots?: string[]
   /** Recent browser console errors captured automatically for bug reports */
   console_errors?: ConsoleError[]
+  /** Recent failed API calls (4xx/5xx) captured automatically */
+  failed_api_calls?: FailedApiCall[]
   /** Agent and browser diagnostics for debugging */
   diagnostics?: DiagnosticInfo
 }

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -829,6 +829,43 @@ export function _resetCapturedErrors() {
   capturedErrors.length = 0
 }
 
+// ── Failed API calls ring buffer (for feedback modal) ────────────────
+// Tracks recent 4xx/5xx API responses so the feedback modal can include
+// them in bug reports. Separate from the console error buffer because
+// these carry structured status/endpoint info rather than free-text.
+const API_ERROR_RING_BUFFER_SIZE = 30
+
+interface FailedApiCall {
+  timestamp: string
+  status: number | string
+  endpoint: string
+  detail?: string
+}
+
+const failedApiCalls: FailedApiCall[] = []
+
+export function pushFailedApiCall(status: number | string, endpoint: string, detail?: string) {
+  const entry: FailedApiCall = {
+    timestamp: new Date().toISOString(),
+    status,
+    endpoint: endpoint.slice(0, HTTP_ENDPOINT_MAX_LEN),
+    ...(detail && { detail: detail.slice(0, ERROR_DETAIL_MAX_LEN) }),
+  }
+  failedApiCalls.push(entry)
+  if (failedApiCalls.length > API_ERROR_RING_BUFFER_SIZE) {
+    failedApiCalls.shift()
+  }
+}
+
+export function getRecentFailedApiCalls(): FailedApiCall[] {
+  return [...failedApiCalls]
+}
+
+/** @internal — exported for test isolation only */
+export function _resetFailedApiCalls() {
+  failedApiCalls.length = 0
+}
+
 // ── Per-card / per-page error throttling (#10092) ──────────────────────
 // CI/CD cards poll every 30-120s. Without throttling, a single broken card
 // generates dozens of ksc_error events per session. We cap emissions to at
@@ -930,6 +967,7 @@ export function emitHttpError(
   endpoint: string,
   detail?: string,
 ) {
+  pushFailedApiCall(status, endpoint, detail)
   // Strip query string to avoid GA4 cardinality explosion and PII leakage.
   const endpointPath = endpoint.split('?')[0]
   const page = window.location.pathname

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -27,6 +27,8 @@ export {
   emitChunkReloadRecoveryFailed,
   markErrorReported,
   captureUtmParams,
+  getRecentBrowserErrors,
+  getRecentFailedApiCalls,
 } from './analytics-core'
 export type { EmitErrorExtra } from './analytics-core'
 


### PR DESCRIPTION
## Summary
- Wire the existing browser console error ring buffer (`getRecentBrowserErrors()`) into the feedback modal submit — console errors were being captured but never sent to the issue
- Add a new failed API calls ring buffer (`pushFailedApiCall`/`getRecentFailedApiCalls`) to track recent 4xx/5xx responses, wired into `emitHttpError`
- Add agent connection state to diagnostics: connection status, failure count, last error
- Add browser context: screen resolution, window size, page URL
- Backend renders all new sections as collapsible `<details>` blocks in created GitHub issues

Fixes the missing diagnostics section in feedback issues (e.g. #11336 showed console errors but no agent/browser info).

## Test plan
- [ ] Open feedback modal, submit a test bug report
- [ ] Verify the created GitHub issue has all 3 collapsible sections: Browser Console Errors, Failed API Calls, Diagnostics
- [ ] Verify diagnostics table shows agent info (when connected) and browser info (always)
- [ ] Verify failed API calls section appears when there are recent errors
- [ ] Verify no section appears when there are no entries (empty sections are omitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)