### PR TITLE
test(quantum): RTL coverage for QuantumCircuitViewer and QuantumQubitGrid components (#13832)

### DIFF
--- a/web/src/components/cards/quantum/__tests__/QuantumCircuitViewer.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumCircuitViewer.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+const mockUseQuantumCircuitAscii = vi.fn()
+vi.mock('../../../../hooks/useCachedQuantum', () => ({
+  useQuantumCircuitAscii: (...args: unknown[]) => mockUseQuantumCircuitAscii(...args),
+  QUANTUM_CIRCUIT_DEFAULT_POLL_MS: 10000,
+}))
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isQuantumForcedToDemo: vi.fn().mockReturnValue(false),
+}))
+
+const mockUseAuth = vi.fn()
+vi.mock('../../../../lib/auth', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: vi.fn().mockReturnValue({ showSkeleton: false }),
+  useReportCardDataState: vi.fn().mockReturnValue(undefined),
+}))
+
+import { QuantumCircuitViewer } from '../QuantumCircuitViewer'
+
+function defaultAuth() {
+  return { isAuthenticated: true, isLoading: false, login: vi.fn(), logout: vi.fn() }
+}
+
+function defaultHook(overrides: Record<string, unknown> = {}) {
+  return {
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('QuantumCircuitViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAuth.mockReturnValue(defaultAuth())
+    mockUseQuantumCircuitAscii.mockReturnValue(defaultHook())
+  })
+
+  it('renders ASCII circuit inside pre.quantum-circuit-display when circuitAscii is provided', () => {
+    const ASCII = '     ┌───┐\nq_0: ┤ H ├──■──\n     └───┘┌─┴─┐\nq_1: ─────┤ X ├\n          └───┘'
+    mockUseQuantumCircuitAscii.mockReturnValue(
+      defaultHook({ data: { circuitAscii: ASCII } }),
+    )
+    const { container } = render(<QuantumCircuitViewer />)
+    const pre = container.querySelector('pre.quantum-circuit-display')
+    expect(pre).toBeTruthy()
+    expect(pre?.textContent).toBe(ASCII)
+    expect(screen.queryByText('Unable to load quantum circuit diagram')).toBeNull()
+  })
+
+  it('renders fallback message when data is null', () => {
+    mockUseQuantumCircuitAscii.mockReturnValue(defaultHook({ data: null }))
+    const { container } = render(<QuantumCircuitViewer />)
+    expect(container.querySelector('pre.quantum-circuit-display')).toBeNull()
+    expect(screen.getByText('Unable to load quantum circuit diagram')).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/quantum/__tests__/QuantumCircuitViewer.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumCircuitViewer.test.tsx
@@ -56,15 +56,29 @@ describe('QuantumCircuitViewer', () => {
     )
     const { container } = render(<QuantumCircuitViewer />)
     const pre = container.querySelector('pre.quantum-circuit-display')
-    expect(pre).toBeTruthy()
-    expect(pre?.textContent).toBe(ASCII)
-    expect(screen.queryByText('Unable to load quantum circuit diagram')).toBeNull()
+    expect(pre).not.toBeNull()
+    expect(pre).toBeInTheDocument()
+    expect(pre!.textContent).toBe(ASCII)
+    expect(screen.queryByText('Unable to load quantum circuit diagram')).not.toBeInTheDocument()
   })
 
   it('renders fallback message when data is null', () => {
     mockUseQuantumCircuitAscii.mockReturnValue(defaultHook({ data: null }))
     const { container } = render(<QuantumCircuitViewer />)
-    expect(container.querySelector('pre.quantum-circuit-display')).toBeNull()
-    expect(screen.getByText('Unable to load quantum circuit diagram')).toBeTruthy()
+    expect(container.querySelector('pre.quantum-circuit-display')).not.toBeInTheDocument()
+    expect(
+      screen.getByText('Unable to load quantum circuit diagram'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders fallback message when circuitAscii is an empty string', () => {
+    mockUseQuantumCircuitAscii.mockReturnValue(
+      defaultHook({ data: { circuitAscii: '' } }),
+    )
+    const { container } = render(<QuantumCircuitViewer />)
+    expect(container.querySelector('pre.quantum-circuit-display')).not.toBeInTheDocument()
+    expect(
+      screen.getByText('Unable to load quantum circuit diagram'),
+    ).toBeInTheDocument()
   })
 })

--- a/web/src/components/cards/quantum/__tests__/QuantumQubitGrid.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumQubitGrid.test.tsx
@@ -74,26 +74,59 @@ describe('QuantumQubitGrid', () => {
     const { container } = render(<QuantumQubitGrid />)
 
     const infoBox = container.querySelector('.bg-blue-50')
-    expect(infoBox).toBeTruthy()
-    expect(within(infoBox as HTMLElement).getByText('5', { exact: true })).toBeTruthy()
-    expect(within(infoBox as HTMLElement).getByText('01010', { exact: true })).toBeTruthy()
-    expect(within(infoBox as HTMLElement).getByText('2.1.0', { exact: true })).toBeTruthy()
+    expect(infoBox).not.toBeNull()
+    expect(infoBox).toBeInTheDocument()
+    const info = within(infoBox as HTMLElement)
+    expect(info.getByText('5', { exact: true })).toBeInTheDocument()
+    expect(info.getByText('01010', { exact: true })).toBeInTheDocument()
+    expect(info.getByText('2.1.0', { exact: true })).toBeInTheDocument()
 
-    expect(screen.getByText('Quantum Qubit Display -- Latest Run')).toBeTruthy()
+    expect(screen.getByText('Quantum Qubit Display -- Latest Run')).toBeInTheDocument()
   })
 
   it('renders logo fallback with num_qubits=8 and empty pattern when data is null', () => {
     mockUseQuantumQubitGridData.mockReturnValue(defaultHook({ data: null }))
     const { container } = render(<QuantumQubitGrid />)
 
-    expect(screen.getByText('Quantum Qubit Display -- Latest Run')).toBeTruthy()
+    expect(screen.getByText('Quantum Qubit Display -- Latest Run')).toBeInTheDocument()
 
     const infoBox = container.querySelector('.bg-blue-50')
-    expect(infoBox).toBeTruthy()
-    expect(within(infoBox as HTMLElement).getByText('8', { exact: true })).toBeTruthy()
+    expect(infoBox).not.toBeNull()
+    expect(infoBox).toBeInTheDocument()
+    expect(within(infoBox as HTMLElement).getByText('8', { exact: true })).toBeInTheDocument()
 
-    expect(container.querySelector('svg')).toBeTruthy()
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg).toBeInTheDocument()
 
-    expect(screen.queryByText('01010')).toBeNull()
+    expect(screen.queryByText('01010')).not.toBeInTheDocument()
+  })
+
+  it('renders logo fallback when hook returns qubits null but versionInfo is present', () => {
+    mockUseQuantumQubitGridData.mockReturnValue(
+      defaultHook({
+        data: {
+          qubits: null,
+          versionInfo: {
+            version: '9.9.9',
+            commit: 'deadbeef',
+            timestamp: '2026-05-02T12:00:00Z',
+          },
+        },
+      }),
+    )
+    const { container } = render(<QuantumQubitGrid />)
+
+    const infoBox = container.querySelector('.bg-blue-50')
+    expect(infoBox).not.toBeNull()
+    const info = within(infoBox as HTMLElement)
+    expect(info.getByText('8', { exact: true })).toBeInTheDocument()
+    expect(info.getByText('9.9.9', { exact: true })).toBeInTheDocument()
+    expect(info.getByText('deadbeef', { exact: true })).toBeInTheDocument()
+
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg).toBeInTheDocument()
+    expect(screen.queryByText('01010')).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/cards/quantum/__tests__/QuantumQubitGrid.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumQubitGrid.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+
+const mockUseQuantumQubitGridData = vi.fn()
+vi.mock('../../../../hooks/useCachedQuantum', () => ({
+  useQuantumQubitGridData: (...args: unknown[]) => mockUseQuantumQubitGridData(...args),
+  DEMO_QUANTUM_QUBITS: { num_qubits: 5, pattern: '01010' },
+  QUANTUM_QUBIT_GRID_DEFAULT_POLL_MS: 5000,
+}))
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isQuantumForcedToDemo: vi.fn().mockReturnValue(false),
+}))
+
+const mockUseAuth = vi.fn()
+vi.mock('../../../../lib/auth', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('dompurify', () => ({
+  default: {
+    sanitize: (svg: string) => svg,
+  },
+}))
+
+const mockUseReportCardDataState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: (opts: unknown) => mockUseReportCardDataState(opts),
+  useCardLoadingState: vi.fn().mockReturnValue({ showSkeleton: false }),
+}))
+
+import { QuantumQubitGrid } from '../QuantumQubitGrid'
+
+function defaultAuth() {
+  return { isAuthenticated: true, isLoading: false, login: vi.fn(), logout: vi.fn() }
+}
+
+function defaultHook(overrides: Record<string, unknown> = {}) {
+  return {
+    data: null,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('QuantumQubitGrid', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAuth.mockReturnValue(defaultAuth())
+    mockUseQuantumQubitGridData.mockReturnValue(defaultHook())
+    mockUseReportCardDataState.mockReturnValue(undefined)
+  })
+
+  it('renders qubit count, pattern, and version in info box when qubits data is present', () => {
+    mockUseQuantumQubitGridData.mockReturnValue(
+      defaultHook({
+        data: {
+          qubits: { num_qubits: 5, pattern: '01010' },
+          versionInfo: {
+            version: '2.1.0',
+            commit: 'abc123',
+            timestamp: '2026-05-01T00:00:00Z',
+          },
+        },
+      }),
+    )
+    const { container } = render(<QuantumQubitGrid />)
+
+    const infoBox = container.querySelector('.bg-blue-50')
+    expect(infoBox).toBeTruthy()
+    expect(within(infoBox as HTMLElement).getByText('5', { exact: true })).toBeTruthy()
+    expect(within(infoBox as HTMLElement).getByText('01010', { exact: true })).toBeTruthy()
+    expect(within(infoBox as HTMLElement).getByText('2.1.0', { exact: true })).toBeTruthy()
+
+    expect(screen.getByText('Quantum Qubit Display -- Latest Run')).toBeTruthy()
+  })
+
+  it('renders logo fallback with num_qubits=8 and empty pattern when data is null', () => {
+    mockUseQuantumQubitGridData.mockReturnValue(defaultHook({ data: null }))
+    const { container } = render(<QuantumQubitGrid />)
+
+    expect(screen.getByText('Quantum Qubit Display -- Latest Run')).toBeTruthy()
+
+    const infoBox = container.querySelector('.bg-blue-50')
+    expect(infoBox).toBeTruthy()
+    expect(within(infoBox as HTMLElement).getByText('8', { exact: true })).toBeTruthy()
+
+    expect(container.querySelector('svg')).toBeTruthy()
+
+    expect(screen.queryByText('01010')).toBeNull()
+  })
+})


### PR DESCRIPTION
Refs #13832

Adds Vitest + RTL coverage for the quantum circuit and qubit grid card UIs (tests 13–16 from the issue).

**QuantumCircuitViewer.test.tsx**
- Renders ASCII circuit inside `pre.quantum-circuit-display` when `circuitAscii` is provided.
- Renders fallback `Unable to load quantum circuit diagram` when hook `data` is null.

**QuantumQubitGrid.test.tsx**
- Renders qubit count, pattern, and backend version inside the blue info panel when nested `data.qubits` / `data.versionInfo` are present (queries scoped with `within` + `exact: true` to avoid mask `<option>` label collisions).
- Renders logo-mode fallback (`num_qubits` 8, no `01010` pattern) and an `svg` when hook `data` is null.

Build and lint are validated by CI per project guidelines.