### PR TITLE
fix: pre-build frontend natively to avoid QEMU arm64 hang

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,11 +286,45 @@ jobs:
             --repo "${{ github.repository }}" \
             --clobber
 
-  # Build Docker images per-platform in parallel to avoid QEMU cross-compilation
-  # timeout. Each platform builds natively-emulated in its own job, then the
-  # manifest job merges them into a single multi-arch manifest list.
-  docker-build:
+  # Build frontend natively to avoid QEMU arm64 emulation hanging on Vite
+  build-frontend:
     needs: [determine-version, release]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: needs.release.result == 'success'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: web
+        run: npm run build
+        env:
+          VITE_APP_VERSION: ${{ needs.determine-version.outputs.version }}
+          VITE_COMMIT_HASH: ${{ github.sha }}
+
+      - name: Upload frontend dist
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: frontend-dist
+          path: web/dist/
+          retention-days: 1
+
+  # Build Docker images per-platform in parallel. The frontend is pre-built
+  # natively above to avoid QEMU arm64 emulation hanging on Vite's bundler.
+  docker-build:
+    needs: [determine-version, release, build-frontend]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     if: needs.release.result == 'success'
@@ -307,6 +341,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download pre-built frontend
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: frontend-dist
+          path: web/dist/
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,17 +27,16 @@ WORKDIR /app
 ARG APP_VERSION=0.0.0
 ARG COMMIT_HASH=unknown
 
-# Copy package files
-COPY web/package*.json web/.npmrc ./
-RUN npm ci
-
-# Copy source
+# Copy pre-built dist first (CI injects this to skip Vite under QEMU)
 COPY web/ ./
 
-# Build with version and commit hash baked into the JS bundle
-ENV VITE_APP_VERSION=${APP_VERSION}
-ENV VITE_COMMIT_HASH=${COMMIT_HASH}
-RUN npm run build
+# Build only if dist/ was not pre-built by CI
+RUN if [ -d dist ] && [ -n "$(ls -A dist 2>/dev/null)" ]; then \
+      echo "Using pre-built frontend dist/"; \
+    else \
+      npm ci && \
+      VITE_APP_VERSION=${APP_VERSION} VITE_COMMIT_HASH=${COMMIT_HASH} npm run build; \
+    fi
 
 # Final stage
 FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc


### PR DESCRIPTION
## Summary
- Adds a `build-frontend` job to the release workflow that builds the Vite frontend natively on amd64
- Docker build jobs download the pre-built `dist/` artifact, skipping the in-container Vite build
- Dockerfile detects pre-built `dist/` and skips `npm ci + npm run build` when present
- Local `docker build` still works unchanged (triggers full build when no pre-built dist exists)

The arm64 Docker build has been hanging indefinitely at Vite/Rolldown's "rendering chunks..." step under QEMU emulation. Both the May 2nd scheduled nightly and a manual re-trigger hung for 5+ hours before cancellation. The Go cross-compilation works fine — only the Node.js/Vite frontend build is affected by QEMU performance.

## Test plan
- [ ] Merge and trigger manual release workflow
- [ ] Verify `build-frontend` job completes and uploads artifact
- [ ] Verify both `docker-build` jobs (amd64 + arm64) complete within timeout
- [ ] Verify `docker-manifest` creates multi-arch manifest
- [ ] Verify local `docker build .` still works (full build, no pre-built dist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)