### PR TITLE
🐛 Fix test failures, color contrast, and ErrorBoundary wraps

### DIFF
--- a/pkg/agent/provider_openai_compat_test.go
+++ b/pkg/agent/provider_openai_compat_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -78,9 +79,12 @@ func TestChatViaOpenAICompatible(t *testing.T) {
 }
 
 func TestStreamViaOpenAICompatible(t *testing.T) {
+	var mu sync.Mutex
 	var capturedAuth string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		capturedAuth = r.Header.Get("Authorization")
+		mu.Unlock()
 		if capturedAuth != "Bearer test-key" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -107,6 +111,8 @@ func TestStreamViaOpenAICompatible(t *testing.T) {
 		t.Fatalf("streamViaOpenAICompatible failed: %v", err)
 	}
 
+	mu.Lock()
+	defer mu.Unlock()
 	if capturedAuth != "Bearer test-key" {
 		t.Errorf("Expected Authorization header %q, got %q", "Bearer test-key", capturedAuth)
 	}

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -334,7 +334,6 @@ if [ -z "$FAST_MODE" ]; then
           ["console-error-scan"]=600
           ["ui-compliance-test"]=600
           ["cache-test"]=600
-          ["deploy-test"]=600
           ["benchmark-test"]=600
           # deploy-test: npm run build (~2m) + vite preview start (up to 3m) + 11 tests
           #   running serially with 6-minute per-test timeout. Default 300s cap kills

--- a/web/src/components/aiagents/AIAgents.tsx
+++ b/web/src/components/aiagents/AIAgents.tsx
@@ -8,6 +8,7 @@ import { ExternalLink } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { aiAgentsDashboardConfig } from '../../config/dashboards/ai-agents'
 import { RotatingTip } from '../ui/RotatingTip'
+import { PageErrorBoundary } from '../PageErrorBoundary'
 
 const STORAGE_KEYS: Record<string, string> = {
   kagenti: 'kubestellar-aiagents-kagenti-cards',
@@ -23,7 +24,7 @@ function getTabDefaultCards(tabId: string) {
     position: { w: card.position?.w || 4, h: card.position?.h || 2 } }))
 }
 
-export function AIAgents() {
+function AIAgentsContent() {
   const { t } = useTranslation('common')
   const { summary, isLoading, isDemoData: hookIsDemoData, refetch, error } = useKagentiSummary()
   const tabs = aiAgentsDashboardConfig.tabs || []
@@ -149,5 +150,13 @@ export function AIAgents() {
         </div>
       )}
     </DashboardPage>
+  )
+}
+
+export function AIAgents() {
+  return (
+    <PageErrorBoundary>
+      <AIAgentsContent />
+    </PageErrorBoundary>
   )
 }

