### PR TITLE
fix: use console.error for permanent reconnect failure in useUpdateProgress

### DIFF
--- a/web/src/hooks/useUpdateProgress.ts
+++ b/web/src/hooks/useUpdateProgress.ts
@@ -214,7 +214,7 @@ export function useUpdateProgress() {
 
           // Check if we've exceeded max reconnect attempts
           if (reconnectAttemptsRef.current >= MAX_WS_RECONNECT_ATTEMPTS) {
-            console.warn('[UpdateProgress] Max reconnect attempts exceeded, giving up')
+            console.error('[UpdateProgress] Max reconnect attempts exceeded, giving up')
             return
           }
 
@@ -234,7 +234,7 @@ export function useUpdateProgress() {
       } catch {
         // Agent not available, retry later with exponential backoff
         if (reconnectAttemptsRef.current >= MAX_WS_RECONNECT_ATTEMPTS) {
-          console.warn('[UpdateProgress] Max reconnect attempts exceeded, giving up')
+          console.error('[UpdateProgress] Max reconnect attempts exceeded, giving up')
           return
         }
 


### PR DESCRIPTION
When the update-progress WebSocket runs out of retries and stops
trying — that's it. The hook is done. No more reconnect attempts,
no more data, the feature is offline. But it logged at warn level,
same as a routine connection blip.

Bumped both occurrences to console.error. This is a terminal event
and operators should see it that way — not buried in a sea of
warn-level noise. Same treatment the presence tracker and GPU
monitor got.