### PR TITLE
test(quantum): Vitest coverage for useQuantumQubitGridData hook glue (#13832)

### DIFF
--- a/web/src/hooks/__tests__/useQuantumQubitGridData.test.ts
+++ b/web/src/hooks/__tests__/useQuantumQubitGridData.test.ts
@@ -1,0 +1,78 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import {
+  useQuantumQubitGridData,
+  DEMO_QUANTUM_QUBITS,
+  DEMO_QUANTUM_STATUS,
+} from '../useCachedQuantum'
+import { useCache } from '../../lib/cache'
+
+vi.mock('../../lib/cache', () => ({ useCache: vi.fn() }))
+vi.mock('../../lib/quantum/pollingContext', () => ({
+  isGlobalQuantumPollingPaused: vi.fn().mockReturnValue(false),
+}))
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('useQuantumQubitGridData', () => {
+  it('returns disabled result with data null when isAuthenticated is false', () => {
+    const mockRefetch = vi.fn()
+    vi.mocked(useCache).mockReturnValue({
+      data: null,
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      isFailed: false,
+      error: null,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: mockRefetch,
+    })
+
+    const { result } = renderHook(() =>
+      useQuantumQubitGridData({ isAuthenticated: false }),
+    )
+
+    expect(result.current.data).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isRefreshing).toBe(false)
+    expect(result.current.isDemoData).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(result.current.isFailed).toBe(false)
+    expect(result.current.consecutiveFailures).toBe(0)
+    expect(result.current.lastRefresh).toBeNull()
+    expect(typeof result.current.refetch).toBe('function')
+  })
+
+  it('maps DEMO_QUANTUM_QUBITS and version_info correctly in demo mode', () => {
+    const demoData = {
+      qubits: DEMO_QUANTUM_QUBITS,
+      versionInfo: DEMO_QUANTUM_STATUS.version_info ?? null,
+    }
+
+    vi.mocked(useCache).mockReturnValueOnce({
+      data: demoData,
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: true,
+      isFailed: false,
+      error: null,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+
+    const { result } = renderHook(() =>
+      useQuantumQubitGridData({ isAuthenticated: true }),
+    )
+
+    expect(result.current.isDemoData).toBe(true)
+    expect(result.current.data).not.toBeNull()
+    expect(result.current.data?.qubits?.num_qubits).toBe(2)
+    expect(result.current.data?.qubits?.pattern).toBe('00')
+    expect(result.current.data?.versionInfo?.version).toBe('v0.2.58')
+    expect(result.current.data?.versionInfo?.commit).toBe('demo')
+  })
+})

--- a/web/src/hooks/__tests__/useQuantumQubitGridData.test.ts
+++ b/web/src/hooks/__tests__/useQuantumQubitGridData.test.ts
@@ -19,15 +19,19 @@ beforeEach(() => {
 describe('useQuantumQubitGridData', () => {
   it('returns disabled result with data null when isAuthenticated is false', () => {
     const mockRefetch = vi.fn()
+    const noisyCacheData = {
+      qubits: DEMO_QUANTUM_QUBITS,
+      versionInfo: DEMO_QUANTUM_STATUS.version_info ?? null,
+    }
     vi.mocked(useCache).mockReturnValue({
-      data: null,
-      isLoading: false,
-      isRefreshing: false,
-      isDemoFallback: false,
-      isFailed: false,
-      error: null,
-      consecutiveFailures: 0,
-      lastRefresh: null,
+      data: noisyCacheData,
+      isLoading: true,
+      isRefreshing: true,
+      isDemoFallback: true,
+      isFailed: true,
+      error: 'cache fetch failed',
+      consecutiveFailures: 5,
+      lastRefresh: 123456789,
       refetch: mockRefetch,
     })
 
@@ -43,7 +47,7 @@ describe('useQuantumQubitGridData', () => {
     expect(result.current.isFailed).toBe(false)
     expect(result.current.consecutiveFailures).toBe(0)
     expect(result.current.lastRefresh).toBeNull()
-    expect(typeof result.current.refetch).toBe('function')
+    expect(result.current.refetch).toBe(mockRefetch)
   })
 
   it('maps DEMO_QUANTUM_QUBITS and version_info correctly in demo mode', () => {
@@ -51,6 +55,22 @@ describe('useQuantumQubitGridData', () => {
       qubits: DEMO_QUANTUM_QUBITS,
       versionInfo: DEMO_QUANTUM_STATUS.version_info ?? null,
     }
+
+    vi.mocked(useCache).mockReturnValueOnce({
+      data: demoData,
+      isLoading: true,
+      isRefreshing: false,
+      isDemoFallback: true,
+      isFailed: false,
+      error: null,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+    const { result: loadingResult } = renderHook(() =>
+      useQuantumQubitGridData({ isAuthenticated: true }),
+    )
+    expect(loadingResult.current.isDemoData).toBe(false)
 
     vi.mocked(useCache).mockReturnValueOnce({
       data: demoData,


### PR DESCRIPTION
Part of #13832

### What this adds
- `useQuantumQubitGridData.test.ts` — 2 Vitest tests
  1. Unauthenticated path returns `getDisabledResult(null)` shape with all flags false
  2. Demo mode returns `DEMO_QUANTUM_QUBITS` + `version_info` correctly mapped, `isDemoData: true`

### What this does NOT include
Other quantum hook tests (PRs 1–2) and UI component tests (PRs 4–6) are separate per #13832 scope.

### Notes
- All commits signed with DCO (`git commit -s`)
- Build and lint validated by CI — not run locally per CLAUDE.md