### PR TITLE
fix: banner overlap when multiple status banners stack

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -783,11 +783,12 @@ export function Layout({ children: _children }: LayoutProps) {
               key={banner.id}
               style={{
                 top: NAVBAR_HEIGHT_PX + (index * BANNER_HEIGHT_PX),
+                height: BANNER_HEIGHT_PX,
                 left: sidebarWidthPx,
                 ...banner.style,
               }}
               className={cn(
-                'fixed transition-[left,right] duration-300',
+                'fixed transition-[left,right] duration-300 overflow-hidden',
                 banner.className,
               )}
             >

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -94,8 +94,8 @@ export const DEFAULT_PAGE_SIZE = 5
 // ── Layout dimensions ──────────────────────────────────────────────────
 /** Height of the top navbar in pixels (h-16 = 64px) */
 export const NAVBAR_HEIGHT_PX = 64
-/** Height of each status banner (network, demo, offline) in pixels */
-export const BANNER_HEIGHT_PX = 36
+/** Height of each status banner (network, demo, offline) in pixels — matches min-h-11 (44px) dismiss buttons */
+export const BANNER_HEIGHT_PX = 44
 /** Collapse mobile banner stacks into a summary row once this many alerts are active. */
 export const MOBILE_BANNER_COLLAPSE_THRESHOLD = 2
 /** Root CSS variable used to push dashboard content below the open filter panel */


### PR DESCRIPTION
## Summary

- `BANNER_HEIGHT_PX` was 36px but dismiss buttons use `min-h-11` (44px), causing banners to overlap when stacked
- Bumped constant to 44px to match actual rendered height
- Added explicit `height` and `overflow-hidden` to each banner div for consistent sizing

## Test plan

- [ ] Demo + autonomous banners no longer overlap
- [ ] Main content padding still correct below banners
- [ ] Single banner displays correctly
- [ ] Mobile banner collapse still works