### PR TITLE
fix: use stable key in HelmValuesDiff values list

### DIFF
--- a/web/src/components/cards/HelmValuesDiff.tsx
+++ b/web/src/components/cards/HelmValuesDiff.tsx
@@ -479,9 +479,9 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
                 {values}
               </pre>
             ) : (
-              valueEntries.map((entry, idx) => (
+              valueEntries.map((entry) => (
                 <div
-                  key={idx}
+                  key={entry.path}
                   className="p-2 rounded bg-blue-500/10 border-l-2 border-blue-500"
                 >
                   <div className="flex items-center gap-2">


### PR DESCRIPTION
Fixes #11976

## SUMMARY

This PR fixes an incorrect React reconciliation issue in the Helm values diff list by replacing an unstable index-based key with a stable identifier. The change ensures consistent rendering when the list is filtered, sorted, or paginated.

The update is localized to `web/src/components/cards/HelmValuesDiff.tsx` within the `HelmValuesDiff` component.

---

## FIX

```tsx
// Before
valueEntries.map((entry, idx) => (
  <div key={idx}>

// After
valueEntries.map((entry) => (
  <div key={entry.path}>
```

This ensures React correctly tracks each item across updates, preventing mismatched DOM reuse.
