### PR TITLE
🐛 Fix cluster status values and alert state consistency

### DIFF
--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -1,6 +1,68 @@
 # Reviewer Log
 
-## Pass 90 — 2026-05-01T09:38–09:55 UTC
+## Pass 92 — 2026-05-01T21:00–21:30 UTC
+
+### Trigger
+KICK — nightlyPlaywright=RED. 100 unaddressed Copilot comments (3 HIGH, 72 MEDIUM, 25 LOW). GA4 nominal.
+
+### RED Analysis
+**nightlyPlaywright=RED**: Scanner-owned per actionable.json. Not fixed this pass.
+
+### HIGH Copilot Comments Fixed
+
+| PR | Issue | Fix |
+|----|-------|-----|
+| #11318 | events.go limit not clamped | Added maxEventLimit=1000 const; clamp before store call and response — branch fix/pr11318-events-limit-clamp |
+| #11326 | drasi_proxy_test hop-by-hop header | Added assert.Empty for Proxy-Authenticate in RoundTripFunc — branch fix/pr11326-drasi-proxy-hop-by-hop |
+| #11323 | startup-oauth.sh go build path | Already MERGED before this pass |
+
+### PRs Created
+
+| PR | Branch | Title |
+|----|--------|-------|
+| #11351 | fix/11314 | Add missing Dashboard title icon |
+| #11352 | fix/11329 | fix(missions): theme-aware colors in light mode |
+| #11353 | fix/11339 | fix(pod-logs): align log viewer background with theme tokens |
+| #11354 | fix/11335 | feat(missions): Clear All and multi-select in resolution history |
+| #11356 | fix/mcp-test-failures | fix: slog style, SSE timeout, MCP test backoff adaptations |
+
+### MEDIUM Copilot Comments Fixed (PR#11356)
+- custom_resources.go: nil-guard + slog key/value style (PRs #11288/#11289)
+- feedback_requests.go: 5 recover blocks converted to key/value slog style
+- kagenti_provider/client.go: SSE httpClient Timeout 10s→0 (ctx controls lifetime)
+
+### Test Fixes (issue #11348)
+- helm.test.ts, networking.test.ts, storage.test.ts: adapt for exponential-backoff cascading
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+## Pass 91 — 2026-05-01T19:20–19:36 UTC
+
+### Trigger
+KICK — CI=0%, nightlyPlaywright=RED, deploy:vllm-d=RED, deploy:pok-prod=RED. 100 unaddressed Copilot comments (3 HIGH). GA4 nominal.
+
+### RED Analysis
+**CI=0%**: Transient — CI checks were in_progress when snapshot taken. All completed successfully.
+**deploy:vllm-d / deploy:pok-prod RED**: Both in_progress on run #25229545865, completed SUCCESS. No issue needed.
+**nightlyPlaywright=RED**: Root cause — card-loading-compliance.spec.ts used `async (_fixtures, testInfo)` instead of `async ({}, testInfo)` (5 instances). Filed issue #11322. PR #11324 opened.
+
+### HIGH Copilot Comments
+All 3 HIGH comments (PRs #11254, #11269, #11279) on MERGED PRs. missions.go code is correct. No action needed.
+
+### PRs
+- PR #11317 MERGED (fix/copilot-review-batch-2)
+- PR #11323 MERGED (fix/startup-ldflags)
+- PR #11324 open — Playwright RED fix
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+
 
 ### Trigger
 KICK — nightly=RED, nightlyPlaywright=RED. 73 unaddressed Copilot comments (2 HIGH). GA4 nominal.

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -730,23 +730,8 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
     )
   }, [])
 
-  // Calculate alert statistics — memoize to prevent unstable references in context consumers
-  // #7336 — Compute stats from deduplicated alerts so counters match
-  // the displayed alert list (which uses deduplicateAlerts).
-  const stats: AlertStats = useMemo(() => {
-    const deduped = deduplicateAlerts(alerts, rules)
-    const unacknowledgedFiring = deduped.filter(a => a.status === 'firing' && !a.acknowledgedAt)
-    return {
-      total: deduped.length,
-      firing: unacknowledgedFiring.length,
-      resolved: deduped.filter(a => a.status === 'resolved').length,
-      critical: unacknowledgedFiring.filter(a => a.severity === 'critical').length,
-      warning: unacknowledgedFiring.filter(a => a.severity === 'warning').length,
-      info: unacknowledgedFiring.filter(a => a.severity === 'info').length,
-      acknowledged: deduped.filter(a => a.acknowledgedAt && a.status === 'firing').length }
-  }, [alerts, rules])
-
   // Get active (firing) alerts - exclude acknowledged alerts. Deduplicated via shared helper.
