### PR TITLE
🐛 fix: prevent dashboard filter panel layout shift

### DIFF
--- a/web/e2e/visual/app-dashboard-filter-panel-layout.spec.ts
+++ b/web/e2e/visual/app-dashboard-filter-panel-layout.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect, type Page } from '@playwright/test'
+import { setupDemoMode } from '../helpers/setup'
+
+const DESKTOP_VIEWPORT = { width: 1440, height: 900 }
+const ROOT_VISIBLE_TIMEOUT_MS = 15_000
+const PANEL_VISIBLE_TIMEOUT_MS = 15_000
+const DASHBOARD_VISIBLE_TIMEOUT_MS = 15_000
+const LAYOUT_SETTLE_TIMEOUT_MS = 5_000
+const INITIAL_LAYOUT_SETTLE_TIMEOUT_MS = 15_000
+const LAYOUT_STABILITY_POLL_INTERVAL_MS = 250
+const REQUIRED_STABLE_LAYOUT_SAMPLES = 8
+const LAYOUT_SHIFT_TOLERANCE_PX = 1
+const MAIN_CONTENT_SELECTOR = '#main-content'
+const DASHBOARD_STAT_BLOCK_TEST_ID = 'stat-block-clusters'
+const DASHBOARD_CARDS_GRID_TEST_ID = 'dashboard-cards-grid'
+
+type DashboardLayoutMetrics = {
+  statY: number
+  scrollHeight: number
+}
+
+async function setupAndNavigateToDashboard(page: Page) {
+  await setupDemoMode(page)
+  await page.goto('/')
+  await page.waitForLoadState('domcontentloaded')
+  await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: ROOT_VISIBLE_TIMEOUT_MS })
+  await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: DASHBOARD_VISIBLE_TIMEOUT_MS })
+  await expect(page.getByTestId(DASHBOARD_STAT_BLOCK_TEST_ID)).toBeVisible({ timeout: DASHBOARD_VISIBLE_TIMEOUT_MS })
+  await expect(page.getByTestId(DASHBOARD_CARDS_GRID_TEST_ID)).toBeVisible({ timeout: DASHBOARD_VISIBLE_TIMEOUT_MS })
+}
+
+async function measureDashboardLayout(page: Page): Promise<DashboardLayoutMetrics> {
+  return page.evaluate(({ mainContentSelector, statBlockTestId }) => {
+    const mainContent = document.querySelector<HTMLElement>(mainContentSelector)
+    const statBlock = document.querySelector<HTMLElement>(`[data-testid="${statBlockTestId}"]`)
+
+    if (!mainContent || !statBlock) {
+      throw new Error('Dashboard layout elements were not measurable')
+    }
+
+    return {
+      statY: statBlock.getBoundingClientRect().y,
+      scrollHeight: mainContent.scrollHeight,
+    }
+  }, {
+    mainContentSelector: MAIN_CONTENT_SELECTOR,
+    statBlockTestId: DASHBOARD_STAT_BLOCK_TEST_ID,
+  })
+}
+
+async function waitForStableDashboardLayout(page: Page) {
+  let previous: DashboardLayoutMetrics | null = null
+  let stableSamples = 0
+
+  await expect
+    .poll(async () => {
+      const current = await measureDashboardLayout(page)
+      const isStable = previous !== null &&
+        Math.abs(current.statY - previous.statY) <= LAYOUT_SHIFT_TOLERANCE_PX &&
+        Math.abs(current.scrollHeight - previous.scrollHeight) <= LAYOUT_SHIFT_TOLERANCE_PX
+
+      stableSamples = isStable ? stableSamples + 1 : 0
+      previous = current
+      return stableSamples >= REQUIRED_STABLE_LAYOUT_SAMPLES
+    }, {
+      message: 'dashboard layout should settle before measuring filter-panel shift',
+      timeout: INITIAL_LAYOUT_SETTLE_TIMEOUT_MS,
+      intervals: [LAYOUT_STABILITY_POLL_INTERVAL_MS],
+    })
+    .toBe(true)
+}
+
+test.describe('Dashboard filter panel layout — desktop', () => {
+  test.use({ viewport: DESKTOP_VIEWPORT })
+
+  test('global filter panel opens without shifting dashboard stats', async ({ page }, testInfo) => {
+    await setupAndNavigateToDashboard(page)
+    await waitForStableDashboardLayout(page)
+
+    const before = await measureDashboardLayout(page)
+
+    await page.getByTestId('navbar-cluster-filter-btn').click()
+
+    const panel = page.getByTestId('navbar-cluster-filter-dropdown')
+    await expect(panel).toBeVisible({ timeout: PANEL_VISIBLE_TIMEOUT_MS })
+
+    await testInfo.attach('dashboard-filter-panel-open', {
+      body: await page.screenshot({ fullPage: false }),
+      contentType: 'image/png',
+    })
+
+    await expect
+      .poll(async () => {
+        const after = await measureDashboardLayout(page)
+        const statShift = Math.abs(after.statY - before.statY)
+        const scrollHeightDelta = Math.abs(after.scrollHeight - before.scrollHeight)
+
+        return statShift <= LAYOUT_SHIFT_TOLERANCE_PX && scrollHeightDelta <= LAYOUT_SHIFT_TOLERANCE_PX
+      }, {
+        message: 'dashboard stats should not move or change scroll height when the filter panel opens',
+        timeout: LAYOUT_SETTLE_TIMEOUT_MS,
+      })
+      .toBe(true)
+  })
+})

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,7 +1,7 @@
 import { type CSSProperties, ReactNode, Suspense, useState, useEffect, useRef } from 'react'
 import { safeLazy } from '../../lib/safeLazy'
 import { useTranslation } from 'react-i18next'
