### PR TITLE
test(console-missions): Vitest RTL for Console AI cards (#15338)

### DIFF
--- a/web/src/components/cards/console-missions/__tests__/ConsoleIssuesCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleIssuesCard.test.tsx
@@ -148,9 +148,9 @@ describe('ConsoleIssuesCard', () => {
       })
       render(<ConsoleIssuesCard />)
 
-      expect(screen.getByText('2')).toBeInTheDocument()
+      expect(screen.getByTitle('2 pods with issues - Click to view first issue')).toHaveTextContent('2')
       expect(screen.getByText('Pod Issues')).toBeInTheDocument()
-      expect(screen.getByText('1')).toBeInTheDocument()
+      expect(screen.getByTitle('1 deployment with issues - Click to view first issue')).toHaveTextContent('1')
       expect(screen.getByText('Deployment Issues')).toBeInTheDocument()
     })
 

--- a/web/src/components/cards/console-missions/__tests__/ConsoleIssuesCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleIssuesCard.test.tsx
@@ -1,0 +1,309 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ConsoleIssuesCard } from '../ConsoleIssuesCard'
+import type { DeploymentIssue, PodIssue } from '../../../../hooks/mcp/types'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const mockStartMission = vi.fn()
+const mockUseMissions = vi.fn()
+vi.mock('../../../../hooks/useMissions', () => ({
+  useMissions: () => mockUseMissions(),
+}))
+
+const mockUseCachedPodIssues = vi.fn()
+const mockUseCachedDeploymentIssues = vi.fn()
+vi.mock('../../../../hooks/useCachedData', () => ({
+  useCachedPodIssues: () => mockUseCachedPodIssues(),
+  useCachedDeploymentIssues: () => mockUseCachedDeploymentIssues(),
+}))
+
+const mockSelectedClusters = vi.fn(() => [] as string[])
+vi.mock('../../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({
+    selectedClusters: mockSelectedClusters(),
+    isAllClustersSelected: true,
+    customFilter: '',
+  }),
+}))
+
+const mockDrillToPod = vi.fn()
+const mockDrillToDeployment = vi.fn()
+vi.mock('../../../../hooks/useDrillDown', () => ({
+  useDrillDownActions: () => ({
+    drillToPod: mockDrillToPod,
+    drillToDeployment: mockDrillToDeployment,
+  }),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+vi.mock('../shared', () => ({
+  useApiKeyCheck: () => ({
+    showKeyPrompt: false,
+    checkKeyAndRun: (fn: () => void) => fn(),
+    goToSettings: vi.fn(),
+    dismissPrompt: vi.fn(),
+  }),
+  ApiKeyPromptModal: () => null,
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePodIssue(overrides: Partial<PodIssue> = {}): PodIssue {
+  return {
+    name: 'crashloop-pod',
+    namespace: 'default',
+    cluster: 'prod',
+    status: 'CrashLoopBackOff',
+    reason: 'BackOff',
+    issues: ['Container restarting'],
+    restarts: 5,
+    ...overrides,
+  }
+}
+
+function makeDeploymentIssue(overrides: Partial<DeploymentIssue> = {}): DeploymentIssue {
+  return {
+    name: 'web-deploy',
+    namespace: 'apps',
+    cluster: 'staging',
+    replicas: 3,
+    readyReplicas: 1,
+    reason: 'Unavailable',
+    message: 'Minimum replicas not available',
+    ...overrides,
+  }
+}
+
+function setupDefaults({
+  podIssues = [] as PodIssue[],
+  deploymentIssues = [] as DeploymentIssue[],
+  podIssuesLoading = false,
+  deployIssuesLoading = false,
+  podsRefreshing = false,
+  deploysRefreshing = false,
+  podsDemoFallback = false,
+  deploysDemoFallback = false,
+  podsFailed = false,
+  deploysFailed = false,
+  podsFailures = 0,
+  deploysFailures = 0,
+  missions = [] as { type: string; status: string }[],
+} = {}) {
+  mockUseMissions.mockReturnValue({
+    startMission: mockStartMission,
+    missions,
+  })
+  mockUseCachedPodIssues.mockReturnValue({
+    issues: podIssues,
+    isLoading: podIssuesLoading,
+    isRefreshing: podsRefreshing,
+    isDemoFallback: podsDemoFallback,
+    isFailed: podsFailed,
+    consecutiveFailures: podsFailures,
+  })
+  mockUseCachedDeploymentIssues.mockReturnValue({
+    issues: deploymentIssues,
+    isLoading: deployIssuesLoading,
+    isRefreshing: deploysRefreshing,
+    isDemoFallback: deploysDemoFallback,
+    isFailed: deploysFailed,
+    consecutiveFailures: deploysFailures,
+  })
+  mockUseCardLoadingState.mockReturnValue({})
+  mockSelectedClusters.mockReturnValue([])
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ConsoleIssuesCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDefaults()
+  })
+
+  describe('issue list render', () => {
+    it('renders pod and deployment issue counts in summary tiles', () => {
+      setupDefaults({
+        podIssues: [makePodIssue(), makePodIssue({ name: 'pod-b' })],
+        deploymentIssues: [makeDeploymentIssue()],
+      })
+      render(<ConsoleIssuesCard />)
+
+      expect(screen.getByText('2')).toBeInTheDocument()
+      expect(screen.getByText('Pod Issues')).toBeInTheDocument()
+      expect(screen.getByText('1')).toBeInTheDocument()
+      expect(screen.getByText('Deployment Issues')).toBeInTheDocument()
+    })
+
+    it('renders top pod issues in the preview list', () => {
+      setupDefaults({
+        podIssues: [
+          makePodIssue({ name: 'alpha-pod', status: 'Error' }),
+          makePodIssue({ name: 'beta-pod', status: 'Pending' }),
+        ],
+      })
+      render(<ConsoleIssuesCard />)
+
+      expect(screen.getByText('alpha-pod')).toBeInTheDocument()
+      expect(screen.getByText('Error')).toBeInTheDocument()
+      expect(screen.getByText('beta-pod')).toBeInTheDocument()
+    })
+
+    it('shows overflow count when more than three issues exist', () => {
+      setupDefaults({
+        podIssues: [
+          makePodIssue({ name: 'p1' }),
+          makePodIssue({ name: 'p2' }),
+          makePodIssue({ name: 'p3' }),
+          makePodIssue({ name: 'p4' }),
+        ],
+      })
+      render(<ConsoleIssuesCard />)
+
+      expect(screen.getByText('+1 more issues')).toBeInTheDocument()
+    })
+
+    it('drills to pod when a preview row is clicked', async () => {
+      const issue = makePodIssue({ name: 'click-pod', cluster: 'prod', namespace: 'kube-system' })
+      setupDefaults({ podIssues: [issue] })
+      render(<ConsoleIssuesCard />)
+
+      await userEvent.click(screen.getByText('click-pod'))
+      expect(mockDrillToPod).toHaveBeenCalledWith(
+        'prod',
+        'kube-system',
+        'click-pod',
+        expect.objectContaining({ status: issue.status }),
+      )
+    })
+
+    it('starts repair mission when Ask AI to Fix is clicked', async () => {
+      setupDefaults({ podIssues: [makePodIssue()] })
+      render(<ConsoleIssuesCard />)
+
+      await userEvent.click(screen.getByText('Ask AI to Fix'))
+      expect(mockStartMission).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'repair', title: 'Fix Cluster Issues' }),
+      )
+    })
+  })
+
+  describe('empty state', () => {
+    it('shows All Clear when there are no issues', () => {
+      setupDefaults()
+      render(<ConsoleIssuesCard />)
+
+      expect(screen.getByText('All Clear')).toBeInTheDocument()
+      expect(screen.getByTitle('No pod issues')).toHaveTextContent('0')
+      expect(screen.getByTitle('No deployment issues')).toHaveTextContent('0')
+    })
+
+    it('disables the repair button when total issues is zero', () => {
+      setupDefaults()
+      render(<ConsoleIssuesCard />)
+
+      expect(screen.getByRole('button', { name: /All Clear/i })).toBeDisabled()
+    })
+  })
+
+  describe('loading skeleton integration', () => {
+    it('reports loading to CardWrapper when fetching with no cached data', () => {
+      setupDefaults({ podIssuesLoading: true, deployIssuesLoading: true })
+      render(<ConsoleIssuesCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isLoading: true,
+          hasAnyData: false,
+        }),
+      )
+    })
+
+    it('does not report loading when cached issues exist while refreshing', () => {
+      setupDefaults({
+        podIssues: [makePodIssue()],
+        podIssuesLoading: true,
+        podsRefreshing: true,
+      })
+      render(<ConsoleIssuesCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isLoading: false,
+          isRefreshing: true,
+          hasAnyData: true,
+        }),
+      )
+    })
+  })
+
+  describe('useCardLoadingState integration', () => {
+    it('passes isDemoData=true when pod hook uses demo fallback', () => {
+      setupDefaults({ podsDemoFallback: true, podIssues: [makePodIssue()] })
+      render(<ConsoleIssuesCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true }),
+      )
+    })
+
+    it('passes isDemoData=true when deployment hook uses demo fallback', () => {
+      setupDefaults({ deploysDemoFallback: true, deploymentIssues: [makeDeploymentIssue()] })
+      render(<ConsoleIssuesCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true }),
+      )
+    })
+
+    it('passes isFailed and max consecutiveFailures from both hooks', () => {
+      setupDefaults({
+        podsFailed: true,
+        deploysFailed: true,
+        podsFailures: 2,
+        deploysFailures: 5,
+      })
+      render(<ConsoleIssuesCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isFailed: true,
+          consecutiveFailures: 5,
+        }),
+      )
+    })
+  })
+
+  describe('running repair mission', () => {
+    it('shows Repair in Progress and disables button when a repair mission is running', () => {
+      setupDefaults({
+        podIssues: [makePodIssue()],
+        missions: [{ type: 'repair', status: 'running' }],
+      })
+      render(<ConsoleIssuesCard />)
+
+      expect(screen.getByText('Repair in Progress')).toBeInTheDocument()
+      expect(screen.getByText('Fixing...')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Repair in Progress/i })).toBeDisabled()
+    })
+  })
+})

