### PR TITLE
fix: detach singleflight context in github-pipelines

### DIFF
--- a/pkg/api/handlers/github_pipelines_cache.go
+++ b/pkg/api/handlers/github_pipelines_cache.go
@@ -72,6 +72,13 @@ func (h *GitHubPipelinesHandler) serveCached(c *fiber.Ctx, key string, build fun
 	}
 
 	v, err, _ := h.fetchGrp.Do(key, func() (any, error) {
+		// Detach from the triggering HTTP request context so the fetch
+		// survives if the caller disconnects.  Singleflight coalesces
+		// concurrent callers; if the "winner" disconnects, a request-tied
+		// context would cancel the in-flight GitHub API calls for everyone.
+		detachedCtx, cancel := context.WithTimeout(context.Background(), ghpFetchTimeout)
+		defer cancel()
+		c.SetUserContext(detachedCtx)
 		return build(c)
 	})
 	if err != nil {

--- a/pkg/api/handlers/github_pipelines_types.go
+++ b/pkg/api/handlers/github_pipelines_types.go
@@ -35,6 +35,7 @@ const (
 	ghpNightlyReleaseWFFile = "release.yml"
 	ghpNightlyReleaseCron   = "0 5 * * *"
 	ghpHTTPTimeout          = 15 * time.Second
+	ghpFetchTimeout         = 45 * time.Second
 	ghpMutationHTTPTimeout  = 15 * time.Second
 	ghpMaxErrorBodyBytes    = 10_000
 	ghpMaxLogBytes          = 10 * 1024 * 1024 // 10 MB cap on job log downloads

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -362,6 +362,12 @@ func JWTAuth(secret string) fiber.Handler {
 				"/api/rewards/",
 				"/api/issue-stats",
 				"/api/github-pipelines",
+				"/api/mcp/",
+				"/api/alerts",
+				"/api/providers/health",
+				"/api/gitops/operators",
+				"/api/gitops/helm-releases",
+				"/api/namespaces",
 			}
 			for _, prefix := range widgetPublicPrefixes {
 				if strings.HasPrefix(c.Path(), prefix) {


### PR DESCRIPTION
## Summary
- **Detach singleflight fetch context** from the triggering HTTP request in github-pipelines cache. Uses `context.Background()` with a 45s timeout instead of `c.UserContext()`. Fixes Nightly Release Pulse widget "failed to fetch pipeline data" caused by request context cancellation.
- **Expand widget auth bypass allowlist** in JWTAuth middleware. PR #14891 correctly removed the overly broad `requireViewerOrAbove` bypass, but the narrow JWTAuth allowlist didn't include `/api/mcp/` or other widget endpoints. Adds: `/api/mcp/`, `/api/alerts`, `/api/providers/health`, `/api/gitops/operators`, `/api/gitops/helm-releases`, `/api/namespaces`. All are read-only GET, guarded by exact `source=="ubersicht-widget"` match.

## Test plan
- [ ] Verify Nightly Release Pulse widget renders data
- [ ] Verify MCP widgets (pods, nodes, deployments, GPU, etc.) work without JWT
- [ ] Verify non-widget requests still require auth
- [ ] Verify github-pipelines views (matrix, flow, failures) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)