### PR TITLE
ci: auto-close PRs from new accounts with no prior contributions

### DIFF
--- a/.github/workflows/new-contributor-pr-gate.yml
+++ b/.github/workflows/new-contributor-pr-gate.yml
@@ -1,0 +1,69 @@
+name: New Contributor PR Gate
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-contributor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check contributor history
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          REPO="${{ github.repository }}"
+          MIN_ACCOUNT_AGE_DAYS=30
+
+          # Skip bots and known automation
+          if [[ "$AUTHOR" == *"[bot]"* ]] || [[ "$AUTHOR" == "dependabot"* ]]; then
+            echo "Bot account — skipping gate."
+            exit 0
+          fi
+
+          # Check if author has any prior merged PRs or commits to this repo
+          MERGED_PRS=$(gh api "repos/${REPO}/pulls?state=closed&per_page=100" \
+            --jq "[.[] | select(.user.login == \"${AUTHOR}\" and .merged_at != null)] | length" 2>/dev/null || echo "0")
+
+          PRIOR_ISSUES=$(gh api "repos/${REPO}/issues?state=all&creator=${AUTHOR}&per_page=10" \
+            --jq '[.[] | select(.pull_request == null)] | length' 2>/dev/null || echo "0")
+
+          if [ "$MERGED_PRS" != "0" ] || [ "$PRIOR_ISSUES" != "0" ]; then
+            echo "Author has ${MERGED_PRS} merged PRs and ${PRIOR_ISSUES} issues — existing contributor."
+            exit 0
+          fi
+
+          # Check account age
+          CREATED_AT=$(gh api "users/${AUTHOR}" --jq '.created_at' 2>/dev/null || echo "")
+          if [ -z "$CREATED_AT" ]; then
+            echo "Could not fetch account age — allowing PR."
+            exit 0
+          fi
+
+          CREATED_EPOCH=$(date -d "$CREATED_AT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED_AT" +%s 2>/dev/null || echo "0")
+          NOW_EPOCH=$(date +%s)
+          AGE_DAYS=$(( (NOW_EPOCH - CREATED_EPOCH) / 86400 ))
+
+          if [ "$AGE_DAYS" -ge "$MIN_ACCOUNT_AGE_DAYS" ]; then
+            echo "Account is ${AGE_DAYS} days old (>= ${MIN_ACCOUNT_AGE_DAYS}) — allowing PR."
+            exit 0
+          fi
+
+          echo "New account (${AGE_DAYS} days) with no prior contributions — closing PR."
+
+          gh pr close "${{ github.event.pull_request.number }}" \
+            --repo "${REPO}" \
+            --comment "👋 Welcome! This repo requires new contributors to open an issue first before submitting a PR. This helps us coordinate work and avoid duplicate effort.
+
+          **Your account** is less than ${MIN_ACCOUNT_AGE_DAYS} days old and has no prior contributions to this repo.
+
+          **Next steps:**
+          1. Open an issue describing what you'd like to work on
+          2. Wait for a maintainer to approve and assign it to you
+          3. Then submit your PR referencing that issue
+
+          This is an automated check — if you believe this was a mistake, comment on this PR and a maintainer will review."


### PR DESCRIPTION
## Summary
- Adds a workflow that auto-closes PRs from accounts < 30 days old with zero prior merged PRs or issues on this repo
- Bots and existing contributors are exempted
- Closed PRs get a friendly message directing the author to open an issue first
- Triggered by `pull_request_target: [opened]` so it runs on the base repo's workflow, not the fork's

## Context
We've been getting low-quality PRs from new accounts (empty descriptions, no linked issues, changes that don't correspond to real features). GitHub doesn't natively support restricting PR creation while keeping issues open, so this workflow fills that gap.

## Test plan
- [ ] Verify workflow triggers on new PRs from accounts with no history
- [ ] Verify existing contributors (merged PRs or issues) are not blocked
- [ ] Verify bot accounts are exempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)