### PR TITLE
fix: prevent setState on unmounted component in HIPAADashboard

### DIFF
--- a/web/src/components/compliance/HIPAADashboard.tsx
+++ b/web/src/components/compliance/HIPAADashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, memo } from 'react'
+import { useState, useEffect, useMemo, memo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { hipaaDashboardConfig } from '../../config/dashboards/hipaa'
@@ -58,6 +58,7 @@ export const HIPAADashboardContent = memo(function HIPAADashboardContent() {
   const [expandedSafeguard, setExpandedSafeguard] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'safeguards' | 'phi' | 'flows'>('safeguards')
   const [autoRefresh, setAutoRefresh] = useState(false)
+  const cancelledRef = useRef(false)
 
   const fetchData = async () => {
     setLoading(true)
@@ -70,18 +71,29 @@ export const HIPAADashboardContent = memo(function HIPAADashboardContent() {
         authFetch('/api/compliance/hipaa/summary'),
       ])
       if (!sgRes.ok || !nsRes.ok || !flRes.ok || !smRes.ok) throw new Error('Failed to load HIPAA data')
-      setSafeguards(await sgRes.json())
-      setPHINamespaces(await nsRes.json())
-      setDataFlows(await flRes.json())
-      setSummary(await smRes.json())
+      const sgData = await sgRes.json()
+      const nsData = await nsRes.json()
+      const flData = await flRes.json()
+      const smData = await smRes.json()
+      if (cancelledRef.current) return
+      setSafeguards(sgData)
+      setPHINamespaces(nsData)
+      setDataFlows(flData)
+      setSummary(smData)
     } catch (e: unknown) {
+      if (cancelledRef.current) return
       setError(e instanceof Error ? e.message : 'Failed to load HIPAA data')
     } finally {
+      if (cancelledRef.current) return
       setLoading(false)
     }
   }
 
-  useEffect(() => { fetchData() }, [])
+  useEffect(() => {
+    cancelledRef.current = false
+    fetchData()
+    return () => { cancelledRef.current = true }
+  }, [])
 
   const scoreColor = useMemo(() => {
     if (!summary) return 'text-muted-foreground'


### PR DESCRIPTION
Fourth dashboard in the compliance suite with the same pattern —
four API calls fire on mount, resolve asynchronously, and dump into
setState with no one checking if the component is still around.

Same cancelledRef fix — .json() parsing pulled ahead of the guard,
checks in catch and finally, ref reset on mount and flipped in
cleanup. Nothing fancy, just the same treatment the other three
already got.