### PR TITLE
🐛 Fix mission rename visibility and preview panel padding

### DIFF
--- a/web/src/components/dashboard/customizer/PreviewPanel.tsx
+++ b/web/src/components/dashboard/customizer/PreviewPanel.tsx
@@ -20,7 +20,7 @@ export function PreviewPanel({ hoveredCard }: PreviewPanelProps) {
   const tCard = t as (key: string, defaultValue?: string) => string
 
   return (
-    <div className="w-64 border-l border-border pl-4 shrink-0 hidden lg:block">
+    <div className="w-64 border-l border-border px-4 shrink-0 hidden lg:block">
       <div className="text-xs text-muted-foreground uppercase tracking-wide mb-2">
         {t('dashboard.addCard.preview', 'Preview')}
       </div>

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -447,7 +447,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               <h3 className="font-semibold text-foreground flex-1 truncate">{mission.title}</h3>
               <button
                 onClick={startEditingTitle}
-                className="p-0.5 rounded transition-colors opacity-0 group-hover:opacity-100 hover:bg-secondary"
+                className="p-0.5 rounded transition-colors text-muted-foreground hover:bg-secondary"
                 title={t('missionChat.renameTitle', { defaultValue: 'Rename mission' })}
                 data-testid="mission-title-edit-btn"
               >


### PR DESCRIPTION
Fixes #11421
Fixes #11422

## Changes
- Made mission rename action always visible instead of hover-only
- Added proper right padding to Console Studio preview panel