--- a/web/src/components/compliance/RBACAuditDashboard.tsx
+++ b/web/src/components/compliance/RBACAuditDashboard.tsx
@@ -34,7 +34,7 @@ const SEVERITY_STYLES: Record<string, string> = {
   high: 'bg-orange-500/20 text-orange-300 border-orange-500/30',
   medium: 'bg-amber-500/20 text-amber-300 border-amber-500/30',
   low: 'bg-blue-500/20 text-blue-300 border-blue-500/30',
-  info: 'bg-gray-500/20 text-gray-300 border-gray-500/30',
+  info: 'bg-gray-500/20 text-gray-200 border-gray-500/30',
 }
 
 const RISK_STYLES: Record<string, string> = {
@@ -202,7 +202,7 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
                     {f.severity}
                   </span>
                 </div>
-                <p className="text-sm text-gray-300 mb-2">{f.description}</p>
+                <p className="text-sm text-gray-200 mb-2">{f.description}</p>
                 <p className="text-xs text-blue-300">
                   <span className="font-medium">Recommendation:</span> {f.recommendation}
                 </p>
@@ -238,9 +238,9 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
                     </div>
                   </td>
                   <td className="p-3">
-                    <span className="px-2 py-1 bg-gray-700/50 rounded text-xs text-gray-300">{b.kind}</span>
+                    <span className="px-2 py-1 bg-gray-700/50 rounded text-xs text-gray-200">{b.kind}</span>
                   </td>
-                  <td className="p-3 text-gray-300">
+                  <td className="p-3 text-gray-200">
                     <div className="flex items-center gap-1">
                       {b.subject_kind === 'User' ? <Users className="w-3 h-3" /> :
                        b.subject_kind === 'Group' ? <Users className="w-3 h-3" /> :
@@ -249,9 +249,9 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
                     </div>
                     <span className="text-xs text-gray-500">{b.subject_kind}</span>
                   </td>
-                  <td className="p-3 text-gray-300 font-mono text-xs">{b.role_name}</td>
-                  <td className="p-3 text-gray-300">{b.cluster}</td>
-                  <td className="p-3 text-gray-300">{b.namespace || '—'}</td>
+                  <td className="p-3 text-gray-200 font-mono text-xs">{b.role_name}</td>
+                  <td className="p-3 text-gray-200">{b.cluster}</td>
+                  <td className="p-3 text-gray-200">{b.namespace || '—'}</td>
                   <td className="p-3">
                     <span className={`font-medium text-xs ${RISK_STYLES[b.risk_level] || 'text-gray-400'}`}>
                       {b.risk_level === 'critical' ? <AlertTriangle className="w-3 h-3 inline mr-1" /> : null}

--- a/web/src/components/compliance/SessionDashboard.tsx
+++ b/web/src/components/compliance/SessionDashboard.tsx
@@ -30,7 +30,7 @@ interface SessionSummary {
 const STATUS_STYLES: Record<string, string> = {
   active: 'bg-emerald-500/20 text-emerald-300 border-emerald-500/30',
   idle: 'bg-amber-500/20 text-amber-300 border-amber-500/30',
-  expired: 'bg-gray-500/20 text-gray-300 border-gray-500/30',
+  expired: 'bg-gray-500/20 text-gray-200 border-gray-500/30',
   terminated: 'bg-red-500/20 text-red-300 border-red-500/30',
 }
 
@@ -162,10 +162,10 @@ export const SessionDashboardContent = memo(function SessionDashboardContent() {
                       <span className="text-white font-medium">{s.user}</span>
                     </div>
                   </td>
-                  <td className="p-3 text-gray-300">{s.provider}</td>
+                  <td className="p-3 text-gray-200">{s.provider}</td>
                   <td className="p-3 text-gray-400 text-xs">{new Date(s.login_time).toLocaleString()}</td>
                   <td className="p-3 text-gray-400 text-xs">{new Date(s.last_activity).toLocaleString()}</td>
-                  <td className="p-3 text-gray-300 font-mono text-xs">{s.ip_address}</td>
+                  <td className="p-3 text-gray-200 font-mono text-xs">{s.ip_address}</td>
                   <td className="p-3 text-gray-400 text-xs truncate max-w-[150px]">
                     <div className="flex items-center gap-1">
                       <Monitor className="w-3 h-3 shrink-0" />
@@ -173,7 +173,7 @@ export const SessionDashboardContent = memo(function SessionDashboardContent() {
                     </div>
                   </td>
                   <td className="p-3">
-                    <span className={`px-2 py-1 rounded-full text-xs font-medium border ${STATUS_STYLES[s.status] || 'bg-gray-500/20 text-gray-300 border-gray-500/30'}`}>
+                    <span className={`px-2 py-1 rounded-full text-xs font-medium border ${STATUS_STYLES[s.status] || 'bg-gray-500/20 text-gray-200 border-gray-500/30'}`}>
                       {s.status}
                     </span>
                   </td>
@@ -197,7 +197,7 @@ export const SessionDashboardContent = memo(function SessionDashboardContent() {
                     <div className="text-sm text-gray-400">{p.description}</div>
                   </div>
                 </div>
-                <span className="px-2 py-1 bg-gray-700/50 rounded text-xs text-gray-300">{p.scope}</span>
+                <span className="px-2 py-1 bg-gray-700/50 rounded text-xs text-gray-200">{p.scope}</span>
               </div>
               <div className="grid grid-cols-4 gap-4 mt-3">
                 <div>

--- a/web/src/components/compliance/SigstoreDashboard.tsx
+++ b/web/src/components/compliance/SigstoreDashboard.tsx
@@ -117,7 +117,7 @@ export const SigstoreDashboardContent = memo(function SigstoreDashboardContent()
   if (loading) return (
     <div className="flex items-center justify-center h-64">
       <Loader2 className="w-8 h-8 animate-spin text-blue-400" />
-      <span className="ml-3 text-gray-300">Loading Sigstore data…</span>
+      <span className="ml-3 text-gray-200">Loading Sigstore data…</span>
     </div>
   )
 
@@ -175,17 +175,17 @@ export const SigstoreDashboardContent = memo(function SigstoreDashboardContent()
           <div className="flex items-center gap-3 flex-wrap">
             <div className="flex items-center gap-2 bg-gray-900/50 border border-gray-600 rounded px-3 py-2">
               <ShieldCheck className="w-4 h-4 text-green-400" />
-              <span className="text-sm text-gray-300">{summary.trust_roots} Trust Roots</span>
+              <span className="text-sm text-gray-200">{summary.trust_roots} Trust Roots</span>
             </div>
             <span className="text-gray-600">→</span>
             <div className="flex items-center gap-2 bg-gray-900/50 border border-gray-600 rounded px-3 py-2">
               <BadgeCheck className="w-4 h-4 text-blue-400" />
-              <span className="text-sm text-gray-300">{summary.policies_enforced} Policies</span>
+              <span className="text-sm text-gray-200">{summary.policies_enforced} Policies</span>
             </div>
             <span className="text-gray-600">→</span>
             <div className="flex items-center gap-2 bg-gray-900/50 border border-gray-600 rounded px-3 py-2">
               <CheckCircle2 className="w-4 h-4 text-green-400" />
-              <span className="text-sm text-gray-300">{summary.verified_signatures} Verified</span>
+              <span className="text-sm text-gray-200">{summary.verified_signatures} Verified</span>
             </div>
           </div>
         </div>
@@ -224,8 +224,8 @@ export const SigstoreDashboardContent = memo(function SigstoreDashboardContent()
               {signatures.map((s, i) => (
                 <tr key={i} className="border-b border-gray-800 hover:bg-gray-800/30">
                   <td className="py-2 px-3 text-white font-mono text-xs max-w-xs truncate">{s.image}</td>
-                  <td className="py-2 px-3 text-gray-300 text-xs">{s.signer}</td>
-                  <td className="py-2 px-3 text-gray-300 text-xs">{s.issuer}</td>
+                  <td className="py-2 px-3 text-gray-200 text-xs">{s.signer}</td>
+                  <td className="py-2 px-3 text-gray-200 text-xs">{s.issuer}</td>
                   <td className="py-2 px-3">
                     {s.transparency_log ? <CheckCircle2 className="w-4 h-4 text-green-400" /> : <XCircle className="w-4 h-4 text-gray-500" />}
                   </td>
@@ -259,9 +259,9 @@ export const SigstoreDashboardContent = memo(function SigstoreDashboardContent()
               {verifications.map((v) => (
                 <tr key={v.id} className="border-b border-gray-800 hover:bg-gray-800/30">
                   <td className="py-2 px-3 text-white font-mono text-xs max-w-xs truncate">{v.image}</td>
-                  <td className="py-2 px-3 text-gray-300 text-xs">{v.policy}</td>
-                  <td className="py-2 px-3 text-gray-300 text-xs">{v.cosign_version}</td>
-                  <td className="py-2 px-3 text-gray-300">{v.certificate_chain} certs</td>
+                  <td className="py-2 px-3 text-gray-200 text-xs">{v.policy}</td>
+                  <td className="py-2 px-3 text-gray-200 text-xs">{v.cosign_version}</td>
+                  <td className="py-2 px-3 text-gray-200">{v.certificate_chain} certs</td>
                   <td className="py-2 px-3">
                     <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs border ${RESULT_BG[v.result]} ${RESULT_COLORS[v.result]}`}>
                       {RESULT_ICON[v.result]}

--- a/web/src/components/deployments/Deployments.tsx
+++ b/web/src/components/deployments/Deployments.tsx
@@ -10,6 +10,7 @@ import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards, deploymentsDashboardConfig } from '../../config/dashboards'
 import { RotatingTip } from '../ui/RotatingTip'
 import { migrateStorageKey } from '../../lib/dashboards/migrateStorageKey'
+import { PageErrorBoundary } from '../PageErrorBoundary'
 
 /** Storage key sourced from central dashboard config to prevent mismatches */
 const DEPLOYMENTS_CARDS_KEY = deploymentsDashboardConfig.storageKey ?? 'deployments-dashboard-cards'
@@ -21,7 +22,7 @@ migrateStorageKey(LEGACY_DEPLOYMENTS_CARDS_KEY, DEPLOYMENTS_CARDS_KEY)
 // Default cards for the deployments dashboard
 const DEFAULT_DEPLOYMENTS_CARDS = getDefaultCards('deployments')
 
-export function Deployments() {
+function DeploymentsContent() {
   const { t } = useTranslation()
   // Use cached hooks for stale-while-revalidate pattern
   const { deployments, isLoading, isRefreshing: dataRefreshing, lastRefresh, refetch, error: deploymentsError } = useCachedDeployments()
@@ -131,5 +132,13 @@ export function Deployments() {
         </div>
       )}
     </DashboardPage>
+  )
+}
+
+export function Deployments() {
+  return (
+    <PageErrorBoundary>
+      <DeploymentsContent />
+    </PageErrorBoundary>
   )
 }

--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -4,6 +4,7 @@ import { useCanI } from '../../hooks/usePermissions'
 import { useClusters, useNamespaces } from '../../hooks/useMCP'
 import { Button } from '../ui/Button'
 import { useTranslation } from 'react-i18next'
+import { PageErrorBoundary } from '../PageErrorBoundary'
 
 const COMMON_VERBS = ['get', 'list', 'create', 'update', 'delete', 'watch', 'patch']
 
@@ -163,7 +164,7 @@ function formReducer(state: FormState, action: FormAction): FormState {
   }
 }
 
-export function CanIChecker() {
+function CanICheckerContent() {
   const { t } = useTranslation('common')
   const { deduplicatedClusters: rawClusters } = useClusters()
   const clusters = rawClusters.map(c => c.name)
@@ -595,5 +596,13 @@ export function CanIChecker() {
         )}
       </div>
     </div>
+  )
+}
+
+export function CanIChecker() {
+  return (
+    <PageErrorBoundary>
+      <CanICheckerContent />
+    </PageErrorBoundary>
   )
 }

--- a/web/src/hooks/__tests__/agentConnectivity.test.tsx
+++ b/web/src/hooks/__tests__/agentConnectivity.test.tsx
@@ -58,6 +58,11 @@ vi.mock('../../lib/utils/localStorage', () => ({
   safeSetItem: vi.fn(),
 }))
 
+// Mock AlertsContext service modules (added after #11559 refactor)
+vi.mock('../../contexts/notifications', () => ({}))
+vi.mock('../../contexts/alertStorage', () => ({}))
+vi.mock('../../contexts/alertRunbooks', () => ({}))
+
 // Dynamically imported after each module reset
 let useLocalAgent: typeof import('../useLocalAgent').useLocalAgent
 let reportAgentDataError: typeof import('../useLocalAgent').reportAgentDataError

--- a/web/src/lib/__tests__/agentLoopbackFailurePaths.test.ts
+++ b/web/src/lib/__tests__/agentLoopbackFailurePaths.test.ts
@@ -243,6 +243,10 @@ describe('agentFetchers failure paths', () => {
         }
       },
     }))
+    // Mock AlertsContext service modules (added after #11559 refactor)
+    vi.mock('../../../contexts/notifications', () => ({}))
+    vi.mock('../../../contexts/alertStorage', () => ({}))
+    vi.mock('../../../contexts/alertRunbooks', () => ({}))
   })
 
   afterEach(() => {


### PR DESCRIPTION
Fixes #11630
Fixes #11631
Fixes #11632

- Fix 5 test failures from AlertsContext refactor by adding mocks for new service modules
- Improve color contrast (text-gray-300 → text-gray-200) in compliance components for WCAG AA
- Add PageErrorBoundary wraps around complex components (CanIChecker, Deployments, AIAgents)