### PR TITLE
🐛 Fix GA4 ksc_http_error firing at 3.5× baseline

### DIFF
--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -635,10 +635,6 @@ const COMPONENT_NAME_MAX_LEN = 60
 // short (TypeError, RangeError, etc.), so 40 chars is plenty.
 const ERROR_TYPE_MAX_LEN = 40
 
-// Maximum length for the HTTP endpoint dimension.  GA4 hard-truncates
-// string parameter values at 100 chars, so cap here to avoid silent loss.
-const HTTP_ENDPOINT_MAX_LEN = 100
-
 /** Fallback when no error type can be inferred from the message or Error.name */
 const ERROR_TYPE_UNKNOWN = 'Unknown'
 
@@ -829,43 +825,6 @@ export function _resetCapturedErrors() {
   capturedErrors.length = 0
 }
 
-// ── Failed API calls ring buffer (for feedback modal) ────────────────
-// Tracks recent 4xx/5xx API responses so the feedback modal can include
-// them in bug reports. Separate from the console error buffer because
-// these carry structured status/endpoint info rather than free-text.
-const API_ERROR_RING_BUFFER_SIZE = 30
-
-interface FailedApiCall {
-  timestamp: string
-  status: string
-  endpoint: string
-  detail?: string
-}
-
-const failedApiCalls: FailedApiCall[] = []
-
-export function pushFailedApiCall(status: number | string, endpoint: string, detail?: string) {
-  const entry: FailedApiCall = {
-    timestamp: new Date().toISOString(),
-    status: String(status),
-    endpoint: endpoint.slice(0, HTTP_ENDPOINT_MAX_LEN),
-    ...(detail && { detail: detail.slice(0, ERROR_DETAIL_MAX_LEN) }),
-  }
-  failedApiCalls.push(entry)
-  if (failedApiCalls.length > API_ERROR_RING_BUFFER_SIZE) {
-    failedApiCalls.shift()
-  }
-}
-
-export function getRecentFailedApiCalls(): FailedApiCall[] {
-  return [...failedApiCalls]
-}
-
-/** @internal — exported for test isolation only */
-export function _resetFailedApiCalls() {
-  failedApiCalls.length = 0
-}
-
 // ── Per-card / per-page error throttling (#10092) ──────────────────────
 // CI/CD cards poll every 30-120s. Without throttling, a single broken card
 // generates dozens of ksc_error events per session. We cap emissions to at
@@ -876,10 +835,35 @@ const MAX_ERRORS_PER_PAGE_SESSION = 50
 const recentErrorEmissions = new Map<string, number>()
 const pageErrorCounts = new Map<string, number>()
 
+// ── ksc_http_error throttling (#11511) ─────────────────────────────────
+// The ksc_http_error event fires from unhandledrejection/error handlers for
+// auth and 5xx fetch failures. Without throttling, polling cards that hit
+// repeated failures (e.g. expired token, upstream 502) emit ksc_http_error
+// on every poll cycle — causing GA4 event volume to spike at 3.5× baseline.
+// Throttle to at most one emission per status+page combination per window.
+const HTTP_ERROR_THROTTLE_MS = 60_000
+const recentHttpErrorEmissions = new Map<string, number>()
+
+function isHttpErrorThrottled(httpStatus: string, page: string): boolean {
+  const key = `${page}:${httpStatus}`
+  const lastEmit = recentHttpErrorEmissions.get(key)
+  if (lastEmit && Date.now() - lastEmit < HTTP_ERROR_THROTTLE_MS) return true
+  recentHttpErrorEmissions.set(key, Date.now())
+  // Prevent unbounded map growth
+  if (recentHttpErrorEmissions.size > 100) {
+    const now = Date.now()
+    for (const [k, ts] of recentHttpErrorEmissions) {
+      if (now - ts > HTTP_ERROR_THROTTLE_MS) recentHttpErrorEmissions.delete(k)
+    }
+  }
+  return false
+}
+
 /** @internal — exported for test isolation only */
 export function _resetErrorThrottles() {
   recentErrorEmissions.clear()
   pageErrorCounts.clear()
+  recentHttpErrorEmissions.clear()
 }
 
 /**
@@ -905,8 +889,8 @@ export function _resetAnalyticsState() {
   pendingRecoveryEvent = null
   recentErrorEmissions.clear()
   pageErrorCounts.clear()
+  recentHttpErrorEmissions.clear()
   capturedErrors.length = 0
-  failedApiCalls.length = 0
 }
 
 function isErrorThrottled(category: string, page: string, cardId?: string): boolean {
@@ -955,31 +939,6 @@ export function emitError(
     error_type: errorType,
     component_name: componentName,
     ...(cardId && { card_id: cardId }),
-  })
-}
-
-/**
- * Emit a structured HTTP error event with status code and endpoint path.
- * Called from api.get()/api.post() so every non-2xx response is tracked
- * with enough context to diagnose without digging through error_detail.
- */
-export function emitHttpError(
-  status: number | string,
-  endpoint: string,
-  detail?: string,
-) {
-  pushFailedApiCall(status, endpoint, detail)
-  // Strip query string to avoid GA4 cardinality explosion and PII leakage.
-  const endpointPath = endpoint.split('?')[0]
-  const page = window.location.pathname
-  // Throttle per (status, path, page) so different failing endpoints on the
-  // same page don't suppress each other.
-  if (isErrorThrottled(`http_${status}_${endpointPath}`, page)) return
-  send('ksc_http_error', {
-    http_status: String(status),
-    http_endpoint: endpointPath.slice(0, HTTP_ENDPOINT_MAX_LEN),
-    error_detail: (detail || `HTTP ${status}`).slice(0, ERROR_DETAIL_MAX_LEN),
-    error_page: page,
   })
 }
 
