### PR TITLE
test(ui): add Vitest suites for useMissionFilters, useMissionRecommendations, and useMissionTree hooks

### DIFF
--- a/web/src/components/missions/__tests__/useMissionFilters.test.ts
+++ b/web/src/components/missions/__tests__/useMissionFilters.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { MissionExport, MissionMatch } from '../../../lib/missions/types'
+import { useMissionFilters } from '../useMissionFilters'
+
+function makeMission(overrides: Partial<MissionExport> = {}): MissionExport {
+  return {
+    id: 'test-mission',
+    title: 'Test Mission',
+    description: 'A test mission',
+    type: 'fixer',
+    source: 'community',
+    content: '',
+    tags: [],
+    version: '1.0',
+    author: 'test',
+    ...overrides,
+  } as unknown as MissionExport
+}
+
+function makeMatch(mission: MissionExport, score = 0.8, matchPercent?: number): MissionMatch {
+  return { mission, score, matchPercent: matchPercent ?? Math.round(score * 100), reason: 'test' } as unknown as MissionMatch
+}
+
+const INSTALLER = makeMission({ id: 'inst-1', title: 'Istio Installer', type: 'installer', category: 'Networking', tags: ['graduated'] })
+const INSTALLER2 = makeMission({ id: 'inst-2', title: 'Envoy Proxy', type: 'installer', category: 'Storage', tags: ['sandbox'] })
+const FIXER = makeMission({ id: 'fix-1', title: 'Fix DNS', type: 'fixer' })
+const FIXER2 = makeMission({ id: 'fix-2', title: 'Fix Network', type: 'troubleshoot' })
+const MATCH_HIGH = makeMatch(FIXER, 0.9, 90)
+const MATCH_LOW = makeMatch(FIXER2, 0.1, 10)
+
+function renderFilters(
+  recommendations: MissionMatch[] = [],
+  installerMissions: MissionExport[] = [],
+  fixerMissions: MissionExport[] = [],
+) {
+  return renderHook(() => useMissionFilters({ recommendations, installerMissions, fixerMissions }))
+}
+
+describe('useMissionFilters', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  // ── Initial state ─────────────────────────────────────────────────────────
+
+  it('initialises searchQuery to empty string', () => {
+    const { result } = renderFilters()
+    expect(result.current.searchQuery).toBe('')
+  })
+
+  it('initialises all category/type filters to "All"', () => {
+    const { result } = renderFilters()
+    expect(result.current.categoryFilter).toBe('All')
+    expect(result.current.installerCategoryFilter).toBe('All')
+    expect(result.current.installerMaturityFilter).toBe('All')
+    expect(result.current.fixerTypeFilter).toBe('All')
+    expect(result.current.maturityFilter).toBe('All')
+    expect(result.current.missionClassFilter).toBe('All')
+    expect(result.current.difficultyFilter).toBe('All')
+  })
+
+  it('initialises matchSourceFilter to "all"', () => {
+    const { result } = renderFilters()
+    expect(result.current.matchSourceFilter).toBe('all')
+  })
+
+  it('initialises minMatchPercent to 25', () => {
+    const { result } = renderFilters()
+    expect(result.current.minMatchPercent).toBe(25)
+  })
+
+  it('initialises selectedTags to empty Set', () => {
+    const { result } = renderFilters()
+    expect(result.current.selectedTags.size).toBe(0)
+  })
+
+  it('initialises cncfFilter to empty string', () => {
+    const { result } = renderFilters()
+    expect(result.current.cncfFilter).toBe('')
+  })
+
+  it('initialises installerSearch and fixerSearch to empty strings', () => {
+    const { result } = renderFilters()
+    expect(result.current.installerSearch).toBe('')
+    expect(result.current.fixerSearch).toBe('')
+  })
+
+  // ── handleInstallerSearchChange ───────────────────────────────────────────
+
+  it('handleInstallerSearchChange updates installerSearch', () => {
+    const { result } = renderFilters([], [INSTALLER], [])
+    act(() => { result.current.handleInstallerSearchChange('istio') })
+    expect(result.current.installerSearch).toBe('istio')
+  })
+
+  it('handleInstallerSearchChange clears searchQuery when both would be set', () => {
+    const { result } = renderFilters([], [INSTALLER], [])
+    act(() => { result.current.setSearchQuery('global') })
+    act(() => { result.current.handleInstallerSearchChange('istio') })
+    expect(result.current.searchQuery).toBe('')
+    expect(result.current.installerSearch).toBe('istio')
+  })
+
+  it('handleInstallerSearchChange does not clear searchQuery when empty value passed', () => {
+    const { result } = renderFilters([], [INSTALLER], [])
+    act(() => { result.current.setSearchQuery('global') })
+    act(() => { result.current.handleInstallerSearchChange('') })
+    expect(result.current.searchQuery).toBe('global')
+  })
+
+  // ── handleFixerSearchChange ───────────────────────────────────────────────
+
+  it('handleFixerSearchChange updates fixerSearch', () => {
+    const { result } = renderFilters([], [], [FIXER])
+    act(() => { result.current.handleFixerSearchChange('dns') })
+    expect(result.current.fixerSearch).toBe('dns')
+  })
+
+  it('handleFixerSearchChange clears searchQuery when both would be set', () => {
+    const { result } = renderFilters([], [], [FIXER])
+    act(() => { result.current.setSearchQuery('global') })
+    act(() => { result.current.handleFixerSearchChange('dns') })
+    expect(result.current.searchQuery).toBe('')
+    expect(result.current.fixerSearch).toBe('dns')
+  })
+
+  it('handleFixerSearchChange does not clear searchQuery when empty value passed', () => {
+    const { result } = renderFilters([], [], [FIXER])
+    act(() => { result.current.setSearchQuery('global') })
+    act(() => { result.current.handleFixerSearchChange('') })
+    expect(result.current.searchQuery).toBe('global')
+  })
+
+  // ── filteredInstallers ────────────────────────────────────────────────────
+
+  it('filteredInstallers returns all missions when no filters set', () => {
+    const { result } = renderFilters([], [INSTALLER, INSTALLER2], [])
+    expect(result.current.filteredInstallers).toHaveLength(2)
+  })
+
+  it('filteredInstallers filters by category', () => {
+    const { result } = renderFilters([], [INSTALLER, INSTALLER2], [])
+    act(() => { result.current.setInstallerCategoryFilter('Networking') })
+    expect(result.current.filteredInstallers).toHaveLength(1)
+    expect(result.current.filteredInstallers[0].id).toBe('inst-1')
+  })
+
+  it('filteredInstallers filters by maturity tag', () => {
+    const { result } = renderFilters([], [INSTALLER, INSTALLER2], [])
+    act(() => { result.current.setInstallerMaturityFilter('graduated') })
+    expect(result.current.filteredInstallers).toHaveLength(1)
+    expect(result.current.filteredInstallers[0].id).toBe('inst-1')
+  })
+
+  it('filteredInstallers filters by local installerSearch text', () => {
+    const { result } = renderFilters([], [INSTALLER, INSTALLER2], [])
+    act(() => { result.current.handleInstallerSearchChange('istio') })
+    expect(result.current.filteredInstallers).toHaveLength(1)
+    expect(result.current.filteredInstallers[0].id).toBe('inst-1')
+  })
+
+  it('filteredInstallers uses global searchQuery when installerSearch is empty', () => {
+    const { result } = renderFilters([], [INSTALLER, INSTALLER2], [])
+    act(() => { result.current.setSearchQuery('istio') })
+    expect(result.current.filteredInstallers).toHaveLength(1)
+    expect(result.current.filteredInstallers[0].id).toBe('inst-1')
+  })
+
+  // ── filteredFixers ────────────────────────────────────────────────────────
+
+  it('filteredFixers returns all fixers when no filters set', () => {
+    const { result } = renderFilters([], [], [FIXER, FIXER2])
+    expect(result.current.filteredFixers).toHaveLength(2)
+  })
+
+  it('filteredFixers filters by type', () => {
+    const { result } = renderFilters([], [], [FIXER, FIXER2])
+    act(() => { result.current.setFixerTypeFilter('troubleshoot') })
+    expect(result.current.filteredFixers).toHaveLength(1)
+    expect(result.current.filteredFixers[0].id).toBe('fix-2')
+  })
+
+  it('filteredFixers filters by local fixerSearch text', () => {
+    const { result } = renderFilters([], [], [FIXER, FIXER2])
+    act(() => { result.current.handleFixerSearchChange('dns') })
+    expect(result.current.filteredFixers).toHaveLength(1)
+    expect(result.current.filteredFixers[0].id).toBe('fix-1')
+  })
+
+  it('filteredFixers uses global searchQuery when fixerSearch is empty', () => {
+    const { result } = renderFilters([], [], [FIXER, FIXER2])
+    act(() => { result.current.setSearchQuery('network') })
+    expect(result.current.filteredFixers).toHaveLength(1)
+    expect(result.current.filteredFixers[0].id).toBe('fix-2')
+  })
+
+  // ── filteredRecommendations ───────────────────────────────────────────────
+
+  it('filteredRecommendations returns all at 0% minMatchPercent', () => {
+    const { result } = renderFilters([MATCH_HIGH, MATCH_LOW], [], [FIXER, FIXER2])
+    act(() => { result.current.setMinMatchPercent(0) })
+    expect(result.current.filteredRecommendations).toHaveLength(2)
+  })
+
+  it('filteredRecommendations filters out low-score matches', () => {
+    const { result } = renderFilters([MATCH_HIGH, MATCH_LOW], [], [FIXER, FIXER2])
+    act(() => { result.current.setMinMatchPercent(50) })
+    expect(result.current.filteredRecommendations).toHaveLength(1)
+    expect(result.current.filteredRecommendations[0].mission.id).toBe('fix-1')
+  })
+
+  it('filteredRecommendations filters by text searchQuery', () => {
+    const { result } = renderFilters([MATCH_HIGH, MATCH_LOW], [], [FIXER, FIXER2])
+    act(() => {
+      result.current.setMinMatchPercent(0)
+      result.current.setSearchQuery('dns')
+    })
+    expect(result.current.filteredRecommendations).toHaveLength(1)
+    expect(result.current.filteredRecommendations[0].mission.id).toBe('fix-1')
+  })
+
+  // ── clearAllFilters ───────────────────────────────────────────────────────
+
+  it('clearAllFilters resets all filter state to defaults', () => {
+    const { result } = renderFilters([MATCH_HIGH], [INSTALLER], [FIXER])
+    act(() => {
+      result.current.setMinMatchPercent(80)
+      result.current.setCategoryFilter('Networking')
+      result.current.setMaturityFilter('graduated')
+      result.current.setMissionClassFilter('installer')
+      result.current.setDifficultyFilter('easy')
+      result.current.setMatchSourceFilter('cluster')
+      result.current.setCncfFilter('prometheus')
+      result.current.setSearchQuery('test')
+      result.current.setSelectedTags(new Set(['tag1']))
+    })
+    act(() => { result.current.clearAllFilters() })
+    expect(result.current.minMatchPercent).toBe(0)
+    expect(result.current.categoryFilter).toBe('All')
+    expect(result.current.maturityFilter).toBe('All')
+    expect(result.current.missionClassFilter).toBe('All')
+    expect(result.current.difficultyFilter).toBe('All')
+    expect(result.current.matchSourceFilter).toBe('all')
+    expect(result.current.cncfFilter).toBe('')
+    expect(result.current.searchQuery).toBe('')
+    expect(result.current.selectedTags.size).toBe(0)
+  })
+
+  // ── activeFilterCount ─────────────────────────────────────────────────────
+
+  it('activeFilterCount increases when a filter is set', () => {
+    const { result } = renderFilters()
+    const initial = result.current.activeFilterCount
+    act(() => { result.current.setCategoryFilter('Networking') })
+    expect(result.current.activeFilterCount).toBeGreaterThan(initial)
+  })
+
+  it('activeFilterCount decreases after clearAllFilters', () => {
+    const { result } = renderFilters()
+    act(() => {
+      result.current.setCategoryFilter('Networking')
+      result.current.setMaturityFilter('graduated')
+    })
+    const withFilters = result.current.activeFilterCount
+    act(() => { result.current.clearAllFilters() })
+    expect(result.current.activeFilterCount).toBeLessThan(withFilters)
+  })
+
+  // ── setSelectedTags ───────────────────────────────────────────────────────
+
+  it('setSelectedTags updates the tag Set', () => {
+    const { result } = renderFilters()
+    act(() => { result.current.setSelectedTags(new Set(['k8s', 'network'])) })
+    expect(result.current.selectedTags.has('k8s')).toBe(true)
+    expect(result.current.selectedTags.has('network')).toBe(true)
+  })
+
+  // ── facetCounts ───────────────────────────────────────────────────────────
+
+  it('facetCounts is defined for empty recommendations', () => {
+    const { result } = renderFilters()
+    expect(result.current.facetCounts).toBeDefined()
+  })
+
+  it('facetCounts is defined when recommendations are present', () => {
+    const { result } = renderFilters([MATCH_HIGH])
+    expect(result.current.facetCounts).toBeDefined()
+  })
+})

