### PR TITLE
🐛 fix(demoMode): decouple VITE_NO_LOCAL_AGENT from isNetlifyDeployment

### DIFF
--- a/web/src/lib/demoMode.ts
+++ b/web/src/lib/demoMode.ts
@@ -29,15 +29,15 @@ const GPU_CACHE_KEY = 'kubestellar-gpu-cache'
 
 /**
  * Whether running on a Netlify deployment (console.kubestellar.io, preview deploys)
- * or an environment where the local kc-agent is explicitly suppressed.
- * These environments have no backend/agent access, so demo mode is forced.
+ * or VITE_DEMO_MODE is explicitly set. These environments have no backend access,
+ * so demo mode is forced.
  *
- * VITE_NO_LOCAL_AGENT is set at build time for in-cluster deployments
- * (Helm/Kubernetes) where no local kc-agent exists on the user's machine.
+ * Note: VITE_NO_LOCAL_AGENT is NOT included here — it indicates no local kc-agent
+ * WebSocket, but in-cluster Helm deployments still have a live backend with a
+ * pod ServiceAccount and should serve real cluster data.
  */
 export const isNetlifyDeployment = typeof window !== 'undefined' && (
   import.meta.env.VITE_DEMO_MODE === 'true' ||
-  import.meta.env.VITE_NO_LOCAL_AGENT === 'true' ||
   window.location.hostname.includes('netlify.app') ||
   window.location.hostname.includes('deploy-preview-') ||
   window.location.hostname === 'console.kubestellar.io'


### PR DESCRIPTION
Fixes #11369

## Summary
Remove `VITE_NO_LOCAL_AGENT` from the `isNetlifyDeployment` check in `demoMode.ts`. This flag indicates no local kc-agent on the user's machine (correct for in-cluster Helm deployments), but was incorrectly forcing demo mode, causing all cluster data panels to show static demo data instead of live data.

## Changes
- `web/src/lib/demoMode.ts`: Remove `import.meta.env.VITE_NO_LOCAL_AGENT === 'true'` from `isNetlifyDeployment` condition

## Root Cause
`isNetlifyDeployment` being true forces `isDemoModeForced = true`, making it impossible to toggle off demo mode. In-cluster deployments correctly set `NO_LOCAL_AGENT=true` (no local agent WebSocket), but this should not trigger demo mode since the backend has a live k8s client via the pod ServiceAccount.

## Testing
- In-cluster Helm deployment should now show live cluster data
- Netlify deployments unaffected (still detected by hostname checks)
- Agent WebSocket suppression unaffected (still handled in `network.ts`)