### PR TITLE
fix: guard mcp cache loaders against non-array localstorage data

### DIFF
--- a/web/src/hooks/mcp/__tests__/compute.gpu.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.gpu.test.ts
@@ -875,6 +875,18 @@ describe('loadGPUCacheFromStorage — via module reload', () => {
     updateGPUNodeCache({ isLoading: true })
     expect(gpuNodeCache.isLoading).toBe(true)
   })
+
+  it('returns default empty cache when localStorage nodes is not an array', async () => {
+    const { __computeTestables } = await import('../compute')
+    const { loadGPUCacheFromStorage, GPU_CACHE_KEY } = __computeTestables
+    localStorage.setItem(GPU_CACHE_KEY, JSON.stringify({
+      nodes: 'corrupted-string',
+      lastUpdated: new Date().toISOString(),
+    }))
+    const result = loadGPUCacheFromStorage()
+    expect(Array.isArray(result.nodes)).toBe(true)
+    expect(result.nodes).toHaveLength(0)
+  })
 })
 
 describe('saveGPUCacheToStorage — edge cases', () => {

--- a/web/src/hooks/mcp/__tests__/networking-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking-pure.test.ts
@@ -83,6 +83,15 @@ describe('loadServicesCacheFromStorage', () => {
     expect(loadServicesCacheFromStorage('services:all')).toBeNull()
   })
 
+  it('returns null when data is not an array', () => {
+    localStorage.setItem('kubestellar-services-cache', JSON.stringify({
+      data: 'corrupted',
+      key: 'services:all',
+      timestamp: new Date().toISOString(),
+    }))
+    expect(loadServicesCacheFromStorage('services:all')).toBeNull()
+  })
+
   it('returns cached data when key matches and not stale', () => {
     const data = [{ name: 'kubernetes', namespace: 'default', cluster: 'c1', type: 'ClusterIP' }]
     localStorage.setItem('kubestellar-services-cache', JSON.stringify({

--- a/web/src/hooks/mcp/__tests__/operators-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/operators-pure.test.ts
@@ -72,6 +72,11 @@ describe('loadOperatorsCacheFromStorage', () => {
     expect(loadOperatorsCacheFromStorage('operators:all')).toBeNull()
   })
 
+  it('returns null when data is not an array', () => {
+    localStorage.setItem(OPERATORS_CACHE_KEY, JSON.stringify({ data: 'corrupted', timestamp: 1000, key: 'operators:all' }))
+    expect(loadOperatorsCacheFromStorage('operators:all')).toBeNull()
+  })
+
   it('uses Date.now() fallback when timestamp missing', () => {
     const before = Date.now()
     localStorage.setItem(OPERATORS_CACHE_KEY, JSON.stringify({ data: [{ name: 'op' }], key: 'operators:all' }))

--- a/web/src/hooks/mcp/__tests__/operators-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/operators-pure.test.ts
@@ -136,6 +136,11 @@ describe('loadSubscriptionsCacheFromStorage', () => {
     localStorage.setItem(SUBSCRIPTIONS_CACHE_KEY, 'broken')
     expect(loadSubscriptionsCacheFromStorage('subs:all')).toBeNull()
   })
+
+  it('returns null when data is not an array', () => {
+    localStorage.setItem(SUBSCRIPTIONS_CACHE_KEY, JSON.stringify({ data: 'corrupted', timestamp: 1000, key: 'subs:all' }))
+    expect(loadSubscriptionsCacheFromStorage('subs:all')).toBeNull()
+  })
 })
 
 // ── saveSubscriptionsCacheToStorage ──

--- a/web/src/hooks/mcp/__tests__/storage-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage-pure.test.ts
@@ -123,6 +123,11 @@ describe('loadPVCsCacheFromStorage', () => {
     localStorage.setItem(PVCS_CACHE_KEY, JSON.stringify({ key: 'k', data: [] }))
     expect(loadPVCsCacheFromStorage('k')).toBeNull()
   })
+
+  it('returns null when data is not an array', () => {
+    localStorage.setItem(PVCS_CACHE_KEY, JSON.stringify({ key: 'k', data: 'corrupted', timestamp: new Date().toISOString() }))
+    expect(loadPVCsCacheFromStorage('k')).toBeNull()
+  })
 })
 
 describe('savePVCsCacheToStorage', () => {

--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -46,7 +46,7 @@ function loadGPUCacheFromStorage(): GPUNodeCache {
     const stored = localStorage.getItem(GPU_CACHE_KEY)
     if (stored) {
       const parsed = JSON.parse(stored)
-      if (parsed.nodes && parsed.nodes.length > 0) {
+      if (Array.isArray(parsed.nodes) && parsed.nodes.length > 0) {
         return {
           nodes: parsed.nodes,
           lastUpdated: parsed.lastUpdated ? new Date(parsed.lastUpdated) : null,

--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -786,3 +786,8 @@ function getDemoNodes(): NodeInfo[] {
     },
   ]
 }
+
+export const __computeTestables = {
+  loadGPUCacheFromStorage,
+  GPU_CACHE_KEY,
+}

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -53,7 +53,7 @@ function loadServicesCacheFromStorage(cacheKey: string): { data: Service[], time
     const stored = localStorage.getItem(SERVICES_CACHE_KEY)
     if (stored) {
       const parsed = JSON.parse(stored)
-      if (parsed.key === cacheKey && parsed.data && parsed.data.length > 0) {
+      if (parsed.key === cacheKey && Array.isArray(parsed.data) && parsed.data.length > 0) {
         const timestamp = parsed.timestamp ? new Date(parsed.timestamp) : new Date()
         // Enforce cache TTL — discard stale entries so stale data is never
         // served after a fetch failure (#7125)

--- a/web/src/hooks/mcp/operators.ts
+++ b/web/src/hooks/mcp/operators.ts
@@ -34,7 +34,7 @@ function loadOperatorsCacheFromStorage(cacheKey: string): { data: Operator[], ti
     const stored = localStorage.getItem(OPERATORS_CACHE_KEY)
     if (stored) {
       const parsed = JSON.parse(stored)
-      if (parsed.key === cacheKey && parsed.data && parsed.data.length > 0) {
+      if (parsed.key === cacheKey && Array.isArray(parsed.data) && parsed.data.length > 0) {
         return { data: parsed.data, timestamp: parsed.timestamp || Date.now() }
       }
     }
@@ -56,7 +56,7 @@ function loadSubscriptionsCacheFromStorage(cacheKey: string): { data: OperatorSu
     const stored = localStorage.getItem(SUBSCRIPTIONS_CACHE_KEY)
     if (stored) {
       const parsed = JSON.parse(stored)
-      if (parsed.key === cacheKey && parsed.data && parsed.data.length > 0) {
+      if (parsed.key === cacheKey && Array.isArray(parsed.data) && parsed.data.length > 0) {
         return { data: parsed.data, timestamp: parsed.timestamp || Date.now() }
       }
     }

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -53,7 +53,7 @@ function loadPVCsCacheFromStorage(cacheKey: string): { data: PVC[], timestamp: D
     const stored = localStorage.getItem(PVCS_CACHE_KEY)
     if (stored) {
       const parsed = JSON.parse(stored)
-      if (parsed.key === cacheKey && parsed.data && parsed.data.length > 0) {
+      if (parsed.key === cacheKey && Array.isArray(parsed.data) && parsed.data.length > 0) {
         const timestamp = parsed.timestamp ? new Date(parsed.timestamp) : new Date()
         pvcsCache = { data: parsed.data, timestamp, key: cacheKey }
         return { data: parsed.data, timestamp }


### PR DESCRIPTION
Fixes #11882

## what

four `hooks/mcp/*` cache loaders read a json blob from localstorage and treat the result as an array without checking its shape.

if localstorage contains a value with a different shape (stale schema, browser extension write, quotaexceeded truncation), the truthy length check passes for strings, `setOperators('corrupted')` sets state to a non-array, and the next render crashes with `x.map is not a function`.

same class as the bugs fixed in #10857. that pr caught 6 sister sites. these 4 were missed.

## fix

add `Array.isArray(parsed.data)` (or `parsed.nodes`) before the length check at each affected site:

- `web/src/hooks/mcp/operators.ts:37` operators cache
- `web/src/hooks/mcp/operators.ts:59` subscriptions cache
- `web/src/hooks/mcp/storage.ts:56` pvc cache
- `web/src/hooks/mcp/networking.ts:56` services cache
- `web/src/hooks/mcp/compute.ts:49` gpu cache

four sister hooks already use this pattern (`helm.ts:83`, `buildpacks.ts:68`, `crossplane.ts:81`, `security.ts:33`). this pr brings the inconsistent ones in line.

## test plan

- [x] cd web && npx vitest run src/hooks/mcp/__tests__/operators-pure.test.ts
- new test case `returns null when data is not an array` fails on `main`, passes with this fix