### PR TITLE
test(netlify): Vitest handler tests for identity-oidc and identity-rbac functions

### DIFF
--- a/web/netlify/functions/__tests__/identity-oidc-rbac.test.ts
+++ b/web/netlify/functions/__tests__/identity-oidc-rbac.test.ts
@@ -35,14 +35,29 @@ function runBadInputSuite(name: string, handler: HandlerFn, path: string) {
       expect(body.error).toContain("Invalid cluster");
     });
 
-    it("returns 405 for POST", async () => {
+    it("returns 405 for POST with Allow header", async () => {
       const res = await handler(makeIdentityRequest(path, { method: "POST" }));
       expect(res.status).toBe(405);
+      expect(res.headers.get("Allow")).toBe("GET, OPTIONS");
       const body = await readJson<{ error: string }>(res);
       expect(body.error).toContain("Method not allowed");
     });
   });
 }
+
+describe("wrapIdentityDemoResponse — CORS preflight", () => {
+  it("returns 204 OPTIONS with Access-Control-Allow-Methods and Allow-Headers", async () => {
+    const res = await oidcSummaryHandler(
+      makeIdentityRequest(API_OIDC_SUMMARY, { method: "OPTIONS" }),
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Methods")).toBe("GET, OPTIONS");
+    expect(res.headers.get("Access-Control-Allow-Headers")).toBe("Content-Type");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://console.kubestellar.io",
+    );
+  });
+});
 
 function runUpstreamErrorSuite(name: string, handler: HandlerFn, path: string) {
   describe(`${name} — upstream/serialization error`, () => {

--- a/web/netlify/functions/__tests__/identity-oidc-rbac.test.ts
+++ b/web/netlify/functions/__tests__/identity-oidc-rbac.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Vitest handler tests for identity OIDC + RBAC Netlify functions (#15399, Part of #4189).
+ *
+ * Run from web/: npm run test:netlify-identity
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertNoForbiddenIdentityFields,
+  makeIdentityRequest,
+  readJson,
+} from "./netlify-handler-helpers";
+
+import oidcSummaryHandler from "../identity-oidc-summary.mts";
+import oidcProvidersHandler from "../identity-oidc-providers.mts";
+import oidcSessionsHandler from "../identity-oidc-sessions.mts";
+import rbacSummaryHandler from "../identity-rbac-summary.mts";
+import rbacFindingsHandler from "../identity-rbac-findings.mts";
+
+const API_OIDC_SUMMARY = "/api/identity/oidc/summary";
+const API_OIDC_PROVIDERS = "/api/identity/oidc/providers";
+const API_OIDC_SESSIONS = "/api/identity/oidc/sessions";
+const API_RBAC_SUMMARY = "/api/identity/rbac/summary";
+const API_RBAC_FINDINGS = "/api/identity/rbac/findings";
+
+const INVALID_CLUSTER_SEARCH = "cluster=not valid!!!";
+
+type HandlerFn = (req: Request) => Promise<Response>;
+
+function runBadInputSuite(name: string, handler: HandlerFn, path: string) {
+  describe(`${name} — bad input`, () => {
+    it("returns 400 for invalid cluster query parameter", async () => {
+      const res = await handler(makeIdentityRequest(path, { search: INVALID_CLUSTER_SEARCH }));
+      expect(res.status).toBe(400);
+      const body = await readJson<{ error: string }>(res);
+      expect(body.error).toContain("Invalid cluster");
+    });
+
+    it("returns 405 for POST", async () => {
+      const res = await handler(makeIdentityRequest(path, { method: "POST" }));
+      expect(res.status).toBe(405);
+      const body = await readJson<{ error: string }>(res);
+      expect(body.error).toContain("Method not allowed");
+    });
+  });
+}
+
+function runUpstreamErrorSuite(name: string, handler: HandlerFn, path: string) {
+  describe(`${name} — upstream/serialization error`, () => {
+    let stringifySpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      stringifySpy = vi.spyOn(JSON, "stringify").mockImplementation(() => {
+        throw new Error("serialization failed");
+      });
+    });
+
+    afterEach(() => {
+      stringifySpy.mockRestore();
+    });
+
+    it("returns 502 when response JSON serialization fails", async () => {
+      const res = await handler(makeIdentityRequest(path));
+      expect(res.status).toBe(502);
+      const raw = await res.text();
+      expect(raw).toContain("unavailable");
+      assertNoForbiddenIdentityFields(raw);
+    });
+  });
+}
+
+describe("identity-oidc-summary", () => {
+  it("returns normalized OIDC summary shape on happy path", async () => {
+    const res = await oidcSummaryHandler(makeIdentityRequest(API_OIDC_SUMMARY));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+
+    const body = await readJson<{
+      total_providers: number;
+      active_providers: number;
+      total_users: number;
+      active_sessions: number;
+      failed_logins_24h: number;
+      mfa_adoption: number;
+      evaluated_at: string;
+    }>(res);
+
+    expect(body.total_providers).toBeGreaterThan(0);
+    expect(body.active_providers).toBeLessThanOrEqual(body.total_providers);
+    expect(body.mfa_adoption).toBeGreaterThanOrEqual(0);
+    expect(() => new Date(body.evaluated_at).toISOString()).not.toThrow();
+    assertNoForbiddenIdentityFields(JSON.stringify(body));
+  });
+
+  runBadInputSuite("identity-oidc-summary", oidcSummaryHandler, API_OIDC_SUMMARY);
+  runUpstreamErrorSuite("identity-oidc-summary", oidcSummaryHandler, API_OIDC_SUMMARY);
+});
+
+describe("identity-oidc-providers", () => {
+  it("returns provider list with bindings metadata on happy path", async () => {
+    const res = await oidcProvidersHandler(makeIdentityRequest(API_OIDC_PROVIDERS));
+    expect(res.status).toBe(200);
+
+    const body = await readJson<
+      Array<{
+        id: string;
+        name: string;
+        issuer_url: string;
+        status: string;
+        protocol: string;
+        client_id: string;
+        users_synced: number;
+        groups_mapped: number;
+      }>
+    >(res);
+
+    expect(body.length).toBeGreaterThanOrEqual(3);
+    expect(body[0]).toMatchObject({
+      id: expect.any(String),
+      name: expect.any(String),
+      issuer_url: expect.stringMatching(/^https:\/\//),
+      status: expect.any(String),
+      client_id: expect.any(String),
+      groups_mapped: expect.any(Number),
+    });
+    assertNoForbiddenIdentityFields(JSON.stringify(body));
+  });
+
+  runBadInputSuite("identity-oidc-providers", oidcProvidersHandler, API_OIDC_PROVIDERS);
+  runUpstreamErrorSuite("identity-oidc-providers", oidcProvidersHandler, API_OIDC_PROVIDERS);
+});
+
+describe("identity-oidc-sessions", () => {
+  it("returns session list with active flag on happy path", async () => {
+    const res = await oidcSessionsHandler(makeIdentityRequest(API_OIDC_SESSIONS));
+    expect(res.status).toBe(200);
+
+    const body = await readJson<
+      Array<{
+        id: string;
+        user: string;
+        provider_name: string;
+        active: boolean;
+        login_time: string;
+        expires_at: string;
+      }>
+    >(res);
+
+    expect(body.length).toBeGreaterThan(0);
+    expect(body.some((s) => s.active)).toBe(true);
+    expect(body.some((s) => !s.active)).toBe(true);
+    assertNoForbiddenIdentityFields(JSON.stringify(body));
+  });
+
+  runBadInputSuite("identity-oidc-sessions", oidcSessionsHandler, API_OIDC_SESSIONS);
+  runUpstreamErrorSuite("identity-oidc-sessions", oidcSessionsHandler, API_OIDC_SESSIONS);
+});
+
+describe("identity-rbac-summary", () => {
+  it("returns RBAC summary with binding counts on happy path", async () => {
+    const res = await rbacSummaryHandler(makeIdentityRequest(API_RBAC_SUMMARY));
+    expect(res.status).toBe(200);
+
+    const body = await readJson<{
+      total_bindings: number;
+      cluster_role_bindings: number;
+      role_bindings: number;
+      over_privileged: number;
+      unused_bindings: number;
+      compliance_score: number;
+      evaluated_at: string;
+    }>(res);
+
+    expect(body.total_bindings).toBe(
+      body.cluster_role_bindings + body.role_bindings,
+    );
+    expect(body.compliance_score).toBeGreaterThanOrEqual(0);
+    expect(body.compliance_score).toBeLessThanOrEqual(100);
+    assertNoForbiddenIdentityFields(JSON.stringify(body));
+  });
+
+  runBadInputSuite("identity-rbac-summary", rbacSummaryHandler, API_RBAC_SUMMARY);
+  runUpstreamErrorSuite("identity-rbac-summary", rbacSummaryHandler, API_RBAC_SUMMARY);
+});
+
+describe("identity-rbac-findings", () => {
+  it("returns findings with severity and cluster on happy path", async () => {
+    const res = await rbacFindingsHandler(makeIdentityRequest(API_RBAC_FINDINGS));
+    expect(res.status).toBe(200);
+
+    const body = await readJson<
+      Array<{
+        id: string;
+        finding_type: string;
+        severity: string;
+        subject: string;
+        cluster: string;
+        recommendation: string;
+      }>
+    >(res);
+
+    expect(body.length).toBeGreaterThan(0);
+    const severities = new Set(body.map((f) => f.severity));
+    expect(severities.has("critical")).toBe(true);
+    expect(body.every((f) => f.cluster.length > 0)).toBe(true);
+    assertNoForbiddenIdentityFields(JSON.stringify(body));
+  });
+
+  runBadInputSuite("identity-rbac-findings", rbacFindingsHandler, API_RBAC_FINDINGS);
+  runUpstreamErrorSuite("identity-rbac-findings", rbacFindingsHandler, API_RBAC_FINDINGS);
+});

--- a/web/netlify/functions/__tests__/netlify-handler-helpers.ts
+++ b/web/netlify/functions/__tests__/netlify-handler-helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Shared helpers for Netlify function handler tests (#15397).
+ * Shared helpers for Netlify function handler tests (#15397, #15399).
  */
 import { expect } from "vitest";
 
@@ -7,6 +7,16 @@ import { expect } from "vitest";
 export const FAKE_GITHUB_TOKEN = "gho_TEST_TOKEN_15397_do_not_leak";
 
 export const FAKE_MUTATE_AUTH_TOKEN = "mutate-auth-token-15397-secret";
+
+/** Field names that must never appear in identity demo API responses */
+export const FORBIDDEN_IDENTITY_RESPONSE_KEYS = [
+  "client_secret",
+  "refresh_token",
+  "access_token",
+  "password",
+  "GITHUB_TOKEN",
+  "GITHUB_MUTATIONS_TOKEN",
+] as const;
 
 export async function readJson<T = unknown>(res: Response): Promise<T> {
   return res.json() as Promise<T>;
@@ -19,6 +29,28 @@ export function assertResponseHasNoSecrets(
   for (const secret of secrets) {
     expect(bodyText).not.toContain(secret);
   }
+}
+
+export function assertNoForbiddenIdentityFields(bodyText: string): void {
+  for (const field of FORBIDDEN_IDENTITY_RESPONSE_KEYS) {
+    expect(bodyText).not.toContain(`"${field}"`);
+  }
+  assertResponseHasNoSecrets(bodyText, [
+    FAKE_GITHUB_TOKEN,
+    "github_pat_",
+    "Bearer gho_",
+  ]);
+}
+
+export function makeIdentityRequest(
+  path: string,
+  options?: { method?: string; search?: string },
+): Request {
+  const search = options?.search ? `?${options.search}` : "";
+  return new Request(`https://console.kubestellar.io${path}${search}`, {
+    method: options?.method ?? "GET",
+    headers: { Origin: "https://console.kubestellar.io" },
+  });
 }
 
 export function freshBlobCacheEntry<T>(payload: T): string {

--- a/web/netlify/functions/_shared/identity-demo-request.ts
+++ b/web/netlify/functions/_shared/identity-demo-request.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared request guards for identity demo Netlify handlers (#15399).
+ * Adds method validation, optional cluster query validation, and safe JSON responses.
+ */
+import { buildCorsHeaders, handlePreflight } from "./cors";
+
+const CLUSTER_PARAM_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
+const CORS_OPTIONS = {
+  methods: "GET, OPTIONS",
+  headers: "Content-Type",
+} as const;
+
+function jsonResponse(
+  body: unknown,
+  status: number,
+  corsHeaders: Record<string, string>,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+/**
+ * Wrap static identity demo payloads with CORS, method checks, and error handling.
+ */
+export async function wrapIdentityDemoResponse(
+  req: Request,
+  body: unknown,
+): Promise<Response> {
+  const corsHeaders = buildCorsHeaders(req, CORS_OPTIONS);
+
+  if (req.method === "OPTIONS") {
+    return handlePreflight(req, CORS_OPTIONS);
+  }
+
+  if (req.method !== "GET") {
+    return jsonResponse({ error: "Method not allowed" }, 405, corsHeaders);
+  }
+
+  const cluster = new URL(req.url).searchParams.get("cluster");
+  if (cluster !== null && cluster !== "" && !CLUSTER_PARAM_RE.test(cluster)) {
+    return jsonResponse({ error: "Invalid cluster parameter" }, 400, corsHeaders);
+  }
+
+  try {
+    return jsonResponse(body, 200, corsHeaders);
+  } catch (error) {
+    console.error(
+      "[identity-demo] response serialization failed:",
+      error instanceof Error ? error.message : error,
+    );
+    // Static JSON — avoid stringify in the error path (may be what failed).
+    return new Response('{"error":"Identity data temporarily unavailable"}', {
+      status: 502,
+      headers: {
+        ...corsHeaders,
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/web/netlify/functions/_shared/identity-demo-request.ts
+++ b/web/netlify/functions/_shared/identity-demo-request.ts
@@ -15,11 +15,13 @@ function jsonResponse(
   body: unknown,
   status: number,
   corsHeaders: Record<string, string>,
+  extraHeaders?: Record<string, string>,
 ): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: {
       ...corsHeaders,
+      ...extraHeaders,
       "Content-Type": "application/json",
     },
   });
@@ -32,14 +34,19 @@ export async function wrapIdentityDemoResponse(
   req: Request,
   body: unknown,
 ): Promise<Response> {
-  const corsHeaders = buildCorsHeaders(req, CORS_OPTIONS);
-
   if (req.method === "OPTIONS") {
     return handlePreflight(req, CORS_OPTIONS);
   }
 
+  const corsHeaders = buildCorsHeaders(req, CORS_OPTIONS);
+
   if (req.method !== "GET") {
-    return jsonResponse({ error: "Method not allowed" }, 405, corsHeaders);
+    return jsonResponse(
+      { error: "Method not allowed" },
+      405,
+      corsHeaders,
+      { Allow: CORS_OPTIONS.methods },
+    );
   }
 
   const cluster = new URL(req.url).searchParams.get("cluster");

--- a/web/netlify/functions/identity-oidc-providers.mts
+++ b/web/netlify/functions/identity-oidc-providers.mts
@@ -3,6 +3,7 @@
  *
  * Returns demo OIDC provider list for the enterprise OIDC dashboard.
  */
+import { wrapIdentityDemoResponse } from "./_shared/identity-demo-request";
 
 /** Offset constants for demo timestamps (milliseconds) */
 const FIVE_MINUTES_MS = 300_000;
@@ -11,19 +12,13 @@ const FIFTEEN_MINUTES_MS = 900_000;
 const TWENTY_MINUTES_MS = 1_200_000;
 const ONE_DAY_MS = 86_400_000;
 
-export default async () => {
+export default async (req: Request) => {
   const now = Date.now();
-  return new Response(
-    JSON.stringify([
-      { id: "oidc-1", name: "Okta Production", issuer_url: "https://company.okta.com", status: "connected", protocol: "OIDC", client_id: "okta-prod-001", users_synced: 485, last_sync: new Date(now - FIVE_MINUTES_MS).toISOString(), groups_mapped: 12 },
-      { id: "oidc-2", name: "Azure AD", issuer_url: "https://login.microsoftonline.com/tenant-id", status: "connected", protocol: "OIDC", client_id: "azure-ad-001", users_synced: 312, last_sync: new Date(now - TEN_MINUTES_MS).toISOString(), groups_mapped: 8 },
-      { id: "oidc-3", name: "GitHub Enterprise", issuer_url: "https://github.com/login/oauth", status: "connected", protocol: "OAuth2", client_id: "gh-ent-001", users_synced: 198, last_sync: new Date(now - FIFTEEN_MINUTES_MS).toISOString(), groups_mapped: 15 },
-      { id: "oidc-4", name: "Google Workspace", issuer_url: "https://accounts.google.com", status: "connected", protocol: "OIDC", client_id: "gws-001", users_synced: 252, last_sync: new Date(now - TWENTY_MINUTES_MS).toISOString(), groups_mapped: 6 },
-      { id: "oidc-5", name: "Keycloak Staging", issuer_url: "https://keycloak.staging.internal", status: "degraded", protocol: "OIDC", client_id: "kc-staging-001", users_synced: 0, last_sync: new Date(now - ONE_DAY_MS).toISOString(), groups_mapped: 3 },
-    ]),
-    {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    },
-  );
+  return wrapIdentityDemoResponse(req, [
+    { id: "oidc-1", name: "Okta Production", issuer_url: "https://company.okta.com", status: "connected", protocol: "OIDC", client_id: "okta-prod-001", users_synced: 485, last_sync: new Date(now - FIVE_MINUTES_MS).toISOString(), groups_mapped: 12 },
+    { id: "oidc-2", name: "Azure AD", issuer_url: "https://login.microsoftonline.com/tenant-id", status: "connected", protocol: "OIDC", client_id: "azure-ad-001", users_synced: 312, last_sync: new Date(now - TEN_MINUTES_MS).toISOString(), groups_mapped: 8 },
+    { id: "oidc-3", name: "GitHub Enterprise", issuer_url: "https://github.com/login/oauth", status: "connected", protocol: "OAuth2", client_id: "gh-ent-001", users_synced: 198, last_sync: new Date(now - FIFTEEN_MINUTES_MS).toISOString(), groups_mapped: 15 },
+    { id: "oidc-4", name: "Google Workspace", issuer_url: "https://accounts.google.com", status: "connected", protocol: "OIDC", client_id: "gws-001", users_synced: 252, last_sync: new Date(now - TWENTY_MINUTES_MS).toISOString(), groups_mapped: 6 },
+    { id: "oidc-5", name: "Keycloak Staging", issuer_url: "https://keycloak.staging.internal", status: "degraded", protocol: "OIDC", client_id: "kc-staging-001", users_synced: 0, last_sync: new Date(now - ONE_DAY_MS).toISOString(), groups_mapped: 3 },
+  ]);
 };

--- a/web/netlify/functions/identity-oidc-sessions.mts
+++ b/web/netlify/functions/identity-oidc-sessions.mts
@@ -3,6 +3,7 @@
  *
  * Returns demo OIDC session list for the enterprise OIDC dashboard.
  */
+import { wrapIdentityDemoResponse } from "./_shared/identity-demo-request";
 
 /** Offset constants for demo timestamps (milliseconds) */
 const TEN_MINUTES_MS = 600_000;
@@ -17,22 +18,16 @@ const FOUR_HOURS_MS = 14_400_000;
 const FIFTEEN_MINUTES_MS = 900_000;
 const SEVENTY_FIVE_MINUTES_MS = 4_500_000;
 
-export default async () => {
+export default async (req: Request) => {
   const now = Date.now();
-  return new Response(
-    JSON.stringify([
-      { id: "sess-1", user: "alice@company.com", provider_id: "oidc-1", provider_name: "Okta Production", login_time: new Date(now - ONE_HOUR_MS).toISOString(), expires_at: new Date(now + TWO_HOURS_MS).toISOString(), ip_address: "10.0.1.42", active: true },
-      { id: "sess-2", user: "bob@company.com", provider_id: "oidc-2", provider_name: "Azure AD", login_time: new Date(now - TWO_HOURS_MS).toISOString(), expires_at: new Date(now + ONE_HOUR_MS).toISOString(), ip_address: "10.0.2.18", active: true },
-      { id: "sess-3", user: "carol@company.com", provider_id: "oidc-3", provider_name: "GitHub Enterprise", login_time: new Date(now - THIRTY_MINUTES_MS).toISOString(), expires_at: new Date(now + NINETY_MINUTES_MS).toISOString(), ip_address: "10.0.1.55", active: true },
-      { id: "sess-4", user: "dave@company.com", provider_id: "oidc-1", provider_name: "Okta Production", login_time: new Date(now - NINETY_MINUTES_MS).toISOString(), expires_at: new Date(now + THIRTY_MINUTES_MS).toISOString(), ip_address: "172.16.0.22", active: true },
-      { id: "sess-5", user: "eve@company.com", provider_id: "oidc-4", provider_name: "Google Workspace", login_time: new Date(now - TEN_MINUTES_MS).toISOString(), expires_at: new Date(now + THREE_HOURS_MS).toISOString(), ip_address: "10.0.3.7", active: true },
-      { id: "sess-6", user: "frank@company.com", provider_id: "oidc-2", provider_name: "Azure AD", login_time: new Date(now - FOUR_HOURS_MS).toISOString(), expires_at: new Date(now - THIRTY_MINUTES_MS).toISOString(), ip_address: "10.0.1.91", active: false },
-      { id: "sess-7", user: "grace@company.com", provider_id: "oidc-1", provider_name: "Okta Production", login_time: new Date(now - FIFTEEN_MINUTES_MS).toISOString(), expires_at: new Date(now + TWO_AND_HALF_HOURS_MS).toISOString(), ip_address: "192.168.1.14", active: true },
-      { id: "sess-8", user: "hank@company.com", provider_id: "oidc-3", provider_name: "GitHub Enterprise", login_time: new Date(now - FORTY_FIVE_MINUTES_MS).toISOString(), expires_at: new Date(now + SEVENTY_FIVE_MINUTES_MS).toISOString(), ip_address: "10.0.2.33", active: true },
-    ]),
-    {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    },
-  );
+  return wrapIdentityDemoResponse(req, [
+    { id: "sess-1", user: "alice@company.com", provider_id: "oidc-1", provider_name: "Okta Production", login_time: new Date(now - ONE_HOUR_MS).toISOString(), expires_at: new Date(now + TWO_HOURS_MS).toISOString(), ip_address: "10.0.1.42", active: true },
+    { id: "sess-2", user: "bob@company.com", provider_id: "oidc-2", provider_name: "Azure AD", login_time: new Date(now - TWO_HOURS_MS).toISOString(), expires_at: new Date(now + ONE_HOUR_MS).toISOString(), ip_address: "10.0.2.18", active: true },
+    { id: "sess-3", user: "carol@company.com", provider_id: "oidc-3", provider_name: "GitHub Enterprise", login_time: new Date(now - THIRTY_MINUTES_MS).toISOString(), expires_at: new Date(now + NINETY_MINUTES_MS).toISOString(), ip_address: "10.0.1.55", active: true },
+    { id: "sess-4", user: "dave@company.com", provider_id: "oidc-1", provider_name: "Okta Production", login_time: new Date(now - NINETY_MINUTES_MS).toISOString(), expires_at: new Date(now + THIRTY_MINUTES_MS).toISOString(), ip_address: "172.16.0.22", active: true },
+    { id: "sess-5", user: "eve@company.com", provider_id: "oidc-4", provider_name: "Google Workspace", login_time: new Date(now - TEN_MINUTES_MS).toISOString(), expires_at: new Date(now + THREE_HOURS_MS).toISOString(), ip_address: "10.0.3.7", active: true },
+    { id: "sess-6", user: "frank@company.com", provider_id: "oidc-2", provider_name: "Azure AD", login_time: new Date(now - FOUR_HOURS_MS).toISOString(), expires_at: new Date(now - THIRTY_MINUTES_MS).toISOString(), ip_address: "10.0.1.91", active: false },
+    { id: "sess-7", user: "grace@company.com", provider_id: "oidc-1", provider_name: "Okta Production", login_time: new Date(now - FIFTEEN_MINUTES_MS).toISOString(), expires_at: new Date(now + TWO_AND_HALF_HOURS_MS).toISOString(), ip_address: "192.168.1.14", active: true },
+    { id: "sess-8", user: "hank@company.com", provider_id: "oidc-3", provider_name: "GitHub Enterprise", login_time: new Date(now - FORTY_FIVE_MINUTES_MS).toISOString(), expires_at: new Date(now + SEVENTY_FIVE_MINUTES_MS).toISOString(), ip_address: "10.0.2.33", active: true },
+  ]);
 };

--- a/web/netlify/functions/identity-oidc-summary.mts
+++ b/web/netlify/functions/identity-oidc-summary.mts
@@ -6,20 +6,16 @@
  * the same static demo data as the MSW handler so enterprise dashboards
  * render correctly without a Go backend.
  */
-export default async () => {
-  return new Response(
-    JSON.stringify({
-      total_providers: 5,
-      active_providers: 4,
-      total_users: 1247,
-      active_sessions: 89,
-      failed_logins_24h: 7,
-      mfa_adoption: 82,
-      evaluated_at: new Date().toISOString(),
-    }),
-    {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    },
-  );
+import { wrapIdentityDemoResponse } from "./_shared/identity-demo-request";
+
+export default async (req: Request) => {
+  return wrapIdentityDemoResponse(req, {
+    total_providers: 5,
+    active_providers: 4,
+    total_users: 1247,
+    active_sessions: 89,
+    failed_logins_24h: 7,
+    mfa_adoption: 82,
+    evaluated_at: new Date().toISOString(),
+  });
 };

--- a/web/netlify/functions/identity-rbac-findings.mts
+++ b/web/netlify/functions/identity-rbac-findings.mts
@@ -3,19 +3,15 @@
  *
  * Returns demo RBAC audit findings for the enterprise RBAC Audit dashboard.
  */
-export default async () => {
-  return new Response(
-    JSON.stringify([
-      { id: "find-1", finding_type: "cluster_admin_user", severity: "critical", subject: "alice@company.com", description: "User has cluster-admin role bound directly. This grants unrestricted access to all resources.", cluster: "prod-east", namespace: "*", recommendation: "Replace with scoped roles targeting specific namespaces and resources." },
-      { id: "find-2", finding_type: "stale_binding", severity: "high", subject: "former-admin@company.com", description: "ClusterRoleBinding for cluster-admin has not been used in 30+ days. User may have left the organization.", cluster: "prod-east", namespace: "*", recommendation: "Remove the binding and verify user employment status." },
-      { id: "find-3", finding_type: "wildcard_resource", severity: "high", subject: "ci-deployer", description: "ServiceAccount has wildcard resource permissions in the ci-cd namespace.", cluster: "prod-east", namespace: "ci-cd", recommendation: "Restrict to specific resource types: deployments, services, configmaps." },
-      { id: "find-4", finding_type: "excessive_secrets_access", severity: "medium", subject: "developers", description: "Group \"developers\" can list and read secrets in the app-dev namespace.", cluster: "prod-east", namespace: "app-dev", recommendation: "Use CSI secret store driver instead of direct secret access." },
-      { id: "find-5", finding_type: "unused_binding", severity: "medium", subject: "interns", description: "RoleBinding for \"interns\" group has not been used in 3+ days. May indicate stale permissions.", cluster: "staging", namespace: "sandbox", recommendation: "Review and remove if no longer needed." },
-      { id: "find-6", finding_type: "broad_namespace_admin", severity: "high", subject: "sre-team", description: "Group has admin role in production namespace, granting full control including RBAC modification.", cluster: "prod-east", namespace: "production", recommendation: "Use edit role instead and manage RBAC separately through policy." },
-    ]),
-    {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    },
-  );
+import { wrapIdentityDemoResponse } from "./_shared/identity-demo-request";
+
+export default async (req: Request) => {
+  return wrapIdentityDemoResponse(req, [
+    { id: "find-1", finding_type: "cluster_admin_user", severity: "critical", subject: "alice@company.com", description: "User has cluster-admin role bound directly. This grants unrestricted access to all resources.", cluster: "prod-east", namespace: "*", recommendation: "Replace with scoped roles targeting specific namespaces and resources." },
+    { id: "find-2", finding_type: "stale_binding", severity: "high", subject: "former-admin@company.com", description: "ClusterRoleBinding for cluster-admin has not been used in 30+ days. User may have left the organization.", cluster: "prod-east", namespace: "*", recommendation: "Remove the binding and verify user employment status." },
+    { id: "find-3", finding_type: "wildcard_resource", severity: "high", subject: "ci-deployer", description: "ServiceAccount has wildcard resource permissions in the ci-cd namespace.", cluster: "prod-east", namespace: "ci-cd", recommendation: "Restrict to specific resource types: deployments, services, configmaps." },
+    { id: "find-4", finding_type: "excessive_secrets_access", severity: "medium", subject: "developers", description: "Group \"developers\" can list and read secrets in the app-dev namespace.", cluster: "prod-east", namespace: "app-dev", recommendation: "Use CSI secret store driver instead of direct secret access." },
+    { id: "find-5", finding_type: "unused_binding", severity: "medium", subject: "interns", description: "RoleBinding for \"interns\" group has not been used in 3+ days. May indicate stale permissions.", cluster: "staging", namespace: "sandbox", recommendation: "Review and remove if no longer needed." },
+    { id: "find-6", finding_type: "broad_namespace_admin", severity: "high", subject: "sre-team", description: "Group has admin role in production namespace, granting full control including RBAC modification.", cluster: "prod-east", namespace: "production", recommendation: "Use edit role instead and manage RBAC separately through policy." },
+  ]);
 };

--- a/web/netlify/functions/identity-rbac-summary.mts
+++ b/web/netlify/functions/identity-rbac-summary.mts
@@ -3,20 +3,16 @@
  *
  * Returns demo RBAC audit summary data for the enterprise RBAC dashboard.
  */
-export default async () => {
-  return new Response(
-    JSON.stringify({
-      total_bindings: 147,
-      cluster_role_bindings: 34,
-      role_bindings: 113,
-      over_privileged: 8,
-      unused_bindings: 12,
-      compliance_score: 78,
-      evaluated_at: new Date().toISOString(),
-    }),
-    {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    },
-  );
+import { wrapIdentityDemoResponse } from "./_shared/identity-demo-request";
+
+export default async (req: Request) => {
+  return wrapIdentityDemoResponse(req, {
+    total_bindings: 147,
+    cluster_role_bindings: 34,
+    role_bindings: 113,
+    over_privileged: 8,
+    unused_bindings: 12,
+    compliance_score: 78,
+    evaluated_at: new Date().toISOString(),
+  });
 };

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "test": "vitest",
     "test:card-wrapper": "vitest run src/hooks/__tests__/useTimeoutFlag.test.ts src/components/cards/__tests__/CardWrapper.test.tsx",
     "test:netlify-github-cluster": "vitest run netlify/functions/__tests__/github-pipelines.test.ts netlify/functions/__tests__/github-pipelines-mutate.test.ts netlify/functions/__tests__/nightly-e2e.test.ts netlify/functions/__tests__/issue-stats.test.ts",
+    "test:netlify-identity": "vitest run netlify/functions/__tests__/identity-oidc-rbac.test.ts",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "test:e2e": "npm run build && playwright test",


### PR DESCRIPTION
## Summary

Fixes #15399

Adds handler-level Vitest tests for the identity OIDC and RBAC Netlify functions used by `OIDCDashboard` and `RBACAuditDashboard` on console.kubestellar.io.

### Handlers covered (5)
- `identity-oidc-summary`, `identity-oidc-providers`, `identity-oidc-sessions`
- `identity-rbac-summary`, `identity-rbac-findings`

### Implementation notes
Handlers were static demo endpoints with no request guards. This PR adds [`wrapIdentityDemoResponse`](web/netlify/functions/_shared/identity-demo-request.ts) so each handler:
- Supports `OPTIONS` / `GET` only (`405` on `POST`)
- Validates optional `?cluster=` query (`400` on malformed values)
- Returns `502` with a static JSON body if response serialization fails

### Tests (20 total — 4 per handler)
| Case | Coverage |
|------|----------|
| Happy path | Normalized shapes (summary counts, provider list, sessions, RBAC findings) |
| Bad input | Invalid `cluster` → 400; `POST` → 405 |
| Upstream/serialization | Mocked `JSON.stringify` failure → 502 |
| Secret masking | No `client_secret`, tokens, or env-like secrets in bodies |

## Test plan

```bash
cd web && npm run test:netlify-identity
```

20/20 passed locally.

Part of #4189