### PR TITLE
fix(i18n): wire Retry buttons through translation layer in 8 compliance dashboards

### DIFF
--- a/web/src/components/compliance/BAADashboard.tsx
+++ b/web/src/components/compliance/BAADashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, memo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { baaDashboardConfig } from '../../config/dashboards/baa'
 import {
@@ -36,6 +37,7 @@ const PROVIDER_ICONS: Record<string, typeof Cloud> = {
 }
 
 export const BAADashboardContent = memo(function BAADashboardContent() {
+  const { t } = useTranslation()
   const [agreements, setAgreements] = useState<BAAgreement[]>([])
   const [alerts, setAlerts] = useState<BAAAlert[]>([])
   const [summary, setSummary] = useState<BAASummary | null>(null)
@@ -83,7 +85,7 @@ export const BAADashboardContent = memo(function BAADashboardContent() {
     <div className="p-6 text-center">
       <XCircle className="w-12 h-12 text-red-400 mx-auto mb-3" />
       <p className="text-red-300 mb-4">{error}</p>
-      <button onClick={fetchData} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm">Retry</button>
+      <button onClick={fetchData} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm">{t('common.retry', 'Retry')}</button>
     </div>
   )
 

--- a/web/src/components/compliance/GxPDashboard.tsx
+++ b/web/src/components/compliance/GxPDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, memo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { gxpDashboardConfig } from '../../config/dashboards/gxp'
 import {
@@ -44,6 +45,7 @@ const ACTION_STYLES: Record<string, string> = {
 }
 
 export const GxPDashboardContent = memo(function GxPDashboardContent() {
+  const { t } = useTranslation()
   const [summary, setSummary] = useState<GxPSummary | null>(null)
   const [records, setRecords] = useState<AuditRecord[]>([])
   const [signatures, setSignatures] = useState<Signature[]>([])
@@ -103,7 +105,7 @@ export const GxPDashboardContent = memo(function GxPDashboardContent() {
     <div className="p-6 text-center">
       <XCircle className="w-12 h-12 text-red-400 mx-auto mb-3" />
       <p className="text-red-300 mb-4">{error}</p>
-      <button onClick={fetchData} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm">Retry</button>
+      <button onClick={fetchData} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm">{t('common.retry', 'Retry')}</button>
     </div>
   )
 

--- a/web/src/components/compliance/HIPAADashboard.tsx
+++ b/web/src/components/compliance/HIPAADashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, memo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { hipaaDashboardConfig } from '../../config/dashboards/hipaa'
 import {
@@ -47,6 +48,7 @@ const SAFEGUARD_ICONS: Record<string, typeof Shield> = {
 }
 
 export const HIPAADashboardContent = memo(function HIPAADashboardContent() {
+  const { t } = useTranslation()
   const [safeguards, setSafeguards] = useState<HIPAASafeguard[]>([])
   const [phiNamespaces, setPHINamespaces] = useState<PHINamespace[]>([])
   const [dataFlows, setDataFlows] = useState<DataFlow[]>([])
@@ -99,7 +101,7 @@ export const HIPAADashboardContent = memo(function HIPAADashboardContent() {
     <div className="p-6 text-center">
       <XCircle className="w-12 h-12 text-red-400 mx-auto mb-3" />
       <p className="text-red-300 mb-4">{error}</p>
-      <button onClick={fetchData} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm">Retry</button>
+      <button onClick={fetchData} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm">{t('common.retry', 'Retry')}</button>
     </div>
   )
 

--- a/web/src/components/compliance/LicenseComplianceDashboard.tsx
+++ b/web/src/components/compliance/LicenseComplianceDashboard.tsx
@@ -6,6 +6,7 @@
  * (LGPL, MPL), and provides a fleet-wide license inventory.
  */
 import { useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   CheckCircle2, XCircle, AlertTriangle, Loader2,
   BookOpen,
@@ -60,6 +61,7 @@ const RISK_ICONS: Record<LicenseRisk, typeof CheckCircle2> = {
 }
 
 export default function LicenseComplianceDashboard() {
+  const { t } = useTranslation()
   const [packages, setPackages] = useState<LicensePackage[]>([])
   const [categories, setCategories] = useState<LicenseCategory[]>([])
   const [summary, setSummary] = useState<LicenseSummary | null>(null)
@@ -106,7 +108,7 @@ export default function LicenseComplianceDashboard() {
     <div className="p-6 text-center">
       <XCircle className="w-12 h-12 text-red-400 mx-auto mb-3" />
       <p className="text-red-300 mb-4">{error}</p>
-      <button onClick={fetchData} className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-sm">Retry</button>
+      <button onClick={fetchData} className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-sm">{t('common.retry', 'Retry')}</button>
     </div>
   )
 

--- a/web/src/components/compliance/OIDCDashboard.tsx
+++ b/web/src/components/compliance/OIDCDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, memo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { oidcDashboardConfig } from '../../config/dashboards/oidc'
 import {
@@ -35,6 +36,7 @@ const STATUS_STYLES: Record<string, string> = {
 }
 
 export const OIDCDashboardContent = memo(function OIDCDashboardContent() {
+  const { t } = useTranslation()
   const [providers, setProviders] = useState<OIDCProvider[]>([])
   const [sessions, setSessions] = useState<OIDCSession[]>([])
   const [summary, setSummary] = useState<OIDCSummary | null>(null)
@@ -76,7 +78,7 @@ export const OIDCDashboardContent = memo(function OIDCDashboardContent() {
     <div className="p-6 text-center">
       <XCircle className="w-12 h-12 text-red-400 mx-auto mb-3" />
       <p className="text-red-300 mb-4">{error}</p>
-      <button onClick={fetchData} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm">Retry</button>
+      <button onClick={fetchData} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm">{t('common.retry', 'Retry')}</button>
     </div>
   )
 

--- a/web/src/components/compliance/RBACAuditDashboard.tsx
+++ b/web/src/components/compliance/RBACAuditDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, memo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { rbacAuditDashboardConfig } from '../../config/dashboards/rbac-audit'
 import {
@@ -45,6 +46,7 @@ const RISK_STYLES: Record<string, string> = {
 }
 
 export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent() {
+  const { t } = useTranslation()
   const [bindings, setBindings] = useState<RBACBinding[]>([])
   const [findings, setFindings] = useState<RBACFinding[]>([])
   const [summary, setSummary] = useState<RBACSummary | null>(null)
@@ -99,7 +101,7 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
     <div className="p-6 text-center">
       <XCircle className="w-12 h-12 text-red-400 mx-auto mb-3" />
       <p className="text-red-300 mb-4">{error}</p>
-      <button onClick={fetchData} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm">Retry</button>
+      <button onClick={fetchData} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm">{t('common.retry', 'Retry')}</button>
     </div>
   )
 

--- a/web/src/components/compliance/SessionDashboard.tsx
+++ b/web/src/components/compliance/SessionDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, memo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { sessionManagementDashboardConfig } from '../../config/dashboards/session-management'
 import {
@@ -35,6 +36,7 @@ const STATUS_STYLES: Record<string, string> = {
 }
 
 export const SessionDashboardContent = memo(function SessionDashboardContent() {
+  const { t } = useTranslation()
   const [sessions, setSessions] = useState<ActiveSession[]>([])
   const [policies, setPolicies] = useState<SessionPolicy[]>([])
   const [summary, setSummary] = useState<SessionSummary | null>(null)
@@ -76,7 +78,7 @@ export const SessionDashboardContent = memo(function SessionDashboardContent() {
     <div className="p-6 text-center">
       <XCircle className="w-12 h-12 text-red-400 mx-auto mb-3" />
       <p className="text-red-300 mb-4">{error}</p>
-      <button onClick={fetchData} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm">Retry</button>
+      <button onClick={fetchData} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm">{t('common.retry', 'Retry')}</button>
     </div>
   )
 

--- a/web/src/components/compliance/SigningStatusDashboard.tsx
+++ b/web/src/components/compliance/SigningStatusDashboard.tsx
@@ -6,6 +6,7 @@
  * operators can enforce supply chain integrity controls.
  */
 import { useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   BadgeCheck, XCircle, AlertTriangle, Loader2,
   Shield, ShieldAlert, ShieldOff, Server,
@@ -58,6 +59,7 @@ const MODE_STYLES: Record<string, string> = {
 }
 
 export default function SigningStatusDashboard() {
+  const { t } = useTranslation()
   const [images, setImages] = useState<SignedImage[]>([])
   const [policies, setPolicies] = useState<SigningPolicy[]>([])
   const [summary, setSummary] = useState<SigningSummary | null>(null)
@@ -104,7 +106,7 @@ export default function SigningStatusDashboard() {
     <div className="p-6 text-center">
       <XCircle className="w-12 h-12 text-red-400 mx-auto mb-3" />
       <p className="text-red-300 mb-4">{error}</p>
-      <button onClick={fetchData} className="px-4 py-2 bg-purple-600 hover:bg-purple-700 rounded-lg text-sm">Retry</button>
+      <button onClick={fetchData} className="px-4 py-2 bg-purple-600 hover:bg-purple-700 rounded-lg text-sm">{t('common.retry', 'Retry')}</button>
     </div>
   )
 


### PR DESCRIPTION
Eight compliance dashboards had a hardcoded Retry button in their error state — BAA, GxP, HIPAA, License Compliance, OIDC, RBAC Audit, Session Management, and Signing Status. Every other dashboard in the project that shows a Retry button goes through t(), these eight just got missed.

Added useTranslation import and hook to each component, wrapped the button text in t('common.retry', 'Retry'). No new translation keys needed — common.retry already exists. Same three-line change per file, same pattern as every other dashboard in the codebase.