### PR TITLE
fix: make helm and gh soft dependencies for mission preflight

### DIFF
--- a/pkg/agent/provider_claudecode.go
+++ b/pkg/agent/provider_claudecode.go
@@ -14,16 +14,20 @@ import (
 	"github.com/kubestellar/console/pkg/safego"
 )
 
-// RequiredMissionTools lists the CLI binaries that must be available in
-// PATH for AI missions to execute cluster operations. Each entry is a
-// binary name passed to exec.LookPath during the pre-launch readiness
-// check. Keep this list in sync with the tools referenced in
-// ClaudeCodeSystemPrompt and the --allowedTools flag below.
+// RequiredMissionTools lists CLI binaries that MUST be on PATH for any
+// mission to run. Missing any of these is a hard failure.
 var RequiredMissionTools = []string{
 	"kubectl", // Kubernetes CLI — cluster inspection & management
-	"helm",    // Helm — chart-based deployments
 	"git",     // Git — version control operations
-	"gh",      // GitHub CLI — PR creation, issue triage
+}
+
+// OptionalMissionTools lists CLI binaries that enhance missions but are
+// not strictly required. Missing tools are logged as warnings; missions
+// that need them will fail at execution time with a clear error from
+// the agent rather than a blanket preflight block.
+var OptionalMissionTools = []string{
+	"helm", // Helm — chart-based deployments
+	"gh",   // GitHub CLI — PR creation, issue triage
 }
 
 // ToolDependencyError is returned when one or more required CLI tools
@@ -38,8 +42,8 @@ func (e *ToolDependencyError) Error() string {
 }
 
 // CheckToolDependencies verifies that every binary in RequiredMissionTools
-// is available on PATH via exec.LookPath. Returns nil when all tools are
-// present, or a *ToolDependencyError listing the missing ones.
+// is available on PATH. Optional tools are checked but only produce a log
+// warning — they do not block mission execution.
 func CheckToolDependencies() error {
 	var missing []string
 	for _, tool := range RequiredMissionTools {
@@ -49,6 +53,12 @@ func CheckToolDependencies() error {
 	}
 	if len(missing) > 0 {
 		return &ToolDependencyError{MissingTools: missing}
+	}
+
+	for _, tool := range OptionalMissionTools {
+		if _, err := exec.LookPath(tool); err != nil {
+			slog.Warn("optional mission tool not found on PATH", "tool", tool)
+		}
 	}
 	return nil
 }

--- a/pkg/agent/provider_claudecode_test.go
+++ b/pkg/agent/provider_claudecode_test.go
@@ -96,3 +96,26 @@ func TestRequiredMissionTools_NotEmpty(t *testing.T) {
 		t.Error("RequiredMissionTools must not be empty")
 	}
 }
+
+func TestOptionalMissionTools_NotEmpty(t *testing.T) {
+	if len(OptionalMissionTools) == 0 {
+		t.Error("OptionalMissionTools must not be empty")
+	}
+}
+
+func TestCheckToolDependencies_OptionalToolsMissing_NoError(t *testing.T) {
+	err := CheckToolDependencies()
+	if err != nil {
+		tde, ok := err.(*ToolDependencyError)
+		if !ok {
+			t.Fatalf("expected *ToolDependencyError, got %T", err)
+		}
+		for _, tool := range tde.MissingTools {
+			for _, opt := range OptionalMissionTools {
+				if tool == opt {
+					t.Errorf("optional tool %q should not cause a hard failure", tool)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Moves `helm` and `gh` from `RequiredMissionTools` to new `OptionalMissionTools` list
- Missing optional tools now log a warning instead of blocking all missions
- Only `kubectl` and `git` remain as hard requirements
- Adds tests for `OptionalMissionTools` and verifies optional tools don't cause hard failures

## Why
GA4 shows `execution_error: missing required tools: gh` blocking missions that don't need GitHub CLI (troubleshoot, analyze, repair). The all-or-nothing preflight check was rejecting every mission if any of the 4 tools was missing, even when the specific mission only needed kubectl.

## Test plan
- [ ] Verify missions run without `gh` installed (troubleshoot, analyze, repair types)
- [ ] Verify missions that need `gh` (PR creation) fail gracefully at execution time with clear error
- [ ] Verify `go test ./pkg/agent/...` passes
- [ ] Monitor GA4 `ksc_mission_error` events for reduction in `execution_error` codes

Fixes the `missing required tools: gh` execution errors seen in GA4 mission error tracking.