### PR TITLE
Detect safeLazy timeout as chunk load error for auto-reload

### DIFF
--- a/web/src/lib/chunkErrors.ts
+++ b/web/src/lib/chunkErrors.ts
@@ -34,6 +34,8 @@ export function isChunkLoadMessage(msg: string): boolean {
     msg.includes('Importing a module script failed') ||
     // safeLazy() throws this when a named export is missing from a stale chunk
     msg.includes('chunk may be stale') ||
+    // safeLazy() timeout — chunk server unreachable after deploy (old chunk URL 404s)
+    msg.includes('timed out') ||
     // Generic fetch failure — often occurs when a chunk 404s on the CDN
     msg.includes('Failed to fetch') ||
     // Network error variant seen in Firefox for missing chunks


### PR DESCRIPTION
## Summary
- `safeLazy()` timeout errors ("timed out after 8000ms") were not recognized by `isChunkLoadMessage()`, causing them to fall through to `PageErrorBoundary` ("Something went wrong") instead of `ChunkErrorBoundary` (auto-reload)
- Adds `msg.includes('timed out')` to the detection list
- GA4 shows 11 chunk reload recovery + 10 error events today from frequent deploys

## Root cause
When Netlify deploys a new build, old chunk URLs 404. The `safeLazy` wrapper times out after 8s trying to fetch the missing chunk, but the timeout error message didn't match any pattern in `isChunkLoadMessage()`.

## Test plan
- [ ] Verify chunk timeout errors now trigger auto-reload instead of error page
- [ ] Verify `ksc_error` events decrease after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)