### PR TITLE
fix: enable local cluster start button for detected clusters

### DIFF
--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -166,8 +166,6 @@ const LocalClusterControls = memo(function LocalClusterControls({
   const { clusterLifecycle, clusters } = useLocalClusterTools()
   const [actionInProgress, setActionInProgress] = useState<string | null>(null)
   const tool = providerToTool(provider)
-  const controlsDisabled = unreachable
-  const disabledTooltip = t('cluster.controlsDisabledOffline')
 
   if (!tool) return null
 
@@ -177,6 +175,13 @@ const LocalClusterControls = memo(function LocalClusterControls({
   )
   const effectiveTool = localCluster?.tool || tool
   const effectiveName = localCluster?.name || clusterName.replace(/^kind-/, '')
+
+  // Enable controls for detected local clusters even if unreachable (they can be started)
+  // Only disable for cloud clusters or if we have no info about the cluster
+  const isDetectedLocalCluster = !!localCluster
+  const controlsDisabled = unreachable && !isDetectedLocalCluster
+  const disabledTooltip = t('cluster.controlsDisabledOffline')
+
   const isStopped = localCluster?.status === 'stopped' || unreachable
 
   const handleAction = async (action: 'start' | 'stop' | 'restart', e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary

Allow the play/start button to function for detected local clusters (kind, minikube, k3d) even when they show as unreachable. This enables users to start stopped clusters from the UI.

## Changes

- Modified LocalClusterControls to only disable controls for cloud clusters (EKS, GKE, AKS)
- Detected local clusters can now be started even if momentarily unreachable
- Cloud clusters remain disabled when unreachable (cannot be started from UI anyway)

## Related to

Follows up on commit 9e82a47de which disabled cluster controls too broadly. This refines the logic to distinguish between local clusters (which should be startable) and cloud clusters (which cannot be started from the UI).

## Test plan

- [ ] Start dev server and verify play button shows for stopped kind clusters
- [ ] Verify play button is still disabled for cloud clusters when unreachable
- [ ] Click play button to start a stopped kind cluster
- [ ] Verify cluster transitions from 'stopped' to 'running' state