### PR TITLE
  feat(kb): cross-reference preflight errors against KB coverage

### DIFF
--- a/scripts/kb-query-gap-tracker.sh
+++ b/scripts/kb-query-gap-tracker.sh
@@ -58,3 +58,46 @@ echo "3. Validate all existing install missions against latest CNCF project vers
 
 echo ""
 echo "Report written to: $OUTPUT"
+
+# 4. Preflight error KB coverage
+# Cross-references every PreflightErrorCode from preflightCheck.ts against
+# console-kb mission paths to find which error remediation paths have no KB coverage.
+echo "" >> "$OUTPUT"
+echo "## Preflight Error KB Coverage" >> "$OUTPUT"
+echo "" >> "$OUTPUT"
+echo "Maps each \`PreflightErrorCode\` from \`preflightCheck.ts\` to KB mission coverage." >> "$OUTPUT"
+echo "" >> "$OUTPUT"
+echo "| Error Code | Search Terms | Missions Found |" >> "$OUTPUT"
+echo "|------------|-------------|----------------|" >> "$OUTPUT"
+
+declare -A PREFLIGHT_COVERAGE=(
+  ["MISSING_CREDENTIALS"]="kubeconfig credentials setup"
+  ["EXPIRED_CREDENTIALS"]="certificate rotation renewal"
+  ["RBAC_DENIED"]="rbac permissions rolebinding clusterrole"
+  ["CONTEXT_NOT_FOUND"]="kubeconfig context cluster"
+  ["CLUSTER_UNREACHABLE"]="cluster connectivity network troubleshoot"
+  ["MISSING_TOOLS"]="kubectl helm tool prerequisites install"
+  ["UNKNOWN_EXECUTION_FAILURE"]="troubleshoot debug error recovery"
+)
+
+PREFLIGHT_UNCOVERED=0
+for code in "${!PREFLIGHT_COVERAGE[@]}"; do
+  terms="${PREFLIGHT_COVERAGE[$code]}"
+  jq_pattern=$(echo "$terms" | tr ' ' '|')
+  count=$(gh api "repos/$KB_REPO/git/trees/main?recursive=1" \
+    --jq "[.tree[].path | select(test(\"${jq_pattern}\"; \"i\"))] | length" \
+    2>/dev/null || echo "0")
+  if [ "$count" = "0" ]; then
+    echo "| \`$code\` | $terms | ❌ none |" >> "$OUTPUT"
+    PREFLIGHT_UNCOVERED=$((PREFLIGHT_UNCOVERED + 1))
+  else
+    echo "| \`$code\` | $terms | ✅ $count |" >> "$OUTPUT"
+  fi
+done
+
+echo "" >> "$OUTPUT"
+if [ "$PREFLIGHT_UNCOVERED" -gt 0 ]; then
+  echo "⚠️  **$PREFLIGHT_UNCOVERED preflight error code(s) have no KB coverage.**" >> "$OUTPUT"
+fi
+
+echo "PREFLIGHT_UNCOVERED=$PREFLIGHT_UNCOVERED"

--- a/scripts/kb-query-gap-tracker.sh
+++ b/scripts/kb-query-gap-tracker.sh
@@ -70,19 +70,23 @@ echo "" >> "$OUTPUT"
 echo "| Error Code | Search Terms | Missions Found |" >> "$OUTPUT"
 echo "|------------|-------------|----------------|" >> "$OUTPUT"
 
