### PR TITLE
test(netlify): Vitest handler tests for missions-browse, missions-scores, analytics-dashboard (Part of #4189)

### DIFF
--- a/web/netlify/functions/__tests__/analytics-accm.test.ts
+++ b/web/netlify/functions/__tests__/analytics-accm.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Vitest handler tests for analytics-accm.mts (#15403, Part of #4189).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { assertResponseHasNoSecrets, makeNetlifyRequest, readJson } from "./netlify-handler-helpers";
+import type { ACCMData } from "../analytics-accm/helpers";
+
+const { mockGet, mockSet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSet: vi.fn(),
+}));
+
+const {
+  mockFetchACCMFromGist,
+  mockFetchRecentPRs,
+  mockFetchRecentIssues,
+  mockFetchWorkflowRuns,
+  SAMPLE_ACCM,
+} = vi.hoisted(() => ({
+  mockFetchACCMFromGist: vi.fn(),
+  mockFetchRecentPRs: vi.fn(),
+  mockFetchRecentIssues: vi.fn(),
+  mockFetchWorkflowRuns: vi.fn(),
+  SAMPLE_ACCM: {
+    weeklyActivity: [
+      {
+        week: "2026-W20",
+        prsOpened: 3,
+        prsMerged: 2,
+        issuesOpened: 1,
+        issuesClosed: 0,
+        aiPrs: 1,
+        humanPrs: 2,
+        aiIssues: 0,
+        humanIssues: 1,
+        uniqueContributors: 4,
+      },
+    ],
+    ciPassRates: [],
+    contributorGrowth: { total: 10, weekly: [] },
+    cachedAt: new Date().toISOString(),
+  },
+}));
+
+vi.mock("@netlify/blobs", () => ({
+  getStore: () => ({ get: mockGet, set: mockSet }),
+}));
+
+vi.mock("../analytics-accm/gist", () => ({
+  fetchACCMFromGist: mockFetchACCMFromGist,
+}));
+
+vi.mock("../analytics-accm/fetchers", () => ({
+  fetchRecentPRs: mockFetchRecentPRs,
+  fetchRecentIssues: mockFetchRecentIssues,
+  fetchWorkflowRuns: mockFetchWorkflowRuns,
+}));
+
+vi.mock("../analytics-accm/aggregation", () => ({
+  aggregateWeeklyActivity: vi.fn(() => SAMPLE_ACCM.weeklyActivity),
+  aggregateCIPassRates: vi.fn(() => SAMPLE_ACCM.ciPassRates),
+  aggregateContributorGrowth: vi.fn(() => SAMPLE_ACCM.contributorGrowth),
+}));
+
+import handler from "../analytics-accm.mts";
+
+const API_ANALYTICS_ACCM = "/api/analytics-accm";
+
+describe("analytics-accm", () => {
+  let envGet: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue(undefined);
+    mockFetchACCMFromGist.mockResolvedValue(null);
+    mockFetchRecentPRs.mockResolvedValue([]);
+    mockFetchRecentIssues.mockResolvedValue([]);
+    mockFetchWorkflowRuns.mockResolvedValue([]);
+
+    envGet = vi.fn((key: string) => {
+      if (key === "GITHUB_TOKEN") return "gho_TEST_TOKEN_do_not_leak";
+      return undefined;
+    });
+    vi.stubGlobal("Netlify", { env: { get: envGet } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 405 for non-GET methods", async () => {
+    const res = await handler(
+      makeNetlifyRequest(API_ANALYTICS_ACCM, { method: "POST" }),
+    );
+    expect(res.status).toBe(405);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toBe("Method not allowed");
+  });
+
+  it("returns precomputed gist data when gist fetch succeeds", async () => {
+    mockFetchACCMFromGist.mockResolvedValue(SAMPLE_ACCM);
+    const res = await handler(makeNetlifyRequest(API_ANALYTICS_ACCM));
+    expect(res.status).toBe(200);
+
+    const body = await readJson<ACCMData & { source: string }>(res);
+    expect(body.source).toBe("gist");
+    expect(body.weeklyActivity).toHaveLength(1);
+    expect(body.weeklyActivity[0].week).toBe("2026-W20");
+    expect(mockFetchRecentPRs).not.toHaveBeenCalled();
+    assertResponseHasNoSecrets(JSON.stringify(body), ["gho_TEST_TOKEN_do_not_leak"]);
+  });
+
+  it("serves valid blob cache without calling gist or GitHub", async () => {
+    const cacheEntry = {
+      data: SAMPLE_ACCM,
+      expiresAt: Date.now() + 60_000,
+    };
+    mockGet.mockResolvedValue(JSON.stringify(cacheEntry));
+
+    const res = await handler(makeNetlifyRequest(API_ANALYTICS_ACCM));
+    expect(res.status).toBe(200);
+    const body = await readJson<ACCMData & { fromCache: boolean }>(res);
+    expect(body.fromCache).toBe(true);
+    expect(body.weeklyActivity[0].prsOpened).toBe(3);
+    expect(mockFetchACCMFromGist).not.toHaveBeenCalled();
+  });
+
+  it("falls back to live aggregation when gist is unavailable", async () => {
+    mockFetchACCMFromGist.mockResolvedValue(null);
+    const res = await handler(makeNetlifyRequest(API_ANALYTICS_ACCM));
+    expect(res.status).toBe(200);
+
+    const body = await readJson<ACCMData>(res);
+    expect(body.weeklyActivity).toHaveLength(1);
+    expect(mockFetchRecentPRs).toHaveBeenCalled();
+    expect(mockFetchRecentIssues).toHaveBeenCalled();
+    expect(mockFetchWorkflowRuns).toHaveBeenCalled();
+  });
+
+  it("returns 502 when live fetch pipeline fails", async () => {
+    mockFetchACCMFromGist.mockResolvedValue(null);
+    mockFetchRecentPRs.mockRejectedValue(new Error("GitHub API down"));
+
+    const res = await handler(makeNetlifyRequest(API_ANALYTICS_ACCM));
+    expect(res.status).toBe(502);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toBe("Failed to fetch ACCM metrics");
+    assertResponseHasNoSecrets(JSON.stringify(body), ["gho_TEST_TOKEN_do_not_leak"]);
+  });
+});

