### PR TITLE
fix: log GetUser error in ListAllFeatureRequests (#13300)

### DIFF
--- a/pkg/api/handlers/feedback_requests.go
+++ b/pkg/api/handlers/feedback_requests.go
@@ -396,7 +396,7 @@ func (h *FeedbackHandler) ListAllFeatureRequests(c *fiber.Ctx) error {
 	// Get current user's GitHub login for ownership comparison
 	user, err := h.store.GetUser(c.UserContext(), userID)
 	if err != nil {
-		slog.Warn("[Feedback] failed to get user for queue", "userID", userID, "error", err)
+		slog.Warn("[Feedback] failed to get user for queue", "user_id", userID, "error", err)
 	}
 	currentGitHubLogin := ""
 	if user != nil {

--- a/pkg/api/handlers/feedback_requests.go
+++ b/pkg/api/handlers/feedback_requests.go
@@ -394,7 +394,10 @@ func (h *FeedbackHandler) ListAllFeatureRequests(c *fiber.Ctx) error {
 	countOnly := c.Query("count_only") == "true"
 
 	// Get current user's GitHub login for ownership comparison
-	user, _ := h.store.GetUser(c.UserContext(), userID)
+	user, err := h.store.GetUser(c.UserContext(), userID)
+	if err != nil {
+		slog.Warn("[Feedback] failed to get user for queue", "userID", userID, "error", err)
+	}
 	currentGitHubLogin := ""
 	if user != nil {
 		currentGitHubLogin = user.GitHubLogin


### PR DESCRIPTION
## Summary

Fixes #13300

## Root cause

`ListAllFeatureRequests` called `h.store.GetUser()` and discarded the error with `_`. Other `GetUser` call sites in the same file handle errors.

## Impact

When `GetUser` fails (DB timeout, pool exhaustion, etc.), the error was invisible, `currentGitHubLogin` became empty, and the queue could show degraded GitHub results without operator visibility.

## Fix

Use `user, err :=` and `slog.Warn` with `userID` and `error` fields, then fall through. The handler already degrades when login is empty (ownership badges omitted; existing GitHub/local fallbacks).

Warn (not Error or HTTP 500) is intentional: a transient user lookup failure should not break the entire queue view.

## Testing

- `GOTOOLCHAIN=auto go build ./pkg/api/handlers/...` — pass
- `GOTOOLCHAIN=auto go test ./pkg/api/handlers/...` — `TestServiceExportsHandlers_List` fails locally with a 1000ms internal timeout (appears unrelated / flaky); feedback-related tests (`TestListFeatureRequests`, `TestCheckPreviewStatus`, `TestGetIssueLinkCapabilities`) pass
- `grep GetUser` on `feedback_requests.go` — no discarded `GetUser` errors
<- re-trigger ci -->