### PR TITLE
🐛 fix: use vi.hoisted() for mockShowToast to prevent undefined mock in vi.mock factory closes #14096

### DIFF
--- a/web/src/components/ui/__tests__/FileAttachmentButton.test.tsx
+++ b/web/src/components/ui/__tests__/FileAttachmentButton.test.tsx
@@ -8,7 +8,7 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
-const mockShowToast = vi.fn()
+const mockShowToast = vi.hoisted(() => vi.fn())
 vi.mock('../Toast', () => ({
   useToast: () => ({ showToast: mockShowToast }),
 }))


### PR DESCRIPTION
…vi.mock factory closes #14096

> **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.

> **New CNCF project card?** New cards go in [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo. PRs adding new cards here will be redirected.

> **Use a coding agent.** This repo is primarily developed with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Opus 4.5/4.6). It knows all codebase patterns (isDemoData, useCardLoadingState, locale strings, DCO). Manual PRs that miss required patterns will be sent back.

### 📌 Fixes 

Fixes #14096
---

### 📝 Summary of Changes

- Fixed mock hoisting issue in FileAttachmentButton.test.tsx
- mockShowToast was captured as undefined because vi.mock factories 
  are hoisted above variable declarations by Vitest
- Used vi.hoisted() to ensure mockShowToast is defined when the 
  vi.mock factory runs
- This fix was reviewed and verified using Claude (claude.ai)
---

### Changes Made

- [x] Fixed mockShowToast declaration using vi.hoisted() in 
      FileAttachmentButton.test.tsx

- [ ] Updated ...
- [ ] Refactored ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [ ] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Simple one-line fix — changed vi.fn() to vi.hoisted(() => vi.fn()) 
so the mock is correctly initialized when vi.mock factory runs._
