### PR TITLE
fix(ci): harden coverage gate — remove || true, fail on missing summary, guard badge update (#14369)

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -63,7 +63,7 @@ jobs:
           fi
 
           echo "status=run" >> "$GITHUB_OUTPUT"
-          npx vitest run --coverage --reporter=verbose 2>&1 | tail -40 || true
+          npx vitest run --coverage --reporter=verbose 2>&1 | tail -40
 
       - name: Check coverage against threshold
         id: gate
@@ -75,6 +75,10 @@ jobs:
           SUMMARY_FILE="coverage/coverage-summary.json"
 
           if [ ! -f "$SUMMARY_FILE" ]; then
+            if [ "${{ steps.run-tests.outputs.status }}" = "run" ]; then
+              echo "::error::vitest ran but produced no coverage-summary.json — gate fails"
+              exit 1
+            fi
             echo "::warning::No coverage summary found — cannot enforce gate"
             echo "status=skip" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -466,7 +466,7 @@ jobs:
                   ``,
                   failedSection,
                   ``,
-                  `Coverage was merged. Badge update was skipped due to test failures.`,
+                  `Coverage was merged. Badge update was skipped due to a test shard failure.`,
                   ``,
                   `### Action needed`,
                   `1. For each failing test, determine if it's a **test update needed** or a **potential regression**`,
@@ -482,5 +482,5 @@ jobs:
       - name: Fail if any shard failed
         if: needs.test-shard.result == 'failure'
         run: |
-          echo "::error::One or more test shards failed. Coverage was still merged and badge updated, but this workflow is marked as failed."
+          echo "::error::One or more test shards failed. Coverage was merged; badge update was skipped."
           exit 1

--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -260,6 +260,7 @@ jobs:
           retention-days: 30
 
       - name: Update coverage badge gist (with regression guard)
+        if: steps.failures.outputs.count == '0' && needs.test-shard.result != 'failure'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GIST_ID: ${{ env.GIST_ID }}
@@ -465,7 +466,7 @@ jobs:
                   ``,
                   failedSection,
                   ``,
-                  `Coverage was still merged and the badge updated (currently **${{ steps.cov.outputs.pct }}%**), but the failing tests need attention.`,
+                  `Coverage was merged. Badge update was skipped due to test failures.`,
                   ``,
                   `### Action needed`,
                   `1. For each failing test, determine if it's a **test update needed** or a **potential regression**`,


### PR DESCRIPTION
## Summary

Fixes three enforcement gaps in the CI coverage workflows identified in #14369.
Part of LFX Mentorship #4189.

## Changes

### \`.github/workflows/coverage-gate.yml\`
- **Fix A**: Removed \`|| true\` from vitest run step — vitest exit code now propagates
- **Fix B**: Missing \`coverage-summary.json\` after a live run now exits 1 instead of silently skipping

### \`.github/workflows/coverage-hourly.yml\`
- **Fix C**: Badge update step guarded with \`if: steps.failures.outputs.count == '0' && needs.test-shard.result != 'failure'\`
- **Fix D**: Updated self-documented issue body string to reflect badge skip behavior

## What is NOT changed
- \`MAX_DROP_PCT: 5\` regression guard — already works correctly
- \`COVERAGE_THRESHOLD\` — stays at 91%
- Stretch goals deferred (coverage-config.json, coverage-override label, merge-policy)

## Testing
CI validates on PR. Per CLAUDE.md, \`npm run build\` and \`npm run lint\` not run locally.

Fixes #14369
Part of #4189" 