### PR TITLE
test(quantum): Vitest coverage for useQuantumCircuitAscii hook glue (#13832)

### DIFF
--- a/web/src/hooks/__tests__/useQuantumCircuitAscii.test.ts
+++ b/web/src/hooks/__tests__/useQuantumCircuitAscii.test.ts
@@ -1,0 +1,66 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useQuantumCircuitAscii, DEMO_QUANTUM_CIRCUIT } from '../useCachedQuantum'
+import { useCache } from '../../lib/cache'
+
+vi.mock('../../lib/cache', () => ({ useCache: vi.fn() }))
+vi.mock('../../lib/quantum/pollingContext', () => ({
+  isGlobalQuantumPollingPaused: vi.fn().mockReturnValue(false),
+}))
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('useQuantumCircuitAscii', () => {
+  it('returns disabled result with data null when isAuthenticated is false', () => {
+    const mockRefetch = vi.fn()
+    vi.mocked(useCache).mockReturnValue({
+      data: null,
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      isFailed: false,
+      error: null,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: mockRefetch,
+    })
+
+    const { result } = renderHook(() =>
+      useQuantumCircuitAscii({ isAuthenticated: false }),
+    )
+
+    expect(result.current.data).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isRefreshing).toBe(false)
+    expect(result.current.isDemoData).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(result.current.isFailed).toBe(false)
+    expect(result.current.consecutiveFailures).toBe(0)
+    expect(result.current.lastRefresh).toBeNull()
+    expect(typeof result.current.refetch).toBe('function')
+  })
+
+  it('returns DEMO_QUANTUM_CIRCUIT and isDemoData true in demo mode', () => {
+    vi.mocked(useCache).mockReturnValueOnce({
+      data: DEMO_QUANTUM_CIRCUIT,
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: true,
+      isFailed: false,
+      error: null,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+
+    const { result } = renderHook(() =>
+      useQuantumCircuitAscii({ isAuthenticated: true }),
+    )
+
+    expect(result.current.isDemoData).toBe(true)
+    expect(result.current.data).not.toBeNull()
+    expect(result.current.data?.circuitAscii).toMatch(/[┌─┤]/)
+  })
+})

--- a/web/src/hooks/__tests__/useQuantumCircuitAscii.test.ts
+++ b/web/src/hooks/__tests__/useQuantumCircuitAscii.test.ts
@@ -1,6 +1,10 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
-import { useQuantumCircuitAscii, DEMO_QUANTUM_CIRCUIT } from '../useCachedQuantum'
+import {
+  useQuantumCircuitAscii,
+  DEMO_QUANTUM_CIRCUIT,
+  QUANTUM_CIRCUIT_DEFAULT_POLL_MS,
+} from '../useCachedQuantum'
 import { useCache } from '../../lib/cache'
 
 vi.mock('../../lib/cache', () => ({ useCache: vi.fn() }))
@@ -8,27 +12,46 @@ vi.mock('../../lib/quantum/pollingContext', () => ({
   isGlobalQuantumPollingPaused: vi.fn().mockReturnValue(false),
 }))
 
+const MOCK_CACHE_ERROR_MESSAGE = 'cache fetch failed'
+const MOCK_CONSECUTIVE_FAILURES = 5
+const MOCK_LAST_REFRESH_MS = 123456789
+
 beforeEach(() => {
-  vi.resetAllMocks()
+  vi.clearAllMocks()
 })
 
 describe('useQuantumCircuitAscii', () => {
   it('returns disabled result with data null when isAuthenticated is false', () => {
     const mockRefetch = vi.fn()
     vi.mocked(useCache).mockReturnValue({
-      data: null,
-      isLoading: false,
-      isRefreshing: false,
-      isDemoFallback: false,
-      isFailed: false,
-      error: null,
-      consecutiveFailures: 0,
-      lastRefresh: null,
+      data: DEMO_QUANTUM_CIRCUIT,
+      isLoading: true,
+      isRefreshing: true,
+      isDemoFallback: true,
+      isFailed: true,
+      error: MOCK_CACHE_ERROR_MESSAGE,
+      consecutiveFailures: MOCK_CONSECUTIVE_FAILURES,
+      lastRefresh: MOCK_LAST_REFRESH_MS,
       refetch: mockRefetch,
+      retryFetch: vi.fn(),
+      clearAndRefetch: vi.fn(),
     })
 
     const { result } = renderHook(() =>
       useQuantumCircuitAscii({ isAuthenticated: false }),
+    )
+
+    expect(vi.mocked(useCache).mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        key: 'quantum-circuit-ascii',
+        category: 'realtime',
+        refreshInterval: QUANTUM_CIRCUIT_DEFAULT_POLL_MS,
+        autoRefresh: true,
+        enabled: false,
+        initialData: null,
+        demoData: DEMO_QUANTUM_CIRCUIT,
+        fetcher: expect.any(Function),
+      }),
     )
 
     expect(result.current.data).toBeNull()
@@ -39,7 +62,7 @@ describe('useQuantumCircuitAscii', () => {
     expect(result.current.isFailed).toBe(false)
     expect(result.current.consecutiveFailures).toBe(0)
     expect(result.current.lastRefresh).toBeNull()
-    expect(typeof result.current.refetch).toBe('function')
+    expect(result.current.refetch).toBe(mockRefetch)
   })
 
   it('returns DEMO_QUANTUM_CIRCUIT and isDemoData true in demo mode', () => {
@@ -53,14 +76,60 @@ describe('useQuantumCircuitAscii', () => {
       consecutiveFailures: 0,
       lastRefresh: null,
       refetch: vi.fn(),
+      retryFetch: vi.fn(),
+      clearAndRefetch: vi.fn(),
     })
 
     const { result } = renderHook(() =>
       useQuantumCircuitAscii({ isAuthenticated: true }),
     )
 
+    expect(vi.mocked(useCache).mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        key: 'quantum-circuit-ascii',
+        enabled: true,
+        demoData: DEMO_QUANTUM_CIRCUIT,
+      }),
+    )
+
     expect(result.current.isDemoData).toBe(true)
-    expect(result.current.data).not.toBeNull()
-    expect(result.current.data?.circuitAscii).toMatch(/[┌─┤]/)
+    expect(result.current.data).toEqual(DEMO_QUANTUM_CIRCUIT)
+  })
+
+  it('sets isDemoData false when isDemoFallback true and isLoading true', () => {
+    vi.mocked(useCache).mockReturnValueOnce({
+      data: DEMO_QUANTUM_CIRCUIT,
+      isLoading: true,
+      isRefreshing: false,
+      isDemoFallback: true,
+      isFailed: false,
+      error: null,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+      retryFetch: vi.fn(),
+      clearAndRefetch: vi.fn(),
+    })
+
+    const { result } = renderHook(() =>
+      useQuantumCircuitAscii({ isAuthenticated: true }),
+    )
+
+    expect(result.current.isDemoData).toBe(false)
+  })
+
+  it('disables cache when forceDemo is true even if authenticated', () => {
+    renderHook(() =>
+      useQuantumCircuitAscii({
+        isAuthenticated: true,
+        forceDemo: true,
+      }),
+    )
+
+    expect(vi.mocked(useCache).mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        enabled: false,
+      }),
+    )
   })
 })


### PR DESCRIPTION
Part of #13832

Adds Vitest tests for the `useQuantumCircuitAscii` glue layer:
- **Disabled path**: `isAuthenticated: false` returns null data with flags normalized via `getDisabledResult`, `refetch` forwarded, and `useCache` wired with `enabled: false` and expected key/demo/fetcher
- **Demo mode**: `isDemoFallback` + not loading returns `DEMO_QUANTUM_CIRCUIT` with `isDemoData: true` (exact object match)
- **Loading + demo**: `isDemoFallback: true` while `isLoading: true` keeps `isDemoData` false
- **`forceDemo`**: cache `enabled: false` when authenticated with `forceDemo: true`

Note: `useQuantumAuthStatus` tests were merged in #13911 — this PR only adds `useQuantumCircuitAscii.test.ts`.

Out of scope: other quantum UI tests per #13832.

- [x] DCO signed (`git commit -s`)
- [x] Rebased / aligned with current main
- [x] Build and lint validated by CI (not run locally per CLAUDE.md)