### PR TITLE
🐛 Fix pod modal content panel contrast and change control empty state

### DIFF
--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -1,6 +1,68 @@
 # Reviewer Log
 
-## Pass 90 — 2026-05-01T09:38–09:55 UTC
+## Pass 92 — 2026-05-01T21:00–21:30 UTC
+
+### Trigger
+KICK — nightlyPlaywright=RED. 100 unaddressed Copilot comments (3 HIGH, 72 MEDIUM, 25 LOW). GA4 nominal.
+
+### RED Analysis
+**nightlyPlaywright=RED**: Scanner-owned per actionable.json. Not fixed this pass.
+
+### HIGH Copilot Comments Fixed
+
+| PR | Issue | Fix |
+|----|-------|-----|
+| #11318 | events.go limit not clamped | Added maxEventLimit=1000 const; clamp before store call and response — branch fix/pr11318-events-limit-clamp |
+| #11326 | drasi_proxy_test hop-by-hop header | Added assert.Empty for Proxy-Authenticate in RoundTripFunc — branch fix/pr11326-drasi-proxy-hop-by-hop |
+| #11323 | startup-oauth.sh go build path | Already MERGED before this pass |
+
+### PRs Created
+
+| PR | Branch | Title |
+|----|--------|-------|
+| #11351 | fix/11314 | Add missing Dashboard title icon |
+| #11352 | fix/11329 | fix(missions): theme-aware colors in light mode |
+| #11353 | fix/11339 | fix(pod-logs): align log viewer background with theme tokens |
+| #11354 | fix/11335 | feat(missions): Clear All and multi-select in resolution history |
+| #11356 | fix/mcp-test-failures | fix: slog style, SSE timeout, MCP test backoff adaptations |
+
+### MEDIUM Copilot Comments Fixed (PR#11356)
+- custom_resources.go: nil-guard + slog key/value style (PRs #11288/#11289)
+- feedback_requests.go: 5 recover blocks converted to key/value slog style
+- kagenti_provider/client.go: SSE httpClient Timeout 10s→0 (ctx controls lifetime)
+
+### Test Fixes (issue #11348)
+- helm.test.ts, networking.test.ts, storage.test.ts: adapt for exponential-backoff cascading
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+## Pass 91 — 2026-05-01T19:20–19:36 UTC
+
+### Trigger
+KICK — CI=0%, nightlyPlaywright=RED, deploy:vllm-d=RED, deploy:pok-prod=RED. 100 unaddressed Copilot comments (3 HIGH). GA4 nominal.
+
+### RED Analysis
+**CI=0%**: Transient — CI checks were in_progress when snapshot taken. All completed successfully.
+**deploy:vllm-d / deploy:pok-prod RED**: Both in_progress on run #25229545865, completed SUCCESS. No issue needed.
+**nightlyPlaywright=RED**: Root cause — card-loading-compliance.spec.ts used `async (_fixtures, testInfo)` instead of `async ({}, testInfo)` (5 instances). Filed issue #11322. PR #11324 opened.
+
+### HIGH Copilot Comments
+All 3 HIGH comments (PRs #11254, #11269, #11279) on MERGED PRs. missions.go code is correct. No action needed.
+
+### PRs
+- PR #11317 MERGED (fix/copilot-review-batch-2)
+- PR #11323 MERGED (fix/startup-ldflags)
+- PR #11324 open — Playwright RED fix
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+
 
 ### Trigger
 KICK — nightly=RED, nightlyPlaywright=RED. 73 unaddressed Copilot comments (2 HIGH). GA4 nominal.

--- a/web/src/components/cards/ComplianceDrift.tsx
+++ b/web/src/components/cards/ComplianceDrift.tsx
@@ -177,6 +177,9 @@ export function ComplianceDrift({ config: _config }: CardConfig) {
           <Loader2 className="w-6 h-6 animate-spin opacity-50" />
         )}
         <p>{t('complianceDrift.scanning')}</p>
+        <p className="text-xs text-muted-foreground/60">
+          {t('complianceDrift.scanningHint', { defaultValue: 'Checking compliance tools across clusters…' })}
+        </p>
       </div>
     )
   }
@@ -199,8 +202,24 @@ export function ComplianceDrift({ config: _config }: CardConfig) {
     )
   }
 
