### PR TITLE
  test(ui): add Vitest suites for RangeSliderInput, FileAttachmentButton, and Slider

### DIFF
--- a/web/src/components/ui/__tests__/FileAttachmentButton.test.tsx
+++ b/web/src/components/ui/__tests__/FileAttachmentButton.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}))
+
+const mockShowToast = vi.fn()
+vi.mock('../Toast', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}))
+
+import { FileAttachmentButton } from '../FileAttachmentButton'
+
+describe('FileAttachmentButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders without crashing', () => {
+    const { container } = render(<FileAttachmentButton />)
+    expect(container).toBeTruthy()
+  })
+
+  it('renders the attachment button with correct test id', () => {
+    render(<FileAttachmentButton />)
+    expect(screen.getByTestId('file-attachment-button')).toBeInTheDocument()
+  })
+
+  it('is not disabled by default', () => {
+    render(<FileAttachmentButton />)
+    expect(screen.getByTestId('file-attachment-button')).not.toBeDisabled()
+  })
+
+  it('disables the button when disabled prop is true', () => {
+    render(<FileAttachmentButton disabled />)
+    expect(screen.getByTestId('file-attachment-button')).toBeDisabled()
+  })
+
+  it('does not show a file indicator initially', () => {
+    render(<FileAttachmentButton />)
+    expect(screen.queryByRole('button', { name: /clear file/i })).not.toBeInTheDocument()
+  })
+
+  it('shows file indicator and calls onFileSelected after a file is chosen', () => {
+    const onFileSelected = vi.fn()
+    const { container } = render(<FileAttachmentButton onFileSelected={onFileSelected} />)
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(['hello'], 'test.txt', { type: 'text/plain' })
+
+    Object.defineProperty(input, 'files', { value: [file], configurable: true })
+    fireEvent.change(input)
+
+    expect(onFileSelected).toHaveBeenCalledWith(file)
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringContaining('test.txt'),
+      'info',
+    )
+    expect(screen.getByText('test.txt')).toBeInTheDocument()
+  })
+
+  it('clears the file indicator when the clear button is clicked', () => {
+    const { container } = render(<FileAttachmentButton />)
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(['data'], 'report.pdf', { type: 'application/pdf' })
+    Object.defineProperty(input, 'files', { value: [file], configurable: true })
+    fireEvent.change(input)
+
+    expect(screen.getByText('report.pdf')).toBeInTheDocument()
+
+    const clearBtn = screen.getByTitle('Clear file')
+    fireEvent.click(clearBtn)
+
+    expect(screen.queryByText('report.pdf')).not.toBeInTheDocument()
+  })
+
+  it('does not call onFileSelected when no file is present in the event', () => {
+    const onFileSelected = vi.fn()
+    const { container } = render(<FileAttachmentButton onFileSelected={onFileSelected} />)
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    Object.defineProperty(input, 'files', { value: [], configurable: true })
+    fireEvent.change(input)
+
+    expect(onFileSelected).not.toHaveBeenCalled()
+  })
+
+  it('applies compact sizing classes when compact prop is true', () => {
+    render(<FileAttachmentButton compact />)
+    const btn = screen.getByTestId('file-attachment-button')
+    expect(btn.className).toContain('h-10')
+    expect(btn.className).toContain('w-10')
+  })
+
+  it('applies default (non-compact) sizing class when compact is false', () => {
+    render(<FileAttachmentButton compact={false} />)
+    const btn = screen.getByTestId('file-attachment-button')
+    expect(btn.className).toContain('p-3')
+  })
+
+  it('has a hidden file input element accepting all file types', () => {
+    const { container } = render(<FileAttachmentButton />)
+    const input = container.querySelector('input[type="file"]')
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveClass('hidden')
+    expect(input).toHaveAttribute('accept', '*/*')
+  })
+})

