### PR TITLE
🐛 Fix nightly test suite and workflow failures

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -73,7 +73,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nightly-build-output
           path: web/dist
@@ -145,7 +145,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nightly-build-output
           path: web/dist

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -323,6 +323,7 @@ if [ -z "$FAST_MODE" ]; then
           ["ui-compliance-test"]=600
           ["cache-test"]=600
           ["benchmark-test"]=600
+          ["deploy-test"]=600
           ["ai-ml-test"]=900
           ["nav-test"]=900
           ["perf-test"]=1200


### PR DESCRIPTION
Fixes #11393
Fixes #11394
Fixes #11395
Fixes #11396

## Changes

1. **Fix Playwright Cross-Browser artifact download failure** — Updated `download-artifact` from v4 (`d3f86a10`) to v8.0.1 (`3e5f45b2`) in `playwright-nightly.yml` to match the `upload-artifact` v7.0.1 used in the build job. The version mismatch caused cross-browser and mobile jobs to fail when downloading the build output.

2. **Fix deploy-test wall-clock timeout** — Added `deploy-test` with a 600s override to `PLAYWRIGHT_SUITE_TIMEOUT_OVERRIDES` in `run-all-tests.sh`. The suite runs 11 sequential tests (workers: 1) which regularly exceed the default 300s cap, causing timeout kills.