### PR TITLE
🐛 Fix panic risk from unguarded type assertions in gitops_argo.go

### DIFF
--- a/pkg/api/handlers/gitops_argo.go
+++ b/pkg/api/handlers/gitops_argo.go
@@ -271,17 +271,21 @@ func (h *GitOpsHandlers) GetArgoHealthSummary(c *fiber.Ctx) error {
 	}
 
 	for _, app := range appList.Items {
+		var key string
 		switch app.HealthStatus {
 		case "Healthy":
-			summary["healthy"] = summary["healthy"].(int) + 1
+			key = "healthy"
 		case "Degraded":
-			summary["degraded"] = summary["degraded"].(int) + 1
+			key = "degraded"
 		case "Progressing":
-			summary["progressing"] = summary["progressing"].(int) + 1
+			key = "progressing"
 		case "Missing":
-			summary["missing"] = summary["missing"].(int) + 1
+			key = "missing"
 		default:
-			summary["unknown"] = summary["unknown"].(int) + 1
+			key = "unknown"
+		}
+		if v, ok := summary[key].(int); ok {
+			summary[key] = v + 1
 		}
 	}
 
@@ -320,13 +324,17 @@ func (h *GitOpsHandlers) GetArgoSyncSummary(c *fiber.Ctx) error {
 	}
 
 	for _, app := range appList.Items {
+		var key string
 		switch app.SyncStatus {
 		case "Synced":
-			summary["synced"] = summary["synced"].(int) + 1
+			key = "synced"
 		case "OutOfSync":
-			summary["outOfSync"] = summary["outOfSync"].(int) + 1
+			key = "outOfSync"
 		default:
-			summary["unknown"] = summary["unknown"].(int) + 1
+			key = "unknown"
+		}
+		if v, ok := summary[key].(int); ok {
+			summary[key] = v + 1
 		}
 	}
 

--- a/pkg/api/handlers/gitops_argo.go
+++ b/pkg/api/handlers/gitops_argo.go
@@ -284,9 +284,15 @@ func (h *GitOpsHandlers) GetArgoHealthSummary(c *fiber.Ctx) error {
 		default:
 			key = "unknown"
 		}
-		if v, ok := summary[key].(int); ok {
-			summary[key] = v + 1
+		count := 0
+		if current, exists := summary[key]; exists {
+			if v, ok := current.(int); ok {
+				count = v
+			} else {
+				slog.Warn("[ArgoCD] unexpected counter type in health summary", "key", key, "type", fmt.Sprintf("%T", current))
+			}
 		}
+		summary[key] = count + 1
 	}
 
 	return c.JSON(fiber.Map{
@@ -333,9 +339,15 @@ func (h *GitOpsHandlers) GetArgoSyncSummary(c *fiber.Ctx) error {
 		default:
 			key = "unknown"
 		}
-		if v, ok := summary[key].(int); ok {
-			summary[key] = v + 1
+		count := 0
+		if current, exists := summary[key]; exists {
+			if v, ok := current.(int); ok {
+				count = v
+			} else {
+				slog.Warn("[ArgoCD] unexpected counter type in sync summary", "key", key, "type", fmt.Sprintf("%T", current))
+			}
 		}
+		summary[key] = count + 1
 	}
 
 	return c.JSON(fiber.Map{


### PR DESCRIPTION
Fixed #12882
## Summary

Fixes unguarded `.(int)` type assertions on `fiber.Map` in `GetArgoHealthSummary` and `GetArgoSyncSummary` handlers. These bare assertions panic if any map key is not an `int`, which would crash the entire Fiber server process.

## Changes

- Replace `summary["key"].(int) + 1` with comma-ok form: `if v, ok := summary[key].(int); ok { summary[key] = v + 1 }`
- Refactored switch to assign a `key` variable first, then do a single safe assertion — reduces duplication

## Why it matters

Currently safe because the map is initialized with integer zeros immediately above. But one future copy-paste or new status key with a non-integer default would cause an unrecovered panic, taking down all handlers — not just this one.

## Test Plan

- [ ] `GET /api/gitops/argocd/health` returns correct counts with no panic
- [ ] `GET /api/gitops/argocd/sync` returns correct counts with no panic
- [ ] Handler returns gracefully when ArgoCD reports an unknown health/sync status