### PR TITLE
feat(kb): track zero-result KB browse paths and expose /api/missions/gaps

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,6 +20,7 @@ import (
 	"github.com/kubestellar/console/pkg/api/audit"
 	"github.com/kubestellar/console/pkg/client"
 	"github.com/kubestellar/console/pkg/settings"
+	"github.com/kubestellar/console/pkg/store"
 )
 
 const (
@@ -396,6 +398,16 @@ func sanitizeRef(ref string) (string, error) {
 	return ref, nil
 }
 
+// kbGapsDefaultLimit is the default number of gap entries returned by GetKBGaps.
+const kbGapsDefaultLimit = 20
+
+// kbGapStore is the minimal store interface required by MissionsHandler.
+// *store.SQLiteStore satisfies this automatically (duck typing).
+type kbGapStore interface {
+	RecordKBGap(ctx context.Context, path string) error
+	ListTopKBGaps(ctx context.Context, n int) ([]store.KBQueryGap, error)
+}
+
 // MissionsHandler handles mission-related API endpoints (knowledge base browsing,
 // validation, sharing).
 type MissionsHandler struct {
@@ -403,6 +415,7 @@ type MissionsHandler struct {
 	githubAPIURL string // defaults to "https://api.github.com"
 	githubRawURL string // defaults to "https://raw.githubusercontent.com"
 	cache        *missionsResponseCache
+	store        kbGapStore // optional; nil disables gap tracking
 }
 
 // NewMissionsHandler creates a new MissionsHandler with default settings.
@@ -415,11 +428,19 @@ func NewMissionsHandler() *MissionsHandler {
 	}
 }
 
+// WithStore attaches a store for KB query gap tracking and returns the handler
+// for chaining. Safe to omit — gap tracking is a no-op when store is nil.
+func (h *MissionsHandler) WithStore(s kbGapStore) *MissionsHandler {
+	h.store = s
+	return h
+}
+
 // RegisterRoutes registers all mission routes on the given Fiber router group.
 func (h *MissionsHandler) RegisterRoutes(g fiber.Router) {
 	g.Post("/validate", h.ValidateMission)
 	g.Post("/share/slack", h.ShareToSlack)
 	g.Post("/share/github", h.ShareToGitHub)
+	g.Get("/gaps", h.GetKBGaps)
 }
 
 // RegisterPublicRoutes registers unauthenticated browse/file routes (proxies to public GitHub repo).
@@ -725,8 +746,38 @@ func (h *MissionsHandler) BrowseConsoleKB(c *fiber.Ctx) error {
 		slog.Info("[missions] cache MISS, stored (browse)", "path", path)
 	}
 
+	// Record zero-result browse paths for the KB gap tracker.
+	// Fires asynchronously so it never delays the response.
+	if len(entries) == 0 && h.store != nil {
+		go func() {
+			if err := h.store.RecordKBGap(context.Background(), path); err != nil {
+				slog.Warn("[missions] failed to record KB gap", "path", path, "error", err)
+			}
+		}()
+	}
+
 	c.Set("X-Cache", "MISS")
 	return c.JSON(entries)
+}
+
+// GetKBGaps returns the top zero-result KB browse paths, ordered by hit count.
+// GET /api/missions/gaps?limit=20
+func (h *MissionsHandler) GetKBGaps(c *fiber.Ctx) error {
+	if h.store == nil {
+		return c.JSON(fiber.Map{"gaps": []store.KBQueryGap{}, "source": "disabled"})
+	}
+
+	limit := c.QueryInt("limit", kbGapsDefaultLimit)
+	gaps, err := h.store.ListTopKBGaps(c.Context(), limit)
+	if err != nil {
+		slog.Error("[missions] failed to list KB gaps", "error", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "failed to retrieve KB gaps")
+	}
+
+	return c.JSON(fiber.Map{
+		"gaps":  gaps,
+		"count": len(gaps),
+	})
 }
 
 // ---------- Get a single file ----------

