### PR TITLE
🐛 Fix global filter dropdown not closing on Escape key

### DIFF
--- a/web/src/components/ui/ClusterFilterDropdown.tsx
+++ b/web/src/components/ui/ClusterFilterDropdown.tsx
@@ -71,6 +71,18 @@ export function ClusterFilterDropdown({
     }
   }, [showClusterFilter, calculatePosition])
 
+  // Close dropdown on Escape key (document-level so it works regardless of focus)
+  useEffect(() => {
+    if (!showClusterFilter) return
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setShowClusterFilter(false)
+      }
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [showClusterFilter, setShowClusterFilter])
+
   if (availableClusters.length < minClusters) {
     return null
   }
@@ -116,6 +128,10 @@ export function ClusterFilterDropdown({
               right: dropdownStyle.right,
             }}
             onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                setShowClusterFilter(false)
+                return
+              }
               if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
               e.preventDefault()
               const items = e.currentTarget.querySelectorAll<HTMLElement>('[role="option"]:not([disabled])')


### PR DESCRIPTION
Fixes #11592
Fixes #11593
Fixes #11594
Fixes #11595
Fixes #11596
Fixes #11597
Fixes #11598
Fixes #11599
Fixes #11600
Fixes #11601

Add a document-level Escape key listener to the ClusterFilterDropdown component. When the dropdown is open and the user presses Escape, it now closes properly. This fixes the bug across all pages (Dashboard, Clusters, Deployments, Pods, Services, Settings, Workloads, Events, Operators).

### Changes
- Added a `useEffect` with a document-level `keydown` listener that closes the dropdown on Escape (active only when dropdown is open)
- Added Escape handling in the portal div's `onKeyDown` handler for completeness