-  // Empty state: all clusters within baseline (only show after all hooks finish)
+  // Empty state: no compliance tools detected or all clusters within baseline
   if (!isLoading && !isRefreshing && drifts.length === 0) {
+    const hasAnyStatuses = Object.keys(kyvernoStatuses || {}).length > 0 ||
+      Object.keys(trivyStatuses || {}).length > 0 ||
+      Object.keys(kubescapeStatuses || {}).length > 0
+
+    if (!hasAnyStatuses) {
+      return (
+        <div className="flex flex-col items-center justify-center h-full gap-2 text-center p-4">
+          <Info className="w-8 h-8 text-muted-foreground opacity-50" />
+          <p className="text-sm font-medium text-foreground">{t('complianceDrift.noToolsDetected', { defaultValue: 'No compliance tools detected' })}</p>
+          <p className="text-xs text-muted-foreground">
+            {t('complianceDrift.noToolsHint', { defaultValue: 'Install Kyverno, Trivy, or Kubescape to enable drift detection.' })}
+          </p>
+        </div>
+      )
+    }
+
     return (
       <div className="flex flex-col items-center justify-center h-full gap-2 text-center p-4">
         <CheckCircle2 className="w-8 h-8 text-green-400" />

--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -170,7 +170,17 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
               </Select>
             </div>
           </div>
-          {(filteredChanges || []).map(change => {
+          {(filteredChanges || []).length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <CheckCircle2 className="w-8 h-8 text-emerald-400 opacity-60 mb-3" />
+              <p className="text-sm font-medium text-zinc-200">No change records found</p>
+              <p className="text-xs text-zinc-500 mt-1">
+                {filterApproval !== 'all'
+                  ? `No changes with status "${filterApproval}". Try changing the filter.`
+                  : 'Change records will appear here when changes are detected across your clusters.'}
+              </p>
+            </div>
+          ) : (filteredChanges || []).map(change => {
             const approval = APPROVAL_STYLES[change.approval_status] ?? APPROVAL_STYLES.pending
             return (
               <div key={change.id} className="rounded-lg border border-zinc-700/30 bg-zinc-800/50 p-4">

--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -1398,7 +1398,7 @@ Please:
                     <span className="text-sm text-muted-foreground">{t('drilldown.status.fetchingPodStatus')}</span>
                   </div>
                 ) : podStatusOutput ? (
-                  <pre className="p-3 rounded-lg bg-black/50 border border-border overflow-x-auto text-xs text-foreground font-mono">
+                  <pre className="p-3 rounded-lg bg-secondary/50 border border-border overflow-x-auto text-xs text-foreground font-mono">
                     <code className="text-muted-foreground"># kubectl get pod {podName} -n {namespace} -o wide</code>
                     {'\n'}
                     {podStatusOutput}
@@ -1464,7 +1464,7 @@ Please:
                     View all
                   </button>
                 </div>
-                <pre className="p-3 rounded-lg bg-black/50 border border-border overflow-x-auto text-xs text-foreground font-mono max-h-32 overflow-y-auto">
+                <pre className="p-3 rounded-lg bg-secondary/50 border border-border overflow-x-auto text-xs text-foreground font-mono max-h-32 overflow-y-auto">
                   {eventsOutput.includes('No resources found')
                     ? `No events found for pod ${podName}`
                     : eventsOutput.split('\n').slice(0, 6).join('\n')}

--- a/web/src/components/drilldown/views/pod-drilldown/PodOutputTab.tsx
+++ b/web/src/components/drilldown/views/pod-drilldown/PodOutputTab.tsx
@@ -105,7 +105,7 @@ export function PodOutputTab({
               )}
             </button>
           </div>
-          <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
+          <pre className="p-4 rounded-lg bg-secondary/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
             <code className="text-muted-foreground">{kubectlComment}</code>
             {'\n\n'}
             {output}


### PR DESCRIPTION
Fixes #11427
Fixes #11430

## Changes
- Fixed content panels (Describe, YAML, Logs, Overview, Events) contrast in pod details modal for light theme by replacing `bg-black/50` with `bg-secondary/50`
- Added proper empty state messaging for Change Control warnings panel when no change records exist
- Improved ComplianceDrift card with descriptive loading hint and proper empty state when no compliance tools are detected