### PR TITLE
fix(netlify): retry rate-limit 403 in missions-file.mts

### DIFF
--- a/web/netlify/functions/missions-file.mts
+++ b/web/netlify/functions/missions-file.mts
@@ -83,9 +83,10 @@ export default async (request: Request): Promise<Response> => {
       resp = await fetch(rawUrl, {
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
-      // Don't retry 4xx (client errors) — only transient 5xx
-      if (resp.ok || resp.status === 404 || resp.status < 500) break;
-      console.warn(`[missions-file] Upstream ${resp.status}, attempt ${attempt + 1}/${MAX_RETRIES + 1}`);
+      // Retry rate-limit 403s (x-ratelimit-remaining: 0) but not permission-denied 403s
+      const isRateLimited403 = resp.status === 403 && resp.headers.get("x-ratelimit-remaining") === "0"
+      if (resp.ok || resp.status === 404 || (resp.status < 500 && !isRateLimited403)) break;
+      console.warn(`[missions-file] Upstream ${resp.status}${isRateLimited403 ? " (rate-limited)" : ""}, attempt ${attempt + 1}/${MAX_RETRIES + 1}`);
     }
 
     if (!resp) {


### PR DESCRIPTION
## Summary

Distinguishes rate-limit 403 from permission-denied 403 in the GitHub fetch retry loop. Previously all 4xx responses broke out immediately, causing unnecessary 502s when GitHub's API rate limit was hit.

**Introducing commit:** 11e026013

## Change

```typescript
// Before — all 4xx treated as permanent
if (resp.ok || resp.status === 404 || resp.status < 500) break

// After — rate-limit 403 retried, permission-denied 403 is permanent
const isRateLimited403 = resp.status === 403 && resp.headers.get('x-ratelimit-remaining') === '0'
if (resp.ok || resp.status === 404 || (resp.status < 500 && !isRateLimited403)) break
```

## Test plan
- [ ] Normal fetch: no change in behaviour
- [ ] GitHub returns permission-denied 403 (no rate-limit header): breaks immediately, returns 502
- [ ] GitHub returns rate-limit 403 (x-ratelimit-remaining: 0): retries with exponential backoff

Fixes #12335

