### PR TITLE
🐛 Fix AI predictor text concat, cluster status values, and alert state consistency

### DIFF
--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -1,6 +1,68 @@
 # Reviewer Log
 
-## Pass 90 — 2026-05-01T09:38–09:55 UTC
+## Pass 92 — 2026-05-01T21:00–21:30 UTC
+
+### Trigger
+KICK — nightlyPlaywright=RED. 100 unaddressed Copilot comments (3 HIGH, 72 MEDIUM, 25 LOW). GA4 nominal.
+
+### RED Analysis
+**nightlyPlaywright=RED**: Scanner-owned per actionable.json. Not fixed this pass.
+
+### HIGH Copilot Comments Fixed
+
+| PR | Issue | Fix |
+|----|-------|-----|
+| #11318 | events.go limit not clamped | Added maxEventLimit=1000 const; clamp before store call and response — branch fix/pr11318-events-limit-clamp |
+| #11326 | drasi_proxy_test hop-by-hop header | Added assert.Empty for Proxy-Authenticate in RoundTripFunc — branch fix/pr11326-drasi-proxy-hop-by-hop |
+| #11323 | startup-oauth.sh go build path | Already MERGED before this pass |
+
+### PRs Created
+
+| PR | Branch | Title |
+|----|--------|-------|
+| #11351 | fix/11314 | Add missing Dashboard title icon |
+| #11352 | fix/11329 | fix(missions): theme-aware colors in light mode |
+| #11353 | fix/11339 | fix(pod-logs): align log viewer background with theme tokens |
+| #11354 | fix/11335 | feat(missions): Clear All and multi-select in resolution history |
+| #11356 | fix/mcp-test-failures | fix: slog style, SSE timeout, MCP test backoff adaptations |
+
+### MEDIUM Copilot Comments Fixed (PR#11356)
+- custom_resources.go: nil-guard + slog key/value style (PRs #11288/#11289)
+- feedback_requests.go: 5 recover blocks converted to key/value slog style
+- kagenti_provider/client.go: SSE httpClient Timeout 10s→0 (ctx controls lifetime)
+
+### Test Fixes (issue #11348)
+- helm.test.ts, networking.test.ts, storage.test.ts: adapt for exponential-backoff cascading
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+## Pass 91 — 2026-05-01T19:20–19:36 UTC
+
+### Trigger
+KICK — CI=0%, nightlyPlaywright=RED, deploy:vllm-d=RED, deploy:pok-prod=RED. 100 unaddressed Copilot comments (3 HIGH). GA4 nominal.
+
+### RED Analysis
+**CI=0%**: Transient — CI checks were in_progress when snapshot taken. All completed successfully.
+**deploy:vllm-d / deploy:pok-prod RED**: Both in_progress on run #25229545865, completed SUCCESS. No issue needed.
+**nightlyPlaywright=RED**: Root cause — card-loading-compliance.spec.ts used `async (_fixtures, testInfo)` instead of `async ({}, testInfo)` (5 instances). Filed issue #11322. PR #11324 opened.
+
+### HIGH Copilot Comments
+All 3 HIGH comments (PRs #11254, #11269, #11279) on MERGED PRs. missions.go code is correct. No action needed.
+
+### PRs
+- PR #11317 MERGED (fix/copilot-review-batch-2)
+- PR #11323 MERGED (fix/startup-ldflags)
+- PR #11324 open — Playwright RED fix
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+
 
 ### Trigger
 KICK — nightly=RED, nightlyPlaywright=RED. 73 unaddressed Copilot comments (2 HIGH). GA4 nominal.

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -726,6 +726,13 @@ export const CardWrapper = memo(function CardWrapper({
                 {!onRefresh && (isVisuallySpinning || effectiveIsLoading || forceSkeletonForOffline) && !effectiveIsFailed && (
                   <RefreshCw className="w-3 h-3 text-blue-400 animate-spin" aria-hidden="true" />
                 )}
+                {/* Separator between failure badge and timestamp to prevent text concatenation (#11402) */}
+                {effectiveIsFailed && (() => {
+                  const effectiveLastUpdated = lastUpdated ?? childDataState?.lastUpdated
+                  return effectiveLastUpdated && !isVisuallySpinning && !effectiveIsLoading
+                    ? <span className="text-2xs text-muted-foreground/50 select-none" aria-hidden="true">·</span>
+                    : null
+                })()}
                 {/* Last updated indicator — use prop or child-reported timestamp.
                   * Still rendered when refresh is failing (#9104): hiding the
                   * timestamp on failure removed the only signal about data age,

--- a/web/src/components/layout/SidebarShell.tsx
+++ b/web/src/components/layout/SidebarShell.tsx
@@ -477,7 +477,11 @@ export function SidebarShell({
             {renderIcon(item.icon, isCollapsed ? 'w-6 h-6' : 'w-5 h-5')}
             {!isCollapsed && (() => {
               const dashId = HREF_TO_DASHBOARD_ID[item.href]
-              const count = dashId ? DASHBOARD_CONFIGS[dashId]?.cards?.length : null
+              // Skip card count for alerts dashboard — the header AlertBadge already
+              // shows the actual firing alert count; showing the dashboard card count
+              // here (e.g. "5") creates a conflicting signal (#11404).
+              const count = dashId && item.href !== '/alerts'
+                ? DASHBOARD_CONFIGS[dashId]?.cards?.length : null
               const isGC = isGroundControlItem(item.href)
               return (
                 <span className="flex-1 min-w-0 flex items-center gap-1">
@@ -697,9 +701,10 @@ export function SidebarShell({
           </div>
         )}
 
-        {/* Viewer count + commit hash */}
+        {/* Viewer count + commit hash — separated from cluster status to prevent
+          * the commit SHA from visually merging with cluster counts (#11403). */}
         {features.activeUsers && !isCollapsed && (
-          <div className="mt-auto pt-4 flex flex-col items-center gap-1">
+          <div className="mt-auto pt-4 border-t border-border/30 flex flex-col items-center gap-1">
             <div className="flex items-center justify-center gap-2">
               <div
                 className="flex items-center gap-1 px-2 text-muted-foreground/60"
@@ -711,7 +716,7 @@ export function SidebarShell({
                 </span>
               </div>
               <span className="text-2xs text-muted-foreground/40 font-mono" title={`Commit: ${__COMMIT_HASH__}`}>
-                {__COMMIT_HASH__.substring(0, 7)}
+                #{__COMMIT_HASH__.substring(0, 7)}
               </span>
             </div>
             {/* Developer mode: warn when running an older commit, or show upgrade progress */}


### PR DESCRIPTION
Fixes #11402
Fixes #11403
Fixes #11404

## Changes
- Add separator between error badge and timestamp in CardWrapper to prevent text concatenation (#11402)
- Add border separator and hash prefix to commit SHA display in sidebar to prevent merging with status counts (#11403)
- Exclude /alerts route from sidebar card counts to eliminate conflicting alert state display (#11404)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>