### PR TITLE
test(ui): add Vitest suites for MissionBrowser tab components

### DIFF
--- a/web/src/components/missions/__tests__/MissionBrowserFixesTab.test.tsx
+++ b/web/src/components/missions/__tests__/MissionBrowserFixesTab.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { MissionExport } from '../../../lib/missions/types'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+vi.mock('../FixerCard', () => ({
+  FixerCard: ({ mission, onSelect, onImport }: { mission: MissionExport; onSelect: () => void; onImport: () => void }) => (
+    <div data-testid="fixer-card" data-id={mission.id}>
+      <button onClick={onSelect}>Select {mission.title}</button>
+      <button onClick={onImport}>Import {mission.title}</button>
+    </div>
+  ),
+}))
+
+vi.mock('../browser', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../browser')>()
+  return {
+    ...actual,
+    EmptyState: ({ message }: { message: string }) => <div data-testid="empty-state">{message}</div>,
+    MissionFetchErrorBanner: ({ message }: { message: string }) => <div data-testid="fetch-error">{message}</div>,
+    VirtualizedMissionGrid: ({ items, renderItem }: { items: MissionExport[]; renderItem: (m: MissionExport) => React.ReactNode }) => (
+      <div data-testid="virtualized-grid">{items.map(renderItem)}</div>
+    ),
+  }
+})
+
+vi.mock('../missionBrowserConstants', () => ({
+  CATEGORY_FILTERS: ['All', 'Troubleshoot', 'Deploy'],
+}))
+
+import { MissionBrowserFixesTab } from '../MissionBrowserFixesTab'
+
+const MISSION: MissionExport = {
+  id: 'fix-1',
+  title: 'Fix NetworkPolicy',
+  description: 'Fixes networking issues',
+  type: 'fixer',
+  source: 'community',
+  content: '',
+  tags: [],
+  version: '1.0',
+  author: 'test',
+} as unknown as MissionExport
+
+function renderFixesTab(overrides: Partial<React.ComponentProps<typeof MissionBrowserFixesTab>> = {}) {
+  const props = {
+    fixerMissions: [],
+    filteredFixers: [],
+    loadingFixers: false,
+    missionFetchError: null,
+    fixerSearch: '',
+    onFixerSearchChange: vi.fn(),
+    globalSearchActive: false,
+    globalSearchQuery: '',
+    fixerTypeFilter: 'All',
+    onFixerTypeFilterChange: vi.fn(),
+    viewMode: 'grid' as const,
+    onSelectMission: vi.fn(),
+    onImportMission: vi.fn(),
+    onCopyLink: vi.fn(),
+    ...overrides,
+  }
+  return { ...render(<MissionBrowserFixesTab {...props} />), props }
+}
+
+describe('MissionBrowserFixesTab', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  // ── Search input ────────────────────────────────────────────────────────────
+
+  it('renders search input with placeholder', () => {
+    renderFixesTab()
+    expect(screen.getByPlaceholderText('Search fixes…')).toBeInTheDocument()
+  })
+
+  it('shows current fixerSearch value in input', () => {
+    renderFixesTab({ fixerSearch: 'network' })
+    expect(screen.getByDisplayValue('network')).toBeInTheDocument()
+  })
+
+  it('calls onFixerSearchChange when typing in search', () => {
+    const onFixerSearchChange = vi.fn()
+    renderFixesTab({ onFixerSearchChange })
+    fireEvent.change(screen.getByPlaceholderText('Search fixes…'), { target: { value: 'dns' } })
+    expect(onFixerSearchChange).toHaveBeenCalledWith('dns')
+  })
+
+  // ── Global search active banner ─────────────────────────────────────────────
+
+  it('shows global search filter hint when global search active and no local search', () => {
+    renderFixesTab({ globalSearchActive: true, globalSearchQuery: 'istio', fixerSearch: '' })
+    expect(screen.getByText(/Filtered by global search/)).toBeInTheDocument()
+    expect(screen.getByText(/istio/)).toBeInTheDocument()
+  })
+
+  it('hides global search hint when local fixerSearch is set', () => {
+    renderFixesTab({ globalSearchActive: true, globalSearchQuery: 'istio', fixerSearch: 'dns' })
+    expect(screen.queryByText(/Filtered by global search/)).not.toBeInTheDocument()
+  })
+
+  it('hides global search hint when globalSearchActive is false', () => {
+    renderFixesTab({ globalSearchActive: false, globalSearchQuery: 'istio' })
+    expect(screen.queryByText(/Filtered by global search/)).not.toBeInTheDocument()
+  })
+
+  // ── Type filter select ──────────────────────────────────────────────────────
+
+  it('renders type filter dropdown with All Types option', () => {
+    renderFixesTab()
+    expect(screen.getByDisplayValue('All Types')).toBeInTheDocument()
+  })
+
+  it('renders category options from CATEGORY_FILTERS', () => {
+    renderFixesTab()
+    const select = screen.getByDisplayValue('All Types')
+    expect(select).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Troubleshoot' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Deploy' })).toBeInTheDocument()
+  })
+
+  it('calls onFixerTypeFilterChange when filter changes', () => {
+    const onFixerTypeFilterChange = vi.fn()
+    renderFixesTab({ onFixerTypeFilterChange })
+    fireEvent.change(screen.getByDisplayValue('All Types'), { target: { value: 'Deploy' } })
+    expect(onFixerTypeFilterChange).toHaveBeenCalledWith('Deploy')
+  })
+
+  // ── Loading state ───────────────────────────────────────────────────────────
+
+  it('shows loading spinner when loading and no filtered items', () => {
+    renderFixesTab({ loadingFixers: true, filteredFixers: [] })
+    expect(screen.getByText('Loading fixes…')).toBeInTheDocument()
+  })
+
+  it('shows progressive loading banner with count when loading with some items', () => {
+    renderFixesTab({
+      loadingFixers: true,
+      filteredFixers: [MISSION],
+      fixerMissions: [MISSION],
+    })
+    expect(screen.getByText(/Loading… 1 found so far/)).toBeInTheDocument()
+  })
+
+  // ── Empty states ────────────────────────────────────────────────────────────
+
+  it('shows "No fixer missions found" when no items and not loading', () => {
+    renderFixesTab({ filteredFixers: [], fixerMissions: [], loadingFixers: false })
+    expect(screen.getByTestId('empty-state')).toHaveTextContent('No fixer missions found')
+  })
+
+  it('shows "No fixes match your filters" when missions exist but filtered result empty', () => {
+    renderFixesTab({ filteredFixers: [], fixerMissions: [MISSION], loadingFixers: false })
+    expect(screen.getByTestId('empty-state')).toHaveTextContent('No fixes match your filters')
+  })
+
+  // ── Error banner ────────────────────────────────────────────────────────────
+
+  it('shows error banner when missionFetchError is set and no missions', () => {
+    renderFixesTab({ missionFetchError: 'Network timeout', fixerMissions: [] })
+    expect(screen.getByTestId('fetch-error')).toHaveTextContent('Network timeout')
+  })
+
+  it('hides error banner when missions are present even with error', () => {
+    renderFixesTab({ missionFetchError: 'Network timeout', fixerMissions: [MISSION] })
+    expect(screen.queryByTestId('fetch-error')).not.toBeInTheDocument()
+  })
+
+  // ── Mission grid & cards ────────────────────────────────────────────────────
+
+  it('renders the virtualized grid when filteredFixers is non-empty', () => {
+    renderFixesTab({ filteredFixers: [MISSION], fixerMissions: [MISSION] })
+    expect(screen.getByTestId('virtualized-grid')).toBeInTheDocument()
+    expect(screen.getByTestId('fixer-card')).toBeInTheDocument()
+  })
+
+  it('calls onSelectMission when Select is clicked on a fixer card', () => {
+    const onSelectMission = vi.fn()
+    renderFixesTab({ filteredFixers: [MISSION], fixerMissions: [MISSION], onSelectMission })
+    fireEvent.click(screen.getByText('Select Fix NetworkPolicy'))
+    expect(onSelectMission).toHaveBeenCalledWith(MISSION)
+  })
+
+  it('calls onImportMission when Import is clicked on a fixer card', () => {
+    const onImportMission = vi.fn()
+    renderFixesTab({ filteredFixers: [MISSION], fixerMissions: [MISSION], onImportMission })
+    fireEvent.click(screen.getByText('Import Fix NetworkPolicy'))
+    expect(onImportMission).toHaveBeenCalledWith(MISSION)
+  })
+
+  // ── Count footer ────────────────────────────────────────────────────────────
+
+  it('shows count footer when filteredFixers is non-empty and not loading', () => {
+    renderFixesTab({
+      filteredFixers: [MISSION],
+      fixerMissions: [MISSION],
+      loadingFixers: false,
+    })
+    expect(screen.getByText('Showing 1 of 1 fixer missions')).toBeInTheDocument()
+  })
+
+  it('shows loading count footer when loading with items', () => {
+    renderFixesTab({
+      filteredFixers: [MISSION],
+      fixerMissions: [MISSION],
+      loadingFixers: true,
+    })
+    expect(screen.getByText('1 loaded…')).toBeInTheDocument()
+  })
+
+  it('hides count footer when filteredFixers is empty', () => {
+    renderFixesTab({ filteredFixers: [], fixerMissions: [] })
+    expect(screen.queryByText(/Showing.*fixer missions/)).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/missions/__tests__/MissionBrowserInstallersTab.test.tsx
+++ b/web/src/components/missions/__tests__/MissionBrowserInstallersTab.test.tsx
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { MissionExport } from '../../../lib/missions/types'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+vi.mock('../InstallerCard', () => ({
+  InstallerCard: ({ mission, onSelect, onImport }: { mission: MissionExport; onSelect: () => void; onImport: () => void }) => (
+    <div data-testid="installer-card" data-id={mission.id}>
+      <button onClick={onSelect}>Select {mission.title}</button>
+      <button onClick={onImport}>Import {mission.title}</button>
+    </div>
+  ),
+}))
+
+vi.mock('../browser', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../browser')>()
+  return {
+    ...actual,
+    EmptyState: ({ message }: { message: string }) => <div data-testid="empty-state">{message}</div>,
+    MissionFetchErrorBanner: ({ message }: { message: string }) => <div data-testid="fetch-error">{message}</div>,
+    VirtualizedMissionGrid: ({ items, renderItem }: { items: MissionExport[]; renderItem: (m: MissionExport) => React.ReactNode }) => (
+      <div data-testid="virtualized-grid">{items.map(renderItem)}</div>
+    ),
+  }
+})
+
+vi.mock('../missionBrowserConstants', () => ({
+  CNCF_CATEGORIES: ['All', 'Networking', 'Storage'],
+  MATURITY_LEVELS: ['All', 'graduated', 'incubating', 'sandbox'],
+}))
+
+import { MissionBrowserInstallersTab } from '../MissionBrowserInstallersTab'
+
+const INSTALLER: MissionExport = {
+  id: 'install-1',
+  title: 'Install Istio',
+  description: 'Installs Istio service mesh',
+  type: 'installer',
+  source: 'community',
+  content: '',
+  tags: [],
+  version: '1.0',
+  author: 'test',
+} as unknown as MissionExport
+
+function renderInstallersTab(overrides: Partial<React.ComponentProps<typeof MissionBrowserInstallersTab>> = {}) {
+  const props = {
+    installerMissions: [],
+    filteredInstallers: [],
+    loadingInstallers: false,
+    missionFetchError: null,
+    installerSearch: '',
+    onInstallerSearchChange: vi.fn(),
+    globalSearchActive: false,
+    globalSearchQuery: '',
+    installerCategoryFilter: 'All',
+    onInstallerCategoryFilterChange: vi.fn(),
+    installerMaturityFilter: 'All',
+    onInstallerMaturityFilterChange: vi.fn(),
+    viewMode: 'grid' as const,
+    onSelectMission: vi.fn(),
+    onImportMission: vi.fn(),
+    onCopyLink: vi.fn(),
+    ...overrides,
+  }
+  return { ...render(<MissionBrowserInstallersTab {...props} />), props }
+}
+
+describe('MissionBrowserInstallersTab', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  // ── Search input ────────────────────────────────────────────────────────────
+
+  it('renders search input with placeholder', () => {
+    renderInstallersTab()
+    expect(screen.getByPlaceholderText('Search installers…')).toBeInTheDocument()
+  })
+
+  it('shows current installerSearch value', () => {
+    renderInstallersTab({ installerSearch: 'istio' })
+    expect(screen.getByDisplayValue('istio')).toBeInTheDocument()
+  })
+
+  it('calls onInstallerSearchChange when typing', () => {
+    const onInstallerSearchChange = vi.fn()
+    renderInstallersTab({ onInstallerSearchChange })
+    fireEvent.change(screen.getByPlaceholderText('Search installers…'), { target: { value: 'nginx' } })
+    expect(onInstallerSearchChange).toHaveBeenCalledWith('nginx')
+  })
+
+  // ── Global search banner ────────────────────────────────────────────────────
+
+  it('shows global search hint when global search is active and no local search', () => {
+    renderInstallersTab({ globalSearchActive: true, globalSearchQuery: 'mesh', installerSearch: '' })
+    expect(screen.getByText(/Filtered by global search/)).toBeInTheDocument()
+    expect(screen.getByText(/mesh/)).toBeInTheDocument()
+  })
+
+  it('hides global search hint when local search is set', () => {
+    renderInstallersTab({ globalSearchActive: true, globalSearchQuery: 'mesh', installerSearch: 'istio' })
+    expect(screen.queryByText(/Filtered by global search/)).not.toBeInTheDocument()
+  })
+
+  // ── Category filter ─────────────────────────────────────────────────────────
+
+  it('renders category dropdown with All Categories option', () => {
+    renderInstallersTab()
+    expect(screen.getByDisplayValue('All Categories')).toBeInTheDocument()
+  })
+
+  it('renders category options from CNCF_CATEGORIES', () => {
+    renderInstallersTab()
+    expect(screen.getByRole('option', { name: 'Networking' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Storage' })).toBeInTheDocument()
+  })
+
+  it('calls onInstallerCategoryFilterChange when category changes', () => {
+    const onInstallerCategoryFilterChange = vi.fn()
+    renderInstallersTab({ onInstallerCategoryFilterChange })
+    fireEvent.change(screen.getByDisplayValue('All Categories'), { target: { value: 'Networking' } })
+    expect(onInstallerCategoryFilterChange).toHaveBeenCalledWith('Networking')
+  })
+
+  // ── Maturity filter ─────────────────────────────────────────────────────────
+
+  it('renders maturity dropdown with All Maturity option', () => {
+    renderInstallersTab()
+    expect(screen.getByDisplayValue('All Maturity')).toBeInTheDocument()
+  })
+
+  it('renders maturity options with capitalized labels', () => {
+    renderInstallersTab()
+    expect(screen.getByRole('option', { name: 'Graduated' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Incubating' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Sandbox' })).toBeInTheDocument()
+  })
+
+  it('calls onInstallerMaturityFilterChange when maturity changes', () => {
+    const onInstallerMaturityFilterChange = vi.fn()
+    renderInstallersTab({ onInstallerMaturityFilterChange })
+    fireEvent.change(screen.getByDisplayValue('All Maturity'), { target: { value: 'graduated' } })
+    expect(onInstallerMaturityFilterChange).toHaveBeenCalledWith('graduated')
+  })
+
+  // ── Loading states ──────────────────────────────────────────────────────────
+
+  it('shows loading spinner when loading and no filtered items', () => {
+    renderInstallersTab({ loadingInstallers: true, filteredInstallers: [] })
+    expect(screen.getByText('Loading CNCF installers…')).toBeInTheDocument()
+  })
+
+  it('shows progressive loading banner with count when loading with items', () => {
+    renderInstallersTab({
+      loadingInstallers: true,
+      filteredInstallers: [INSTALLER],
+      installerMissions: [INSTALLER],
+    })
+    expect(screen.getByText(/Loading… 1 found so far/)).toBeInTheDocument()
+  })
+
+  // ── Empty states ────────────────────────────────────────────────────────────
+
+  it('shows "No installer missions found" when empty and not loading', () => {
+    renderInstallersTab({ filteredInstallers: [], installerMissions: [], loadingInstallers: false })
+    expect(screen.getByTestId('empty-state')).toHaveTextContent('No installer missions found')
+  })
+
+  it('shows "No installers match your filters" when missions exist but filtered result empty', () => {
+    renderInstallersTab({ filteredInstallers: [], installerMissions: [INSTALLER], loadingInstallers: false })
+    expect(screen.getByTestId('empty-state')).toHaveTextContent('No installers match your filters')
+  })
+
+  // ── Error banner ────────────────────────────────────────────────────────────
+
+  it('shows error banner when fetch error present and no missions', () => {
+    renderInstallersTab({ missionFetchError: 'Rate limited', installerMissions: [] })
+    expect(screen.getByTestId('fetch-error')).toHaveTextContent('Rate limited')
+  })
+
+  it('hides error banner when missions are present', () => {
+    renderInstallersTab({ missionFetchError: 'Rate limited', installerMissions: [INSTALLER] })
+    expect(screen.queryByTestId('fetch-error')).not.toBeInTheDocument()
+  })
+
+  // ── Grid & cards ────────────────────────────────────────────────────────────
+
+  it('renders virtualized grid when filteredInstallers is non-empty', () => {
+    renderInstallersTab({ filteredInstallers: [INSTALLER], installerMissions: [INSTALLER] })
+    expect(screen.getByTestId('virtualized-grid')).toBeInTheDocument()
+    expect(screen.getByTestId('installer-card')).toBeInTheDocument()
+  })
+
+  it('calls onSelectMission when Select is clicked on installer card', () => {
+    const onSelectMission = vi.fn()
+    renderInstallersTab({ filteredInstallers: [INSTALLER], installerMissions: [INSTALLER], onSelectMission })
+    fireEvent.click(screen.getByText('Select Install Istio'))
+    expect(onSelectMission).toHaveBeenCalledWith(INSTALLER)
+  })
+
+  it('calls onImportMission when Import is clicked on installer card', () => {
+    const onImportMission = vi.fn()
+    renderInstallersTab({ filteredInstallers: [INSTALLER], installerMissions: [INSTALLER], onImportMission })
+    fireEvent.click(screen.getByText('Import Install Istio'))
+    expect(onImportMission).toHaveBeenCalledWith(INSTALLER)
+  })
+
+  // ── Count footer ────────────────────────────────────────────────────────────
+
+  it('shows count footer when items loaded and not loading', () => {
+    renderInstallersTab({
+      filteredInstallers: [INSTALLER],
+      installerMissions: [INSTALLER],
+      loadingInstallers: false,
+    })
+    expect(screen.getByText('Showing 1 of 1 installer missions')).toBeInTheDocument()
+  })
+
+  it('shows loading count footer when still loading', () => {
+    renderInstallersTab({
+      filteredInstallers: [INSTALLER],
+      installerMissions: [INSTALLER],
+      loadingInstallers: true,
+    })
+    expect(screen.getByText('1 loaded…')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/missions/__tests__/MissionBrowserRecommendedTab.test.tsx
+++ b/web/src/components/missions/__tests__/MissionBrowserRecommendedTab.test.tsx
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { MissionExport, MissionMatch, BrowseEntry } from '../../../lib/missions/types'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+vi.mock('../../lib/analytics', () => ({ emitFixerGitHubLink: vi.fn() }))
+vi.mock('../../../lib/analytics', () => ({ emitFixerGitHubLink: vi.fn() }))
+
+const { mockResetMissionCache } = vi.hoisted(() => ({
+  mockResetMissionCache: vi.fn(),
+}))
+vi.mock('../browser', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../browser')>()
+  return {
+    ...actual,
+    EmptyState: ({ message }: { message: string }) => <div data-testid="empty-state">{message}</div>,
+    MissionFetchErrorBanner: ({ message }: { message: string }) => <div data-testid="fetch-error">{message}</div>,
+    VirtualizedMissionGrid: ({ items, renderItem }: { items: unknown[]; renderItem: (m: unknown) => React.ReactNode }) => (
+      <div data-testid="virtualized-grid">{items.map((item, i) => <div key={i}>{renderItem(item)}</div>)}</div>
+    ),
+    RecommendationCard: ({ match, onSelect }: { match: MissionMatch; onSelect: () => void }) => (
+      <div data-testid="recommendation-card">
+        <button onClick={onSelect}>Select {match.mission.title}</button>
+      </div>
+    ),
+    DirectoryListing: ({ entries, onSelect }: { entries: BrowseEntry[]; onSelect: (e: BrowseEntry) => void }) => (
+      <div data-testid="directory-listing">
+        {entries.map((e) => (
+          <button key={e.path} onClick={() => onSelect(e)}>{e.name}</button>
+        ))}
+      </div>
+    ),
+    buildDirectoryEntryNode: vi.fn((entry) => ({ ...entry, id: entry.path, source: 'community', loaded: false })),
+    resetMissionCache: mockResetMissionCache,
+    CollapsibleSection: ({ children, title }: { children: React.ReactNode; title: string }) => (
+      <div data-testid="collapsible-section">
+        <span>{title}</span>
+        {children}
+      </div>
+    ),
+  }
+})
+
+vi.mock('../../ui/CollapsibleSection', () => ({
+  CollapsibleSection: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <div data-testid="collapsible-section">
+      <span>{title}</span>
+      {children}
+    </div>
+  ),
+}))
+
+import { MissionBrowserRecommendedTab } from '../MissionBrowserRecommendedTab'
+
+const MISSION: MissionExport = {
+  id: 'fix-1',
+  title: 'Fix DNS',
+  description: 'Fixes DNS',
+  type: 'fixer',
+  source: 'community',
+  content: '',
+  tags: [],
+  version: '1.0',
+  author: 'test',
+} as unknown as MissionExport
+
+const MATCH: MissionMatch = { mission: MISSION, score: 0.9, reason: 'cluster match' } as unknown as MissionMatch
+
+const DIR_ENTRY: BrowseEntry = {
+  name: 'networking',
+  path: 'fixes/networking',
+  type: 'directory',
+} as BrowseEntry
+
+const DEFAULT_PROGRESS = { step: 'Done', detail: '', found: 0, scanned: 0 }
+
+function renderRecommendedTab(overrides: Partial<React.ComponentProps<typeof MissionBrowserRecommendedTab>> = {}) {
+  const props = {
+    tokenError: null,
+    missionFetchError: null,
+    loadingRecommendations: false,
+    searchProgress: DEFAULT_PROGRESS,
+    hasCluster: false,
+    recommendations: [],
+    filteredRecommendations: [],
+    onSelectMission: vi.fn(),
+    onImportMission: vi.fn(),
+    onCopyLink: vi.fn(),
+    loading: false,
+    filteredEntries: [],
+    selectedPath: null,
+    selectedNode: null,
+    viewMode: 'grid' as const,
+    onImportDirectoryEntry: vi.fn(),
+    onToggleNode: vi.fn(),
+    onSelectNode: vi.fn(),
+    ...overrides,
+  }
+  return { ...render(<MissionBrowserRecommendedTab {...props} />), props }
+}
+
+describe('MissionBrowserRecommendedTab', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  // ── Token error banners ─────────────────────────────────────────────────────
+
+  it('shows rate limit warning when tokenError is rate_limited', () => {
+    renderRecommendedTab({ tokenError: 'rate_limited' })
+    expect(screen.getByText('GitHub API rate limit reached')).toBeInTheDocument()
+  })
+
+  it('shows invalid token warning when tokenError is token_invalid', () => {
+    renderRecommendedTab({ tokenError: 'token_invalid' })
+    expect(screen.getByText('GitHub token is invalid or expired')).toBeInTheDocument()
+  })
+
+  it('shows no token banner when tokenError is null', () => {
+    renderRecommendedTab({ tokenError: null })
+    expect(screen.queryByText('GitHub API rate limit reached')).not.toBeInTheDocument()
+    expect(screen.queryByText('GitHub token is invalid or expired')).not.toBeInTheDocument()
+  })
+
+  it('shows GitHub token creation link in rate limit banner', () => {
+    renderRecommendedTab({ tokenError: 'rate_limited' })
+    expect(screen.getByText('Create a GitHub personal access token')).toBeInTheDocument()
+  })
+
+  // ── Fetch error banner ──────────────────────────────────────────────────────
+
+  it('shows fetch error when present with no recommendations', () => {
+    renderRecommendedTab({
+      missionFetchError: 'Connection refused',
+      recommendations: [],
+      loadingRecommendations: false,
+    })
+    expect(screen.getByTestId('fetch-error')).toHaveTextContent('Connection refused')
+  })
+
+  it('hides fetch error when loading recommendations', () => {
+    renderRecommendedTab({
+      missionFetchError: 'Connection refused',
+      loadingRecommendations: true,
+      recommendations: [],
+    })
+    expect(screen.queryByTestId('fetch-error')).not.toBeInTheDocument()
+  })
+
+  it('hides fetch error when recommendations are present', () => {
+    renderRecommendedTab({
+      missionFetchError: 'Connection refused',
+      recommendations: [MATCH],
+      filteredRecommendations: [MATCH],
+    })
+    expect(screen.queryByTestId('fetch-error')).not.toBeInTheDocument()
+  })
+
+  // ── Recommendations section ─────────────────────────────────────────────────
+
+  it('renders CollapsibleSection with "Recommended for Your Cluster" when hasCluster', () => {
+    renderRecommendedTab({
+      recommendations: [MATCH],
+      filteredRecommendations: [MATCH],
+      hasCluster: true,
+    })
+    expect(screen.getByText('Recommended for Your Cluster')).toBeInTheDocument()
+  })
+
+  it('renders CollapsibleSection with "Explore CNCF Fixes" when no cluster', () => {
+    renderRecommendedTab({
+      recommendations: [MATCH],
+      filteredRecommendations: [MATCH],
+      hasCluster: false,
+    })
+    expect(screen.getByText('Explore CNCF Fixes')).toBeInTheDocument()
+  })
+
+  it('renders recommendation cards for filteredRecommendations', () => {
+    renderRecommendedTab({
+      recommendations: [MATCH],
+      filteredRecommendations: [MATCH],
+    })
+    expect(screen.getByTestId('recommendation-card')).toBeInTheDocument()
+  })
+
+  it('calls onSelectMission when a recommendation card is selected', () => {
+    const onSelectMission = vi.fn()
+    renderRecommendedTab({
+      recommendations: [MATCH],
+      filteredRecommendations: [MATCH],
+      onSelectMission,
+    })
+    fireEvent.click(screen.getByText('Select Fix DNS'))
+    expect(onSelectMission).toHaveBeenCalledWith(MISSION)
+  })
+
+  it('shows no recommendations section when recommendations list is empty', () => {
+    renderRecommendedTab({ recommendations: [], filteredRecommendations: [] })
+    expect(screen.queryByTestId('collapsible-section')).not.toBeInTheDocument()
+  })
+
+  // ── Loading state ───────────────────────────────────────────────────────────
+
+  it('shows Connecting step text when loadingRecommendations and step is Connecting', () => {
+    renderRecommendedTab({
+      loadingRecommendations: true,
+      recommendations: [MATCH],
+      filteredRecommendations: [],
+      searchProgress: { step: 'Connecting', detail: '', found: 0, scanned: 0 },
+    })
+    expect(screen.getByText('Connecting to knowledge base…')).toBeInTheDocument()
+  })
+
+  it('shows scanned count when found > 0 during loading', () => {
+    renderRecommendedTab({
+      loadingRecommendations: true,
+      recommendations: [MATCH],
+      filteredRecommendations: [],
+      searchProgress: { step: 'Scanning', detail: 'fixes/', found: 5, scanned: 10 },
+    })
+    expect(screen.getByText(/5 found · 10 scanned/)).toBeInTheDocument()
+  })
+
+  // ── Directory listing ───────────────────────────────────────────────────────
+
+  it('shows loading spinner when loading=true', () => {
+    const { container } = renderRecommendedTab({ loading: true })
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('renders DirectoryListing when filteredEntries is non-empty', () => {
+    renderRecommendedTab({ filteredEntries: [DIR_ENTRY], loading: false })
+    expect(screen.getByTestId('directory-listing')).toBeInTheDocument()
+    expect(screen.getByText('networking')).toBeInTheDocument()
+  })
+
+  it('calls onToggleNode and onSelectNode when a directory entry is clicked', () => {
+    const onToggleNode = vi.fn()
+    const onSelectNode = vi.fn()
+    renderRecommendedTab({
+      filteredEntries: [DIR_ENTRY],
+      loading: false,
+      onToggleNode,
+      onSelectNode,
+    })
+    fireEvent.click(screen.getByText('networking'))
+    expect(onToggleNode).toHaveBeenCalled()
+    expect(onSelectNode).toHaveBeenCalled()
+  })
+
+  it('shows "No files in this directory" when selectedPath set but no entries', () => {
+    renderRecommendedTab({ filteredEntries: [], selectedPath: 'fixes/networking', loading: false })
+    expect(screen.getByTestId('empty-state')).toHaveTextContent('No files in this directory')
+  })
+
+  it('shows "Select a folder" message when no selectedPath and no entries', () => {
+    renderRecommendedTab({ filteredEntries: [], selectedPath: null, loading: false })
+    expect(screen.getByTestId('empty-state')).toHaveTextContent('Select a folder from the sidebar to browse missions')
+  })
+
+  // ── Browse on GitHub link ───────────────────────────────────────────────────
+
+  it('shows Browse on GitHub link when not loading', () => {
+    renderRecommendedTab({ loading: false })
+    expect(screen.getByText('Browse all fixes on GitHub')).toBeInTheDocument()
+  })
+
+  it('hides Browse on GitHub link when loading', () => {
+    renderRecommendedTab({ loading: true })
+    expect(screen.queryByText('Browse all fixes on GitHub')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/missions/__tests__/MissionBrowserScheduleActionTab.test.tsx
+++ b/web/src/components/missions/__tests__/MissionBrowserScheduleActionTab.test.tsx
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+const { mockShowToast, mockGetState, mockCreateAction } = vi.hoisted(() => ({
+  mockShowToast: vi.fn(),
+  mockGetState: vi.fn(),
+  mockCreateAction: vi.fn(),
+}))
+
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}))
+
+vi.mock('../../../services/stellar', () => ({
+  stellarApi: {
+    getState: mockGetState,
+    createAction: mockCreateAction,
+  },
+}))
+
+import { MissionBrowserScheduleActionTab } from '../MissionBrowserScheduleActionTab'
+
+function renderScheduleTab(isActive = true) {
+  return render(<MissionBrowserScheduleActionTab isActive={isActive} />)
+}
+
+describe('MissionBrowserScheduleActionTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetState.mockResolvedValue({ clustersWatching: ['cluster-a', 'cluster-b'] })
+    mockCreateAction.mockResolvedValue({})
+  })
+
+  // ── Initial render ──────────────────────────────────────────────────────────
+
+  it('renders the Schedule Action heading', () => {
+    renderScheduleTab()
+    expect(screen.getByText('Schedule Action')).toBeInTheDocument()
+  })
+
+  it('renders the Create action submit button', () => {
+    renderScheduleTab()
+    expect(screen.getByRole('button', { name: 'Create action' })).toBeInTheDocument()
+  })
+
+  it('renders Action type dropdown with ScaleDeployment as default', () => {
+    renderScheduleTab()
+    expect(screen.getByDisplayValue('Scale Deployment')).toBeInTheDocument()
+  })
+
+  it('does not load clusters when isActive=false', () => {
+    renderScheduleTab(false)
+    expect(mockGetState).not.toHaveBeenCalled()
+  })
+
+  it('loads clusters when isActive=true', async () => {
+    renderScheduleTab(true)
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled())
+  })
+
+  it('populates cluster dropdown from API state', async () => {
+    renderScheduleTab(true)
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'cluster-a' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'cluster-b' })).toBeInTheDocument()
+    })
+  })
+
+  it('shows "No clusters available" when API returns empty list', async () => {
+    mockGetState.mockResolvedValue({ clustersWatching: [] })
+    renderScheduleTab(true)
+    await waitFor(() => {
+      expect(screen.getByText('No clusters available')).toBeInTheDocument()
+    })
+  })
+
+  // ── Action types ────────────────────────────────────────────────────────────
+
+  it('renders all 5 action type options', () => {
+    renderScheduleTab()
+    expect(screen.getByRole('option', { name: 'Scale Deployment' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Restart Deployment' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Delete Pod' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Cordon Node' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Delete Cluster' })).toBeInTheDocument()
+  })
+
+  it('shows Namespace and Deployment name fields for ScaleDeployment', () => {
+    renderScheduleTab()
+    expect(screen.getByText('Namespace')).toBeInTheDocument()
+    expect(screen.getByText('Deployment name')).toBeInTheDocument()
+  })
+
+  it('shows Replicas field for ScaleDeployment', () => {
+    renderScheduleTab()
+    expect(screen.getByText('Replicas (0–50)')).toBeInTheDocument()
+  })
+
+  it('shows Node name field when CordonNode is selected', async () => {
+    renderScheduleTab()
+    fireEvent.change(screen.getByDisplayValue('Scale Deployment'), { target: { value: 'CordonNode' } })
+    await waitFor(() => expect(screen.getByText('Node name')).toBeInTheDocument())
+  })
+
+  it('shows Confirm token field when DeleteCluster is selected', async () => {
+    renderScheduleTab()
+    fireEvent.change(screen.getByDisplayValue('Scale Deployment'), { target: { value: 'DeleteCluster' } })
+    await waitFor(() => expect(screen.getByText('Confirm token')).toBeInTheDocument())
+  })
+
+  it('shows Pod name label for DeletePod action', async () => {
+    renderScheduleTab()
+    fireEvent.change(screen.getByDisplayValue('Scale Deployment'), { target: { value: 'DeletePod' } })
+    await waitFor(() => expect(screen.getByText('Pod name')).toBeInTheDocument())
+  })
+
+  it('hides namespace/name fields for CordonNode', async () => {
+    renderScheduleTab()
+    fireEvent.change(screen.getByDisplayValue('Scale Deployment'), { target: { value: 'CordonNode' } })
+    await waitFor(() => {
+      expect(screen.queryByText('Namespace')).not.toBeInTheDocument()
+      expect(screen.queryByText('Deployment name')).not.toBeInTheDocument()
+    })
+  })
+
+  // ── Destructive warning ─────────────────────────────────────────────────────
+
+  it('shows destructive warning for DeletePod', async () => {
+    renderScheduleTab()
+    fireEvent.change(screen.getByDisplayValue('Scale Deployment'), { target: { value: 'DeletePod' } })
+    await waitFor(() => {
+      expect(screen.getByText(/This action is destructive/)).toBeInTheDocument()
+    })
+  })
+
+  it('shows destructive warning for DeleteCluster', async () => {
+    renderScheduleTab()
+    fireEvent.change(screen.getByDisplayValue('Scale Deployment'), { target: { value: 'DeleteCluster' } })
+    await waitFor(() => {
+      expect(screen.getByText(/This action is destructive/)).toBeInTheDocument()
+    })
+  })
+
+  it('does not show destructive warning for ScaleDeployment', () => {
+    renderScheduleTab()
+    expect(screen.queryByText(/This action is destructive/)).not.toBeInTheDocument()
+  })
+
+  // ── Schedule mode ───────────────────────────────────────────────────────────
+
+  it('renders "After approval" and "Scheduled time" radio options', () => {
+    renderScheduleTab()
+    expect(screen.getByLabelText('After approval')).toBeInTheDocument()
+    expect(screen.getByLabelText('Scheduled time')).toBeInTheDocument()
+  })
+
+  it('defaults to after-approval mode', () => {
+    renderScheduleTab()
+    const afterApproval = screen.getByLabelText('After approval') as HTMLInputElement
+    expect(afterApproval.checked).toBe(true)
+  })
+
+  it('shows datetime input when Scheduled time is selected', async () => {
+    renderScheduleTab()
+    fireEvent.click(screen.getByLabelText('Scheduled time'))
+    await waitFor(() => {
+      expect(document.querySelector('input[type="datetime-local"]')).toBeInTheDocument()
+    })
+  })
+
+  // ── Form validation & submission ────────────────────────────────────────────
+
+  it('shows warning toast when submitting without a cluster selected', async () => {
+    mockGetState.mockResolvedValue({ clustersWatching: [] })
+    renderScheduleTab(true)
+    await waitFor(() => expect(screen.getByText('No clusters available')).toBeInTheDocument())
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create action' }))
+    })
+    expect(mockShowToast).toHaveBeenCalledWith('Select a cluster first.', 'warning')
+  })
+
+  it('calls stellarApi.createAction on valid submission', async () => {
+    renderScheduleTab(true)
+    await waitFor(() => expect(screen.getByRole('option', { name: 'cluster-a' })).toBeInTheDocument())
+
+    fireEvent.change(screen.getByLabelText('Cluster'), { target: { value: 'cluster-a' } })
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: 'Create action' }).closest('form')!)
+    })
+
+    await waitFor(() => expect(mockCreateAction).toHaveBeenCalled())
+  })
+
+  it('shows success toast after successful action creation', async () => {
+    renderScheduleTab(true)
+    await waitFor(() => expect(screen.getByRole('option', { name: 'cluster-a' })).toBeInTheDocument())
+
+    fireEvent.change(screen.getByLabelText('Cluster'), { target: { value: 'cluster-a' } })
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: 'Create action' }).closest('form')!)
+    })
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        'Action created — waiting for approval in Stellar panel.',
+        'success',
+      )
+    })
+  })
+
+  it('shows error toast when createAction fails', async () => {
+    mockCreateAction.mockRejectedValue(new Error('Server error'))
+    renderScheduleTab(true)
+    await waitFor(() => expect(screen.getByRole('option', { name: 'cluster-a' })).toBeInTheDocument())
+
+    fireEvent.change(screen.getByLabelText('Cluster'), { target: { value: 'cluster-a' } })
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: 'Create action' }).closest('form')!)
+    })
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith('Server error', 'error')
+    })
+  })
+
+  it('disables submit button while submitting', async () => {
+    let resolveCreate!: () => void
+    mockCreateAction.mockReturnValue(new Promise<void>((res) => { resolveCreate = res }))
+
+    renderScheduleTab(true)
+    await waitFor(() => expect(screen.getByRole('option', { name: 'cluster-a' })).toBeInTheDocument())
+    fireEvent.change(screen.getByLabelText('Cluster'), { target: { value: 'cluster-a' } })
+
+    act(() => {
+      fireEvent.submit(screen.getByRole('button', { name: 'Create action' }).closest('form')!)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Creating…' })).toBeDisabled()
+    })
+
+    resolveCreate()
+  })
+})

