### PR TITLE
fix: log cleanup errors in orbit temp file handling

### DIFF
--- a/pkg/api/handlers/orbit.go
+++ b/pkg/api/handlers/orbit.go
@@ -450,17 +450,23 @@ func (h *OrbitHandler) saveToDiskLocked() {
 	// Best-effort cleanup if we bail out before the rename.
 	defer func() {
 		if _, err := os.Stat(tmpPath); err == nil {
-			_ = os.Remove(tmpPath)
+			if err := os.Remove(tmpPath); err != nil {
+				slog.Warn("orbit: failed to clean up temp file", "path", tmpPath, "error", err)
+			}
 		}
 	}()
 	if _, err := tmp.Write(data); err != nil {
 		slog.Error("orbit: failed to write temp data file", "path", tmpPath, "error", err)
-		_ = tmp.Close()
+		if err := tmp.Close(); err != nil {
+			slog.Warn("orbit: failed to close temp file after write error", "path", tmpPath, "error", err)
+		}
 		return
 	}
 	if err := tmp.Sync(); err != nil {
 		slog.Error("orbit: failed to fsync temp data file", "path", tmpPath, "error", err)
-		_ = tmp.Close()
+		if err := tmp.Close(); err != nil {
+			slog.Warn("orbit: failed to close temp file after sync error", "path", tmpPath, "error", err)
+		}
 		return
 	}
 	if err := tmp.Close(); err != nil {


### PR DESCRIPTION
Three deferred cleanup operations silently discarded errors — removing the temp file after a failed write, and closing the file after write and sync failures. If cleanup itself failed (disk full, permission denied, stale NFS handle), operators had no visibility.

Replaced each discarded error with a Warn-level log, following the existing pattern a few lines down where a similar non-fatal chmod failure is already logged.