### PR TITLE
fix(i18n): wrap theme removal toast in translation layer

### DIFF
--- a/web/src/components/settings/sections/ThemeSection.tsx
+++ b/web/src/components/settings/sections/ThemeSection.tsx
@@ -55,7 +55,7 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
         setTheme('kubestellar')
       }
     } catch {
-      showToast('Failed to remove theme. Your browser storage may be unavailable.', 'error')
+      showToast(t('settings.theme.removeFailed', 'Failed to remove theme. Your browser storage may be unavailable.'), 'error')
     }
     setConfirmRemoveId(null)
   }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -203,6 +203,9 @@
       "light": "Light",
       "system": "System"
     },
+    "theme": {
+      "removeFailed": "Failed to remove theme. Your browser storage may be unavailable."
+    },
     "accessibility": {
       "title": "Accessibility",
       "subtitle": "Customize accessibility features",


### PR DESCRIPTION
The ThemeSection shows a toast when removing a theme fails, but
the string was raw English — every other toast in the settings
panel goes through t(), this one just got overlooked.

Wrapped it in t() and added the key under settings.theme.removeFailed.
Same i18n pattern we've been applying across the codebase.