### PR TITLE
feat: add regression-driven dynamic focus areas to auto-qa

### DIFF
--- a/.github/workflows/auto-qa-tuner.yml
+++ b/.github/workflows/auto-qa-tuner.yml
@@ -238,6 +238,109 @@ jobs:
           echo "Max issues: $(jq '.max_issues_override' "$CONFIG")"
           echo "PR guidance: $(jq -r '.pr_guidance' "$CONFIG")"
 
+      - name: Detect regression patterns and update focus overrides
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CONFIG="$CONFIG_FILE"
+          [ ! -f "$CONFIG" ] && exit 0
+
+          SEVEN_DAYS_AGO=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)
+
+          # Fetch auto-qa issues from the past 7 days (both open and closed)
+          gh issue list --state all --limit 100 \
+            --label auto-qa \
+            --search "created:>=$SEVEN_DAYS_AGO" \
+            --json number,title,labels,state,createdAt \
+            > /tmp/recent-autoqa-issues.json 2>/dev/null || echo "[]" > /tmp/recent-autoqa-issues.json
+
+          ISSUE_COUNT=$(jq 'length' /tmp/recent-autoqa-issues.json)
+          echo "Found $ISSUE_COUNT auto-qa issues in the past 7 days"
+
+          if [ "$ISSUE_COUNT" -eq 0 ]; then
+            echo "No recent issues — skipping regression detection"
+            exit 0
+          fi
+
+          # Count issues per auto-qa sub-label (e.g., auto-qa:a11y, auto-qa:loading-gaps)
+          jq -r '.[].labels[].name' /tmp/recent-autoqa-issues.json 2>/dev/null \
+            | grep -E '^auto-qa:' | grep -v '^auto-qa$' \
+            | sed 's/^auto-qa://' \
+            | sort | uniq -c | sort -rn \
+            > /tmp/regression-counts.txt || true
+
+          echo "Issue frequency by sub-category:"
+          cat /tmp/regression-counts.txt
+
+          # Identify repeat offenders: sub-categories with 3+ issues in 7 days
+          # These indicate regressions that keep being reintroduced
+          REPEAT_THRESHOLD=3
+          REPEAT_CATS=$(awk -v thresh="$REPEAT_THRESHOLD" '$1 >= thresh {print $2}' /tmp/regression-counts.txt | head -5)
+
+          # Map sub-categories back to focus areas
+          map_to_focus() {
+            local subcat="$1"
+            case "$subcat" in
+              unused-deps|lazy-loading|bundle-analysis|large-files|import-cost) echo "performance" ;;
+              hardcoded-creds|dep-age|hardcoded) echo "security" ;;
+              aria|aria-gaps|keyboard|keyboard-nav|color-contrast|event-parity) echo "a11y" ;;
+              magic-numbers|tooltips) echo "operator" ;;
+              single-cluster|health) echo "sre" ;;
+              todos|complexity|console-logs|any-types|memory-leaks) echo "features" ;;
+              swallowed|loading-states|modal-safety|feedback-gaps|loading-gaps) echo "resilience" ;;
+              hardcoded-colors|spacing|dark-mode|touch-targets|component-patterns) echo "consistency" ;;
+              *) echo "" ;;
+            esac
+          }
+
+          # Build focus_overrides: areas with repeat regressions get boosted
+          FOCUS_OVERRIDES=""
+          for CAT in $REPEAT_CATS; do
+            FOCUS=$(map_to_focus "$CAT")
+            if [ -n "$FOCUS" ]; then
+              COUNT=$(grep -w "$CAT" /tmp/regression-counts.txt | awk '{print $1}')
+              echo "Regression detected: $CAT ($COUNT issues in 7d) -> boosting focus area: $FOCUS"
+              FOCUS_OVERRIDES="${FOCUS_OVERRIDES:+$FOCUS_OVERRIDES,}$FOCUS"
+            fi
+          done
+
+          # Deduplicate focus overrides
+          FOCUS_OVERRIDES=$(echo "$FOCUS_OVERRIDES" | tr ',' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
+
+          # Also detect title-level repeats (same issue title pattern appearing 2+ times)
+          jq -r '.[].title' /tmp/recent-autoqa-issues.json \
+            | sed 's/\[Auto-QA\] //' | sed 's/[0-9]\+/N/g' \
+            | sort | uniq -c | sort -rn \
+            | awk '$1 >= 2 {$1=""; print substr($0,2)}' \
+            > /tmp/repeat-titles.txt || true
+
+          REPEAT_TITLE_COUNT=$(wc -l < /tmp/repeat-titles.txt | tr -d ' ')
+          if [ "$REPEAT_TITLE_COUNT" -gt 0 ]; then
+            echo "Repeat issue titles (same pattern 2+ times in 7d):"
+            head -10 /tmp/repeat-titles.txt
+          fi
+
+          # Write focus_overrides and regression data to tuning config
+          TMP=$(mktemp)
+          OVERRIDES_JSON=$(echo "$FOCUS_OVERRIDES" | tr ',' '\n' | jq -R -s 'split("\n") | map(select(. != ""))')
+          REPEAT_TITLES_JSON=$(head -5 /tmp/repeat-titles.txt | jq -R -s 'split("\n") | map(select(. != ""))')
+
+          jq --argjson overrides "$OVERRIDES_JSON" \
+             --argjson repeats "$REPEAT_TITLES_JSON" \
+             --argjson issue_count "$ISSUE_COUNT" \
+             --argjson repeat_count "$REPEAT_TITLE_COUNT" '
+            .regression_insights = {
+              "focus_overrides": $overrides,
+              "repeat_issue_patterns": $repeats,
+              "total_issues_7d": $issue_count,
+              "repeat_pattern_count": $repeat_count,
+              "last_analyzed": (now | todate)
+            }
+          ' "$CONFIG" > "$TMP" && mv "$TMP" "$CONFIG"
+
+          echo "Focus overrides: ${FOCUS_OVERRIDES:-none}"
+          echo "Repeat patterns: $REPEAT_TITLE_COUNT"
+
       - name: Commit tuning config
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -95,7 +95,10 @@ jobs:
             echo "boosted=$BOOSTED" >> "$GITHUB_OUTPUT"
             echo "max_issues=$MAX_ISSUES" >> "$GITHUB_OUTPUT"
             echo "pr_guidance=$PR_GUIDANCE" >> "$GITHUB_OUTPUT"
-            echo "Tuning config loaded — blocked: ${BLOCKED:-none}, boosted: ${BOOSTED:-none}, max_issues: ${MAX_ISSUES:-default}"
+            # Export regression-driven focus overrides (areas with repeat issues)
+            FOCUS_OVERRIDES=$(jq -r '.regression_insights.focus_overrides // [] | join(",")' "$CONFIG")
+            echo "focus_overrides=$FOCUS_OVERRIDES" >> "$GITHUB_OUTPUT"
+            echo "Tuning config loaded — blocked: ${BLOCKED:-none}, boosted: ${BOOSTED:-none}, max_issues: ${MAX_ISSUES:-default}, focus_overrides: ${FOCUS_OVERRIDES:-none}"
           else
             echo "blocked=" >> "$GITHUB_OUTPUT"
             echo "boosted=" >> "$GITHUB_OUTPUT"
@@ -109,6 +112,7 @@ jobs:
         id: focus
         env:
           FOCUS_OVERRIDE: ${{ inputs.focus_override }}
+          FOCUS_OVERRIDES_REGRESSION: ${{ steps.tuning.outputs.focus_overrides }}
         run: |
           OVERRIDE="$FOCUS_OVERRIDE"
           if [ -n "$OVERRIDE" ] && [ "$OVERRIDE" != "none" ]; then
@@ -117,6 +121,10 @@ jobs:
           else
             # All 8 focus areas
             AREAS=("performance" "security" "a11y" "operator" "sre" "features" "resilience" "consistency")
+
+            # Parse regression-driven focus overrides (comma-separated list of areas
+            # where repeat issues were detected in the past 7 days)
+            IFS=',' read -ra REGRESSION_AREAS <<< "${FOCUS_OVERRIDES_REGRESSION:-}"
 
             # Try weighted selection from tuning config
             WEIGHTS_FILE="/tmp/rotation-weights.json"
@@ -136,6 +144,17 @@ jobs:
                 ENTRIES=${ENTRIES:-10}
                 [ "$ENTRIES" -le 0 ] && continue
                 [ "$ENTRIES" -gt 20 ] && ENTRIES=20
+
+                # Boost areas flagged by regression detector (2x pool entries)
+                for REGAREA in "${REGRESSION_AREAS[@]}"; do
+                  if [ "$AREA" = "$REGAREA" ]; then
+                    ENTRIES=$((ENTRIES * 2))
+                    [ "$ENTRIES" -gt 40 ] && ENTRIES=40
+                    echo "  Regression boost: $AREA (pool entries doubled to $ENTRIES)"
+                    break
+                  fi
+                done
+
                 for ((i=0; i<ENTRIES; i++)); do
                   POOL+=("$AREA")
                 done
@@ -153,6 +172,9 @@ jobs:
                   W=$(jq -r --arg a "$AREA" '.[$a] // 1.0' "$WEIGHTS_FILE")
                   echo "  $AREA: weight=$W"
                 done
+                if [ -n "$FOCUS_OVERRIDES_REGRESSION" ]; then
+                  echo "  Regression-boosted areas: $FOCUS_OVERRIDES_REGRESSION"
+                fi
               else
                 # All weights are 0 — fall back to fixed rotation
                 DOY=$(date -u +%j)


### PR DESCRIPTION
## Summary
- Adds a **regression detector** step to the auto-qa-tuner daily job that analyzes the past 7 days of auto-qa issues to identify repeat patterns
- Focus areas with 3+ issues in 7 days get flagged as regression hotspots and written to `focus_overrides` in the tuning config
- Auto-qa reads `focus_overrides` and **doubles the pool weight** for those areas, making them ~2x more likely to be selected as the daily focus
- Also tracks repeat issue title patterns (same normalized title appearing 2+ times) for diagnostic visibility

## How it works
1. **Tuner** (daily at 3am UTC): scans recent auto-qa issues → counts per sub-category → maps sub-categories to focus areas → writes `regression_insights.focus_overrides` to tuning config
2. **Auto-qa** (4x daily): reads `focus_overrides` → doubles pool entries for flagged areas → weighted random selection now favors areas with active regressions

This closes the loop: areas that keep producing issues get more scrutiny automatically, without manual rotation weight adjustments.

## Test plan
- [ ] Verify tuner workflow YAML is valid (`actionlint` or manual review)
- [ ] Verify auto-qa workflow YAML is valid
- [ ] Run tuner manually (`workflow_dispatch` with `job_override=daily`) to confirm regression detection works
- [ ] Verify focus_overrides appear in tuning config after tuner run
- [ ] Verify auto-qa logs show "Regression boost" for overridden areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)