### PR TITLE
🐛 Fix enterprise pages light theme contrast

### DIFF
--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -1,6 +1,68 @@
 # Reviewer Log
 
-## Pass 90 — 2026-05-01T09:38–09:55 UTC
+## Pass 92 — 2026-05-01T21:00–21:30 UTC
+
+### Trigger
+KICK — nightlyPlaywright=RED. 100 unaddressed Copilot comments (3 HIGH, 72 MEDIUM, 25 LOW). GA4 nominal.
+
+### RED Analysis
+**nightlyPlaywright=RED**: Scanner-owned per actionable.json. Not fixed this pass.
+
+### HIGH Copilot Comments Fixed
+
+| PR | Issue | Fix |
+|----|-------|-----|
+| #11318 | events.go limit not clamped | Added maxEventLimit=1000 const; clamp before store call and response — branch fix/pr11318-events-limit-clamp |
+| #11326 | drasi_proxy_test hop-by-hop header | Added assert.Empty for Proxy-Authenticate in RoundTripFunc — branch fix/pr11326-drasi-proxy-hop-by-hop |
+| #11323 | startup-oauth.sh go build path | Already MERGED before this pass |
+
+### PRs Created
+
+| PR | Branch | Title |
+|----|--------|-------|
+| #11351 | fix/11314 | Add missing Dashboard title icon |
+| #11352 | fix/11329 | fix(missions): theme-aware colors in light mode |
+| #11353 | fix/11339 | fix(pod-logs): align log viewer background with theme tokens |
+| #11354 | fix/11335 | feat(missions): Clear All and multi-select in resolution history |
+| #11356 | fix/mcp-test-failures | fix: slog style, SSE timeout, MCP test backoff adaptations |
+
+### MEDIUM Copilot Comments Fixed (PR#11356)
+- custom_resources.go: nil-guard + slog key/value style (PRs #11288/#11289)
+- feedback_requests.go: 5 recover blocks converted to key/value slog style
+- kagenti_provider/client.go: SSE httpClient Timeout 10s→0 (ctx controls lifetime)
+
+### Test Fixes (issue #11348)
+- helm.test.ts, networking.test.ts, storage.test.ts: adapt for exponential-backoff cascading
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+## Pass 91 — 2026-05-01T19:20–19:36 UTC
+
+### Trigger
+KICK — CI=0%, nightlyPlaywright=RED, deploy:vllm-d=RED, deploy:pok-prod=RED. 100 unaddressed Copilot comments (3 HIGH). GA4 nominal.
+
+### RED Analysis
+**CI=0%**: Transient — CI checks were in_progress when snapshot taken. All completed successfully.
+**deploy:vllm-d / deploy:pok-prod RED**: Both in_progress on run #25229545865, completed SUCCESS. No issue needed.
+**nightlyPlaywright=RED**: Root cause — card-loading-compliance.spec.ts used `async (_fixtures, testInfo)` instead of `async ({}, testInfo)` (5 instances). Filed issue #11322. PR #11324 opened.
+
+### HIGH Copilot Comments
+All 3 HIGH comments (PRs #11254, #11269, #11279) on MERGED PRs. missions.go code is correct. No action needed.
+
+### PRs
+- PR #11317 MERGED (fix/copilot-review-batch-2)
+- PR #11323 MERGED (fix/startup-ldflags)
+- PR #11324 open — Playwright RED fix
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+
 
 ### Trigger
 KICK — nightly=RED, nightlyPlaywright=RED. 73 unaddressed Copilot comments (2 HIGH). GA4 nominal.

--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -134,8 +134,8 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
           <SummaryCard label="Approved" value={summary.approved_changes} icon={<CheckCircle2 className="w-5 h-5 text-emerald-400" />} />
           <SummaryCard label="Unapproved" value={summary.unapproved_changes} icon={<XCircle className="w-5 h-5 text-red-400" />} accent={summary.unapproved_changes > 0 ? 'red' : undefined} />
           <SummaryCard label="Violations" value={summary.policy_violations} icon={<ShieldAlert className="w-5 h-5 text-orange-400" />} accent={summary.policy_violations > 0 ? 'orange' : undefined} />
-          <div className="rounded-xl border border-zinc-700/50 bg-zinc-800/50 p-4">
-            <div className="flex items-center gap-2 mb-2"><AlertTriangle className={`w-5 h-5 ${riskColor(summary.risk_score)}`} /><span className="text-xs text-zinc-400">Risk Score</span></div>
+          <div className="rounded-xl border border-border bg-card p-4">
+            <div className="flex items-center gap-2 mb-2"><AlertTriangle className={`w-5 h-5 ${riskColor(summary.risk_score)}`} /><span className="text-xs text-muted-foreground">Risk Score</span></div>
             <div className="flex items-baseline gap-2">
               <p className={`text-2xl font-bold ${riskColor(summary.risk_score)}`}>{summary.risk_score}</p>
               <span className={`text-xs px-1.5 py-0.5 rounded ${riskBg(summary.risk_score)} ${riskColor(summary.risk_score)}`}>
@@ -146,9 +146,9 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
         </div>
       )}
 