-import { Link, useLocation } from 'react-router-dom'
+import { Link, matchPath, useLocation } from 'react-router-dom'
 import {
   Box,
   Wifi,
@@ -52,6 +52,7 @@ import {
   NAVBAR_HEIGHT_PX,
   BANNER_HEIGHT_PX,
   MOBILE_BANNER_COLLAPSE_THRESHOLD,
+  NAVBAR_FILTER_PANEL_OFFSET_CSS_VAR,
   SIDEBAR_CONTROLS_OFFSET_PX,
 } from '../../lib/constants/ui'
 import { CLOSE_ANIMATION_MS, UI_FEEDBACK_TIMEOUT_MS, TOAST_DISMISS_MS } from '../../lib/constants/network'
@@ -225,6 +226,12 @@ export function Layout({ children: _children }: LayoutProps) {
   const [mobileBannerStackExpanded, setMobileBannerStackExpanded] = useState(false)
   const [wasBackendDown, setWasBackendDown] = useState(false)
   const [updateToastDismissed, setUpdateToastDismissed] = useState(false)
+  const isDashboardRoute =
+    location.pathname === ROUTES.HOME ||
+    location.pathname === ROUTES.DASHBOARD_ALIAS ||
+    location.pathname === ROUTES.MISSIONS ||
+    matchPath(ROUTES.CUSTOM_DASHBOARD, location.pathname) !== null
+  const shouldReserveNavbarFilterPanelOffset = !isDashboardRoute
 
   // Allow any component to open the install dialog via a custom event
   useEffect(() => {
@@ -835,6 +842,12 @@ export function Layout({ children: _children }: LayoutProps) {
           className="relative flex-1 p-4 pb-8 pb-[calc(2rem+env(safe-area-inset-bottom))] md:p-6 md:pb-8 md:pb-[calc(2rem+env(safe-area-inset-bottom))] overflow-y-auto overflow-x-hidden scroll-enhanced min-w-0"
           data-transition-margin="true"
         >
+          {shouldReserveNavbarFilterPanelOffset && (
+            <div
+              aria-hidden
+              style={{ height: `var(${NAVBAR_FILTER_PANEL_OFFSET_CSS_VAR}, 0px)` }}
+            />
+          )}
           <NavigationProgress />
           {/*
             Key the Outlet by location.pathname so route changes are a clean

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -192,6 +192,7 @@ export function Layout({ children: _children }: LayoutProps) {
   const { t } = useTranslation()
   const { config } = useSidebarConfig()
   const { isMobile } = useMobile()
+  const location = useLocation()
   const sidebarWidthPx = isMobile
     ? 0
     : config.collapsed

--- a/web/src/components/layout/navbar/ClusterFilterPanel.tsx
+++ b/web/src/components/layout/navbar/ClusterFilterPanel.tsx
@@ -1,10 +1,11 @@
-import { useState, useRef, useEffect, ReactNode } from 'react'
+import { useState, useRef, useEffect, useLayoutEffect, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Search, Server, Activity, Filter, Check, AlertTriangle, Save, X, Trash2, WifiOff, Globe } from 'lucide-react'
 import { AlertCircle, CheckCircle2 } from 'lucide-react'
 import { useGlobalFilters, SEVERITY_LEVELS, SEVERITY_CONFIG, STATUS_LEVELS, STATUS_CONFIG } from '../../../hooks/useGlobalFilters'
 import { useModalState } from '../../../lib/modals'
 import { cn } from '../../../lib/cn'
+import { NAVBAR_FILTER_PANEL_GAP_PX, NAVBAR_FILTER_PANEL_OFFSET_CSS_VAR } from '../../../lib/constants/ui'
 import { Tooltip } from '../../ui/Tooltip'
 import { Input } from '../../ui/Input'
 
@@ -141,6 +142,7 @@ export function ClusterFilterPanel({ showLabel = false }: ClusterFilterPanelProp
   const [newName, setNewName] = useState('')
   const [newColor, setNewColor] = useState(FILTER_SET_COLORS[0])
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
 
   // Helper to get cluster status tooltip
@@ -191,6 +193,38 @@ export function ClusterFilterPanel({ showLabel = false }: ClusterFilterPanelProp
     triggerRef.current?.focus()
   }
 
+  useLayoutEffect(() => {
+    const rootStyle = document.documentElement.style
+
+    if (!showDropdown || showLabel) {
+      rootStyle.removeProperty(NAVBAR_FILTER_PANEL_OFFSET_CSS_VAR)
+      return undefined
+    }
+
+    const updatePanelOffset = () => {
+      const panelHeight = panelRef.current?.offsetHeight ?? 0
+      rootStyle.setProperty(
+        NAVBAR_FILTER_PANEL_OFFSET_CSS_VAR,
+        `${panelHeight + NAVBAR_FILTER_PANEL_GAP_PX}px`
+      )
+    }
+
+    updatePanelOffset()
+    window.addEventListener('resize', updatePanelOffset)
+
+    let resizeObserver: ResizeObserver | undefined
+    if (typeof ResizeObserver !== 'undefined' && panelRef.current) {
+      resizeObserver = new ResizeObserver(() => updatePanelOffset())
+      resizeObserver.observe(panelRef.current)
+    }
+
+    return () => {
+      window.removeEventListener('resize', updatePanelOffset)
+      resizeObserver?.disconnect()
+      rootStyle.removeProperty(NAVBAR_FILTER_PANEL_OFFSET_CSS_VAR)
+    }
+  }, [showDropdown, showLabel])
+
   return (
     <>
       {/* Filter icon button — isolate creates a stacking context to prevent
@@ -231,6 +265,7 @@ export function ClusterFilterPanel({ showLabel = false }: ClusterFilterPanelProp
         {showDropdown && (
           <div
             id={FILTER_PANEL_ID}
+            ref={panelRef}
             data-testid="navbar-cluster-filter-dropdown"
             className="absolute top-full right-0 mt-2 w-80 bg-card border border-border rounded-lg shadow-xl z-toast max-h-[80vh] overflow-y-auto"
             role="dialog"

--- a/web/src/components/layout/navbar/__tests__/ClusterFilterPanel.test.tsx
+++ b/web/src/components/layout/navbar/__tests__/ClusterFilterPanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { ClusterFilterPanel } from '../ClusterFilterPanel'
+import { NAVBAR_FILTER_PANEL_OFFSET_CSS_VAR } from '../../../../lib/constants/ui'
 
 const filterMocks = {
   toggleCluster: vi.fn(),
@@ -77,6 +78,7 @@ vi.mock('../../../ui/Tooltip', () => ({
 describe('ClusterFilterPanel', () => {
   beforeEach(() => {
     Object.values(filterMocks).forEach((mockFn) => mockFn.mockReset())
+    document.documentElement.style.removeProperty(NAVBAR_FILTER_PANEL_OFFSET_CSS_VAR)
   })
 
   it('exposes dialog semantics and restores focus on Escape', () => {
@@ -116,6 +118,6 @@ describe('ClusterFilterPanel', () => {
 
     const dropdown = screen.getByTestId('navbar-cluster-filter-dropdown')
     expect(dropdown).toHaveClass('absolute', 'top-full', 'right-0')
-    expect(document.documentElement.style.getPropertyValue('--navbar-filter-panel-offset')).toBe('')
+    expect(document.documentElement.style.getPropertyValue(NAVBAR_FILTER_PANEL_OFFSET_CSS_VAR)).toBe('8px')
   })
 })

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -98,6 +98,10 @@ export const NAVBAR_HEIGHT_PX = 64
 export const BANNER_HEIGHT_PX = 44
 /** Collapse mobile banner stacks into a summary row once this many alerts are active. */
 export const MOBILE_BANNER_COLLAPSE_THRESHOLD = 2
+/** Root CSS variable used to push non-dashboard content below the open filter panel. */
+export const NAVBAR_FILTER_PANEL_OFFSET_CSS_VAR = '--navbar-filter-panel-offset'
+/** Gap between the navbar and the expanded filter panel (mt-2 = 8px). */
+export const NAVBAR_FILTER_PANEL_GAP_PX = 8
 /**
  * Horizontal offset (in pixels) from the sidebar's right edge at which the
  * floating collapse + pin control container is anchored (see Sidebar.tsx).


### PR DESCRIPTION
## Summary
- Fixes #14230
- Stop reserving navbar filter-panel space on the home dashboard routes (`/`, `/dashboard`) so the Custom Filter dropdown stays overlay-only and does not push the Stats Overview/cards down.
- Keep the existing reserved-space behavior on non-dashboard routes, including the compliance page.
- Add a Playwright visual-layout regression that checks dashboard stat position and `#main-content` scroll height when the filter opens.

## Validation
- `npm ci`
- `npm test -- run src/components/layout/navbar/__tests__`
- `APP_VISUAL_BASE_URL=http://127.0.0.1:5174 npx playwright test --config e2e/visual/app-visual.config.ts app-dashboard-filter-panel-layout.spec.ts`
- `APP_VISUAL_BASE_URL=http://127.0.0.1:5174 npx playwright test --config e2e/visual/app-visual.config.ts app-compliance-filter-panel-visual.spec.ts`
- `git diff --cached --check`
- `git diff --cached | gitleaks stdin --no-banner --redact`

Not run locally: `npm run build` / `npm run lint`, per this repo's agent guidance to leave those checks to CI.