### PR TITLE
fix: race in TestServer_HandleWebSocket_Upgrade

### DIFF
--- a/pkg/agent/server_ai_websocket_test.go
+++ b/pkg/agent/server_ai_websocket_test.go
@@ -40,12 +40,13 @@ func TestServer_HandleWebSocket_Upgrade(t *testing.T) {
 		t.Errorf("Expected status 101, got %d", resp.StatusCode)
 	}
 
-	// Verify client registration
-	s.clientsMux.Lock()
-	if len(s.clients) != 1 {
-		t.Errorf("Expected 1 registered client, got %d", len(s.clients))
-	}
-	s.clientsMux.Unlock()
+	// Verify client registration — poll because the server goroutine may not
+	// have reached s.clients[conn] yet when Dial returns.
+	require.Eventually(t, func() bool {
+		s.clientsMux.Lock()
+		defer s.clientsMux.Unlock()
+		return len(s.clients) == 1
+	}, 2*time.Second, 10*time.Millisecond, "Expected 1 registered client")
 
 	// Wait for cleanup on close — poll instead of a fixed sleep to avoid flakiness.
 	conn.Close()


### PR DESCRIPTION
## Summary
- `TestServer_HandleWebSocket_Upgrade` had a race condition: it checked `len(s.clients)==1` immediately after `Dial` returned, but the server goroutine may not have registered the client yet
- Use `require.Eventually` (same pattern already used for the cleanup assertion) to poll until registration completes
- This race caused today's nightly release to fail, leaving the Homebrew formula stale

## Test plan
- [x] `go test ./pkg/agent/ -run TestServer_HandleWebSocket_Upgrade -count=10` — 10/10 pass
- [ ] CI build/lint pass
- [ ] Re-run nightly release after merge to update Homebrew formula