### PR TITLE
fix: guard against undefined cluster in handleDiagnose and handleRepair when targetClusters is empty

### DIFF
--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -254,12 +254,13 @@ export function Missions(_props: MissionsProps) {
   // AI Diagnose handler
   const handleDiagnose = (mission: DeployMission) => {
     checkKeyAndRun(() => {
-      const targetClustersStr = (mission.targetClusters || []).join(', ')
+      if (!mission.targetClusters?.length) return
+      const targetClustersStr = mission.targetClusters.join(', ')
       const failedClusterNames = (mission.clusterStatuses || [])
         .filter(cs => cs.status === 'failed')
         .map(cs => cs.cluster)
         .join(', ')
-      
+
       startMission({
         title: `Diagnose ${mission.workload}`,
         description: `Analyze failed deployment to ${mission.targetClusters.length} cluster(s)`,
@@ -290,7 +291,8 @@ Please:
   // AI Repair handler
   const handleRepair = (mission: DeployMission) => {
     checkKeyAndRun(() => {
-      const targetClustersStr = (mission.targetClusters || []).join(', ')
+      if (!mission.targetClusters?.length) return
+      const targetClustersStr = mission.targetClusters.join(', ')
       const failedClusterNames = (mission.clusterStatuses || [])
         .filter(cs => cs.status === 'failed')
         .map(cs => cs.cluster)


### PR DESCRIPTION
## Summary

Fixes #13616

## What Changed

Added an early-return guard in both `handleDiagnose` and `handleRepair`
in `web/src/components/cards/Missions.tsx`:

```ts
if (!mission.targetClusters?.length) return
```

Also removed the now-redundant defensive `|| []` on the `.join()` call
since the guard ensures `targetClusters` is non-empty before proceeding.

## Before / After

**Before:**
```ts
const targetClustersStr = (mission.targetClusters || []).join(', ')
startMission({ cluster: mission.targetClusters[0] }) // ← undefined
```

**After:**
```ts
if (!mission.targetClusters?.length) return          // ← guard
const targetClustersStr = mission.targetClusters.join(', ')
startMission({ cluster: mission.targetClusters[0] }) // ← now safe
```

## Why This Fix Is Correct

- `?.length` handles both `undefined`/`null` and empty arrays (falsy `0`)
- After the guard, TypeScript narrows `targetClusters` to non-empty `string[]`
- Change is minimal and focused — no other logic touched
- `tsc --noEmit` deferred to CI per `CLAUDE.md`