### PR TITLE
test(status-cards): Vitest renderHook + RTL for LimaStatus — createCachedHook factory

### DIFF
--- a/web/src/components/cards/lima_status/LimaStatus.tsx
+++ b/web/src/components/cards/lima_status/LimaStatus.tsx
@@ -85,8 +85,7 @@ export function LimaStatus() {
           )}
           {isHealthy ? t('lima.healthy') : t('lima.degraded')}
         </div>
-
-
+        {isDemoData && <span className="demo-badge">{t('lima.demo')}</span>}
       </div>
 
       {/* Metric tiles */}

--- a/web/src/components/cards/lima_status/__tests__/LimaStatus.test.tsx
+++ b/web/src/components/cards/lima_status/__tests__/LimaStatus.test.tsx
@@ -35,7 +35,7 @@ vi.mock('../../../../lib/cards/CardComponents', () => ({
 
 import { LimaStatus } from '../LimaStatus'
 import { LIMA_DEMO_DATA } from '../demoData'
-import { __testables, type UseLimaStatusResult } from '../useLimaStatus'
+import { buildLimaStatus, toDemoStatus, type UseLimaStatusResult } from '../useLimaStatus'
 import type { LimaInstance } from '../demoData'
 
 const BASE_INSTANCE: LimaInstance = {
@@ -50,7 +50,7 @@ const BASE_INSTANCE: LimaInstance = {
   lastSeen: new Date().toISOString(),
 }
 
-const HEALTHY_DATA = __testables.buildLimaStatus([
+const HEALTHY_DATA = buildLimaStatus([
   BASE_INSTANCE,
   { ...BASE_INSTANCE, name: 'lima-default' },
 ])
@@ -89,7 +89,7 @@ describe('LimaStatus', () => {
   })
 
   it('renders not-detected state when health is not-detected', () => {
-    setup({ data: __testables.buildLimaStatus([]) })
+    setup({ data: buildLimaStatus([]) })
     render(<LimaStatus />)
 
     expect(screen.getByText('lima.notDetected')).toBeTruthy()
@@ -108,7 +108,13 @@ describe('LimaStatus', () => {
   })
 
   it('renders degraded badge when health is degraded', () => {
-    setup({ data: __testables.toDemoStatus(LIMA_DEMO_DATA) })
+    // Build an explicit degraded fixture so this test is resilient to
+    // future changes in LIMA_DEMO_DATA's health value.
+    const degradedStatus = {
+      ...toDemoStatus(LIMA_DEMO_DATA),
+      health: 'degraded' as const,
+    }
+    setup({ data: degradedStatus })
     render(<LimaStatus />)
 
     expect(screen.getByText('lima.degraded')).toBeTruthy()
@@ -116,7 +122,7 @@ describe('LimaStatus', () => {
   })
 
   it('renders demo badge when isDemoData is true', () => {
-    setup({ data: __testables.toDemoStatus(LIMA_DEMO_DATA), isDemoData: true })
+    setup({ data: toDemoStatus(LIMA_DEMO_DATA), isDemoData: true })
     render(<LimaStatus />)
 
     expect(screen.getByText('lima.demo')).toBeTruthy()

--- a/web/src/components/cards/lima_status/__tests__/LimaStatus.test.tsx
+++ b/web/src/components/cards/lima_status/__tests__/LimaStatus.test.tsx
@@ -1,43 +1,124 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
 
-vi.mock('../../../../lib/demoMode', () => ({
-  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
-  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
-  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
-  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
-  isFeatureEnabled: () => true,
-}))
-
-vi.mock('../../../../hooks/useDemoMode', () => ({
-  getDemoMode: () => true, default: () => true,
-  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
-  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
-  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
-  setGlobalDemoMode: vi.fn(),
-}))
-
-vi.mock('../../../../lib/analytics', () => ({
-  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
-  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
-
-vi.mock('../../../../hooks/useTokenUsage', () => ({
-  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
-  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
-}))
+const mockUseLimaStatus = vi.fn()
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
-  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
-  Trans: ({ children }: { children: React.ReactNode }) => children,
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../useLimaStatus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../useLimaStatus')>()
+  return {
+    ...actual,
+    useLimaStatus: () => mockUseLimaStatus(),
+  }
+})
+
+vi.mock('../../../ui/Skeleton', () => ({
+  Skeleton: ({ height }: { height?: number }) => (
+    <div data-testid="skeleton" data-height={height} />
+  ),
+}))
+
+vi.mock('../../../../lib/cards/CardComponents', () => ({
+  MetricTile: ({ label, value }: { label: string; value: number | string }) => (
+    <div data-testid="metric-tile">
+      <span>{label}</span>: <span>{value}</span>
+    </div>
+  ),
 }))
 
 import { LimaStatus } from '../LimaStatus'
+import { LIMA_DEMO_DATA } from '../demoData'
+import { __testables, type UseLimaStatusResult } from '../useLimaStatus'
+import type { LimaInstance } from '../demoData'
+
+const BASE_INSTANCE: LimaInstance = {
+  name: 'lima-k3s',
+  status: 'running',
+  cpuCores: 4,
+  memoryGB: 8,
+  diskGB: 60,
+  arch: 'x86_64',
+  os: 'Ubuntu 22.04 LTS',
+  limaVersion: '0.18.0',
+  lastSeen: new Date().toISOString(),
+}
+
+const HEALTHY_DATA = __testables.buildLimaStatus([
+  BASE_INSTANCE,
+  { ...BASE_INSTANCE, name: 'lima-default' },
+])
+
+function setup(overrides?: Partial<UseLimaStatusResult>) {
+  mockUseLimaStatus.mockReturnValue({
+    data: HEALTHY_DATA,
+    loading: false,
+    isRefreshing: false,
+    error: false,
+    consecutiveFailures: 0,
+    showSkeleton: false,
+    showEmptyState: false,
+    isDemoData: false,
+    ...overrides,
+  })
+}
 
 describe('LimaStatus', () => {
-  it('renders without crashing', () => {
-    const { container } = render(<LimaStatus />)
-    expect(container).toBeTruthy()
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders skeleton when showSkeleton is true', () => {
+    setup({ showSkeleton: true })
+    render(<LimaStatus />)
+
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0)
+  })
+
+  it('renders fetch error when error and showEmptyState are true', () => {
+    setup({ error: true, showEmptyState: true })
+    render(<LimaStatus />)
+
+    expect(screen.getByText('lima.fetchError')).toBeTruthy()
+  })
+
+  it('renders not-detected state when health is not-detected', () => {
+    setup({ data: __testables.buildLimaStatus([]) })
+    render(<LimaStatus />)
+
+    expect(screen.getByText('lima.notDetected')).toBeTruthy()
+    expect(screen.getByText('lima.notDetectedHint')).toBeTruthy()
+  })
+
+  it('renders healthy live data with VM list and metrics', () => {
+    setup()
+    render(<LimaStatus />)
+
+    expect(screen.getByText('lima.healthy')).toBeTruthy()
+    expect(screen.getByText('lima.totalInstances')).toBeTruthy()
+    expect(screen.getByText('lima.instances')).toBeTruthy()
+    expect(screen.getByText('lima-k3s')).toBeTruthy()
+    expect(screen.getByText('lima-default')).toBeTruthy()
+  })
+
+  it('renders degraded badge when health is degraded', () => {
+    setup({ data: __testables.toDemoStatus(LIMA_DEMO_DATA) })
+    render(<LimaStatus />)
+
+    expect(screen.getByText('lima.degraded')).toBeTruthy()
+    expect(screen.getByText('lima-test')).toBeTruthy()
+  })
+
+  it('renders demo badge when isDemoData is true', () => {
+    setup({ data: __testables.toDemoStatus(LIMA_DEMO_DATA), isDemoData: true })
+    render(<LimaStatus />)
+
+    expect(screen.getByText('lima.demo')).toBeTruthy()
   })
 })

--- a/web/src/components/cards/lima_status/__tests__/useLimaStatus.test.ts
+++ b/web/src/components/cards/lima_status/__tests__/useLimaStatus.test.ts
@@ -25,7 +25,10 @@ vi.mock('../../../../lib/cache', async (importOriginal) => {
           data: result.data,
           isLoading: result.isLoading,
           isRefreshing: result.isRefreshing,
-          isDemoFallback: result.isDemoFallback && !result.isLoading,
+          // Return isDemoFallback raw — let useLimaStatus enforce the
+          // `&& !isLoading` gate via effectiveIsDemoData, so that guard
+          // is actually exercised by the tests rather than duplicated here.
+          isDemoFallback: result.isDemoFallback,
           error: result.error,
           isFailed: result.isFailed,
           consecutiveFailures: result.consecutiveFailures,
@@ -42,7 +45,7 @@ vi.mock('../../CardDataContext', () => ({
   useCardLoadingState: (args: Record<string, unknown>) => mockUseCardLoadingState(args),
 }))
 
-import { useLimaStatus, __testables } from '../useLimaStatus'
+import { useLimaStatus, buildLimaStatus, toDemoStatus } from '../useLimaStatus'
 import { LIMA_DEMO_DATA, type LimaInstance } from '../demoData'
 
 const refetch = vi.fn(async () => {})
@@ -65,10 +68,10 @@ const STOPPED_INSTANCE: LimaInstance = {
   status: 'stopped',
 }
 
-const HEALTHY_DATA = __testables.buildLimaStatus([BASE_INSTANCE, { ...BASE_INSTANCE, name: 'lima-default' }])
-const DEGRADED_DATA = __testables.buildLimaStatus([BASE_INSTANCE, STOPPED_INSTANCE])
-const NOT_DETECTED_DATA = __testables.buildLimaStatus([])
-const DEMO_DATA = __testables.toDemoStatus(LIMA_DEMO_DATA)
+const HEALTHY_DATA = buildLimaStatus([BASE_INSTANCE, { ...BASE_INSTANCE, name: 'lima-default' }])
+const DEGRADED_DATA = buildLimaStatus([BASE_INSTANCE, STOPPED_INSTANCE])
+const NOT_DETECTED_DATA = buildLimaStatus([])
+const DEMO_DATA = toDemoStatus(LIMA_DEMO_DATA)
 
 function setupCacheReturn(overrides: Record<string, unknown>) {
   mockUseCache.mockReturnValue({

--- a/web/src/components/cards/lima_status/__tests__/useLimaStatus.test.ts
+++ b/web/src/components/cards/lima_status/__tests__/useLimaStatus.test.ts
@@ -1,0 +1,194 @@
+/**
+ * useLimaStatus tests — createCachedHook factory pattern.
+ *
+ * Unlike Contour/Flux (manual useCache + __testables), Lima uses createCachedHook.
+ * Mock createCachedHook (not useCache alone) so the factory-created useCachedLima
+ * hook returns controlled cache results.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { mockUseCache, mockUseCardLoadingState } = vi.hoisted(() => ({
+  mockUseCache: vi.fn(),
+  mockUseCardLoadingState: vi.fn(),
+}))
+
+vi.mock('../../../../lib/cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../lib/cache')>()
+  return {
+    ...actual,
+    useCache: (config: Record<string, unknown>) => mockUseCache(config),
+    createCachedHook: (config: Record<string, unknown>) => {
+      return () => {
+        const result = mockUseCache(config)
+        return {
+          data: result.data,
+          isLoading: result.isLoading,
+          isRefreshing: result.isRefreshing,
+          isDemoFallback: result.isDemoFallback && !result.isLoading,
+          error: result.error,
+          isFailed: result.isFailed,
+          consecutiveFailures: result.consecutiveFailures,
+          lastRefresh: result.lastRefresh,
+          refetch: result.refetch,
+          retryFetch: result.retryFetch,
+        }
+      }
+    },
+  }
+})
+
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (args: Record<string, unknown>) => mockUseCardLoadingState(args),
+}))
+
+import { useLimaStatus, __testables } from '../useLimaStatus'
+import { LIMA_DEMO_DATA, type LimaInstance } from '../demoData'
+
+const refetch = vi.fn(async () => {})
+
+const BASE_INSTANCE: LimaInstance = {
+  name: 'lima-k3s',
+  status: 'running',
+  cpuCores: 4,
+  memoryGB: 8,
+  diskGB: 60,
+  arch: 'x86_64',
+  os: 'Ubuntu 22.04 LTS',
+  limaVersion: '0.18.0',
+  lastSeen: new Date().toISOString(),
+}
+
+const STOPPED_INSTANCE: LimaInstance = {
+  ...BASE_INSTANCE,
+  name: 'lima-test',
+  status: 'stopped',
+}
+
+const HEALTHY_DATA = __testables.buildLimaStatus([BASE_INSTANCE, { ...BASE_INSTANCE, name: 'lima-default' }])
+const DEGRADED_DATA = __testables.buildLimaStatus([BASE_INSTANCE, STOPPED_INSTANCE])
+const NOT_DETECTED_DATA = __testables.buildLimaStatus([])
+const DEMO_DATA = __testables.toDemoStatus(LIMA_DEMO_DATA)
+
+function setupCacheReturn(overrides: Record<string, unknown>) {
+  mockUseCache.mockReturnValue({
+    data: HEALTHY_DATA,
+    isLoading: false,
+    isRefreshing: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    isDemoFallback: false,
+    error: null,
+    lastRefresh: null,
+    refetch,
+    retryFetch: vi.fn(),
+    ...overrides,
+  })
+}
+
+function lastLoadingStateCall() {
+  const calls = mockUseCardLoadingState.mock.calls
+  return calls[calls.length - 1][0] as Record<string, unknown>
+}
+
+describe('useLimaStatus (createCachedHook factory)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupCacheReturn({})
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+  })
+
+  it('uses lima-status cache key through the createCachedHook factory', () => {
+    renderHook(() => useLimaStatus())
+
+    expect(mockUseCache).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'lima-status' }),
+    )
+  })
+
+  it('returns healthy data when all VMs are running', () => {
+    const { result } = renderHook(() => useLimaStatus())
+
+    expect(result.current.data.health).toBe('healthy')
+    expect(result.current.data.runningNodes).toBe(2)
+    expect(result.current.data.stoppedNodes).toBe(0)
+  })
+
+  it('returns degraded data when a VM is stopped', () => {
+    setupCacheReturn({ data: DEGRADED_DATA })
+
+    const { result } = renderHook(() => useLimaStatus())
+
+    expect(result.current.data.health).toBe('degraded')
+    expect(result.current.data.stoppedNodes).toBe(1)
+  })
+
+  it('returns not-detected when no Lima instances exist', () => {
+    setupCacheReturn({ data: NOT_DETECTED_DATA })
+
+    const { result } = renderHook(() => useLimaStatus())
+
+    expect(result.current.data.health).toBe('not-detected')
+    expect(result.current.data.totalNodes).toBe(0)
+  })
+
+  it('exposes isDemoData when cache reports demo fallback and not loading', () => {
+    setupCacheReturn({
+      data: DEMO_DATA,
+      isDemoFallback: true,
+    })
+
+    const { result } = renderHook(() => useLimaStatus())
+
+    expect(result.current.isDemoData).toBe(true)
+    expect(lastLoadingStateCall().isDemoData).toBe(true)
+  })
+
+  it('isDemoData is false during loading even when isDemoFallback is true', () => {
+    setupCacheReturn({
+      data: DEMO_DATA,
+      isLoading: true,
+      isDemoFallback: true,
+    })
+
+    const { result } = renderHook(() => useLimaStatus())
+
+    expect(result.current.isDemoData).toBe(false)
+    expect(lastLoadingStateCall().isDemoData).toBe(false)
+  })
+
+  it('surfaces showSkeleton from useCardLoadingState', () => {
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false })
+
+    const { result } = renderHook(() => useLimaStatus())
+
+    expect(result.current.showSkeleton).toBe(true)
+  })
+
+  it('sets error when fetch failed and no VM data is available', () => {
+    setupCacheReturn({
+      data: NOT_DETECTED_DATA,
+      isFailed: true,
+      consecutiveFailures: 2,
+    })
+
+    const { result } = renderHook(() => useLimaStatus())
+
+    expect(result.current.error).toBe(true)
+    expect(result.current.consecutiveFailures).toBe(2)
+  })
+
+  it('does not set error when fetch failed but stale VM data remains', () => {
+    setupCacheReturn({
+      data: HEALTHY_DATA,
+      isFailed: true,
+      consecutiveFailures: 1,
+    })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: true })
+
+    const { result } = renderHook(() => useLimaStatus())
+
+    expect(result.current.error).toBe(false)
+    expect(result.current.consecutiveFailures).toBe(1)
+  })
+})

--- a/web/src/components/cards/lima_status/useLimaStatus.ts
+++ b/web/src/components/cards/lima_status/useLimaStatus.ts
@@ -39,7 +39,7 @@ interface LimaListResponse {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function buildLimaStatus(instances: LimaInstance[], lastCheckTime?: string): LimaStatus {
+export function buildLimaStatus(instances: LimaInstance[], lastCheckTime?: string): LimaStatus {
   const runningNodes = instances.filter(i => i.status === 'running').length
   const stoppedNodes = instances.filter(i => i.status === 'stopped').length
   const brokenNodes = instances.filter(i => i.status === 'broken').length
@@ -65,7 +65,7 @@ function buildLimaStatus(instances: LimaInstance[], lastCheckTime?: string): Lim
   }
 }
 
-function toDemoStatus(demo: LimaDemoData): LimaStatus {
+export function toDemoStatus(demo: LimaDemoData): LimaStatus {
   return {
     instances: demo.instances,
     totalNodes: demo.totalNodes,
@@ -166,10 +166,4 @@ export function useLimaStatus(): UseLimaStatusResult {
     showEmptyState,
     isDemoData: effectiveIsDemoData,
   }
-}
-
-/** Pure helpers for unit tests (factory hook — mock createCachedHook, not useCache directly). */
-export const __testables = {
-  buildLimaStatus,
-  toDemoStatus,
 }

--- a/web/src/components/cards/lima_status/useLimaStatus.ts
+++ b/web/src/components/cards/lima_status/useLimaStatus.ts
@@ -167,3 +167,9 @@ export function useLimaStatus(): UseLimaStatusResult {
     isDemoData: effectiveIsDemoData,
   }
 }
+
+/** Pure helpers for unit tests (factory hook — mock createCachedHook, not useCache directly). */
+export const __testables = {
+  buildLimaStatus,
+  toDemoStatus,
+}

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3011,6 +3011,7 @@
     "syncedDaysAgo": "{{count}}d ago"
   },
   "lima": {
+    "demo": "Demo",
     "healthy": "Healthy",
     "degraded": "Degraded",
     "notDetected": "Lima Not Detected",


### PR DESCRIPTION
## Summary

- Adds `useLimaStatus.test.ts` with Vitest `renderHook` coverage for healthy, degraded, not-detected, demo, skeleton, and error states — mocks **`createCachedHook`** (factory pattern), not raw `useCache` like Contour/Flux.
- Deepens `LimaStatus.test.tsx` beyond smoke-only: skeleton, fetch error, not-detected, live VM list, degraded state, and `isDemoData` demo badge.
- Exposes `__testables` (`buildLimaStatus`, `toDemoStatus`) and renders demo badge on the card when `isDemoData` is true.

Part of #4189

Fixes #15276

## Test plan

- [x] `cd web && npx vitest run src/components/cards/lima_status/__tests__` — 2 files, 15 tests passed locally
- [ ] CI Vitest shard passes on PR
- [ ] Coverage gate on modified files

## Note

Separate from Contour/Flux ([#15274](https://github.com/kubestellar/console/pull/15274) / `test/contour-flux-status-renderhook-rtl`) — Lima uses `createCachedHook` factory; Contour/Flux use manual `useCache`.