### PR TITLE
fix(workload): abort multi-cluster deploy on dependency failure

### DIFF
--- a/pkg/api/v1alpha1/workload_types.go
+++ b/pkg/api/v1alpha1/workload_types.go
@@ -110,6 +110,7 @@ type DeployedDep struct {
 	Kind   string `json:"kind"`
 	Name   string `json:"name"`
 	Action string `json:"action"` // "created", "updated", "skipped", "failed"
+	Error  string `json:"error,omitempty"`
 }
 
 // DeployResponse represents the response from a deploy request

--- a/pkg/k8s/workload.go
+++ b/pkg/k8s/workload.go
@@ -723,7 +723,26 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 			depResults := applyDependencies(clusterCtx, targetClient, bundle.Dependencies)
 			mu.Lock()
 			allDepResults = append(allDepResults, depResults...)
+			
+			// Check if any dependency failed to deploy
+			hasFailedDep := false
+			for _, dr := range depResults {
+				if dr.Action == "failed" {
+					failed = append(failed, targetCluster)
+					if dr.Error != "" {
+						errs = append(errs, fmt.Errorf("cluster %s: dependency %s/%s failed: %s", targetCluster, dr.Kind, dr.Name, dr.Error))
+					} else {
+						errs = append(errs, fmt.Errorf("cluster %s: dependency %s/%s failed", targetCluster, dr.Kind, dr.Name))
+					}
+					hasFailedDep = true
+					break // Record one failure reason per cluster to avoid spam
+				}
+			}
 			mu.Unlock()
+			
+			if hasFailedDep {
+				return // Abort workload deployment for this cluster if deps failed
+			}
 
 			// 4c. Apply the workload itself
 			objCopy := cleanedObj.DeepCopy()
@@ -888,6 +907,7 @@ func applyDependencies(
 			_, err = resource.Update(ctx, objCopy, metav1.UpdateOptions{})
 			if err != nil {
 				result.Action = "failed"
+				result.Error = err.Error()
 				slog.Error("[deploy] failed to update dependency", "kind", dep.Kind, "name", dep.Name, "error", err)
 			} else {
 				result.Action = "updated"
@@ -898,6 +918,7 @@ func applyDependencies(
 			_, err = resource.Create(ctx, objCopy, metav1.CreateOptions{})
 			if err != nil {
 				result.Action = "failed"
+				result.Error = err.Error()
 				slog.Error("[deploy] failed to create dependency", "kind", dep.Kind, "name", dep.Name, "error", err)
 			} else {
 				result.Action = "created"
@@ -906,6 +927,7 @@ func applyDependencies(
 		} else {
 			// Real error (network, RBAC, etc.) — do not assume resource is missing
 			result.Action = "failed"
+			result.Error = err.Error()
 			slog.Error("[deploy] failed to check dependency", "kind", dep.Kind, "name", dep.Name, "error", err)
 		}
 

--- a/pkg/k8s/workload_test.go
+++ b/pkg/k8s/workload_test.go
@@ -2,6 +2,8 @@ package k8s
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -528,5 +530,104 @@ func TestDeployWorkload(t *testing.T) {
 	_, srcErr := sourceClient.Resource(gvr).Namespace("default").Get(context.Background(), "dep1", metav1.GetOptions{})
 	if srcErr != nil {
 		t.Errorf("Source should still have dep1: %v", srcErr)
+	}
+}
+
+func TestDeployWorkloadWithFailingDependency(t *testing.T) {
+	deployObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "dep1",
+				"namespace": "default",
+				"labels":    map[string]interface{}{"app": "nginx"},
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "c1",
+								"image": "nginx",
+							},
+						},
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "vol1",
+								"secret": map[string]interface{}{
+									"secretName": "sec1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	secObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      "sec1",
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	gvrMap := buildTestGVRMap()
+
+	sourceClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrMap, deployObj, secObj)
+	sourceClient.PrependReactor("list", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{
+			Object: map[string]interface{}{"kind": "DeploymentList", "apiVersion": "apps/v1"},
+			Items:  []unstructured.Unstructured{*deployObj},
+		}, nil
+	})
+
+	sourceClient.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, secObj, nil
+	})
+
+	targetClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrMap)
+
+	// Make sure target client fails when creating the secret
+	targetClient.PrependReactor("create", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated admission webhook failure for secret")
+	})
+
+	m, _ := NewMultiClusterClient("")
+	m.rawConfig = &api.Config{Contexts: map[string]*api.Context{
+		"src": {Cluster: "source"},
+		"tgt": {Cluster: "target"},
+	}}
+	m.dynamicClients["src"] = sourceClient
+	m.dynamicClients["tgt"] = targetClient
+
+	opts := &DeployOptions{DeployedBy: "test-user"}
+	resp, err := m.DeployWorkload(context.Background(), "src", "default", "dep1", []string{"tgt"}, 5, opts)
+	if err != nil {
+		t.Fatalf("DeployWorkload returned an error instead of handling partial failure: %v", err)
+	}
+
+	if resp.Success {
+		t.Errorf("Expected failure because the dependency failed to deploy, got Success=true")
+	}
+
+	if len(resp.DeployedTo) > 0 {
+		t.Errorf("Expected no successful deployment to target cluster, got %v", resp.DeployedTo)
+	}
+
+	if len(resp.FailedClusters) != 1 || resp.FailedClusters[0] != "tgt" {
+		t.Errorf("Expected target cluster to be in FailedClusters, got %v", resp.FailedClusters)
+	}
+
+	if !strings.Contains(resp.Message, "simulated admission webhook failure for secret") {
+		t.Errorf("Expected error message to contain simulated failure, got: %s", resp.Message)
 	}
 }


### PR DESCRIPTION


###  Fixes

Fixes #11554

---

###  Summary of Changes

- Fixed a critical false-positive success scenario in multi-cluster workload deployment
- Ensured dependency application results are validated before deploying primary workloads
- Prevented deployments from succeeding when required dependencies (Secrets, ConfigMaps, etc.) fail
- Added test coverage to prevent regression of silent dependency failures

---

### Changes Made

- [x] Updated `MultiClusterClient.DeployWorkload` to validate `depResults` after `applyDependencies`
- [x] Added early abort logic when any dependency returns `Action == "failed"`
- [x] Ensured failed clusters are correctly tracked and surfaced in the response
- [x] Propagated dependency failure errors to the top-level response
- [x] Prevented primary workload deployment when dependencies fail
- [x] Added unit test `TestDeployWorkloadWithFailingDependency` in `pkg/k8s/workload_test.go`

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [x] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

N/A (backend logic fix, no UI changes)

---

###  Reviewer Notes

**Root Issue:**
Previously, dependency deployment failures were ignored. Even if critical resources like Secrets failed to deploy (due to RBAC, quotas, etc.), the system proceeded with the primary workload and returned `Success: true`.

**Fix Behavior:**
- The deployment process now validates dependency results immediately.
- If any dependency fails:
  - The target cluster is marked as failed
  - The workload deployment is aborted for that cluster
  - The error is surfaced in the response

**Impact:**
- Eliminates false-positive success states
- Prevents broken workloads (e.g., pods stuck in `CreateContainerConfigError`)
- Improves reliability of multi-cluster orchestration
- Ensures CI/CD systems correctly detect failures

**Test Coverage:**
- Added a regression test simulating a failing Secret deployment using fake clients
- Verifies:
  - `Success == false`
  - Cluster is listed in `FailedClusters`
  - Error message reflects dependency failure

---
