### PR TITLE
🌱 test: add Vitest coverage for EnterpriseComplianceCards (#15522)

### DIFF
--- a/web/src/components/cards/EnterpriseComplianceCards.tsx
+++ b/web/src/components/cards/EnterpriseComplianceCards.tsx
@@ -42,7 +42,7 @@ function useSummaryData<T extends Record<string, unknown>>(endpoint: string) {
   }
 }
 
-function ScoreRing({ score, size = 64 }: { score: number; size?: number }) {
+export function ScoreRing({ score, size = 64 }: { score: number; size?: number }) {
   const r = (size - 8) / 2
   const circ = 2 * Math.PI * r
   const offset = circ - (score / 100) * circ

--- a/web/src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx
+++ b/web/src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx
@@ -47,8 +47,7 @@ describe('EnterpriseComplianceCards', () => {
   describe('HIPAACard (Pattern A - useEffect/authFetch)', () => {
     it('renders loading state initially', async () => {
       // Return an unresolved promise to keep it in loading state
-      let resolvePromise: any;
-      const promise = new Promise(resolve => { resolvePromise = resolve; });
+      const promise = new Promise(() => {});
       (authFetch as any).mockReturnValue(promise);
 
       render(
@@ -63,6 +62,7 @@ describe('EnterpriseComplianceCards', () => {
     });
 
     it('renders success state and navigates on click', async () => {
+      const user = userEvent.setup();
       const mockResponse = { ok: true };
       const mockData = { overall_score: 85, safeguards_passed: 10, safeguards_failed: 2, phi_namespaces: 3, encrypted_flows: 7 };
       (authFetch as any).mockResolvedValue(mockResponse);
@@ -85,13 +85,13 @@ describe('EnterpriseComplianceCards', () => {
 
       // Click card
       const cardShell = screen.getByText('HIPAA Compliance').closest('div')?.parentElement;
-      if (cardShell) {
-        await userEvent.click(cardShell);
-        expect(mockNavigate).toHaveBeenCalledWith('/hipaa');
-      }
+      expect(cardShell).toBeTruthy();
+      await user.click(cardShell!);
+      expect(mockNavigate).toHaveBeenCalledWith('/hipaa');
     });
 
     it('renders error state on fetch rejection', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       (authFetch as any).mockRejectedValue(new Error('Network error'));
 
       render(
@@ -105,6 +105,7 @@ describe('EnterpriseComplianceCards', () => {
         expect(errorText).toBeInTheDocument();
         expect(errorText.className).toContain('text-red-400');
       });
+      consoleSpy.mockRestore();
     });
 
     it('renders "No data" state when response is not ok', async () => {
@@ -151,6 +152,7 @@ describe('EnterpriseComplianceCards', () => {
     });
 
     it('renders success state and navigates on click', async () => {
+      const user = userEvent.setup();
       const mockData = { overall_score: 72, implemented_controls: 50, partial_controls: 10, planned_controls: 5, total_controls: 65 };
       (useCache as any).mockReturnValue({ data: mockData, error: null });
 
@@ -163,10 +165,9 @@ describe('EnterpriseComplianceCards', () => {
       expect(screen.getByText('72%')).toBeInTheDocument();
       
       const cardShell = screen.getByText('NIST 800-53').closest('div')?.parentElement;
-      if (cardShell) {
-        await userEvent.click(cardShell);
-        expect(mockNavigate).toHaveBeenCalledWith('/nist');
-      }
+      expect(cardShell).toBeTruthy();
+      await user.click(cardShell!);
+      expect(mockNavigate).toHaveBeenCalledWith('/nist');
     });
   });
 
@@ -195,6 +196,7 @@ describe('EnterpriseComplianceCards', () => {
 
   describe('ComplianceFrameworksCard (Pattern C - static)', () => {
     it('renders without crashing and navigates on click', async () => {
+      const user = userEvent.setup();
       render(
         <MemoryRouter>
           <ComplianceFrameworksCard />
@@ -204,10 +206,9 @@ describe('EnterpriseComplianceCards', () => {
       expect(screen.getByText('Compliance Frameworks')).toBeInTheDocument();
 
       const cardShell = screen.getByText('Compliance Frameworks').closest('div')?.parentElement;
-      if (cardShell) {
-        await userEvent.click(cardShell);
-        expect(mockNavigate).toHaveBeenCalledWith('/compliance-frameworks');
-      }
+      expect(cardShell).toBeTruthy();
+      await user.click(cardShell!);
+      expect(mockNavigate).toHaveBeenCalledWith('/compliance-frameworks');
     });
   });
 });

--- a/web/src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx
+++ b/web/src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  HIPAACard,
+  NISTCard,
+  ComplianceFrameworksCard,
+  ScoreRing
+} from '../EnterpriseComplianceCards';
+import { authFetch, safeJson } from '../../../lib/api';
+import { useCache } from '../../../lib/cache';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual as any,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../../../lib/api', () => ({
+  authFetch: vi.fn(),
+  safeJson: vi.fn(),
+}));
+
+vi.mock('../../../lib/cache', () => ({
+  useCache: vi.fn(),
+}));
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === 'failedToLoad' || key === 'messages.failedToLoad') return 'failedToLoad';
+      return key;
+    }
+  })
+}));
+
+describe('EnterpriseComplianceCards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('HIPAACard (Pattern A - useEffect/authFetch)', () => {
+    it('renders loading state initially', async () => {
+      // Return an unresolved promise to keep it in loading state
+      let resolvePromise: any;
+      const promise = new Promise(resolve => { resolvePromise = resolve; });
+      (authFetch as any).mockReturnValue(promise);
+
+      render(
+        <MemoryRouter>
+          <HIPAACard />
+        </MemoryRouter>
+      );
+
+      const loadingText = screen.getByText('Loading…');
+      expect(loadingText).toBeInTheDocument();
+      expect(loadingText.className).toContain('text-gray-500');
+    });
+
+    it('renders success state and navigates on click', async () => {
+      const mockResponse = { ok: true };
+      const mockData = { overall_score: 85, safeguards_passed: 10, safeguards_failed: 2, phi_namespaces: 3, encrypted_flows: 7 };
+      (authFetch as any).mockResolvedValue(mockResponse);
+      (safeJson as any).mockResolvedValue(mockData);
+
+      render(
+        <MemoryRouter>
+          <HIPAACard />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('85%')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('10')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByText('7')).toBeInTheDocument();
+
+      // Click card
+      const cardShell = screen.getByText('HIPAA Compliance').closest('div')?.parentElement;
+      if (cardShell) {
+        await userEvent.click(cardShell);
+        expect(mockNavigate).toHaveBeenCalledWith('/hipaa');
+      }
+    });
+
+    it('renders error state on fetch rejection', async () => {
+      (authFetch as any).mockRejectedValue(new Error('Network error'));
+
+      render(
+        <MemoryRouter>
+          <HIPAACard />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        const errorText = screen.getByText('Network error');
+        expect(errorText).toBeInTheDocument();
+        expect(errorText.className).toContain('text-red-400');
+      });
+    });
+
+    it('renders "No data" state when response is not ok', async () => {
+      (authFetch as any).mockResolvedValue({ ok: false });
+
+      render(
+        <MemoryRouter>
+          <HIPAACard />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('No data')).toBeInTheDocument();
+      });
+      expect(safeJson).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('NISTCard (Pattern B - useCache)', () => {
+    it('renders loading state when data is null and no error', () => {
+      (useCache as any).mockReturnValue({ data: null, error: null });
+
+      render(
+        <MemoryRouter>
+          <NISTCard />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText('Loading…')).toBeInTheDocument();
+    });
+
+    it('renders error state with translated text', () => {
+      (useCache as any).mockReturnValue({ data: null, error: new Error('fail') });
+
+      render(
+        <MemoryRouter>
+          <NISTCard />
+        </MemoryRouter>
+      );
+
+      const errorText = screen.getByText('failedToLoad');
+      expect(errorText).toBeInTheDocument();
+      expect(errorText.className).toContain('text-red-400');
+    });
+
+    it('renders success state and navigates on click', async () => {
+      const mockData = { overall_score: 72, implemented_controls: 50, partial_controls: 10, planned_controls: 5, total_controls: 65 };
+      (useCache as any).mockReturnValue({ data: mockData, error: null });
+
+      render(
+        <MemoryRouter>
+          <NISTCard />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText('72%')).toBeInTheDocument();
+      
+      const cardShell = screen.getByText('NIST 800-53').closest('div')?.parentElement;
+      if (cardShell) {
+        await userEvent.click(cardShell);
+        expect(mockNavigate).toHaveBeenCalledWith('/nist');
+      }
+    });
+  });
+
+  describe('ScoreRing (shared helper)', () => {
+    it('renders green ring when score is >= 80', () => {
+      const { container } = render(<ScoreRing score={85} />);
+      const circles = container.querySelectorAll('circle');
+      expect(circles[1].getAttribute('stroke')).toBe('hsl(var(--chart-success, 142 71% 45%))');
+      expect(screen.getByText('85%')).toBeInTheDocument();
+    });
+
+    it('renders amber ring when score is >= 60 and < 80', () => {
+      const { container } = render(<ScoreRing score={65} />);
+      const circles = container.querySelectorAll('circle');
+      expect(circles[1].getAttribute('stroke')).toBe('hsl(var(--chart-warning, 45 93% 47%))');
+      expect(screen.getByText('65%')).toBeInTheDocument();
+    });
+
+    it('renders red ring when score is < 60', () => {
+      const { container } = render(<ScoreRing score={40} />);
+      const circles = container.querySelectorAll('circle');
+      expect(circles[1].getAttribute('stroke')).toBe('hsl(var(--chart-danger, 0 84% 60%))');
+      expect(screen.getByText('40%')).toBeInTheDocument();
+    });
+  });
+
+  describe('ComplianceFrameworksCard (Pattern C - static)', () => {
+    it('renders without crashing and navigates on click', async () => {
+      render(
+        <MemoryRouter>
+          <ComplianceFrameworksCard />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText('Compliance Frameworks')).toBeInTheDocument();
+
+      const cardShell = screen.getByText('Compliance Frameworks').closest('div')?.parentElement;
+      if (cardShell) {
+        await userEvent.click(cardShell);
+        expect(mockNavigate).toHaveBeenCalledWith('/compliance-frameworks');
+      }
+    });
+  });
+});


### PR DESCRIPTION
Fixes #15522

Adds comprehensive Vitest coverage for the EnterpriseComplianceCards component testing different data fetching patterns and the shared ScoreRing component.