### PR TITLE
fix: add nil k8sClient guard in StartWatcher to prevent panic

### DIFF
--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -139,7 +139,7 @@ func (h *ConsolePersistenceHandlers) StartWatcher(ctx context.Context) error {
 	}
 
 	if h.k8sClient == nil {
-		return fmt.Errorf("no kubernetes client available")
+		return fmt.Errorf("%s", noClusterAccessMsg)
 	}
 
 	activeCluster, err := h.persistenceStore.GetActiveCluster(ctx)

--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -138,6 +138,10 @@ func (h *ConsolePersistenceHandlers) StartWatcher(ctx context.Context) error {
 		return nil
 	}
 
+	if h.k8sClient == nil {
+		return fmt.Errorf("no kubernetes client available")
+	}
+
 	activeCluster, err := h.persistenceStore.GetActiveCluster(ctx)
 	if err != nil {
 		slog.Warn("[ConsolePersistence] cannot start watcher", "error", err)


### PR DESCRIPTION
StartWatcher was the only method on ConsolePersistenceHandlers that
dereferenced h.k8sClient without a nil check. checkClusterHealth
and getClusterClient both guard against it — StartWatcher just got
missed.

When a user enables persistence on a standalone or demo console
where k8sClient was never initialized, StartWatcher panics with a
nil pointer dereference on GetDynamicClient. The caller already
handles StartWatcher's error gracefully with a Warn-level log, so
this turns a crash into a logged warning with clean degradation.