### PR TITLE
fix: Chaos Mesh card live PodChaos sync (#13756)

### DIFF
--- a/pkg/api/handlers/custom_resources.go
+++ b/pkg/api/handlers/custom_resources.go
@@ -17,6 +17,7 @@ import (
 type CustomResourceItem struct {
 	Name      string                 `json:"name"`
 	Namespace string                 `json:"namespace,omitempty"`
+	Kind      string                 `json:"kind,omitempty"`
 	Cluster   string                 `json:"cluster"`
 	Status    map[string]interface{} `json:"status,omitempty"`
 	Spec      map[string]interface{} `json:"spec,omitempty"`
@@ -222,6 +223,10 @@ func (h *MCPHandlers) listCR(
 // parseCRItem extracts the key fields from an unstructured custom resource.
 func parseCRItem(obj map[string]interface{}, clusterName string) CustomResourceItem {
 	item := CustomResourceItem{Cluster: clusterName}
+
+	if kind, ok := obj["kind"].(string); ok {
+		item.Kind = kind
+	}
 
 	if metadata, ok := obj["metadata"].(map[string]interface{}); ok {
 		if name, ok := metadata["name"].(string); ok {

--- a/pkg/api/handlers/custom_resources_test.go
+++ b/pkg/api/handlers/custom_resources_test.go
@@ -52,3 +52,25 @@ func TestMCPHandlers_GetCustomResources(t *testing.T) {
 		assert.Equal(t, 400, resp.StatusCode)
 	})
 }
+
+func TestParseCRItem_IncludesKindAndFlatFields(t *testing.T) {
+	obj := map[string]interface{}{
+		"apiVersion": "chaos-mesh.org/v1alpha1",
+		"kind":       "PodChaos",
+		"metadata": map[string]interface{}{
+			"name":      "demo-pod-kill",
+			"namespace": "chaos-demo",
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "AllInjected", "status": "True"},
+			},
+		},
+	}
+	item := parseCRItem(obj, "kind-kubestellar")
+	assert.Equal(t, "PodChaos", item.Kind)
+	assert.Equal(t, "demo-pod-kill", item.Name)
+	assert.Equal(t, "chaos-demo", item.Namespace)
+	assert.Equal(t, "kind-kubestellar", item.Cluster)
+	assert.Contains(t, item.Status, "conditions")
+}

--- a/web/src/components/cards/chaos_mesh_status/__tests__/helpers.test.ts
+++ b/web/src/components/cards/chaos_mesh_status/__tests__/helpers.test.ts
@@ -1,96 +1,241 @@
 import { describe, it, expect } from 'vitest'
 import { __testables } from '../useChaosMeshStatus'
 
-const { getExperimentPhase, isExperimentFailed, buildChaosMeshStatus } = __testables
+const {
+  getExperimentPhase,
+  getWorkflowPhase,
+  isExperimentFailed,
+  buildChaosMeshStatus,
+  coerceCardPhase,
+  derivePhaseFromConditions,
+} = __testables
 
-const validExp = {
-  metadata: { name: 'test-1', namespace: 'default' },
-  kind: 'PodChaos',
-  status: { phase: 'Running', startTime: '2026-04-24T00:00:00Z' }
-}
-
-const failedExp = {
-  metadata: { name: 'test-2', namespace: 'default' },
-  kind: 'NetworkChaos',
-  status: { phase: 'Failed', startTime: '2026-04-24T00:00:00Z' }
-}
-
-const workflow = {
-  metadata: { name: 'wf-1', namespace: 'default' },
-  status: { phase: 'Running', progress: '1/3' }
+/** Shape returned by GET /api/mcp/custom-resources (flat fields, see CustomResourceItem in Go). */
+function wireItem(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'demo-pod-kill',
+    namespace: 'chaos-demo',
+    cluster: 'kind-kubestellar',
+    kind: 'PodChaos',
+    status: {} as Record<string, unknown>,
+    ...overrides,
+  }
 }
 
 describe('Chaos Mesh Hook Helpers', () => {
-  describe('getExperimentPhase', () => {
-    it('returns phase when available', () => {
-      expect(getExperimentPhase(validExp)).toBe('Running')
+  describe('derivePhaseFromConditions', () => {
+    it('returns Paused when Paused condition is True', () => {
+      const conditions = [
+        { type: 'Paused', status: 'True' },
+        { type: 'AllInjected', status: 'True' },
+      ]
+      expect(derivePhaseFromConditions(conditions)).toBe('Paused')
     })
 
-    it('returns Unknown when phase is missing', () => {
-      expect(getExperimentPhase({ metadata: { name: 'test' } })).toBe('Unknown')
+    it('returns Failed when Failed condition is True', () => {
+      const conditions = [
+        { type: 'Failed', status: 'True' },
+        { type: 'AllInjected', status: 'True' },
+      ]
+      expect(derivePhaseFromConditions(conditions)).toBe('Failed')
+    })
+
+    it('returns Finished when AllRecovered is True', () => {
+      const conditions = [
+        { type: 'AllInjected', status: 'True' },
+        { type: 'AllRecovered', status: 'True' },
+      ]
+      expect(derivePhaseFromConditions(conditions)).toBe('Finished')
+    })
+
+    it('returns Running when AllInjected is True', () => {
+      const conditions = [
+        { type: 'Selected', status: 'True' },
+        { type: 'AllInjected', status: 'True' },
+        { type: 'AllRecovered', status: 'False' },
+        { type: 'Paused', status: 'False' },
+      ]
+      expect(derivePhaseFromConditions(conditions)).toBe('Running')
+    })
+
+    it('returns Running when only Selected is True', () => {
+      const conditions = [{ type: 'Selected', status: 'True' }]
+      expect(derivePhaseFromConditions(conditions)).toBe('Running')
+    })
+
+    it('returns Unknown for empty or non-array', () => {
+      expect(derivePhaseFromConditions(undefined)).toBe('Unknown')
+      expect(derivePhaseFromConditions([])).toBe('Unknown')
+    })
+  })
+
+  describe('getExperimentPhase', () => {
+    it('prefers legacy status.phase string when present', () => {
+      const item = wireItem({
+        status: {
+          phase: 'Running',
+          conditions: [{ type: 'AllRecovered', status: 'True' }],
+        },
+      })
+      expect(getExperimentPhase(item)).toBe('Running')
+    })
+
+    it('uses conditions when status.phase is absent', () => {
+      const item = wireItem({
+        status: {
+          conditions: [
+            { type: 'Selected', status: 'True' },
+            { type: 'AllInjected', status: 'True' },
+          ],
+        },
+      })
+      expect(getExperimentPhase(item)).toBe('Running')
+    })
+
+    it('returns Unknown when phase missing and conditions inconclusive', () => {
+      expect(getExperimentPhase(wireItem({ status: {} }))).toBe('Unknown')
+    })
+  })
+
+  describe('getWorkflowPhase', () => {
+    it('uses status.phase when set', () => {
+      const wf = wireItem({ kind: 'Workflow', name: 'wf-1', status: { phase: 'Finished', progress: '1/1' } })
+      expect(getWorkflowPhase(wf)).toBe('Finished')
+    })
+  })
+
+  describe('coerceCardPhase', () => {
+    it('passes through known phases', () => {
+      expect(coerceCardPhase('Running')).toBe('Running')
+      expect(coerceCardPhase('Paused')).toBe('Paused')
+    })
+
+    it('maps unknown strings to Unknown', () => {
+      expect(coerceCardPhase('Run')).toBe('Unknown')
+      expect(coerceCardPhase('')).toBe('Unknown')
     })
   })
 
   describe('isExperimentFailed', () => {
-    it('returns true for Failed phase', () => {
-      expect(isExperimentFailed(failedExp)).toBe(true)
+    it('returns true when phase Failed', () => {
+      const item = wireItem({ status: { phase: 'Failed' } })
+      expect(isExperimentFailed(item)).toBe(true)
     })
 
-    it('returns false for non-Failed phase', () => {
-      expect(isExperimentFailed(validExp)).toBe(false)
+    it('returns false for Running', () => {
+      const item = wireItem({ status: { conditions: [{ type: 'AllInjected', status: 'True' }] } })
+      expect(isExperimentFailed(item)).toBe(false)
     })
   })
 
   describe('buildChaosMeshStatus', () => {
-    it('returns not-installed when no experiments exist', () => {
+    it('returns not-installed when no experiments and no workflows', () => {
       const result = buildChaosMeshStatus([], [])
       expect(result.health).toBe('not-installed')
     })
 
-    it('returns healthy when no experiments are failed', () => {
-      const result = buildChaosMeshStatus([validExp], [workflow])
+    it('returns healthy with workflows when no experiments', () => {
+      const wf = wireItem({
+        name: 'resilience-suite',
+        namespace: 'default',
+        cluster: 'kind-kubestellar',
+        kind: 'Workflow',
+        status: { phase: 'Running', progress: '2/4' },
+      })
+      const result = buildChaosMeshStatus([], [wf])
       expect(result.health).toBe('healthy')
+      expect(result.workflows).toHaveLength(1)
+      expect(result.experiments).toHaveLength(0)
+      expect(result.summary.totalExperiments).toBe(0)
+      expect(result.workflows[0].name).toBe('resilience-suite')
+    })
+
+    it('maps flat wire fields for experiments and workflows', () => {
+      const podChaos = wireItem({
+        name: 'demo-pod-kill',
+        namespace: 'chaos-demo',
+        cluster: 'kind-kubestellar',
+        kind: 'PodChaos',
+        status: {
+          conditions: [{ type: 'AllInjected', status: 'True' }],
+        },
+      })
+      const wf = {
+        name: 'resilience-suite',
+        namespace: 'default',
+        cluster: 'kind-kubestellar',
+        kind: 'Workflow',
+        status: { phase: 'Running', progress: '2/4' },
+      }
+      const result = buildChaosMeshStatus([podChaos], [wf])
+      expect(result.experiments[0]).toMatchObject({
+        name: 'demo-pod-kill',
+        namespace: 'chaos-demo',
+        cluster: 'kind-kubestellar',
+        kind: 'PodChaos',
+        phase: 'Running',
+      })
+      expect(result.workflows[0]).toMatchObject({
+        name: 'resilience-suite',
+        namespace: 'default',
+        cluster: 'kind-kubestellar',
+        phase: 'Running',
+        progress: '2/4',
+      })
       expect(result.summary.totalExperiments).toBe(1)
       expect(result.summary.running).toBe(1)
+      expect(result.health).toBe('healthy')
     })
 
     it('returns degraded when any experiment is failed', () => {
-      const result = buildChaosMeshStatus([validExp, failedExp], [workflow])
+      const ok = wireItem({ name: 'a', status: { phase: 'Running' } })
+      const bad = wireItem({ name: 'b', status: { phase: 'Failed' } })
+      const result = buildChaosMeshStatus([ok, bad], [])
       expect(result.health).toBe('degraded')
       expect(result.summary.totalExperiments).toBe(2)
       expect(result.summary.failed).toBe(1)
       expect(result.summary.running).toBe(1)
     })
 
-    it('maps workflows correctly', () => {
-      const result = buildChaosMeshStatus([validExp], [workflow])
-      expect(result.workflows).toHaveLength(1)
-      expect(result.workflows[0].name).toBe('wf-1')
-      expect(result.workflows[0].phase).toBe('Running')
-      expect(result.workflows[0].progress).toBe('1/3')
-    })
-
-    it('maps flattened backend custom-resource items', () => {
-      const result = buildChaosMeshStatus([
-        {
-          name: 'demo-pod-kill',
-          namespace: 'chaos-demo',
-          status: { phase: 'Running', startTime: '2026-04-24T00:00:00Z' },
-        },
-      ], [
-        {
-          name: 'chaos-workflow',
-          namespace: 'chaos-demo',
-          status: { phase: 'Running', progress: '1/2' },
-        },
-      ])
+    it('maps flattened backend items without kind to Unknown kind', () => {
+      const result = buildChaosMeshStatus(
+        [
+          {
+            name: 'demo-pod-kill',
+            namespace: 'chaos-demo',
+            status: { phase: 'Running', startTime: '2026-04-24T00:00:00Z' },
+          },
+        ],
+        [
+          {
+            name: 'chaos-workflow',
+            namespace: 'chaos-demo',
+            status: { phase: 'Running', progress: '1/2' },
+          },
+        ],
+      )
 
       expect(result.summary.totalExperiments).toBe(1)
       expect(result.experiments[0].name).toBe('demo-pod-kill')
       expect(result.experiments[0].namespace).toBe('chaos-demo')
-      expect(result.experiments[0].kind).toBe('PodChaos')
+      expect(result.experiments[0].kind).toBe('Unknown')
       expect(result.workflows[0].name).toBe('chaos-workflow')
       expect(result.workflows[0].namespace).toBe('chaos-demo')
+    })
+
+    it('accepts legacy nested metadata when flat name is absent', () => {
+      const result = buildChaosMeshStatus(
+        [
+          {
+            metadata: { name: 'meta-exp', namespace: 'meta-ns' },
+            status: { phase: 'Paused' },
+          },
+        ],
+        [],
+      )
+      expect(result.experiments[0].name).toBe('meta-exp')
+      expect(result.experiments[0].namespace).toBe('meta-ns')
+      expect(result.experiments[0].phase).toBe('Paused')
     })
   })
 })

--- a/web/src/components/cards/chaos_mesh_status/demoData.ts
+++ b/web/src/components/cards/chaos_mesh_status/demoData.ts
@@ -5,6 +5,8 @@
 export interface ChaosMeshExperiment {
   name: string
   namespace: string
+  /** Kube context / cluster name when joined from /api/mcp/custom-resources */
+  cluster?: string
   kind: string
   phase: 'Running' | 'Finished' | 'Failed' | 'Paused' | 'Unknown'
   startTime: string
@@ -13,6 +15,7 @@ export interface ChaosMeshExperiment {
 export interface ChaosMeshWorkflow {
   name: string
   namespace: string
+  cluster?: string
   phase: 'Running' | 'Finished' | 'Failed' | 'Unknown'
   progress: string
 }

--- a/web/src/components/cards/chaos_mesh_status/index.tsx
+++ b/web/src/components/cards/chaos_mesh_status/index.tsx
@@ -56,7 +56,10 @@ export function ChaosMeshStatus() {
             </thead>
             <tbody>
               {(data.experiments || []).map(exp => (
-                <tr key={`${exp.namespace}/${exp.name}`} className="border-b border-border/20 last:border-0">
+                <tr
+                  key={`${exp.cluster ?? ''}/${exp.namespace}/${exp.name}`}
+                  className="border-b border-border/20 last:border-0"
+                >
                   <td className="py-2">{exp.name}</td>
                   <td className="py-2 text-muted-foreground">{exp.namespace}</td>
                   <td className="py-2 text-muted-foreground">{exp.kind}</td>
@@ -88,7 +91,10 @@ export function ChaosMeshStatus() {
               </thead>
               <tbody>
                 {(data.workflows || []).map(wf => (
-                  <tr key={`${wf.namespace}/${wf.name}`} className="border-b border-border/20 last:border-0">
+                  <tr
+                    key={`${wf.cluster ?? ''}/${wf.namespace}/${wf.name}`}
+                    className="border-b border-border/20 last:border-0"
+                  >
                     <td className="py-2">{wf.name}</td>
                     <td className="py-2 text-muted-foreground">{wf.namespace}</td>
                     <td className="py-2">

--- a/web/src/components/cards/chaos_mesh_status/useChaosMeshStatus.ts
+++ b/web/src/components/cards/chaos_mesh_status/useChaosMeshStatus.ts
@@ -5,8 +5,8 @@ import { authFetch } from '../../../lib/api'
 import {
   CHAOS_MESH_DEMO_DATA,
   INITIAL_DATA,
-  type ChaosMeshStatusData,
   type ChaosMeshExperiment,
+  type ChaosMeshStatusData,
   type ChaosMeshWorkflow,
 } from './demoData'
 
@@ -16,11 +16,23 @@ import {
 
 const CACHE_KEY = 'chaos-mesh-status'
 
+/** Chaos Mesh CR condition `status` when the condition applies. */
+const CHAOS_MESH_CONDITION_STATUS_TRUE = 'True'
+
+/** Chaos Mesh CR `status.conditions[].type` values used for phase derivation. */
+const CHAOS_MESH_CONDITION_TYPE_PAUSED = 'Paused'
+const CHAOS_MESH_CONDITION_TYPE_FAILED = 'Failed'
+const CHAOS_MESH_CONDITION_TYPE_ALL_RECOVERED = 'AllRecovered'
+const CHAOS_MESH_CONDITION_TYPE_ALL_INJECTED = 'AllInjected'
+const CHAOS_MESH_CONDITION_TYPE_SELECTED = 'Selected'
+
+const DEFAULT_NAMESPACE = 'default'
+
 // ---------------------------------------------------------------------------
-// Internal Types
+// Internal Types — GET /api/mcp/custom-resources items (flat + optional legacy metadata)
 // ---------------------------------------------------------------------------
 
-interface CustomResourceItem {
+interface ChaosMeshCustomResourceItem {
   metadata?: {
     name?: string
     namespace?: string
@@ -33,36 +45,114 @@ interface CustomResourceItem {
 }
 
 interface CustomResourceResponse {
-  items?: CustomResourceItem[]
+  items?: ChaosMeshCustomResourceItem[]
+}
+
+interface ChaosMeshCondition {
+  type?: string
+  status?: string
+}
+
+function resolveItemName(e: ChaosMeshCustomResourceItem): string {
+  return e.name ?? e.metadata?.name ?? ''
+}
+
+function resolveItemNamespace(e: ChaosMeshCustomResourceItem): string {
+  const ns = e.namespace ?? e.metadata?.namespace
+  return ns && ns.length > 0 ? ns : DEFAULT_NAMESPACE
 }
 
 // ---------------------------------------------------------------------------
 // Pure helpers (exported via __testables for unit testing)
 // ---------------------------------------------------------------------------
 
-function getExperimentPhase(item: unknown): string {
-  const obj = item as CustomResourceItem
-  if (typeof obj?.status?.phase === 'string') {
-    return obj.status.phase
+function chaosConditionIsTrue(conditions: unknown, conditionType: string): boolean {
+  if (!Array.isArray(conditions)) {
+    return false
+  }
+  for (const c of conditions) {
+    if (!c || typeof c !== 'object') {
+      continue
+    }
+    const row = c as ChaosMeshCondition
+    if (row.type === conditionType && row.status === CHAOS_MESH_CONDITION_STATUS_TRUE) {
+      return true
+    }
+  }
+  return false
+}
+
+function derivePhaseFromConditions(conditions: unknown): string {
+  if (chaosConditionIsTrue(conditions, CHAOS_MESH_CONDITION_TYPE_PAUSED)) {
+    return 'Paused'
+  }
+  if (chaosConditionIsTrue(conditions, CHAOS_MESH_CONDITION_TYPE_FAILED)) {
+    return 'Failed'
+  }
+  if (chaosConditionIsTrue(conditions, CHAOS_MESH_CONDITION_TYPE_ALL_RECOVERED)) {
+    return 'Finished'
+  }
+  if (chaosConditionIsTrue(conditions, CHAOS_MESH_CONDITION_TYPE_ALL_INJECTED)) {
+    return 'Running'
+  }
+  if (chaosConditionIsTrue(conditions, CHAOS_MESH_CONDITION_TYPE_SELECTED)) {
+    return 'Running'
   }
   return 'Unknown'
+}
+
+function coerceCardPhase(phase: string): ChaosMeshExperiment['phase'] {
+  if (phase === 'Running' || phase === 'Finished' || phase === 'Failed' || phase === 'Paused' || phase === 'Unknown') {
+    return phase
+  }
+  return 'Unknown'
+}
+
+/** Phase for PodChaos and other chaos-mesh.org experiment CRs (conditions or legacy phase string). */
+function getExperimentPhase(item: unknown): string {
+  const obj = item as ChaosMeshCustomResourceItem
+  if (typeof obj?.status?.phase === 'string' && obj.status.phase.length > 0) {
+    return obj.status.phase
+  }
+  return derivePhaseFromConditions(obj?.status?.conditions)
+}
+
+/** Phase for Workflow CRs — prefer status.phase, else conditions. */
+function getWorkflowPhase(item: unknown): string {
+  const obj = item as ChaosMeshCustomResourceItem
+  if (typeof obj?.status?.phase === 'string' && obj.status.phase.length > 0) {
+    return obj.status.phase
+  }
+  return derivePhaseFromConditions(obj?.status?.conditions)
 }
 
 function isExperimentFailed(item: unknown): boolean {
   return getExperimentPhase(item) === 'Failed'
 }
 
-function buildChaosMeshStatus(experiments: CustomResourceItem[], workflows: CustomResourceItem[]): ChaosMeshStatusData {
-  if (experiments.length === 0) {
+function buildChaosMeshStatus(
+  experiments: ChaosMeshCustomResourceItem[],
+  workflows: ChaosMeshCustomResourceItem[],
+): ChaosMeshStatusData {
+  if (experiments.length === 0 && workflows.length === 0) {
     return INITIAL_DATA
   }
 
   const mappedExperiments: ChaosMeshExperiment[] = experiments.map(e => ({
-    name: e.metadata?.name ?? e.name ?? '',
-    namespace: e.metadata?.namespace ?? e.namespace ?? 'default',
-    kind: e.kind ?? 'PodChaos',
-    phase: getExperimentPhase(e) as ChaosMeshExperiment['phase'],
+    name: resolveItemName(e),
+    namespace: resolveItemNamespace(e),
+    cluster: e.cluster,
+    kind: e.kind && e.kind.length > 0 ? e.kind : 'Unknown',
+    phase: coerceCardPhase(getExperimentPhase(e)),
     startTime: typeof e.status?.startTime === 'string' ? e.status.startTime : '',
+  }))
+
+  const mappedWorkflows: ChaosMeshWorkflow[] = workflows.map(w => ({
+    name: resolveItemName(w),
+    namespace: resolveItemNamespace(w),
+    cluster: w.cluster,
+    phase: coerceCardPhase(getWorkflowPhase(w)) as ChaosMeshWorkflow['phase'],
+    progress: typeof w.status?.progress === 'string' ? w.status.progress : '0/0',
   }))
 
   const summary = {
@@ -71,13 +161,6 @@ function buildChaosMeshStatus(experiments: CustomResourceItem[], workflows: Cust
     finished: mappedExperiments.filter(e => e.phase === 'Finished').length,
     failed: mappedExperiments.filter(e => e.phase === 'Failed').length,
   }
-
-  const mappedWorkflows: ChaosMeshWorkflow[] = workflows.map(w => ({
-    name: w.metadata?.name ?? w.name ?? '',
-    namespace: w.metadata?.namespace ?? w.namespace ?? 'default',
-    phase: (typeof w.status?.phase === 'string' ? w.status.phase : 'Unknown') as ChaosMeshWorkflow['phase'],
-    progress: typeof w.status?.progress === 'string' ? w.status.progress : '0/0',
-  }))
 
   return {
     experiments: mappedExperiments,
@@ -93,7 +176,6 @@ function buildChaosMeshStatus(experiments: CustomResourceItem[], workflows: Cust
 
 async function fetchChaosMeshStatus(): Promise<ChaosMeshStatusData> {
   const [expsRes, wfsRes] = await Promise.all([
-    // All chaos experiment CRDs live under chaos-mesh.org group
     authFetch('/api/mcp/custom-resources?group=chaos-mesh.org&version=v1alpha1&resource=podchaos', {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
@@ -109,7 +191,7 @@ async function fetchChaosMeshStatus(): Promise<ChaosMeshStatusData> {
   }
 
   const expsJson = (await expsRes.json()) as CustomResourceResponse
-  
+
   let wfsJson: CustomResourceResponse = { items: [] }
   if (wfsRes.ok) {
     try {
@@ -149,7 +231,9 @@ export function useChaosMeshStatus(): UseChaosMeshStatusResult {
     })
 
   const effectiveIsDemoData = isDemoFallback && !isLoading
-  const hasAnyData = data.health === 'not-installed' ? true : data.summary.totalExperiments > 0
+  const workflowCount = (data.workflows || []).length
+  const hasAnyData =
+    data.health === 'not-installed' ? true : data.summary.totalExperiments > 0 || workflowCount > 0
 
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isLoading && !hasAnyData,
@@ -178,6 +262,9 @@ export function useChaosMeshStatus(): UseChaosMeshStatusResult {
 
 export const __testables = {
   getExperimentPhase,
+  getWorkflowPhase,
   isExperimentFailed,
   buildChaosMeshStatus,
+  coerceCardPhase,
+  derivePhaseFromConditions,
 }


### PR DESCRIPTION
## Summary
- Align `useChaosMeshStatus` with the flat JSON shape returned by `GET /api/mcp/custom-resources` (name/namespace/cluster/kind/status), matching other cards that consume this endpoint. Keeps optional legacy `metadata.*` resolution for transitional payloads.
- Derive experiment phase from Chaos Mesh `status.conditions` when `status.phase` is absent (PodChaos and related CRs).
- Include `cluster` in experiment/workflow row keys to avoid duplicate React keys across contexts.
- Add `kind` to Go `CustomResourceItem` and populate it in `parseCRItem`; extend handler tests.
- Rebased onto `main` after #13760: `category: 'realtime'`, `refetch`, and Copilot follow-ups — early return only when **both** experiments and workflows are empty; `hasAnyData` treats workflow rows as data so workflow-only installs are not stuck in not-installed.

## Related issues
- **Fixes #13756** — live PodChaos / custom-resources sync.
- **Related: #13762** — follow-up filed for phase counters + kind; this PR implements condition-based phases, backend `Kind`, and correct kind fallback (`Unknown` when absent, not hardcoded `PodChaos`).

## Test plan
- [x] `cd web && npx vitest run src/components/cards/chaos_mesh_status`
- [x] `go test ./pkg/api/handlers/ -run 'TestMCPHandlers_GetCustomResources|TestParseCRItem'`
- [ ] Maintainer: with a running kind cluster + Chaos Mesh, apply issue repro `PodChaos` and confirm the card shows non-zero totals and sensible phase after refresh (see #13756).

Fixes #13756