### PR TITLE
🐛 fix reviewer-flagged HIGH/MEDIUM issues

### DIFF
--- a/pkg/agent/provider_openai_compat_test.go
+++ b/pkg/agent/provider_openai_compat_test.go
@@ -10,6 +10,24 @@ import (
 	"testing"
 )
 
+// isolateConfigManager replaces the global config manager with a fresh
+// isolated instance backed by a temp directory. This prevents tests from
+// picking up keys from ~/.kc/config.yaml on developer or CI machines, where
+// in-memory keys (lowest precedence) would otherwise be silently overridden
+// by a pre-existing on-disk config.
+func isolateConfigManager(t *testing.T) *ConfigManager {
+	t.Helper()
+	cm := &ConfigManager{
+		configPath:  t.TempDir() + "/config.yaml",
+		config:      &AgentConfig{Agents: make(map[string]AgentKeyConfig)},
+		keyValidity: make(map[string]bool),
+	}
+	old := globalConfigManager
+	globalConfigManager = cm
+	t.Cleanup(func() { globalConfigManager = old })
+	return cm
+}
+
 func TestChatViaOpenAICompatible(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer test-key" {
@@ -42,7 +60,7 @@ func TestChatViaOpenAICompatible(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cm := GetConfigManager()
+	cm := isolateConfigManager(t)
 	cm.SetAPIKeyInMemory("test-provider", "test-key")
 
 	req := &ChatRequest{Prompt: "Hi"}
@@ -61,6 +79,10 @@ func TestChatViaOpenAICompatible(t *testing.T) {
 
 func TestStreamViaOpenAICompatible(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		fmt.Fprintf(w, "data: %s\n\n", `{"choices":[{"delta":{"content":"Hello"}}],"usage":null}`)
 		fmt.Fprintf(w, "data: %s\n\n", `{"choices":[{"delta":{"content":" world"}}],"usage":null}`)
@@ -69,7 +91,7 @@ func TestStreamViaOpenAICompatible(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cm := GetConfigManager()
+	cm := isolateConfigManager(t)
 	cm.SetAPIKeyInMemory("test-provider", "test-key")
 
 	var chunks []string

--- a/web/src/hooks/mcp/workloadQueries.ts
+++ b/web/src/hooks/mcp/workloadQueries.ts
@@ -1501,7 +1501,7 @@ export function useReplicaSets(cluster?: string, namespace?: string): UseReplica
         })
         if (response.ok) {
           const data = await response.json()
-          setReplicaSets(data.replicaSets || [])
+          setReplicaSets(data.replicasets || [])
           setError(null)
           setConsecutiveFailures(0)
           setIsLoading(false)
@@ -1524,7 +1524,7 @@ export function useReplicaSets(cluster?: string, namespace?: string): UseReplica
       const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/replicasets?${params}`)
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
       const data = await resp.json()
-      setReplicaSets(data.replicaSets || [])
+      setReplicaSets(data.replicasets || [])
       setError(null)
       setConsecutiveFailures(0)
     } catch (err: unknown) {
@@ -1814,7 +1814,7 @@ if (typeof window !== 'undefined') {
   registerCacheReset('workloads', () => {
     // Set resetting flag to trigger skeleton display in all subscribed hooks
     setWorkloadsSharedState({
-      cacheVersion: Math.random(), // Change value to force notification
+      cacheVersion: Date.now(), // Monotonically increasing to force notification
       isResetting: true,
     })
     notifyWorkloadsSubscribers()

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -2,9 +2,9 @@
  * Workloads hooks module - orchestrator that re-exports query and subscription functionality.
  *
  * This module was split from a 1880-line god module into:
- * - workloadQueries.ts: Query hooks and their dependencies (~700 lines)
- * - workloadSubscriptions.ts: Subscription state management (~300 lines)
- * - workloads.ts: Type definitions and orchestration (~400 lines)
+ * - workloadQueries.ts: Query hooks and their dependencies (~1852 lines)
+ * - workloadSubscriptions.ts: Subscription state management (~37 lines)
+ * - workloads.ts: Backward-compatible re-exports and orchestration (~63 lines)
  *
  * Issue #11546: Decompose god module for better maintainability.
  */
@@ -24,6 +24,7 @@ export type {
   UseHPAsResult,
   UseReplicaSetsResult,
   UseStatefulSetsResult,
+  UseDaemonSetsResult,
   UseCronJobsResult,
   UsePodLogsResult,
 } from './workloadQueries'

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -885,7 +885,13 @@ function isHttpErrorThrottled(httpStatus: string, page: string): boolean {
   const key = `${page}:${httpStatus}`
   const lastEmit = recentHttpErrorEmissions.get(key)
   if (lastEmit && Date.now() - lastEmit < HTTP_ERROR_THROTTLE_MS) return true
-  recentHttpErrorEmissions.set(key, Date.now())
+  // Only record the timestamp when send() will actually fire. If analytics is
+  // not yet initialized or the user hasn't interacted, send() silently drops
+  // the event — recording the timestamp now would suppress the next real
+  // emission that should be sent, causing under-reporting.
+  if (initialized && userHasInteracted) {
+    recentHttpErrorEmissions.set(key, Date.now())
+  }
   // Prevent unbounded map growth
   if (recentHttpErrorEmissions.size > 100) {
     const now = Date.now()


### PR DESCRIPTION
### HIGH
- **analytics-core.ts:888**: Only record throttle timestamp when `initialized && userHasInteracted` — premature recording suppressed legitimate events after analytics init
- **provider_openai_compat_test.go:50**: `isolateConfigManager(t)` swaps global config singleton to temp-dir instance, preventing disk config from overriding in-memory key
- **provider_openai_compat_test.go:69**: Add Authorization header check to TestStreamViaOpenAICompatible (parity with chat test)

### MEDIUM
- **workloadQueries.ts:1504,1527**: Fix `data.replicaSets` → `data.replicasets` (server returns lowercase-plural; camelCase read always returned `[]`)
- **workloadQueries.ts:1817**: Replace `Math.random()` with `Date.now()` for monotonically increasing cacheVersion
- **workloads.ts:7**: Update module-size doc comments to actual split
- **workloads.ts:26**: Add missing `UseDaemonSetsResult` to type re-exports