--- a/web/src/components/cards/console-missions/__tests__/ConsoleKubeconfigAuditCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleKubeconfigAuditCard.test.tsx
@@ -120,9 +120,9 @@ describe('ConsoleKubeconfigAuditCard', () => {
       })
       render(<ConsoleKubeconfigAuditCard />)
 
-      expect(screen.getByText('2')).toBeInTheDocument()
+      expect(screen.getByTitle('2 total cluster contexts in kubeconfig')).toHaveTextContent('2')
       expect(screen.getByText('Total Contexts')).toBeInTheDocument()
-      expect(screen.getByText('1')).toBeInTheDocument()
+      expect(screen.getByTitle('1 offline cluster - Click to view first')).toHaveTextContent('1')
       expect(screen.getByText('Offline')).toBeInTheDocument()
     })
 

--- a/web/src/components/cards/console-missions/__tests__/ConsoleKubeconfigAuditCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleKubeconfigAuditCard.test.tsx
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ConsoleKubeconfigAuditCard } from '../ConsoleKubeconfigAuditCard'
+import type { ClusterInfo } from '../../../../hooks/mcp/types'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const mockStartMission = vi.fn()
+const mockUseMissions = vi.fn()
+vi.mock('../../../../hooks/useMissions', () => ({
+  useMissions: () => mockUseMissions(),
+}))
+
+const mockUseClusters = vi.fn()
+vi.mock('../../../../hooks/useMCP', () => ({
+  useClusters: () => mockUseClusters(),
+}))
+
+vi.mock('../../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({
+    selectedClusters: [],
+    isAllClustersSelected: true,
+    customFilter: '',
+  }),
+}))
+
+const mockDrillToCluster = vi.fn()
+vi.mock('../../../../hooks/useDrillDown', () => ({
+  useDrillDownActions: () => ({
+    drillToCluster: mockDrillToCluster,
+  }),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+}))
+
+vi.mock('../shared', () => ({
+  useApiKeyCheck: () => ({
+    showKeyPrompt: false,
+    checkKeyAndRun: (fn: () => void) => fn(),
+    goToSettings: vi.fn(),
+    dismissPrompt: vi.fn(),
+  }),
+  ApiKeyPromptModal: () => null,
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCluster(overrides: Partial<ClusterInfo> = {}): ClusterInfo {
+  return {
+    name: 'prod',
+    healthy: true,
+    reachable: true,
+    nodeCount: 3,
+    podCount: 10,
+    ...overrides,
+  } as ClusterInfo
+}
+
+function setupDefaults({
+  clusters = [makeCluster()] as ClusterInfo[],
+  isLoading = false,
+  isRefreshing = false,
+  isFailed = false,
+  consecutiveFailures = 0,
+  isDemoMode = false,
+  missions = [] as { title: string; status: string }[],
+} = {}) {
+  mockUseMissions.mockReturnValue({
+    startMission: mockStartMission,
+    missions,
+  })
+  mockUseClusters.mockReturnValue({
+    deduplicatedClusters: clusters,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+  })
+  mockIsDemoMode.mockReturnValue(isDemoMode)
+  mockUseCardLoadingState.mockReturnValue({})
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ConsoleKubeconfigAuditCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDefaults()
+  })
+
+  describe('audit result display', () => {
+    it('renders total context count and offline count in summary tiles', () => {
+      setupDefaults({
+        clusters: [
+          makeCluster({ name: 'healthy-a' }),
+          makeCluster({ name: 'offline-b', reachable: false, errorMessage: 'Connection refused' }),
+        ],
+      })
+      render(<ConsoleKubeconfigAuditCard />)
+
+      expect(screen.getByText('2')).toBeInTheDocument()
+      expect(screen.getByText('Total Contexts')).toBeInTheDocument()
+      expect(screen.getByText('1')).toBeInTheDocument()
+      expect(screen.getByText('Offline')).toBeInTheDocument()
+    })
+
+    it('lists unreachable clusters in the preview with error messages', () => {
+      setupDefaults({
+        clusters: [
+          makeCluster({
+            name: 'stale-context',
+            reachable: false,
+            errorMessage: 'dial tcp: connection refused',
+          }),
+        ],
+      })
+      render(<ConsoleKubeconfigAuditCard />)
+
+      expect(screen.getByText('stale-context')).toBeInTheDocument()
+      expect(screen.getByText('dial tcp: connection refused')).toBeInTheDocument()
+    })
+
+    it('shows reachable banner when all clusters are online', () => {
+      setupDefaults({
+        clusters: [makeCluster({ name: 'online-only' })],
+      })
+      render(<ConsoleKubeconfigAuditCard />)
+
+      expect(screen.getByText('All clusters reachable')).toBeInTheDocument()
+      expect(screen.getByText('0')).toBeInTheDocument()
+    })
+
+    it('drills to cluster when an offline preview row is clicked', async () => {
+      setupDefaults({
+        clusters: [
+          makeCluster({ name: 'offline-cluster', reachable: false, errorType: 'network' }),
+        ],
+      })
+      render(<ConsoleKubeconfigAuditCard />)
+
+      await userEvent.click(screen.getByText('offline-cluster'))
+      expect(mockDrillToCluster).toHaveBeenCalledWith('offline-cluster')
+    })
+
+    it('starts kubeconfig audit mission when Run Audit is clicked', async () => {
+      setupDefaults({
+        clusters: [makeCluster({ name: 'ctx-a' }), makeCluster({ name: 'ctx-b' })],
+      })
+      render(<ConsoleKubeconfigAuditCard />)
+
+      await userEvent.click(screen.getByText('Run Audit'))
+      expect(mockStartMission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Kubeconfig Audit',
+          type: 'analyze',
+        }),
+      )
+    })
+  })
+
+  describe('error state integration', () => {
+    it('passes isFailed to useCardLoadingState when cluster fetch fails', () => {
+      setupDefaults({ isFailed: true, consecutiveFailures: 3, clusters: [] })
+      render(<ConsoleKubeconfigAuditCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isFailed: true,
+          consecutiveFailures: 3,
+        }),
+      )
+    })
+
+    it('reports loading when clusters are fetching with no cached data', () => {
+      setupDefaults({ isLoading: true, clusters: [] })
+      render(<ConsoleKubeconfigAuditCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isLoading: true,
+          hasAnyData: false,
+        }),
+      )
+    })
+  })
+
+  describe('useCardLoadingState integration', () => {
+    it('passes isDemoData=true when demo mode is active', () => {
+      setupDefaults({ isDemoMode: true, clusters: [makeCluster()] })
+      render(<ConsoleKubeconfigAuditCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true }),
+      )
+    })
+
+    it('passes isRefreshing when cluster data is refreshing', () => {
+      setupDefaults({ isRefreshing: true, clusters: [makeCluster()] })
+      render(<ConsoleKubeconfigAuditCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isRefreshing: true, hasAnyData: true }),
+      )
+    })
+  })
+
+  describe('running audit mission', () => {
+    it('shows Auditing state and disables button when audit mission is running', () => {
+      setupDefaults({
+        clusters: [makeCluster()],
+        missions: [{ title: 'Kubeconfig Audit', status: 'running' }],
+      })
+      render(<ConsoleKubeconfigAuditCard />)
+
+      expect(screen.getByText('Auditing...')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Auditing/i })).toBeDisabled()
+    })
+  })
+})

