### PR TITLE
🌱 Add useModal hook setIsOpen and migrate initial consumers

### DIFF
--- a/web/src/components/gpu/GPUInventoryTab.tsx
+++ b/web/src/components/gpu/GPUInventoryTab.tsx
@@ -13,7 +13,8 @@ import {
   UTILIZATION_MEDIUM_THRESHOLD,
 } from './gpu-constants'
 import { useGPUTaintFilter, GPUTaintFilterControl } from '../cards/GPUTaintFilter'
-import { useRef, useState } from 'react'
+import { useRef } from 'react'
+import { useModal } from '../../hooks/useModal'
 
 export interface GPUInventoryTabProps {
   gpuClusters: GPUClusterInfo[]
@@ -30,7 +31,7 @@ export function GPUInventoryTab({
 }: GPUInventoryTabProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { distinctTaints, toleratedKeys, toggle, clear, isVisible, hiddenGPUCount } = useGPUTaintFilter(nodes)
-  const [isFilterOpen, setIsFilterOpen] = useState(false)
+  const { isOpen: isFilterOpen, setIsOpen: setIsFilterOpen } = useModal()
   const filterRef = useRef<HTMLDivElement>(null)
 
   return (

--- a/web/src/components/nodes/Nodes.tsx
+++ b/web/src/components/nodes/Nodes.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { AlertCircle, ShieldAlert } from 'lucide-react'
 import { useClusters, useGPUNodes } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'

--- a/web/src/components/nodes/Nodes.tsx
+++ b/web/src/components/nodes/Nodes.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { AlertCircle, ShieldAlert } from 'lucide-react'
 import { useClusters, useGPUNodes } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
@@ -9,6 +9,7 @@ import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
 import { RotatingTip } from '../ui/RotatingTip'
 import { useTranslation } from 'react-i18next'
+import { useModal } from '../../hooks/useModal'
 import { useGPUTaintFilter, GPUTaintFilterControl } from '../cards/GPUTaintFilter'
 
 const NODES_CARDS_KEY = 'kubestellar-nodes-cards'
@@ -26,7 +27,7 @@ export function Nodes() {
   const { selectedClusters: globalSelectedClusters, isAllClustersSelected } = useGlobalFilters()
 
   const { isVisible, hiddenGPUCount, distinctTaints, toleratedKeys, toggle, clear } = useGPUTaintFilter(gpuNodes)
-  const [isFilterOpen, setIsFilterOpen] = useState(false)
+  const { isOpen: isFilterOpen, setIsOpen: setIsFilterOpen } = useModal()
   const filterRef = useRef<HTMLDivElement>(null)
 
   // Filter clusters based on global selection

--- a/web/src/components/pods/Pods.tsx
+++ b/web/src/components/pods/Pods.tsx
@@ -6,6 +6,7 @@ import { useCachedPodIssues } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useIsModeSwitching } from '../../lib/unified/demo'
+import { useModal } from '../../hooks/useModal'
 import { StatusIndicator } from '../charts/StatusIndicator'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { Skeleton } from '../ui/Skeleton'
@@ -44,7 +45,7 @@ export function Pods() {
   const { showToast } = useToast()
 
   // State for the custom delete-confirmation dialog
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const deleteConfirm = useModal()
   const [isDeleting, setIsDeleting] = useState(false)
   const pendingDeleteRef = useRef<PendingDeleteTarget | null>(null)
 
@@ -93,7 +94,7 @@ export function Pods() {
   const handleDeletePod = (e: React.MouseEvent, cluster: string, namespace: string, name: string) => {
     e.stopPropagation()
     pendingDeleteRef.current = { cluster, namespace, name }
-    setShowDeleteConfirm(true)
+    deleteConfirm.open()
   }
 
   /** Execute the deletion after the user confirms via ConfirmDialog */
@@ -111,7 +112,7 @@ export function Pods() {
       showToast(t('pods.deleteErrorDetail', 'Failed to delete pod: {{detail}}', { detail }), 'error')
     } finally {
       setIsDeleting(false)
-      setShowDeleteConfirm(false)
+      deleteConfirm.close()
       pendingDeleteRef.current = null
     }
   }, [showToast, t, refetchPodIssues])
@@ -359,8 +360,8 @@ export function Pods() {
       </div>
       {/* Delete-confirmation dialog (replaces window.confirm) */}
       <ConfirmDialog
-        isOpen={showDeleteConfirm}
-        onClose={() => { setShowDeleteConfirm(false); pendingDeleteRef.current = null }}
+        isOpen={deleteConfirm.isOpen}
+        onClose={() => { deleteConfirm.close(); pendingDeleteRef.current = null }}
         onConfirm={executeDeletePod}
         title={t('pods.confirmDeleteTitle', 'Delete Pod')}
         message={t('pods.confirmDeleteMessage', 'Are you sure you want to delete pod {{name}}? This action cannot be undone.', { name: pendingDeleteRef.current?.name ?? '' })}

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useModal } from '../../hooks/useModal'
 import {
   Download,
   RefreshCw,
@@ -143,11 +144,11 @@ export function UpdateSettings() {
     (o) => !o.devOnly || installMethod === 'dev'
   )
 
-  const [showReleaseNotes, setShowReleaseNotes] = useState(false)
-  const [showPrereqs, setShowPrereqs] = useState(false)
-  const [showScopeInfo, setShowScopeInfo] = useState(false)
+  const releaseNotes = useModal()
+  const prereqs = useModal()
+  const scopeInfo = useModal()
   const [copiedCommand, setCopiedCommand] = useState<string | null>(null)
-  const [channelDropdownOpen, setChannelDropdownOpen] = useState(false)
+  const channelDropdown = useModal()
   const [triggerState, setTriggerState] = useState<'idle' | 'triggered' | 'error'>('idle')
   const [triggerError, setTriggerError] = useState<string | null>(null)
   // Tracks a user-requested cancellation so we can show a pending state on the
@@ -350,14 +351,14 @@ export function UpdateSettings() {
       {/* Scope info — explains what System Updates controls vs. other update types */}
       <div className="mb-4">
         <button
-          onClick={() => setShowScopeInfo(!showScopeInfo)}
+          onClick={scopeInfo.toggle}
           className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           <Info className="w-4 h-4" />
           <span>{t('settings.updates.scopeInfoToggle')}</span>
-          {showScopeInfo ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+          {scopeInfo.isOpen ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
         </button>
-        {showScopeInfo && (
+        {scopeInfo.isOpen && (
           <div className="mt-3 rounded-lg bg-secondary/50 border border-border p-4 space-y-3 text-sm">
             <div>
               <span className="font-medium text-foreground">{t('settings.updates.scopeSystemTitle')}</span>
@@ -389,7 +390,7 @@ export function UpdateSettings() {
         </label>
         <div className="relative">
           <button
-            onClick={() => setChannelDropdownOpen(!channelDropdownOpen)}
+            onClick={channelDropdown.toggle}
             className="w-full flex items-center justify-between px-4 py-3 rounded-lg bg-secondary border border-border text-foreground hover:bg-secondary/80 transition-colors"
           >
             <span className="flex items-center gap-2">
@@ -397,17 +398,17 @@ export function UpdateSettings() {
               {visibleChannels.find((o) => o.value === channel)?.label}
             </span>
             <ChevronDown
-              className={`w-4 h-4 transition-transform ${channelDropdownOpen ? 'rotate-180' : ''}`}
+              className={`w-4 h-4 transition-transform ${channelDropdown.isOpen ? 'rotate-180' : ''}`}
             />
           </button>
-          {channelDropdownOpen && (
+          {channelDropdown.isOpen && (
             <div className="absolute z-dropdown mt-2 w-full rounded-lg bg-card border border-border shadow-xl">
               {visibleChannels.map((option) => (
                 <button
                   key={option.value}
                   onClick={() => {
                     setChannel(option.value)
-                    setChannelDropdownOpen(false)
+                    channelDropdown.close()
                   }}
                   className={`w-full flex items-center justify-between px-4 py-3 hover:bg-secondary/50 transition-colors first:rounded-t-lg last:rounded-b-lg ${
                     channel === option.value ? 'bg-primary/10' : ''
@@ -446,7 +447,7 @@ export function UpdateSettings() {
         return (
           <div className="mb-4 rounded-lg bg-secondary/30 border border-border overflow-hidden">
             <button
-              onClick={() => setShowPrereqs(!showPrereqs)}
+              onClick={prereqs.toggle}
               className="w-full flex items-center justify-between px-4 py-3 text-sm hover:bg-secondary/50 transition-colors"
             >
               <div className="flex items-center gap-2">
@@ -459,9 +460,9 @@ export function UpdateSettings() {
                     : t('settings.updates.prereqsMissing', { count: failCount })}
                 </span>
               </div>
-              {showPrereqs ? <ChevronUp className="w-4 h-4 text-muted-foreground" /> : <ChevronDown className="w-4 h-4 text-muted-foreground" />}
+              {prereqs.isOpen ? <ChevronUp className="w-4 h-4 text-muted-foreground" /> : <ChevronDown className="w-4 h-4 text-muted-foreground" />}
             </button>
-            {showPrereqs && (
+            {prereqs.isOpen && (
               <div className="px-4 pb-4 space-y-2 border-t border-border pt-3">
                 <PrereqRow
                   ok={agentConnected}
@@ -965,17 +966,17 @@ export function UpdateSettings() {
       {latestRelease && latestRelease.releaseNotes && (
         <div className="mb-4">
           <button
-            onClick={() => setShowReleaseNotes(!showReleaseNotes)}
+            onClick={releaseNotes.toggle}
             className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
           >
-            {showReleaseNotes ? (
+            {releaseNotes.isOpen ? (
               <ChevronUp className="w-4 h-4" />
             ) : (
               <ChevronDown className="w-4 h-4" />
             )}
             {t('settings.updates.releaseNotes')}
           </button>
-          {showReleaseNotes && (
+          {releaseNotes.isOpen && (
             <div className="mt-2 p-4 rounded-lg bg-secondary/30 border border-border">
               <pre className="text-sm text-muted-foreground whitespace-pre-wrap font-sans">
                 {latestRelease.releaseNotes}

--- a/web/src/hooks/__tests__/useModal.test.ts
+++ b/web/src/hooks/__tests__/useModal.test.ts
@@ -33,6 +33,14 @@ describe('useModal', () => {
     expect(result.current.isOpen).toBe(false)
   })
 
+  it('setIsOpen() sets arbitrary value', () => {
+    const { result } = renderHook(() => useModal())
+    act(() => result.current.setIsOpen(true))
+    expect(result.current.isOpen).toBe(true)
+    act(() => result.current.setIsOpen(false))
+    expect(result.current.isOpen).toBe(false)
+  })
+
   it('returns stable callback references across renders', () => {
     const { result, rerender } = renderHook(() => useModal())
     const firstOpen = result.current.open

--- a/web/src/hooks/useModal.ts
+++ b/web/src/hooks/useModal.ts
@@ -5,6 +5,8 @@ export interface UseModalResult {
   open: () => void
   close: () => void
   toggle: () => void
+  /** Escape hatch for components that accept a raw setter (e.g. `setIsOpen`). */
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 /**
@@ -22,5 +24,5 @@ export function useModal(initialOpen = false): UseModalResult {
   const open = useCallback(() => setIsOpen(true), [])
   const close = useCallback(() => setIsOpen(false), [])
   const toggle = useCallback(() => setIsOpen((v) => !v), [])
-  return { isOpen, open, close, toggle }
+  return { isOpen, open, close, toggle, setIsOpen }
 }


### PR DESCRIPTION
Fixes #11565

Add a reusable `useModal` hook to standardize modal open/close patterns. Migrates initial consumers as proof of concept. The remaining ~1200 instances can be migrated incrementally.

## Changes

- **`useModal.ts`**: Expose `setIsOpen` escape hatch for components that accept a raw state setter (e.g. `GPUTaintFilterControl`)
- **`useModal.test.ts`**: Add test coverage for `setIsOpen`
- **`Nodes.tsx`**: Migrate `isFilterOpen` → `useModal()`
- **`GPUInventoryTab.tsx`**: Migrate `isFilterOpen` → `useModal()`
- **`Pods.tsx`**: Migrate `showDeleteConfirm` → `useModal()` (`deleteConfirm` object)
- **`UpdateSettings.tsx`**: Migrate 4 toggle states (`showReleaseNotes`, `showPrereqs`, `showScopeInfo`, `channelDropdownOpen`) → `useModal()`