--- a/web/netlify/functions/__tests__/analytics-accm.test.ts
+++ b/web/netlify/functions/__tests__/analytics-accm.test.ts
@@ -2,7 +2,12 @@
  * Vitest handler tests for analytics-accm.mts (#15403, Part of #4189).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { assertResponseHasNoSecrets, makeNetlifyRequest, readJson } from "./netlify-handler-helpers";
+import {
+  assertResponseHasNoSecrets,
+  FAKE_GITHUB_TOKEN,
+  makeNetlifyRequest,
+  readJson,
+} from "./netlify-handler-helpers";
 import type { ACCMData } from "../analytics-accm/helpers";
 
 const { mockGet, mockSet } = vi.hoisted(() => ({
@@ -79,7 +84,7 @@ describe("analytics-accm", () => {
     mockFetchWorkflowRuns.mockResolvedValue([]);
 
     envGet = vi.fn((key: string) => {
-      if (key === "GITHUB_TOKEN") return "gho_TEST_TOKEN_do_not_leak";
+      if (key === "GITHUB_TOKEN") return FAKE_GITHUB_TOKEN;
       return undefined;
     });
     vi.stubGlobal("Netlify", { env: { get: envGet } });
@@ -108,7 +113,7 @@ describe("analytics-accm", () => {
     expect(body.weeklyActivity).toHaveLength(1);
     expect(body.weeklyActivity[0].week).toBe("2026-W20");
     expect(mockFetchRecentPRs).not.toHaveBeenCalled();
-    assertResponseHasNoSecrets(JSON.stringify(body), ["gho_TEST_TOKEN_do_not_leak"]);
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_GITHUB_TOKEN]);
   });
 
   it("serves valid blob cache without calling gist or GitHub", async () => {
@@ -146,6 +151,6 @@ describe("analytics-accm", () => {
     expect(res.status).toBe(502);
     const body = await readJson<{ error: string }>(res);
     expect(body.error).toBe("Failed to fetch ACCM metrics");
-    assertResponseHasNoSecrets(JSON.stringify(body), ["gho_TEST_TOKEN_do_not_leak"]);
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_GITHUB_TOKEN]);
   });
 });

--- a/web/netlify/functions/__tests__/analytics-dashboard.test.ts
+++ b/web/netlify/functions/__tests__/analytics-dashboard.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Vitest handler tests for analytics-dashboard.mts (#15403, Part of #4189).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertResponseHasNoSecrets,
+  makeNetlifyRequest,
+  readJson,
+} from "./netlify-handler-helpers";
+import type { DashboardData } from "../_shared/analytics-dashboard-types";
+
+const { mockGet, mockSet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSet: vi.fn(),
+}));
+
+const { mockFetchDashboardData, mockGetAccessToken } = vi.hoisted(() => ({
+  mockFetchDashboardData: vi.fn(),
+  mockGetAccessToken: vi.fn(),
+}));
+
+vi.mock("@netlify/blobs", () => ({
+  getStore: () => ({ get: mockGet, set: mockSet }),
+}));
+
+vi.mock("../_shared/analytics-dashboard", () => ({
+  fetchDashboardData: mockFetchDashboardData,
+  CACHE_KEY_PREFIX: "dashboard-data",
+  CACHE_STORE: "analytics-dashboard",
+  CACHE_TTL_MS: 900_000,
+}));
+
+vi.mock("../_shared/analytics-dashboard-auth", () => ({
+  getAccessToken: mockGetAccessToken,
+}));
+
+import handler from "../analytics-dashboard.mts";
+
+const API_ANALYTICS_DASHBOARD = "/api/analytics-dashboard";
+
+const FAKE_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----\nMOCK_KEY\n-----END PRIVATE KEY-----\n";
+const FAKE_SERVICE_ACCOUNT = {
+  client_email: "analytics@test.iam.gserviceaccount.com",
+  private_key: FAKE_PRIVATE_KEY,
+  project_id: "test-project",
+};
+const FAKE_SA_B64 = Buffer.from(JSON.stringify(FAKE_SERVICE_ACCOUNT)).toString("base64");
+
+const EMPTY_DASHBOARD: DashboardData = {
+  overview: {
+    activeUsers: 0,
+    sessions: 0,
+    pageViews: 0,
+    avgEngagementTime: 0,
+    bounceRate: 0,
+    eventsPerSession: 0,
+  },
+  overviewPrevious: {
+    activeUsers: 0,
+    sessions: 0,
+    pageViews: 0,
+    avgEngagementTime: 0,
+    bounceRate: 0,
+    eventsPerSession: 0,
+  },
+  dailyUsers: [],
+  topPages: [],
+  topEvents: [],
+  countries: [],
+  trafficSources: [],
+  devices: [],
+  funnel: {
+    landing: 0,
+    login: 0,
+    commandCopied: 0,
+    agentConnected: 0,
+    fixerViewed: 0,
+    missionStarted: 0,
+  },
+  cncfOutreach: [],
+  engagementByPage: [],
+  newVsReturning: [],
+  missions: {
+    started: 0,
+    completed: 0,
+    errored: 0,
+    rated: 0,
+    topTypes: [],
+  },
+  cardPopularity: [],
+  featureAdoption: [],
+  weeklyRetention: [],
+  errors: [],
+  dailyFunnel: [],
+  cachedAt: new Date().toISOString(),
+  propertyId: "525401563",
+  dateRange: "28daysAgo - today",
+};
+
+const BUCKETED_DASHBOARD: DashboardData = {
+  ...EMPTY_DASHBOARD,
+  dailyUsers: [
+    { date: "20260501", users: 10, sessions: 12 },
+    { date: "20260502", users: 5, sessions: 6 },
+  ],
+  overview: {
+    activeUsers: 15,
+    sessions: 18,
+    pageViews: 40,
+    avgEngagementTime: 120,
+    bounceRate: 0.25,
+    eventsPerSession: 2.1,
+  },
+};
+
+describe("analytics-dashboard", () => {
+  let envGet: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue(undefined);
+    mockGetAccessToken.mockResolvedValue("ya29.mock-token");
+    mockFetchDashboardData.mockResolvedValue(BUCKETED_DASHBOARD);
+
+    envGet = vi.fn((key: string) => {
+      if (key === "GA4_SERVICE_ACCOUNT_JSON") return FAKE_SA_B64;
+      if (key === "GA4_PROPERTY_ID") return "525401563";
+      return undefined;
+    });
+    vi.stubGlobal("Netlify", { env: { get: envGet } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 503 when GA4 configuration is missing", async () => {
+    envGet.mockReturnValue(undefined);
+    const res = await handler(makeNetlifyRequest(API_ANALYTICS_DASHBOARD));
+    expect(res.status).toBe(503);
+    const body = await readJson<{ error: string; hint?: string }>(res);
+    expect(body.error).toBe("Missing configuration");
+    expect(mockFetchDashboardData).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when service account JSON is not valid base64 JSON", async () => {
+    envGet.mockImplementation((key: string) => {
+      if (key === "GA4_SERVICE_ACCOUNT_JSON") return "not-valid-json!!!";
+      if (key === "GA4_PROPERTY_ID") return "525401563";
+      return undefined;
+    });
+
+    const res = await handler(makeNetlifyRequest(API_ANALYTICS_DASHBOARD));
+    expect(res.status).toBe(500);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("Invalid GA4_SERVICE_ACCOUNT_JSON");
+  });
+
+  it("returns dashboard data with date buckets on successful fetch", async () => {
+    const res = await handler(makeNetlifyRequest(API_ANALYTICS_DASHBOARD));
+    expect(res.status).toBe(200);
+
+    const body = await readJson<DashboardData & { filterMode: string }>(res);
+    expect(body.filterMode).toBe("production");
+    expect(body.dailyUsers).toHaveLength(2);
+    expect(body.dailyUsers[0].date).toBe("20260501");
+    expect(body.overview.activeUsers).toBe(15);
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_PRIVATE_KEY, "ya29.mock-token"]);
+    expect(mockFetchDashboardData).toHaveBeenCalledWith(
+      "525401563",
+      "ya29.mock-token",
+      "production",
+    );
+  });
+
+  it("handles empty dailyUsers from upstream without throwing", async () => {
+    mockFetchDashboardData.mockResolvedValue(EMPTY_DASHBOARD);
+    const res = await handler(makeNetlifyRequest(API_ANALYTICS_DASHBOARD));
+    expect(res.status).toBe(200);
+    const body = await readJson<DashboardData>(res);
+    expect(body.dailyUsers).toEqual([]);
+    expect(body.overview.activeUsers).toBe(0);
+  });
+
+  it("serves valid blob cache without calling GA4", async () => {
+    const cachedPayload = {
+      data: BUCKETED_DASHBOARD,
+      expiresAt: Date.now() + 60_000,
+    };
+    mockGet.mockResolvedValue(JSON.stringify(cachedPayload));
+
+    const res = await handler(makeNetlifyRequest(API_ANALYTICS_DASHBOARD));
+    expect(res.status).toBe(200);
+    const body = await readJson<DashboardData & { fromCache: boolean }>(res);
+    expect(body.fromCache).toBe(true);
+    expect(body.dailyUsers).toHaveLength(2);
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
+    expect(mockFetchDashboardData).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when GA4 fetch fails", async () => {
+    mockFetchDashboardData.mockRejectedValue(new Error("GA4 API unavailable"));
+    const res = await handler(makeNetlifyRequest(API_ANALYTICS_DASHBOARD));
+    expect(res.status).toBe(502);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toBe("Failed to fetch analytics data");
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_PRIVATE_KEY]);
+  });
+});