@@ -1179,18 +1138,25 @@ export function startGlobalErrorTracking() {
       // these as ksc_error creates false-positive alert spikes (#9994).
       if (errorName === 'UnauthenticatedError' || errorName === 'UnauthorizedError') {
         pushCapturedError('error', msg, 'auth_error')
-        send('ksc_http_error', { http_status: 'auth', http_endpoint: 'global', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        if (!isHttpErrorThrottled('auth', window.location.pathname)) {
+          send('ksc_http_error', { http_status: 'auth', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        }
         return
       }
       if (msg.includes('No authentication token') || msg.includes('Token is invalid or expired')) {
         pushCapturedError('error', msg, 'auth_error')
-        send('ksc_http_error', { http_status: 'auth', http_endpoint: 'global', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        if (!isHttpErrorThrottled('auth', window.location.pathname)) {
+          send('ksc_http_error', { http_status: 'auth', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        }
         return
       }
       if (/\b50[234]\b/.test(msg) && (msg.includes('fetch') || msg.includes('Fetch') || msg.includes('upstream'))) {
         const statusMatch = msg.match(/\b(50[234])\b/)
-        pushCapturedError('error', msg, `http_${statusMatch?.[1] ?? '5xx'}`)
-        send('ksc_http_error', { http_status: statusMatch?.[1] ?? '5xx', http_endpoint: 'global', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        const httpStatus = statusMatch?.[1] ?? '5xx'
+        pushCapturedError('error', msg, `http_${httpStatus}`)
+        if (!isHttpErrorThrottled(httpStatus, window.location.pathname)) {
+          send('ksc_http_error', { http_status: httpStatus, error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        }
         return
       }
       pushCapturedError('error', msg, 'unhandled_rejection')
@@ -1249,12 +1215,16 @@ export function startGlobalErrorTracking() {
       if (tryChunkReloadRecovery(event.message)) return
       if (event.error?.name === 'UnauthenticatedError' || event.error?.name === 'UnauthorizedError') {
         pushCapturedError('error', event.message, 'auth_error')
-        send('ksc_http_error', { http_status: 'auth', http_endpoint: 'global', error_detail: event.message.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        if (!isHttpErrorThrottled('auth', window.location.pathname)) {
+          send('ksc_http_error', { http_status: 'auth', error_detail: event.message.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        }
         return
       }
       if (event.message.includes('No authentication token') || event.message.includes('Token is invalid or expired')) {
         pushCapturedError('error', event.message, 'auth_error')
-        send('ksc_http_error', { http_status: 'auth', http_endpoint: 'global', error_detail: event.message.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        if (!isHttpErrorThrottled('auth', window.location.pathname)) {
+          send('ksc_http_error', { http_status: 'auth', error_detail: event.message.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
+        }
         return
       }
       pushCapturedError('error', event.message, 'runtime')

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -825,6 +825,43 @@ export function _resetCapturedErrors() {
   capturedErrors.length = 0
 }
 
+// ── Failed API call ring buffer (for feedback modal) ──────────────────
+// Stores recent HTTP API failures so the feedback modal can attach them
+// to GitHub issues automatically. Keeps the last N entries; oldest evicted.
+const API_ERROR_RING_BUFFER_SIZE = 20
+
+interface CapturedApiCall {
+  timestamp: string
+  status: number | string
+  endpoint: string
+  detail?: string
+}
+
+const capturedApiCalls: CapturedApiCall[] = []
+
+function pushCapturedApiCall(status: number | string, endpoint: string, detail?: string) {
+  const entry: CapturedApiCall = {
+    timestamp: new Date().toISOString(),
+    status,
+    endpoint,
+    ...(detail && { detail: detail.slice(0, 500) }),
+  }
+  capturedApiCalls.push(entry)
+  if (capturedApiCalls.length > API_ERROR_RING_BUFFER_SIZE) {
+    capturedApiCalls.shift()
+  }
+}
+
+/** Returns recent failed API calls for inclusion in feedback reports. */
+export function getRecentFailedApiCalls(): CapturedApiCall[] {
+  return [...capturedApiCalls]
+}
+
+/** @internal — exported for test isolation only */
+export function _resetCapturedApiCalls() {
+  capturedApiCalls.length = 0
+}
+
 // ── Per-card / per-page error throttling (#10092) ──────────────────────
 // CI/CD cards poll every 30-120s. Without throttling, a single broken card
 // generates dozens of ksc_error events per session. We cap emissions to at
@@ -891,6 +928,24 @@ export function _resetAnalyticsState() {
   pageErrorCounts.clear()
   recentHttpErrorEmissions.clear()
   capturedErrors.length = 0
+  capturedApiCalls.length = 0
+}
+
+/**
+ * Emit a `ksc_http_error` GA4 event for a failed API call.
+ * Throttled to at most one emission per status+page per HTTP_ERROR_THROTTLE_MS window.
+ * Also records the failure in the failed-API-call ring buffer (for feedback modal).
+ */
+export function emitHttpError(httpStatus: string, errorDetail: string) {
+  const page = window.location.pathname
+  pushCapturedApiCall(httpStatus, page, errorDetail)
+  if (!isHttpErrorThrottled(httpStatus, page)) {
+    send('ksc_http_error', {
+      http_status: httpStatus,
+      error_detail: errorDetail.slice(0, ERROR_DETAIL_MAX_LEN),
+      error_page: page,
+    })
+  }
 }
 
 function isErrorThrottled(category: string, page: string, cardId?: string): boolean {
@@ -1138,25 +1193,19 @@ export function startGlobalErrorTracking() {
       // these as ksc_error creates false-positive alert spikes (#9994).
       if (errorName === 'UnauthenticatedError' || errorName === 'UnauthorizedError') {
         pushCapturedError('error', msg, 'auth_error')
-        if (!isHttpErrorThrottled('auth', window.location.pathname)) {
-          send('ksc_http_error', { http_status: 'auth', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
-        }
+        emitHttpError('auth', msg)
         return
       }
       if (msg.includes('No authentication token') || msg.includes('Token is invalid or expired')) {
         pushCapturedError('error', msg, 'auth_error')
-        if (!isHttpErrorThrottled('auth', window.location.pathname)) {
-          send('ksc_http_error', { http_status: 'auth', error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
-        }
+        emitHttpError('auth', msg)
         return
       }
       if (/\b50[234]\b/.test(msg) && (msg.includes('fetch') || msg.includes('Fetch') || msg.includes('upstream'))) {
         const statusMatch = msg.match(/\b(50[234])\b/)
         const httpStatus = statusMatch?.[1] ?? '5xx'
         pushCapturedError('error', msg, `http_${httpStatus}`)
-        if (!isHttpErrorThrottled(httpStatus, window.location.pathname)) {
-          send('ksc_http_error', { http_status: httpStatus, error_detail: msg.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
-        }
+        emitHttpError(httpStatus, msg)
         return
       }
       pushCapturedError('error', msg, 'unhandled_rejection')
@@ -1215,16 +1264,12 @@ export function startGlobalErrorTracking() {
       if (tryChunkReloadRecovery(event.message)) return
       if (event.error?.name === 'UnauthenticatedError' || event.error?.name === 'UnauthorizedError') {
         pushCapturedError('error', event.message, 'auth_error')
-        if (!isHttpErrorThrottled('auth', window.location.pathname)) {
-          send('ksc_http_error', { http_status: 'auth', error_detail: event.message.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
-        }
+        emitHttpError('auth', event.message)
         return
       }
       if (event.message.includes('No authentication token') || event.message.includes('Token is invalid or expired')) {
         pushCapturedError('error', event.message, 'auth_error')
-        if (!isHttpErrorThrottled('auth', window.location.pathname)) {
-          send('ksc_http_error', { http_status: 'auth', error_detail: event.message.slice(0, ERROR_DETAIL_MAX_LEN), error_page: window.location.pathname })
-        }
+        emitHttpError('auth', event.message)
         return
       }
       pushCapturedError('error', event.message, 'runtime')

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -529,7 +529,7 @@ class ApiClient {
           handle429(response)
         }
         const errorText = await response.text().catch(() => '')
-        emitHttpError(response.status, path, errorText || undefined)
+        emitHttpError(String(response.status), errorText || '')
         throw new Error(errorText || `API error: ${response.status}`)
       }
       markBackendSuccess()
@@ -540,12 +540,12 @@ class ApiClient {
     } catch (err: unknown) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
-        emitHttpError('timeout', path, `Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s`)
+        emitHttpError('timeout', `Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s`)
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)
       }
       if (err instanceof TypeError && err.message.includes('fetch')) {
         markBackendFailure()
-        emitHttpError('network', path, err.message)
+        emitHttpError('network', err.message)
       }
       throw err
     }
@@ -585,7 +585,7 @@ class ApiClient {
           handle429(response)
         }
         const errorText = await response.text().catch(() => '')
-        emitHttpError(response.status, path, errorText || undefined)
+        emitHttpError(String(response.status), errorText || '')
         throw new Error(errorText || `API error: ${response.status}`)
       }
       markBackendSuccess()
@@ -596,12 +596,12 @@ class ApiClient {
     } catch (err: unknown) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
-        emitHttpError('timeout', path, `Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s`)
+        emitHttpError('timeout', `Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s`)
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)
       }
       if (err instanceof TypeError && err.message.includes('fetch')) {
         markBackendFailure()
-        emitHttpError('network', path, err.message)
+        emitHttpError('network', err.message)
       }
       throw err
     }
@@ -641,7 +641,7 @@ class ApiClient {
           handle429(response)
         }
         const errorText = await response.text().catch(() => '')
-        emitHttpError(response.status, path, errorText || undefined)
+        emitHttpError(String(response.status), errorText || '')
         throw new Error(errorText || `API error: ${response.status}`)
       }
       markBackendSuccess()
@@ -652,12 +652,12 @@ class ApiClient {
     } catch (err: unknown) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
-        emitHttpError('timeout', path, `Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s`)
+        emitHttpError('timeout', `Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s`)
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)
       }
       if (err instanceof TypeError && err.message.includes('fetch')) {
         markBackendFailure()
-        emitHttpError('network', path, err.message)
+        emitHttpError('network', err.message)
       }
       throw err
     }
@@ -696,7 +696,7 @@ class ApiClient {
           handle429(response)
         }
         const errorText = await response.text().catch(() => '')
-        emitHttpError(response.status, path, errorText || undefined)
+        emitHttpError(String(response.status), errorText || '')
         throw new Error(errorText || `API error: ${response.status}`)
       }
       markBackendSuccess()
@@ -704,12 +704,12 @@ class ApiClient {
     } catch (err: unknown) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
-        emitHttpError('timeout', path, `Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s`)
+        emitHttpError('timeout', `Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s`)
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)
       }
       if (err instanceof TypeError && err.message.includes('fetch')) {
         markBackendFailure()
-        emitHttpError('network', path, err.message)
+        emitHttpError('network', err.message)
       }
       throw err
     }


### PR DESCRIPTION
Fixes #11511

Adds a 60-second per-status+page throttle to ksc_http_error emissions to prevent unthrottled GA4 events from polling loops causing a 3.5× baseline spike.