### PR TITLE
🔧 Fix CacheStore deduplication and histogram retry comment

### DIFF
--- a/web/src/hooks/useResultHistogram.ts
+++ b/web/src/hooks/useResultHistogram.ts
@@ -132,7 +132,7 @@ async function fetchHistogramWithRetry(
 
   if (response.status === RATE_LIMIT_STATUS) {
     if (attempt < maxAttempts - 1) {
-      // Exponential backoff: 100ms, 300ms, 900ms
+      // Exponential backoff: 100ms, 200ms, 400ms
       const delayMs = 100 * Math.pow(2, attempt)
       await new Promise(resolve => setTimeout(resolve, delayMs))
       return fetchHistogramWithRetry(sortBy, attempt + 1, maxAttempts)

--- a/web/src/lib/cache/cacheCore.ts
+++ b/web/src/lib/cache/cacheCore.ts
@@ -186,6 +186,7 @@ export class CacheStore<T> {
   resetToInitialData(): void {
     this.resetVersion++
     this.fetchingRef = false
+    this.inFlightPromise = null
     this.initialDataLoaded = false
     this.setState({
       data: this.initialData,
@@ -203,6 +204,7 @@ export class CacheStore<T> {
   resetForModeTransition(): void {
     this.resetVersion++
     this.fetchingRef = false
+    this.inFlightPromise = null
     this.initialDataLoaded = false
     this.storageLoadPromise = null
     this.setState({


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #14892 addressing Copilot review feedback about request deduplication and backoff timing.

## Changes

### 1. Clear inFlightPromise on reset (Copilot feedback)

The `inFlightPromise` field added in PR #14892 was never cleared when a store was reset. This could cause the store to get stuck in `isLoading` if:

1. A fetch was in-flight when `resetVersion` incremented (mode transition or explicit reset)
2. A subsequent `fetch()` call would return the stale promise instead of starting a fresh request
3. The old promise might never complete, leaving `isLoading` stuck

**Fix:** Clear `inFlightPromise = null` in both reset methods:
- `resetToInitialData()`
- `resetForModeTransition()`

### 2. Fix histogram retry backoff comment

Comment said "100ms, 300ms, 900ms" but the formula `100 * Math.pow(2, attempt)` actually produces:
- attempt 0: 100ms ✓
- attempt 1: 200ms (not 300ms)
- attempt 2: 400ms (not 900ms)

**Fix:** Updated comment to "100ms, 200ms, 400ms"

## Files Changed

- `web/src/lib/cache/cacheCore.ts` — Clear inFlightPromise on reset
- `web/src/hooks/useResultHistogram.ts` — Fix backoff interval comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)