### PR TITLE
fix: use === undefined instead of falsy check in dedup.ts shareMetricsBetweenSameServerClusters

### DIFF
--- a/web/src/hooks/mcp/__tests__/dedup-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/dedup-coverage.test.ts
@@ -32,7 +32,7 @@ describe('dedup.ts extended coverage', () => {
       expect(shareMetricsBetweenSameServerClusters(undefined as unknown as ClusterInfo[])).toEqual([])
     })
 
-    it('copies pod count from source when target has zero', () => {
+    it('does not overwrite explicit podCount:0 with stale source data', () => {
       const withPods = makeCluster({
         name: 'full',
         server: 'https://api.example.com',
@@ -47,7 +47,8 @@ describe('dedup.ts extended coverage', () => {
       })
       const result = shareMetricsBetweenSameServerClusters([noPods, withPods])
       const alias = result.find(c => c.name === 'alias')!
-      expect(alias.podCount).toBe(50)
+      // podCount:0 is an explicit value (scaled-to-zero), not missing — must be preserved
+      expect(alias.podCount).toBe(0)
     })
 
     it('copies memory and storage metrics via nullish coalescing', () => {

--- a/web/src/hooks/mcp/dedup.ts
+++ b/web/src/hooks/mcp/dedup.ts
@@ -49,8 +49,8 @@ export function shareMetricsBetweenSameServerClusters(clusters: ClusterInfo[] | 
     if (!source) return cluster
 
     // Check if we need to copy anything - include nodeCount, podCount, and capacity/requests
-    const needsNodes = (!cluster.nodeCount || cluster.nodeCount === 0) && source.nodeCount && source.nodeCount > 0
-    const needsPods = (!cluster.podCount || cluster.podCount === 0) && source.podCount && source.podCount > 0
+    const needsNodes = cluster.nodeCount === undefined && source.nodeCount !== undefined && source.nodeCount > 0
+    const needsPods = cluster.podCount === undefined && source.podCount !== undefined && source.podCount > 0
     const needsCapacity = !cluster.cpuCores && source.cpuCores
     const needsRequests = !cluster.cpuRequestsCores && source.cpuRequestsCores
 


### PR DESCRIPTION
Fixes #14132

## What Changed

Changed falsy `||` checks to explicit `=== undefined` in
`shareMetricsBetweenSameServerClusters` in `dedup.ts`:

```ts
// BEFORE
if (!cluster.nodeCount || cluster.nodeCount === 0)
if (!cluster.podCount  || cluster.podCount  === 0)

// AFTER
if (cluster.nodeCount === undefined)
if (cluster.podCount  === undefined)
```

Also corrected `dedup-coverage.test.ts:35` which was asserting
the buggy overwrite behaviour as expected — renamed and fixed
to assert that explicit `podCount: 0` is preserved.

## Why This Fix Is Correct

Same falsy trap pattern as `shared.ts:594` fixed in issue #13913.
`dedup.ts` contains a parallel implementation of
`shareMetricsBetweenSameServerClusters` with the identical flaw.

When a cluster scales to 0 pods, `!cluster.podCount` evaluates
to `true`, causing stale alias values to overwrite the valid zero.

## Test Results

128 tests passing, 0 failures