### PR TITLE
🐛 fix: guard against division by zero in StockMarketTicker portfolio summary

### DIFF
--- a/web/src/components/cards/StockMarketTicker.tsx
+++ b/web/src/components/cards/StockMarketTicker.tsx
@@ -707,7 +707,7 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
   // Calculate portfolio summary
   const portfolioSummary = useMemo(() => {
     const totalChange = stockData.reduce((sum, stock) => sum + stock.changePercent, 0)
-    const avgChange = totalChange / stockData.length
+    const avgChange = stockData.length > 0 ? totalChange / stockData.length : 0
     const gainers = stockData.filter(s => s.change > 0).length
     const losers = stockData.filter(s => s.change < 0).length
 


### PR DESCRIPTION
Fixes #13074

## What

Guard `stockData.length` before dividing to prevent `NaN` when the array is empty.

## Why

When `stockData` is `[]` (initial render with `initialData: []` at line 555, or after the user removes all stocks), `totalChange / stockData.length` evaluates to `0 / 0 = NaN`. This `NaN` propagates into the rendered portfolio summary.

## Fix

```diff
- const avgChange = totalChange / stockData.length
+ const avgChange = stockData.length > 0 ? totalChange / stockData.length : 0

