### PR TITLE
test(cards): CardWrapper PR B — error boundary child-throws, collapse restore, resize menu

### DIFF
--- a/web/src/components/cards/__tests__/CardWrapper.test.tsx
+++ b/web/src/components/cards/__tests__/CardWrapper.test.tsx
@@ -1,8 +1,8 @@
 /**
  * CardWrapper — shared shell for every dashboard card (#15264).
  *
- * PR A: demo badge, failure banner, collapse persistence, expand modal sizing,
- * mode-switch skeleton. Lazy modals / snooze / missions integration deferred to PR B.
+ * PR A: demo badge, failure banner, collapse write, expand modal outer sizing,
+ * mode-switch skeleton. PR B: error boundary, collapse restore, modal content heights.
  *
  * Run from web/:  npm run test:card-wrapper
  * (Do not run npx vitest from repo root — that skips vite.config.ts jsdom + @/ aliases.)
@@ -68,6 +68,8 @@ vi.mock('../../../hooks/useSnoozedCards', () => ({
 vi.mock('../../../lib/analytics', () => ({
   emitCardExpanded: vi.fn(),
   emitCardRefreshed: vi.fn(),
+  emitError: vi.fn(),
+  markErrorReported: vi.fn(),
 }))
 
 vi.mock('react-i18next', () => ({
@@ -290,6 +292,162 @@ describe('CardWrapper', () => {
 
       expect(document.querySelector('[data-card-skeleton="true"]')).toBeTruthy()
       expect(screen.getByTestId('card-child')).toBeInTheDocument()
+    })
+  })
+
+  describe('error boundary — child throws', () => {
+    // ErrorThrower: controlled throw via prop
+    function ErrorThrower({ shouldThrow }: { shouldThrow: boolean }) {
+      if (shouldThrow) throw new Error('boom')
+      return <div data-testid="card-child">recovered</div>
+    }
+
+    it('renders CardErrorFallback when child throws', () => {
+      // suppress React's console.error for expected boundary errors
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      render(
+        <CardWrapper cardId={TEST_CARD_ID} cardType={TEST_CARD_TYPE} isDemoData={false}>
+          <ErrorThrower shouldThrow={true} />
+        </CardWrapper>,
+      )
+      spy.mockRestore()
+
+      expect(screen.getByText('cardWrapper.renderErrorTitle')).toBeInTheDocument()
+      expect(screen.getByText('cardWrapper.renderErrorMessage')).toBeInTheDocument()
+    })
+
+    it('recovers after retry when shouldThrow is reset to false', async () => {
+      const user = userEvent.setup()
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      let shouldThrow = true
+
+      const { rerender } = render(
+        <CardWrapper cardId={TEST_CARD_ID} cardType={TEST_CARD_TYPE} isDemoData={false}>
+          <ErrorThrower shouldThrow={shouldThrow} />
+        </CardWrapper>,
+      )
+      spy.mockRestore()
+
+      // Error fallback is shown
+      expect(screen.getByText('cardWrapper.renderErrorTitle')).toBeInTheDocument()
+
+      // Fix the throw, then click retry
+      shouldThrow = false
+      rerender(
+        <CardWrapper cardId={TEST_CARD_ID} cardType={TEST_CARD_TYPE} isDemoData={false}>
+          <ErrorThrower shouldThrow={shouldThrow} />
+        </CardWrapper>,
+      )
+
+      const retryBtn = screen.getByRole('button', { name: /cardWrapper\.renderRetryLeft/i })
+      await user.click(retryBtn)
+
+      await waitFor(() => {
+        expect(screen.getByText('recovered')).toBeInTheDocument()
+      })
+    })
+
+    it('shows error fallback even when isDemoData is true', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      render(
+        <CardWrapper cardId={TEST_CARD_ID} cardType={TEST_CARD_TYPE} isDemoData={true}>
+          <ErrorThrower shouldThrow={true} />
+        </CardWrapper>,
+      )
+      spy.mockRestore()
+
+      expect(screen.getByText('cardWrapper.renderErrorTitle')).toBeInTheDocument()
+    })
+
+    it('calls onRefresh when retry button clicked on CardFailureBanner', async () => {
+      const user = userEvent.setup()
+      const onRefresh = vi.fn()
+      renderCardWrapper({ isFailed: true, consecutiveFailures: 1, onRefresh })
+
+      const retryBtn = screen.getByRole('button', { name: 'cardWrapper.failureRetry' })
+      await user.click(retryBtn)
+
+      expect(onRefresh).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('collapse restore on remount', () => {
+    it('starts expanded when localStorage has no entry', () => {
+      renderCardWrapper({ cardId: TEST_CARD_ID })
+      expect(screen.getByText(CHILD_CONTENT_TEXT)).toBeInTheDocument()
+    })
+
+    it('starts collapsed when cardId is already in localStorage on mount', () => {
+      localStorage.setItem(
+        COLLAPSED_CARDS_STORAGE_KEY,
+        JSON.stringify([TEST_CARD_ID]),
+      )
+      renderCardWrapper({ cardId: TEST_CARD_ID })
+      expect(screen.queryByText(CHILD_CONTENT_TEXT)).not.toBeInTheDocument()
+    })
+
+    it('removes cardId from localStorage when user expands a pre-collapsed card', async () => {
+      const user = userEvent.setup()
+      localStorage.setItem(
+        COLLAPSED_CARDS_STORAGE_KEY,
+        JSON.stringify([TEST_CARD_ID]),
+      )
+      renderCardWrapper({ cardId: TEST_CARD_ID })
+
+      const expandBtn = screen.getByRole('button', { name: 'Expand card' })
+      await user.click(expandBtn)
+
+      await waitFor(() => {
+        const stored = JSON.parse(
+          localStorage.getItem(COLLAPSED_CARDS_STORAGE_KEY) ?? '[]',
+        ) as string[]
+        expect(stored).not.toContain(TEST_CARD_ID)
+      })
+      expect(screen.getByText(CHILD_CONTENT_TEXT)).toBeInTheDocument()
+    })
+
+    it('falls back to expanded when localStorage contains corrupt JSON', () => {
+      localStorage.setItem(COLLAPSED_CARDS_STORAGE_KEY, 'not-json')
+      expect(() => renderCardWrapper({ cardId: TEST_CARD_ID })).not.toThrow()
+      expect(screen.getByText(CHILD_CONTENT_TEXT)).toBeInTheDocument()
+    })
+  })
+
+  describe('expanded modal content-container sizing', () => {
+    it('default card type uses max-w-4xl / min-h-[80vh] container', async () => {
+      const user = userEvent.setup()
+      renderCardWrapper({ cardType: TEST_CARD_TYPE }) // 'cluster_health'
+
+      await user.click(screen.getByRole('button', { name: 'Expand full screen' }))
+
+      const modal = await screen.findByTestId('drilldown-modal')
+      expect(modal).toHaveClass('max-w-4xl')
+      expect(modal).toHaveClass('min-h-[80vh]')
+
+      const content = modal.querySelector('.scroll-enhanced')
+      expect(content).toHaveClass('max-h-[calc(80vh-80px)]')
+    })
+
+    it('LARGE_EXPANDED_CARDS content container uses h-[calc(95vh-80px)]', async () => {
+      const user = userEvent.setup()
+      renderCardWrapper({ cardType: LARGE_EXPANDED_CARD_TYPE }) // 'cluster_comparison'
+
+      await user.click(screen.getByRole('button', { name: 'Expand full screen' }))
+
+      const modal = await screen.findByTestId('drilldown-modal')
+      const content = modal.querySelector('.scroll-enhanced')
+      expect(content).toHaveClass('h-[calc(95vh-80px)]')
+    })
+
+    it('FULLSCREEN_EXPANDED_CARDS content container uses h-[calc(98vh-80px)]', async () => {
+      const user = userEvent.setup()
+      renderCardWrapper({ cardType: FULLSCREEN_CARD_TYPE }) // 'cluster_locations'
+
+      await user.click(screen.getByRole('button', { name: 'Expand full screen' }))
+
+      const modal = await screen.findByTestId('drilldown-modal')
+      const content = modal.querySelector('.scroll-enhanced')
+      expect(content).toHaveClass('h-[calc(98vh-80px)]')
     })
   })
 })

--- a/web/src/components/cards/__tests__/CardWrapper.test.tsx
+++ b/web/src/components/cards/__tests__/CardWrapper.test.tsx
@@ -127,6 +127,22 @@ function CardStateReporter({ state }: { state: CardDataState }) {
   return <div data-testid="card-child">{CHILD_CONTENT_TEXT}</div>
 }
 
+/** Suppress expected React error-boundary console.error; always restores the spy. */
+function withSuppressedConsoleError(run: () => void) {
+  const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  try {
+    run()
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+function expectModalScrollContent(modal: HTMLElement) {
+  const content = modal.querySelector('.scroll-enhanced')
+  expect(content).not.toBeNull()
+  return content as HTMLElement
+}
+
 describe('CardWrapper', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -213,6 +229,17 @@ describe('CardWrapper', () => {
       await waitFor(() => {
         expect(screen.queryByTestId('card-failure-banner')).not.toBeInTheDocument()
       })
+    })
+
+    it('calls onRefresh when retry button is clicked', async () => {
+      const user = userEvent.setup()
+      const onRefresh = vi.fn()
+      renderCardWrapper({ isFailed: true, consecutiveFailures: 1, onRefresh })
+
+      const retryBtn = screen.getByRole('button', { name: 'cardWrapper.failureRetry' })
+      await user.click(retryBtn)
+
+      expect(onRefresh).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -303,14 +330,13 @@ describe('CardWrapper', () => {
     }
 
     it('renders CardErrorFallback when child throws', () => {
-      // suppress React's console.error for expected boundary errors
-      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
-      render(
-        <CardWrapper cardId={TEST_CARD_ID} cardType={TEST_CARD_TYPE} isDemoData={false}>
-          <ErrorThrower shouldThrow={true} />
-        </CardWrapper>,
-      )
-      spy.mockRestore()
+      withSuppressedConsoleError(() => {
+        render(
+          <CardWrapper cardId={TEST_CARD_ID} cardType={TEST_CARD_TYPE} isDemoData={false}>
+            <ErrorThrower shouldThrow={true} />
+          </CardWrapper>,
+        )
+      })
 
       expect(screen.getByText('cardWrapper.renderErrorTitle')).toBeInTheDocument()
       expect(screen.getByText('cardWrapper.renderErrorMessage')).toBeInTheDocument()
@@ -318,22 +344,22 @@ describe('CardWrapper', () => {
 
     it('recovers after retry when shouldThrow is reset to false', async () => {
       const user = userEvent.setup()
-      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
       let shouldThrow = true
+      let rerender: ReturnType<typeof render>['rerender']
 
-      const { rerender } = render(
-        <CardWrapper cardId={TEST_CARD_ID} cardType={TEST_CARD_TYPE} isDemoData={false}>
-          <ErrorThrower shouldThrow={shouldThrow} />
-        </CardWrapper>,
-      )
-      spy.mockRestore()
+      withSuppressedConsoleError(() => {
+        const result = render(
+          <CardWrapper cardId={TEST_CARD_ID} cardType={TEST_CARD_TYPE} isDemoData={false}>
+            <ErrorThrower shouldThrow={shouldThrow} />
+          </CardWrapper>,
+        )
+        rerender = result.rerender
+      })
 
-      // Error fallback is shown
       expect(screen.getByText('cardWrapper.renderErrorTitle')).toBeInTheDocument()
 
-      // Fix the throw, then click retry
       shouldThrow = false
-      rerender(
+      rerender!(
         <CardWrapper cardId={TEST_CARD_ID} cardType={TEST_CARD_TYPE} isDemoData={false}>
           <ErrorThrower shouldThrow={shouldThrow} />
         </CardWrapper>,
@@ -348,26 +374,15 @@ describe('CardWrapper', () => {
     })
 
     it('shows error fallback even when isDemoData is true', () => {
-      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
-      render(
-        <CardWrapper cardId={TEST_CARD_ID} cardType={TEST_CARD_TYPE} isDemoData={true}>
-          <ErrorThrower shouldThrow={true} />
-        </CardWrapper>,
-      )
-      spy.mockRestore()
+      withSuppressedConsoleError(() => {
+        render(
+          <CardWrapper cardId={TEST_CARD_ID} cardType={TEST_CARD_TYPE} isDemoData={true}>
+            <ErrorThrower shouldThrow={true} />
+          </CardWrapper>,
+        )
+      })
 
       expect(screen.getByText('cardWrapper.renderErrorTitle')).toBeInTheDocument()
-    })
-
-    it('calls onRefresh when retry button clicked on CardFailureBanner', async () => {
-      const user = userEvent.setup()
-      const onRefresh = vi.fn()
-      renderCardWrapper({ isFailed: true, consecutiveFailures: 1, onRefresh })
-
-      const retryBtn = screen.getByRole('button', { name: 'cardWrapper.failureRetry' })
-      await user.click(retryBtn)
-
-      expect(onRefresh).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -424,8 +439,7 @@ describe('CardWrapper', () => {
       expect(modal).toHaveClass('max-w-4xl')
       expect(modal).toHaveClass('min-h-[80vh]')
 
-      const content = modal.querySelector('.scroll-enhanced')
-      expect(content).toHaveClass('max-h-[calc(80vh-80px)]')
+      expect(expectModalScrollContent(modal)).toHaveClass('max-h-[calc(80vh-80px)]')
     })
 
     it('LARGE_EXPANDED_CARDS content container uses h-[calc(95vh-80px)]', async () => {
@@ -435,8 +449,7 @@ describe('CardWrapper', () => {
       await user.click(screen.getByRole('button', { name: 'Expand full screen' }))
 
       const modal = await screen.findByTestId('drilldown-modal')
-      const content = modal.querySelector('.scroll-enhanced')
-      expect(content).toHaveClass('h-[calc(95vh-80px)]')
+      expect(expectModalScrollContent(modal)).toHaveClass('h-[calc(95vh-80px)]')
     })
 
     it('FULLSCREEN_EXPANDED_CARDS content container uses h-[calc(98vh-80px)]', async () => {
@@ -446,8 +459,7 @@ describe('CardWrapper', () => {
       await user.click(screen.getByRole('button', { name: 'Expand full screen' }))
 
       const modal = await screen.findByTestId('drilldown-modal')
-      const content = modal.querySelector('.scroll-enhanced')
-      expect(content).toHaveClass('h-[calc(98vh-80px)]')
+      expect(expectModalScrollContent(modal)).toHaveClass('h-[calc(98vh-80px)]')
     })
   })
 })


### PR DESCRIPTION
## What this PR does

Extends `web/src/components/cards/__tests__/CardWrapper.test.tsx` with the three behavior groups explicitly deferred from PR A (#15265):

| Group | Tests added |
|---|---|
| Error boundary — child throws | 4 tests: `CardErrorFallback` render, retry recovery, demo-mode doesn't suppress, `onRefresh` called |
| Collapse restore on remount | 4 tests: default expanded, pre-stored collapsed, expand removes from storage, corrupt JSON fallback |
| Modal content-container sizing | 3 tests: default `max-w-4xl`, LARGE `h-[calc(95vh-80px)]`, FULLSCREEN `h-[calc(98vh-80px)]` |

## Why each test matters

- **Error boundary**: `CardErrorFallback` is the user-visible last resort for card crashes. Without RTL coverage it's only exercised in production failures.
- **Collapse restore**: PR A only tested the *write* side. This closes the read-on-remount gap.
- **Resize content containers**: PR A tested outer modal classes; this completes the inner scroll container height class assertions.

## Test run

```
cd web && npm run test:card-wrapper
# 27 passed locally (16 PR A + 11 PR B)
```

## Scope

- File changed: `web/src/components/cards/__tests__/CardWrapper.test.tsx` only
- No production code changes
- No new mocking strategies — follows PR A patterns exactly
- `CardActionMenu` width/height submenus remain covered in `card-wrapper/CardActionMenu.test.tsx`

## Checklist

- [x] All new tests assert specific states, not just "renders without crashing"
- [x] `console.error` suppressed inside error boundary tests (expected React behavior)
- [x] `localStorage.clear()` called in `beforeEach`/`afterEach` (already in PR A scaffold)
- [x] No `Fixes #4189` — hold is still active; use `Part of #4189` only

## References

- Closes #15419
- Part of #4189
- PR A (foundation): #15265
- Constants verified in `CardWrapper.tsx`: `COLLAPSED_CARDS_STORAGE_KEY`, `LARGE_EXPANDED_CARDS`, `FULLSCREEN_EXPANDED_CARDS`