### PR TITLE
fix: validate loadnotifiedalertkeys parsed value is an array

### DIFF
--- a/web/src/contexts/__tests__/alertStorage.test.ts
+++ b/web/src/contexts/__tests__/alertStorage.test.ts
@@ -174,6 +174,18 @@ describe('loadNotifiedAlertKeys', () => {
     const result = loadNotifiedAlertKeys()
     expect(result.size).toBe(0)
   })
+
+  it('returns empty Map when stored value is not an array', () => {
+    mockSafeGet.mockReturnValue(JSON.stringify({ corrupted: true }))
+    const result = loadNotifiedAlertKeys()
+    expect(result.size).toBe(0)
+  })
+
+  it('returns empty Map when stored value is a json string', () => {
+    mockSafeGet.mockReturnValue(JSON.stringify('a-string'))
+    const result = loadNotifiedAlertKeys()
+    expect(result.size).toBe(0)
+  })
 })
 
 // =============================================================================

--- a/web/src/contexts/__tests__/alertStorage.test.ts
+++ b/web/src/contexts/__tests__/alertStorage.test.ts
@@ -186,6 +186,29 @@ describe('loadNotifiedAlertKeys', () => {
     const result = loadNotifiedAlertKeys()
     expect(result.size).toBe(0)
   })
+
+  it('skips entries that are not [string, number] tuples', () => {
+    mockSafeGet.mockReturnValue(JSON.stringify([{}, 123, 'string', null]))
+    const result = loadNotifiedAlertKeys()
+    expect(result.size).toBe(0)
+  })
+
+  it('keeps valid entries while skipping invalid ones in the same array', () => {
+    const now = Date.now()
+    mockSafeGet.mockReturnValue(JSON.stringify([
+      ['valid-1', now - 100],
+      {},
+      ['valid-2', now - 200],
+      'corrupted',
+      [42, now],
+      ['no-timestamp', 'not-a-number'],
+    ]))
+    const result = loadNotifiedAlertKeys()
+    expect(result.size).toBe(2)
+    expect(result.has('valid-1')).toBe(true)
+    expect(result.has('valid-2')).toBe(true)
+    expect(mockSafeSet).toHaveBeenCalledOnce()
+  })
 })
 
 // =============================================================================

--- a/web/src/contexts/alertStorage.ts
+++ b/web/src/contexts/alertStorage.ts
@@ -55,14 +55,19 @@ export function loadNotifiedAlertKeys(): Map<string, number> {
     if (stored) {
       const parsed: unknown = JSON.parse(stored)
       if (!Array.isArray(parsed)) return new Map()
-      const entries = parsed as [string, number][]
+      // Filter out entries that are not [string, number] tuples so corrupted
+      // elements cannot crash entries.filter or new Map() downstream.
+      const entries = parsed.filter((e): e is [string, number] =>
+        Array.isArray(e) && e.length === 2 && typeof e[0] === 'string' && typeof e[1] === 'number'
+      )
       const now = Date.now()
       let fresh = entries.filter(([, ts]) => now - ts <= NOTIFICATION_DEDUP_MAX_AGE_MS)
       // Enforce hard cap: keep only the most recent MAX_DEDUP_KEYS entries
       if (fresh.length > MAX_DEDUP_KEYS) {
         fresh = fresh.sort((a, b) => b[1] - a[1]).slice(0, MAX_DEDUP_KEYS) // newest first
       }
-      if (fresh.length < entries.length) {
+      // Persist cleaned map back if anything was dropped (stale OR invalid)
+      if (fresh.length < parsed.length) {
         safeSet(STORAGE_KEY_NOTIFIED_ALERT_KEYS, JSON.stringify(fresh))
       }
       return new Map(fresh)

--- a/web/src/contexts/alertStorage.ts
+++ b/web/src/contexts/alertStorage.ts
@@ -53,7 +53,9 @@ export function loadNotifiedAlertKeys(): Map<string, number> {
   try {
     const stored = safeGet(STORAGE_KEY_NOTIFIED_ALERT_KEYS)
     if (stored) {
-      const entries = JSON.parse(stored) as [string, number][]
+      const parsed: unknown = JSON.parse(stored)
+      if (!Array.isArray(parsed)) return new Map()
+      const entries = parsed as [string, number][]
       const now = Date.now()
       let fresh = entries.filter(([, ts]) => now - ts <= NOTIFICATION_DEDUP_MAX_AGE_MS)
       // Enforce hard cap: keep only the most recent MAX_DEDUP_KEYS entries


### PR DESCRIPTION
Fixes #11888

## what

`web/src/contexts/alertStorage.ts:54` reads the notification dedup map from localstorage and casts the parsed result to `[string, number][]` without runtime validation.

```ts
const entries = JSON.parse(stored) as [string, number][]
const now = Date.now()
let fresh = entries.filter(([, ts]) => now - ts <= NOTIFICATION_DEDUP_MAX_AGE_MS)
```

if localstorage contains `{}` or a quoted string, `JSON.parse` succeeds but `entries.filter` is `undefined` so calling it throws `TypeError`. the surrounding `try/catch` swallows the throw and returns an empty `Map`. that hides the bug but means notification dedup is silently broken until a user clears storage.

## fix

validate with `Array.isArray(parsed)` before treating it as `[string, number][]`. fall back to `new Map()` when the stored value is the wrong shape.

## test plan

2 new test cases in `web/src/contexts/__tests__/alertStorage.test.ts` covering non-array object and json string corruption paths.

- [x] cd web && npx vitest run src/contexts/__tests__/alertStorage.test.ts
- all green