### PR TITLE
fix(ci): remove continue-on-error from accessibility test step

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -344,7 +344,6 @@ jobs:
             --grep="accessibility|a11y"
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:4173
-        continue-on-error: true
 
   # Visual regression testing moved to .github/workflows/visual-regression.yml
   # The previous job here was non-functional (--update-snapshots always passed,


### PR DESCRIPTION
## Summary

Removes `continue-on-error: true` from the accessibility test step in playwright.yml. With it set, axe-core failures were visible in the run summary but never blocked a PR merge — WCAG regressions could ship with a green CI status.

**Introducing commit:** ed37c8b25

## Change

```yaml
# Removed from the 'Run accessibility tests' step:
- continue-on-error: true
```

## Test plan
- [ ] A PR that introduces a new axe-core violation will now fail CI
- [ ] PRs with zero a11y violations pass as before

Fixes #12337

