### PR TITLE
fix: add visual fill track to settings slider inputs

### DIFF
--- a/web/src/components/settings/sections/AISettingsSection.tsx
+++ b/web/src/components/settings/sections/AISettingsSection.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { Cpu } from 'lucide-react'
 import { AIMode } from '../../../hooks/useAIMode'
 import { emitAIModeChanged } from '../../../lib/analytics'
+import { RangeSlider } from '../../ui/RangeSlider'
 
 interface AISettingsSectionProps {
   mode: AIMode
@@ -26,10 +27,9 @@ export function AISettingsSection({ mode, setMode, description }: AISettingsSect
       <div className="space-y-4">
         <div className="flex items-center gap-4">
           <span id="ai-mode-low" className="text-sm text-muted-foreground w-20">{t('settings.aiMode.lowAI')}</span>
-          <input
-            type="range"
-            min="0"
-            max="2"
+          <RangeSlider
+            min={0}
+            max={2}
             value={mode === 'low' ? 0 : mode === 'medium' ? 1 : 2}
             onChange={(e) => {
               const val = parseInt(e.target.value)
@@ -40,13 +40,8 @@ export function AISettingsSection({ mode, setMode, description }: AISettingsSect
             aria-label="AI usage mode"
             aria-valuetext={`${mode} AI mode`}
             aria-describedby="ai-mode-low ai-mode-high"
-            className="flex-1 h-2 bg-secondary rounded-full appearance-none cursor-pointer
-              [&::-webkit-slider-thumb]:appearance-none
-              [&::-webkit-slider-thumb]:w-4
-              [&::-webkit-slider-thumb]:h-4
-              [&::-webkit-slider-thumb]:bg-purple-500
-              [&::-webkit-slider-thumb]:rounded-full
-              [&::-webkit-slider-thumb]:cursor-pointer"
+            fillColor="bg-purple-500"
+            className="flex-1 text-purple-500"
           />
           <span id="ai-mode-high" className="text-sm text-muted-foreground w-20 text-right">{t('settings.aiMode.highAI')}</span>
         </div>

--- a/web/src/components/settings/sections/PredictionSettingsSection.tsx
+++ b/web/src/components/settings/sections/PredictionSettingsSection.tsx
@@ -5,6 +5,7 @@ import type { PredictionSettings } from '../../../types/predictions'
 import { usePredictionFeedback } from '../../../hooks/usePredictionFeedback'
 import { CollapsibleSection } from '../../ui/CollapsibleSection'
 import { Button } from '../../ui/Button'
+import { RangeSlider } from '../../ui/RangeSlider'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { emitAIPredictionsToggled, emitConfidenceThresholdChanged, emitConsensusModeToggled } from '../../../lib/analytics'
 
@@ -137,21 +138,15 @@ export function PredictionSettingsSection({
                   </div>
                 </div>
               </div>
-              <input
+              <RangeSlider
                 id="predictions-analysis-interval"
-                type="range"
-                min="15"
-                max="120"
-                step="15"
+                min={15}
+                max={120}
+                step={15}
                 value={settings.interval}
                 onChange={(e) => handleIntervalChange(parseInt(e.target.value))}
-                className="w-full h-2 bg-secondary rounded-full appearance-none cursor-pointer
-                  [&::-webkit-slider-thumb]:appearance-none
-                  [&::-webkit-slider-thumb]:w-4
-                  [&::-webkit-slider-thumb]:h-4
-                  [&::-webkit-slider-thumb]:bg-blue-500
-                  [&::-webkit-slider-thumb]:rounded-full
-                  [&::-webkit-slider-thumb]:cursor-pointer"
+                fillColor="bg-blue-500"
+                className="text-blue-500"
               />
               <div className="flex justify-between text-xs text-muted-foreground mt-1">
                 <span>{t('settings.predictions.intervalMin')}</span>
@@ -173,20 +168,14 @@ export function PredictionSettingsSection({
                   </div>
                 </div>
               </div>
-              <input
+              <RangeSlider
                 id="predictions-min-confidence"
-                type="range"
-                min="50"
-                max="90"
+                min={50}
+                max={90}
                 value={settings.minConfidence}
                 onChange={(e) => handleConfidenceChange(parseInt(e.target.value))}
-                className="w-full h-2 bg-secondary rounded-full appearance-none cursor-pointer
-                  [&::-webkit-slider-thumb]:appearance-none
-                  [&::-webkit-slider-thumb]:w-4
-                  [&::-webkit-slider-thumb]:h-4
-                  [&::-webkit-slider-thumb]:bg-blue-500
-                  [&::-webkit-slider-thumb]:rounded-full
-                  [&::-webkit-slider-thumb]:cursor-pointer"
+                fillColor="bg-blue-500"
+                className="text-blue-500"
               />
               <div className="flex justify-between text-xs text-muted-foreground mt-1">
                 <span>{t('settings.predictions.confidenceMin')}</span>

--- a/web/src/components/ui/RangeSlider.tsx
+++ b/web/src/components/ui/RangeSlider.tsx
@@ -31,14 +31,19 @@ export function RangeSlider({
   }, [value, min, max])
 
   return (
-    <div className="relative w-full">
+    <div className="relative w-full h-2">
+      {/* Unfilled track background */}
+      <div
+        className="absolute top-0 left-0 w-full h-2 rounded-full bg-secondary pointer-events-none"
+        aria-hidden="true"
+      />
       {/* Fill track */}
       <div
-        className={cn('absolute top-1/2 left-0 h-2 rounded-full -translate-y-1/2 pointer-events-none', fillColor)}
+        className={cn('absolute top-0 left-0 h-2 rounded-full pointer-events-none', fillColor)}
         style={{ width: `${percentage}%` }}
         aria-hidden="true"
       />
-      {/* Native range input */}
+      {/* Native range input — transparent track so fill shows through */}
       <input
         id={id}
         type="range"
@@ -46,16 +51,20 @@ export function RangeSlider({
         max={max}
         value={value}
         className={cn(
-          'relative w-full h-2 bg-secondary rounded-full appearance-none cursor-pointer',
+          'absolute top-0 left-0 w-full h-2 bg-transparent rounded-full appearance-none cursor-pointer',
+          '[&::-webkit-slider-runnable-track]:bg-transparent',
+          '[&::-webkit-slider-runnable-track]:h-2',
+          '[&::-webkit-slider-runnable-track]:rounded-full',
           '[&::-webkit-slider-thumb]:appearance-none',
           '[&::-webkit-slider-thumb]:w-4',
           '[&::-webkit-slider-thumb]:h-4',
           '[&::-webkit-slider-thumb]:rounded-full',
           '[&::-webkit-slider-thumb]:bg-current',
           '[&::-webkit-slider-thumb]:cursor-pointer',
-          '[&::-webkit-slider-thumb]:relative',
-          '[&::-webkit-slider-thumb]:z-10',
           '[&::-webkit-slider-thumb]:shadow-md',
+          '[&::-webkit-slider-thumb]:-mt-1',
+          '[&::-moz-range-track]:bg-transparent',
+          '[&::-moz-range-track]:h-2',
           '[&::-moz-range-thumb]:w-4',
           '[&::-moz-range-thumb]:h-4',
           '[&::-moz-range-thumb]:rounded-full',
@@ -63,8 +72,6 @@ export function RangeSlider({
           '[&::-moz-range-thumb]:cursor-pointer',
           '[&::-moz-range-thumb]:border-0',
           '[&::-moz-range-thumb]:shadow-md',
-          '[&::-moz-range-progress]:bg-current',
-          '[&::-moz-range-progress]:rounded-full',
           className,
         )}
         {...props}

--- a/web/src/components/ui/RangeSlider.tsx
+++ b/web/src/components/ui/RangeSlider.tsx
@@ -8,8 +8,9 @@ interface RangeSliderProps extends Omit<InputHTMLAttributes<HTMLInputElement>, '
 
 /**
  * A range input with a visible fill track from the left edge to the thumb.
- * Wraps a native <input type="range"> with a background gradient that
- * dynamically reflects the current value as a percentage of the range.
+ * Wraps a native <input type="range"> with an absolutely positioned fill
+ * overlay whose width dynamically reflects the current value as a percentage
+ * of the range.
  */
 export function RangeSlider({
   fillColor = 'bg-blue-500',

--- a/web/src/components/ui/RangeSlider.tsx
+++ b/web/src/components/ui/RangeSlider.tsx
@@ -1,0 +1,73 @@
+import { type InputHTMLAttributes, useId, useMemo } from 'react'
+import { cn } from '../../lib/cn'
+
+interface RangeSliderProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  /** Color of the filled track portion (Tailwind bg class) */
+  fillColor?: string
+}
+
+/**
+ * A range input with a visible fill track from the left edge to the thumb.
+ * Wraps a native <input type="range"> with a background gradient that
+ * dynamically reflects the current value as a percentage of the range.
+ */
+export function RangeSlider({
+  fillColor = 'bg-blue-500',
+  value,
+  min = 0,
+  max = 100,
+  className,
+  ...props
+}: RangeSliderProps) {
+  const id = useId()
+
+  const percentage = useMemo(() => {
+    const numValue = typeof value === 'number' ? value : Number(value ?? min)
+    const numMin = Number(min)
+    const numMax = Number(max)
+    if (numMax === numMin) return 0
+    return ((numValue - numMin) / (numMax - numMin)) * 100
+  }, [value, min, max])
+
+  return (
+    <div className="relative w-full">
+      {/* Fill track */}
+      <div
+        className={cn('absolute top-1/2 left-0 h-2 rounded-full -translate-y-1/2 pointer-events-none', fillColor)}
+        style={{ width: `${percentage}%` }}
+        aria-hidden="true"
+      />
+      {/* Native range input */}
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        value={value}
+        className={cn(
+          'relative w-full h-2 bg-secondary rounded-full appearance-none cursor-pointer',
+          '[&::-webkit-slider-thumb]:appearance-none',
+          '[&::-webkit-slider-thumb]:w-4',
+          '[&::-webkit-slider-thumb]:h-4',
+          '[&::-webkit-slider-thumb]:rounded-full',
+          '[&::-webkit-slider-thumb]:bg-current',
+          '[&::-webkit-slider-thumb]:cursor-pointer',
+          '[&::-webkit-slider-thumb]:relative',
+          '[&::-webkit-slider-thumb]:z-10',
+          '[&::-webkit-slider-thumb]:shadow-md',
+          '[&::-moz-range-thumb]:w-4',
+          '[&::-moz-range-thumb]:h-4',
+          '[&::-moz-range-thumb]:rounded-full',
+          '[&::-moz-range-thumb]:bg-current',
+          '[&::-moz-range-thumb]:cursor-pointer',
+          '[&::-moz-range-thumb]:border-0',
+          '[&::-moz-range-thumb]:shadow-md',
+          '[&::-moz-range-progress]:bg-current',
+          '[&::-moz-range-progress]:rounded-full',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION


### Fixes

Fixes #13536

---

###  Summary of Changes

- Slider inputs (AI Usage Mode, Analysis Interval, Minimum Confidence) previously showed only a thumb dot on an unfilled track, making it impossible to read the selected value at a glance
- Added a filled track overlay that dynamically sizes as a percentage of the range, clearly indicating the current value

---

### Changes Made

- [x] Created reusable `RangeSlider` component (`web/src/components/ui/RangeSlider.tsx`) with a colored fill div overlay
- [x] Updated `AISettingsSection` to use `RangeSlider` with purple fill track
- [x] Updated `PredictionSettingsSection` to use `RangeSlider` with blue fill track for both Analysis Interval and Minimum Confidence sliders
- [x] Supports WebKit and Firefox slider pseudo-elements

---

### Checklist

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

**Before:** Slider shows only a thumb dot on a flat, unfilled track — impossible to determine value at a glance.

<img width="828" height="251" alt="Screenshot 2026-05-14 at 10 59 56" src="https://github.com/user-attachments/assets/4300a3a0-aa4f-4f0f-8906-3671ec0e704e" />


**After:** Track is filled from the left edge up to the thumb position with a colored fill (purple for AI Mode, blue for Prediction settings), clearly indicating the current value and how much of the range has been selected.

<img width="844" height="248" alt="Screenshot 2026-05-14 at 12 29 46" src="https://github.com/user-attachments/assets/4d54ae29-0aa5-449e-b1f0-c98523f9fc88" />


---

###  Reviewer Notes

The `RangeSlider` component uses a positioned div overlay for the fill track rather than CSS gradients on the input itself. This approach:
- Works consistently across browsers (WebKit, Firefox)
- Preserves the native input thumb and accessibility semantics
- Accepts a customizable `fillColor` prop for different color themes
- Is reusable for any future slider needs in the codebase