### PR TITLE
🐛 Fix toolbar labels, filter text, and AI panel header merging

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -682,7 +682,7 @@ export const CardWrapper = memo(function CardWrapper({
             onMouseLeave={() => setShowSummary(false)}
           >
             {/* Header */}
-            <div data-tour="card-header" className="flex flex-wrap items-center justify-between gap-y-2 px-4 py-3 border-b border-border/50">
+            <div data-tour="card-header" className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 px-4 py-3 border-b border-border/50">
               <div className="flex items-center gap-2 min-w-0">
                 {dragHandle}
                 {ResolvedIcon && <ResolvedIcon className={cn('w-4 h-4 shrink-0', resolvedIconColor)} />}
@@ -752,7 +752,7 @@ export const CardWrapper = memo(function CardWrapper({
                   )
                 })()}
               </div>
-              <div className="flex items-center gap-1 shrink-0">
+              <div className="flex items-center gap-1.5 shrink-0" role="toolbar" aria-label={t('cardWrapper.cardActions', { defaultValue: 'Card actions' })}>
                 {/* Collapse/expand button */}
                 <button
                   onClick={() => setCollapsed(!isCollapsed)}

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -754,7 +754,7 @@ export function MissionSidebar() {
           )}
         </div>
         {/* Toolbar and window controls — split so close/minimize never overflow */}
-        <div className="flex items-center gap-1 min-w-0">
+        <div className="flex items-center gap-1.5 min-w-0" role="toolbar" aria-label={t('missionSidebar.headerActions', { defaultValue: 'Mission panel actions' })}>
           {/* + button with dropdown — outside overflow-hidden so the dropdown isn't clipped */}
           <div className="relative mr-1 shrink-0" ref={addMenuRef}>
             <button
@@ -848,34 +848,38 @@ export function MissionSidebar() {
               <button
                 onClick={() => setFullScreen(false)}
                 className="p-1 rounded transition-colors hover:bg-black/5 dark:hover:bg-white/10"
+                aria-label={t('missionSidebar.exitFullScreen')}
                 title={t('missionSidebar.exitFullScreen')}
               >
-                <Minimize2 className="w-5 h-5 text-muted-foreground" />
+                <Minimize2 className="w-5 h-5 text-muted-foreground" aria-hidden="true" />
               </button>
             ) : (
               <>
                 <button
                   onClick={() => setFullScreen(true)}
                   className="p-1 rounded transition-colors hover:bg-black/5 dark:hover:bg-white/10"
+                  aria-label={t('missionSidebar.fullScreen')}
                   title={t('missionSidebar.fullScreen')}
                 >
-                  <Maximize2 className="w-5 h-5 text-muted-foreground" />
+                  <Maximize2 className="w-5 h-5 text-muted-foreground" aria-hidden="true" />
                 </button>
                 <button
                   onClick={minimizeSidebar}
                   className="p-1 rounded transition-colors hover:bg-black/5 dark:hover:bg-white/10"
+                  aria-label={t('missionSidebar.minimizeSidebar')}
                   title={t('missionSidebar.minimizeSidebar')}
                 >
-                  <PanelRightClose className="w-5 h-5 text-muted-foreground" />
+                  <PanelRightClose className="w-5 h-5 text-muted-foreground" aria-hidden="true" />
                 </button>
               </>
             ))}
             <button
               onClick={closeSidebar}
               className="min-w-[44px] min-h-[44px] p-2 rounded transition-colors hover:bg-black/5 dark:hover:bg-white/10 flex items-center justify-center"
+              aria-label={t('missionSidebar.closeSidebar')}
               title={t('missionSidebar.closeSidebar')}
             >
-              <X className="w-5 h-5 text-muted-foreground" />
+              <X className="w-5 h-5 text-muted-foreground" aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/web/src/components/layout/navbar/SearchDropdown.tsx
+++ b/web/src/components/layout/navbar/SearchDropdown.tsx
@@ -407,8 +407,8 @@ export function SearchDropdown() {
           placeholder={t('layout.navbar.searchPlaceholder')}
           className="w-full pl-10 pr-16 py-2 bg-secondary rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500/50"
         />
-        <kbd className="absolute right-3 top-1/2 -translate-y-1/2 hidden sm:flex items-center gap-1 px-1.5 py-0.5 text-xs text-muted-foreground bg-secondary rounded">
-          <Command className="w-3 h-3" />K
+        <kbd className="absolute right-3 top-1/2 -translate-y-1/2 hidden sm:flex items-center gap-1 px-1.5 py-0.5 text-xs text-muted-foreground bg-secondary rounded" aria-hidden="true">
+          <Command className="w-3 h-3" /><span>K</span>
         </kbd>
 
         {/* Cmd+K feature hint tooltip */}

--- a/web/src/components/shared/DashboardHeader.tsx
+++ b/web/src/components/shared/DashboardHeader.tsx
@@ -120,7 +120,7 @@ export function DashboardHeader({
 
       {/* Right side: controls + timestamp below */}
       <div className="flex flex-col items-end gap-0.5 shrink-0">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3" role="toolbar" aria-label={t('shared.dashboardHeader.toolbarLabel', { defaultValue: 'Dashboard controls' })}>
           {rightExtra}
           {onAutoRefreshChange && (
             <label
@@ -143,10 +143,12 @@ export function DashboardHeader({
             onClick={onRefresh}
             disabled={isFetching}
             className="p-2 rounded-lg hover:bg-secondary transition-colors disabled:opacity-50"
+            aria-label={t('common.refreshClusterData')}
             title={t('common.refreshClusterData')}
           >
             <RefreshCw
               className={`w-4 h-4 ${(isFetching || spinning) ? 'animate-spin' : ''}`}
+              aria-hidden="true"
             />
           </button>
         </div>


### PR DESCRIPTION
Fixes #11399
Fixes #11400
Fixes #11401
Fixes #11402

## Changes
- Added proper `aria-label` and `aria-hidden` attributes to AI Missions panel header action buttons (fullscreen, minimize, close) and wrapped them in a `role="toolbar"` container to prevent screen readers from concatenating button labels
- Fixed filter label showing 'KNo filters' by adding `aria-hidden="true"` to the SearchDropdown `<kbd>` keyboard shortcut indicator, preventing the 'K' text from bleeding into adjacent filter panel accessible text
- Added `aria-label` to DashboardHeader refresh button and wrapped controls in `role="toolbar"` for proper label separation between 'Auto', 'Refresh cluster data', and 'Updated' text
- Added `gap-x-3` horizontal spacing to CardWrapper header and `role="toolbar"` with `aria-label` to card action buttons to separate 'Refresh failed' + timestamp text from 'Collapse card' control labels