### PR TITLE
test(status-cards): Vitest renderHook + RTL for ContourStatus and FluxStatus

### DIFF
--- a/web/src/components/cards/contour_status/__tests__/ContourStatus.test.tsx
+++ b/web/src/components/cards/contour_status/__tests__/ContourStatus.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+const mockUseContourStatus = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../useContourStatus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../useContourStatus')>()
+  return {
+    ...actual,
+    useContourStatus: () => mockUseContourStatus(),
+  }
+})
+
+vi.mock('../../../ui/Skeleton', () => ({
+  Skeleton: () => <div data-testid="skeleton" />,
+  SkeletonList: () => <div data-testid="skeleton-list" />,
+  SkeletonStats: () => <div data-testid="skeleton-stats" />,
+}))
+
+vi.mock('../../../../lib/cards/CardComponents', () => ({
+  MetricTile: ({ label, value }: { label: string; value: number | string }) => (
+    <div data-testid="metric-tile">
+      <span>{label}</span>: <span>{value}</span>
+    </div>
+  ),
+}))
+
+import ContourStatus from '../index'
+import { CONTOUR_DEMO_DATA } from '../demoData'
+import { __testables } from '../useContourStatus'
+
+const validProxy = {
+  name: 'app-proxy',
+  namespace: 'default',
+  cluster: 'dev',
+  fqdn: 'app.example.com',
+  status: 'Valid' as const,
+  conditions: [] as string[],
+}
+
+const HEALTHY_DATA = __testables.buildContourStatus(
+  [validProxy],
+  { total: 2, ready: 2, notReady: 0 },
+)
+
+function setup(overrides?: Record<string, unknown>) {
+  mockUseContourStatus.mockReturnValue({
+    data: HEALTHY_DATA,
+    error: false,
+    consecutiveFailures: 0,
+    showSkeleton: false,
+    showEmptyState: false,
+    isDemoData: false,
+    ...overrides,
+  })
+}
+
+describe('ContourStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders skeleton when showSkeleton is true', () => {
+    setup({ showSkeleton: true })
+    render(<ContourStatus />)
+
+    expect(screen.getByTestId('skeleton-stats')).toBeTruthy()
+    expect(screen.getByTestId('skeleton-list')).toBeTruthy()
+  })
+
+  it('renders fetch error when error and showEmptyState are true', () => {
+    setup({ error: true, showEmptyState: true })
+    render(<ContourStatus />)
+
+    expect(screen.getByText('contourStatus.fetchError')).toBeTruthy()
+  })
+
+  it('renders not-installed state when health is not-installed', () => {
+    setup({
+      data: __testables.buildContourStatus([], { total: 0, ready: 0, notReady: 0 }),
+    })
+    render(<ContourStatus />)
+
+    expect(screen.getByText('contourStatus.notInstalled')).toBeTruthy()
+    expect(screen.getByText('contourStatus.notInstalledHint')).toBeTruthy()
+  })
+
+  it('renders healthy live data with proxy metrics and list', () => {
+    setup()
+    render(<ContourStatus />)
+
+    expect(screen.getByText('contourStatus.healthy')).toBeTruthy()
+    expect(screen.getByText('contourStatus.totalProxies')).toBeTruthy()
+    expect(screen.getByText('contourStatus.sectionProxies')).toBeTruthy()
+    expect(screen.getByText('app-proxy')).toBeTruthy()
+  })
+
+  it('renders degraded badge when health is degraded', () => {
+    setup({ data: CONTOUR_DEMO_DATA })
+    render(<ContourStatus />)
+
+    expect(screen.getByText('contourStatus.degraded')).toBeTruthy()
+    expect(screen.getByText('staging-proxy')).toBeTruthy()
+  })
+
+  it('renders demo badge when isDemoData is true', () => {
+    setup({ data: CONTOUR_DEMO_DATA, isDemoData: true })
+    render(<ContourStatus />)
+
+    expect(screen.getByText('Demo')).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/contour_status/__tests__/ContourStatus.test.tsx
+++ b/web/src/components/cards/contour_status/__tests__/ContourStatus.test.tsx
@@ -33,9 +33,9 @@ vi.mock('../../../../lib/cards/CardComponents', () => ({
   ),
 }))
 
-import ContourStatus from '../index'
+import { ContourStatus } from '../index'
 import { CONTOUR_DEMO_DATA } from '../demoData'
-import { __testables } from '../useContourStatus'
+import { __testables, type UseContourStatusResult } from '../useContourStatus'
 
 const validProxy = {
   name: 'app-proxy',
@@ -51,7 +51,7 @@ const HEALTHY_DATA = __testables.buildContourStatus(
   { total: 2, ready: 2, notReady: 0 },
 )
 
-function setup(overrides?: Record<string, unknown>) {
+function setup(overrides?: Partial<UseContourStatusResult>) {
   mockUseContourStatus.mockReturnValue({
     data: HEALTHY_DATA,
     error: false,

--- a/web/src/components/cards/contour_status/__tests__/ContourStatus.test.tsx
+++ b/web/src/components/cards/contour_status/__tests__/ContourStatus.test.tsx
@@ -115,6 +115,6 @@ describe('ContourStatus', () => {
     setup({ data: CONTOUR_DEMO_DATA, isDemoData: true })
     render(<ContourStatus />)
 
-    expect(screen.getByText('Demo')).toBeTruthy()
+    expect(screen.getByText('contourStatus.demo')).toBeTruthy()
   })
 })

--- a/web/src/components/cards/contour_status/__tests__/useContourStatus.test.ts
+++ b/web/src/components/cards/contour_status/__tests__/useContourStatus.test.ts
@@ -176,7 +176,7 @@ describe('useContourStatus', () => {
     expect(result.current.showSkeleton).toBe(true)
   })
 
-  it('sets error when fetch failed and no data available', () => {
+  it('does not set error when fetch failed but stale healthy data remains', () => {
     mockUseCache.mockReturnValue({
       data: HEALTHY_DATA,
       isLoading: false,
@@ -192,5 +192,27 @@ describe('useContourStatus', () => {
 
     expect(result.current.error).toBe(false)
     expect(result.current.consecutiveFailures).toBe(2)
+  })
+
+  it('sets error when fetch failed and no proxy data is available', () => {
+    mockUseCache.mockReturnValue({
+      data: {
+        ...HEALTHY_DATA,
+        health: 'healthy',
+        proxies: [],
+        summary: { totalProxies: 0, validProxies: 0, invalidProxies: 0 },
+      },
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: true,
+      consecutiveFailures: 1,
+      isDemoFallback: false,
+      refetch,
+    })
+
+    const { result } = renderHook(() => useContourStatus())
+
+    expect(result.current.error).toBe(true)
+    expect(result.current.consecutiveFailures).toBe(1)
   })
 })

--- a/web/src/components/cards/contour_status/__tests__/useContourStatus.test.ts
+++ b/web/src/components/cards/contour_status/__tests__/useContourStatus.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockUseCache = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+
+vi.mock('../../../../lib/cache', () => ({
+  useCache: (args: Record<string, unknown>) => mockUseCache(args),
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (args: Record<string, unknown>) => mockUseCardLoadingState(args),
+}))
+
+import { useContourStatus, __testables } from '../useContourStatus'
+import { CONTOUR_DEMO_DATA } from '../demoData'
+import type { ContourProxyStatus } from '../demoData'
+
+const refetch = vi.fn(async () => {})
+
+const validProxy: ContourProxyStatus = {
+  name: 'app-proxy',
+  namespace: 'default',
+  cluster: 'dev',
+  fqdn: 'app.example.com',
+  status: 'Valid',
+  conditions: [],
+}
+
+const invalidProxy: ContourProxyStatus = {
+  name: 'broken-proxy',
+  namespace: 'staging',
+  cluster: 'dev',
+  fqdn: 'broken.example.com',
+  status: 'Invalid',
+  conditions: ['IncompleteRule'],
+}
+
+const HEALTHY_DATA = __testables.buildContourStatus(
+  [validProxy],
+  { total: 2, ready: 2, notReady: 0 },
+)
+
+const DEGRADED_DATA = __testables.buildContourStatus(
+  [validProxy, invalidProxy],
+  { total: 3, ready: 2, notReady: 1 },
+)
+
+const NOT_INSTALLED_DATA = __testables.buildContourStatus([], { total: 0, ready: 0, notReady: 0 })
+
+function lastLoadingStateCall() {
+  const calls = mockUseCardLoadingState.mock.calls
+  return calls[calls.length - 1][0] as Record<string, unknown>
+}
+
+describe('useContourStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: HEALTHY_DATA,
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+      isDemoFallback: false,
+      refetch,
+    })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+  })
+
+  it('uses services cache category for Contour status', () => {
+    renderHook(() => useContourStatus())
+
+    expect(mockUseCache).toHaveBeenCalledWith(expect.objectContaining({
+      key: 'contour-status',
+      category: 'services',
+    }))
+  })
+
+  it('returns healthy data when all proxies are valid', () => {
+    const { result } = renderHook(() => useContourStatus())
+
+    expect(result.current.data.health).toBe('healthy')
+    expect(result.current.data.summary.invalidProxies).toBe(0)
+  })
+
+  it('returns degraded data when any proxy is invalid', () => {
+    mockUseCache.mockReturnValue({
+      data: DEGRADED_DATA,
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+      isDemoFallback: false,
+      refetch,
+    })
+
+    const { result } = renderHook(() => useContourStatus())
+
+    expect(result.current.data.health).toBe('degraded')
+    expect(result.current.data.summary.invalidProxies).toBeGreaterThan(0)
+  })
+
+  it('returns not-installed health from cache data', () => {
+    mockUseCache.mockReturnValue({
+      data: NOT_INSTALLED_DATA,
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+      isDemoFallback: false,
+      refetch,
+    })
+
+    const { result } = renderHook(() => useContourStatus())
+
+    expect(result.current.data.health).toBe('not-installed')
+  })
+
+  it('exposes isDemoData when cache reports demo fallback and not loading', () => {
+    mockUseCache.mockReturnValue({
+      data: CONTOUR_DEMO_DATA,
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+      isDemoFallback: true,
+      refetch,
+    })
+
+    const { result } = renderHook(() => useContourStatus())
+
+    expect(result.current.isDemoData).toBe(true)
+    expect(lastLoadingStateCall().isDemoData).toBe(true)
+  })
+
+  it('isDemoData is false during loading even when isDemoFallback is true', () => {
+    mockUseCache.mockReturnValue({
+      data: CONTOUR_DEMO_DATA,
+      isLoading: true,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+      isDemoFallback: true,
+      refetch,
+    })
+
+    const { result } = renderHook(() => useContourStatus())
+
+    expect(result.current.isDemoData).toBe(false)
+    expect(lastLoadingStateCall().isDemoData).toBe(false)
+  })
+
+  it('treats not-installed as hasAnyData to avoid infinite skeleton', () => {
+    mockUseCache.mockReturnValue({
+      data: NOT_INSTALLED_DATA,
+      isLoading: true,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+      isDemoFallback: false,
+      refetch,
+    })
+
+    renderHook(() => useContourStatus())
+
+    expect(lastLoadingStateCall().hasAnyData).toBe(true)
+    expect(lastLoadingStateCall().isLoading).toBe(false)
+  })
+
+  it('surfaces showSkeleton from useCardLoadingState', () => {
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false })
+
+    const { result } = renderHook(() => useContourStatus())
+
+    expect(result.current.showSkeleton).toBe(true)
+  })
+
+  it('sets error when fetch failed and no data available', () => {
+    mockUseCache.mockReturnValue({
+      data: HEALTHY_DATA,
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: true,
+      consecutiveFailures: 2,
+      isDemoFallback: false,
+      refetch,
+    })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: true })
+
+    const { result } = renderHook(() => useContourStatus())
+
+    expect(result.current.error).toBe(false)
+    expect(result.current.consecutiveFailures).toBe(2)
+  })
+})

