### PR TITLE
🐛 Fix Namespace Manager showing no namespaces

### DIFF
--- a/reviewer_log.md
+++ b/reviewer_log.md
@@ -1,6 +1,68 @@
 # Reviewer Log
 
-## Pass 90 — 2026-05-01T09:38–09:55 UTC
+## Pass 92 — 2026-05-01T21:00–21:30 UTC
+
+### Trigger
+KICK — nightlyPlaywright=RED. 100 unaddressed Copilot comments (3 HIGH, 72 MEDIUM, 25 LOW). GA4 nominal.
+
+### RED Analysis
+**nightlyPlaywright=RED**: Scanner-owned per actionable.json. Not fixed this pass.
+
+### HIGH Copilot Comments Fixed
+
+| PR | Issue | Fix |
+|----|-------|-----|
+| #11318 | events.go limit not clamped | Added maxEventLimit=1000 const; clamp before store call and response — branch fix/pr11318-events-limit-clamp |
+| #11326 | drasi_proxy_test hop-by-hop header | Added assert.Empty for Proxy-Authenticate in RoundTripFunc — branch fix/pr11326-drasi-proxy-hop-by-hop |
+| #11323 | startup-oauth.sh go build path | Already MERGED before this pass |
+
+### PRs Created
+
+| PR | Branch | Title |
+|----|--------|-------|
+| #11351 | fix/11314 | Add missing Dashboard title icon |
+| #11352 | fix/11329 | fix(missions): theme-aware colors in light mode |
+| #11353 | fix/11339 | fix(pod-logs): align log viewer background with theme tokens |
+| #11354 | fix/11335 | feat(missions): Clear All and multi-select in resolution history |
+| #11356 | fix/mcp-test-failures | fix: slog style, SSE timeout, MCP test backoff adaptations |
+
+### MEDIUM Copilot Comments Fixed (PR#11356)
+- custom_resources.go: nil-guard + slog key/value style (PRs #11288/#11289)
+- feedback_requests.go: 5 recover blocks converted to key/value slog style
+- kagenti_provider/client.go: SSE httpClient Timeout 10s→0 (ctx controls lifetime)
+
+### Test Fixes (issue #11348)
+- helm.test.ts, networking.test.ts, storage.test.ts: adapt for exponential-backoff cascading
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+## Pass 91 — 2026-05-01T19:20–19:36 UTC
+
+### Trigger
+KICK — CI=0%, nightlyPlaywright=RED, deploy:vllm-d=RED, deploy:pok-prod=RED. 100 unaddressed Copilot comments (3 HIGH). GA4 nominal.
+
+### RED Analysis
+**CI=0%**: Transient — CI checks were in_progress when snapshot taken. All completed successfully.
+**deploy:vllm-d / deploy:pok-prod RED**: Both in_progress on run #25229545865, completed SUCCESS. No issue needed.
+**nightlyPlaywright=RED**: Root cause — card-loading-compliance.spec.ts used `async (_fixtures, testInfo)` instead of `async ({}, testInfo)` (5 instances). Filed issue #11322. PR #11324 opened.
+
+### HIGH Copilot Comments
+All 3 HIGH comments (PRs #11254, #11269, #11279) on MERGED PRs. missions.go code is correct. No action needed.
+
+### PRs
+- PR #11317 MERGED (fix/copilot-review-batch-2)
+- PR #11323 MERGED (fix/startup-ldflags)
+- PR #11324 open — Playwright RED fix
+
+### GA4
+Nominal — no anomalies.
+
+---
+
+
 
 ### Trigger
 KICK — nightly=RED, nightlyPlaywright=RED. 73 unaddressed Copilot comments (2 HIGH). GA4 nominal.

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -136,6 +136,8 @@ export function NamespaceManager() {
     const fetchPromises = clustersToFetch.map(async (cluster) => {
       try {
         let clusterNamespaces: NamespaceDetails[] = []
+        let agentFailed = false
+        let apiFailed = false
 
         // Always try local agent first (works without backend auth)
         try {
@@ -158,8 +160,11 @@ export function NamespaceManager() {
                 createdAt: ns.createdAt || new Date().toISOString()
               }))
             }
+          } else {
+            agentFailed = true
           }
         } catch (err: unknown) {
+          agentFailed = true
           if (err instanceof DOMException && err.name === 'AbortError') {
             console.warn(`[NamespaceManager] ${t('namespaces.errors.requestTimedOut')}`, cluster)
           } else if (err instanceof TypeError) {
@@ -177,7 +182,7 @@ export function NamespaceManager() {
 
             // Extract unique namespaces from pods
             const nsSet = new Set<string>()
-            response.data.pods?.forEach(pod => {
+            ;(response.data.pods || []).forEach(pod => {
               if (pod.namespace) nsSet.add(pod.namespace)
             })
 
@@ -190,8 +195,14 @@ export function NamespaceManager() {
               })
             })
           } catch {
+            apiFailed = true
             // API also failed - cluster is likely unreachable
           }
+        }
+
+        // Track as failed if both data sources returned no data due to errors
+        if (clusterNamespaces.length === 0 && agentFailed && apiFailed) {
+          failedClusters.push(cluster)
         }
 
         // Only cache if we got data
@@ -234,7 +245,15 @@ export function NamespaceManager() {
 
     // Only show error if ALL clusters failed (no namespaces at all)
     if (failedClusters.length > 0 && totalCachedNamespaces === 0) {
-      setError(`Unable to connect to clusters. Check that the KC agent is running.`)
+      setError(t('namespaces.errors.unableToConnect', 'Unable to connect to clusters. Check that the KC agent is running.'))
+      // Allow retry on next trigger since all clusters failed
+      hasFetchedRef.current = false
+    } else if (failedClusters.length > 0) {
+      // Some clusters failed but we have partial data - show partial error
+      setError(t('namespaces.errors.someClustersUnavailable', {
+        count: failedClusters.length,
+        defaultValue: '{{count}} cluster(s) could not be reached. Showing cached data for available clusters.'
+      }))
     } else {
       // Clear any previous error since we have data
       setError(null)
@@ -243,7 +262,7 @@ export function NamespaceManager() {
     setLoading(false)
     setLoadingClusters(new Set())
     setLastUpdated(new Date())
-  }, [allClusterNames])
+  }, [allClusterNames, t])
 
   const handleRefreshNamespaces = () => fetchNamespaces(true)
   const { showIndicator, triggerRefresh } = useRefreshIndicator(handleRefreshNamespaces)
@@ -639,7 +658,7 @@ export function NamespaceManager() {
             </>
           )}
 
-          {filteredNamespaces.length === 0 && !loading && loadingClusters.size === 0 && (
+          {filteredNamespaces.length === 0 && !loading && loadingClusters.size === 0 && !error && (
             <div className="flex flex-col items-center justify-center h-40 text-muted-foreground">
               <Folder className="w-12 h-12 mb-3 opacity-50" />
               <p>{t('namespaces.noNamespaces')}</p>


### PR DESCRIPTION
Fixes #11482

## Problem
When the KC agent returns 404 and the pods API returns 401, both inner catch blocks silently swallowed errors without marking clusters as failed. This caused the UI to show 'No namespaces found' instead of a connection error message.

## Root Causes
1. **Silent failure tracking**: Inner try-catch blocks caught errors but never propagated failure status to `failedClusters`, so the error banner never displayed.
2. **Empty state shown despite errors**: The 'No namespaces found' message rendered whenever `filteredNamespaces` was empty, regardless of whether fetches actually failed.

## Fix
- Track `agentFailed`/`apiFailed` flags per cluster; push to `failedClusters` when both sources fail
- Show partial-failure message when some clusters are unreachable but others have data
- Reset `hasFetchedRef` on total failure to allow auto-retry on next interval
- Array safety: guard `response.data.pods` with `(... || [])`