-      <div className="flex gap-1 border-b border-zinc-700/50 pb-0">
+      <div className="flex gap-1 border-b border-border pb-0">
         {(['changes', 'violations', 'policies'] as const).map(tab => (
-          <button key={tab} onClick={() => setActiveTab(tab)} className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-colors ${activeTab === tab ? 'bg-zinc-700/50 text-zinc-100 border-b-2 border-indigo-400' : 'text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800/50'}`}>
+          <button key={tab} onClick={() => setActiveTab(tab)} className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-colors ${activeTab === tab ? 'bg-secondary text-foreground border-b-2 border-indigo-400' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'}`}>
             {tab === 'changes' && `Changes (${changes.length})`}
             {tab === 'violations' && `Violations (${violations.length})`}
             {tab === 'policies' && `Policies (${policies.length})`}
@@ -159,7 +159,7 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
       {activeTab === 'changes' && (
         <div className="space-y-3">
           <div className="flex items-center gap-2">
-            <Filter className="w-4 h-4 text-zinc-400" />
+            <Filter className="w-4 h-4 text-muted-foreground" />
             <div className="w-44">
               <Select value={filterApproval} onChange={e => setFilterApproval(e.target.value)} selectSize="sm">
                 <option value="all">All statuses</option>
@@ -173,25 +173,25 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
           {(filteredChanges || []).map(change => {
             const approval = APPROVAL_STYLES[change.approval_status] ?? APPROVAL_STYLES.pending
             return (
-              <div key={change.id} className="rounded-lg border border-zinc-700/30 bg-zinc-800/50 p-4">
+              <div key={change.id} className="rounded-lg border border-border bg-card p-4">
                 <div className="flex items-center justify-between mb-2">
                   <div className="flex items-center gap-2">
                     <span className={`inline-flex items-center px-2 py-0.5 rounded-full border text-xs font-medium ${approval.bg}`}>{approval.label}</span>
-                    <span className="text-sm font-medium text-zinc-200">{change.resource_kind}/{change.resource_name}</span>
-                    <code className="text-xs bg-zinc-700/50 px-1.5 py-0.5 rounded text-zinc-400">{change.change_type}</code>
+                    <span className="text-sm font-medium text-foreground">{change.resource_kind}/{change.resource_name}</span>
+                    <code className="text-xs bg-secondary px-1.5 py-0.5 rounded text-muted-foreground">{change.change_type}</code>
                   </div>
                   <div className="flex items-center gap-2">
                     <span className={`text-sm font-mono font-bold ${riskColor(change.risk_score)}`}>{change.risk_score}</span>
-                    <span className="text-xs text-zinc-500">{change.cluster}</span>
+                    <span className="text-xs text-muted-foreground">{change.cluster}</span>
                   </div>
                 </div>
-                <p className="text-sm text-zinc-300 mb-2">{change.description}</p>
-                <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500">
+                <p className="text-sm text-foreground/80 mb-2">{change.description}</p>
+                <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
                   <span className="flex items-center gap-1"><User className="w-3 h-3" />{change.actor}</span>
                   <span className="flex items-center gap-1"><Clock className="w-3 h-3" />{new Date(change.timestamp).toLocaleString()}</span>
                   {change.ticket_ref && <span className="flex items-center gap-1"><FileText className="w-3 h-3" />{change.ticket_ref}</span>}
                   {change.approved_by && <span>Approved by: {change.approved_by}</span>}
-                  {change.diff_summary && <code className="bg-zinc-700/30 px-1 rounded">{change.diff_summary}</code>}
+                  {change.diff_summary && <code className="bg-secondary px-1 rounded">{change.diff_summary}</code>}
                 </div>
               </div>
             )
@@ -201,16 +201,16 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
 
       {activeTab === 'violations' && (
         <div className="space-y-2">
-          {(violations || []).length === 0 ? <p className="text-zinc-500 text-sm text-center py-8">No policy violations detected</p> : (violations || []).map(v => (
-            <div key={v.id} className="rounded-lg border border-zinc-700/30 bg-zinc-900/30 p-3">
+          {(violations || []).length === 0 ? <p className="text-muted-foreground text-sm text-center py-8">No policy violations detected</p> : (violations || []).map(v => (
+            <div key={v.id} className="rounded-lg border border-border bg-card p-3">
               <div className="flex items-center justify-between mb-1">
                 <div className="flex items-center gap-2">
                   <span className={`inline-flex items-center px-2 py-0.5 rounded-full border text-xs font-medium ${SEVERITY_STYLES[v.severity] ?? SEVERITY_STYLES.low}`}>{v.severity}</span>
-                  <code className="text-xs text-zinc-400">{v.policy}</code>
+                  <code className="text-xs text-muted-foreground">{v.policy}</code>
                 </div>
-                <code className="text-xs text-zinc-500">{v.change_id}</code>
+                <code className="text-xs text-muted-foreground">{v.change_id}</code>
               </div>
-              <p className="text-sm text-zinc-300">{v.description}</p>
+              <p className="text-sm text-foreground/80">{v.description}</p>
             </div>
           ))}
         </div>
@@ -219,16 +219,16 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
       {activeTab === 'policies' && (
         <div className="space-y-2">
           {(policies || []).map(p => (
-            <div key={p.id} className="rounded-lg border border-zinc-700/30 bg-zinc-900/30 p-4">
+            <div key={p.id} className="rounded-lg border border-border bg-card p-4">
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-2">
                   <span className={`inline-flex items-center px-2 py-0.5 rounded-full border text-xs font-medium ${SEVERITY_STYLES[p.severity] ?? SEVERITY_STYLES.low}`}>{p.severity}</span>
-                  <span className="text-sm font-medium text-zinc-200">{p.name}</span>
+                  <span className="text-sm font-medium text-foreground">{p.name}</span>
                 </div>
-                <code className="text-xs bg-zinc-700/50 px-1.5 py-0.5 rounded text-zinc-400">{p.scope}</code>
+                <code className="text-xs bg-secondary px-1.5 py-0.5 rounded text-muted-foreground">{p.scope}</code>
               </div>
-              <p className="text-sm text-zinc-400 mb-2">{p.description}</p>
-              <div className="flex gap-3 text-xs text-zinc-500">
+              <p className="text-sm text-muted-foreground mb-2">{p.description}</p>
+              <div className="flex gap-3 text-xs text-muted-foreground">
                 {p.requires_approval && <span className="flex items-center gap-1"><CheckCircle2 className="w-3 h-3 text-emerald-400" />Requires approval</span>}
                 {p.requires_ticket && <span className="flex items-center gap-1"><FileText className="w-3 h-3 text-blue-400" />Requires ticket</span>}
               </div>
@@ -242,9 +242,9 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
 
 function SummaryCard({ label, value, icon, accent }: { label: string; value: number; icon: React.ReactNode; accent?: string }) {
   return (
-    <div className="rounded-xl border border-zinc-700/50 bg-zinc-800/50 p-4">
-      <div className="flex items-center gap-2 mb-2">{icon}<span className="text-xs text-zinc-400">{label}</span></div>
-      <p className={`text-2xl font-bold ${accent === 'red' ? 'text-red-400' : accent === 'orange' ? 'text-orange-400' : 'text-zinc-100'}`}>{value}</p>
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className="flex items-center gap-2 mb-2">{icon}<span className="text-xs text-muted-foreground">{label}</span></div>
+      <p className={`text-2xl font-bold ${accent === 'red' ? 'text-red-400' : accent === 'orange' ? 'text-orange-400' : 'text-foreground'}`}>{value}</p>
     </div>
   )
 }

--- a/web/src/components/compliance/ComplianceFrameworks.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.tsx
@@ -46,10 +46,10 @@ function StatusBadge({ status }: { status: string }) {
 
 function SeverityBadge({ severity }: { severity: string }) {
   const colors: Record<string, string> = {
-    critical: 'bg-red-500/20 text-red-300 border-red-500/30',
-    high:     'bg-orange-500/20 text-orange-300 border-orange-500/30',
-    medium:   'bg-yellow-500/20 text-yellow-300 border-yellow-500/30',
-    low:      'bg-zinc-500/20 text-zinc-300 border-zinc-500/30',
+    critical: 'bg-red-500/20 text-red-400 border-red-500/30',
+    high:     'bg-orange-500/20 text-orange-400 border-orange-500/30',
+    medium:   'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
+    low:      'bg-zinc-500/20 text-muted-foreground border-zinc-500/30',
   }
   return (
     <span className={`px-1.5 py-0.5 text-[10px] font-medium rounded border ${colors[severity] ?? colors.low}`}>
@@ -70,7 +70,7 @@ function ScoreRing({ score }: { score: number }) {
   return (
     <div className="relative inline-flex items-center justify-center w-28 h-28">
       <svg className="transform -rotate-90" width={80} height={80}>
-        <circle cx={40} cy={40} r={r} className="stroke-zinc-800" strokeWidth={6} fill="none" />
+        <circle cx={40} cy={40} r={r} className="stroke-secondary" strokeWidth={6} fill="none" />
         <circle
           cx={40} cy={40} r={r}
           stroke="currentColor"
@@ -82,7 +82,7 @@ function ScoreRing({ score }: { score: number }) {
           className={`transition-all duration-700 ${ringColor}`}
         />
       </svg>
-      <span className="absolute text-lg font-bold text-white">{pct.toFixed(0)}%</span>
+      <span className="absolute text-lg font-bold text-foreground">{pct.toFixed(0)}%</span>
     </div>
   )
 }
@@ -91,11 +91,11 @@ function ScoreRing({ score }: { score: number }) {
 
 function CheckRow({ check }: { check: ComplianceCheck }) {
   return (
-    <div className="flex items-start gap-3 py-2 px-3 rounded-md bg-zinc-900/50 hover:bg-zinc-800/50 transition-colors">
+    <div className="flex items-start gap-3 py-2 px-3 rounded-md bg-secondary/50 hover:bg-secondary/70 transition-colors">
       <StatusBadge status={check.status} />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <span className="text-xs font-medium text-zinc-200 truncate">{check.name}</span>
+          <span className="text-xs font-medium text-foreground truncate">{check.name}</span>
           <SeverityBadge severity={check.severity} />
         </div>
         {check.message && <p className="text-[11px] text-muted-foreground mt-0.5">{check.message}</p>}
@@ -114,19 +114,19 @@ function ControlAccordion({ control }: { control: ControlResult }) {
   const Icon = open ? ChevronDown : ChevronRight
 
   return (
-    <div className="border border-zinc-800 rounded-lg overflow-hidden">
+    <div className="border border-border rounded-lg overflow-hidden">
       <button
-        className="w-full flex items-center gap-3 px-4 py-3 bg-zinc-900/70 hover:bg-zinc-800/50 transition-colors text-left"
+        className="w-full flex items-center gap-3 px-4 py-3 bg-card hover:bg-secondary/50 transition-colors text-left"
         onClick={() => setOpen(v => !v)}
         type="button"
       >
         <Icon className="w-4 h-4 text-muted-foreground shrink-0" />
         <StatusBadge status={control.status} />
-        <span className="text-sm font-medium text-zinc-200 flex-1 truncate">{control.id}: {control.name}</span>
-        <span className="text-xs text-zinc-500">{control.checks.length} checks</span>
+        <span className="text-sm font-medium text-foreground flex-1 truncate">{control.id}: {control.name}</span>
+        <span className="text-xs text-muted-foreground">{control.checks.length} checks</span>
       </button>
       {open && (
-        <div className="px-4 py-2 space-y-1.5 bg-zinc-950/50">
+        <div className="px-4 py-2 space-y-1.5 bg-background/50">
           {control.checks.map(ch => <CheckRow key={ch.id} check={ch} />)}
         </div>
       )}
@@ -142,17 +142,17 @@ function FrameworkCard({ fw, selected, onSelect }: { fw: Framework; selected: bo
       className={`text-left p-4 rounded-lg border transition-all ${
         selected
           ? 'border-blue-500/60 bg-blue-500/10 shadow-lg shadow-blue-500/5'
-          : 'border-zinc-800 bg-zinc-900/60 hover:border-zinc-700'
+          : 'border-border bg-card hover:border-border/80'
       }`}
       onClick={onSelect}
       type="button"
     >
       <div className="flex items-center gap-2 mb-1">
         <Shield className="w-4 h-4 text-blue-400" />
-        <span className="text-sm font-semibold text-zinc-100">{fw.name}</span>
+        <span className="text-sm font-semibold text-foreground">{fw.name}</span>
       </div>
       <p className="text-xs text-muted-foreground line-clamp-2 mb-2">{fw.description}</p>
-      <div className="flex gap-3 text-[11px] text-zinc-500">
+      <div className="flex gap-3 text-[11px] text-muted-foreground">
         <span>{fw.controls} controls</span>
         <span>{fw.checks} checks</span>
         <span className="capitalize">{fw.category}</span>
@@ -287,14 +287,14 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
 
       {/* Evaluate bar */}
       {selectedFw && (
-        <div className="flex items-center gap-4 p-4 rounded-lg border border-zinc-800 bg-zinc-900/60">
-          <span className="text-sm text-zinc-300 font-medium whitespace-nowrap">
+        <div className="flex items-center gap-4 p-4 rounded-lg border border-border bg-card">
+          <span className="text-sm text-foreground font-medium whitespace-nowrap">
             Evaluate <span className="text-blue-400">{selectedFw.name}</span> on:
           </span>
           <select
             value={selectedCluster}
             onChange={e => setSelectedCluster(e.target.value)}
-            className="flex-1 max-w-xs bg-zinc-800 text-zinc-200 text-sm rounded-md border border-zinc-700 px-3 py-1.5 focus:outline-hidden focus:ring-1 focus:ring-blue-500"
+            className="flex-1 max-w-xs bg-secondary text-foreground text-sm rounded-md border border-border px-3 py-1.5 focus:outline-hidden focus:ring-1 focus:ring-blue-500"
           >
             {clusterNames.length === 0 && <option value="">No clusters available</option>}
             {clusterNames.map(name => (
@@ -304,7 +304,7 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
           <button
             onClick={handleEvaluate}
             disabled={isEvaluating || !selectedCluster}
-            className="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-zinc-700 disabled:text-zinc-500 text-white text-sm font-medium rounded-md transition-colors flex items-center gap-2"
+            className="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-secondary disabled:text-muted-foreground text-white text-sm font-medium rounded-md transition-colors flex items-center gap-2"
             type="button"
           >
             {isEvaluating ? <Loader2 className="w-4 h-4 animate-spin" /> : <Shield className="w-4 h-4" />}
@@ -324,12 +324,12 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
       {result && (
         <div className="space-y-6">
           {/* Score summary */}
-          <div className="flex items-center gap-8 p-6 rounded-lg border border-zinc-800 bg-zinc-900/60">
+          <div className="flex items-center gap-8 p-6 rounded-lg border border-border bg-card">
             <ScoreRing score={result.score} />
             <div className="space-y-2">
-              <h2 className="text-lg font-bold text-white">{result.framework_name}</h2>
+              <h2 className="text-lg font-bold text-foreground">{result.framework_name}</h2>
               <p className="text-sm text-muted-foreground">
-                Cluster: <span className="text-zinc-200">{result.cluster}</span>
+                Cluster: <span className="text-foreground">{result.cluster}</span>
               </p>
               <div className="flex gap-4 text-sm">
                 <span className="text-emerald-400">✓ {result.passed} passed</span>
@@ -337,7 +337,7 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
                 <span className="text-yellow-400">◐ {result.partial} partial</span>
                 {result.skipped > 0 && <span className="text-zinc-500">— {result.skipped} skipped</span>}
               </div>
-              <p className="text-xs text-zinc-500">
+              <p className="text-xs text-muted-foreground">
                 Evaluated at {new Date(result.evaluated_at).toLocaleString()}
               </p>
             </div>
@@ -345,7 +345,7 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
 
           {/* Control-by-control results */}
           <div className="space-y-2">
-            <h3 className="text-sm font-semibold text-zinc-300 uppercase tracking-wider">
+            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
               Controls ({result.controls.length})
             </h3>
             {result.controls.map(ctrl => (
@@ -357,7 +357,7 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
 
       {/* Empty state */}
       {!result && !isEvaluating && selectedFw && (
-        <div className="text-center py-12 text-zinc-500">
+        <div className="text-center py-12 text-muted-foreground">
           <Shield className="w-12 h-12 mx-auto mb-3 opacity-30" />
           <p className="text-sm">Select a framework and cluster, then click <strong>Run Evaluation</strong></p>
         </div>

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -112,8 +112,8 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
 
       {summary && (
         <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-          <div className="rounded-xl border border-zinc-700/50 bg-zinc-800/50 p-4">
-            <div className="flex items-center gap-2 mb-2"><ShieldAlert className="w-5 h-5 text-indigo-400" /><span className="text-xs text-zinc-400">Compliance Score</span></div>
+          <div className="rounded-xl border border-border bg-card p-4">
+            <div className="flex items-center gap-2 mb-2"><ShieldAlert className="w-5 h-5 text-indigo-400" /><span className="text-xs text-muted-foreground">Compliance Score</span></div>
             <p className={`text-2xl font-bold ${scoreColor(summary.compliance_score)}`}>{summary.compliance_score}%</p>
           </div>
           <SummaryCard label="Rules" value={summary.total_rules} icon={<ShieldAlert className="w-5 h-5 text-blue-400" />} />
@@ -123,9 +123,9 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
         </div>
       )}
 
-      <div className="flex gap-1 border-b border-zinc-700/50 pb-0">
+      <div className="flex gap-1 border-b border-border pb-0">
         {(['violations', 'principals', 'rules'] as const).map(tab => (
-          <button key={tab} onClick={() => setActiveTab(tab)} className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-colors ${activeTab === tab ? 'bg-zinc-700/50 text-zinc-100 border-b-2 border-indigo-400' : 'text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800/50'}`}>
+          <button key={tab} onClick={() => setActiveTab(tab)} className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-colors ${activeTab === tab ? 'bg-secondary text-foreground border-b-2 border-indigo-400' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'}`}>
             {tab === 'violations' && `Violations (${violations.length})`}
             {tab === 'principals' && `Principals (${principals.length})`}
             {tab === 'rules' && `Rules (${rules.length})`}
@@ -136,7 +136,7 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
       {activeTab === 'violations' && (
         <div className="space-y-3">
           <div className="flex items-center gap-2">
-            <Filter className="w-4 h-4 text-zinc-400" />
+            <Filter className="w-4 h-4 text-muted-foreground" />
             <div className="w-40">
               <Select value={filterSeverity} onChange={e => setFilterSeverity(e.target.value)} selectSize="sm">
                 <option value="all">All severities</option>
@@ -147,19 +147,19 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
               </Select>
             </div>
           </div>
-          {filteredViolations.length === 0 ? <p className="text-zinc-500 text-sm text-center py-8">No violations found</p> : filteredViolations.map(v => (
-            <div key={v.id} className="rounded-lg border border-zinc-700/30 bg-zinc-800/50 p-4">
+          {filteredViolations.length === 0 ? <p className="text-muted-foreground text-sm text-center py-8">No violations found</p> : filteredViolations.map(v => (
+            <div key={v.id} className="rounded-lg border border-border bg-card p-4">
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-2">
                   <span className={`inline-flex items-center px-2 py-0.5 rounded-full border text-xs font-medium ${SEVERITY_STYLES[v.severity] ?? SEVERITY_STYLES.medium}`}>{v.severity}</span>
-                  <span className="text-sm font-medium text-zinc-200">{TYPE_ICONS[v.principal_type] ?? '👤'} {v.principal}</span>
+                  <span className="text-sm font-medium text-foreground">{TYPE_ICONS[v.principal_type] ?? '👤'} {v.principal}</span>
                 </div>
-                <code className="text-xs text-zinc-500">{v.rule_id}</code>
+                <code className="text-xs text-muted-foreground">{v.rule_id}</code>
               </div>
-              <p className="text-sm text-zinc-300 mb-2">{v.description}</p>
+              <p className="text-sm text-foreground/80 mb-2">{v.description}</p>
               <div className="flex gap-2 text-xs">
                 <span className="bg-red-500/10 text-red-300 px-2 py-0.5 rounded">{v.role_a}</span>
-                <span className="text-zinc-500">conflicts with</span>
+                <span className="text-muted-foreground">conflicts with</span>
                 <span className="bg-red-500/10 text-red-300 px-2 py-0.5 rounded">{v.role_b}</span>
               </div>
             </div>
@@ -172,19 +172,19 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
           {principals.map(p => {
             const hasViolation = violations.some(v => v.principal === p.name)
             return (
-              <div key={p.name} className={`rounded-lg border p-3 ${hasViolation ? 'border-red-500/30 bg-red-500/5' : 'border-zinc-700/30 bg-zinc-900/30'}`}>
+              <div key={p.name} className={`rounded-lg border p-3 ${hasViolation ? 'border-red-500/30 bg-red-500/5' : 'border-border bg-card'}`}>
                 <div className="flex items-center justify-between mb-1">
                   <div className="flex items-center gap-2">
                     <span>{TYPE_ICONS[p.type] ?? '👤'}</span>
-                    <span className="text-sm font-medium text-zinc-200">{p.name}</span>
-                    <code className="text-xs text-zinc-500">{p.type}</code>
+                    <span className="text-sm font-medium text-foreground">{p.name}</span>
+                    <code className="text-xs text-muted-foreground">{p.type}</code>
                     {hasViolation ? <AlertTriangle className="w-4 h-4 text-red-400" /> : <CheckCircle2 className="w-4 h-4 text-emerald-400" />}
                   </div>
                 </div>
                 <div className="flex flex-wrap gap-1 mt-1">
-                  {(p.roles || []).map(r => <span key={r} className="text-xs bg-zinc-700/50 px-1.5 py-0.5 rounded text-zinc-300">{r}</span>)}
+                  {(p.roles || []).map(r => <span key={r} className="text-xs bg-secondary px-1.5 py-0.5 rounded text-foreground/80">{r}</span>)}
                 </div>
-                <div className="text-xs text-zinc-500 mt-1">Clusters: {(p.clusters || []).join(', ')}</div>
+                <div className="text-xs text-muted-foreground mt-1">Clusters: {(p.clusters || []).join(', ')}</div>
               </div>
             )
           })}
@@ -194,19 +194,19 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
       {activeTab === 'rules' && (
         <div className="space-y-2">
           {rules.map(r => (
-            <div key={r.id} className="rounded-lg border border-zinc-700/30 bg-zinc-900/30 p-4">
+            <div key={r.id} className="rounded-lg border border-border bg-card p-4">
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-2">
                   <span className={`inline-flex items-center px-2 py-0.5 rounded-full border text-xs font-medium ${SEVERITY_STYLES[r.severity] ?? SEVERITY_STYLES.medium}`}>{r.severity}</span>
-                  <span className="text-sm font-medium text-zinc-200">{r.name}</span>
+                  <span className="text-sm font-medium text-foreground">{r.name}</span>
                 </div>
-                <code className="text-xs bg-zinc-700/50 px-1.5 py-0.5 rounded text-zinc-400">{r.regulation}</code>
+                <code className="text-xs bg-secondary px-1.5 py-0.5 rounded text-muted-foreground">{r.regulation}</code>
               </div>
-              <p className="text-sm text-zinc-400 mb-2">{r.description}</p>
+              <p className="text-sm text-muted-foreground mb-2">{r.description}</p>
               <div className="flex gap-2 text-xs">
-                <span className="bg-zinc-700/50 px-2 py-0.5 rounded text-zinc-300">{r.role_a}</span>
+                <span className="bg-secondary px-2 py-0.5 rounded text-foreground/80">{r.role_a}</span>
                 <XCircle className="w-4 h-4 text-red-400" />
-                <span className="bg-zinc-700/50 px-2 py-0.5 rounded text-zinc-300">{r.role_b}</span>
+                <span className="bg-secondary px-2 py-0.5 rounded text-foreground/80">{r.role_b}</span>
               </div>
             </div>
           ))}
@@ -218,9 +218,9 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
 
 function SummaryCard({ label, value, icon, accent }: { label: string; value: number; icon: React.ReactNode; accent?: string }) {
   return (
-    <div className="rounded-xl border border-zinc-700/50 bg-zinc-800/50 p-4">
-      <div className="flex items-center gap-2 mb-2">{icon}<span className="text-xs text-zinc-400">{label}</span></div>
-      <p className={`text-2xl font-bold ${accent === 'red' ? 'text-red-400' : 'text-zinc-100'}`}>{value}</p>
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className="flex items-center gap-2 mb-2">{icon}<span className="text-xs text-muted-foreground">{label}</span></div>
+      <p className={`text-2xl font-bold ${accent === 'red' ? 'text-red-400' : 'text-foreground'}`}>{value}</p>
     </div>
   )
 }


### PR DESCRIPTION
Fixes #11428
Fixes #11429
Fixes #11438

## Changes
- Fixed /enterprise/frameworks page for proper light theme styling
- Fixed /enterprise/change-control page contrast and readability in light mode
- Fixed /enterprise/sod page contrast and badge visibility in light mode

### What was wrong
All three pages used hardcoded dark theme colors (bg-zinc-800, bg-zinc-900, text-zinc-200, border-zinc-700) which made cards, badges, and text appear faded or invisible in light mode.

### Fix
Replaced hardcoded colors with semantic Tailwind tokens:
- `bg-zinc-800/50` → `bg-card`
- `bg-zinc-900/30` → `bg-card`
- `border-zinc-700/30` → `border-border`
- `text-zinc-200` → `text-foreground`
- `text-zinc-400` → `text-muted-foreground`
- `bg-zinc-700/50` → `bg-secondary`

Status colors (green, yellow, red, orange) are preserved as they work in both themes.