--- a/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
@@ -1,0 +1,457 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ConsoleOfflineDetectionCard } from '../ConsoleOfflineDetectionCard'
+import type { ClusterInfo, GPUNode, PodIssue } from '../../../../hooks/mcp/types'
+import type { NodeData } from '../offlineDataTransforms'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string; count?: number }) => {
+      if (opts?.defaultValue) return String(opts.defaultValue)
+      if (key.includes('allHealthy')) return 'All Healthy'
+      if (key.includes('gpuIssues')) return 'GPU Issues'
+      if (key.includes('predicted')) return 'Predicted'
+      if (key.includes('issuesTooltip') && opts?.count !== undefined) {
+        return `${opts.count} cluster issues`
+      }
+      if (key.includes('unhealthy')) return 'Unhealthy'
+      if (key.includes('offline')) return 'Offline'
+      return key
+    },
+  }),
+}))
+
+const mockStartMission = vi.fn()
+const mockUseMissions = vi.fn()
+vi.mock('../../../../hooks/useMissions', () => ({
+  useMissions: () => mockUseMissions(),
+}))
+
+const mockUseCachedGPUNodes = vi.fn()
+const mockUseCachedPodIssues = vi.fn()
+vi.mock('../../../../hooks/useCachedData', () => ({
+  useCachedGPUNodes: () => mockUseCachedGPUNodes(),
+  useCachedPodIssues: () => mockUseCachedPodIssues(),
+}))
+
+const mockUseClusters = vi.fn()
+vi.mock('../../../../hooks/useMCP', () => ({
+  useClusters: () => mockUseClusters(),
+}))
+
+vi.mock('../../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({
+    selectedClusters: [],
+    isAllClustersSelected: true,
+    customFilter: '',
+    selectedDistributions: [],
+    isAllDistributionsSelected: true,
+  }),
+}))
+
+const mockDrillToCluster = vi.fn()
+const mockDrillToNode = vi.fn()
+vi.mock('../../../../hooks/useDrillDown', () => ({
+  useDrillDownActions: () => ({
+    drillToCluster: mockDrillToCluster,
+    drillToNode: mockDrillToNode,
+  }),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+const mockUseCardDemoState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+  useCardDemoState: () => mockUseCardDemoState(),
+}))
+
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+}))
+
+vi.mock('../../clusters/useClusterFiltering', () => ({
+  useClusterFiltering: ({ clusters }: { clusters: ClusterInfo[] }) => ({
+    globalFilteredClusters: clusters,
+  }),
+}))
+
+vi.mock('../../../../hooks/usePredictionSettings', () => ({
+  usePredictionSettings: () => ({
+    settings: {
+      thresholds: {
+        highRestartCount: 3,
+        cpuPressure: 80,
+        memoryPressure: 85,
+      },
+      interval: 30,
+      aiEnabled: false,
+    },
+  }),
+}))
+
+const mockTriggerAIAnalysis = vi.fn()
+vi.mock('../../../../hooks/useAIPredictions', () => ({
+  useAIPredictions: () => ({
+    predictions: [],
+    isAnalyzing: false,
+    analyze: mockTriggerAIAnalysis,
+    isEnabled: false,
+  }),
+}))
+
+vi.mock('../../../../hooks/usePredictionFeedback', () => ({
+  usePredictionFeedback: () => ({
+    submitFeedback: vi.fn(),
+    getFeedback: () => null,
+  }),
+}))
+
+vi.mock('../../../../hooks/useMetricsHistory', () => ({
+  useMetricsHistory: () => ({
+    getClusterTrend: () => undefined,
+    getPodRestartTrend: () => undefined,
+  }),
+}))
+
+vi.mock('../shared', () => ({
+  useApiKeyCheck: () => ({
+    showKeyPrompt: false,
+    checkKeyAndRun: (fn: () => void) => fn(),
+    goToSettings: vi.fn(),
+    dismissPrompt: vi.fn(),
+  }),
+  ApiKeyPromptModal: () => null,
+}))
+
+vi.mock('../DynamicCardErrorBoundary', () => ({
+  DynamicCardErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../../../../lib/cards/CardComponents', () => ({
+  CardControlsRow: () => <div data-testid="card-controls-row" />,
+  CardSearchInput: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string
+    onChange: (v: string) => void
+    placeholder?: string
+  }) => (
+    <input
+      data-testid="search-input"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+    />
+  ),
+  CardPaginationFooter: () => <div data-testid="pagination-footer" />,
+  CardAIActions: () => null,
+}))
+
+const mockGetNodesCache = vi.fn(() => [] as NodeData[])
+vi.mock('../nodeCache', () => ({
+  getNodesCache: () => mockGetNodesCache(),
+  subscribeToNodes: () => () => {},
+  fetchAllNodes: vi.fn(() =>
+    Promise.resolve({ nodes: [], error: null, consecutiveFailures: 0 }),
+  ),
+  OFFLINE_DETECTION_FAILURE_THRESHOLD: 3,
+  GPU_CLUSTER_EXHAUSTION_THRESHOLD: 0.8,
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCluster(overrides: Partial<ClusterInfo> = {}): ClusterInfo {
+  return {
+    name: 'prod',
+    healthy: true,
+    reachable: true,
+    nodeCount: 3,
+    podCount: 10,
+    ...overrides,
+  } as ClusterInfo
+}
+
+function makePodIssue(overrides: Partial<PodIssue> = {}): PodIssue {
+  return {
+    name: 'unstable-pod',
+    namespace: 'default',
+    cluster: 'prod',
+    status: 'Running',
+    reason: 'CrashLoopBackOff',
+    issues: ['High restart count'],
+    restarts: 6,
+    ...overrides,
+  }
+}
+
+function makeGpuNode(overrides: Partial<GPUNode> = {}): GPUNode {
+  return {
+    name: 'gpu-worker',
+    cluster: 'prod',
+    gpuCount: 0,
+    gpuAllocated: 0,
+    gpuType: 'nvidia-tesla',
+    ...overrides,
+  } as GPUNode
+}
+
+function setupDefaults({
+  clusters = [makeCluster()] as ClusterInfo[],
+  podIssues = [] as PodIssue[],
+  gpuNodes = [] as GPUNode[],
+  nodes = [] as NodeData[],
+  podsLoading = false,
+  gpuLoading = false,
+  podsDemoFallback = false,
+  gpuDemoFallback = false,
+  podsFailed = false,
+  gpuFailed = false,
+  podsFailures = 0,
+  gpuFailures = 0,
+  shouldUseDemoData = true,
+  isDemoMode = false,
+  missions = [] as { title: string; status: string }[],
+} = {}) {
+  mockUseMissions.mockReturnValue({
+    startMission: mockStartMission,
+    missions,
+  })
+  mockUseClusters.mockReturnValue({
+    deduplicatedClusters: clusters,
+  })
+  mockUseCachedPodIssues.mockReturnValue({
+    issues: podIssues,
+    isLoading: podsLoading,
+    isRefreshing: false,
+    isDemoFallback: podsDemoFallback,
+    isFailed: podsFailed,
+    consecutiveFailures: podsFailures,
+  })
+  mockUseCachedGPUNodes.mockReturnValue({
+    nodes: gpuNodes,
+    isLoading: gpuLoading,
+    isRefreshing: false,
+    isDemoFallback: gpuDemoFallback,
+    isFailed: gpuFailed,
+    consecutiveFailures: gpuFailures,
+  })
+  mockUseCardDemoState.mockReturnValue({ shouldUseDemoData })
+  mockIsDemoMode.mockReturnValue(isDemoMode)
+  mockGetNodesCache.mockReturnValue(nodes)
+  mockUseCardLoadingState.mockReturnValue({})
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ConsoleOfflineDetectionCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDefaults()
+  })
+
+  describe('online/offline status summary', () => {
+    it('shows zero issues with healthy styling when all clusters are reachable', () => {
+      setupDefaults({
+        clusters: [makeCluster({ name: 'healthy-prod' })],
+        nodes: [{ name: 'node-a', cluster: 'healthy-prod', status: 'Ready', unschedulable: false }],
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      const issuesTile = screen.getByTitle('All Healthy')
+      expect(issuesTile).toBeInTheDocument()
+      expect(issuesTile.querySelector('.text-red-400')).toBeNull()
+      expect(screen.getByText('All Healthy')).toBeInTheDocument()
+    })
+
+    it('shows issue count with offline tooltip when unreachable clusters exist', () => {
+      setupDefaults({
+        clusters: [
+          makeCluster({ name: 'reachable' }),
+          makeCluster({
+            name: 'offline-cluster',
+            reachable: false,
+            healthy: false,
+            errorMessage: 'Connection timed out',
+          }),
+        ],
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      expect(screen.getByTitle('1 cluster issues')).toBeInTheDocument()
+      expect(screen.getByText('Offline')).toBeInTheDocument()
+      expect(screen.getByText('Connection timed out')).toBeInTheDocument()
+    })
+
+    it('counts not-ready nodes as current cluster issues', () => {
+      setupDefaults({
+        clusters: [makeCluster({ name: 'prod' })],
+        nodes: [
+          { name: 'worker-down', cluster: 'prod', status: 'NotReady', unschedulable: false },
+        ],
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      expect(screen.getByTitle('1 cluster issues')).toBeInTheDocument()
+      expect(screen.getByText('worker-down')).toBeInTheDocument()
+    })
+
+    it('drills to cluster when issues tile is clicked and issues exist', async () => {
+      setupDefaults({
+        clusters: [
+          makeCluster({ name: 'broken', reachable: false, healthy: false }),
+        ],
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      await userEvent.click(screen.getByTitle('1 cluster issues'))
+      expect(mockDrillToCluster).toHaveBeenCalledWith('broken')
+    })
+  })
+
+  describe('GPU and prediction summary tiles', () => {
+    it('shows GPU issue count when GPU nodes report zero GPUs', () => {
+      setupDefaults({
+        gpuNodes: [makeGpuNode({ name: 'gpu-0', cluster: 'prod' })],
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      expect(screen.getByTitle('1 GPU issue - Click to view')).toHaveTextContent('1')
+      expect(screen.getByText('gpu-0')).toBeInTheDocument()
+      expect(screen.getByText('0 GPUs available')).toBeInTheDocument()
+    })
+
+    it('shows predicted risk count from high-restart pods', () => {
+      setupDefaults({
+        podIssues: [makePodIssue({ restarts: 10, name: 'crash-pod' })],
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      expect(screen.getByTitle(/Current: 1 heuristic/)).toHaveTextContent('1')
+      expect(screen.getByText('crash-pod')).toBeInTheDocument()
+      expect(screen.getByText('10 restarts')).toBeInTheDocument()
+    })
+  })
+
+  describe('healthy banner and analysis action', () => {
+    it('renders All Healthy action when no issues or predictions match filters', () => {
+      setupDefaults({
+        clusters: [makeCluster()],
+        nodes: [{ name: 'n1', cluster: 'prod', status: 'Ready', unschedulable: false }],
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      expect(screen.getByRole('button', { name: /All Healthy/i })).toBeDisabled()
+    })
+
+    it('starts analysis mission when issues exist and button is clicked', async () => {
+      setupDefaults({
+        clusters: [
+          makeCluster({ name: 'offline', reachable: false, healthy: false }),
+        ],
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      await userEvent.click(screen.getByRole('button', { name: /Analyze 1 Issue/i }))
+      expect(mockStartMission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'troubleshoot',
+          title: 'Health Issue Analysis',
+        }),
+      )
+    })
+  })
+
+  describe('search filter', () => {
+    it('filters listed items when search query is entered', async () => {
+      setupDefaults({
+        clusters: [
+          makeCluster({ name: 'alpha-offline', reachable: false }),
+          makeCluster({ name: 'beta-offline', reachable: false }),
+        ],
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      expect(screen.getAllByText('alpha-offline').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('beta-offline').length).toBeGreaterThan(0)
+
+      await userEvent.type(screen.getByTestId('search-input'), 'alpha')
+      expect(screen.getAllByText('alpha-offline').length).toBeGreaterThan(0)
+      expect(screen.queryByText('beta-offline')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('useCardLoadingState integration', () => {
+    it('passes isDemoData when demo mode or demo fallbacks are active', () => {
+      setupDefaults({
+        isDemoMode: true,
+        podsDemoFallback: true,
+        podIssues: [makePodIssue()],
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true }),
+      )
+    })
+
+    it('passes isDemoData when GPU hook uses demo fallback', () => {
+      setupDefaults({
+        gpuDemoFallback: true,
+        gpuNodes: [makeGpuNode()],
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true }),
+      )
+    })
+
+    it('reports loading when pod and GPU sources are loading with no data', () => {
+      setupDefaults({
+        podsLoading: true,
+        gpuLoading: true,
+        shouldUseDemoData: true,
+        clusters: [],
+        podIssues: [],
+        gpuNodes: [],
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isLoading: true,
+          hasAnyData: false,
+        }),
+      )
+    })
+
+    it('suppresses card failure when only one data source has failed', () => {
+      setupDefaults({
+        podsFailed: true,
+        podsFailures: 5,
+        gpuFailed: false,
+        shouldUseDemoData: true,
+      })
+      render(<ConsoleOfflineDetectionCard />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isFailed: false,
+        }),
+      )
+    })
+  })
+})

--- a/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ConsoleOfflineDetectionCard } from '../ConsoleOfflineDetectionCard'
@@ -131,7 +132,7 @@ vi.mock('../shared', () => ({
 }))
 
 vi.mock('../DynamicCardErrorBoundary', () => ({
-  DynamicCardErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DynamicCardErrorBoundary: ({ children }: { children: ReactNode }) => <>{children}</>,
 }))
 
 vi.mock('../../../../lib/cards/CardComponents', () => ({
@@ -270,10 +271,10 @@ describe('ConsoleOfflineDetectionCard', () => {
       })
       render(<ConsoleOfflineDetectionCard />)
 
-      const issuesTile = screen.getByTitle('All Healthy')
-      expect(issuesTile).toBeInTheDocument()
-      expect(issuesTile.querySelector('.text-red-400')).toBeNull()
+      expect(screen.getByTitle('All Healthy')).toBeInTheDocument()
       expect(screen.getByText('All Healthy')).toBeInTheDocument()
+      expect(screen.queryByText('Offline')).not.toBeInTheDocument()
+      expect(screen.queryByText('Unhealthy')).not.toBeInTheDocument()
     })
 
     it('shows issue count with offline tooltip when unreachable clusters exist', () => {


### PR DESCRIPTION
## Summary

Adds Vitest + React Testing Library coverage for the three Console AI mission cards that previously had no component tests (only `ConsoleHealthCheckCard` was tested):

- **console_ai_issues** (`ConsoleIssuesCard`) — issue list, empty state, loading/`useCardLoadingState`, `isDemoData`, repair mission flow
- **console_ai_kubeconfig_audit** (`ConsoleKubeconfigAuditCard`) — audit summary tiles, offline cluster preview, error/`isFailed` integration, demo mode path
- **console_ai_offline_detection** (`ConsoleOfflineDetectionCard`) — healthy vs offline issue counts, GPU/prediction tiles, search filter, `isDemoData` and partial-failure load state

Tests follow the depth benchmark in `KyvernoPolicies.test.tsx` and the existing `ConsoleHealthCheckCard.test.tsx` mock patterns (not smoke-only “renders without crashing”).

Part of #4189  
Fixes #15338

## Test plan

- [x] `cd web && npx vitest run src/components/cards/console-missions/__tests__/ConsoleIssuesCard.test.tsx src/components/cards/console-missions/__tests__/ConsoleKubeconfigAuditCard.test.tsx src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx` — **36/36 passed** locally
- [ ] CI Vitest job on PR
- [ ] Coverage gate on modified files (no production code changed)