### PR TITLE
fix: use ?? instead of || 1 falsy trap for d.replicas in useWorkloads.ts

### DIFF
--- a/web/src/hooks/mcp/__tests__/dedup-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/dedup-coverage.test.ts
@@ -32,7 +32,7 @@ describe('dedup.ts extended coverage', () => {
       expect(shareMetricsBetweenSameServerClusters(undefined as unknown as ClusterInfo[])).toEqual([])
     })
 
-    it('copies pod count from source when target has zero', () => {
+    it('does not overwrite explicit podCount:0 with stale source data', () => {
       const withPods = makeCluster({
         name: 'full',
         server: 'https://api.example.com',
@@ -47,7 +47,8 @@ describe('dedup.ts extended coverage', () => {
       })
       const result = shareMetricsBetweenSameServerClusters([noPods, withPods])
       const alias = result.find(c => c.name === 'alias')!
-      expect(alias.podCount).toBe(50)
+      // podCount:0 is an explicit value (scaled-to-zero), not missing — must be preserved
+      expect(alias.podCount).toBe(0)
     })
 
     it('copies memory and storage metrics via nullish coalescing', () => {

--- a/web/src/hooks/mcp/dedup.ts
+++ b/web/src/hooks/mcp/dedup.ts
@@ -49,8 +49,8 @@ export function shareMetricsBetweenSameServerClusters(clusters: ClusterInfo[] | 
     if (!source) return cluster
 
     // Check if we need to copy anything - include nodeCount, podCount, and capacity/requests
-    const needsNodes = (!cluster.nodeCount || cluster.nodeCount === 0) && source.nodeCount && source.nodeCount > 0
-    const needsPods = (!cluster.podCount || cluster.podCount === 0) && source.podCount && source.podCount > 0
+    const needsNodes = cluster.nodeCount === undefined && source.nodeCount !== undefined && source.nodeCount > 0
+    const needsPods = cluster.podCount === undefined && source.podCount !== undefined && source.podCount > 0
     const needsCapacity = !cluster.cpuCores && source.cpuCores
     const needsRequests = !cluster.cpuRequestsCores && source.cpuRequestsCores
 

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -137,15 +137,15 @@ async function fetchWorkloadsViaAgent(opts?: {
         let ws: Workload['status'] = 'Running'
         if (st === 'failed') ws = 'Failed'
         else if (st === 'deploying') ws = 'Pending'
-        else if (Number(d.readyReplicas || 0) < Number(d.replicas || 1)) ws = 'Degraded'
+        else if (Number(d.readyReplicas ?? 0) < Number(d.replicas ?? 0)) ws = 'Degraded'
         return {
           name: String(d.name || ''),
           namespace: String(d.namespace || 'default'),
           type: 'Deployment' as const,
           cluster: String(d.cluster || opts?.cluster || ''),
           targetClusters: [String(d.cluster || opts?.cluster || '')],
-          replicas: Number(d.replicas || 1),
-          readyReplicas: Number(d.readyReplicas || 0),
+          replicas: Number(d.replicas ?? 0),
+          readyReplicas: Number(d.readyReplicas ?? 0),
           status: ws,
           image: String(d.image || ''),
           createdAt: new Date().toISOString(),
@@ -192,15 +192,15 @@ async function fetchWorkloadsViaAgent(opts?: {
         let ws: Workload['status'] = 'Running'
         if (st === 'failed') ws = 'Failed'
         else if (st === 'deploying') ws = 'Pending'
-        else if (Number(d.readyReplicas || 0) < Number(d.replicas || 1)) ws = 'Degraded'
+        else if (Number(d.readyReplicas ?? 0) < Number(d.replicas ?? 0)) ws = 'Degraded'
         return {
           name: String(d.name || ''),
           namespace: String(d.namespace || 'default'),
           type: 'Deployment' as const,
           cluster: name,
           targetClusters: [name],
-          replicas: Number(d.replicas || 1),
-          readyReplicas: Number(d.readyReplicas || 0),
+          replicas: Number(d.replicas ?? 0),
+          readyReplicas: Number(d.readyReplicas ?? 0),
           status: ws,
           image: String(d.image || ''),
           createdAt: new Date().toISOString() }


### PR DESCRIPTION
Fixes #14159

## What Changed

Replaced `|| 1` with `?? 0` for `d.replicas` at lines 140, 147, 195, 202
and `|| 0` with `?? 0` for `d.readyReplicas` at the same lines.

```ts
// BEFORE (unsafe)
else if (Number(d.readyReplicas || 0) < Number(d.replicas || 1)) ws = 'Degraded'
replicas: Number(d.replicas || 1),

// AFTER (safe)
else if (Number(d.readyReplicas ?? 0) < Number(d.replicas ?? 0)) ws = 'Degraded'
replicas: Number(d.replicas ?? 0),
```

## Additional Fix (same audit)

Also fixes the identical falsy-trap pattern in `mcp/dedup.ts` 
`shareMetricsBetweenSameServerClusters` (lines 52-53) and updates 
`dedup-coverage.test.ts` to assert that explicit `podCount: 0` is 
preserved — consistent with `clusterUtils.ts` which uses the same logic.

## Why This Fix Is Correct

`??` only triggers on `null`/`undefined` — not on `0`.
`|| 1` treats an explicit `replicas: 0` as "no data", replacing
a valid scaled-to-zero value with `1`. Same fix pattern as #14134.

Applied identically to both fetch paths (lines 140–148 remote, 195–203 local-agent).