### PR TITLE
🐛 Fix hardware health, metrics, and resource utilization display

### DIFF
--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -1,6 +1,68 @@
 # Reviewer Log
 
-## Pass 90 — 2026-05-01T09:38–09:55 UTC
+## Pass 92 — 2026-05-01T21:00–21:30 UTC
+
+### Trigger
+KICK — nightlyPlaywright=RED. 100 unaddressed Copilot comments (3 HIGH, 72 MEDIUM, 25 LOW). GA4 nominal.
+
+### RED Analysis
+**nightlyPlaywright=RED**: Scanner-owned per actionable.json. Not fixed this pass.
+
+### HIGH Copilot Comments Fixed
+
+| PR | Issue | Fix |
+|----|-------|-----|
+| #11318 | events.go limit not clamped | Added maxEventLimit=1000 const; clamp before store call and response — branch fix/pr11318-events-limit-clamp |
+| #11326 | drasi_proxy_test hop-by-hop header | Added assert.Empty for Proxy-Authenticate in RoundTripFunc — branch fix/pr11326-drasi-proxy-hop-by-hop |
+| #11323 | startup-oauth.sh go build path | Already MERGED before this pass |
+
+### PRs Created
+
+| PR | Branch | Title |
+|----|--------|-------|
+| #11351 | fix/11314 | Add missing Dashboard title icon |
+| #11352 | fix/11329 | fix(missions): theme-aware colors in light mode |
+| #11353 | fix/11339 | fix(pod-logs): align log viewer background with theme tokens |
+| #11354 | fix/11335 | feat(missions): Clear All and multi-select in resolution history |
+| #11356 | fix/mcp-test-failures | fix: slog style, SSE timeout, MCP test backoff adaptations |
+
+### MEDIUM Copilot Comments Fixed (PR#11356)
+- custom_resources.go: nil-guard + slog key/value style (PRs #11288/#11289)
+- feedback_requests.go: 5 recover blocks converted to key/value slog style
+- kagenti_provider/client.go: SSE httpClient Timeout 10s→0 (ctx controls lifetime)
+
+### Test Fixes (issue #11348)
+- helm.test.ts, networking.test.ts, storage.test.ts: adapt for exponential-backoff cascading
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+## Pass 91 — 2026-05-01T19:20–19:36 UTC
+
+### Trigger
+KICK — CI=0%, nightlyPlaywright=RED, deploy:vllm-d=RED, deploy:pok-prod=RED. 100 unaddressed Copilot comments (3 HIGH). GA4 nominal.
+
+### RED Analysis
+**CI=0%**: Transient — CI checks were in_progress when snapshot taken. All completed successfully.
+**deploy:vllm-d / deploy:pok-prod RED**: Both in_progress on run #25229545865, completed SUCCESS. No issue needed.
+**nightlyPlaywright=RED**: Root cause — card-loading-compliance.spec.ts used `async (_fixtures, testInfo)` instead of `async ({}, testInfo)` (5 instances). Filed issue #11322. PR #11324 opened.
+
+### HIGH Copilot Comments
+All 3 HIGH comments (PRs #11254, #11269, #11279) on MERGED PRs. missions.go code is correct. No action needed.
+
+### PRs
+- PR #11317 MERGED (fix/copilot-review-batch-2)
+- PR #11323 MERGED (fix/startup-ldflags)
+- PR #11324 open — Playwright RED fix
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+
 
 ### Trigger
 KICK — nightly=RED, nightlyPlaywright=RED. 73 unaddressed Copilot comments (2 HIGH). GA4 nominal.

--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -334,13 +334,16 @@ export const ClusterMetrics = memo(function ClusterMetrics() {
 
   return (
     <div className="h-full flex flex-col">
-      {/* Header with metric value and selector — @container responsive */}
+      {/* Current Value */}
       <div className="flex flex-wrap @lg:flex-nowrap items-center justify-between gap-y-2 mb-2">
         <div>
-          <h4 className="text-sm font-medium text-foreground">{config.label}</h4>
-          <p className="text-2xl font-bold text-foreground">
-            {selectedMetric === 'memory' ? realValues.memory.toFixed(1) : Math.round(currentValue)}<span className="text-sm text-muted-foreground">{config.unit}</span>
-          </p>
+          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{t('cards:clusterMetrics.currentValue')}</h4>
+          <div className="flex items-baseline gap-2">
+            <p className="text-2xl font-bold text-foreground">
+              {selectedMetric === 'memory' ? realValues.memory.toFixed(1) : Math.round(currentValue)}<span className="text-sm text-muted-foreground">{config.unit}</span>
+            </p>
+            <span className="text-xs text-muted-foreground">· {config.label}</span>
+          </div>
         </div>
         <div className="flex gap-1">
           {(Object.keys(metricConfig) as MetricType[]).map((key) => (
@@ -463,26 +466,31 @@ export const ClusterMetrics = memo(function ClusterMetrics() {
         )}
       </div>
 
-      {/* Stats - show when we have time series data */}
+      {/* Summary Statistics */}
       {data.length > 0 && (
-        <div className="mt-3 pt-3 border-t border-border/50 grid grid-cols-2 @md:grid-cols-3 gap-4">
-          <div>
-            <p className="text-xs text-muted-foreground">{t('cards:clusterMetrics.min')}</p>
-            <p className="text-sm font-medium text-foreground">
-              {(() => { const vals = data.map((d) => d.value); return Math.round(vals.length > 0 ? Math.min(...vals) : 0) })()}{config.unit}
-            </p>
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">{t('cards:clusterMetrics.avg')}</p>
-            <p className="text-sm font-medium text-foreground">
-              {Math.round(data.reduce((a, b) => a + b.value, 0) / data.length)}{config.unit}
-            </p>
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">{t('cards:clusterMetrics.max')}</p>
-            <p className="text-sm font-medium text-foreground">
-              {(() => { const vals = data.map((d) => d.value); return Math.round(vals.length > 0 ? Math.max(...vals) : 0) })()}{config.unit}
-            </p>
+        <div className="mt-3 pt-3 border-t border-border/50">
+          <h5 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+            {t('cards:clusterMetrics.timePeriodSummary', { timeRange: TIME_RANGE_OPTIONS.find(opt => opt.value === timeRange)?.label })}
+          </h5>
+          <div className="grid grid-cols-2 @md:grid-cols-3 gap-4">
+            <div>
+              <p className="text-xs text-muted-foreground">{t('cards:clusterMetrics.min')}</p>
+              <p className="text-sm font-medium text-foreground">
+                {(() => { const vals = data.map((d) => d.value); return Math.round(vals.length > 0 ? Math.min(...vals) : 0) })()}{config.unit}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">{t('cards:clusterMetrics.avg')}</p>
+              <p className="text-sm font-medium text-foreground">
+                {Math.round(data.reduce((a, b) => a + b.value, 0) / data.length)}{config.unit}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">{t('cards:clusterMetrics.max')}</p>
+              <p className="text-sm font-medium text-foreground">
+                {(() => { const vals = data.map((d) => d.value); return Math.round(vals.length > 0 ? Math.max(...vals) : 0) })()}{config.unit}
+              </p>
+            </div>
           </div>
         </div>
       )}

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -904,10 +904,17 @@ export function HardwareHealthCard() {
             {sortedInventory.length === 0 && (
               <div className="flex flex-col items-center justify-center h-full text-sm text-muted-foreground py-8">
                 <Server className="w-6 h-6 mb-2 text-muted-foreground/50" />
-                {search || localClusterFilter.length > 0
-                  ? 'No matching nodes'
-                  : 'No nodes tracked yet'}
-                <span className="text-xs mt-1">Waiting for device scan...</span>
+                {search || localClusterFilter.length > 0 ? (
+                  'No matching nodes'
+                ) : (
+                  <div className="text-center">
+                    <div>No hardware devices detected</div>
+                    <div className="text-xs mt-2 max-w-xs text-center leading-4">
+                      This card monitors GPU, NVMe storage, network interfaces, and InfiniBand devices.
+                      Install hardware discovery tools on your nodes or check if devices are properly recognized by Kubernetes.
+                    </div>
+                  </div>
+                )}
               </div>
             )}
           </>

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -270,23 +270,29 @@ function ResourceUsageInternal() {
         ))}
       </div>
 
-      <div className={`mt-4 pt-3 border-t border-border/50 grid gap-2 text-center`} style={{ gridTemplateColumns: `repeat(${footerCols}, minmax(0, 1fr))` }}>
-        <div>
-          <p className="text-xs text-muted-foreground">{t('resourceUsage.totalCPU')}</p>
-          <p className="text-sm font-medium text-foreground">{totals.cpu.total} {t('resourceUsage.cores')}</p>
-        </div>
-        <div>
-          <p className="text-xs text-muted-foreground">{t('resourceUsage.totalRAM')}</p>
-          <p className="text-sm font-medium text-foreground">{totals.memory.total} GB</p>
-        </div>
-        {accelerators.map(accel => (
-          <div key={accel.key}>
-            <p className="text-xs text-muted-foreground">{t('resourceUsage.totalLabel', { label: accel.label })}</p>
-            <p className="text-sm font-medium text-foreground">
-              <span className={accel.color}>{accel.data.used}</span>/{accel.data.total}
-            </p>
+      {/* Resource Details */}
+      <div className={`mt-4 pt-3 border-t border-border/50`}>
+        <h5 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+          {t('resourceUsage.capacityBreakdown')}
+        </h5>
+        <div className={`grid gap-2 text-center`} style={{ gridTemplateColumns: `repeat(${footerCols}, minmax(0, 1fr))` }}>
+          <div>
+            <p className="text-xs text-muted-foreground">{t('resourceUsage.totalCPU')}</p>
+            <p className="text-sm font-medium text-foreground">{totals.cpu.total} {t('resourceUsage.cores')}</p>
           </div>
-        ))}
+          <div>
+            <p className="text-xs text-muted-foreground">{t('resourceUsage.totalRAM')}</p>
+            <p className="text-sm font-medium text-foreground">{totals.memory.total} GB</p>
+          </div>
+          {accelerators.map(accel => (
+            <div key={accel.key}>
+              <p className="text-xs text-muted-foreground">{t('resourceUsage.totalLabel', { label: accel.label })}</p>
+              <p className="text-sm font-medium text-foreground">
+                <span className={accel.color}>{accel.data.used}</span>/{accel.data.total}
+              </p>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -1204,7 +1204,7 @@
     "infiniband": "InfiniBand",
     "monitoring": "Monitoring",
     "deviceDisappearances": "Device Disappearances",
-    "noDevicesDetected": "No devices detected",
+    "noDevicesDetected": "No hardware devices detected on this node (GPU, NVMe, NICs, or InfiniBand devices)",
     "hideSnoozedAlerts": "Hide snoozed alerts",
     "showSnoozedAlerts": "Show snoozed alerts",
     "snoozeAllVisible": "Snooze all visible alerts",
@@ -1388,7 +1388,9 @@
     "chartWillAppear": "Chart will appear after collecting more data",
     "min": "Min",
     "avg": "Avg",
-    "max": "Max"
+    "max": "Max",
+    "currentValue": "Current Value",
+    "timePeriodSummary": "{{timeRange}} Summary"
   },
   "clusterNetwork": {
     "noNetworkData": "No network data",
@@ -2772,7 +2774,8 @@
     "cores": "cores",
     "totalLabel": "Total {{label}}",
     "overcommitted": "{{used}}/{{total}} overcommitted",
-    "viewDetailsAria": "View resource usage details"
+    "viewDetailsAria": "View resource usage details",
+    "capacityBreakdown": "Capacity Breakdown"
   },
   "serviceExports": {
     "loadFailed": "Failed to load service exports",


### PR DESCRIPTION
Fixes #11413
Fixes #11414
Fixes #11415

- Fix hardware health card display issues
- Fix metrics/monitoring display problems
- Fix resource utilization display issues

## Changes Made

### Hardware Health Card Improvements
- Updated "No devices detected" message to be more explanatory: "No hardware devices detected on this node (GPU, NVMe, NICs, or InfiniBand devices)"
- Added better empty state messaging explaining what the card monitors and suggesting next steps
- Improved context for users when no hardware is available

### ClusterMetrics Card De-duplication
- Added clear hierarchy with section headers
- Current value section shows real-time metric
- Time period summary section shows min/avg/max statistics
- Reduced visual clutter and confusion about what each section represents

### ResourceUsage Card Improvements
- Added "Capacity Breakdown" section header
- Clarified that bottom section shows total capacity vs utilization percentages above
- Better information architecture between gauges and detailed numbers

### Translation Updates
- Added `currentValue`, `timePeriodSummary`, `capacityBreakdown` keys
- Improved `noDevicesDetected` message
- Enhanced user-facing messaging throughout

These changes address the core issues of unclear messaging and duplicated information display that were causing confusion in the hardware monitoring interface.