### PR TITLE
🐛 Fix GA4 error spike: protect JSON parsing, add auth failure dedup

### DIFF
--- a/web/src/hooks/mcp/agentFetch.ts
+++ b/web/src/hooks/mcp/agentFetch.ts
@@ -17,7 +17,7 @@ export function getLocalAgentURL(): string {
 export const AGENT_TOKEN_STORAGE_KEY = 'kc-agent-token'
 const AGENT_TOKEN_FETCH_TIMEOUT_MS = 5000
 /** How long to remember that the backend returned no token (avoids repeated 5s timeouts). */
-const AGENT_TOKEN_NEGATIVE_CACHE_MS = 30_000
+const AGENT_TOKEN_NEGATIVE_CACHE_MS = 300_000
 
 let agentTokenPromise: Promise<string> | null = null
 /** Session-level dedup: only emit one agent_token_failure per page load */
@@ -47,7 +47,11 @@ export function _resetAgentTokenState(): void {
  * WebSocket connections open before token fetch completes (#13034).
  */
 export function getAgentToken(): Promise<string> {
-  if (isDemoMode() || isNetlifyDeployment || isLocalAgentSuppressed()) return Promise.resolve('')
+  if (isDemoMode() || isNetlifyDeployment || isLocalAgentSuppressed()) {
+    // Remove stale cached token so it doesn't leak into SSE/WS auth headers
+    localStorage.removeItem(AGENT_TOKEN_STORAGE_KEY)
+    return Promise.resolve('')
+  }
 
   const cached = localStorage.getItem(AGENT_TOKEN_STORAGE_KEY)
   if (cached) return Promise.resolve(cached)

--- a/web/src/hooks/useKagentBackend.ts
+++ b/web/src/hooks/useKagentBackend.ts
@@ -191,6 +191,7 @@ async function runRefresh(bypassThrottle = false): Promise<void> {
       }))
     } catch (error: unknown) {
       if (error instanceof DOMException && error.name === 'AbortError') return
+      console.debug('[useKagentBackend] refresh failed:', error instanceof Error ? error.message : error)
       setSharedState(current => ({ ...current, hasPolled: true }))
     } finally {
       if (activeRefreshController === controller) {

--- a/web/src/lib/kagentBackend.ts
+++ b/web/src/lib/kagentBackend.ts
@@ -34,7 +34,11 @@ export async function fetchKagentStatus(options: { signal?: AbortSignal } = {}):
       signal: getRequestSignal(KAGENT_STATUS_TIMEOUT_MS, options.signal),
     })
     if (!resp.ok) return { available: false, reason: `HTTP ${resp.status}` }
-    return resp.json()
+    try {
+      return await resp.json()
+    } catch {
+      return { available: false, reason: 'invalid JSON response' }
+    }
   } catch (error: unknown) {
     if (error instanceof DOMException && error.name === 'AbortError') {
       throw error
@@ -49,8 +53,12 @@ export async function fetchKagentAgents(options: { signal?: AbortSignal } = {}):
       signal: getRequestSignal(KAGENT_STATUS_TIMEOUT_MS, options.signal),
     })
     if (!resp.ok) return []