--- a/web/src/components/cards/contour_status/index.tsx
+++ b/web/src/components/cards/contour_status/index.tsx
@@ -70,7 +70,7 @@ function ProxySection({
 
 export function ContourStatus() {
   const { t } = useTranslation('cards')
-  const { data, error, showSkeleton, showEmptyState } = useContourStatus()
+  const { data, error, showSkeleton, showEmptyState, isDemoData } = useContourStatus()
 
   const isHealthy = data.health === 'healthy'
 
@@ -107,7 +107,8 @@ export function ContourStatus() {
   }
 
   return (
-    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden relative">
+      {isDemoData && <span className="demo-badge">Demo</span>}
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${

--- a/web/src/components/cards/contour_status/index.tsx
+++ b/web/src/components/cards/contour_status/index.tsx
@@ -108,7 +108,7 @@ export function ContourStatus() {
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden relative">
-      {isDemoData && <span className="demo-badge">Demo</span>}
+      {isDemoData && <span className="demo-badge">{t('contourStatus.demo')}</span>}
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${

--- a/web/src/components/cards/contour_status/useContourStatus.ts
+++ b/web/src/components/cards/contour_status/useContourStatus.ts
@@ -242,6 +242,7 @@ export interface UseContourStatusResult {
   consecutiveFailures: number
   showSkeleton: boolean
   showEmptyState: boolean
+  isDemoData: boolean
 }
 
 export function useContourStatus(): UseContourStatusResult {
@@ -276,6 +277,7 @@ export function useContourStatus(): UseContourStatusResult {
     consecutiveFailures,
     showSkeleton,
     showEmptyState,
+    isDemoData: effectiveIsDemoData,
   }
 }
 

--- a/web/src/components/cards/flux_status/__tests__/FluxStatus.test.tsx
+++ b/web/src/components/cards/flux_status/__tests__/FluxStatus.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+const mockUseFluxStatus = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../useFluxStatus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../useFluxStatus')>()
+  return {
+    ...actual,
+    useFluxStatus: () => mockUseFluxStatus(),
+  }
+})
+
+vi.mock('../../../ui/Skeleton', () => ({
+  Skeleton: () => <div data-testid="skeleton" />,
+  SkeletonList: () => <div data-testid="skeleton-list" />,
+  SkeletonStats: () => <div data-testid="skeleton-stats" />,
+}))
+
+vi.mock('../../../../lib/cards/CardComponents', () => ({
+  MetricTile: ({ label, value }: { label: string; value: number | string }) => (
+    <div data-testid="metric-tile">
+      <span>{label}</span>: <span>{value}</span>
+    </div>
+  ),
+}))
+
+import FluxStatus from '../index'
+import { FLUX_DEMO_DATA } from '../demoData'
+import { __testables } from '../useFluxStatus'
+import type { FluxResourceStatus } from '../demoData'
+
+const syncedSource: FluxResourceStatus = {
+  kind: 'GitRepository',
+  name: 'flux-system',
+  namespace: 'flux-system',
+  cluster: 'dev',
+  ready: true,
+}
+
+const syncedKustomization: FluxResourceStatus = {
+  kind: 'Kustomization',
+  name: 'apps',
+  namespace: 'flux-system',
+  cluster: 'dev',
+  ready: true,
+}
+
+const HEALTHY_DATA = __testables.buildFluxStatus(
+  [syncedSource],
+  [syncedKustomization],
+  [],
+)
+
+function setup(overrides?: Record<string, unknown>) {
+  mockUseFluxStatus.mockReturnValue({
+    data: HEALTHY_DATA,
+    error: false,
+    consecutiveFailures: 0,
+    showSkeleton: false,
+    showEmptyState: false,
+    isDemoData: false,
+    ...overrides,
+  })
+}
+
+describe('FluxStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders skeleton when showSkeleton is true', () => {
+    setup({ showSkeleton: true })
+    render(<FluxStatus />)
+
+    expect(screen.getByTestId('skeleton-stats')).toBeTruthy()
+    expect(screen.getByTestId('skeleton-list')).toBeTruthy()
+  })
+
+  it('renders fetch error when error and showEmptyState are true', () => {
+    setup({ error: true, showEmptyState: true })
+    render(<FluxStatus />)
+
+    expect(screen.getByText('fluxStatus.fetchError')).toBeTruthy()
+  })
+
+  it('renders not-installed state when health is not-installed', () => {
+    setup({
+      data: __testables.buildFluxStatus([], [], []),
+    })
+    render(<FluxStatus />)
+
+    expect(screen.getByText('fluxStatus.notInstalled')).toBeTruthy()
+    expect(screen.getByText('fluxStatus.notInstalledHint')).toBeTruthy()
+  })
+
+  it('renders healthy live data with kustomization synced', () => {
+    setup()
+    render(<FluxStatus />)
+
+    expect(screen.getByText('fluxStatus.healthy')).toBeTruthy()
+    expect(screen.getByText('fluxStatus.kustomizations')).toBeTruthy()
+    expect(screen.getByText('fluxStatus.sectionKustomizations')).toBeTruthy()
+    expect(screen.getByText('apps')).toBeTruthy()
+  })
+
+  it('renders degraded state when kustomization sync failed', () => {
+    setup({ data: FLUX_DEMO_DATA })
+    render(<FluxStatus />)
+
+    expect(screen.getByText('fluxStatus.degraded')).toBeTruthy()
+    expect(screen.getByText('monitoring')).toBeTruthy()
+  })
+
+  it('renders demo badge when isDemoData is true', () => {
+    setup({ data: FLUX_DEMO_DATA, isDemoData: true })
+    render(<FluxStatus />)
+
+    expect(screen.getByText('Demo')).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/flux_status/__tests__/FluxStatus.test.tsx
+++ b/web/src/components/cards/flux_status/__tests__/FluxStatus.test.tsx
@@ -33,9 +33,9 @@ vi.mock('../../../../lib/cards/CardComponents', () => ({
   ),
 }))
 
-import FluxStatus from '../index'
+import { FluxStatus } from '../index'
 import { FLUX_DEMO_DATA } from '../demoData'
-import { __testables } from '../useFluxStatus'
+import { __testables, type UseFluxStatusResult } from '../useFluxStatus'
 import type { FluxResourceStatus } from '../demoData'
 
 const syncedSource: FluxResourceStatus = {
@@ -60,7 +60,7 @@ const HEALTHY_DATA = __testables.buildFluxStatus(
   [],
 )
 
-function setup(overrides?: Record<string, unknown>) {
+function setup(overrides?: Partial<UseFluxStatusResult>) {
   mockUseFluxStatus.mockReturnValue({
     data: HEALTHY_DATA,
     error: false,

--- a/web/src/components/cards/flux_status/__tests__/FluxStatus.test.tsx
+++ b/web/src/components/cards/flux_status/__tests__/FluxStatus.test.tsx
@@ -124,6 +124,6 @@ describe('FluxStatus', () => {
     setup({ data: FLUX_DEMO_DATA, isDemoData: true })
     render(<FluxStatus />)
 
-    expect(screen.getByText('Demo')).toBeTruthy()
+    expect(screen.getByText('fluxStatus.demo')).toBeTruthy()
   })
 })

--- a/web/src/components/cards/flux_status/__tests__/useFluxStatus.test.ts
+++ b/web/src/components/cards/flux_status/__tests__/useFluxStatus.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mockUseCache = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+
+vi.mock('../../../../lib/cache', () => ({
+  useCache: (args: Record<string, unknown>) => mockUseCache(args),
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (args: Record<string, unknown>) => mockUseCardLoadingState(args),
+}))
+
+import { useFluxStatus, __testables } from '../useFluxStatus'
+import { FLUX_DEMO_DATA } from '../demoData'
+import type { FluxResourceStatus } from '../demoData'
+
+const refetch = vi.fn(async () => {})
+
+const syncedSource: FluxResourceStatus = {
+  kind: 'GitRepository',
+  name: 'flux-system',
+  namespace: 'flux-system',
+  cluster: 'dev',
+  ready: true,
+  revision: 'main@sha1:abc',
+}
+
+const syncedKustomization: FluxResourceStatus = {
+  kind: 'Kustomization',
+  name: 'apps',
+  namespace: 'flux-system',
+  cluster: 'dev',
+  ready: true,
+  revision: 'main@sha1:abc',
+}
+
+const failedKustomization: FluxResourceStatus = {
+  kind: 'Kustomization',
+  name: 'monitoring',
+  namespace: 'flux-system',
+  cluster: 'dev',
+  ready: false,
+  reason: 'ReconciliationFailed',
+}
+
+const HEALTHY_DATA = __testables.buildFluxStatus(
+  [syncedSource],
+  [syncedKustomization],
+  [],
+)
+
+const DEGRADED_DATA = __testables.buildFluxStatus(
+  [syncedSource],
+  [syncedKustomization, failedKustomization],
+  [],
+)
+
+const NOT_INSTALLED_DATA = __testables.buildFluxStatus([], [], [])
+
+function lastLoadingStateCall() {
+  const calls = mockUseCardLoadingState.mock.calls
+  return calls[calls.length - 1][0] as Record<string, unknown>
+}
+
+describe('useFluxStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue({
+      data: HEALTHY_DATA,
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+      isDemoFallback: false,
+      refetch,
+    })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+  })
+
+  it('uses gitops cache category for Flux status', () => {
+    renderHook(() => useFluxStatus())
+
+    expect(mockUseCache).toHaveBeenCalledWith(expect.objectContaining({
+      key: 'flux-status',
+      category: 'gitops',
+    }))
+  })
+
+  it('returns healthy data when all resources are ready', () => {
+    const { result } = renderHook(() => useFluxStatus())
+
+    expect(result.current.data.health).toBe('healthy')
+    expect(result.current.data.kustomizations.notReady).toBe(0)
+  })
+
+  it('returns degraded data when kustomization sync failed', () => {
+    mockUseCache.mockReturnValue({
+      data: DEGRADED_DATA,
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+      isDemoFallback: false,
+      refetch,
+    })
+
+    const { result } = renderHook(() => useFluxStatus())
+
+    expect(result.current.data.health).toBe('degraded')
+    expect(result.current.data.kustomizations.notReady).toBe(1)
+  })
+
+  it('returns not-installed health when no Flux resources exist', () => {
+    mockUseCache.mockReturnValue({
+      data: NOT_INSTALLED_DATA,
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+      isDemoFallback: false,
+      refetch,
+    })
+
+    const { result } = renderHook(() => useFluxStatus())
+
+    expect(result.current.data.health).toBe('not-installed')
+  })
+
+  it('exposes isDemoData when cache reports demo fallback and not loading', () => {
+    mockUseCache.mockReturnValue({
+      data: FLUX_DEMO_DATA,
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+      isDemoFallback: true,
+      refetch,
+    })
+
+    const { result } = renderHook(() => useFluxStatus())
+
+    expect(result.current.isDemoData).toBe(true)
+    expect(lastLoadingStateCall().isDemoData).toBe(true)
+  })
+
+  it('isDemoData is false during loading even when isDemoFallback is true', () => {
+    mockUseCache.mockReturnValue({
+      data: FLUX_DEMO_DATA,
+      isLoading: true,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+      isDemoFallback: true,
+      refetch,
+    })
+
+    const { result } = renderHook(() => useFluxStatus())
+
+    expect(result.current.isDemoData).toBe(false)
+    expect(lastLoadingStateCall().isDemoData).toBe(false)
+  })
+
+  it('treats not-installed as hasAnyData to avoid infinite skeleton', () => {
+    mockUseCache.mockReturnValue({
+      data: NOT_INSTALLED_DATA,
+      isLoading: true,
+      isRefreshing: false,
+      isFailed: false,
+      consecutiveFailures: 0,
+      isDemoFallback: false,
+      refetch,
+    })
+
+    renderHook(() => useFluxStatus())
+
+    expect(lastLoadingStateCall().hasAnyData).toBe(true)
+    expect(lastLoadingStateCall().isLoading).toBe(false)
+  })
+
+  it('surfaces showSkeleton from useCardLoadingState', () => {
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false })
+
+    const { result } = renderHook(() => useFluxStatus())
+
+    expect(result.current.showSkeleton).toBe(true)
+  })
+
+  it('forwards consecutiveFailures from cache', () => {
+    mockUseCache.mockReturnValue({
+      data: HEALTHY_DATA,
+      isLoading: false,
+      isRefreshing: false,
+      isFailed: true,
+      consecutiveFailures: 3,
+      isDemoFallback: false,
+      refetch,
+    })
+
+    const { result } = renderHook(() => useFluxStatus())
+
+    expect(result.current.consecutiveFailures).toBe(3)
+  })
+})

--- a/web/src/components/cards/flux_status/index.tsx
+++ b/web/src/components/cards/flux_status/index.tsx
@@ -109,7 +109,7 @@ export function FluxStatus() {
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden relative">
-      {isDemoData && <span className="demo-badge">Demo</span>}
+      {isDemoData && <span className="demo-badge">{t('fluxStatus.demo')}</span>}
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${

--- a/web/src/components/cards/flux_status/index.tsx
+++ b/web/src/components/cards/flux_status/index.tsx
@@ -70,7 +70,7 @@ function ResourceSection({
 
 export function FluxStatus() {
   const { t } = useTranslation('cards')
-  const { data, error, showSkeleton, showEmptyState } = useFluxStatus()
+  const { data, error, showSkeleton, showEmptyState, isDemoData } = useFluxStatus()
 
   const totalNotReady = data.sources.notReady + data.kustomizations.notReady + data.helmReleases.notReady
   const isHealthy = data.health === 'healthy'
@@ -108,7 +108,8 @@ export function FluxStatus() {
   }
 
   return (
-    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden relative">
+      {isDemoData && <span className="demo-badge">Demo</span>}
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${

--- a/web/src/components/cards/flux_status/useFluxStatus.ts
+++ b/web/src/components/cards/flux_status/useFluxStatus.ts
@@ -249,6 +249,7 @@ export interface UseFluxStatusResult {
   consecutiveFailures: number
   showSkeleton: boolean
   showEmptyState: boolean
+  isDemoData: boolean
 }
 
 export function useFluxStatus(): UseFluxStatusResult {
@@ -282,6 +283,7 @@ export function useFluxStatus(): UseFluxStatusResult {
     consecutiveFailures,
     showSkeleton,
     showEmptyState,
+    isDemoData: effectiveIsDemoData,
   }
 }
 

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3116,6 +3116,7 @@
     "noExperiments": "No experiments found."
   },
   "fluxStatus": {
+    "demo": "Demo",
     "healthy": "Healthy",
     "degraded": "Degraded",
     "notInstalled": "Flux not detected",
@@ -3137,6 +3138,7 @@
     "syncedDaysAgo": "{{count}}d ago"
   },
   "contourStatus": {
+    "demo": "Demo",
     "healthy": "Healthy",
     "degraded": "Degraded",
     "notInstalled": "Contour not detected",


### PR DESCRIPTION
## Summary

- Adds `useContourStatus.test.ts` and `useFluxStatus.test.ts` with Vitest `renderHook` coverage for healthy, degraded, not-installed, and demo states (mocked `useCache` / `useCardLoadingState`).
- Adds `ContourStatus.test.tsx` and `FluxStatus.test.tsx` with RTL coverage for loading skeleton, live data, degraded state, and demo badge.
- Aligns Contour/Flux with the `chaos_mesh_status` pattern: exposes `isDemoData` from hooks and renders the demo badge on live data views.
- Extends existing `helpers.test.ts` files (unchanged).

Part of #4189

Fixes #15269

## Test plan

- [x] `cd web && npx vitest run src/components/cards/contour_status/__tests__ src/components/cards/flux_status/__tests__` — 6 files, 39 tests passed locally
- [ ] CI Vitest shard passes on PR
- [ ] Coverage gate on modified files