### PR TITLE
chore: demote UnifiedDemoProvider fallback logs from warn to debug

### DIFF
--- a/web/src/lib/unified/demo/UnifiedDemoContext.ts
+++ b/web/src/lib/unified/demo/UnifiedDemoContext.ts
@@ -26,22 +26,22 @@ const defaultContextValue: UnifiedDemoContextValue = {
   isDemoMode: false,
   isForced: false,
   toggleDemoMode: () => {
-    console.warn('UnifiedDemoProvider not mounted')
+    console.debug('UnifiedDemoProvider not mounted')
   },
   setDemoMode: () => {
-    console.warn('UnifiedDemoProvider not mounted')
+    console.debug('UnifiedDemoProvider not mounted')
   },
   isModeSwitching: false,
   modeVersion: 0,
   getDemoData: <T = unknown>() => createDefaultDemoDataState<T>(),
   registerGenerator: () => {
-    console.warn('UnifiedDemoProvider not mounted')
+    console.debug('UnifiedDemoProvider not mounted')
   },
   regenerate: () => {
-    console.warn('UnifiedDemoProvider not mounted')
+    console.debug('UnifiedDemoProvider not mounted')
   },
   regenerateAll: () => {
-    console.warn('UnifiedDemoProvider not mounted')
+    console.debug('UnifiedDemoProvider not mounted')
   },
 }
 


### PR DESCRIPTION
Five fallback functions in the UnifiedDemoContext default value log "UnifiedDemoProvider not mounted" at warn level. These aren't real failures — they're expected when a component accesses the demo context outside the provider tree, same as the cache worker does when it falls back to IndexedDB.

Knocked them down to debug so they don't show up in the production console for every user. Developers can still see them by enabling Verbose level in Chrome DevTools.

Same pattern already used by the cache worker (workerRpc.ts), OPFS fallback (opfsFallback.ts), and SSE client (sseClient.ts) for equivalent diagnostic messages.