### PR TITLE
🐛 Fix metric merge nullish destination checks and add coverage tests

### DIFF
--- a/web/src/hooks/mcp/__tests__/clusterUtils.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusterUtils.test.ts
@@ -174,6 +174,85 @@ describe('clusterUtils.deduplicateClustersByServer', () => {
     expect(result[0].cpuUsageCores).toBe(8)
   })
 
+  it('does not overwrite cpuUsage=0 (valid idle) from primary with alias non-zero value', () => {
+    // Tests the nullish-destination fix: the destination check must be `== null`,
+    // not `!value`, so that a valid 0 already set is never silently overwritten.
+    const primary = makeCluster({
+      name: 'primary',
+      server: 'https://api.test',
+      cpuCores: 16,
+      cpuUsageCores: 0,        // valid: cluster is idle
+      cpuUsageMillicores: 0,
+    })
+    const alias = makeCluster({
+      name: 'generated-context/api-server:6443/user',
+      server: 'https://api.test',
+      cpuUsageCores: 5,
+      cpuUsageMillicores: 5000,
+    })
+    const result = deduplicateClustersByServer([primary, alias])
+    // 0 is a real value; alias must NOT overwrite it
+    expect(result[0].cpuUsageCores).toBe(0)
+    expect(result[0].cpuUsageMillicores).toBe(0)
+  })
+
+  it('does not overwrite memoryUsage=0 from primary with alias non-zero value', () => {
+    const primary = makeCluster({
+      name: 'primary',
+      server: 'https://api.test',
+      memoryGB: 32,
+      memoryUsageGB: 0,
+      memoryUsageBytes: 0,
+    })
+    const alias = makeCluster({
+      name: 'generated-context/api-server:6443/user',
+      server: 'https://api.test',
+      memoryUsageGB: 10,
+      memoryUsageBytes: 10_737_418_240,
+    })
+    const result = deduplicateClustersByServer([primary, alias])
+    expect(result[0].memoryUsageGB).toBe(0)
+    expect(result[0].memoryUsageBytes).toBe(0)
+  })
+
+  it('does not overwrite cpuRequests=0 from primary with alias non-zero value', () => {
+    const primary = makeCluster({
+      name: 'primary',
+      server: 'https://api.test',
+      cpuCores: 8,
+      cpuRequestsCores: 0,
+      cpuRequestsMillicores: 0,
+    })
+    const alias = makeCluster({
+      name: 'generated-context/api-server:6443/user',
+      server: 'https://api.test',
+      cpuRequestsCores: 3,
+      cpuRequestsMillicores: 3000,
+    })
+    const result = deduplicateClustersByServer([primary, alias])
+    expect(result[0].cpuRequestsCores).toBe(0)
+    expect(result[0].cpuRequestsMillicores).toBe(0)
+  })
+
+  it('does not overwrite memoryRequests=0 from primary with alias non-zero value', () => {
+    const primary = makeCluster({
+      name: 'primary',
+      server: 'https://api.test',
+      memoryGB: 16,
+      memoryRequestsGB: 0,
+      memoryRequestsBytes: 0,
+    })
+    const alias = makeCluster({
+      name: 'generated-context/api-server:6443/user',
+      server: 'https://api.test',
+      memoryRequestsGB: 8,
+      memoryRequestsBytes: 8_589_934_592,
+    })
+    const result = deduplicateClustersByServer([primary, alias])
+    expect(result[0].memoryRequestsGB).toBe(0)
+    expect(result[0].memoryRequestsBytes).toBe(0)
+  })
+
   it('merges both request and usage metrics from same alias cluster', () => {
     const primary = makeCluster({
       name: 'primary',

--- a/web/src/hooks/mcp/__tests__/workloadSubscriptions.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloadSubscriptions.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for workloadSubscriptions.ts
+ *
+ * Covers the pub/sub state management for workloads cache reset notifications.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import {
+  notifyWorkloadsSubscribers,
+  subscribeWorkloadsCache,
+  getWorkloadsSharedState,
+  setWorkloadsSharedState,
+  type WorkloadsSharedState,
+  type WorkloadsSubscriber,
+} from '../workloadSubscriptions'
+
+// ---------------------------------------------------------------------------
+// Reset module state between tests to avoid leakage
+// ---------------------------------------------------------------------------
+
+// We manipulate module-level state directly, so reset via setWorkloadsSharedState
+// and unsubscribe all callbacks using the unsubscribe handles returned by subscribe.
+beforeEach(() => {
+  setWorkloadsSharedState({ cacheVersion: 0, isResetting: false })
+})
+
+// ---------------------------------------------------------------------------
+// getWorkloadsSharedState / setWorkloadsSharedState
+// ---------------------------------------------------------------------------
+
+describe('getWorkloadsSharedState / setWorkloadsSharedState', () => {
+  it('returns the initial default state', () => {
+    const state = getWorkloadsSharedState()
+    expect(state.cacheVersion).toBe(0)
+    expect(state.isResetting).toBe(false)
+  })
+
+  it('merges partial state updates', () => {
+    setWorkloadsSharedState({ cacheVersion: 3 })
+    expect(getWorkloadsSharedState().cacheVersion).toBe(3)
+    expect(getWorkloadsSharedState().isResetting).toBe(false)
+  })
+
+  it('sets isResetting to true without touching cacheVersion', () => {
+    setWorkloadsSharedState({ cacheVersion: 5 })
+    setWorkloadsSharedState({ isResetting: true })
+    const state = getWorkloadsSharedState()
+    expect(state.cacheVersion).toBe(5)
+    expect(state.isResetting).toBe(true)
+  })
+
+  it('overwrites both fields when both are provided', () => {
+    setWorkloadsSharedState({ cacheVersion: 7, isResetting: true })
+    const state = getWorkloadsSharedState()
+    expect(state.cacheVersion).toBe(7)
+    expect(state.isResetting).toBe(true)
+  })
+
+  it('returns a reference to the current state object', () => {
+    setWorkloadsSharedState({ cacheVersion: 1 })
+    const s1 = getWorkloadsSharedState()
+    setWorkloadsSharedState({ cacheVersion: 2 })
+    const s2 = getWorkloadsSharedState()
+    // State after second set should differ from first capture
+    expect(s2.cacheVersion).toBe(2)
+    // s1 was captured before the update — its value may differ
+    expect(s1.cacheVersion).not.toBe(s2.cacheVersion)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// subscribeWorkloadsCache / unsubscribe
+// ---------------------------------------------------------------------------
+
+describe('subscribeWorkloadsCache', () => {
+  it('returns an unsubscribe function', () => {
+    const cb: WorkloadsSubscriber = vi.fn()
+    const unsub = subscribeWorkloadsCache(cb)
+    expect(typeof unsub).toBe('function')
+    unsub()
+  })
+
+  it('registers a callback that is called on notify', () => {
+    const cb: WorkloadsSubscriber = vi.fn()
+    const unsub = subscribeWorkloadsCache(cb)
+
+    notifyWorkloadsSubscribers()
+
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(cb).toHaveBeenCalledWith(getWorkloadsSharedState())
+    unsub()
+  })
+
+  it('callback receives the current shared state', () => {
+    setWorkloadsSharedState({ cacheVersion: 42, isResetting: true })
+    const cb: WorkloadsSubscriber = vi.fn()
+    const unsub = subscribeWorkloadsCache(cb)
+
+    notifyWorkloadsSubscribers()
+
+    const received = (cb as ReturnType<typeof vi.fn>).mock.calls[0][0] as WorkloadsSharedState
+    expect(received.cacheVersion).toBe(42)
+    expect(received.isResetting).toBe(true)
+    unsub()
+  })
+
+  it('multiple subscribers all receive the notification', () => {
+    const cb1: WorkloadsSubscriber = vi.fn()
+    const cb2: WorkloadsSubscriber = vi.fn()
+    const cb3: WorkloadsSubscriber = vi.fn()
+
+    const u1 = subscribeWorkloadsCache(cb1)
+    const u2 = subscribeWorkloadsCache(cb2)
+    const u3 = subscribeWorkloadsCache(cb3)
+
+    notifyWorkloadsSubscribers()
+
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).toHaveBeenCalledTimes(1)
+    expect(cb3).toHaveBeenCalledTimes(1)
+
+    u1(); u2(); u3()
+  })
+
+  it('unsubscribed callback is NOT called on subsequent notifies', () => {
+    const cb: WorkloadsSubscriber = vi.fn()
+    const unsub = subscribeWorkloadsCache(cb)
+
+    notifyWorkloadsSubscribers()
+    expect(cb).toHaveBeenCalledTimes(1)
+
+    unsub()
+    notifyWorkloadsSubscribers()
+    expect(cb).toHaveBeenCalledTimes(1) // still 1 — not called again
+  })
+
+  it('unsubscribing one does not affect other subscribers', () => {
+    const cb1: WorkloadsSubscriber = vi.fn()
+    const cb2: WorkloadsSubscriber = vi.fn()
+
+    const u1 = subscribeWorkloadsCache(cb1)
+    const u2 = subscribeWorkloadsCache(cb2)
+
+    u1() // unsubscribe cb1 only
+    notifyWorkloadsSubscribers()
+
+    expect(cb1).not.toHaveBeenCalled()
+    expect(cb2).toHaveBeenCalledTimes(1)
+
+    u2()
+  })
+
+  it('calling unsubscribe twice is safe (no throw)', () => {
+    const cb: WorkloadsSubscriber = vi.fn()
+    const unsub = subscribeWorkloadsCache(cb)
+    expect(() => { unsub(); unsub() }).not.toThrow()
+  })
+
+  it('notifying with no subscribers is safe', () => {
+    // All subscribers from previous tests should be cleaned up via beforeEach
+    // Re-confirm: notify with zero subscribers should not throw
+    expect(() => notifyWorkloadsSubscribers()).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// notifyWorkloadsSubscribers
+// ---------------------------------------------------------------------------
+
+describe('notifyWorkloadsSubscribers', () => {
+  it('calls subscribers multiple times when called multiple times', () => {
+    const cb: WorkloadsSubscriber = vi.fn()
+    const unsub = subscribeWorkloadsCache(cb)
+
+    notifyWorkloadsSubscribers()
+    notifyWorkloadsSubscribers()
+    notifyWorkloadsSubscribers()
+
+    expect(cb).toHaveBeenCalledTimes(3)
+    unsub()
+  })
+
+  it('notified state reflects the latest setWorkloadsSharedState call', () => {
+    const states: WorkloadsSharedState[] = []
+    const cb: WorkloadsSubscriber = (s) => states.push({ ...s })
+    const unsub = subscribeWorkloadsCache(cb)
+
+    setWorkloadsSharedState({ cacheVersion: 1 })
+    notifyWorkloadsSubscribers()
+
+    setWorkloadsSharedState({ cacheVersion: 2, isResetting: true })
+    notifyWorkloadsSubscribers()
+
+    expect(states).toHaveLength(2)
+    expect(states[0].cacheVersion).toBe(1)
+    expect(states[1].cacheVersion).toBe(2)
+    expect(states[1].isResetting).toBe(true)
+
+    unsub()
+  })
+})

--- a/web/src/hooks/mcp/clusterUtils.ts
+++ b/web/src/hooks/mcp/clusterUtils.ts
@@ -210,21 +210,21 @@ export function deduplicateClustersByServer(clusters: ClusterInfo[]): ClusterInf
     // Legacy merge loop: fill in request/usage metrics that may come from a
     // different cluster context than the one that reported capacity.
     for (const cluster of (group || [])) {
-      // Merge request metrics — use nullish check to preserve valid 0 values
-      if (cluster.cpuRequestsCores != null && !bestMetrics.cpuRequestsCores) {
+      // Merge request metrics — nullish checks on both sides preserve valid 0 values
+      if (cluster.cpuRequestsCores != null && bestMetrics.cpuRequestsCores == null) {
         bestMetrics.cpuRequestsMillicores = cluster.cpuRequestsMillicores
         bestMetrics.cpuRequestsCores = cluster.cpuRequestsCores
       }
-      if (cluster.memoryRequestsGB != null && !bestMetrics.memoryRequestsGB) {
+      if (cluster.memoryRequestsGB != null && bestMetrics.memoryRequestsGB == null) {
         bestMetrics.memoryRequestsBytes = cluster.memoryRequestsBytes
         bestMetrics.memoryRequestsGB = cluster.memoryRequestsGB
       }
-      // Merge usage metrics — use nullish check to preserve valid 0 values
-      if (cluster.cpuUsageCores != null && !bestMetrics.cpuUsageCores) {
+      // Merge usage metrics — nullish checks on both sides preserve valid 0 values
+      if (cluster.cpuUsageCores != null && bestMetrics.cpuUsageCores == null) {
         bestMetrics.cpuUsageMillicores = cluster.cpuUsageMillicores
         bestMetrics.cpuUsageCores = cluster.cpuUsageCores
       }
-      if (cluster.memoryUsageGB != null && !bestMetrics.memoryUsageGB) {
+      if (cluster.memoryUsageGB != null && bestMetrics.memoryUsageGB == null) {
         bestMetrics.memoryUsageBytes = cluster.memoryUsageBytes
         bestMetrics.memoryUsageGB = cluster.memoryUsageGB
       }

--- a/web/src/lib/__tests__/navigationIcons.test.ts
+++ b/web/src/lib/__tests__/navigationIcons.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for navigationIcons.ts
+ *
+ * Covers the NAVIGATION_ICONS record and getNavigationIcon() fallback logic.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { NAVIGATION_ICONS, getNavigationIcon } from '../navigationIcons'
+
+// ---------------------------------------------------------------------------
+// NAVIGATION_ICONS record
+// ---------------------------------------------------------------------------
+
+describe('NAVIGATION_ICONS', () => {
+  it('is a non-empty record', () => {
+    expect(typeof NAVIGATION_ICONS).toBe('object')
+    expect(Object.keys(NAVIGATION_ICONS).length).toBeGreaterThan(0)
+  })
+
+  it('all values are non-empty strings', () => {
+    for (const [key, value] of Object.entries(NAVIGATION_ICONS)) {
+      expect(typeof value, `icon for "${key}" should be a string`).toBe('string')
+      expect(value.length, `icon for "${key}" should be non-empty`).toBeGreaterThan(0)
+    }
+  })
+
+  it('contains primary navigation entries', () => {
+    expect(NAVIGATION_ICONS['dashboard']).toBeTruthy()
+    expect(NAVIGATION_ICONS['clusters']).toBeTruthy()
+    expect(NAVIGATION_ICONS['alerts']).toBeTruthy()
+    expect(NAVIGATION_ICONS['settings']).toBeTruthy()
+  })
+
+  it('contains all expected primary nav items', () => {
+    const primaryIds = [
+      'dashboard', 'clusters', 'cluster-admin', 'compliance',
+      'enterprise', 'deploy', 'insights', 'ai-ml', 'ai-agents',
+      'acmm', 'ci-cd', 'multi-tenancy', 'alerts', 'arcade',
+    ]
+    for (const id of primaryIds) {
+      expect(NAVIGATION_ICONS[id], `missing primary nav icon for "${id}"`).toBeTruthy()
+    }
+  })
+
+  it('contains discoverable dashboard entries', () => {
+    const discoverable = [
+      'compute', 'cost', 'deployments', 'events', 'gitops',
+      'helm', 'logs', 'network', 'nodes', 'operators', 'pods',
+      'security', 'services', 'storage', 'workloads',
+    ]
+    for (const id of discoverable) {
+      expect(NAVIGATION_ICONS[id], `missing discoverable icon for "${id}"`).toBeTruthy()
+    }
+  })
+
+  it('contains secondary navigation entries', () => {
+    const secondary = ['marketplace', 'history', 'namespaces', 'users', 'settings']
+    for (const id of secondary) {
+      expect(NAVIGATION_ICONS[id], `missing secondary icon for "${id}"`).toBeTruthy()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getNavigationIcon
+// ---------------------------------------------------------------------------
+
+describe('getNavigationIcon', () => {
+  it('returns the icon name for a known primary nav ID', () => {
+    expect(getNavigationIcon('dashboard')).toBe('LayoutDashboard')
+  })
+
+  it('returns the icon name for clusters', () => {
+    expect(getNavigationIcon('clusters')).toBe('Server')
+  })
+
+  it('returns the icon name for alerts', () => {
+    expect(getNavigationIcon('alerts')).toBe('Bell')
+  })
+
+  it('returns the icon name for ai-ml', () => {
+    expect(getNavigationIcon('ai-ml')).toBe('Sparkles')
+  })
+
+  it('returns the icon name for pods', () => {
+    expect(getNavigationIcon('pods')).toBe('Hexagon')
+  })
+
+  it('returns the icon name for settings', () => {
+    expect(getNavigationIcon('settings')).toBe('Settings')
+  })
+
+  it('falls back to LayoutDashboard for unknown IDs', () => {
+    expect(getNavigationIcon('unknown-page')).toBe('LayoutDashboard')
+    expect(getNavigationIcon('')).toBe('LayoutDashboard')
+    expect(getNavigationIcon('does-not-exist')).toBe('LayoutDashboard')
+  })
+
+  it('returns LayoutDashboard for IDs similar to but not matching known entries', () => {
+    expect(getNavigationIcon('Dashboard')).toBe('LayoutDashboard') // case-sensitive
+    expect(getNavigationIcon('CLUSTERS')).toBe('LayoutDashboard') // case-sensitive
+  })
+
+  it('returns all icons from NAVIGATION_ICONS correctly', () => {
+    for (const [id, expectedIcon] of Object.entries(NAVIGATION_ICONS)) {
+      expect(getNavigationIcon(id)).toBe(expectedIcon)
+    }
+  })
+})


### PR DESCRIPTION
Fixes #11646

## Summary

### Bug fix: `clusterUtils.ts` metric merge overwrite-with-zero

The destination-side conditions in the `deduplicateClustersByServer` merge loop used truthy checks (`!bestMetrics.cpuUsageCores`) which would incorrectly overwrite a valid `0` (idle cluster) with data from a later alias. Fixed all four to `== null`.

### New tests

| File | Tests | Coverage |
|------|-------|----------|
| `clusterUtils.test.ts` | +4 | validates destination-side nullish fix |
| `workloadSubscriptions.test.ts` (new) | 15 | 0% → 100% |
| `navigationIcons.test.ts` (new) | 15 | 0% → 100% |