### PR TITLE
🐛 Fix light theme contrast on Air-Gap and FedRAMP pages

### DIFF
--- a/web/src/components/compliance/AirGapDashboard.tsx
+++ b/web/src/components/compliance/AirGapDashboard.tsx
@@ -41,10 +41,10 @@ const CATEGORIES = ['all', 'registry', 'dns', 'ntp', 'updates', 'telemetry'] as 
 
 const statusIcon = (status: string) => {
   switch (status) {
-    case 'ready': return <CheckCircle2 className="w-4 h-4 text-green-400" />
-    case 'not_ready': return <XCircle className="w-4 h-4 text-red-400" />
-    case 'partial': return <AlertTriangle className="w-4 h-4 text-yellow-400" />
-    default: return <AlertTriangle className="w-4 h-4 text-gray-400" />
+    case 'ready': return <CheckCircle2 className="w-4 h-4 text-green-600 dark:text-green-400" />
+    case 'not_ready': return <XCircle className="w-4 h-4 text-red-600 dark:text-red-400" />
+    case 'partial': return <AlertTriangle className="w-4 h-4 text-yellow-600 dark:text-yellow-400" />
+    default: return <AlertTriangle className="w-4 h-4 text-muted-foreground" />
   }
 }
 
@@ -59,10 +59,10 @@ const statusLabel = (status: string) => {
 
 const statusColor = (status: string) => {
   switch (status) {
-    case 'ready': return 'text-green-400'
-    case 'not_ready': return 'text-red-400'
-    case 'partial': return 'text-yellow-400'
-    default: return 'text-gray-400'
+    case 'ready': return 'text-green-700 dark:text-green-400 font-medium'
+    case 'not_ready': return 'text-red-700 dark:text-red-400 font-medium'
+    case 'partial': return 'text-yellow-700 dark:text-yellow-400 font-medium'
+    default: return 'text-muted-foreground'
   }
 }
 
@@ -105,14 +105,14 @@ export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
 
   if (loading) return (
     <div className="flex items-center justify-center h-64">
-      <Loader2 className="w-8 h-8 animate-spin text-blue-400" />
+      <Loader2 className="w-8 h-8 animate-spin text-primary" />
       <span className="ml-3 text-muted-foreground">Loading air-gap readiness…</span>
     </div>
   )
 
   if (error) return (
     <div className="p-6 bg-red-500/10 border border-red-500/30 rounded-lg">
-      <p className="text-red-400">{error}</p>
+      <p className="text-red-600 dark:text-red-400">{error}</p>
     </div>
   )
 
@@ -132,23 +132,23 @@ export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
       {/* Summary cards */}
       {summary && (
         <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-          <div className="bg-card/50 rounded-lg p-4 border border-border">
+          <div className="bg-card rounded-lg p-4 border border-border shadow-sm">
             <p className="text-sm text-muted-foreground">Overall Readiness</p>
-            <p className="text-2xl font-bold text-foreground">{summary.overall_readiness}%</p>
+            <p className="text-2xl font-bold text-foreground">{summary.overall_readiness ?? 0}%</p>
           </div>
-          <div className="bg-card/50 rounded-lg p-4 border border-border">
+          <div className="bg-card rounded-lg p-4 border border-border shadow-sm">
             <p className="text-sm text-muted-foreground">Total Requirements</p>
             <p className="text-2xl font-bold text-foreground">{summary.total_requirements}</p>
           </div>
-          <div className="bg-card/50 rounded-lg p-4 border border-green-500/30">
+          <div className="bg-card rounded-lg p-4 border border-green-500/30 shadow-sm">
             <p className="text-sm text-muted-foreground">Ready</p>
-            <p className="text-2xl font-bold text-green-600 dark:text-green-400">{summary.ready}</p>
+            <p className="text-2xl font-bold text-green-700 dark:text-green-400">{summary.ready}</p>
           </div>
-          <div className="bg-card/50 rounded-lg p-4 border border-red-500/30">
+          <div className="bg-card rounded-lg p-4 border border-red-500/30 shadow-sm">
             <p className="text-sm text-muted-foreground">Not Ready</p>
-            <p className="text-2xl font-bold text-red-600 dark:text-red-400">{summary.not_ready}</p>
+            <p className="text-2xl font-bold text-red-700 dark:text-red-400">{summary.not_ready}</p>
           </div>
-          <div className="bg-card/50 rounded-lg p-4 border border-yellow-500/30">
+          <div className="bg-card rounded-lg p-4 border border-yellow-500/30 shadow-sm">
             <p className="text-sm text-muted-foreground">Partial</p>
             <p className="text-2xl font-bold text-yellow-700 dark:text-yellow-400">{summary.partial}</p>
           </div>
@@ -162,7 +162,7 @@ export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
             key={tab}
             onClick={() => setActiveTab(tab)}
             className={`px-4 py-2 rounded-t text-sm font-medium transition-colors ${
-              activeTab === tab ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'
+              activeTab === tab ? 'bg-secondary text-foreground' : 'text-muted-foreground hover:text-foreground'
             }`}
           >
             {tab === 'requirements' ? 'Requirements' : tab === 'clusters' ? 'Clusters' : 'Summary'}
@@ -178,28 +178,28 @@ export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
               <button
                 key={cat}
                 onClick={() => setCategoryFilter(cat)}
-                className={`px-3 py-1 rounded text-xs capitalize ${categoryFilter === cat ? 'bg-blue-500 text-white' : 'bg-muted text-muted-foreground'}`}
+                className={`px-3 py-1 rounded text-xs capitalize font-medium ${categoryFilter === cat ? 'bg-primary text-primary-foreground' : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'}`}
               >{cat === 'all' ? 'All Categories' : cat}</button>
             ))}
           </div>
 
