### PR TITLE
fix: offset weekly release cron to avoid GitHub dedup with nightly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
   schedule:
     # Nightly at 5 AM UTC (midnight Eastern during EST, 1 AM during EDT)
     - cron: '0 5 * * *'
-    # Weekly on Sunday at 5 AM UTC
-    - cron: '0 5 * * 0'
+    # Weekly on Sunday at 8 AM UTC (3 AM Eastern) — offset from nightly to avoid dedup
+    - cron: '0 8 * * 0'
   workflow_dispatch:
     inputs:
       release_type:
@@ -55,7 +55,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             RELEASE_TYPE="${{ github.event.inputs.release_type }}"
-          elif [ "${{ github.event.schedule }}" = "0 5 * * 0" ]; then
+          elif [ "${{ github.event.schedule }}" = "0 8 * * 0" ]; then
             RELEASE_TYPE="weekly"
           else
             RELEASE_TYPE="nightly"


### PR DESCRIPTION
## Summary
- Moves the weekly release cron from `0 5 * * 0` to `0 8 * * 0` (8 AM UTC / 3 AM Eastern on Sundays)
- Updates the `github.event.schedule` check in the release type determination to match

GitHub Actions deduplicates cron triggers that fire at the same time. Both the nightly (`0 5 * * *`) and weekly (`0 5 * * 0`) schedules resolved to 5 AM UTC on Sundays, so GitHub only ran one workflow — which defaulted to `nightly`. This caused weekly releases to be silently skipped every Sunday.

## Test plan
- [ ] Next Sunday (May 11): verify nightly fires at 5 AM UTC and weekly fires at 8 AM UTC
- [ ] Verify the weekly release creates a stable (non-prerelease) version tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)