### PR TITLE
fix: keep ClusterCosts aggregates consistent across pagination

### DIFF
--- a/web/src/components/cards/ClusterCosts.test.tsx
+++ b/web/src/components/cards/ClusterCosts.test.tsx
@@ -71,6 +71,7 @@ vi.mock('../ui/StatusBadge', () => ({
 describe('ClusterCosts', () => {
   const baseCardData = {
     items: [] as Array<Record<string, unknown>>,
+    allFilteredItems: [] as Array<Record<string, unknown>>,
     totalItems: 0,
     currentPage: 1,
     totalPages: 1,
@@ -141,7 +142,7 @@ describe('ClusterCosts', () => {
       isFailed: false,
       consecutiveFailures: 0,
     })
-    mockUseCardData.mockReturnValue({ ...baseCardData, items, totalItems: 1 })
+    mockUseCardData.mockReturnValue({ ...baseCardData, items, allFilteredItems: items, totalItems: 1 })
 
     render(<ClusterCosts />)
     expect(screen.getByText('prod')).toBeTruthy()
@@ -150,5 +151,44 @@ describe('ClusterCosts', () => {
       'prod',
       expect.objectContaining({ monthly: 1440, cpus: 8 }),
     )
+  })
+
+  it('shows totals from all filtered clusters, not just the visible page', () => {
+    // Simulate 7 clusters total, page size 5 — only 5 are in `items`, all 7 in `allFilteredItems`
+    const makeCluster = (name: string, monthly: number) => ({
+      cluster: name, name, healthy: true, cpus: 4, memory: 32, gpus: 0,
+      hourly: monthly / 720, daily: monthly / 30, monthly, provider: 'aws',
+    })
+    const page1Items = [
+      makeCluster('c1', 1000),
+      makeCluster('c2', 1000),
+      makeCluster('c3', 1000),
+      makeCluster('c4', 1000),
+      makeCluster('c5', 1000),
+    ]
+    const allItems = [
+      ...page1Items,
+      makeCluster('c6', 1000),
+      makeCluster('c7', 1000),
+    ]
+    mockUseClusters.mockReturnValue({
+      deduplicatedClusters: allItems.map(c => ({
+        name: c.name, healthy: true, cpuCores: 4, nodeCount: 1, context: c.name,
+      })),
+      isLoading: false, isRefreshing: false, isFailed: false, consecutiveFailures: 0,
+    })
+    mockUseCardData.mockReturnValue({
+      ...baseCardData,
+      items: page1Items,
+      allFilteredItems: allItems,
+      totalItems: allItems.length,
+      needsPagination: true,
+      totalPages: 2,
+    })
+
+    render(<ClusterCosts />)
+
+    // Banner must show $7,000 (all 7 clusters), not $5,000 (page 1 only)
+    expect(screen.getByText('$7,000')).toBeTruthy()
   })
 })

--- a/web/src/components/cards/ClusterCosts.tsx
+++ b/web/src/components/cards/ClusterCosts.tsx
@@ -308,6 +308,7 @@ export const ClusterCosts = memo(function ClusterCosts({ config }: ClusterCostsP
   // Use shared card data hook for filtering, sorting, and pagination
   const {
     items: clusterCosts,
+    allFilteredItems: allFilteredClusterCosts,
     totalItems,
     currentPage,
     totalPages,
@@ -338,21 +339,28 @@ export const ClusterCosts = memo(function ClusterCosts({ config }: ClusterCostsP
       comparators: SORT_COMPARATORS },
     defaultLimit: 5 })
 
-  const totalMonthly = clusterCosts.reduce((sum, c) => sum + c.monthly, 0)
-  const totalDaily = clusterCosts.reduce((sum, c) => sum + c.daily, 0)
+  // Aggregates use allFilteredClusterCosts (all filtered clusters, not just the current page)
+  // so the banner and cost bars reflect total spend, not just what's visible.
+  const totalMonthly = useMemo(
+    () => allFilteredClusterCosts.reduce((sum, c) => sum + c.monthly, 0),
+    [allFilteredClusterCosts]
+  )
+  const totalDaily = useMemo(
+    () => allFilteredClusterCosts.reduce((sum, c) => sum + c.daily, 0),
+    [allFilteredClusterCosts]
+  )
 
-  // Memoize provider breakdown counts to avoid recomputing in render
   const providerBreakdown = useMemo(() => {
     const counts: Record<string, number> = {}
-    for (const c of clusterCosts) {
+    for (const c of allFilteredClusterCosts) {
       counts[c.provider] = (counts[c.provider] || 0) + 1
     }
     return counts
-  }, [clusterCosts])
+  }, [allFilteredClusterCosts])
 
   const uniqueProviders = useMemo(() =>
-    Array.from(new Set(clusterCosts.map(c => c.provider))),
-    [clusterCosts]
+    Array.from(new Set(allFilteredClusterCosts.map(c => c.provider))),
+    [allFilteredClusterCosts]
   )
 
   if (isLoading && allClusters.length === 0) {


### PR DESCRIPTION
## SUMMARY

This PR fixes aggregate calculations in the `ClusterCosts` card so financial summaries and provider breakdowns reflect the full filtered dataset instead of only the currently visible page. It updates `ClusterCosts.tsx` to use `allFilteredItems` from `useCardData` for totals and aggregate metrics, and adds regression coverage in `ClusterCosts.test.tsx` for multi-page scenarios.

### Primarily affected files

* `web/src/components/cards/ClusterCosts.tsx`
* `web/src/components/cards/ClusterCosts.test.tsx`

---

## FIX

```tsx
// Before
const {
  items: clusterCosts,
} = useCardData(allClusterCosts, { defaultLimit: 5 })

const totalMonthly = clusterCosts.reduce((sum, c) => sum + c.monthly, 0)


// After
const {
  items: clusterCosts,
  allFilteredItems: allFilteredClusterCosts,
} = useCardData(allClusterCosts, { defaultLimit: 5 })

const totalMonthly = useMemo(
  () => allFilteredClusterCosts.reduce((sum, c) => sum + c.monthly, 0),
  [allFilteredClusterCosts]
)
```