--- a/web/src/components/ui/__tests__/RangeSliderInput.test.tsx
+++ b/web/src/components/ui/__tests__/RangeSliderInput.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { RangeSliderInput } from '../RangeSliderInput'
+
+describe('RangeSliderInput', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<RangeSliderInput value={50} onChange={() => {}} />)
+    expect(container).toBeTruthy()
+  })
+
+  it('renders a range input with the given value', () => {
+    const { container } = render(<RangeSliderInput value={40} onChange={() => {}} />)
+    const input = container.querySelector('input[type="range"]')
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveValue('40')
+  })
+
+  it('applies fill width at 50% for midpoint value', () => {
+    const { container } = render(<RangeSliderInput value={50} min={0} max={100} onChange={() => {}} />)
+    const fill = container.querySelector('[data-slider-fill="true"]') as HTMLElement
+    expect(fill?.style.width).toBe('50%')
+  })
+
+  it('sets fill width to 0% when value equals min', () => {
+    const { container } = render(<RangeSliderInput value={0} min={0} max={100} onChange={() => {}} />)
+    const fill = container.querySelector('[data-slider-fill="true"]') as HTMLElement
+    expect(fill?.style.width).toBe('0%')
+  })
+
+  it('sets fill width to 100% when value equals max', () => {
+    const { container } = render(<RangeSliderInput value={100} min={0} max={100} onChange={() => {}} />)
+    const fill = container.querySelector('[data-slider-fill="true"]') as HTMLElement
+    expect(fill?.style.width).toBe('100%')
+  })
+
+  it('clamps fill to 0% when value is below min', () => {
+    const { container } = render(<RangeSliderInput value={-10} min={0} max={100} onChange={() => {}} />)
+    const fill = container.querySelector('[data-slider-fill="true"]') as HTMLElement
+    expect(fill?.style.width).toBe('0%')
+  })
+
+  it('clamps fill to 100% when value exceeds max', () => {
+    const { container } = render(<RangeSliderInput value={200} min={0} max={100} onChange={() => {}} />)
+    const fill = container.querySelector('[data-slider-fill="true"]') as HTMLElement
+    expect(fill?.style.width).toBe('100%')
+  })
+
+  it('renders fill at 0% when min equals max (zero-range guard)', () => {
+    const { container } = render(<RangeSliderInput value={50} min={50} max={50} onChange={() => {}} />)
+    const fill = container.querySelector('[data-slider-fill="true"]') as HTMLElement
+    expect(fill?.style.width).toBe('0%')
+  })
+
+  it('uses string value by parsing it numerically', () => {
+    const { container } = render(<RangeSliderInput value="75" min={0} max={100} onChange={() => {}} />)
+    const fill = container.querySelector('[data-slider-fill="true"]') as HTMLElement
+    expect(fill?.style.width).toBe('75%')
+  })
+
+  it('falls back to min fill when value is a non-numeric string', () => {
+    const { container } = render(<RangeSliderInput value="abc" min={0} max={100} onChange={() => {}} />)
+    const fill = container.querySelector('[data-slider-fill="true"]') as HTMLElement
+    expect(fill?.style.width).toBe('0%')
+  })
+
+  it('applies disabled attribute to the input when disabled is true', () => {
+    const { container } = render(<RangeSliderInput value={50} onChange={() => {}} disabled />)
+    const input = container.querySelector('input[type="range"]')
+    expect(input).toBeDisabled()
+  })
+
+  it('forwards custom className to the input element', () => {
+    const { container } = render(<RangeSliderInput value={50} onChange={() => {}} className="custom-class" />)
+    const input = container.querySelector('input[type="range"]')
+    expect(input?.className).toContain('custom-class')
+  })
+
+  it('applies containerClassName to the outer wrapper', () => {
+    const { container } = render(
+      <RangeSliderInput value={50} onChange={() => {}} containerClassName="outer-wrapper" />,
+    )
+    expect(container.firstChild).toHaveClass('outer-wrapper')
+  })
+
+  it('applies trackClassName to the track background', () => {
+    const { container } = render(
+      <RangeSliderInput value={50} onChange={() => {}} trackClassName="custom-track" />,
+    )
+    const track = container.querySelector('.custom-track')
+    expect(track).toBeInTheDocument()
+  })
+
+  it('applies fillClassName to the fill element', () => {
+    const { container } = render(
+      <RangeSliderInput value={50} onChange={() => {}} fillClassName="custom-fill" />,
+    )
+    const fill = container.querySelector('[data-slider-fill="true"]')
+    expect(fill?.className).toContain('custom-fill')
+  })
+
+  it('forwards min, max, step to the underlying input', () => {
+    const { container } = render(
+      <RangeSliderInput value={5} min={1} max={10} step={2} onChange={() => {}} />,
+    )
+    const input = container.querySelector('input[type="range"]')
+    expect(input).toHaveAttribute('min', '1')
+    expect(input).toHaveAttribute('max', '10')
+    expect(input).toHaveAttribute('step', '2')
+  })
+})

