### PR TITLE
fix: replace as any casts with defaultValue in vCluster i18n keys

### DIFF
--- a/web/src/components/settings/sections/LocalClustersSection.tsx
+++ b/web/src/components/settings/sections/LocalClustersSection.tsx
@@ -111,12 +111,10 @@ function getVClusterActionMessage(feedback: VClusterActionFeedback, t: TFunction
   if (feedback.state === 'error') {
     return feedback.message
       ? friendlyErrorMessage(feedback.message)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      : String(t(`${keyBase}Fallback` as any, { name: feedback.name, namespace: feedback.namespace }))
+      : String(t(`${keyBase}Fallback`, { name: feedback.name, namespace: feedback.namespace, defaultValue: '' }))
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return String(t(keyBase as any, { name: feedback.name, namespace: feedback.namespace }))
+  return String(t(keyBase, { name: feedback.name, namespace: feedback.namespace, defaultValue: '' }))
 }
 
 function VClusterActionBanner({


### PR DESCRIPTION
Two t() calls used as any to bypass TypeScript on dynamically constructed translation keys, requiring eslint-disable-next-line comments. Replaced with the i18next-approved defaultValue option — the same pattern already used elsewhere in this file for dynamic keys. Removes two eslint-disable comments and both as any casts.