--- a/web/src/components/missions/__tests__/useMissionRecommendations.test.ts
+++ b/web/src/components/missions/__tests__/useMissionRecommendations.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import type { MissionExport, MissionMatch } from '../../../lib/missions/types'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const { mockMissionCache, mockGetCachedRecommendations, mockSetCachedRecommendations, mockStartMissionCacheFetch, mockMatchMissionsToCluster } = vi.hoisted(() => ({
+  mockMissionCache: {
+    installers: [] as MissionExport[],
+    fixes: [] as MissionExport[],
+    fetchError: null as string | null,
+    installersDone: false,
+    fixesDone: false,
+    listeners: new Set<() => void>(),
+  },
+  mockGetCachedRecommendations: vi.fn<() => MissionMatch[] | null>(() => null),
+  mockSetCachedRecommendations: vi.fn(),
+  mockStartMissionCacheFetch: vi.fn(),
+  mockMatchMissionsToCluster: vi.fn<() => MissionMatch[]>(() => []),
+}))
+
+vi.mock('../browser', () => ({
+  missionCache: mockMissionCache,
+  getCachedRecommendations: mockGetCachedRecommendations,
+  setCachedRecommendations: mockSetCachedRecommendations,
+  startMissionCacheFetch: mockStartMissionCacheFetch,
+}))
+
+vi.mock('../../../lib/missions/matcher', () => ({
+  matchMissionsToCluster: mockMatchMissionsToCluster,
+}))
+
+import { useMissionRecommendations } from '../useMissionRecommendations'
+
+const FIXER: MissionExport = {
+  id: 'fix-1',
+  title: 'Fix DNS',
+  type: 'fixer',
+} as unknown as MissionExport
+
+const FIXER2: MissionExport = {
+  id: 'fix-2',
+  title: 'Fix Network',
+  type: 'fixer',
+} as unknown as MissionExport
+
+const INSTALLER: MissionExport = {
+  id: 'inst-1',
+  title: 'Install Istio',
+  type: 'installer',
+} as unknown as MissionExport
+
+const MATCH: MissionMatch = { mission: FIXER, score: 0.9, reason: 'cluster match' } as unknown as MissionMatch
+
+describe('useMissionRecommendations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMissionCache.installers = []
+    mockMissionCache.fixes = []
+    mockMissionCache.fetchError = null
+    mockMissionCache.installersDone = false
+    mockMissionCache.fixesDone = false
+    mockMissionCache.listeners = new Set()
+    mockGetCachedRecommendations.mockReturnValue(null)
+    mockMatchMissionsToCluster.mockReturnValue([])
+  })
+
+  // ── isOpen=false guard ─────────────────────────────────────────────────────
+
+  it('does not call startMissionCacheFetch when isOpen=false', () => {
+    renderHook(() => useMissionRecommendations(false, null))
+    expect(mockStartMissionCacheFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns empty recommendations when isOpen=false', () => {
+    const { result } = renderHook(() => useMissionRecommendations(false, null))
+    expect(result.current.recommendations).toHaveLength(0)
+  })
+
+  it('returns empty installer and fixer missions when isOpen=false', () => {
+    const { result } = renderHook(() => useMissionRecommendations(false, null))
+    expect(result.current.installerMissions).toHaveLength(0)
+    expect(result.current.fixerMissions).toHaveLength(0)
+  })
+
+  it('does not register listeners when isOpen=false', () => {
+    renderHook(() => useMissionRecommendations(false, null))
+    expect(mockMissionCache.listeners.size).toBe(0)
+  })
+
+  // ── isOpen=true bootstrap ─────────────────────────────────────────────────
+
+  it('calls startMissionCacheFetch when isOpen=true', () => {
+    renderHook(() => useMissionRecommendations(true, null))
+    expect(mockStartMissionCacheFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('registers listeners on missionCache when isOpen=true', () => {
+    renderHook(() => useMissionRecommendations(true, null))
+    expect(mockMissionCache.listeners.size).toBeGreaterThan(0)
+  })
+
+  it('removes all listeners on unmount', () => {
+    const { unmount } = renderHook(() => useMissionRecommendations(true, null))
+    unmount()
+    expect(mockMissionCache.listeners.size).toBe(0)
+  })
+
+  // ── loadingRecommendations ─────────────────────────────────────────────────
+
+  it('sets loadingRecommendations=true when fixes empty and fixesDone=false', () => {
+    mockMissionCache.fixes = []
+    mockMissionCache.fixesDone = false
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.loadingRecommendations).toBe(true)
+  })
+
+  it('sets loadingRecommendations=false when fixes available', () => {
+    mockMissionCache.fixes = [FIXER]
+    mockMissionCache.fixesDone = true
+    mockMatchMissionsToCluster.mockReturnValue([MATCH])
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.loadingRecommendations).toBe(false)
+  })
+
+  // ── recommendations via cache ─────────────────────────────────────────────
+
+  it('uses cached recommendations when getCachedRecommendations returns a value', () => {
+    mockMissionCache.fixes = [FIXER]
+    mockGetCachedRecommendations.mockReturnValue([MATCH])
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.recommendations).toEqual([MATCH])
+    expect(mockMatchMissionsToCluster).not.toHaveBeenCalled()
+  })
+
+  it('calls matchMissionsToCluster when no cached recommendations', () => {
+    mockMissionCache.fixes = [FIXER]
+    mockGetCachedRecommendations.mockReturnValue(null)
+    mockMatchMissionsToCluster.mockReturnValue([MATCH])
+    renderHook(() => useMissionRecommendations(true, null))
+    expect(mockMatchMissionsToCluster).toHaveBeenCalledWith([FIXER], null)
+  })
+
+  it('sets recommendations from matchMissionsToCluster result', () => {
+    mockMissionCache.fixes = [FIXER]
+    mockGetCachedRecommendations.mockReturnValue(null)
+    mockMatchMissionsToCluster.mockReturnValue([MATCH])
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.recommendations).toEqual([MATCH])
+  })
+
+  it('calls setCachedRecommendations after matching', () => {
+    mockMissionCache.fixes = [FIXER]
+    mockGetCachedRecommendations.mockReturnValue(null)
+    mockMatchMissionsToCluster.mockReturnValue([MATCH])
+    renderHook(() => useMissionRecommendations(true, null))
+    expect(mockSetCachedRecommendations).toHaveBeenCalledWith([MATCH], null)
+  })
+
+  it('passes clusterContext to matchMissionsToCluster', () => {
+    mockMissionCache.fixes = [FIXER]
+    mockGetCachedRecommendations.mockReturnValue(null)
+    const cluster = { name: 'prod-cluster' } as any
+    renderHook(() => useMissionRecommendations(true, cluster))
+    expect(mockMatchMissionsToCluster).toHaveBeenCalledWith([FIXER], cluster)
+  })
+
+  // ── hasCluster ─────────────────────────────────────────────────────────────
+
+  it('hasCluster=false when clusterContext is null', () => {
+    mockMissionCache.fixes = [FIXER]
+    mockMatchMissionsToCluster.mockReturnValue([MATCH])
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.hasCluster).toBe(false)
+  })
+
+  it('hasCluster=true when clusterContext is provided', () => {
+    mockMissionCache.fixes = [FIXER]
+    mockMatchMissionsToCluster.mockReturnValue([MATCH])
+    const cluster = { name: 'test-cluster' } as any
+    const { result } = renderHook(() => useMissionRecommendations(true, cluster))
+    expect(result.current.hasCluster).toBe(true)
+  })
+
+  // ── loadingInstallers / loadingFixers ──────────────────────────────────────
+
+  it('loadingInstallers=true when installersDone=false', () => {
+    mockMissionCache.installersDone = false
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.loadingInstallers).toBe(true)
+  })
+
+  it('loadingInstallers=false when installersDone=true', () => {
+    mockMissionCache.installersDone = true
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.loadingInstallers).toBe(false)
+  })
+
+  it('loadingFixers=true when fixesDone=false', () => {
+    mockMissionCache.fixesDone = false
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.loadingFixers).toBe(true)
+  })
+
+  it('loadingFixers=false when fixesDone=true', () => {
+    mockMissionCache.fixesDone = true
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.loadingFixers).toBe(false)
+  })
+
+  // ── missionFetchError ──────────────────────────────────────────────────────
+
+  it('reflects fetchError from cache', () => {
+    mockMissionCache.fetchError = 'rate limited'
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.missionFetchError).toBe('rate limited')
+  })
+
+  it('missionFetchError is null when cache has no error', () => {
+    mockMissionCache.fetchError = null
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.missionFetchError).toBeNull()
+  })
+
+  // ── initial installer/fixer lists from cache ───────────────────────────────
+
+  it('initialises installerMissions from missionCache.installers', () => {
+    mockMissionCache.installers = [INSTALLER]
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.installerMissions).toHaveLength(1)
+    expect(result.current.installerMissions[0].id).toBe('inst-1')
+  })
+
+  it('initialises fixerMissions from missionCache.fixes', () => {
+    mockMissionCache.fixes = [FIXER]
+    mockMatchMissionsToCluster.mockReturnValue([MATCH])
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.fixerMissions).toHaveLength(1)
+    expect(result.current.fixerMissions[0].id).toBe('fix-1')
+  })
+
+  // ── cache listener updates ─────────────────────────────────────────────────
+
+  it('updates installer and fixer lists when a cache listener fires', async () => {
+    mockMissionCache.installers = []
+    mockMissionCache.fixes = []
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.installerMissions).toHaveLength(0)
+
+    await act(async () => {
+      mockMissionCache.installers = [INSTALLER]
+      mockMissionCache.fixes = [FIXER, FIXER2]
+      mockMissionCache.listeners.forEach((l) => l())
+    })
+
+    expect(result.current.installerMissions).toHaveLength(1)
+    expect(result.current.fixerMissions).toHaveLength(2)
+  })
+
+  it('updates missionFetchError when cache listener fires', async () => {
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.missionFetchError).toBeNull()
+
+    await act(async () => {
+      mockMissionCache.fetchError = 'Connection refused'
+      mockMissionCache.listeners.forEach((l) => l())
+    })
+
+    expect(result.current.missionFetchError).toBe('Connection refused')
+  })
+
+  // ── tokenError ─────────────────────────────────────────────────────────────
+
+  it('tokenError is null initially (no external token state yet)', () => {
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.tokenError).toBeNull()
+  })
+
+  // ── searchProgress ─────────────────────────────────────────────────────────
+
+  it('searchProgress.step is "Scanning" when fixes still loading', () => {
+    mockMissionCache.fixes = []
+    mockMissionCache.fixesDone = false
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.searchProgress.step).toBe('Scanning')
+  })
+
+  it('searchProgress.step is "Done" when fixes loaded and fixesDone=true', () => {
+    mockMissionCache.fixes = [FIXER]
+    mockMissionCache.fixesDone = true
+    mockMatchMissionsToCluster.mockReturnValue([MATCH])
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.searchProgress.step).toBe('Done')
+  })
+
+  it('searchProgress.found equals the number of fixes when loaded', () => {
+    mockMissionCache.fixes = [FIXER, FIXER2]
+    mockMissionCache.fixesDone = true
+    mockMatchMissionsToCluster.mockReturnValue([MATCH])
+    const { result } = renderHook(() => useMissionRecommendations(true, null))
+    expect(result.current.searchProgress.found).toBe(2)
+  })
+})

