### PR TITLE
fix: use live getter for agent URL to respect suppressLocalAgent

### DIFF
--- a/web/src/hooks/mcp/__tests__/clusters.dedup.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.dedup.test.ts
@@ -51,7 +51,7 @@ vi.mock('../shared', async () => {
     CLUSTER_POLL_INTERVAL_MS: m.CLUSTER_POLL_INTERVAL_MS,
     MIN_REFRESH_INDICATOR_MS: m.MIN_REFRESH_INDICATOR_MS,
     CACHE_TTL_MS: m.CACHE_TTL_MS,
-    LOCAL_AGENT_URL: m.LOCAL_AGENT_URL,
+    getLocalAgentURL: m.getLocalAgentURL,
     // Forwarded real implementations
     getEffectiveInterval: m.getEffectiveInterval,
     notifyClusterSubscribers: m.notifyClusterSubscribers,

--- a/web/src/hooks/mcp/__tests__/clusters.health.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.health.test.ts
@@ -52,7 +52,7 @@ vi.mock('../shared', async () => {
     CLUSTER_POLL_INTERVAL_MS: m.CLUSTER_POLL_INTERVAL_MS,
     MIN_REFRESH_INDICATOR_MS: m.MIN_REFRESH_INDICATOR_MS,
     CACHE_TTL_MS: m.CACHE_TTL_MS,
-    LOCAL_AGENT_URL: m.LOCAL_AGENT_URL,
+    getLocalAgentURL: m.getLocalAgentURL,
     // Forwarded real implementations
     getEffectiveInterval: m.getEffectiveInterval,
     notifyClusterSubscribers: m.notifyClusterSubscribers,

--- a/web/src/hooks/mcp/__tests__/clusters.list.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.list.test.ts
@@ -51,7 +51,7 @@ vi.mock('../shared', async () => {
     CLUSTER_POLL_INTERVAL_MS: m.CLUSTER_POLL_INTERVAL_MS,
     MIN_REFRESH_INDICATOR_MS: m.MIN_REFRESH_INDICATOR_MS,
     CACHE_TTL_MS: m.CACHE_TTL_MS,
-    LOCAL_AGENT_URL: m.LOCAL_AGENT_URL,
+    getLocalAgentURL: m.getLocalAgentURL,
     // Forwarded real implementations
     getEffectiveInterval: m.getEffectiveInterval,
     notifyClusterSubscribers: m.notifyClusterSubscribers,

--- a/web/src/hooks/mcp/__tests__/compute.gpu.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.gpu.test.ts
@@ -76,7 +76,7 @@ vi.mock('../shared', () => ({
   GPU_POLL_INTERVAL_MS: 30_000,
   MIN_REFRESH_INDICATOR_MS: 500,
   getEffectiveInterval: (ms: number) => ms,
-  LOCAL_AGENT_URL: 'http://localhost:8585',
+  getLocalAgentURL: () => 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
   clusterCacheRef: mockClusterCacheRef,
 }))

--- a/web/src/hooks/mcp/__tests__/compute.nodes.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.nodes.test.ts
@@ -76,7 +76,7 @@ vi.mock('../shared', () => ({
   GPU_POLL_INTERVAL_MS: 30_000,
   MIN_REFRESH_INDICATOR_MS: 500,
   getEffectiveInterval: (ms: number) => ms,
-  LOCAL_AGENT_URL: 'http://localhost:8585',
+  getLocalAgentURL: () => 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
   clusterCacheRef: mockClusterCacheRef,
 }))

--- a/web/src/hooks/mcp/__tests__/compute.nvidia.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.nvidia.test.ts
@@ -76,7 +76,7 @@ vi.mock('../shared', () => ({
   GPU_POLL_INTERVAL_MS: 30_000,
   MIN_REFRESH_INDICATOR_MS: 500,
   getEffectiveInterval: (ms: number) => ms,
-  LOCAL_AGENT_URL: 'http://localhost:8585',
+  getLocalAgentURL: () => 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
   clusterCacheRef: mockClusterCacheRef,
 }))

--- a/web/src/hooks/mcp/__tests__/config.test.ts
+++ b/web/src/hooks/mcp/__tests__/config.test.ts
@@ -59,7 +59,7 @@ vi.mock('../../../lib/modeTransition', () => ({
 }))
 
 vi.mock('../shared', () => ({
-  LOCAL_AGENT_URL: 'http://localhost:8585',
+  getLocalAgentURL: () => 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
 }))
 

--- a/web/src/hooks/mcp/__tests__/events.test.ts
+++ b/web/src/hooks/mcp/__tests__/events.test.ts
@@ -68,7 +68,7 @@ vi.mock('../shared', () => ({
     const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
     return Math.min(ms * multiplier, 600_000)
   },
-  LOCAL_AGENT_URL: 'http://localhost:8585',
+  getLocalAgentURL: () => 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
 }))
 

--- a/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
@@ -38,7 +38,7 @@ vi.mock('../../useLocalAgent', () => ({
 }))
 
 vi.mock('../shared', () => ({
-  LOCAL_AGENT_URL: 'http://localhost:8585',
+  getLocalAgentURL: () => 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
   clusterCacheRef: mockClusterCacheRef,
 }))

--- a/web/src/hooks/mcp/__tests__/kagenti.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagenti.test.ts
@@ -36,7 +36,7 @@ vi.mock('../../useLocalAgent', () => ({
 }))
 
 vi.mock('../shared', () => ({
-  LOCAL_AGENT_URL: 'http://localhost:8585',
+  getLocalAgentURL: () => 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
   clusterCacheRef: mockClusterCacheRef,
 }))

--- a/web/src/hooks/mcp/__tests__/namespaces.test.ts
+++ b/web/src/hooks/mcp/__tests__/namespaces.test.ts
@@ -57,7 +57,7 @@ vi.mock('../../../lib/kubectlProxy', () => ({
 }))
 
 vi.mock('../shared', () => ({
-  LOCAL_AGENT_URL: 'http://localhost:8585',
+  getLocalAgentURL: () => 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
   clusterCacheRef: mockClusterCacheRef,
 }))

--- a/web/src/hooks/mcp/__tests__/networking-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking-pure.test.ts
@@ -29,7 +29,7 @@ vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
   getEffectiveInterval: (base: number) => base,
-  LOCAL_AGENT_URL: 'http://127.0.0.1:8585/mcp',
+  getLocalAgentURL: () => 'http://127.0.0.1:8585/mcp',
   agentFetch: vi.fn(),
   clusterCacheRef: { current: new Map() },
 }))

--- a/web/src/hooks/mcp/__tests__/networking.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking.test.ts
@@ -76,7 +76,7 @@ vi.mock('../shared', () => ({
     const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
     return Math.min(ms * multiplier, 600_000)
   },
-  LOCAL_AGENT_URL: 'http://localhost:8585',
+  getLocalAgentURL: () => 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
   clusterCacheRef: mockClusterCacheRef,
 }))

--- a/web/src/hooks/mcp/__tests__/shared-pure-funcs.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-pure-funcs.test.ts
@@ -94,7 +94,7 @@ import {
   GPU_POLL_INTERVAL_MS,
   CACHE_TTL_MS,
   MIN_REFRESH_INDICATOR_MS,
-  LOCAL_AGENT_URL,
+  getLocalAgentURL,
   // Pure functions
   getEffectiveInterval,
   shareMetricsBetweenSameServerClusters,
@@ -178,8 +178,9 @@ describe('shared.ts - Exported constants', () => {
     expect(MIN_REFRESH_INDICATOR_MS).toBe(HALF_SECOND_MS)
   })
 
-  it('LOCAL_AGENT_URL is re-exported from constants', () => {
-    expect(typeof LOCAL_AGENT_URL).toBe('string')
+  it('getLocalAgentURL is re-exported as a function', () => {
+    expect(typeof getLocalAgentURL).toBe('function')
+    expect(typeof getLocalAgentURL()).toBe('string')
   })
 })
 

--- a/web/src/hooks/mcp/__tests__/shared-websocket-detect.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-websocket-detect.test.ts
@@ -94,7 +94,7 @@ import {
   GPU_POLL_INTERVAL_MS,
   CACHE_TTL_MS,
   MIN_REFRESH_INDICATOR_MS,
-  LOCAL_AGENT_URL,
+  getLocalAgentURL,
   // Pure functions
   getEffectiveInterval,
   shareMetricsBetweenSameServerClusters,

--- a/web/src/hooks/mcp/__tests__/storage.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage.test.ts
@@ -84,7 +84,7 @@ vi.mock('../shared', () => ({
     const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
     return Math.min(ms * multiplier, 600_000)
   },
-  LOCAL_AGENT_URL: 'http://localhost:8585',
+  getLocalAgentURL: () => 'http://localhost:8585',
   agentFetch: (...args: unknown[]) => fetch(...(args as Parameters<typeof fetch>)),
   clusterCacheRef: mockClusterCacheRef,
 }))

--- a/web/src/hooks/mcp/__tests__/workloadQueries.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloadQueries.test.ts
@@ -100,7 +100,7 @@ vi.mock('../shared', () => ({
   clusterCacheRef: { clusters: [] },
   agentFetch: (...args: unknown[]) => mockAgentFetch(...args),
   fetchWithRetry: (...args: unknown[]) => mockFetchWithRetry(...args),
-  LOCAL_AGENT_URL: 'http://127.0.0.1:8585',
+  getLocalAgentURL: () => 'http://127.0.0.1:8585',
 }))
 
 vi.mock('../../../lib/constants/network', () => ({

--- a/web/src/hooks/mcp/__tests__/workloads.branches.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.branches.test.ts
@@ -85,7 +85,7 @@ vi.mock('../shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   MIN_REFRESH_INDICATOR_MS: 500,
   getEffectiveInterval: (ms: number) => ms,
-  LOCAL_AGENT_URL: 'http://localhost:8585',
+  getLocalAgentURL: () => 'http://localhost:8585',
   clusterCacheRef: mockClusterCacheRef,
   agentFetch: vi.fn().mockImplementation(() => Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))),
   fetchWithRetry: (url: string, opts: Record<string, unknown> = {}) => {

--- a/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
@@ -91,7 +91,7 @@ vi.mock('../shared', () => ({
     const multiplier = Math.pow(2, Math.min(consecutiveFailures, 5))
     return Math.min(ms * multiplier, 600_000)
   },
-  LOCAL_AGENT_URL: 'http://localhost:8585',
+  getLocalAgentURL: () => 'http://localhost:8585',
   clusterCacheRef: mockClusterCacheRef,
   agentFetch: (...args: unknown[]) => mockAgentFetch(...args),
   fetchWithRetry: (url: string, opts: Record<string, unknown> = {}) => {

--- a/web/src/hooks/mcp/agentFetch.ts
+++ b/web/src/hooks/mcp/agentFetch.ts
@@ -6,8 +6,13 @@ import {
 } from '../../lib/constants'
 import { isLocalAgentSuppressed } from '../../lib/constants/network'
 
-// Re-export for backward compatibility
-export const LOCAL_AGENT_URL = LOCAL_AGENT_HTTP_URL
+// Re-export as a live getter. LOCAL_AGENT_HTTP_URL is a mutable `let` that
+// gets set to '' by suppressLocalAgent() (in-cluster deployments). A `const`
+// snapshot would freeze the initial 'http://127.0.0.1:8585' value, causing
+// mixed-content errors on Safari when accessing the deployed console.
+export function getLocalAgentURL(): string {
+  return LOCAL_AGENT_HTTP_URL
+}
 
 export const AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'
 const AGENT_TOKEN_FETCH_TIMEOUT_MS = 5000

--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -5,7 +5,7 @@ import { isDemoMode } from '../../lib/demoMode'
 import { useDemoMode } from '../useDemoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
-import { GPU_POLL_INTERVAL_MS, getEffectiveInterval, LOCAL_AGENT_URL, agentFetch } from './shared'
+import { GPU_POLL_INTERVAL_MS, getEffectiveInterval, getLocalAgentURL, agentFetch } from './shared'
 import { subscribePolling } from './pollingManager'
 import { MCP_EXTENDED_TIMEOUT_MS, MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import { classifyError, type ClusterErrorType } from '../../lib/errorClassifier'
@@ -169,7 +169,7 @@ async function fetchGPUNodes(cluster?: string, _source?: string) {
       try {
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), MCP_EXTENDED_TIMEOUT_MS)
-        const response = await agentFetch(`${LOCAL_AGENT_URL}/gpu-nodes?${params}`, {
+        const response = await agentFetch(`${getLocalAgentURL()}/gpu-nodes?${params}`, {
           signal: controller.signal,
           headers: { 'Accept': 'application/json' },
         })
@@ -486,7 +486,7 @@ export function useNodes(cluster?: string) {
       try {
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), MCP_HOOK_TIMEOUT_MS)
-        const response = await agentFetch(`${LOCAL_AGENT_URL}/nodes?cluster=${encodeURIComponent(cluster)}`, {
+        const response = await agentFetch(`${getLocalAgentURL()}/nodes?cluster=${encodeURIComponent(cluster)}`, {
           signal: controller.signal,
           headers: { 'Accept': 'application/json' },
         })

--- a/web/src/hooks/mcp/config.ts
+++ b/web/src/hooks/mcp/config.ts
@@ -5,7 +5,7 @@ import { isDemoMode } from '../../lib/demoMode'
 import { useDemoMode } from '../useDemoMode'
 import { registerRefetch } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
-import { LOCAL_AGENT_URL, agentFetch } from './shared'
+import { getLocalAgentURL, agentFetch } from './shared'
 import { MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { ConfigMap, Secret, ServiceAccount } from './types'
 
@@ -32,7 +32,7 @@ export function useConfigMaps(cluster?: string, namespace?: string) {
         if (namespace) params.append('namespace', namespace)
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), MCP_HOOK_TIMEOUT_MS)
-        const response = await agentFetch(`${LOCAL_AGENT_URL}/configmaps?${params}`, {
+        const response = await agentFetch(`${getLocalAgentURL()}/configmaps?${params}`, {
           signal: controller.signal,
           headers: { 'Accept': 'application/json' },
         })
@@ -137,7 +137,7 @@ export function useSecrets(cluster?: string, namespace?: string) {
         if (namespace) params.append('namespace', namespace)
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), MCP_HOOK_TIMEOUT_MS)
-        const response = await agentFetch(`${LOCAL_AGENT_URL}/secrets?${params}`, {
+        const response = await agentFetch(`${getLocalAgentURL()}/secrets?${params}`, {
           signal: controller.signal,
           headers: { 'Accept': 'application/json' },
         })
@@ -242,7 +242,7 @@ export function useServiceAccounts(cluster?: string, namespace?: string) {
         if (namespace) params.append('namespace', namespace)
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), MCP_HOOK_TIMEOUT_MS)
-        const response = await agentFetch(`${LOCAL_AGENT_URL}/serviceaccounts?${params}`, {
+        const response = await agentFetch(`${getLocalAgentURL()}/serviceaccounts?${params}`, {
           signal: controller.signal,
           headers: { 'Accept': 'application/json' },
         })

--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -5,7 +5,7 @@ import { isDemoMode } from '../../lib/demoMode'
 import { useDemoMode } from '../useDemoMode'
 import { registerRefetch } from '../../lib/modeTransition'
 import { registerCacheReset } from '../../lib/modeTransition'
-import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, agentFetch } from './shared'
+import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, getLocalAgentURL, agentFetch } from './shared'
 import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { ClusterEvent } from './types'
@@ -116,7 +116,7 @@ export function useEvents(cluster?: string, namespace?: string, limit = 20) {
         params.append('limit', limit.toString())
 
         const timeoutId = setTimeout(() => abortControllerRef.current?.abort(), MCP_HOOK_TIMEOUT_MS)
-        const response = await agentFetch(`${LOCAL_AGENT_URL}/events?${params}`, {
+        const response = await agentFetch(`${getLocalAgentURL()}/events?${params}`, {
           signal,
           headers: { 'Accept': 'application/json' },
         })

--- a/web/src/hooks/mcp/kagenti.ts
+++ b/web/src/hooks/mcp/kagenti.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { mapSettledWithConcurrency } from '../../lib/utils/concurrency'
 import { isAgentUnavailable, reportAgentDataSuccess } from '../useLocalAgent'
-import { clusterCacheRef, LOCAL_AGENT_URL, agentFetch as sharedAgentFetch } from './shared'
+import { clusterCacheRef, getLocalAgentURL, agentFetch as sharedAgentFetch } from './shared'
 import { deduplicateClustersByServer } from './dedup'
 import { useCache } from '../../lib/cache'
 
@@ -148,7 +148,7 @@ async function agentFetch<T>(path: string, cluster: string, namespace?: string):
   const ctrl = new AbortController()
   const tid = setTimeout(() => ctrl.abort(), AGENT_TIMEOUT)
   try {
-    const res = await sharedAgentFetch(`${LOCAL_AGENT_URL}${path}?${params}`, {
+    const res = await sharedAgentFetch(`${getLocalAgentURL()}${path}?${params}`, {
       signal: ctrl.signal,
       headers: { Accept: 'application/json' } })
     clearTimeout(tid)

--- a/web/src/hooks/mcp/namespaces.ts
+++ b/web/src/hooks/mcp/namespaces.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { isDemoMode } from '../../lib/demoMode'
-import { LOCAL_AGENT_URL, agentFetch, clusterCacheRef } from './shared'
+import { getLocalAgentURL, agentFetch, clusterCacheRef } from './shared'
 import type { PodInfo, NamespaceStats } from './types'
 import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 
@@ -83,7 +83,7 @@ export function useNamespaces(cluster?: string, forceLive = false) {
       try {
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), NAMESPACE_FETCH_TIMEOUT_MS)
-        const response = await agentFetch(`${LOCAL_AGENT_URL}/namespaces?cluster=${encodeURIComponent(cluster)}`, {
+        const response = await agentFetch(`${getLocalAgentURL()}/namespaces?cluster=${encodeURIComponent(cluster)}`, {
           signal: controller.signal,
           headers: { 'Accept': 'application/json' },
         })

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -5,7 +5,7 @@ import { useDemoMode } from '../useDemoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
-import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, agentFetch, clusterCacheRef } from './shared'
+import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, getLocalAgentURL, agentFetch, clusterCacheRef } from './shared'
 import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS, DEPLOY_ABORT_TIMEOUT_MS, SERVICES_CACHE_TTL_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { Service, Ingress, NetworkPolicy } from './types'
@@ -172,7 +172,7 @@ export function useServices(cluster?: string, namespace?: string) {
         if (namespace) agentParams.append('namespace', namespace)
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), MCP_HOOK_TIMEOUT_MS)
-        const response = await agentFetch(`${LOCAL_AGENT_URL}/services?${agentParams}`, {
+        const response = await agentFetch(`${getLocalAgentURL()}/services?${agentParams}`, {
           signal: controller.signal,
           headers: { 'Accept': 'application/json' },
         })
@@ -408,7 +408,7 @@ export function useIngresses(cluster?: string, namespace?: string) {
         if (namespace) params.append('namespace', namespace)
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), MCP_HOOK_TIMEOUT_MS)
-        const response = await agentFetch(`${LOCAL_AGENT_URL}/ingresses?${params}`, {
+        const response = await agentFetch(`${getLocalAgentURL()}/ingresses?${params}`, {
           signal: controller.signal,
           headers: { 'Accept': 'application/json' },
         })
@@ -517,7 +517,7 @@ export function useNetworkPolicies(cluster?: string, namespace?: string) {
         if (namespace) params.append('namespace', namespace)
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), MCP_HOOK_TIMEOUT_MS)
-        const response = await agentFetch(`${LOCAL_AGENT_URL}/networkpolicies?${params}`, {
+        const response = await agentFetch(`${getLocalAgentURL()}/networkpolicies?${params}`, {
           signal: controller.signal,
           headers: { 'Accept': 'application/json' },
         })

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -18,7 +18,7 @@ import {
 import { STORAGE_KEY_TOKEN } from '../../lib/constants/storage'
 import { MCP_PROBE_TIMEOUT_MS, FOCUS_DELAY_MS, KUBECTL_MAX_TIMEOUT_MS } from '../../lib/constants/network'
 import type { ClusterInfo, ClusterHealth } from './types'
-import { LOCAL_AGENT_URL, agentFetch, AGENT_TOKEN_STORAGE_KEY } from './agentFetch'
+import { getLocalAgentURL, agentFetch, AGENT_TOKEN_STORAGE_KEY } from './agentFetch'
 import { shareMetricsBetweenSameServerClusters, deduplicateClustersByServer, detectDistributionFromNamespaces, detectDistributionFromServer } from './clusterUtils'
 
 // Re-export canonical constant under the name used by MCP hooks
@@ -49,7 +49,7 @@ const CLUSTER_NOTIFY_DEBOUNCE_MS = 50
 export const MIN_REFRESH_INDICATOR_MS = 500
 
 // agentFetch — extracted to ./agentFetch (auth-injecting fetch wrapper)
-export { LOCAL_AGENT_URL, agentFetch, _resetAgentTokenState } from './agentFetch'
+export { getLocalAgentURL, agentFetch, _resetAgentTokenState } from './agentFetch'
 
 // ============================================================================
 // Shared Cluster State - ensures all useClusters() consumers see the same data
@@ -801,7 +801,7 @@ async function fetchClusterListFromAgent(): Promise<ClusterInfo[] | null> {
   try {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), MCP_PROBE_TIMEOUT_MS)
-    const response = await agentFetch(`${LOCAL_AGENT_URL}/clusters`, {
+    const response = await agentFetch(`${getLocalAgentURL()}/clusters`, {
       signal: controller.signal,
     })
     clearTimeout(timeoutId)
@@ -873,7 +873,7 @@ export async function fetchSingleClusterHealth(clusterName: string, kubectlConte
       const context = kubectlContext || clusterName
       const controller = new AbortController()
       const timeoutId = setTimeout(() => controller.abort(), MCP_HOOK_TIMEOUT_MS)
-      const response = await agentFetch(`${LOCAL_AGENT_URL}/cluster-health?cluster=${encodeURIComponent(context)}`, {
+      const response = await agentFetch(`${getLocalAgentURL()}/cluster-health?cluster=${encodeURIComponent(context)}`, {
         signal: controller.signal,
         headers: { 'Accept': 'application/json' },
       })

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -3,7 +3,7 @@ import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode } from '../../lib/demoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { kubectlProxy } from '../../lib/kubectlProxy'
-import { REFRESH_INTERVAL_MS, getEffectiveInterval, LOCAL_AGENT_URL, agentFetch, clusterCacheRef } from './shared'
+import { REFRESH_INTERVAL_MS, getEffectiveInterval, getLocalAgentURL, agentFetch, clusterCacheRef } from './shared'
 import { deduplicateClustersByServer } from './dedup'
 import { subscribePolling } from './pollingManager'
 import { settledWithConcurrency } from '../../lib/utils/concurrency'
@@ -162,7 +162,7 @@ export function usePVCs(cluster?: string, namespace?: string) {
               if (namespace) params.append('namespace', namespace)
               const controller = new AbortController()
               const timeoutId = setTimeout(() => controller.abort(), MCP_HOOK_TIMEOUT_MS)
-              const response = await agentFetch(`${LOCAL_AGENT_URL}/pvcs?${params}`, {
+              const response = await agentFetch(`${getLocalAgentURL()}/pvcs?${params}`, {
                 signal: controller.signal,
                 headers: { 'Accept': 'application/json' },
               })


### PR DESCRIPTION
## Summary
- `LOCAL_AGENT_URL` was a `const` snapshot captured at module load time — it kept `http://127.0.0.1:8585` even after `suppressLocalAgent()` set `LOCAL_AGENT_HTTP_URL` to `''`
- Safari/Firefox block mixed content (HTTPS page → HTTP localhost), so GPU node fetches silently failed → "No clusters with GPUs found"
- Chrome's localhost exemption masked the bug, which is why it worked for some users but not others
- Replace `const LOCAL_AGENT_URL` with `getLocalAgentURL()` function that reads the live binding

## Root cause
The `/health` endpoint correctly returns `no_local_agent: true` for in-cluster Helm deployments. `useBranding` calls `suppressLocalAgent(true)` which sets `LOCAL_AGENT_HTTP_URL = ''`. But `LOCAL_AGENT_URL` in `agentFetch.ts` was `export const LOCAL_AGENT_URL = LOCAL_AGENT_HTTP_URL` — a one-time value capture, not a live binding. All fetch functions kept using the stale `http://127.0.0.1:8585` URL.

## Test plan
- [x] Verified `/health` returns `no_local_agent: true` on vllm-d deployment
- [x] Confirmed browser logs show mixed-content blocks to `http://127.0.0.1:8585/gpu-nodes`
- [x] All 28 files updated (source + tests)
- [ ] After deploy: Safari users should see GPU clusters in the reservation dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)