### PR TITLE
test(cards): Vitest RTL for GitHubCIMonitor, PipelineFlow, WorkflowMatrix (#15336)

### DIFF
--- a/web/src/components/cards/pipelines/__tests__/PipelineFlow.test.tsx
+++ b/web/src/components/cards/pipelines/__tests__/PipelineFlow.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { PipelineFlow } from '../PipelineFlow'
 import { DEMO_FLOW, type FlowPayload } from '../../../../hooks/useGitHubPipelines'
@@ -117,9 +117,15 @@ class MockResizeObserver {
   unobserve = vi.fn()
 }
 
+const OriginalResizeObserver = globalThis.ResizeObserver
+
 describe('PipelineFlow', () => {
   beforeAll(() => {
     globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+  })
+
+  afterAll(() => {
+    globalThis.ResizeObserver = OriginalResizeObserver
   })
 
   beforeEach(() => {

--- a/web/src/components/cards/pipelines/__tests__/PipelineFlow.test.tsx
+++ b/web/src/components/cards/pipelines/__tests__/PipelineFlow.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PipelineFlow } from '../PipelineFlow'
+import { DEMO_FLOW, type FlowPayload } from '../../../../hooks/useGitHubPipelines'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('framer-motion', () => ({
+  useReducedMotion: () => true,
+}))
+
+const mockUsePipelineFlow = vi.fn()
+const mockRunMutation = vi.fn()
+vi.mock('../../../../hooks/useGitHubPipelines', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../hooks/useGitHubPipelines')>()
+  return {
+    ...actual,
+    usePipelineFlow: (...args: unknown[]) => mockUsePipelineFlow(...args),
+    usePipelineMutations: () => ({ run: mockRunMutation }),
+    getPipelineRepos: () => ['kubestellar/console', 'kubestellar/docs'],
+  }
+})
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  useDemoMode: () => mockUseDemoMode(),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+vi.mock('../PipelineFilterContext', () => ({
+  usePipelineFilter: () => null,
+}))
+
+vi.mock('../PipelineDataContext', () => ({
+  usePipelineData: () => null,
+}))
+
+vi.mock('../EmbedButton', () => ({
+  EmbedButton: () => null,
+}))
+
+vi.mock('../RepoSubtitle', () => ({
+  RepoSubtitle: ({ repo }: { repo: string }) => <span data-testid="repo-subtitle">{repo}</span>,
+}))
+
+vi.mock('../../../../hooks/useMissions', () => ({
+  useMissions: () => ({ startMission: vi.fn() }),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFlowWithFailure(): FlowPayload {
+  const base = structuredClone(DEMO_FLOW)
+  base.runs.push({
+    run: {
+      id: 99999002,
+      repo: 'kubestellar/console',
+      name: 'fullstack-e2e',
+      headBranch: 'main',
+      status: 'completed',
+      conclusion: 'failure',
+      event: 'push',
+      runNumber: 458,
+      htmlUrl: '#',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    jobs: [
+      {
+        id: 2001,
+        name: 'e2e',
+        status: 'completed',
+        conclusion: 'failure',
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        htmlUrl: '#',
+        steps: [
+          { name: 'Checkout', status: 'completed', conclusion: 'success', number: 1 },
+          { name: 'Run Playwright', status: 'completed', conclusion: 'failure', number: 2 },
+        ],
+      },
+    ],
+  })
+  return base
+}
+
+function setupFlow(data: FlowPayload | null, opts: { isLoading?: boolean; error?: string | null } = {}) {
+  mockUsePipelineFlow.mockReturnValue({
+    data,
+    isLoading: opts.isLoading ?? false,
+    isRefreshing: false,
+    error: opts.error ?? null,
+    refetch: vi.fn(),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+class MockResizeObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+}
+
+describe('PipelineFlow', () => {
+  beforeAll(() => {
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseCardLoadingState.mockReturnValue({})
+    mockRunMutation.mockResolvedValue({ ok: true })
+    setupFlow(DEMO_FLOW)
+  })
+
+  describe('flow stages', () => {
+    it('renders trigger, workflow, job, and step columns for in-flight runs', () => {
+      render(<PipelineFlow />)
+      expect(screen.getByText('pull_request')).toBeInTheDocument()
+      expect(screen.getByText('Go Tests')).toBeInTheDocument()
+      expect(screen.getByText('go test ./...')).toBeInTheDocument()
+      expect(screen.getByText('Checkout')).toBeInTheDocument()
+      expect(screen.getByText('Run full Go test suite')).toBeInTheDocument()
+      expect(screen.getByText(/1 in flight/)).toBeInTheDocument()
+    })
+  })
+
+  describe('failed-stage highlight', () => {
+    it('shows diagnose control on jobs with failure conclusion', () => {
+      setupFlow(makeFlowWithFailure())
+      render(<PipelineFlow />)
+      const diagnoseButtons = screen.getAllByTitle('Diagnose with AI')
+      expect(diagnoseButtons.length).toBeGreaterThan(0)
+      expect(screen.getByText('fullstack-e2e')).toBeInTheDocument()
+      expect(screen.getByText('e2e')).toBeInTheDocument()
+    })
+  })
+
+  describe('empty state', () => {
+    it('shows message when no runs are in flight', () => {
+      setupFlow({ runs: [] })
+      render(<PipelineFlow />)
+      expect(screen.getByText('No runs in flight.')).toBeInTheDocument()
+    })
+  })
+
+  describe('demo data path', () => {
+    it('passes isDemoData=true to useCardLoadingState in demo mode', () => {
+      mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+      render(<PipelineFlow />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true, hasAnyData: true }),
+      )
+    })
+  })
+
+  describe('error state', () => {
+    it('shows load error when fetch fails with no cached data', () => {
+      setupFlow(null, { error: 'HTTP 503' })
+      render(<PipelineFlow />)
+      expect(screen.getByText(/pipelines\.failedToLoadPipelineFlow/)).toBeInTheDocument()
+      expect(screen.getByText(/HTTP 503/)).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/components/cards/pipelines/__tests__/WorkflowMatrix.test.tsx
+++ b/web/src/components/cards/pipelines/__tests__/WorkflowMatrix.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { WorkflowMatrix } from '../WorkflowMatrix'
+import { DEMO_MATRIX, type MatrixPayload } from '../../../../hooks/useGitHubPipelines'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const mockUsePipelineMatrix = vi.fn()
+vi.mock('../../../../hooks/useGitHubPipelines', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../hooks/useGitHubPipelines')>()
+  return {
+    ...actual,
+    usePipelineMatrix: (...args: unknown[]) => mockUsePipelineMatrix(...args),
+    getPipelineRepos: () => ['kubestellar/console'],
+  }
+})
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  useDemoMode: () => mockUseDemoMode(),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+vi.mock('../PipelineFilterContext', () => ({
+  usePipelineFilter: () => null,
+}))
+
+vi.mock('../PipelineDataContext', () => ({
+  usePipelineData: () => null,
+}))
+
+vi.mock('../EmbedButton', () => ({
+  EmbedButton: () => null,
+}))
+
+vi.mock('../RepoSubtitle', () => ({
+  RepoSubtitle: ({ repo }: { repo: string }) => <span data-testid="repo-subtitle">{repo}</span>,
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMatrixWithKnownCells(): MatrixPayload {
+  return {
+    days: 2,
+    range: ['2026-05-21', '2026-05-22'],
+    workflows: [
+      {
+        repo: 'kubestellar/console',
+        name: 'Go Tests',
+        cells: [
+          { date: '2026-05-21', conclusion: 'success', htmlUrl: 'https://example.com/1' },
+          { date: '2026-05-22', conclusion: 'failure', htmlUrl: 'https://example.com/2' },
+        ],
+      },
+      {
+        repo: 'kubestellar/console',
+        name: 'Release',
+        cells: [
+          { date: '2026-05-21', conclusion: 'timed_out', htmlUrl: '#' },
+          { date: '2026-05-22', conclusion: null, htmlUrl: '#' },
+        ],
+      },
+    ],
+  }
+}
+
+function setupMatrix(data: MatrixPayload | null, opts: { isLoading?: boolean; error?: string | null } = {}) {
+  mockUsePipelineMatrix.mockReturnValue({
+    data,
+    isLoading: opts.isLoading ?? false,
+    isRefreshing: false,
+    error: opts.error ?? null,
+    refetch: vi.fn(),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WorkflowMatrix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseCardLoadingState.mockReturnValue({})
+    setupMatrix(DEMO_MATRIX)
+  })
+
+  describe('matrix grid', () => {
+    it('renders workflow rows from matrix data', () => {
+      setupMatrix(makeMatrixWithKnownCells())
+      render(<WorkflowMatrix />)
+      expect(screen.getByText('Go Tests')).toBeInTheDocument()
+      expect(screen.getByText('Release')).toBeInTheDocument()
+      expect(screen.getByText(/2 workflows/)).toBeInTheDocument()
+    })
+
+    it('renders one heatmap cell per day with status-specific colors', () => {
+      setupMatrix(makeMatrixWithKnownCells())
+      const { container } = render(<WorkflowMatrix />)
+      // Cells render newest-first (server order reversed for display)
+      const goTestsCells = container.querySelectorAll('[aria-label^="2026-05-"]')
+      expect(goTestsCells.length).toBeGreaterThanOrEqual(2)
+      expect(
+        screen.getByRole('link', { name: '2026-05-22: failure' }).className,
+      ).toMatch(/bg-red-500/)
+      expect(
+        screen.getByRole('link', { name: '2026-05-21: success' }).className,
+      ).toMatch(/bg-green-500/)
+      expect(
+        screen.getByLabelText('2026-05-21: timed_out').className,
+      ).toMatch(/bg-orange-500/)
+      expect(
+        screen.getByLabelText('2026-05-22: no run').className,
+      ).toMatch(/bg-muted/)
+    })
+
+    it('links cells with htmlUrl to GitHub', () => {
+      setupMatrix(makeMatrixWithKnownCells())
+      render(<WorkflowMatrix />)
+      const link = screen.getByRole('link', { name: /2026-05-21: success/ })
+      expect(link).toHaveAttribute('href', 'https://example.com/1')
+    })
+  })
+
+  describe('range controls', () => {
+    it('switches day range when user clicks 30d', async () => {
+      const user = userEvent.setup()
+      render(<WorkflowMatrix />)
+      await user.click(screen.getByRole('button', { name: '30d' }))
+      expect(mockUsePipelineMatrix).toHaveBeenLastCalledWith(null, 30, true)
+    })
+  })
+
+  describe('empty state', () => {
+    it('shows message when no workflow activity in range', () => {
+      setupMatrix({ days: 14, range: [], workflows: [] })
+      render(<WorkflowMatrix />)
+      expect(screen.getByText('No workflow activity in this range.')).toBeInTheDocument()
+    })
+  })
+
+  describe('demo data path', () => {
+    it('passes isDemoData=true to useCardLoadingState in demo mode', () => {
+      mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+      render(<WorkflowMatrix />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true, hasAnyData: true }),
+      )
+    })
+  })
+
+  describe('error state', () => {
+    it('shows load error when fetch fails with no cached data', () => {
+      setupMatrix(null, { error: 'HTTP 500' })
+      render(<WorkflowMatrix />)
+      expect(screen.getByText(/pipelines\.failedToLoadMatrix/)).toBeInTheDocument()
+      expect(screen.getByText(/HTTP 500/)).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/components/cards/pipelines/__tests__/WorkflowMatrix.test.tsx
+++ b/web/src/components/cards/pipelines/__tests__/WorkflowMatrix.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { WorkflowMatrix } from '../WorkflowMatrix'
 import { DEMO_MATRIX, type MatrixPayload } from '../../../../hooks/useGitHubPipelines'
@@ -111,22 +111,25 @@ describe('WorkflowMatrix', () => {
 
     it('renders one heatmap cell per day with status-specific colors', () => {
       setupMatrix(makeMatrixWithKnownCells())
-      const { container } = render(<WorkflowMatrix />)
+      render(<WorkflowMatrix />)
+
+      const goTestsRow = screen.getByText('Go Tests').closest('.flex.items-center.gap-2')
+      expect(goTestsRow).not.toBeNull()
+      const goTestsScope = within(goTestsRow as HTMLElement)
       // Cells render newest-first (server order reversed for display)
-      const goTestsCells = container.querySelectorAll('[aria-label^="2026-05-"]')
-      expect(goTestsCells.length).toBeGreaterThanOrEqual(2)
-      expect(
-        screen.getByRole('link', { name: '2026-05-22: failure' }).className,
-      ).toMatch(/bg-red-500/)
-      expect(
-        screen.getByRole('link', { name: '2026-05-21: success' }).className,
-      ).toMatch(/bg-green-500/)
-      expect(
-        screen.getByLabelText('2026-05-21: timed_out').className,
-      ).toMatch(/bg-orange-500/)
-      expect(
-        screen.getByLabelText('2026-05-22: no run').className,
-      ).toMatch(/bg-muted/)
+      expect(goTestsScope.getAllByRole('link')).toHaveLength(2)
+      expect(goTestsScope.getByRole('link', { name: '2026-05-22: failure' }).className).toMatch(
+        /bg-red-500/,
+      )
+      expect(goTestsScope.getByRole('link', { name: '2026-05-21: success' }).className).toMatch(
+        /bg-green-500/,
+      )
+
+      const releaseRow = screen.getByText('Release').closest('.flex.items-center.gap-2')
+      expect(releaseRow).not.toBeNull()
+      const releaseScope = within(releaseRow as HTMLElement)
+      expect(releaseScope.getByLabelText('2026-05-21: timed_out').className).toMatch(/bg-orange-500/)
+      expect(releaseScope.getByLabelText('2026-05-22: no run').className).toMatch(/bg-muted/)
     })
 
     it('links cells with htmlUrl to GitHub', () => {

--- a/web/src/components/cards/workload-monitor/__tests__/GitHubCIMonitor.test.tsx
+++ b/web/src/components/cards/workload-monitor/__tests__/GitHubCIMonitor.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { GitHubCIMonitor } from '../GitHubCIMonitor'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const mockUseCache = vi.fn()
+vi.mock('../../../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+vi.mock('../../../../hooks/useMissions', () => ({
+  useMissions: () => ({ startMission: vi.fn() }),
+}))
+
+vi.mock('../../pipelines/PipelineFilterContext', () => ({
+  usePipelineFilter: () => null,
+}))
+
+vi.mock('../WorkloadMonitorAlerts', () => ({
+  WorkloadMonitorAlerts: () => <div data-testid="workload-monitor-alerts" />,
+}))
+
+vi.mock('../../../../lib/cards/CardComponents', () => ({
+  CardSearchInput: () => <input data-testid="card-search" />,
+  CardAIActions: () => null,
+}))
+
+vi.mock('../../../../lib/cards/cardHooks', () => ({
+  useCardData: (data: unknown[]) => ({
+    items: data,
+    totalItems: data.length,
+    currentPage: 1,
+    totalPages: 1,
+    goToPage: vi.fn(),
+    needsPagination: false,
+    itemsPerPage: 8,
+    setItemsPerPage: vi.fn(),
+    filters: { search: '', setSearch: vi.fn() },
+    sorting: {
+      sortBy: 'status',
+      setSortBy: vi.fn(),
+      sortDirection: 'asc' as const,
+      setSortDirection: vi.fn(),
+    },
+    containerRef: { current: null },
+    containerStyle: undefined,
+  }),
+  commonComparators: {
+    string: () => () => 0,
+    number: () => () => 0,
+    statusOrder: () => () => 0,
+    date: () => () => 0,
+    boolean: () => () => 0,
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NOW = '2026-05-22T12:00:00Z'
+const FIVE_MIN_AGO = '2026-05-22T11:55:00Z'
+
+function makeWorkflow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'run-1',
+    name: 'CI / Build & Test',
+    repo: 'kubestellar/console',
+    status: 'completed',
+    conclusion: 'success',
+    branch: 'main',
+    event: 'push',
+    runNumber: 100,
+    createdAt: FIVE_MIN_AGO,
+    updatedAt: FIVE_MIN_AGO,
+    url: 'https://github.com/kubestellar/console/actions/runs/100',
+    ...overrides,
+  }
+}
+
+function setupCache({
+  workflows = [] as ReturnType<typeof makeWorkflow>[],
+  isLoading = false,
+  isRefreshing = false,
+  isDemo = false,
+  isFailed = false,
+  consecutiveFailures = 0,
+} = {}) {
+  mockUseCache.mockReturnValue({
+    data: { workflows, isDemo },
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    refetch: vi.fn(),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GitHubCIMonitor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(NOW))
+    mockUseCardLoadingState.mockReturnValue({})
+    setupCache()
+  })
+
+  describe('loading state', () => {
+    it('shows skeleton when loading with no workflows yet', () => {
+      setupCache({ isLoading: true, workflows: [] })
+      const { container } = render(<GitHubCIMonitor />)
+      expect(container.querySelector('.animate-pulse, [class*="skeleton"]') ?? container.innerHTML).toBeTruthy()
+      expect(screen.queryByText('GitHub CI')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('run list and status badges', () => {
+    it('renders workflow names and repo branches', () => {
+      setupCache({
+        workflows: [
+          makeWorkflow({ id: '1', name: 'CI / Build & Test', conclusion: 'success' }),
+          makeWorkflow({
+            id: '2',
+            name: 'CI / Lint',
+            conclusion: 'failure',
+            branch: 'feat/ci-tests',
+            status: 'completed',
+          }),
+        ],
+      })
+      render(<GitHubCIMonitor />)
+      expect(screen.getByText('CI / Build & Test')).toBeInTheDocument()
+      expect(screen.getByText('CI / Lint')).toBeInTheDocument()
+      expect(screen.getByText(/console · main/)).toBeInTheDocument()
+      expect(screen.getByText(/console · feat\/ci-tests/)).toBeInTheDocument()
+    })
+
+    it('shows success, failure, and in_progress status labels', () => {
+      setupCache({
+        workflows: [
+          makeWorkflow({ id: '1', conclusion: 'success', status: 'completed' }),
+          makeWorkflow({
+            id: '2',
+            name: 'CI / Lint',
+            conclusion: 'failure',
+            status: 'completed',
+          }),
+          makeWorkflow({
+            id: '3',
+            name: 'Release / Publish',
+            conclusion: null,
+            status: 'in_progress',
+          }),
+        ],
+      })
+      render(<GitHubCIMonitor />)
+      expect(screen.getByText('success')).toBeInTheDocument()
+      expect(screen.getByText('failure')).toBeInTheDocument()
+      expect(screen.getByText('in_progress')).toBeInTheDocument()
+    })
+
+    it('displays formatTimeAgo for each run updatedAt', () => {
+      setupCache({ workflows: [makeWorkflow({ updatedAt: FIVE_MIN_AGO })] })
+      render(<GitHubCIMonitor />)
+      expect(screen.getByText('5m ago')).toBeInTheDocument()
+    })
+  })
+
+  describe('demo data path', () => {
+    it('shows demo token banner when isDemo is true', () => {
+      setupCache({
+        isDemo: true,
+        workflows: [makeWorkflow()],
+      })
+      render(<GitHubCIMonitor />)
+      expect(screen.getByText(/No GitHub token configured/)).toBeInTheDocument()
+      expect(screen.getByText('Add Token')).toBeInTheDocument()
+    })
+
+    it('reports isDemoData to useCardLoadingState after load completes', () => {
+      setupCache({ isDemo: true, workflows: [makeWorkflow()] })
+      render(<GitHubCIMonitor />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true, hasAnyData: true }),
+      )
+    })
+
+    it('does not report demo during initial loading', () => {
+      setupCache({ isLoading: true, isDemo: true, workflows: [] })
+      render(<GitHubCIMonitor />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: false }),
+      )
+    })
+  })
+
+  describe('error state', () => {
+    it('shows error message when fetch failed', () => {
+      setupCache({
+        isFailed: true,
+        consecutiveFailures: 1,
+        workflows: [makeWorkflow()],
+      })
+      render(<GitHubCIMonitor />)
+      expect(screen.getByText('Failed to fetch workflows')).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/components/cards/workload-monitor/__tests__/GitHubCIMonitor.test.tsx
+++ b/web/src/components/cards/workload-monitor/__tests__/GitHubCIMonitor.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { GitHubCIMonitor } from '../GitHubCIMonitor'
 
@@ -122,11 +122,16 @@ describe('GitHubCIMonitor', () => {
     setupCache()
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   describe('loading state', () => {
     it('shows skeleton when loading with no workflows yet', () => {
       setupCache({ isLoading: true, workflows: [] })
       const { container } = render(<GitHubCIMonitor />)
-      expect(container.querySelector('.animate-pulse, [class*="skeleton"]') ?? container.innerHTML).toBeTruthy()
+      const skeletons = container.querySelectorAll('.animate-pulse')
+      expect(skeletons.length).toBeGreaterThan(0)
       expect(screen.queryByText('GitHub CI')).not.toBeInTheDocument()
     })
   })

--- a/web/src/components/cards/workload-monitor/__tests__/gitHubCIUtils.test.ts
+++ b/web/src/components/cards/workload-monitor/__tests__/gitHubCIUtils.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  formatTimeAgo,
+  loadRepos,
+  saveRepos,
+  REPOS_STORAGE_KEY,
+  DEFAULT_REPOS,
+} from '../gitHubCIUtils'
+
+describe('gitHubCIUtils', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.useRealTimers()
+  })
+
+  describe('loadRepos / saveRepos', () => {
+    it('returns DEFAULT_REPOS when localStorage is empty', () => {
+      expect(loadRepos()).toEqual(DEFAULT_REPOS)
+    })
+
+    it('persists and reloads a custom repo list', () => {
+      const custom = ['acme/widgets', 'acme/gadgets']
+      saveRepos(custom)
+      expect(localStorage.getItem(REPOS_STORAGE_KEY)).toBe(JSON.stringify(custom))
+      expect(loadRepos()).toEqual(custom)
+    })
+
+    it('falls back to DEFAULT_REPOS when stored JSON is invalid', () => {
+      localStorage.setItem(REPOS_STORAGE_KEY, 'not-json')
+      expect(loadRepos()).toEqual(DEFAULT_REPOS)
+    })
+
+    it('falls back to DEFAULT_REPOS when stored array is empty', () => {
+      localStorage.setItem(REPOS_STORAGE_KEY, '[]')
+      expect(loadRepos()).toEqual(DEFAULT_REPOS)
+    })
+
+    it('falls back to DEFAULT_REPOS when stored value is not an array', () => {
+      localStorage.setItem(REPOS_STORAGE_KEY, '{"repo":"x"}')
+      expect(loadRepos()).toEqual(DEFAULT_REPOS)
+    })
+  })
+
+  describe('formatTimeAgo (re-export)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-05-22T12:00:00Z'))
+    })
+
+    it('formats recent timestamps for workflow run rows', () => {
+      expect(formatTimeAgo('2026-05-22T11:55:00Z')).toBe('5m ago')
+    })
+
+    it('returns just now at the sub-minute boundary', () => {
+      expect(formatTimeAgo('2026-05-22T11:59:45Z')).toBe('just now')
+    })
+
+    it('returns hours ago for older runs', () => {
+      expect(formatTimeAgo('2026-05-22T09:00:00Z')).toBe('3h ago')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds Vitest + React Testing Library coverage for the three CI pipeline card components that had no component-level tests, per [#15336](https://github.com/kubestellar/console/issues/15336) and the mentorship test-coverage plan.

- **GitHubCIMonitor** — loading skeleton, run list, success/failure/in_progress badges, demo banner, `useCardLoadingState` demo path, error state
- **gitHubCIUtils** — `loadRepos` / `saveRepos` persistence and `formatTimeAgo` boundary checks
- **PipelineFlow** — trigger/workflow/job/step columns, failed-job diagnose affordance, empty state, demo `isDemoData`
- **WorkflowMatrix** — workflow rows, heatmap cell colors by conclusion, range control, empty/error/demo paths

Pipeline hooks (`usePipelineFlow`, `usePipelineMatrix`) remain covered in `useGitHubPipelines.test.ts`; this PR closes the **component rendering** gap only.

Part of #4189 (not `Fixes` while mentorship issue has `hold`).

## Test plan

- [x] `npx vitest run` on all four new test files — **28/28 passed** locally
- [ ] CI Vitest job green on PR
- [ ] Coverage gate on modified files (if applicable)