### PR TITLE
🐛 Fix cluster fetch error handling in Storage cards

### DIFF
--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -139,6 +139,18 @@ export function StorageOverview() {
     )
   }
 
+  // When all cluster fetches have failed, show unified error state instead of
+  // rendering misleading partial/empty data from stale cache (#11539).
+  if (isFailed && !isDemoFallback && !isDemoMode) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <AlertTriangle className="w-8 h-8 mb-2 text-red-400 opacity-70" />
+        <p className="text-sm text-red-400">{t('storageOverview.allFetchesFailed')}</p>
+        <p className="text-xs mt-1 text-center px-4">{t('storageOverview.allFetchesFailedHint')}</p>
+      </div>
+    )
+  }
+
   return (
     <div className="h-full flex flex-col">
       {/* Controls */}

--- a/web/src/components/cards/longhorn_status/index.tsx
+++ b/web/src/components/cards/longhorn_status/index.tsx
@@ -240,6 +240,23 @@ export function LonghornStatus() {
     )
   }
 
+  // When all cluster fetches have failed, show unified error state instead of
+  // rendering misleading partial/empty data from stale cache (#11539).
+  if (isFailed && !isDemoData) {
+    return (
+      <div className="h-full flex items-center justify-center p-4">
+        <EmptyState
+          icon={<AlertTriangle className="w-8 h-8 text-red-400/70" />}
+          title={t('longhornStatus.allFetchesFailed', 'All cluster fetches failed')}
+          description={t(
+            'longhornStatus.allFetchesFailedHint',
+            'Unable to reach any cluster. Check connectivity and try again.',
+          )}
+        />
+      </div>
+    )
+  }
+
   const isHealthy = data.health === 'healthy'
   const volumes = (data.volumes ?? []).slice(0, VOLUME_PAGE_SIZE)
   const nodes = (data.nodes ?? []).slice(0, NODE_PAGE_SIZE)

--- a/web/src/components/cards/vitess_status/index.tsx
+++ b/web/src/components/cards/vitess_status/index.tsx
@@ -138,6 +138,20 @@ export function VitessStatus() {
     )
   }
 
+  // When all cluster fetches have failed, show unified error state instead of
+  // rendering misleading partial/empty data from stale cache (#11539).
+  if (isFailed && !isDemoData) {
+    return (
+      <div className="h-full flex items-center justify-center p-4">
+        <EmptyState
+          icon={<AlertTriangle className="w-8 h-8 text-red-400/70" />}
+          title={t('vitessStatus.allFetchesFailed')}
+          description={t('vitessStatus.allFetchesFailedHint')}
+        />
+      </div>
+    )
+  }
+
   const isHealthy = data.health === 'healthy'
   const keyspaces = (data.keyspaces ?? []).slice(0, KEYSPACE_PAGE_SIZE)
   const tablets = data.tablets ?? []

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -2871,7 +2871,9 @@
     "footer": "{{pvcs}} PVCs across {{clusters}} clusters",
     "acrossClusters": "across {{count}} clusters",
     "acrossClusters_one": "across {{count}} cluster",
-    "acrossClusters_other": "across {{count}} clusters"
+    "acrossClusters_other": "across {{count}} clusters",
+    "allFetchesFailed": "All cluster fetches failed",
+    "allFetchesFailedHint": "Unable to reach any cluster. Check connectivity and try again."
   },
   "flatcar": {
     "healthy": "Healthy",
@@ -3446,7 +3448,9 @@
     "shardsCount_one": "{{count}} shard",
     "shardsCount_other": "{{count}} shards",
     "tabletsCount_one": "{{count}} tablet",
-    "tabletsCount_other": "{{count}} tablets"
+    "tabletsCount_other": "{{count}} tablets",
+    "allFetchesFailed": "All cluster fetches failed",
+    "allFetchesFailedHint": "Unable to reach any cluster. Check connectivity and try again."
   },
   "kubecostOverview": {
     "monthlyCost": "Monthly Cost",


### PR DESCRIPTION
Fixes #11539

## Summary

When all cluster fetches fail, Storage cards now show a unified error state instead of misleading partial/empty data.

## Changes

- Added proper error state rendering in StorageOverview, Longhorn, and Vitess cards when all cluster fetches fail
- Cards display a clear error message instead of empty/partial stats from stale cache
- Added i18n keys for the new error messages
- Uses existing EmptyState and error UI patterns

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>