### PR TITLE
test: add Vitest tests for EventSummary

### DIFF
--- a/web/src/components/cards/__tests__/EventSummary.test.tsx
+++ b/web/src/components/cards/__tests__/EventSummary.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EventSummary } from '../EventSummary'
+import type { ClusterEvent } from '../../../hooks/useMCP'
+
+const mockUseCachedEvents = vi.fn()
+const mockUseGlobalFilters = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+const mockUseChartFilters = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => (
+      opts?.count !== undefined ? `${key}:${opts.count}` : key
+    ),
+  }),
+}))
+
+vi.mock('../../../hooks/useCachedData', () => ({
+  useCachedEvents: (...args: unknown[]) => mockUseCachedEvents(...args),
+}))
+
+vi.mock('../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => mockUseGlobalFilters(),
+}))
+
+vi.mock('../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+vi.mock('../../../lib/cards/cardHooks', () => ({
+  useChartFilters: (...args: unknown[]) => mockUseChartFilters(...args),
+}))
+
+vi.mock('../../ui/RefreshIndicator', () => ({
+  RefreshButton: () => <button data-testid="refresh-button" />,
+}))
+
+vi.mock('../../../lib/cards/CardComponents', () => ({
+  CardSkeleton: () => <div data-testid="card-skeleton" />,
+}))
+
+function makeEvent(overrides: Partial<ClusterEvent> = {}): ClusterEvent {
+  return {
+    type: 'Normal',
+    reason: 'PodStarted',
+    message: 'Pod started successfully',
+    object: 'Pod/my-pod',
+    namespace: 'default',
+    cluster: 'prod',
+    count: 1,
+    lastSeen: new Date().toISOString(),
+    ...overrides,
+  } as ClusterEvent
+}
+
+describe('EventSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCachedEvents.mockReturnValue({
+      events: [],
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      refetch: vi.fn(),
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+    })
+    mockUseGlobalFilters.mockReturnValue({
+      filterByCluster: (events: ClusterEvent[]) => events,
+    })
+    mockUseCardLoadingState.mockReturnValue({
+      showSkeleton: false,
+      showEmptyState: false,
+    })
+    mockUseChartFilters.mockReturnValue({
+      localClusterFilter: [],
+      toggleClusterFilter: vi.fn(),
+      clearClusterFilter: vi.fn(),
+      availableClusters: [],
+      showClusterFilter: false,
+      setShowClusterFilter: vi.fn(),
+      clusterFilterRef: { current: null },
+    })
+  })
+
+  it('renders skeleton when loading state is active', () => {
+    mockUseCardLoadingState.mockReturnValue({
+      showSkeleton: true,
+      showEmptyState: false,
+    })
+
+    render(<EventSummary />)
+
+    expect(screen.getByTestId('card-skeleton')).toBeTruthy()
+  })
+
+  it('renders empty state when no events are available', () => {
+    mockUseCardLoadingState.mockReturnValue({
+      showSkeleton: false,
+      showEmptyState: true,
+    })
+
+    render(<EventSummary />)
+
+    expect(screen.getByText('eventSummary.noEvents')).toBeTruthy()
+    expect(screen.getByText('eventSummary.noEventsHint')).toBeTruthy()
+  })
+
+  it('renders error banner when the fetch failed', () => {
+    mockUseCachedEvents.mockReturnValue({
+      events: [],
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      refetch: vi.fn(),
+      isFailed: true,
+      consecutiveFailures: 3,
+      lastRefresh: null,
+    })
+
+    render(<EventSummary />)
+
+    expect(screen.getByText('eventSummary.errorLoading')).toBeTruthy()
+    expect(screen.getByText('eventSummary.fetchFailed:3')).toBeTruthy()
+  })
+
+  it('aggregates warning and normal events and renders top reasons', () => {
+    mockUseCachedEvents.mockReturnValue({
+      events: [
+        makeEvent({ type: 'Warning', reason: 'ImagePullBackOff', cluster: 'prod' }),
+        makeEvent({ type: 'Warning', reason: 'ImagePullBackOff', cluster: undefined }),
+        makeEvent({ type: 'Normal', reason: 'PodStarted', cluster: 'prod' }),
+        makeEvent({ type: 'Normal', reason: 'Scheduled', cluster: 'dev' }),
+        makeEvent({ type: 'Normal', reason: 'Scheduled', cluster: 'dev' }),
+      ],
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      refetch: vi.fn(),
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+    })
+
+    render(<EventSummary />)
+
+    expect(screen.getByText('eventSummary.nEvents:5')).toBeTruthy()
+    expect(screen.getByText('common:common.warnings')).toBeTruthy()
+    expect(screen.getByText('common:common.normal')).toBeTruthy()
+    expect(screen.getByText('ImagePullBackOff')).toBeTruthy()
+    expect(screen.getByText('PodStarted')).toBeTruthy()
+    expect(screen.getByText('Scheduled')).toBeTruthy()
+  })
+
+  it('filters events by cluster through the global filter hook', () => {
+    mockUseGlobalFilters.mockReturnValue({
+      filterByCluster: (events: ClusterEvent[]) => events.filter(event => event.cluster === 'prod'),
+    })
+    mockUseCachedEvents.mockReturnValue({
+      events: [
+        makeEvent({ type: 'Warning', reason: 'ImagePullBackOff', cluster: 'prod' }),
+        makeEvent({ type: 'Normal', reason: 'PodStarted', cluster: 'dev' }),
+      ],
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      refetch: vi.fn(),
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+    })
+
+    render(<EventSummary />)
+
+    expect(screen.getByText('eventSummary.nEvents:1')).toBeTruthy()
+    expect(screen.getByText('ImagePullBackOff')).toBeTruthy()
+    expect(screen.queryByText('PodStarted')).toBeNull()
+  })
+})


### PR DESCRIPTION

### 📌 Fixes

Related to #4189

---

### 📝 Summary of Changes

Adds Vitest coverage for EventSummary.tsx covering loading, empty, error, aggregation, and cluster-filtered rendering states.

This follows the existing hook-mocking and branch-testing patterns already used in nearby card component tests.

---

### Changes Made

- [x] Added Vitest tests for `EventSummary.tsx`
- [x] Added loading skeleton state coverage
- [x] Added empty state rendering coverage
- [x] Added failed fetch/error banner coverage
- [x] Added event aggregation rendering coverage
- [x] Added cluster filtering behavior coverage
- [x] Added mocked hook-based setup following existing repository testing patterns

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [x] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs 
Attached local Vitest run screenshot showing passing test results.

<img width="865" height="350" alt="Screenshot 2026-05-08 204012" src="https://github.com/user-attachments/assets/9bf209cd-b713-4959-b442-efe679f773f9" />


---

### 👀 Reviewer Notes

Focused test-only PR following existing Vitest patterns used in nearby dashboard card component tests.

