### PR TITLE
🐛 fix(tests): update MCP hook tests for exponential backoff behavior

### DIFF
--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -1,6 +1,68 @@
 # Reviewer Log
 
-## Pass 90 — 2026-05-01T09:38–09:55 UTC
+## Pass 92 — 2026-05-01T21:00–21:30 UTC
+
+### Trigger
+KICK — nightlyPlaywright=RED. 100 unaddressed Copilot comments (3 HIGH, 72 MEDIUM, 25 LOW). GA4 nominal.
+
+### RED Analysis
+**nightlyPlaywright=RED**: Scanner-owned per actionable.json. Not fixed this pass.
+
+### HIGH Copilot Comments Fixed
+
+| PR | Issue | Fix |
+|----|-------|-----|
+| #11318 | events.go limit not clamped | Added maxEventLimit=1000 const; clamp before store call and response — branch fix/pr11318-events-limit-clamp |
+| #11326 | drasi_proxy_test hop-by-hop header | Added assert.Empty for Proxy-Authenticate in RoundTripFunc — branch fix/pr11326-drasi-proxy-hop-by-hop |
+| #11323 | startup-oauth.sh go build path | Already MERGED before this pass |
+
+### PRs Created
+
+| PR | Branch | Title |
+|----|--------|-------|
+| #11351 | fix/11314 | Add missing Dashboard title icon |
+| #11352 | fix/11329 | fix(missions): theme-aware colors in light mode |
+| #11353 | fix/11339 | fix(pod-logs): align log viewer background with theme tokens |
+| #11354 | fix/11335 | feat(missions): Clear All and multi-select in resolution history |
+| #11356 | fix/mcp-test-failures | fix: slog style, SSE timeout, MCP test backoff adaptations |
+
+### MEDIUM Copilot Comments Fixed (PR#11356)
+- custom_resources.go: nil-guard + slog key/value style (PRs #11288/#11289)
+- feedback_requests.go: 5 recover blocks converted to key/value slog style
+- kagenti_provider/client.go: SSE httpClient Timeout 10s→0 (ctx controls lifetime)
+
+### Test Fixes (issue #11348)
+- helm.test.ts, networking.test.ts, storage.test.ts: adapt for exponential-backoff cascading
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+## Pass 91 — 2026-05-01T19:20–19:36 UTC
+
+### Trigger
+KICK — CI=0%, nightlyPlaywright=RED, deploy:vllm-d=RED, deploy:pok-prod=RED. 100 unaddressed Copilot comments (3 HIGH). GA4 nominal.
+
+### RED Analysis
+**CI=0%**: Transient — CI checks were in_progress when snapshot taken. All completed successfully.
+**deploy:vllm-d / deploy:pok-prod RED**: Both in_progress on run #25229545865, completed SUCCESS. No issue needed.
+**nightlyPlaywright=RED**: Root cause — card-loading-compliance.spec.ts used `async (_fixtures, testInfo)` instead of `async ({}, testInfo)` (5 instances). Filed issue #11322. PR #11324 opened.
+
+### HIGH Copilot Comments
+All 3 HIGH comments (PRs #11254, #11269, #11279) on MERGED PRs. missions.go code is correct. No action needed.
+
+### PRs
+- PR #11317 MERGED (fix/copilot-review-batch-2)
+- PR #11323 MERGED (fix/startup-ldflags)
+- PR #11324 open — Playwright RED fix
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+
 
 ### Trigger
 KICK — nightly=RED, nightlyPlaywright=RED. 73 unaddressed Copilot comments (2 HIGH). GA4 nominal.

--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -1,5 +1,46 @@
 # Reviewer Log
 
+## Pass 93 — 2026-05-01T23:13–23:30 UTC
+
+### Trigger
+KICK — Continue standing reviewer duties: fix REDs, merge green PRs. GA4 nominal (no anomalies). Copilot comments down to 48 unaddressed (from 49).
+
+### Status
+- **ci**: 100 ✓ (all workflow runs passing)
+- **GA4**: Nominal, 0 anomalies ✓
+- **nightlyPlaywright**: RED=0 (false GREEN indicator; actual nightly runs still failing since 2026-04-28) — issue #11371 filed for scanner
+- **nightlyRel**: GREEN ✓ (release.yml #139 successful)
+- **deploy_vllm_d / deploy_pok_prod**: 0 (false negatives in health-check.sh due to gh auth; actual runs SUCCESS)
+- **Copilot comments**: 48 unaddressed (3 HIGH, 38 MEDIUM, 7 LOW)
+
+### Recent Merges (2026-05-01)
+- #11373: ci: upgrade docker/setup-buildx-action to v4 — merged 2026-05-01T23:12+Z (rebase of #11367)
+- #11372: Address Copilot review findings from #11326, #11355, #11366 — 3 HIGH comments fixed — merged 2026-05-01T23:11:59Z
+  - Fixed: drasi_proxy_test hop-by-hop header assertion, FeedbackModal + SubmitTab page_url OAuth stripping, service_exports_test route mismatch
+
+
+### Open PRs & Worktrees
+
+| PR | Branch | Title | Status | Issue |
+|----|--------|-------|--------|-------|
+| #11375 | (branch) | fix(e2e): stabilize Playwright tests | dirty (merge conflict) | |
+| #11374 | (branch) | fix(tests): update MCP hook tests for exponential backoff | dirty (merge conflict) | |
+| #11376 | fix/copilot-comments-p95 | fix(startup-oauth.sh): track agent build PID | NEW (CI pending) | #11334 |
+
+### Copilot Comments Addressed This Pass
+- startup-oauth.sh: PID tracking for AGENT_BUILD_PID in cleanup; launch_kc_agent() function refactored for idempotency
+- ResolutionHistoryPanel: i18n fixes (t('common.resolutionHistory'), translated aria-label)
+- common.json: added 'selectItem' key for dynamic label translations
+- Branch: fix/copilot-comments-p95, pushed, PR #11376 created
+
+### Next Steps
+1. Wait for CI on PR #11376, then merge (requires lgtm/approved)
+2. Investigate PR #11375 and #11374 merge conflicts — rebase if needed
+3. Re-run health-check to verify remaining RED indicators
+4. Check remaining 45 MEDIUM/LOW Copilot comments for sweep opportunities
+
+---
+
 ## Pass 92 — 2026-05-01T21:00–21:30 UTC
 
 ### Trigger

--- a/web/src/hooks/mcp/__tests__/clusters.health.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.health.test.ts
@@ -607,6 +607,7 @@ describe('useMCPStatus — additional branches', () => {
     const { result } = renderHook(() => useMCPStatus())
     await act(async () => { await Promise.resolve() })
     expect(result.current.status).toEqual(initialStatus)
+    expect(result.current.consecutiveFailures).toBe(0)
 
     // Subsequent poll errors
     mockAgentFetch.mockRejectedValue(new Error('Network error'))
@@ -614,6 +615,7 @@ describe('useMCPStatus — additional branches', () => {
     await act(async () => { await Promise.resolve() })
     expect(result.current.error).toBe('MCP bridge not available')
     expect(result.current.status).toBeNull()
+    expect(result.current.consecutiveFailures).toBe(1)
     vi.useRealTimers()
   })
 
@@ -624,17 +626,19 @@ describe('useMCPStatus — additional branches', () => {
     const { result } = renderHook(() => useMCPStatus())
     await act(async () => { await Promise.resolve() })
     expect(result.current.error).toBe('MCP bridge not available')
+    expect(result.current.consecutiveFailures).toBe(1)
 
-    // Now succeed
+    // Now succeed - need to advance by backoff interval (2x = 240s after 1 failure)
     const good: MCPStatus = {
       opsClient: { available: true, toolCount: 1 },
       deployClient: { available: false, toolCount: 0 },
     }
     mockAgentFetch.mockImplementation(() => Promise.resolve(new Response(JSON.stringify(good), { status: 200 })))
-    await act(async () => { vi.advanceTimersByTime(REFRESH_INTERVAL_MS) })
+    await act(async () => { vi.advanceTimersByTime(REFRESH_INTERVAL_MS * 2) })
     await act(async () => { await Promise.resolve() })
     expect(result.current.error).toBeNull()
     expect(result.current.status).toEqual(good)
+    expect(result.current.consecutiveFailures).toBe(0)
     vi.useRealTimers()
   })
 })

--- a/web/src/hooks/mcp/__tests__/events.test.ts
+++ b/web/src/hooks/mcp/__tests__/events.test.ts
@@ -63,7 +63,11 @@ vi.mock('../../../lib/modeTransition', () => ({
 vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
-  getEffectiveInterval: (ms: number) => ms,
+  getEffectiveInterval: (ms: number, consecutiveFailures = 0) => {
+    if (consecutiveFailures <= 0) return ms
+    const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
+    return Math.min(ms * multiplier, 600_000)
+  },
   LOCAL_AGENT_URL: 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
 }))

--- a/web/src/hooks/mcp/__tests__/helm.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm.test.ts
@@ -50,7 +50,11 @@ vi.mock('../../../lib/modeTransition', () => ({
 
 vi.mock('../shared', () => ({
   MIN_REFRESH_INDICATOR_MS: 500,
-  getEffectiveInterval: (ms: number) => ms,
+  getEffectiveInterval: (ms: number, consecutiveFailures = 0) => {
+    if (consecutiveFailures <= 0) return ms
+    const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
+    return Math.min(ms * multiplier, 600_000)
+  },
   agentFetch: vi.fn().mockImplementation(() => Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))),
 }))
 

--- a/web/src/hooks/mcp/__tests__/networking.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking.test.ts
@@ -71,7 +71,11 @@ vi.mock('../../../lib/kubectlProxy', () => ({
 vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
-  getEffectiveInterval: (ms: number) => ms,
+  getEffectiveInterval: (ms: number, consecutiveFailures = 0) => {
+    if (consecutiveFailures <= 0) return ms
+    const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
+    return Math.min(ms * multiplier, 600_000)
+  },
   LOCAL_AGENT_URL: 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
   clusterCacheRef: mockClusterCacheRef,

--- a/web/src/hooks/mcp/__tests__/storage.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage.test.ts
@@ -79,7 +79,11 @@ vi.mock('../../../lib/kubectlProxy', () => ({
 vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
-  getEffectiveInterval: (ms: number) => ms,
+  getEffectiveInterval: (ms: number, consecutiveFailures = 0) => {
+    if (consecutiveFailures <= 0) return ms
+    const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
+    return Math.min(ms * multiplier, 600_000)
+  },
   LOCAL_AGENT_URL: 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
   clusterCacheRef: mockClusterCacheRef,

--- a/web/src/hooks/mcp/__tests__/workloads.core.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.core.test.ts
@@ -84,7 +84,11 @@ vi.mock('../../../lib/kubectlProxy', () => ({
 vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
-  getEffectiveInterval: (ms: number) => ms,
+  getEffectiveInterval: (ms: number, consecutiveFailures = 0) => {
+    if (consecutiveFailures <= 0) return ms
+    const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
+    return Math.min(ms * multiplier, 600_000)
+  },
   clusterCacheRef: mockClusterCacheRef,
   agentFetch: vi.fn().mockImplementation(async (...args: unknown[]) => {
     const result = await mockApiGet(...args)

--- a/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
@@ -86,7 +86,11 @@ vi.mock('../../../lib/kubectlProxy', () => ({
 vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
-  getEffectiveInterval: (ms: number) => ms,
+  getEffectiveInterval: (ms: number, consecutiveFailures = 0) => {
+    if (consecutiveFailures <= 0) return ms
+    const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
+    return Math.min(ms * multiplier, 600_000)
+  },
   LOCAL_AGENT_URL: 'http://localhost:8585',
   clusterCacheRef: mockClusterCacheRef,
   agentFetch: (...args: unknown[]) => mockAgentFetch(...args),


### PR DESCRIPTION
Fixes #11348

Updates 15 failing MCP hook tests to align with exponential backoff retry behavior introduced in PR #11343. Tests now correctly account for the new retry timing and failure threshold logic.

## Changes
- Updated `getEffectiveInterval` mock to implement exponential backoff (2x per failure, capped at 600s)
- Added `consecutiveFailures` assertions in clusters.health.test.ts
- Fixed timer advancement to account for backoff intervals (2x after 1 failure)
- Applied changes to all 7 affected test files:
  - clusters.health.test.ts
  - events.test.ts
  - helm.test.ts
  - networking.test.ts
  - storage.test.ts
  - workloads.core.test.ts
  - workloads.extended.test.ts

## Test Failures Fixed
All 15 test failures mentioned in #11348 related to:
- getCachedHealth behavior
- useMCPStatus error handling
- SSE failure handling
- Consecutive failure tracking
- Data preservation on errors