### PR TITLE
✨ feat: add rotating tips for Drasi dashboard  

### DIFF
--- a/web/src/components/ui/RotatingTip.tsx
+++ b/web/src/components/ui/RotatingTip.tsx
@@ -244,6 +244,13 @@ const TIPS: Record<string, string[]> = {
     'Arcade cards remember your layout between sessions automatically.',
     'Try combining GPU, compliance, and cluster cards for a unified overview.',
   ],
+  drasi: [
+    'Drasi sources connect to databases, message queues, and Kubernetes events as live data streams.',
+    'Continuous queries update automatically as source data changes — no polling required.',
+    'Reactions trigger downstream actions (webhooks, SignalR, Gremlin) when query results change.',
+    'Set VITE_DRASI_API_URL to connect the console to your Drasi management API.',
+    'The reactive graph view shows how sources, queries, and reactions are wired together.',
+  ],
 }
 
 interface RotatingTipProps {


### PR DESCRIPTION
## Summary
- `Drasi.tsx` uses `<RotatingTip page="drasi" />` but the `drasi` key was missing from the `TIPS` object in `RotatingTip.tsx`
- The component silently rendered nothing on the Drasi dashboard
- Added 5 contextual tips covering Drasi sources, continuous queries, reactions, configuration, and the reactive graph view

## Test plan
- [ ] Navigate to /drasi in demo mode
- [ ] A "Tip:" banner should appear in the top-right of the dashboard header
- [ ] Tip rotates each session

🤖 Authored with [Claude Code](https://claude.com/claude-code)