-declare -A PREFLIGHT_COVERAGE=(
-  ["MISSING_CREDENTIALS"]="kubeconfig credentials setup"
-  ["EXPIRED_CREDENTIALS"]="certificate rotation renewal"
-  ["RBAC_DENIED"]="rbac permissions rolebinding clusterrole"
-  ["CONTEXT_NOT_FOUND"]="kubeconfig context cluster"
-  ["CLUSTER_UNREACHABLE"]="cluster connectivity network troubleshoot"
-  ["MISSING_TOOLS"]="kubectl helm tool prerequisites install"
-  ["UNKNOWN_EXECUTION_FAILURE"]="troubleshoot debug error recovery"
+# Defined in explicit order so report output is stable across runs.
+# Each entry is "ERROR_CODE:search terms" — terms are OR-joined into a jq regex.
+# 7 additional gh API calls; well within the 5000/hr token rate limit.
+PREFLIGHT_ENTRIES=(
+  "MISSING_CREDENTIALS:kubeconfig credentials setup"
+  "EXPIRED_CREDENTIALS:certificate rotation renewal"
+  "RBAC_DENIED:rbac permissions rolebinding clusterrole"
+  "CONTEXT_NOT_FOUND:kubeconfig context cluster"
+  "CLUSTER_UNREACHABLE:cluster connectivity network troubleshoot"
+  "MISSING_TOOLS:kubectl helm tool prerequisites install"
+  "UNKNOWN_EXECUTION_FAILURE:troubleshoot debug error recovery"
 )
 
 PREFLIGHT_UNCOVERED=0
-for code in "${!PREFLIGHT_COVERAGE[@]}"; do
-  terms="${PREFLIGHT_COVERAGE[$code]}"
+for entry in "${PREFLIGHT_ENTRIES[@]}"; do
+  code="${entry%%:*}"
+  terms="${entry#*:}"
   jq_pattern=$(echo "$terms" | tr ' ' '|')
   count=$(gh api "repos/$KB_REPO/git/trees/main?recursive=1" \
     --jq "[.tree[].path | select(test(\"${jq_pattern}\"; \"i\"))] | length" \


### PR DESCRIPTION
Description:

  > **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers
  required patterns, common pitfalls, and the full file checklist.

  > **New CNCF project card?** New cards go in [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace),
  not this repo. PRs adding new cards here will be redirected.

  > **Use a coding agent.** This repo is primarily developed with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Opus
  4.5/4.6). It knows all codebase patterns (isDemoData, useCardLoadingState, locale strings, DCO). Manual PRs that miss required
  patterns will be sent back.

  ### 📌 Fixes

  N/A

  ---

  ### 📝 Summary of Changes

  - `kb-query-gap-tracker.sh` only checked 8 hardcoded ops — never verified whether KB missions cover the 7 `PreflightErrorCode` paths
  defined in `preflightCheck.ts`
  - When a user hits `RBAC_DENIED` mid-mission, the AI has no KB entry to recommend — this surfaces that gap automatically every nightly
   run

  ---

  ### Changes Made

  - [x] Added section 4 to `kb-query-gap-tracker.sh` — maps each `PreflightErrorCode` to KB mission search terms and produces a coverage
   table
  - [x] Emits `PREFLIGHT_UNCOVERED=N` to stdout so CI can parse it
  - [x] Appends a `⚠️ ` warning to the gap report when any error code has zero KB coverage

  ---

  ### Checklist

  - [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
  - [x] I have reviewed the project's contribution guidelines
  - [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
  - [ ] I have written unit tests for the changes (if applicable) 
  - [x] I have tested the changes locally and ensured they work as expected
  - [x] All commits are signed with DCO (`git commit -s`)
  
  ---
  
  ### Screenshots or Logs (if applicable)

  Bash syntax verified with `bash -n`. Pattern building, table row format, and `PREFLIGHT_UNCOVERED` counter tested locally against
  simulated inputs — correct output in both covered and uncovered scenarios.
  
  ---
  
  ### 👀 Reviewer Notes
  
  The search term mapping is a heuristic against console-kb file paths — e.g. `RBAC_DENIED` maps to
  `rbac|permissions|rolebinding|clusterrole`. May need tuning once console-kb grows. The `PREFLIGHT_UNCOVERED=N` line on stdout is
  intentionally machine-readable for future CI parsing.