### PR TITLE
test(quantum): Vitest coverage for useQuantumAuthStatus hook glue (#13832)

### DIFF
--- a/web/src/hooks/__tests__/useQuantumAuthStatus.test.ts
+++ b/web/src/hooks/__tests__/useQuantumAuthStatus.test.ts
@@ -1,0 +1,99 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+vi.mock('../../lib/cache', () => ({ useCache: vi.fn() }))
+vi.mock('../../lib/quantum/pollingContext', () => ({
+  isGlobalQuantumPollingPaused: vi.fn().mockReturnValue(false),
+}))
+
+import { useQuantumAuthStatus } from '../useCachedQuantum'
+import { useCache } from '../../lib/cache'
+
+const mockRefetch = vi.fn()
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('useQuantumAuthStatus', () => {
+  it('returns disabled result with authenticated:false when isAuthenticated is false', () => {
+    vi.mocked(useCache).mockReturnValue({
+      data: { authenticated: false },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      isFailed: false,
+      error: null,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: mockRefetch,
+    })
+
+    const { result } = renderHook(() =>
+      useQuantumAuthStatus({ isAuthenticated: false }),
+    )
+
+    expect(result.current.data).toEqual({ authenticated: false })
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isRefreshing).toBe(false)
+    expect(result.current.isDemoData).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(result.current.isFailed).toBe(false)
+    expect(result.current.consecutiveFailures).toBe(0)
+    expect(result.current.lastRefresh).toBeNull()
+    expect(typeof result.current.refetch).toBe('function')
+  })
+
+  it('sets isDemoData=true only when isDemoFallback=true AND isLoading=false', () => {
+    // Case A: isDemoFallback=true, isLoading=true → isDemoData false
+    vi.mocked(useCache).mockReturnValueOnce({
+      data: { authenticated: false },
+      isLoading: true,
+      isRefreshing: false,
+      isDemoFallback: true,
+      isFailed: false,
+      error: null,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+    const { result: r1 } = renderHook(() =>
+      useQuantumAuthStatus({ isAuthenticated: true }),
+    )
+    expect(r1.current.isDemoData).toBe(false)
+
+    // Case B: isDemoFallback=true, isLoading=false → isDemoData true
+    vi.mocked(useCache).mockReturnValueOnce({
+      data: { authenticated: false },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: true,
+      isFailed: false,
+      error: null,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+    const { result: r2 } = renderHook(() =>
+      useQuantumAuthStatus({ isAuthenticated: true }),
+    )
+    expect(r2.current.isDemoData).toBe(true)
+
+    // Case C: isDemoFallback=false, isLoading=false → isDemoData false
+    vi.mocked(useCache).mockReturnValueOnce({
+      data: { authenticated: true },
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      isFailed: false,
+      error: null,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    })
+    const { result: r3 } = renderHook(() =>
+      useQuantumAuthStatus({ isAuthenticated: true }),
+    )
+    expect(r3.current.isDemoData).toBe(false)
+  })
+})

--- a/web/src/hooks/__tests__/useQuantumAuthStatus.test.ts
+++ b/web/src/hooks/__tests__/useQuantumAuthStatus.test.ts
@@ -18,14 +18,14 @@ beforeEach(() => {
 describe('useQuantumAuthStatus', () => {
   it('returns disabled result with authenticated:false when isAuthenticated is false', () => {
     vi.mocked(useCache).mockReturnValue({
-      data: { authenticated: false },
-      isLoading: false,
-      isRefreshing: false,
-      isDemoFallback: false,
-      isFailed: false,
-      error: null,
-      consecutiveFailures: 0,
-      lastRefresh: null,
+      data: { authenticated: true },
+      isLoading: true,
+      isRefreshing: true,
+      isDemoFallback: true,
+      isFailed: true,
+      error: 'cache fetch failed',
+      consecutiveFailures: 5,
+      lastRefresh: 123456789,
       refetch: mockRefetch,
     })
 
@@ -41,7 +41,7 @@ describe('useQuantumAuthStatus', () => {
     expect(result.current.isFailed).toBe(false)
     expect(result.current.consecutiveFailures).toBe(0)
     expect(result.current.lastRefresh).toBeNull()
-    expect(typeof result.current.refetch).toBe('function')
+    expect(result.current.refetch).toBe(mockRefetch)
   })
 
   it('sets isDemoData=true only when isDemoFallback=true AND isLoading=false', () => {


### PR DESCRIPTION
Part of #13832

Adds 2 Vitest tests for the `useQuantumAuthStatus` glue layer:
- **Test 1**: Unauthenticated path returns `getDisabledResult` shape with `data.authenticated=false` and all flags cleared (9 assertions)
- **Test 2**: `isDemoData` = `isDemoFallback && !isLoading` — all three cases verified

Key difference from useQuantumSystemStatus: disabled path returns `{ authenticated: false }` (DEFAULT_AUTH_STATUS), not null.

Out of scope: other quantum hook tests and UI component tests are in separate PRs per #13832.

- All commits DCO signed (`git commit -s`)
- Build and lint validated by CI — not run locally per CLAUDE.md