### PR TITLE
🐛 Fix status label theme and pod modal contrast in light mode

### DIFF
--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -1398,7 +1398,7 @@ Please:
                     <span className="text-sm text-muted-foreground">{t('drilldown.status.fetchingPodStatus')}</span>
                   </div>
                 ) : podStatusOutput ? (
-                  <pre className="p-3 rounded-lg bg-black/50 border border-border overflow-x-auto text-xs text-foreground font-mono">
+                  <pre className="p-3 rounded-lg bg-muted border border-border overflow-x-auto text-xs text-foreground font-mono">
                     <code className="text-muted-foreground"># kubectl get pod {podName} -n {namespace} -o wide</code>
                     {'\n'}
                     {podStatusOutput}
@@ -1464,7 +1464,7 @@ Please:
                     View all
                   </button>
                 </div>
-                <pre className="p-3 rounded-lg bg-black/50 border border-border overflow-x-auto text-xs text-foreground font-mono max-h-32 overflow-y-auto">
+                <pre className="p-3 rounded-lg bg-muted border border-border overflow-x-auto text-xs text-foreground font-mono max-h-32 overflow-y-auto">
                   {eventsOutput.includes('No resources found')
                     ? `No events found for pod ${podName}`
                     : eventsOutput.split('\n').slice(0, 6).join('\n')}
@@ -1626,7 +1626,7 @@ Please:
 
       {/* AI Actions Footer - Always visible */}
       {agentConnected && issues.length > 0 && (
-        <div className="border-t border-border bg-card/30">
+        <div className="border-t border-border bg-card">
           <PodAiAnalysis
             aiAnalysis={aiAnalysis}
             aiAnalysisLoading={aiAnalysisLoading}

--- a/web/src/components/drilldown/views/pod-drilldown/PodOutputTab.tsx
+++ b/web/src/components/drilldown/views/pod-drilldown/PodOutputTab.tsx
@@ -105,7 +105,7 @@ export function PodOutputTab({
               )}
             </button>
           </div>
-          <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
+          <pre className="p-4 rounded-lg bg-muted border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
             <code className="text-muted-foreground">{kubectlComment}</code>
             {'\n\n'}
             {output}

--- a/web/src/components/marketplace/Marketplace.tsx
+++ b/web/src/components/marketplace/Marketplace.tsx
@@ -35,13 +35,13 @@ const TYPE_LABELS: Record<MarketplaceItemType, { label: string; icon: typeof Lay
   theme: { label: 'Themes', icon: Palette } }
 
 const DIFFICULTY_CONFIG = {
-  beginner: { label: 'Beginner', color: 'text-green-400 bg-green-950', stars: 1 },
-  intermediate: { label: 'Intermediate', color: 'text-yellow-400 bg-yellow-950', stars: 2 },
-  advanced: { label: 'Advanced', color: 'text-red-400 bg-red-950', stars: 3 } } as const
+  beginner: { label: 'Beginner', color: 'text-green-400 bg-green-500/10', stars: 1 },
+  intermediate: { label: 'Intermediate', color: 'text-yellow-400 bg-yellow-500/10', stars: 2 },
+  advanced: { label: 'Advanced', color: 'text-red-400 bg-red-500/10', stars: 3 } } as const
 
 const MATURITY_CONFIG = {
-  graduated: { label: 'Graduated', color: 'text-green-400 bg-green-950 border-green-800' },
-  incubating: { label: 'Incubating', color: 'text-blue-400 bg-blue-950 border-blue-800' } } as const
+  graduated: { label: 'Graduated', color: 'text-green-400 bg-green-500/10 border-green-500/30' },
+  incubating: { label: 'Incubating', color: 'text-blue-400 bg-blue-500/10 border-blue-500/30' } } as const
 
 // --- CNCF Progress Banner ---
 function CNCFProgressBanner({ stats }: { stats: CNCFStats }) {


### PR DESCRIPTION
Fixes #11423
Fixes #11427

## Changes
- Replaced hardcoded dark-only background colors (`bg-green-950`, `bg-blue-950`, etc.) on marketplace status/difficulty labels with theme-safe `bg-*/10` variants that work in both light and dark modes
- Replaced `bg-black/50` on pod detail `<pre>` blocks with semantic `bg-muted` for proper light theme contrast
- Replaced `bg-card/30` footer with `bg-card` for full opacity in light theme