### PR TITLE
🐛 Fix arm64 docker build timeout in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,7 +292,7 @@ jobs:
   docker-build:
     needs: [determine-version, release]
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     if: needs.release.result == 'success'
     strategy:
       fail-fast: false
@@ -330,6 +330,27 @@ jobs:
       - name: Build and push per-platform image
         id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        continue-on-error: true
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            APP_VERSION=${{ needs.determine-version.outputs.version }}
+            COMMIT_HASH=${{ github.sha }}
+          cache-from: type=gha,scope=docker-${{ steps.prep.outputs.pair }}
+          cache-to: type=gha,scope=docker-${{ steps.prep.outputs.pair }},mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Wait before retry
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "::warning::Build failed for ${{ matrix.platform }}, retrying in 30s..."
+          sleep 30
+
+      - name: Build and push per-platform image (retry)
+        id: build-retry
+        if: steps.build.outcome == 'failure'
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -343,7 +364,7 @@ jobs:
       - name: Export digest
         run: |
           mkdir -p /home/runner/digests
-          digest="${{ steps.build.outputs.digest }}"
+          digest="${{ steps.build-retry.outputs.digest || steps.build.outputs.digest }}"
           touch "/home/runner/digests/${digest#sha256:}"
 
       - name: Upload digest


### PR DESCRIPTION
Fixes #11663

The nightly release workflow's `docker-build (linux/arm64)` job was getting cancelled mid-build due to resource/time limits. This PR:
- Increases the timeout from 45 to 90 minutes for docker builds (QEMU-emulated arm64 is significantly slower than native amd64)
- Adds retry logic: if the initial build fails (e.g., runner preemption), waits 30s and retries once before failing the job
- Uses a fallback expression for digest export to handle both first-attempt and retry-attempt outputs

This ensures the multi-arch manifest and helm release complete successfully.