### PR TITLE
test(cards): Pure Vitest for GitHubActivity.utils + deepen GitHubActivity RTL

### DIFF
--- a/web/src/components/cards/GitHubActivity.utils.ts
+++ b/web/src/components/cards/GitHubActivity.utils.ts
@@ -93,4 +93,13 @@ function getDemoGitHubData(repoName: string) {
 
 // Custom hook for GitHub data fetching via useCache (SWR, demo fallback, persistence)
 
-export { isStale, getSavedRepos, saveRepos, getDemoGitHubData, DEFAULT_REPO, CURRENT_REPO_STORAGE_KEY, githubFetchError }
+export {
+  isStale,
+  getSavedRepos,
+  saveRepos,
+  getDemoGitHubData,
+  DEFAULT_REPO,
+  SAVED_REPOS_STORAGE_KEY,
+  CURRENT_REPO_STORAGE_KEY,
+  githubFetchError,
+}

--- a/web/src/components/cards/__tests__/GitHubActivity.test.tsx
+++ b/web/src/components/cards/__tests__/GitHubActivity.test.tsx
@@ -1,5 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MS_PER_DAY } from '../../../lib/constants/time'
+import { getDemoGitHubData } from '../GitHubActivity.utils'
 
 // Standard mocks
 vi.mock('../../../lib/demoMode', () => ({
@@ -45,29 +48,70 @@ vi.mock('../CardDataContext', () => ({
   useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
 }))
 
-vi.mock('../../../lib/cards/cardHooks', () => ({
-  useCardData: () => ({
-    items: [], totalItems: 0, currentPage: 1, totalPages: 0, itemsPerPage: 5,
-    goToPage: vi.fn(), needsPagination: false, setItemsPerPage: vi.fn(),
-    filters: { search: '', setSearch: vi.fn(), localClusterFilter: [], toggleClusterFilter: vi.fn(), clearClusterFilter: vi.fn(), availableClusters: [], showClusterFilter: false, setShowClusterFilter: vi.fn(), clusterFilterRef: { current: null }, clusterFilterBtnRef: { current: null }, dropdownStyle: null },
-    sorting: { sortBy: '', setSortBy: vi.fn(), sortDirection: 'asc' as const, setSortDirection: vi.fn(), toggleSortDirection: vi.fn() },
-    containerRef: { current: null }, containerStyle: undefined,
-  }),
-  commonComparators: { string: () => () => 0, number: () => () => 0, statusOrder: () => () => 0, date: () => () => 0, boolean: () => () => 0 },
-}))
-
 vi.mock('../../ui/Toast', () => ({
   useToast: () => ({ showToast: vi.fn() }),
   ToastProvider: ({ children }: { children: React.ReactNode }) => children,
 }))
+
+vi.mock('../pipelines/PipelineFilterContext', () => ({
+  usePipelineFilter: () => null,
+}))
+
+const mockRefetch = vi.fn()
+const mockUseCache = vi.fn()
+
+vi.mock('../../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+function makeStorage(initial: Record<string, string> = {}): Storage {
+  const store = { ...initial }
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { Object.keys(store).forEach(k => delete store[k]) },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length },
+  } as Storage
+}
+
+function buildLoadedCacheData(overrides?: {
+  prs?: ReturnType<typeof getDemoGitHubData>['prs']
+  issues?: ReturnType<typeof getDemoGitHubData>['issues']
+}) {
+  const demo = getDemoGitHubData('kubestellar/console')
+  return {
+    repoInfo: demo.repoInfo,
+    prs: overrides?.prs ?? demo.prs,
+    issues: overrides?.issues ?? demo.issues,
+    releases: demo.releases,
+    contributors: demo.contributors,
+    openPRCount: demo.openPRCount,
+    openIssueCount: demo.openIssueCount,
+  }
+}
 
 import { GitHubActivity } from '../GitHubActivity'
 
 describe('GitHubActivity', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubGlobal('localStorage', makeStorage())
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
+    mockUseCache.mockReturnValue({
+      data: buildLoadedCacheData(),
+      isLoading: false,
+      isRefreshing: false,
+      error: null,
+      isDemoFallback: true,
+      refetch: mockRefetch,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('renders without crashing', () => {
@@ -80,16 +124,141 @@ describe('GitHubActivity', () => {
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })
 
-  it('renders correctly in demo mode', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+  it('shows loading skeleton when data is loading and repoInfo is absent', () => {
+    mockUseCache.mockReturnValue({
+      data: {
+        repoInfo: null,
+        prs: [],
+        issues: [],
+        releases: [],
+        contributors: [],
+        openPRCount: 0,
+        openIssueCount: 0,
+      },
+      isLoading: true,
+      isRefreshing: false,
+      error: null,
+      isDemoFallback: false,
+      refetch: mockRefetch,
+    })
+
     const { container } = render(<GitHubActivity />)
-    expect(container).toBeTruthy()
+    expect(container.querySelector('.h-full')).toBeTruthy()
+    expect(screen.queryByText('cards:github.fetchError')).not.toBeInTheDocument()
   })
 
-  it('renders correctly in non-demo mode', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
-    const { container } = render(<GitHubActivity />)
-    expect(container).toBeTruthy()
+  it('renders error banner with message and retry when fetch fails', () => {
+    const fetchError = 'Failed to fetch repo: Console proxy rate limit exceeded (not GitHub).'
+    mockUseCache.mockReturnValue({
+      data: {
+        repoInfo: null,
+        prs: [],
+        issues: [],
+        releases: [],
+        contributors: [],
+        openPRCount: 0,
+        openIssueCount: 0,
+      },
+      isLoading: false,
+      isRefreshing: false,
+      error: fetchError,
+      isDemoFallback: false,
+      refetch: mockRefetch,
+    })
+
+    render(<GitHubActivity />)
+
+    expect(screen.getByText('cards:github.fetchError')).toBeInTheDocument()
+    expect(screen.getByText(fetchError)).toBeInTheDocument()
+    expect(screen.getByText('common:common.retry')).toBeInTheDocument()
+    expect(screen.getByText('common:common.error')).toBeInTheDocument()
   })
 
+  it('shows stale count in stats when open PRs are older than 14 days', () => {
+    const staleUpdatedAt = new Date(Date.now() - 15 * MS_PER_DAY).toISOString()
+    const demo = getDemoGitHubData('kubestellar/console')
+    const stalePr = { ...demo.prs[0], state: 'open' as const, updated_at: staleUpdatedAt, merged_at: null }
+
+    mockUseCache.mockReturnValue({
+      data: buildLoadedCacheData({ prs: [stalePr, ...demo.prs.slice(1)] }),
+      isLoading: false,
+      isRefreshing: false,
+      error: null,
+      isDemoFallback: true,
+      refetch: mockRefetch,
+    })
+
+    render(<GitHubActivity />)
+
+    const openPrsStat = screen.getByText('cards:github.openPRs').closest('div')?.parentElement
+    expect(openPrsStat).toBeTruthy()
+    const statBlock = within(openPrsStat as HTMLElement)
+    expect(statBlock.getByText(/1/)).toBeInTheDocument()
+    expect(statBlock.getByText(/cards:github\.stale/)).toBeInTheDocument()
+  })
+
+  it('renders stale badge on an open PR list item older than 14 days', () => {
+    const staleUpdatedAt = new Date(Date.now() - 15 * MS_PER_DAY).toISOString()
+    const demo = getDemoGitHubData('kubestellar/console')
+    const stalePr = {
+      ...demo.prs[0],
+      number: 9001,
+      title: 'stale-open-pr-for-test',
+      state: 'open' as const,
+      updated_at: staleUpdatedAt,
+      merged_at: null,
+    }
+
+    mockUseCache.mockReturnValue({
+      data: buildLoadedCacheData({ prs: [stalePr] }),
+      isLoading: false,
+      isRefreshing: false,
+      error: null,
+      isDemoFallback: true,
+      refetch: mockRefetch,
+    })
+
+    render(<GitHubActivity />)
+
+    expect(screen.getByText(/#9001 stale-open-pr-for-test/)).toBeInTheDocument()
+    expect(screen.getAllByText('cards:github.stale').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('opens repo editor and adds a repository via inline CRUD', async () => {
+    const user = userEvent.setup()
+    render(<GitHubActivity />)
+
+    const configureButtons = screen.getAllByTitle('cards:github.configureRepo')
+    await user.click(configureButtons[0])
+
+    const input = screen.getByPlaceholderText('owner/repo (e.g., facebook/react)')
+    await user.type(input, 'facebook/react')
+    await user.click(screen.getByTitle('cards:githubActivity.addRepo'))
+
+    expect(screen.getByText('facebook/react')).toBeInTheDocument()
+    expect(localStorage.getItem('github_activity_saved_repos')).toContain('facebook/react')
+  })
+
+  it('selects a different saved repo when clicking a repo chip', async () => {
+    localStorage.setItem(
+      'github_activity_saved_repos',
+      JSON.stringify(['kubestellar/console', 'kubernetes/kubernetes']),
+    )
+
+    const user = userEvent.setup()
+    render(<GitHubActivity />)
+
+    const configureButtons = screen.getAllByTitle('cards:github.configureRepo')
+    await user.click(configureButtons[0])
+
+    await user.click(screen.getByText('kubernetes/kubernetes'))
+
+    expect(localStorage.getItem('github_activity_repo')).toBe('kubernetes/kubernetes')
+  })
+
+  it('renders demo PR content when cache returns demo fallback data', () => {
+    render(<GitHubActivity />)
+    expect(screen.getByText(/#842 feat: Add multi-cluster GPU scheduling/)).toBeInTheDocument()
+    expect(screen.getByText('cards:github.pullRequests')).toBeInTheDocument()
+  })
 })

--- a/web/src/components/cards/__tests__/GitHubActivity.test.tsx
+++ b/web/src/components/cards/__tests__/GitHubActivity.test.tsx
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MS_PER_DAY } from '../../../lib/constants/time'
-import { getDemoGitHubData } from '../GitHubActivity.utils'
+import {
+  CURRENT_REPO_STORAGE_KEY,
+  getDemoGitHubData,
+  SAVED_REPOS_STORAGE_KEY,
+} from '../GitHubActivity.utils'
 
 // Standard mocks
 vi.mock('../../../lib/demoMode', () => ({
@@ -142,9 +146,10 @@ describe('GitHubActivity', () => {
       refetch: mockRefetch,
     })
 
-    const { container } = render(<GitHubActivity />)
-    expect(container.querySelector('.h-full')).toBeTruthy()
+    render(<GitHubActivity />)
     expect(screen.queryByText('cards:github.fetchError')).not.toBeInTheDocument()
+    expect(screen.queryByText('cards:github.openPRs')).not.toBeInTheDocument()
+    expect(screen.queryByText(/#842/)).not.toBeInTheDocument()
   })
 
   it('renders error banner with message and retry when fetch fails', () => {
@@ -190,11 +195,8 @@ describe('GitHubActivity', () => {
 
     render(<GitHubActivity />)
 
-    const openPrsStat = screen.getByText('cards:github.openPRs').closest('div')?.parentElement
-    expect(openPrsStat).toBeTruthy()
-    const statBlock = within(openPrsStat as HTMLElement)
-    expect(statBlock.getByText(/1/)).toBeInTheDocument()
-    expect(statBlock.getByText(/cards:github\.stale/)).toBeInTheDocument()
+    expect(screen.getByText('cards:github.openPRs')).toBeInTheDocument()
+    expect(screen.getByText(/1\s+cards:github\.stale/)).toBeInTheDocument()
   })
 
   it('renders stale badge on an open PR list item older than 14 days', () => {
@@ -236,12 +238,12 @@ describe('GitHubActivity', () => {
     await user.click(screen.getByTitle('cards:githubActivity.addRepo'))
 
     expect(screen.getByText('facebook/react')).toBeInTheDocument()
-    expect(localStorage.getItem('github_activity_saved_repos')).toContain('facebook/react')
+    expect(localStorage.getItem(SAVED_REPOS_STORAGE_KEY)).toContain('facebook/react')
   })
 
   it('selects a different saved repo when clicking a repo chip', async () => {
     localStorage.setItem(
-      'github_activity_saved_repos',
+      SAVED_REPOS_STORAGE_KEY,
       JSON.stringify(['kubestellar/console', 'kubernetes/kubernetes']),
     )
 
@@ -253,7 +255,7 @@ describe('GitHubActivity', () => {
 
     await user.click(screen.getByText('kubernetes/kubernetes'))
 
-    expect(localStorage.getItem('github_activity_repo')).toBe('kubernetes/kubernetes')
+    expect(localStorage.getItem(CURRENT_REPO_STORAGE_KEY)).toBe('kubernetes/kubernetes')
   })
 
   it('renders demo PR content when cache returns demo fallback data', () => {

--- a/web/src/components/cards/__tests__/GitHubActivity.utils.test.ts
+++ b/web/src/components/cards/__tests__/GitHubActivity.utils.test.ts
@@ -7,14 +7,13 @@ import { MS_PER_DAY } from '../../../lib/constants/time'
 import {
   DEFAULT_REPO,
   CURRENT_REPO_STORAGE_KEY,
+  SAVED_REPOS_STORAGE_KEY,
   getDemoGitHubData,
   getSavedRepos,
   githubFetchError,
   isStale,
   saveRepos,
 } from '../GitHubActivity.utils'
-
-const SAVED_REPOS_STORAGE_KEY = 'github_activity_saved_repos'
 
 function makeStorage(initial: Record<string, string> = {}): Storage {
   const store = { ...initial }
@@ -115,6 +114,10 @@ describe('getSavedRepos / saveRepos', () => {
     vi.stubGlobal('localStorage', makeStorage())
   })
 
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('returns default repo when localStorage is empty', () => {
     expect(getSavedRepos()).toEqual([DEFAULT_REPO])
   })
@@ -132,11 +135,8 @@ describe('getSavedRepos / saveRepos', () => {
   })
 
   it('returns default repo when window is undefined (SSR)', () => {
-    const originalWindow = globalThis.window
-    // @ts-expect-error — simulate SSR environment
-    delete globalThis.window
+    vi.stubGlobal('window', undefined)
     expect(getSavedRepos()).toEqual([DEFAULT_REPO])
-    globalThis.window = originalWindow
   })
 
   it('saveRepos silently ignores localStorage quota errors', () => {

--- a/web/src/components/cards/__tests__/GitHubActivity.utils.test.ts
+++ b/web/src/components/cards/__tests__/GitHubActivity.utils.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure Vitest unit tests for GitHubActivity.utils.ts
+ * Covers isStale boundaries, githubFetchError (#8307), localStorage repos, demo data.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MS_PER_DAY } from '../../../lib/constants/time'
+import {
+  DEFAULT_REPO,
+  CURRENT_REPO_STORAGE_KEY,
+  getDemoGitHubData,
+  getSavedRepos,
+  githubFetchError,
+  isStale,
+  saveRepos,
+} from '../GitHubActivity.utils'
+
+const SAVED_REPOS_STORAGE_KEY = 'github_activity_saved_repos'
+
+function makeStorage(initial: Record<string, string> = {}): Storage {
+  const store = { ...initial }
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { Object.keys(store).forEach(k => delete store[k]) },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length },
+  } as Storage
+}
+
+// ─── isStale (14-day boundary) ───────────────────────────────────────────────
+
+describe('isStale', () => {
+  const FIXED_NOW = new Date('2026-05-21T12:00:00Z')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(FIXED_NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns false when updated exactly 14 days ago (boundary, not stale)', () => {
+    const exactly14DaysAgo = new Date(FIXED_NOW.getTime() - 14 * MS_PER_DAY).toISOString()
+    expect(isStale(exactly14DaysAgo)).toBe(false)
+  })
+
+  it('returns false when updated 13 days ago (1 day under boundary)', () => {
+    const thirteenDaysAgo = new Date(FIXED_NOW.getTime() - 13 * MS_PER_DAY).toISOString()
+    expect(isStale(thirteenDaysAgo)).toBe(false)
+  })
+
+  it('returns true when updated 15 days ago (1 day over boundary)', () => {
+    const fifteenDaysAgo = new Date(FIXED_NOW.getTime() - 15 * MS_PER_DAY).toISOString()
+    expect(isStale(fifteenDaysAgo)).toBe(true)
+  })
+
+  it('returns true when updated more than 14 days ago', () => {
+    const twentyDaysAgo = new Date(FIXED_NOW.getTime() - 20 * MS_PER_DAY).toISOString()
+    expect(isStale(twentyDaysAgo)).toBe(true)
+  })
+})
+
+// ─── githubFetchError (#8307 JSON .error vs statusText) ─────────────────────
+
+describe('githubFetchError', () => {
+  it('uses JSON body error field when present', async () => {
+    const response = new Response(
+      JSON.stringify({ error: 'Console proxy rate limit exceeded (not GitHub).' }),
+      { status: 429, statusText: 'Too Many Requests' },
+    )
+    const err = await githubFetchError(response, 'Failed to fetch repo')
+    expect(err.message).toBe(
+      'Failed to fetch repo: Console proxy rate limit exceeded (not GitHub).',
+    )
+  })
+
+  it('falls back to statusText when JSON has no error field', async () => {
+    const response = new Response(JSON.stringify({ message: 'other' }), {
+      status: 500,
+      statusText: 'Internal Server Error',
+    })
+    const err = await githubFetchError(response, 'Failed to fetch open PRs')
+    expect(err.message).toBe('Failed to fetch open PRs: Internal Server Error')
+  })
+
+  it('falls back to statusText when body is not JSON', async () => {
+    const response = new Response('not json', { status: 502, statusText: 'Bad Gateway' })
+    const err = await githubFetchError(response, 'Failed to fetch issues')
+    expect(err.message).toBe('Failed to fetch issues: Bad Gateway')
+  })
+
+  it('falls back to status when statusText is empty', async () => {
+    const response = new Response('', { status: 503, statusText: '' })
+    const err = await githubFetchError(response, 'Failed to fetch releases')
+    expect(err.message).toBe('Failed to fetch releases: 503')
+  })
+
+  it('falls back to statusText when JSON error field is empty string', async () => {
+    const response = new Response(JSON.stringify({ error: '' }), {
+      status: 403,
+      statusText: 'Forbidden',
+    })
+    const err = await githubFetchError(response, 'Failed to fetch contributors')
+    expect(err.message).toBe('Failed to fetch contributors: Forbidden')
+  })
+})
+
+// ─── getSavedRepos / saveRepos (localStorage) ────────────────────────────────
+
+describe('getSavedRepos / saveRepos', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', makeStorage())
+  })
+
+  it('returns default repo when localStorage is empty', () => {
+    expect(getSavedRepos()).toEqual([DEFAULT_REPO])
+  })
+
+  it('round-trips repos via saveRepos and getSavedRepos', () => {
+    const repos = ['kubestellar/console', 'facebook/react']
+    saveRepos(repos)
+    expect(getSavedRepos()).toEqual(repos)
+    expect(localStorage.getItem(SAVED_REPOS_STORAGE_KEY)).toBe(JSON.stringify(repos))
+  })
+
+  it('returns default repo when stored JSON is malformed', () => {
+    localStorage.setItem(SAVED_REPOS_STORAGE_KEY, 'not-json{{{')
+    expect(getSavedRepos()).toEqual([DEFAULT_REPO])
+  })
+
+  it('returns default repo when window is undefined (SSR)', () => {
+    const originalWindow = globalThis.window
+    // @ts-expect-error — simulate SSR environment
+    delete globalThis.window
+    expect(getSavedRepos()).toEqual([DEFAULT_REPO])
+    globalThis.window = originalWindow
+  })
+
+  it('saveRepos silently ignores localStorage quota errors', () => {
+    vi.stubGlobal('localStorage', {
+      setItem: () => { throw new Error('QuotaExceededError') },
+      getItem: () => null,
+    })
+    expect(() => saveRepos(['org/repo'])).not.toThrow()
+  })
+})
+
+describe('CURRENT_REPO_STORAGE_KEY', () => {
+  it('exports the expected localStorage key for current repo selection', () => {
+    expect(CURRENT_REPO_STORAGE_KEY).toBe('github_activity_repo')
+  })
+})
+
+// ─── getDemoGitHubData ───────────────────────────────────────────────────────
+
+describe('getDemoGitHubData', () => {
+  it('returns expected demo shape for a given repo name', () => {
+    const data = getDemoGitHubData('kubestellar/console')
+
+    expect(data.prs.length).toBeGreaterThan(0)
+    expect(data.issues.length).toBeGreaterThan(0)
+    expect(data.releases.length).toBeGreaterThan(0)
+    expect(data.contributors.length).toBeGreaterThan(0)
+    expect(data.repoInfo.full_name).toBe('kubestellar/console')
+    expect(data.repoInfo.name).toBe('console')
+    expect(data.openPRCount).toBe(2)
+    expect(data.openIssueCount).toBe(2)
+    expect(data.repoInfo.stargazers_count).toBeGreaterThan(0)
+  })
+
+  it('uses repo segment as name when full_name has owner/repo', () => {
+    const data = getDemoGitHubData('facebook/react')
+    expect(data.repoInfo.full_name).toBe('facebook/react')
+    expect(data.repoInfo.name).toBe('react')
+  })
+})


### PR DESCRIPTION
## Summary

- Add pure Vitest unit tests for `GitHubActivity.utils.ts`: `isStale` (14-day boundary), `githubFetchError` (JSON `.error` vs `statusText` per #8307), `getSavedRepos`/`saveRepos` localStorage round-trip, and `getDemoGitHubData` shape.
- Deepen `GitHubActivity.test.tsx` beyond four smoke cases: loading skeleton, error banner with retry, stale stats/badge, repo selector CRUD, and demo PR content (test files ~16KB vs prior ~4.2KB).

Part of #4189

Fixes #15281

## Test plan

- [x] `cd web && npx vitest run src/components/cards/__tests__/GitHubActivity.utils.test.ts src/components/cards/__tests__/GitHubActivity.test.tsx` — 26 tests pass
- [ ] CI Vitest + coverage gate on modified files