### PR TITLE
🌱 : feat(agent) implement unit test coverage for OpenAI providers and Prometheus proxy

### DIFF
--- a/pkg/agent/prometheus_test.go
+++ b/pkg/agent/prometheus_test.go
@@ -1,0 +1,111 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/console/pkg/k8s"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestServer_HandlePrometheusQuery(t *testing.T) {
+	// 1. Setup mock Prometheus server
+	promServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify parameters
+		if r.URL.Query().Get("query") != "up" && !strings.Contains(r.URL.Query().Get("query"), "aaaa") {
+			t.Errorf("Unexpected query: %s", r.URL.Query().Get("query"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer promServer.Close()
+
+	// 2. Setup Server with mocked k8sClient
+	k8sClient, _ := k8s.NewMultiClusterClient("")
+	
+	// Inject a fake typed client so GetRestConfig doesn't early-return with error
+	k8sClient.InjectClient("test-cluster", fake.NewSimpleClientset())
+	
+	// Inject our test rest config pointing to the mock server
+	k8sClient.InjectRestConfig("test-cluster", &rest.Config{
+		Host: promServer.URL,
+	})
+
+	server := &Server{
+		k8sClient:      k8sClient,
+		allowedOrigins: []string{"*"},
+	}
+
+	// 3. Test Cases
+	tests := []struct {
+		name       string
+		query      string
+		expectCode int
+	}{
+		{
+			name:       "Success",
+			query:      "/prometheus/query?cluster=test-cluster&namespace=default&query=up",
+			expectCode: http.StatusOK,
+		},
+		{
+			name:       "Missing Parameters",
+			query:      "/prometheus/query?cluster=test-cluster",
+			expectCode: http.StatusBadRequest,
+		},
+		{
+			name:       "Invalid Cluster",
+			query:      "/prometheus/query?cluster=invalid$cluster&namespace=default&query=up",
+			expectCode: http.StatusBadRequest,
+		},
+		{
+			name:       "Query Too Long",
+			query:      "/prometheus/query?cluster=test-cluster&namespace=default&query=" + strings.Repeat("a", maxPromQLQueryLength+1),
+			expectCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.query, nil)
+			w := httptest.NewRecorder()
+
+			server.handlePrometheusQuery(w, req)
+
+			if w.Code != tt.expectCode {
+				t.Errorf("Expected status %d, got %d. Body: %s", tt.expectCode, w.Code, w.Body.String())
+			}
+
+			if tt.expectCode == http.StatusOK {
+				var resp map[string]interface{}
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("Failed to decode response: %v", err)
+				}
+				if resp["status"] != "success" {
+					t.Errorf("Expected status 'success', got %v", resp["status"])
+				}
+			}
+		})
+	}
+}
+
+func TestPromCacheKey(t *testing.T) {
+	config1 := &rest.Config{Host: "http://host1", BearerToken: "token1"}
+	config2 := &rest.Config{Host: "http://host1", BearerToken: "token2"}
+	config3 := &rest.Config{Host: "http://host2", BearerToken: "token1"}
+
+	key1 := promCacheKey(config1)
+	key2 := promCacheKey(config2)
+	key3 := promCacheKey(config3)
+
+	if key1 == key2 {
+		t.Error("Keys for different tokens should differ")
+	}
+	if key1 == key3 {
+		t.Error("Keys for different hosts should differ")
+	}
+}

