### PR TITLE
fix: remove dialog keyboard hints + fix navbar dropdown z-index

### DIFF
--- a/web/e2e/nightly/navbar-dropdown-visibility.spec.ts
+++ b/web/e2e/nightly/navbar-dropdown-visibility.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from '@playwright/test'
+import { setupDemoAndNavigate, mockApiFallback, ELEMENT_VISIBLE_TIMEOUT_MS } from '../helpers/setup'
+
+/**
+ * Nightly Navbar Dropdown Visibility Check
+ *
+ * Validates that ALL navbar dropdown panels render fully visible and
+ * on top of page content (not clipped or obscured by dashboard cards,
+ * stat widgets, or other stacking contexts).
+ *
+ * Each dropdown is opened, verified visible, and checked that its
+ * bounding box is fully within the viewport. Then the dropdown is
+ * closed before proceeding to the next.
+ *
+ * Run locally:
+ *   npx playwright test e2e/nightly/navbar-dropdown-visibility.spec.ts \
+ *     -c e2e/nightly/nightly.config.ts
+ */
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/** Time to wait after clicking a trigger for the dropdown to appear (ms) */
+const DROPDOWN_APPEAR_MS = 3_000
+
+/** Time to wait for page to settle before interacting (ms) */
+const PAGE_SETTLE_MS = 2_000
+
+/** Minimum expected z-index for navbar dropdowns */
+const MIN_DROPDOWN_Z_INDEX = 400
+
+/** Viewport dimensions matching nightly.config.ts */
+const VIEWPORT_WIDTH = 1280
+const VIEWPORT_HEIGHT = 900
+
+interface DropdownSpec {
+  name: string
+  triggerTestId: string
+  dropdownTestId: string
+}
+
+const NAVBAR_DROPDOWNS: DropdownSpec[] = [
+  {
+    name: 'Agent Status',
+    triggerTestId: 'navbar-agent-status-btn',
+    dropdownTestId: 'navbar-agent-status-dropdown',
+  },
+  {
+    name: 'Token Usage',
+    triggerTestId: 'navbar-token-usage-btn',
+    dropdownTestId: 'navbar-token-usage-dropdown',
+  },
+  {
+    name: 'Cluster Filter',
+    triggerTestId: 'navbar-cluster-filter-btn',
+    dropdownTestId: 'navbar-cluster-filter-dropdown',
+  },
+  {
+    name: 'Alerts',
+    triggerTestId: 'navbar-alerts-btn',
+    dropdownTestId: 'navbar-alerts-dropdown',
+  },
+  {
+    name: 'User Profile',
+    triggerTestId: 'navbar-profile-btn',
+    dropdownTestId: 'navbar-profile-dropdown',
+  },
+]
+
+test.describe('Navbar dropdown visibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockApiFallback(page)
+    await setupDemoAndNavigate(page, '/')
+    await page.waitForTimeout(PAGE_SETTLE_MS)
+  })
+
+  for (const dropdown of NAVBAR_DROPDOWNS) {
+    test(`${dropdown.name} dropdown renders on top and fully visible`, async ({ page }) => {
+      const trigger = page.getByTestId(dropdown.triggerTestId)
+
+      // Some dropdowns may not be rendered at this viewport (e.g. hidden on certain views)
+      if (!(await trigger.isVisible().catch(() => false))) {
+        test.skip()
+        return
+      }
+
+      // Use native click for cross-browser stability (webkit/firefox can miss
+      // React event handlers during mid-render when using Playwright's synthetic click)
+      await trigger.evaluate((el) => (el as HTMLElement).click())
+
+      const panel = page.getByTestId(dropdown.dropdownTestId)
+      await expect(panel).toBeVisible({ timeout: DROPDOWN_APPEAR_MS })
+
+      // Verify the dropdown's bounding box is fully within the viewport
+      const box = await panel.boundingBox()
+      expect(box, `${dropdown.name} dropdown should have a bounding box`).not.toBeNull()
+
+      if (box) {
+        expect(box.x, `${dropdown.name} left edge should be >= 0`).toBeGreaterThanOrEqual(0)
+        expect(box.y, `${dropdown.name} top edge should be >= 0`).toBeGreaterThanOrEqual(0)
+        expect(
+          box.x + box.width,
+          `${dropdown.name} right edge should be within viewport`
+        ).toBeLessThanOrEqual(VIEWPORT_WIDTH)
+        expect(
+          box.y + box.height,
+          `${dropdown.name} bottom edge should be within viewport`
+        ).toBeLessThanOrEqual(VIEWPORT_HEIGHT)
+      }
+
+      // Verify computed z-index is high enough to be on top of dashboard content
+      const zIndex = await panel.evaluate((el) => {
+        const style = window.getComputedStyle(el)
+        return parseInt(style.zIndex, 10) || 0
+      })
+      expect(
+        zIndex,
+        `${dropdown.name} z-index (${zIndex}) should be >= ${MIN_DROPDOWN_Z_INDEX}`
+      ).toBeGreaterThanOrEqual(MIN_DROPDOWN_Z_INDEX)
+
+      // Verify the dropdown is not obscured by clicking an element inside it.
+      // Playwright's click() will fail if another element intercepts the click.
+      const firstClickable = panel.locator('button, a, input, [role="menuitem"]').first()
+      if (await firstClickable.isVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS }).catch(() => false)) {
+        await firstClickable.click({ trial: true, timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
+      }
+
+      // Close the dropdown (press Escape) before the next test
+      await page.keyboard.press('Escape')
+      await expect(panel).not.toBeVisible({ timeout: DROPDOWN_APPEAR_MS })
+    })
+  }
+})

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -129,6 +129,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
     <div className="relative" ref={dropdownRef}>
       {/* Trigger button */}
       <button
