### PR TITLE
fix: resolve button text truncation in AI Missions panel

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -1376,25 +1376,28 @@ export function MissionSidebar() {
                   setShowNewMission(true)
                   setTimeout(() => newMissionInputRef.current?.focus(), FOCUS_DELAY_MS)
                 }}
-                className="flex flex-col items-center justify-center gap-1.5 px-3 py-3 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors h-[72px]"
+                title={t('missionSidebar.startCustomMission')}
+                className="flex flex-col items-center justify-center gap-1.5 px-2 py-3 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors min-h-[72px]"
               >
                 <Sparkles className="w-6 h-6 shrink-0" />
-                <span className="text-center leading-tight text-xs truncate max-w-full">{t('missionSidebar.startCustomMission')}</span>
+                <span className="text-center leading-tight text-xs break-words max-w-full">{t('missionSidebar.startCustomMission')}</span>
               </button>
             )}
             <button
               onClick={() => openMissionBrowser()}
-              className="flex flex-col items-center justify-center gap-1.5 px-3 py-3 text-sm font-medium bg-secondary text-foreground rounded-lg hover:bg-secondary/80 transition-colors h-[72px]"
+              title={t('layout.missionSidebar.browseCommunityMissions')}
+              className="flex flex-col items-center justify-center gap-1.5 px-2 py-3 text-sm font-medium bg-secondary text-foreground rounded-lg hover:bg-secondary/80 transition-colors min-h-[72px]"
             >
               <Globe className="w-6 h-6 shrink-0" />
-              <span className="text-center leading-tight text-xs truncate max-w-full">{t('layout.missionSidebar.browseCommunityMissions')}</span>
+              <span className="text-center leading-tight text-xs break-words max-w-full">{t('layout.missionSidebar.browseCommunityMissions')}</span>
             </button>
             <button
               onClick={() => setShowMissionControl(true)}
-              className="flex flex-col items-center justify-center gap-1.5 px-3 py-3 text-sm font-medium bg-linear-to-r from-purple-600 to-indigo-600 text-white rounded-lg hover:from-purple-500 hover:to-indigo-500 transition-colors shadow-lg shadow-purple-500/25 h-[72px]"
+              title={t('layout.missionSidebar.missionControl')}
+              className="flex flex-col items-center justify-center gap-1.5 px-2 py-3 text-sm font-medium bg-linear-to-r from-purple-600 to-indigo-600 text-white rounded-lg hover:from-purple-500 hover:to-indigo-500 transition-colors shadow-lg shadow-purple-500/25 min-h-[72px]"
             >
               <Rocket className="w-6 h-6 shrink-0" />
-              <span className="text-center leading-tight text-xs truncate max-w-full">{t('layout.missionSidebar.missionControl')}</span>
+              <span className="text-center leading-tight text-xs break-words max-w-full">{t('layout.missionSidebar.missionControl')}</span>
             </button>
           </div>
           {/* Hint to open history when missions exist */}


### PR DESCRIPTION
Fixes #13332 
<img width="344" height="360" alt="Screenshot 2026-05-13 at 01 56 50" src="https://github.com/user-attachments/assets/fa0a2d84-6257-418e-9174-4c271bed0307" />
<img width="472" height="713" alt="Screenshot 2026-05-13 at 01 56 57" src="https://github.com/user-attachments/assets/5da788b9-ec7f-477d-b020-ccf98935511b" />
 
 -Action button labels in the AI Missions dashboard panel ("Start Custom Mission", "Browse Community Missions", "Mission Control") were truncated with ellipsis, making them indistinguishable.

Changes
Removed truncate class from button text spans, replacing with break-words to allow text to wrap to a second line
Changed h-[72px] (fixed height) to min-h-[72px] so buttons can grow when text wraps while maintaining visual alignment
Reduced horizontal padding (px-3 → px-2) to give more room for text within the grid columns
Added title attributes on each button for hover tooltips showing the full label
What was tested
Verified the frontend renders correctly on localhost:5174 with labels fully visible
Buttons remain responsive and aligned in the 3-column grid layout
Build/lint validated by CI
Before / After
Before: "Start Cust...", "Browse C...", "Mission C..."
After: Full labels visible, wrapping to second line when needed