### PR TITLE
🐛 Fix Übersicht widget export: parse errors, auth, URLs, and issue reporting

### DIFF
--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -346,6 +346,12 @@ const bearerScheme = "Bearer "
 // Token resolution order: Authorization header -> HttpOnly cookie -> _token query param (SSE only).
 func JWTAuth(secret string) fiber.Handler {
 	return func(c *fiber.Ctx) error {
+		// Übersicht desktop widgets use curl without auth tokens.
+		// Allow read-only access when source=widget is present (#widget-auth).
+		if c.Method() == fiber.MethodGet && strings.Contains(c.Query("source"), "widget") {
+			return c.Next()
+		}
+
 		authHeader := c.Get("Authorization")
 		var tokenString string
 

--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -114,7 +114,7 @@ function generateCardRenderFunction(cardType: string, displayName?: string): str
   );`
 
   const issueButton = `
-        <button style={styles.issueBtn} onClick={() => openIssue(error)}>Report Issue</button>`
+        <div style={{marginTop: '8px'}}><button style={styles.issueBtn} onClick={() => openIssue(error)}>Report Issue</button></div>`
 
   switch (cardType) {
     case 'cluster_health':
@@ -501,7 +501,7 @@ export const render = ({ output }) => {
   }
 
   if (error) {
-    return <div style={styles.row}><span style={{color: styles.colors.error}}>Error</span><button style={styles.issueBtn} onClick={() => openIssue(error)}>Report Issue</button></div>;
+    return <div style={{...styles.column}}><div style={styles.row}><span style={{color: styles.colors.error}}>Error</span></div><div><button style={styles.issueBtn} onClick={() => openIssue(error)}>Report Issue</button></div></div>;
   }
 
   // Extract values from API responses.
@@ -635,7 +635,7 @@ export const render = ({ output }) => {
   }
 
   if (error) {
-    return <div style={styles.card}><span style={{color: styles.colors.error}}>Error: {error}</span><button style={styles.issueBtn} onClick={() => openIssue(error)}>Report Issue</button></div>;
+    return <div style={styles.card}><span style={{color: styles.colors.error}}>Error: {error}</span><div style={{marginTop: '8px'}}><button style={styles.issueBtn} onClick={() => openIssue(error)}>Report Issue</button></div></div>;
   }
 
   return (

--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -17,13 +17,18 @@ export interface WidgetConfig {
   theme: 'dark' | 'light'
 }
 
+// Übersicht widgets run outside the browser, so curl needs a full URL.
+// When the API endpoint is empty (same-origin in-browser), fall back to localhost:8080.
+const UBERSICHT_FALLBACK_URL = 'http://localhost:8080'
+
 // Resolve the API endpoint for widget curl commands.
 // For nightly E2E, use the public (no-auth) endpoint so widgets work without JWT.
 function resolveWidgetEndpoint(apiEndpoint: string, cardApiPath: string): string {
+  const base = apiEndpoint || UBERSICHT_FALLBACK_URL
   if (cardApiPath === '/api/nightly-e2e/runs') {
-    return `${apiEndpoint}/api/public/nightly-e2e/runs`
+    return `${base}/api/public/nightly-e2e/runs`
   }
-  return `${apiEndpoint}${cardApiPath}`
+  return `${base}${cardApiPath}`
 }
 
 // Generate Übersicht widget code for a single card
@@ -41,8 +46,7 @@ export function generateCardWidget(
   /** Append source param so the backend can attribute traffic from exported widgets */
   const curlUrl = baseUrl + (baseUrl.includes('?') ? '&' : '?') + 'source=ubersicht-widget'
   const widgetName = cardType.replace(/_/g, '-')
-  // Use the API endpoint origin as the console URL (backend serves the frontend)
-  const consoleUrl = apiEndpoint.replace(/\/api$/, '')
+  const consoleUrl = (apiEndpoint || UBERSICHT_FALLBACK_URL).replace(/\/api$/, '')
   const shellCode = generateWidgetShell(widgetName, consoleUrl)
 
   return `/**
@@ -83,7 +87,7 @@ function generateCardRenderFunction(cardType: string, displayName?: string): str
     } else {
       data = JSON.parse(trimmed);
     }
-  } catch (e: unknown) {
+  } catch (e) {
     error = 'Parse error';
   }
 
@@ -109,6 +113,9 @@ function generateCardRenderFunction(cardType: string, displayName?: string): str
     </div>
   );`
 
+  const issueButton = `
+        <button style={styles.issueBtn} onClick={() => openIssue(error)}>Report Issue</button>`
+
   switch (cardType) {
     case 'cluster_health':
       return `
@@ -119,7 +126,7 @@ export const render = ({ output }) => {${parseBlock}
           <span style={{...styles.statusDot, backgroundColor: styles.colors.error}} />
           ${card.displayName}
         </div>
-        <span style={{color: styles.colors.error}}>Error: {error}</span>${wrapClose}
+        <span style={{color: styles.colors.error}}>Error: {error}</span>${issueButton}${wrapClose}
   }
 
   const clusters = data?.clusters || [];
@@ -151,7 +158,7 @@ export const render = ({ output }) => {${parseBlock}
           <span style={{...styles.statusDot, backgroundColor: styles.colors.error}} />
           ${card.displayName}
         </div>
-        <span style={{color: styles.colors.error}}>Error: {error}</span>${wrapClose}
+        <span style={{color: styles.colors.error}}>Error: {error}</span>${issueButton}${wrapClose}
   }
 
   const issues = data?.issues || data || [];
@@ -200,7 +207,7 @@ export const render = ({ output }) => {${parseBlock}
           <span style={{...styles.statusDot, backgroundColor: styles.colors.error}} />
           Nightly E2E Status
         </div>
-        <span style={{color: styles.colors.error}}>Error: {error}</span>${wrapClose}
+        <span style={{color: styles.colors.error}}>Error: {error}</span>${issueButton}${wrapClose}
   }
 
   const guides = data?.guides || [];
@@ -255,9 +262,9 @@ ${wrapOpen}
                   if (h < 24) return h + 'h ago';
                   return Math.floor(h / 24) + 'd ago';
                 };
-                const tooltip = g.guide + ' (' + platform + ')\\n' +
-                  'Pass rate: ' + g.passRate + '% (' + passed + '/' + completed.length + ')\\n' +
-                  (failed > 0 ? 'Failed: ' + failed + '\\n' : '') +
+                const tooltip = g.guide + ' (' + platform + ')\\\\n' +
+                  'Pass rate: ' + g.passRate + '% (' + passed + '/' + completed.length + ')\\\\n' +
+                  (failed > 0 ? 'Failed: ' + failed + '\\\\n' : '') +
                   (lastRun ? 'Last run: ' + (lastRun.conclusion || lastRun.status) + ' ' + timeAgo(lastRun.updatedAt || lastRun.createdAt) : '');
                 return (
                 <div key={g.guide + g.platform} style={{display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px'}}>
@@ -391,7 +398,7 @@ export const render = ({ output }) => {${parseBlock}
           <span style={{...styles.statusDot, backgroundColor: styles.colors.error}} />
           ${card.displayName}
         </div>
-        <span style={{color: styles.colors.error}}>Error: {error}</span>${wrapClose}
+        <span style={{color: styles.colors.error}}>Error: {error}</span>${issueButton}${wrapClose}
   }
 
   const nodes = data?.nodes || data || [];
@@ -431,7 +438,7 @@ export const render = ({ output }) => {${parseBlock}
 
   if (error) {${wrapOpen}
         <div style={styles.cardTitle}>${safeTitleExpr}</div>
-        <span style={{color: styles.colors.error}}>Error: {error}</span>${wrapClose}
+        <span style={{color: styles.colors.error}}>Error: {error}</span>${issueButton}${wrapClose}
   }
 ${wrapOpen}
         <div style={styles.cardTitle}>${safeTitleExpr}</div>
@@ -455,8 +462,8 @@ export function generateStatWidget(
     throw new Error('No valid stat IDs provided')
   }
 
-  // For stats we use the first endpoint (most stat widgets share one)
-  const endpoint = `${apiEndpoint}${stats[0].apiEndpoint}`
+  const base = apiEndpoint || UBERSICHT_FALLBACK_URL
+  const endpoint = `${base}${stats[0].apiEndpoint}`
 
   return `/**
  * Stats Widget
@@ -489,12 +496,12 @@ export const render = ({ output }) => {
     } else {
       data = JSON.parse(trimmed);
     }
-  } catch (e: unknown) {
+  } catch (e) {
     error = 'Parse error';
   }
 
   if (error) {
-    return <div style={styles.row}><span style={{color: styles.colors.error}}>Error</span></div>;
+    return <div style={styles.row}><span style={{color: styles.colors.error}}>Error</span><button style={styles.issueBtn} onClick={() => openIssue(error)}>Report Issue</button></div>;
   }
 
   // Extract values from API responses.
@@ -590,7 +597,8 @@ export function generateTemplateWidget(
       `Template "${templateId}" has no resolvable data endpoint (no cards and no stat.apiEndpoint)`,
     )
   }
-  const curlUrl = `${apiEndpoint}${firstEndpoint}`
+  const base = apiEndpoint || UBERSICHT_FALLBACK_URL
+  const curlUrl = `${base}${firstEndpoint}`
 
   return `/**
  * ${template.displayName} Widget
@@ -622,12 +630,12 @@ export const render = ({ output }) => {
     } else {
       data = JSON.parse(trimmed);
     }
-  } catch (e: unknown) {
+  } catch (e) {
     error = 'Parse error';
   }
 
   if (error) {
-    return <div style={styles.card}><span style={{color: styles.colors.error}}>Error: {error}</span></div>;
+    return <div style={styles.card}><span style={{color: styles.colors.error}}>Error: {error}</span><button style={styles.issueBtn} onClick={() => openIssue(error)}>Report Issue</button></div>;
   }
 
   return (

--- a/web/src/lib/widgets/styleConverter.ts
+++ b/web/src/lib/widgets/styleConverter.ts
@@ -311,6 +311,17 @@ export function generateWidgetStyles(): string {
     color: 'rgba(255,255,255,0.3)',
     letterSpacing: '2px',
   },
+  issueBtn: {
+    background: 'none',
+    border: '1px solid rgba(255,255,255,0.15)',
+    borderRadius: '4px',
+    color: '#9ca3af',
+    fontSize: '10px',
+    padding: '2px 6px',
+    cursor: 'pointer',
+    marginTop: '8px',
+    pointerEvents: 'auto',
+  },
 };`
 }
 
@@ -332,13 +343,13 @@ const getStoredPosition = () => {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) return JSON.parse(stored);
-  } catch (e: unknown) {
+  } catch (e) {
     console.debug('[Widget] failed to load stored position:', e);
   }
   return { top: 20, left: 20 };
 };
 const savePosition = (pos) => {
-  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(pos)); } catch (e: unknown) {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(pos)); } catch (e) {
     console.debug('[Widget] failed to save position:', e);
   }
 };
@@ -374,6 +385,12 @@ const WIDGET_UTM = 'utm_source=widget&utm_medium=ubersicht&utm_campaign=widget-u
 const openConsole = (path = '') => {
   const sep = path.includes('?') ? '&' : '?';
   run(\`open "\${CONSOLE_URL}\${path}\${sep}\${WIDGET_UTM}"\`);
+};
+const WIDGET_NAME = '${widgetName}';
+const openIssue = (errorMsg) => {
+  const title = encodeURIComponent('[Widget] ' + WIDGET_NAME + ': ' + (errorMsg || 'unknown error'));
+  const body = encodeURIComponent('**Widget:** ' + WIDGET_NAME + '\\n**Error:** ' + (errorMsg || 'unknown') + '\\n**Platform:** Übersicht (macOS)\\n\\n_Describe what you were doing when this happened:_\\n');
+  run(\`open "https://github.com/kubestellar/console/issues/new?title=\${title}&body=\${body}&labels=kind/bug,area/widgets"\`);
 };
 
 export const className = css\`

--- a/web/src/lib/widgets/styleConverter.ts
+++ b/web/src/lib/widgets/styleConverter.ts
@@ -319,7 +319,6 @@ export function generateWidgetStyles(): string {
     fontSize: '10px',
     padding: '2px 6px',
     cursor: 'pointer',
-    marginTop: '8px',
     pointerEvents: 'auto',
   },
 };`


### PR DESCRIPTION
## Summary

- **Fix TypeScript syntax in generated JSX** — `catch (e: unknown)` is invalid in Übersicht's JSX parser; changed to `catch (e)` in all template strings (5 occurrences across `codeGenerator.ts` and `styleConverter.ts`)
- **Fix empty API URLs** — When `BACKEND_DEFAULT_URL` is empty (same-origin), curl commands got relative paths like `/api/mcp/clusters` which fail outside the browser. Added `UBERSICHT_FALLBACK_URL = 'http://localhost:8080'` fallback
- **Fix nightly-e2e tooltip newline escaping** — Template literal `\\n` emitted literal newlines that broke string constants in the generated widget file
- **Auth bypass for desktop widgets** — `source=widget` query param on GET requests skips JWT auth so curl-based widgets can fetch data without tokens
- **"Report Issue" button on all widget error states** — Opens a pre-filled GitHub issue with widget name, error context, and `kind/bug` + `area/widgets` labels

## Test plan

- [x] Generated all 30 card widgets from fixed source — no TypeScript syntax in output
- [x] Verified curl URLs contain full `http://localhost:8080` prefix
- [x] Verified nightly-e2e tooltip uses `\n` escape (not literal newline)
- [x] Verified "Report Issue" button renders on its own line below error text
- [x] All 30 widgets installed in `~/Library/Application Support/Übersicht/widgets/` — render without parse errors
- [ ] Verify widgets fetch live data after backend restart with auth bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)