--- a/web/netlify/functions/__tests__/missions-browse.test.ts
+++ b/web/netlify/functions/__tests__/missions-browse.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Vitest handler tests for missions-browse.mts (#15403, Part of #4189).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertResponseHasNoSecrets,
+  FAKE_GITHUB_TOKEN,
+  makeNetlifyRequest,
+  readJson,
+} from "./netlify-handler-helpers";
+
+const { mockGet, mockSetJSON } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSetJSON: vi.fn(),
+}));
+
+vi.mock("@netlify/blobs", () => ({
+  getStore: () => ({ get: mockGet, setJSON: mockSetJSON }),
+}));
+
+import handler from "../missions-browse.mts";
+
+const API_MISSIONS_BROWSE = "/api/missions/browse";
+
+function makeBrowseRequest(search = ""): Request {
+  return makeNetlifyRequest(API_MISSIONS_BROWSE, { search });
+}
+
+describe("missions-browse", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(null);
+    mockSetJSON.mockResolvedValue(undefined);
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 400 for invalid path query", async () => {
+    const res = await handler(makeBrowseRequest("path=../secrets"));
+    expect(res.status).toBe(400);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toBe("invalid path");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("transforms GitHub entries and filters infrastructure files on happy path", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      text: async () =>
+        JSON.stringify([
+          { type: "file", name: "index.json", path: "fixes/index.json", size: 10 },
+          { type: "dir", name: "demo", path: "fixes/demo", size: 0 },
+          { type: "file", name: ".gitkeep", path: "fixes/.gitkeep", size: 0 },
+        ]),
+    });
+
+    const res = await handler(makeBrowseRequest("path=fixes"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("MISS");
+
+    const body = await readJson<Array<{ name: string; type: string; path: string }>>(res);
+    expect(body).toEqual([{ name: "demo", path: "fixes/demo", type: "directory", size: 0 }]);
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_GITHUB_TOKEN]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/repos/kubestellar/console-kb/contents/fixes"),
+      expect.any(Object),
+    );
+  });
+
+  it("returns cached listing on blob cache hit without calling GitHub", async () => {
+    const cachedBody = JSON.stringify([{ name: "cached", path: "fixes/cached", type: "file", size: 1 }]);
+    mockGet.mockResolvedValue({ body: cachedBody, fetchedAt: Date.now() });
+
+    const res = await handler(makeBrowseRequest("path=fixes"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(fetchMock).not.toHaveBeenCalled();
+    const body = await readJson(res);
+    expect(body).toEqual([{ name: "cached", path: "fixes/cached", type: "file", size: 1 }]);
+  });
+
+  it("returns 502 when upstream fails and no cache exists", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, headers: { get: () => null }, text: async () => "error" });
+    const res = await handler(makeBrowseRequest("path=fixes"));
+    expect(res.status).toBe(502);
+    const body = await readJson<{ error: string; code?: string }>(res);
+    expect(body.error).toContain("upstream");
+  });
+});

