### PR TITLE
fix: handle refresh errors after close and reopen in feedback handler

### DIFF
--- a/pkg/api/handlers/feedback_requests.go
+++ b/pkg/api/handlers/feedback_requests.go
@@ -1117,7 +1117,11 @@ func (h *FeedbackHandler) CloseRequest(c *fiber.Ctx) error {
 	if err := h.store.CloseFeatureRequest(c.UserContext(), requestID, true); err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to close request")
 	}
-	request, _ = h.store.GetFeatureRequest(c.UserContext(), requestID)
+	if refreshed, err := h.store.GetFeatureRequest(c.UserContext(), requestID); err == nil {
+		request = refreshed
+	} else {
+		slog.Warn("[Feedback] failed to refresh request after close", "id", requestID, "error", err)
+	}
 	return c.JSON(request)
 }
 
@@ -1209,7 +1213,11 @@ func (h *FeedbackHandler) ReopenRequest(c *fiber.Ctx) error {
 	if err := h.store.UpdateFeatureRequestStatus(c.UserContext(), requestID, models.RequestStatusTriageAccepted); err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to reopen request")
 	}
-	request, _ = h.store.GetFeatureRequest(c.UserContext(), requestID)
+	if refreshed, err := h.store.GetFeatureRequest(c.UserContext(), requestID); err == nil {
+		request = refreshed
+	} else {
+		slog.Warn("[Feedback] failed to refresh request after reopen", "id", requestID, "error", err)
+	}
 	return c.JSON(request)
 }
 

--- a/pkg/api/handlers/feedback_requests.go
+++ b/pkg/api/handlers/feedback_requests.go
@@ -1117,10 +1117,12 @@ func (h *FeedbackHandler) CloseRequest(c *fiber.Ctx) error {
 	if err := h.store.CloseFeatureRequest(c.UserContext(), requestID, true); err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to close request")
 	}
-	if refreshed, err := h.store.GetFeatureRequest(c.UserContext(), requestID); err == nil {
+	if refreshed, err := h.store.GetFeatureRequest(c.UserContext(), requestID); err == nil && refreshed != nil {
 		request = refreshed
-	} else {
+	} else if err != nil {
 		slog.Warn("[Feedback] failed to refresh request after close", "id", requestID, "error", err)
+	} else {
+		slog.Warn("[Feedback] refresh returned nil request after close", "id", requestID)
 	}
 	return c.JSON(request)
 }
@@ -1213,10 +1215,12 @@ func (h *FeedbackHandler) ReopenRequest(c *fiber.Ctx) error {
 	if err := h.store.UpdateFeatureRequestStatus(c.UserContext(), requestID, models.RequestStatusTriageAccepted); err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to reopen request")
 	}
-	if refreshed, err := h.store.GetFeatureRequest(c.UserContext(), requestID); err == nil {
+	if refreshed, err := h.store.GetFeatureRequest(c.UserContext(), requestID); err == nil && refreshed != nil {
 		request = refreshed
-	} else {
+	} else if err != nil {
 		slog.Warn("[Feedback] failed to refresh request after reopen", "id", requestID, "error", err)
+	} else {
+		slog.Warn("[Feedback] refresh returned nil request after reopen", "id", requestID)
 	}
 	return c.JSON(request)
 }


### PR DESCRIPTION
CloseRequest and ReopenRequest both re-fetch the feature request after mutating it in the store, then return the result as JSON. The re-fetch error was silently discarded with _, which meant a transient DB failure could return stale data (showing a ticket as open when it was just closed, or closed when it was just reopened).

Replaced the discarded error with a proper check — on success the response carries fresh data, on failure the old request is still returned but the error is logged at Warn level so operators can debug DB issues. Every other GetFeatureRequest call in this file already follows this pattern.