### PR TITLE
🐛 Sanitize WorkloadDeployment status error messages in console_persistence.go

### DIFF
--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -637,8 +637,7 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 	if err != nil {
 		slog.Error("[reconcile] failed to resolve ManagedWorkload",
 			"name", wd.Name, "error", err)
-		h.setTerminalStatus(wd, "Failed",
-			fmt.Sprintf("Failed to resolve ManagedWorkload: %v", err), updateStatus)
+		h.setTerminalStatus(wd, "Failed", "Failed to resolve ManagedWorkload", updateStatus)
 		return
 	}
 
@@ -647,8 +646,7 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 	if err != nil {
 		slog.Error("[reconcile] failed to resolve target clusters",
 			"name", wd.Name, "error", err)
-		h.setTerminalStatus(wd, "Failed",
-			fmt.Sprintf("Failed to resolve target clusters: %v", err), updateStatus)
+		h.setTerminalStatus(wd, "Failed", "Failed to resolve target clusters", updateStatus)
 		return
 	}
 	if len(targets) == 0 {

--- a/pkg/api/handlers/console_persistence_test.go
+++ b/pkg/api/handlers/console_persistence_test.go
@@ -181,3 +181,47 @@ func TestClusterMatchesFilters_OneFails(t *testing.T) {
 
 	assert.False(t, h.clusterMatchesFilters(cluster, health, nil, filters))
 }
+
+// TestSetTerminalStatus_SanitizedMessage verifies that the message stored in
+// wd.Status.History does not contain raw error text — only the generic string
+// passed by the caller. This prevents internal Kubernetes error details from
+// leaking via the WorkloadDeployment status API.
+func TestSetTerminalStatus_SanitizedMessage(t *testing.T) {
+	h := newTestHandler()
+	noop := func(*v1alpha1.WorkloadDeployment) {}
+
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{
+			name:    "ManagedWorkload resolution failure uses generic message",
+			message: "Failed to resolve ManagedWorkload",
+		},
+		{
+			name:    "target cluster resolution failure uses generic message",
+			message: "Failed to resolve target clusters",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wd := &v1alpha1.WorkloadDeployment{}
+			h.setTerminalStatus(wd, "Failed", tc.message, noop)
+
+			if len(wd.Status.History) == 0 {
+				t.Fatal("expected a history entry to be appended")
+			}
+			got := wd.Status.History[len(wd.Status.History)-1].Message
+
+			// Exact message must match — no raw error text appended.
+			assert.Equal(t, tc.message, got)
+
+			// Must not contain Go error formatting artefacts that would
+			// indicate a raw err was embedded via fmt.Sprintf("...: %v", err).
+			assert.NotContains(t, got, "%v")
+			assert.NotContains(t, got, "failed to get")
+			assert.NotContains(t, got, "connection refused")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Raw Kubernetes errors from `resolveManagedWorkload` and `resolveTargetClusters` were passed verbatim to `setTerminalStatus`, which stores them in `wd.Status.History[].Message`. This field is persisted to the K8s CR and returned in WorkloadDeployment status API responses — leaking internal resource names, cluster topology, and API server error details to clients.

The `slog.Error` calls immediately above already capture the full raw error server-side, so the verbose message in the status field is redundant.

## Changes

- `line 641`: `fmt.Sprintf("Failed to resolve ManagedWorkload: %v", err)` → `"Failed to resolve ManagedWorkload"`
- `line 651`: `fmt.Sprintf("Failed to resolve target clusters: %v", err)` → `"Failed to resolve target clusters"`

## Test Plan

- [ ] Deploy a WorkloadDeployment that fails ManagedWorkload resolution — status message shows generic text, raw error appears only in server logs
- [ ] Deploy a WorkloadDeployment that fails cluster resolution — same behavior
- [ ] Successful deployments unaffected

Related to #13218