### PR TITLE
Hide backend-unavailable banner on Netlify

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -356,7 +356,7 @@ export function Layout({ children: _children }: LayoutProps) {
     updateProgress != null &&
     !['idle', 'done', 'failed', 'cancelled'].includes(updateProgress.status)
   const showBackendBanner =
-    (backendDown || wasBackendDown) && !isUpdateInProgress
+    (backendDown || wasBackendDown) && !isUpdateInProgress && !isDemoModeForced
   const backendRecovering = backendDown && (
     Boolean(watchdogStage) ||
     restartState === 'restarting' ||


### PR DESCRIPTION
## Summary
- Suppress the red "Backend unavailable" banner on `console.kubestellar.io`
- The production site runs in forced demo mode on Netlify — there is no Go backend, so the banner is misleading
- One-line fix: add `&& !isDemoModeForced` to `showBackendBanner` condition

## Test plan
- [ ] Verify `console.kubestellar.io` no longer shows "Backend unavailable" banner
- [ ] Verify local dev with backend still shows the banner when backend is actually down
- [ ] Verify demo mode toggle still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)