### PR TITLE
feat: add /dashboard route alias for main dashboard

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -690,6 +690,7 @@ function FullDashboardApp({ liveLocation }: { liveLocation: Location }) {
             warm-nav is near-instant (no unmount/remount). */}
         <Route element={<ProtectedRoute><Layout /></ProtectedRoute>}>
           <Route index element={<Dashboard />} />
+          <Route path={ROUTES.DASHBOARD_ALIAS} element={<Navigate to={ROUTES.HOME} replace />} />
           <Route path={ROUTES.CUSTOM_DASHBOARD} element={<CustomDashboard />} />
           {/* Test routes — rendered with Layout but not cached by KeepAlive */}
           <Route path={ROUTES.PERF_ALL_CARDS} element={<AllCardsPerfTest />} />

--- a/web/src/config/routes.ts
+++ b/web/src/config/routes.ts
@@ -11,6 +11,7 @@ export const ROUTES = {
   AUTH_CALLBACK: '/auth/callback',
   // Main routes
   HOME: '/',
+  DASHBOARD_ALIAS: '/dashboard',
   CUSTOM_DASHBOARD: '/custom-dashboard/:id',
   
   // Settings & Management


### PR DESCRIPTION
## Summary

- Add `/dashboard` as a route alias that redirects to `/` (the main dashboard)
- Add `DASHBOARD_ALIAS` constant to `routes.ts`
- Uses `<Navigate replace />` for a clean client-side redirect (no flash, replaces history entry)

## Test plan
- [x] Navigate to `/dashboard` -> redirects to `/`
- [x] Browser back button works correctly (replace, not push)
- [x] Existing `/` route unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)