### PR TITLE
🐛 Fix cluster status display, alert consistency, and hardware health context

### DIFF
--- a/web/src/components/cards/ClusterHealth.tsx
+++ b/web/src/components/cards/ClusterHealth.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useLocation } from 'react-router-dom'
 import { CheckCircle, WifiOff, Cpu, Loader2, ExternalLink, AlertTriangle, KeyRound, Server } from 'lucide-react'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useClusters, ClusterInfo } from '../../hooks/useMCP'
@@ -81,6 +82,7 @@ const CLUSTER_SORT_COMPARATORS = {
 
 export function ClusterHealth() {
   const { t } = useTranslation(['cards', 'common'])
+  const location = useLocation()
   const {
     deduplicatedClusters: rawClusters,
     isLoading: isLoadingHook,
@@ -93,6 +95,10 @@ export function ClusterHealth() {
   const { isDemoMode } = useDemoMode()
   const [selectedCluster, setSelectedCluster] = useState<string | null>(null)
   const federation = useFederationAwareness()
+
+  // Hide the inline stats grid when this card is rendered on the Clusters page,
+  // which already has its own StatsOverview showing the same metrics (#11415).
+  const hideStatsGrid = location.pathname === '/clusters'
 
   // Use shared card data hook for filtering, sorting, and pagination
   const {
@@ -265,7 +271,8 @@ export function ClusterHealth() {
         className="mb-4"
       />
 
-      {/* Stats */}
+      {/* Stats — hidden on /clusters page where StatsOverview already shows these metrics */}
+      {!hideStatsGrid && (
       <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-4">
         <div className="p-3 rounded-lg bg-green-500/10 border border-green-500/20 min-w-0 overflow-hidden" title={t('clusterHealth.healthyTooltip', { count: healthyClusters })}>
           <div className="flex items-center gap-1.5 mb-1 min-w-0">
@@ -316,6 +323,7 @@ export function ClusterHealth() {
           )
         })}
       </div>
+      )}
 
       {/* Cluster list */}
       <div ref={containerRef} className="flex-1 space-y-2 overflow-y-auto" style={containerStyle}>

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -890,7 +890,10 @@ export function HardwareHealthCard() {
                           <StatusBadge color="green" size="xs">GPU Driver</StatusBadge>
                         )}
                         {getTotalDevices(node.devices) === 0 && (
-                          <span className="text-2xs text-muted-foreground italic">{t('hardwareHealth.noDevicesDetected')}</span>
+                          <span className="text-2xs text-muted-foreground italic" title={t('hardwareHealth.noDevicesExplanation')}>
+                            {t('hardwareHealth.noDevicesDetected')}
+                            <span className="block text-muted-foreground/60 mt-0.5">{t('hardwareHealth.noDevicesExplanation')}</span>
+                          </span>
                         )}
                       </div>
                     </div>

--- a/web/src/components/layout/SidebarShell.tsx
+++ b/web/src/components/layout/SidebarShell.tsx
@@ -132,7 +132,10 @@ const SIDEBAR_MAX_WIDTH_PX = 480
 /** Index of the primary (dashboard list) section — "Add more..." button renders after it */
 const PRIMARY_SECTION_INDEX = 0
 
-/** Map sidebar item href to dashboard config ID for card count display */
+/** Map sidebar item href to dashboard config ID for card count display.
+ * NOTE: '/alerts' is intentionally excluded — displaying the card count
+ * next to "Alerts" would be confused with the active alert count shown
+ * in the header badge (#11404). */
 const HREF_TO_DASHBOARD_ID: Record<string, string> = {
   '/': 'main', '/compute': 'compute', '/security': 'security',
   '/gitops': 'gitops', '/storage': 'storage', '/network': 'network',
@@ -140,7 +143,7 @@ const HREF_TO_DASHBOARD_ID: Record<string, string> = {
   '/clusters': 'clusters', '/compliance': 'compliance', '/cost': 'cost',
   '/gpu-reservations': 'gpu', '/nodes': 'nodes', '/deployments': 'deployments',
   '/pods': 'pods', '/services': 'services', '/helm': 'helm',
-  '/alerts': 'alerts', '/ai-ml': 'ai-ml', '/ci-cd': 'ci-cd',
+  '/ai-ml': 'ai-ml', '/ci-cd': 'ci-cd',
   '/logs': 'logs', '/data-compliance': 'data-compliance', '/arcade': 'arcade',
   '/deploy': 'deploy', '/ai-agents': 'ai-agents',
   '/llm-d-benchmarks': 'llm-d-benchmarks', '/cluster-admin': 'cluster-admin',
@@ -663,6 +666,7 @@ export function SidebarShell({
               {t('labels.clusterStatus')}
             </h4>
             <div className="space-y-2">
+              {healthyClusters > 0 && (
               <button
                 onClick={() => handleClusterStatusClick('healthy')}
                 className="w-full flex items-center justify-between hover:bg-secondary/50 rounded px-1 py-0.5 transition-colors"
@@ -673,6 +677,8 @@ export function SidebarShell({
                 </span>
                 <span className="text-sm font-medium text-green-400">{healthyClusters}</span>
               </button>
+              )}
+              {unhealthyClusters > 0 && (
               <button
                 onClick={() => handleClusterStatusClick('unhealthy')}
                 className="w-full flex items-center justify-between hover:bg-secondary/50 rounded px-1 py-0.5 transition-colors"
@@ -683,6 +689,8 @@ export function SidebarShell({
                 </span>
                 <span className="text-sm font-medium text-red-400">{unhealthyClusters}</span>
               </button>
+              )}
+              {unreachableClusters > 0 && (
               <button
                 onClick={() => handleClusterStatusClick('unreachable')}
                 className="w-full flex items-center justify-between hover:bg-secondary/50 rounded px-1 py-0.5 transition-colors"
@@ -693,6 +701,10 @@ export function SidebarShell({
                 </span>
                 <span className="text-sm font-medium text-yellow-400">{unreachableClusters}</span>
               </button>
+              )}
+              {healthyClusters === 0 && unhealthyClusters === 0 && unreachableClusters === 0 && (
+                <span className="text-xs text-muted-foreground italic">{t('labels.noClusters', 'No clusters configured')}</span>
+              )}
             </div>
           </div>
         )}

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -1205,6 +1205,7 @@
     "monitoring": "Monitoring",
     "deviceDisappearances": "Device Disappearances",
     "noDevicesDetected": "No devices detected",
+    "noDevicesExplanation": "This is normal when no GPU, NIC, NVMe, or InfiniBand devices are configured on this node.",
     "hideSnoozedAlerts": "Hide snoozed alerts",
     "showSnoozedAlerts": "Show snoozed alerts",
     "snoozeAllVisible": "Snooze all visible alerts",


### PR DESCRIPTION
Fixes #11403
Fixes #11404
Fixes #11413
Fixes #11414
Fixes #11415

## Changes
- Fixed malformed cluster status values by hiding zero-count status rows in sidebar, preventing visual concatenation with viewer count and commit hash
- Fixed conflicting alert states between header and sidebar by removing ambiguous card count from Alerts nav item
- Added descriptive empty state for Hardware Health card explaining what devices are expected
- Fixed duplicate metrics display by hiding ClusterHealth card stats grid on /clusters page where StatsOverview already shows the same data