### PR TITLE
fix: ignore frontend build artifacts (dist, tsbuildinfo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ data/
 
 # Beads ledger — runtime state, not source code
 .beads/
+
+# Frontend build output
+web/dist/
+web/*.tsbuildinfo
+*.tsbuildinfo


### PR DESCRIPTION
## Description
Running the console generates frontend build artifacts inside `web/dist/` and TypeScript build info files (`*.tsbuildinfo`). These are currently not ignored by Git, resulting in a large number of untracked files appearing in the working tree.

This creates noise in source control and can confuse contributors into thinking there are meaningful changes.

## Changes
- Added `web/dist/` and `*.tsbuildinfo` to `.gitignore`
- Removed already tracked build artifacts from the Git index

## Impact
- Keeps working tree clean after running the console
- Prevents accidental commits of build artifacts
- Improves developer experience during local development and Playwright testing

## Notes
- No runtime or functional changes
- Only affects Git tracking behavior