-          <div className="bg-card/50 rounded-lg border border-border overflow-hidden">
+          <div className="bg-card rounded-lg border border-border overflow-hidden shadow-sm">
             <table className="w-full text-sm">
               <thead>
-                <tr className="text-muted-foreground border-b border-border">
-                  <th className="text-left p-3">ID</th>
-                  <th className="text-left p-3">Name</th>
-                  <th className="text-left p-3">Category</th>
-                  <th className="text-left p-3">Status</th>
-                  <th className="text-left p-3">Details</th>
+                <tr className="text-muted-foreground border-b border-border bg-muted/50">
+                  <th className="text-left p-3 font-medium">ID</th>
+                  <th className="text-left p-3 font-medium">Name</th>
+                  <th className="text-left p-3 font-medium">Category</th>
+                  <th className="text-left p-3 font-medium">Status</th>
+                  <th className="text-left p-3 font-medium">Details</th>
                 </tr>
               </thead>
               <tbody>
                 {filteredRequirements.map(r => (
                   <tr key={r.id} className="border-b border-border/50 hover:bg-muted/30">
-                    <td className="p-3 font-mono text-blue-600 dark:text-blue-300">{r.id}</td>
+                    <td className="p-3 font-mono text-primary">{r.id}</td>
                     <td className="p-3 text-foreground">{r.name}</td>
-                    <td className="p-3"><span className="px-2 py-0.5 rounded bg-muted text-muted-foreground text-xs capitalize">{r.category}</span></td>
+                    <td className="p-3"><span className="px-2 py-0.5 rounded bg-secondary text-secondary-foreground text-xs capitalize">{r.category}</span></td>
                     <td className="p-3">
                       <span className="flex items-center gap-1.5">
                         {statusIcon(r.status)}
@@ -219,7 +219,7 @@ export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
       {activeTab === 'clusters' && (
         <div className="space-y-4">
           {clusters.map(cluster => (
-            <div key={cluster.id} className="bg-card/50 rounded-lg border border-border p-4">
+            <div key={cluster.id} className="bg-card rounded-lg border border-border p-4 shadow-sm">
               <div className="flex items-center justify-between mb-3">
                 <div className="flex items-center gap-3">
                   {statusIcon(cluster.status)}
@@ -253,7 +253,7 @@ export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
       {/* Summary tab */}
       {activeTab === 'summary' && summary && (
         <div className="space-y-4">
-          <div className="bg-card/50 rounded-lg border border-border p-6">
+          <div className="bg-card rounded-lg border border-border p-6 shadow-sm">
             <h3 className="text-lg font-semibold text-foreground mb-4">Air-Gap Assessment Overview</h3>
             <div className="grid grid-cols-2 gap-4">
               <div>
@@ -262,7 +262,7 @@ export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">Not Ready</p>
-                <p className="text-xl font-bold text-red-600 dark:text-red-400">{summary.not_ready}</p>
+                <p className="text-xl font-bold text-red-700 dark:text-red-400">{summary.not_ready}</p>
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">Overall Readiness</p>
@@ -278,13 +278,13 @@ export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">Last Evaluated</p>
-                <p className="text-sm text-muted-foreground">{new Date(summary.evaluated_at).toLocaleString()}</p>
+                <p className="text-sm text-foreground">{new Date(summary.evaluated_at).toLocaleString()}</p>
               </div>
             </div>
           </div>
 
           {/* Cluster readiness breakdown */}
-          <div className="bg-card/50 rounded-lg border border-border p-6">
+          <div className="bg-card rounded-lg border border-border p-6 shadow-sm">
             <h3 className="text-lg font-semibold text-foreground mb-4">Cluster Readiness</h3>
             <div className="space-y-3">
               {clusters.map(c => (

--- a/web/src/components/compliance/FedRAMPDashboard.tsx
+++ b/web/src/components/compliance/FedRAMPDashboard.tsx
@@ -45,10 +45,10 @@ interface FedRAMPScore {
 
 const controlStatusIcon = (status: string) => {
   switch (status) {
-    case 'satisfied': return <CheckCircle2 className="w-4 h-4 text-green-400" />
-    case 'partially_satisfied': return <AlertTriangle className="w-4 h-4 text-yellow-400" />
-    case 'planned': return <Clock className="w-4 h-4 text-blue-400" />
-    default: return <XCircle className="w-4 h-4 text-gray-400" />
+    case 'satisfied': return <CheckCircle2 className="w-4 h-4 text-green-600 dark:text-green-400" />
+    case 'partially_satisfied': return <AlertTriangle className="w-4 h-4 text-yellow-600 dark:text-yellow-400" />
+    case 'planned': return <Clock className="w-4 h-4 text-blue-600 dark:text-blue-400" />
+    default: return <XCircle className="w-4 h-4 text-muted-foreground" />
   }
 }
 
@@ -63,19 +63,28 @@ const controlStatusLabel = (status: string) => {
 
 const controlStatusColor = (status: string) => {
   switch (status) {
-    case 'satisfied': return 'text-green-400'
-    case 'partially_satisfied': return 'text-yellow-400'
-    case 'planned': return 'text-blue-400'
-    default: return 'text-gray-400'
+    case 'satisfied': return 'text-green-700 dark:text-green-400 font-medium'
+    case 'partially_satisfied': return 'text-yellow-700 dark:text-yellow-400 font-medium'
+    case 'planned': return 'text-blue-700 dark:text-blue-400 font-medium'
+    default: return 'text-muted-foreground'
+  }
+}
+
+const authorizationStatusStyle = (status: string) => {
+  switch (status) {
+    case 'authorized': return 'text-green-700 dark:text-green-400'
+    case 'in_progress': return 'text-orange-700 dark:text-orange-400'
+    case 'pending': return 'text-yellow-700 dark:text-yellow-400'
+    default: return 'text-foreground'
   }
 }
 
 const milestoneStatusBadge = (status: string) => {
   switch (status) {
-    case 'open': return <span className="px-2 py-0.5 rounded text-xs font-semibold bg-red-500/20 text-red-400 border border-red-500/30">Open</span>
-    case 'delayed': return <span className="px-2 py-0.5 rounded text-xs font-semibold bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">Delayed</span>
-    case 'closed': return <span className="px-2 py-0.5 rounded text-xs font-semibold bg-green-500/20 text-green-400 border border-green-500/30">Closed</span>
-    default: return <span className="px-2 py-0.5 rounded text-xs bg-gray-700 text-gray-300">{status}</span>
+    case 'open': return <span className="px-2 py-0.5 rounded text-xs font-semibold bg-red-500/20 text-red-700 dark:text-red-400 border border-red-500/30">Open</span>
+    case 'delayed': return <span className="px-2 py-0.5 rounded text-xs font-semibold bg-yellow-500/20 text-yellow-700 dark:text-yellow-400 border border-yellow-500/30">Delayed</span>
+    case 'closed': return <span className="px-2 py-0.5 rounded text-xs font-semibold bg-green-500/20 text-green-700 dark:text-green-400 border border-green-500/30">Closed</span>
+    default: return <span className="px-2 py-0.5 rounded text-xs bg-secondary text-secondary-foreground">{status}</span>
   }
 }
 
@@ -118,14 +127,14 @@ export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
 
   if (loading) return (
     <div className="flex items-center justify-center h-64">
-      <Loader2 className="w-8 h-8 animate-spin text-blue-400" />
-      <span className="ml-3 text-gray-300">Loading FedRAMP readiness…</span>
+      <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      <span className="ml-3 text-muted-foreground">Loading FedRAMP readiness…</span>
     </div>
   )
 
   if (error) return (
     <div className="p-6 bg-red-500/10 border border-red-500/30 rounded-lg">
-      <p className="text-red-400">{error}</p>
+      <p className="text-red-600 dark:text-red-400">{error}</p>
     </div>
   )
 
@@ -145,37 +154,37 @@ export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
       {/* Summary cards */}
       {score && (
         <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-          <div className="bg-gray-800/50 rounded-lg p-4 border border-gray-700">
-            <p className="text-sm text-gray-400">Overall Score</p>
-            <p className="text-2xl font-bold text-white">{score.overall_score}%</p>
+          <div className="bg-card rounded-lg p-4 border border-border shadow-sm">
+            <p className="text-sm text-muted-foreground">Overall Score</p>
+            <p className="text-2xl font-bold text-foreground">{score.overall_score}%</p>
           </div>
-          <div className="bg-gray-800/50 rounded-lg p-4 border border-gray-700">
-            <p className="text-sm text-gray-400">Authorization</p>
-            <p className="text-2xl font-bold text-white capitalize">{score.authorization_status}</p>
+          <div className="bg-card rounded-lg p-4 border border-border shadow-sm">
+            <p className="text-sm text-muted-foreground">Authorization</p>
+            <p className={`text-2xl font-bold capitalize ${authorizationStatusStyle(score.authorization_status)}`}>{score.authorization_status.replace('_', ' ')}</p>
           </div>
-          <div className="bg-gray-800/50 rounded-lg p-4 border border-green-500/30">
-            <p className="text-sm text-gray-400">Satisfied</p>
-            <p className="text-2xl font-bold text-green-400">{score.controls_satisfied}</p>
+          <div className="bg-card rounded-lg p-4 border border-green-500/30 shadow-sm">
+            <p className="text-sm text-muted-foreground">Satisfied</p>
+            <p className="text-2xl font-bold text-green-700 dark:text-green-400">{score.controls_satisfied}</p>
           </div>
-          <div className="bg-gray-800/50 rounded-lg p-4 border border-yellow-500/30">
-            <p className="text-sm text-gray-400">Partial</p>
-            <p className="text-2xl font-bold text-yellow-400">{score.controls_partially_satisfied}</p>
+          <div className="bg-card rounded-lg p-4 border border-yellow-500/30 shadow-sm">
+            <p className="text-sm text-muted-foreground">Partial</p>
+            <p className="text-2xl font-bold text-yellow-700 dark:text-yellow-400">{score.controls_partially_satisfied}</p>
           </div>
-          <div className="bg-gray-800/50 rounded-lg p-4 border border-blue-500/30">
-            <p className="text-sm text-gray-400">Impact Level</p>
-            <p className="text-2xl font-bold text-blue-400 capitalize">{score.impact_level}</p>
+          <div className="bg-card rounded-lg p-4 border border-blue-500/30 shadow-sm">
+            <p className="text-sm text-muted-foreground">Impact Level</p>
+            <p className="text-2xl font-bold text-blue-700 dark:text-blue-400 capitalize">{score.impact_level}</p>
           </div>
         </div>
       )}
 
       {/* Tabs */}
-      <div className="flex gap-2 border-b border-gray-700 pb-2">
+      <div className="flex gap-2 border-b border-border pb-2">
         {(['controls', 'poams', 'readiness'] as const).map(tab => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
             className={`px-4 py-2 rounded-t text-sm font-medium transition-colors ${
-              activeTab === tab ? 'bg-gray-700 text-white' : 'text-gray-400 hover:text-white'
+              activeTab === tab ? 'bg-secondary text-foreground' : 'text-muted-foreground hover:text-foreground'
             }`}
           >
             {tab === 'controls' ? 'Controls' : tab === 'poams' ? 'POAMs' : 'Readiness'}
@@ -191,35 +200,35 @@ export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
               <button
                 key={s}
                 onClick={() => setStatusFilter(s)}
-                className={`px-3 py-1 rounded text-xs ${statusFilter === s ? 'bg-blue-500 text-white' : 'bg-gray-700 text-gray-300'}`}
+                className={`px-3 py-1 rounded text-xs font-medium ${statusFilter === s ? 'bg-primary text-primary-foreground' : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'}`}
               >{s === 'all' ? 'All Statuses' : controlStatusLabel(s)}</button>
             ))}
           </div>
 
-          <div className="bg-gray-800/50 rounded-lg border border-gray-700 overflow-hidden">
+          <div className="bg-card rounded-lg border border-border overflow-hidden shadow-sm">
             <table className="w-full text-sm">
               <thead>
-                <tr className="text-gray-400 border-b border-gray-700">
-                  <th className="text-left p-3">Control</th>
-                  <th className="text-left p-3">Name</th>
-                  <th className="text-left p-3">Family</th>
-                  <th className="text-left p-3">Status</th>
-                  <th className="text-left p-3">Responsible</th>
+                <tr className="text-muted-foreground border-b border-border bg-muted/50">
+                  <th className="text-left p-3 font-medium">Control</th>
+                  <th className="text-left p-3 font-medium">Name</th>
+                  <th className="text-left p-3 font-medium">Family</th>
+                  <th className="text-left p-3 font-medium">Status</th>
+                  <th className="text-left p-3 font-medium">Responsible</th>
                 </tr>
               </thead>
               <tbody>
                 {filteredControls.map(c => (
-                  <tr key={c.id} className="border-b border-gray-700/50 hover:bg-gray-700/30">
-                    <td className="p-3 font-mono text-blue-300">{c.id}</td>
-                    <td className="p-3 text-white">{c.name}</td>
-                    <td className="p-3"><span className="px-2 py-0.5 rounded bg-gray-700 text-gray-300 text-xs">{c.family}</span></td>
+                  <tr key={c.id} className="border-b border-border/50 hover:bg-muted/30">
+                    <td className="p-3 font-mono text-primary">{c.id}</td>
+                    <td className="p-3 text-foreground">{c.name}</td>
+                    <td className="p-3"><span className="px-2 py-0.5 rounded bg-secondary text-secondary-foreground text-xs font-medium">{c.family}</span></td>
                     <td className="p-3">
                       <span className="flex items-center gap-1.5">
                         {controlStatusIcon(c.status)}
                         <span className={controlStatusColor(c.status)}>{controlStatusLabel(c.status)}</span>
                       </span>
                     </td>
-                    <td className="p-3 text-gray-300">{c.responsible}</td>
+                    <td className="p-3 text-foreground">{c.responsible}</td>
                   </tr>
                 ))}
               </tbody>
@@ -230,38 +239,38 @@ export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
 
       {/* POAMs tab */}
       {activeTab === 'poams' && (
-        <div className="bg-gray-800/50 rounded-lg border border-gray-700 overflow-hidden">
+        <div className="bg-card rounded-lg border border-border overflow-hidden shadow-sm">
           <table className="w-full text-sm">
             <thead>
-              <tr className="text-gray-400 border-b border-gray-700">
-                <th className="text-left p-3">POAM ID</th>
-                <th className="text-left p-3">Control</th>
-                <th className="text-left p-3">Title</th>
-                <th className="text-left p-3">Risk</th>
-                <th className="text-left p-3">Status</th>
-                <th className="text-left p-3">Scheduled</th>
-                <th className="text-left p-3">Vendor</th>
+              <tr className="text-muted-foreground border-b border-border bg-muted/50">
+                <th className="text-left p-3 font-medium">POAM ID</th>
+                <th className="text-left p-3 font-medium">Control</th>
+                <th className="text-left p-3 font-medium">Title</th>
+                <th className="text-left p-3 font-medium">Risk</th>
+                <th className="text-left p-3 font-medium">Status</th>
+                <th className="text-left p-3 font-medium">Scheduled</th>
+                <th className="text-left p-3 font-medium">Vendor</th>
               </tr>
             </thead>
             <tbody>
               {poams.map(p => (
-                <tr key={p.id} className="border-b border-gray-700/50 hover:bg-gray-700/30">
-                  <td className="p-3 font-mono text-blue-300">{p.id}</td>
-                  <td className="p-3 text-gray-300">{p.control_id}</td>
-                  <td className="p-3 text-white">{p.title}</td>
+                <tr key={p.id} className="border-b border-border/50 hover:bg-muted/30">
+                  <td className="p-3 font-mono text-primary">{p.id}</td>
+                  <td className="p-3 text-muted-foreground">{p.control_id}</td>
+                  <td className="p-3 text-foreground">{p.title}</td>
                   <td className="p-3">
-                    <span className={`px-2 py-0.5 rounded text-xs ${
-                      p.risk_level === 'high' ? 'bg-red-500/20 text-red-400' :
-                      p.risk_level === 'moderate' ? 'bg-yellow-500/20 text-yellow-400' :
-                      'bg-gray-500/20 text-gray-400'
+                    <span className={`px-2 py-0.5 rounded text-xs font-medium ${
+                      p.risk_level === 'high' ? 'bg-red-500/20 text-red-700 dark:text-red-400' :
+                      p.risk_level === 'moderate' ? 'bg-yellow-500/20 text-yellow-700 dark:text-yellow-400' :
+                      'bg-muted text-muted-foreground'
                     }`}>{p.risk_level}</span>
                   </td>
                   <td className="p-3">{milestoneStatusBadge(p.milestone_status)}</td>
-                  <td className="p-3 text-gray-300 text-xs">{new Date(p.scheduled_completion).toLocaleDateString()}</td>
+                  <td className="p-3 text-muted-foreground text-xs">{new Date(p.scheduled_completion).toLocaleDateString()}</td>
                   <td className="p-3">
                     {p.vendor_dependency
-                      ? <span className="text-yellow-400 text-xs">Yes</span>
-                      : <span className="text-gray-500 text-xs">No</span>
+                      ? <span className="text-yellow-700 dark:text-yellow-400 text-xs font-medium">Yes</span>
+                      : <span className="text-muted-foreground text-xs">No</span>
                     }
                   </td>
                 </tr>
@@ -274,63 +283,63 @@ export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
       {/* Readiness tab */}
       {activeTab === 'readiness' && score && (
         <div className="space-y-4">
-          <div className="bg-gray-800/50 rounded-lg border border-gray-700 p-6">
-            <h3 className="text-lg font-semibold text-white mb-4">FedRAMP Readiness Overview</h3>
+          <div className="bg-card rounded-lg border border-border p-6 shadow-sm">
+            <h3 className="text-lg font-semibold text-foreground mb-4">FedRAMP Readiness Overview</h3>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <p className="text-sm text-gray-400">Total Controls</p>
-                <p className="text-xl font-bold text-white">{score.controls_total}</p>
+                <p className="text-sm text-muted-foreground">Total Controls</p>
+                <p className="text-xl font-bold text-foreground">{score.controls_total}</p>
               </div>
               <div>
-                <p className="text-sm text-gray-400">Authorization Status</p>
-                <p className="text-xl font-bold text-white capitalize">{score.authorization_status}</p>
+                <p className="text-sm text-muted-foreground">Authorization Status</p>
+                <p className={`text-xl font-bold capitalize ${authorizationStatusStyle(score.authorization_status)}`}>{score.authorization_status.replace('_', ' ')}</p>
               </div>
               <div>
-                <p className="text-sm text-gray-400">Overall Score</p>
+                <p className="text-sm text-muted-foreground">Overall Score</p>
                 <div className="flex items-center gap-2">
-                  <div className="flex-1 h-3 bg-gray-700 rounded-full overflow-hidden">
+                  <div className="flex-1 h-3 bg-muted rounded-full overflow-hidden">
                     <div
                       className="h-full bg-linear-to-r from-blue-500 to-green-500 rounded-full"
                       style={{ width: `${score.overall_score}%` }}
                     />
                   </div>
-                  <span className="text-white font-bold">{score.overall_score}%</span>
+                  <span className="text-foreground font-bold">{score.overall_score}%</span>
                 </div>
               </div>
               <div>
-                <p className="text-sm text-gray-400">Impact Level</p>
-                <p className="text-xl font-bold text-blue-400 capitalize">{score.impact_level}</p>
+                <p className="text-sm text-muted-foreground">Impact Level</p>
+                <p className="text-xl font-bold text-blue-700 dark:text-blue-400 capitalize">{score.impact_level}</p>
               </div>
               <div>
-                <p className="text-sm text-gray-400">Open POAMs</p>
-                <p className="text-xl font-bold text-red-400">{score.poams_open}</p>
+                <p className="text-sm text-muted-foreground">Open POAMs</p>
+                <p className="text-xl font-bold text-red-700 dark:text-red-400">{score.poams_open}</p>
               </div>
               <div>
-                <p className="text-sm text-gray-400">Last Evaluated</p>
-                <p className="text-sm text-gray-300">{new Date(score.evaluated_at).toLocaleString()}</p>
+                <p className="text-sm text-muted-foreground">Last Evaluated</p>
+                <p className="text-sm text-foreground">{new Date(score.evaluated_at).toLocaleString()}</p>
               </div>
             </div>
           </div>
 
           {/* Control status breakdown */}
-          <div className="bg-gray-800/50 rounded-lg border border-gray-700 p-6">
-            <h3 className="text-lg font-semibold text-white mb-4">Control Status Breakdown</h3>
+          <div className="bg-card rounded-lg border border-border p-6 shadow-sm">
+            <h3 className="text-lg font-semibold text-foreground mb-4">Control Status Breakdown</h3>
             <div className="space-y-3">
               {[
-                { label: 'Satisfied', count: score.controls_satisfied, color: 'bg-green-500', textColor: 'text-green-400' },
-                { label: 'Partially Satisfied', count: score.controls_partially_satisfied, color: 'bg-yellow-500', textColor: 'text-yellow-400' },
-                { label: 'Planned', count: score.controls_planned, color: 'bg-blue-500', textColor: 'text-blue-400' },
+                { label: 'Satisfied', count: score.controls_satisfied, color: 'bg-green-500', textColor: 'text-green-700 dark:text-green-400' },
+                { label: 'Partially Satisfied', count: score.controls_partially_satisfied, color: 'bg-yellow-500', textColor: 'text-yellow-700 dark:text-yellow-400' },
+                { label: 'Planned', count: score.controls_planned, color: 'bg-blue-500', textColor: 'text-blue-700 dark:text-blue-400' },
               ].map(item => (
                 <div key={item.label} className="flex items-center gap-3">
-                  <span className="w-40 text-sm text-gray-300">{item.label}</span>
-                  <div className="flex-1 h-2 bg-gray-700 rounded-full overflow-hidden">
+                  <span className="w-40 text-sm text-foreground">{item.label}</span>
+                  <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
                     <div
                       className={`h-full ${item.color} rounded-full`}
                       style={{ width: score.controls_total > 0 ? `${(item.count / score.controls_total) * 100}%` : '0%' }}
                     />
                   </div>
                   <span className={`text-sm w-12 text-right font-bold ${item.textColor}`}>{item.count}</span>
-                  <ArrowRight className="w-4 h-4 text-gray-500" />
+                  <ArrowRight className="w-4 h-4 text-muted-foreground" />
                 </div>
               ))}
             </div>


### PR DESCRIPTION
Fixes #11550
Fixes #11551

## Changes

- Replace hardcoded dark theme colors (`bg-gray-800/50`, `text-gray-400`, `text-white`, `border-gray-700`) with semantic Tailwind classes (`bg-card`, `text-foreground`, `text-muted-foreground`, `border-border`, `bg-secondary`)
- Fix missing Overall Readiness numeric value with nullish coalescing fallback
- Add proper semantic status colors with `dark:` variants for both themes
- Add `authorizationStatusStyle` for FedRAMP authorization badge (orange for in_progress)
- Improve table readability with `bg-muted/50` header backgrounds and consistent borders
- Improve filter chip visibility with `bg-primary`/`bg-secondary` patterns
- Add `shadow-sm` to cards for better visual separation in light theme
- Add `font-medium` to status labels for better visual hierarchy