### PR TITLE
fix: Expand quantum proxy allowlist to include auth, qasm, execute, loop, qubits endpoints

### DIFF
--- a/pkg/api/handlers/quantum_proxy.go
+++ b/pkg/api/handlers/quantum_proxy.go
@@ -51,11 +51,16 @@ func NewQuantumProxyHandler() *QuantumProxyHandler {
 
 // allowedQuantumPaths lists valid API path prefixes for the quantum proxy.
 var allowedQuantumPaths = []string{
-	"result",
+	"auth",
 	"circuit",
-	"job",
-	"status",
+	"execute",
 	"health",
+	"job",
+	"loop",
+	"qasm",
+	"qubits",
+	"result",
+	"status",
 }
 
 // isAllowedQuantumPath validates that the endpoint matches an allowed prefix.


### PR DESCRIPTION
## Summary

Fixes the regression from #13408 that broke quantum cards by restricting the allowlist too narrowly.

The security patch added a restrictive allowlist that only allowed 5 paths (result, circuit, job, status, health), but quantum cards require 10 endpoints total. This fix adds the missing paths:
- `auth/*` for credential management
- `qasm/*` for circuit file operations  
- `execute` for job execution
- `loop/*` for loop control
- `qubits/*` for qubit grid data

## Test plan
- Quantum cards should no longer report 'Invalid quantum API path' errors
- All quantum endpoints should proxy correctly through the allowlist validation