--- a/web/src/components/ui/__tests__/Slider.test.tsx
+++ b/web/src/components/ui/__tests__/Slider.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Slider } from '../Slider'
+
+describe('Slider', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<Slider value={5000} onChange={() => {}} />)
+    expect(container).toBeTruthy()
+  })
+
+  it('renders the underlying range input', () => {
+    const { container } = render(<Slider value={5000} onChange={() => {}} />)
+    expect(container.querySelector('input[type="range"]')).toBeInTheDocument()
+  })
+
+  it('does not render a label element when label prop is omitted', () => {
+    render(<Slider value={5000} onChange={() => {}} />)
+    expect(screen.queryByRole('label')).not.toBeInTheDocument()
+  })
+
+  it('renders the label text when label prop is provided', () => {
+    render(<Slider label="Timeout" value={5000} onChange={() => {}} />)
+    expect(screen.getByText('Timeout')).toBeInTheDocument()
+  })
+
+  it('displays value with unit suffix by default', () => {
+    render(<Slider label="Speed" value={3000} unit="ms" onChange={() => {}} />)
+    expect(screen.getByText('3000ms')).toBeInTheDocument()
+  })
+
+  it('displays an empty unit when unit is not provided', () => {
+    render(<Slider label="Level" value={7000} onChange={() => {}} />)
+    expect(screen.getByText('7000')).toBeInTheDocument()
+  })
+
+  it('uses formatValue to display a custom label instead of raw value+unit', () => {
+    const formatValue = vi.fn((v: number) => `${v / 1000}s`)
+    render(<Slider label="Interval" value={5000} formatValue={formatValue} unit="ms" onChange={() => {}} />)
+    expect(formatValue).toHaveBeenCalledWith(5000)
+    expect(screen.getByText('5s')).toBeInTheDocument()
+  })
+
+  it('ignores formatValue when value is not a number', () => {
+    const formatValue = vi.fn((v: number) => `${v}x`)
+    render(<Slider label="Count" value="not-a-number" formatValue={formatValue} onChange={() => {}} />)
+    expect(formatValue).not.toHaveBeenCalled()
+    expect(screen.getByText('not-a-number')).toBeInTheDocument()
+  })
+
+  it('passes min, max, step down to the range input', () => {
+    const { container } = render(
+      <Slider value={2000} min={500} max={10000} step={500} onChange={() => {}} />,
+    )
+    const input = container.querySelector('input[type="range"]')
+    expect(input).toHaveAttribute('min', '500')
+    expect(input).toHaveAttribute('max', '10000')
+    expect(input).toHaveAttribute('step', '500')
+  })
+
+  it('disables the range input when disabled prop is true', () => {
+    const { container } = render(<Slider value={5000} onChange={() => {}} disabled />)
+    expect(container.querySelector('input[type="range"]')).toBeDisabled()
+  })
+
+  it('links the label element to the range input via matching id', () => {
+    render(<Slider label="Retry delay" value={2000} onChange={() => {}} />)
+    const labelEl = screen.getByText('Retry delay').closest('label')
+    const input = screen.getByRole('slider')
+    expect(labelEl).toHaveAttribute('for', input.id)
+  })
+})


### PR DESCRIPTION

 ## PR Description:

  ### 📌 Fixes

  No issue linked — autonomous test generation for previously untested UI components.

  ---

  ### 📝 Summary of Changes

  - Adds complete Vitest/RTL suites for 3 UI components that had zero test coverage
  - 38 tests total, all passing locally

  ---

  ### Changes Made

  - [x] Added tests for `web/src/components/ui/__tests__/RangeSliderInput.test.tsx`
  - [x] Added tests for `web/src/components/ui/__tests__/FileAttachmentButton.test.tsx`
  - [x] Added tests for `web/src/components/ui/__tests__/Slider.test.tsx`

  ---

  ### Checklist

  - [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
  - [x] I have reviewed the project's contribution guidelines
  - [x] New cards target console-marketplace, not this repo
  - [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
  - [x] I have written unit tests for the changes (if applicable)
  - [x] I have tested the changes locally and ensured they work as expected
  - [x] All commits are signed with DCO (`git commit -s`)

  ---

  ### Screenshots or Logs (if applicable)

  Test Files  3 passed (3)
  Tests       38 passed (38)
  Duration    3.44s

  ---

  ### 👀 Reviewer Notes

  Covers three previously untested components:
  - **RangeSliderInput** — fill percentage math (boundary clamping, zero-range guard, string/numeric value parsing), disabled state, all
   className props, min/max/step forwarding
  - **FileAttachmentButton** — file selection flow, onFileSelected callback, toast trigger, file indicator display + clear, disabled
  state, compact vs default sizing
  - **Slider** — label rendering, value + unit display, formatValue override, prop passthrough to RangeSliderInput, label↔input ID
  linkage
