### PR TITLE
ui: show parallel build progress for frontend and backend

### DIFF
--- a/cmd/watcher/watcher_html.go
+++ b/cmd/watcher/watcher_html.go
@@ -126,10 +126,11 @@ var reloading=false;
 var elapsedEl=document.getElementById('elapsed');
 
 // Stage ordering
-var STAGES=['watchdog','npm_install','frontend_build','vite_starting','backend_compiling','backend_starting','ready'];
+var STAGES=['watchdog','npm_install','parallel_build','frontend_build','vite_starting','backend_compiling','backend_starting','ready'];
 
 function normalizeStage(s){
   if(s==='vite_starting') return 'frontend_build';
+  if(s==='parallel_build') return 'parallel_build';
   return s;
 }
 
@@ -146,23 +147,37 @@ function updateSteps(stage){
   var displayStages=[];
   steps.forEach(function(el){displayStages.push(el.getAttribute('data-stage'))});
 
-  var activeIdx=displayStages.indexOf(displayStage);
+  // parallel_build: both frontend and backend build concurrently
+  var isParallel=stage==='parallel_build';
 
-  steps.forEach(function(el,i){
-    el.classList.remove('done','active','waiting');
-    if(activeIdx>=0){
-      if(i<activeIdx) el.classList.add('done');
-      else if(i===activeIdx) el.classList.add(displayStage==='ready'?'done':'active');
+  if(isParallel){
+    var fbIdx=displayStages.indexOf('frontend_build');
+    var bcIdx=displayStages.indexOf('backend_compiling');
+    steps.forEach(function(el,i){
+      el.classList.remove('done','active','waiting');
+      if(i<fbIdx) el.classList.add('done');
+      else if(i===fbIdx||i===bcIdx) el.classList.add('active');
       else el.classList.add('waiting');
-    } else {
-      el.classList.add('waiting');
-    }
-  });
+    });
+  } else {
+    var activeIdx=displayStages.indexOf(displayStage);
+    steps.forEach(function(el,i){
+      el.classList.remove('done','active','waiting');
+      if(activeIdx>=0){
+        if(i<activeIdx) el.classList.add('done');
+        else if(i===activeIdx) el.classList.add(displayStage==='ready'?'done':'active');
+        else el.classList.add('waiting');
+      } else {
+        el.classList.add('waiting');
+      }
+    });
+  }
 
   var subtitle=document.querySelector('.subtitle');
   var labels={
     'watchdog':'Preparing environment\u2026',
     'npm_install':'Installing dependencies\u2026',
+    'parallel_build':'Building frontend & backend\u2026',
     'frontend_build':'Building frontend\u2026',
     'vite_starting':'Starting dev server\u2026',
     'backend_compiling':'Compiling backend\u2026',

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -473,6 +473,9 @@ if [ "$USE_DEV_SERVER" = true ]; then
     # Use "|| true" before capturing $? so set -e doesn't fire before we can
     # handle the error and print a friendly message.
     if [ -n "$BACKEND_BUILD_PID" ]; then
+        if kill -0 "$BACKEND_BUILD_PID" 2>/dev/null; then
+            write_stage "backend_compiling"
+        fi
         wait "$BACKEND_BUILD_PID" || true
         BACKEND_BUILD_EXIT=$?
         if [ "$BACKEND_BUILD_EXIT" -ne 0 ] || [ ! -x "$BACKEND_BIN" ]; then
@@ -567,7 +570,7 @@ else
     ) &
     BACKEND_BUILD_PID=$!
 
-    write_stage "frontend_build"
+    write_stage "parallel_build"
     echo -e "${GREEN}Building frontend...${NC}"
     if ! (cd web && npm run build); then
         echo ""
@@ -598,9 +601,14 @@ else
     launch_kc_agent
 
     # Wait for backend build to finish, then start the pre-built binary.
+    # If the backend build is still running (frontend finished first), show
+    # the "Compiling backend" stage so the user sees progress.
     # Use "|| true" before capturing $? so set -e doesn't fire before we can
     # handle the error and print a friendly message.
     if [ -n "$BACKEND_BUILD_PID" ]; then
+        if kill -0 "$BACKEND_BUILD_PID" 2>/dev/null; then
+            write_stage "backend_compiling"
+        fi
         wait "$BACKEND_BUILD_PID" || true
         BACKEND_BUILD_EXIT=$?
         if [ "$BACKEND_BUILD_EXIT" -ne 0 ] || [ ! -x "$BACKEND_BIN" ]; then


### PR DESCRIPTION
## Summary

- During startup, the watcher loading page now shows **both** "Building frontend" and "Compiling backend" with spinners simultaneously
- Subtitle reads "Building frontend & backend..." during the parallel phase
- When the frontend finishes first, transitions to showing only "Compiling backend" until that completes

## Before

Only "Building frontend" spinner shown — backend build was invisible:

```
  ✓  Preparing environment
  ✓  Installing dependencies
  ◎  Building frontend        ← only this spinner
  ○  Compiling backend        ← looked like it hadn't started
  ○  Backend initializing
  ○  Ready
```

## After

Both steps show spinners when building concurrently:

```
  ✓  Preparing environment
  ✓  Installing dependencies
  ◎  Building frontend        ← spinner
  ◎  Compiling backend        ← spinner (both active)
  ○  Backend initializing
  ○  Ready
```

## Test plan

- [ ] `bash startup-oauth.sh` — verify both spinners appear during build phase
- [ ] Verify transition to single "Compiling backend" spinner when frontend finishes first
- [ ] `bash startup-oauth.sh --dev` — verify dev mode still works (no parallel_build stage, backend builds during npm install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)