### PR TITLE
fix: prevent setState on unmounted component in compliance auto-refresh

### DIFF
--- a/web/src/components/compliance/LicenseComplianceDashboard.tsx
+++ b/web/src/components/compliance/LicenseComplianceDashboard.tsx
@@ -82,10 +82,13 @@ export default function LicenseComplianceDashboard() {
         authFetch('/api/supply-chain/licenses/summary'),
       ])
       if (!pkgRes.ok || !catRes.ok || !sumRes.ok) throw new Error('Failed to load license data')
+      const packages = await pkgRes.json()
+      const categories = await catRes.json()
+      const summaryData = await sumRes.json()
       if (!mountedRef.current) return
-      setPackages(await pkgRes.json())
-      setCategories(await catRes.json())
-      setSummary(await sumRes.json())
+      setPackages(packages)
+      setCategories(categories)
+      setSummary(summaryData)
     } catch (e: unknown) {
       if (!mountedRef.current) return
       setError(e instanceof Error ? e.message : 'Failed to load license data')

--- a/web/src/components/compliance/LicenseComplianceDashboard.tsx
+++ b/web/src/components/compliance/LicenseComplianceDashboard.tsx
@@ -5,7 +5,7 @@
  * flags deny-listed licenses (GPL, AGPL, SSPL, etc.) and warn-listed ones
  * (LGPL, MPL), and provides a fleet-wide license inventory.
  */
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   CheckCircle2, XCircle, AlertTriangle, Loader2,
@@ -70,6 +70,7 @@ export default function LicenseComplianceDashboard() {
   const [activeTab, setActiveTab] = useState<'violations' | 'inventory' | 'categories'>('violations')
   const [filterRisk, setFilterRisk] = useState<LicenseRisk | null>('denied')
   const [autoRefresh, setAutoRefresh] = useState(false)
+  const mountedRef = useRef(true)
 
   const fetchData = async () => {
     setLoading(true)
@@ -81,20 +82,27 @@ export default function LicenseComplianceDashboard() {
         authFetch('/api/supply-chain/licenses/summary'),
       ])
       if (!pkgRes.ok || !catRes.ok || !sumRes.ok) throw new Error('Failed to load license data')
+      if (!mountedRef.current) return
       setPackages(await pkgRes.json())
       setCategories(await catRes.json())
       setSummary(await sumRes.json())
     } catch (e: unknown) {
+      if (!mountedRef.current) return
       setError(e instanceof Error ? e.message : 'Failed to load license data')
     } finally {
+      if (!mountedRef.current) return
       setLoading(false)
     }
   }
 
   useEffect(() => {
+    mountedRef.current = true
     fetchData()
     const id = setInterval(fetchData, LICENSE_REFRESH_MS)
-    return () => clearInterval(id)
+    return () => {
+      mountedRef.current = false
+      clearInterval(id)
+    }
   }, [])
 
   if (loading) return (

--- a/web/src/components/compliance/SigningStatusDashboard.tsx
+++ b/web/src/components/compliance/SigningStatusDashboard.tsx
@@ -80,10 +80,13 @@ export default function SigningStatusDashboard() {
         authFetch('/api/supply-chain/signing/summary'),
       ])
       if (!imgRes.ok || !polRes.ok || !sumRes.ok) throw new Error('Failed to load signing data')
+      const images = await imgRes.json()
+      const policies = await polRes.json()
+      const summaryData = await sumRes.json()
       if (!mountedRef.current) return
-      setImages(await imgRes.json())
-      setPolicies(await polRes.json())
-      setSummary(await sumRes.json())
+      setImages(images)
+      setPolicies(policies)
+      setSummary(summaryData)
     } catch (e: unknown) {
       if (!mountedRef.current) return
       setError(e instanceof Error ? e.message : 'Failed to load signing data')

--- a/web/src/components/compliance/SigningStatusDashboard.tsx
+++ b/web/src/components/compliance/SigningStatusDashboard.tsx
@@ -5,7 +5,7 @@
  * Surfaces unsigned images, failed verifications, and policy violations so
  * operators can enforce supply chain integrity controls.
  */
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   BadgeCheck, XCircle, AlertTriangle, Loader2,
@@ -68,6 +68,7 @@ export default function SigningStatusDashboard() {
   const [activeTab, setActiveTab] = useState<'images' | 'policies'>('images')
   const [filterUnsigned, setFilterUnsigned] = useState(false)
   const [autoRefresh, setAutoRefresh] = useState(false)
+  const mountedRef = useRef(true)
 
   const fetchData = async () => {
     setLoading(true)
@@ -79,20 +80,27 @@ export default function SigningStatusDashboard() {
         authFetch('/api/supply-chain/signing/summary'),
       ])
       if (!imgRes.ok || !polRes.ok || !sumRes.ok) throw new Error('Failed to load signing data')
+      if (!mountedRef.current) return
       setImages(await imgRes.json())
       setPolicies(await polRes.json())
       setSummary(await sumRes.json())
     } catch (e: unknown) {
+      if (!mountedRef.current) return
       setError(e instanceof Error ? e.message : 'Failed to load signing data')
     } finally {
+      if (!mountedRef.current) return
       setLoading(false)
     }
   }
 
   useEffect(() => {
+    mountedRef.current = true
     fetchData()
     const id = setInterval(fetchData, REFRESH_INTERVAL_MS)
-    return () => clearInterval(id)
+    return () => {
+      mountedRef.current = false
+      clearInterval(id)
+    }
   }, [])
 
   if (loading) return (


### PR DESCRIPTION
SigningStatusDashboard and LicenseComplianceDashboard both poll their
endpoints on a setInterval for live data. Problem is, the cleanup
only clears the interval — if the user navigates away while a
fetch is mid-flight, every setState after the await fires on an
already-gone component.

Added a mountedRef flag that gets checked after each await, in the
catch block, and in the finally. Once the component unmounts, the
flag flips to false and all pending state updates silently bail.
The manual refresh buttons call the same fetchData — they now
respect the mount state too, which is correct behavior.

Both files got the same five-line treatment. Zero behavior change
for the happy path — the flag is only a guard on the way out.