### PR TITLE
test(netlify): Vitest handler tests for github-pipelines, nightly-e2e, issue-stats

### DIFF
--- a/web/netlify/functions/__tests__/github-pipelines-mutate.test.ts
+++ b/web/netlify/functions/__tests__/github-pipelines-mutate.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Vitest handler tests for github-pipelines-mutate.mts (#15397, Part of #4189).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertResponseHasNoSecrets,
+  FAKE_MUTATE_AUTH_TOKEN,
+  readJson,
+} from "./netlify-handler-helpers";
+
+const { mockEnforceSimpleRateLimit, mockMutate } = vi.hoisted(() => ({
+  mockEnforceSimpleRateLimit: vi.fn(),
+  mockMutate: vi.fn(),
+}));
+
+vi.mock("../_shared/rate-limit", () => ({
+  enforceSimpleRateLimit: mockEnforceSimpleRateLimit,
+}));
+
+vi.mock("../github-pipelines/mutations", () => ({
+  mutate: mockMutate,
+}));
+
+import handler from "../github-pipelines-mutate.mts";
+
+function makeMutateRequest(options?: {
+  method?: string;
+  op?: string;
+  repo?: string;
+  run?: string;
+  bearer?: string;
+}): Request {
+  const params = new URLSearchParams();
+  if (options?.op) params.set("op", options.op);
+  if (options?.repo) params.set("repo", options.repo);
+  if (options?.run) params.set("run", options.run);
+  const headers: Record<string, string> = { Origin: "https://console.kubestellar.io" };
+  if (options?.bearer) {
+    headers.Authorization = `Bearer ${options.bearer}`;
+  }
+  return new Request(`https://console.kubestellar.io/api/github-pipelines/mutate?${params}`, {
+    method: options?.method ?? "POST",
+    headers,
+  });
+}
+
+describe("github-pipelines-mutate", () => {
+  const originalMutateToken = process.env.GITHUB_PIPELINES_MUTATE_AUTH_TOKEN;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GITHUB_PIPELINES_MUTATE_AUTH_TOKEN = FAKE_MUTATE_AUTH_TOKEN;
+    mockEnforceSimpleRateLimit.mockResolvedValue({ limited: false });
+    mockMutate.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, op: "rerun", run: "99", repo: "kubestellar/console" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    if (originalMutateToken === undefined) {
+      delete process.env.GITHUB_PIPELINES_MUTATE_AUTH_TOKEN;
+    } else {
+      process.env.GITHUB_PIPELINES_MUTATE_AUTH_TOKEN = originalMutateToken;
+    }
+  });
+
+  it("returns 503 when mutation auth token is not configured", async () => {
+    delete process.env.GITHUB_PIPELINES_MUTATE_AUTH_TOKEN;
+    const res = await handler(makeMutateRequest({ bearer: FAKE_MUTATE_AUTH_TOKEN }));
+    expect(res.status).toBe(503);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("disabled");
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 without authorized credential", async () => {
+    const res = await handler(makeMutateRequest({ op: "rerun", repo: "kubestellar/console", run: "12345" }));
+    expect(res.status).toBe(401);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("auth");
+    expect(mockMutate).not.toHaveBeenCalled();
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_MUTATE_AUTH_TOKEN]);
+  });
+
+  it("returns 400 for non-numeric run id before calling mutate", async () => {
+    const res = await handler(
+      makeMutateRequest({
+        op: "rerun",
+        repo: "kubestellar/console",
+        run: "abc",
+        bearer: FAKE_MUTATE_AUTH_TOKEN,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("run");
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when mutation rate limit is exceeded", async () => {
+    mockEnforceSimpleRateLimit.mockResolvedValue({ limited: true, retryAfterSeconds: 120 });
+    const res = await handler(
+      makeMutateRequest({
+        op: "rerun",
+        repo: "kubestellar/console",
+        run: "12345",
+        bearer: FAKE_MUTATE_AUTH_TOKEN,
+      }),
+    );
+    expect(res.status).toBe(429);
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("forwards authorized rerun to mutate and returns success", async () => {
+    const res = await handler(
+      makeMutateRequest({
+        op: "rerun",
+        repo: "kubestellar/console",
+        run: "12345",
+        bearer: FAKE_MUTATE_AUTH_TOKEN,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockMutate).toHaveBeenCalledWith("rerun", "kubestellar/console", "12345");
+    const body = await readJson<{ ok: boolean }>(res);
+    expect(body.ok).toBe(true);
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_MUTATE_AUTH_TOKEN]);
+  });
+
+  it("returns 405 for GET", async () => {
+    const res = await handler(
+      makeMutateRequest({ method: "GET", bearer: FAKE_MUTATE_AUTH_TOKEN }),
+    );
+    expect(res.status).toBe(405);
+  });
+});

--- a/web/netlify/functions/__tests__/github-pipelines.test.ts
+++ b/web/netlify/functions/__tests__/github-pipelines.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Vitest handler tests for github-pipelines.mts (#15397, Part of #4189).
+ *
+ * Run from web/: npm run test:netlify-github-cluster
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertResponseHasNoSecrets,
+  FAKE_GITHUB_TOKEN,
+  freshBlobCacheEntry,
+  readJson,
+} from "./netlify-handler-helpers";
+
+const SAMPLE_PULSE = {
+  lastRun: {
+    conclusion: "success",
+    createdAt: "2026-05-22T00:00:00Z",
+    htmlUrl: "https://github.com/kubestellar/console/actions/runs/1",
+    runNumber: 42,
+    releaseTag: "v0.3.21-nightly.20260522",
+  },
+  streak: 2,
+  streakKind: "success",
+  recent: [{ conclusion: "success", createdAt: "2026-05-21T00:00:00Z", htmlUrl: "https://example.com/r/2" }],
+  nextCron: "0 5 * * *",
+};
+
+const SAMPLE_MATRIX = {
+  days: 14,
+  range: ["2026-05-08", "2026-05-22"],
+  workflows: [{ repo: "kubestellar/console", name: "CI", cells: [] }],
+};
+
+const { mockGet, mockSet, mockEnforceSimpleRateLimit, mockBuildPulse, mockBuildMatrix, mockBuildFlow, mockBuildFailures, mockBuildLog } =
+  vi.hoisted(() => ({
+    mockGet: vi.fn(),
+    mockSet: vi.fn(),
+    mockEnforceSimpleRateLimit: vi.fn(),
+    mockBuildPulse: vi.fn(),
+    mockBuildMatrix: vi.fn(),
+    mockBuildFlow: vi.fn(),
+    mockBuildFailures: vi.fn(),
+    mockBuildLog: vi.fn(),
+  }));
+
+vi.mock("@netlify/blobs", () => ({
+  getStore: () => ({ get: mockGet, set: mockSet }),
+}));
+
+vi.mock("../_shared/rate-limit", () => ({
+  enforceSimpleRateLimit: mockEnforceSimpleRateLimit,
+}));
+
+vi.mock("../github-pipelines/views", () => ({
+  buildPulse: mockBuildPulse,
+  buildMatrix: mockBuildMatrix,
+  buildFlow: mockBuildFlow,
+  buildFailures: mockBuildFailures,
+  buildLog: mockBuildLog,
+}));
+
+import handler from "../github-pipelines.mts";
+
+function makeRequest(search = "view=pulse"): Request {
+  return new Request(`https://console.kubestellar.io/api/github-pipelines?${search}`, {
+    method: "GET",
+    headers: {
+      Origin: "https://console.kubestellar.io",
+      "x-nf-client-connection-ip": "203.0.113.10",
+    },
+  });
+}
+
+describe("github-pipelines", () => {
+  const originalToken = process.env.GITHUB_TOKEN;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GITHUB_TOKEN = FAKE_GITHUB_TOKEN;
+    mockEnforceSimpleRateLimit.mockResolvedValue({ limited: false });
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue(undefined);
+    mockBuildPulse.mockResolvedValue(SAMPLE_PULSE);
+    mockBuildMatrix.mockResolvedValue(SAMPLE_MATRIX);
+    mockBuildFlow.mockResolvedValue({ runs: [] });
+    mockBuildFailures.mockResolvedValue({ runs: [] });
+    mockBuildLog.mockResolvedValue(
+      new Response(JSON.stringify({ lines: ["log line"] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalToken;
+    }
+  });
+
+  it("returns 204 for OPTIONS preflight", async () => {
+    const res = await handler(
+      new Request("https://console.kubestellar.io/api/github-pipelines", { method: "OPTIONS" }),
+    );
+    expect(res.status).toBe(204);
+  });
+
+  it("returns 500 when GITHUB_TOKEN is not configured", async () => {
+    delete process.env.GITHUB_TOKEN;
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(500);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("GITHUB_TOKEN");
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_GITHUB_TOKEN]);
+  });
+
+  it("returns 400 for unknown view", async () => {
+    const res = await handler(makeRequest("view=not-a-real-view"));
+    expect(res.status).toBe(400);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toBe("unknown view");
+  });
+
+  it("returns 429 when read rate limit is exceeded", async () => {
+    mockEnforceSimpleRateLimit.mockResolvedValue({ limited: true, retryAfterSeconds: 60 });
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(429);
+    const body = await readJson<{ error: string; retryAfter: number }>(res);
+    expect(body.error).toContain("Rate limit");
+    expect(body.retryAfter).toBe(60);
+    expect(mockBuildPulse).not.toHaveBeenCalled();
+  });
+
+  it("returns pulse payload with repos list on happy path", async () => {
+    const res = await handler(makeRequest("view=pulse"));
+    expect(res.status).toBe(200);
+    const body = await readJson<typeof SAMPLE_PULSE & { repos: string[] }>(res);
+    expect(body.streak).toBe(SAMPLE_PULSE.streak);
+    expect(body.repos).toContain("kubestellar/console");
+    expect(res.headers.get("X-Cache")).toBe("MISS");
+    const raw = JSON.stringify(body);
+    assertResponseHasNoSecrets(raw, [FAKE_GITHUB_TOKEN, "gho_", "github_pat_"]);
+  });
+
+  it("returns cached pulse without calling buildPulse", async () => {
+    const cachedPayload = { ...SAMPLE_PULSE, repos: ["kubestellar/console"] };
+    mockGet.mockResolvedValue(freshBlobCacheEntry(cachedPayload));
+    const res = await handler(makeRequest("view=pulse"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(mockBuildPulse).not.toHaveBeenCalled();
+    const body = await readJson(res);
+    expect(body).toMatchObject({ streak: SAMPLE_PULSE.streak, repos: ["kubestellar/console"] });
+  });
+
+  it("returns 500 with repos when buildPulse throws (upstream error)", async () => {
+    mockBuildPulse.mockRejectedValue(new Error("pulse: GitHub 502"));
+    const res = await handler(makeRequest("view=pulse"));
+    expect(res.status).toBe(500);
+    const body = await readJson<{ error: string; repos: string[] }>(res);
+    expect(body.error).toBe("Internal error");
+    expect(body.repos.length).toBeGreaterThan(0);
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_GITHUB_TOKEN]);
+  });
+
+  it("returns matrix payload for view=matrix", async () => {
+    const res = await handler(makeRequest("view=matrix&days=14"));
+    expect(res.status).toBe(200);
+    const body = await readJson<typeof SAMPLE_MATRIX & { repos: string[] }>(res);
+    expect(body.days).toBe(14);
+    expect(body.workflows.length).toBeGreaterThan(0);
+    expect(body.repos).toContain("kubestellar/console");
+    expect(mockBuildMatrix).toHaveBeenCalled();
+  });
+
+  it("returns 400 for log view with invalid job param", async () => {
+    const res = await handler(makeRequest("view=log&repo=kubestellar/console&job=not-numeric"));
+    expect(res.status).toBe(400);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("job");
+    expect(mockBuildLog).not.toHaveBeenCalled();
+  });
+
+  it("returns 405 for non-GET methods", async () => {
+    const res = await handler(
+      new Request("https://console.kubestellar.io/api/github-pipelines?view=pulse", { method: "POST" }),
+    );
+    expect(res.status).toBe(405);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("GET");
+  });
+});

--- a/web/netlify/functions/__tests__/issue-stats.test.ts
+++ b/web/netlify/functions/__tests__/issue-stats.test.ts
@@ -13,8 +13,12 @@ const { mockGet, mockSetJSON } = vi.hoisted(() => ({
   mockSetJSON: vi.fn(),
 }));
 
+// issue-stats.mts uses store.get(key, { type: "json" }) — Netlify returns a parsed object, not a string.
 vi.mock("@netlify/blobs", () => ({
-  getStore: () => ({ get: mockGet, setJSON: mockSetJSON }),
+  getStore: () => ({
+    get: mockGet,
+    setJSON: mockSetJSON,
+  }),
 }));
 
 import handler from "../issue-stats.mts";
@@ -121,6 +125,7 @@ describe("issue-stats", () => {
 
   it("returns cached stats on blob cache hit", async () => {
     const cachedStats = [{ date: "2026-05-20", opened: 1, closed: 0, prsMerged: 0 }];
+    // Parsed shape returned by get(..., { type: "json" }) in issue-stats.mts
     mockGet.mockResolvedValue({
       timestamp: Date.now(),
       stats: cachedStats,

--- a/web/netlify/functions/__tests__/issue-stats.test.ts
+++ b/web/netlify/functions/__tests__/issue-stats.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Vitest handler tests for issue-stats.mts (#15397, Part of #4189).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertResponseHasNoSecrets,
+  FAKE_GITHUB_TOKEN,
+  readJson,
+} from "./netlify-handler-helpers";
+
+const { mockGet, mockSetJSON } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSetJSON: vi.fn(),
+}));
+
+vi.mock("@netlify/blobs", () => ({
+  getStore: () => ({ get: mockGet, setJSON: mockSetJSON }),
+}));
+
+import handler from "../issue-stats.mts";
+
+function makeRequest(search = "repo=kubestellar/console&days=7"): Request {
+  return new Request(`https://console.kubestellar.io/api/issue-stats?${search}`, {
+    method: "GET",
+    headers: { Origin: "https://console.kubestellar.io" },
+  });
+}
+
+function makeIssue(createdAt: string, state: string, closedAt?: string) {
+  return {
+    created_at: createdAt,
+    state,
+    closed_at: closedAt ?? null,
+  };
+}
+
+function makeMergedPr(mergedAt: string) {
+  return {
+    merged_at: mergedAt,
+    state: "closed",
+  };
+}
+
+describe("issue-stats", () => {
+  const originalToken = process.env.GITHUB_TOKEN;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GITHUB_TOKEN = FAKE_GITHUB_TOKEN;
+    mockGet.mockResolvedValue(null);
+    mockSetJSON.mockResolvedValue(undefined);
+
+    const today = new Date();
+    const yesterday = new Date(today.getTime() - 86_400_000);
+    const createdToday = today.toISOString();
+    const createdYesterday = yesterday.toISOString();
+    const closedToday = today.toISOString().slice(0, 10);
+
+    fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () =>
+          JSON.stringify([
+            makeIssue(createdToday, "open"),
+            makeIssue(createdYesterday, "closed", `${closedToday}T12:00:00Z`),
+          ]),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify([makeMergedPr(createdToday)]),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalToken;
+    }
+  });
+
+  it("returns 400 for invalid repo format", async () => {
+    const res = await handler(makeRequest("repo=not-valid!!!&days=7"));
+    expect(res.status).toBe(400);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("Invalid repo");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when GITHUB_TOKEN is not configured", async () => {
+    delete process.env.GITHUB_TOKEN;
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(500);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("GITHUB_TOKEN");
+  });
+
+  it("returns daily stats array on happy path", async () => {
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await readJson<Array<{ date: string; opened: number; closed: number; prsMerged: number }>>(res);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+    expect(body[0]).toMatchObject({
+      date: expect.any(String),
+      opened: expect.any(Number),
+      closed: expect.any(Number),
+      prsMerged: expect.any(Number),
+    });
+    expect(res.headers.get("X-Cache")).toBe("MISS");
+    const raw = JSON.stringify(body);
+    assertResponseHasNoSecrets(raw, [FAKE_GITHUB_TOKEN, "Bearer ", "gho_"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const authHeader = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(authHeader.Authorization).toContain("Bearer");
+    expect(raw).not.toContain(FAKE_GITHUB_TOKEN);
+  });
+
+  it("returns cached stats on blob cache hit", async () => {
+    const cachedStats = [{ date: "2026-05-20", opened: 1, closed: 0, prsMerged: 0 }];
+    mockGet.mockResolvedValue({
+      timestamp: Date.now(),
+      stats: cachedStats,
+    });
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+    expect(body).toEqual(cachedStats);
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when GitHub fetch throws", async () => {
+    fetchMock.mockReset();
+    fetchMock.mockRejectedValue(new Error("network failure"));
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(502);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("unavailable");
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_GITHUB_TOKEN]);
+  });
+
+  it("returns 405 for non-GET methods", async () => {
+    const res = await handler(
+      new Request("https://console.kubestellar.io/api/issue-stats", { method: "POST" }),
+    );
+    expect(res.status).toBe(405);
+  });
+});

--- a/web/netlify/functions/__tests__/netlify-handler-helpers.ts
+++ b/web/netlify/functions/__tests__/netlify-handler-helpers.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared helpers for Netlify function handler tests (#15397).
+ */
+
+/** Fake token — must never appear in response bodies */
+export const FAKE_GITHUB_TOKEN = "gho_TEST_TOKEN_15397_do_not_leak";
+
+export const FAKE_MUTATE_AUTH_TOKEN = "mutate-auth-token-15397-secret";
+
+export async function readJson<T = unknown>(res: Response): Promise<T> {
+  return res.json() as Promise<T>;
+}
+
+export function assertResponseHasNoSecrets(
+  bodyText: string,
+  secrets: string[],
+): void {
+  for (const secret of secrets) {
+    expect(bodyText).not.toContain(secret);
+  }
+}
+
+export function freshBlobCacheEntry<T>(payload: T): string {
+  return JSON.stringify({ payload, fetchedAt: Date.now() });
+}

--- a/web/netlify/functions/__tests__/netlify-handler-helpers.ts
+++ b/web/netlify/functions/__tests__/netlify-handler-helpers.ts
@@ -1,6 +1,7 @@
 /**
  * Shared helpers for Netlify function handler tests (#15397).
  */
+import { expect } from "vitest";
 
 /** Fake token — must never appear in response bodies */
 export const FAKE_GITHUB_TOKEN = "gho_TEST_TOKEN_15397_do_not_leak";

--- a/web/netlify/functions/__tests__/nightly-e2e.test.ts
+++ b/web/netlify/functions/__tests__/nightly-e2e.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Vitest handler tests for nightly-e2e.mts (#15397, Part of #4189).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertResponseHasNoSecrets,
+  FAKE_GITHUB_TOKEN,
+  readJson,
+} from "./netlify-handler-helpers";
+
+const SAMPLE_GUIDES = [
+  {
+    guide: "llm-d-inference",
+    acronym: "INF",
+    platform: "linux",
+    repo: "llm-d/llm-d",
+    workflowFile: "nightly-e2e.yml",
+    runs: [],
+    passRate: 100,
+    trend: "stable",
+    latestConclusion: "success",
+    model: "test-model",
+    gpuType: "nvidia",
+    gpuCount: 1,
+    llmdImages: {},
+    otherImages: {},
+  },
+];
+
+const { mockGet, mockSet, mockFetchAll } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSet: vi.fn(),
+  mockFetchAll: vi.fn(),
+}));
+
+vi.mock("@netlify/blobs", () => ({
+  getStore: () => ({ get: mockGet, set: mockSet }),
+}));
+
+vi.mock("../_shared/nightly-e2e", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../_shared/nightly-e2e")>();
+  return {
+    ...actual,
+    fetchAll: mockFetchAll,
+  };
+});
+
+import handler from "../nightly-e2e.mts";
+
+function makeRequest(method = "GET"): Request {
+  return new Request("https://console.kubestellar.io/api/nightly-e2e/runs", {
+    method,
+    headers: { Origin: "https://console.kubestellar.io" },
+  });
+}
+
+describe("nightly-e2e", () => {
+  const originalToken = process.env.GITHUB_TOKEN;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GITHUB_TOKEN = FAKE_GITHUB_TOKEN;
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue(undefined);
+    mockFetchAll.mockResolvedValue(SAMPLE_GUIDES);
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalToken;
+    }
+  });
+
+  it("returns 503 when GITHUB_TOKEN is not configured", async () => {
+    delete process.env.GITHUB_TOKEN;
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(503);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("GITHUB_TOKEN");
+    expect(mockFetchAll).not.toHaveBeenCalled();
+  });
+
+  it("returns fresh guides on happy path", async () => {
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await readJson<{
+      guides: typeof SAMPLE_GUIDES;
+      fromCache: boolean;
+      cachedAt: string;
+    }>(res);
+    expect(body.fromCache).toBe(false);
+    expect(body.guides).toHaveLength(1);
+    expect(body.guides[0].guide).toBe("llm-d-inference");
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_GITHUB_TOKEN]);
+    expect(mockFetchAll).toHaveBeenCalledWith(FAKE_GITHUB_TOKEN, expect.anything());
+  });
+
+  it("returns cached guides when blob entry is fresh", async () => {
+    const entry = {
+      guides: SAMPLE_GUIDES,
+      cachedAt: new Date().toISOString(),
+      expiresAt: Date.now() + 60_000,
+    };
+    mockGet.mockResolvedValue(JSON.stringify(entry));
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await readJson<{ guides: unknown[]; fromCache: boolean }>(res);
+    expect(body.fromCache).toBe(true);
+    expect(mockFetchAll).not.toHaveBeenCalled();
+  });
+
+  it("returns stale cached guides when fetch fails but stale window is valid", async () => {
+    const entry = {
+      guides: SAMPLE_GUIDES,
+      cachedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+      expiresAt: Date.now() - 60_000,
+    };
+    mockGet.mockResolvedValue(JSON.stringify(entry));
+    mockFetchAll.mockRejectedValue(new Error("GitHub API down"));
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await readJson<{ guides: unknown[]; stale: boolean; fromCache: boolean }>(res);
+    expect(body.stale).toBe(true);
+    expect(body.fromCache).toBe(true);
+  });
+
+  it("returns 502 when fetch fails and no stale cache exists", async () => {
+    mockFetchAll.mockRejectedValue(new Error("GitHub API down"));
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(502);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("Failed to fetch");
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_GITHUB_TOKEN]);
+  });
+});

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:card-wrapper": "vitest run src/hooks/__tests__/useTimeoutFlag.test.ts src/components/cards/__tests__/CardWrapper.test.tsx",
+    "test:netlify-github-cluster": "vitest run netlify/functions/__tests__/github-pipelines.test.ts netlify/functions/__tests__/github-pipelines-mutate.test.ts netlify/functions/__tests__/nightly-e2e.test.ts netlify/functions/__tests__/issue-stats.test.ts",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "test:e2e": "npm run build && playwright test",


### PR DESCRIPTION
## Summary

Fixes #15397

Adds handler-level Vitest tests for the production Netlify CI/GitHub cluster. Frontend hook tests (`useGitHubPipelines.test.ts`) do not cover handler normalization, error shapes, or secret masking.

- **github-pipelines** (10 tests): pulse/matrix happy paths, blob cache hit, rate limit, unknown view, log bad-input, upstream 500, missing token, OPTIONS/405
- **github-pipelines-mutate** (6 tests): auth required, bad run id, rate limit, authorized rerun, disabled when token unset
- **nightly-e2e** (5 tests): fresh fetch, cache hit, stale serve on upstream failure, 502 without cache, missing token
- **issue-stats** (6 tests): invalid repo 400, happy path daily stats shape, cache hit, upstream 502, missing token, 405

All external HTTP is stubbed; responses are asserted to never contain `GITHUB_TOKEN` or mutation auth secrets.

## Test plan

```bash
cd web && npm run test:netlify-github-cluster
```

27/27 passed locally.

Part of #4189