### PR TITLE
🌱 test(e2e): add enterprise compliance portal test suite and stable locators

### DIFF
--- a/web/e2e/enterprise-compliance.spec.ts
+++ b/web/e2e/enterprise-compliance.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test'
+import { setupDemoMode, mockApiFallback } from './helpers/setup'
+
+test.describe('Enterprise Compliance Portal', () => {
+  test.beforeEach(async ({ page }) => {
+    // Standard setup for authenticated demo state
+    await setupDemoMode(page)
+    
+    // Bypass Go backend for E2E speed and stability
+    await mockApiFallback(page)
+
+    // Mock specific compliance endpoints to avoid crashes and provide deterministic data
+    await page.route('**/api/compliance/**', async (route) => {
+      const url = route.request().url()
+      
+      // Default summary/score mock with all required fields to prevent component crashes
+      if (url.includes('/summary') || url.includes('/score')) {
+        await route.fulfill({ 
+          json: { 
+            overall_score: 85, 
+            evaluated_at: new Date().toISOString(),
+            // HIPAA fields
+            safeguards_passed: 10,
+            total_safeguards: 12,
+            phi_namespaces: 5,
+            compliant_namespaces: 4,
+            data_flows: 20,
+            encrypted_flows: 18,
+            // NIST fields
+            total_controls: 100,
+            implemented_controls: 80,
+            baseline: 'moderate',
+            // FedRAMP fields
+            authorization_status: 'authorized',
+            impact_level: 'moderate',
+            controls_satisfied: 200,
+            controls_total: 300,
+            poams_open: 5
+          } 
+        })
+      } else {
+        // Return empty arrays for list endpoints (controls, safeguards, families, etc.)
+        await route.fulfill({ json: [] })
+      }
+    })
+
+    // Navigate to Enterprise portal
+    await page.goto('/enterprise')
+    await page.waitForLoadState('networkidle')
+  })
+
+  test('displays enterprise compliance portal home', async ({ page }) => {
+    // Verify we are on the Enterprise Portal
+    await expect(page.getByTestId('enterprise-portal')).toBeVisible({ timeout: 15000 })
+    
+    // Check for core landing page content
+    await expect(page.getByTestId('dashboard-title')).toHaveText(/Enterprise Compliance Portal/i)
+    
+    // Verify vertical summary cards exist - use headings to disambiguate from sidebar
+    await expect(page.getByRole('heading', { name: 'FinTech & Regulatory' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Healthcare & Life Sciences' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Government & Defense' })).toBeVisible()
+  })
+
+  test.describe('Vertical Dashboards', () => {
+    const verticals = [
+      { id: 'hipaa', label: 'HIPAA Compliance', title: /HIPAA Security Rule Compliance/i },
+      { id: 'nist', label: 'NIST 800-53', title: /NIST 800-53 Control Mapping/i },
+      { id: 'fedramp', label: 'FedRAMP', title: /FedRAMP Readiness/i },
+    ]
+
+    for (const vertical of verticals) {
+      test(`navigates to ${vertical.label} vertical`, async ({ page }) => {
+        // Click on the vertical in the sidebar
+        const navItem = page.locator(`[data-testid="sidebar-item"][data-test-label="${vertical.label}"]`)
+        await navItem.click()
+        
+        // Wait for navigation and header update
+        await expect(page.getByTestId('dashboard-title')).toHaveText(vertical.title, { timeout: 15000 })
+        
+        // Vertical dashboards should have the enterprise sidebar
+        await expect(page.getByTestId('sidebar')).toBeVisible()
+      })
+    }
+  })
+
+  test('sidebar navigation works', async ({ page }) => {
+    // Ensure sidebar is present
+    const sidebar = page.getByTestId('sidebar')
+    await expect(sidebar).toBeVisible()
+    
+    // Click 'Frameworks' and verify navigation
+    await sidebar.locator('[data-testid="sidebar-item"][data-test-label="Frameworks"]').click()
+    await expect(page.getByTestId('dashboard-title')).toHaveText(/Compliance Frameworks/i)
+  })
+
+  test('summary stats are displayed', async ({ page }) => {
+    // Enterprise portal home should show aggregate stats
+    await expect(page.getByText('Overall Score')).toBeVisible()
+    await expect(page.getByText('Active Verticals')).toBeVisible()
+  })
+})

--- a/web/src/components/enterprise/EnterprisePortal.tsx
+++ b/web/src/components/enterprise/EnterprisePortal.tsx
@@ -177,7 +177,7 @@ export default function EnterprisePortal() {
   const sections = ENTERPRISE_NAV_SECTIONS.filter((s) => s.id !== 'overview')
 
   return (
-    <div className="p-6 max-w-7xl mx-auto">
+    <div data-testid="enterprise-portal" className="p-6 max-w-7xl mx-auto">
       {/* Header with tip bar, auto-refresh, and refresh button */}
       <DashboardHeader
         title="Enterprise Compliance Portal"

--- a/web/src/components/layout/SidebarShell.tsx
+++ b/web/src/components/layout/SidebarShell.tsx
@@ -466,6 +466,8 @@ export function SidebarShell({
           <>
           <NavLink
             to={item.href}
+            data-testid="sidebar-item"
+            data-test-label={item.label}
             onClick={() => emitSidebarNavigated(item.href)}
             onDoubleClick={(e) => handleDoubleClick(item, e)}
             onMouseEnter={() => prefetchDashboard(item.href)}


### PR DESCRIPTION
### 📝 Summary of Changes

- Implemented a comprehensive E2E test suite for the Enterprise Compliance portal.
- Added stable `data-testid` locators to core layout and portal components to resolve selector fragility.
- Hardened the E2E environment with robust API mocking for compliance vertical endpoints.

---

### Changes Made

- [x] **Added E2E Tests**: Created `web/e2e/enterprise-compliance.spec.ts` covering the landing page, vertical navigation (HIPAA, NIST, FedRAMP), and sidebar functionality.
- [x] **Stable Locators**: Added `data-testid="enterprise-portal"` to `EnterprisePortal.tsx` and `data-testid="sidebar-item"` with `data-test-label` to `SidebarShell.tsx`.
- [x] **API Resilience**: Implemented a robust `page.route` handler in the test suite to mock `/api/compliance/**` responses, ensuring components don't crash on empty or malformed data.
- [x] **Selector Refactoring**: Switched from fragile text-based selectors to role-based and test-ID-based locators to resolve strict mode violations and timing issues.

---

### Checklist

- [x] I have reviewed the project's contribution guidelines
- [x] I have tested the changes locally and ensured they work as expected (6/6 tests passing)
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

**Playwright Test Execution Result:**
```text
Running 6 tests using 6 workers

  ✓  Enterprise Compliance Portal › summary stats are displayed (16.4s)
  ✓  Enterprise Compliance Portal › displays enterprise compliance portal home (16.6s)
  ✓  Enterprise Compliance Portal › Vertical Dashboards › navigates to FedRAMP vertical (17.1s)
  ✓  Enterprise Compliance Portal › sidebar navigation works (17.2s)
  ✓  Enterprise Compliance Portal › Vertical Dashboards › navigates to NIST 800-53 vertical (17.4s)
  ✓  Enterprise Compliance Portal › Vertical Dashboards › navigates to HIPAA Compliance vertical (17.8s)

  6 passed (18.7s)
