### PR TITLE
🐛 fix: hardcoded English strings in Drasi dashboard stat blocks

### DIFF
--- a/web/src/components/drasi/Drasi.tsx
+++ b/web/src/components/drasi/Drasi.tsx
@@ -3,6 +3,7 @@
  *
  * Reactive data pipelines — visualize sources, continuous queries, and reactions.
  */
+import { useTranslation } from 'react-i18next'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
 import { RotatingTip } from '../ui/RotatingTip'
@@ -19,31 +20,32 @@ const DEMO_QUERY_COUNT = 4
 const DEMO_REACTION_COUNT = 1
 
 export function Drasi() {
+  const { t } = useTranslation()
   const { data, isLoading, error } = useDrasiResources()
 
-  const hasRealData = !!data && (data.sources.length > 0 || data.queries.length > 0)
+  const hasRealData = !!data && ((data.sources || []).length > 0 || (data.queries || []).length > 0)
   const isDemoData = !hasRealData && !isLoading
 
   const getStatValue = (blockId: string): StatBlockValue => {
     switch (blockId) {
       case 'sources':
         return {
-          value: data?.sources.length ?? (isDemoData ? DEMO_SOURCE_COUNT : 0),
-          sublabel: 'sources',
+          value: (data?.sources || []).length || (isDemoData ? DEMO_SOURCE_COUNT : 0),
+          sublabel: t('common:drasi.statSources'),
           isClickable: false,
           isDemo: isDemoData,
         }
       case 'queries':
         return {
-          value: data?.queries.length ?? (isDemoData ? DEMO_QUERY_COUNT : 0),
-          sublabel: 'continuous queries',
+          value: (data?.queries || []).length || (isDemoData ? DEMO_QUERY_COUNT : 0),
+          sublabel: t('common:drasi.statContinuousQueries'),
           isClickable: false,
           isDemo: isDemoData,
         }
       case 'reactions':
         return {
-          value: data?.reactions.length ?? (isDemoData ? DEMO_REACTION_COUNT : 0),
-          sublabel: 'reactions',
+          value: (data?.reactions || []).length || (isDemoData ? DEMO_REACTION_COUNT : 0),
+          sublabel: t('common:drasi.statReactions'),
           isClickable: false,
           isDemo: isDemoData,
         }
@@ -72,7 +74,7 @@ export function Drasi() {
     >
       {error && (
         <div className="mb-4 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400">
-          <div className="font-medium">Error loading Drasi resources</div>
+          <div className="font-medium">{t('common:drasi.errorLoadingResources')}</div>
           <div className="text-sm text-muted-foreground">{error}</div>
         </div>
       )}

--- a/web/src/components/drasi/Drasi.tsx
+++ b/web/src/components/drasi/Drasi.tsx
@@ -31,21 +31,21 @@ export function Drasi() {
       case 'sources':
         return {
           value: (data?.sources || []).length || (isDemoData ? DEMO_SOURCE_COUNT : 0),
-          sublabel: t('common:drasi.statSources'),
+          sublabel: t('drasi.statSources'),
           isClickable: false,
           isDemo: isDemoData,
         }
       case 'queries':
         return {
           value: (data?.queries || []).length || (isDemoData ? DEMO_QUERY_COUNT : 0),
-          sublabel: t('common:drasi.statContinuousQueries'),
+          sublabel: t('drasi.statContinuousQueries'),
           isClickable: false,
           isDemo: isDemoData,
         }
       case 'reactions':
         return {
           value: (data?.reactions || []).length || (isDemoData ? DEMO_REACTION_COUNT : 0),
-          sublabel: t('common:drasi.statReactions'),
+          sublabel: t('drasi.statReactions'),
           isClickable: false,
           isDemo: isDemoData,
         }
@@ -74,7 +74,7 @@ export function Drasi() {
     >
       {error && (
         <div className="mb-4 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400">
-          <div className="font-medium">{t('common:drasi.errorLoadingResources')}</div>
+          <div className="font-medium">{t('drasi.errorLoadingResources')}</div>
           <div className="text-sm text-muted-foreground">{error}</div>
         </div>
       )}

--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -2906,4 +2906,11 @@
       "gapConfigSource": "<strong>Config source</strong> - Unified uses converted configs, legacy uses raw definitions"
     }
   }
+,
+  "drasi": {
+    "statSources": "sources",
+    "statContinuousQueries": "continuous queries",
+    "statReactions": "reactions",
+    "errorLoadingResources": "Error loading Drasi resources"
+  }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1795,7 +1795,11 @@
     "copy": "Copy",
     "copied": "Copied",
     "flowLabel": "Flow",
-    "flowAllResources": "All resources"
+    "flowAllResources": "All resources",
+    "statSources": "sources",
+    "statContinuousQueries": "continuous queries",
+    "statReactions": "reactions",
+    "errorLoadingResources": "Error loading Drasi resources"
   },
   "missionChat": {
     "saveTranscript": "Save transcript",

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -2906,4 +2906,11 @@
       "gapConfigSource": "<strong>Config source</strong> - Unified uses converted configs, legacy uses raw definitions"
     }
   }
+,
+  "drasi": {
+    "statSources": "sources",
+    "statContinuousQueries": "continuous queries",
+    "statReactions": "reactions",
+    "errorLoadingResources": "Error loading Drasi resources"
+  }
 }

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -2906,4 +2906,11 @@
       "gapConfigSource": "<strong>Config source</strong> - Unified uses converted configs, legacy uses raw definitions"
     }
   }
