### PR TITLE
fix(i18n): wrap drilldown toast messages in translation layer

### DIFF
--- a/web/src/components/drilldown/views/BuildpackDrillDown.tsx
+++ b/web/src/components/drilldown/views/BuildpackDrillDown.tsx
@@ -200,7 +200,7 @@ export function BuildpackDrillDown({ data }: Props) {
       }
     } catch (error: unknown) {
       console.error('Failed to fetch image info:', error)
-      showToast('Failed to fetch image info', 'error')
+      showToast(t('drilldown.buildpack.fetchImageError', 'Failed to fetch image info'), 'error')
     }
     setLoading(false)
   }
@@ -245,7 +245,7 @@ export function BuildpackDrillDown({ data }: Props) {
       }
     } catch (error: unknown) {
       console.error('Failed to fetch builds:', error)
-      showToast('Failed to fetch builds', 'error')
+      showToast(t('drilldown.buildpack.fetchBuildsError', 'Failed to fetch builds'), 'error')
       setBuilds([])
     }
     setBuildsLoading(false)
@@ -300,7 +300,7 @@ export function BuildpackDrillDown({ data }: Props) {
       }
     } catch (error: unknown) {
       console.error('Failed to fetch logs:', error)
-      showToast('Failed to fetch logs', 'error')
+      showToast(t('drilldown.buildpack.fetchLogsError', 'Failed to fetch logs'), 'error')
       setLogs('Error fetching logs')
     }
 

--- a/web/src/components/drilldown/views/YAMLDrillDown.tsx
+++ b/web/src/components/drilldown/views/YAMLDrillDown.tsx
@@ -78,7 +78,7 @@ export function YAMLDrillDown({ data }: Props) {
     // of an unhandled exception that whites out the dialog.
     const result = downloadText(`${resourceName}.yaml`, yaml, 'text/yaml')
     if (!result.ok) {
-      showToast(t('drilldown.yaml.downloadError', `Failed to download YAML: ${result.error?.message || 'unknown error'}`), 'error')
+      showToast(t('drilldown.yaml.downloadError', { detail: result.error?.message || 'unknown error' }), 'error')
       return
     }
     emitDataExported('yaml_download', resourceType)

--- a/web/src/components/drilldown/views/YAMLDrillDown.tsx
+++ b/web/src/components/drilldown/views/YAMLDrillDown.tsx
@@ -68,7 +68,7 @@ export function YAMLDrillDown({ data }: Props) {
       copiedTimerRef.current = setTimeout(() => setCopied(false), UI_FEEDBACK_TIMEOUT_MS)
       emitDataExported('yaml_copy', resourceType)
     } catch {
-      showToast('Failed to copy to clipboard', 'error')
+      showToast(t('drilldown.yaml.copyError', 'Failed to copy to clipboard'), 'error')
     }
   }
 
@@ -78,7 +78,7 @@ export function YAMLDrillDown({ data }: Props) {
     // of an unhandled exception that whites out the dialog.
     const result = downloadText(`${resourceName}.yaml`, yaml, 'text/yaml')
     if (!result.ok) {
-      showToast(`Failed to download YAML: ${result.error?.message || 'unknown error'}`, 'error')
+      showToast(t('drilldown.yaml.downloadError', `Failed to download YAML: ${result.error?.message || 'unknown error'}`), 'error')
       return
     }
     emitDataExported('yaml_download', resourceType)

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2281,7 +2281,7 @@
     },
     "yaml": {
       "copyError": "Failed to copy to clipboard",
-      "downloadError": "Failed to download YAML: {{error}}"
+      "downloadError": "Failed to download YAML"
     },
     "ai": {
       "title": "AI Analysis",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2274,6 +2274,15 @@
       "manifest": "Manifest",
       "issues": "Issues"
     },
+    "buildpack": {
+      "fetchImageError": "Failed to fetch image info",
+      "fetchBuildsError": "Failed to fetch builds",
+      "fetchLogsError": "Failed to fetch logs"
+    },
+    "yaml": {
+      "copyError": "Failed to copy to clipboard",
+      "downloadError": "Failed to download YAML: {{error}}"
+    },
     "ai": {
       "title": "AI Analysis",
       "notConnected": "AI agent not connected",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2281,7 +2281,7 @@
     },
     "yaml": {
       "copyError": "Failed to copy to clipboard",
-      "downloadError": "Failed to download YAML"
+      "downloadError": "Failed to download YAML: {{detail}}"
     },
     "ai": {
       "title": "AI Analysis",


### PR DESCRIPTION
Five showToast calls in BuildpackDrillDown and YAMLDrillDown were still 
using raw English strings — fetch failures, copy-to-clipboard errors, 
and download failures. Both components already import useTranslation 
and call t() everywhere else in their JSX — the toast calls just got 
missed during the original i18n pass.

Wrapped each one in t() with English fallbacks and added five new keys 
under the drilldown.* namespace. Zero new imports, zero new hook calls, 
same pattern we've used in three previous i18n PRs.