### PR TITLE
🐛 fix: demo deployment versions showing "unknown", rss_feed in cluster-admin layout, ArgoCD stat hardcoded to 0

### DIFF
--- a/web/src/components/deploy/Deploy.tsx
+++ b/web/src/components/deploy/Deploy.tsx
@@ -3,6 +3,7 @@ import type { DragEndEvent } from '@dnd-kit/core'
 import { useClusterGroups } from '../../hooks/useClusterGroups'
 import { useClusters, useDeployments } from '../../hooks/useMCP'
 import { useCachedDeployments } from '../../hooks/useCachedData'
+import { useArgoCDApplications } from '../../hooks/useArgoCD'
 import { StatBlockValue } from '../ui/StatsOverview'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
@@ -24,6 +25,7 @@ export function Deploy() {
   const { t } = useTranslation(['cards', 'common'])
   const { isLoading: deploymentsLoading, isRefreshing: deploymentsRefreshing, lastUpdated, refetch } = useDeployments()
   const { deployments: cachedDeployments } = useCachedDeployments()
+  const { applications: argoCDApps, isDemoData: isArgoCDDemo } = useArgoCDApplications()
 
   const publishCardEvent = useCardPublish()
   const { mutate: deployWorkload } = useDeployWorkload()
@@ -51,7 +53,7 @@ export function Deploy() {
       case 'failed':
         return { value: failedCount, sublabel: t('common:common.failed') }
       case 'argocd':
-        return { value: 0, sublabel: t('common:deploy.applications'), isDemo: true }
+        return { value: argoCDApps.length, sublabel: t('common:deploy.applications'), isDemo: isArgoCDDemo }
       default:
         return { value: '-' }
     }


### PR DESCRIPTION
## Summary

This PR fixes three UI bugs found while navigating the KubeStellar Console in Demo Mode:

### Bug 1 — Deployment Status card shows "unknown" for all version labels
`getDemoDeployments()` in `demoData.ts` defined all 6 demo deployments without an `image` field. The `DeploymentStatus` card calls `extractImageTag(deployment.image)`, and `extractImageTag(undefined)` returns `'unknown'` by design. Added realistic image tags to all 6 demo entries so users see meaningful version labels (`nginx:1.25`, `redis:7`, etc.) instead of `unknown`.

### Bug 2 — `rss_feed` card included in Cluster Admin default layout (22 cards instead of 21)
`cluster-admin.ts` default config contained `rss_feed` as a 22nd card, breaking the expected 21-card layout spec. An RSS news feed is irrelevant to cluster administration. Removed the entry. This also fixes the failing Playwright test that asserts exactly 21 default cards.

### Bug 3 — ArgoCD Apps stat block hardcoded to `0` on `/deploy` dashboard
`Deploy.tsx` returned `{ value: 0, isDemo: true }` unconditionally for the `argocd` stat block, regardless of actual data or demo mode. Replaced with `useArgoCDApplications()` so the stat reflects the real app count (43 in demo mode, live count when connected).

## Files changed

- `web/src/hooks/useCachedData/demoData.ts` — add `image` field to all demo deployments
- `web/src/config/dashboards/cluster-admin.ts` — remove `rss_feed` from default layout
- `web/src/components/deploy/Deploy.tsx` — wire ArgoCD stat to `useArgoCDApplications()`

## Test plan

- [ ] Navigate to `/deploy` in Demo Mode → Deployment Status card shows image tags (`nginx:1.25`, `redis:7`, etc.) instead of `unknown`
- [ ] Navigate to `/cluster-admin` → Restore Default Layout → confirm 21 cards total, no RSS Feed card
- [ ] Navigate to `/deploy` → Stats Overview → ArgoCD Apps shows `43` in Demo Mode instead of `0`
- [ ] Run `npx playwright test e2e/cluster-admin-cards.spec.ts` → 21-card layout test passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
