### PR TITLE
fix: use console.error for permanent disconnect in useActiveUsers

### DIFF
--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -306,7 +306,7 @@ function startPresenceConnection() {
 
       // Check if we've exceeded max reconnect attempts
       if (presenceReconnectAttempts >= MAX_WS_RECONNECT_ATTEMPTS) {
-        console.warn('[ActiveUsers] Max reconnect attempts exceeded, giving up')
+        console.error('[ActiveUsers] Max reconnect attempts exceeded, giving up')
         return
       }
 


### PR DESCRIPTION
Same as the update-progress hook — a max-retries-exceeded
disconnect means the presence tracker is permanently offline. It
was logging at warn, same level as a routine reconnection.

Bumped to console.error. Terminal events should surface as errors.