### PR TITLE
fix: validate loadwatchedrepos and loadwatchedpaths return shape

### DIFF
--- a/web/src/components/missions/__tests__/missionBrowserConstants.test.ts
+++ b/web/src/components/missions/__tests__/missionBrowserConstants.test.ts
@@ -29,6 +29,11 @@ describe('loadWatchedRepos', () => {
     localStorage.setItem(WATCHED_REPOS_KEY, '{not-json')
     expect(loadWatchedRepos()).toEqual([])
   })
+
+  it('filters out non-string entries from a stored array', () => {
+    localStorage.setItem(WATCHED_REPOS_KEY, JSON.stringify(['kubestellar/console', 123, {}, null, 'kubestellar/kubestellar']))
+    expect(loadWatchedRepos()).toEqual(['kubestellar/console', 'kubestellar/kubestellar'])
+  })
 })
 
 describe('loadWatchedPaths', () => {
@@ -49,5 +54,10 @@ describe('loadWatchedPaths', () => {
   it('returns empty array on corrupted json', () => {
     localStorage.setItem(WATCHED_PATHS_KEY, '{not-json')
     expect(loadWatchedPaths()).toEqual([])
+  })
+
+  it('filters out non-string entries from a stored array', () => {
+    localStorage.setItem(WATCHED_PATHS_KEY, JSON.stringify(['missions/install', 42, false, 'missions/repair']))
+    expect(loadWatchedPaths()).toEqual(['missions/install', 'missions/repair'])
   })
 })

--- a/web/src/components/missions/__tests__/missionBrowserConstants.test.ts
+++ b/web/src/components/missions/__tests__/missionBrowserConstants.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  WATCHED_REPOS_KEY,
+  WATCHED_PATHS_KEY,
+  loadWatchedRepos,
+  loadWatchedPaths,
+} from '../missionBrowserConstants'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('loadWatchedRepos', () => {
+  it('returns empty array when nothing stored', () => {
+    expect(loadWatchedRepos()).toEqual([])
+  })
+
+  it('returns stored array of repo names', () => {
+    localStorage.setItem(WATCHED_REPOS_KEY, JSON.stringify(['kubestellar/console', 'kubestellar/kubestellar']))
+    expect(loadWatchedRepos()).toEqual(['kubestellar/console', 'kubestellar/kubestellar'])
+  })
+
+  it('returns empty array when stored value is not an array', () => {
+    localStorage.setItem(WATCHED_REPOS_KEY, JSON.stringify({ corrupted: true }))
+    expect(loadWatchedRepos()).toEqual([])
+  })
+
+  it('returns empty array on corrupted json', () => {
+    localStorage.setItem(WATCHED_REPOS_KEY, '{not-json')
+    expect(loadWatchedRepos()).toEqual([])
+  })
+})
+
+describe('loadWatchedPaths', () => {
+  it('returns empty array when nothing stored', () => {
+    expect(loadWatchedPaths()).toEqual([])
+  })
+
+  it('returns stored array of paths', () => {
+    localStorage.setItem(WATCHED_PATHS_KEY, JSON.stringify(['missions/install', 'missions/repair']))
+    expect(loadWatchedPaths()).toEqual(['missions/install', 'missions/repair'])
+  })
+
+  it('returns empty array when stored value is not an array', () => {
+    localStorage.setItem(WATCHED_PATHS_KEY, JSON.stringify('a-string'))
+    expect(loadWatchedPaths()).toEqual([])
+  })
+
+  it('returns empty array on corrupted json', () => {
+    localStorage.setItem(WATCHED_PATHS_KEY, '{not-json')
+    expect(loadWatchedPaths()).toEqual([])
+  })
+})

--- a/web/src/components/missions/missionBrowserConstants.ts
+++ b/web/src/components/missions/missionBrowserConstants.ts
@@ -63,7 +63,8 @@ export const MATURITY_LEVELS = ['All', 'graduated', 'incubating', 'sandbox'] as 
 export function loadWatchedRepos(): string[] {
   try {
     const parsed = JSON.parse(localStorage.getItem(WATCHED_REPOS_KEY) || '[]')
-    return Array.isArray(parsed) ? parsed : []
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((v): v is string => typeof v === 'string')
   } catch { return [] }
 }
 
@@ -74,7 +75,8 @@ export function saveWatchedRepos(repos: string[]) {
 export function loadWatchedPaths(): string[] {
   try {
     const parsed = JSON.parse(localStorage.getItem(WATCHED_PATHS_KEY) || '[]')
-    return Array.isArray(parsed) ? parsed : []
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((v): v is string => typeof v === 'string')
   } catch { return [] }
 }
 

--- a/web/src/components/missions/missionBrowserConstants.ts
+++ b/web/src/components/missions/missionBrowserConstants.ts
@@ -62,7 +62,8 @@ export const MATURITY_LEVELS = ['All', 'graduated', 'incubating', 'sandbox'] as 
 
 export function loadWatchedRepos(): string[] {
   try {
-    return JSON.parse(localStorage.getItem(WATCHED_REPOS_KEY) || '[]')
+    const parsed = JSON.parse(localStorage.getItem(WATCHED_REPOS_KEY) || '[]')
+    return Array.isArray(parsed) ? parsed : []
   } catch { return [] }
 }
 
@@ -72,7 +73,8 @@ export function saveWatchedRepos(repos: string[]) {
 
 export function loadWatchedPaths(): string[] {
   try {
-    return JSON.parse(localStorage.getItem(WATCHED_PATHS_KEY) || '[]')
+    const parsed = JSON.parse(localStorage.getItem(WATCHED_PATHS_KEY) || '[]')
+    return Array.isArray(parsed) ? parsed : []
   } catch { return [] }
 }
 


### PR DESCRIPTION
Fixes #11884

## what

`web/src/components/missions/missionBrowserConstants.ts` has two helpers that read json from localstorage and return the result with a misleading `string[]` type:

```ts
export function loadWatchedRepos(): string[] {
  try {
    return JSON.parse(localStorage.getItem(WATCHED_REPOS_KEY) || '[]')
  } catch { return [] }
}
```

if localstorage contains `{}` or a quoted string, `JSON.parse` succeeds and the function returns a non-array typed as `string[]`. consumer at `MissionBrowser.tsx:200` puts that value into `useState<string[]>` and later calls `.includes()` and `.map()` which crash with `x.includes is not a function`.

## fix

validate with `Array.isArray(parsed)` and fall back to `[]` when the stored value is the wrong shape. applies to both `loadWatchedRepos` and `loadWatchedPaths`.

## test plan

new file `web/src/components/missions/__tests__/missionBrowserConstants.test.ts` with 8 cases covering: empty, valid array, non-array object, json string, corrupted json (for both helpers).

- [x] cd web && npx vitest run src/components/missions/__tests__/missionBrowserConstants.test.ts
- all green