--- a/pkg/api/handlers/missions_test.go
+++ b/pkg/api/handlers/missions_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1004,6 +1006,48 @@ func TestGetMissionScore_UpstreamError(t *testing.T) {
 	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
 }
 
+// ---------- GetKBGaps ----------
+
+func TestGetKBGaps_NoStore_ReturnsDisabled(t *testing.T) {
+	// Handler created without a store — gaps endpoint returns disabled source
+	app, _ := setupMissionsTest()
+
+	req, err := http.NewRequest("GET", "/api/missions/gaps", nil)
+	require.NoError(t, err)
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "disabled", body["source"])
+}
+
+func TestGetKBGaps_WithStore_ReturnsGaps(t *testing.T) {
+	app := fiber.New()
+	handler := NewMissionsHandler().WithStore(&stubKBGapStore{
+		gaps: []store.KBQueryGap{
+			{Path: "fixes/istio", HitCount: 3, LastSeen: "2026-05-01T00:00:00Z"},
+			{Path: "fixes/cert-manager", HitCount: 1, LastSeen: "2026-05-02T00:00:00Z"},
+		},
+	})
+	handler.RegisterRoutes(app.Group("/api/missions"))
+	handler.RegisterPublicRoutes(app.Group("/api/missions"))
+
+	req, err := http.NewRequest("GET", "/api/missions/gaps?limit=5", nil)
+	require.NoError(t, err)
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, float64(2), body["count"])
+	gaps := body["gaps"].([]interface{})
+	require.Len(t, gaps, 2)
+	assert.Equal(t, "fixes/istio", gaps[0].(map[string]interface{})["path"])
+}
+
 // ---------- Helpers ----------
 
 // mockTransport is a http.RoundTripper that delegates to a handler function.
@@ -1013,4 +1057,15 @@ type mockTransport struct {
 
 func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.handler(req)
+}
+
+// stubKBGapStore satisfies the kbGapStore interface for handler tests.
+type stubKBGapStore struct {
+	gaps []store.KBQueryGap
+}
+
+func (s *stubKBGapStore) RecordKBGap(_ context.Context, _ string) error { return nil }
+
+func (s *stubKBGapStore) ListTopKBGaps(_ context.Context, _ int) ([]store.KBQueryGap, error) {
+	return s.gaps, nil
 }

