### PR TITLE
refactor: migrate remaining hardcoded route strings to ROUTES constants

### DIFF
--- a/web/e2e/compliance/a11y-compliance.spec.ts
+++ b/web/e2e/compliance/a11y-compliance.spec.ts
@@ -8,6 +8,7 @@
  */
 import { test, expect} from '@playwright/test'
 import AxeBuilder from '@axe-core/playwright'
+import { ROUTES } from '../../src/config/routes'
 import * as fs from 'fs'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
@@ -49,21 +50,21 @@ interface A11yReport {
 // ---------------------------------------------------------------------------
 
 const ROUTES_TO_AUDIT = [
-  { name: 'Dashboard', path: '/' },
-  { name: 'Clusters', path: '/clusters' },
-  { name: 'Settings', path: '/settings' },
-  { name: 'Compute', path: '/compute' },
-  { name: 'Security', path: '/security' },
-  { name: 'Deployments', path: '/deployments' },
-  { name: 'Helm', path: '/helm' },
-  { name: 'GPU Reservations', path: '/gpu-reservations' },
-  { name: 'AI/ML', path: '/ai-ml' },
-  { name: 'Logs', path: '/logs' },
-  { name: 'Events', path: '/events' },
-  { name: 'Pods', path: '/pods' },
-  { name: 'Services', path: '/services' },
-  { name: 'Nodes', path: '/nodes' },
-  { name: 'Workloads', path: '/workloads' },
+  { name: 'Dashboard', path: ROUTES.HOME },
+  { name: 'Clusters', path: ROUTES.CLUSTERS },
+  { name: 'Settings', path: ROUTES.SETTINGS },
+  { name: 'Compute', path: ROUTES.COMPUTE },
+  { name: 'Security', path: ROUTES.SECURITY },
+  { name: 'Deployments', path: ROUTES.DEPLOYMENTS },
+  { name: 'Helm', path: ROUTES.HELM },
+  { name: 'GPU Reservations', path: ROUTES.GPU_RESERVATIONS },
+  { name: 'AI/ML', path: ROUTES.AI_ML },
+  { name: 'Logs', path: ROUTES.LOGS },
+  { name: 'Events', path: ROUTES.EVENTS },
+  { name: 'Pods', path: ROUTES.PODS },
+  { name: 'Services', path: ROUTES.SERVICES },
+  { name: 'Nodes', path: ROUTES.NODES },
+  { name: 'Workloads', path: ROUTES.WORKLOADS },
 ]
 
 const IS_CI = !!process.env.CI

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -154,7 +154,7 @@ if (typeof window !== 'undefined') {
   const PREFETCH_DASHBOARD_TIMEOUT_MS = 2_000
 
   /** Routes where chunk prefetching is skipped to avoid errors during OAuth flow (#9767) */
-  const SKIP_PREFETCH_PATHS = new Set(['/login', '/auth/callback'])
+  const SKIP_PREFETCH_PATHS: ReadonlySet<string> = new Set([ROUTES.LOGIN, ROUTES.AUTH_CALLBACK])
 
   const prefetchRoutes = async () => {
     // Skip prefetching on auth pages — during OAuth redirects, the browser
@@ -298,7 +298,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
     // Save the intended destination so AuthCallback can return here after login.
     // This preserves deep-link params like ?mission= through the OAuth round-trip.
     const destination = location.pathname + location.search
-    if (destination !== '/' && destination !== '/login') {
+    if (destination !== ROUTES.HOME && destination !== ROUTES.LOGIN) {
       safeSet(RETURN_TO_KEY, destination)
     }
     return <Navigate to={ROUTES.LOGIN} replace />
@@ -423,9 +423,11 @@ const ROUTE_TITLES: Record<string, string> = {
 
 
 /** Map route paths to dashboard IDs for duration analytics */
-function pathToDashboardId(path: string): string | null {
-  if (path === '/') return 'main'
-  if (path.startsWith('/custom-dashboard/')) return path.replace('/custom-dashboard/', 'custom-')
+function pathToDashboardId(path?: string | null): string | null {
+  if (!path) return null
+  if (path === ROUTES.HOME) return 'main'
+  const customPrefix = ROUTES.CUSTOM_DASHBOARD.replace(':id', '')
+  if (path.startsWith(customPrefix)) return path.replace(customPrefix, 'custom-')
   const id = path.replace(/^\//, '')
   return id || null
 }
@@ -602,7 +604,7 @@ function useLiveUrl(): string {
       }
     },
     getLiveUrl,
-    () => '/',
+    () => ROUTES.HOME,
   )
 }
 

--- a/web/src/components/layout/SidebarShell.tsx
+++ b/web/src/components/layout/SidebarShell.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react'
 import { iconRegistry } from '../../lib/icons'
 import { cn } from '../../lib/cn'
+import { ROUTES } from '../../config/routes'
 import { Tooltip } from '../ui/Tooltip'
 import { SnoozedCards } from './SnoozedCards'
 import {
@@ -35,7 +36,6 @@ import type { SnoozedRecommendation } from '../../hooks/useSnoozedRecommendation
 import type { SnoozedMission } from '../../hooks/useSnoozedMissions'
 import { useActiveUsers } from '../../hooks/useActiveUsers'
 import { useMissions } from '../../hooks/useMissions'
-import { ROUTES } from '../../config/routes'
 import { DASHBOARD_CONFIGS } from '../../config/dashboards/index'
 import { emitSidebarNavigated, emitDashboardRenamed } from '../../lib/analytics'
 import { prefetchDashboard } from '../../lib/prefetchDashboard'
@@ -139,21 +139,21 @@ const PRIMARY_SECTION_INDEX = 0
 
 /** Map sidebar item href to dashboard config ID for card count display. */
 const HREF_TO_DASHBOARD_ID: Record<string, string> = {
-  '/': 'main', '/compute': 'compute', '/security': 'security',
-  '/gitops': 'gitops', '/storage': 'storage', '/network': 'network',
-  '/events': 'events', '/alerts': 'alerts', '/workloads': 'workloads', '/operators': 'operators',
-  '/clusters': 'clusters', '/compliance': 'compliance', '/cost': 'cost',
-  '/gpu-reservations': 'gpu', '/nodes': 'nodes', '/deployments': 'deployments',
-  '/pods': 'pods', '/services': 'services', '/helm': 'helm',
-  '/ai-ml': 'ai-ml', '/ci-cd': 'ci-cd',
-  '/logs': 'logs', '/data-compliance': 'data-compliance', '/arcade': 'arcade',
-  '/deploy': 'deploy', '/ai-agents': 'ai-agents',
-  '/llm-d-benchmarks': 'llm-d-benchmarks', '/cluster-admin': 'cluster-admin',
-  '/insights': 'insights', '/drasi': 'drasi',
-  '/multi-tenancy': 'multi-tenancy', '/acmm': 'acmm',
+  [ROUTES.HOME]: 'main', [ROUTES.COMPUTE]: 'compute', [ROUTES.SECURITY]: 'security',
+  [ROUTES.GITOPS]: 'gitops', [ROUTES.STORAGE]: 'storage', [ROUTES.NETWORK]: 'network',
+  [ROUTES.EVENTS]: 'events', [ROUTES.ALERTS]: 'alerts', [ROUTES.WORKLOADS]: 'workloads', [ROUTES.OPERATORS]: 'operators',
+  [ROUTES.CLUSTERS]: 'clusters', [ROUTES.COMPLIANCE]: 'compliance', [ROUTES.COST]: 'cost',
+  [ROUTES.GPU_RESERVATIONS]: 'gpu', [ROUTES.NODES]: 'nodes', [ROUTES.DEPLOYMENTS]: 'deployments',
+  [ROUTES.PODS]: 'pods', [ROUTES.SERVICES]: 'services', [ROUTES.HELM]: 'helm',
+  [ROUTES.AI_ML]: 'ai-ml', [ROUTES.CI_CD]: 'ci-cd',
+  [ROUTES.LOGS]: 'logs', [ROUTES.DATA_COMPLIANCE]: 'data-compliance', [ROUTES.ARCADE]: 'arcade',
+  [ROUTES.DEPLOY]: 'deploy', [ROUTES.AI_AGENTS]: 'ai-agents',
+  [ROUTES.LLM_D_BENCHMARKS]: 'llm-d-benchmarks', [ROUTES.CLUSTER_ADMIN]: 'cluster-admin',
+  [ROUTES.INSIGHTS]: 'insights', [ROUTES.DRASI]: 'drasi',
+  [ROUTES.MULTI_TENANCY]: 'multi-tenancy', [ROUTES.ACMM]: 'acmm',
 }
 
-const CUSTOM_DASHBOARD_PREFIX = '/custom-dashboard/'
+const CUSTOM_DASHBOARD_PREFIX = ROUTES.CUSTOM_DASHBOARD.replace(':id', '')
 
 function isGroundControlItem(href: string): boolean {
   if (!href.startsWith(CUSTOM_DASHBOARD_PREFIX)) return false

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -4,6 +4,7 @@ import { setActiveProject } from '../lib/project/context'
 import { setQuantumWorkloadAvailable } from '../lib/demoMode'
 import { NAVIGATION_ICONS } from '../lib/navigationIcons'
 import { safeGetItem, safeRemoveItem, safeSetItem } from '../lib/utils/localStorage'
+import { ROUTES } from '../config/routes'
 
 /** Width of the collapsed sidebar in pixels (w-20 = 5rem = 80px) */
 export const SIDEBAR_COLLAPSED_WIDTH_PX = 80
@@ -54,20 +55,20 @@ function subscribe(listener: () => void): () => void {
 
 // Core dashboards shown in sidebar by default (reduced from 28 to 9 to cut clutter)
 export const DEFAULT_PRIMARY_NAV: SidebarItem[] = [
-  { id: 'dashboard', name: 'Dashboard', icon: NAVIGATION_ICONS['dashboard'], href: '/', type: 'link', order: 0 },
-  { id: 'clusters', name: 'My Clusters', icon: NAVIGATION_ICONS['clusters'], href: '/clusters', type: 'link', order: 1 },
-  { id: 'cluster-admin', name: 'Cluster Admin', icon: NAVIGATION_ICONS['cluster-admin'], href: '/cluster-admin', type: 'link', order: 2 },
-  { id: 'compliance', name: 'Sec. Compliance', icon: NAVIGATION_ICONS['compliance'], href: '/compliance', type: 'link', order: 2.5 },
-  { id: 'enterprise', name: 'Enterprise', icon: NAVIGATION_ICONS['enterprise'], href: '/enterprise', type: 'link', order: 2.7 },
-  { id: 'deploy', name: 'Deploy', icon: NAVIGATION_ICONS['deploy'], href: '/deploy', type: 'link', order: 3 },
-  { id: 'insights', name: 'Insights', icon: NAVIGATION_ICONS['insights'], href: '/insights', type: 'link', order: 3.5 },
-  { id: 'ai-ml', name: 'AI/ML', icon: NAVIGATION_ICONS['ai-ml'], href: '/ai-ml', type: 'link', order: 4 },
-  { id: 'ai-agents', name: 'AI Agents', icon: NAVIGATION_ICONS['ai-agents'], href: '/ai-agents', type: 'link', order: 5 },
-  { id: 'ci-cd', name: 'CI/CD', icon: NAVIGATION_ICONS['ci-cd'], href: '/ci-cd', type: 'link', order: 5.5 },
-  { id: 'acmm', name: 'ACMM', icon: NAVIGATION_ICONS['acmm'], href: '/acmm', type: 'link', order: 6 },
-  { id: 'multi-tenancy', name: 'Multi-Tenancy', icon: NAVIGATION_ICONS['multi-tenancy'], href: '/multi-tenancy', type: 'link', order: 6.5 },
-  { id: 'alerts', name: 'Alerts', icon: NAVIGATION_ICONS['alerts'], href: '/alerts', type: 'link', order: 7 },
-  { id: 'arcade', name: 'Arcade', icon: NAVIGATION_ICONS['arcade'], href: '/arcade', type: 'link', order: 8 },
+  { id: 'dashboard', name: 'Dashboard', icon: NAVIGATION_ICONS['dashboard'], href: ROUTES.HOME, type: 'link', order: 0 },
+  { id: 'clusters', name: 'My Clusters', icon: NAVIGATION_ICONS['clusters'], href: ROUTES.CLUSTERS, type: 'link', order: 1 },
+  { id: 'cluster-admin', name: 'Cluster Admin', icon: NAVIGATION_ICONS['cluster-admin'], href: ROUTES.CLUSTER_ADMIN, type: 'link', order: 2 },
+  { id: 'compliance', name: 'Sec. Compliance', icon: NAVIGATION_ICONS['compliance'], href: ROUTES.COMPLIANCE, type: 'link', order: 2.5 },
+  { id: 'enterprise', name: 'Enterprise', icon: NAVIGATION_ICONS['enterprise'], href: ROUTES.ENTERPRISE, type: 'link', order: 2.7 },
+  { id: 'deploy', name: 'Deploy', icon: NAVIGATION_ICONS['deploy'], href: ROUTES.DEPLOY, type: 'link', order: 3 },
+  { id: 'insights', name: 'Insights', icon: NAVIGATION_ICONS['insights'], href: ROUTES.INSIGHTS, type: 'link', order: 3.5 },
+  { id: 'ai-ml', name: 'AI/ML', icon: NAVIGATION_ICONS['ai-ml'], href: ROUTES.AI_ML, type: 'link', order: 4 },
+  { id: 'ai-agents', name: 'AI Agents', icon: NAVIGATION_ICONS['ai-agents'], href: ROUTES.AI_AGENTS, type: 'link', order: 5 },
+  { id: 'ci-cd', name: 'CI/CD', icon: NAVIGATION_ICONS['ci-cd'], href: ROUTES.CI_CD, type: 'link', order: 5.5 },
+  { id: 'acmm', name: 'ACMM', icon: NAVIGATION_ICONS['acmm'], href: ROUTES.ACMM, type: 'link', order: 6 },
+  { id: 'multi-tenancy', name: 'Multi-Tenancy', icon: NAVIGATION_ICONS['multi-tenancy'], href: ROUTES.MULTI_TENANCY, type: 'link', order: 6.5 },
+  { id: 'alerts', name: 'Alerts', icon: NAVIGATION_ICONS['alerts'], href: ROUTES.ALERTS, type: 'link', order: 7 },
+  { id: 'arcade', name: 'Arcade', icon: NAVIGATION_ICONS['arcade'], href: ROUTES.ARCADE, type: 'link', order: 8 },
 ]
 
 /**
@@ -76,35 +77,35 @@ export const DEFAULT_PRIMARY_NAV: SidebarItem[] = [
  * Users can add any of these to their sidebar via the customizer.
  */
 export const DISCOVERABLE_DASHBOARDS: SidebarItem[] = [
-  { id: 'quantum', name: 'Quantum Demo', icon: NAVIGATION_ICONS['quantum'], href: '/quantum', type: 'link', order: 0 },
-  { id: 'compute', name: 'Compute', icon: NAVIGATION_ICONS['compute'], href: '/compute', type: 'link', order: 1 },
-  { id: 'cost', name: 'Cost', icon: NAVIGATION_ICONS['cost'], href: '/cost', type: 'link', order: 2 },
-  { id: 'data-compliance', name: 'Data Compliance', icon: NAVIGATION_ICONS['data-compliance'], href: '/data-compliance', type: 'link', order: 3 },
-  { id: 'deployments', name: 'Deployments', icon: NAVIGATION_ICONS['deployments'], href: '/deployments', type: 'link', order: 4 },
-  { id: 'events', name: 'Events', icon: NAVIGATION_ICONS['events'], href: '/events', type: 'link', order: 5 },
-  { id: 'gitops', name: 'GitOps', icon: NAVIGATION_ICONS['gitops'], href: '/gitops', type: 'link', order: 6 },
-  { id: 'gpu-reservations', name: 'GPU Reservations', icon: NAVIGATION_ICONS['gpu-reservations'], href: '/gpu-reservations', type: 'link', order: 7 },
-  { id: 'karmada-ops', name: 'Karmada Ops', icon: NAVIGATION_ICONS['karmada-ops'], href: '/karmada-ops', type: 'link', order: 8 },
-  { id: 'helm', name: 'Helm', icon: NAVIGATION_ICONS['helm'], href: '/helm', type: 'link', order: 8 },
-  { id: 'llm-d-benchmarks', name: 'llm-d Benchmarks', icon: NAVIGATION_ICONS['llm-d-benchmarks'], href: '/llm-d-benchmarks', type: 'link', order: 9 },
-  { id: 'logs', name: 'Logs', icon: NAVIGATION_ICONS['logs'], href: '/logs', type: 'link', order: 10 },
-  { id: 'network', name: 'Network', icon: NAVIGATION_ICONS['network'], href: '/network', type: 'link', order: 11 },
-  { id: 'nodes', name: 'Nodes', icon: NAVIGATION_ICONS['nodes'], href: '/nodes', type: 'link', order: 12 },
-  { id: 'operators', name: 'Operators', icon: NAVIGATION_ICONS['operators'], href: '/operators', type: 'link', order: 13 },
-  { id: 'pods', name: 'Pods', icon: NAVIGATION_ICONS['pods'], href: '/pods', type: 'link', order: 14 },
-  { id: 'security', name: 'Security', icon: NAVIGATION_ICONS['security'], href: '/security', type: 'link', order: 15 },
-  { id: 'security-posture', name: 'Security Posture', icon: NAVIGATION_ICONS['security-posture'], href: '/security-posture', type: 'link', order: 16 },
-  { id: 'services', name: 'Services', icon: NAVIGATION_ICONS['services'], href: '/services', type: 'link', order: 17 },
-  { id: 'storage', name: 'Storage', icon: NAVIGATION_ICONS['storage'], href: '/storage', type: 'link', order: 18 },
-  { id: 'workloads', name: 'Workloads', icon: NAVIGATION_ICONS['workloads'], href: '/workloads', type: 'link', order: 19 },
+  { id: 'quantum', name: 'Quantum Demo', icon: NAVIGATION_ICONS['quantum'], href: ROUTES.QUANTUM, type: 'link', order: 0 },
+  { id: 'compute', name: 'Compute', icon: NAVIGATION_ICONS['compute'], href: ROUTES.COMPUTE, type: 'link', order: 1 },
+  { id: 'cost', name: 'Cost', icon: NAVIGATION_ICONS['cost'], href: ROUTES.COST, type: 'link', order: 2 },
+  { id: 'data-compliance', name: 'Data Compliance', icon: NAVIGATION_ICONS['data-compliance'], href: ROUTES.DATA_COMPLIANCE, type: 'link', order: 3 },
+  { id: 'deployments', name: 'Deployments', icon: NAVIGATION_ICONS['deployments'], href: ROUTES.DEPLOYMENTS, type: 'link', order: 4 },
+  { id: 'events', name: 'Events', icon: NAVIGATION_ICONS['events'], href: ROUTES.EVENTS, type: 'link', order: 5 },
+  { id: 'gitops', name: 'GitOps', icon: NAVIGATION_ICONS['gitops'], href: ROUTES.GITOPS, type: 'link', order: 6 },
+  { id: 'gpu-reservations', name: 'GPU Reservations', icon: NAVIGATION_ICONS['gpu-reservations'], href: ROUTES.GPU_RESERVATIONS, type: 'link', order: 7 },
+  { id: 'karmada-ops', name: 'Karmada Ops', icon: NAVIGATION_ICONS['karmada-ops'], href: ROUTES.KARMADA_OPS, type: 'link', order: 8 },
+  { id: 'helm', name: 'Helm', icon: NAVIGATION_ICONS['helm'], href: ROUTES.HELM, type: 'link', order: 8 },
+  { id: 'llm-d-benchmarks', name: 'llm-d Benchmarks', icon: NAVIGATION_ICONS['llm-d-benchmarks'], href: ROUTES.LLM_D_BENCHMARKS, type: 'link', order: 9 },
+  { id: 'logs', name: 'Logs', icon: NAVIGATION_ICONS['logs'], href: ROUTES.LOGS, type: 'link', order: 10 },
+  { id: 'network', name: 'Network', icon: NAVIGATION_ICONS['network'], href: ROUTES.NETWORK, type: 'link', order: 11 },
+  { id: 'nodes', name: 'Nodes', icon: NAVIGATION_ICONS['nodes'], href: ROUTES.NODES, type: 'link', order: 12 },
+  { id: 'operators', name: 'Operators', icon: NAVIGATION_ICONS['operators'], href: ROUTES.OPERATORS, type: 'link', order: 13 },
+  { id: 'pods', name: 'Pods', icon: NAVIGATION_ICONS['pods'], href: ROUTES.PODS, type: 'link', order: 14 },
+  { id: 'security', name: 'Security', icon: NAVIGATION_ICONS['security'], href: ROUTES.SECURITY, type: 'link', order: 15 },
+  { id: 'security-posture', name: 'Security Posture', icon: NAVIGATION_ICONS['security-posture'], href: ROUTES.SECURITY_POSTURE, type: 'link', order: 16 },
+  { id: 'services', name: 'Services', icon: NAVIGATION_ICONS['services'], href: ROUTES.SERVICES, type: 'link', order: 17 },
+  { id: 'storage', name: 'Storage', icon: NAVIGATION_ICONS['storage'], href: ROUTES.STORAGE, type: 'link', order: 18 },
+  { id: 'workloads', name: 'Workloads', icon: NAVIGATION_ICONS['workloads'], href: ROUTES.WORKLOADS, type: 'link', order: 19 },
 ]
 
 const DEFAULT_SECONDARY_NAV: SidebarItem[] = [
-  { id: 'marketplace', name: 'Marketplace', icon: NAVIGATION_ICONS['marketplace'], href: '/marketplace', type: 'link', order: 0 },
-  { id: 'history', name: 'Card History', icon: NAVIGATION_ICONS['history'], href: '/history', type: 'link', order: 1 },
-  { id: 'namespaces', name: 'Namespaces', icon: NAVIGATION_ICONS['namespaces'], href: '/namespaces', type: 'link', order: 2 },
-  { id: 'users', name: 'User Management', icon: NAVIGATION_ICONS['users'], href: '/users', type: 'link', order: 3 },
-  { id: 'settings', name: 'Settings', icon: NAVIGATION_ICONS['settings'], href: '/settings', type: 'link', order: 4 },
+  { id: 'marketplace', name: 'Marketplace', icon: NAVIGATION_ICONS['marketplace'], href: ROUTES.MARKETPLACE, type: 'link', order: 0 },
+  { id: 'history', name: 'Card History', icon: NAVIGATION_ICONS['history'], href: ROUTES.HISTORY, type: 'link', order: 1 },
+  { id: 'namespaces', name: 'Namespaces', icon: NAVIGATION_ICONS['namespaces'], href: ROUTES.NAMESPACES, type: 'link', order: 2 },
+  { id: 'users', name: 'User Management', icon: NAVIGATION_ICONS['users'], href: ROUTES.USERS, type: 'link', order: 3 },
+  { id: 'settings', name: 'Settings', icon: NAVIGATION_ICONS['settings'], href: ROUTES.SETTINGS, type: 'link', order: 4 },
 ]
 
 const DEFAULT_NAV_ITEMS = [...DEFAULT_PRIMARY_NAV, ...DEFAULT_SECONDARY_NAV]

--- a/web/src/lib/prefetchDashboard.ts
+++ b/web/src/lib/prefetchDashboard.ts
@@ -80,8 +80,8 @@ const CARD_DATA_PREFETCH: Record<string, Array<{ key: string; fetcher: () => Pro
 /** Avoid re-triggering for the same link on repeated hover */
 let lastPrefetchedHref: string | null = null
 
-export function prefetchDashboard(href: string): void {
-  if (href === lastPrefetchedHref) return
+export function prefetchDashboard(href?: string | null): void {
+  if (!href || href === lastPrefetchedHref) return
   lastPrefetchedHref = href
 
   // Demo mode uses synchronous data — no fetching needed


### PR DESCRIPTION
### 📌 Related

Related to #12939

---

### 📝 Summary of Changes

This PR continues the route consolidation effort by replacing the remaining hardcoded route path literals with centralized `ROUTES` constants from `config/routes.ts`.

The goal is to reduce route duplication, prevent silent route drift, and improve maintainability so future route changes automatically propagate across route consumers safely.

This refactor preserves all existing routing behavior while making route usage more consistent across application logic, sidebar configuration, prefetching, and accessibility tests.

---

### Changes Made

* [x] Replaced remaining hardcoded route strings in `SidebarShell.tsx`
* [x] Updated `HREF_TO_DASHBOARD_ID` and `CUSTOM_DASHBOARD_PREFIX` to derive values from centralized `ROUTES`
* [x] Updated sidebar navigation configuration in `useSidebarConfig.ts` to use `ROUTES.*`
* [x] Replaced remaining hardcoded route checks in `App.tsx`
* [x] Updated route parsing logic to derive values from centralized routes
* [x] Updated accessibility route audit test configuration to use `ROUTES.*`
* [x] Added safer nullable handling in `prefetchDashboard.ts`
* [x] Preserved all existing route behavior with no intended functional changes

---

### Checklist

Please ensure the following before submitting your PR:

* [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
* [x] I have reviewed the project's contribution guidelines
* [x] New cards target [[console-marketplace](https://github.com/kubestellar/console-marketplace)](https://github.com/kubestellar/console-marketplace), not this repo
* [x] I have tested the changes locally and ensured they work as expected
* [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

Validation performed:

* TypeScript typecheck passes (`tsc --noEmit`)
* Route smoke tests pass
* Sidebar configuration tests pass
* ESLint passes on modified files with no new warnings

---

### 👀 Reviewer Notes

This is a behavior-preserving refactor focused on making `config/routes.ts` the single source of truth for route paths across application logic, sidebar configuration, prefetching, and route audit tests.

Pre-existing CI flakes and unrelated accessibility issues observed on `main` were intentionally left out of scope for this PR.