### PR TITLE
feat(ci): hourly MTTR badge workflow

### DIFF
--- a/.github/workflows/mttr-badge.yml
+++ b/.github/workflows/mttr-badge.yml
@@ -1,0 +1,139 @@
+name: MTTR Badge
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: read
+  pull-requests: read
+
+jobs:
+  mttr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Calculate MTTR and update badge
+        uses: actions/github-script@v7
+        env:
+          BADGE_GIST_ID: 4ae525a9797e8f83231ac344fcb47226
+          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const LOOKBACK_DAYS = 30;
+            const PR_LIMIT = 300;
+            const FIXES_RE = /(?:fixes|closes|resolves)\s+#(\d+)/gi;
+
+            // Fetch merged PRs from the last 30 days
+            const since = new Date(Date.now() - LOOKBACK_DAYS * 86400000).toISOString();
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 100,
+            });
+
+            const mergedPrs = prs
+              .filter(pr => pr.merged_at && new Date(pr.merged_at) >= new Date(since))
+              .slice(0, PR_LIMIT);
+
+            console.log(`Found ${mergedPrs.length} merged PRs in last ${LOOKBACK_DAYS} days`);
+
+            // Extract issue refs from PR bodies
+            const issueRefs = [];
+            for (const pr of mergedPrs) {
+              const body = pr.body || '';
+              let match;
+              const re = new RegExp(FIXES_RE.source, FIXES_RE.flags);
+              while ((match = re.exec(body)) !== null) {
+                issueRefs.push({
+                  issue: parseInt(match[1], 10),
+                  mergedAt: pr.merged_at,
+                });
+              }
+            }
+
+            if (issueRefs.length === 0) {
+              console.log('No Fixes/Closes refs found — skipping badge update');
+              return;
+            }
+
+            // Fetch issue createdAt for each unique issue
+            const uniqueIssues = [...new Set(issueRefs.map(r => r.issue))];
+            console.log(`Fetching createdAt for ${uniqueIssues.length} issues`);
+
+            const createdAt = {};
+            for (const num of uniqueIssues) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                });
+                createdAt[num] = issue.created_at;
+              } catch (e) {
+                console.log(`Could not fetch issue #${num}: ${e.message}`);
+              }
+            }
+
+            // Compute durations (issue filed → PR merged) in minutes
+            const durations = [];
+            for (const ref of issueRefs) {
+              const ca = createdAt[ref.issue];
+              if (!ca) continue;
+              const issueMs = new Date(ca).getTime();
+              const mergeMs = new Date(ref.mergedAt).getTime();
+              if (mergeMs <= issueMs) continue;
+              durations.push(Math.round((mergeMs - issueMs) / 60000));
+            }
+
+            if (durations.length === 0) {
+              console.log('No valid durations computed — skipping');
+              return;
+            }
+
+            durations.sort((a, b) => a - b);
+            const median = durations[Math.floor(durations.length / 2)];
+            const avg = Math.round(durations.reduce((s, d) => s + d, 0) / durations.length);
+            const p90 = durations[Math.min(Math.floor(durations.length * 0.9), durations.length - 1)];
+
+            console.log(`MTTR: median=${median}m avg=${avg}m p90=${p90}m count=${durations.length}`);
+
+            // Determine badge color
+            const GOOD_THRESHOLD_MIN = 60;
+            const WARN_THRESHOLD_MIN = 240;
+            let color;
+            if (median <= GOOD_THRESHOLD_MIN) color = 'brightgreen';
+            else if (median <= WARN_THRESHOLD_MIN) color = 'yellow';
+            else color = 'red';
+
+            // Update gist badge
+            const gistId = process.env.BADGE_GIST_ID;
+            const gistToken = process.env.GIST_TOKEN;
+            if (!gistToken) {
+              console.log('No GIST_TOKEN — skipping badge update');
+              return;
+            }
+
+            const badge = {
+              schemaVersion: 1,
+              label: 'MTTR',
+              message: `${median} min`,
+              color,
+            };
+
+            const { Octokit } = await import('@octokit/rest');
+            const gistKit = new Octokit({ auth: gistToken });
+            await gistKit.gists.update({
+              gist_id: gistId,
+              files: {
+                'median-fix.json': {
+                  content: JSON.stringify(badge),
+                },
+              },
+            });
+
+            console.log(`Badge updated: ${JSON.stringify(badge)}`);


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that calculates MTTR (Mean Time to Resolution) every hour and updates the README badge gist.

**Logic** (mirrors hive's `api-collector.sh`):
1. Fetches merged PRs from the last 30 days
2. Extracts `Fixes #N` / `Closes #N` references from PR bodies
3. Fetches `createdAt` for each referenced issue
4. Computes median(merge_time - issue_created_time) in minutes
5. Updates the shields.io badge gist with median value + color threshold

**Badge thresholds**: ≤60m green, ≤240m yellow, >240m red

**Schedule**: Hourly at :17 (avoids top-of-hour congestion)

Uses existing `GIST_TOKEN` repo secret to update gist `4ae525a9797e8f83231ac344fcb47226`.

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch`
- [ ] Verify gist badge updates with correct median value
- [ ] Compare with hive dashboard MTTR (should match)