### PR TITLE
test(cards): direct Vitest coverage for CardLoadingState presentational component

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:card-wrapper": "vitest run src/hooks/__tests__/useTimeoutFlag.test.ts src/components/cards/__tests__/CardWrapper.test.tsx",
+    "test:card-loading-state": "vitest run src/components/cards/__tests__/CardLoadingState.test.tsx",
     "test:netlify-github-cluster": "vitest run netlify/functions/__tests__/github-pipelines.test.ts netlify/functions/__tests__/github-pipelines-mutate.test.ts netlify/functions/__tests__/nightly-e2e.test.ts netlify/functions/__tests__/issue-stats.test.ts",
     "test:netlify-identity": "vitest run netlify/functions/__tests__/identity-oidc-rbac.test.ts",
     "test:drilldown-gaps": "vitest run src/components/drilldown/views/__tests__ -t \"DrillDown interactions\"",

--- a/web/src/components/cards/CardLoadingState.tsx
+++ b/web/src/components/cards/CardLoadingState.tsx
@@ -131,6 +131,7 @@ export function CardLoadingState({
         </div>
       )}
       <div
+        data-testid="card-loading-children"
         className={cn(
           'min-h-0',
           shouldHideChildren ? 'hidden' : 'flex flex-1 flex-col'

--- a/web/src/components/cards/__tests__/CardLoadingState.test.tsx
+++ b/web/src/components/cards/__tests__/CardLoadingState.test.tsx
@@ -14,6 +14,7 @@ const TEST_CARD_TYPE = 'cluster_health'
 const TEST_CARD_TITLE = 'Cluster Health'
 const CHILD_CONTENT_TEXT = 'card-loading-child-content'
 const SKELETON_ROW_COUNT = 3
+const CHILDREN_CONTAINER_TEST_ID = 'card-loading-children'
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
@@ -60,10 +61,19 @@ function emptyChildDataState(overrides: Partial<CardDataState> = {}): CardDataSt
 }
 
 function getChildrenContainer() {
-  const child = screen.getByTestId('card-child')
-  const container = child.closest('.min-h-0')
-  expect(container).not.toBeNull()
-  return container as HTMLElement
+  return screen.getByTestId(CHILDREN_CONTAINER_TEST_ID)
+}
+
+function getTimeoutPanel(container: HTMLElement) {
+  const panel = container.querySelector('[data-card-loading-timeout="true"]')
+  expect(panel).not.toBeNull()
+  return panel as HTMLElement
+}
+
+function getEmptyStatePanel(container: HTMLElement) {
+  const panel = container.querySelector('[data-card-empty-state="true"]')
+  expect(panel).not.toBeNull()
+  return panel as HTMLElement
 }
 
 describe('CardLoadingState', () => {
@@ -82,6 +92,7 @@ describe('CardLoadingState', () => {
       })
 
       expect(screen.queryByTestId('card-child')).not.toBeInTheDocument()
+      expect(screen.queryByTestId(CHILDREN_CONTAINER_TEST_ID)).not.toBeInTheDocument()
       expect(container.querySelector('[data-card-skeleton="true"]')).not.toBeInTheDocument()
       expect(container.querySelector('[data-card-loading-timeout="true"]')).not.toBeInTheDocument()
       expect(container.querySelector('[data-card-empty-state="true"]')).not.toBeInTheDocument()
@@ -103,9 +114,9 @@ describe('CardLoadingState', () => {
 
   describe('skeleton branch', () => {
     it('renders data-card-skeleton and hides children', () => {
-      renderCardLoadingState({ shouldShowSkeleton: true })
+      const { container } = renderCardLoadingState({ shouldShowSkeleton: true })
 
-      expect(document.querySelector('[data-card-skeleton="true"]')).toBeInTheDocument()
+      expect(container.querySelector('[data-card-skeleton="true"]')).toBeInTheDocument()
       expect(getChildrenContainer()).toHaveClass('hidden')
     })
   })
@@ -120,25 +131,24 @@ describe('CardLoadingState', () => {
         childDataState: timeoutState(),
       })
 
-      const panel = document.querySelector('[data-card-loading-timeout="true"]')
-      expect(panel).not.toBeNull()
-      const timeoutPanel = panel as HTMLElement
+      const timeoutPanel = getTimeoutPanel(container)
       expect(within(timeoutPanel).getByText('cardWrapper.loadingTimedOutTitle')).toBeInTheDocument()
       expect(within(timeoutPanel).getByText('cardWrapper.loadingTimedOutMessage')).toBeInTheDocument()
-      expect(container.querySelector('[data-card-loading-timeout="true"] svg')).toBeTruthy()
+      expect(timeoutPanel.querySelector('svg')).toBeTruthy()
       expect(getChildrenContainer()).toHaveClass('hidden')
     })
 
     it('calls onLoadingTimeoutRetry when retry button is clicked', async () => {
       const user = userEvent.setup()
       const onLoadingTimeoutRetry = vi.fn()
-      renderCardLoadingState({
+      const { container } = renderCardLoadingState({
         cardLoadingTimedOut: true,
         childDataState: timeoutState(),
         onLoadingTimeoutRetry,
       })
 
-      const retryBtn = screen.getByRole('button', {
+      const timeoutPanel = getTimeoutPanel(container)
+      const retryBtn = within(timeoutPanel).getByRole('button', {
         name: 'cardWrapper.loadingTimedOutRetry',
       })
       await user.click(retryBtn)
@@ -149,31 +159,29 @@ describe('CardLoadingState', () => {
     it('calls onRemove when remove button is clicked', async () => {
       const user = userEvent.setup()
       const onRemove = vi.fn()
-      renderCardLoadingState({
+      const { container } = renderCardLoadingState({
         cardLoadingTimedOut: true,
         childDataState: timeoutState(),
         onRemove,
       })
 
-      const panel = document.querySelector('[data-card-loading-timeout="true"]') as HTMLElement
-      expect(panel).not.toBeNull()
-      const removeBtn = within(panel).getByTestId('card-remove-button')
+      const timeoutPanel = getTimeoutPanel(container)
+      const removeBtn = within(timeoutPanel).getByTestId('card-remove-button')
       await user.click(removeBtn)
 
       expect(onRemove).toHaveBeenCalledTimes(1)
     })
 
     it('applies animate-spin to RefreshCw when isVisuallySpinning is true', () => {
-      renderCardLoadingState({
+      const { container } = renderCardLoadingState({
         cardLoadingTimedOut: true,
         childDataState: timeoutState(),
         onLoadingTimeoutRetry: vi.fn(),
         isVisuallySpinning: true,
       })
 
-      const panel = document.querySelector('[data-card-loading-timeout="true"]') as HTMLElement
-      expect(panel).not.toBeNull()
-      const retryBtn = within(panel).getByRole('button', {
+      const timeoutPanel = getTimeoutPanel(container)
+      const retryBtn = within(timeoutPanel).getByRole('button', {
         name: 'cardWrapper.loadingTimedOutRetry',
       })
       expect(retryBtn.querySelector('.animate-spin')).toBeTruthy()
@@ -182,25 +190,26 @@ describe('CardLoadingState', () => {
 
   describe('empty-state branch', () => {
     it('renders empty-state panel when loaded without data', () => {
-      renderCardLoadingState({
+      const { container } = renderCardLoadingState({
         childDataState: emptyChildDataState(),
       })
 
-      const panel = document.querySelector('[data-card-empty-state="true"]') as HTMLElement
-      expect(panel).not.toBeNull()
-      expect(within(panel).getByText('cardWrapper.noDataTitle')).toBeInTheDocument()
+      const emptyPanel = getEmptyStatePanel(container)
+      expect(within(emptyPanel).getByText('cardWrapper.noDataTitle')).toBeInTheDocument()
       expect(getChildrenContainer()).toHaveClass('hidden')
     })
 
     it('calls onRefresh when refresh button is clicked', async () => {
       const user = userEvent.setup()
       const onRefresh = vi.fn()
-      renderCardLoadingState({
+      const { container } = renderCardLoadingState({
         childDataState: emptyChildDataState(),
         onRefresh,
       })
 
-      const refreshBtn = screen.getByRole('button', {
+      const emptyPanel = getEmptyStatePanel(container)
+      // Production reuses cardWrapper.loadingTimedOutRetry for empty-state refresh aria-label.
+      const refreshBtn = within(emptyPanel).getByRole('button', {
         name: 'cardWrapper.loadingTimedOutRetry',
       })
       await user.click(refreshBtn)
@@ -209,27 +218,27 @@ describe('CardLoadingState', () => {
     })
 
     it('does not render empty state when loading timed out', () => {
-      renderCardLoadingState({
+      const { container } = renderCardLoadingState({
         cardLoadingTimedOut: true,
         childDataState: emptyChildDataState({ isLoading: true }),
       })
 
-      expect(document.querySelector('[data-card-empty-state="true"]')).not.toBeInTheDocument()
-      expect(document.querySelector('[data-card-loading-timeout="true"]')).toBeInTheDocument()
+      expect(container.querySelector('[data-card-empty-state="true"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-card-loading-timeout="true"]')).toBeInTheDocument()
     })
   })
 
   describe('normal children branch', () => {
     it('shows children with flex layout when no branch is active', () => {
-      renderCardLoadingState({
+      const { container } = renderCardLoadingState({
         childDataState: emptyChildDataState({ hasData: true }),
       })
 
       expect(screen.getByTestId('card-child')).toHaveTextContent(CHILD_CONTENT_TEXT)
       expect(getChildrenContainer()).toHaveClass('flex', 'flex-1', 'flex-col')
       expect(getChildrenContainer()).not.toHaveClass('hidden')
-      expect(document.querySelector('[data-card-skeleton="true"]')).not.toBeInTheDocument()
-      expect(document.querySelector('[data-card-empty-state="true"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-card-skeleton="true"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-card-empty-state="true"]')).not.toBeInTheDocument()
     })
   })
 

--- a/web/src/components/cards/__tests__/CardLoadingState.test.tsx
+++ b/web/src/components/cards/__tests__/CardLoadingState.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * Direct Vitest coverage for CardLoadingState presentational branches (#15510).
+ *
+ * Run from web/:  npm run test:card-loading-state
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CardLoadingState, type CardLoadingStateProps } from '../CardLoadingState'
+import type { CardDataState } from '../CardDataContext'
+
+const TEST_CARD_ID = 'card-loading-test-id'
+const TEST_CARD_TYPE = 'cluster_health'
+const TEST_CARD_TITLE = 'Cluster Health'
+const CHILD_CONTENT_TEXT = 'card-loading-child-content'
+const SKELETON_ROW_COUNT = 3
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+vi.mock('../card-wrapper/InstallCTAFlow', () => ({
+  InstallCTAFlow: ({ cardType, title }: { cardType: string; title: string }) => (
+    <div data-testid="install-cta-flow" data-card-type={cardType} data-title={title} />
+  ),
+}))
+
+function renderCardLoadingState(overrides: Partial<CardLoadingStateProps> = {}) {
+  const props: CardLoadingStateProps = {
+    cardId: TEST_CARD_ID,
+    cardType: TEST_CARD_TYPE,
+    title: TEST_CARD_TITLE,
+    children: <div data-testid="card-child">{CHILD_CONTENT_TEXT}</div>,
+    isVisible: true,
+    isExpanded: false,
+    shouldShowSkeleton: false,
+    skeletonType: 'list',
+    skeletonRows: SKELETON_ROW_COUNT,
+    cardLoadingTimedOut: false,
+    childDataState: null,
+    isVisuallySpinning: false,
+    showInstallCta: false,
+    ...overrides,
+  }
+  return render(<CardLoadingState {...props} />)
+}
+
+function emptyChildDataState(overrides: Partial<CardDataState> = {}): CardDataState {
+  return {
+    isFailed: false,
+    consecutiveFailures: 0,
+    isLoading: false,
+    hasData: false,
+    ...overrides,
+  }
+}
+
+function getChildrenContainer() {
+  const child = screen.getByTestId('card-child')
+  const container = child.closest('.min-h-0')
+  expect(container).not.toBeNull()
+  return container as HTMLElement
+}
+
+describe('CardLoadingState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('invisible-card branch', () => {
+    it('renders bare skeleton without header and does not mount children', () => {
+      const { container } = renderCardLoadingState({
+        isVisible: false,
+        isExpanded: false,
+        shouldShowSkeleton: true,
+        cardLoadingTimedOut: true,
+        childDataState: emptyChildDataState(),
+      })
+
+      expect(screen.queryByTestId('card-child')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-card-skeleton="true"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-card-loading-timeout="true"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-card-empty-state="true"]')).not.toBeInTheDocument()
+      expect(container.querySelector('.min-h-card')).toBeInTheDocument()
+    })
+
+    it('still renders when expanded even if not visible', () => {
+      renderCardLoadingState({
+        isVisible: false,
+        isExpanded: true,
+        childDataState: emptyChildDataState({ hasData: true }),
+      })
+
+      expect(screen.getByTestId('card-child')).toBeInTheDocument()
+      expect(getChildrenContainer()).toHaveClass('flex', 'flex-1', 'flex-col')
+      expect(getChildrenContainer()).not.toHaveClass('hidden')
+    })
+  })
+
+  describe('skeleton branch', () => {
+    it('renders data-card-skeleton and hides children', () => {
+      renderCardLoadingState({ shouldShowSkeleton: true })
+
+      expect(document.querySelector('[data-card-skeleton="true"]')).toBeInTheDocument()
+      expect(getChildrenContainer()).toHaveClass('hidden')
+    })
+  })
+
+  describe('loading timeout branch', () => {
+    const timeoutState = () =>
+      emptyChildDataState({ isLoading: true, hasData: false })
+
+    it('renders timeout panel with AlertTriangle when timed out without data', () => {
+      const { container } = renderCardLoadingState({
+        cardLoadingTimedOut: true,
+        childDataState: timeoutState(),
+      })
+
+      const panel = document.querySelector('[data-card-loading-timeout="true"]')
+      expect(panel).not.toBeNull()
+      const timeoutPanel = panel as HTMLElement
+      expect(within(timeoutPanel).getByText('cardWrapper.loadingTimedOutTitle')).toBeInTheDocument()
+      expect(within(timeoutPanel).getByText('cardWrapper.loadingTimedOutMessage')).toBeInTheDocument()
+      expect(container.querySelector('[data-card-loading-timeout="true"] svg')).toBeTruthy()
+      expect(getChildrenContainer()).toHaveClass('hidden')
+    })
+
+    it('calls onLoadingTimeoutRetry when retry button is clicked', async () => {
+      const user = userEvent.setup()
+      const onLoadingTimeoutRetry = vi.fn()
+      renderCardLoadingState({
+        cardLoadingTimedOut: true,
+        childDataState: timeoutState(),
+        onLoadingTimeoutRetry,
+      })
+
+      const retryBtn = screen.getByRole('button', {
+        name: 'cardWrapper.loadingTimedOutRetry',
+      })
+      await user.click(retryBtn)
+
+      expect(onLoadingTimeoutRetry).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onRemove when remove button is clicked', async () => {
+      const user = userEvent.setup()
+      const onRemove = vi.fn()
+      renderCardLoadingState({
+        cardLoadingTimedOut: true,
+        childDataState: timeoutState(),
+        onRemove,
+      })
+
+      const panel = document.querySelector('[data-card-loading-timeout="true"]') as HTMLElement
+      expect(panel).not.toBeNull()
+      const removeBtn = within(panel).getByTestId('card-remove-button')
+      await user.click(removeBtn)
+
+      expect(onRemove).toHaveBeenCalledTimes(1)
+    })
+
+    it('applies animate-spin to RefreshCw when isVisuallySpinning is true', () => {
+      renderCardLoadingState({
+        cardLoadingTimedOut: true,
+        childDataState: timeoutState(),
+        onLoadingTimeoutRetry: vi.fn(),
+        isVisuallySpinning: true,
+      })
+
+      const panel = document.querySelector('[data-card-loading-timeout="true"]') as HTMLElement
+      expect(panel).not.toBeNull()
+      const retryBtn = within(panel).getByRole('button', {
+        name: 'cardWrapper.loadingTimedOutRetry',
+      })
+      expect(retryBtn.querySelector('.animate-spin')).toBeTruthy()
+    })
+  })
+
+  describe('empty-state branch', () => {
+    it('renders empty-state panel when loaded without data', () => {
+      renderCardLoadingState({
+        childDataState: emptyChildDataState(),
+      })
+
+      const panel = document.querySelector('[data-card-empty-state="true"]') as HTMLElement
+      expect(panel).not.toBeNull()
+      expect(within(panel).getByText('cardWrapper.noDataTitle')).toBeInTheDocument()
+      expect(getChildrenContainer()).toHaveClass('hidden')
+    })
+
+    it('calls onRefresh when refresh button is clicked', async () => {
+      const user = userEvent.setup()
+      const onRefresh = vi.fn()
+      renderCardLoadingState({
+        childDataState: emptyChildDataState(),
+        onRefresh,
+      })
+
+      const refreshBtn = screen.getByRole('button', {
+        name: 'cardWrapper.loadingTimedOutRetry',
+      })
+      await user.click(refreshBtn)
+
+      expect(onRefresh).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not render empty state when loading timed out', () => {
+      renderCardLoadingState({
+        cardLoadingTimedOut: true,
+        childDataState: emptyChildDataState({ isLoading: true }),
+      })
+
+      expect(document.querySelector('[data-card-empty-state="true"]')).not.toBeInTheDocument()
+      expect(document.querySelector('[data-card-loading-timeout="true"]')).toBeInTheDocument()
+    })
+  })
+
+  describe('normal children branch', () => {
+    it('shows children with flex layout when no branch is active', () => {
+      renderCardLoadingState({
+        childDataState: emptyChildDataState({ hasData: true }),
+      })
+
+      expect(screen.getByTestId('card-child')).toHaveTextContent(CHILD_CONTENT_TEXT)
+      expect(getChildrenContainer()).toHaveClass('flex', 'flex-1', 'flex-col')
+      expect(getChildrenContainer()).not.toHaveClass('hidden')
+      expect(document.querySelector('[data-card-skeleton="true"]')).not.toBeInTheDocument()
+      expect(document.querySelector('[data-card-empty-state="true"]')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('InstallCTAFlow', () => {
+    it('renders InstallCTAFlow when showInstallCta is true', () => {
+      renderCardLoadingState({
+        showInstallCta: true,
+        childDataState: emptyChildDataState({ hasData: true }),
+      })
+
+      const cta = screen.getByTestId('install-cta-flow')
+      expect(cta).toHaveAttribute('data-card-type', TEST_CARD_TYPE)
+      expect(cta).toHaveAttribute('data-title', TEST_CARD_TITLE)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds direct Vitest + RTL coverage for `CardLoadingState.tsx` ([#15510](https://github.com/kubestellar/console/issues/15510)), the shared presentational component used by every card for skeleton, timeout, empty, and child visibility branches.

## Tests added (12)

| Branch | Coverage |
|--------|----------|
| Invisible card | Bare `CardSkeleton` (no `data-card-skeleton` wrapper), children not mounted; expanded bypass |
| Skeleton | `[data-card-skeleton="true"]`, children container `hidden` |
| Loading timeout | Panel + i18n keys, retry/remove callbacks, `animate-spin` on `RefreshCw` |
| Empty state | Panel + refresh callback; timeout takes precedence over empty |
| Normal children | `flex flex-1 flex-col` (not `hidden`) when data present |
| Install CTA | Mocked `InstallCTAFlow` via `data-testid="install-cta-flow"` |

## Test run

```bash
cd web && npm run test:card-loading-state
# 12 passed locally
```

## Scope

- `web/src/components/cards/__tests__/CardLoadingState.test.tsx` (new)
- `web/package.json` — `test:card-loading-state` script
- No production code changes
- Asserts i18n keys / `aria-label` / `data-testid` (not raw English strings)

## References

- Closes #15510
- Part of #4189
- Complements indirect coverage in `CardWrapper.test.tsx` (#15265)