### PR TITLE
fix: use console.error for GPU utilization fetch failure

### DIFF
--- a/web/src/hooks/useGPUUtilizations.ts
+++ b/web/src/hooks/useGPUUtilizations.ts
@@ -58,7 +58,7 @@ export function useGPUUtilizations(reservationIds: string[]) {
       setData(result || {})
     } catch (err) {
       const message = err instanceof Error ? err.message : 'GPU utilization fetch failed'
-      console.warn('[useGPUUtilizations] Fetch failed:', message)
+      console.error('[useGPUUtilizations] Fetch failed:', message)
       setError(message)
       setIsFailed(true)
       setData({})


### PR DESCRIPTION
The catch block sets isFailed=true and the UI goes red — but the
log stayed at warn. A failed data fetch is an error. Bumped it
to console.error so it surfaces at the right severity.