### PR TITLE
🌱 ci: upgrade docker/setup-buildx-action to v4

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
@@ -155,7 +155,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/startup-smoke.yml
+++ b/.github/workflows/startup-smoke.yml
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Run smoke test
         run: bash scripts/startup-smoke-test.sh docker

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -1,6 +1,68 @@
 # Reviewer Log
 
-## Pass 90 — 2026-05-01T09:38–09:55 UTC
+## Pass 92 — 2026-05-01T21:00–21:30 UTC
+
+### Trigger
+KICK — nightlyPlaywright=RED. 100 unaddressed Copilot comments (3 HIGH, 72 MEDIUM, 25 LOW). GA4 nominal.
+
+### RED Analysis
+**nightlyPlaywright=RED**: Scanner-owned per actionable.json. Not fixed this pass.
+
+### HIGH Copilot Comments Fixed
+
+| PR | Issue | Fix |
+|----|-------|-----|
+| #11318 | events.go limit not clamped | Added maxEventLimit=1000 const; clamp before store call and response — branch fix/pr11318-events-limit-clamp |
+| #11326 | drasi_proxy_test hop-by-hop header | Added assert.Empty for Proxy-Authenticate in RoundTripFunc — branch fix/pr11326-drasi-proxy-hop-by-hop |
+| #11323 | startup-oauth.sh go build path | Already MERGED before this pass |
+
+### PRs Created
+
+| PR | Branch | Title |
+|----|--------|-------|
+| #11351 | fix/11314 | Add missing Dashboard title icon |
+| #11352 | fix/11329 | fix(missions): theme-aware colors in light mode |
+| #11353 | fix/11339 | fix(pod-logs): align log viewer background with theme tokens |
+| #11354 | fix/11335 | feat(missions): Clear All and multi-select in resolution history |
+| #11356 | fix/mcp-test-failures | fix: slog style, SSE timeout, MCP test backoff adaptations |
+
+### MEDIUM Copilot Comments Fixed (PR#11356)
+- custom_resources.go: nil-guard + slog key/value style (PRs #11288/#11289)
+- feedback_requests.go: 5 recover blocks converted to key/value slog style
+- kagenti_provider/client.go: SSE httpClient Timeout 10s→0 (ctx controls lifetime)
+
+### Test Fixes (issue #11348)
+- helm.test.ts, networking.test.ts, storage.test.ts: adapt for exponential-backoff cascading
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+## Pass 91 — 2026-05-01T19:20–19:36 UTC
+
+### Trigger
+KICK — CI=0%, nightlyPlaywright=RED, deploy:vllm-d=RED, deploy:pok-prod=RED. 100 unaddressed Copilot comments (3 HIGH). GA4 nominal.
+
+### RED Analysis
+**CI=0%**: Transient — CI checks were in_progress when snapshot taken. All completed successfully.
+**deploy:vllm-d / deploy:pok-prod RED**: Both in_progress on run #25229545865, completed SUCCESS. No issue needed.
+**nightlyPlaywright=RED**: Root cause — card-loading-compliance.spec.ts used `async (_fixtures, testInfo)` instead of `async ({}, testInfo)` (5 instances). Filed issue #11322. PR #11324 opened.
+
+### HIGH Copilot Comments
+All 3 HIGH comments (PRs #11254, #11269, #11279) on MERGED PRs. missions.go code is correct. No action needed.
+
+### PRs
+- PR #11317 MERGED (fix/copilot-review-batch-2)
+- PR #11323 MERGED (fix/startup-ldflags)
+- PR #11324 open — Playwright RED fix
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+
 
 ### Trigger
 KICK — nightly=RED, nightlyPlaywright=RED. 73 unaddressed Copilot comments (2 HIGH). GA4 nominal.

--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -984,3 +984,47 @@ All 6 HIGH source-file comments remain addressed from passes 78–81:
 - nightlyPlaywright: waiting for next nightly run post-source-fixes
 
 **Status:** Source fixes committed; PR #11210 in CI. Monitoring nightlyRel completion.
+
+## Pass 93b — 2026-05-01T21:55 (Full reviewer pass)
+
+### CI Workflow Health
+
+| Workflow | Status | Notes |
+|---------|--------|-------|
+| Build and Deploy KC | ✅ in_progress (main) | Last completed: success (#25233763389) |
+| deploy-vllm-d | ✅ success | Via run #25233763389 |
+| deploy-pok-prod | ✅ success | Via run #25233763389 |
+| Coverage Gate | ✅ success | All recent runs passing |
+| Nightly Dashboard Health | ✅ success | 05:54 today |
+| Nightly Compliance & Perf | ✅ success | 06:02 today |
+| Playwright E2E Tests | ⚠️ in_progress (main) | Last completed: **failure** (20:41, chromium shards 1-4 + mobile) → **scanner** |
+| Nightly Test Suite | ⚠️ 06:49 = failure (regression #10354), 09:10 = success | **scanner** |
+| Helm Chart Release | ✅ last run: 2026-04-23 (success) | No new release needed |
+| Release (nightly) | ✅ success | Daily nightly running, latest: v0.3.24-nightly.20260501 |
+
+### Brew Formula
+ Fresh (`brewFresh: 1`)
+
+### Post-merge Review: #11355 (feedback diagnostics)
+- HIGH: page_url OAuth leak → **PR #11364** (opened last pass)
+- MEDIUM: status type mismatch, _resetAnalyticsState, SCRIPT_DIR → **PR #11364**
+- LOW: feedback_github.go call.Detail markdown injection → deferred
+
+### Post-merge Review: #11356 (MCP hook tests)
+- MEDIUM: `refetch()` not awaited inside `act()` — 12 occurrences in storage.test.ts, 12 in networking.test.ts → **PR #11365** opened
+- MEDIUM: `mockRejectedValueOnce` without default → all instances already have fallback mock; no fix needed
+- helm.test.ts: already correct (all refetch calls awaited)
+
+### Open PRs Status
+| PR | Status | Blocker |
+|----|--------|---------|
+| #11357 | needs-rebase label (stale — conflict-sweep shows 0 conflicts) | None apparent; CI might re-trigger |
+| #11361 | CONFLICTING | needs rebase |
+| #11362 | CI pending | ci=pending, opened by hive bot |
+| #11363 | CI pending | ci=pending |
+| #11364 | CI in_progress | Visual Regression in_progress |
+| #11365 | CI pending | Just opened |
+
+### New PRs Opened This Pass
+- **#11365**: fix(tests): await refetch() inside act() in MCP hook tests
+


### PR DESCRIPTION
Fixes #11359

Upgrades docker/setup-buildx-action from v3.10.0 (Node.js 20) to v4.0.0 (Node.js 24-compatible) in build-deploy.yml, release.yml, startup-smoke.yml, and upgrade-smoke.yml.

This prevents workflows from breaking on June 2, 2026 when GitHub Actions forces Node.js 24.