--- a/web/netlify/functions/__tests__/missions-scores.test.ts
+++ b/web/netlify/functions/__tests__/missions-scores.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Vitest handler tests for missions-scores.mts (#15403, Part of #4189).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertResponseHasNoSecrets,
+  FAKE_GITHUB_TOKEN,
+  makeNetlifyRequest,
+  readJson,
+} from "./netlify-handler-helpers";
+
+const { mockGet, mockSetJSON } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSetJSON: vi.fn(),
+}));
+
+vi.mock("@netlify/blobs", () => ({
+  getStore: () => ({ get: mockGet, setJSON: mockSetJSON }),
+}));
+
+import handler from "../missions-scores.mts";
+
+const API_MISSIONS_SCORES = "/api/missions/scores";
+const DEMO_HEADERS = { "X-Demo-Mode": "true" };
+
+const SAMPLE_INDEX = {
+  missions: [
+    {
+      path: "fixes/alpha/mission-a.json",
+      title: "Mission A",
+      cncfProjects: ["console"],
+      qualityScore: 90,
+      qualityPass: true,
+    },
+    {
+      path: "fixes/beta/mission-b.json",
+      title: "Mission B",
+      cncfProjects: ["console"],
+      qualityScore: 90,
+      qualityPass: true,
+    },
+    {
+      path: "fixes/gamma/mission-c.json",
+      title: "Mission C",
+      cncfProjects: ["console"],
+      qualityScore: 50,
+      qualityPass: false,
+    },
+    {
+      path: "fixes/delta/mission-d.json",
+      title: "Mission D (no score)",
+      cncfProjects: ["console"],
+      qualityPass: false,
+    },
+  ],
+};
+
+describe("missions-scores", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(null);
+    mockSetJSON.mockResolvedValue(undefined);
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns demo leaderboard list without upstream fetch", async () => {
+    const res = await handler(
+      makeNetlifyRequest(API_MISSIONS_SCORES, { headers: DEMO_HEADERS }),
+    );
+    expect(res.status).toBe(200);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const body = await readJson<{ count: number; scores: Array<{ qualityScore: number }> }>(res);
+    expect(body.count).toBe(1);
+    expect(body.scores[0].qualityScore).toBe(85);
+    assertResponseHasNoSecrets(JSON.stringify(body), [FAKE_GITHUB_TOKEN]);
+  });
+
+  it("returns demo single mission when project and id are provided", async () => {
+    const res = await handler(
+      makeNetlifyRequest(API_MISSIONS_SCORES, {
+        search: "project=demo&id=demo-123",
+        headers: DEMO_HEADERS,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await readJson<{ project: string; qualityScore: number }>(res);
+    expect(body.project).toBe("demo");
+    expect(body.qualityScore).toBe(85);
+  });
+
+  it("paginates scored missions and excludes entries without qualityScore", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      text: async () => JSON.stringify(SAMPLE_INDEX),
+    });
+
+    const res = await handler(
+      makeNetlifyRequest(API_MISSIONS_SCORES, { search: "limit=2&offset=0" }),
+    );
+    expect(res.status).toBe(200);
+
+    const body = await readJson<{
+      count: number;
+      scores: Array<{ title: string; qualityScore: number }>;
+      hasMore: boolean;
+      limit: number;
+      offset: number;
+    }>(res);
+
+    expect(body.count).toBe(3);
+    expect(body.limit).toBe(2);
+    expect(body.offset).toBe(0);
+    expect(body.hasMore).toBe(true);
+    expect(body.scores).toHaveLength(2);
+    expect(body.scores[0].title).toBe("Mission A");
+    expect(body.scores[1].title).toBe("Mission B");
+    expect(body.scores.every((s) => s.qualityScore === 90)).toBe(true);
+  });
+
+  it("returns 404 when project/id do not match any mission", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      text: async () => JSON.stringify(SAMPLE_INDEX),
+    });
+
+    const res = await handler(
+      makeNetlifyRequest(API_MISSIONS_SCORES, { search: "project=missing&id=nope" }),
+    );
+    expect(res.status).toBe(404);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toBe("KB mission not found");
+  });
+
+  it("returns 502 when upstream fetch fails without cache", async () => {
+    fetchMock.mockRejectedValue(new Error("network failure"));
+    const res = await handler(makeNetlifyRequest(API_MISSIONS_SCORES));
+    expect(res.status).toBe(502);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toContain("upstream");
+  });
+});

