### PR TITLE
fix(nightly-e2e): remove Benchmarking/Simulated Accelerator, rename to Optimized Baseline

### DIFF
--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -148,26 +148,22 @@ type NightlyE2EHandler struct {
 // GuidePath maps to the directory under guides/ in llm-d/llm-d whose YAML files
 // contain the image references. LLMDImages is populated dynamically at runtime.
 var nightlyWorkflows = []NightlyWorkflow{
-	// OCP — all OCP guides run on H100 except WVA (A100) and SA (CPU)
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-ocp.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "OCP", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, GuidePath: "inference-scheduling"},
+	// OCP — all OCP guides run on H100 except WVA (A100)
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-optimized-baseline-ocp.yaml", Guide: "Optimized Baseline", Acronym: "IS", Platform: "OCP", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, GuidePath: "optimized-baseline"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-ocp.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, GuidePath: "pd-disaggregation"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-precise-prefix-cache-ocp.yaml", Guide: "Precise Prefix Cache", Acronym: "PPC", Platform: "OCP", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, GuidePath: "precise-prefix-cache-aware"},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-simulated-accelerators.yaml", Guide: "Simulated Accelerators", Acronym: "SA", Platform: "OCP", Model: "Simulated", GPUType: "CPU", GPUCount: 0, GuidePath: "simulated-accelerators"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-tiered-prefix-cache-ocp.yaml", Guide: "Tiered Prefix Cache", Acronym: "TPC", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 1, GuidePath: "tiered-prefix-cache"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-ocp.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, GuidePath: "wide-ep-lws"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-ocp.yaml", Guide: "WVA", Acronym: "WVA", Platform: "OCP", Model: "Llama-3.1-8B", GPUType: "A100", GPUCount: 2, GuidePath: "workload-autoscaling"},
-	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-ocp.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "OCP", Model: "opt-125m", GPUType: "A100", GPUCount: 1},
 	// GKE — all GKE guides run on L4
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-gke.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "GKE", Model: "Qwen3-32B", GPUType: "L4", GPUCount: 2, GuidePath: "inference-scheduling"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-optimized-baseline-gke.yaml", Guide: "Optimized Baseline", Acronym: "IS", Platform: "GKE", Model: "Qwen3-32B", GPUType: "L4", GPUCount: 2, GuidePath: "optimized-baseline"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-gke.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "GKE", Model: "Qwen3-0.6B", GPUType: "L4", GPUCount: 2, GuidePath: "pd-disaggregation"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-gke.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "GKE", Model: "Qwen3-0.6B", GPUType: "L4", GPUCount: 2, GuidePath: "wide-ep-lws"},
-	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-gke.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "GKE", Model: "opt-125m", GPUType: "L4", GPUCount: 1},
 	// CKS — all CKS guides run on H100
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-cks.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "CKS", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, GuidePath: "inference-scheduling"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-optimized-baseline-cks.yaml", Guide: "Optimized Baseline", Acronym: "IS", Platform: "CKS", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, GuidePath: "optimized-baseline"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "CKS", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, GuidePath: "pd-disaggregation"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-cks.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "CKS", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, GuidePath: "wide-ep-lws"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-cks.yaml", Guide: "WVA", Acronym: "WVA", Platform: "CKS", Model: "Llama-3.1-8B", GPUType: "H100", GPUCount: 2, GuidePath: "workload-autoscaling"},
-	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nightly-benchmark-cks.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "CKS", Model: "opt-125m", GPUType: "H100", GPUCount: 1},
 }
 
 // isAllowedRepo checks if a repo is in the allowlist derived from nightlyWorkflows.

