### PR TITLE
🐛 Skip infrastructure handshake in demo mode

### DIFF
--- a/web/src/components/InitialInfrastructureGate.tsx
+++ b/web/src/components/InitialInfrastructureGate.tsx
@@ -51,6 +51,13 @@ export function InitialInfrastructureGate({ children }: InitialInfrastructureGat
   const [errorDetails, setErrorDetails] = useState<HandshakeErrorDetail[]>([])
 
   useEffect(() => {
+    // In demo mode there is no real backend — skip the handshake entirely
+    // so the hosted demo (console.kubestellar.io) renders immediately.
+    if (isDemoMode()) {
+      setHandshakeState('ready')
+      return
+    }
+
     const controller = new AbortController()
     setHandshakeState('loading')
     setErrorDetails([])


### PR DESCRIPTION
Fixes #15258

## Summary
- The `InitialInfrastructureGate` handshake (`/api/stellar/state` + `/api/kagent/status`) has no backend to reach on the hosted demo site (console.kubestellar.io), causing auth/network errors that trap demo visitors on a "Demo Session" dead-end screen
- Skip the handshake entirely when `isDemoMode()` is true so demo users land on the dashboard immediately
- Root cause: PR #15259 added a demo-aware auth screen to the gate, but the gate itself should never run in demo mode — there's no backend to handshake with

## Test plan
- [ ] Visit https://console.kubestellar.io — should auto-login and show the dashboard (not the "Demo Session" modal)
- [ ] Visit a Netlify deploy preview — same behavior
- [ ] Local dev with real backend — infrastructure gate still runs normally