### PR TITLE
fix(ci): use fetch for MTTR gist update

### DIFF
--- a/.github/workflows/mttr-badge.yml
+++ b/.github/workflows/mttr-badge.yml
@@ -128,15 +128,23 @@ jobs:
               color,
             };
 
-            const { Octokit } = await import('@octokit/rest');
-            const gistKit = new Octokit({ auth: gistToken });
-            await gistKit.gists.update({
-              gist_id: gistId,
-              files: {
-                'median-fix.json': {
-                  content: JSON.stringify(badge),
-                },
+            const response = await fetch(`https://api.github.com/gists/${gistId}`, {
+              method: 'PATCH',
+              headers: {
+                Authorization: `token ${gistToken}`,
+                Accept: 'application/vnd.github+json',
               },
+              body: JSON.stringify({
+                files: {
+                  'median-fix.json': {
+                    content: JSON.stringify(badge),
+                  },
+                },
+              }),
             });
+            if (!response.ok) {
+              console.log(`Gist update failed: ${response.status} ${response.statusText}`);
+              return;
+            }
 
             console.log(`Badge updated: ${JSON.stringify(badge)}`);


### PR DESCRIPTION
## Summary
- Replace `@octokit/rest` import with native `fetch` API for gist badge update
- `@octokit/rest` is not available in the `actions/github-script@v7` runtime, causing `ERR_MODULE_NOT_FOUND`
- MTTR calculation itself works correctly (median=86m from 375 durations in last 30 days)

Follow-up fix to #11950 and #11952.