### PR TITLE
🌱 fix: deploy-test nightly timeout + post-merge build verification comment permission

### DIFF
--- a/.github/workflows/pr-closed-verification.yml
+++ b/.github/workflows/pr-closed-verification.yml
@@ -235,6 +235,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # || true: GITHUB_TOKEN may not have comment access on some PR origins
+          # (fork PRs, restricted integrations). The build verification succeeded —
+          # a missing success comment is acceptable; only build failures need action.
           gh pr comment "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
             --body "$(cat <<EOF
@@ -242,7 +245,7 @@ jobs:
 
           Both Go and frontend builds compiled successfully against merge commit \`${{ github.event.pull_request.merge_commit_sha }}\`.
           EOF
-          )"
+          )" || true
 
       - name: Fail workflow if builds failed
         if: steps.go_build.outcome == 'failure' || steps.npm_install.outcome == 'failure' || steps.frontend_build.outcome == 'failure'

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -326,6 +326,10 @@ if [ -z "$FAST_MODE" ]; then
           ["ai-ml-test"]=900
           ["nav-test"]=900
           ["perf-test"]=1200
+          # deploy-test: npm run build (~2m) + vite preview start (up to 3m) + 11 tests.
+          # The default 300s cap kills the suite mid-run after server startup.
+          # 900s matches the Playwright-level per-test timeout (300_000ms × slowest path).
+          ["deploy-test"]=900
         )
 
         for script in "${PLAYWRIGHT_SCRIPTS[@]}"; do


### PR DESCRIPTION
Fixes #11395
Fixes #11396

## Changes

### 1. `scripts/run-all-tests.sh` — deploy-test nightly timeout

Adds `deploy-test` to `PLAYWRIGHT_SUITE_TIMEOUT_OVERRIDES` with 900s.

**Root cause:** The default 300s wall-clock cap kills the deploy-test suite mid-run. The `deploy.config.ts` `webServer` command is `npm run build && npx vite preview` with a 180s startup timeout — the build alone can consume the entire 300s budget before any test runs. The nightly shows exactly 300s elapsed with `Suite killed after 300s wall-clock timeout`.

**Fix:** 900s override, matching the Playwright-level per-test timeout (`300_000ms`) and consistent with `nav-test` / `ai-ml-test`.

### 2. `.github/workflows/pr-closed-verification.yml` — comment permission

Adds `|| true` to the "Comment on PR — verification passed" step.

**Root cause:** `GITHUB_TOKEN` on `pull_request:closed` events cannot post comments for some PR origins (`GraphQL: Resource not accessible by integration`). The Go and frontend builds both pass — only the success comment fails, causing a false RED.

**Fix:** `|| true` keeps the workflow green when commenting fails. Genuine build failures still create issues and fail the workflow via the separate "Fail workflow if builds failed" step.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>