### PR TITLE
Fix: Conflicting Agent.md with Claude.md for lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ If a tool-specific file conflicts with `CLAUDE.md`, `CLAUDE.md` wins.
 
 - **Start the console:** `./startup-oauth.sh` (requires `.env` with GitHub OAuth) or `./start-dev.sh` (mock user, no OAuth).
 - **Ports:** backend `8080`, frontend `5174`, kc-agent WebSocket `8585`.
-- **Pre-PR gate:** `cd web && npm run build && npm run lint`.
+- **Pre-PR gate:** Do not run `npm run build` or `npm run lint` locally; CI validates both on the PR.
 - **Testing is mandatory** for UI and API work — see the "MANDATORY Testing Requirements" section in `CLAUDE.md`.
 
 ## Non-negotiable rules (excerpt — full list in `CLAUDE.md`)
@@ -31,4 +31,4 @@ If a tool-specific file conflicts with `CLAUDE.md`, `CLAUDE.md` wins.
 
 ## Reporting back
 
-When you finish a task, summarize what changed and confirm the pre-PR gate (`npm run build && npm run lint`) passed. Do not push or open PRs unless explicitly asked.
+When you finish a task, summarize what changed and note that build/lint are validated by CI on the PR. Do not push or open PRs unless explicitly asked.


### PR DESCRIPTION
> **Adding or modifying a card/dashboard?** No, just a docs.

> **New CNCF project card?** No.

> **Use a coding agent.** No.

### 📌 Fixes

Fixes #12398  (Use "Fixes", "Closes", or "Resolves" for automatic closing)

---

### 📝 Summary of Changes

In AGENTS.md, updated the quick orientation section by replacing couple of lines.
Previous: **Pre-PR gate:** `cd web && npm run build && npm run lint`.
Now: **Pre-PR gate:** Do not run `npm run build` or `npm run lint`.....

Previous: **Pre-PR gate:** `cd web && npm run build && npm run lint`. When you finish a task, summarize....
Now:  **Pre-PR gate:** Do not run `npm run build` or `npm run lint` locally; CI validates both on the PR. When you finish a task, summarize....

---

### Changes Made


- [x] Updated AGENTS.md
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

---

### Checklist

- [ ] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
