### PR TITLE
fix: richer diagnostics and closure policy for workflow failure issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: determine-version
     if: needs.determine-version.outputs.has_changes == 'true'
+    outputs:
+      failed_tests: ${{ steps.go-test.outputs.failed_tests }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -176,7 +178,21 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Run Go tests
-        run: go test -v ./...
+        id: go-test
+        run: |
+          set +e
+          go test -v ./... 2>&1 | tee /tmp/go-test-output.txt
+          TEST_EXIT=$?
+          # Extract failing test names and packages for the failure issue
+          FAILED=$(grep -E '^--- FAIL:|^FAIL\t' /tmp/go-test-output.txt | head -20)
+          if [ -n "$FAILED" ]; then
+            # Multiline output via delimiter
+            EOF_DELIM=$(dd if=/dev/urandom bs=15 count=1 2>/dev/null | base64)
+            echo "failed_tests<<${EOF_DELIM}" >> "$GITHUB_OUTPUT"
+            echo "$FAILED" >> "$GITHUB_OUTPUT"
+            echo "${EOF_DELIM}" >> "$GITHUB_OUTPUT"
+          fi
+          exit $TEST_EXIT
 
       - name: Install frontend dependencies
         working-directory: web
@@ -593,6 +609,7 @@ jobs:
             const testResult = '${{ needs.test.result }}';
             const releaseResult = '${{ needs.release.result }}';
             const helmResult = '${{ needs.helm-release.result }}';
+            const failedTests = `${{ needs.test.outputs.failed_tests }}`.trim();
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const failedJobs = [];
@@ -606,6 +623,20 @@ jobs:
             // of cutting a fresh issue every night.
             const SAME_INCIDENT_HOURS = 48;
 
+            const failedTestSection = failedTests
+              ? `\n**Failing tests:**\n\`\`\`\n${failedTests}\n\`\`\`\n`
+              : '';
+
+            const closurePolicy = [
+              ``,
+              `---`,
+              `### ⚠️ Closure policy`,
+              `Do **not** close this issue until the Release workflow passes on \`main\`.`,
+              `Fixing the failing test is necessary but not sufficient — the nightly`,
+              `must actually succeed and produce a release before this issue is resolved.`,
+              `Verify with: \`gh run list --repo ${context.repo.owner}/${context.repo.repo} --workflow Release --limit 3\``,
+            ].join('\n');
+
             const failureSummary = [
               `## Release Failure — \`${version}\``,
               ``,
@@ -615,8 +646,9 @@ jobs:
               `- test: ${testResult}`,
               `- release: ${releaseResult}`,
               `- helm-release: ${helmResult}`,
-              ``,
+              failedTestSection,
               `**Workflow run:** ${runUrl}`,
+              closurePolicy,
             ].join('\n');
 
             // Look for the most recent release-failure issue (any state).

--- a/.github/workflows/workflow-failure-issue.yml
+++ b/.github/workflows/workflow-failure-issue.yml
@@ -27,6 +27,7 @@ on:
 
 permissions:
   issues: write
+  actions: read
 
 jobs:
   open-issue:
@@ -65,6 +66,19 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Fetch failed jobs for comment
+        if: steps.check.outputs.exists == 'true'
+        id: comment-details
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          FAILED_JOBS=$(gh run view "$RUN_ID" \
+            --repo "${{ github.repository }}" \
+            --json jobs \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")' 2>/dev/null || echo "")
+          echo "failed_jobs=${FAILED_JOBS}" >> "$GITHUB_OUTPUT"
+
       - name: Comment on existing issue
         if: steps.check.outputs.exists == 'true'
         env:
@@ -72,7 +86,12 @@ jobs:
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           RUN_ID: ${{ github.event.workflow_run.id }}
+          FAILED_JOBS: ${{ steps.comment-details.outputs.failed_jobs }}
         run: |
+          JOBS_LINE=""
+          if [ -n "$FAILED_JOBS" ]; then
+            JOBS_LINE="- **Failed jobs:** \`${FAILED_JOBS}\`"
+          fi
           gh issue comment "${{ steps.check.outputs.issue_number }}" \
             --repo "${{ github.repository }}" \
             --body "$(cat <<EOF
@@ -80,6 +99,7 @@ jobs:
 
           - **Run:** [#${RUN_ID}](${RUN_URL})
           - **Time:** $(date -u '+%Y-%m-%d %H:%M UTC')
+          ${JOBS_LINE}
           EOF
           )"
 
@@ -94,6 +114,19 @@ jobs:
             --color "d93f0b" \
             2>/dev/null || true
 
+      - name: Fetch failed job details
+        if: steps.check.outputs.exists == 'false'
+        id: details
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          FAILED_JOBS=$(gh run view "$RUN_ID" \
+            --repo "${{ github.repository }}" \
+            --json jobs \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")' 2>/dev/null || echo "")
+          echo "failed_jobs=${FAILED_JOBS}" >> "$GITHUB_OUTPUT"
+
       - name: Open new issue
         if: steps.check.outputs.exists == 'false'
         env:
@@ -102,7 +135,13 @@ jobs:
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           WORKFLOW_FILE: ${{ github.event.workflow_run.path }}
+          FAILED_JOBS: ${{ steps.details.outputs.failed_jobs }}
         run: |
+          FAILED_LINE=""
+          if [ -n "$FAILED_JOBS" ]; then
+            FAILED_LINE="| **Failed jobs** | \`${FAILED_JOBS}\` |"
+          fi
+
           gh issue create \
             --repo "${{ github.repository }}" \
             --title "Workflow failure: ${WORKFLOW_NAME}" \
@@ -118,11 +157,12 @@ jobs:
           | **Run** | [#${RUN_ID}](${RUN_URL}) |
           | **File** | \`${WORKFLOW_FILE}\` |
           | **Time** | $(date -u '+%Y-%m-%d %H:%M UTC') |
+          ${FAILED_LINE}
 
           ### Next Steps
           1. Check the [failed run](${RUN_URL}) for error details
           2. Fix the underlying issue
-          3. Close this issue once the workflow passes again
+          3. **Do not close** this issue until the workflow passes on \`main\`
 
           ---
           *This issue was automatically created by the workflow failure monitor.*


### PR DESCRIPTION
## Summary
- **Release workflow**: Capture failing test names (`--- FAIL:` lines) from `go test` output and include them in the failure issue body — agents can identify the exact failing test without digging through CI logs
- **Release workflow**: Add closure policy to failure issues: "do not close until the Release workflow passes on main" — prevents premature closure (e.g. scanner closed #12405 after fixing some tests, but the WebSocket race was a separate flake)
- **workflow-failure-issue.yml**: Fetch failed job names via `gh run view` and include them in both new issues and "still failing" comments; added `actions: read` permission

## Test plan
- [ ] CI passes
- [ ] Next nightly release failure (if any) should show failing test names in the issue
- [ ] Workflow-failure issues should show which jobs failed
- [ ] Closure policy text appears in release-failure issues

## Context
Today's nightly release failed due to a race in `TestServer_HandleWebSocket_Upgrade` (fixed in #12519). The failure issue #12405 was created correctly but was prematurely closed by the scanner after fixing unrelated test failures. The nightly never re-ran, leaving brew red all day.