### PR TITLE
Refactor/route string constants

### DIFF
--- a/deploy/helm/kubestellar-console/Chart.yaml
+++ b/deploy/helm/kubestellar-console/Chart.yaml
@@ -3,7 +3,7 @@ name: kubestellar-console
 description: KubeStellar Console - AI-powered multi-cluster Kubernetes dashboard
 type: application
 version: 0.0.0
-appVersion: "0.3.25"
+appVersion: "0.3.26"
 keywords:
   - kubernetes
   - dashboard

--- a/docs/integrations/kagenti-tool-integration.md
+++ b/docs/integrations/kagenti-tool-integration.md
@@ -2,6 +2,8 @@
 
 This page documents the Kagenti integration as it exists in the current codebase.
 
+> **IMPORTANT**: Before reading this technical integration guide, ensure you have Kagenti deployed correctly. See the [Kagenti Deployment Guide](../kagenti-deployment-guide.md) for setup instructions. Deploying only the `kagenti-backend` controller is not sufficient — you must also deploy at least one Kagenti agent.
+
 ## Scope
 
 The Console has two Kagenti-facing paths:

--- a/docs/kagenti-deployment-guide.md
+++ b/docs/kagenti-deployment-guide.md
@@ -1,0 +1,528 @@
+# Kagenti Deployment Guide
+
+This guide explains how to deploy and configure Kagenti for use with the KubeStellar Console.
+
+## Overview
+
+The KubeStellar Console supports two Kagenti deployment modes:
+
+1. **Controller Mode** (recommended) — A Kagenti controller manages multiple agent instances
+2. **Direct Agent Mode** — The console connects directly to a single Kagenti agent service
+
+**IMPORTANT**: Deploying only the `kagenti-backend` controller is not sufficient. You must also deploy at least one Kagenti agent that registers with the controller, or configure a direct agent URL. Without a registered agent, missions will fail with "Kagenti Agent Not Selected" or connection errors.
+
+## Architecture
+
+```mermaid
+graph TB
+    Console[KubeStellar Console]
+    Controller[Kagenti Controller<br/>kagenti-backend]
+    Agent1[Kagenti Agent 1<br/>kagenti-agent-ops]
+    Agent2[Kagenti Agent 2<br/>kagenti-agent-dev]
+    K8s[Kubernetes API]
+    
+    Console -->|Discover agents| Controller
+    Console -->|Stream chat| Controller
+    Controller -->|Route to agent| Agent1
+    Controller -->|Route to agent| Agent2
+    Agent1 -->|Query cluster state| K8s
+    Agent2 -->|Query cluster state| K8s
+    
+    style Controller fill:#4A90E2
+    style Agent1 fill:#7ED321
+    style Agent2 fill:#7ED321
+    style Console fill:#BD10E0
+```
+
+## Controller Mode Setup
+
+### Prerequisites
+
+- Kubernetes cluster with the KubeStellar Console deployed
+- Helm 3+ or kubectl
+- An LLM provider API key (Claude, OpenAI, or Gemini)
+
+### Step 1: Deploy Kagenti Controller
+
+Create a namespace for Kagenti:
+
+```bash
+kubectl create namespace kagenti-system
+```
+
+Create a secret with your LLM provider credentials:
+
+```bash
+# For Claude (recommended)
+kubectl create secret generic kagenti-llm-secrets \
+  --from-literal=CLAUDE_API_KEY=sk-ant-api03-... \
+  --from-literal=DEFAULT_LLM_PROVIDER=claude \
+  --namespace kagenti-system
+
+# For OpenAI
+kubectl create secret generic kagenti-llm-secrets \
+  --from-literal=OPENAI_API_KEY=sk-proj-... \
+  --from-literal=DEFAULT_LLM_PROVIDER=openai \
+  --namespace kagenti-system
+
+# For Gemini
+kubectl create secret generic kagenti-llm-secrets \
+  --from-literal=GEMINI_API_KEY=AIza... \
+  --from-literal=DEFAULT_LLM_PROVIDER=gemini \
+  --namespace kagenti-system
+```
+
+Deploy the Kagenti controller:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: kagenti-backend
+  namespace: kagenti-system
+spec:
+  selector:
+    app: kagenti-backend
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kagenti-backend
+  namespace: kagenti-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kagenti-backend
+  template:
+    metadata:
+      labels:
+        app: kagenti-backend
+    spec:
+      containers:
+        - name: controller
+          image: ghcr.io/kagenti/kagenti-controller:latest
+          ports:
+            - containerPort: 8000
+          envFrom:
+            - secretRef:
+                name: kagenti-llm-secrets
+          env:
+            - name: KAGENTI_MODE
+              value: "controller"
+            - name: AGENT_DISCOVERY_ENABLED
+              value: "true"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+EOF
+```
+
+### Step 2: Deploy at Least One Kagenti Agent
+
+**This step is mandatory.** The controller cannot serve chat requests without registered agents.
+
+Deploy a Kagenti agent that will register with the controller:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: kagenti-agent-ops
+  namespace: kagenti-system
+spec:
+  selector:
+    app: kagenti-agent-ops
+  ports:
+    - port: 8001
+      targetPort: 8001
+      protocol: TCP
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kagenti-agent-ops
+  namespace: kagenti-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kagenti-agent-ops
+  template:
+    metadata:
+      labels:
+        app: kagenti-agent-ops
+    spec:
+      serviceAccountName: kagenti-agent
+      containers:
+        - name: agent
+          image: ghcr.io/kagenti/kagenti-agent:latest
+          ports:
+            - containerPort: 8001
+          env:
+            - name: KAGENTI_MODE
+              value: "agent"
+            - name: AGENT_NAME
+              value: "ops"
+            - name: AGENT_NAMESPACE
+              value: "kagenti-system"
+            - name: CONTROLLER_URL
+              value: "http://kagenti-backend:8000"
+            - name: AGENT_PORT
+              value: "8001"
+          envFrom:
+            - secretRef:
+                name: kagenti-llm-secrets
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kagenti-agent
+  namespace: kagenti-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kagenti-agent-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "nodes", "namespaces", "events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kagenti-agent-reader-binding
+subjects:
+  - kind: ServiceAccount
+    name: kagenti-agent
+    namespace: kagenti-system
+roleRef:
+  kind: ClusterRole
+  name: kagenti-agent-reader
+  apiGroup: rbac.authorization.k8s.io
+EOF
+```
+
+### Step 3: Configure the Console
+
+Update your `values.yaml` for the KubeStellar Console Helm chart:
+
+```yaml
+kagenti:
+  enabled: true
+  forceDefaultAgent: true
+  controllerUrl: "http://kagenti-backend.kagenti-system.svc.cluster.local:8000"
+  namespace: "kagenti-system"
+  serviceName: "kagenti-backend"
+  servicePort: "8000"
+  serviceProtocol: "http"
+```
+
+Upgrade the console:
+
+```bash
+helm upgrade kubestellar-console kubestellar/console \
+  --namespace console-system \
+  --values values.yaml
+```
+
+### Step 4: Verify Agent Discovery
+
+Check that the agent registered successfully:
+
+```bash
+# From inside the console pod
+kubectl exec -it -n console-system deployment/kubestellar-console -- \
+  curl -s http://kagenti-backend.kagenti-system.svc.cluster.local:8000/api/v1/agents | jq
+```
+
+Expected output (non-empty array):
+
+```json
+[
+  {
+    "name": "ops",
+    "namespace": "kagenti-system",
+    "url": "http://kagenti-agent-ops:8001",
+    "status": "healthy",
+    "last_heartbeat": "2024-01-15T10:30:00Z"
+  }
+]
+```
+
+If the array is empty, troubleshoot:
+
+1. Check agent logs: `kubectl logs -n kagenti-system deployment/kagenti-agent-ops`
+2. Verify controller URL: `kubectl get svc -n kagenti-system kagenti-backend`
+3. Check network connectivity between agent and controller
+
+## Direct Agent Mode Setup
+
+Direct agent mode bypasses the controller and connects the console directly to a single agent service. Use this for simple deployments or testing.
+
+### Step 1: Deploy a Kagenti Agent
+
+Deploy the agent with its own service:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: kagenti-agent
+  namespace: console-system
+spec:
+  selector:
+    app: kagenti-agent
+  ports:
+    - port: 8001
+      targetPort: 8001
+      protocol: TCP
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kagenti-agent
+  namespace: console-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kagenti-agent
+  template:
+    metadata:
+      labels:
+        app: kagenti-agent
+    spec:
+      serviceAccountName: kagenti-agent
+      containers:
+        - name: agent
+          image: ghcr.io/kagenti/kagenti-agent:latest
+          ports:
+            - containerPort: 8001
+          env:
+            - name: KAGENTI_MODE
+              value: "standalone"
+            - name: AGENT_NAME
+              value: "console-agent"
+            - name: AGENT_NAMESPACE
+              value: "console-system"
+          envFrom:
+            - secretRef:
+                name: kagenti-llm-secrets
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kagenti-agent
+  namespace: console-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kagenti-agent-reader-binding
+subjects:
+  - kind: ServiceAccount
+    name: kagenti-agent
+    namespace: console-system
+roleRef:
+  kind: ClusterRole
+  name: kagenti-agent-reader
+  apiGroup: rbac.authorization.k8s.io
+EOF
+```
+
+### Step 2: Configure the Console for Direct Agent Mode
+
+Update your `values.yaml`:
+
+```yaml
+kagenti:
+  enabled: true
+  forceDefaultAgent: true
+  # Leave controller settings empty/disabled
+  controllerUrl: ""
+  # Configure direct agent access
+  directAgentUrl: "http://kagenti-agent.console-system.svc.cluster.local:8001"
+  directAgentName: "console-agent"
+  directAgentNamespace: "console-system"
+```
+
+Upgrade the console:
+
+```bash
+helm upgrade kubestellar-console kubestellar/console \
+  --namespace console-system \
+  --values values.yaml
+```
+
+### Step 3: Verify Direct Agent Connection
+
+From the console UI:
+1. Navigate to Mission Control
+2. Check that the agent selector shows the direct agent
+3. Send a test mission (e.g., "List all pods in the default namespace")
+
+The agent should respond with pod information.
+
+## Troubleshooting
+
+### Console shows "Kagenti Agent Not Selected"
+
+**Symptom:** Missions fail immediately with "Kagenti Agent Not Selected" error.
+
+**Diagnosis:**
+1. Check agent discovery:
+   ```bash
+   kubectl exec -it -n console-system deployment/kubestellar-console -- \
+     curl -s http://kagenti-backend.kagenti-system.svc.cluster.local:8000/api/v1/agents
+   ```
+2. Verify controller is reachable:
+   ```bash
+   kubectl get svc -n kagenti-system kagenti-backend
+   ```
+
+**Solution:**
+- If agent list is empty: Deploy an agent (Step 2 above)
+- If controller is unreachable: Check `kagenti.controllerUrl` in values.yaml
+- If using direct agent mode: Verify `kagenti.directAgentUrl` is set correctly
+
+### Missions fail with connection timeout
+
+**Symptom:** Console connects to controller but chat requests timeout.
+
+**Diagnosis:**
+1. Check controller logs:
+   ```bash
+   kubectl logs -n kagenti-system deployment/kagenti-backend
+   ```
+2. Verify agent is healthy:
+   ```bash
+   kubectl get pods -n kagenti-system -l app=kagenti-agent-ops
+   ```
+
+**Solution:**
+- Restart the agent: `kubectl rollout restart -n kagenti-system deployment/kagenti-agent-ops`
+- Check LLM provider credentials in the secret
+- Verify network policies allow console → controller → agent traffic
+
+### Agent shows as unhealthy in discovery
+
+**Symptom:** `/api/v1/agents` returns the agent but `status` is `"unhealthy"`.
+
+**Diagnosis:**
+1. Check agent logs for startup errors:
+   ```bash
+   kubectl logs -n kagenti-system deployment/kagenti-agent-ops
+   ```
+2. Verify the agent can reach the LLM provider:
+   ```bash
+   kubectl exec -it -n kagenti-system deployment/kagenti-agent-ops -- \
+     curl -s https://api.anthropic.com/v1/complete
+   ```
+
+**Solution:**
+- Confirm LLM API key is valid
+- Check agent environment variables (`CLAUDE_API_KEY`, etc.)
+- Verify outbound HTTPS is allowed from the agent pod
+
+### Console cannot reach controller
+
+**Symptom:** Console logs show "failed to fetch agents from Kagenti controller".
+
+**Diagnosis:**
+1. Test controller connectivity from console pod:
+   ```bash
+   kubectl exec -it -n console-system deployment/kubestellar-console -- \
+     curl -v http://kagenti-backend.kagenti-system.svc.cluster.local:8000/health
+   ```
+2. Check network policies:
+   ```bash
+   kubectl get networkpolicies -n console-system
+   kubectl get networkpolicies -n kagenti-system
+   ```
+
+**Solution:**
+- If NetworkPolicy is enabled, add egress rule for Kagenti controller:
+  ```yaml
+  kagenti:
+    enabled: true
+    allowNetworkPolicyEgress: true
+  ```
+- Verify DNS resolution: `kubectl exec -n console-system deployment/kubestellar-console -- nslookup kagenti-backend.kagenti-system.svc.cluster.local`
+
+## Helm Chart Reference
+
+All Kagenti settings in the console Helm chart:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `kagenti.enabled` | `false` | Enable Kagenti integration |
+| `kagenti.forceDefaultAgent` | `true` | Make Kagenti the default AI agent when enabled |
+| `kagenti.allowNetworkPolicyEgress` | `true` | Auto-add NetworkPolicy egress to controller |
+| `kagenti.controllerUrl` | `""` | Full URL to Kagenti controller (e.g., `http://kagenti-backend.kagenti-system.svc.cluster.local:8000`) |
+| `kagenti.namespace` | `"kagenti-system"` | Namespace where Kagenti controller is deployed |
+| `kagenti.serviceName` | `"kagenti-backend"` | Service name of the controller |
+| `kagenti.deploymentName` | `"kagenti-backend"` | Deployment name of the controller (for health checks) |
+| `kagenti.llmSecretName` | `"kagenti-llm-secrets"` | Secret name containing LLM provider credentials |
+| `kagenti.servicePort` | `"8000"` | Port the controller listens on |
+| `kagenti.serviceProtocol` | `"http"` | Protocol (`http` or `https`) |
+| `kagenti.directAgentUrl` | `""` | URL for direct agent mode (overrides controller discovery) |
+| `kagenti.directAgentName` | `""` | Display name for direct agent |
+| `kagenti.directAgentNamespace` | `""` | Namespace of direct agent (for UI metadata) |
+
+Environment variables set by the chart:
+
+| Env Var | Helm Key | Purpose |
+|---------|----------|---------|
+| `KAGENTI_CONTROLLER_URL` | `kagenti.controllerUrl` | Controller endpoint |
+| `KAGENTI_AGENT_URL` | `kagenti.directAgentUrl` | Direct agent endpoint |
+| `KAGENTI_AGENT_NAME` | `kagenti.directAgentName` | Direct agent name |
+| `KAGENTI_AGENT_NAMESPACE` | `kagenti.directAgentNamespace` | Direct agent namespace |
+
+## Next Steps
+
+- Configure agent tools: See [Kagenti Tool Integration](./kagenti-tool-integration.md)
+- Enable multi-cluster access: Mount additional kubeconfigs via `extraEnv` or use kc-agent
+- Monitor agent performance: Check console backend logs for LLM token usage
+
+## References
+
+- [Kagenti Official Documentation](https://kagenti.dev)
+- [KubeStellar Console Helm Chart](../deploy/helm/kubestellar-console/values.yaml)
+- [Kagenti Tool Integration](./kagenti-tool-integration.md)
+- [Mission Control User Guide](./missions.md)

--- a/docs/kagenti-tools.md
+++ b/docs/kagenti-tools.md
@@ -517,6 +517,41 @@ case "get_services":
 - **Tool callback URL**: The Kagenti agent must be configured to call tools back to the console endpoint (`/api/kagenti-provider/tools/call-direct`)
 - **Agent-to-agent communication**: If using the Kagenti A2A protocol, agents must have network access to the console backend
 
+### Controller mode vs direct-agent mode
+
+Mission Control can reach Kagenti in two supported in-cluster layouts:
+
+1. **Controller mode (default)**
+   - The console talks to the Kagenti controller and discovers agents from `GET /api/kagenti-provider/agents`
+   - Missions require **at least one registered agent** in that discovery list
+   - If the controller is reachable but returns zero agents, Mission Control cannot start a mission
+
+2. **Direct-agent mode**
+   - The console skips controller discovery and targets one agent service directly
+   - Use this when you want Missions to always talk to a specific agent
+
+**Helm values**
+
+```yaml
+kagenti:
+  directAgentUrl: "http://my-agent.my-namespace.svc:8080"
+  directAgentName: "my-agent"
+  directAgentNamespace: "my-namespace"
+```
+
+**Equivalent environment variables**
+
+```bash
+KAGENTI_AGENT_URL=http://my-agent.my-namespace.svc:8080
+KAGENTI_AGENT_NAME=my-agent
+KAGENTI_AGENT_NAMESPACE=my-namespace
+```
+
+- `kagenti.directAgentUrl` / `KAGENTI_AGENT_URL` enables direct-agent mode
+- `kagenti.directAgentName` / `KAGENTI_AGENT_NAME` controls the displayed agent name in the console
+- `kagenti.directAgentNamespace` / `KAGENTI_AGENT_NAMESPACE` controls the displayed namespace in the console
+- If you stay in controller mode, make sure at least one Kagenti agent is registered before opening Mission Control
+
 ### Performance Considerations
 
 - **Cluster context timeout**: Context gathering has a 10-second timeout per chat invocation. For clusters with slow API servers, context may be omitted
@@ -562,6 +597,22 @@ case "get_services":
 3. Check for slow API servers or large namespaces
 
 **Solution:** Increase `clusterContextTimeout` in `pkg/api/handlers/kagenti_provider_proxy.go` or optimize cluster queries.
+
+### Mission Control reports zero Kagenti agents discovered
+
+**Symptom:** Mission Control says Kagenti is available, but no agents are discovered.
+
+**Diagnostic path:**
+1. Call `GET /api/kagenti-provider/status`
+   - If `available=false`, fix connectivity first (controller URL, Service, RBAC, or direct-agent URL)
+2. Call `GET /api/kagenti-provider/agents`
+   - If the response is `{"agents":[]}`, the console can reach Kagenti but no agent is registered for Mission Control to use
+3. Check which deployment mode you intended:
+   - **Controller mode:** confirm at least one agent is registered with the Kagenti controller
+   - **Direct-agent mode:** confirm `kagenti.directAgentUrl`, `kagenti.directAgentName`, and `kagenti.directAgentNamespace` (or the `KAGENTI_AGENT_*` env vars) are set on the console deployment
+4. If using Helm, inspect the rendered Deployment and verify the `KAGENTI_AGENT_URL`, `KAGENTI_AGENT_NAME`, and `KAGENTI_AGENT_NAMESPACE` environment variables are present when direct-agent mode is expected
+
+**Solution:** Register at least one Kagenti agent in controller mode, or configure direct-agent mode so the console can synthesize a single reachable agent.
 
 ### Context block is missing from agent messages
 

--- a/web/e2e/compliance/a11y-compliance.spec.ts
+++ b/web/e2e/compliance/a11y-compliance.spec.ts
@@ -48,22 +48,24 @@ interface A11yReport {
 // Constants
 // ---------------------------------------------------------------------------
 
+import { ROUTES } from '../../src/config/routes'
+
 const ROUTES_TO_AUDIT = [
-  { name: 'Dashboard', path: '/' },
-  { name: 'Clusters', path: '/clusters' },
-  { name: 'Settings', path: '/settings' },
-  { name: 'Compute', path: '/compute' },
-  { name: 'Security', path: '/security' },
-  { name: 'Deployments', path: '/deployments' },
-  { name: 'Helm', path: '/helm' },
-  { name: 'GPU Reservations', path: '/gpu-reservations' },
-  { name: 'AI/ML', path: '/ai-ml' },
-  { name: 'Logs', path: '/logs' },
-  { name: 'Events', path: '/events' },
-  { name: 'Pods', path: '/pods' },
-  { name: 'Services', path: '/services' },
-  { name: 'Nodes', path: '/nodes' },
-  { name: 'Workloads', path: '/workloads' },
+  { name: 'Dashboard', path: ROUTES.HOME },
+  { name: 'Clusters', path: ROUTES.CLUSTERS },
+  { name: 'Settings', path: ROUTES.SETTINGS },
+  { name: 'Compute', path: ROUTES.COMPUTE },
+  { name: 'Security', path: ROUTES.SECURITY },
+  { name: 'Deployments', path: ROUTES.DEPLOYMENTS },
+  { name: 'Helm', path: ROUTES.HELM },
+  { name: 'GPU Reservations', path: ROUTES.GPU_RESERVATIONS },
+  { name: 'AI/ML', path: ROUTES.AI_ML },
+  { name: 'Logs', path: ROUTES.LOGS },
+  { name: 'Events', path: ROUTES.EVENTS },
+  { name: 'Pods', path: ROUTES.PODS },
+  { name: 'Services', path: ROUTES.SERVICES },
+  { name: 'Nodes', path: ROUTES.NODES },
+  { name: 'Workloads', path: ROUTES.WORKLOADS },
 ]
 
 const IS_CI = !!process.env.CI
@@ -219,7 +221,7 @@ test('a11y compliance — WCAG 2.1 AA multi-route audit', async ({ page }, testI
   console.log('[A11y] Phase 3: Testing keyboard navigation')
 
   // Navigate to dashboard for keyboard tests
-  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: PAGE_LOAD_TIMEOUT_MS })
+  await page.goto(ROUTES.HOME, { waitUntil: 'domcontentloaded', timeout: PAGE_LOAD_TIMEOUT_MS })
   try {
     await page.waitForSelector('[data-testid="sidebar"]', { timeout: 8_000 })
   } catch { /* continue */ }
@@ -257,7 +259,7 @@ test('a11y compliance — WCAG 2.1 AA multi-route audit', async ({ page }, testI
 
   if (focusRate >= 0.8) {
     addCheck({
-      route: '/',
+      route: ROUTES.HOME,
       routeName: 'Dashboard',
       category: 'keyboard-nav',
       status: 'pass',
@@ -266,7 +268,7 @@ test('a11y compliance — WCAG 2.1 AA multi-route audit', async ({ page }, testI
     })
   } else if (focusRate >= 0.5) {
     addCheck({
-      route: '/',
+      route: ROUTES.HOME,
       routeName: 'Dashboard',
       category: 'keyboard-nav',
       status: 'warn',
@@ -275,7 +277,7 @@ test('a11y compliance — WCAG 2.1 AA multi-route audit', async ({ page }, testI
     })
   } else {
     addCheck({
-      route: '/',
+      route: ROUTES.HOME,
       routeName: 'Dashboard',
       category: 'keyboard-nav',
       status: 'fail',
@@ -306,7 +308,7 @@ test('a11y compliance — WCAG 2.1 AA multi-route audit', async ({ page }, testI
         const dialogClosed = await page.locator('[role="dialog"]').count() === 0
 
         addCheck({
-          route: '/',
+          route: ROUTES.HOME,
           routeName: 'Dashboard',
           category: 'focus-management',
           status: dialogClosed ? 'pass' : 'warn',
@@ -315,7 +317,7 @@ test('a11y compliance — WCAG 2.1 AA multi-route audit', async ({ page }, testI
         })
       } else {
         addCheck({
-          route: '/',
+          route: ROUTES.HOME,
           routeName: 'Dashboard',
           category: 'focus-management',
           status: 'skip',
@@ -325,7 +327,7 @@ test('a11y compliance — WCAG 2.1 AA multi-route audit', async ({ page }, testI
       }
     } catch {
       addCheck({
-        route: '/',
+        route: ROUTES.HOME,
         routeName: 'Dashboard',
         category: 'focus-management',
         status: 'skip',
@@ -335,7 +337,7 @@ test('a11y compliance — WCAG 2.1 AA multi-route audit', async ({ page }, testI
     }
   } else {
     addCheck({
-      route: '/',
+      route: ROUTES.HOME,
       routeName: 'Dashboard',
       category: 'focus-management',
       status: 'skip',

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -154,7 +154,7 @@ if (typeof window !== 'undefined') {
   const PREFETCH_DASHBOARD_TIMEOUT_MS = 2_000
 
   /** Routes where chunk prefetching is skipped to avoid errors during OAuth flow (#9767) */
-  const SKIP_PREFETCH_PATHS = new Set(['/login', '/auth/callback'])
+  const SKIP_PREFETCH_PATHS: Set<string> = new Set([ROUTES.LOGIN, ROUTES.AUTH_CALLBACK])
 
   const prefetchRoutes = async () => {
     // Skip prefetching on auth pages — during OAuth redirects, the browser
@@ -298,7 +298,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
     // Save the intended destination so AuthCallback can return here after login.
     // This preserves deep-link params like ?mission= through the OAuth round-trip.
     const destination = location.pathname + location.search
-    if (destination !== '/' && destination !== '/login') {
+    if (destination !== ROUTES.HOME && destination !== ROUTES.LOGIN) {
       safeSet(RETURN_TO_KEY, destination)
     }
     return <Navigate to={ROUTES.LOGIN} replace />
@@ -424,8 +424,9 @@ const ROUTE_TITLES: Record<string, string> = {
 
 /** Map route paths to dashboard IDs for duration analytics */
 function pathToDashboardId(path: string): string | null {
-  if (path === '/') return 'main'
-  if (path.startsWith('/custom-dashboard/')) return path.replace('/custom-dashboard/', 'custom-')
+  if (path === ROUTES.HOME) return 'main'
+  const customPrefix = ROUTES.CUSTOM_DASHBOARD.replace(':id', '')
+  if (path.startsWith(customPrefix)) return path.replace(customPrefix, 'custom-')
   const id = path.replace(/^\//, '')
   return id || null
 }
@@ -602,7 +603,7 @@ function useLiveUrl(): string {
       }
     },
     getLiveUrl,
-    () => '/',
+    () => ROUTES.HOME,
   )
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -423,7 +423,8 @@ const ROUTE_TITLES: Record<string, string> = {
 
 
 /** Map route paths to dashboard IDs for duration analytics */
-function pathToDashboardId(path: string): string | null {
+function pathToDashboardId(path?: string | null): string | null {
+  if (!path) return null
   if (path === ROUTES.HOME) return 'main'
   const customPrefix = ROUTES.CUSTOM_DASHBOARD.replace(':id', '')
   if (path.startsWith(customPrefix)) return path.replace(customPrefix, 'custom-')

--- a/web/src/components/cards/DataComplianceCards.tsx
+++ b/web/src/components/cards/DataComplianceCards.tsx
@@ -5,7 +5,7 @@
  * - Cert-Manager: TLS certificate lifecycle management
  */
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { Shield, CheckCircle2, AlertTriangle, Clock, AlertCircle } from 'lucide-react'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useCertManager } from '../../hooks/useCertManager'
@@ -14,7 +14,7 @@ import { kubectlProxy } from '../../lib/kubectlProxy'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
-import { KUBECTL_DEFAULT_TIMEOUT_MS, METRICS_SERVER_TIMEOUT_MS } from '../../lib/constants/network'
+import { KUBECTL_DEFAULT_TIMEOUT_MS, METRICS_SERVER_TIMEOUT_MS, DEFAULT_REFRESH_INTERVAL_MS } from '../../lib/constants/network'
 
 interface CardConfig {
   config?: Record<string, unknown>
@@ -44,82 +44,139 @@ export function VaultSecrets({ config: _config }: CardConfig) {
   const { deduplicatedClusters: allClusters } = useClusters()
   const [vaultStatus, setVaultStatus] = useState<VaultStatus>(DEMO_VAULT)
   const [isLoading, setIsLoading] = useState(true)
+  const [isRefreshing, setIsRefreshing] = useState(false)
   const [secretCount, setSecretCount] = useState(0)
+  const [fetchError, setFetchError] = useState(false)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
+  const fetchInProgress = useRef(false)
+  const initialLoadDone = useRef(false)
 
   const clusters = useMemo(() =>
     allClusters.filter(c => c.reachable === true),
     [allClusters]
   )
 
+  const refetch = useCallback(async () => {
+    if (isDemoMode || clusters.length === 0 || fetchInProgress.current) return
+    fetchInProgress.current = true
+
+    if (initialLoadDone.current) {
+      setIsRefreshing(true)
+    } else {
+      setIsLoading(true)
+    }
+
+    let found = false
+    let totalPods = 0
+    let readyPods = 0
+    let secrets = 0
+    let anyError = false
+
+    for (const cluster of clusters) {
+      try {
+        const podsResult = await kubectlProxy.exec(
+          ['get', 'pods', '-A', '-l', 'app.kubernetes.io/name=vault', '-o', 'json'],
+          { context: cluster.name, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
+        )
+        if (podsResult.exitCode === 0 && podsResult.output) {
+          const data = JSON.parse(podsResult.output)
+          const items = data.items || []
+          if (items.length > 0) {
+            found = true
+            totalPods += items.length
+            readyPods += items.filter((p: { status?: { phase?: string } }) =>
+              p.status?.phase === 'Running'
+            ).length
+          }
+        }
+
+        const secretsResult = await kubectlProxy.exec(
+          ['get', 'secrets', '-A', '-o', 'jsonpath={range .items[?(@.type=="Opaque")]}1{end}'],
+          { context: cluster.name, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
+        )
+        if (secretsResult.exitCode === 0 && secretsResult.output) {
+          secrets += secretsResult.output.length
+        }
+      } catch {
+        anyError = true
+      }
+    }
+
+    if (anyError && !found && secrets === 0) {
+      // All clusters failed — mark as failed fetch
+      setFetchError(true)
+      setConsecutiveFailures(prev => prev + 1)
+    } else {
+      setVaultStatus({
+        installed: found,
+        podCount: totalPods,
+        readyPods,
+        sealedStatus: found ? (readyPods > 0 ? 'unsealed' : 'sealed') : 'unknown',
+      })
+      setSecretCount(secrets)
+      setFetchError(false)
+      setConsecutiveFailures(0)
+    }
+    setIsLoading(false)
+    setIsRefreshing(false)
+    initialLoadDone.current = true
+    fetchInProgress.current = false
+  }, [clusters, isDemoMode])
+
   useEffect(() => {
     if (isDemoMode || clusters.length === 0) {
       setVaultStatus(DEMO_VAULT)
       setSecretCount(0)
       setIsLoading(false)
+      setFetchError(false)
+      setConsecutiveFailures(0)
       return
     }
+    refetch()
+  }, [clusters, isDemoMode, refetch])
 
-    let cancelled = false
-    async function detect() {
-      setIsLoading(true)
-      let found = false
-      let totalPods = 0
-      let readyPods = 0
-      let secrets = 0
+  // Auto-refresh on interval (consistent with useCertManager pattern)
+  useEffect(() => {
+    if (isDemoMode || clusters.length === 0) return
+    const interval = setInterval(() => refetch(), DEFAULT_REFRESH_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [isDemoMode, clusters.length, refetch])
 
-      for (const cluster of clusters) {
-        try {
-          // Check for Vault pods (helm release or operator)
-          const podsResult = await kubectlProxy.exec(
-            ['get', 'pods', '-A', '-l', 'app.kubernetes.io/name=vault', '-o', 'json'],
-            { context: cluster.name, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
-          )
-          if (podsResult.exitCode === 0 && podsResult.output) {
-            const data = JSON.parse(podsResult.output)
-            const items = data.items || []
-            if (items.length > 0) {
-              found = true
-              totalPods += items.length
-              readyPods += items.filter((p: { status?: { phase?: string } }) =>
-                p.status?.phase === 'Running'
-              ).length
-            }
-          }
-
-          // Count opaque secrets (user-managed) in this cluster
-          const secretsResult = await kubectlProxy.exec(
-            ['get', 'secrets', '-A', '-o', 'jsonpath={range .items[?(@.type=="Opaque")]}1{end}'],
-            { context: cluster.name, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
-          )
-          if (secretsResult.exitCode === 0 && secretsResult.output) {
-            secrets += secretsResult.output.length
-          }
-        } catch {
-          // Continue to next cluster
-        }
-      }
-
-      if (!cancelled) {
-        setVaultStatus({
-          installed: found,
-          podCount: totalPods,
-          readyPods,
-          sealedStatus: found ? (readyPods > 0 ? 'unsealed' : 'sealed') : 'unknown',
-        })
-        setSecretCount(secrets)
-        setIsLoading(false)
-      }
-    }
-
-    detect()
-    return () => { cancelled = true }
-  }, [clusters, isDemoMode])
+  const isFailed = consecutiveFailures >= 3
 
   useCardLoadingState({
     isLoading: isLoading && !vaultStatus.installed,
+    isRefreshing,
     hasAnyData: true,
     isDemoData: isDemoMode,
+    isFailed,
+    consecutiveFailures,
   })
+
+  // Fetch error state — show error banner with retry
+  if (fetchError && !isDemoMode) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-start gap-2 p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-xs" role="alert">
+          <AlertTriangle className="w-4 h-4 text-red-400 shrink-0 mt-0.5" />
+          <div className="flex-1">
+            <p className="text-red-400 font-medium">Failed to fetch Vault status</p>
+            <p className="text-muted-foreground">
+              Check cluster connectivity.{' '}
+              <button onClick={() => refetch()} className="text-red-400 hover:underline">
+                Retry →
+              </button>
+            </p>
+          </div>
+        </div>
+        {isFailed && (
+          <p className="text-xs text-red-400/70 text-center">
+            {consecutiveFailures} consecutive failures
+          </p>
+        )}
+      </div>
+    )
+  }
 
   // Vault not detected — show install notice with real secret count
   if (!isLoading && !vaultStatus.installed) {
@@ -215,85 +272,140 @@ export function ExternalSecrets({ config: _config }: CardConfig) {
   const { deduplicatedClusters: allClusters } = useClusters()
   const [esoStatus, setEsoStatus] = useState<ESOStatus>(DEMO_ESO)
   const [isLoading, setIsLoading] = useState(true)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [fetchError, setFetchError] = useState(false)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
+  const fetchInProgress = useRef(false)
+  const initialLoadDone = useRef(false)
 
   const clusters = useMemo(() =>
     allClusters.filter(c => c.reachable === true),
     [allClusters]
   )
 
+  const refetch = useCallback(async () => {
+    if (isDemoMode || clusters.length === 0 || fetchInProgress.current) return
+    fetchInProgress.current = true
+
+    if (initialLoadDone.current) {
+      setIsRefreshing(true)
+    } else {
+      setIsLoading(true)
+    }
+
+    let found = false
+    let stores = 0
+    let totalES = 0
+    let synced = 0
+    let failed = 0
+    let pending = 0
+    let anyError = false
+
+    for (const cluster of clusters) {
+      try {
+        const crdCheck = await kubectlProxy.exec(
+          ['get', 'crd', 'externalsecrets.external-secrets.io', '-o', 'name'],
+          { context: cluster.name, timeout: METRICS_SERVER_TIMEOUT_MS }
+        )
+        if (crdCheck.exitCode !== 0) continue
+        found = true
+
+        const storesResult = await kubectlProxy.exec(
+          ['get', 'secretstores,clustersecretstores', '-A', '-o', 'jsonpath={range .items[*]}1{end}'],
+          { context: cluster.name, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
+        )
+        if (storesResult.exitCode === 0 && storesResult.output) {
+          stores += storesResult.output.length
+        }
+
+        const esResult = await kubectlProxy.exec(
+          ['get', 'externalsecrets', '-A', '-o', 'json'],
+          { context: cluster.name, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
+        )
+        if (esResult.exitCode === 0 && esResult.output) {
+          const data = JSON.parse(esResult.output)
+          const items = data.items || []
+          totalES += items.length
+          for (const item of items) {
+            const conditions = item.status?.conditions || []
+            const readyCondition = conditions.find((c: { type: string }) => c.type === 'Ready')
+            if (readyCondition?.status === 'True') synced++
+            else if (readyCondition?.reason === 'SecretSyncedError') failed++
+            else pending++
+          }
+        }
+      } catch {
+        anyError = true
+      }
+    }
+
+    if (anyError && !found && totalES === 0) {
+      setFetchError(true)
+      setConsecutiveFailures(prev => prev + 1)
+    } else {
+      setEsoStatus({ installed: found, totalStores: stores, totalExternalSecrets: totalES, synced, failed, pending })
+      setFetchError(false)
+      setConsecutiveFailures(0)
+    }
+    setIsLoading(false)
+    setIsRefreshing(false)
+    initialLoadDone.current = true
+    fetchInProgress.current = false
+  }, [clusters, isDemoMode])
+
   useEffect(() => {
     if (isDemoMode || clusters.length === 0) {
       setEsoStatus(DEMO_ESO)
       setIsLoading(false)
+      setFetchError(false)
+      setConsecutiveFailures(0)
       return
     }
+    refetch()
+  }, [clusters, isDemoMode, refetch])
 
-    let cancelled = false
-    async function detect() {
-      setIsLoading(true)
-      let found = false
-      let stores = 0
-      let totalES = 0
-      let synced = 0
-      let failed = 0
-      let pending = 0
+  // Auto-refresh on interval
+  useEffect(() => {
+    if (isDemoMode || clusters.length === 0) return
+    const interval = setInterval(() => refetch(), DEFAULT_REFRESH_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [isDemoMode, clusters.length, refetch])
 
-      for (const cluster of clusters) {
-        try {
-          // Check if ESO CRD exists
-          const crdCheck = await kubectlProxy.exec(
-            ['get', 'crd', 'externalsecrets.external-secrets.io', '-o', 'name'],
-            { context: cluster.name, timeout: METRICS_SERVER_TIMEOUT_MS }
-          )
-          if (crdCheck.exitCode !== 0) continue
-          found = true
-
-          // Count SecretStores + ClusterSecretStores
-          const storesResult = await kubectlProxy.exec(
-            ['get', 'secretstores,clustersecretstores', '-A', '-o', 'jsonpath={range .items[*]}1{end}'],
-            { context: cluster.name, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
-          )
-          if (storesResult.exitCode === 0 && storesResult.output) {
-            stores += storesResult.output.length
-          }
-
-          // Count ExternalSecrets with status
-          const esResult = await kubectlProxy.exec(
-            ['get', 'externalsecrets', '-A', '-o', 'json'],
-            { context: cluster.name, timeout: KUBECTL_DEFAULT_TIMEOUT_MS }
-          )
-          if (esResult.exitCode === 0 && esResult.output) {
-            const data = JSON.parse(esResult.output)
-            const items = data.items || []
-            totalES += items.length
-            for (const item of items) {
-              const conditions = item.status?.conditions || []
-              const readyCondition = conditions.find((c: { type: string }) => c.type === 'Ready')
-              if (readyCondition?.status === 'True') synced++
-              else if (readyCondition?.reason === 'SecretSyncedError') failed++
-              else pending++
-            }
-          }
-        } catch {
-          // Continue to next cluster
-        }
-      }
-
-      if (!cancelled) {
-        setEsoStatus({ installed: found, totalStores: stores, totalExternalSecrets: totalES, synced, failed, pending })
-        setIsLoading(false)
-      }
-    }
-
-    detect()
-    return () => { cancelled = true }
-  }, [clusters, isDemoMode])
+  const isFailed = consecutiveFailures >= 3
 
   useCardLoadingState({
     isLoading: isLoading && !esoStatus.installed,
+    isRefreshing,
     hasAnyData: true,
     isDemoData: isDemoMode,
+    isFailed,
+    consecutiveFailures,
   })
+
+  // Fetch error state
+  if (fetchError && !isDemoMode) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-start gap-2 p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-xs" role="alert">
+          <AlertTriangle className="w-4 h-4 text-red-400 shrink-0 mt-0.5" />
+          <div className="flex-1">
+            <p className="text-red-400 font-medium">Failed to fetch ESO status</p>
+            <p className="text-muted-foreground">
+              Check cluster connectivity.{' '}
+              <button onClick={() => refetch()} className="text-red-400 hover:underline">
+                Retry →
+              </button>
+            </p>
+          </div>
+        </div>
+        {isFailed && (
+          <p className="text-xs text-red-400/70 text-center">
+            {consecutiveFailures} consecutive failures
+          </p>
+        )}
+      </div>
+    )
+  }
 
   // ESO not detected
   if (!isLoading && !esoStatus.installed) {

--- a/web/src/components/cards/__tests__/DataComplianceCards.states.test.tsx
+++ b/web/src/components/cards/__tests__/DataComplianceCards.states.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * Regression tests for compliance card refresh/failure visibility.
+ *
+ * Covers: loading, refreshing, failed fetch, stale/consecutive failures,
+ * healthy/fresh install state for VaultSecrets, ExternalSecrets, CertManager.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { VaultSecrets, ExternalSecrets, CertManager } from '../DataComplianceCards'
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../../../hooks/useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+  getDemoMode: () => true, default: () => true,
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+const mockClusters = vi.fn(() => [])
+vi.mock('../../../hooks/useMCP', () => ({
+  useClusters: () => {
+    const clusters = mockClusters()
+    return { clusters, deduplicatedClusters: clusters }
+  },
+}))
+
+const mockKubectlExec = vi.fn()
+vi.mock('../../../lib/kubectlProxy', () => ({
+  kubectlProxy: { exec: (...args: unknown[]) => mockKubectlExec(...args) },
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+const mockUseCertManager = vi.fn()
+vi.mock('../../../hooks/useCertManager', () => ({
+  useCertManager: () => mockUseCertManager(),
+}))
+
+vi.mock('../../ui/StatusBadge', () => ({
+  StatusBadge: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="status-badge">{children}</span>
+  ),
+}))
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function cluster(name = 'prod') {
+  return { name, reachable: true }
+}
+
+// ── VaultSecrets: failure/refresh states ────────────────────────────────
+
+describe('VaultSecrets — refresh/failure visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsDemoMode.mockReturnValue(false)
+    mockClusters.mockReturnValue([])
+    mockUseCardLoadingState.mockReturnValue({})
+  })
+
+  it('shows error banner when all cluster scans throw', async () => {
+    mockClusters.mockReturnValue([cluster()])
+    mockKubectlExec.mockRejectedValue(new Error('timeout'))
+
+    await act(async () => render(<VaultSecrets />))
+    await waitFor(() =>
+      expect(screen.getByText('Failed to fetch Vault status')).toBeInTheDocument()
+    )
+    expect(screen.getByText(/Retry/)).toBeInTheDocument()
+  })
+
+  it('reports isFailed=true to useCardLoadingState after errors', async () => {
+    mockClusters.mockReturnValue([cluster()])
+    mockKubectlExec.mockRejectedValue(new Error('fail'))
+
+    await act(async () => render(<VaultSecrets />))
+    await waitFor(() => {
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isFailed: false })
+      )
+    })
+  })
+
+  it('reports isRefreshing via useCardLoadingState', async () => {
+    mockClusters.mockReturnValue([cluster()])
+    mockKubectlExec.mockResolvedValue({ exitCode: 1, output: '' })
+
+    await act(async () => render(<VaultSecrets />))
+    // After initial load, isRefreshing should be reported
+    expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+      expect.objectContaining({ isRefreshing: expect.any(Boolean) })
+    )
+  })
+
+  it('reports consecutiveFailures to useCardLoadingState', async () => {
+    mockClusters.mockReturnValue([cluster()])
+    mockKubectlExec.mockRejectedValue(new Error('fail'))
+
+    await act(async () => render(<VaultSecrets />))
+    await waitFor(() => {
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ consecutiveFailures: expect.any(Number) })
+      )
+    })
+  })
+
+  it('recovers from error when retry succeeds', async () => {
+    mockClusters.mockReturnValue([cluster()])
+    // First call fails
+    mockKubectlExec.mockRejectedValueOnce(new Error('fail'))
+
+    await act(async () => render(<VaultSecrets />))
+    await waitFor(() =>
+      expect(screen.getByText('Failed to fetch Vault status')).toBeInTheDocument()
+    )
+
+    // Setup success for retry
+    mockKubectlExec
+      .mockResolvedValueOnce({ exitCode: 0, output: JSON.stringify({ items: [{ status: { phase: 'Running' } }] }) })
+      .mockResolvedValueOnce({ exitCode: 0, output: '11' })
+
+    // Click retry
+    const retryBtn = screen.getByText(/Retry/)
+    await act(async () => retryBtn.click())
+
+    await waitFor(() =>
+      expect(screen.getByText('unsealed')).toBeInTheDocument()
+    )
+  })
+
+  it('shows healthy state when data is fresh', async () => {
+    mockClusters.mockReturnValue([cluster()])
+    const podsPayload = JSON.stringify({
+      items: [{ status: { phase: 'Running' } }],
+    })
+    mockKubectlExec
+      .mockResolvedValueOnce({ exitCode: 0, output: podsPayload })
+      .mockResolvedValueOnce({ exitCode: 0, output: '11' })
+
+    await act(async () => render(<VaultSecrets />))
+    await waitFor(() =>
+      expect(screen.getByText('unsealed')).toBeInTheDocument()
+    )
+    // No error elements should be present
+    expect(screen.queryByText(/Failed to fetch/)).not.toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})
+
+// ── ExternalSecrets: failure/refresh states ─────────────────────────────
+
+describe('ExternalSecrets — refresh/failure visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsDemoMode.mockReturnValue(false)
+    mockClusters.mockReturnValue([])
+    mockUseCardLoadingState.mockReturnValue({})
+  })
+
+  it('shows error banner when all cluster scans throw', async () => {
+    mockClusters.mockReturnValue([cluster()])
+    mockKubectlExec.mockRejectedValue(new Error('timeout'))
+
+    await act(async () => render(<ExternalSecrets />))
+    await waitFor(() =>
+      expect(screen.getByText('Failed to fetch ESO status')).toBeInTheDocument()
+    )
+    expect(screen.getByText(/Retry/)).toBeInTheDocument()
+  })
+
+  it('reports isFailed and consecutiveFailures to useCardLoadingState', async () => {
+    mockClusters.mockReturnValue([cluster()])
+    mockKubectlExec.mockRejectedValue(new Error('fail'))
+
+    await act(async () => render(<ExternalSecrets />))
+    await waitFor(() => {
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isFailed: expect.any(Boolean),
+          consecutiveFailures: expect.any(Number),
+          isRefreshing: expect.any(Boolean),
+        })
+      )
+    })
+  })
+
+  it('shows healthy state when ESO is installed and data fresh', async () => {
+    mockClusters.mockReturnValue([cluster()])
+    const items = [{ status: { conditions: [{ type: 'Ready', status: 'True' }] } }]
+    mockKubectlExec
+      .mockResolvedValueOnce({ exitCode: 0, output: 'crd' }) // CRD check
+      .mockResolvedValueOnce({ exitCode: 0, output: '11' }) // stores
+      .mockResolvedValueOnce({ exitCode: 0, output: JSON.stringify({ items }) }) // ES list
+
+    await act(async () => render(<ExternalSecrets />))
+    await waitFor(() =>
+      expect(screen.getByText('100% synced')).toBeInTheDocument()
+    )
+    expect(screen.queryByText(/Failed to fetch/)).not.toBeInTheDocument()
+  })
+})
+
+// ── CertManager: failure/refresh states ────────────────────────────────
+
+const DEFAULT_CERT_STATUS = {
+  installed: true,
+  totalCertificates: 10,
+  validCertificates: 7,
+  expiringSoon: 2,
+  expired: 1,
+  pending: 0,
+  failed: 0,
+  recentRenewals: 3,
+}
+
+function setupCertManager(overrides = {}) {
+  mockUseCertManager.mockReturnValue({
+    status: { ...DEFAULT_CERT_STATUS, ...overrides },
+    issuers: [],
+    isLoading: false,
+    isRefreshing: false,
+    consecutiveFailures: 0,
+    isFailed: false,
+    ...overrides,
+  })
+}
+
+describe('CertManager — refresh/failure visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCardLoadingState.mockReturnValue({})
+  })
+
+  it('passes isRefreshing to useCardLoadingState when refreshing', () => {
+    setupCertManager({ isRefreshing: true })
+    render(<CertManager />)
+    expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+      expect.objectContaining({ isRefreshing: true })
+    )
+  })
+
+  it('passes isFailed and consecutiveFailures when fetch fails', () => {
+    setupCertManager({ isFailed: true, consecutiveFailures: 5 })
+    render(<CertManager />)
+    expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+      expect.objectContaining({ isFailed: true, consecutiveFailures: 5 })
+    )
+  })
+
+  it('shows loading skeleton when loading with no issuers', () => {
+    setupCertManager({ isLoading: true, issuers: [] })
+    render(<CertManager />)
+    const animated = document.querySelector('.animate-pulse')
+    expect(animated).toBeInTheDocument()
+  })
+
+  it('shows healthy installed state when data fresh', () => {
+    setupCertManager({
+      issuers: [{ id: 'i1', name: 'le', kind: 'ClusterIssuer', status: 'ready', certificateCount: 5 }],
+    })
+    render(<CertManager />)
+    expect(screen.getByText('7')).toBeInTheDocument() // valid certs
+    expect(screen.getByText('le')).toBeInTheDocument() // issuer name
+  })
+})

--- a/web/src/components/compliance/FedRAMPDashboard.test.tsx
+++ b/web/src/components/compliance/FedRAMPDashboard.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { FedRAMPDashboardContent as FedRAMPDashboard } from './FedRAMPDashboard'
+import { authFetch } from '../../lib/api'
 
 const mockControls = [
   { id: 'AC-1', name: 'Access Control Policy', description: 'Define access policies.', family: 'AC', status: 'satisfied', responsible: 'Platform Team', implementation: 'RBAC and OPA' },
@@ -15,16 +16,25 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
 }))
 vi.mock('../../lib/api', () => ({
-  authFetch: vi.fn((url: string) => {
-    if (url.includes('/controls')) return Promise.resolve({ ok: true, json: () => Promise.resolve(mockControls) })
-    if (url.includes('/poams')) return Promise.resolve({ ok: true, json: () => Promise.resolve(mockPOAMs) })
-    if (url.includes('/score')) return Promise.resolve({ ok: true, json: () => Promise.resolve(mockScore) })
-    return Promise.resolve({ ok: false })
-  }),
+  authFetch: vi.fn(),
 }))
 
+const mockAuthFetch = vi.mocked(authFetch)
+
+function mockFedRAMPFetches(score = mockScore) {
+  mockAuthFetch.mockImplementation((url: string) => {
+    if (url.includes('/controls')) return Promise.resolve({ ok: true, json: () => Promise.resolve(mockControls) })
+    if (url.includes('/poams')) return Promise.resolve({ ok: true, json: () => Promise.resolve(mockPOAMs) })
+    if (url.includes('/score')) return Promise.resolve({ ok: true, json: () => Promise.resolve(score) })
+    return Promise.resolve({ ok: false })
+  })
+}
+
 describe('FedRAMPDashboard', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFedRAMPFetches()
+  })
 
   it('renders the dashboard title', async () => {
     render(<FedRAMPDashboard />)
@@ -53,5 +63,13 @@ describe('FedRAMPDashboard', () => {
       const el = screen.getByText('in process')
       expect(el.className).toContain('text-orange')
     })
+  })
+
+  it('falls back to Unknown when authorization_status is missing', async () => {
+    mockFedRAMPFetches({ ...mockScore, authorization_status: undefined })
+
+    render(<FedRAMPDashboard />)
+
+    await waitFor(() => expect(screen.getByText('Unknown')).toBeInTheDocument())
   })
 })

--- a/web/src/components/compliance/FedRAMPDashboard.tsx
+++ b/web/src/components/compliance/FedRAMPDashboard.tsx
@@ -32,7 +32,7 @@ interface POAM {
 
 interface FedRAMPScore {
   overall_score: number
-  authorization_status: string
+  authorization_status?: string | null
   impact_level: string
   controls_satisfied: number
   controls_partially_satisfied: number
@@ -70,7 +70,7 @@ const controlStatusColor = (status: string) => {
   }
 }
 
-const authorizationStatusStyle = (status: string) => {
+const authorizationStatusStyle = (status?: string | null) => {
   switch (status) {
     case 'authorized': return 'text-green-700 dark:text-green-400'
     case 'in_progress':
@@ -79,6 +79,8 @@ const authorizationStatusStyle = (status: string) => {
     default: return 'text-foreground'
   }
 }
+
+const formatAuthorizationStatus = (status?: string | null) => status?.replace(/_/g, ' ') ?? 'Unknown'
 
 const milestoneStatusBadge = (status: string) => {
   switch (status) {
@@ -161,7 +163,7 @@ export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
           </div>
           <div className="bg-card rounded-lg p-4 border border-border shadow-sm">
             <p className="text-sm text-muted-foreground">Authorization</p>
-            <p className={`text-2xl font-bold capitalize ${authorizationStatusStyle(score.authorization_status)}`}>{score.authorization_status.replace('_', ' ')}</p>
+            <p className={`text-2xl font-bold capitalize ${authorizationStatusStyle(score.authorization_status)}`}>{formatAuthorizationStatus(score.authorization_status)}</p>
           </div>
           <div className="bg-card rounded-lg p-4 border border-green-500/30 shadow-sm">
             <p className="text-sm text-muted-foreground">Satisfied</p>
@@ -293,7 +295,7 @@ export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">Authorization Status</p>
-                <p className={`text-xl font-bold capitalize ${authorizationStatusStyle(score.authorization_status)}`}>{score.authorization_status.replace('_', ' ')}</p>
+                <p className={`text-xl font-bold capitalize ${authorizationStatusStyle(score.authorization_status)}`}>{formatAuthorizationStatus(score.authorization_status)}</p>
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">Overall Score</p>

--- a/web/src/components/compliance/GxPDashboard.tsx
+++ b/web/src/components/compliance/GxPDashboard.tsx
@@ -250,7 +250,7 @@ export const GxPDashboardContent = memo(function GxPDashboardContent() {
                           {sigs.map(s => (
                             <span key={s.id} className={`px-2 py-0.5 rounded text-xs border ${MEANING_STYLES[s.meaning] || ''}`}>
                               <PenTool className="w-3 h-3 inline mr-1" />
-                              {s.meaning} by {s.user_id.split('@')[0]} ({s.auth_method})
+                              {s.meaning} by {(s.user_id ?? '').split('@')[0]} ({s.auth_method})
                             </span>
                           ))}
                         </div>

--- a/web/src/components/compliance/RBACAuditDashboard.tsx
+++ b/web/src/components/compliance/RBACAuditDashboard.tsx
@@ -196,7 +196,7 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
                   <div className="flex items-center gap-3">
                     <ShieldAlert className="w-5 h-5 text-amber-400" />
                     <div>
-                      <div className="text-white font-medium">{f.finding_type.replace(/_/g, ' ')}</div>
+                      <div className="text-white font-medium">{(f.finding_type ?? '').replace(/_/g, ' ')}</div>
                       <div className="text-sm text-gray-400">{f.subject} — {f.cluster}/{f.namespace}</div>
                     </div>
                   </div>

--- a/web/src/components/compliance/SBOMDashboard.tsx
+++ b/web/src/components/compliance/SBOMDashboard.tsx
@@ -123,7 +123,7 @@ function buildVulnerabilities(packages: SBOMPackage[]): SBOMVulnerability[] {
 function buildLicenseSummary(packages: SBOMPackage[]) {
   return packages.reduce(
     (counts, pkg) => {
-      const normalizedLicense = pkg.license.trim().toLowerCase()
+      const normalizedLicense = (pkg.license ?? '').trim().toLowerCase()
       if (!normalizedLicense || normalizedLicense === 'unknown') {
         counts.unknown += 1
       } else if (normalizedLicense.includes('gpl') || normalizedLicense.includes('agpl') || normalizedLicense.includes('sspl')) {

--- a/web/src/components/compliance/ThreatIntelDashboard.tsx
+++ b/web/src/components/compliance/ThreatIntelDashboard.tsx
@@ -322,7 +322,7 @@ const ThreatIntelDashboard = memo(function ThreatIntelDashboard() {
                   <td className="p-3">
                     <span className="flex items-center gap-1.5">
                       {IOC_STATUS_ICON[ioc.status]}
-                      <span className="text-gray-300 capitalize">{ioc.status.replace('_', ' ')}</span>
+                      <span className="text-gray-300 capitalize">{(ioc.status ?? '').replace('_', ' ')}</span>
                     </span>
                   </td>
                   <td className="p-3 text-white">{ioc.matched_resource}</td>

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -783,12 +783,12 @@ export function Layout({ children: _children }: LayoutProps) {
               key={banner.id}
               style={{
                 top: NAVBAR_HEIGHT_PX + (index * BANNER_HEIGHT_PX),
-                height: BANNER_HEIGHT_PX,
+                minHeight: BANNER_HEIGHT_PX,
                 left: sidebarWidthPx,
                 ...banner.style,
               }}
               className={cn(
-                'fixed transition-[left,right] duration-300 overflow-hidden',
+                'fixed transition-[left,right] duration-300',
                 banner.className,
               )}
             >

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -783,11 +783,12 @@ export function Layout({ children: _children }: LayoutProps) {
               key={banner.id}
               style={{
                 top: NAVBAR_HEIGHT_PX + (index * BANNER_HEIGHT_PX),
+                height: BANNER_HEIGHT_PX,
                 left: sidebarWidthPx,
                 ...banner.style,
               }}
               className={cn(
-                'fixed transition-[left,right] duration-300',
+                'fixed transition-[left,right] duration-300 overflow-hidden',
                 banner.className,
               )}
             >

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -56,6 +56,7 @@ import {
   SIDEBAR_CONTROLS_OFFSET_PX,
 } from '../../lib/constants/ui'
 import { CLOSE_ANIMATION_MS, UI_FEEDBACK_TIMEOUT_MS, TOAST_DISMISS_MS } from '../../lib/constants/network'
+import { STORAGE_KEY_AUTONOMOUS_BANNER_DISMISSED } from '../../lib/constants/storage'
 import { TourOverlay, TourPrompt } from '../onboarding/Tour'
 import { TourProvider } from '../../hooks/useTour'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
@@ -209,9 +210,8 @@ export function Layout({ children: _children }: LayoutProps) {
   const { kagentAvailable, kagentiAvailable } = useKagentBackend()
   const [offlineBannerDismissed, setOfflineBannerDismissed] = useState(false)
   const [demoBannerDismissed, setDemoBannerDismissed] = useState(false)
-  const AUTONOMOUS_BANNER_STORAGE_KEY = 'kc-autonomous-banner-dismissed'
   const [autonomousBannerDismissed, setAutonomousBannerDismissed] = useState(
-    () => safeGetItem(AUTONOMOUS_BANNER_STORAGE_KEY) === 'true'
+    () => safeGetItem(STORAGE_KEY_AUTONOMOUS_BANNER_DISMISSED) === 'true'
   )
   const [showSetupDialog, setShowSetupDialog] = useState(false)
   const [showInClusterAgentDialog, setShowInClusterAgentDialog] =
@@ -604,7 +604,7 @@ export function Layout({ children: _children }: LayoutProps) {
         <div className="flex items-center justify-center gap-2 md:gap-3 py-1.5 px-3 md:px-4">
           <span className="text-sm" aria-hidden="true">🐝</span>
           <span className="text-sm text-purple-300 font-medium">
-            This project is fully autonomous — maintained by AI agents.
+            {t('layout.autonomousBannerMessage')}
           </span>
           <a
             href={HIVE_DASHBOARD_URL}
@@ -612,7 +612,7 @@ export function Layout({ children: _children }: LayoutProps) {
             rel="noopener noreferrer"
             className="hidden sm:inline-flex items-center gap-1 text-xs px-2 py-1 bg-purple-500/20 hover:bg-purple-500/30 text-purple-300 rounded transition-colors whitespace-nowrap"
           >
-            Watch them live
+            {t('layout.watchLive')}
             <ExternalLink className="w-3 h-3" aria-hidden="true" />
           </a>
           <a
@@ -621,12 +621,12 @@ export function Layout({ children: _children }: LayoutProps) {
             rel="noopener noreferrer"
             className="sm:hidden text-xs text-purple-300 underline underline-offset-2 whitespace-nowrap"
           >
-            Watch live →
+            {t('layout.watchLiveMobile')}
           </a>
           <button
             onClick={() => {
               setAutonomousBannerDismissed(true)
-              safeSetItem(AUTONOMOUS_BANNER_STORAGE_KEY, 'true')
+              safeSetItem(STORAGE_KEY_AUTONOMOUS_BANNER_DISMISSED, 'true')
             }}
             className="ml-1 md:ml-2 p-2 min-h-11 min-w-11 flex items-center justify-center hover:bg-purple-500/20 rounded-full transition-colors"
             aria-label={t('buttons.dismissBanner')}

--- a/web/src/components/layout/SidebarShell.tsx
+++ b/web/src/components/layout/SidebarShell.tsx
@@ -137,23 +137,25 @@ const SIDEBAR_RESIZE_HANDLE_WIDTH_PX = 6
 /** Index of the primary (dashboard list) section — "Add more..." button renders after it */
 const PRIMARY_SECTION_INDEX = 0
 
+import { ROUTES } from '../../config/routes'
+
 /** Map sidebar item href to dashboard config ID for card count display. */
 const HREF_TO_DASHBOARD_ID: Record<string, string> = {
-  '/': 'main', '/compute': 'compute', '/security': 'security',
-  '/gitops': 'gitops', '/storage': 'storage', '/network': 'network',
-  '/events': 'events', '/alerts': 'alerts', '/workloads': 'workloads', '/operators': 'operators',
-  '/clusters': 'clusters', '/compliance': 'compliance', '/cost': 'cost',
-  '/gpu-reservations': 'gpu', '/nodes': 'nodes', '/deployments': 'deployments',
-  '/pods': 'pods', '/services': 'services', '/helm': 'helm',
-  '/ai-ml': 'ai-ml', '/ci-cd': 'ci-cd',
-  '/logs': 'logs', '/data-compliance': 'data-compliance', '/arcade': 'arcade',
-  '/deploy': 'deploy', '/ai-agents': 'ai-agents',
-  '/llm-d-benchmarks': 'llm-d-benchmarks', '/cluster-admin': 'cluster-admin',
-  '/insights': 'insights', '/drasi': 'drasi',
-  '/multi-tenancy': 'multi-tenancy', '/acmm': 'acmm',
+  [ROUTES.HOME]: 'main', [ROUTES.COMPUTE]: 'compute', [ROUTES.SECURITY]: 'security',
+  [ROUTES.GITOPS]: 'gitops', [ROUTES.STORAGE]: 'storage', [ROUTES.NETWORK]: 'network',
+  [ROUTES.EVENTS]: 'events', [ROUTES.ALERTS]: 'alerts', [ROUTES.WORKLOADS]: 'workloads', [ROUTES.OPERATORS]: 'operators',
+  [ROUTES.CLUSTERS]: 'clusters', [ROUTES.COMPLIANCE]: 'compliance', [ROUTES.COST]: 'cost',
+  [ROUTES.GPU_RESERVATIONS]: 'gpu', [ROUTES.NODES]: 'nodes', [ROUTES.DEPLOYMENTS]: 'deployments',
+  [ROUTES.PODS]: 'pods', [ROUTES.SERVICES]: 'services', [ROUTES.HELM]: 'helm',
+  [ROUTES.AI_ML]: 'ai-ml', [ROUTES.CI_CD]: 'ci-cd',
+  [ROUTES.LOGS]: 'logs', [ROUTES.DATA_COMPLIANCE]: 'data-compliance', [ROUTES.ARCADE]: 'arcade',
+  [ROUTES.DEPLOY]: 'deploy', [ROUTES.AI_AGENTS]: 'ai-agents',
+  [ROUTES.LLM_D_BENCHMARKS]: 'llm-d-benchmarks', [ROUTES.CLUSTER_ADMIN]: 'cluster-admin',
+  [ROUTES.INSIGHTS]: 'insights', [ROUTES.DRASI]: 'drasi',
+  [ROUTES.MULTI_TENANCY]: 'multi-tenancy', [ROUTES.ACMM]: 'acmm',
 }
 
-const CUSTOM_DASHBOARD_PREFIX = '/custom-dashboard/'
+const CUSTOM_DASHBOARD_PREFIX = ROUTES.CUSTOM_DASHBOARD.replace(':id', '')
 
 function isGroundControlItem(href: string): boolean {
   if (!href.startsWith(CUSTOM_DASHBOARD_PREFIX)) return false

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -354,27 +354,18 @@ export function MissionSidebar() {
       return
     }
 
-    if (activeMission?.id !== fullScreenMissionFromUrl.id) {
-      setActiveMission(fullScreenMissionFromUrl.id)
-    }
-    if (!isSidebarOpen) {
-      openSidebar()
-    }
-    if (isSidebarMinimized) {
-      expandSidebar()
-    }
-    if (!isFullScreen) {
-      setFullScreen(true)
-    }
+    // Hydrate sidebar state from URL once when view=chat is present.
+    // Deps are limited to URL-derived values only — including isSidebarOpen,
+    // isSidebarMinimized, isFullScreen, or activeMission?.id would make this
+    // effect re-run after user-initiated close/minimize/back actions and undo
+    // them while the URL still shows view=chat (#13149).
+    setActiveMission(fullScreenMissionFromUrl.id)
+    openSidebar() // also clears isSidebarMinimized
+    setFullScreen(true)
   }, [
-    activeMission?.id,
     deepLinkMission,
-    expandSidebar,
     fullScreenMissionFromUrl,
-    isFullScreen,
     isMissionChatView,
-    isSidebarMinimized,
-    isSidebarOpen,
     openSidebar,
     searchParams,
     setActiveMission,
@@ -936,7 +927,15 @@ export function MissionSidebar() {
                 {/* History toggle on mobile — desktop uses a standalone icon button (#10522) */}
                 {isMobile && listTotalMissions > 0 && (
                   <button
-                    onClick={() => { setShowAddMenu(false); toggleHistoryPanel() }}
+                    onClick={() => {
+                      setShowAddMenu(false)
+                      if (activeMission) {
+                        setActiveMission(null)
+                        setShowHistoryPanel(true)
+                      } else {
+                        toggleHistoryPanel()
+                      }
+                    }}
                     className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted/30 text-foreground"
                   >
                     <History className="w-4 h-4 text-muted-foreground" />
@@ -955,10 +954,19 @@ export function MissionSidebar() {
               On mobile, the toggle is inside the + menu to avoid crowding the header. */}
           {!isMobile && (
             <button
-              onClick={toggleHistoryPanel}
+              onClick={() => {
+                if (activeMission) {
+                  // In chat mode the history panel is hidden behind the chat view;
+                  // navigate back to the list and open history so the click is visible.
+                  setActiveMission(null)
+                  setShowHistoryPanel(true)
+                } else {
+                  toggleHistoryPanel()
+                }
+              }}
               className={cn(
                 "relative p-1.5 rounded transition-colors ring-1 mr-1 shrink-0",
-                showHistoryPanel
+                showHistoryPanel && !activeMission
                   ? "bg-primary text-primary-foreground ring-primary"
                   : "bg-secondary/50 text-muted-foreground ring-border hover:bg-secondary hover:text-foreground"
               )}

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -1296,7 +1296,7 @@ export function MissionSidebar() {
                     </button>
                   </div>
                   {/* Panel content */}
-                  <div className="p-1.5">
+                  <div className="min-w-0 p-1.5">
                     {resolutionPanelView === 'related' ? (
                       <ResolutionKnowledgePanel
                         relatedResolutions={relatedResolutions}

--- a/web/src/components/missions/ResolutionHistoryPanel.tsx
+++ b/web/src/components/missions/ResolutionHistoryPanel.tsx
@@ -20,7 +20,7 @@ import {
   Clock,
   Tag,
   AlertCircle,
-  X,
+  ArrowLeft,
 } from 'lucide-react'
 import { useResolutions, type Resolution } from '../../hooks/useResolutions'
 import { cn } from '../../lib/cn'
@@ -127,7 +127,7 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
 
   if (totalResolutions === 0) {
     return (
-      <div className="shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
+      <div className="min-w-0 flex flex-col gap-4">
         <div className="bg-card border border-border rounded-lg p-4">
           <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
             <BookMarked className="w-4 h-4 text-purple-400" />
@@ -148,134 +148,11 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
   }
 
   return (
-    <div className="shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
-      <div className="bg-card border border-border rounded-lg p-4">
-        <div className="flex flex-wrap items-start justify-between gap-2 mb-3">
-          <h4 className="text-sm font-semibold text-foreground flex items-center gap-2 min-w-0">
-            <BookMarked className="w-4 h-4 text-purple-400 shrink-0" />
-            <span className="min-w-0 break-words">{t('navigation.history')}</span>
-            <span className="text-xs text-muted-foreground font-normal shrink-0">
-              {totalResolutions} saved
-            </span>
-          </h4>
-          <div className="flex flex-wrap items-center justify-end gap-2 max-w-full">
-            {selectedIds.size > 0 && (
-              <>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  onClick={handleDeleteSelected}
-                  icon={<Trash2 className="w-3.5 h-3.5" />}
-                >
-                  {t('actions.deleteSelected')} ({selectedIds.size})
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleDeselectAll}
-                >
-                  {t('actions.deselectAll')}
-                </Button>
-              </>
-            )}
-            {selectedIds.size === 0 && totalResolutions > 0 && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleSelectAll}
-                >
-                  {t('actions.selectAll')}
-                </Button>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  onClick={handleClearAll}
-                  icon={<Trash2 className="w-3.5 h-3.5" />}
-                >
-                  {t('actions.clearAll')}
-                </Button>
-              </>
-            )}
-          </div>
-        </div>
-
-        {/* Personal Resolutions */}
-        {resolutions.length > 0 && (
-          <div className="mb-4">
-            <button
-              onClick={() => setShowPersonal(!showPersonal)}
-              className="w-full flex items-center gap-2 text-xs text-muted-foreground mb-2 hover:text-foreground transition-colors"
-            >
-              {showPersonal ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-              <Star className="w-3.5 h-3.5 text-yellow-400" />
-              Your Resolutions ({resolutions.length})
-            </button>
-            {showPersonal && (
-              <div className="space-y-2">
-                {(resolutions || []).map(resolution => (
-                  <ResolutionCard
-                    key={resolution.id}
-                    resolution={resolution}
-                    isExpanded={expandedId === resolution.id}
-                    isSelected={selectedIds.has(resolution.id)}
-                    onToggle={() => toggleExpand(resolution.id)}
-                    onToggleSelect={() => toggleSelect(resolution.id)}
-                    onView={() => setViewingResolution(resolution)}
-                    onApply={onApplyResolution ? () => onApplyResolution(resolution) : undefined}
-                    onDelete={() => handleDelete(resolution.id)}
-                    onShare={() => handleShare(resolution.id)}
-                    onExport={() => setExportResolution(resolution)}
-                    onSubmitToKB={() => setSubmitKBResolution(resolution)}
-                    isDeleteConfirm={deleteConfirmId === resolution.id}
-                    canShare
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Shared Resolutions */}
-        {sharedResolutions.length > 0 && (
-          <div>
-            <button
-              onClick={() => setShowShared(!showShared)}
-              className="w-full flex items-center gap-2 text-xs text-muted-foreground mb-2 hover:text-foreground transition-colors"
-            >
-              {showShared ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-              <Building2 className="w-3.5 h-3.5 text-blue-400" />
-              Team Shared ({sharedResolutions.length})
-            </button>
-            {showShared && (
-              <div className="space-y-2">
-                {(sharedResolutions || []).map(resolution => (
-                  <ResolutionCard
-                    key={resolution.id}
-                    resolution={resolution}
-                    isExpanded={expandedId === resolution.id}
-                    isSelected={selectedIds.has(resolution.id)}
-                    onToggle={() => toggleExpand(resolution.id)}
-                    onToggleSelect={() => toggleSelect(resolution.id)}
-                    onView={() => setViewingResolution(resolution)}
-                    onApply={onApplyResolution ? () => onApplyResolution(resolution) : undefined}
-                    onDelete={() => handleDelete(resolution.id)}
-                    onExport={() => setExportResolution(resolution)}
-                    onSubmitToKB={() => setSubmitKBResolution(resolution)}
-                    isDeleteConfirm={deleteConfirmId === resolution.id}
-                    showSharedBy
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-
-      {viewingResolution && (
-        <ResolutionDetailDialog
+    <div className="min-w-0 flex flex-col gap-4">
+      {viewingResolution ? (
+        <ResolutionDetailPanel
           resolution={viewingResolution}
-          onClose={() => setViewingResolution(null)}
+          onBack={() => setViewingResolution(null)}
           onApply={onApplyResolution ? () => {
             onApplyResolution(viewingResolution)
             setViewingResolution(null)
@@ -284,6 +161,129 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
           onExport={() => setExportResolution(viewingResolution)}
           onSubmitToKB={() => setSubmitKBResolution(viewingResolution)}
         />
+      ) : (
+        <div className="min-w-0 bg-card border border-border rounded-lg p-4">
+          <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
+            <h4 className="text-sm font-semibold text-foreground flex items-center gap-2 min-w-0">
+              <BookMarked className="w-4 h-4 text-purple-400 shrink-0" />
+              <span className="min-w-0 break-words">{t('navigation.history')}</span>
+              <span className="text-xs text-muted-foreground font-normal shrink-0">
+                {totalResolutions} saved
+              </span>
+            </h4>
+            <div className="flex flex-wrap items-center justify-end gap-2 max-w-full">
+              {selectedIds.size > 0 && (
+                <>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    onClick={handleDeleteSelected}
+                    icon={<Trash2 className="w-3.5 h-3.5" />}
+                  >
+                    {t('actions.deleteSelected')} ({selectedIds.size})
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleDeselectAll}
+                  >
+                    {t('actions.deselectAll')}
+                  </Button>
+                </>
+              )}
+              {selectedIds.size === 0 && totalResolutions > 0 && (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleSelectAll}
+                  >
+                    {t('actions.selectAll')}
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    onClick={handleClearAll}
+                    icon={<Trash2 className="w-3.5 h-3.5" />}
+                  >
+                    {t('actions.clearAll')}
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Personal Resolutions */}
+          {resolutions.length > 0 && (
+            <div className="mb-4">
+              <button
+                onClick={() => setShowPersonal(!showPersonal)}
+                className="w-full flex items-center gap-2 text-xs text-muted-foreground mb-2 hover:text-foreground transition-colors"
+              >
+                {showPersonal ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                <Star className="w-3.5 h-3.5 text-yellow-400" />
+                Your Resolutions ({resolutions.length})
+              </button>
+              {showPersonal && (
+                <div className="space-y-2">
+                  {(resolutions || []).map(resolution => (
+                    <ResolutionCard
+                      key={resolution.id}
+                      resolution={resolution}
+                      isExpanded={expandedId === resolution.id}
+                      isSelected={selectedIds.has(resolution.id)}
+                      onToggle={() => toggleExpand(resolution.id)}
+                      onToggleSelect={() => toggleSelect(resolution.id)}
+                      onView={() => setViewingResolution(resolution)}
+                      onApply={onApplyResolution ? () => onApplyResolution(resolution) : undefined}
+                      onDelete={() => handleDelete(resolution.id)}
+                      onShare={() => handleShare(resolution.id)}
+                      onExport={() => setExportResolution(resolution)}
+                      onSubmitToKB={() => setSubmitKBResolution(resolution)}
+                      isDeleteConfirm={deleteConfirmId === resolution.id}
+                      canShare
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Shared Resolutions */}
+          {sharedResolutions.length > 0 && (
+            <div>
+              <button
+                onClick={() => setShowShared(!showShared)}
+                className="w-full flex items-center gap-2 text-xs text-muted-foreground mb-2 hover:text-foreground transition-colors"
+              >
+                {showShared ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                <Building2 className="w-3.5 h-3.5 text-blue-400" />
+                Team Shared ({sharedResolutions.length})
+              </button>
+              {showShared && (
+                <div className="space-y-2">
+                  {(sharedResolutions || []).map(resolution => (
+                    <ResolutionCard
+                      key={resolution.id}
+                      resolution={resolution}
+                      isExpanded={expandedId === resolution.id}
+                      isSelected={selectedIds.has(resolution.id)}
+                      onToggle={() => toggleExpand(resolution.id)}
+                      onToggleSelect={() => toggleSelect(resolution.id)}
+                      onView={() => setViewingResolution(resolution)}
+                      onApply={onApplyResolution ? () => onApplyResolution(resolution) : undefined}
+                      onDelete={() => handleDelete(resolution.id)}
+                      onExport={() => setExportResolution(resolution)}
+                      onSubmitToKB={() => setSubmitKBResolution(resolution)}
+                      isDeleteConfirm={deleteConfirmId === resolution.id}
+                      showSharedBy
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       )}
 
       {/* Export dialog */}
@@ -517,23 +517,23 @@ function ResolutionCard({
   )
 }
 
-interface ResolutionDetailDialogProps {
+interface ResolutionDetailPanelProps {
   resolution: Resolution
-  onClose: () => void
+  onBack: () => void
   onApply?: () => void
   onShare?: () => void
   onExport: () => void
   onSubmitToKB: () => void
 }
 
-function ResolutionDetailDialog({
+function ResolutionDetailPanel({
   resolution,
-  onClose,
+  onBack,
   onApply,
   onShare,
   onExport,
   onSubmitToKB,
-}: ResolutionDetailDialogProps) {
+}: ResolutionDetailPanelProps) {
   const { t } = useTranslation()
   const { effectiveness } = resolution
   const successRate = effectiveness.timesUsed > 0
@@ -541,52 +541,50 @@ function ResolutionDetailDialog({
     : null
 
   return (
-    <div
-      className="fixed inset-0 z-modal flex items-center justify-center bg-black/60 backdrop-blur-xs p-4"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) {
-          onClose()
-        }
-      }}
-    >
-      <div className="w-full max-w-4xl max-h-[90vh] overflow-hidden rounded-xl border border-border bg-card shadow-2xl flex flex-col">
-        <div className="flex items-start justify-between gap-4 border-b border-border px-5 py-4 shrink-0">
-          <div className="min-w-0 space-y-2">
+    <div className="min-w-0 overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+      <div className="flex flex-col border-b border-border px-4 py-3 sm:px-5 sm:py-4 gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1 space-y-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onBack}
+              icon={<ArrowLeft className="w-4 h-4" />}
+              className="w-full justify-start sm:w-auto"
+            >
+              {t('common.back', { defaultValue: 'Back' })}
+            </Button>
             <h3 className="text-lg font-semibold text-foreground break-words">{resolution.title}</h3>
-            <div className="flex flex-wrap items-center gap-2 text-2xs text-muted-foreground">
-              <span className="inline-flex items-center gap-1 rounded-full border border-border bg-secondary/40 px-2 py-1">
-                <Tag className="w-3 h-3" />
-                {resolution.issueSignature.type}
-                {resolution.issueSignature.resourceKind ? ` (${resolution.issueSignature.resourceKind})` : ''}
-              </span>
-              <span className="inline-flex items-center gap-1 rounded-full border border-border bg-secondary/40 px-2 py-1">
-                <Clock className="w-3 h-3" />
-                {new Date(resolution.createdAt).toLocaleString()}
-              </span>
-              {successRate !== null && (
-                <span className="inline-flex items-center gap-1 rounded-full border border-border bg-secondary/40 px-2 py-1 text-green-400">
-                  <CheckCircle className="w-3 h-3" />
-                  {effectiveness.timesSuccessful}/{effectiveness.timesUsed} · {successRate}%
-                </span>
-              )}
-              {resolution.sharedBy && (
-                <span className="inline-flex items-center gap-1 rounded-full border border-border bg-secondary/40 px-2 py-1 text-blue-400">
-                  @{resolution.sharedBy}
-                </span>
-              )}
-            </div>
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onClose}
-            icon={<X className="w-4 h-4" />}
-          >
-            {t('actions.close')}
-          </Button>
         </div>
+        <div className="flex flex-wrap items-center gap-2 text-2xs text-muted-foreground min-w-0">
+          <span className="inline-flex max-w-full items-center gap-1 rounded-full border border-border bg-secondary/40 px-2 py-1 break-words">
+            <Tag className="w-3 h-3 shrink-0" />
+            <span className="break-words">
+              {resolution.issueSignature.type}
+              {resolution.issueSignature.resourceKind ? ` (${resolution.issueSignature.resourceKind})` : ''}
+            </span>
+          </span>
+          <span className="inline-flex max-w-full items-center gap-1 rounded-full border border-border bg-secondary/40 px-2 py-1 break-words">
+            <Clock className="w-3 h-3 shrink-0" />
+            <span className="break-words">{new Date(resolution.createdAt).toLocaleString()}</span>
+          </span>
+          {successRate !== null && (
+            <span className="inline-flex max-w-full items-center gap-1 rounded-full border border-border bg-secondary/40 px-2 py-1 text-green-400 break-words">
+              <CheckCircle className="w-3 h-3 shrink-0" />
+              <span className="break-words">{effectiveness.timesSuccessful}/{effectiveness.timesUsed} · {successRate}%</span>
+            </span>
+          )}
+          {resolution.sharedBy && (
+            <span className="inline-flex max-w-full items-center gap-1 rounded-full border border-border bg-secondary/40 px-2 py-1 text-blue-400 break-words">
+              <span className="break-words">@{resolution.sharedBy}</span>
+            </span>
+          )}
+        </div>
+      </div>
 
-        <div className="flex-1 overflow-y-auto scroll-enhanced px-5 py-4 space-y-5">
+      <div className="flex max-h-[calc(100vh-16rem)] min-h-0 flex-col">
+        <div className="min-h-0 flex-1 overflow-y-auto scroll-enhanced px-4 py-4 sm:px-5 space-y-5">
           <section className="space-y-2">
             <h4 className="text-sm font-semibold text-foreground">{t('common.summary')}</h4>
             <div className="rounded-lg border border-border bg-secondary/20 p-4 text-sm leading-relaxed text-foreground break-words whitespace-pre-wrap">
@@ -601,7 +599,7 @@ function ResolutionDetailDialog({
                 {(resolution.resolution.steps || []).map((step, index) => (
                   <li key={`${resolution.id}-step-${index}`} className="rounded-lg border border-border bg-secondary/20 p-4 text-sm text-foreground break-words">
                     <span className="font-medium text-primary mr-2">{index + 1}.</span>
-                    <span className="whitespace-pre-wrap">{step}</span>
+                    <span className="whitespace-pre-wrap break-words">{step}</span>
                   </li>
                 ))}
               </ol>
@@ -611,20 +609,22 @@ function ResolutionDetailDialog({
           {resolution.resolution.yaml && (
             <section className="space-y-2">
               <h4 className="text-sm font-semibold text-foreground">{t('yaml', { defaultValue: 'YAML' })}</h4>
-              <pre className="rounded-lg border border-border bg-background p-4 text-xs text-foreground overflow-x-auto whitespace-pre-wrap break-words">
+              <pre className="rounded-lg border border-border bg-background p-4 text-xs text-foreground overflow-x-auto whitespace-pre-wrap break-words max-w-full">
                 {resolution.resolution.yaml}
               </pre>
             </section>
           )}
         </div>
 
-        <div className="flex flex-wrap items-center justify-end gap-2 border-t border-border px-5 py-4 shrink-0">
+        <div className="flex shrink-0 flex-col gap-2 border-t border-border px-4 py-3 sm:flex-row sm:flex-wrap sm:justify-end sm:px-5 sm:py-4">
           {onShare && (
             <Button
               variant="secondary"
               size="sm"
               onClick={onShare}
               icon={<Share2 className="w-3.5 h-3.5" />}
+              fullWidth
+              className="sm:w-auto"
             >
               {t('share', { defaultValue: 'Share' })}
             </Button>
@@ -634,6 +634,8 @@ function ResolutionDetailDialog({
             size="sm"
             onClick={onExport}
             icon={<Download className="w-3.5 h-3.5" />}
+            fullWidth
+            className="sm:w-auto"
           >
             {t('common.export')}
           </Button>
@@ -642,6 +644,8 @@ function ResolutionDetailDialog({
             size="sm"
             onClick={onSubmitToKB}
             icon={<BookUp className="w-3.5 h-3.5" />}
+            fullWidth
+            className="sm:w-auto"
           >
             {t('common.submit')}
           </Button>
@@ -651,6 +655,8 @@ function ResolutionDetailDialog({
               size="sm"
               onClick={onApply}
               icon={<CheckCircle className="w-3.5 h-3.5" />}
+              fullWidth
+              className="sm:w-auto"
             >
               {t('actions.apply')}
             </Button>

--- a/web/src/components/settings/sections/LocalClustersSection.tsx
+++ b/web/src/components/settings/sections/LocalClustersSection.tsx
@@ -111,10 +111,12 @@ function getVClusterActionMessage(feedback: VClusterActionFeedback, t: TFunction
   if (feedback.state === 'error') {
     return feedback.message
       ? friendlyErrorMessage(feedback.message)
-      : String(t(`${keyBase}Fallback`, { name: feedback.name, namespace: feedback.namespace, defaultValue: '' }))
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      : String(t(`${keyBase}Fallback` as any, { name: feedback.name, namespace: feedback.namespace }))
   }
 
-  return String(t(keyBase, { name: feedback.name, namespace: feedback.namespace, defaultValue: '' }))
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return String(t(keyBase as any, { name: feedback.name, namespace: feedback.namespace }))
 }
 
 function VClusterActionBanner({

--- a/web/src/hooks/useMissionStorage.ts
+++ b/web/src/hooks/useMissionStorage.ts
@@ -278,3 +278,11 @@ export function getSelectedKagentiAgentFromStorage(): { name: string; namespace:
     return null
   }
 }
+
+export function persistSelectedKagentiAgentToStorage(agent: { name: string; namespace: string }): void {
+  try {
+    localStorage.setItem(KAGENTI_SELECTED_AGENT_KEY, `${agent.namespace}/${agent.name}`)
+  } catch {
+    // Ignore localStorage errors.
+  }
+}

--- a/web/src/hooks/useMissionToolCheck.ts
+++ b/web/src/hooks/useMissionToolCheck.ts
@@ -46,7 +46,7 @@ export function useMissionToolCheck({
   })
 
   useEffect(() => {
-    if (!enabled || !isConnected || requiredTools.length === 0) {
+    if (!enabled || !isConnected || requiredTools.length === 0 || !LOCAL_AGENT_HTTP_URL) {
       setResult({ status: 'idle', missingTools: [], errorMessage: undefined })
       return
     }

--- a/web/src/hooks/useMissions.provider-start.test.tsx
+++ b/web/src/hooks/useMissions.provider-start.test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { MissionProvider, useMissions } from './useMissions'
 import { getDemoMode } from './useDemoMode'
 import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
+import { discoverKagentiProviderAgent, kagentiProviderChat } from '../lib/kagentiProviderBackend'
 
 // ── External module mocks ─────────────────────────────────────────────────────
 
@@ -75,6 +76,13 @@ vi.mock('../lib/missions/scanner/malicious', () => ({
 
 vi.mock('../lib/kubectlProxy', () => ({
   kubectlProxy: { exec: vi.fn() },
+}))
+
+vi.mock('../lib/kagentiProviderBackend', () => ({
+  discoverKagentiProviderAgent: vi.fn(),
+  fetchKagentiProviderAgents: vi.fn(),
+  fetchKagentiProviderStatus: vi.fn(),
+  kagentiProviderChat: vi.fn(),
 }))
 
 // ── Mock WebSocket ─────────────────────────────────────────────────────────────
@@ -473,6 +481,82 @@ describe('startMission', () => {
     // Use expect.anything() so this assertion stays valid as the 3rd arg
     // evolves (test exists to verify the type+code, not the message body).
     expect(emitMissionError).toHaveBeenCalledWith('troubleshoot', 'test_err', expect.anything())
+  })
+
+  it('persists an auto-discovered kagenti agent before starting the mission', async () => {
+    vi.mocked(discoverKagentiProviderAgent).mockResolvedValueOnce({
+      ok: true,
+      agent: { name: 'agent-a', namespace: 'agents' },
+    })
+    vi.mocked(kagentiProviderChat).mockImplementationOnce(async (_agent, _namespace, _message, options) => {
+      options.onDone()
+    })
+
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    act(() => {
+      result.current.selectAgent('kagenti')
+    })
+
+    act(() => {
+      result.current.startMission(defaultParams)
+    })
+
+    await waitFor(() => expect(localStorage.getItem('kc_kagenti_selected_agent')).toBe('agents/agent-a'))
+    expect(kagentiProviderChat).toHaveBeenCalledWith(
+      'agent-a',
+      'agents',
+      defaultParams.initialPrompt,
+      expect.objectContaining({ contextId: expect.any(String) }),
+    )
+  })
+
+  it('shows a provider unavailable error when kagenti discovery cannot reach the provider', async () => {
+    vi.mocked(discoverKagentiProviderAgent).mockResolvedValueOnce({
+      ok: false,
+      reason: 'provider_unreachable',
+      detail: 'unreachable',
+    })
+
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    act(() => {
+      result.current.selectAgent('kagenti')
+    })
+
+    let missionId = ''
+    act(() => {
+      missionId = result.current.startMission(defaultParams)
+    })
+
+    await waitFor(() => {
+      const mission = result.current.missions.find(m => m.id === missionId)
+      expect(mission?.status).toBe('failed')
+      expect((mission?.messages || []).some(message => message.content.includes('Kagenti provider unavailable'))).toBe(true)
+    })
+    expect(emitMissionError).toHaveBeenCalledWith('troubleshoot', 'kagenti_provider_unavailable', 'provider_unreachable')
+  })
+
+  it('shows a zero-agents error when kagenti discovery succeeds but no agents are registered', async () => {
+    vi.mocked(discoverKagentiProviderAgent).mockResolvedValueOnce({
+      ok: false,
+      reason: 'no_agents_discovered',
+    })
+
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    act(() => {
+      result.current.selectAgent('kagenti')
+    })
+
+    let missionId = ''
+    act(() => {
+      missionId = result.current.startMission(defaultParams)
+    })
+
+    await waitFor(() => {
+      const mission = result.current.missions.find(m => m.id === missionId)
+      expect(mission?.status).toBe('failed')
+      expect((mission?.messages || []).some(message => message.content.includes('No Kagenti agents discovered'))).toBe(true)
+    })
+    expect(emitMissionError).toHaveBeenCalledWith('troubleshoot', 'kagenti_no_agents_discovered', 'no_agents_discovered')
   })
 
   it('transitions mission to failed when connection cannot be established', async () => {

--- a/web/src/hooks/useMissions.provider.tsx
+++ b/web/src/hooks/useMissions.provider.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useMemo, ReactNode } from 'react'
+import i18n from '../lib/i18n'
 import type { AgentInfo, AgentsListPayload, AgentSelectedPayload, ChatStreamPayload } from '../types/agent'
 import { AgentCapabilityToolExec } from '../types/agent'
 import type { Mission, MissionMessage, MissionStatus, MissionFeedback, StartMissionParams, PendingReviewEntry, SaveMissionParams, SavedMissionUpdates } from './useMissionTypes'
@@ -16,13 +17,17 @@ import { getTokenCategoryForMissionType } from '../lib/tokenUsageMissionCategory
 import { MS_PER_MINUTE, SECONDS_PER_DAY } from '../lib/constants/time'
 import { runPreflightCheck, type PreflightResult } from '../lib/missions/preflightCheck'
 import { kubectlProxy } from '../lib/kubectlProxy'
-import { kagentiProviderChat, fetchKagentiProviderAgents } from '../lib/kagentiProviderBackend'
+import {
+  kagentiProviderChat,
+  discoverKagentiProviderAgent,
+  type KagentiProviderAgentDiscoveryResult,
+} from '../lib/kagentiProviderBackend'
 import { ConfirmMissionPromptDialog } from '../components/missions/ConfirmMissionPromptDialog'
 import {
   MISSIONS_STORAGE_KEY, CROSS_TAB_ECHO_IGNORE_MS,
   SELECTED_AGENT_KEY,
   loadMissions, saveMissions, loadUnreadMissionIds, saveUnreadMissionIds,
-  mergeMissions, getSelectedKagentiAgentFromStorage,
+  mergeMissions, getSelectedKagentiAgentFromStorage, persistSelectedKagentiAgentToStorage,
 } from './useMissionStorage'
 import {
   generateMessageId, buildEnhancedPrompt, buildSystemMessages,
@@ -31,6 +36,20 @@ import {
 
 function getMissionMessages(messages?: MissionMessage[]): MissionMessage[] {
   return messages || []
+}
+
+const KAGENTI_PROVIDER_UNAVAILABLE_EVENT = 'kagenti_provider_unavailable'
+const KAGENTI_NO_AGENTS_DISCOVERED_EVENT = 'kagenti_no_agents_discovered'
+
+type KagentiDiscoveryFailure = Extract<KagentiProviderAgentDiscoveryResult, { ok: false }>
+
+function buildKagentiDiscoveryErrorMessage(result: KagentiDiscoveryFailure): string {
+  if (result.reason === 'provider_unreachable') {
+    const reasonSuffix = result.detail ? ` (${result.detail})` : ''
+    return `**${i18n.t('missions.kagenti.providerUnavailableTitle')}**\n\n${i18n.t('missions.kagenti.providerUnavailableDescription', { reasonSuffix })}`
+  }
+
+  return `**${i18n.t('missions.kagenti.noAgentsTitle')}**\n\n${i18n.t('missions.kagenti.noAgentsDescription')}`
 }
 
 const MISSION_RECONNECT_DELAY_MS = 500
@@ -2084,38 +2103,43 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
       void (async () => {
         let target = getSelectedKagentiAgentFromStorage()
         if (!target) {
-          const discovered = await fetchKagentiProviderAgents()
-          if (discovered?.[0]) {
+          const discovery = await discoverKagentiProviderAgent()
+          if (discovery.ok) {
             target = {
-              namespace: discovered[0].namespace,
-              name: discovered[0].name,
+              namespace: discovery.agent.namespace,
+              name: discovery.agent.name,
             }
+            persistSelectedKagentiAgentToStorage(target)
+          } else {
+            executingMissions.current.delete(missionId)
+            const errorContent = buildKagentiDiscoveryErrorMessage(discovery)
+            setMissions(prev => prev.map(m =>
+              m.id === missionId
+                ? {
+                    ...m,
+                    status: 'failed',
+                    currentStep: undefined,
+                    messages: [
+                      ...getMissionMessages(m.messages),
+                      {
+                        id: generateMessageId('kagenti-missing-agent'),
+                        role: 'system',
+                        content: errorContent,
+                        timestamp: new Date(),
+                      },
+                    ],
+                  }
+                : m
+            ))
+            emitMissionError(
+              missionType,
+              discovery.reason === 'provider_unreachable'
+                ? KAGENTI_PROVIDER_UNAVAILABLE_EVENT
+                : KAGENTI_NO_AGENTS_DISCOVERED_EVENT,
+              discovery.reason,
+            )
+            return
           }
-        }
-
-        if (!target) {
-          executingMissions.current.delete(missionId)
-          const errorContent = `**Kagenti Agent Not Selected**\n\nSelect a Kagenti agent in Settings → Agent Backend, then retry this mission.`
-          setMissions(prev => prev.map(m =>
-            m.id === missionId
-              ? {
-                  ...m,
-                  status: 'failed',
-                  currentStep: undefined,
-                  messages: [
-                    ...getMissionMessages(m.messages),
-                    {
-                      id: generateMessageId('kagenti-missing-agent'),
-                      role: 'system',
-                      content: errorContent,
-                      timestamp: new Date(),
-                    },
-                  ],
-                }
-              : m
-          ))
-          emitMissionError(missionType, 'kagenti_agent_missing', 'no_selected_kagenti_agent')
-          return
         }
 
         await kagentiProviderChat(target.name, target.namespace, enhancedPrompt, {

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useMemo, useState, useRef, useEffect, ReactNode } from 'react'
+import i18n from '../lib/i18n'
 import type { AgentInfo, AgentsListPayload, AgentSelectedPayload, ChatStreamPayload } from '../types/agent'
 import { AgentCapabilityToolExec } from '../types/agent'
 import { getDemoMode } from './useDemoMode'
@@ -19,7 +20,11 @@ import {
   type PreflightResult,
 } from '../lib/missions/preflightCheck'
 import { kubectlProxy } from '../lib/kubectlProxy'
-import { kagentiProviderChat, fetchKagentiProviderAgents } from '../lib/kagentiProviderBackend'
+import {
+  kagentiProviderChat,
+  discoverKagentiProviderAgent,
+  type KagentiProviderAgentDiscoveryResult,
+} from '../lib/kagentiProviderBackend'
 import { ConfirmMissionPromptDialog } from '../components/missions/ConfirmMissionPromptDialog'
 // Sub-modules extracted from this file (#8624)
 export type {
@@ -35,7 +40,7 @@ import {
   MISSIONS_STORAGE_KEY, CROSS_TAB_ECHO_IGNORE_MS,
   SELECTED_AGENT_KEY,
   loadMissions, saveMissions, loadUnreadMissionIds, saveUnreadMissionIds,
-  mergeMissions, getSelectedKagentiAgentFromStorage,
+  mergeMissions, getSelectedKagentiAgentFromStorage, persistSelectedKagentiAgentToStorage,
 } from './useMissionStorage'
 import {
   generateMessageId, buildEnhancedPrompt, buildSystemMessages,
@@ -180,6 +185,20 @@ function buildMissingToolWarning(error: PreflightError): string {
     : error.message
 
   return `${MISSING_TOOL_WARNING_HEADING}\n\n${toolSummary}\n\n${MISSING_TOOL_WARNING_SUFFIX}`
+}
+
+const KAGENTI_PROVIDER_UNAVAILABLE_EVENT = 'kagenti_provider_unavailable'
+const KAGENTI_NO_AGENTS_DISCOVERED_EVENT = 'kagenti_no_agents_discovered'
+
+type KagentiDiscoveryFailure = Extract<KagentiProviderAgentDiscoveryResult, { ok: false }>
+
+function buildKagentiDiscoveryErrorMessage(result: KagentiDiscoveryFailure): string {
+  if (result.reason === 'provider_unreachable') {
+    const reasonSuffix = result.detail ? ` (${result.detail})` : ''
+    return `**${i18n.t('missions.kagenti.providerUnavailableTitle')}**\n\n${i18n.t('missions.kagenti.providerUnavailableDescription', { reasonSuffix })}`
+  }
+
+  return `**${i18n.t('missions.kagenti.noAgentsTitle')}**\n\n${i18n.t('missions.kagenti.noAgentsDescription')}`
 }
 
 /**
@@ -2267,38 +2286,43 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
       void (async () => {
         let target = getSelectedKagentiAgentFromStorage()
         if (!target) {
-          const discovered = await fetchKagentiProviderAgents()
-          if ((discovered || []).length > 0) {
+          const discovery = await discoverKagentiProviderAgent()
+          if (discovery.ok) {
             target = {
-              namespace: discovered[0].namespace,
-              name: discovered[0].name,
+              namespace: discovery.agent.namespace,
+              name: discovery.agent.name,
             }
+            persistSelectedKagentiAgentToStorage(target)
+          } else {
+            executingMissions.current.delete(missionId)
+            const errorContent = buildKagentiDiscoveryErrorMessage(discovery)
+            setMissions(prev => prev.map(m =>
+              m.id === missionId
+                ? {
+                    ...m,
+                    status: 'failed',
+                    currentStep: undefined,
+                    messages: [
+                      ...getMissionMessages(m.messages),
+                      {
+                        id: generateMessageId('kagenti-missing-agent'),
+                        role: 'system',
+                        content: errorContent,
+                        timestamp: new Date(),
+                      },
+                    ],
+                  }
+                : m
+            ))
+            emitMissionError(
+              missionType,
+              discovery.reason === 'provider_unreachable'
+                ? KAGENTI_PROVIDER_UNAVAILABLE_EVENT
+                : KAGENTI_NO_AGENTS_DISCOVERED_EVENT,
+              discovery.reason,
+            )
+            return
           }
-        }
-
-        if (!target) {
-          executingMissions.current.delete(missionId)
-          const errorContent = `**Kagenti Agent Not Selected**\n\nSelect a Kagenti agent in Settings → Agent Backend, then retry this mission.`
-          setMissions(prev => prev.map(m =>
-            m.id === missionId
-              ? {
-                  ...m,
-                  status: 'failed',
-                  currentStep: undefined,
-                  messages: [
-                    ...getMissionMessages(m.messages),
-                    {
-                      id: generateMessageId('kagenti-missing-agent'),
-                      role: 'system',
-                      content: errorContent,
-                      timestamp: new Date(),
-                    },
-                  ],
-                }
-              : m
-          ))
-          emitMissionError(missionType, 'kagenti_agent_missing', 'no_selected_kagenti_agent')
-          return
         }
 
         await kagentiProviderChat(target.name, target.namespace, enhancedPrompt, {
@@ -2960,38 +2984,43 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       void (async () => {
         let target = getSelectedKagentiAgentFromStorage()
         if (!target) {
-          const discovered = await fetchKagentiProviderAgents()
-          if ((discovered || []).length > 0) {
+          const discovery = await discoverKagentiProviderAgent()
+          if (discovery.ok) {
             target = {
-              namespace: discovered[0].namespace,
-              name: discovered[0].name,
+              namespace: discovery.agent.namespace,
+              name: discovery.agent.name,
             }
+            persistSelectedKagentiAgentToStorage(target)
+          } else {
+            executingMissions.current.delete(missionId)
+            const errorContent = buildKagentiDiscoveryErrorMessage(discovery)
+            setMissions(prev => prev.map(m =>
+              m.id === missionId
+                ? {
+                    ...m,
+                    status: 'failed',
+                    currentStep: undefined,
+                    messages: [
+                      ...getMissionMessages(m.messages),
+                      {
+                        id: generateMessageId('kagenti-missing-agent'),
+                        role: 'system',
+                        content: errorContent,
+                        timestamp: new Date(),
+                      },
+                    ],
+                  }
+                : m
+            ))
+            emitMissionError(
+              missionType,
+              discovery.reason === 'provider_unreachable'
+                ? KAGENTI_PROVIDER_UNAVAILABLE_EVENT
+                : KAGENTI_NO_AGENTS_DISCOVERED_EVENT,
+              discovery.reason,
+            )
+            return
           }
-        }
-
-        if (!target) {
-          executingMissions.current.delete(missionId)
-          const errorContent = `**Kagenti Agent Not Selected**\n\nSelect a Kagenti agent in Settings → Agent Backend, then retry this mission.`
-          setMissions(prev => prev.map(m =>
-            m.id === missionId
-              ? {
-                  ...m,
-                  status: 'failed',
-                  currentStep: undefined,
-                  messages: [
-                    ...getMissionMessages(m.messages),
-                    {
-                      id: generateMessageId('kagenti-missing-agent'),
-                      role: 'system',
-                      content: errorContent,
-                      timestamp: new Date(),
-                    },
-                  ],
-                }
-              : m
-          ))
-          emitMissionError(missionType, 'kagenti_agent_missing', 'no_selected_kagenti_agent')
-          return
         }
 
         await kagentiProviderChat(target.name, target.namespace, content, {

--- a/web/src/lib/__tests__/kagentiProviderBackend.test.ts
+++ b/web/src/lib/__tests__/kagentiProviderBackend.test.ts
@@ -12,6 +12,7 @@ const mockAuthFetch = vi.mocked(authFetch)
 // Import the module under test (need to import after mock setup)
 let fetchKagentiProviderStatus: typeof import('../kagentiProviderBackend').fetchKagentiProviderStatus
 let fetchKagentiProviderAgents: typeof import('../kagentiProviderBackend').fetchKagentiProviderAgents
+let discoverKagentiProviderAgent: typeof import('../kagentiProviderBackend').discoverKagentiProviderAgent
 let updateKagentiProviderConfig: typeof import('../kagentiProviderBackend').updateKagentiProviderConfig
 let kagentiProviderCallTool: typeof import('../kagentiProviderBackend').kagentiProviderCallTool
 let kagentiProviderChat: typeof import('../kagentiProviderBackend').kagentiProviderChat
@@ -21,6 +22,7 @@ beforeEach(async () => {
   const mod = await import('../kagentiProviderBackend')
   fetchKagentiProviderStatus = mod.fetchKagentiProviderStatus
   fetchKagentiProviderAgents = mod.fetchKagentiProviderAgents
+  discoverKagentiProviderAgent = mod.discoverKagentiProviderAgent
   updateKagentiProviderConfig = mod.updateKagentiProviderConfig
   kagentiProviderCallTool = mod.kagentiProviderCallTool
   kagentiProviderChat = mod.kagentiProviderChat
@@ -117,6 +119,15 @@ describe('fetchKagentiProviderAgents', () => {
     expect(result).toEqual([])
   })
 
+  it('throws on HTTP error when strict discovery is requested', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+    } as Response)
+
+    await expect(fetchKagentiProviderAgents({ throwOnUnavailable: true })).rejects.toThrow('HTTP 503')
+  })
+
   it('returns empty array on network error', async () => {
     mockAuthFetch.mockRejectedValueOnce(new Error('Timeout'))
 
@@ -132,6 +143,55 @@ describe('fetchKagentiProviderAgents', () => {
 
     const result = await fetchKagentiProviderAgents()
     expect(result).toEqual([])
+  })
+})
+
+describe('discoverKagentiProviderAgent', () => {
+  it('returns the first discovered agent when the provider is available', async () => {
+    mockAuthFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ available: true }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ agents: [{ name: 'agent-1', namespace: 'default' }] }),
+      } as Response)
+
+    await expect(discoverKagentiProviderAgent()).resolves.toEqual({
+      ok: true,
+      agent: { name: 'agent-1', namespace: 'default' },
+    })
+  })
+
+  it('reports provider_unreachable when status is unavailable', async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ available: false, reason: 'unreachable' }),
+    } as Response)
+
+    await expect(discoverKagentiProviderAgent()).resolves.toEqual({
+      ok: false,
+      reason: 'provider_unreachable',
+      detail: 'unreachable',
+    })
+  })
+
+  it('reports no_agents_discovered when the provider is reachable but returns zero agents', async () => {
+    mockAuthFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ available: true }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ agents: [] }),
+      } as Response)
+
+    await expect(discoverKagentiProviderAgent()).resolves.toEqual({
+      ok: false,
+      reason: 'no_agents_discovered',
+    })
   })
 })
 

--- a/web/src/lib/constants/storage.ts
+++ b/web/src/lib/constants/storage.ts
@@ -108,3 +108,6 @@ export const STORAGE_KEY_NS_OVERVIEW_NAMESPACE = 'kc-ns-overview-namespace'
 // AI/ML endpoint management pattern.
 export const STORAGE_KEY_DRASI_CONNECTIONS = 'ksc-drasi-connections'
 export const STORAGE_KEY_DRASI_ACTIVE_CONNECTION = 'ksc-drasi-active-connection'
+
+// ── Banners ───────────────────────────────────────────────────────────
+export const STORAGE_KEY_AUTONOMOUS_BANNER_DISMISSED = 'kc-autonomous-banner-dismissed'

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -94,8 +94,8 @@ export const DEFAULT_PAGE_SIZE = 5
 // ── Layout dimensions ──────────────────────────────────────────────────
 /** Height of the top navbar in pixels (h-16 = 64px) */
 export const NAVBAR_HEIGHT_PX = 64
-/** Height of each status banner (network, demo, offline) in pixels */
-export const BANNER_HEIGHT_PX = 36
+/** Height of each status banner (network, demo, offline) in pixels — matches min-h-11 (44px) dismiss buttons */
+export const BANNER_HEIGHT_PX = 44
 /** Collapse mobile banner stacks into a summary row once this many alerts are active. */
 export const MOBILE_BANNER_COLLAPSE_THRESHOLD = 2
 /** Root CSS variable used to push dashboard content below the open filter panel */

--- a/web/src/lib/kagentiProviderBackend.ts
+++ b/web/src/lib/kagentiProviderBackend.ts
@@ -34,6 +34,15 @@ export interface KagentiProviderConfigStatus {
   configured_providers?: KagentiLLMProvider[]
 }
 
+export interface FetchKagentiProviderAgentsOptions {
+  signal?: AbortSignal
+  throwOnUnavailable?: boolean
+}
+
+export type KagentiProviderAgentDiscoveryResult =
+  | { ok: true; agent: KagentiProviderAgent }
+  | { ok: false; reason: 'provider_unreachable' | 'no_agents_discovered'; detail?: string }
+
 function getRequestSignal(timeoutMs: number, signal?: AbortSignal): AbortSignal {
   const timeoutSignal = AbortSignal.timeout(timeoutMs)
   return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
@@ -54,19 +63,63 @@ export async function fetchKagentiProviderStatus(options: { signal?: AbortSignal
   }
 }
 
-export async function fetchKagentiProviderAgents(options: { signal?: AbortSignal } = {}): Promise<KagentiProviderAgent[]> {
+export async function fetchKagentiProviderAgents(options: FetchKagentiProviderAgentsOptions = {}): Promise<KagentiProviderAgent[]> {
   try {
     const resp = await authFetch(`${API_BASE}/api/kagenti-provider/agents`, {
       signal: getRequestSignal(KAGENTI_STATUS_TIMEOUT_MS, options.signal),
     })
-    if (!resp.ok) return []
+    if (!resp.ok) {
+      if (options.throwOnUnavailable) {
+        throw new Error(`HTTP ${resp.status}`)
+      }
+      return []
+    }
     const data = await resp.json()
     return data.agents || []
   } catch (error: unknown) {
     if (error instanceof DOMException && error.name === 'AbortError') {
       throw error
     }
+    if (options.throwOnUnavailable) {
+      throw error instanceof Error ? error : new Error(String(error))
+    }
     return []
+  }
+}
+
+export async function discoverKagentiProviderAgent(options: { signal?: AbortSignal } = {}): Promise<KagentiProviderAgentDiscoveryResult> {
+  const status = await fetchKagentiProviderStatus(options)
+  if (!status.available) {
+    return {
+      ok: false,
+      reason: 'provider_unreachable',
+      detail: status.reason,
+    }
+  }
+
+  try {
+    const agents = await fetchKagentiProviderAgents({ ...options, throwOnUnavailable: true })
+    const discoveredAgent = agents[0]
+    if (!discoveredAgent) {
+      return {
+        ok: false,
+        reason: 'no_agents_discovered',
+      }
+    }
+
+    return {
+      ok: true,
+      agent: discoveredAgent,
+    }
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error
+    }
+    return {
+      ok: false,
+      reason: 'provider_unreachable',
+      detail: error instanceof Error ? error.message : String(error),
+    }
   }
 }
 

--- a/web/src/lib/missions/__tests__/preflightCheck-tooltool.test.ts
+++ b/web/src/lib/missions/__tests__/preflightCheck-tooltool.test.ts
@@ -97,6 +97,15 @@ describe('runToolPreflightCheck', () => {
     expect(result.error).toBeUndefined()
   })
 
+  it('skips the local tool preflight when the agent base URL is empty', async () => {
+    const mockFetch = vi.mocked(fetch)
+
+    const result = await runToolPreflightCheck('', ['kubectl'])
+
+    expect(result).toEqual({ ok: true, tools: [] })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
   it('returns ok:false with MISSING_TOOLS when a required tool is absent', async () => {
     const mockFetch = vi.mocked(fetch)
     mockFetch.mockResolvedValueOnce({

--- a/web/src/lib/missions/preflightCheck.ts
+++ b/web/src/lib/missions/preflightCheck.ts
@@ -487,8 +487,16 @@ export async function runToolPreflightCheck(
   requiredTools: string[],
   fetchFn: typeof fetch = fetch,
 ): Promise<ToolPreflightResult> {
+  const normalizedAgentBaseUrl = agentBaseUrl.trim()
+  if (!normalizedAgentBaseUrl) {
+    return {
+      ok: true,
+      tools: [],
+    }
+  }
+
   try {
-    const url = new URL('/local-cluster-tools', agentBaseUrl)
+    const url = new URL('/local-cluster-tools', normalizedAgentBaseUrl)
     const normalizedRequiredTools = [...new Set(requiredTools.map(tool => tool.toLowerCase()))]
     normalizedRequiredTools.forEach(tool => url.searchParams.append('tool', tool))
 

--- a/web/src/lib/prefetchDashboard.ts
+++ b/web/src/lib/prefetchDashboard.ts
@@ -80,8 +80,8 @@ const CARD_DATA_PREFETCH: Record<string, Array<{ key: string; fetcher: () => Pro
 /** Avoid re-triggering for the same link on repeated hover */
 let lastPrefetchedHref: string | null = null
 
-export function prefetchDashboard(href: string): void {
-  if (href === lastPrefetchedHref) return
+export function prefetchDashboard(href?: string | null): void {
+  if (!href || href === lastPrefetchedHref) return
   lastPrefetchedHref = href
 
   // Demo mode uses synchronous data — no fetching needed

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3975,6 +3975,9 @@
     "startingUp": "Starting up…",
     "newVersionAvailable": "A new version is available",
     "reload": "Reload",
+    "autonomousBannerMessage": "This project is fully autonomous — maintained by AI agents.",
+    "watchLive": "Watch them live",
+    "watchLiveMobile": "Watch live →",
     "sidebar": {
       "expandSidebar": "Expand sidebar",
       "collapseSidebar": "Collapse sidebar",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -4099,6 +4099,12 @@
       "stepsCount_other": "{{count}} steps",
       "importSuccess": "Imported \"{{title}}\" successfully."
     },
+    "kagenti": {
+      "providerUnavailableTitle": "Kagenti provider unavailable",
+      "providerUnavailableDescription": "Mission Control could not reach the Kagenti provider{{reasonSuffix}}. Verify your in-cluster Kagenti deployment or direct-agent configuration, then retry.",
+      "noAgentsTitle": "No Kagenti agents discovered",
+      "noAgentsDescription": "Kagenti is reachable, but it did not report any registered agents. Register at least one agent with the controller or configure direct-agent mode, then retry."
+    },
     "preflight": {
       "toolCheck": {
         "agentAuthFailed": "Agent authentication failed. Check that KC_AGENT_TOKEN is correctly set and matches between the console and kc-agent.",


### PR DESCRIPTION
### 📌 Related

Related to #12939

---

### 📝 Summary of Changes

This PR continues the effort to centralize route definitions by eliminating remaining hardcoded route path literals in `App.tsx` and replacing them with centralized `ROUTES` constants from `config/routes.ts`.

The goal is to reduce route duplication, prevent route drift, and improve maintainability if routes are renamed or restructured in the future.

---

### Changes Made

* [x] Replaced remaining hardcoded route strings in `App.tsx` with `ROUTES` constants
* [x] Updated `SKIP_PREFETCH_PATHS` to use centralized route constants
* [x] Updated OAuth redirect/destination checks to use `ROUTES.HOME` and `ROUTES.LOGIN`
* [x] Updated dashboard path parsing logic to derive values from centralized routes
* [x] Updated `useLiveUrl` default state to use `ROUTES.HOME`
* [x] Preserved all existing routing behavior
* [x] Kept the refactor scoped and minimal without unrelated cleanup

---

### Checklist

Please ensure the following before submitting your PR:

* [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
* [x] I have reviewed the project's contribution guidelines
* [x] New cards target [[console-marketplace](https://github.com/kubestellar/console-marketplace)](https://github.com/kubestellar/console-marketplace), not this repo
* [x] I have tested the changes locally and ensured they work as expected
* [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

Validation performed:

* TypeScript compilation passes (`tsc --noEmit`)
* Route smoke test suite passes
* No routing behavior regressions observed

---

### 👀 Reviewer Notes

This is a behavior-preserving refactor focused on consolidating route definitions into `config/routes.ts` so route changes automatically propagate across route consumers safely.