### PR TITLE
  fix: don't force global demo mode when quantum workload is absent

### DIFF
--- a/web/src/lib/__tests__/demoMode.test.ts
+++ b/web/src/lib/__tests__/demoMode.test.ts
@@ -10,6 +10,8 @@ import {
   setDemoToken,
   getDemoMode,
   setGlobalDemoMode,
+  setQuantumWorkloadAvailable,
+  isQuantumForcedToDemo,
 } from '../demoMode'
 
 describe('isDemoMode', () => {
@@ -283,5 +285,47 @@ describe('cross-tab storage event sync', () => {
 
     expect(capturedValue).toBeNull()
     unsub()
+  })
+})
+
+// ── setQuantumWorkloadAvailable must NOT touch global demo mode ──
+
+describe('setQuantumWorkloadAvailable', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setDemoMode(false, true)
+    setQuantumWorkloadAvailable(true)
+  })
+
+  it('setting available=false does not enable global demo mode', () => {
+    setQuantumWorkloadAvailable(false)
+    expect(isDemoMode()).toBe(false)
+  })
+
+  it('setting available=true does not disable global demo mode', () => {
+    setDemoMode(true, true)
+    setQuantumWorkloadAvailable(true)
+    expect(isDemoMode()).toBe(true)
+  })
+
+  it('isQuantumForcedToDemo returns true when workload unavailable', () => {
+    setQuantumWorkloadAvailable(false)
+    expect(isQuantumForcedToDemo()).toBe(true)
+  })
+
+  it('isQuantumForcedToDemo returns false when workload available', () => {
+    setQuantumWorkloadAvailable(true)
+    expect(isQuantumForcedToDemo()).toBe(false)
+  })
+
+  it('global demo mode and quantum demo mode are independent', () => {
+    setQuantumWorkloadAvailable(false)
+    expect(isDemoMode()).toBe(false)
+    expect(isQuantumForcedToDemo()).toBe(true)
+
+    setDemoMode(true, true)
+    setQuantumWorkloadAvailable(true)
+    expect(isDemoMode()).toBe(true)
+    expect(isQuantumForcedToDemo()).toBe(false)
   })
 })

--- a/web/src/lib/demoMode.ts
+++ b/web/src/lib/demoMode.ts
@@ -43,18 +43,10 @@ export function isQuantumWorkloadAvailable(): boolean {
 
 /**
  * Set quantum workload availability (called after fetching /health).
- * Automatically forces quantum cards into demo mode if workload is not available.
+ * Quantum cards read isQuantumForcedToDemo() directly — no global demo mode change needed.
  */
 export function setQuantumWorkloadAvailable(available: boolean): void {
   quantumWorkloadAvailable = available
-
-  // If quantum workload not available, force demo mode (unless user explicitly disabled it)
-  if (!available && canToggleDemoMode()) {
-    const userExplicitlyDisabled = localStorage.getItem(DEMO_MODE_KEY) === 'false'
-    if (!userExplicitlyDisabled) {
-      setDemoMode(true, false) // auto-set for quantum, not user-initiated
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
---
  PR Description:

  > **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers
  required patterns, common pitfalls, and the full file checklist.

  > **New CNCF project card?** New cards go in [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace),
  not this repo. PRs adding new cards here will be redirected.

  > **Use a coding agent.** This repo is primarily developed with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Opus
  4.5/4.6). It knows all codebase patterns (isDemoData, useCardLoadingState, locale strings, DCO). Manual PRs that miss required
  patterns will be sent back.

  ### 📌 Fixes

   Related to #14065

  ---

  ### 📝 Summary of Changes

  - `setQuantumWorkloadAvailable(false)` was calling `setDemoMode(true)` — the global toggle — whenever the quantum workload wasn't
  detected, silently switching every live-data card (Pods, Deployments, GPU, Helm, etc.) to demo data on all self-hosted deployments.
  - All quantum components already gate on `isQuantumForcedToDemo()` directly, so the `setDemoMode()` call was redundant AND harmful.
  - Removed the erroneous `setDemoMode()` call entirely. Quantum cards continue to work correctly via `isQuantumForcedToDemo()`. No
  other code path is affected.

  ---

  ### Changes Made

  - [x] Removed `setDemoMode(true, false)` from `setQuantumWorkloadAvailable()` in `web/src/lib/demoMode.ts`
  - [x] Updated JSDoc comment on the function to reflect correct behavior
  - [x] Added 5 regression tests to `web/src/lib/__tests__/demoMode.test.ts` covering: global demo mode stays off when quantum is
  absent, quantum and global demo flags are fully independent, `isQuantumForcedToDemo()` still returns correct values

  ---

  ### Checklist

  - [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
  - [x] I have reviewed the project's contribution guidelines
  - [x] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
  - [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
  - [x] I have written unit tests for the changes (if applicable)
  - [x] I have tested the changes locally and ensured they work as expected
  - [x] All commits are signed with DCO (`git commit -s`)

  ---

  ### Screenshots or Logs (if applicable)

  **Before:** `localStorage.getItem('kubestellar-demo-mode')` returns `'true'` unexpectedly on any self-hosted deployment without the
  quantum workload — all live cards show synthetic data silently.

  **After:** Global demo mode is untouched. Quantum cards still enter demo mode via `isQuantumForcedToDemo()`. All 30 demoMode tests
  pass including 5 new regression tests.

  ---

  ### 👀 Reviewer Notes

  The fix is a 9-line deletion in `demoMode.ts`. No behavior change for Netlify deployments (demo mode is forced there regardless). No
  behavior change for quantum cards (they already used `isQuantumForcedToDemo()` directly). Only self-hosted operators without the
  quantum workload are affected — and for them, live cluster data is now correctly displayed.
