### PR TITLE
fix(i18n): wrap Cancel and Reset labels in WorkloadMonitorDiagnose

### DIFF
--- a/web/src/components/cards/workload-monitor/WorkloadMonitorDiagnose.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitorDiagnose.tsx
@@ -163,7 +163,7 @@ export function WorkloadMonitorDiagnose({
               className="flex items-center gap-1 text-xs px-2 py-1 rounded-md bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors"
             >
               <Ban className="w-3 h-3" />
-              Cancel
+              {t('common.cancel', 'Cancel')}
             </button>
           )}
           {(state.phase === 'complete' || state.phase === 'failed') && (
@@ -172,7 +172,7 @@ export function WorkloadMonitorDiagnose({
               className="flex items-center gap-1 text-xs px-2 py-1 rounded-md bg-secondary text-muted-foreground hover:text-foreground transition-colors"
             >
               <RotateCcw className="w-3 h-3" />
-              Reset
+              {t('common.reset', 'Reset')}
             </button>
           )}
         </div>


### PR DESCRIPTION
Missed two raw strings in the diagnose panel — the Cancel and Reset buttons were hardcoded while every other label in the same component already goes through t(). Both keys (common.cancel, common.reset) already exist in the translation file, so no new keys needed.

Just two JSX changes, same pattern as the other buttons in this file. No visual or functional difference.