--- a/web/src/components/missions/__tests__/useMissionTree.test.ts
+++ b/web/src/components/missions/__tests__/useMissionTree.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { TreeNode } from '../browser'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const { mockFetchTreeChildren, mockGetKubaraConfig, mockIsDemoMode } = vi.hoisted(() => ({
+  mockFetchTreeChildren: vi.fn<() => Promise<TreeNode[]>>(),
+  mockGetKubaraConfig: vi.fn(),
+  mockIsDemoMode: vi.fn(() => false),
+}))
+
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: mockIsDemoMode,
+}))
+
+// Full mock — avoids loading React components (VirtualizedMissionGrid / TreeNodeItem)
+// that import @tanstack/react-virtual, causing OOM in jsdom.
+// Inline pure tree helpers so state mutations work correctly.
+vi.mock('../browser', () => {
+  function updateNodeInTree(nodes: TreeNode[], nodeId: string, updates: Partial<TreeNode>): TreeNode[] {
+    return nodes.map((node) => {
+      if (node.id === nodeId) return { ...node, ...updates }
+      if (node.children) return { ...node, children: updateNodeInTree(node.children, nodeId, updates) }
+      return node
+    })
+  }
+  function removeNodeFromTree(nodes: TreeNode[], nodeId: string): TreeNode[] {
+    return nodes
+      .filter((n) => n.id !== nodeId)
+      .map((n) => n.children ? { ...n, children: removeNodeFromTree(n.children, nodeId) } : n)
+  }
+  return {
+    updateNodeInTree,
+    removeNodeFromTree,
+    fetchTreeChildren: mockFetchTreeChildren,
+    getKubaraConfig: mockGetKubaraConfig,
+  }
+})
+
+import { useMissionTree } from '../useMissionTree'
+
+const KUBARA_CFG = {
+  repoOwner: 'kubara-io',
+  repoName: 'kubara',
+  catalogPath: 'go-binary/templates/embedded/managed-service-catalog/helm',
+}
+
+const DEFAULT_PROPS = {
+  isOpen: true,
+  isAuthenticated: false,
+  user: null as unknown,
+  watchedRepos: [] as string[],
+  watchedPaths: [] as string[],
+}
+
+const CHILD_NODE: TreeNode = {
+  id: 'community/fixes/dns',
+  name: 'dns',
+  path: 'fixes/dns',
+  type: 'directory',
+  source: 'community',
+  loaded: false,
+}
+
+async function renderTree(props = DEFAULT_PROPS) {
+  const rendered = renderHook(() => useMissionTree(props))
+  // Flush all microtasks (effects + getKubaraConfig().then()) to avoid act() warnings
+  await act(async () => {})
+  return rendered
+}
+
+describe('useMissionTree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetKubaraConfig.mockResolvedValue(KUBARA_CFG)
+    mockFetchTreeChildren.mockResolvedValue([])
+  })
+
+  // ── Initial state (isOpen=false) ───────────────────────────────────────────
+
+  it('starts with null selectedPath', async () => {
+    const { result } = await renderTree({ ...DEFAULT_PROPS, isOpen: false })
+    expect(result.current.selectedPath).toBeNull()
+  })
+
+  it('starts with empty expandedNodes set', async () => {
+    const { result } = await renderTree({ ...DEFAULT_PROPS, isOpen: false })
+    expect(result.current.expandedNodes.size).toBe(0)
+  })
+
+  it('selectedTreeNode is null when selectedPath is null', async () => {
+    const { result } = await renderTree({ ...DEFAULT_PROPS, isOpen: false })
+    expect(result.current.selectedTreeNode).toBeNull()
+  })
+
+  it('does not build tree when isOpen=false', async () => {
+    const { result } = await renderTree({ ...DEFAULT_PROPS, isOpen: false })
+    expect(result.current.treeNodes).toHaveLength(0)
+  })
+
+  // ── Tree initialization ────────────────────────────────────────────────────
+
+  it('creates community root node when isOpen=true', async () => {
+    const { result } = await renderTree()
+    expect(result.current.treeNodes.map((n) => n.id)).toContain('community')
+  })
+
+  it('creates kubara root node when isOpen=true', async () => {
+    const { result } = await renderTree()
+    expect(result.current.treeNodes.map((n) => n.id)).toContain('kubara')
+  })
+
+  it('creates local root node when isOpen=true', async () => {
+    const { result } = await renderTree()
+    expect(result.current.treeNodes.map((n) => n.id)).toContain('local')
+  })
+
+  it('does NOT create github node when not authenticated', async () => {
+    const { result } = await renderTree({ ...DEFAULT_PROPS, isAuthenticated: false })
+    expect(result.current.treeNodes.map((n) => n.id)).not.toContain('github')
+  })
+
+  it('creates github node when authenticated with a user', async () => {
+    const { result } = await renderTree({
+      ...DEFAULT_PROPS,
+      isAuthenticated: true,
+      user: { login: 'testuser' },
+      watchedRepos: ['org/repo'],
+    })
+    expect(result.current.treeNodes.map((n) => n.id)).toContain('github')
+  })
+
+  it('populates github children from watchedRepos', async () => {
+    const { result } = await renderTree({
+      ...DEFAULT_PROPS,
+      isAuthenticated: true,
+      user: { login: 'testuser' },
+      watchedRepos: ['org/repo-a', 'org/repo-b'],
+    })
+    const github = result.current.treeNodes.find((n) => n.id === 'github')
+    expect(github?.children).toHaveLength(2)
+  })
+
+  it('populates local children from watchedPaths', async () => {
+    const { result } = await renderTree({
+      ...DEFAULT_PROPS,
+      watchedPaths: ['/tmp/missions', '/home/user/missions'],
+    })
+    const local = result.current.treeNodes.find((n) => n.id === 'local')
+    expect(local?.children).toHaveLength(2)
+  })
+
+  it('re-initializes tree when isOpen transitions from false to true', async () => {
+    const { result, rerender } = renderHook(
+      ({ open }) => useMissionTree({ ...DEFAULT_PROPS, isOpen: open }),
+      { initialProps: { open: false } },
+    )
+    expect(result.current.treeNodes).toHaveLength(0)
+    await act(async () => { rerender({ open: true }) })
+    expect(result.current.treeNodes.length).toBeGreaterThan(0)
+  })
+
+  // ── getKubaraConfig ────────────────────────────────────────────────────────
+
+  it('calls getKubaraConfig when isOpen=true', async () => {
+    await renderTree()
+    expect(mockGetKubaraConfig).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates kubara node path from getKubaraConfig result', async () => {
+    mockGetKubaraConfig.mockResolvedValue({ ...KUBARA_CFG, catalogPath: 'charts/helm' })
+    const { result } = await renderTree()
+    const kubara = result.current.treeNodes.find((n) => n.id === 'kubara')
+    expect(kubara?.path).toBe('charts/helm')
+  })
+
+  // ── toggleNode ─────────────────────────────────────────────────────────────
+
+  it('toggleNode adds node to expandedNodes', async () => {
+    mockFetchTreeChildren.mockResolvedValue([CHILD_NODE])
+    const { result } = await renderTree()
+
+    const community = result.current.treeNodes.find((n) => n.id === 'community')!
+    await act(async () => { await result.current.toggleNode(community) })
+
+    expect(result.current.expandedNodes.has('community')).toBe(true)
+  })
+
+  it('toggleNode collapses an already-expanded node', async () => {
+    mockFetchTreeChildren.mockResolvedValue([CHILD_NODE])
+    const { result } = await renderTree()
+
+    const community = result.current.treeNodes.find((n) => n.id === 'community')!
+    await act(async () => { await result.current.toggleNode(community) })
+    await act(async () => { await result.current.toggleNode(community) })
+
+    expect(result.current.expandedNodes.has('community')).toBe(false)
+  })
+
+  it('calls fetchTreeChildren when expanding unloaded node', async () => {
+    mockFetchTreeChildren.mockResolvedValue([CHILD_NODE])
+    const { result } = await renderTree()
+
+    const community = result.current.treeNodes.find((n) => n.id === 'community')!
+    await act(async () => { await result.current.toggleNode(community) })
+
+    expect(mockFetchTreeChildren).toHaveBeenCalledWith(community)
+  })
+
+  it('does not re-fetch on second expand (node already loaded)', async () => {
+    mockFetchTreeChildren.mockResolvedValue([CHILD_NODE])
+    const { result } = await renderTree()
+
+    const community = result.current.treeNodes.find((n) => n.id === 'community')!
+    await act(async () => { await result.current.toggleNode(community) })
+    await act(async () => { await result.current.toggleNode(community) })
+    const reloaded = result.current.treeNodes.find((n) => n.id === 'community')!
+    await act(async () => { await result.current.toggleNode(reloaded) })
+
+    expect(mockFetchTreeChildren).toHaveBeenCalledTimes(1)
+  })
+
+  it('node gets children and loaded=true after successful fetchTreeChildren', async () => {
+    mockFetchTreeChildren.mockResolvedValue([CHILD_NODE])
+    const { result } = await renderTree()
+
+    const community = result.current.treeNodes.find((n) => n.id === 'community')!
+    await act(async () => { await result.current.toggleNode(community) })
+
+    const updated = result.current.treeNodes.find((n) => n.id === 'community')
+    expect(updated?.children).toHaveLength(1)
+    expect(updated?.loaded).toBe(true)
+  })
+
+  // ── expandNode error handling ───────────────────────────────────────────────
+
+  it('sets error description on node when fetchTreeChildren throws', async () => {
+    mockFetchTreeChildren.mockRejectedValue(new Error('network error'))
+    const { result } = await renderTree()
+
+    const community = result.current.treeNodes.find((n) => n.id === 'community')!
+    await act(async () => { await result.current.toggleNode(community) })
+
+    const updated = result.current.treeNodes.find((n) => n.id === 'community')
+    expect(updated?.description).toContain('Failed to load')
+    expect(updated?.loaded).toBe(true)
+  })
+
+  // ── refreshNode ────────────────────────────────────────────────────────────
+
+  it('refreshNode resets node to unloaded state', async () => {
+    mockFetchTreeChildren.mockResolvedValue([CHILD_NODE])
+    const { result } = await renderTree()
+
+    const community = result.current.treeNodes.find((n) => n.id === 'community')!
+    await act(async () => { await result.current.toggleNode(community) })
+    expect(result.current.treeNodes.find((n) => n.id === 'community')?.loaded).toBe(true)
+
+    act(() => {
+      result.current.refreshNode(result.current.treeNodes.find((n) => n.id === 'community')!)
+    })
+
+    expect(result.current.treeNodes.find((n) => n.id === 'community')?.loaded).toBe(false)
+  })
+
+  it('refreshNode removes node from expandedNodes', async () => {
+    mockFetchTreeChildren.mockResolvedValue([CHILD_NODE])
+    const { result } = await renderTree()
+
+    const community = result.current.treeNodes.find((n) => n.id === 'community')!
+    await act(async () => { await result.current.toggleNode(community) })
+    expect(result.current.expandedNodes.has('community')).toBe(true)
+
+    act(() => {
+      result.current.refreshNode(result.current.treeNodes.find((n) => n.id === 'community')!)
+    })
+
+    expect(result.current.expandedNodes.has('community')).toBe(false)
+  })
+
+  // ── addLocalNode ───────────────────────────────────────────────────────────
+
+  it('addLocalNode adds node to the local tree children', async () => {
+    const { result } = await renderTree()
+
+    const newNode: TreeNode = {
+      id: 'local/custom', name: 'custom', path: '/tmp/custom',
+      type: 'directory', source: 'local', loaded: true,
+    }
+    act(() => { result.current.addLocalNode(newNode) })
+
+    const local = result.current.treeNodes.find((n) => n.id === 'local')
+    expect(local?.children?.some((c) => c.id === 'local/custom')).toBe(true)
+  })
+
+  it('addLocalNode expands the local root node', async () => {
+    const { result } = await renderTree()
+
+    const newNode: TreeNode = {
+      id: 'local/custom', name: 'custom', path: '/tmp/custom',
+      type: 'directory', source: 'local', loaded: true,
+    }
+    act(() => { result.current.addLocalNode(newNode) })
+
+    expect(result.current.expandedNodes.has('local')).toBe(true)
+  })
+
+  it('addLocalNode sets selectedPath to the new node id', async () => {
+    const { result } = await renderTree()
+
+    const newNode: TreeNode = {
+      id: 'local/custom', name: 'custom', path: '/tmp/custom',
+      type: 'directory', source: 'local', loaded: true,
+    }
+    act(() => { result.current.addLocalNode(newNode) })
+
+    expect(result.current.selectedPath).toBe('local/custom')
+  })
+
+  it('addLocalNode deduplicates — same id added twice results in one entry', async () => {
+    const { result } = await renderTree()
+
+    const node: TreeNode = {
+      id: 'local/dup', name: 'dup', path: '/tmp/dup',
+      type: 'directory', source: 'local', loaded: true,
+    }
+    act(() => { result.current.addLocalNode(node) })
+    act(() => { result.current.addLocalNode(node) })
+
+    const local = result.current.treeNodes.find((n) => n.id === 'local')
+    const dups = local?.children?.filter((c) => c.id === 'local/dup') ?? []
+    expect(dups).toHaveLength(1)
+  })
+
+  // ── selectedTreeNode ────────────────────────────────────────────────────────
+
+  it('selectedTreeNode is null when selectedPath is null', async () => {
+    const { result } = await renderTree()
+    expect(result.current.selectedTreeNode).toBeNull()
+  })
+
+  it('selectedTreeNode returns the node matching selectedPath', async () => {
+    const { result } = await renderTree()
+    act(() => { result.current.setSelectedPath('community') })
+    expect(result.current.selectedTreeNode?.id).toBe('community')
+  })
+
+  it('setSelectedPath updates selectedPath state', async () => {
+    const { result } = await renderTree()
+    act(() => { result.current.setSelectedPath('kubara') })
+    expect(result.current.selectedPath).toBe('kubara')
+  })
+})