--- a/pkg/api/routes_api_core.go
+++ b/pkg/api/routes_api_core.go
@@ -146,7 +146,7 @@ func (s *Server) setupAPICoreRoutes(routes *routeSetupContext) {
 	api.Post("/events", events.RecordEvent)
 	api.Get("/events", events.GetEvents)
 
-	missions := handlers.NewMissionsHandler()
+	missions := handlers.NewMissionsHandler().WithStore(s.store)
 	missions.RegisterRoutes(api.Group("/missions"))
 
 	orbitDataDir := filepath.Dir(s.config.DatabasePath)

--- a/pkg/api/routes_public.go
+++ b/pkg/api/routes_public.go
@@ -79,7 +79,7 @@ s.app.Get("/api/youtube/thumbnail/:id", publicLimiter, handlers.YouTubeThumbnail
 s.app.Get("/api/medium/blog", publicLimiter, handlers.MediumBlogHandler)
 
 // Mission knowledge base browse/file (public — proxies to public GitHub repo)
-missions := handlers.NewMissionsHandler()
+missions := handlers.NewMissionsHandler().WithStore(s.store)
 missions.RegisterPublicRoutes(s.app.Group("/api/missions"))
 
 // Compliance frameworks public read endpoints (no auth — needed for demo mode).

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -939,6 +939,15 @@ func (s *SQLiteStore) migrate() error {
 		)`,
 		"CREATE INDEX IF NOT EXISTS idx_stellar_activity_ts ON stellar_activity(ts DESC)",
 		"CREATE INDEX IF NOT EXISTS idx_stellar_activity_user_ts ON stellar_activity(user_id, ts DESC)",
+		// KB query gap tracker — records zero-result browse paths so maintainers
+		// know which KB content is missing from the knowledge base.
+		`CREATE TABLE IF NOT EXISTS kb_query_gaps (
+			id        INTEGER PRIMARY KEY AUTOINCREMENT,
+			path      TEXT NOT NULL,
+			queried_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		"CREATE INDEX IF NOT EXISTS idx_kb_query_gaps_path ON kb_query_gaps(path)",
+		"CREATE INDEX IF NOT EXISTS idx_kb_query_gaps_ts  ON kb_query_gaps(queried_at DESC)",
 	}
 	for i, migration := range migrations {
 		if _, err := s.db.ExecContext(ctx, migration); err != nil {

--- a/pkg/store/sqlite_kb_gaps.go
+++ b/pkg/store/sqlite_kb_gaps.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	kbGapMaxTopN   = 100
+	kbGapDefaultN  = 20
+	// kbGapRetention is how long gap rows are kept before sweep.
+	kbGapRetention = 90 * 24 * time.Hour
+)
+
+// RecordKBGap appends a row for a browse path that returned zero results.
+func (s *SQLiteStore) RecordKBGap(ctx context.Context, path string) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO kb_query_gaps (path, queried_at) VALUES (?, CURRENT_TIMESTAMP)`,
+		path,
+	)
+	return err
+}
+
+// ListTopKBGaps returns the top n zero-result paths ordered by hit count desc.
+// n is clamped to kbGapMaxTopN; 0 uses kbGapDefaultN.
+func (s *SQLiteStore) ListTopKBGaps(ctx context.Context, n int) ([]KBQueryGap, error) {
+	if n <= 0 {
+		n = kbGapDefaultN
+	}
+	if n > kbGapMaxTopN {
+		n = kbGapMaxTopN
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT path, COUNT(*) AS hit_count, MAX(queried_at) AS last_seen
+		FROM   kb_query_gaps
+		GROUP  BY path
+		ORDER  BY hit_count DESC, last_seen DESC
+		LIMIT  ?`, n)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	gaps := make([]KBQueryGap, 0)
+	for rows.Next() {
+		var g KBQueryGap
+		if err := rows.Scan(&g.Path, &g.HitCount, &g.LastSeen); err != nil {
+			return nil, err
+		}
+		gaps = append(gaps, g)
+	}
+	return gaps, rows.Err()
+}
+
+// SweepOldKBGaps deletes gap rows older than kbGapRetention.
+// Returns the number of rows deleted.
+func (s *SQLiteStore) SweepOldKBGaps(ctx context.Context) (int64, error) {
+	cutoff := time.Now().UTC().Add(-kbGapRetention).Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM kb_query_gaps WHERE queried_at < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}

--- a/pkg/store/sqlite_kb_gaps_test.go
+++ b/pkg/store/sqlite_kb_gaps_test.go
@@ -1,0 +1,111 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestKBGapStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	s, err := NewSQLiteStore(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func TestRecordKBGap_Single(t *testing.T) {
+	s := newTestKBGapStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.RecordKBGap(ctx, "fixes/cert-manager"))
+
+	gaps, err := s.ListTopKBGaps(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, gaps, 1)
+	assert.Equal(t, "fixes/cert-manager", gaps[0].Path)
+	assert.Equal(t, 1, gaps[0].HitCount)
+	assert.NotEmpty(t, gaps[0].LastSeen)
+}
+
+func TestListTopKBGaps_OrderByHitCount(t *testing.T) {
+	s := newTestKBGapStore(t)
+	ctx := context.Background()
+
+	// "fixes/istio" queried 3 times, "fixes/argocd" 1 time
+	for i := 0; i < 3; i++ {
+		require.NoError(t, s.RecordKBGap(ctx, "fixes/istio"))
+	}
+	require.NoError(t, s.RecordKBGap(ctx, "fixes/argocd"))
+
+	gaps, err := s.ListTopKBGaps(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, gaps, 2)
+
+	assert.Equal(t, "fixes/istio", gaps[0].Path)
+	assert.Equal(t, 3, gaps[0].HitCount)
+	assert.Equal(t, "fixes/argocd", gaps[1].Path)
+	assert.Equal(t, 1, gaps[1].HitCount)
+}
+
+func TestListTopKBGaps_LimitRespected(t *testing.T) {
+	s := newTestKBGapStore(t)
+	ctx := context.Background()
+
+	paths := []string{"a", "b", "c", "d", "e"}
+	for _, p := range paths {
+		require.NoError(t, s.RecordKBGap(ctx, p))
+	}
+
+	gaps, err := s.ListTopKBGaps(ctx, 3)
+	require.NoError(t, err)
+	assert.Len(t, gaps, 3)
+}
+
+func TestListTopKBGaps_DefaultLimit(t *testing.T) {
+	s := newTestKBGapStore(t)
+	ctx := context.Background()
+
+	// Insert more than kbGapDefaultN paths
+	for i := 0; i < kbGapDefaultN+5; i++ {
+		require.NoError(t, s.RecordKBGap(ctx, string(rune('a'+i))))
+	}
+
+	// n=0 should use kbGapDefaultN
+	gaps, err := s.ListTopKBGaps(ctx, 0)
+	require.NoError(t, err)
+	assert.Len(t, gaps, kbGapDefaultN)
+}
+
+func TestListTopKBGaps_Empty(t *testing.T) {
+	s := newTestKBGapStore(t)
+	gaps, err := s.ListTopKBGaps(context.Background(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, gaps)
+}
+
+func TestSweepOldKBGaps(t *testing.T) {
+	s := newTestKBGapStore(t)
+	ctx := context.Background()
+
+	// Insert a fresh gap
+	require.NoError(t, s.RecordKBGap(ctx, "fixes/new"))
+
+	// Manually insert an ancient row
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO kb_query_gaps (path, queried_at) VALUES (?, datetime('now', '-100 days'))`,
+		"fixes/ancient",
+	)
+	require.NoError(t, err)
+
+	deleted, err := s.SweepOldKBGaps(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted, "only the ancient row should be swept")
+
+	gaps, err := s.ListTopKBGaps(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, gaps, 1)
+	assert.Equal(t, "fixes/new", gaps[0].Path)
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -283,6 +283,13 @@ type StellarAuditEntry struct {
 	Detail     string    `json:"detail"`
 }
 
+// KBQueryGap represents one row in the kb_query_gaps table.
+type KBQueryGap struct {
+	Path      string `json:"path"`
+	HitCount  int    `json:"hitCount"`
+	LastSeen  string `json:"lastSeen"`
+}
+
 // AuditEntry represents a single row in the audit_log table (#8670 Phase 3).
 type AuditEntry struct {
 	ID        int64  `json:"id"`
@@ -513,6 +520,13 @@ type Store interface {
 	SaveClusterGroup(ctx context.Context, name string, data []byte) error
 	DeleteClusterGroup(ctx context.Context, name string) error
 	ListClusterGroups(ctx context.Context) (map[string][]byte, error)
+
+	// KB Query Gaps — records browse paths that returned zero results so
+	// maintainers can identify missing knowledge-base content.
+	RecordKBGap(ctx context.Context, path string) error
+	// ListTopKBGaps returns the n most-queried zero-result paths, sorted by
+	// hit count descending.
+	ListTopKBGaps(ctx context.Context, n int) ([]KBQueryGap, error)
 
 	// Cluster Events — cross-cluster event journal (#9967 Phase 1).
 	// InsertOrUpdateEvent upserts an event keyed by event_uid.

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -569,6 +569,18 @@ func (m *MockStore) QueryAuditLogs(_ context.Context, limit int, userID, action 
 	return args.Get(0).([]store.AuditEntry), args.Error(1)
 }
 
+func (m *MockStore) RecordKBGap(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *MockStore) ListTopKBGaps(_ context.Context, n int) ([]store.KBQueryGap, error) {
+	args := m.Called(n)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]store.KBQueryGap), args.Error(1)
+}
+
 func (m *MockStore) InsertOrUpdateEvent(_ context.Context, _ store.ClusterEvent) error {
 	return nil
 }


### PR DESCRIPTION
> **Adding or modifying a card/dashboard?** Read the [[Card Development Guide](https://chatgpt.com/c/.github/CARD_DEVELOPMENT_GUIDE.md)](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.

> **New CNCF project card?** New cards go in [[kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace)](https://github.com/kubestellar/console-marketplace), not this repo. PRs adding new cards here will be redirected.

> **Use a coding agent.** This repo is primarily developed with [[Claude Code](https://docs.anthropic.com/en/docs/claude-code)](https://docs.anthropic.com/en/docs/claude-code) (Opus 4.5/4.6). It knows all codebase patterns (isDemoData, useCardLoadingState, locale strings, DCO). Manual PRs that miss required patterns will be sent back.

### 📌 Fixes

Fixes # N/A

---

### 📝 Summary of Changes

* Adds SQLite-backed tracking for KB browse paths that return zero results
* Exposes `GET /api/missions/gaps` endpoint for maintainers to identify the most-requested missing KB content
* Gap recording runs asynchronously and never blocks KB browse responses

---

### Changes Made

* [x] Added `kb_query_gaps` SQLite table via schema migration in `pkg/store/sqlite.go`
* [x] Added `KBQueryGap` model and `RecordKBGap` / `ListTopKBGaps` to the `Store` interface in `pkg/store/store.go`
* [x] Implemented `RecordKBGap`, `ListTopKBGaps`, and `SweepOldKBGaps` in `pkg/store/sqlite_kb_gaps.go`
* [x] Added `kbGapStore` minimal interface and `WithStore()` setter to `MissionsHandler`
* [x] Hooked gap recording into `BrowseConsoleKB` when zero results are returned
* [x] Added `GET /api/missions/gaps` API handler returning top missing KB paths ordered by hit count
* [x] Wired store injection into `MissionsHandler` in both `routes_public.go` and `routes_api_core.go`
* [x] Updated `MockStore` in `pkg/test/mock_store.go` for new interface methods
* [x] Added unit tests for `RecordKBGap`, `ListTopKBGaps`, `SweepOldKBGaps`, and `GetKBGaps`

---

### Checklist

Please ensure the following before submitting your PR:

* [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
* [x] I have reviewed the project's contribution guidelines
* [x] New cards target [[console-marketplace](https://github.com/kubestellar/console-marketplace)](https://github.com/kubestellar/console-marketplace), not this repo
* [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
* [x] I have written unit tests for the changes (if applicable)
* [x] I have tested the changes locally and ensured they work as expected
* [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

```txt
--- PASS: TestRecordKBGap_Single (0.02s)
--- PASS: TestListTopKBGaps_OrderByHitCount (0.02s)
--- PASS: TestListTopKBGaps_LimitRespected (0.02s)
--- PASS: TestListTopKBGaps_DefaultLimit (0.02s)
--- PASS: TestListTopKBGaps_Empty (0.02s)
--- PASS: TestSweepOldKBGaps (0.02s)
--- PASS: TestGetKBGaps_NoStore_ReturnsDisabled (0.00s)
--- PASS: TestGetKBGaps_WithStore_ReturnsGaps (0.00s)

PASS    ok  github.com/kubestellar/console/pkg/store          2.023s
PASS    ok  github.com/kubestellar/console/pkg/api/handlers   0.705s
```

---

### 👀 Reviewer Notes

* Gap recording is fire-and-forget via goroutine and never adds latency to `BrowseConsoleKB`
* `kbGapStore` keeps `MissionsHandler` decoupled from the full `store.Store` interface through duck typing
* Handlers created without a store are nil-safe and return `source: "disabled"` from `/api/missions/gaps`
* `SweepOldKBGaps` supports pruning records older than 90 days