### PR TITLE
fix: prevent setState on unmounted component in RBACAuditDashboard

### DIFF
--- a/web/src/components/compliance/RBACAuditDashboard.tsx
+++ b/web/src/components/compliance/RBACAuditDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, memo } from 'react'
+import { useState, useEffect, useMemo, memo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { rbacAuditDashboardConfig } from '../../config/dashboards/rbac-audit'
@@ -55,6 +55,7 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
   const [activeTab, setActiveTab] = useState<'findings' | 'bindings'>('findings')
   const [severityFilter, setSeverityFilter] = useState('all')
   const [autoRefresh, setAutoRefresh] = useState(false)
+  const cancelledRef = useRef(false)
 
   const fetchData = async () => {
     setLoading(true)
@@ -66,17 +67,27 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
         authFetch('/api/identity/rbac/findings'),
       ])
       if (!smRes.ok || !bRes.ok || !fRes.ok) throw new Error('Failed to load RBAC data')
-      setSummary(await smRes.json())
-      setBindings(await bRes.json())
-      setFindings(await fRes.json())
+      const smData = await smRes.json()
+      const bData = await bRes.json()
+      const fData = await fRes.json()
+      if (cancelledRef.current) return
+      setSummary(smData)
+      setBindings(bData)
+      setFindings(fData)
     } catch (e: unknown) {
+      if (cancelledRef.current) return
       setError(e instanceof Error ? e.message : 'Failed to load RBAC data')
     } finally {
+      if (cancelledRef.current) return
       setLoading(false)
     }
   }
 
-  useEffect(() => { fetchData() }, [])
+  useEffect(() => {
+    cancelledRef.current = false
+    fetchData()
+    return () => { cancelledRef.current = true }
+  }, [])
 
   const filteredFindings = useMemo(() => {
     if (severityFilter === 'all') return findings


### PR DESCRIPTION
Same story as ChangeControlAudit — three parallel API calls fire on
mount, resolve asynchronously, and dump into setState with no one
checking whether the component is still alive. The useEffect had no
cleanup, so any in-flight fetch that landed after navigation would
update a component that was already gone.

Pulled the .json() parsing ahead of the cancelledRef guard so all
async work finishes before we check, then added the same guard in
catch and finally. The ref resets on mount and flips on unmount —
same pattern we've used in three other compliance dashboards now.