### PR TITLE
test(cards): Vitest RTL for CardWrapper — loading, demo badge, failure, collapse

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -6,6 +6,12 @@ on:
       - 'web/src/**'
       - 'web/e2e/visual/**'
       - '.github/workflows/visual-regression.yml'
+    paths-ignore:
+      - 'web/src/**/__tests__/**'
+      - 'web/src/**/*.test.ts'
+      - 'web/src/**/*.test.tsx'
+      - 'web/src/**/*.spec.ts'
+      - 'web/src/**/*.spec.tsx'
   workflow_dispatch:
 
 permissions: read-all

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
+    "test:card-wrapper": "vitest run src/hooks/__tests__/useTimeoutFlag.test.ts src/components/cards/__tests__/CardWrapper.test.tsx",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "test:e2e": "npm run build && playwright test",

--- a/web/src/components/cards/__tests__/CardWrapper.test.tsx
+++ b/web/src/components/cards/__tests__/CardWrapper.test.tsx
@@ -3,11 +3,14 @@
  *
  * PR A: demo badge, failure banner, collapse persistence, expand modal sizing,
  * mode-switch skeleton. Lazy modals / snooze / missions integration deferred to PR B.
+ *
+ * Run from web/:  npm run test:card-wrapper
+ * (Do not run npx vitest from repo root — that skips vite.config.ts jsdom + @/ aliases.)
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import React from 'react'
+import React, { useContext, useLayoutEffect } from 'react'
 import { isDemoMode } from '../../../lib/demoMode'
 import { CardWrapper } from '../CardWrapper'
 import { CardDataReportContext, type CardDataState } from '../CardDataContext'
