### PR TITLE
fix: validate loadclustercards return shape

### DIFF
--- a/web/src/components/clusters/__tests__/utils.test.ts
+++ b/web/src/components/clusters/__tests__/utils.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../../lib/utils/localStorage', () => ({
   safeSetItem: vi.fn(),
 }))
 
+import { safeGetItem } from '../../../lib/utils/localStorage'
 import {
   isClusterUnreachable,
   isClusterHealthy,
@@ -252,6 +253,24 @@ describe('loadClusterCards', () => {
     const cards = loadClusterCards()
     expect(Array.isArray(cards)).toBe(true)
     expect(cards.length).toBe(0)
+  })
+
+  it('returns parsed array when stored data is a valid array', () => {
+    vi.mocked(safeGetItem).mockReturnValueOnce(JSON.stringify([
+      { id: 'a', card_type: 'pod_issues', config: {} },
+    ]))
+    const cards = loadClusterCards()
+    expect(cards).toEqual([{ id: 'a', card_type: 'pod_issues', config: {} }])
+  })
+
+  it('returns empty array when stored value is not an array', () => {
+    vi.mocked(safeGetItem).mockReturnValueOnce(JSON.stringify({ corrupted: true }))
+    expect(loadClusterCards()).toEqual([])
+  })
+
+  it('returns empty array on corrupted json', () => {
+    vi.mocked(safeGetItem).mockReturnValueOnce('{not-json')
+    expect(loadClusterCards()).toEqual([])
   })
 })
 

--- a/web/src/components/clusters/utils.ts
+++ b/web/src/components/clusters/utils.ts
@@ -148,7 +148,9 @@ const CLUSTERS_CARDS_KEY = 'kubestellar-clusters-cards'
 export function loadClusterCards(): ClusterCard[] {
   try {
     const stored = safeGetItem(CLUSTERS_CARDS_KEY)
-    return stored ? JSON.parse(stored) : []
+    if (!stored) return []
+    const parsed = JSON.parse(stored)
+    return Array.isArray(parsed) ? parsed : []
   } catch {
     return []
   }


### PR DESCRIPTION
Fixes #11886

## what

`web/src/components/clusters/utils.ts:148` reads cluster cards from localstorage and returns `JSON.parse(stored)` typed as `ClusterCard[]` without validating the shape.

```ts
export function loadClusterCards(): ClusterCard[] {
  try {
    const stored = safeGetItem(CLUSTERS_CARDS_KEY)
    return stored ? JSON.parse(stored) : []
  } catch {
    return []
  }
}
```

if localstorage contains `{}` or a quoted string, the function returns a non-array typed as `ClusterCard[]`. consumers iterate the result with `.map()` and `.filter()` which then crash.

## fix

validate with `Array.isArray(parsed)` before returning. fall back to `[]` when the stored value is the wrong shape.

## test plan

3 new test cases in `web/src/components/clusters/__tests__/utils.test.ts` covering valid array, non-array object, and corrupted json paths.

- [x] cd web && npx vitest run src/components/clusters/__tests__/utils.test.ts
- all green