### PR TITLE
fix: sync HelmReleaseStatus summary counts with filtered results

### DIFF
--- a/web/src/components/cards/HelmReleaseStatus.tsx
+++ b/web/src/components/cards/HelmReleaseStatus.tsx
@@ -103,6 +103,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
   // Use shared card data hook for filtering, sorting, and pagination
   const {
     items: releases,
+    allFilteredItems,
     totalItems,
     currentPage,
     totalPages,
@@ -177,9 +178,9 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
 
   const UNKNOWN_TIME_LABEL = 'Unknown'
 
-  // Counts from namespace-filtered releases (pre-pagination summary)
-  const deployedCount = namespacedReleases.filter(r => r.status === 'deployed').length
-  const failedCount = namespacedReleases.filter(r => r.status === 'failed').length
+  // Counts from the fully-filtered set so all three summary boxes describe the same population
+  const deployedCount = allFilteredItems.filter(r => r.status === 'deployed').length
+  const failedCount = allFilteredItems.filter(r => r.status === 'failed').length
 
   if (showSkeleton) {
     return (


### PR DESCRIPTION
fixes #13079
## SUMMARY

This PR fixes a summary counter desynchronization issue in the Helm Release Status card where the Total, Deployed, and Failed counts could describe different release populations after search or cluster filtering. The change updates the summary metrics to use the same filtered dataset that drives the visible list.

The update is localized to `web/src/components/cards/HelmReleaseStatus.tsx` within the `HelmReleaseStatus` component.

---

## FIX

```tsx id="i7gq4n"
// Before
const deployedCount = namespacedReleases.filter(r => r.status === 'deployed').length

// After
const deployedCount = allFilteredItems.filter(r => r.status === 'deployed').length
```