--- a/pkg/api/handlers/nightly_e2e_test.go
+++ b/pkg/api/handlers/nightly_e2e_test.go
@@ -23,7 +23,7 @@ func TestNightlyE2EHandler(t *testing.T) {
 		path = strings.TrimPrefix(path, "/api/v3")
 
 		// Workflow runs endpoint
-		if path == "/repos/llm-d/llm-d/actions/workflows/nightly-e2e-inference-scheduling-ocp.yaml/runs" {
+		if path == "/repos/llm-d/llm-d/actions/workflows/nightly-e2e-optimized-baseline-ocp.yaml/runs" {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"workflow_runs":[{"id":123,"status":"completed","conclusion":"success","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T01:00:00Z","html_url":"http://github.com/123","run_number":1,"event":"push"}]}`))
 			return
@@ -62,7 +62,7 @@ func TestNightlyE2EHandler(t *testing.T) {
 		// Check the specific workflow we mocked
 		found := false
 		for _, g := range result.Guides {
-			if g.WorkflowFile == "nightly-e2e-inference-scheduling-ocp.yaml" {
+			if g.WorkflowFile == "nightly-e2e-optimized-baseline-ocp.yaml" {
 				found = true
 				assert.Len(t, g.Runs, 1)
 				assert.Equal(t, int64(123), g.Runs[0].ID)

--- a/web/netlify/functions/nightly-e2e.mts
+++ b/web/netlify/functions/nightly-e2e.mts
@@ -103,25 +103,21 @@ interface CacheEntry {
 
 const NIGHTLY_WORKFLOWS: NightlyWorkflow[] = [
   // OCP
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-inference-scheduling-ocp.yaml", guide: "Inference Scheduling", acronym: "IS", platform: "OCP", model: "Qwen3-32B", gpuType: "H100", gpuCount: 2, guidePath: "inference-scheduling" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-optimized-baseline-ocp.yaml", guide: "Optimized Baseline", acronym: "IS", platform: "OCP", model: "Qwen3-32B", gpuType: "H100", gpuCount: 2, guidePath: "optimized-baseline" },
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-pd-disaggregation-ocp.yaml", guide: "PD Disaggregation", acronym: "PD", platform: "OCP", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2, guidePath: "pd-disaggregation" },
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-precise-prefix-cache-ocp.yaml", guide: "Precise Prefix Cache", acronym: "PPC", platform: "OCP", model: "Qwen3-32B", gpuType: "H100", gpuCount: 2, guidePath: "precise-prefix-cache-aware" },
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-simulated-accelerators.yaml", guide: "Simulated Accelerators", acronym: "SA", platform: "OCP", model: "Simulated", gpuType: "CPU", gpuCount: 0, guidePath: "simulated-accelerators" },
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-tiered-prefix-cache-ocp.yaml", guide: "Tiered Prefix Cache", acronym: "TPC", platform: "OCP", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 1, guidePath: "tiered-prefix-cache" },
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wide-ep-lws-ocp.yaml", guide: "Wide EP + LWS", acronym: "WEP", platform: "OCP", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2, guidePath: "wide-ep-lws" },
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wva-ocp.yaml", guide: "WVA", acronym: "WVA", platform: "OCP", model: "Llama-3.1-8B", gpuType: "A100", gpuCount: 2, guidePath: "workload-autoscaling" },
-  { repo: "llm-d/llm-d-benchmark", workflowFile: "ci-nighly-benchmark-ocp.yaml", guide: "Benchmarking", acronym: "BM", platform: "OCP", model: "opt-125m", gpuType: "A100", gpuCount: 1 },
   // GKE
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-inference-scheduling-gke.yaml", guide: "Inference Scheduling", acronym: "IS", platform: "GKE", model: "Qwen3-32B", gpuType: "L4", gpuCount: 2, guidePath: "inference-scheduling" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-optimized-baseline-gke.yaml", guide: "Optimized Baseline", acronym: "IS", platform: "GKE", model: "Qwen3-32B", gpuType: "L4", gpuCount: 2, guidePath: "optimized-baseline" },
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-pd-disaggregation-gke.yaml", guide: "PD Disaggregation", acronym: "PD", platform: "GKE", model: "Qwen3-0.6B", gpuType: "L4", gpuCount: 2, guidePath: "pd-disaggregation" },
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wide-ep-lws-gke.yaml", guide: "Wide EP + LWS", acronym: "WEP", platform: "GKE", model: "Qwen3-0.6B", gpuType: "L4", gpuCount: 2, guidePath: "wide-ep-lws" },
-  { repo: "llm-d/llm-d-benchmark", workflowFile: "ci-nighly-benchmark-gke.yaml", guide: "Benchmarking", acronym: "BM", platform: "GKE", model: "opt-125m", gpuType: "L4", gpuCount: 1 },
   // CKS
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-inference-scheduling-cks.yaml", guide: "Inference Scheduling", acronym: "IS", platform: "CKS", model: "Qwen3-32B", gpuType: "H100", gpuCount: 2, guidePath: "inference-scheduling" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-optimized-baseline-cks.yaml", guide: "Optimized Baseline", acronym: "IS", platform: "CKS", model: "Qwen3-32B", gpuType: "H100", gpuCount: 2, guidePath: "optimized-baseline" },
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", guide: "PD Disaggregation", acronym: "PD", platform: "CKS", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2, guidePath: "pd-disaggregation" },
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wide-ep-lws-cks.yaml", guide: "Wide EP + LWS", acronym: "WEP", platform: "CKS", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2, guidePath: "wide-ep-lws" },
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wva-cks.yaml", guide: "WVA", acronym: "WVA", platform: "CKS", model: "Llama-3.1-8B", gpuType: "H100", gpuCount: 2, guidePath: "workload-autoscaling" },
-  { repo: "llm-d/llm-d-benchmark", workflowFile: "ci-nightly-benchmark-cks.yaml", guide: "Benchmarking", acronym: "BM", platform: "CKS", model: "opt-125m", gpuType: "H100", gpuCount: 1 },
 ];
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/widgets/WidgetExportModal.tsx
+++ b/web/src/components/widgets/WidgetExportModal.tsx
@@ -1336,11 +1336,9 @@ function NightlyE2EPreview() {
         { acronym: 'IS', dots: ['g','g','r','g','g','g','g'] },
         { acronym: 'PD', dots: ['g','g','g','g','g','g','g'] },
         { acronym: 'PPC', dots: ['g','r','g','g','g','r','g'] },
-        { acronym: 'SA', dots: ['g','g','g','g','g','g','g'] },
         { acronym: 'TPC', dots: ['g','g','g','r','g','g','g'] },
         { acronym: 'WEP', dots: ['g','g','g','g','g','g','b'] },
         { acronym: 'WVA', dots: ['g','r','g','g','r','g','g'] },
-        { acronym: 'BM', dots: ['r','r','g','r','g','r','g'] },
       ] },
     {
       name: 'GKE', color: '#3b82f6',
@@ -1348,7 +1346,6 @@ function NightlyE2EPreview() {
         { acronym: 'IS', dots: ['g','g','g','g','g','g','g'] },
         { acronym: 'PD', dots: ['r','g','g','g','g','g','g'] },
         { acronym: 'WEP', dots: ['g','g','g','g','g','g','g'] },
-        { acronym: 'BM', dots: ['b','g','g','r','g','g','g'] },
       ] },
     {
       name: 'CKS', color: '#a855f7',
@@ -1356,7 +1353,6 @@ function NightlyE2EPreview() {
         { acronym: 'IS', dots: [] as string[] },
         { acronym: 'PD', dots: [] as string[] },
         { acronym: 'WEP', dots: [] as string[] },
-        { acronym: 'BM', dots: [] as string[] },
       ] },
   ]
   const dotColor: Record<string, string> = { g: '#22c55e', r: '#ef4444', b: '#60a5fa' }

--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -58,49 +58,41 @@ export interface NightlyGuideStatus {
 const IMG_CUDA_DEV = { 'llm-d-cuda-dev': 'latest' }
 const IMG_PD = { 'llm-d-cuda-dev': 'latest', 'llm-d-routing-sidecar': 'v0.5.0' }
 const IMG_PPC = { 'llm-d-cuda-dev': 'latest', 'llm-d-uds-tokenizer': 'v0.5.1-rc1' }
-const IMG_SA = { 'llm-d-inference-sim': 'v0.7.1', 'llm-d-routing-sidecar': 'v0.5.0' }
 const IMG_WEP = { 'llm-d-cuda-dev': 'latest', 'llm-d-routing-sidecar': 'v0.5.0' }
 const IMG_WVA = { 'llm-d-cuda-dev': 'latest', 'llm-d-workload-variant-autoscaler': 'nightly' }
 
 export const NIGHTLY_WORKFLOWS: NightlyWorkflowConfig[] = [
   // OCP — all OCP guides run on H100 except WVA (A100) and SA (CPU)
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-ocp.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'OCP', model: 'Qwen3-32B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_CUDA_DEV },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-optimized-baseline-ocp.yaml', guide: 'Optimized Baseline', acronym: 'IS', platform: 'OCP', model: 'Qwen3-32B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_CUDA_DEV },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-ocp.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'OCP', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_PD },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-precise-prefix-cache-ocp.yaml', guide: 'Precise Prefix Cache', acronym: 'PPC', platform: 'OCP', model: 'Qwen3-32B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_PPC },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-simulated-accelerators.yaml', guide: 'Simulated Accelerators', acronym: 'SA', platform: 'OCP', model: 'Simulated', gpuType: 'CPU', gpuCount: 0, llmdImages: IMG_SA },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-tiered-prefix-cache-ocp.yaml', guide: 'Tiered Prefix Cache', acronym: 'TPC', platform: 'OCP', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 1, llmdImages: IMG_CUDA_DEV },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-ocp.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'OCP', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_WEP },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wva-ocp.yaml', guide: 'WVA', acronym: 'WVA', platform: 'OCP', model: 'Llama-3.1-8B', gpuType: 'A100', gpuCount: 2, llmdImages: IMG_WVA },
-  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nighly-benchmark-ocp.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'OCP', model: 'opt-125m', gpuType: 'A100', gpuCount: 1, llmdImages: IMG_CUDA_DEV },
   // GKE — all GKE guides run on L4
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-gke.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'GKE', model: 'Qwen3-32B', gpuType: 'L4', gpuCount: 2, llmdImages: IMG_CUDA_DEV },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-optimized-baseline-gke.yaml', guide: 'Optimized Baseline', acronym: 'IS', platform: 'GKE', model: 'Qwen3-32B', gpuType: 'L4', gpuCount: 2, llmdImages: IMG_CUDA_DEV },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-gke.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'GKE', model: 'Qwen3-0.6B', gpuType: 'L4', gpuCount: 2, llmdImages: IMG_PD },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-gke.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'GKE', model: 'Qwen3-0.6B', gpuType: 'L4', gpuCount: 2, llmdImages: IMG_WEP },
-  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nighly-benchmark-gke.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'GKE', model: 'opt-125m', gpuType: 'L4', gpuCount: 1, llmdImages: IMG_CUDA_DEV },
   // CKS — all CKS guides run on H100
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-cks.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'CKS', model: 'Qwen3-32B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_CUDA_DEV },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-optimized-baseline-cks.yaml', guide: 'Optimized Baseline', acronym: 'IS', platform: 'CKS', model: 'Qwen3-32B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_CUDA_DEV },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-cks.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'CKS', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_PD },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-cks.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'CKS', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_WEP },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wva-cks.yaml', guide: 'WVA', acronym: 'WVA', platform: 'CKS', model: 'Llama-3.1-8B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_WVA },
-  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nightly-benchmark-cks.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'CKS', model: 'opt-125m', gpuType: 'H100', gpuCount: 1, llmdImages: IMG_CUDA_DEV },
 ]
 
 // Seeded patterns per guide for deterministic demo data
 const DEMO_PATTERNS: Record<string, ('success' | 'failure' | 'in_progress')[]> = {
   // OCP
-  'Inference Scheduling-OCP': ['success', 'success', 'failure', 'success', 'success', 'success', 'success'],
+  'Optimized Baseline-OCP': ['success', 'success', 'failure', 'success', 'success', 'success', 'success'],
   'PD Disaggregation-OCP': ['success', 'success', 'success', 'success', 'success', 'success', 'success'],
   'Precise Prefix Cache-OCP': ['success', 'failure', 'success', 'success', 'success', 'failure', 'success'],
-  'Simulated Accelerators-OCP': ['success', 'success', 'success', 'success', 'success', 'success', 'success'],
   'Tiered Prefix Cache-OCP': ['success', 'success', 'success', 'failure', 'success', 'success', 'success'],
   'Wide EP + LWS-OCP': ['success', 'success', 'success', 'success', 'success', 'success', 'in_progress'],
   'WVA-OCP': ['success', 'failure', 'success', 'success', 'failure', 'success', 'success'],
-  'Benchmarking-OCP': ['failure', 'failure', 'success', 'failure', 'success', 'failure', 'success'],
   // GKE
-  'Inference Scheduling-GKE': ['success', 'success', 'success', 'success', 'success', 'success', 'success'],
+  'Optimized Baseline-GKE': ['success', 'success', 'success', 'success', 'success', 'success', 'success'],
   'PD Disaggregation-GKE': ['failure', 'success', 'success', 'success', 'success', 'success', 'success'],
   'Wide EP + LWS-GKE': ['success', 'success', 'success', 'success', 'success', 'success', 'success'],
-  'Benchmarking-GKE': ['in_progress', 'success', 'success', 'failure', 'success', 'success', 'success'],
   // CKS — no runs yet, empty arrays
 }
 


### PR DESCRIPTION
## Summary

- Remove **Benchmarking** rows from all platforms (OCP, GKE, CKS)
- Remove **Simulated Accelerators** row (OCP)
- Rename **Inference Scheduling** to **Optimized Baseline** to match the upstream workflow rename in `llm-d/llm-d`
- Update workflow file references from `nightly-e2e-inference-scheduling-*.yaml` to `nightly-e2e-optimized-baseline-*.yaml`

Changes synced across all 3 data layers:
- Go backend (`pkg/api/handlers/nightly_e2e.go`)
- Netlify function (`web/netlify/functions/nightly-e2e.mts`)
- Frontend demo data + widget preview (`nightlyE2EDemoData.ts`, `WidgetExportModal.tsx`)

## Test plan
- [x] Go test updated to reference new workflow filename
- [x] Widget preview rows updated (SA and BM removed)
- [x] Demo patterns updated (removed SA/BM entries, renamed IS keys)
- [ ] Verify on deploy preview: card shows Optimized Baseline, no BM/SA rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)