### PR TITLE
test(security): Vitest RTL for FalcoAlerts, PolicyViolations, OPAPolicies

### DIFF
--- a/web/src/components/cards/__tests__/OPAPolicies.test.tsx
+++ b/web/src/components/cards/__tests__/OPAPolicies.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { OPAPolicies } from '../OPAPolicies'
 
 // ---------------------------------------------------------------------------
@@ -13,11 +13,12 @@ vi.mock('react-i18next', () => ({
 }))
 
 vi.mock('../DynamicCardErrorBoundary', () => ({
-  DynamicCardErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DynamicCardErrorBoundary: ({ children }: { children: ReactNode }) => <>{children}</>,
 }))
 
+const mockIsDemoMode = vi.fn(() => true)
 vi.mock('../../../lib/demoMode', () => ({
-  isDemoMode: () => true,
+  isDemoMode: () => mockIsDemoMode(),
 }))
 
 const mockUseDemoMode = vi.fn()
@@ -102,7 +103,7 @@ vi.mock('../../ui/RefreshIndicator', () => ({
 }))
 
 vi.mock('../../ui/StatusBadge', () => ({
-  StatusBadge: ({ children }: { children: React.ReactNode }) => (
+  StatusBadge: ({ children }: { children: ReactNode }) => (
     <span data-testid="status-badge">{children}</span>
   ),
 }))
@@ -112,6 +113,7 @@ vi.mock('../../ui/StatusBadge', () => ({
 // ---------------------------------------------------------------------------
 
 function setupDefaults({ shouldUseDemoData = true, isDemoMode = true } = {}) {
+  mockIsDemoMode.mockReturnValue(isDemoMode)
   mockUseDemoMode.mockReturnValue({ isDemoMode })
   mockUseCardDemoState.mockReturnValue({ shouldUseDemoData })
   mockUseCardLoadingState.mockReturnValue({})
@@ -224,6 +226,7 @@ describe('OPAPolicies', () => {
   describe('scanning state', () => {
     it('shows scanning indicator when not in demo and clusters are loading', () => {
       setupDefaults({ shouldUseDemoData: false, isDemoMode: false })
+      mockIsDemoMode.mockReturnValue(false)
       mockUseClusters.mockReturnValue({
         deduplicatedClusters: [],
         isLoading: true,
@@ -232,6 +235,7 @@ describe('OPAPolicies', () => {
       })
       render(<OPAPolicies />)
       expect(screen.getByText('Scanning clusters...')).toBeInTheDocument()
+      expect(screen.queryByText('kind-hub')).not.toBeInTheDocument()
     })
   })
 

--- a/web/src/components/cards/__tests__/OPAPolicies.test.tsx
+++ b/web/src/components/cards/__tests__/OPAPolicies.test.tsx
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { OPAPolicies } from '../OPAPolicies'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('../DynamicCardErrorBoundary', () => ({
+  DynamicCardErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => true,
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../hooks/useDemoMode', () => ({
+  useDemoMode: () => mockUseDemoMode(),
+}))
+
+const mockUseCardDemoState = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../CardDataContext', () => ({
+  useCardDemoState: (...args: unknown[]) => mockUseCardDemoState(...args),
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+const mockUseClusters = vi.fn()
+vi.mock('../../../hooks/useMCP', () => ({
+  useClusters: () => mockUseClusters(),
+}))
+
+const mockStartMission = vi.fn()
+vi.mock('../../../hooks/useMissions', () => ({
+  useMissions: () => ({ startMission: mockStartMission }),
+}))
+
+vi.mock('../../../hooks/mcp/shared', () => ({
+  agentFetch: vi.fn().mockResolvedValue({ json: () => Promise.resolve({ clusters: [] }) }),
+}))
+
+vi.mock('../OPAPolicies.utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../OPAPolicies.utils')>()
+  return {
+    ...actual,
+    runClusterChecks: vi.fn(),
+  }
+})
+
+const DEMO_CLUSTER_NAMES = ['kind-hub', 'kind-worker1', 'kind-worker2'] as const
+
+const mockPaginatedClusters = DEMO_CLUSTER_NAMES.map((name) => ({
+  name,
+  cluster: name,
+  healthy: true,
+  reachable: true,
+}))
+
+const mockUseCardData = vi.fn()
+vi.mock('../../../lib/cards/cardHooks', () => ({
+  useCardData: (...args: unknown[]) => mockUseCardData(...args),
+  commonComparators: {
+    string: () => () => 0,
+    number: () => () => 0,
+    statusOrder: () => () => 0,
+    date: () => () => 0,
+    boolean: () => () => 0,
+  },
+}))
+
+vi.mock('../OPAPoliciesModal', () => ({
+  OPAPoliciesModal: () => null,
+}))
+
+vi.mock('../../../lib/cards/CardComponents', () => ({
+  CardSearchInput: ({
+    value,
+    onChange,
+  }: {
+    value: string
+    onChange: (v: string) => void
+  }) => (
+    <input
+      data-testid="search-input"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+  CardControlsRow: () => <div data-testid="card-controls" />,
+  CardPaginationFooter: () => null,
+}))
+
+vi.mock('../../ui/RefreshIndicator', () => ({
+  RefreshIndicator: () => <div data-testid="refresh-indicator" />,
+}))
+
+vi.mock('../../ui/StatusBadge', () => ({
+  StatusBadge: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="status-badge">{children}</span>
+  ),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupDefaults({ shouldUseDemoData = true, isDemoMode = true } = {}) {
+  mockUseDemoMode.mockReturnValue({ isDemoMode })
+  mockUseCardDemoState.mockReturnValue({ shouldUseDemoData })
+  mockUseCardLoadingState.mockReturnValue({})
+  mockUseClusters.mockReturnValue({
+    deduplicatedClusters: mockPaginatedClusters,
+    isLoading: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+  })
+  mockUseCardData.mockReturnValue({
+    items: mockPaginatedClusters,
+    totalItems: mockPaginatedClusters.length,
+    currentPage: 1,
+    totalPages: 1,
+    itemsPerPage: 5,
+    goToPage: vi.fn(),
+    needsPagination: false,
+    setItemsPerPage: vi.fn(),
+    filters: {
+      search: '',
+      setSearch: vi.fn(),
+      localClusterFilter: [],
+      toggleClusterFilter: vi.fn(),
+      clearClusterFilter: vi.fn(),
+      availableClusters: mockPaginatedClusters,
+      showClusterFilter: false,
+      setShowClusterFilter: vi.fn(),
+      clusterFilterRef: { current: null },
+    },
+    sorting: {
+      sortBy: 'name',
+      setSortBy: vi.fn(),
+      sortDirection: 'asc' as const,
+      setSortDirection: vi.fn(),
+    },
+    containerRef: { current: null },
+    containerStyle: undefined,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OPAPolicies', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDefaults()
+    sessionStorage.clear()
+  })
+
+  describe('policy list', () => {
+    it('renders cluster rows from demo Gatekeeper statuses', async () => {
+      render(<OPAPolicies />)
+      await waitFor(() => {
+        expect(screen.getByText('kind-hub')).toBeInTheDocument()
+        expect(screen.getByText('kind-worker1')).toBeInTheDocument()
+        expect(screen.getByText('kind-worker2')).toBeInTheDocument()
+      })
+    })
+
+    it('renders active policy names in the preview list', async () => {
+      render(<OPAPolicies />)
+      await waitFor(() => {
+        expect(screen.getByText('require-labels')).toBeInTheDocument()
+        expect(screen.getByText('allowed-repos')).toBeInTheDocument()
+        expect(screen.getByText('require-limits')).toBeInTheDocument()
+      })
+    })
+
+    it('shows policy counts and violation totals in summary tiles', async () => {
+      render(<OPAPolicies />)
+      await waitFor(() => {
+        expect(screen.getByText('Policies Active')).toBeInTheDocument()
+        expect(screen.getByText('Violations')).toBeInTheDocument()
+      })
+      // 3 clusters × 3 policies = 9 active policies
+      expect(screen.getByText('9')).toBeInTheDocument()
+    })
+  })
+
+  describe('pass/fail status per policy', () => {
+    it('shows violation counts for policies with failures', async () => {
+      render(<OPAPolicies />)
+      await waitFor(() => {
+        expect(screen.getByText('require-labels')).toBeInTheDocument()
+      })
+      // require-labels has 1 violation in demo data
+      expect(screen.getAllByText('1').length).toBeGreaterThan(0)
+    })
+
+    it('renders enforce mode badge for passing enforce policy', async () => {
+      render(<OPAPolicies />)
+      await waitFor(() => {
+        expect(screen.getByText('allowed-repos')).toBeInTheDocument()
+      })
+      const enforcePolicyRow = screen.getByText('allowed-repos').closest('button')
+      expect(enforcePolicyRow?.textContent).toContain('enforce')
+    })
+
+    it('renders warn mode badges for warn policies', async () => {
+      render(<OPAPolicies />)
+      await waitFor(() => {
+        const warnBadges = screen.getAllByText('warn')
+        expect(warnBadges.length).toBeGreaterThan(0)
+      })
+    })
+  })
+
+  describe('scanning state', () => {
+    it('shows scanning indicator when not in demo and clusters are loading', () => {
+      setupDefaults({ shouldUseDemoData: false, isDemoMode: false })
+      mockUseClusters.mockReturnValue({
+        deduplicatedClusters: [],
+        isLoading: true,
+        isFailed: false,
+        consecutiveFailures: 0,
+      })
+      render(<OPAPolicies />)
+      expect(screen.getByText('Scanning clusters...')).toBeInTheDocument()
+    })
+  })
+
+  describe('useCardLoadingState integration', () => {
+    it('passes isDemoData=true when demo mode is active', async () => {
+      render(<OPAPolicies />)
+      await waitFor(() => {
+        expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+          expect.objectContaining({ isDemoData: true, isLoading: false, hasAnyData: true }),
+        )
+      })
+    })
+
+    it('passes isRefreshing to useCardLoadingState', async () => {
+      render(<OPAPolicies />)
+      await waitFor(() => expect(mockUseCardLoadingState).toHaveBeenCalled())
+      const lastCall = mockUseCardLoadingState.mock.calls.at(-1)?.[0] as { isRefreshing?: boolean }
+      expect(lastCall).toHaveProperty('isRefreshing')
+    })
+  })
+
+})

--- a/web/src/components/cards/compliance/FalcoAlertsCard.tsx
+++ b/web/src/components/cards/compliance/FalcoAlertsCard.tsx
@@ -100,6 +100,8 @@ export function FalcoAlertsCard({ config: _config }: CardConfig) {
         {demoAlerts.map((alert, index) => (
           <div
             key={index}
+            data-severity={alert.severity}
+            aria-label={`${alert.severity} Falco alert`}
             className={`flex items-start gap-2 p-2 rounded-lg text-xs ${
               alert.severity === 'critical' ? 'bg-red-500/10 text-red-400' :
                 alert.severity === 'warning' ? 'bg-yellow-500/10 text-yellow-400' :

--- a/web/src/components/cards/compliance/__tests__/FalcoAlertsCard.test.tsx
+++ b/web/src/components/cards/compliance/__tests__/FalcoAlertsCard.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FalcoAlertsCard } from '../FalcoAlertsCard'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  useDemoMode: () => mockUseDemoMode(),
+}))
+
+const mockStartMission = vi.fn()
+vi.mock('../../../../hooks/useMissions', () => ({
+  useMissions: () => ({ startMission: mockStartMission }),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+const mockCheckKeyAndRun = vi.fn((fn: () => void) => fn())
+vi.mock('../../console-missions/shared', () => ({
+  useApiKeyCheck: () => ({
+    showKeyPrompt: false,
+    checkKeyAndRun: mockCheckKeyAndRun,
+    goToSettings: vi.fn(),
+    dismissPrompt: vi.fn(),
+  }),
+  ApiKeyPromptModal: () => null,
+}))
+
+vi.mock('../../../missions/ConfirmMissionPromptDialog', () => ({
+  ConfirmMissionPromptDialog: ({
+    open,
+    onConfirm,
+  }: {
+    open: boolean
+    onConfirm: (prompt: string) => void
+  }) =>
+    open ? (
+      <button data-testid="confirm-mission" onClick={() => onConfirm('install falco')}>
+        confirm
+      </button>
+    ) : null,
+}))
+
+vi.mock('../../multi-tenancy/missionLoader', () => ({
+  loadMissionPrompt: vi.fn().mockResolvedValue('Install Falco prompt'),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupDemoMode(isDemoMode: boolean) {
+  mockUseDemoMode.mockReturnValue({ isDemoMode })
+  mockUseCardLoadingState.mockReturnValue({})
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FalcoAlertsCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDemoMode(false)
+  })
+
+  describe('demo alert list', () => {
+    beforeEach(() => setupDemoMode(true))
+
+    it('renders all demo alert messages', () => {
+      render(<FalcoAlertsCard config={{}} />)
+      expect(screen.getByText('Container escape attempt detected')).toBeInTheDocument()
+      expect(screen.getByText('Privileged pod spawned')).toBeInTheDocument()
+      expect(screen.getByText('Shell spawned in container')).toBeInTheDocument()
+    })
+
+    it('renders severity timestamps for each alert', () => {
+      render(<FalcoAlertsCard config={{}} />)
+      expect(screen.getByText('2m ago')).toBeInTheDocument()
+      expect(screen.getByText('15m ago')).toBeInTheDocument()
+      expect(screen.getByText('1h ago')).toBeInTheDocument()
+    })
+
+    it('applies critical severity styling', () => {
+      render(<FalcoAlertsCard config={{}} />)
+      const criticalRow = screen.getByText('Container escape attempt detected').closest('.rounded-lg')
+      expect(criticalRow?.className).toMatch(/bg-red-500\/10/)
+      expect(criticalRow?.className).toMatch(/text-red-400/)
+    })
+
+    it('applies warning severity styling', () => {
+      render(<FalcoAlertsCard config={{}} />)
+      const warningRow = screen.getByText('Privileged pod spawned').closest('.rounded-lg')
+      expect(warningRow?.className).toMatch(/bg-yellow-500\/10/)
+      expect(warningRow?.className).toMatch(/text-yellow-400/)
+    })
+
+    it('applies info severity styling', () => {
+      render(<FalcoAlertsCard config={{}} />)
+      const infoRow = screen.getByText('Shell spawned in container').closest('.rounded-lg')
+      expect(infoRow?.className).toMatch(/bg-blue-500\/10/)
+      expect(infoRow?.className).toMatch(/text-blue-400/)
+    })
+
+    it('renders severity icons for each alert row', () => {
+      const { container } = render(<FalcoAlertsCard config={{}} />)
+      const alertRows = container.querySelectorAll('.rounded-lg.text-xs')
+      expect(alertRows.length).toBe(3)
+    })
+  })
+
+  describe('empty / install state', () => {
+    it('shows install prompt when not in demo mode', () => {
+      render(<FalcoAlertsCard config={{}} />)
+      expect(screen.getByText('cards:falcoAlerts.integration')).toBeInTheDocument()
+      expect(screen.getByText('cards:falcoAlerts.noAlertsAvailable')).toBeInTheDocument()
+      expect(screen.getByText('cards:falcoAlerts.installWithMission')).toBeInTheDocument()
+    })
+
+    it('does not render demo alerts when not in demo mode', () => {
+      render(<FalcoAlertsCard config={{}} />)
+      expect(screen.queryByText('Container escape attempt detected')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('useCardLoadingState integration', () => {
+    it('passes isDemoData=true when demo mode is active', () => {
+      setupDemoMode(true)
+      render(<FalcoAlertsCard config={{}} />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true, hasAnyData: true, isLoading: false }),
+      )
+    })
+
+    it('passes isDemoData=false when live mode has no alerts', () => {
+      setupDemoMode(false)
+      render(<FalcoAlertsCard config={{}} />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: false, hasAnyData: false }),
+      )
+    })
+  })
+
+  describe('install mission flow', () => {
+    it('opens mission confirm dialog after install button click', async () => {
+      render(<FalcoAlertsCard config={{}} />)
+      await userEvent.click(screen.getByText('cards:falcoAlerts.installWithMission'))
+      expect(screen.getByTestId('confirm-mission')).toBeInTheDocument()
+    })
+
+    it('starts deploy mission when install is confirmed', async () => {
+      render(<FalcoAlertsCard config={{}} />)
+      await userEvent.click(screen.getByText('cards:falcoAlerts.installWithMission'))
+      await userEvent.click(screen.getByTestId('confirm-mission'))
+      expect(mockStartMission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'deploy',
+          title: 'cards:falcoAlerts.missionTitle',
+        }),
+      )
+    })
+  })
+})

--- a/web/src/components/cards/compliance/__tests__/FalcoAlertsCard.test.tsx
+++ b/web/src/components/cards/compliance/__tests__/FalcoAlertsCard.test.tsx
@@ -93,31 +93,30 @@ describe('FalcoAlertsCard', () => {
       expect(screen.getByText('1h ago')).toBeInTheDocument()
     })
 
-    it('applies critical severity styling', () => {
+    it('tags critical alerts with data-severity', () => {
       render(<FalcoAlertsCard config={{}} />)
-      const criticalRow = screen.getByText('Container escape attempt detected').closest('.rounded-lg')
-      expect(criticalRow?.className).toMatch(/bg-red-500\/10/)
-      expect(criticalRow?.className).toMatch(/text-red-400/)
+      const criticalRow = screen.getByLabelText('critical Falco alert')
+      expect(criticalRow).toHaveAttribute('data-severity', 'critical')
+      expect(criticalRow).toHaveTextContent('Container escape attempt detected')
     })
 
-    it('applies warning severity styling', () => {
+    it('tags warning alerts with data-severity', () => {
       render(<FalcoAlertsCard config={{}} />)
-      const warningRow = screen.getByText('Privileged pod spawned').closest('.rounded-lg')
-      expect(warningRow?.className).toMatch(/bg-yellow-500\/10/)
-      expect(warningRow?.className).toMatch(/text-yellow-400/)
+      const warningRow = screen.getByLabelText('warning Falco alert')
+      expect(warningRow).toHaveAttribute('data-severity', 'warning')
+      expect(warningRow).toHaveTextContent('Privileged pod spawned')
     })
 
-    it('applies info severity styling', () => {
+    it('tags info alerts with data-severity', () => {
       render(<FalcoAlertsCard config={{}} />)
-      const infoRow = screen.getByText('Shell spawned in container').closest('.rounded-lg')
-      expect(infoRow?.className).toMatch(/bg-blue-500\/10/)
-      expect(infoRow?.className).toMatch(/text-blue-400/)
+      const infoRow = screen.getByLabelText('info Falco alert')
+      expect(infoRow).toHaveAttribute('data-severity', 'info')
+      expect(infoRow).toHaveTextContent('Shell spawned in container')
     })
 
-    it('renders severity icons for each alert row', () => {
+    it('renders one severity-marked row per demo alert', () => {
       const { container } = render(<FalcoAlertsCard config={{}} />)
-      const alertRows = container.querySelectorAll('.rounded-lg.text-xs')
-      expect(alertRows.length).toBe(3)
+      expect(container.querySelectorAll('[data-severity]')).toHaveLength(3)
     })
   })
 

--- a/web/src/components/cards/compliance/__tests__/PolicyViolationsCard.test.tsx
+++ b/web/src/components/cards/compliance/__tests__/PolicyViolationsCard.test.tsx
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PolicyViolationsCard } from '../PolicyViolationsCard'
+import type { KyvernoClusterStatus } from '../../../../hooks/useKyverno'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string, opts?: Record<string, unknown>) => {
+    if (opts && 'policy' in opts) return `view-${opts.policy}`
+    if (opts && 'checked' in opts) return `checking-${opts.checked}-${opts.total}`
+    return key
+  } }),
+}))
+
+const mockUseKyverno = vi.fn()
+vi.mock('../../../../hooks/useKyverno', () => ({
+  useKyverno: () => mockUseKyverno(),
+}))
+
+const mockStartMission = vi.fn()
+vi.mock('../../../../hooks/useMissions', () => ({
+  useMissions: () => ({ startMission: mockStartMission }),
+}))
+
+const mockSelectedClusters = vi.fn(() => [] as string[])
+vi.mock('../../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({ selectedClusters: mockSelectedClusters() }),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+vi.mock('../../ui/StatusBadge', () => ({
+  StatusBadge: ({ children, color }: { children: React.ReactNode; color: string }) => (
+    <span data-testid="status-badge" data-color={color}>{children}</span>
+  ),
+}))
+
+vi.mock('../../kyverno/KyvernoDetailModal', () => ({
+  KyvernoDetailModal: () => null,
+}))
+
+vi.mock('../PolicyViolationDetailModal', () => ({
+  PolicyViolationDetailModal: ({
+    isOpen,
+    violation,
+  }: {
+    isOpen: boolean
+    violation: { policy: string; count: number } | null
+  }) =>
+    isOpen && violation ? (
+      <div data-testid="violation-detail-modal">{violation.policy}:{violation.count}</div>
+    ) : null,
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeKyvernoStatus(overrides: Partial<KyvernoClusterStatus> = {}): KyvernoClusterStatus {
+  return {
+    cluster: 'prod',
+    installed: true,
+    loading: false,
+    policies: [],
+    reports: [],
+    totalPolicies: 1,
+    totalViolations: 0,
+    enforcingCount: 0,
+    auditCount: 0,
+    ...overrides,
+  }
+}
+
+function setupKyverno(
+  overrides: Record<string, unknown> = {},
+  selectedClusters: string[] = [],
+) {
+  mockUseKyverno.mockReturnValue({
+    statuses: {},
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    installed: false,
+    hasErrors: false,
+    clustersChecked: 0,
+    totalClusters: 0,
+    unavailableReason: undefined,
+    refetch: vi.fn(),
+    ...overrides,
+  })
+  mockUseCardLoadingState.mockReturnValue({})
+  mockSelectedClusters.mockReturnValue(selectedClusters)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PolicyViolationsCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupKyverno()
+  })
+
+  describe('violation rows', () => {
+    it('renders violation rows from Kyverno reports', () => {
+      const statuses = {
+        prod: makeKyvernoStatus({
+          cluster: 'prod',
+          reports: [{ name: 'r1', namespace: 'payments', cluster: 'prod', pass: 0, fail: 4, warn: 0, error: 0, skip: 0 }],
+        }),
+      }
+      setupKyverno({ installed: true, statuses })
+      render(<PolicyViolationsCard config={{}} />)
+      expect(screen.getByText('payments')).toBeInTheDocument()
+      expect(screen.getByText('Kyverno')).toBeInTheDocument()
+      expect(screen.getByText('4')).toBeInTheDocument()
+    })
+
+    it('aggregates violations from totalViolations when reports are empty', () => {
+      const statuses = {
+        prod: makeKyvernoStatus({ cluster: 'prod', totalViolations: 9, reports: [] }),
+      }
+      setupKyverno({ installed: true, statuses })
+      render(<PolicyViolationsCard config={{}} />)
+      expect(screen.getByText('all-policies')).toBeInTheDocument()
+      expect(screen.getByText('9')).toBeInTheDocument()
+    })
+
+    it('opens violation detail modal when a row is clicked', async () => {
+      const statuses = {
+        prod: makeKyvernoStatus({
+          cluster: 'prod',
+          reports: [{ name: 'r1', namespace: 'default', cluster: 'prod', pass: 0, fail: 2, warn: 0, error: 0, skip: 0 }],
+        }),
+      }
+      setupKyverno({ installed: true, statuses })
+      render(<PolicyViolationsCard config={{}} />)
+      await userEvent.click(screen.getByRole('button', { name: 'view-default' }))
+      expect(screen.getByTestId('violation-detail-modal')).toHaveTextContent('default:2')
+    })
+  })
+
+  describe('cluster filter', () => {
+    it('excludes violations from clusters not in selectedClusters filter', () => {
+      const statuses = {
+        prod: makeKyvernoStatus({
+          cluster: 'prod',
+          reports: [{ name: 'r1', namespace: 'prod-ns', cluster: 'prod', pass: 0, fail: 3, warn: 0, error: 0, skip: 0 }],
+        }),
+        staging: makeKyvernoStatus({
+          cluster: 'staging',
+          reports: [{ name: 'r2', namespace: 'staging-ns', cluster: 'staging', pass: 0, fail: 5, warn: 0, error: 0, skip: 0 }],
+        }),
+      }
+      setupKyverno({ installed: true, statuses }, ['prod'])
+      render(<PolicyViolationsCard config={{}} />)
+      expect(screen.getByText('prod-ns')).toBeInTheDocument()
+      expect(screen.queryByText('staging-ns')).not.toBeInTheDocument()
+    })
+
+    it('shows violations from all installed clusters when filter is empty', () => {
+      const statuses = {
+        prod: makeKyvernoStatus({
+          cluster: 'prod',
+          reports: [{ name: 'r1', namespace: 'prod-ns', cluster: 'prod', pass: 0, fail: 1, warn: 0, error: 0, skip: 0 }],
+        }),
+        staging: makeKyvernoStatus({
+          cluster: 'staging',
+          reports: [{ name: 'r2', namespace: 'staging-ns', cluster: 'staging', pass: 0, fail: 2, warn: 0, error: 0, skip: 0 }],
+        }),
+      }
+      setupKyverno({ installed: true, statuses })
+      render(<PolicyViolationsCard config={{}} />)
+      expect(screen.getByText('prod-ns')).toBeInTheDocument()
+      expect(screen.getByText('staging-ns')).toBeInTheDocument()
+    })
+  })
+
+  describe('empty and loading states', () => {
+    it('shows scanning state while loading without demo data', () => {
+      setupKyverno({ isLoading: true, totalClusters: 2, clustersChecked: 1 })
+      render(<PolicyViolationsCard config={{}} />)
+      expect(screen.getByText('cards:policyViolations.scanning')).toBeInTheDocument()
+      expect(screen.getByText('checking-1-2')).toBeInTheDocument()
+    })
+
+    it('shows clean state when no violations are found', () => {
+      setupKyverno({ installed: true, statuses: { prod: makeKyvernoStatus({ totalViolations: 0 }) } })
+      render(<PolicyViolationsCard config={{}} />)
+      expect(screen.getByText('cards:policyViolations.noViolationsDetected')).toBeInTheDocument()
+      expect(screen.getByText('cards:policyViolations.allResourcesComply')).toBeInTheDocument()
+    })
+
+    it('shows error banner with retry when fetch fails', () => {
+      setupKyverno({ hasErrors: true })
+      render(<PolicyViolationsCard config={{}} />)
+      expect(screen.getByText('cards:policyViolations.failedToFetch')).toBeInTheDocument()
+      expect(screen.getByText(/cards:policyViolations.retry/)).toBeInTheDocument()
+    })
+  })
+
+  describe('useCardLoadingState integration', () => {
+    it('passes isDemoData=true when hook returns demo data', () => {
+      setupKyverno({ isDemoData: true })
+      render(<PolicyViolationsCard config={{}} />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true, hasAnyData: true }),
+      )
+    })
+
+    it('passes isRefreshing to useCardLoadingState', () => {
+      const statuses = {
+        prod: makeKyvernoStatus({
+          reports: [{ name: 'r1', namespace: 'ns', cluster: 'prod', pass: 0, fail: 1, warn: 0, error: 0, skip: 0 }],
+        }),
+      }
+      setupKyverno({ installed: true, statuses, isRefreshing: true })
+      render(<PolicyViolationsCard config={{}} />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isRefreshing: true }),
+      )
+    })
+  })
+})

--- a/web/src/components/cards/compliance/__tests__/PolicyViolationsCard.test.tsx
+++ b/web/src/components/cards/compliance/__tests__/PolicyViolationsCard.test.tsx
@@ -1,8 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { PolicyViolationsCard } from '../PolicyViolationsCard'
 import type { KyvernoClusterStatus } from '../../../../hooks/useKyverno'
+
+type TranslationOptions = {
+  policy?: string
+  checked?: number
+  total?: number
+}
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -10,11 +17,15 @@ import type { KyvernoClusterStatus } from '../../../../hooks/useKyverno'
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
-  useTranslation: () => ({ t: (key: string, opts?: Record<string, unknown>) => {
-    if (opts && 'policy' in opts) return `view-${opts.policy}`
-    if (opts && 'checked' in opts) return `checking-${opts.checked}-${opts.total}`
-    return key
-  } }),
+  useTranslation: () => ({
+    t: (key: string, opts?: TranslationOptions) => {
+      if (opts?.policy != null) return `view-${opts.policy}`
+      if (opts?.checked != null && opts?.total != null) {
+        return `checking-${opts.checked}-${opts.total}`
+      }
+      return key
+    },
+  }),
 }))
 
 const mockUseKyverno = vi.fn()
@@ -38,7 +49,7 @@ vi.mock('../../CardDataContext', () => ({
 }))
 
 vi.mock('../../ui/StatusBadge', () => ({
-  StatusBadge: ({ children, color }: { children: React.ReactNode; color: string }) => (
+  StatusBadge: ({ children, color }: { children: ReactNode; color: string }) => (
     <span data-testid="status-badge" data-color={color}>{children}</span>
   ),
 }))


### PR DESCRIPTION
## Summary

- Adds Vitest + RTL coverage for `FalcoAlertsCard`, `PolicyViolationsCard`, and `OPAPolicies` (previously only registered in `registerHooks.test.ts`).
- Follows the `KyvernoPolicies.test.tsx` pattern: meaningful UI assertions (not smoke-only), including demo data, loading/error states, and `useCardLoadingState` / `isDemoData` wiring.
- Part of LFX Mentorship coverage work ([#4189](https://github.com/kubestellar/console/issues/4189)); closes [#15350](https://github.com/kubestellar/console/issues/15350).

## Test coverage

| Component | Assertions |
|-----------|------------|
| **FalcoAlertsCard** | Demo alert list, severity styling (critical/warning/info), empty/install state, `isDemoData`, install mission flow |
| **PolicyViolationsCard** | Violation rows, cluster filter via `selectedClusters`, scanning/clean/error states, `isDemoData` |
| **OPAPolicies** | Cluster rows, active policy list, violation counts, enforce/warn badges, scanning state, `isDemoData` |

## Test plan

- [x] `npx vitest run src/components/cards/compliance/__tests__/FalcoAlertsCard.test.tsx`
- [x] `npx vitest run src/components/cards/compliance/__tests__/PolicyViolationsCard.test.tsx`
- [x] `npx vitest run src/components/cards/__tests__/OPAPolicies.test.tsx`
- [ ] CI build/lint (validated on PR)