### PR TITLE
fix(backend): sanitize raw GitHub API error in feedback_requests.go

### DIFF
--- a/pkg/api/handlers/feedback_requests.go
+++ b/pkg/api/handlers/feedback_requests.go
@@ -112,7 +112,7 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 		if errors.Is(err, errGitHubInsufficientPermissions) {
 			return fiber.NewError(fiber.StatusForbidden, "GitHub could not create the issue because the current token does not have permission to open issues in this repository. Re-authenticate with GitHub OAuth and try again, or open the issue directly on GitHub.")
 		}
-		return fiber.NewError(fiber.StatusBadGateway, fmt.Sprintf("Failed to create GitHub issue: %v", err))
+		return fiber.NewError(fiber.StatusBadGateway, "Failed to create GitHub issue")
 	}
 	request.GitHubIssueNumber = &issueNumber
 	request.Status = models.RequestStatusOpen


### PR DESCRIPTION
## Summary

- Removes raw GitHub API error from the 502 response body in `feedback_requests.go:115`
- The full error was already logged server-side via `slog.Error` at line 97 — no diagnostic information is lost
- Introducing commit: `071711f1b`

## Change

```go
// Before
return fiber.NewError(fiber.StatusBadGateway, fmt.Sprintf("Failed to create GitHub issue: %v", err))

// After
return fiber.NewError(fiber.StatusBadGateway, "Failed to create GitHub issue")
```

## Test plan
- [ ] Submit a feature request via the console UI with a valid token — success flow unchanged
- [ ] Simulate a GitHub API failure — browser receives generic 502 message, full error visible in backend logs only

Fixes #12169
