### PR TITLE
chore: demote widget position save/load failures from warn to debug

### DIFF
--- a/web/src/lib/widgets/styleConverter.ts
+++ b/web/src/lib/widgets/styleConverter.ts
@@ -333,13 +333,13 @@ const getStoredPosition = () => {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) return JSON.parse(stored);
   } catch (e: unknown) {
-    console.warn('[Widget] failed to load stored position:', e);
+    console.debug('[Widget] failed to load stored position:', e);
   }
   return { top: 20, left: 20 };
 };
 const savePosition = (pos) => {
   try { localStorage.setItem(STORAGE_KEY, JSON.stringify(pos)); } catch (e: unknown) {
-    console.warn('[Widget] failed to save position:', e);
+    console.debug('[Widget] failed to save position:', e);
   }
 };
 let widgetPosition = getStoredPosition();


### PR DESCRIPTION
Two localStorage operations for the floating widget's position log at warn level when they fail — reading a corrupted key, writing when storage is full, or browsing in private mode. These are graceful fallbacks (load defaults to {top:20, left:20}, save simply skips persistence) and the widget works perfectly either way.

Moved both to debug so they don't clutter the production console. Developers can still see them locally during npm run dev, and the Vite production build strips console.debug entirely.

Follows the same pattern from workerRpc.ts, opfsFallback.ts, sseClient.ts, and UnifiedDemoContext.ts for equivalent non-critical fallback messages.