### PR TITLE
🔒 fix: sanitize SVG output in QuantumQubitGrid via DOMPurify to prevent XSS

### DIFF
--- a/web/src/components/cards/quantum/QuantumQubitGrid.tsx
+++ b/web/src/components/cards/quantum/QuantumQubitGrid.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react'
+import DOMPurify from 'dompurify'
 import { AlertCircle, RefreshCw } from 'lucide-react'
 import { useReportCardDataState } from '../CardDataContext'
 import { isGlobalQuantumPollingPaused } from '../../../lib/quantum/pollingContext'
@@ -342,7 +343,7 @@ export const QuantumQubitGrid: React.FC = () => {
         {/* SVG Grid */}
         <div className="flex justify-center p-4 bg-gray-50 dark:bg-gray-900 rounded-lg">
           <div
-            dangerouslySetInnerHTML={{ __html: svgContent }}
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(svgContent, { USE_PROFILES: { svg: true, svgFilters: true } }) }}
             style={{ filter: isDemoFallback ? 'brightness(0.9)' : 'none' }}
           />
         </div>


### PR DESCRIPTION
Fixes #13121

## What

Add DOMPurify sanitization to the `dangerouslySetInnerHTML` call in `QuantumQubitGrid.tsx` that renders SVG content without sanitization.

## Why

`QuantumQubitGrid` renders SVG via `dangerouslySetInnerHTML={{ __html: svgContent }}` without any sanitization. While the SVG is generated internally by `renderQubitSVG()`, the `pattern` field originates from the `/api/quantum/qubits/simple` API endpoint. If that API is ever compromised or returns crafted data, the unsanitized SVG becomes an XSS attack vector via:

- Embedded `<script>` tags
- SVG event handlers (`onload`, `onerror`)
- Malformed SVG with JavaScript URIs

## Defense-in-Depth

This mirrors the **existing pattern** in `ClusterLocations.tsx` (line 261), which already sanitizes its SVG with:
```tsx
DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } })

