### PR TITLE
🌱 add deploy-test to nightly wall-clock timeout overrides

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -327,10 +327,14 @@ if [ -z "$FAST_MODE" ]; then
         #     Playwright-level timeout (900_000ms) and fits within the 120m
         #     workflow backstop. perf-test bumped to 1200s — 29 dashboard
         #     variants all pass but exceed 900s wall-clock (#nightly-fix).
+        #   deploy-test: 11 serial tests (workers=1) with build/preview startup.
+        #     Suite killed after 300s wall-clock timeout — default cap too tight
+        #     for the combined vite build + 11-test run. 600s gives headroom.
         declare -A PLAYWRIGHT_SUITE_TIMEOUT_OVERRIDES=(
           ["console-error-scan"]=600
           ["ui-compliance-test"]=600
           ["cache-test"]=600
+          ["deploy-test"]=600
           ["benchmark-test"]=600
           # deploy-test: npm run build (~2m) + vite preview start (up to 3m) + 11 tests
           #   running serially with 6-minute per-test timeout. Default 300s cap kills


### PR DESCRIPTION
Fixes deploy-test suite being killed by the 300s wall-clock cap.

`deploy-test` runs 11 serial tests with a build + vite preview startup. The combined wall-clock time exceeds the default 300s cap, causing the suite to be killed before all tests complete. Setting the override to 600s matches the per-test Playwright timeout (360s) and gives headroom for the build step (~2m).

Originally submitted as #11519; rebased over main to resolve reviewer_log.md merge conflict.