### PR TITLE
  test: vitest suites for SubmitToKBDialog, SaveResolutionDialog, and CardRequestDialog

### DIFF
--- a/web/src/components/missions/__tests__/CardRequestDialog.test.tsx
+++ b/web/src/components/missions/__tests__/CardRequestDialog.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * CardRequestDialog unit tests
+ *
+ * Covers: null render when no projects, project list rendering,
+ * request submission, submitting state, success state, error state,
+ * retry flow, toast feedback, and close button.
+ */
+
+import type React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
+
+// ── Hoisted mock refs ────────────────────────────────────────────────────
+
+const { mockApiPost, mockShowToast, mockEmitCardRequest } = vi.hoisted(() => ({
+  mockApiPost: vi.fn().mockResolvedValue({}),
+  mockShowToast: vi.fn(),
+  mockEmitCardRequest: vi.fn(),
+}))
+
+// ── Module mocks ─────────────────────────────────────────────────────────
+
+vi.mock('../../../lib/api', () => ({
+  api: { post: mockApiPost },
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitGroundControlCardRequestOpened: mockEmitCardRequest,
+}))
+
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (key === 'orbit.cardRequest') return `Request card for ${opts?.project}`
+      if (key === 'orbit.cardRequestRequested') return 'Requested'
+      if (key === 'orbit.cardRequestAction') return 'Request Card'
+      if (key === 'orbit.cardRequestSending') return 'Sending...'
+      if (key === 'orbit.cardRequestRetry') return 'Retry'
+      return key
+    },
+  }),
+}))
+
+import { CardRequestDialog } from '../CardRequestDialog'
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+const PROJECTS = ['Prometheus', 'Grafana', 'Jaeger']
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('CardRequestDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiPost.mockResolvedValue({})
+  })
+
+  // ── Null / empty state ───────────────────────────────────────────────
+
+  it('renders nothing when missingProjects is empty', () => {
+    const { container } = render(
+      <CardRequestDialog missingProjects={[]} onClose={vi.fn()} />,
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing when missingProjects is undefined', () => {
+    const { container } = render(
+      // @ts-expect-error testing undefined
+      <CardRequestDialog missingProjects={undefined} onClose={vi.fn()} />,
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  // ── Rendering ────────────────────────────────────────────────────────
+
+  it('renders the "Missing monitoring cards" header', () => {
+    render(<CardRequestDialog missingProjects={PROJECTS} onClose={vi.fn()} />)
+    expect(screen.getByText(/Missing monitoring cards/i)).toBeInTheDocument()
+  })
+
+  it('renders one row per project', () => {
+    render(<CardRequestDialog missingProjects={PROJECTS} onClose={vi.fn()} />)
+    for (const project of PROJECTS) {
+      expect(screen.getByText(`Request card for ${project}`)).toBeInTheDocument()
+    }
+  })
+
+  it('renders a Request Card button for each project', () => {
+    render(<CardRequestDialog missingProjects={PROJECTS} onClose={vi.fn()} />)
+    const buttons = screen.getAllByRole('button', { name: /Request Card/i })
+    expect(buttons.length).toBe(PROJECTS.length)
+  })
+
+  it('renders close button in header', () => {
+    const onClose = vi.fn()
+    render(<CardRequestDialog missingProjects={PROJECTS} onClose={onClose} />)
+    // The header X button should exist
+    const closeButtons = screen.getAllByRole('button')
+    expect(closeButtons.length).toBeGreaterThanOrEqual(PROJECTS.length + 1)
+  })
+
+  // ── Submission flow ──────────────────────────────────────────────────
+
+  it('calls api.post when Request Card button is clicked', async () => {
+    render(<CardRequestDialog missingProjects={['Prometheus']} onClose={vi.fn()} />)
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Request Card/i }))
+    })
+    expect(mockApiPost).toHaveBeenCalledWith('/api/feedback/requests', expect.objectContaining({
+      title: 'Card Request: Prometheus monitoring card',
+      request_type: 'feature',
+    }))
+  })
+
+  it('includes project description in the API request body', async () => {
+    render(<CardRequestDialog missingProjects={['Prometheus']} onClose={vi.fn()} />)
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Request Card/i }))
+    })
+    expect(mockApiPost).toHaveBeenCalledWith('/api/feedback/requests', expect.objectContaining({
+      description: expect.stringContaining('Prometheus'),
+    }))
+  })
+
+  it('emits analytics event on successful submission', async () => {
+    render(<CardRequestDialog missingProjects={['Grafana']} onClose={vi.fn()} />)
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Request Card/i }))
+    })
+    expect(mockEmitCardRequest).toHaveBeenCalledWith('Grafana')
+  })
+
+  it('shows success toast after successful submission', async () => {
+    render(<CardRequestDialog missingProjects={['Prometheus']} onClose={vi.fn()} />)
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Request Card/i }))
+    })
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringContaining('Prometheus'),
+      'success',
+    )
+  })
+
+  it('shows "Requested" label after successful submission', async () => {
+    render(<CardRequestDialog missingProjects={['Prometheus']} onClose={vi.fn()} />)
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Request Card/i }))
+    })
+    expect(screen.getByText('Requested')).toBeInTheDocument()
+  })
+
+  it('hides the Request Card button after successful submission', async () => {
+    render(<CardRequestDialog missingProjects={['Prometheus']} onClose={vi.fn()} />)
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Request Card/i }))
+    })
+    expect(screen.queryByRole('button', { name: /Request Card/i })).not.toBeInTheDocument()
+  })
+
+  // ── Submitting state ─────────────────────────────────────────────────
+
+  it('shows "Sending..." while the request is in-flight', async () => {
+    let resolvePost: () => void
+    mockApiPost.mockReturnValue(new Promise<void>((res) => { resolvePost = res }))
+
+    render(<CardRequestDialog missingProjects={['Prometheus']} onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /Request Card/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Sending...')).toBeInTheDocument()
+    })
+
+    await act(async () => { resolvePost!() })
+  })
+
+  it('disables the button while submitting', async () => {
+    mockApiPost.mockReturnValue(new Promise(() => {})) // never resolves
+    render(<CardRequestDialog missingProjects={['Prometheus']} onClose={vi.fn()} />)
+    const btn = screen.getByRole('button', { name: /Request Card/i })
+    fireEvent.click(btn)
+    await waitFor(() => {
+      expect(screen.getByText('Sending...')).toBeInTheDocument()
+    })
+    expect(btn).toBeDisabled()
+  })
+
+  // ── Error / retry state ──────────────────────────────────────────────
+
+  it('shows Retry button when submission fails', async () => {
+    mockApiPost.mockRejectedValue(new Error('Network error'))
+    render(<CardRequestDialog missingProjects={['Prometheus']} onClose={vi.fn()} />)
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Request Card/i }))
+    })
+    expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument()
+  })
+
+  it('shows warning toast when submission fails', async () => {
+    mockApiPost.mockRejectedValue(new Error('Network error'))
+    render(<CardRequestDialog missingProjects={['Prometheus']} onClose={vi.fn()} />)
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Request Card/i }))
+    })
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringContaining('Could not submit'),
+      'warning',
+    )
+  })
+
+  it('retries the submission when Retry button is clicked', async () => {
+    mockApiPost.mockRejectedValueOnce(new Error('First fail'))
+    mockApiPost.mockResolvedValueOnce({})
+    render(<CardRequestDialog missingProjects={['Prometheus']} onClose={vi.fn()} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Request Card/i }))
+    })
+
+    expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Retry/i }))
+    })
+
+    expect(mockApiPost).toHaveBeenCalledTimes(2)
+    expect(screen.getByText('Requested')).toBeInTheDocument()
+  })
+
+  it('clears error state when retrying', async () => {
+    mockApiPost.mockRejectedValueOnce(new Error('fail'))
+    mockApiPost.mockResolvedValueOnce({})
+    render(<CardRequestDialog missingProjects={['Prometheus']} onClose={vi.fn()} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Request Card/i }))
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Retry/i }))
+    })
+
+    expect(screen.queryByRole('button', { name: /Retry/i })).not.toBeInTheDocument()
+  })
+
+  // ── Independent project state ────────────────────────────────────────
+
+  it('only marks the submitted project as requested, others stay unchanged', async () => {
+    render(<CardRequestDialog missingProjects={['Prometheus', 'Grafana']} onClose={vi.fn()} />)
+    const buttons = screen.getAllByRole('button', { name: /Request Card/i })
+
+    await act(async () => {
+      fireEvent.click(buttons[0]) // submit only Prometheus
+    })
+
+    expect(screen.getByText('Requested')).toBeInTheDocument()
+    // Grafana still has its Request Card button
+    expect(screen.getByRole('button', { name: /Request Card/i })).toBeInTheDocument()
+  })
+
+  // ── Close button ─────────────────────────────────────────────────────
+
+  it('calls onClose when the X button is clicked', () => {
+    const onClose = vi.fn()
+    render(<CardRequestDialog missingProjects={['Prometheus']} onClose={onClose} />)
+    // The X button has no text - find it by its role among non-"Request Card" buttons
+    const allButtons = screen.getAllByRole('button')
+    const closeBtn = allButtons.find((b) => !b.textContent?.includes('Request Card'))
+    expect(closeBtn).toBeDefined()
+    fireEvent.click(closeBtn!)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/components/missions/__tests__/SaveResolutionDialog.test.tsx
+++ b/web/src/components/missions/__tests__/SaveResolutionDialog.test.tsx
@@ -1,0 +1,412 @@
+/**
+ * SaveResolutionDialog unit tests
+ *
+ * Covers: closed state, open render, generating state, AI error with retry,
+ * form field editing, validation, save success, step management, visibility toggle.
+ */
+
+import type React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
+
+// ── Hoisted mock refs ────────────────────────────────────────────────────
+
+const { mockSaveResolution, mockDetectIssueSignature, mockAppendWsAuthToken } = vi.hoisted(() => ({
+  mockSaveResolution: vi.fn(),
+  mockDetectIssueSignature: vi.fn(() => ({
+    type: 'CrashLoopBackOff',
+    resourceKind: 'Pod',
+    errorPattern: undefined,
+    namespace: 'default',
+  })),
+  mockAppendWsAuthToken: vi.fn().mockResolvedValue('ws://mock/ws'),
+}))
+
+// ── Module mocks ─────────────────────────────────────────────────────────
+
+vi.mock('../../../hooks/useResolutions', () => ({
+  useResolutions: () => ({ saveResolution: mockSaveResolution }),
+  detectIssueSignature: mockDetectIssueSignature,
+}))
+
+vi.mock('../../../lib/utils/wsAuth', () => ({
+  appendWsAuthToken: mockAppendWsAuthToken,
+}))
+
+vi.mock('../../../lib/constants', () => ({
+  LOCAL_AGENT_WS_URL: 'ws://localhost:8585/ws',
+}))
+
+vi.mock('../../../lib/modals/BaseModal', () => ({
+  BaseModal: Object.assign(
+    ({ children, isOpen }: { children: React.ReactNode; isOpen: boolean }) =>
+      isOpen ? <div role="dialog">{children}</div> : null,
+    {
+      Header: ({ title, onClose }: { title: string; onClose?: () => void }) => (
+        <div>
+          <h1>{title}</h1>
+          {onClose && <button onClick={onClose} aria-label="close dialog">×</button>}
+        </div>
+      ),
+      Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Footer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    }
+  ),
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'dashboard.missions.saveResolution': 'Save Resolution',
+        'dashboard.missions.titleRequired': 'Title is required',
+        'dashboard.missions.issueTypeRequired': 'Issue type is required',
+        'dashboard.missions.summaryRequired': 'Summary is required',
+        'dashboard.missions.failedToSave': 'Failed to save',
+        'dashboard.missions.generatingAISummary': 'Generating AI Summary...',
+        'dashboard.missions.creatingReusablePair': 'Creating a reusable problem/solution pair',
+        'dashboard.missions.aiGeneratedReview': 'AI-generated — please review',
+        'dashboard.missions.title': 'Title',
+        'dashboard.missions.issueType': 'Issue Type',
+        'dashboard.missions.resourceKind': 'Resource Kind',
+        'dashboard.missions.problemAndSolution': 'Problem & Solution',
+        'dashboard.missions.remediationSteps': 'Remediation Steps',
+        'dashboard.missions.yamlConfig': 'YAML / Config',
+        'dashboard.missions.visibility': 'Visibility',
+        'dashboard.missions.private': 'Private',
+        'dashboard.missions.shareToOrg': 'Share to Org',
+        'dashboard.missions.regenerate': 'Regenerate',
+        'dashboard.missions.generating': 'Generating...',
+        'dashboard.missions.addStep': '+ Add step',
+        'actions.cancel': 'Cancel',
+        'common.saving': 'Saving...',
+        'common.retry': 'Retry',
+        'dashboard.missions.titlePlaceholder': 'Brief title',
+        'dashboard.missions.issueTypePlaceholder': 'e.g. CrashLoopBackOff',
+        'dashboard.missions.resourceKindPlaceholder': 'e.g. Pod',
+        'dashboard.missions.problemSolutionPlaceholder': 'Describe the problem and solution',
+        'dashboard.missions.stepPlaceholder': 'Step description',
+        'dashboard.missions.yamlPlaceholder': 'Paste YAML here (optional)',
+      }
+      return translations[key] ?? key
+    },
+  }),
+}))
+
+// ── WebSocket mock ────────────────────────────────────────────────────────
+
+type WsCallback = (event: unknown) => void
+
+class MockWebSocket {
+  static lastInstance: MockWebSocket | null = null
+  onopen: WsCallback | null = null
+  onmessage: WsCallback | null = null
+  onerror: WsCallback | null = null
+  onclose: WsCallback | null = null
+  sent: string[] = []
+  readyState = 0
+
+  constructor(public url: string) {
+    MockWebSocket.lastInstance = this
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.readyState = 3
+  }
+
+  // Test helpers
+  simulateOpen() {
+    this.readyState = 1
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+
+  simulateError() {
+    this.onerror?.(new Event('error'))
+  }
+
+  simulateClose(code = 1000) {
+    this.onclose?.(new CloseEvent('close', { code }))
+  }
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+const BASE_MISSION = {
+  id: 'mission-1',
+  title: 'Debug nginx crash',
+  description: 'nginx pod keeps crashing with OOM',
+  agent: 'claude',
+  cluster: 'prod-us',
+  messages: [
+    { role: 'user', content: 'nginx pod is crashloopbackoff' },
+    { role: 'assistant', content: 'Let me check the logs...' },
+  ],
+  status: 'complete',
+  createdAt: '2026-01-01T00:00:00Z',
+}
+
+const DEFAULT_PROPS = {
+  mission: BASE_MISSION as never,
+  isOpen: true,
+  onClose: vi.fn(),
+  onSaved: vi.fn(),
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+async function renderDialogAndWaitForError(props = DEFAULT_PROPS) {
+  // Make WS error immediately: after appendWsAuthToken resolves, WS is created,
+  // then we simulate error so generateSummary catch fires → isGenerating=false
+  global.WebSocket = MockWebSocket as unknown as typeof WebSocket
+  const result = render(<SaveResolutionDialog {...props} />)
+
+  await act(async () => {
+    await Promise.resolve() // let appendWsAuthToken resolve
+    await Promise.resolve() // let new WebSocket(url) be created
+    MockWebSocket.lastInstance?.simulateError()
+    await Promise.resolve() // let catch + state updates propagate
+  })
+
+  return result
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+import { SaveResolutionDialog } from '../SaveResolutionDialog'
+
+describe('SaveResolutionDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    MockWebSocket.lastInstance = null
+    global.WebSocket = MockWebSocket as unknown as typeof WebSocket
+    mockAppendWsAuthToken.mockResolvedValue('ws://mock/ws')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ── Closed / open ────────────────────────────────────────────────────
+
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(
+      <SaveResolutionDialog mission={BASE_MISSION as never} isOpen={false} onClose={vi.fn()} />,
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the dialog title when open', async () => {
+    render(<SaveResolutionDialog {...DEFAULT_PROPS} />)
+    expect(screen.getByRole('heading', { name: /Save Resolution/i })).toBeInTheDocument()
+  })
+
+  // ── Generating state ─────────────────────────────────────────────────
+
+  it('shows generating indicator immediately on open', async () => {
+    // appendWsAuthToken takes time, so isGenerating=true during that time
+    mockAppendWsAuthToken.mockReturnValue(new Promise(() => {})) // never resolves
+    render(<SaveResolutionDialog {...DEFAULT_PROPS} />)
+    expect(screen.getByText('Generating AI Summary...')).toBeInTheDocument()
+  })
+
+  it('pre-fills title from mission while generating', async () => {
+    mockAppendWsAuthToken.mockReturnValue(new Promise(() => {}))
+    render(<SaveResolutionDialog {...DEFAULT_PROPS} />)
+    const titleInput = screen.getByPlaceholderText('Brief title') as HTMLInputElement
+    expect(titleInput.value).toBe(BASE_MISSION.title)
+  })
+
+  it('disables form inputs while generating', async () => {
+    mockAppendWsAuthToken.mockReturnValue(new Promise(() => {}))
+    render(<SaveResolutionDialog {...DEFAULT_PROPS} />)
+    const titleInput = screen.getByPlaceholderText('Brief title')
+    expect(titleInput).toBeDisabled()
+  })
+
+  // ── AI error state ───────────────────────────────────────────────────
+
+  it('shows AI error message after WebSocket failure', async () => {
+    await renderDialogAndWaitForError()
+    expect(screen.getByText(/Could not reach the local agent/i)).toBeInTheDocument()
+  })
+
+  it('shows retry button after AI error', async () => {
+    await renderDialogAndWaitForError()
+    expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument()
+  })
+
+  it('re-triggers AI generation when retry button is clicked', async () => {
+    await renderDialogAndWaitForError()
+    const retryBtn = screen.getByRole('button', { name: /Retry/i })
+    await act(async () => {
+      fireEvent.click(retryBtn)
+    })
+    expect(mockAppendWsAuthToken).toHaveBeenCalledTimes(2)
+  })
+
+  it('enables form fields after AI error', async () => {
+    await renderDialogAndWaitForError()
+    const titleInput = screen.getByPlaceholderText('Brief title')
+    expect(titleInput).not.toBeDisabled()
+  })
+
+  // ── Form interaction ─────────────────────────────────────────────────
+
+  it('allows editing the title field', async () => {
+    await renderDialogAndWaitForError()
+    const input = screen.getByPlaceholderText('Brief title') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'My custom fix' } })
+    expect(input.value).toBe('My custom fix')
+  })
+
+  it('allows editing the issue type field', async () => {
+    await renderDialogAndWaitForError()
+    const input = screen.getByPlaceholderText('e.g. CrashLoopBackOff') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'OOMKilled' } })
+    expect(input.value).toBe('OOMKilled')
+  })
+
+  it('allows editing the summary textarea', async () => {
+    await renderDialogAndWaitForError()
+    const textarea = screen.getByPlaceholderText('Describe the problem and solution') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: 'Fixed by increasing memory limit' } })
+    expect(textarea.value).toBe('Fixed by increasing memory limit')
+  })
+
+  // ── Step management ──────────────────────────────────────────────────
+
+  it('adds a new step when Add step is clicked', async () => {
+    await renderDialogAndWaitForError()
+    const addBtn = screen.getByText('+ Add step')
+    fireEvent.click(addBtn)
+    const inputs = screen.getAllByPlaceholderText('Step description')
+    expect(inputs.length).toBe(2)
+  })
+
+  it('removes a step when the remove button is clicked', async () => {
+    await renderDialogAndWaitForError()
+    const addBtn = screen.getByText('+ Add step')
+    fireEvent.click(addBtn)
+    const removeButtons = screen.getAllByRole('button').filter(b =>
+      b.querySelector('svg') && b.className.includes('hover:bg-red'),
+    )
+    expect(removeButtons.length).toBeGreaterThan(0)
+    fireEvent.click(removeButtons[0])
+    const inputs = screen.getAllByPlaceholderText('Step description')
+    expect(inputs.length).toBe(1)
+  })
+
+  it('allows editing step content', async () => {
+    await renderDialogAndWaitForError()
+    const input = screen.getByPlaceholderText('Step description') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'kubectl apply -f fix.yaml' } })
+    expect(input.value).toBe('kubectl apply -f fix.yaml')
+  })
+
+  // ── Visibility toggle ────────────────────────────────────────────────
+
+  it('defaults to private visibility', async () => {
+    await renderDialogAndWaitForError()
+    const privateBtn = screen.getByRole('button', { name: /Private/i })
+    expect(privateBtn.className).toContain('bg-primary')
+  })
+
+  it('switches to shared visibility on click', async () => {
+    await renderDialogAndWaitForError()
+    const shareBtn = screen.getByRole('button', { name: /Share to Org/i })
+    fireEvent.click(shareBtn)
+    expect(shareBtn.className).toContain('bg-blue-500')
+  })
+
+  // ── Validation ───────────────────────────────────────────────────────
+
+  it('shows error when saving with empty title', async () => {
+    await renderDialogAndWaitForError()
+    const titleInput = screen.getByPlaceholderText('Brief title') as HTMLInputElement
+    fireEvent.change(titleInput, { target: { value: '' } })
+    fireEvent.click(screen.getByRole('button', { name: /Save Resolution/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Title is required')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when saving with empty issue type', async () => {
+    await renderDialogAndWaitForError()
+    // Set title but clear issue type
+    const titleInput = screen.getByPlaceholderText('Brief title')
+    fireEvent.change(titleInput, { target: { value: 'My Title' } })
+    const issueInput = screen.getByPlaceholderText('e.g. CrashLoopBackOff') as HTMLInputElement
+    fireEvent.change(issueInput, { target: { value: '' } })
+    fireEvent.click(screen.getByRole('button', { name: /Save Resolution/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Issue type is required')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when saving with empty summary', async () => {
+    await renderDialogAndWaitForError()
+    const titleInput = screen.getByPlaceholderText('Brief title')
+    fireEvent.change(titleInput, { target: { value: 'My Title' } })
+    const issueInput = screen.getByPlaceholderText('e.g. CrashLoopBackOff')
+    fireEvent.change(issueInput, { target: { value: 'CrashLoopBackOff' } })
+    // summary textarea is empty by default after error
+    fireEvent.click(screen.getByRole('button', { name: /Save Resolution/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Summary is required')).toBeInTheDocument()
+    })
+  })
+
+  // ── Save success ─────────────────────────────────────────────────────
+
+  it('calls saveResolution and closes on valid save', async () => {
+    const onClose = vi.fn()
+    const onSaved = vi.fn()
+    await renderDialogAndWaitForError({ ...DEFAULT_PROPS, onClose, onSaved })
+
+    // Fill required fields
+    fireEvent.change(screen.getByPlaceholderText('Brief title'), { target: { value: 'Nginx OOM fix' } })
+    fireEvent.change(screen.getByPlaceholderText('e.g. CrashLoopBackOff'), { target: { value: 'OOMKilled' } })
+    fireEvent.change(screen.getByPlaceholderText('Describe the problem and solution'), { target: { value: 'Increased memory limit' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Save Resolution/i }))
+    })
+
+    expect(mockSaveResolution).toHaveBeenCalledTimes(1)
+    expect(mockSaveResolution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        missionId: 'mission-1',
+        title: 'Nginx OOM fix',
+        visibility: 'private',
+      }),
+    )
+    expect(onSaved).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  // ── Cancel / Regenerate ──────────────────────────────────────────────
+
+  it('calls onClose when cancel is clicked', async () => {
+    const onClose = vi.fn()
+    render(<SaveResolutionDialog mission={BASE_MISSION as never} isOpen onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls appendWsAuthToken when regenerate is clicked', async () => {
+    await renderDialogAndWaitForError()
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Regenerate/i }))
+    })
+    expect(mockAppendWsAuthToken).toHaveBeenCalledTimes(2)
+  })
+})

--- a/web/src/components/missions/__tests__/SubmitToKBDialog.test.tsx
+++ b/web/src/components/missions/__tests__/SubmitToKBDialog.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * SubmitToKBDialog unit tests
+ *
+ * Covers: closed state, open render, CNCF detection, filename generation,
+ * mission type toggle, security scan states, submit/cancel behaviour,
+ * long-URL fallback to issue link.
+ */
+
+import type React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import type { MockedFunction } from 'vitest'
+
+// ── Hoisted mock refs ────────────────────────────────────────────────────
+
+const { mockBuildGitHubNewFileUrl, mockBuildGitHubIssueUrl } = vi.hoisted(() => ({
+  mockBuildGitHubNewFileUrl: vi.fn(() => 'https://github.com/kubestellar/console-kb/new/master'),
+  mockBuildGitHubIssueUrl: vi.fn(() => 'https://github.com/kubestellar/console-kb/issues/new'),
+}))
+
+// ── Module mocks ─────────────────────────────────────────────────────────
+
+vi.mock('@/lib/githubUrls', () => ({
+  buildGitHubNewFileUrl: mockBuildGitHubNewFileUrl,
+  buildGitHubIssueUrl: mockBuildGitHubIssueUrl,
+}))
+
+vi.mock('../../../lib/missions/scanner/index', () => ({
+  fullScan: vi.fn(() => ({ valid: true, findings: [] })),
+}))
+
+vi.mock('../../../lib/modals/BaseModal', () => ({
+  BaseModal: Object.assign(
+    ({ children, isOpen }: { children: React.ReactNode; isOpen: boolean }) =>
+      isOpen ? <div role="dialog">{children}</div> : null,
+    {
+      Header: ({ title, onClose }: { title: string; onClose?: () => void }) => (
+        <div>
+          <h1>{title}</h1>
+          {onClose && <button onClick={onClose} aria-label="close dialog">×</button>}
+        </div>
+      ),
+      Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Footer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    }
+  ),
+}))
+
+// Import after mocks are in place
+import { SubmitToKBDialog } from '../SubmitToKBDialog'
+import type { Resolution } from '../../../hooks/useResolutions'
+import { fullScan } from '../../../lib/missions/scanner/index'
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+const BASE_RESOLUTION: Resolution = {
+  id: 'res-1',
+  missionId: 'mission-1',
+  userId: 'user-1',
+  title: 'Fix kyverno webhook failure',
+  visibility: 'private',
+  issueSignature: {
+    type: 'WebhookTimeout',
+    resourceKind: 'Policy',
+    namespace: 'kyverno',
+  },
+  resolution: {
+    summary: 'Restart kyverno pods to clear webhook state',
+    steps: ['kubectl rollout restart -n kyverno', 'Verify webhooks respond'],
+  },
+  context: { cluster: 'prod', operators: ['kyverno'] },
+  effectiveness: { timesUsed: 1, timesSuccessful: 1 },
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+}
+
+const PLAIN_RESOLUTION: Resolution = {
+  id: 'res-2',
+  missionId: 'mission-2',
+  userId: 'user-2',
+  title: 'Increase pod memory limit',
+  visibility: 'private',
+  issueSignature: { type: 'OOMKilled', resourceKind: 'Pod' },
+  resolution: {
+    summary: 'Set memory limit to 512Mi',
+    steps: ['Edit deployment', 'Apply change'],
+  },
+  context: { cluster: 'dev' },
+  effectiveness: { timesUsed: 0, timesSuccessful: 0 },
+  createdAt: '2026-02-01T00:00:00Z',
+  updatedAt: '2026-02-01T00:00:00Z',
+}
+
+const DEFAULT_PROPS = {
+  resolution: BASE_RESOLUTION,
+  isOpen: true,
+  onClose: vi.fn(),
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function renderDialog(props = DEFAULT_PROPS) {
+  return render(<SubmitToKBDialog {...props} />)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('SubmitToKBDialog', () => {
+  let mockWindowOpen: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWindowOpen = vi.fn()
+    vi.stubGlobal('open', mockWindowOpen)
+    ;(fullScan as MockedFunction<typeof fullScan>).mockReturnValue({ valid: true, findings: [] })
+    mockBuildGitHubNewFileUrl.mockReturnValue('https://github.com/kubestellar/console-kb/new/master')
+    mockBuildGitHubIssueUrl.mockReturnValue('https://github.com/kubestellar/console-kb/issues/new')
+  })
+
+  // ── Closed / open rendering ──────────────────────────────────────────
+
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(
+      <SubmitToKBDialog resolution={BASE_RESOLUTION} isOpen={false} onClose={vi.fn()} />,
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the dialog title when open', () => {
+    renderDialog()
+    expect(screen.getByRole('heading', { name: /Submit to Knowledge Base/i })).toBeInTheDocument()
+  })
+
+  it('shows the resolution title in the preview section', () => {
+    renderDialog()
+    expect(screen.getByText(BASE_RESOLUTION.title)).toBeInTheDocument()
+  })
+
+  it('shows issue type in the preview section', () => {
+    renderDialog()
+    const matches = screen.getAllByText(/WebhookTimeout/)
+    expect(matches.length).toBeGreaterThan(0)
+  })
+
+  it('shows step count in the preview section', () => {
+    renderDialog()
+    expect(screen.getByText(/2 steps/)).toBeInTheDocument()
+  })
+
+  // ── Mission type toggle ──────────────────────────────────────────────
+
+  it('defaults to Fixer mission type', () => {
+    renderDialog()
+    const fixerBtn = screen.getByRole('button', { name: /Fixer/i })
+    expect(fixerBtn.className).toContain('bg-purple-500')
+  })
+
+  it('switches to Install Mission when clicked', () => {
+    renderDialog()
+    const installBtn = screen.getByRole('button', { name: /Install Mission/i })
+    fireEvent.click(installBtn)
+    expect(installBtn.className).toContain('bg-blue-500')
+  })
+
+  it('shows fixes/troubleshoot target dir for fixer type', () => {
+    renderDialog()
+    expect(screen.getByText('fixes/troubleshoot/')).toBeInTheDocument()
+  })
+
+  it('shows fixes/cncf-install target dir after switching to install', () => {
+    renderDialog()
+    fireEvent.click(screen.getByRole('button', { name: /Install Mission/i }))
+    expect(screen.getByText('fixes/cncf-install/')).toBeInTheDocument()
+  })
+
+  // ── CNCF project detection ───────────────────────────────────────────
+
+  it('auto-detects CNCF project from operators list', () => {
+    renderDialog()
+    const input = screen.getByPlaceholderText(/e.g., Istio, Argo CD/i) as HTMLInputElement
+    expect(input.value).toBe('Kyverno')
+  })
+
+  it('shows empty CNCF project for plain resolution with no keywords', () => {
+    renderDialog({ ...DEFAULT_PROPS, resolution: PLAIN_RESOLUTION })
+    // OOMKilled has no CNCF keyword
+    const input = screen.getByPlaceholderText(/e.g., Istio, Argo CD/i) as HTMLInputElement
+    expect(input.value).toBe('')
+  })
+
+  it('allows editing the CNCF project field', () => {
+    renderDialog()
+    const input = screen.getByPlaceholderText(/e.g., Istio, Argo CD/i) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Falco' } })
+    expect(input.value).toBe('Falco')
+  })
+
+  // ── Filename generation ──────────────────────────────────────────────
+
+  it('generates a fixer- prefixed filename from the resolution title', () => {
+    renderDialog()
+    const input = screen.getByDisplayValue(/fixer-fix-kyverno-webhook-failure/) as HTMLInputElement
+    expect(input.value).toMatch(/^fixer-fix-kyverno-webhook-failure/)
+  })
+
+  it('generates an install- prefixed filename after switching to install type', () => {
+    renderDialog()
+    fireEvent.click(screen.getByRole('button', { name: /Install Mission/i }))
+    const input = screen.getByDisplayValue(/install-fix-kyverno-webhook-failure/) as HTMLInputElement
+    expect(input.value).toMatch(/^install-fix-kyverno-webhook-failure/)
+  })
+
+  it('allows editing the filename', () => {
+    renderDialog()
+    const input = screen.getByDisplayValue(/fixer-fix-kyverno/) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'custom-fix.json' } })
+    expect(input.value).toBe('custom-fix.json')
+  })
+
+  // ── Security scan ────────────────────────────────────────────────────
+
+  it('runs fullScan automatically on open', () => {
+    renderDialog()
+    expect(fullScan).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows "No sensitive data detected" when scan finds no issues', () => {
+    renderDialog()
+    expect(screen.getByText(/No sensitive data detected/i)).toBeInTheDocument()
+  })
+
+  it('shows warning count when scan finds issues', () => {
+    ;(fullScan as MockedFunction<typeof fullScan>).mockReturnValue({
+      valid: false,
+      findings: [
+        { severity: 'warning', field: 'title', message: 'Contains token' },
+        { severity: 'error', field: 'steps', message: 'Possible secret' },
+      ],
+    })
+    renderDialog()
+    expect(screen.getByText(/2 finding\(s\)/i)).toBeInTheDocument()
+  })
+
+  // ── Submit / Cancel ──────────────────────────────────────────────────
+
+  it('disables Submit to KB when filename is empty', () => {
+    renderDialog()
+    const input = screen.getByDisplayValue(/fixer-fix-kyverno/) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '' } })
+    const submitBtn = screen.getByRole('button', { name: /Submit to KB/i })
+    expect(submitBtn).toBeDisabled()
+  })
+
+  it('enables Submit to KB when filename is not empty', () => {
+    renderDialog()
+    const submitBtn = screen.getByRole('button', { name: /Submit to KB/i })
+    expect(submitBtn).not.toBeDisabled()
+  })
+
+  it('calls window.open and onClose when Submit to KB is clicked', () => {
+    const onClose = vi.fn()
+    render(<SubmitToKBDialog resolution={BASE_RESOLUTION} isOpen onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: /Submit to KB/i }))
+    expect(mockWindowOpen).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to GitHub issue URL when new-file URL exceeds 7500 chars', () => {
+    mockBuildGitHubNewFileUrl.mockReturnValue('x'.repeat(7501))
+    const onClose = vi.fn()
+    render(<SubmitToKBDialog resolution={BASE_RESOLUTION} isOpen onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: /Submit to KB/i }))
+    expect(mockBuildGitHubIssueUrl).toHaveBeenCalledTimes(1)
+    expect(mockWindowOpen).toHaveBeenCalledWith(
+      mockBuildGitHubIssueUrl.mock.results[0].value,
+      '_blank',
+      'noopener,noreferrer',
+    )
+  })
+
+  it('calls onClose when Cancel button is clicked', () => {
+    const onClose = vi.fn()
+    render(<SubmitToKBDialog resolution={BASE_RESOLUTION} isOpen onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when header close button is clicked', () => {
+    const onClose = vi.fn()
+    render(<SubmitToKBDialog resolution={BASE_RESOLUTION} isOpen onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: /close dialog/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
 Description:

  ### 📌 Fixes

N/A

  ---

  ### 📝 Summary of Changes

  - Add comprehensive Vitest unit test suites for three mission dialog components
  - 67 tests covering render states, user interactions, API flows, and validation

  ---

  ### Changes Made

  - [x] Added `SubmitToKBDialog.test.tsx` — 24 tests: closed/open render, CNCF auto-detection, mission type toggle, filename generation, security scan states, submit/cancel,
  long-URL fallback to GitHub issue
  - [x] Added `SaveResolutionDialog.test.tsx` — 23 tests: closed/open render, generating state, WebSocket error/retry, form editing, step management, visibility toggle, save
  validation, save success
  error/retry flow, per-project state independence
 
  ---

  ### Checklist
  
  - [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
  - [x] I have reviewed the project's contribution guidelines
  - [x] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
  - [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
  - [x] I have written unit tests for the changes (if applicable)
  - [x] I have tested the changes locally and ensured they work as expected
  - [x] All commits are signed with DCO (`git commit -s`)
  
  ---
  
  ### Screenshots or Logs (if applicable)

  Test Files  3 passed (3)
       Tests  67 passed (67)
    Duration  3.95s

  Full suite: 290 tests across 23 files — all passing

  ---

  ### 👀 Reviewer Notes

  Pure test additions — no production code modified. Mocks cover `BaseModal`, `fullScan`, `@/lib/githubUrls`, `useResolutions`, `appendWsAuthToken`, `WebSocket`, `api.post`,
  analytics, `useToast`, and `react-i18next` to keep tests isolated and fast.