### PR TITLE
🐛 Fix deduplicateClustersByServer: merge request metrics during dedup

### DIFF
--- a/web/src/hooks/mcp/clusterUtils.ts
+++ b/web/src/hooks/mcp/clusterUtils.ts
@@ -183,6 +183,11 @@ export function deduplicateClustersByServer(clusters: ClusterInfo[]): ClusterInf
           cpuRequestsCores: cluster.cpuRequestsCores,
           memoryRequestsBytes: cluster.memoryRequestsBytes,
           memoryRequestsGB: cluster.memoryRequestsGB,
+          cpuUsageMillicores: cluster.cpuUsageMillicores,
+          cpuUsageCores: cluster.cpuUsageCores,
+          memoryUsageBytes: cluster.memoryUsageBytes,
+          memoryUsageGB: cluster.memoryUsageGB,
+          metricsAvailable: cluster.metricsAvailable,
           pvcCount: cluster.pvcCount,
           pvcBoundCount: cluster.pvcBoundCount,
         }
@@ -202,9 +207,10 @@ export function deduplicateClustersByServer(clusters: ClusterInfo[]): ClusterInf
       const alias = group.find(c => c !== primary && c.podCount !== undefined)
       if (alias) bestMetrics.podCount = alias.podCount
     }
-    // Legacy merge loop preserved only for request metrics (below).
+    // Legacy merge loop: fill in request/usage metrics that may come from a
+    // different cluster context than the one that reported capacity.
     for (const cluster of (group || [])) {
-      // Merge request metrics - these may come from a different cluster than capacity
+      // Merge request metrics
       if (cluster.cpuRequestsCores && !bestMetrics.cpuRequestsCores) {
         bestMetrics.cpuRequestsMillicores = cluster.cpuRequestsMillicores
         bestMetrics.cpuRequestsCores = cluster.cpuRequestsCores
@@ -212,6 +218,19 @@ export function deduplicateClustersByServer(clusters: ClusterInfo[]): ClusterInf
       if (cluster.memoryRequestsGB && !bestMetrics.memoryRequestsGB) {
         bestMetrics.memoryRequestsBytes = cluster.memoryRequestsBytes
         bestMetrics.memoryRequestsGB = cluster.memoryRequestsGB
+      }
+      // Merge usage metrics
+      if (cluster.cpuUsageCores && !bestMetrics.cpuUsageCores) {
+        bestMetrics.cpuUsageMillicores = cluster.cpuUsageMillicores
+        bestMetrics.cpuUsageCores = cluster.cpuUsageCores
+      }
+      if (cluster.memoryUsageGB && !bestMetrics.memoryUsageGB) {
+        bestMetrics.memoryUsageBytes = cluster.memoryUsageBytes
+        bestMetrics.memoryUsageGB = cluster.memoryUsageGB
+      }
+      // Merge metricsAvailable flag
+      if (cluster.metricsAvailable && !bestMetrics.metricsAvailable) {
+        bestMetrics.metricsAvailable = cluster.metricsAvailable
       }
     }
 


### PR DESCRIPTION
Fixes #11635

Add cpuUsage*, memoryUsage*, and metricsAvailable fields to the bestMetrics merge block and legacy merge loop in deduplicateClustersByServer. These fields were already merged by shareMetricsBetweenSameServerClusters but were dropped during deduplication, causing clusters that only report usage/availability metrics from one context to show zero/missing values after dedup.