+  // Computed BEFORE stats so stats.firing can reference the same list (#11404).
   const activeAlerts = useMemo(() => {
     const firing = alerts.filter(a => a.status === 'firing' && !a.acknowledgedAt)
     return deduplicateAlerts(firing, rules)
@@ -757,6 +742,26 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
     const acked = alerts.filter(a => a.status === 'firing' && a.acknowledgedAt)
     return deduplicateAlerts(acked, rules)
   }, [alerts, rules])
+
+  // Calculate alert statistics — memoize to prevent unstable references in context consumers.
+  // #11404 — Filter-then-deduplicate for each category so that a resolved
+  // alert can never shadow a firing alert during dedup. stats.firing now
+  // equals activeAlerts.length, keeping the header AlertBadge and dashboard
+  // stat blocks in sync.
+  const stats: AlertStats = useMemo(() => {
+    const resolvedAlerts = deduplicateAlerts(
+      alerts.filter(a => a.status === 'resolved'),
+      rules
+    )
+    return {
+      total: activeAlerts.length + acknowledgedAlerts.length + resolvedAlerts.length,
+      firing: activeAlerts.length,
+      resolved: resolvedAlerts.length,
+      critical: activeAlerts.filter(a => a.severity === 'critical').length,
+      warning: activeAlerts.filter(a => a.severity === 'warning').length,
+      info: activeAlerts.filter(a => a.severity === 'info').length,
+      acknowledged: acknowledgedAlerts.length }
+  }, [alerts, rules, activeAlerts, acknowledgedAlerts])
 
   // Acknowledge an alert — transitions signalType from 'state' to 'acknowledged' (#8750)
   const acknowledgeAlert = useCallback((alertId: string, acknowledgedBy?: string) => {

--- a/web/src/hooks/useUniversalStats.ts
+++ b/web/src/hooks/useUniversalStats.ts
@@ -17,6 +17,7 @@ import { useAlerts, useAlertRules } from './useAlerts'
 import { StatBlockValue } from '../components/ui/StatsOverview'
 import { useDrillDownActions } from './useDrillDown'
 import { MS_PER_HOUR } from '../lib/constants/time'
+import { isClusterUnreachable, isClusterHealthy } from '../components/clusters/utils'
 
 // Cost estimation constants (per-month, rough cloud averages)
 const COST_PER_CPU = 30          // USD per vCPU per month
@@ -62,11 +63,13 @@ export function useUniversalStats() {
   const { rules: alertRules } = useAlertRules()
 
   // ─── Cluster-derived values ───
+  // Use the shared isClusterUnreachable / isClusterHealthy helpers so that
+  // universal stats match the Sidebar and ClusterHealth card exactly (#11403).
   const safeClusters = deduplicatedClusters || []
   const totalClusters = safeClusters.length
-  const healthyClusters = safeClusters.filter(c => c.healthy).length
-  const unhealthyClusters = safeClusters.filter(c => !c.healthy).length
-  const unreachableClusters = safeClusters.filter(c => c.reachable === false).length
+  const unreachableClusters = safeClusters.filter(c => isClusterUnreachable(c)).length
+  const healthyClusters = safeClusters.filter(c => !isClusterUnreachable(c) && isClusterHealthy(c)).length
+  const unhealthyClusters = safeClusters.filter(c => !isClusterUnreachable(c) && !isClusterHealthy(c)).length
   const totalNodes = safeClusters.reduce((sum, c) => sum + (c.nodeCount || 0), 0)
   const totalPods = safeClusters.reduce((sum, c) => sum + (c.podCount || 0), 0)
   const totalCPUs = safeClusters.reduce((sum, c) => sum + (c.cpuCores || 0), 0)


### PR DESCRIPTION
Fixes #11403
Fixes #11404

## Changes

### Cluster status display (#11403)
`useUniversalStats` computed cluster health/unhealthy/unreachable counts using raw field checks (`c.healthy`, `c.reachable === false`) instead of the shared `isClusterHealthy`/`isClusterUnreachable` helpers from `clusters/utils.ts`. This caused dashboard stat blocks to show different values than the Sidebar and ClusterHealth card — clusters with `healthy: undefined` or auth-error `errorType` were miscategorized.

**Fix:** Import and use the shared helpers so all three display surfaces produce identical counts.

### Alert state consistency (#11404)
`AlertsContext` computed `stats.firing` by deduplicating ALL alerts first, then filtering for firing status. A more-recent resolved alert could shadow a still-firing alert during dedup, making `stats.firing < activeAlerts.length`. The header `AlertBadge` (using `activeAlerts`) and dashboard stat blocks (using `stats.firing`) would show conflicting counts.

**Fix:** Filter each category (active, acknowledged, resolved) first, then deduplicate independently. `stats.firing` now always equals `activeAlerts.length`.