### PR TITLE
🏗 refactor(mcp): extract agentFetch and fetchWithRetry from shared.ts god module

### DIFF
--- a/web/src/hooks/mcp/agentFetch.ts
+++ b/web/src/hooks/mcp/agentFetch.ts
@@ -1,0 +1,125 @@
+import { isDemoMode, isNetlifyDeployment } from '../../lib/demoMode'
+import { emitAgentTokenFailure } from '../../lib/analytics'
+import {
+  LOCAL_AGENT_HTTP_URL,
+  MCP_HOOK_TIMEOUT_MS,
+} from '../../lib/constants'
+import { isLocalAgentSuppressed } from '../../lib/constants/network'
+
+// Re-export for backward compatibility
+export const LOCAL_AGENT_URL = LOCAL_AGENT_HTTP_URL
+
+export const AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'
+const AGENT_TOKEN_FETCH_TIMEOUT_MS = 5000
+/** How long to remember that the backend returned no token (avoids repeated 5s timeouts). */
+const AGENT_TOKEN_NEGATIVE_CACHE_MS = 30_000
+
+let agentTokenPromise: Promise<string> | null = null
+/** Session-level dedup: only emit one agent_token_failure per page load */
+let agentTokenFailureEmitted = false
+/** Timestamp of last negative result (empty/error) — used for short-TTL in-memory cache. */
+let agentTokenNegativeCacheUntil = 0
+
+/** Reset internal getAgentToken state — exposed for tests only. */
+export function _resetAgentTokenState(): void {
+  agentTokenPromise = null
+  agentTokenFailureEmitted = false
+  agentTokenNegativeCacheUntil = 0
+}
+
+/**
+ * Lazily fetch the kc-agent token from the backend. The token is cached
+ * in localStorage so subsequent calls (and page reloads) don't re-fetch.
+ *
+ * On Netlify / demo mode there is no kc-agent backend, so we skip the
+ * fetch entirely to avoid 404 → HTML parse errors that pollute GA4
+ * (#10643, root cause of the 48-hour blank dashboard in #10398).
+ *
+ * Negative results (empty token or fetch error) are cached in memory for
+ * AGENT_TOKEN_NEGATIVE_CACHE_MS to avoid repeated 5s timeouts (#11120).
+ */
+function getAgentToken(): Promise<string> {
+  if (isDemoMode() || isNetlifyDeployment || isLocalAgentSuppressed()) return Promise.resolve('')
+
+  const cached = localStorage.getItem(AGENT_TOKEN_STORAGE_KEY)
+  if (cached) return Promise.resolve(cached)
+
+  // Short-circuit if we recently got an empty/failed result
+  if (Date.now() < agentTokenNegativeCacheUntil) return Promise.resolve('')
+
+  if (!agentTokenPromise) {
+    agentTokenPromise = fetch('/api/agent/token', {
+      credentials: 'include',
+      signal: AbortSignal.timeout(AGENT_TOKEN_FETCH_TIMEOUT_MS),
+    })
+      .then(r => r.ok ? r.json() : { token: '' })
+      .then((data: { token?: string }) => {
+        const token = data.token || ''
+        if (token) {
+          localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, token)
+        } else {
+          agentTokenNegativeCacheUntil = Date.now() + AGENT_TOKEN_NEGATIVE_CACHE_MS
+          if (!agentTokenFailureEmitted) {
+            agentTokenFailureEmitted = true
+            emitAgentTokenFailure('empty token from /api/agent/token')
+          }
+        }
+        agentTokenPromise = null
+        return token
+      })
+      .catch((err) => {
+        agentTokenNegativeCacheUntil = Date.now() + AGENT_TOKEN_NEGATIVE_CACHE_MS
+        if (!agentTokenFailureEmitted) {
+          agentTokenFailureEmitted = true
+          emitAgentTokenFailure(err?.message || 'network error')
+        }
+        agentTokenPromise = null
+        return ''
+      })
+  }
+  return agentTokenPromise
+}
+
+/**
+ * Drop-in replacement for `fetch()` that auto-injects the KC_AGENT_TOKEN
+ * Authorization header when calling the kc-agent HTTP API. Without this,
+ * requests to kc-agent are rejected when KC_AGENT_TOKEN is configured.
+ */
+export async function agentFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const token = await getAgentToken()
+  const headers = new Headers(init?.headers)
+  if (token && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${token}`)
+  }
+  // #10000 — CSRF defence-in-depth: state-changing requests must carry a
+  // custom header that browsers never attach to cross-origin form POSTs.
+  // The kc-agent requireCSRF middleware rejects POST/PUT/DELETE/PATCH
+  // without this header.
+  if (!headers.has('X-Requested-With')) {
+    headers.set('X-Requested-With', 'XMLHttpRequest')
+  }
+  // Use caller-provided signal, or fall back to a default timeout
+  const signal = init?.signal ?? AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS)
+  const response = await fetch(input, { ...init, headers, signal })
+
+  // kc-agent generates a new token on each restart. If we get 401 and we
+  // actually injected our token (caller had no pre-existing Authorization
+  // header), clear the cached token and retry once with a fresh one.
+  const weInjectedToken = token && !new Headers(init?.headers).has('Authorization')
+  if (response.status === 401 && weInjectedToken) {
+    localStorage.removeItem(AGENT_TOKEN_STORAGE_KEY)
+    agentTokenPromise = null
+    agentTokenNegativeCacheUntil = 0
+    const freshToken = await getAgentToken()
+    if (freshToken && freshToken !== token) {
+      const retryHeaders = new Headers(init?.headers)
+      retryHeaders.set('Authorization', `Bearer ${freshToken}`)
+      if (!retryHeaders.has('X-Requested-With')) {
+        retryHeaders.set('X-Requested-With', 'XMLHttpRequest')
+      }
+      return fetch(input, { ...init, headers: retryHeaders, signal })
+    }
+  }
+
+  return response
+}

--- a/web/src/hooks/mcp/clusterUtils.ts
+++ b/web/src/hooks/mcp/clusterUtils.ts
@@ -1,0 +1,13 @@
+/**
+ * clusterUtils — convenience re-export barrel for cluster utility functions.
+ *
+ * Phase 1: Re-exports from shared.ts so consumers can import from a stable
+ *          path without pulling in the entire cluster cache.
+ * Phase 2 (#11530): Flip direction — move implementations here, make shared.ts
+ *                   import from this module.
+ */
+export {
+  clusterDisplayName,
+  shareMetricsBetweenSameServerClusters,
+  deduplicateClustersByServer,
+} from './shared'

--- a/web/src/hooks/mcp/fetchWithRetry.ts
+++ b/web/src/hooks/mcp/fetchWithRetry.ts
@@ -1,0 +1,100 @@
+import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants'
+import { agentFetch } from './agentFetch'
+
+/** Options for fetchWithRetry */
+export interface FetchWithRetryOptions extends RequestInit {
+  /** Maximum number of retry attempts (default: 2, so 3 total attempts) */
+  maxRetries?: number
+  /** Initial backoff delay in ms (default: 500). Doubles on each retry. */
+  initialBackoffMs?: number
+  /** Timeout per attempt in ms (default: MCP_HOOK_TIMEOUT_MS) */
+  timeoutMs?: number
+}
+
+/**
+ * Returns true for errors that are worth retrying: network failures and timeouts.
+ */
+function isTransientError(error: unknown): boolean {
+  // Network error (fetch throws TypeError on network failure)
+  if (error instanceof TypeError) return true
+  // AbortError from timeout — worth retrying
+  if (error instanceof DOMException && error.name === 'AbortError') return true
+  return false
+}
+
+/**
+ * Fetch with automatic retry on transient failures.
+ *
+ * Retries when:
+ * - The fetch itself throws (network error, DNS failure, timeout)
+ * - The server returns a 5xx status code
+ *
+ * Does NOT retry on:
+ * - 4xx errors (client errors — retrying won't help)
+ * - Successful responses (2xx/3xx)
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: FetchWithRetryOptions = {},
+): Promise<Response> {
+  const {
+    maxRetries = 2,
+    initialBackoffMs = 500,
+    timeoutMs = MCP_HOOK_TIMEOUT_MS,
+    ...fetchOptions
+  } = options
+
+  let lastError: unknown
+  const totalAttempts = maxRetries + 1
+
+  for (let attempt = 0; attempt < totalAttempts; attempt++) {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+    // Named handler so we can remove it after fetch completes (#4772)
+    const onCallerAbort = () => controller.abort()
+    if (fetchOptions.signal) {
+      fetchOptions.signal.addEventListener('abort', onCallerAbort)
+    }
+
+    try {
+      const response = await agentFetch(url, {
+        ...fetchOptions,
+        signal: controller.signal,
+      })
+      clearTimeout(timeoutId)
+
+      // Don't retry on 4xx — those are permanent client errors
+      if (response.status >= 400 && response.status < 500) {
+        return response
+      }
+
+      // Retry on 5xx server errors (unless this is the last attempt)
+      if (response.status >= 500 && attempt < totalAttempts - 1) {
+        lastError = new Error(`Server error: ${response.status}`)
+        const backoff = initialBackoffMs * Math.pow(2, attempt)
+        await new Promise(resolve => setTimeout(resolve, backoff))
+        continue
+      }
+
+      return response
+    } catch (err: unknown) {
+      clearTimeout(timeoutId)
+      lastError = err
+      // Only retry on transient errors
+      if (!isTransientError(err) || attempt >= totalAttempts - 1) {
+        throw err
+      }
+      const backoff = initialBackoffMs * Math.pow(2, attempt)
+      await new Promise(resolve => setTimeout(resolve, backoff))
+    } finally {
+      // Remove abort listener to prevent accumulation (#4772)
+      if (fetchOptions.signal) {
+        fetchOptions.signal.removeEventListener('abort', onCallerAbort)
+      }
+    }
+  }
+
+  // Should not reach here, but just in case
+  throw lastError
+}

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -8,7 +8,6 @@ import { resetFailuresForCluster, resetAllCacheFailures } from '../../lib/cache'
 import { clusterCacheRef, setClusterCacheRefClusters } from './clusterCacheRef'
 import { hostnameEndsWith, hostnameContainsLabel } from '../../lib/utils/urlHostname'
 import { appendWsAuthToken } from '../../lib/utils/wsAuth'
-import { emitAgentTokenFailure } from '../../lib/analytics'
 import { MS_PER_MINUTE } from '../../lib/constants/time'
 import {
   LOCAL_AGENT_HTTP_URL,
@@ -17,8 +16,9 @@ import {
   DEFAULT_REFRESH_INTERVAL_MS,
 } from '../../lib/constants'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants/storage'
-import { MCP_PROBE_TIMEOUT_MS, FOCUS_DELAY_MS, KUBECTL_MAX_TIMEOUT_MS, isLocalAgentSuppressed } from '../../lib/constants/network'
+import { MCP_PROBE_TIMEOUT_MS, FOCUS_DELAY_MS, KUBECTL_MAX_TIMEOUT_MS } from '../../lib/constants/network'
 import type { ClusterInfo, ClusterHealth } from './types'
+import { LOCAL_AGENT_URL, agentFetch, _resetAgentTokenState, AGENT_TOKEN_STORAGE_KEY } from './agentFetch'
 
 // Re-export canonical constant under the name used by MCP hooks
 export const REFRESH_INTERVAL_MS = DEFAULT_REFRESH_INTERVAL_MS
@@ -50,123 +50,8 @@ const CLUSTER_NOTIFY_DEBOUNCE_MS = 50
 // Minimum time to show the "Updating" indicator (ensures visibility for fast API responses)
 export const MIN_REFRESH_INDICATOR_MS = 500
 
-// Re-export for backward compatibility
-export const LOCAL_AGENT_URL = LOCAL_AGENT_HTTP_URL
-
-const AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'
-const AGENT_TOKEN_FETCH_TIMEOUT_MS = 5000
-/** How long to remember that the backend returned no token (avoids repeated 5s timeouts). */
-const AGENT_TOKEN_NEGATIVE_CACHE_MS = 30_000
-
-let agentTokenPromise: Promise<string> | null = null
-/** Session-level dedup: only emit one agent_token_failure per page load */
-let agentTokenFailureEmitted = false
-/** Timestamp of last negative result (empty/error) — used for short-TTL in-memory cache. */
-let agentTokenNegativeCacheUntil = 0
-
-/** Reset internal getAgentToken state — exposed for tests only. */
-export function _resetAgentTokenState(): void {
-  agentTokenPromise = null
-  agentTokenFailureEmitted = false
-  agentTokenNegativeCacheUntil = 0
-}
-
-/**
- * Lazily fetch the kc-agent token from the backend. The token is cached
- * in localStorage so subsequent calls (and page reloads) don't re-fetch.
- *
- * On Netlify / demo mode there is no kc-agent backend, so we skip the
- * fetch entirely to avoid 404 → HTML parse errors that pollute GA4
- * (#10643, root cause of the 48-hour blank dashboard in #10398).
- *
- * Negative results (empty token or fetch error) are cached in memory for
- * AGENT_TOKEN_NEGATIVE_CACHE_MS to avoid repeated 5s timeouts (#11120).
- */
-function getAgentToken(): Promise<string> {
-  if (isDemoMode() || isNetlifyDeployment || isLocalAgentSuppressed()) return Promise.resolve('')
-
-  const cached = localStorage.getItem(AGENT_TOKEN_STORAGE_KEY)
-  if (cached) return Promise.resolve(cached)
-
-  // Short-circuit if we recently got an empty/failed result
-  if (Date.now() < agentTokenNegativeCacheUntil) return Promise.resolve('')
-
-  if (!agentTokenPromise) {
-    agentTokenPromise = fetch('/api/agent/token', {
-      credentials: 'include',
-      signal: AbortSignal.timeout(AGENT_TOKEN_FETCH_TIMEOUT_MS),
-    })
-      .then(r => r.ok ? r.json() : { token: '' })
-      .then((data: { token?: string }) => {
-        const token = data.token || ''
-        if (token) {
-          localStorage.setItem(AGENT_TOKEN_STORAGE_KEY, token)
-        } else {
-          agentTokenNegativeCacheUntil = Date.now() + AGENT_TOKEN_NEGATIVE_CACHE_MS
-          if (!agentTokenFailureEmitted) {
-            agentTokenFailureEmitted = true
-            emitAgentTokenFailure('empty token from /api/agent/token')
-          }
-        }
-        agentTokenPromise = null
-        return token
-      })
-      .catch((err) => {
-        agentTokenNegativeCacheUntil = Date.now() + AGENT_TOKEN_NEGATIVE_CACHE_MS
-        if (!agentTokenFailureEmitted) {
-          agentTokenFailureEmitted = true
-          emitAgentTokenFailure(err?.message || 'network error')
-        }
-        agentTokenPromise = null
-        return ''
-      })
-  }
-  return agentTokenPromise
-}
-
-/**
- * Drop-in replacement for `fetch()` that auto-injects the KC_AGENT_TOKEN
- * Authorization header when calling the kc-agent HTTP API. Without this,
- * requests to kc-agent are rejected when KC_AGENT_TOKEN is configured.
- */
-export async function agentFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-  const token = await getAgentToken()
-  const headers = new Headers(init?.headers)
-  if (token && !headers.has('Authorization')) {
-    headers.set('Authorization', `Bearer ${token}`)
-  }
-  // #10000 — CSRF defence-in-depth: state-changing requests must carry a
-  // custom header that browsers never attach to cross-origin form POSTs.
-  // The kc-agent requireCSRF middleware rejects POST/PUT/DELETE/PATCH
-  // without this header.
-  if (!headers.has('X-Requested-With')) {
-    headers.set('X-Requested-With', 'XMLHttpRequest')
-  }
-  // Use caller-provided signal, or fall back to a default timeout
-  const signal = init?.signal ?? AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS)
-  const response = await fetch(input, { ...init, headers, signal })
-
-  // kc-agent generates a new token on each restart. If we get 401 and we
-  // actually injected our token (caller had no pre-existing Authorization
-  // header), clear the cached token and retry once with a fresh one.
-  const weInjectedToken = token && !new Headers(init?.headers).has('Authorization')
-  if (response.status === 401 && weInjectedToken) {
-    localStorage.removeItem(AGENT_TOKEN_STORAGE_KEY)
-    agentTokenPromise = null
-    agentTokenNegativeCacheUntil = 0
-    const freshToken = await getAgentToken()
-    if (freshToken && freshToken !== token) {
-      const retryHeaders = new Headers(init?.headers)
-      retryHeaders.set('Authorization', `Bearer ${freshToken}`)
-      if (!retryHeaders.has('X-Requested-With')) {
-        retryHeaders.set('X-Requested-With', 'XMLHttpRequest')
-      }
-      return fetch(input, { ...init, headers: retryHeaders, signal })
-    }
-  }
-
-  return response
-}
+// agentFetch — extracted to ./agentFetch (auth-injecting fetch wrapper)
+export { LOCAL_AGENT_URL, agentFetch, _resetAgentTokenState } from './agentFetch'
 
 // ============================================================================
 // Shared Cluster State - ensures all useClusters() consumers see the same data
@@ -1961,108 +1846,8 @@ export function getHealthCheckFailures(): number {
   return healthCheckFailures
 }
 
-// ============================================================================
-// fetchWithRetry — Retry wrapper for transient failures (#3258)
-// Retries on network errors and 5xx responses with exponential backoff.
-// ============================================================================
-
-/** Options for fetchWithRetry */
-export interface FetchWithRetryOptions extends RequestInit {
-  /** Maximum number of retry attempts (default: 2, so 3 total attempts) */
-  maxRetries?: number
-  /** Initial backoff delay in ms (default: 500). Doubles on each retry. */
-  initialBackoffMs?: number
-  /** Timeout per attempt in ms (default: MCP_HOOK_TIMEOUT_MS) */
-  timeoutMs?: number
-}
-
-/**
- * Returns true for errors that are worth retrying: network failures and timeouts.
- */
-function isTransientError(error: unknown): boolean {
-  // Network error (fetch throws TypeError on network failure)
-  if (error instanceof TypeError) return true
-  // AbortError from timeout — worth retrying
-  if (error instanceof DOMException && error.name === 'AbortError') return true
-  return false
-}
-
-/**
- * Fetch with automatic retry on transient failures.
- *
- * Retries when:
- * - The fetch itself throws (network error, DNS failure, timeout)
- * - The server returns a 5xx status code
- *
- * Does NOT retry on:
- * - 4xx errors (client errors — retrying won't help)
- * - Successful responses (2xx/3xx)
- */
-export async function fetchWithRetry(
-  url: string,
-  options: FetchWithRetryOptions = {},
-): Promise<Response> {
-  const {
-    maxRetries = 2,
-    initialBackoffMs = 500,
-    timeoutMs = MCP_HOOK_TIMEOUT_MS,
-    ...fetchOptions
-  } = options
-
-  let lastError: unknown
-  const totalAttempts = maxRetries + 1
-
-  for (let attempt = 0; attempt < totalAttempts; attempt++) {
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
-
-    // Named handler so we can remove it after fetch completes (#4772)
-    const onCallerAbort = () => controller.abort()
-    if (fetchOptions.signal) {
-      fetchOptions.signal.addEventListener('abort', onCallerAbort)
-    }
-
-    try {
-      const response = await agentFetch(url, {
-        ...fetchOptions,
-        signal: controller.signal,
-      })
-      clearTimeout(timeoutId)
-
-      // Don't retry on 4xx — those are permanent client errors
-      if (response.status >= 400 && response.status < 500) {
-        return response
-      }
-
-      // Retry on 5xx server errors (unless this is the last attempt)
-      if (response.status >= 500 && attempt < totalAttempts - 1) {
-        lastError = new Error(`Server error: ${response.status}`)
-        const backoff = initialBackoffMs * Math.pow(2, attempt)
-        await new Promise(resolve => setTimeout(resolve, backoff))
-        continue
-      }
-
-      return response
-    } catch (err: unknown) {
-      clearTimeout(timeoutId)
-      lastError = err
-      // Only retry on transient errors
-      if (!isTransientError(err) || attempt >= totalAttempts - 1) {
-        throw err
-      }
-      const backoff = initialBackoffMs * Math.pow(2, attempt)
-      await new Promise(resolve => setTimeout(resolve, backoff))
-    } finally {
-      // Remove abort listener to prevent accumulation (#4772)
-      if (fetchOptions.signal) {
-        fetchOptions.signal.removeEventListener('abort', onCallerAbort)
-      }
-    }
-  }
-
-  // Should not reach here, but just in case
-  throw lastError
-}
+// fetchWithRetry — extracted to ./fetchWithRetry
+export { FetchWithRetryOptions, fetchWithRetry } from './fetchWithRetry'
 
 /** Shorten a cluster name for display — strips context prefix, truncates long names */
 export function clusterDisplayName(name: string): string {

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1847,7 +1847,8 @@ export function getHealthCheckFailures(): number {
 }
 
 // fetchWithRetry — extracted to ./fetchWithRetry
-export { FetchWithRetryOptions, fetchWithRetry } from './fetchWithRetry'
+export type { FetchWithRetryOptions } from './fetchWithRetry'
+export { fetchWithRetry } from './fetchWithRetry'
 
 /** Shorten a cluster name for display — strips context prefix, truncates long names */
 export function clusterDisplayName(name: string): string {


### PR DESCRIPTION
## Summary

Phase 1 of #11530 — split `hooks/mcp/shared.ts` (2085 lines) into focused submodules.

## Changes

### New files
- **`agentFetch.ts`** (125 lines) — agent token lifecycle state + `agentFetch()` auth-injecting fetch wrapper. Standalone: no imports from shared.ts.
- **`fetchWithRetry.ts`** (100 lines) — `FetchWithRetryOptions` + `fetchWithRetry()` generic retry wrapper with exponential backoff. Imports `agentFetch` for retried requests.
- **`clusterUtils.ts`** (13 lines) — re-export barrel: `clusterDisplayName`, `shareMetricsBetweenSameServerClusters`, `deduplicateClustersByServer`. Phase 2 will move implementations here.

### Modified
- **`shared.ts`** — removes agentFetch/fetchWithRetry implementations (227 lines removed), adds `import + re-export` from new submodules. All 21+ existing imports from `./mcp/shared` continue to work unchanged.

## Why

`hooks/mcp/shared.ts` combined 5+ concerns: agent token management, cluster cache state, WebSocket connection, fetch retry logic, distribution detection. Large files slow down code review and prevent tree-shaking. This is Phase 1 of the planned decomposition.

## Testing

Pure structural refactor — no logic changes. All existing imports from `./mcp/shared` resolve via re-exports. CI build + lint validates no broken imports.

## Next (Phase 2)

Move cluster distribution detection, dedup, and cache persistence into `clusterUtils.ts`, reducing shared.ts from ~1870 to ~1300 lines.