### PR TITLE
fix: resolve Playwright CI failures across 4 test suites

### DIFF
--- a/web/e2e/cluster-admin-cards.spec.ts
+++ b/web/e2e/cluster-admin-cards.spec.ts
@@ -694,7 +694,7 @@ test.describe('Cluster Admin Cards — EtcdStatus, DNSHealth, AdmissionWebhooks'
       await page.goto('/cluster-admin')
       await page.waitForLoadState('domcontentloaded')
 
-      // All 21 default card types from cluster-admin.ts config
+      // All 24 default card types from cluster-admin.ts config
       const EXPECTED_CARD_TYPES = [
         'kubectl',
         'node_debug',
@@ -717,9 +717,12 @@ test.describe('Cluster Admin Cards — EtcdStatus, DNSHealth, AdmissionWebhooks'
         'alert_rules',
         'security_issues',
         'console_ai_health_check',
+        'etcd_status',
+        'dns_health',
+        'admission_webhooks',
       ]
 
-      const EXPECTED_CARD_COUNT = 21
+      const EXPECTED_CARD_COUNT = 24
 
       // Wait for the dashboard grid to be visible
       const grid = page.locator('[data-testid="dashboard-cards-grid"], .grid')

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -828,6 +828,7 @@ function FullDashboardApp({ liveLocation }: { liveLocation: Location }) {
           {/* /feature, /features open the feedback modal on the feature tab */}
           <Route path={ROUTES.FEATURE} element={<FeatureRedirect />} />
           <Route path={ROUTES.FEATURES} element={<FeatureRedirect />} />
+          <Route path="*" element={<SuspenseRoute><NotFound /></SuspenseRoute>} />
         </Route>
 
         <Route path="*" element={<SuspenseRoute><NotFound /></SuspenseRoute>} />

--- a/web/src/components/clusters/components/CardConfigModal.tsx
+++ b/web/src/components/clusters/components/CardConfigModal.tsx
@@ -42,10 +42,11 @@ export function CardConfigModal({
         <div className="space-y-4">
           {/* Cluster Filter */}
           <div>
-            <label className="block text-sm font-medium text-foreground mb-2">
+            <label htmlFor="card-config-cluster" className="block text-sm font-medium text-foreground mb-2">
               Filter by Cluster
             </label>
             <select
+              id="card-config-cluster"
               value={(config.cluster as string) || ''}
               onChange={(e) => setConfig(prev => ({ ...prev, cluster: e.target.value || undefined }))}
               className="w-full px-3 py-2 bg-secondary/50 border border-border rounded-lg text-foreground"
@@ -59,10 +60,11 @@ export function CardConfigModal({
 
           {/* Namespace Filter */}
           <div>
-            <label className="block text-sm font-medium text-foreground mb-2">
+            <label htmlFor="card-config-namespace" className="block text-sm font-medium text-foreground mb-2">
               Filter by Namespace
             </label>
             <input
+              id="card-config-namespace"
               type="text"
               value={(config.namespace as string) || ''}
               onChange={(e) => setConfig(prev => ({ ...prev, namespace: e.target.value || undefined }))}
@@ -87,10 +89,11 @@ export function CardConfigModal({
 
           {/* Max Items */}
           <div>
-            <label className="block text-sm font-medium text-foreground mb-2">
+            <label htmlFor="card-config-max-items" className="block text-sm font-medium text-foreground mb-2">
               Max Items to Display
             </label>
             <input
+              id="card-config-max-items"
               type="number"
               value={(config.maxItems as number) || 10}
               onChange={(e) => setConfig(prev => ({ ...prev, maxItems: parseInt(e.target.value) || 10 }))}

--- a/web/src/components/layout/navbar/SearchDropdown.tsx
+++ b/web/src/components/layout/navbar/SearchDropdown.tsx
@@ -333,8 +333,10 @@ export function SearchDropdown() {
         // with the `capture: true` on the addEventListener call below so
         // this listener wins regardless of registration order.
         event.stopPropagation()
-        inputRef.current?.focus()
         openSearch()
+        // Defer focus until after React commits the open state so inputRef is
+        // guaranteed to be attached and the input is focusable (#find-and-search).
+        requestAnimationFrame(() => inputRef.current?.focus())
         emitGlobalSearchOpened('keyboard')
       }
 

--- a/web/src/config/dashboards/cluster-admin.ts
+++ b/web/src/config/dashboards/cluster-admin.ts
@@ -43,6 +43,10 @@ export const clusterAdminDashboardConfig: UnifiedDashboardConfig = {
     // Row 9: Security & info
     { id: 'ca-security-1', cardType: 'security_issues', position: { w: 4, h: 3, x: 0, y: 25 } },
     { id: 'ca-ai-1', cardType: 'console_ai_health_check', position: { w: 4, h: 3, x: 4, y: 25 } },
+    // Row 10: Cluster infrastructure monitoring
+    { id: 'ca-etcd-1', cardType: 'etcd_status', position: { w: 4, h: 3, x: 0, y: 28 } },
+    { id: 'ca-dns-1', cardType: 'dns_health', position: { w: 4, h: 3, x: 4, y: 28 } },
+    { id: 'ca-webhooks-1', cardType: 'admission_webhooks', position: { w: 4, h: 3, x: 8, y: 28 } },
   ],
   features: {
     dragDrop: true,


### PR DESCRIPTION
> **Use a coding agent.** This PR was generated and reviewed with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Sonnet 4.6), which knows all codebase patterns (isDemoData, useCardLoadingState, locale strings, DCO).

### 📌 Fixes

Related to #4190

> **Note:** Using "Related to" instead of "Fixes" so the mentorship tracking issue #4190 is not auto-closed by this PR.

---

### 📝 Summary of Changes

Resolves four categories of failing Playwright CI tests identified in the April 28 mentor triage: `cluster-admin-cards.spec.ts` (25 tests), `find-and-search.spec.ts` (Ctrl+K shortcut), `a11y.spec.ts` (axe `label` rule), and `not-found.spec.ts` (2 tests). All fixes are surgical — no refactoring, no new abstractions.

---

### Changes Made

- [x] **`web/src/config/dashboards/cluster-admin.ts`** — Added `etcd_status`, `dns_health`, and `admission_webhooks` cards to the cluster-admin default layout (row 10, `y=28`, `w=4`, `h=3`). The preset was not auto-pinning these three infrastructure monitoring cards, which are registered in `CARD_COMPONENTS` and the unified config but were absent from the default placement list.

- [x] **`web/e2e/cluster-admin-cards.spec.ts`** — Updated the "Default Layout" test: `EXPECTED_CARD_COUNT` 21 → 24, added `'etcd_status'`, `'dns_health'`, `'admission_webhooks'` to `EXPECTED_CARD_TYPES`. Pre-existing `String.raw` warnings at lines 509–547, 805 were not introduced here.

- [x] **`web/src/components/layout/navbar/SearchDropdown.tsx`** — Fixed Ctrl+K focus race. `openSearch()` triggers an async React state update; calling `inputRef.current?.focus()` synchronously before the state commits means the input is not yet in its open/focusable state. Deferred the focus call with `requestAnimationFrame(() => inputRef.current?.focus())` so it runs after React's next paint.

- [x] **`web/src/components/clusters/components/CardConfigModal.tsx`** — Three form controls (cluster `<select>`, namespace `<input>`, max-items `<input>`) had `<label>` elements with no `htmlFor` and controls with no `id`. Added matching `htmlFor`/`id` pairs (`card-config-cluster`, `card-config-namespace`, `card-config-max-items`) to satisfy axe's `label` rule (WCAG 2.1 AA, SC 1.3.1).

- [x] **`web/src/App.tsx`** — The pathless layout route (`<Route element={<ProtectedRoute><Layout/></ProtectedRoute>}>`) matches every path. The sibling `<Route path="*"><NotFound/></Route>` at the bottom of the route tree was therefore unreachable for authenticated users — unmatched paths rendered Layout with an empty outlet instead of `NotFound`. Moved the wildcard inside the layout route so `NotFound` renders correctly for any unmatched authenticated URL.

---

### Checklist

- [x] I used a coding agent (Claude Code, Sonnet 4.6) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo (no new cards added — only existing registered cards added to a default layout)
- [x] isDemoData is wired correctly (no card component changes — layout config and route fixes only)
- [x] I have written unit tests for the changes (spec updated to match new card count)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

**Root cause trace — `cluster-admin-cards` (25 failures):**

The mentor's hint was: *"The /cluster-admin dashboard presets may not be auto-pinning these cards."*
Confirmed by tracing `useDashboardCards` → `CARD_COMPONENTS` registry → `cluster-admin.ts` default config. `etcd_status`, `dns_health`, and `admission_webhooks` are all registered at `cardRegistry.ts:733–736` and in the lazy-loaded `cluster-admin-bundle`, but the default placement list only had 21 cards stopping at row 9.

**Root cause trace — `find-and-search` (Ctrl+K focus):**

```
// Before (race condition)
openSearch()                      // schedules state update → React re-renders async
inputRef.current?.focus()         // runs NOW, before re-render — input not focusable yet
emitGlobalSearchOpened('keyboard')

// After (correct)
openSearch()
requestAnimationFrame(() => inputRef.current?.focus())  // deferred past next paint
emitGlobalSearchOpened('keyboard')
```

**Root cause trace — `a11y` (CardConfigModal label violations):**

```tsx
// Before — axe flags label-without-for and input-without-label
<label className="...">Filter by Cluster</label>
<select value={...} onChange={...}>

// After — properly associated
<label htmlFor="card-config-cluster" className="...">Filter by Cluster</label>
<select id="card-config-cluster" value={...} onChange={...}>
```

**Root cause trace — `not-found` (empty outlet):**

```
React Router v6 route resolution for /does-not-exist-xyz:
  ┌─ <Route path="*"> → FullDashboardApp            ← matches
  │   ├─ <Route element={<ProtectedRoute><Layout/>>  ← pathless, matches EVERYTHING
  │   │   ├─ <Route index>                           ← no match
  │   │   └─ ... (all specific paths)                ← no match
  │   │   └─ (no wildcard here — outlet renders empty)
  │   └─ <Route path="*"><NotFound/>                 ← NEVER REACHED (sibling, not child)
  └─
```

After fix: `<Route path="*"><NotFound/></Route>` is inside the layout route, so it wins the child-route match and `NotFound` renders inside `Layout`.

---

### 👀 Reviewer Notes

- The `App.tsx` outer `<Route path="*"><NotFound/></Route>` (now at the sibling level) still covers the case where a user hits an unmatched route before authentication. Both wildcards are intentional.
- No changes to Go backend, Helm charts, auth middleware, or CI workflows — this is a frontend-only, tier/2-standard change.
- Pre-existing SonarCloud diagnostics on `SearchDropdown.tsx` (S6759, S1874, S3776, S6582) and `cluster-admin-cards.spec.ts` (String.raw warnings) were not introduced by this PR.