### PR DESCRIPTION
## Summary

* Add comprehensive Vitest unit test suites for 3 mission control hooks (90 tests total)
* `useMissionFilters` (31 tests) — covers initial defaults for all 12 filter fields, `handleInstallerSearchChange`/`handleFixerSearchChange` with global query clear behavior, installer/fixer/recommendation filtering, `clearAllFilters`, `activeFilterCount`, `setSelectedTags`, and `facetCounts`
* `useMissionRecommendations` (30 tests) — covers closed-state guards, bootstrap behavior, cached vs fresh recommendations, cluster-context matching, cache updates, loading/error states, live listener updates, token errors, and `searchProgress`
* `useMissionTree` (29 tests) — covers initial closed state, tree initialization, authenticated GitHub nodes, watched repos/paths, kubara config updates, node toggle/refresh flows, fetch errors, local node insertion/deduplication, and `selectedTreeNode` derivation
* Fix mock initialization issues using `vi.hoisted()` for factories referencing outer mock variables
* Replace partial `'../browser'` mock with full mock in `useMissionTree` tests to avoid jsdom OOM caused by `@tanstack/react-virtual`
* Flush async microtasks with `await act(async () => {})` after `renderHook` to prevent worker timeouts from deferred `getKubaraConfig()` promises

## Test Plan

