### PR TITLE
fix(netlify): log blob cache write failures instead of swallowing them

### DIFF
--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -566,7 +566,7 @@ export default async (req: Request) => {
       data,
       expiresAt: Date.now() + CACHE_TTL_MS,
     };
-    store.set(cacheKey, JSON.stringify(entry)).catch(() => {});
+    store.set(cacheKey, JSON.stringify(entry)).catch((err) => { console.warn("[acmm-scan] blob cache write failed:", err instanceof Error ? err.message : err) });
 
     return new Response(JSON.stringify(data), {
       status: 200,

--- a/web/netlify/functions/analytics-accm.mts
+++ b/web/netlify/functions/analytics-accm.mts
@@ -608,7 +608,7 @@ export default async (req: Request) => {
       data: gistData,
       expiresAt: Date.now() + CACHE_TTL_MS,
     };
-    store.set(CACHE_KEY, JSON.stringify(cacheEntry)).catch(() => {});
+    store.set(CACHE_KEY, JSON.stringify(cacheEntry)).catch((err) => { console.warn("[analytics-accm] blob cache write failed:", err instanceof Error ? err.message : err) });
     return new Response(JSON.stringify({ ...gistData, source: "gist" }), {
       status: 200,
       headers: { ...headers, "Content-Type": "application/json" },
@@ -625,7 +625,7 @@ export default async (req: Request) => {
       data,
       expiresAt: Date.now() + CACHE_TTL_MS,
     };
-    store.set(CACHE_KEY, JSON.stringify(cacheEntry)).catch(() => {});
+    store.set(CACHE_KEY, JSON.stringify(cacheEntry)).catch((err) => { console.warn("[analytics-accm] blob cache write failed:", err instanceof Error ? err.message : err) });
 
     return new Response(JSON.stringify(data), {
       status: 200,

--- a/web/netlify/functions/analytics-dashboard.mts
+++ b/web/netlify/functions/analytics-dashboard.mts
@@ -952,7 +952,7 @@ export default async (req: Request) => {
         cacheKey,
         JSON.stringify({ data, expiresAt: Date.now() + CACHE_TTL_MS })
       )
-      .catch(() => {});
+      .catch((err) => { console.warn("[analytics-dashboard] blob cache write failed:", err instanceof Error ? err.message : err) });
 
     return new Response(JSON.stringify({ ...data, filterMode }), {
       status: 200,

--- a/web/netlify/functions/analytics-dashboard.mts
+++ b/web/netlify/functions/analytics-dashboard.mts
@@ -203,7 +203,7 @@ async function getAccessToken(
     accessToken,
     expiresAt: Date.now() + expiresIn * 1000,
   };
-  store.set(TOKEN_CACHE_KEY, JSON.stringify(cacheEntry)).catch(() => {});
+  store.set(TOKEN_CACHE_KEY, JSON.stringify(cacheEntry)).catch((err) => { console.warn("[analytics-dashboard] blob cache write failed:", err instanceof Error ? err.message : err) });
 
   return accessToken;
 }

--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -591,7 +591,7 @@ async function buildMatrix(
   // Merge freshest data into the history blob so 90-day ranges work
   const history = await readHistory(store);
   mergeIntoHistory(history, freshRuns);
-  await writeHistory(store, history).catch(() => {});
+  await writeHistory(store, history).catch((err) => { console.warn("[github-pipelines] history write failed:", err instanceof Error ? err.message : err) });
 
   // Build the date range (oldest → newest)
   const range: string[] = [];
@@ -963,7 +963,7 @@ export default async (req: Request): Promise<Response> => {
     // Wrap payload with the repo list so the client never hardcodes it.
     // Cards read `repos` from the response to populate their filter dropdown.
     const wrapped = { ...(payload as Record<string, unknown>), repos: REPOS };
-    await writeCache(store, cacheKey, wrapped).catch(() => {});
+    await writeCache(store, cacheKey, wrapped).catch((err) => { console.warn("[github-pipelines] blob cache write failed:", err instanceof Error ? err.message : err) });
     return jsonResponse(wrapped, {
       headers: {
         ...baseHeaders,

--- a/web/netlify/functions/missions-browse.mts
+++ b/web/netlify/functions/missions-browse.mts
@@ -138,7 +138,7 @@ export default async (request: Request): Promise<Response> => {
 
     // Store in cache (best-effort, don't block response)
     const entry: BrowseCacheEntry = { body, fetchedAt: Date.now() };
-    store.setJSON(cacheKey, entry).catch(() => {});
+    store.setJSON(cacheKey, entry).catch((err) => { console.warn("[missions-browse] blob cache write failed:", err instanceof Error ? err.message : err) });
 
     return new Response(body, {
       status: 200,

--- a/web/netlify/functions/missions-file.mts
+++ b/web/netlify/functions/missions-file.mts
@@ -121,7 +121,7 @@ export default async (request: Request): Promise<Response> => {
 
     // Store in cache (best-effort, don't block response)
     const entry: CacheEntry = { body, contentType, fetchedAt: Date.now() };
-    store.setJSON(cacheKey, entry).catch(() => {});
+    store.setJSON(cacheKey, entry).catch((err) => { console.warn("[missions-file] blob cache write failed:", err instanceof Error ? err.message : err) });
 
     return new Response(body, {
       status: 200,

--- a/web/netlify/functions/missions-scores.mts
+++ b/web/netlify/functions/missions-scores.mts
@@ -128,7 +128,7 @@ export default async (request: Request): Promise<Response> => {
           return jsonResponse(corsHeaders, { error: "response too large" }, 413);
         }
         const entry: CacheEntry = { body: bodyText, contentType: "application/json", fetchedAt: Date.now() };
-        store.setJSON(cacheKey, entry).catch(() => {});
+        store.setJSON(cacheKey, entry).catch((err) => { console.warn("[missions-scores] blob cache write failed:", err instanceof Error ? err.message : err) });
       }
     }
 

--- a/web/netlify/functions/nightly-e2e.mts
+++ b/web/netlify/functions/nightly-e2e.mts
@@ -325,7 +325,7 @@ async function fetchGuideImages(
     images: result,
     expiresAt: Date.now() + IMAGE_CACHE_TTL_MS,
   };
-  store.set(IMAGE_CACHE_KEY, JSON.stringify(cacheEntry)).catch(() => {});
+  store.set(IMAGE_CACHE_KEY, JSON.stringify(cacheEntry)).catch((err) => { console.warn("[nightly-e2e] blob cache write failed:", err instanceof Error ? err.message : err) });
 
   return result;
 }
@@ -458,7 +458,7 @@ async function enrichRunsWithImages(
 
   // Persist updated cache (best-effort)
   if (cacheUpdated) {
-    store.set(RUN_IMAGE_CACHE_KEY, JSON.stringify(cache)).catch(() => {});
+    store.set(RUN_IMAGE_CACHE_KEY, JSON.stringify(cache)).catch((err) => { console.warn("[nightly-e2e] run-image cache write failed:", err instanceof Error ? err.message : err) });
   }
 }
 
@@ -684,7 +684,7 @@ export default async (req: Request) => {
       cachedAt: now,
       expiresAt: Date.now() + ttl,
     };
-    store.set(CACHE_KEY, JSON.stringify(cacheEntry)).catch(() => {});
+    store.set(CACHE_KEY, JSON.stringify(cacheEntry)).catch((err) => { console.warn("[nightly-e2e] blob cache write failed:", err instanceof Error ? err.message : err) });
 
     return new Response(
       JSON.stringify({ guides, cachedAt: now, fromCache: false }),

--- a/web/netlify/functions/presence.mts
+++ b/web/netlify/functions/presence.mts
@@ -77,7 +77,7 @@ export default async (req: Request) => {
         const ts = parseInt(raw, 10);
         if (ts < cutoff) {
           // Expired — clean up in background (best-effort)
-          store.delete(blob.key).catch(() => {});
+          store.delete(blob.key).catch((err) => { console.warn("[presence] blob delete failed:", err instanceof Error ? err.message : err) });
           return false;
         }
         return true;


### PR DESCRIPTION
## Summary

13 `.catch(() => {})` handlers across 8 Netlify functions silently dropped Netlify Blob write errors. When Blob storage is unavailable, every request degrades to slow upstream fetches with zero observability — no log, no alert, no signal for operators.

**Introducing commit:** 107d55b35 (acmm-scan), 941b273df (github-pipelines), others per function.

## Change

Replaced all silent catches with `console.warn()` including the function name and error message. Cache writes remain best-effort and non-blocking — only observability is added.

**Affected functions (9 files, 13 sites):**
- analytics-dashboard, acmm-scan, missions-file, missions-browse, missions-scores, analytics-accm, github-pipelines, presence, nightly-e2e

## Test plan
- [ ] Normal operation: no change in behaviour
- [ ] Blob storage unavailable: console.warn appears in Netlify function logs with function name and error message

Addresses #12321

