### PR TITLE
🐛 Fix test failure in Coverage Suite run #1968

### DIFF
--- a/web/src/hooks/__tests__/useDiagnoseRepairLoop.test.ts
+++ b/web/src/hooks/__tests__/useDiagnoseRepairLoop.test.ts
@@ -280,6 +280,10 @@ describe('useDiagnoseRepairLoop', () => {
     act(() => { hook.result.current.approveAllRepairs() })
     act(() => { hook.result.current.executeRepairs() })
 
+    // Regression guard (#11560/#11562): the stale *diagnosis* mission is
+    // already 'completed' at this point. The repair-completion useEffect
+    // must NOT immediately transition past 'repairing' due to that stale
+    // status — it should only fire when the *repair* mission changes.
     expect(hook.result.current.state.phase).toBe('repairing')
     expect(mockSendMessage).toHaveBeenCalledWith('mission-123', expect.stringContaining('Execute'))
 


### PR DESCRIPTION
Fixes #11560

The test `useDiagnoseRepairLoop > executeRepairs sends message to mission and transitions to verifying` was failing because the repair-completion useEffect was immediately triggered by the stale diagnosis mission status.

This was already fixed in #11562 by removing `state.phase` from the effect dependency array. This PR adds a regression guard comment to the test documenting the race condition to prevent future regressions.