* [x] All 90 tests pass locally across all 3 files
* [x] No production code modified — only new test files added
* [x] Visual Regression / App Visual Regression CI unaffected
* [x] `vi.hoisted()` used correctly for all mocks referencing outer `vi.fn()` variables
* [x] `matchPercent` field used on `MissionMatch` fixtures to match implementation behavior
* [x] `useMissionTree` worker timeout resolved via async `act()` microtask flush pattern

### 📌 Fixes

Fixes N/A

---

### 📝 Summary of Changes

* Added full Vitest coverage for `useMissionFilters`, `useMissionRecommendations`, and `useMissionTree`
* Improved hook test stability by correcting hoisted mock usage and async microtask flushing
* Prevented jsdom memory issues in `useMissionTree` by fully mocking browser utilities and isolating pure helpers

---

### Changes Made

* [x] Added comprehensive unit tests for mission control hooks
* [x] Added filter/search/recommendation coverage for `useMissionFilters`
* [x] Added cache/loading/error/listener coverage for `useMissionRecommendations`
* [x] Added initialization/tree mutation/refresh coverage for `useMissionTree`
* [x] Refactored mock setup using `vi.hoisted()`
* [x] Fixed jsdom OOM issue caused by partial browser mock imports
* [x] Added async flush handling to stabilize hook lifecycle assertions

---

### Checklist

* [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
* [x] I have reviewed the project's contribution guidelines
* [x] New cards target console-marketplace, not this repo
* [x] isDemoData is wired correctly (not applicable — no card changes)
* [x] I have written unit tests for the changes
* [x] I have tested the changes locally and ensured they work as expected
* [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

* N/A — test-only changes

---

### 👀 Reviewer Notes

* `useMissionTree` required a full mock of `'../browser'` to avoid loading `@tanstack/react-virtual` in jsdom test workers
* `await act(async () => {})` is intentionally used after `renderHook` to flush deferred `getKubaraConfig()` promises before assertions
* `matchPercent` is intentionally used instead of `score` in fixtures to align with current filtering logic
