### PR TITLE
added /MIME type.*text\/event-stream/i and a proper SSE mock route fo…

### DIFF
--- a/web/e2e/helpers/setup.ts
+++ b/web/e2e/helpers/setup.ts
@@ -77,6 +77,7 @@ export const EXPECTED_ERROR_PATTERNS = [
   /Access-Control-Allow-Origin.*localhost/i, // WebKit CORS variant referencing localhost origin
   /Access-Control-Allow-Origin.*127\.0\.0\.1/i, // WebKit CORS variant referencing loopback IP
   /Notification permission/i, // Firefox blocks notification requests outside user gestures
+  /MIME type.*text\/event-stream/i, // SSE endpoint returning wrong content-type in dev mode
   /Notification prompting can only be done from a user gesture/i, // WebKit/Safari wording for notification gesture block
   /ERR_CONNECTION_REFUSED/i, // Backend/agent not running in CI
   /net::ERR_CONNECTION_REFUSED.*(:8585|:8080|localhost)/i, // Agent/backend ports only in demo mode (#11294)
@@ -246,6 +247,14 @@ export async function mockApiFallback(page: Page) {
       }),
     })
   })
+
+  await page.route('**/api/stellar/stream*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: ': keep-alive\n\n',
+    })
+  )
 
   // IMPORTANT: Playwright matches routes in REVERSE registration order (last registered = first matched).
   // Register the catch-all FIRST (lowest priority) so the active-users specific mock below


### PR DESCRIPTION
## 📌 Fixes

Fixes #14439 

---

## 📝 Summary of Changes

Fixed Playwright smoke test failures caused by the missing Server-Sent Events (SSE) mock endpoint for `/api/stellar/stream` when running against the Vite dev server (`localhost:5174`).

The Vite dev server returned `application/json` instead of `text/event-stream`, causing the browser to reject the `EventSource` connection and produce console errors that failed the smoke suite.

This PR:

* adds an expected error pattern for the MIME type mismatch
* adds a proper SSE mock route in `mockApiFallback` for `/api/stellar/stream`
* restores smoke suite stability for local Vite-based test runs

---

## Changes Made

* [x] Added `/MIME type.*text\/event-stream/i` to `EXPECTED_ERROR_PATTERNS`
* [x] Added SSE mock handler for `/api/stellar/stream` in `mockApiFallback`
* [x] Fixed smoke suite failures caused by EventSource connection rejection
* [x] Verified smoke tests pass against Vite dev server (`localhost:5174`)

---

## Checklist

Please ensure the following before submitting your PR:

* [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
* [x] I have reviewed the project's contribution guidelines
* [x] New cards target [[console-marketplace](https://github.com/kubestellar/console-marketplace)](https://github.com/kubestellar/console-marketplace), not this repo
* [ ] isDemoData is wired correctly (not applicable)
* [ ] I have written unit tests for the changes (if applicable)
* [x] I have tested the changes locally and ensured they work as expected
* [x] All commits are signed with DCO (`git commit -s`)

---

## Screenshots or Logs (if applicable)

Reproducible with:

```bash
PLAYWRIGHT_BASE_URL=http://localhost:5174 npx playwright test --project=chromium smoke.spec.ts
```

Previous error:

```text
EventSource's response has a MIME type ("application/json") that is not "text/event-stream". Aborting the connection.
```

---

## 👀 Reviewer Notes

This issue affected:

* All Route Loading smoke tests
* Error Handling > page handles missing data gracefully
* Mobile Viewport > dashboard loads without error on mobile

The added SSE mock route prevents the browser-level EventSource rejection instead of only suppressing the console error.