### PR TITLE
fix: prevent custom card column misalignment when card width changes

### DIFF
--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -303,7 +303,7 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
                     <span
                       key={col.field}
                       className="text-2xs font-medium text-muted-foreground uppercase"
-                      style={{ width: col.width, flex: col.width ? 'none' : '1' }}
+                      style={{ width: col.width, flex: col.width ? 'none' : '1', minWidth: col.width ? undefined : 0 }}
                     >
                       {col.label}
                     </span>
@@ -332,7 +332,7 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
                       <span
                         key={col.field}
                         className="text-xs text-foreground truncate"
-                        style={{ width: col.width, flex: col.width ? 'none' : '1' }}
+                        style={{ width: col.width, flex: col.width ? 'none' : '1', minWidth: col.width ? undefined : 0 }}
                       >
                         {val}
                       </span>


### PR DESCRIPTION
When a custom card's width changes (e.g. from 4 columns to 12 columns), flexible columns in the table layout would overflow rather than shrink, pushing neighboring columns out of alignment and breaking the text truncation ellipsis.

The root cause was the default CSS flex behavior — flex children have min-width: auto, which prevents them from shrinking below their content size. Long text in a column would blow out the flex layout instead of being truncated.

Added minWidth: 0 to flexible columns (those without an explicit width) in both the column headers and data cell rows. This allows the browser to shrink the column below its content size, letting the existing truncate class handle overflow with ellipsis. Fixed-width columns are untouched.

Fixes #13066