### PR TITLE
🐛 Fix 5 test failures in Coverage Suite run #1997

### DIFF
--- a/web/src/hooks/__tests__/agentConnectivity.test.tsx
+++ b/web/src/hooks/__tests__/agentConnectivity.test.tsx
@@ -59,9 +59,28 @@ vi.mock('../../lib/utils/localStorage', () => ({
 }))
 
 // Mock AlertsContext service modules (added after #11559 refactor)
-vi.mock('../../contexts/notifications', () => ({}))
-vi.mock('../../contexts/alertStorage', () => ({}))
-vi.mock('../../contexts/alertRunbooks', () => ({}))
+vi.mock('../../contexts/notifications', () => ({
+  shouldDispatchBrowserNotification: vi.fn(() => false),
+  isClusterUnreachable: vi.fn(() => false),
+  sendNotifications: vi.fn(),
+  sendBatchedNotifications: vi.fn(),
+}))
+vi.mock('../../contexts/alertStorage', () => ({
+  ALERTS_KEY: 'kc_alerts',
+  MAX_ALERTS: 500,
+  loadNotifiedAlertKeys: vi.fn(() => new Map()),
+  saveNotifiedAlertKeys: vi.fn(),
+  loadFromStorage: vi.fn(() => []),
+  saveToStorage: vi.fn(),
+  saveAlerts: vi.fn(),
+  STORAGE_KEY_AUTH_TOKEN: 'kc-token',
+  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+  DEFAULT_TEMPERATURE_THRESHOLD_F: 100,
+  DEFAULT_WIND_SPEED_THRESHOLD_MPH: 40,
+}))
+vi.mock('../../contexts/alertRunbooks', () => ({
+  findAndExecuteRunbook: vi.fn(() => Promise.resolve(null)),
+}))
 
 // Dynamically imported after each module reset
 let useLocalAgent: typeof import('../useLocalAgent').useLocalAgent

--- a/web/src/lib/__tests__/agentLoopbackFailurePaths.test.ts
+++ b/web/src/lib/__tests__/agentLoopbackFailurePaths.test.ts
@@ -244,9 +244,28 @@ describe('agentFetchers failure paths', () => {
       },
     }))
     // Mock AlertsContext service modules (added after #11559 refactor)
-    vi.mock('../../../contexts/notifications', () => ({}))
-    vi.mock('../../../contexts/alertStorage', () => ({}))
-    vi.mock('../../../contexts/alertRunbooks', () => ({}))
+    vi.mock('../../../contexts/notifications', () => ({
+      shouldDispatchBrowserNotification: vi.fn(() => false),
+      isClusterUnreachable: vi.fn(() => false),
+      sendNotifications: vi.fn(),
+      sendBatchedNotifications: vi.fn(),
+    }))
+    vi.mock('../../../contexts/alertStorage', () => ({
+      ALERTS_KEY: 'kc_alerts',
+      MAX_ALERTS: 500,
+      loadNotifiedAlertKeys: vi.fn(() => new Map()),
+      saveNotifiedAlertKeys: vi.fn(),
+      loadFromStorage: vi.fn(() => []),
+      saveToStorage: vi.fn(),
+      saveAlerts: vi.fn(),
+      STORAGE_KEY_AUTH_TOKEN: 'kc-token',
+      FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+      DEFAULT_TEMPERATURE_THRESHOLD_F: 100,
+      DEFAULT_WIND_SPEED_THRESHOLD_MPH: 40,
+    }))
+    vi.mock('../../../contexts/alertRunbooks', () => ({
+      findAndExecuteRunbook: vi.fn(() => Promise.resolve(null)),
+    }))
   })
 
   afterEach(() => {


### PR DESCRIPTION
Fixes #11645

Fixed 5 test failures caused by incomplete mocks of AlertsContext service modules (notifications, alertStorage, alertRunbooks) after PR #11559 refactored them into separate files.