--- a/web/netlify/functions/__tests__/netlify-handler-helpers.ts
+++ b/web/netlify/functions/__tests__/netlify-handler-helpers.ts
@@ -1,7 +1,13 @@
 /**
- * Shared helpers for Netlify function handler tests (#15397, #15399).
+ * Shared helpers for Netlify function handler tests (#15397, #15399, #15403).
  */
 import { expect } from "vitest";
+
+/** Synthetic host for handler tests — not a real deployment. */
+export const TEST_NETLIFY_BASE_URL = "https://example.test";
+
+/** Local dev origin accepted by buildCorsHeaders allowlist. */
+export const TEST_CORS_ORIGIN = "http://localhost:5174";
 
 /** Fake token — must never appear in response bodies */
 export const FAKE_GITHUB_TOKEN = "gho_TEST_TOKEN_15397_do_not_leak";
@@ -50,6 +56,28 @@ export function makeIdentityRequest(
   return new Request(`https://console.kubestellar.io${path}${search}`, {
     method: options?.method ?? "GET",
     headers: { Origin: "https://console.kubestellar.io" },
+  });
+}
+
+export function makeNetlifyRequest(
+  path: string,
+  options?: {
+    method?: string;
+    search?: string;
+    headers?: Record<string, string>;
+    baseUrl?: string;
+    origin?: string;
+  },
+): Request {
+  const baseUrl = options?.baseUrl ?? TEST_NETLIFY_BASE_URL;
+  const origin = options?.origin ?? TEST_CORS_ORIGIN;
+  const search = options?.search ? `?${options.search}` : "";
+  return new Request(`${baseUrl}${path}${search}`, {
+    method: options?.method ?? "GET",
+    headers: {
+      Origin: origin,
+      ...options?.headers,
+    },
   });
 }
 

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "test:card-wrapper": "vitest run src/hooks/__tests__/useTimeoutFlag.test.ts src/components/cards/__tests__/CardWrapper.test.tsx",
     "test:netlify-github-cluster": "vitest run netlify/functions/__tests__/github-pipelines.test.ts netlify/functions/__tests__/github-pipelines-mutate.test.ts netlify/functions/__tests__/nightly-e2e.test.ts netlify/functions/__tests__/issue-stats.test.ts",
     "test:netlify-identity": "vitest run netlify/functions/__tests__/identity-oidc-rbac.test.ts",
+    "test:netlify-missions-analytics": "vitest run netlify/functions/__tests__/missions-browse.test.ts netlify/functions/__tests__/missions-scores.test.ts netlify/functions/__tests__/analytics-dashboard.test.ts netlify/functions/__tests__/analytics-accm.test.ts",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "test:e2e": "npm run build && playwright test",


### PR DESCRIPTION
## Summary

Adds Vitest handler-level tests for four production Netlify functions that power mission control and analytics:

- **missions-browse** — path validation, GitHub listing transform/filter, blob cache HIT, upstream 502
- **missions-scores** — demo mode, pagination (`limit`/`offset`/`hasMore`), tie scores, missions without `qualityScore` excluded, 404/502 paths
- **analytics-dashboard** — missing/invalid GA4 config (503/500), date-bucketed payload, empty `dailyUsers`, blob cache, normalized 502
- **analytics-accm** — gist path, blob cache, live fallback, 405 POST, normalized 502

**20 tests** via `npm run test:netlify-missions-analytics` (run from `web/`).

Fixes #15403  
Part of #4189

## Test plan

- [x] `cd web && npm run test:netlify-missions-analytics` — 20/20 passed locally
- [ ] CI Coverage Suite / build+lint on PR