--- a/pkg/agent/provider_local_openai_compat_test.go
+++ b/pkg/agent/provider_local_openai_compat_test.go
@@ -1,0 +1,126 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestLocalOpenAICompatProvider_Basics(t *testing.T) {
+	p := NewOllamaProvider()
+	if p.Name() != ProviderKeyOllama {
+		t.Errorf("Expected %s, got %s", ProviderKeyOllama, p.Name())
+	}
+	if p.Capabilities() != CapabilityChat {
+		t.Errorf("Expected CapabilityChat, got %v", p.Capabilities())
+	}
+
+	// Test a few more factories
+	if NewLlamaCppProvider().Name() != ProviderKeyLlamaCpp {
+		t.Errorf("Expected %s", ProviderKeyLlamaCpp)
+	}
+	if NewVLLMProvider().Name() != ProviderKeyVLLM {
+		t.Errorf("Expected %s", ProviderKeyVLLM)
+	}
+}
+
+func TestLocalOpenAICompatProvider_URLPrecedence(t *testing.T) {
+	p := &LocalOpenAICompatProvider{
+		providerKey: "test-local",
+		urlEnvVar:   "TEST_LOCAL_URL",
+		defaultURL:  "http://default:11434",
+		chatPath:    "/v1/chat/completions",
+	}
+
+	// 1. Default
+	if url := p.localOpenAICompatBaseURL(); url != "http://default:11434" {
+		t.Errorf("Expected http://default:11434, got %s", url)
+	}
+
+	// 2. Config override
+	cm := GetConfigManager()
+	cm.SetBaseURL("test-local", "http://config:11434")
+	defer cm.RemoveBaseURL("test-local")
+
+	if url := p.localOpenAICompatBaseURL(); url != "http://config:11434" {
+		t.Errorf("Expected http://config:11434, got %s", url)
+	}
+
+	// 3. Env override
+	os.Setenv("TEST_LOCAL_URL", "http://env:11434")
+	defer os.Unsetenv("TEST_LOCAL_URL")
+
+	if url := p.localOpenAICompatBaseURL(); url != "http://env:11434" {
+		t.Errorf("Expected http://env:11434, got %s", url)
+	}
+}
+
+func TestLocalOpenAICompatProvider_IsAvailable(t *testing.T) {
+	p := &LocalOpenAICompatProvider{
+		providerKey: "test-avail",
+		urlEnvVar:   "TEST_AVAIL_URL",
+		defaultURL:  "http://default:11434",
+	}
+
+	// Default: not available (unlike non-local providers, we want explicit opt-in)
+	if p.IsAvailable() {
+		t.Error("Expected not available by default")
+	}
+
+	// Config available
+	cm := GetConfigManager()
+	cm.SetBaseURL("test-avail", "http://config:11434")
+	if !p.IsAvailable() {
+		t.Error("Expected available via config")
+	}
+	cm.RemoveBaseURL("test-avail")
+
+	// Env available
+	os.Setenv("TEST_AVAIL_URL", "http://env:11434")
+	if !p.IsAvailable() {
+		t.Error("Expected available via env")
+	}
+	os.Unsetenv("TEST_AVAIL_URL")
+}
+
+func TestLocalOpenAICompatProvider_Chat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify placeholder key is sent if no key configured
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer "+localLLMPlaceholderKey {
+			t.Errorf("Expected placeholder key, got %q", auth)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"Local response"}}],"usage":{"total_tokens":10}}`))
+	}))
+	defer server.Close()
+
+	p := &LocalOpenAICompatProvider{
+		name:        "test-chat",
+		providerKey: "test-chat",
+		urlEnvVar:   "TEST_CHAT_URL",
+		chatPath:    "/chat",
+	}
+	os.Setenv("TEST_CHAT_URL", server.URL)
+	defer os.Unsetenv("TEST_CHAT_URL")
+
+	// Ensure no key is set for this provider
+	cm := GetConfigManager()
+	cm.RemoveAPIKey("test-chat")
+
+	resp, err := p.Chat(context.Background(), &ChatRequest{Prompt: "Hi"})
+	if err != nil {
+		t.Fatalf("Chat failed: %v", err)
+	}
+	if resp.Content != "Local response" {
+		t.Errorf("Expected 'Local response', got %q", resp.Content)
+	}
+
+	// Verify the placeholder was actually seeded in memory
+	if cm.GetAPIKey("test-chat") != localLLMPlaceholderKey {
+		t.Errorf("Expected seeded placeholder key")
+	}
+}

--- a/pkg/agent/provider_openai_compat_test.go
+++ b/pkg/agent/provider_openai_compat_test.go
@@ -1,0 +1,124 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestChatViaOpenAICompatible(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		var req map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		resp := map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{
+					"message": map[string]interface{}{
+						"content": "Hello from compat",
+					},
+				},
+			},
+			"usage": map[string]interface{}{
+				"prompt_tokens":     10,
+				"completion_tokens": 5,
+				"total_tokens":      15,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cm := GetConfigManager()
+	cm.SetAPIKeyInMemory("test-provider", "test-key")
+
+	req := &ChatRequest{Prompt: "Hi"}
+	resp, err := chatViaOpenAICompatible(context.Background(), req, "test-provider", server.URL, "test-agent")
+	if err != nil {
+		t.Fatalf("chatViaOpenAICompatible failed: %v", err)
+	}
+
+	if resp.Content != "Hello from compat" {
+		t.Errorf("Expected 'Hello from compat', got %q", resp.Content)
+	}
+	if resp.TokenUsage.TotalTokens != 15 {
+		t.Errorf("Expected 15 tokens, got %d", resp.TokenUsage.TotalTokens)
+	}
+}
+
+func TestStreamViaOpenAICompatible(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "data: %s\n\n", `{"choices":[{"delta":{"content":"Hello"}}],"usage":null}`)
+		fmt.Fprintf(w, "data: %s\n\n", `{"choices":[{"delta":{"content":" world"}}],"usage":null}`)
+		fmt.Fprintf(w, "data: %s\n\n", `{"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	cm := GetConfigManager()
+	cm.SetAPIKeyInMemory("test-provider", "test-key")
+
+	var chunks []string
+	onChunk := func(chunk string) {
+		chunks = append(chunks, chunk)
+	}
+
+	req := &ChatRequest{Prompt: "Hi"}
+	resp, err := streamViaOpenAICompatible(context.Background(), req, "test-provider", server.URL, "test-agent", onChunk)
+	if err != nil {
+		t.Fatalf("streamViaOpenAICompatible failed: %v", err)
+	}
+
+	if resp.Content != "Hello world" {
+		t.Errorf("Expected 'Hello world', got %q", resp.Content)
+	}
+	if strings.Join(chunks, "") != "Hello world" {
+		t.Errorf("Expected chunks to join to 'Hello world', got %q", strings.Join(chunks, ""))
+	}
+	if resp.TokenUsage.TotalTokens != 15 {
+		t.Errorf("Expected 15 tokens, got %d", resp.TokenUsage.TotalTokens)
+	}
+}
+
+func TestBuildOpenAIMessages(t *testing.T) {
+	req := &ChatRequest{
+		SystemPrompt: "Be helpful",
+		Prompt:       "How are you?",
+		History: []ChatMessage{
+			{Role: "user", Content: "Hi"},
+			{Role: "assistant", Content: "Hello!"},
+		},
+	}
+
+	msgs := buildOpenAIMessages(req)
+	if len(msgs) != 4 {
+		t.Fatalf("Expected 4 messages, got %d", len(msgs))
+	}
+
+	if msgs[0]["role"] != "system" || msgs[0]["content"] != "Be helpful" {
+		t.Errorf("First message mismatch")
+	}
+	if msgs[1]["role"] != "user" || msgs[1]["content"] != "Hi" {
+		t.Errorf("Second message mismatch")
+	}
+	if msgs[2]["role"] != "assistant" || msgs[2]["content"] != "Hello!" {
+		t.Errorf("Third message mismatch")
+	}
+	if msgs[3]["role"] != "user" || msgs[3]["content"] != "How are you?" {
+		t.Errorf("Fourth message mismatch")
+	}
+}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -217,6 +217,19 @@ func (m *MultiClusterClient) InjectDynamicClient(contextName string, client dyna
 	m.dynamicClients[contextName] = client
 }
 
