### PR TITLE
🐛 Wrap localStorage.getItem in try/catch in MatchGame

### DIFF
--- a/web/src/components/cards/MatchGame.tsx
+++ b/web/src/components/cards/MatchGame.tsx
@@ -74,15 +74,15 @@ export function MatchGame(_props: CardComponentProps) {
 
   // Load high scores from localStorage
   useEffect(() => {
-    const stored = localStorage.getItem('matchGameHighScores')
-    if (stored) {
-      try {
+    try {
+      const stored = localStorage.getItem('matchGameHighScores')
+      if (stored) {
         setHighScores(JSON.parse(stored))
-      } catch {
-        // User-visible toast already communicates the failure; no console
-        // noise needed (#8816).
-        showToast(t('matchGame.errors.highScoresFailed', 'Could not load high scores.'), 'warning')
       }
+    } catch {
+      // User-visible toast already communicates the failure; no console
+      // noise needed (#8816).
+      showToast(t('matchGame.errors.highScoresFailed', 'Could not load high scores.'), 'warning')
     }
   }, [showToast, t])
 


### PR DESCRIPTION
Fixes #11522

The `localStorage.getItem` call in `MatchGame.tsx` (line 77) was outside the try/catch block. If localStorage throws (private browsing, disabled storage, etc.) it would propagate uncaught.

Moved the getItem call inside the existing try/catch. All other files listed in the issue already have proper try/catch wrapping around their localStorage calls.