### PR TITLE
fix: restore DejaVu priority in quantum circuit viewer font stack

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -446,8 +446,8 @@ layer(base);
 
 /* Quantum circuit display — monospace with proper line height for ASCII art */
 .quantum-circuit-display {
-  /* Theme/system monospace preferred; circuit-art fallbacks for consistent character widths */
-  font-family: var(--font-mono), 'DejaVu Sans Mono', 'Noto Sans Mono', 'Cascadia Code', monospace;
+  /* DejaVu prioritized for reliable Unicode box-drawing character widths; theme fallbacks */
+  font-family: 'DejaVu Sans Mono', 'Noto Sans Mono', 'Cascadia Code', var(--font-mono), monospace;
   font-size: 0.75rem;
   line-height: 1.5;
 }


### PR DESCRIPTION
## Summary
Quantum circuit diagrams render with Unicode box-drawing characters that require uniform character widths for proper alignment. This fix restores DejaVu Sans Mono as the primary font, with theme fonts as fallbacks.

## Problem
PR #13212 reordered the font stack to prioritize theme fonts (`var(--font-mono)` = JetBrains Mono), but JetBrains Mono has variable character widths. This breaks circuit ASCII art alignment, causing labels to offset from circuit lines.

## Solution
Restore correct font stack priority:
```css
font-family: 'DejaVu Sans Mono', 'Noto Sans Mono', 'Cascadia Code', var(--font-mono), monospace;
```

- **DejaVu Sans Mono** → Reliable Unicode box-drawing character rendering
- **Noto/Cascadia** → Fallback options with good character width consistency
- **var(--font-mono)** → Theme customization (still available if DejaVu unavailable)

## Test plan
- [ ] Start dev server with `./start-dev.sh`
- [ ] Navigate to Quantum dashboard
- [ ] Open Circuit Viewer card and verify:
  - Box-drawing characters render (┌ ┤ └ ├ ┐ ┘ ─ ║ ╥ ╩ ═)
  - Labels align with circuit lines (no offset)
  - No console font loading errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)