+,
+  "drasi": {
+    "statSources": "sources",
+    "statContinuousQueries": "continuous queries",
+    "statReactions": "reactions",
+    "errorLoadingResources": "Error loading Drasi resources"
+  }
 }

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -2906,4 +2906,11 @@
       "gapConfigSource": "<strong>Config source</strong> - Unified uses converted configs, legacy uses raw definitions"
     }
   }
+,
+  "drasi": {
+    "statSources": "sources",
+    "statContinuousQueries": "continuous queries",
+    "statReactions": "reactions",
+    "errorLoadingResources": "Error loading Drasi resources"
+  }
 }

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -2906,4 +2906,11 @@
       "gapConfigSource": "<strong>Config source</strong> - Unified uses converted configs, legacy uses raw definitions"
     }
   }
+,
+  "drasi": {
+    "statSources": "sources",
+    "statContinuousQueries": "continuous queries",
+    "statReactions": "reactions",
+    "errorLoadingResources": "Error loading Drasi resources"
+  }
 }

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -2906,4 +2906,11 @@
       "gapConfigSource": "<strong>Config source</strong> - Unified uses converted configs, legacy uses raw definitions"
     }
   }
+,
+  "drasi": {
+    "statSources": "sources",
+    "statContinuousQueries": "continuous queries",
+    "statReactions": "reactions",
+    "errorLoadingResources": "Error loading Drasi resources"
+  }
 }

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -2906,4 +2906,11 @@
       "gapConfigSource": "<strong>Config source</strong> - Unified uses converted configs, legacy uses raw definitions"
     }
   }
+,
+  "drasi": {
+    "statSources": "sources",
+    "statContinuousQueries": "continuous queries",
+    "statReactions": "reactions",
+    "errorLoadingResources": "Error loading Drasi resources"
+  }
 }

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -2906,4 +2906,11 @@
       "gapConfigSource": "<strong>Config source</strong> - Unified uses converted configs, legacy uses raw definitions"
     }
   }
+,
+  "drasi": {
+    "statSources": "sources",
+    "statContinuousQueries": "continuous queries",
+    "statReactions": "reactions",
+    "errorLoadingResources": "Error loading Drasi resources"
+  }
 }


### PR DESCRIPTION
## Problem

The Drasi dashboard stat blocks display hardcoded English strings that bypass the i18n system, making them untranslatable for non-English users:

- `sublabel: 'sources'`
- `sublabel: 'continuous queries'`
- `sublabel: 'reactions'`
- Error banner: `"Error loading Drasi resources"`

`Deploy.tsx` already uses `t()` for all its sublabels — Drasi should follow the same pattern.

## Changes

- `web/src/components/drasi/Drasi.tsx`: add `useTranslation` hook, replace hardcoded sublabels and error message with `t('common:drasi.*')` calls; add array safety guards (`(data?.sources || []).length`)
- `web/src/locales/en/common.json`: add 4 new keys to the `drasi` section
- All 8 non-English locale files: add `drasi` section with the same 4 keys (English as placeholder, consistent with i18n fallback strategy used in this project)

Fixes #12719 
