### PR TITLE
fix: Move path traversal check into allowlist validator for defense-in-depth

### DIFF
--- a/pkg/api/handlers/quantum_proxy.go
+++ b/pkg/api/handlers/quantum_proxy.go
@@ -63,8 +63,13 @@ var allowedQuantumPaths = []string{
 	"status",
 }
 
-// isAllowedQuantumPath validates that the endpoint matches an allowed prefix.
+// isAllowedQuantumPath validates that the endpoint matches an allowed prefix and contains no path traversal attempts.
 func isAllowedQuantumPath(endpoint string) bool {
+	// SECURITY: Reject path traversal attempts
+	if strings.Contains(endpoint, "..") {
+		return false
+	}
+
 	for _, prefix := range allowedQuantumPaths {
 		if endpoint == prefix || strings.HasPrefix(endpoint, prefix+"/") {
 			return true
@@ -77,8 +82,8 @@ func isAllowedQuantumPath(endpoint string) bool {
 func (h *QuantumProxyHandler) ProxyRequest(c *fiber.Ctx) error {
 	endpoint := c.Params("*")
 
-	// SECURITY: Reject path traversal and validate against allowed paths
-	if strings.Contains(endpoint, "..") || !isAllowedQuantumPath(endpoint) {
+	// SECURITY: Validate against allowed paths (includes path traversal check)
+	if !isAllowedQuantumPath(endpoint) {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid quantum API path")
 	}
 
@@ -186,8 +191,8 @@ func (h *QuantumProxyHandler) ProxyResultHistogram(c *fiber.Ctx) error {
 func (h *QuantumProxyHandler) ProxyPostRequest(c *fiber.Ctx) error {
 	endpoint := c.Params("*")
 
-	// SECURITY: Reject path traversal and validate against allowed paths
-	if strings.Contains(endpoint, "..") || !isAllowedQuantumPath(endpoint) {
+	// SECURITY: Validate against allowed paths (includes path traversal check)
+	if !isAllowedQuantumPath(endpoint) {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid quantum API path")
 	}
 

--- a/pkg/api/handlers/quantum_proxy_test.go
+++ b/pkg/api/handlers/quantum_proxy_test.go
@@ -40,9 +40,10 @@ func TestIsAllowedQuantumPath(t *testing.T) {
 		{"config", "config", false},
 		{"admin", "admin", false},
 
-		// Path traversal attempts (note: .. is caught at ProxyRequest level, not by isAllowedQuantumPath)
+		// Path traversal attempts (rejected by isAllowedQuantumPath)
 		{"path traversal ../ prefix", "../auth", false},
-		{"path traversal in middle auth/..", "auth/../status", true}, // isAllowedQuantumPath allows it (.. check happens in ProxyRequest)
+		{"path traversal in middle", "auth/../status", false},
+		{"path traversal complex", "qasm/../../etc/passwd", false},
 
 		// Edge cases
 		{"empty string", "", false},


### PR DESCRIPTION
## Summary

Moves the path traversal (`..`) validation from the handler level into the `isAllowedQuantumPath` function to ensure path traversal attempts are always caught by the allowlist, even if the handler check is ever refactored.

## Changes

- Move `..` check into `isAllowedQuantumPath` validation function
- Remove redundant path traversal checks from `ProxyRequest` and `ProxyPostRequest` handlers
- Update test cases to properly assert that paths containing `..` are rejected at the validation layer
- Add additional path traversal test case: `qasm/../../etc/passwd`

## Security rationale

This provides defense-in-depth: if the handler-level check is ever refactored away (e.g., during future security improvements), the vulnerability won't be reintroduced because the allowlist validator catches it as well.

## Related

Addresses Copilot code review suggestions from PR #13605.