### PR TITLE
fix: quantum proxy routes were missing from netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -278,6 +278,19 @@
   to = "/.netlify/functions/analytics-accm"
   status = 200
 
+# Quantum proxy — forwards /api/quantum/* and /api/result/histogram to the
+# quantum-proxy Netlify function. Without these rules every quantum request
+# falls through to the SPA catch-all and returns HTML instead of JSON.
+[[redirects]]
+  from = "/api/quantum/*"
+  to = "/.netlify/functions/quantum-proxy/:splat"
+  status = 200
+
+[[redirects]]
+  from = "/api/result/histogram"
+  to = "/.netlify/functions/quantum-proxy/result/histogram"
+  status = 200
+
 # SPA routing - redirect all routes to index.html (only if file doesn't exist)
 [[redirects]]
   from = "/*"

--- a/web/netlify/functions/quantum-proxy.mts
+++ b/web/netlify/functions/quantum-proxy.mts
@@ -65,7 +65,9 @@ const ALLOWED_PATHS = new Set([
   "/loop/stop",
   "/qasm/circuit/ascii",
   "/qasm/file",
+  "/qasm/listfiles",
   "/auth",
+  "/auth/status",
   "/auth/save",
   "/auth/clear",
 ]);
@@ -142,6 +144,18 @@ export default async (req: Request, context: Context): Promise<Response> => {
         return new Response(DEMO_CIRCUIT_ASCII_HTML, {
           status: 200,
           headers: { "Content-Type": "text/html" },
+        });
+      }
+      if (path === "/auth/status") {
+        return new Response(JSON.stringify({ authenticated: false }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (path === "/qasm/listfiles") {
+        return new Response(JSON.stringify({ files: ["bell.qasm"] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
         });
       }
     }

--- a/web/src/mocks/handlers.endpoints.ts
+++ b/web/src/mocks/handlers.endpoints.ts
@@ -2159,6 +2159,14 @@ export function createHandlers() {
   //       headers: { 'X-Test-Request': '1' },
   //     })
   //   })
+  // Quantum proxy — pass through to the Netlify function (or Go backend in
+  // local dev). Without these rules MSW swallows every /api/quantum/* request
+  // in demo mode and the quantum panel never receives data.
+  http.get('/api/quantum/*', () => passthrough()),
+  http.post('/api/quantum/*', () => passthrough()),
+  http.delete('/api/quantum/*', () => passthrough()),
+  http.get('/api/result/histogram', () => passthrough()),
+
   http.post('/__test/reset', ({ request }) => {
     if (!request.headers.get('X-Test-Request')) {
       return HttpResponse.json({ error: 'Forbidden' }, { status: 403 })


### PR DESCRIPTION
> **Adding or modifying a card/dashboard?** Read the [[Card Development Guide](https://chatgpt.com/c/.github/CARD_DEVELOPMENT_GUIDE.md)](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.

> **New CNCF project card?** New cards go in [[kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace)](https://github.com/kubestellar/console-marketplace), not this repo. PRs adding new cards here will be redirected.

> **Use a coding agent.** This repo is primarily developed with [[Claude Code](https://docs.anthropic.com/en/docs/claude-code)](https://docs.anthropic.com/en/docs/claude-code) (Opus 4.5/4.6). It knows all codebase patterns (isDemoData, useCardLoadingState, locale strings, DCO). Manual PRs that miss required patterns will be sent back.

### 📌 Fixes

 Fixes #13921

---

### 📝 Summary of Changes

This PR fixes broken quantum API requests on the hosted Netlify deployment.

`/api/quantum/*` routes were not wired to the existing `quantum-proxy`
Netlify function, causing all hosted quantum requests to fall through to the SPA
and return HTML instead of JSON responses.

Additionally, the proxy allowlist was incomplete and demo/MSW mode lacked
handlers for quantum endpoints.

---

### Changes Made

* [x] Added Netlify redirects for `/api/quantum/*`
* [x] Added Netlify redirect for `/api/result/histogram`
* [x] Updated `quantum-proxy.mts` `ALLOWED_PATHS`
* [x] Added `/auth/status` to proxy allowlist
* [x] Added `/qasm/listfiles` to proxy allowlist
* [x] Added demo responses for missing quantum endpoints
* [x] Added MSW passthrough handlers for `/api/quantum/*`
* [x] Fixed hosted quantum cards returning SPA HTML
* [x] Fixed demo mode swallowing quantum requests
* [x] Verified auth status endpoint no longer returns `400 Invalid proxy path`

---

### Checklist

Please ensure the following before submitting your PR:

* [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
* [x] I have reviewed the project's contribution guidelines
* [x] New cards target [[console-marketplace](https://github.com/kubestellar/console-marketplace)](https://github.com/kubestellar/console-marketplace), not this repo
* [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
* [ ] I have written unit tests for the changes (if applicable)
* [x] I have tested the changes locally and ensured they work as expected
* [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

#### Before

```text
GET /api/quantum/status
200 text/html
<!DOCTYPE html>
```

#### After

```text
GET /api/quantum/status
200 application/json
```

#### Fixed endpoints

```text
/api/quantum/auth/status
/api/quantum/qasm/listfiles
/api/result/histogram
```

---

### 👀 Reviewer Notes

The backend routes already existed in `pkg/api/routes_api_core.go`,
but Netlify redirects were missing, making the hosted quantum proxy
function unreachable.

This PR only wires the existing functionality correctly and adds the
missing proxy allowlist/demo handlers required by the current frontend.