+// InjectRestConfig injects a rest config for a cluster (for testing)
+func (m *MultiClusterClient) InjectRestConfig(contextName string, config *rest.Config) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.configs == nil {
+		m.configs = make(map[string]*rest.Config)
+	}
+	m.configs[contextName] = config
+}
+
 // Reload reloads the kubeconfig from disk
 func (m *MultiClusterClient) Reload() error {
 	config, err := clientcmd.LoadFromFile(m.kubeconfig)


### PR DESCRIPTION
### 📝 Summary of Changes

This PR implements comprehensive unit test coverage for the AI provider and observability components within `pkg/agent`. It covers OpenAI-compatible provider logic (both streaming and non-streaming), local LLM runner configurations, and the Prometheus metric proxy handler. Additionally, it enhances the `MultiClusterClient` testing infrastructure to support REST configuration injection.

---

### Changes Made

- [x] **Added tests for OpenAI-compatible providers**: Created `pkg/agent/provider_openai_compat_test.go` to verify chat and streaming chat logic, including header injection and token usage reporting.
- [x] **Added tests for local LLM runners**: Created `pkg/agent/provider_local_openai_compat_test.go` to verify URL precedence (Env > Config > Default), availability detection, and automatic sentinel API key seeding for Ollama, vLLM, and others.
- [x] **Added tests for Prometheus proxy**: Created `pkg/agent/prometheus_test.go` to verify security validation of query parameters (cluster/namespace/service), PromQL length limiting, and successful proxying through the K8s API server.
- [x] **Enhanced Testing Infrastructure**: Added `InjectRestConfig` to `MultiClusterClient` in `pkg/k8s/client.go` to allow mocking of Kubernetes REST configurations in unit tests.

---

### Checklist

- [x] I used a coding agent (Antigravity) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] I have written unit tests for the changes
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

```bash
# Running the new tests
$ go test -v ./pkg/agent -run "TestChatViaOpenAICompatible|TestStreamViaOpenAICompatible|TestLocalOpenAICompatProvider|TestServer_HandlePrometheusQuery"
=== RUN   TestChatViaOpenAICompatible
--- PASS: TestChatViaOpenAICompatible (0.00s)
=== RUN   TestStreamViaOpenAICompatible
--- PASS: TestStreamViaOpenAICompatible (0.00s)
=== RUN   TestLocalOpenAICompatProvider_Basics
--- PASS: TestLocalOpenAICompatProvider_Basics (0.00s)
=== RUN   TestLocalOpenAICompatProvider_URLPrecedence
--- PASS: TestLocalOpenAICompatProvider_URLPrecedence (0.00s)
=== RUN   TestLocalOpenAICompatProvider_IsAvailable
--- PASS: TestLocalOpenAICompatProvider_IsAvailable (0.00s)
=== RUN   TestLocalOpenAICompatProvider_Chat
--- PASS: TestLocalOpenAICompatProvider_Chat (0.00s)
=== RUN   TestServer_HandlePrometheusQuery
--- PASS: TestServer_HandlePrometheusQuery (0.00s)
PASS
ok  	github.com/kubestellar/console/pkg/agent	0.070s
