### PR TITLE
fix: initialize nil slices to prevent null JSON serialization

### DIFF
--- a/pkg/api/handlers/acmm_scan.go
+++ b/pkg/api/handlers/acmm_scan.go
@@ -228,7 +228,7 @@ func ACMMScanHandler(c *fiber.Ctx) error {
 	}
 
 	// Detect criteria
-	var detected []string
+	detected := make([]string, 0)
 	for _, crit := range acmmCriteria {
 		if matchesPatterns(treePaths, crit.Patterns) {
 			detected = append(detected, crit.ID)

--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -901,7 +901,7 @@ func (h *AuthHandler) getGitHubPrimaryEmail(ctx context.Context, accessToken str
 		return "", fmt.Errorf("GitHub emails API returned %d", resp.StatusCode)
 	}
 
-	var emails []gitHubEmail
+	emails := make([]gitHubEmail, 0)
 	if err := json.NewDecoder(resp.Body).Decode(&emails); err != nil {
 		return "", err
 	}

--- a/pkg/api/handlers/benchmarks.go
+++ b/pkg/api/handlers/benchmarks.go
@@ -674,7 +674,7 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 		}
 
 		// Filter to folders only, skip folders older than cutoff
-		var experiments []driveFile
+		experiments := make([]driveFile, 0)
 		for _, item := range topLevel {
 			if item.MimeType != driveFolderMIME {
 				continue
@@ -834,7 +834,7 @@ func (h *BenchmarkHandlers) fetchAllReports(ctx context.Context, cutoff time.Tim
 	}
 
 	// Filter experiments up-front so we know the work set.
-	var experiments []driveFile
+	experiments := make([]driveFile, 0)
 	for _, item := range topLevel {
 		if item.MimeType != driveFolderMIME {
 			continue
@@ -914,7 +914,7 @@ func (h *BenchmarkHandlers) fetchRunFolder(ctx context.Context, folderID, experi
 
 	// First: look for benchmark YAML files directly in this folder
 	reports := make([]BenchmarkReport, 0)
-	var subfolders []driveFile
+	subfolders := make([]driveFile, 0)
 	parseFailures := 0
 	for _, f := range items {
 		if f.MimeType == driveFolderMIME {
@@ -1002,7 +1002,7 @@ func (h *BenchmarkHandlers) downloadAndParseReport(ctx context.Context, f driveF
 // listDriveFolder lists all files in a Google Drive folder, handling pagination
 // so that folders with more than 1000 items are not silently truncated.
 func (h *BenchmarkHandlers) listDriveFolder(ctx context.Context, folderID string) ([]driveFile, error) {
-	var allFiles []driveFile
+	allFiles := make([]driveFile, 0)
 	pageToken := ""
 
 	for {

--- a/pkg/api/handlers/compliance_reports.go
+++ b/pkg/api/handlers/compliance_reports.go
@@ -66,7 +66,7 @@ func (h *ComplianceReportsHandler) GenerateReport(c *fiber.Ctx) error {
 		userName = login
 	}
 
-	var data []byte
+	data := make([]byte, 0)
 	var contentType string
 	var err error
 

--- a/pkg/api/handlers/feedback_config.go
+++ b/pkg/api/handlers/feedback_config.go
@@ -307,7 +307,7 @@ func extractPRNumber(ref string) int {
 // extractLinkedIssueNumbers extracts issue numbers from PR body
 // Looks for patterns like "Fixes #123", "Closes org/repo#456", "Resolves #789"
 func extractLinkedIssueNumbers(body string) []int {
-	var issueNumbers []int
+	issueNumbers := make([]int, 0)
 
 	// Regex to match: Fixes/Closes/Resolves [org/repo]#123
 	// Handles both "#123" and "org/repo#123" formats

--- a/pkg/api/handlers/feedback_github.go
+++ b/pkg/api/handlers/feedback_github.go
@@ -292,13 +292,13 @@ func (h *FeedbackHandler) getLatestBotComment(ctx context.Context, issueNumber i
 		return ""
 	}
 
-	var comments []struct {
+	comments := []struct {
 		Body string `json:"body"`
 		User struct {
 			Login string `json:"login"`
 			Type  string `json:"type"`
 		} `json:"user"`
-	}
+	}{}
 
 	if err := json.NewDecoder(resp.Body).Decode(&comments); err != nil {
 		return ""
@@ -529,7 +529,7 @@ type createdGitHubIssue struct {
 // on the returned slice from a background goroutine.
 func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *models.FeatureRequest, user *models.User, repoOwner, repoName string, screenshots []string, consoleErrors []models.ConsoleError, failedApiCalls []models.FailedApiCall, diagnostics *models.DiagnosticInfo, parentIssueNumber *int, clientAuth string) (int, string, []string, screenshotUploadResult, error) {
 	// Determine labels based on request type and target repo
-	var labels []string
+	labels := make([]string, 0)
 	isDocs := request.TargetRepo == models.TargetRepoDocs
 
 	if isDocs {
@@ -563,7 +563,7 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(ctx context.Context, request *
 	// images to the repo, and replaces the comment with a rendered image.
 	// #7062: validate screenshots upfront but only count as uploaded after
 	// successful delivery via addIssueComment (moved below).
-	var validScreenshots []string
+	validScreenshots := make([]string, 0)
 	var ssResult screenshotUploadResult
 	for i, dataURI := range screenshots {
 		parts := strings.SplitN(dataURI, ",", 2)

--- a/pkg/api/handlers/feedback_requests.go
+++ b/pkg/api/handlers/feedback_requests.go
@@ -625,9 +625,9 @@ func (h *FeedbackHandler) CheckPreviewStatus(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"status": "error", "message": fmt.Sprintf("GitHub API returned %d", resp.StatusCode)})
 	}
 
-	var deployments []struct {
+	deployments := []struct {
 		ID int `json:"id"`
-	}
+	}{}
 	if err := json.NewDecoder(resp.Body).Decode(&deployments); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"status": "error", "message": "Failed to parse deployments"})
 	}
@@ -661,11 +661,11 @@ func (h *FeedbackHandler) CheckPreviewStatus(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"status": "error", "message": fmt.Sprintf("GitHub status API returned %d", resp2.StatusCode)})
 	}
 
-	var statuses []struct {
+	statuses := []struct {
 		State     string `json:"state"`
 		TargetURL string `json:"target_url"`
 		CreatedAt string `json:"created_at"`
-	}
+	}{}
 	if err := json.NewDecoder(resp2.Body).Decode(&statuses); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"status": "error", "message": "Failed to parse deployment statuses"})
 	}
@@ -757,7 +757,7 @@ func (h *FeedbackHandler) getCachedOrFetchPRs(ctx context.Context) []GitHubPR {
 	h.prCacheMu.RUnlock()
 
 	v, _, _ := h.prFetchGroup.Do("prs", func() (interface{}, error) {
-		var allPRs []GitHubPR
+		allPRs := make([]GitHubPR, 0)
 		for _, state := range []string{"open", "closed"} {
 			prs := h.fetchPRPages(ctx, state)
 			allPRs = append(allPRs, prs...)
@@ -786,7 +786,7 @@ func (h *FeedbackHandler) getCachedOrFetchPRs(ctx context.Context) []GitHubPR {
 // fetchPRPages fetches up to maxPRPages pages of PRs for the given state,
 // using the shared HTTP client for connection reuse.
 func (h *FeedbackHandler) fetchPRPages(ctx context.Context, state string) []GitHubPR {
-	var allPRs []GitHubPR
+	allPRs := make([]GitHubPR, 0)
 
 	apiBase := resolveGitHubAPIBase()
 	for page := 1; page <= maxPRPages; page++ {
@@ -811,7 +811,7 @@ func (h *FeedbackHandler) fetchPRPages(ctx context.Context, state string) []GitH
 			if resp.StatusCode != http.StatusOK {
 				return nil, false
 			}
-			var prs []GitHubPR
+			prs := make([]GitHubPR, 0)
 			if err := json.NewDecoder(resp.Body).Decode(&prs); err != nil {
 				return nil, false
 			}
@@ -889,7 +889,7 @@ func (h *FeedbackHandler) fetchGitHubIssuesFromRepo(ctx context.Context, githubL
 			if err != nil {
 				return nil, nil
 			}
-			var issues []GitHubIssue
+			issues := make([]GitHubIssue, 0)
 			if err := json.Unmarshal(body, &issues); err != nil {
 				return nil, nil
 			}

--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -524,7 +524,7 @@ func (h *GitHubPipelinesHandler) serveCached(c *fiber.Ctx, key string, build fun
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "repos marshal failed"})
 	}
-	var body []byte
+	body := make([]byte, 0)
 	if len(inner) > 2 && inner[0] == '{' {
 		// Merge repos into existing object.
 		// Guard against integer overflow before computing the allocation size
@@ -999,12 +999,12 @@ func (h *GitHubPipelinesHandler) buildPulse(c *fiber.Ctx) (any, error) {
 		if relRes.StatusCode == http.StatusOK {
 			// Store rate limit headers from the successful API call
 			ctx = ghpStoreRateLimitHeaders(ctx, relRes)
-			var arr []struct {
+			arr := []struct {
 				TagName     string  `json:"tag_name"`
 				PublishedAt *string `json:"published_at"`
 				CreatedAt   *string `json:"created_at"`
 				Draft       bool    `json:"draft"`
-			}
+			}{}
 			if dec := json.NewDecoder(relRes.Body).Decode(&arr); dec == nil && len(arr) > 0 {
 				// Include drafts — nightly releases on this repo are created as
 				// drafts and never promoted, so filtering them out leaves zero
@@ -1051,9 +1051,9 @@ func (h *GitHubPipelinesHandler) buildPulse(c *fiber.Ctx) (any, error) {
 		if tagRes.StatusCode == http.StatusOK {
 			// Store rate limit headers from the successful API call
 			ctx = ghpStoreRateLimitHeaders(ctx, tagRes)
-			var tags []struct {
+			tags := []struct {
 				Name string `json:"name"`
-			}
+			}{}
 			if err := json.NewDecoder(tagRes.Body).Decode(&tags); err == nil {
 				for _, t := range tags {
 					if ghpNightlyTagRe.MatchString(t.Name) {

--- a/pkg/api/handlers/gitops_drift.go
+++ b/pkg/api/handlers/gitops_drift.go
@@ -353,7 +353,7 @@ var kubectlErrorPatterns = []string{
 // detectKubectlErrors scans text for known kubectl/K8s error patterns
 // and returns the matching error lines. Returns nil when no errors are found.
 func detectKubectlErrors(text string) []string {
-	var errs []string
+	errs := make([]string, 0)
 	for _, line := range strings.Split(text, "\n") {
 		lineLower := strings.ToLower(line)
 		for _, pattern := range kubectlErrorPatterns {

--- a/pkg/api/handlers/gitops_drift.go
+++ b/pkg/api/handlers/gitops_drift.go
@@ -351,7 +351,7 @@ var kubectlErrorPatterns = []string{
 }
 
 // detectKubectlErrors scans text for known kubectl/K8s error patterns
-// and returns the matching error lines. Returns nil when no errors are found.
+// and returns the matching error lines. Returns an empty slice when no errors are found.
 func detectKubectlErrors(text string) []string {
 	errs := make([]string, 0)
 	for _, line := range strings.Split(text, "\n") {

--- a/pkg/api/handlers/gitops_operators.go
+++ b/pkg/api/handlers/gitops_operators.go
@@ -51,7 +51,7 @@ func (h *GitOpsHandlers) ListOperators(c *fiber.Ctx) error {
 		allOperators := make([]Operator, 0)
 		// #7544: Surface per-cluster errors so the frontend can indicate
 		// which clusters failed rather than showing a silent empty state.
-		var clusterErrors []string
+		clusterErrors := make([]string, 0)
 
 		overallCtx, overallCancel := context.WithTimeout(c.Context(), operatorRestOverallTimeout)
 		defer overallCancel()
@@ -477,7 +477,7 @@ func (h *GitOpsHandlers) ListOperatorSubscriptions(c *fiber.Ctx) error {
 		allSubs := make([]OperatorSubscription, 0)
 		// #7545: Surface per-cluster errors so the frontend can indicate
 		// which clusters failed rather than showing a silent empty state.
-		var clusterErrors []string
+		clusterErrors := make([]string, 0)
 
 		for _, cl := range clusters {
 			wg.Add(1)

--- a/pkg/api/handlers/kubara_catalog.go
+++ b/pkg/api/handlers/kubara_catalog.go
@@ -174,11 +174,11 @@ func (h *KubaraCatalogHandler) fetchUpstream() ([]KubaraCatalogEntry, error) {
 	}
 
 	// GitHub Contents API returns an array of objects for directory listings
-	var raw []struct {
+	raw := []struct {
 		Name string `json:"name"`
 		Path string `json:"path"`
 		Type string `json:"type"`
-	}
+	}{}
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, err
 	}

--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -656,7 +656,7 @@ func (h *MissionsHandler) BrowseConsoleKB(c *fiber.Ctx) error {
 	// response was an object, crashing frontend iterators. Now we attempt to
 	// unmarshal as an array first; if that fails, try a single object and wrap
 	// it in an array so the frontend always receives a consistent shape.
-	var ghEntries []map[string]interface{}
+	ghEntries := make([]map[string]interface{}, 0)
 	if err := json.Unmarshal(body, &ghEntries); err != nil {
 		var single map[string]interface{}
 		if singleErr := json.Unmarshal(body, &single); singleErr != nil {
@@ -843,7 +843,7 @@ func (h *MissionsHandler) ValidateMission(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"valid": false, "errors": []string{"invalid mission JSON format"}})
 	}
 
-	var errs []string
+	errs := make([]string, 0)
 	if mission.APIVersion != "kc-mission-v1" {
 		errs = append(errs, "apiVersion must be 'kc-mission-v1'")
 	}

--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -545,7 +545,7 @@ func (h *NightlyE2EHandler) fetchAllGuideImages() map[string]map[string]string {
 
 	// Collect unique guide paths
 	seen := make(map[string]bool)
-	var guidePaths []string
+	guidePaths := make([]string, 0)
 	for _, wf := range nightlyWorkflows {
 		if wf.GuidePath != "" && !seen[wf.GuidePath] {
 			seen[wf.GuidePath] = true
@@ -575,7 +575,7 @@ func (h *NightlyE2EHandler) fetchAllGuideImages() map[string]map[string]string {
 			images := make(map[string]string)
 
 			// Find YAML files under this guide's directory
-			var files []treeEntry
+			files := make([]treeEntry, 0)
 			for _, f := range yamlFiles {
 				if strings.HasPrefix(f.Path, prefix) {
 					files = append(files, f)

--- a/pkg/api/handlers/onboarding.go
+++ b/pkg/api/handlers/onboarding.go
@@ -48,10 +48,10 @@ func (h *OnboardingHandler) GetQuestions(c *fiber.Ctx) error {
 func (h *OnboardingHandler) SaveResponses(c *fiber.Ctx) error {
 	userID := middleware.GetUserID(c)
 
-	var responses []struct {
+	responses := []struct {
 		QuestionKey string `json:"question_key"`
 		Answer      string `json:"answer"`
-	}
+	}{}
 	if err := c.BodyParser(&responses); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
 	}
@@ -148,7 +148,7 @@ func generateDefaultCards(responses []models.OnboardingResponse) []models.Card {
 		respMap[r.QuestionKey] = r.Answer
 	}
 
-	var cards []models.Card
+	cards := make([]models.Card, 0)
 
 	// Always include cluster health
 	cards = append(cards, models.Card{
@@ -225,7 +225,7 @@ func generateDefaultCards(responses []models.OnboardingResponse) []models.Card {
 
 	// Deduplicate cards by type
 	seen := make(map[models.CardType]bool)
-	var unique []models.Card
+	unique := make([]models.Card, 0)
 	for _, card := range cards {
 		if !seen[card.CardType] {
 			seen[card.CardType] = true

--- a/pkg/api/handlers/orbit.go
+++ b/pkg/api/handlers/orbit.go
@@ -387,7 +387,7 @@ func (h *OrbitHandler) loadFromDisk() {
 		return
 	}
 
-	var missions []*OrbitMission
+	missions := make([]*OrbitMission, 0)
 	if err := json.Unmarshal(data, &missions); err != nil {
 		slog.Warn("orbit: failed to parse data file", "path", h.dataFile, "error", err)
 		return

--- a/pkg/api/handlers/rewards.go
+++ b/pkg/api/handlers/rewards.go
@@ -88,7 +88,7 @@ type RewardsHandler struct {
 // Org-level tokens are not expanded (no API call); only explicit repo
 // tokens are used.
 func parseRepos(orgs string) []string {
-	var repos []string
+	repos := make([]string, 0)
 	for _, token := range strings.Fields(orgs) {
 		if strings.HasPrefix(token, "repo:") {
 			repos = append(repos, strings.TrimPrefix(token, "repo:"))
@@ -302,7 +302,7 @@ func (h *RewardsHandler) listRepoItems(repo, login, sinceISO, token string) ([]s
 			return allItems, fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(body[:min(len(body), 200)]))
 		}
 
-		var pageItems []searchItem
+		pageItems := make([]searchItem, 0)
 		if err := json.Unmarshal(body, &pageItems); err != nil {
 			return allItems, fmt.Errorf("unmarshal: %w", err)
 		}
@@ -489,7 +489,7 @@ func (h *RewardsHandler) startEviction() {
 			case <-ticker.C:
 				h.mu.RLock()
 				now := time.Now()
-				var staleKeys []string
+				staleKeys := make([]string, 0)
 				for login, entry := range h.cache {
 					if now.Sub(entry.fetchedAt) > rewardsCacheTTL {
 						staleKeys = append(staleKeys, login)

--- a/pkg/api/handlers/rewards_test.go
+++ b/pkg/api/handlers/rewards_test.go
@@ -53,7 +53,7 @@ func TestParseRepos(t *testing.T) {
 	}{
 		{"repo:kubestellar/console", []string{"kubestellar/console"}},
 		{"repo:kubestellar/console repo:kubestellar/kubestellar", []string{"kubestellar/console", "kubestellar/kubestellar"}},
-		{"org:kubestellar", nil},
+		{"org:kubestellar", []string{}},
 		{"repo:kubestellar/console some-other-token", []string{"kubestellar/console"}},
 	}
 

--- a/pkg/api/handlers/topology.go
+++ b/pkg/api/handlers/topology.go
@@ -80,7 +80,7 @@ func (h *TopologyHandlers) GetTopology(c *fiber.Ctx) error {
 	defer cancel()
 
 	// Collect data from all sources, tracking partial failures (#4774)
-	var partialErrors []string
+	partialErrors := make([]string, 0)
 
 	exports, err := h.k8sClient.ListServiceExports(ctx)
 	if err != nil {

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -508,7 +508,7 @@ func (h *WorkloadHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 		ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
 		defer cancel()
 
-		var labelErrors []string
+		labelErrors := make([]string, 0)
 		for _, cluster := range group.Clusters {
 			if err := h.k8sClient.LabelClusterNodes(ctx, cluster, map[string]string{
 				"kubestellar.io/group": group.Name,
@@ -571,7 +571,7 @@ func (h *WorkloadHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 		for _, c := range group.Clusters {
 			newSet[c] = true
 		}
-		var labelErrors []string
+		labelErrors := make([]string, 0)
 		for _, cluster := range oldGroup.Clusters {
 			if !newSet[cluster] {
 				if err := h.k8sClient.RemoveClusterNodeLabels(ctx, cluster, []string{"kubestellar.io/group"}); err != nil {
@@ -631,7 +631,7 @@ func (h *WorkloadHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 		ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
 		defer cancel()
 
-		var labelErrors []string
+		labelErrors := make([]string, 0)
 		for _, cluster := range group.Clusters {
 			if err := h.k8sClient.RemoveClusterNodeLabels(ctx, cluster, []string{"kubestellar.io/group"}); err != nil {
 				slog.Error("[Workloads] failed to remove label from cluster", "cluster", cluster, "error", err)
@@ -668,7 +668,7 @@ func (h *WorkloadHandlers) SyncClusterGroups(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusRequestEntityTooLarge, "Request body too large")
 	}
 
-	var groups []ClusterGroup
+	groups := make([]ClusterGroup, 0)
 	if err := json.Unmarshal(c.Body(), &groups); err != nil {
 		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body"})
 	}
@@ -1205,7 +1205,7 @@ func (h *WorkloadHandlers) GetDeployLogs(c *fiber.Ctx) error {
 	// Collect k8s events for the deployment and its pods
 	// Use a limit to bound memory usage (#3721)
 	const maxEventsPerQuery = 50
-	var allEvents []corev1.Event
+	allEvents := make([]corev1.Event, 0)
 
 	// Events for the deployment itself
 	deployEvents, _ := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{

--- a/pkg/api/handlers/youtube.go
+++ b/pkg/api/handlers/youtube.go
@@ -227,7 +227,7 @@ func fetchPlaylistViaYTDLP() ([]PlaylistVideo, error) {
 		return nil, fmt.Errorf("yt-dlp failed: %w", err)
 	}
 
-	var videos []PlaylistVideo
+	videos := make([]PlaylistVideo, 0)
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		if line == "" {
 			continue


### PR DESCRIPTION
Forty-one var x []Type declarations across nineteen handler files were
leaving slices as nil. When these ended up in JSON responses, they
serialized as null instead of [] — which breaks the frontend's
(data || []) guards and can crash .map() / .filter() calls.

Replaced each with make([]Type, 0) for named types, or a composite
literal []struct{...}{} for inline struct definitions. Function-scoped
only, zero business logic changes, zero package-level touches.

Twenty files changed, 824 handler tests still green. One test in
rewards_test.go updated to expect the new (correct) empty slice
instead of nil.

Fixes #13310