### PR TITLE
Eliminate pending reservation status, make cards clickable

### DIFF
--- a/pkg/models/gpu.go
+++ b/pkg/models/gpu.go
@@ -11,7 +11,6 @@ import (
 type ReservationStatus string
 
 const (
-	ReservationStatusPending   ReservationStatus = "pending"
 	ReservationStatusActive    ReservationStatus = "active"
 	ReservationStatusCompleted ReservationStatus = "completed"
 	ReservationStatusCancelled ReservationStatus = "cancelled"
@@ -19,7 +18,6 @@ const (
 
 // validStatuses enumerates the allowed reservation status values.
 var validStatuses = map[ReservationStatus]bool{
-	ReservationStatusPending:   true,
 	ReservationStatusActive:    true,
 	ReservationStatusCompleted: true,
 	ReservationStatusCancelled: true,
@@ -29,7 +27,6 @@ var validStatuses = map[ReservationStatus]bool{
 // status. The key is the current status; the value set contains the statuses
 // it may transition to.
 var allowedTransitions = map[ReservationStatus]map[ReservationStatus]bool{
-	ReservationStatusPending:   {ReservationStatusActive: true, ReservationStatusCancelled: true},
 	ReservationStatusActive:    {ReservationStatusCompleted: true, ReservationStatusCancelled: true},
 	ReservationStatusCompleted: {}, // terminal
 	ReservationStatusCancelled: {}, // terminal

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -186,7 +186,6 @@ func TestFeedbackType_Constants(t *testing.T) {
 }
 
 func TestReservationStatus_Constants(t *testing.T) {
-	require.Equal(t, ReservationStatus("pending"), ReservationStatusPending)
 	require.Equal(t, ReservationStatus("active"), ReservationStatusActive)
 	require.Equal(t, ReservationStatus("completed"), ReservationStatusCompleted)
 	require.Equal(t, ReservationStatus("cancelled"), ReservationStatusCancelled)
@@ -293,7 +292,7 @@ func TestGPUReservation_JSONRoundTrip_MultiType(t *testing.T) {
 		GPUType:       "NVIDIA A100",
 		GPUTypes:      []string{"NVIDIA A100", "NVIDIA H100"},
 		DurationHours: 24,
-		Status:        ReservationStatusPending,
+		Status:        ReservationStatusActive,
 	}
 	original.NormalizeGPUTypes()
 

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -444,7 +444,7 @@ func (s *SQLiteStore) migrate() error {
 		start_date TEXT NOT NULL,
 		duration_hours INTEGER DEFAULT 24,
 		notes TEXT DEFAULT '',
-		status TEXT DEFAULT 'pending',
+		status TEXT DEFAULT 'active',
 		quota_name TEXT DEFAULT '',
 		quota_enforced INTEGER DEFAULT 0,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -612,6 +612,16 @@ func (s *SQLiteStore) migrate() error {
 		slog.Debug("[SQLite] migration applied", "migration", migration, "version", i+1)
 	}
 	slog.Info("[SQLite] schema migrations complete", "total_migrations", len(migrations))
+
+	// Data migration: "pending" status is eliminated — reservations are now
+	// provisioned synchronously and go straight to "active". Flip any
+	// legacy pending rows so the UI no longer shows a dead state.
+	if res, err := s.db.ExecContext(ctx,
+		`UPDATE gpu_reservations SET status = 'active', updated_at = CURRENT_TIMESTAMP WHERE status = 'pending'`); err != nil {
+		slog.Warn("[SQLite] failed to migrate pending reservations", "error", err)
+	} else if n, _ := res.RowsAffected(); n > 0 {
+		slog.Info("[SQLite] migrated pending reservations to active", "count", n)
+	}
 
 	return nil
 }

--- a/pkg/store/sqlite_gpu.go
+++ b/pkg/store/sqlite_gpu.go
@@ -57,7 +57,7 @@ func (s *SQLiteStore) CreateGPUReservation(ctx context.Context, reservation *mod
 	}
 	reservation.CreatedAt = time.Now()
 	if reservation.Status == "" {
-		reservation.Status = models.ReservationStatusPending
+		reservation.Status = models.ReservationStatusActive
 	}
 	reservation.NormalizeGPUTypes()
 	gpuTypesEncoded := encodeGPUTypes(reservation.GPUTypes)
@@ -105,7 +105,7 @@ func (s *SQLiteStore) CreateGPUReservationWithCapacity(ctx context.Context, rese
 	}
 	reservation.CreatedAt = time.Now()
 	if reservation.Status == "" {
-		reservation.Status = models.ReservationStatusPending
+		reservation.Status = models.ReservationStatusActive
 	}
 	if capacity <= 0 {
 		// No capacity cap — fall through to the unchecked insert. Matches

--- a/web/src/components/gpu/GPUCalendarTab.tsx
+++ b/web/src/components/gpu/GPUCalendarTab.tsx
@@ -145,7 +145,6 @@ export function GPUCalendarTab({
                   {/* Spanning bars */}
                   {week.bars.map((bar, barIdx) => {
                     const isActive = bar.reservation.status === 'active'
-                    const isPending = bar.reservation.status === 'pending'
                     const isInactive = bar.reservation.status === 'completed' || bar.reservation.status === 'cancelled'
 
                     return (
@@ -157,9 +156,7 @@ export function GPUCalendarTab({
                           'h-[20px]',
                           isInactive
                             ? 'bg-secondary/80 text-muted-foreground'
-                            : isActive
-                              ? 'bg-purple-500/30 text-purple-300'
-                              : 'bg-yellow-500/20 text-yellow-300',
+                            : 'bg-purple-500/30 text-purple-300',
                           bar.isStart ? 'rounded-l-md' : '',
                           bar.isEnd ? 'rounded-r-md' : '',
                         )}
@@ -171,11 +168,8 @@ export function GPUCalendarTab({
                         title={`${bar.reservation.title} (${bar.reservation.gpu_count} GPUs, ${bar.reservation.status})`}
                         aria-label={`${bar.reservation.title}: ${bar.reservation.gpu_count} GPUs, ${bar.reservation.status}`}
                       >
-                        {bar.isStart && (
-                          <>
-                            {isActive && <span className="inline-block w-2 h-2 rounded-full bg-green-400 shrink-0" />}
-                            {isPending && <span className="inline-block w-2 h-2 rounded-full bg-yellow-400 shrink-0" />}
-                          </>
+                        {bar.isStart && isActive && (
+                          <span className="inline-block w-2 h-2 rounded-full bg-green-400 shrink-0" />
                         )}
                         {bar.isStart ? bar.reservation.title : ''}
                       </button>

--- a/web/src/components/gpu/GPUOverviewTab.tsx
+++ b/web/src/components/gpu/GPUOverviewTab.tsx
@@ -31,6 +31,7 @@ export interface GPUOverviewTabProps {
   utilizations: Record<string, GPUUtilizationSnapshot[]> | null
   effectiveDemoMode: boolean
   showOnlyMine: boolean
+  onSelectReservation?: (id: string) => void
 }
 
 export function GPUOverviewTab({
@@ -39,6 +40,7 @@ export function GPUOverviewTab({
   utilizations,
   effectiveDemoMode,
   showOnlyMine,
+  onSelectReservation,
 }: GPUOverviewTabProps) {
   const { t } = useTranslation(['cards', 'common'])
 
@@ -162,7 +164,11 @@ export function GPUOverviewTab({
             const sparkColor = snapshots.length > 0 ? getUtilizationColor(avgUtil) : '#9333ea'
             return (
             <div key={r.id}
-              className="p-3 rounded-lg bg-purple-500/10 border border-purple-500/20"
+              role="button"
+              tabIndex={0}
+              onClick={() => onSelectReservation?.(r.id)}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onSelectReservation?.(r.id) }}
+              className={cn('p-3 rounded-lg bg-purple-500/10 border border-purple-500/20', onSelectReservation && 'cursor-pointer hover:border-purple-500/40 transition-colors')}
             >
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div className="flex items-center gap-4 min-w-0">
@@ -181,7 +187,7 @@ export function GPUOverviewTab({
                     <div className="font-medium text-foreground">{r.gpu_count} <TechnicalAcronym term="GPU">{t('common:common.gpus')}</TechnicalAcronym></div>
                     <div className="text-sm text-muted-foreground">{t('gpuReservations.overview.durationHours', { hours: r.duration_hours })}</div>
                   </div>
-                  <span className={cn('px-2 py-0.5 text-xs rounded-full border', STATUS_COLORS[r.status] || STATUS_COLORS.pending)}>
+                  <span className={cn('px-2 py-0.5 text-xs rounded-full border', STATUS_COLORS[r.status] || STATUS_COLORS.active)}>
                     {r.status}
                   </span>
                   <ClusterBadge cluster={r.cluster} size="sm" />

--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -547,6 +547,7 @@ export function GPUReservations() {
           utilizations={utilizations}
           effectiveDemoMode={effectiveDemoMode}
           showOnlyMine={showOnlyMine}
+          onSelectReservation={(id) => { setExpandedReservationId(id); setActiveTab('quotas') }}
         />
       )}
 

--- a/web/src/components/gpu/GPUReservationsTab.tsx
+++ b/web/src/components/gpu/GPUReservationsTab.tsx
@@ -134,7 +134,7 @@ export function GPUReservationsTab({
                   </div>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className={cn('px-2 py-0.5 text-xs rounded-full border', STATUS_COLORS[r.status] || STATUS_COLORS.pending)}>
+                  <span className={cn('px-2 py-0.5 text-xs rounded-full border', STATUS_COLORS[r.status] || STATUS_COLORS.active)}>
                     {r.status}
                   </span>
                   <ClusterBadge cluster={r.cluster} size="sm" />
@@ -260,7 +260,7 @@ export function GPUReservationsTab({
                     </div>
                     <div>
                       <div className="text-sm text-muted-foreground">{t('common:common.status')}</div>
-                      <span className={cn('inline-flex items-center gap-1.5 px-2 py-0.5 text-xs rounded-full border', STATUS_COLORS[r.status] || STATUS_COLORS.pending)}>
+                      <span className={cn('inline-flex items-center gap-1.5 px-2 py-0.5 text-xs rounded-full border', STATUS_COLORS[r.status] || STATUS_COLORS.active)}>
                         {r.status === 'active' && <span className="w-2 h-2 rounded-full bg-green-400" />}
                         {r.status}
                       </span>

--- a/web/src/components/gpu/__tests__/gpuOverviewStats.test.ts
+++ b/web/src/components/gpu/__tests__/gpuOverviewStats.test.ts
@@ -31,7 +31,7 @@ describe('computeGPUOverviewStats', () => {
       nodes: [],
       reservations: [
         { ...BASE_RESERVATION, gpu_count: 8, status: 'active' },
-        { ...BASE_RESERVATION, id: 'reservation-2', gpu_count: 4, status: 'pending' },
+        { ...BASE_RESERVATION, id: 'reservation-2', gpu_count: 4, status: 'active' },
       ],
       gpuQuotas: EMPTY_QUOTAS,
       gpuClusters: [],
@@ -53,7 +53,7 @@ describe('computeGPUOverviewStats', () => {
       nodes,
       reservations: [
         { ...BASE_RESERVATION, gpu_count: 4, status: 'active' },
-        { ...BASE_RESERVATION, id: 'reservation-2', gpu_count: 5, status: 'pending' },
+        { ...BASE_RESERVATION, id: 'reservation-2', gpu_count: 5, status: 'active' },
         { ...BASE_RESERVATION, id: 'reservation-3', gpu_count: 20, status: 'completed' },
       ],
       gpuQuotas: EMPTY_QUOTAS,

--- a/web/src/components/gpu/gpu-constants.ts
+++ b/web/src/components/gpu/gpu-constants.ts
@@ -42,7 +42,6 @@ export function computeAvgUtilization(snapshots: GPUUtilizationSnapshot[]): numb
 
 // Status badge colors
 export const STATUS_COLORS: Record<string, string> = {
-  pending: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
   active: 'bg-green-500/20 text-green-400 border-green-500/30',
   completed: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
   cancelled: 'bg-red-500/20 text-red-400 border-red-500/30',

--- a/web/src/components/gpu/gpuOverviewStats.ts
+++ b/web/src/components/gpu/gpuOverviewStats.ts
@@ -6,7 +6,7 @@ import { GPU_KEYS, MAX_NAME_DISPLAY_LENGTH } from './gpu-constants'
 const CHART_COLOR_COUNT = 4
 const PERCENT_SCALE = 100
 const ELLIPSIS = '...'
-const RESERVATION_STATUSES_COUNTING_TOWARD_CAPACITY = new Set<GPUReservation['status']>(['active', 'pending'])
+const RESERVATION_STATUSES_COUNTING_TOWARD_CAPACITY = new Set<GPUReservation['status']>(['active'])
 
 export interface GPUClusterSummary {
   name: string

--- a/web/src/hooks/useGPUReservations.ts
+++ b/web/src/hooks/useGPUReservations.ts
@@ -5,7 +5,7 @@ import { isInClusterMode } from './useBackendHealth'
 
 const REFRESH_INTERVAL_MS = 30000
 
-export type ReservationStatus = 'pending' | 'active' | 'completed' | 'cancelled'
+export type ReservationStatus = 'active' | 'completed' | 'cancelled'
 
 export interface GPUReservation {
   id: string
@@ -146,7 +146,7 @@ const DEMO_RESERVATIONS: GPUReservation[] = [
     start_date: new Date(Date.now() + 86400000).toISOString().split('T')[0],
     duration_hours: 24,
     notes: '',
-    status: 'pending',
+    status: 'active',
     quota_name: '',
     quota_enforced: false,
     created_at: new Date(Date.now() - 3600000).toISOString() },


### PR DESCRIPTION
## Summary
- **Remove `pending` status entirely** — reservations are now provisioned synchronously (#13323), so `pending` is dead code. Existing pending rows are migrated to `active` on startup.
- **Make overview cards clickable** — clicking a reservation card on the Overview tab navigates to the Reservations tab with that reservation expanded.
- **Remove yellow pending pill** from all GPU views (overview, reservations, calendar).

Fixes Mike Spreitzer's reservation showing as "pending" on vllm-d — the startup migration flips it to "active".

## Changes
- `pkg/models/gpu.go`: Remove `ReservationStatusPending` constant and state transitions
- `pkg/store/sqlite.go`: Change default to `'active'`, add data migration `UPDATE ... SET status='active' WHERE status='pending'`
- `pkg/store/sqlite_gpu.go`: Default status fallback → active
- `web/src/components/gpu/*`: Remove pending pill color, pending calendar indicator, make overview cards clickable
- `web/src/hooks/useGPUReservations.ts`: Remove `'pending'` from `ReservationStatus` type
- Tests updated

## Test plan
- [ ] Deploy to vllm-d, verify Mike's reservation shows "active" (green pill)
- [ ] Click a reservation card on Overview tab → should switch to Reservations tab with card expanded
- [ ] Create a new reservation → should show "active" immediately (no pending state)