--- a/web/src/components/missions/__tests__/MissionBrowserTabBar.test.tsx
+++ b/web/src/components/missions/__tests__/MissionBrowserTabBar.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+const { mockMissionCache, mockResetMissionCache } = vi.hoisted(() => ({
+  mockMissionCache: { installersDone: true, fixesDone: true },
+  mockResetMissionCache: vi.fn(),
+}))
+
+vi.mock('../browser', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../browser')>()
+  return {
+    ...actual,
+    BROWSER_TABS: [
+      { id: 'recommended', label: 'Recommended', icon: '🔍' },
+      { id: 'installers', label: 'Installers', icon: '📦' },
+      { id: 'fixes', label: 'Fixes', icon: '🔧' },
+      { id: 'schedule', label: 'Schedule Action', icon: '🗓️' },
+    ],
+    missionCache: mockMissionCache,
+    resetMissionCache: mockResetMissionCache,
+  }
+})
+
+import { MissionBrowserTabBar } from '../MissionBrowserTabBar'
+
+function renderTabBar(overrides: Partial<React.ComponentProps<typeof MissionBrowserTabBar>> = {}) {
+  const props = {
+    activeTab: 'recommended' as const,
+    onTabChange: vi.fn(),
+    installerCount: 0,
+    fixerCount: 0,
+    ...overrides,
+  }
+  return { ...render(<MissionBrowserTabBar {...props} />), props }
+}
+
+describe('MissionBrowserTabBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMissionCache.installersDone = true
+    mockMissionCache.fixesDone = true
+  })
+
+  // ── Rendering ───────────────────────────────────────────────────────────────
+
+  it('renders all 4 tab buttons', () => {
+    renderTabBar()
+    expect(screen.getByText('Recommended')).toBeInTheDocument()
+    expect(screen.getByText('Installers')).toBeInTheDocument()
+    expect(screen.getByText('Fixes')).toBeInTheDocument()
+    expect(screen.getByText('Schedule Action')).toBeInTheDocument()
+  })
+
+  it('renders the refresh button', () => {
+    renderTabBar()
+    const buttons = screen.getAllByRole('button')
+    expect(buttons.length).toBe(5) // 4 tabs + 1 refresh
+  })
+
+  it('renders tab icons', () => {
+    renderTabBar()
+    expect(screen.getByText('🔍')).toBeInTheDocument()
+    expect(screen.getByText('📦')).toBeInTheDocument()
+    expect(screen.getByText('🔧')).toBeInTheDocument()
+    expect(screen.getByText('🗓️')).toBeInTheDocument()
+  })
+
+  // ── Active tab styling ──────────────────────────────────────────────────────
+
+  it('highlights the active tab with purple styling', () => {
+    renderTabBar({ activeTab: 'fixes' })
+    const fixesBtn = screen.getByText('Fixes').closest('button')!
+    expect(fixesBtn.className).toContain('bg-purple-500/20')
+    expect(fixesBtn.className).toContain('text-purple-400')
+  })
+
+  it('does not highlight inactive tabs', () => {
+    renderTabBar({ activeTab: 'recommended' })
+    const installersBtn = screen.getByText('Installers').closest('button')!
+    expect(installersBtn.className).not.toContain('bg-purple-500/20')
+  })
+
+  // ── Count badges ────────────────────────────────────────────────────────────
+
+  it('shows installer count badge when installerCount > 0', () => {
+    renderTabBar({ installerCount: 12 })
+    expect(screen.getByText('12')).toBeInTheDocument()
+  })
+
+  it('shows dash for installer count when installerCount is 0', () => {
+    renderTabBar({ installerCount: 0 })
+    const badges = screen.getAllByText('–')
+    expect(badges.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows fixer count badge when fixerCount > 0', () => {
+    renderTabBar({ fixerCount: 7 })
+    expect(screen.getByText('7')).toBeInTheDocument()
+  })
+
+  it('shows dash for fixer count when fixerCount is 0', () => {
+    renderTabBar({ fixerCount: 0 })
+    const badges = screen.getAllByText('–')
+    expect(badges.length).toBeGreaterThanOrEqual(1)
+  })
+
+  // ── Tab click ───────────────────────────────────────────────────────────────
+
+  it('calls onTabChange with the clicked tab id', () => {
+    const onTabChange = vi.fn()
+    renderTabBar({ onTabChange })
+    fireEvent.click(screen.getByText('Fixes'))
+    expect(onTabChange).toHaveBeenCalledWith('fixes')
+  })
+
+  it('calls onTabChange with installers tab id', () => {
+    const onTabChange = vi.fn()
+    renderTabBar({ onTabChange })
+    fireEvent.click(screen.getByText('Installers'))
+    expect(onTabChange).toHaveBeenCalledWith('installers')
+  })
+
+  it('calls onTabChange with recommended tab id', () => {
+    const onTabChange = vi.fn()
+    renderTabBar({ onTabChange })
+    fireEvent.click(screen.getByText('Recommended'))
+    expect(onTabChange).toHaveBeenCalledWith('recommended')
+  })
+
+  // ── Refresh button ──────────────────────────────────────────────────────────
+
+  it('calls resetMissionCache when refresh button is clicked', () => {
+    renderTabBar()
+    const buttons = screen.getAllByRole('button')
+    const refreshBtn = buttons[buttons.length - 1]
+    fireEvent.click(refreshBtn)
+    expect(mockResetMissionCache).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows "Refresh installers" title when installers tab is active', () => {
+    renderTabBar({ activeTab: 'installers' })
+    const buttons = screen.getAllByRole('button')
+    const refreshBtn = buttons[buttons.length - 1]
+    expect(refreshBtn.title).toBe('Refresh installers')
+  })
+
+  it('shows "Refresh fixes" title when fixes tab is active', () => {
+    renderTabBar({ activeTab: 'fixes' })
+    const buttons = screen.getAllByRole('button')
+    const refreshBtn = buttons[buttons.length - 1]
+    expect(refreshBtn.title).toBe('Refresh fixes')
+  })
+
+  it('shows "Refresh all mission data" title for other tabs', () => {
+    renderTabBar({ activeTab: 'recommended' })
+    const buttons = screen.getAllByRole('button')
+    const refreshBtn = buttons[buttons.length - 1]
+    expect(refreshBtn.title).toBe('Refresh all mission data')
+  })
+
+  // ── Refresh spinner (isRefreshing) ──────────────────────────────────────────
+
+  it('spins refresh icon when installers tab is active and installersDone=false', () => {
+    mockMissionCache.installersDone = false
+    const { container } = renderTabBar({ activeTab: 'installers' })
+    const svg = container.querySelector('.animate-spin')
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('spins refresh icon when fixes tab is active and fixesDone=false', () => {
+    mockMissionCache.fixesDone = false
+    const { container } = renderTabBar({ activeTab: 'fixes' })
+    const svg = container.querySelector('.animate-spin')
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('does not spin when schedule tab is active', () => {
+    mockMissionCache.installersDone = false
+    mockMissionCache.fixesDone = false
+    const { container } = renderTabBar({ activeTab: 'schedule' })
+    expect(container.querySelector('.animate-spin')).not.toBeInTheDocument()
+  })
+
+  it('does not spin when cache is done', () => {
+    mockMissionCache.installersDone = true
+    mockMissionCache.fixesDone = true
+    const { container } = renderTabBar({ activeTab: 'recommended' })
+    expect(container.querySelector('.animate-spin')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
> **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.

> **New CNCF project card?** New cards go in [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo. PRs adding new cards here will be redirected.

> **Use a coding agent.** This repo is primarily developed with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Opus 4.5/4.6). It knows all codebase patterns (isDemoData, useCardLoadingState, locale strings, DCO). Manual PRs that miss required patterns will be sent back.




### 📌 Fixes

Fixes N/A

---

### 📝 Summary of Changes

* Added comprehensive Vitest unit test suites for all major MissionBrowser tab components
* Covered loading, empty, error, and populated render states across all tabs
* Added interaction coverage for filters, actions, callbacks, scheduling flows, and conditional rendering paths
* Standardized mock initialization using `vi.hoisted()` for factories referencing outer-scoped variables

---

### Changes Made

* [x] Added `MissionBrowserTabBar` Vitest suite with coverage for:

  * tab rendering and active state styling
  * count badges (`0 → -`, positive counts)
  * refresh button behavior
  * loading spinner animation
  * tooltip titles and click callbacks

* [x] Added `MissionBrowserFixesTab` Vitest suite with coverage for:

  * search and filter interactions
  * loading and progressive count states
  * empty/error states
  * fixer card rendering
  * select/import callbacks
  * footer counts

* [x] Added `MissionBrowserInstallersTab` Vitest suite with coverage for:

  * search and category filtering
  * maturity filter label formatting
  * loading/empty/error states
  * installer card rendering
  * footer counts

* [x] Added `MissionBrowserRecommendedTab` Vitest suite with coverage for:

  * rate-limited/token-invalid banners
  * GitHub token links
  * fetch error handling
  * collapsible section rendering
  * recommendation cards
  * cluster scanning/loading states
  * directory browsing callbacks
  * empty states and GitHub navigation links

* [x] Added `MissionBrowserScheduleActionTab` Vitest suite with coverage for:

  * all supported action types
  * conditional form fields
  * destructive action warnings
  * schedule mode switching
  * datetime input handling
  * validation and toast flows
  * success/error submission handling
  * disabled submit state during async actions

* [x] Refactored test mocks to correctly use `vi.hoisted()` for:

  * `missionCache`
  * `resetMissionCache`
  * `stellarApi`
  * `showToast`

* [x] Added a total of 109 passing tests across 5 new test files

---

### Checklist

Please ensure the following before submitting your PR:

* [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
* [x] I have reviewed the project's contribution guidelines
* [x] New cards target [[console-marketplace](https://github.com/kubestellar/console-marketplace)](https://github.com/kubestellar/console-marketplace), not this repo
* [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
* [x] I have written unit tests for the changes (if applicable)
* [x] I have tested the changes locally and ensured they work as expected
* [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

* `npx vitest run` passes for all 5 MissionBrowser tab test suites locally
* No production UI/component code modified

---

### 👀 Reviewer Notes

* This PR only adds test coverage; no runtime or production behavior changes were introduced
* Full render lifecycle coverage included for each tab component:
  `loading → empty → error → populated`