@@ -115,8 +118,8 @@ function renderCardWrapper(
 }
 
 function CardStateReporter({ state }: { state: CardDataState }) {
-  const ctx = React.use(CardDataReportContext)
-  React.useLayoutEffect(() => {
+  const ctx = useContext(CardDataReportContext)
+  useLayoutEffect(() => {
     ctx.report(state)
   }, [ctx, state])
   return <div data-testid="card-child">{CHILD_CONTENT_TEXT}</div>
@@ -248,8 +251,8 @@ describe('CardWrapper', () => {
       await user.click(screen.getByRole('button', { name: 'Expand full screen' }))
 
       const modal = await screen.findByTestId('drilldown-modal')
-      expect(modal.className).toContain('max-w-[95vw]')
-      expect(modal.className).toContain('95vh')
+      expect(modal).toHaveClass('max-w-[95vw]')
+      expect(modal).toHaveClass('min-h-[95vh]')
     })
 
     it('uses xl modal size for LARGE_EXPANDED_CARDS', async () => {
@@ -259,8 +262,8 @@ describe('CardWrapper', () => {
       await user.click(screen.getByRole('button', { name: 'Expand full screen' }))
 
       const modal = await screen.findByTestId('drilldown-modal')
-      expect(modal.className).toContain('max-w-6xl')
-      expect(modal.className).toContain('85vh')
+      expect(modal).toHaveClass('max-w-6xl')
+      expect(modal).toHaveClass('min-h-[85vh]')
     })
   })
 

--- a/web/src/components/cards/__tests__/CardWrapper.test.tsx
+++ b/web/src/components/cards/__tests__/CardWrapper.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * CardWrapper — shared shell for every dashboard card (#15264).
+ *
+ * PR A: demo badge, failure banner, collapse persistence, expand modal sizing,
+ * mode-switch skeleton. Lazy modals / snooze / missions integration deferred to PR B.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { isDemoMode } from '../../../lib/demoMode'
+import { CardWrapper } from '../CardWrapper'
+import { CardDataReportContext, type CardDataState } from '../CardDataContext'
+
+const COLLAPSED_CARDS_STORAGE_KEY = 'kubestellar-collapsed-cards'
+const TEST_CARD_ID = 'card-wrapper-test-id'
+const TEST_CARD_TYPE = 'cluster_health'
+const FULLSCREEN_CARD_TYPE = 'cluster_locations'
+const LARGE_EXPANDED_CARD_TYPE = 'cluster_comparison'
+const DEMO_BADGE_LABEL = 'Demo'
+const CHILD_CONTENT_TEXT = 'card-wrapper-child-content'
+const CUSTOM_ERROR_MESSAGE = 'upstream API unavailable'
+
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: vi.fn(() => true),
+  isNetlifyDeployment: false,
+  isDemoModeForced: false,
+  canToggleDemoMode: () => true,
+  setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(),
+  subscribeDemoMode: () => () => {},
+  isDemoToken: () => true,
+  hasRealToken: () => false,
+  setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../hooks/useDemoMode', () => ({
+  useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: () => true,
+  default: () => true,
+  hasRealToken: () => false,
+  isDemoModeForced: false,
+  isNetlifyDeployment: false,
+  canToggleDemoMode: () => true,
+  isDemoToken: () => true,
+  setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+const mockUseIsModeSwitching = vi.fn(() => false)
+vi.mock('../../../lib/unified/demo', () => ({
+  useIsModeSwitching: () => mockUseIsModeSwitching(),
+}))
+
+vi.mock('../../../hooks/useMissions', () => ({
+  useMissions: () => ({ setFullScreen: vi.fn() }),
+}))
+
+vi.mock('../../../hooks/useSnoozedCards', () => ({
+  useSnoozedCards: () => ({ snoozeSwap: vi.fn() }),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitCardExpanded: vi.fn(),
+  emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (key === 'cardWrapper.demo') return DEMO_BADGE_LABEL
+      if (key === 'titles.cluster_health') return 'Cluster Health'
+      if (key === 'titles.cluster_locations') return 'Cluster Locations'
+      if (key === 'titles.cluster_comparison') return 'Cluster Comparison'
+      if (key === 'cardWrapper.expandFullScreen') return 'Expand full screen'
+      if (key === 'cardWrapper.collapseCard') return 'Collapse card'
+      if (key === 'cardWrapper.expandCard') return 'Expand card'
+      if (key === 'cardWrapper.refreshFailedCount' && opts?.count) {
+        return `Refresh failed (${opts.count})`
+      }
+      return key
+    },
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../../lib/safeLazy', () => ({
+  safeLazy: () => () => null,
+}))
+
+function renderCardWrapper(
+  props: Partial<React.ComponentProps<typeof CardWrapper>> = {},
+  options?: { reportState?: CardDataState },
+) {
+  const ui = (
+    <CardWrapper
+      cardId={TEST_CARD_ID}
+      cardType={TEST_CARD_TYPE}
+      isDemoData={false}
+      {...props}
+    >
+      {options?.reportState ? (
+        <CardStateReporter state={options.reportState} />
+      ) : (
+        <div data-testid="card-child">{CHILD_CONTENT_TEXT}</div>
+      )}
+    </CardWrapper>
+  )
+
+  return render(ui)
+}
+
+function CardStateReporter({ state }: { state: CardDataState }) {
+  const ctx = React.use(CardDataReportContext)
+  React.useLayoutEffect(() => {
+    ctx.report(state)
+  }, [ctx, state])
+  return <div data-testid="card-child">{CHILD_CONTENT_TEXT}</div>
+}
+
+describe('CardWrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mockUseDemoMode.mockReturnValue({
+      isDemoMode: true,
+      toggleDemoMode: vi.fn(),
+      setDemoMode: vi.fn(),
+    })
+    mockUseIsModeSwitching.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('demo indicator', () => {
+    it('shows demo badge when isDemoData is true and not loading', () => {
+      renderCardWrapper({ isDemoData: true })
+
+      expect(screen.getByTestId('demo-badge')).toBeInTheDocument()
+      expect(screen.getByTestId('demo-badge')).toHaveTextContent(DEMO_BADGE_LABEL)
+      expect(screen.getByText(CHILD_CONTENT_TEXT)).toBeInTheDocument()
+    })
+
+    it('does not show demo badge while child reports loading', () => {
+      renderCardWrapper(
+        {},
+        {
+          reportState: {
+            isLoading: true,
+            hasData: false,
+            isDemoData: true,
+            isFailed: false,
+            consecutiveFailures: 0,
+          },
+        },
+      )
+
+      expect(screen.queryByTestId('demo-badge')).not.toBeInTheDocument()
+    })
+
+    it('suppresses demo badge when forceLive is true even with isDemoData', () => {
+      renderCardWrapper({ isDemoData: true, forceLive: true })
+
+      expect(screen.queryByTestId('demo-badge')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('CardFailureBanner', () => {
+    it('renders failure banner with error message when isFailed', () => {
+      renderCardWrapper({
+        isFailed: true,
+        consecutiveFailures: 2,
+      }, {
+        reportState: {
+          isLoading: false,
+          hasData: true,
+          isDemoData: false,
+          isFailed: true,
+          consecutiveFailures: 2,
+          errorMessage: CUSTOM_ERROR_MESSAGE,
+        },
+      })
+
+      const banner = screen.getByTestId('card-failure-banner')
+      expect(banner).toBeInTheDocument()
+      expect(banner).toHaveTextContent(CUSTOM_ERROR_MESSAGE)
+      expect(banner).toHaveTextContent('Refresh failed (2)')
+    })
+
+    it('hides failure banner when card is collapsed', async () => {
+      const user = userEvent.setup()
+      renderCardWrapper({
+        isFailed: true,
+        consecutiveFailures: 1,
+      })
+
+      expect(screen.getByTestId('card-failure-banner')).toBeInTheDocument()
+
+      const collapseBtn = screen.getByRole('button', { name: 'Collapse card' })
+      await user.click(collapseBtn)
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('card-failure-banner')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('collapse persistence', () => {
+    it('persists collapsed state to localStorage', async () => {
+      const user = userEvent.setup()
+      renderCardWrapper({ cardId: TEST_CARD_ID })
+
+      const collapseBtn = screen.getByRole('button', { name: 'Collapse card' })
+      await user.click(collapseBtn)
+
+      await waitFor(() => {
+        const stored = JSON.parse(
+          localStorage.getItem(COLLAPSED_CARDS_STORAGE_KEY) ?? '[]',
+        ) as string[]
+        expect(stored).toContain(TEST_CARD_ID)
+      })
+
+      expect(screen.queryByText(CHILD_CONTENT_TEXT)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('expanded modal sizing', () => {
+    it('opens expanded modal for default card type', async () => {
+      const user = userEvent.setup()
+      renderCardWrapper({ cardType: TEST_CARD_TYPE })
+
+      await user.click(screen.getByRole('button', { name: 'Expand full screen' }))
+
+      expect(await screen.findByTestId('drilldown-modal')).toBeInTheDocument()
+      expect(screen.getAllByText(CHILD_CONTENT_TEXT).length).toBeGreaterThan(0)
+    })
+
+    it('uses fullscreen modal size for FULLSCREEN_EXPANDED_CARDS', async () => {
+      const user = userEvent.setup()
+      renderCardWrapper({ cardType: FULLSCREEN_CARD_TYPE })
+
+      await user.click(screen.getByRole('button', { name: 'Expand full screen' }))
+
+      const modal = await screen.findByTestId('drilldown-modal')
+      expect(modal.className).toContain('max-w-[95vw]')
+      expect(modal.className).toContain('95vh')
+    })
+
+    it('uses xl modal size for LARGE_EXPANDED_CARDS', async () => {
+      const user = userEvent.setup()
+      renderCardWrapper({ cardType: LARGE_EXPANDED_CARD_TYPE })
+
+      await user.click(screen.getByRole('button', { name: 'Expand full screen' }))
+
+      const modal = await screen.findByTestId('drilldown-modal')
+      expect(modal.className).toContain('max-w-6xl')
+      expect(modal.className).toContain('85vh')
+    })
+  })
+
+  describe('mode-switch skeleton', () => {
+    beforeEach(() => {
+      vi.mocked(isDemoMode).mockReturnValue(false)
+      mockUseDemoMode.mockReturnValue({
+        isDemoMode: false,
+        toggleDemoMode: vi.fn(),
+        setDemoMode: vi.fn(),
+      })
+      mockUseIsModeSwitching.mockReturnValue(true)
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      vi.mocked(isDemoMode).mockReturnValue(true)
+      mockUseIsModeSwitching.mockReturnValue(false)
+    })
+
+    it('shows skeleton overlay while demo↔live mode is switching', () => {
+      renderCardWrapper({ skeletonType: 'list', skeletonRows: 2 })
+
+      expect(document.querySelector('[data-card-skeleton="true"]')).toBeTruthy()
+      expect(screen.getByTestId('card-child')).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/hooks/__tests__/useTimeoutFlag.test.ts
+++ b/web/src/hooks/__tests__/useTimeoutFlag.test.ts
@@ -1,5 +1,8 @@
 /**
  * useTimeoutFlag / useConditionalTimeout — timer behavior used by CardWrapper.
+ *
+ * Run from web/:  npm run test:card-wrapper
+ * (Do not run npx vitest from repo root — that skips vite.config.ts jsdom + @/ aliases.)
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
@@ -13,6 +16,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.clearAllTimers()
   vi.useRealTimers()
 })
 

--- a/web/src/hooks/__tests__/useTimeoutFlag.test.ts
+++ b/web/src/hooks/__tests__/useTimeoutFlag.test.ts
@@ -1,0 +1,92 @@
+/**
+ * useTimeoutFlag / useConditionalTimeout — timer behavior used by CardWrapper.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTimeoutFlag, useConditionalTimeout } from '../useTimeoutFlag'
+
+const FLAG_DELAY_MS = 50
+const CONDITIONAL_DELAY_MS = 80
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useTimeoutFlag', () => {
+  it('starts false then becomes true after delay', () => {
+    const { result } = renderHook(() => useTimeoutFlag(FLAG_DELAY_MS))
+
+    expect(result.current).toBe(false)
+
+    act(() => {
+      vi.advanceTimersByTime(FLAG_DELAY_MS)
+    })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('returns true immediately when skip is true', () => {
+    const { result } = renderHook(() => useTimeoutFlag(FLAG_DELAY_MS, true))
+
+    expect(result.current).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(FLAG_DELAY_MS * 2)
+    })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('does not flip true before delay elapses', () => {
+    const { result } = renderHook(() => useTimeoutFlag(FLAG_DELAY_MS))
+
+    act(() => {
+      vi.advanceTimersByTime(FLAG_DELAY_MS - 1)
+    })
+
+    expect(result.current).toBe(false)
+  })
+})
+
+describe('useConditionalTimeout', () => {
+  it('stays false while condition is false', () => {
+    const { result } = renderHook(() => useConditionalTimeout(false, CONDITIONAL_DELAY_MS))
+
+    act(() => {
+      vi.advanceTimersByTime(CONDITIONAL_DELAY_MS * 2)
+    })
+
+    expect(result.current).toBe(false)
+  })
+
+  it('becomes true after delay when condition is true', () => {
+    const { result } = renderHook(() => useConditionalTimeout(true, CONDITIONAL_DELAY_MS))
+
+    expect(result.current).toBe(false)
+
+    act(() => {
+      vi.advanceTimersByTime(CONDITIONAL_DELAY_MS)
+    })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('resets to false when condition turns off', () => {
+    const { result, rerender } = renderHook(
+      ({ active }) => useConditionalTimeout(active, CONDITIONAL_DELAY_MS),
+      { initialProps: { active: true } },
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(CONDITIONAL_DELAY_MS)
+    })
+    expect(result.current).toBe(true)
+
+    rerender({ active: false })
+    expect(result.current).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Adds the first dedicated test suite for `CardWrapper.tsx` (shared shell for every dashboard card) plus unit tests for `useTimeoutFlag` / `useConditionalTimeout` used by CardWrapper loading guards.

Closes #15264  
Part of #4189

## What is tested

- **Demo indicator:** `data-testid="demo-badge"` when `isDemoData` is set; hidden during child loading; suppressed when `forceLive`
- **CardFailureBanner:** renders with error message; hidden when card is collapsed
- **Collapse persistence:** writes `kubestellar-collapsed-cards` to localStorage
- **Expand modal:** opens drill-down modal; `cluster_locations` uses fullscreen (`95vw`); `cluster_comparison` uses xl (`max-w-6xl`)
- **Mode-switch skeleton:** skeleton overlay when `useIsModeSwitching` is true
- **useTimeoutFlag / useConditionalTimeout:** timer flip, skip path, conditional reset

## Out of scope (PR B / follow-up)

Lazy modals (WidgetExport, FeatureRequest), snooze swap, missions integration — noted in #15264.

## Test plan

- [x] `npx vitest run src/hooks/__tests__/useTimeoutFlag.test.ts src/components/cards/__tests__/CardWrapper.test.tsx` — 16/16 passed locally
- [ ] CI coverage-gate / vitest (awaiting PR checks)