### PR TITLE
feat: faster backend restart detection with friendlier toast

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -672,20 +672,20 @@ export function Layout({ children: _children }: LayoutProps) {
           {/* Agent Setup Dialog — shown when agent not connected; also triggered by open-agent-setup event */}
           <AgentSetupDialog />
 
-      {/* Backend connection lost snackbar — fixed bottom center */}
+      {/* Backend connection lost / restarting snackbar — fixed bottom center */}
       {showBackendBanner && (
         <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-toast animate-in fade-in slide-in-from-bottom-2 duration-300">
           <div className={cn(
             "flex items-center gap-2 px-4 py-3 rounded-lg border shadow-lg text-sm",
             backendDown
-              ? "bg-secondary border-border text-foreground"
+              ? "bg-blue-950/90 border-blue-800/50 text-blue-200"
               : "bg-green-900/80 border-green-700/50 text-green-200"
           )}>
             {backendDown ? (
               <div className="flex flex-col items-center gap-1">
                 <div className="flex items-center gap-2">
-                  <div className="w-2 h-2 rounded-full bg-red-400 animate-pulse" />
-                  <span>{t('layout.connectionLost')}</span>
+                  <Loader2 className="w-4 h-4 animate-spin text-blue-400" />
+                  <span>{t('layout.consoleRestarting')}</span>
                   {restartState === 'restarting' ? (
                     <button disabled className="ml-1 flex items-center gap-1.5 px-2.5 py-2 min-h-11 bg-muted text-muted-foreground rounded text-xs cursor-wait">
                       <Loader2 className="w-3 h-3 animate-spin" />
@@ -715,7 +715,7 @@ export function Layout({ children: _children }: LayoutProps) {
                 {restartError ? (
                   <span className="text-xs text-muted-foreground">{restartError}</span>
                 ) : (
-                  <span className="text-xs text-muted-foreground">{t('layout.connectionLostHint')}</span>
+                  <span className="text-xs text-blue-300/70">{t('layout.consoleRestartingHint')}</span>
                 )}
               </div>
             ) : (

--- a/web/src/hooks/useBackendHealth.ts
+++ b/web/src/hooks/useBackendHealth.ts
@@ -17,12 +17,10 @@ function writeInClusterToSession(): void {
   try { sessionStorage.setItem(SS_IN_CLUSTER_KEY, 'true') } catch { /* ignore */ }
 }
 
-const POLL_INTERVAL = 15000 // Check every 15 seconds
-const FAILURE_THRESHOLD = 4 // Require 4 consecutive failures before showing "Connection lost"
-// Short timeout for health checks — a healthy backend responds in <100ms.
-// Using the default 10s timeout causes false failures when the browser's
-// HTTP/1.1 connection pool (6 per origin) is saturated by SSE streams.
-const HEALTH_CHECK_TIMEOUT_MS = 3000
+const POLL_INTERVAL_MS = 15_000
+const FAST_RETRY_INTERVAL_MS = 3_000
+const FAILURE_THRESHOLD = 4
+const HEALTH_CHECK_TIMEOUT_MS = 3_000
 
 interface BackendState {
   status: BackendStatus
@@ -47,12 +45,13 @@ class BackendHealthManager {
   private isStarted = false
   private isChecking = false
   private initialVersion: string | null = null
+  private isFastRetrying = false
 
   start() {
     if (this.isStarted) return
     this.isStarted = true
     this.checkBackend()
-    this.pollInterval = setInterval(() => this.checkBackend(), POLL_INTERVAL)
+    this.pollInterval = setInterval(() => this.checkBackend(), POLL_INTERVAL_MS)
   }
 
   stop() {
@@ -61,6 +60,21 @@ class BackendHealthManager {
       this.pollInterval = null
     }
     this.isStarted = false
+    this.isFastRetrying = false
+  }
+
+  private switchToFastRetry() {
+    if (this.isFastRetrying || !this.isStarted) return
+    this.isFastRetrying = true
+    if (this.pollInterval) clearInterval(this.pollInterval)
+    this.pollInterval = setInterval(() => this.checkBackend(), FAST_RETRY_INTERVAL_MS)
+  }
+
+  private switchToNormalPoll() {
+    if (!this.isFastRetrying || !this.isStarted) return
+    this.isFastRetrying = false
+    if (this.pollInterval) clearInterval(this.pollInterval)
+    this.pollInterval = setInterval(() => this.checkBackend(), POLL_INTERVAL_MS)
   }
 
   subscribe(listener: (state: BackendState) => void): () => void {
@@ -110,6 +124,7 @@ class BackendHealthManager {
 
       if (response.ok) {
         this.failureCount = 0
+        this.switchToNormalPoll()
 
         // Parse response to check version and status
         try {
@@ -157,11 +172,11 @@ class BackendHealthManager {
       // The agent endpoint uses a separate connection pool.
       const agentAlive = await this.checkAgentHealth()
       if (agentAlive) {
-        // Agent is reachable → backend is likely fine, just connection-starved.
-        // Don't increment failure count.
         this.setState({ status: 'connected', lastCheck: new Date() })
+        this.switchToNormalPoll()
       } else {
         this.failureCount++
+        this.switchToFastRetry()
         if (this.failureCount >= FAILURE_THRESHOLD) {
           this.setState({
             status: 'disconnected',

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3698,6 +3698,8 @@
     "demo": "Demo",
     "connectionLost": "Connection lost",
     "connectionLostHint": "Could not reach the backend — restart the server to reconnect",
+    "consoleRestarting": "Console restarting…",
+    "consoleRestartingHint": "Reconnecting automatically — no action needed",
     "copiedRestartCommand": "Copied — run this in your project root terminal",
     "restarting": "Restarting…",
     "restartedWaiting": "Restarted, waiting for connection…",


### PR DESCRIPTION
## Summary
- Reduce backend restart detection from ~60s to ~12s by switching to fast-retry polling (3s interval) after first health check failure
- Update snackbar styling: blue "Console restarting…" with spinner instead of red "Connection lost" with pulsing dot
- Add i18n keys: `consoleRestarting` and `consoleRestartingHint`

### How it works
- Normal polling: `/health` every 15s (unchanged)
- On first failure: switch to 3s retry interval
- After 4 consecutive failures (4 × 3s = **12s**): show "Console restarting…" toast
- On recovery: switch back to 15s polling, show green "Reconnected" toast (existing behavior)

### Anti-spam guarantees (all existing, no new code needed)
- Single snackbar at a time (`showBackendBanner` boolean)
- No repeat on reconnect (`wasBackendDown` + 3s auto-dismiss)
- Suppressed during auto-updates (`isUpdateInProgress`)
- Separate handling for initial "connecting" state

## Test plan
- [ ] Start console → no restart toast appears
- [ ] Kill backend → within ~12s, "Console restarting…" snackbar appears with spinner
- [ ] Restart backend → snackbar stays until health check passes, then green "Reconnected" for 3s
- [ ] Single transient failure → no snackbar (threshold not met)

🤖 Generated with [Claude Code](https://claude.com/claude-code)