### PR TITLE
fix: route cluster fetches through backend API when running in-cluster

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -2,6 +2,7 @@ import { startTransition } from 'react'
 import { api, isBackendUnavailable } from '../../lib/api'
 import { reportAgentDataError, reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode, isNetlifyDeployment, isDemoToken, subscribeDemoMode } from '../../lib/demoMode'
+import { isInClusterMode } from '../useBackendHealth'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { registerCacheReset, triggerAllRefetches } from '../../lib/modeTransition'
 import { resetFailuresForCluster, resetAllCacheFailures } from '../../lib/cache'
@@ -1133,6 +1134,12 @@ async function fetchClusterListFromAgent(): Promise<ClusterInfo[] | null> {
   // On localhost, always attempt to reach the agent — it may be running even if
   // AgentManager has not detected it yet.
   if (isNetlifyDeployment) return null
+
+  // In-cluster Helm deployments have no local kc-agent. Go directly to the
+  // backend API which authenticates via the pod's ServiceAccount. (#10XXX)
+  if (isInClusterMode()) {
+    return fetchClusterListFromBackendAPI()
+  }
 
   // When kagenti or kagent is the preferred backend, fetch clusters from the
   // backend API (/api/mcp/clusters) which works independently of kc-agent.

--- a/web/src/hooks/useBackendHealth.ts
+++ b/web/src/hooks/useBackendHealth.ts
@@ -3,6 +3,19 @@ import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 
 export type BackendStatus = 'connected' | 'disconnected' | 'connecting'
 
+/** sessionStorage key to persist in-cluster detection across page reloads. */
+const SS_IN_CLUSTER_KEY = 'kc-in-cluster'
+
+/** Read in-cluster flag from sessionStorage synchronously (survives reload, not new tabs). */
+function readInClusterFromSession(): boolean {
+  try { return sessionStorage.getItem(SS_IN_CLUSTER_KEY) === 'true' } catch { return false }
+}
+
+/** Persist in-cluster detection so next page load doesn't need to wait for health check. */
+function writeInClusterToSession(): void {
+  try { sessionStorage.setItem(SS_IN_CLUSTER_KEY, 'true') } catch { /* ignore */ }
+}
+
 const POLL_INTERVAL = 15000 // Check every 15 seconds
 const FAILURE_THRESHOLD = 4 // Require 4 consecutive failures before showing "Connection lost"
 // Short timeout for health checks — a healthy backend responds in <100ms.
@@ -22,7 +35,10 @@ class BackendHealthManager {
     status: 'connecting',
     lastCheck: null,
     versionChanged: false,
-    inCluster: false,
+    // Initialize from sessionStorage so isInClusterMode() is true synchronously
+    // on page reload — avoids the timing race where first data fetch fires before
+    // the async /health response comes back.
+    inCluster: readInClusterFromSession(),
   }
   private listeners: Set<(state: BackendState) => void> = new Set()
   private pollInterval: ReturnType<typeof setInterval> | null = null
@@ -109,11 +125,13 @@ class BackendHealthManager {
             version !== this.initialVersion
           )
 
+          const inCluster = data.in_cluster === true
+          if (inCluster) writeInClusterToSession()
           this.setState({
             status: 'connected',
             lastCheck: new Date(),
             versionChanged,
-            inCluster: data.in_cluster === true,
+            inCluster,
           })
         } catch {
           // JSON parse failed — still mark as connected
@@ -199,5 +217,9 @@ export function isBackendConnected(): boolean {
 /** Returns true only when backend is connected AND running in-cluster (not localhost) */
 export function isInClusterMode(): boolean {
   const state = backendHealthManager.getState()
-  return state.status === 'connected' && state.inCluster
+  // Fast path: confirmed by live health check
+  if (state.status === 'connected' && state.inCluster) return true
+  // Synchronous fallback: use value persisted from a previous health check this session.
+  // This avoids the timing race on page reload where data fetches fire before /health responds.
+  return readInClusterFromSession()
 }

--- a/web/src/lib/cache/fetcherUtils.ts
+++ b/web/src/lib/cache/fetcherUtils.ts
@@ -6,6 +6,7 @@
  */
 
 import { isBackendUnavailable } from '../api'
+import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { fetchSSE } from '../sseClient'
 import { clusterCacheRef } from '../../hooks/mcp/clusterCacheRef'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../constants'
@@ -24,15 +25,22 @@ import { validateArrayResponse } from '../schemas/validate'
 const BACKEND_PREF_KEY = 'kc_agent_backend_preference'
 
 /**
- * Returns true when the user has selected kagenti or kagent as their
- * preferred backend.  In that mode data should be routed through the
- * Go backend (`/api/mcp/`) rather than the local kc-agent (port 8585).
- * See issue #10510.
+ * Returns true when data requests should be routed through the Go backend
+ * (`/api/mcp/`) rather than the local kc-agent (port 8585). This is the
+ * case when:
+ * - The user has explicitly selected kagenti or kagent as their preferred
+ *   backend via the agent selector (kc_agent_backend_preference), OR
+ * - The backend is running in-cluster (Helm deployment) — no local kc-agent
+ *   exists in-cluster; the Go backend has ServiceAccount access instead.
+ * See issues #10510, #10XXX.
  */
 export function isClusterModeBackend(): boolean {
   try {
     const pref = localStorage.getItem(BACKEND_PREF_KEY)
-    return pref === 'kagenti' || pref === 'kagent'
+    if (pref === 'kagenti' || pref === 'kagent') return true
+    // In-cluster Helm deployments have no local kc-agent. The Go backend
+    // authenticates via the pod's ServiceAccount — always route through it.
+    return isInClusterMode()
   } catch {
     return false
   }
@@ -163,13 +171,18 @@ function getReachableClusters(): string[] {
 
 // Fetch list of available clusters from backend (fallback)
 export async function fetchClusters(): Promise<string[]> {
-  // First check local agent data - faster and more accurate reachability
-  const localClusters = getReachableClusters()
-  if (localClusters.length > 0) {
-    return localClusters
+  // In-cluster mode: always fetch from the backend directly.
+  // The local kc-agent cluster cache (clusterCacheRef) is not populated
+  // in-cluster (no kc-agent WebSocket), and may hold stale demo cluster
+  // names from a previous session, causing incorrect fan-out.
+  if (!isInClusterMode()) {
+    const localClusters = getReachableClusters()
+    if (localClusters.length > 0) {
+      return localClusters
+    }
   }
 
-  // In cluster mode (kagenti/kagent), route through the Go backend so the
+  // In cluster mode (kagenti/kagent/in-cluster), route through the Go backend so the
   // request reaches the in-cluster service account instead of the absent
   // local kc-agent. (#10510)
   const fetcher = isClusterModeBackend() ? fetchBackendAPI : fetchAPI


### PR DESCRIPTION
## Issue Description

When the console is deployed via Helm in a Kubernetes cluster, there is no local kc-agent running at port 8585. The frontend had no mechanism to detect this and continued routing all data fetches to the absent local agent. The fetch failed silently, and the fallback in `fullFetchClusters()` served stale demo cluster data from the IndexedDB cache, so `/api/mcp/clusters` was never called. The Go backend — which has ServiceAccount access and can serve real cluster data — was completely bypassed.

## Actual Behaviour

- Dashboard showed 12 hardcoded demo clusters regardless of authentication state.
- `/api/mcp/clusters` was never called on any in-cluster deployment.
- The Go backend's ServiceAccount credentials were unused.
- No error surfaced to the user — silent fallback to demo data.

## Changes Made

**`web/src/hooks/mcp/shared.ts`**
- `fetchClusterListFromAgent()` now returns `fetchClusterListFromBackendAPI()` immediately when `isInClusterMode()` is true, matching the existing `isNetlifyDeployment` short-circuit pattern. This ensures `/api/mcp/clusters` is called and stale IndexedDB cache does not block it.

**`web/src/hooks/useBackendHealth.ts`**
- `inCluster` is persisted to `sessionStorage` after the first successful `/health` response.
- `isInClusterMode()` reads from `sessionStorage` as a synchronous fallback so it returns `true` immediately on page reload, eliminating the timing race where data fetches fired before the async health check completed.

**`web/src/lib/cache/fetcherUtils.ts`**
- `isClusterModeBackend()` returns `true` when `isInClusterMode()` so SSE and stream fetchers also route through the backend.
- `fetchClusters()` skips the local agent cluster cache when in-cluster to prevent fan-out to stale cluster names from a previous session.

---

### Checklist

Please ensure the following before submitting your PR:

- [ ] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [ ] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [ ] I have tested the changes locally and ensured they work as expected
- [ ] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
