### PR TITLE
🐛 Fix isFailed error UI and isDemoFallback logic in storage/network hooks

### DIFF
--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -141,7 +141,7 @@ export function StorageOverview() {
 
   // When all cluster fetches have failed, show unified error state instead of
   // rendering misleading partial/empty data from stale cache (#11539).
-  if (consecutiveFailures > 0 && !isRefreshing && !isDemoFallback && !isDemoMode) {
+  if (consecutiveFailures > 0 && !(clustersRefreshing || pvcsRefreshing) && !isDemoFallback && !isDemoMode) {
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
         <AlertTriangle className="w-8 h-8 mb-2 text-red-400 opacity-70" />

--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -141,7 +141,7 @@ export function StorageOverview() {
 
   // When all cluster fetches have failed, show unified error state instead of
   // rendering misleading partial/empty data from stale cache (#11539).
-  if (isFailed && !isDemoFallback && !isDemoMode) {
+  if (consecutiveFailures > 0 && !isRefreshing && !isDemoFallback && !isDemoMode) {
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
         <AlertTriangle className="w-8 h-8 mb-2 text-red-400 opacity-70" />

--- a/web/src/components/cards/longhorn_status/index.tsx
+++ b/web/src/components/cards/longhorn_status/index.tsx
@@ -242,7 +242,7 @@ export function LonghornStatus() {
 
   // When all cluster fetches have failed, show unified error state instead of
   // rendering misleading partial/empty data from stale cache (#11539).
-  if (isFailed && !isDemoData) {
+  if (consecutiveFailures > 0 && !isRefreshing && !isDemoData) {
     return (
       <div className="h-full flex items-center justify-center p-4">
         <EmptyState

--- a/web/src/components/cards/vitess_status/index.tsx
+++ b/web/src/components/cards/vitess_status/index.tsx
@@ -140,7 +140,7 @@ export function VitessStatus() {
 
   // When all cluster fetches have failed, show unified error state instead of
   // rendering misleading partial/empty data from stale cache (#11539).
-  if (isFailed && !isDemoData) {
+  if (consecutiveFailures > 0 && !isRefreshing && !isDemoData) {
     return (
       <div className="h-full flex items-center justify-center p-4">
         <EmptyState

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -375,6 +375,7 @@ export function useIngresses(cluster?: string, namespace?: string) {
   // Track data presence in a ref so the useCallback doesn't need ingresses in deps
   const hasDataRef = useRef(false)
   hasDataRef.current = ingresses.length > 0
+  const hasReceivedLiveDataRef = useRef(false)
 
   const refetch = useCallback(async () => {
     // If demo mode is enabled, use demo data so the Demo badge correctly
@@ -395,7 +396,7 @@ export function useIngresses(cluster?: string, namespace?: string) {
     }
     // Only show loading skeleton when we have no data yet; otherwise just
     // show refreshing indicator to prevent flickering (#11542).
-    const hasExistingData = hasDataRef.current
+    const hasExistingData = hasDataRef.current || hasReceivedLiveDataRef.current
     if (!hasExistingData) {
       setIsLoading(true)
     }
@@ -415,6 +416,7 @@ export function useIngresses(cluster?: string, namespace?: string) {
         if (response.ok) {
           const data = await response.json()
           setIngresses(data.ingresses || [])
+          hasReceivedLiveDataRef.current = true
           setIsDemoFallback(false)
           setError(null)
           setConsecutiveFailures(0)
@@ -431,7 +433,7 @@ export function useIngresses(cluster?: string, namespace?: string) {
     const token = localStorage.getItem(STORAGE_KEY_TOKEN)
     if (!token) {
       // Only clear data if we never had any; preserve stale data otherwise (#11540)
-      if (!hasDataRef.current) {
+      if (!hasReceivedLiveDataRef.current) {
         setIngresses([])
       }
       setIsLoading(false)
@@ -446,6 +448,7 @@ export function useIngresses(cluster?: string, namespace?: string) {
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
       const data = await resp.json()
       setIngresses(data.ingresses || [])
+      hasReceivedLiveDataRef.current = true
       setIsDemoFallback(false)
       setError(null)
       setConsecutiveFailures(0)
@@ -455,7 +458,7 @@ export function useIngresses(cluster?: string, namespace?: string) {
       const message = err instanceof Error ? err.message : 'Network request failed'
       setError(message)
       setConsecutiveFailures(prev => prev + 1)
-      setIsDemoFallback(false)
+      // Don't flip isDemoFallback on error — preserve demo badge if no live data received (#11640)
     } finally {
       setIsLoading(false)
       setIsRefreshing(false)
@@ -497,11 +500,12 @@ export function useNetworkPolicies(cluster?: string, namespace?: string) {
   // Track data presence in a ref so the useCallback doesn't need networkpolicies in deps
   const hasDataRef = useRef(false)
   hasDataRef.current = networkpolicies.length > 0
+  const hasReceivedLiveDataRef = useRef(false)
 
   const refetch = useCallback(async () => {
     // Only show loading skeleton when we have no data yet; otherwise just
     // show refreshing indicator to prevent flickering (#11542).
-    const hasExistingData = hasDataRef.current
+    const hasExistingData = hasDataRef.current || hasReceivedLiveDataRef.current
     if (!hasExistingData) {
       setIsLoading(true)
     }
@@ -521,6 +525,7 @@ export function useNetworkPolicies(cluster?: string, namespace?: string) {
         if (response.ok) {
           const data = await response.json()
           setNetworkPolicies(data.networkpolicies || [])
+          hasReceivedLiveDataRef.current = true
           setError(null)
           setConsecutiveFailures(0)
           setIsLoading(false)
@@ -540,6 +545,7 @@ export function useNetworkPolicies(cluster?: string, namespace?: string) {
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
       const data = await resp.json()
       setNetworkPolicies(data.networkpolicies || [])
+      hasReceivedLiveDataRef.current = true
       setError(null)
       setConsecutiveFailures(0)
     } catch (err: unknown) {
@@ -548,6 +554,7 @@ export function useNetworkPolicies(cluster?: string, namespace?: string) {
       const message = err instanceof Error ? err.message : 'Network request failed'
       setError(message)
       setConsecutiveFailures(prev => prev + 1)
+      // Don't flip isDemoFallback on error — preserve demo badge if no live data received (#11640)
     } finally {
       setIsLoading(false)
       setIsRefreshing(false)


### PR DESCRIPTION
Fixes #11639
Fixes #11640

- StorageOverview/VitessStatus/LonghornStatus: use `consecutiveFailures > 0 && !isRefreshing` instead of `isFailed` to prevent error UI flashing during background refresh cycles
- useIngresses/useNetworkPolicies: track `hasReceivedLiveDataRef` to avoid incorrectly clearing `isDemoFallback` on fetch errors before live data is received