### PR TITLE
fix: replace falsy || guard with !== undefined in updateSingleCluster…

### DIFF
--- a/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
@@ -1038,7 +1038,7 @@ describe('updateSingleClusterInCache — shareMetrics triggers', () => {
     updateClusterCache({
       clusters: [
         makeCluster({ name: 'store-src', server: 'https://shared-store', storageGB: undefined, nodeCount: 3 }),
-        makeCluster({ name: 'store-dst', server: 'https://shared-store', storageGB: undefined, nodeCount: 0 }),
+        makeCluster({ name: 'store-dst', server: 'https://shared-store', storageGB: undefined, nodeCount: undefined }),
       ],
       isLoading: false,
     })
@@ -1055,7 +1055,7 @@ describe('updateSingleClusterInCache — shareMetrics triggers', () => {
     updateClusterCache({
       clusters: [
         makeCluster({ name: 'mem-src', server: 'https://shared-mem2', memoryGB: undefined, nodeCount: 3 }),
-        makeCluster({ name: 'mem-dst', server: 'https://shared-mem2', memoryGB: undefined, nodeCount: 0 }),
+        makeCluster({ name: 'mem-dst', server: 'https://shared-mem2', memoryGB: undefined, nodeCount: undefined }),
       ],
       isLoading: false,
     })
@@ -1071,8 +1071,8 @@ describe('updateSingleClusterInCache — shareMetrics triggers', () => {
     const POD_COUNT = 150
     updateClusterCache({
       clusters: [
-        makeCluster({ name: 'pod-src', server: 'https://shared-pod', podCount: 0, nodeCount: 3 }),
-        makeCluster({ name: 'pod-dst', server: 'https://shared-pod', podCount: 0, nodeCount: 0 }),
+        makeCluster({ name: 'pod-src', server: 'https://shared-pod', podCount: undefined, nodeCount: 3 }),
+        makeCluster({ name: 'pod-dst', server: 'https://shared-pod', podCount: undefined, nodeCount: undefined }),
       ],
       isLoading: false,
     })
@@ -1082,6 +1082,30 @@ describe('updateSingleClusterInCache — shareMetrics triggers', () => {
 
     const dst = clusterCache.clusters.find(c => c.name === 'pod-dst')!
     expect(dst.podCount).toBe(POD_COUNT)
+  })
+
+  it('does not skip shareMetrics when all metric updates are zero (scaled-to-zero cluster)', () => {
+    // Regression for #13913: falsy || check treated 0 as "no update", so
+    // shareMetricsBetweenSameServerClusters was never called and the alias
+    // cluster never received cpuCores from the same-server peer.
+    const CPU_CORES = 8
+    updateClusterCache({
+      clusters: [
+        makeCluster({ name: 'metric-src', server: 'https://shared-zero', nodeCount: 3, cpuCores: CPU_CORES }),
+        makeCluster({ name: 'metric-dst', server: 'https://shared-zero', nodeCount: 0, cpuCores: undefined }),
+      ],
+      isLoading: false,
+    })
+
+    // Only a zero value in the update — the bug caused the guard to skip shareMetrics entirely
+    updateSingleClusterInCache('metric-dst', { nodeCount: 0 })
+    vi.advanceTimersByTime(CLUSTER_NOTIFY_DEBOUNCE_MS)
+
+    const dst = clusterCache.clusters.find(c => c.name === 'metric-dst')!
+    // shareMetrics must have run and copied cpuCores from metric-src
+    expect(dst.cpuCores).toBe(CPU_CORES)
+    // nodeCount 0 must not be overwritten with metric-src's value
+    expect(dst.nodeCount).toBe(0)
   })
 
   it('does NOT trigger shareMetrics when non-metric keys are updated', () => {

--- a/web/src/hooks/mcp/clusterUtils.ts
+++ b/web/src/hooks/mcp/clusterUtils.ts
@@ -40,8 +40,8 @@ export function shareMetricsBetweenSameServerClusters(clusters: ClusterInfo[]): 
     if (!source) return cluster
 
     // Check if we need to copy anything - include nodeCount, podCount, and capacity/requests
-    const needsNodes = (!cluster.nodeCount || cluster.nodeCount === 0) && source.nodeCount && source.nodeCount > 0
-    const needsPods = (!cluster.podCount || cluster.podCount === 0) && source.podCount && source.podCount > 0
+    const needsNodes = cluster.nodeCount === undefined && source.nodeCount !== undefined && source.nodeCount > 0
+    const needsPods = cluster.podCount === undefined && source.podCount !== undefined && source.podCount > 0
     const needsCapacity = !cluster.cpuCores && source.cpuCores
     const needsRequests = !cluster.cpuRequestsCores && source.cpuRequestsCores
 

--- a/web/src/hooks/mcp/sharedImpl.ts
+++ b/web/src/hooks/mcp/sharedImpl.ts
@@ -589,7 +589,7 @@ export function updateSingleClusterInCache(clusterName: string, updates: Partial
   // Share metrics between clusters pointing to the same server
   // This ensures aliases (like "prow") get metrics from their full-context counterparts
   // Include nodeCount and podCount to ensure all health data is shared
-  if (updates.nodeCount || updates.podCount || updates.cpuCores || updates.memoryGB || updates.storageGB || updates.cpuRequestsCores || updates.memoryRequestsGB) {
+  if (updates.nodeCount !== undefined || updates.podCount !== undefined || updates.cpuCores !== undefined || updates.memoryGB !== undefined || updates.storageGB !== undefined || updates.cpuRequestsCores !== undefined || updates.memoryRequestsGB !== undefined) {
     updatedClusters = shareMetricsBetweenSameServerClusters(updatedClusters)
   }
 


### PR DESCRIPTION
…InCache and clusterUtils

### 📌 Fixes

Resolves #13913

---

### 📝 Summary of Changes

- Fixed a falsy `||` guard in `updateSingleClusterInCache` (`shared.ts:594`) that silently skipped `shareMetricsBetweenSameServerClusters` whenever a cluster scaled to zero, leaving alias clusters with stale non-zero counts.
- Fixed the same falsy-check pattern in `needsNodes`/`needsPods` inside `clusterUtils.ts`, which was overwriting a valid `0` with stale data from a same-server peer - the identical bug that was fixed in `dedup.ts` by #14134.
---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x]  Replaced `||` truthiness guard at `shared.ts:594` with `!== undefined` per-field checks so `shareMetricsBetweenSameServerClusters` is called even when all metric updates are `0`
- [x] Fixed `needsNodes`/`needsPods` in `clusterUtils.ts:43-44` to use `=== undefined` - consistent with `pickMetric` (same file, line 283) and the fix from #14134 applied to `dedup.ts`
- [x] Added regression test in `shared-coverage.test.ts` covering the scaled-to-zero scenario from #13913
- [x] Corrected three existing tests that had `nodeCount: 0` (explicit zero) where they meant `nodeCount: undefined` (not yet received) - they were inadvertently asserting the buggy overwrite behaviour

---

### Checklist

Please ensure the following before submitting your PR:

- [ ] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [x] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->
<img width="842" height="354" alt="image" src="https://github.com/user-attachments/assets/0ba7943b-6d04-476b-8065-31eb35f836a1" />

---

### 👀 Reviewer Notes

- The guard fix and the `clusterUtils.ts` fix are coupled - fixing only the guard without fixing `needsNodes`/`needsPods` would cause `shareMetricsBetweenSameServerClusters` to overwrite a valid `0` with stale data from the peer, making things worse. Both need to land together.
- Pattern is identical to what `pickMetric` (line 283, same file) already does correctly, and to the fix #14134 applied to `dedup.ts`.
