### PR TITLE
fix(startup): use atomic PID updates for kc-agent restarts

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -496,7 +496,8 @@ if [ -x "$INSTALL_DIR/kc-agent" ]; then
     if [ ! -f "$AGENT_PID_FILE" ]; then
         echo "Starting kc-agent as background daemon..."
         nohup "$INSTALL_DIR/kc-agent" >> "$AGENT_LOG_FILE" 2>&1 &
-        echo $! > "$AGENT_PID_FILE"
+        TMP_PID_FILE="${AGENT_PID_FILE}.$$"
+        echo $! > "$TMP_PID_FILE" && mv "$TMP_PID_FILE" "$AGENT_PID_FILE"
         sleep 1
 
         # Verify it started

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -290,7 +290,8 @@ cleanup() {
     kill $BACKEND_PID 2>/dev/null || true
     kill $FRONTEND_PID 2>/dev/null || true
     kill $AGENT_LOOP_PID 2>/dev/null || true
-    kill $AGENT_PID 2>/dev/null || true
+    LATEST_AGENT_PID=$(cat "$AGENT_PID_FILE" 2>/dev/null || true)
+    [ -n "$LATEST_AGENT_PID" ] && kill "$LATEST_AGENT_PID" 2>/dev/null || true
     kill $WATCHDOG_PID 2>/dev/null || true
     kill $AGENT_BUILD_PID 2>/dev/null || true
     kill $BACKEND_BUILD_PID 2>/dev/null || true
@@ -406,7 +407,8 @@ launch_kc_agent() {
         while true; do
             "$KC_AGENT_BIN" "${KC_AGENT_ARGS[@]}" &
             CHILD=$!
-            echo "$CHILD" > "$AGENT_PID_FILE"
+            TMP_PID_FILE="${AGENT_PID_FILE}.$$"
+            echo "$CHILD" > "$TMP_PID_FILE" && mv "$TMP_PID_FILE" "$AGENT_PID_FILE"
             echo "[kc-agent] Started (PID $CHILD)"
             wait $CHILD
             EXIT_CODE=$?


### PR DESCRIPTION
Summary

Improve kc-agent PID handling during restart and cleanup flows by using atomic PID file updates and rereading the latest PID during cleanup.

Changes

* use atomic temp-file replacement for PID updates
* * reread current PID from the PID file during cleanup
* * preserve existing startup behavior and script structure
Impact
This reduces stale PID handling issues during rapid restart and shutdown flows while keeping the implementation small and low risk.

Validation

* bash syntax verification
* * repeated restart/shutdown testing
* * cleanup behavior verification
* * CI validation