+        data-testid="navbar-profile-btn"
         onClick={toggleDropdown}
         aria-expanded={isOpen}
         aria-haspopup="true"
@@ -154,7 +155,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
 
       {/* Dropdown menu */}
       {isOpen && (
-        <div id="profile-dropdown-menu" role="menu" className="absolute right-0 top-full mt-2 w-72 max-w-[calc(100vw-1rem)] max-h-[calc(100vh-5rem)] bg-card border border-border rounded-xl shadow-2xl overflow-hidden overflow-y-auto z-toast">
+        <div id="profile-dropdown-menu" data-testid="navbar-profile-dropdown" role="menu" className="absolute right-0 top-full mt-2 w-72 max-w-[calc(100vw-1rem)] max-h-[calc(100vh-5rem)] bg-card border border-border rounded-xl shadow-2xl overflow-hidden overflow-y-auto z-toast">
           {/* Header with avatar and name */}
           <div className="p-4 bg-secondary border-b border-border">
             <div className="flex items-center gap-3">

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -340,7 +340,7 @@ export function AgentStatusIndicator({ showLabel = false }: AgentStatusIndicator
       {showAgentStatus && (
         <div
           ref={dropdownRef}
-          className="absolute top-full right-0 mt-2 w-96 bg-card border border-border rounded-lg shadow-xl z-dropdown"
+          className="absolute top-full right-0 mt-2 w-96 bg-card border border-border rounded-lg shadow-xl z-toast"
         >
           {/* Demo Mode Toggle */}
           <div className="p-3 border-b border-border">

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -320,6 +320,7 @@ export function AgentStatusIndicator({ showLabel = false }: AgentStatusIndicator
   return (
     <div className="relative" ref={agentRef}>
       <button
+        data-testid="navbar-agent-status-btn"
         onClick={() => setShowAgentStatus(!showAgentStatus)}
         className={cn(
           'flex items-center justify-center gap-2 px-3 py-1.5 h-9 rounded-lg whitespace-nowrap',
@@ -340,6 +341,7 @@ export function AgentStatusIndicator({ showLabel = false }: AgentStatusIndicator
       {showAgentStatus && (
         <div
           ref={dropdownRef}
+          data-testid="navbar-agent-status-dropdown"
           className="absolute top-full right-0 mt-2 w-96 bg-card border border-border rounded-lg shadow-xl z-toast"
         >
           {/* Demo Mode Toggle */}

--- a/web/src/components/layout/navbar/ClusterFilterPanel.tsx
+++ b/web/src/components/layout/navbar/ClusterFilterPanel.tsx
@@ -179,6 +179,7 @@ export function ClusterFilterPanel({ showLabel = false }: ClusterFilterPanelProp
       <div className="relative isolate" ref={dropdownRef}>
         <Tooltip content={t('help.globalClusterFilter')} side="bottom">
           <button
+            data-testid="navbar-cluster-filter-btn"
             onClick={() => toggleDropdown()}
             className={cn(
               'relative flex items-center rounded-lg transition-colors',
@@ -205,7 +206,7 @@ export function ClusterFilterPanel({ showLabel = false }: ClusterFilterPanelProp
 
         {/* Filter dropdown */}
         {showDropdown && (
-          <div className="absolute top-full right-0 mt-2 w-80 bg-card border border-border rounded-lg shadow-xl z-toast max-h-[80vh] overflow-y-auto">
+          <div data-testid="navbar-cluster-filter-dropdown" className="absolute top-full right-0 mt-2 w-80 bg-card border border-border rounded-lg shadow-xl z-toast max-h-[80vh] overflow-y-auto">
 
             {/* Clear All — shown at top when filters are active */}
             {isFiltered && (

--- a/web/src/components/layout/navbar/ClusterFilterPanel.tsx
+++ b/web/src/components/layout/navbar/ClusterFilterPanel.tsx
@@ -205,7 +205,7 @@ export function ClusterFilterPanel({ showLabel = false }: ClusterFilterPanelProp
 
         {/* Filter dropdown */}
         {showDropdown && (
-          <div className="absolute top-full right-0 mt-2 w-80 bg-card border border-border rounded-lg shadow-xl z-dropdown max-h-[80vh] overflow-y-auto">
+          <div className="absolute top-full right-0 mt-2 w-80 bg-card border border-border rounded-lg shadow-xl z-toast max-h-[80vh] overflow-y-auto">
 
             {/* Clear All — shown at top when filters are active */}
             {isFiltered && (

--- a/web/src/components/layout/navbar/TokenUsageWidget.tsx
+++ b/web/src/components/layout/navbar/TokenUsageWidget.tsx
@@ -56,6 +56,7 @@ export function TokenUsageWidget({ showLabel = false }: TokenUsageWidgetProps) {
   return (
     <div className="relative" ref={tokenRef}>
       <button
+        data-testid="navbar-token-usage-btn"
         onClick={() => setShowTokenDetails(!showTokenDetails)}
         className={`flex items-center gap-2 px-3 py-1.5 h-9 rounded-lg transition-colors ${
           isDemoData
@@ -93,7 +94,7 @@ export function TokenUsageWidget({ showLabel = false }: TokenUsageWidgetProps) {
 
       {/* Token details dropdown */}
       {showTokenDetails && (
-        <div className="absolute top-full right-0 mt-2 w-64 bg-card border border-border rounded-lg shadow-xl p-4 z-toast">
+        <div data-testid="navbar-token-usage-dropdown" className="absolute top-full right-0 mt-2 w-64 bg-card border border-border rounded-lg shadow-xl p-4 z-toast">
           <div className="flex items-center justify-between mb-3">
             <h4 className="text-sm font-medium text-foreground">{t('layout.navbar.tokenUsage')}</h4>
             {isDemoData && (

--- a/web/src/components/layout/navbar/TokenUsageWidget.tsx
+++ b/web/src/components/layout/navbar/TokenUsageWidget.tsx
@@ -93,7 +93,7 @@ export function TokenUsageWidget({ showLabel = false }: TokenUsageWidgetProps) {
 
       {/* Token details dropdown */}
       {showTokenDetails && (
-        <div className="absolute top-full right-0 mt-2 w-64 bg-card border border-border rounded-lg shadow-xl p-4 z-dropdown">
+        <div className="absolute top-full right-0 mt-2 w-64 bg-card border border-border rounded-lg shadow-xl p-4 z-toast">
           <div className="flex items-center justify-between mb-3">
             <h4 className="text-sm font-medium text-foreground">{t('layout.navbar.tokenUsage')}</h4>
             {isDemoData && (

--- a/web/src/components/ui/AlertBadge.tsx
+++ b/web/src/components/ui/AlertBadge.tsx
@@ -238,6 +238,7 @@ export function AlertBadge() {
       <Button
         variant="ghost"
         size="sm"
+        data-testid="navbar-alerts-btn"
         onClick={toggle}
         className={`relative p-2 w-9 h-9 ${
           stats.critical > 0 ? 'text-red-400' : stats.warning > 0 ? 'text-orange-400' : ''
@@ -268,6 +269,7 @@ export function AlertBadge() {
           )}
           <div
             ref={dropdownRef}
+            data-testid="navbar-alerts-dropdown"
             role="dialog"
             aria-label="Active Alerts"
             aria-modal={isMobile}

--- a/web/src/lib/modals/BaseModal.tsx
+++ b/web/src/lib/modals/BaseModal.tsx
@@ -325,7 +325,7 @@ function ModalContent({
 
 function ModalFooter({
   children,
-  showKeyboardHints = true,
+  showKeyboardHints = false,
   keyboardHints,
   className = '',
 }: ModalFooterProps) {

--- a/web/src/lib/modals/ModalRuntime.tsx
+++ b/web/src/lib/modals/ModalRuntime.tsx
@@ -399,7 +399,7 @@ export function ModalRuntime({
         that's been disabled via config.
       */}
       <BaseModal.Footer
-        showKeyboardHints={footer?.showKeyboardHints ?? true}
+        showKeyboardHints={footer?.showKeyboardHints ?? false}
         keyboardHints={(() => {
           const hints: { key: string; label: string }[] = []
           if (keyboard.escape === 'close') {


### PR DESCRIPTION
## Summary
- **Remove keyboard hints** from modal footers — "Esc close • Space close" cluttered dialog footers (e.g. Remove Cluster dialog). Default `showKeyboardHints` to `false` in both `BaseModal.Footer` and `ModalRuntime`. Dialogs that explicitly pass `showKeyboardHints` are unaffected.
- **Fix navbar dropdown z-index** — Token Usage, Agent Status, and Cluster Filter dropdowns used `z-dropdown` (100) causing them to render behind dashboard cards and stat widgets. Promoted to `z-toast` (500) matching Profile, Search, and Alerts dropdowns.
- **Add `data-testid` attributes** to all navbar dropdown triggers and panels for reliable test targeting.
- **New nightly test** (`navbar-dropdown-visibility.spec.ts`) — opens each navbar dropdown and verifies:
  - Dropdown is visible and fully within viewport bounds
  - Computed z-index >= 400 (above dashboard content)
  - Dropdown is not obscured (trial click on first interactive element)

## Test plan
- [ ] Open each navbar dropdown (token usage, agent, filter, alerts, profile) — verify they appear above dashboard cards
- [ ] Open Remove Cluster dialog — verify no Esc/Space hints in footer
- [ ] Run nightly test: `npx playwright test e2e/nightly/navbar-dropdown-visibility.spec.ts -c e2e/nightly/nightly.config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)