### PR TITLE
fix: role label takes precedence over deployment name in buildComponentsFromDeployments

### DIFF
--- a/web/src/hooks/__tests__/useStackDiscovery.test.ts
+++ b/web/src/hooks/__tests__/useStackDiscovery.test.ts
@@ -665,6 +665,29 @@ describe('useStackDiscovery', () => {
     unmount()
   })
 
+  it('role label takes precedence over deployment name (fix #13716)', async () => {
+    // Deployment named 'prefill-server' but explicitly labelled role=decode.
+    // Before the fix this landed in prefill because depName.includes('prefill')
+    // fired before role === 'decode' was checked.
+    setupMockExec({
+      pods: [],
+      namespaces: ['llm-d-pd'],
+      deploymentsByNs: {
+        'llm-d-pd': [
+          makeDeployment('prefill-server', 'llm-d-pd', 2, 2, { 'llm-d.ai/role': 'decode' }),
+        ],
+      },
+    })
+
+    const { result, unmount } = renderHook(() => useStackDiscovery(['c1']))
+    await flush()
+
+    const stack = result.current.stacks[0]
+    expect(stack.components.decode.length).toBe(1)
+    expect(stack.components.prefill.length).toBe(0)
+    unmount()
+  })
+
   // ── 11. Stack status computation ───────────────────────────────────────────
 
   it('computes status=healthy when all components are running', async () => {

--- a/web/src/hooks/useStackDiscovery.ts
+++ b/web/src/hooks/useStackDiscovery.ts
@@ -226,9 +226,9 @@ function buildComponentsFromDeployments(
 
     if (isEpp && !epp) {
       epp = { name: dep.metadata.name, namespace, cluster, type: 'epp', status: ready > 0 ? 'running' : 'pending', replicas, readyReplicas: ready }
-    } else if (role === 'prefill' || depName.includes('prefill')) {
+    } else if (role === 'prefill' || (!role && depName.includes('prefill'))) {
       prefill.push({ name: dep.metadata.name, namespace, cluster, type: 'prefill', status: depStatus, replicas, readyReplicas: ready, model: depModel })
-    } else if (role === 'decode' || depName.includes('decode')) {
+    } else if (role === 'decode' || (!role && depName.includes('decode'))) {
       decode.push({ name: dep.metadata.name, namespace, cluster, type: 'decode', status: depStatus, replicas, readyReplicas: ready, model: depModel })
     } else {
       both.push({ name: dep.metadata.name, namespace, cluster, type: 'both', status: depStatus, replicas, readyReplicas: ready, model: depModel })


### PR DESCRIPTION
Addresses #13716

## What Changed

Added `!role` guard to deployment classification in
`buildComponentsFromDeployments` so name-based heuristics only
fire when no `llm-d.ai/role` label is set:

```ts
// Before
} else if (role === 'prefill' || depName.includes('prefill')) {
} else if (role === 'decode'  || depName.includes('decode'))  {

// After
} else if (role === 'prefill' || (!role && depName.includes('prefill'))) {
} else if (role === 'decode'  || (!role && depName.includes('decode')))  {
```

## Why This Fix Is Correct

The pod-level classification 350 lines below in the same file
already uses this pattern correctly — role labels first,
name-based fallback only when role is undefined.
This PR makes deployment classification consistent with that
already-correct pattern.

## Regression Test Added

```ts
it('role label takes precedence over deployment name (regression for #13716)')
// deployment named 'prefill-server' with role=decode
// must land in decode pool, not prefill pool
```

## Test Results

43/43 passing, 0 failures
