### PR TITLE
fix: remove premature context cancel in ghGet that broke pipeline views

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -264,8 +264,12 @@ func resolveGitHubToken() string {
 		if sm := settings.GetSettingsManager(); sm != nil {
 			if all, err := sm.GetAll(); err == nil && all.FeedbackGitHubToken != "" {
 				token = all.FeedbackGitHubToken
+				slog.Info("[config] GitHub token resolved from settings DB", "length", len(token))
 			}
 		}
+	}
+	if token == "" {
+		slog.Warn("[config] GitHub token is EMPTY — GitHub API calls will fail")
 	}
 	return token
 }

--- a/pkg/api/handlers/github_pipelines_client.go
+++ b/pkg/api/handlers/github_pipelines_client.go
@@ -40,8 +40,6 @@ type ghpStepRaw struct {
 }
 
 func (h *GitHubPipelinesHandler) ghGet(ctx context.Context, path string) (*http.Response, error) {
-	ctx, cancel := context.WithTimeout(ctx, ghpHTTPTimeout)
-	defer cancel()
 	fullURL := path
 	if parsed, err := url.Parse(path); err != nil || parsed.Scheme == "" {
 		fullURL = ghpGitHubAPIBase + path


### PR DESCRIPTION
## Summary
- `ghGet` wrapped the parent context in `context.WithTimeout` + `defer cancel()`. The cancel fired when `ghGet` returned — **before callers read the response body** — causing `context canceled` errors in `fetchWorkflowRuns`, `fetchRuns`, and `fetchJobs`.
- This made all pipeline views (pulse, matrix, flow, failures) return 500 errors, breaking the Nightly Release Pulse widget and CI/CD dashboard.
- The HTTP client already has a 15s timeout and the parent context carries a 45s deadline from `serveCached`, so the extra wrapping was redundant.
- Also adds operational logging to `resolveGitHubToken`: logs when the token is resolved from the settings DB fallback, and warns when no token is available.

## Root Cause
```go
// BEFORE (broken): defer cancel() fires before caller reads res.Body
func (h *GitHubPipelinesHandler) ghGet(ctx context.Context, path string) (*http.Response, error) {
    ctx, cancel := context.WithTimeout(ctx, ghpHTTPTimeout)
    defer cancel()  // ← cancels context when ghGet returns, not when body is read
    ...
    return h.httpClient.Do(req)  // caller gets a response whose context is already canceled
}
```

## Test plan
- [x] Verified locally: `curl localhost:8080/api/github-pipelines?view=pulse` returns real data
- [ ] CI build passes
- [ ] Übersicht pulse widget shows live nightly release data

Fixes #14893