-    const data = await resp.json()
-    return data.agents || []
+    try {
+      const data = await resp.json()
+      return data.agents || []
+    } catch {
+      return []
+    }
   } catch (error: unknown) {
     if (error instanceof DOMException && error.name === 'AbortError') {
       throw error

--- a/web/src/lib/kagentiProviderBackend.ts
+++ b/web/src/lib/kagentiProviderBackend.ts
@@ -108,7 +108,11 @@ export async function fetchKagentiProviderStatus(options: { signal?: AbortSignal
       signal: getRequestSignal(KAGENTI_STATUS_TIMEOUT_MS, options.signal),
     })
     if (!resp.ok) return { available: false, reason: `HTTP ${resp.status}` }
-    return resp.json()
+    try {
+      return await resp.json()
+    } catch {
+      return { available: false, reason: 'invalid JSON response' }
+    }
   } catch (error: unknown) {
     if (error instanceof DOMException && error.name === 'AbortError') {
       throw error
@@ -128,8 +132,15 @@ export async function fetchKagentiProviderAgents(options: FetchKagentiProviderAg
       }
       return []
     }
-    const data = await resp.json()
-    return data.agents || []
+    try {
+      const data = await resp.json()
+      return data.agents || []
+    } catch {
+      if (options.throwOnUnavailable) {
+        throw new Error('invalid JSON response')
+      }
+      return []
+    }
   } catch (error: unknown) {
     if (error instanceof DOMException && error.name === 'AbortError') {
       throw error
@@ -201,7 +212,11 @@ export async function updateKagentiProviderConfig(payload: {
     throw new Error(message)
   }
 
-  return resp.json()
+  try {
+    return await resp.json()
+  } catch {
+    return {} as KagentiProviderConfigStatus
+  }
 }
 
 /**

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -17,6 +17,9 @@ import { STORAGE_KEY_TOKEN } from './constants'
 import { emitSseAuthFailure } from './analytics'
 import { isDemoMode } from './demoMode'
 
+/** Session-level dedup: only emit SSE auth failure once per URL path per page load */
+const sseAuthFailureEmitted = new Set<string>()
+
 export interface SSEFetchOptions<T> {
   /** SSE endpoint URL path (e.g. `${LOCAL_AGENT_HTTP_URL}/pods/stream`) */
   url: string
@@ -76,6 +79,7 @@ export function clearSSECache(): void {
   resultCache.clear()
   inflightRequests.clear()
   inflightSubscribers.clear()
+  sseAuthFailureEmitted.clear()
 }
 
 /**
@@ -385,7 +389,11 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
             errorMessage.includes(String(statusCode)),
           )
           if (is401 && currentToken) {
-            emitSseAuthFailure(fullUrl)
+            const pathKey = fullUrl.replace(/\?.*$/, '')
+            if (!sseAuthFailureEmitted.has(pathKey)) {
+              sseAuthFailureEmitted.add(pathKey)
+              emitSseAuthFailure(fullUrl)
+            }
           }
           if (isNonRetryable) {
             console.debug('[SSE] Non-retryable error (endpoint unavailable or auth) — skipping retries')


### PR DESCRIPTION
## Summary

GA4 analysis revealed 4,609 `ksc_error` events over 3 weeks (Apr 29 – May 19), concentrated 95% in India across `/settings`, `/login`, and `/clusters` pages. Root causes:

- **`/settings` (~95 errors/user, 53 users)**: `kagentBackend.ts` and `kagentiProviderBackend.ts` call `resp.json()` without try-catch. When the backend returns HTML instead of JSON (Netlify SPA shell, network errors), the unprotected parse throws unhandled rejections every 30s polling cycle.

- **India concentration (2,845 events from 32 users)**: `getAgentToken()` short-circuits on Netlify deployments, but stale `kc-agent-token` values cached in localStorage bypass the guard. The 30s negative cache meant failures retried aggressively.

- **SSE auth failures (1,549 events from 1 user in Pune)**: Every 401 retry emitted a new `sse_auth_failure` event with no session-level dedup.

### Fixes

1. **Protect all `resp.json()` calls** in `kagentBackend.ts` and `kagentiProviderBackend.ts` with try-catch — returns safe fallback values instead of throwing
2. **Increase agent token negative cache** from 30s to 5min — reduces retry frequency 10x
3. **Clear stale agent tokens on Netlify** — prevents cached tokens from leaking into auth headers
4. **Add SSE auth failure session dedup** — emits once per URL path per page load instead of every retry
5. **Log non-AbortError failures** in `useKagentBackend` to `console.debug` for future diagnosis

### Expected Impact

- Eliminates ~4,000+ `ksc_error` events per 3-week period
- `/settings` errors drop from ~95/user to ~0
- India `agent_token_failure` events drop from 2,845 to ~32 (one per user per session)
- SSE auth failure events drop from 1,549 to ~3 (one per user)

## Test plan

- [ ] TypeScript compiles cleanly (`npx tsc --noEmit` passes)
- [ ] `/settings` page loads without errors when kagent endpoints return HTML
- [ ] On console.kubestellar.io, verify no `ksc_error` events for agent_token_failure
- [ ] SSE 401 responses emit at most one `sse_auth_failure` per URL path per page load
- [ ] Existing kagent/kagenti functionality unaffected when backends are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)