### PR TITLE
✨ feat: add Ctrl+Z / Ctrl+Shift+Z keyboard shortcuts for dashboard undo/redo

### DIFF
--- a/web/src/components/dashboard/FloatingDashboardActions.tsx
+++ b/web/src/components/dashboard/FloatingDashboardActions.tsx
@@ -97,6 +97,32 @@ export function FloatingDashboardActions({
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [isUnifiedMode, onOpenCustomizer])
 
+  // Ctrl+Z / Ctrl+Shift+Z (Ctrl+Y) — undo/redo keyboard shortcuts
+  useEffect(() => {
+    const handleUndoRedo = (e: KeyboardEvent) => {
+      // Skip when user is typing in form fields
+      const tag = (e.target as HTMLElement)?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+
+      const isMod = e.metaKey || e.ctrlKey
+
+      // Ctrl+Z (no shift) → undo
+      if (isMod && e.key === 'z' && !e.shiftKey) {
+        e.preventDefault()
+        if (canUndo) onUndo?.()
+        return
+      }
+
+      // Ctrl+Shift+Z or Ctrl+Y → redo
+      if (isMod && ((e.key === 'z' && e.shiftKey) || e.key === 'y')) {
+        e.preventDefault()
+        if (canRedo) onRedo?.()
+      }
+    }
+    document.addEventListener('keydown', handleUndoRedo)
+    return () => document.removeEventListener('keydown', handleUndoRedo)
+  }, [canUndo, canRedo, onUndo, onRedo])
+
   // Close menu when clicking outside (legacy mode)
   useEffect(() => {
     if (!menuIsOpen) return


### PR DESCRIPTION
Fixes #13763
## What

Add keyboard shortcuts for dashboard undo/redo operations that currently only work via button clicks.

## Shortcuts Added

| Shortcut | Action | Mac Equivalent |
|---|---|---|
| `Ctrl+Z` | Undo last card mutation | `⌘+Z` |
| `Ctrl+Shift+Z` | Redo | `⌘+Shift+Z` |
| `Ctrl+Y` | Redo (Windows alternative) | — |

## Why

The dashboard has undo/redo buttons (`FloatingDashboardActions.tsx`) but no keyboard bindings. Users instinctively press `Ctrl+Z` to undo card changes — nothing happens. Every modern editor (VS Code, Figma, Notion) supports these shortcuts.

## Implementation

- Added a `useEffect` keyboard listener in `FloatingDashboardActions.tsx`
- Follows the **exact same pattern** as the existing `Ctrl+K` shortcut (line 91)
- Form inputs (`INPUT`, `TEXTAREA`, `SELECT`) are excluded to avoid hijacking normal text editing undo
- Uses existing `onUndo` / `onRedo` callbacks — no new infrastructure needed

## Changes

| File | Lines Added |
|---|---|
| `FloatingDashboardActions.tsx` | +26 (single `useEffect` block) |


