### PR TITLE
fix: abort pending mission imports on component unmount

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -464,11 +464,12 @@ export function MissionSidebar() {
       `fixes/${directImportSlug}.json`,
     ]
 
+    const controller = new AbortController()
+
     const tryImport = async () => {
       setIsDirectImporting(true)
       // Race all lookups — resolve as soon as the first succeeds, cancel rest.
       // This avoids waiting for 12 slow 404s when the mission is in cncf-install.
-      const controller = new AbortController()
       let found: MissionExport | null = null
       try {
         found = await Promise.any(paths.map(async (path) => {
@@ -525,6 +526,7 @@ export function MissionSidebar() {
     }
 
     tryImport().finally(() => setIsDirectImporting(false))
+    return () => controller.abort()
   }, [directImportSlug]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Mission list search filter (#3944)


### PR DESCRIPTION
When MissionSidebar imports a mission by slug, it fires off a dozen
concurrent fetch calls and races them with Promise.any — whichever
resolves first wins, the rest get cancelled. That part works fine.

But the AbortController lived inside the async function, so when
the user navigated away mid-import, the useEffect cleanup had
nothing to abort. Pending requests kept running and would eventually
call setState and handleImportMission on a gone component.

Moved the controller into useEffect scope and added abort() in
the cleanup. The existing success-path abort still works — and
now the cleanup path does too.