### PR TITLE
🐛 Add defer/recover to fetchJobLogs goroutine (L869)

### DIFF
--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -868,6 +868,12 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 		sem <- struct{}{}
 		go func(idx int, jobID int64, name, conc string) {
 			defer func() { <-sem }()
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("panic in fetchJobLogs goroutine", "jobID", jobID, "error", r)
+					ch <- logResult{idx: idx, log: JobLog{Name: name, Conclusion: conc, Log: ""}}
+				}
+			}()
 			logText := h.fetchJobLog(repo, jobID)
 			ch <- logResult{idx: idx, log: JobLog{Name: name, Conclusion: conc, Log: logText}}
 		}(i, job.ID, job.Name, conclusion)


### PR DESCRIPTION
Fixes #11710

Adds the same defer/recover guard pattern (used at L296 and L570 after #11708) to the fetchJobLogs goroutine at ~L869. Without this, a panic in fetchJobLog causes channel deadlock since the outer loop expects exactly len(jobs) results from ch.