### PR TITLE
fix: require admin role on GetAuditLog to prevent IDOR

### DIFF
--- a/pkg/api/handlers/audit.go
+++ b/pkg/api/handlers/audit.go
@@ -36,6 +36,9 @@ func (h *AuditHandler) GetAuditLog(c *fiber.Ctx) error {
 	if isDemoMode(c) {
 		return c.JSON(make([]store.AuditEntry, 0))
 	}
+	if err := requireAdmin(c, h.store); err != nil {
+		return err
+	}
 
 	limit := defaultAuditLimit
 	if q := c.Query("limit"); q != "" {


### PR DESCRIPTION
## Summary

- `GetAuditLog` at `/admin/audit-log` was missing a `requireAdmin` check, allowing any authenticated user to read all audit entries
- Added `requireAdmin(c, h.store)` after the demo mode guard, consistent with every other `/admin/*` handler
- Non-admin requests now receive a 403 response

## Root cause

`pkg/api/handlers/audit.go` checked demo mode but never verified the caller's role, so any valid session token was enough to enumerate audit logs for any user via `?user_id=<target>`.

## Test plan

- [ ] Authenticated non-admin user gets 403 on `GET /admin/audit-log`
- [ ] Admin user gets 200 with audit entries
- [ ] Demo mode still returns empty array regardless of role

Fixes #14445