### PR TITLE
🌱 Replace inline spacing values with shared tooltip constants

### DIFF
--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -40,6 +40,7 @@ import {
 } from '../../lib/constants'
 import { hexToRgba } from '../../lib/theme/chartColors'
 import { MS_PER_DAY } from '../../lib/constants/time'
+import { TOOLTIP_INLINE_GAP_PX } from '../../lib/llmd/tooltipSpacing'
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
@@ -412,7 +413,7 @@ const IssueActivityChart = memo(function IssueActivityChart(props: { config?: Is
           const dateLabel = `<span style="color:${CHART_TOOLTIP_LABEL_COLOR};font-weight:600">${dow}, ${fullDate}</span>`
           const lines = params.map(
             p =>
-              `<span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:${p.color};margin-right:6px;"></span>${p.seriesName}: <b>${p.value}</b>`
+              `<span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:${p.color};margin-right:${TOOLTIP_INLINE_GAP_PX}px;"></span>${p.seriesName}: <b>${p.value}</b>`
           )
           return `${dateLabel}<br/>${lines.join('<br/>')}`
         },

--- a/web/src/components/cards/cluster-resource-tree/ClusterResourceTree.tsx
+++ b/web/src/components/cards/cluster-resource-tree/ClusterResourceTree.tsx
@@ -8,7 +8,7 @@ import { useCardLoadingState } from '../CardDataContext'
 import { CardControls, SortDirection } from '../../ui/CardControls'
 import { CardClusterFilter, CardSearchInput } from '../../../lib/cards/CardComponents'
 import { useChartFilters } from '../../../lib/cards/cardHooks'
-import { TreeNode } from './TreeRenderer'
+import { TreeNode, INDENT_PER_LEVEL_PX, BASE_PADDING_LEFT_PX } from './TreeRenderer'
 import { ResourceIcon, SORT_OPTIONS } from './types'
 import { buildNamespaceResources, getVisibleNamespaces, getIssueCounts, getPodsForDeployment } from './TreeBuilder'
 import type { ClusterResourceTreeProps, TreeLens, SortByOption, NamespaceResources, ClusterDataCache } from './types'
@@ -24,7 +24,7 @@ function TruncatedIndicator({ total, shown, indent }: { total: number; shown: nu
   return (
     <div
       className="text-xs text-muted-foreground py-1 px-2"
-      style={{ paddingLeft: `${indent * 16 + 8}px` }}
+      style={{ paddingLeft: `${indent * INDENT_PER_LEVEL_PX + BASE_PADDING_LEFT_PX}px` }}
     >
       +{total - shown} more
     </div>

--- a/web/src/components/cards/cluster-resource-tree/TreeRenderer.tsx
+++ b/web/src/components/cards/cluster-resource-tree/TreeRenderer.tsx
@@ -3,9 +3,9 @@ import { StatusIndicator } from '../../charts/StatusIndicator'
 import type { TreeNodeProps } from './types'
 
 /** Pixels of horizontal indent per tree nesting level */
-const INDENT_PER_LEVEL_PX = 16
+export const INDENT_PER_LEVEL_PX = 16
 /** Base left padding for tree nodes */
-const BASE_PADDING_LEFT_PX = 8
+export const BASE_PADDING_LEFT_PX = 8
 
 interface TreeNodeInternalProps extends TreeNodeProps {
   expandedNodes: Set<string>

--- a/web/src/components/cards/llmd/ParetoFrontier.tsx
+++ b/web/src/components/cards/llmd/ParetoFrontier.tsx
@@ -25,20 +25,16 @@ import { useTranslation } from 'react-i18next'
 import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
 import { downloadDataUrl } from '../../../lib/download'
 import { CHART_MIN_HEIGHT_PX, CHART_AXIS_FONT_SIZE, CHART_AXIS_FONT_SIZE_SM } from '../../../lib/constants/ui'
+import {
+  TOOLTIP_SWATCH_SIZE_PX,
+  TOOLTIP_BADGE_PAD_V_PX,
+  TOOLTIP_GRID_GAP_ROW_PX,
+  TOOLTIP_GRID_GAP_COL_PX,
+  TOOLTIP_BADGE_RADIUS_PX,
+} from '../../../lib/llmd/tooltipSpacing'
 
-// ── Tooltip spacing constants (ECharts renders its own DOM, so Tailwind/CSS vars are unavailable) ──
-/** Spacing between tooltip header and grid body */
-const TOOLTIP_HEADER_MARGIN_PX = '8px'
-/** Horizontal padding for config badge */
-const TOOLTIP_BADGE_PAD_H_PX = '8px'
-/** Vertical padding for config badge */
-const TOOLTIP_BADGE_PAD_V_PX = '2px'
-/** Gap between grid rows */
-const TOOLTIP_GRID_GAP_ROW_PX = '4px'
-/** Gap between grid columns */
-const TOOLTIP_GRID_GAP_COL_PX = '16px'
-/** Badge border-radius */
-const TOOLTIP_BADGE_RADIUS_PX = '4px'
+/** Header bottom margin — larger than the shared 4px token for visual weight */
+const TOOLTIP_HEADER_MARGIN_PX = 8
 
 const LEGEND_PANEL_WIDTH_PX = 130
 
@@ -442,10 +438,10 @@ function ParetoFrontierInternal({ config }: ParetoFrontierProps) {
           const model = getModelShort(pt.model)
           const c = HARDWARE_COLORS[hw] ?? '#6b7280'
           return (
-            `<div style="font-weight:600;margin-bottom:${TOOLTIP_HEADER_MARGIN_PX};color:#f1f5f9">${model} ` +
+            `<div style="font-weight:600;margin-bottom:${TOOLTIP_HEADER_MARGIN_PX}px;color:#f1f5f9">${model} ` +
             `<span style="color:#94a3b8">${hw}</span> ` +
-            `<span style="background:${c}30;color:${c};padding:${TOOLTIP_BADGE_PAD_V_PX} ${TOOLTIP_BADGE_PAD_H_PX};border-radius:${TOOLTIP_BADGE_RADIUS_PX};font-size:10px">${pt.config}</span></div>` +
-            `<div style="display:grid;grid-template-columns:auto auto;gap:${TOOLTIP_GRID_GAP_ROW_PX} ${TOOLTIP_GRID_GAP_COL_PX};font-size:11px">` +
+            `<span style="background:${c}30;color:${c};padding:${TOOLTIP_BADGE_PAD_V_PX}px ${TOOLTIP_SWATCH_SIZE_PX}px;border-radius:${TOOLTIP_BADGE_RADIUS_PX}px;font-size:10px">${pt.config}</span></div>` +
+            `<div style="display:grid;grid-template-columns:auto auto;gap:${TOOLTIP_GRID_GAP_ROW_PX}px ${TOOLTIP_GRID_GAP_COL_PX}px;font-size:11px">` +
             `<span style="color:#94a3b8">Throughput/GPU:</span><span style="font-family:monospace;color:#e2e8f0">${pt.throughputPerGpu.toFixed(0)} tok/s</span>` +
             `<span style="color:#94a3b8">TTFT p50:</span><span style="font-family:monospace;color:#e2e8f0">${pt.ttftP50Ms.toFixed(1)} ms</span>` +
             `<span style="color:#94a3b8">TPOT p50:</span><span style="font-family:monospace;color:#e2e8f0">${pt.tpotP50Ms.toFixed(2)} ms/tok</span>` +

--- a/web/src/lib/llmd/tooltipSpacing.ts
+++ b/web/src/lib/llmd/tooltipSpacing.ts
@@ -21,5 +21,17 @@ export const TOOLTIP_HEADER_MARGIN_PX = 4
 // 6px — inline gap between color swatch and label
 export const TOOLTIP_INLINE_GAP_PX = 6
 
-// 8px — color swatch (dot) diameter
+// 8px — color swatch (dot) diameter; also used for badge horizontal padding
 export const TOOLTIP_SWATCH_SIZE_PX = 8
+
+// ── Badge & grid spacing (used by ParetoFrontier and similar charts) ──
+
+// 2px — badge vertical padding
+export const TOOLTIP_BADGE_PAD_V_PX = 2
+
+// 4px — grid row gap; badge border-radius
+export const TOOLTIP_GRID_GAP_ROW_PX = 4
+export const TOOLTIP_BADGE_RADIUS_PX = 4
+
+// 16px — grid column gap
+export const TOOLTIP_GRID_GAP_COL_PX = 16


### PR DESCRIPTION
Fixes #11564

Centralizes hardcoded px spacing values (4px, 6px, 8px, 16px) into the shared `tooltipSpacing.ts` module and replaces magic numbers in ClusterResourceTree with named constants from TreeRenderer.

**Changes (31 insertions, 22 deletions):**
- `tooltipSpacing.ts`: Added 5 new shared constants (badge padding, grid gaps, border-radius)
- `ParetoFrontier.tsx`: Replaced 6 local duplicate constants with imports from shared module
- `IssueActivityChart.tsx`: Replaced hardcoded `6px` margin with `TOOLTIP_INLINE_GAP_PX`
- `TreeRenderer.tsx`: Exported `INDENT_PER_LEVEL_PX` and `BASE_PADDING_LEFT_PX`
- `ClusterResourceTree.tsx`: Replaced magic numbers `16`/`8` with imported named constants