### PR TITLE
fix: remove explicit showKeyboardHints from two dialogs

### DIFF
--- a/web/src/components/cards/WorkloadImportDialog.tsx
+++ b/web/src/components/cards/WorkloadImportDialog.tsx
@@ -674,10 +674,7 @@ export function WorkloadImportDialog({ isOpen, onClose, onImport }: WorkloadImpo
         {tabContent[activeTab]()}
       </BaseModal.Content>
 
-      <BaseModal.Footer
-        showKeyboardHints
-        keyboardHints={[{ key: 'Esc', label: t('workloadImport.close') }]}
-      />
+      <BaseModal.Footer />
     </BaseModal>
   )
 }

--- a/web/src/components/clusters/components/RemoveClusterDialog.tsx
+++ b/web/src/components/clusters/components/RemoveClusterDialog.tsx
@@ -76,7 +76,7 @@ export function RemoveClusterDialog({
         <p className="text-xs text-muted-foreground">{t('cluster.removeClusterDesc')}</p>
       </BaseModal.Content>
 
-      <BaseModal.Footer showKeyboardHints>
+      <BaseModal.Footer>
         <div className="flex-1" />
         <div className="flex gap-2">
           <button


### PR DESCRIPTION
## Summary
- Remove explicit `showKeyboardHints` from `RemoveClusterDialog` and `WorkloadImportDialog`
- PR #12129 changed the default to `false` but these two dialogs explicitly passed `showKeyboardHints={true}`, overriding the new default
- Now all dialogs consistently hide keyboard hints (Esc/Space) in the footer

## Test plan
- [ ] Open "Remove Offline Cluster" dialog — no "Esc close • Space close" text in footer
- [ ] Open Workload Import dialog — no keyboard hints in footer
- [ ] Other dialogs remain unaffected (they already use the default `false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)