### PR TITLE
🐛 Fix duplicate AI Missions launcher rendering

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, Suspense } from 'react'
 import { safeLazy } from '../../../lib/safeLazy'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { Sun, Moon, Monitor, Menu, X, MoreVertical, ExternalLink, Sparkles } from 'lucide-react'
+import { Sun, Moon, Monitor, Menu, X, MoreVertical, ExternalLink } from 'lucide-react'
 import { useAuth } from '../../../lib/auth'
 import { useSidebarConfig } from '../../../hooks/useSidebarConfig'
 import { useTheme } from '../../../hooks/useTheme'
@@ -21,7 +21,6 @@ const SearchDropdown = safeLazy(() => import('./SearchDropdown'), 'SearchDropdow
 // Lazy-load AgentSelector — agent UI components (~41 KB) are only needed
 // when a local kc-agent is available (never on console.kubestellar.io).
 const AgentSelector = safeLazy(() => import('../../agent/AgentSelector'), 'AgentSelector')
-import { useMissions } from '../../../hooks/useMissions'
 import { TokenUsageWidget } from './TokenUsageWidget'
 import { ClusterFilterPanel } from './ClusterFilterPanel'
 import { AgentStatusIndicator } from './AgentStatusIndicator'
@@ -46,10 +45,6 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
   const { isMobile } = useMobile()
   const { t } = useTranslation()
   const branding = useBranding()
-  const { missions, isSidebarOpen, openSidebar } = useMissions()
-  const missionsNeedingAttention = missions.filter(m =>
-    m.status === 'waiting_input' || m.status === 'failed'
-  ).length
 
   // Close mobile more menu on route change
   useEffect(() => {
@@ -137,25 +132,6 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
           {/* Update Indicator */}
           <UpdateIndicator />
 
-          {/* AI Missions — opens the mission sidebar */}
-          {!isSidebarOpen && (
-            <Tooltip content={t('help.aiMissions')} side="bottom">
-              <button
-                onClick={openSidebar}
-                className="relative flex items-center gap-1.5 px-3 py-1.5 h-9 text-sm font-medium rounded-lg transition-colors bg-purple-500/10 hover:bg-purple-500/20 text-purple-400 border border-purple-500/20 cursor-pointer"
-                aria-label={t('missionSidebar.openAIMissions')}
-              >
-                <Sparkles className="w-4 h-4" />
-                <span>{t('missionSidebar.aiMissions')}</span>
-                {missionsNeedingAttention > 0 && (
-                  <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center w-5 h-5 text-[10px] font-bold bg-purple-500 text-white rounded-full animate-pulse">
-                    {missionsNeedingAttention}
-                  </span>
-                )}
-              </button>
-            </Tooltip>
-          )}
-
           {/* Visit Streak */}
           <StreakBadge />
 
@@ -239,24 +215,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
                     <div className="border-t border-border mx-3 my-1" />
                   </div>
 
-                  {/* Items hidden at <xl (1280px): AI missions, update, token usage, feature request, tour */}
-                  {!isSidebarOpen && (
-                    <div className="px-3 py-2">
-                      <button
-                        onClick={() => { openSidebar(); setShowMobileMore(false) }}
-                        className="relative flex items-center gap-2 w-full px-3 py-2 text-sm font-medium rounded-lg transition-colors bg-purple-500/10 hover:bg-purple-500/20 text-purple-400 cursor-pointer"
-                        aria-label={t('missionSidebar.openAIMissions')}
-                      >
-                        <Sparkles className="w-4 h-4 shrink-0" />
-                        <span className="truncate min-w-0">{t('missionSidebar.aiMissions')}</span>
-                        {missionsNeedingAttention > 0 && (
-                          <span className="flex items-center justify-center w-5 h-5 text-[10px] font-bold bg-purple-500 text-white rounded-full animate-pulse">
-                            {missionsNeedingAttention}
-                          </span>
-                        )}
-                      </button>
-                    </div>
-                  )}
+                  {/* Items hidden at <xl (1280px): update, token usage, feature request, tour */}
                   <div className="px-3 py-2">
                     <UpdateIndicator showLabel />
                   </div>


### PR DESCRIPTION
Fixes #11574

Removes the duplicate AI Missions open-sidebar buttons from the Navbar. The MissionSidebarToggle floating button (rendered in Layout.tsx) already handles all viewports with richer UX (running count, attention badges, animations), so only one launcher is now rendered on the dashboard.