### PR TITLE
fix: replace as any cast with defaultValue in Intoto error key

### DIFF
--- a/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
+++ b/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
@@ -275,7 +275,7 @@ Please proceed step by step.`,
               {(() => {
                 const errorMsg = Object.values(statuses).find(s => s.error)?.error
                 if (typeof errorMsg === 'string' && errorMsg.includes('.')) {
-                  return t(errorMsg as any) // eslint-disable-line @typescript-eslint/no-explicit-any -- dynamic translation key, runtime guard ensures safety
+                  return t(errorMsg, { defaultValue: errorMsg })
                 }
                 return t('intoto_supply_chain.fetchErrorHint')
               })()}{' '}


### PR DESCRIPTION
The fetch error handler used t(errorMsg as any) to translate server-structured error messages containing a dot. Replaced with defaultValue so dynamic keys are accepted without bypassing type checking, and the raw message serves as fallback when no translation exists. Removes the eslint-disable comment and as any cast.