### PR TITLE
🐛 fix: add console.warn logging to silent dashboard create/delete catches

### DIFF
--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -552,8 +552,9 @@ export function CustomDashboard() {
     navigate(ROUTES.HOME)
 
     // Try to delete from backend in the background (may fail offline)
-    deleteDashboard(id).catch(() => {
+    deleteDashboard(id).catch((err) => {
       // Backend deletion is optional — sidebar + localStorage are the source of truth
+      console.warn('[CustomDashboard] backend delete failed (non-critical):', err)
     })
   }
 

--- a/web/src/components/dashboard/customizer/DashboardCustomizer.tsx
+++ b/web/src/components/dashboard/customizer/DashboardCustomizer.tsx
@@ -169,7 +169,7 @@ export function DashboardCustomizer({
                 const localId = `local-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
                 const href = `/custom-dashboard/${localId}`
                 addItem({ name, icon: suggestIconSync(name), href, type: 'link' }, 'primary')
-                await _createDashboard(name).catch(() => { /* offline — sidebar item already added */ })
+                await _createDashboard(name).catch((err) => { console.warn('[DashboardCustomizer] backend create failed (non-critical):', err) })
                 onClose()
                 navigate(href)
               }}

--- a/web/src/components/layout/SidebarCustomizer.tsx
+++ b/web/src/components/layout/SidebarCustomizer.tsx
@@ -374,8 +374,9 @@ export function SidebarCustomizer({ isOpen, onClose, embedded = false }: Sidebar
     navigate(href)
 
     // Try to persist to backend in the background (optional, may fail offline)
-    createDashboard(name).catch(() => {
+    createDashboard(name).catch((err) => {
       // Dashboard works purely from localStorage — backend persistence is optional
+      console.warn('[SidebarCustomizer] backend create failed (non-critical):', err)
     })
 
     // Ask AI agent for a better icon in the background


### PR DESCRIPTION
Fixes #13085

## What

Add `console.warn` logging to 3 dashboard mutation `.catch()` blocks that silently swallow errors.

## Why

Per `CLAUDE.md`, all `.catch()` blocks must log or surface errors — never silently discard them. While these fire-and-forget patterns are intentional (localStorage is the source of truth), the empty catches make debugging impossible when backend persistence fails.

## Changes

| File | Operation | Fix |
|---|---|---|
| `CustomDashboard.tsx:555` | `deleteDashboard()` | Added `console.warn` with `[CustomDashboard]` tag |
| `DashboardCustomizer.tsx:172` | `_createDashboard()` | Added `console.warn` with `[DashboardCustomizer]` tag |
| `SidebarCustomizer.tsx:377` | `createDashboard()` | Added `console.warn` with `[SidebarCustomizer]` tag |

## Notes

- Non-breaking change — no behavior change, only adds debug logging
- Component tag prefixes enable easy DevTools filtering
- Original comments preserved explaining why backend failures are non-critical

