### PR TITLE
fix: use console.error for MCP backend fetch failure

### DIFF
--- a/web/src/hooks/mcp/workloadQueries/shared.ts
+++ b/web/src/hooks/mcp/workloadQueries/shared.ts
@@ -168,7 +168,7 @@ export async function fetchInClusterCollection<T>(
     const collection = data[collectionKey]
     return Array.isArray(collection) ? collection as T[] : []
   } catch (err: unknown) {
-    console.warn(`[${resource}] Backend fetch failed:`, err)
+    console.error(`[${resource}] Backend fetch failed:`, err)
     return null
   }
 }


### PR DESCRIPTION
The shared fetchInClusterCollection helper serves every MCP resource
hook — pods, jobs, configmaps, secrets, the whole set. When the
backend fails, it returns null and... logged at warn.

Bumped to console.error so it matches the severity of the event.
One line, but it touches every resource query in the MCP layer.