### PR TITLE
fix: auto-close IBM Credentials modal after successful save

### DIFF
--- a/web/src/components/cards/quantum/QuantumControlPanel.tsx
+++ b/web/src/components/cards/quantum/QuantumControlPanel.tsx
@@ -98,7 +98,7 @@ const DEMO_STATUS: SystemStatus = {
 
 export const QuantumControlPanel: React.FC = () => {
   const { isAuthenticated, login, isLoading: authIsLoading } = useAuth()
-  const { open: openDrillDown } = useDrillDown()
+  const { open: openDrillDown, close: closeDrillDown } = useDrillDown()
   const [control, setControl] = useState<ControlState>(DEMO_DATA)
   const [status, setStatus] = useState<SystemStatus | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -253,9 +253,10 @@ export const QuantumControlPanel: React.FC = () => {
       data: {
         ibmAuthenticated,
         onSave: handleSaveCredentials,
+        onClose: closeDrillDown,
       },
     })
-  }, [ibmAuthenticated, openDrillDown])
+  }, [ibmAuthenticated, openDrillDown, closeDrillDown])
 
   // Clear IBM Quantum credentials
   const handleClearCredentials = useCallback(async () => {

--- a/web/src/components/drilldown/views/quantum/QuantumCredentialsDrillDown.tsx
+++ b/web/src/components/drilldown/views/quantum/QuantumCredentialsDrillDown.tsx
@@ -19,6 +19,7 @@ export function QuantumCredentialsDrillDown({ data }: Props) {
   const [credentialSaving, setCredentialSaving] = useState(false)
   const ibmAuthenticated = (data.ibmAuthenticated as boolean) || false
   const onSave = data.onSave as ((form: CredentialForm) => Promise<void>) | undefined
+  const onClose = data.onClose as (() => void) | undefined
 
   const handleSaveCredentials = async () => {
     if (!onSave) return
@@ -28,6 +29,10 @@ export function QuantumCredentialsDrillDown({ data }: Props) {
       setCredentialSaving(true)
       await onSave(credentialForm)
       setCredentialForm({ apiKey: '', crn: '' })
+      // Close the modal after successful save
+      if (onClose) {
+        onClose()
+      }
     } catch (err) {
       setCredentialError(err instanceof Error ? err.message : 'Failed to save credentials')
     } finally {


### PR DESCRIPTION
## Summary
The IBM Credentials modal now automatically closes after successfully saving credentials, improving the user experience by eliminating the need for manual dismissal.

## Changes
- **QuantumControlPanel.tsx**: Pass `closeDrillDown` callback to credentials drill-down
- **QuantumCredentialsDrillDown.tsx**: Call `onClose()` after successful save to auto-close modal

## Testing
- ✅ Verified auto-close behavior with dev server restart
- ✅ Build passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)