### PR TITLE
test: strengthen shallow behavioral assertions in ClusterGroups, ComputeOverview, and FleetComplianceHeatmap tests

### DIFF
--- a/web/src/components/cards/__tests__/ClusterGroups.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterGroups.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => true,
@@ -164,12 +165,13 @@ describe('ClusterGroups', () => {
     expect(container).toBeTruthy()
   })
 
-  it('opens CreateGroupForm when Clicking "New Group"', () => {
+  it('opens CreateGroupForm when Clicking "New Group"', async () => {
+    const user = userEvent.setup()
     mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     render(<ClusterGroups />)
     
-    const newGroupButton = screen.getByText('cards:clusterGroups.newGroup')
-    fireEvent.click(newGroupButton)
+    const newGroupButton = screen.getByRole('button', { name: 'cards:clusterGroups.newGroup' })
+    await user.click(newGroupButton)
     
     expect(screen.getByText('cards:clusterGroups.newClusterGroup')).toBeInTheDocument()
   })
@@ -191,14 +193,13 @@ describe('ClusterGroups', () => {
     
     expect(screen.getByText('Group A')).toBeInTheDocument()
     expect(screen.getByText('Group B')).toBeInTheDocument()
-    // Should show cluster counts (2/2 and 1/1 because mockUseClusters returns empty by default)
-    // Wait, ClusterGroups.tsx calculates healthyCount using clusterHealthMap.
-    // If clusters list is empty, healthyCount will be number of clusters since they aren't in map as false.
+    // Verify that the computed cluster counts match the expected format (healthy/total)
     expect(screen.getByText(/2\/2/)).toBeInTheDocument()
     expect(screen.getByText(/1\/1/)).toBeInTheDocument()
   })
 
-  it('opens EditGroupForm when clicking edit button', () => {
+  it('opens EditGroupForm when clicking edit button', async () => {
+    const user = userEvent.setup()
     mockUseClusterGroups.mockReturnValue({
       groups: [{ name: 'Group A', kind: 'static', clusters: ['c1'], color: 'blue' }],
       createGroup: vi.fn(),
@@ -210,17 +211,14 @@ describe('ClusterGroups', () => {
     mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     render(<ClusterGroups />)
     
-    const editButton = screen.getByLabelText('cards:clusterGroups.editGroup')
-    fireEvent.click(editButton)
+    const editButton = screen.getByRole('button', { name: 'cards:clusterGroups.editGroup' })
+    await user.click(editButton)
     
-    // EditGroupForm should render. It likely has a "Save Changes" button or similar.
-    // In ClusterGroupsForms.tsx, EditGroupForm is similar to CreateGroupForm.
-    // Let's check for "Group Name" input or a specific title.
-    // Actually, EditGroupForm in ClusterGroups.tsx is rendered within the same loop.
     expect(screen.getByText(/common.edit.*Group A/)).toBeInTheDocument()
   })
 
-  it('calls deleteGroup when confirmation is accepted', () => {
+  it('calls deleteGroup when confirmation is accepted', async () => {
+    const user = userEvent.setup()
     const deleteGroup = vi.fn()
     mockUseClusterGroups.mockReturnValue({
       groups: [{ name: 'Group A', kind: 'static', clusters: ['c1'], color: 'blue' }],
@@ -233,14 +231,11 @@ describe('ClusterGroups', () => {
     mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     render(<ClusterGroups />)
     
-    const deleteButton = screen.getByLabelText('cards:clusterGroups.deleteGroup')
-    fireEvent.click(deleteButton)
+    const deleteButton = screen.getByRole('button', { name: 'cards:clusterGroups.deleteGroup' })
+    await user.click(deleteButton)
     
-    // ConfirmDialog should be open.
-    // It has a title 'cards:clusterGroups.deleteGroup' (same as button labal but in a dialog).
-    // And a confirm button with text 'common:actions.delete'.
-    const confirmButton = screen.getByText('common:actions.delete')
-    fireEvent.click(confirmButton)
+    const confirmButton = screen.getByRole('button', { name: 'common:actions.delete' })
+    await user.click(confirmButton)
     
     expect(deleteGroup).toHaveBeenCalledWith('Group A')
   })

--- a/web/src/components/cards/__tests__/ClusterGroups.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterGroups.test.tsx
@@ -1,5 +1,6 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => true,
@@ -161,5 +162,86 @@ describe('ClusterGroups', () => {
     })
     const { container } = render(<ClusterGroups />)
     expect(container).toBeTruthy()
+  })
+
+  it('opens CreateGroupForm when Clicking "New Group"', () => {
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    render(<ClusterGroups />)
+    
+    const newGroupButton = screen.getByText('cards:clusterGroups.newGroup')
+    fireEvent.click(newGroupButton)
+    
+    expect(screen.getByText('cards:clusterGroups.newClusterGroup')).toBeInTheDocument()
+  })
+
+  it('renders a list of groups with names and cluster counts', () => {
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    mockUseClusterGroups.mockReturnValue({
+      groups: [
+        { name: 'Group A', kind: 'static', clusters: ['c1', 'c2'], color: 'blue' },
+        { name: 'Group B', kind: 'dynamic', clusters: ['c3'], color: 'green' }
+      ],
+      createGroup: vi.fn(),
+      updateGroup: vi.fn(),
+      deleteGroup: vi.fn(),
+      isPersisted: false,
+    })
+    
+    render(<ClusterGroups />)
+    
+    expect(screen.getByText('Group A')).toBeInTheDocument()
+    expect(screen.getByText('Group B')).toBeInTheDocument()
+    // Should show cluster counts (2/2 and 1/1 because mockUseClusters returns empty by default)
+    // Wait, ClusterGroups.tsx calculates healthyCount using clusterHealthMap.
+    // If clusters list is empty, healthyCount will be number of clusters since they aren't in map as false.
+    expect(screen.getByText(/2\/2/)).toBeInTheDocument()
+    expect(screen.getByText(/1\/1/)).toBeInTheDocument()
+  })
+
+  it('opens EditGroupForm when clicking edit button', () => {
+    mockUseClusterGroups.mockReturnValue({
+      groups: [{ name: 'Group A', kind: 'static', clusters: ['c1'], color: 'blue' }],
+      createGroup: vi.fn(),
+      updateGroup: vi.fn(),
+      deleteGroup: vi.fn(),
+      isPersisted: false,
+    })
+    
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    render(<ClusterGroups />)
+    
+    const editButton = screen.getByLabelText('cards:clusterGroups.editGroup')
+    fireEvent.click(editButton)
+    
+    // EditGroupForm should render. It likely has a "Save Changes" button or similar.
+    // In ClusterGroupsForms.tsx, EditGroupForm is similar to CreateGroupForm.
+    // Let's check for "Group Name" input or a specific title.
+    // Actually, EditGroupForm in ClusterGroups.tsx is rendered within the same loop.
+    expect(screen.getByText(/common.edit.*Group A/)).toBeInTheDocument()
+  })
+
+  it('calls deleteGroup when confirmation is accepted', () => {
+    const deleteGroup = vi.fn()
+    mockUseClusterGroups.mockReturnValue({
+      groups: [{ name: 'Group A', kind: 'static', clusters: ['c1'], color: 'blue' }],
+      createGroup: vi.fn(),
+      updateGroup: vi.fn(),
+      deleteGroup,
+      isPersisted: false,
+    })
+    
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    render(<ClusterGroups />)
+    
+    const deleteButton = screen.getByLabelText('cards:clusterGroups.deleteGroup')
+    fireEvent.click(deleteButton)
+    
+    // ConfirmDialog should be open.
+    // It has a title 'cards:clusterGroups.deleteGroup' (same as button labal but in a dialog).
+    // And a confirm button with text 'common:actions.delete'.
+    const confirmButton = screen.getByText('common:actions.delete')
+    fireEvent.click(confirmButton)
+    
+    expect(deleteGroup).toHaveBeenCalledWith('Group A')
   })
 })

--- a/web/src/components/cards/__tests__/ComputeOverview.test.tsx
+++ b/web/src/components/cards/__tests__/ComputeOverview.test.tsx
@@ -1,5 +1,6 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
 // Standard mocks
 vi.mock('../../../lib/demoMode', () => ({
@@ -89,6 +90,77 @@ describe('ComputeOverview', () => {
   it('calls useCardLoadingState during render', () => {
     render(<ComputeOverview />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
+  })
+
+  it('aggregates CPU cores correctly across clusters', () => {
+    mockUseClusters.mockReturnValue({
+      clusters: [
+        { name: 'c1', cpuCores: 8, healthy: true, reachable: true, nodeCount: 1, podCount: 10 },
+        { name: 'c2', cpuCores: 16, healthy: true, reachable: true, nodeCount: 2, podCount: 20 }
+      ],
+      deduplicatedClusters: [
+        { name: 'c1', cpuCores: 8, healthy: true, reachable: true, nodeCount: 1, podCount: 10 },
+        { name: 'c2', cpuCores: 16, healthy: true, reachable: true, nodeCount: 2, podCount: 20 }
+      ],
+      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+    })
+    
+    render(<ComputeOverview />)
+    
+    // Total should be 24
+    expect(screen.getByText('24')).toBeInTheDocument()
+    // It should also show "computeOverview.cpuCores" label
+    expect(screen.getByText('computeOverview.cpuCores')).toBeInTheDocument()
+  })
+
+  it('aggregates Memory GB correctly across clusters', () => {
+    mockUseClusters.mockReturnValue({
+      clusters: [
+        { name: 'c1', cpuCores: 8, memoryGB: 16, healthy: true, reachable: true, nodeCount: 1, podCount: 10 },
+        { name: 'c2', cpuCores: 16, memoryGB: 32, healthy: true, reachable: true, nodeCount: 2, podCount: 20 }
+      ],
+      deduplicatedClusters: [
+        { name: 'c1', cpuCores: 8, memoryGB: 16, healthy: true, reachable: true, nodeCount: 1, podCount: 10 },
+        { name: 'c2', cpuCores: 16, memoryGB: 32, healthy: true, reachable: true, nodeCount: 2, podCount: 20 }
+      ],
+      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+    })
+    
+    render(<ComputeOverview />)
+    
+    // Total should be 48.
+    expect(screen.getByText(/48/)).toBeInTheDocument()
+  })
+
+  it('renders empty state when no clusters are available', () => {
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: true, hasData: false, isRefreshing: false })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    
+    render(<ComputeOverview />)
+    
+    expect(screen.getByText('computeOverview.noComputeData')).toBeInTheDocument()
+  })
+
+  it('does not double count deduplicated clusters', () => {
+    // raw clusters has 3 items, but deduplicated only has 2
+    mockUseClusters.mockReturnValue({
+      clusters: [
+        { name: 'c1', cpuCores: 10, healthy: true, reachable: true, nodeCount: 1, podCount: 1 },
+        { name: 'c1-alias', cpuCores: 10, healthy: true, reachable: true, nodeCount: 1, podCount: 1 },
+        { name: 'c2', cpuCores: 5, healthy: true, reachable: true, nodeCount: 1, podCount: 1 }
+      ],
+      deduplicatedClusters: [
+        { name: 'c1', cpuCores: 10, healthy: true, reachable: true, nodeCount: 1, podCount: 1 },
+        { name: 'c2', cpuCores: 5, healthy: true, reachable: true, nodeCount: 1, podCount: 1 }
+      ],
+      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+    })
+    
+    render(<ComputeOverview />)
+    
+    // Should show 15, not 25
+    expect(screen.getByText('15')).toBeInTheDocument()
+    expect(screen.queryByText('25')).not.toBeInTheDocument()
   })
 
   it('renders skeleton UI when data is loading', () => {

--- a/web/src/components/cards/__tests__/ComputeOverview.test.tsx
+++ b/web/src/components/cards/__tests__/ComputeOverview.test.tsx
@@ -107,10 +107,10 @@ describe('ComputeOverview', () => {
     
     render(<ComputeOverview />)
     
-    // Total should be 24
-    expect(screen.getByText('24')).toBeInTheDocument()
-    // It should also show "computeOverview.cpuCores" label
-    expect(screen.getByText('computeOverview.cpuCores')).toBeInTheDocument()
+    // Find the CPU Cores card and verify its total count
+    const cpuLabel = screen.getByText('computeOverview.cpuCores')
+    const cpuCard = cpuLabel.closest('.cursor-pointer')
+    expect(cpuCard).toHaveTextContent('24')
   })
 
   it('aggregates Memory GB correctly across clusters', () => {
@@ -128,8 +128,10 @@ describe('ComputeOverview', () => {
     
     render(<ComputeOverview />)
     
-    // Total should be 48.
-    expect(screen.getByText(/48/)).toBeInTheDocument()
+    // Find the Memory card and verify its total count
+    const memoryLabel = screen.getByText('common:common.memory')
+    const memoryCard = memoryLabel.closest('.cursor-pointer')
+    expect(memoryCard).toHaveTextContent(/48/)
   })
 
   it('renders empty state when no clusters are available', () => {
@@ -158,9 +160,11 @@ describe('ComputeOverview', () => {
     
     render(<ComputeOverview />)
     
-    // Should show 15, not 25
-    expect(screen.getByText('15')).toBeInTheDocument()
-    expect(screen.queryByText('25')).not.toBeInTheDocument()
+    // Find the CPU Cores card and verify it shows 15, not 25
+    const cpuLabel = screen.getByText('computeOverview.cpuCores')
+    const cpuCard = cpuLabel.closest('.cursor-pointer')
+    expect(cpuCard).toHaveTextContent('15')
+    expect(cpuCard).not.toHaveTextContent('25')
   })
 
   it('renders skeleton UI when data is loading', () => {

--- a/web/src/components/cards/__tests__/FleetComplianceHeatmap.test.tsx
+++ b/web/src/components/cards/__tests__/FleetComplianceHeatmap.test.tsx
@@ -107,9 +107,9 @@ describe('FleetComplianceHeatmap', () => {
     const amberCell = screen.getByText('65%')
     const redCell = screen.getByText('45%')
     
-    expect(greenCell.className).toContain('bg-green-500')
-    expect(amberCell.className).toContain('bg-yellow-500')
-    expect(redCell.className).toContain('bg-red-500')
+    expect(greenCell).toHaveClass('bg-green-500/20')
+    expect(amberCell).toHaveClass('bg-yellow-500/20')
+    expect(redCell).toHaveClass('bg-red-500/20')
   })
 
   it('renders correct background for Kyverno violation boundaries', () => {
@@ -132,9 +132,9 @@ describe('FleetComplianceHeatmap', () => {
     const amberCell = screen.getByText('5 violations')
     const redCell = screen.getByText('11 violations')
     
-    expect(greenCell.className).toContain('bg-green-500')
-    expect(amberCell.className).toContain('bg-yellow-500')
-    expect(redCell.className).toContain('bg-red-500')
+    expect(greenCell).toHaveClass('bg-green-500/20')
+    expect(amberCell).toHaveClass('bg-yellow-500/20')
+    expect(redCell).toHaveClass('bg-red-500/20')
   })
 
   it('renders correct background for Trivy crit+high boundaries', () => {
@@ -157,9 +157,9 @@ describe('FleetComplianceHeatmap', () => {
     const amberCell = screen.getByText('3 crit/high')
     const redCell = screen.getByText('7 crit/high')
     
-    expect(greenCell.className).toContain('bg-green-500')
-    expect(amberCell.className).toContain('bg-yellow-500')
-    expect(redCell.className).toContain('bg-red-500')
+    expect(greenCell).toHaveClass('bg-green-500/20')
+    expect(amberCell).toHaveClass('bg-yellow-500/20')
+    expect(redCell).toHaveClass('bg-red-500/20')
   })
 
   it('handles empty data by rendering clusters from fallback', () => {

--- a/web/src/components/cards/__tests__/FleetComplianceHeatmap.test.tsx
+++ b/web/src/components/cards/__tests__/FleetComplianceHeatmap.test.tsx
@@ -1,5 +1,6 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
 // Standard mocks
 vi.mock('../../../lib/demoMode', () => ({
@@ -84,6 +85,93 @@ describe('FleetComplianceHeatmap', () => {
   it('renders without crashing', () => {
     const { container } = render(<FleetComplianceHeatmap />)
     expect(container).toBeTruthy()
+  })
+
+  it('renders correct background for Kubescape score thresholds', () => {
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'cluster-green' }, { name: 'cluster-amber' }, { name: 'cluster-red' }] })
+    
+    mockUseKubescape.mockReturnValue({
+      statuses: {
+        'cluster-green': { installed: true, overallScore: 85, totalControls: 10 },
+        'cluster-amber': { installed: true, overallScore: 65, totalControls: 10 },
+        'cluster-red': { installed: true, overallScore: 45, totalControls: 10 }
+      },
+      installed: true,
+      isLoading: false
+    })
+    
+    render(<FleetComplianceHeatmap />)
+    
+    const greenCell = screen.getByText('85%')
+    const amberCell = screen.getByText('65%')
+    const redCell = screen.getByText('45%')
+    
+    expect(greenCell.className).toContain('bg-green-500')
+    expect(amberCell.className).toContain('bg-yellow-500')
+    expect(redCell.className).toContain('bg-red-500')
+  })
+
+  it('renders correct background for Kyverno violation boundaries', () => {
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'cluster-green' }, { name: 'cluster-amber' }, { name: 'cluster-red' }] })
+    
+    mockUseKyverno.mockReturnValue({
+      statuses: {
+        'cluster-green': { installed: true, totalViolations: 2, totalPolicies: 5, policies: [{}, {}] },
+        'cluster-amber': { installed: true, totalViolations: 5, totalPolicies: 5, policies: [{}, {}] },
+        'cluster-red': { installed: true, totalViolations: 11, totalPolicies: 5, policies: [{}, {}] }
+      },
+      installed: true,
+      isLoading: false
+    })
+    
+    render(<FleetComplianceHeatmap />)
+    
+    const greenCell = screen.getByText('2 violations')
+    const amberCell = screen.getByText('5 violations')
+    const redCell = screen.getByText('11 violations')
+    
+    expect(greenCell.className).toContain('bg-green-500')
+    expect(amberCell.className).toContain('bg-yellow-500')
+    expect(redCell.className).toContain('bg-red-500')
+  })
+
+  it('renders correct background for Trivy crit+high boundaries', () => {
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'cluster-green' }, { name: 'cluster-amber' }, { name: 'cluster-red' }] })
+    
+    mockUseTrivy.mockReturnValue({
+      statuses: {
+        'cluster-green': { installed: true, totalReports: 5, vulnerabilities: { critical: 0, high: 0, medium: 0, low: 0 } },
+        'cluster-amber': { installed: true, totalReports: 5, vulnerabilities: { critical: 1, high: 2, medium: 0, low: 0 } },
+        'cluster-red': { installed: true, totalReports: 5, vulnerabilities: { critical: 3, high: 4, medium: 0, low: 0 } }
+      },
+      installed: true,
+      isLoading: false
+    })
+    
+    render(<FleetComplianceHeatmap />)
+    
+    const greenCell = screen.getByText('0 crit/high')
+    const amberCell = screen.getByText('3 crit/high')
+    const redCell = screen.getByText('7 crit/high')
+    
+    expect(greenCell.className).toContain('bg-green-500')
+    expect(amberCell.className).toContain('bg-yellow-500')
+    expect(redCell.className).toContain('bg-red-500')
+  })
+
+  it('handles empty data by rendering clusters from fallback', () => {
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'cluster-1' }] })
+    // All tools not installed
+    
+    render(<FleetComplianceHeatmap />)
+    
+    expect(screen.getByText('cluster-1')).toBeInTheDocument()
+    // No crash, and should show placeholder cells
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
   })
 
   it('calls useCardLoadingState during render', () => {


### PR DESCRIPTION
Resolves #15528

### Summary
This PR strengthens unit test coverage for `ClusterGroups`, `ComputeOverview`, and `FleetComplianceHeatmap` cards in KubeStellar Console by moving beyond basic smoke/mount tests to fully verify behavioral correctness, dynamic calculations, threshold boundaries, and empty state handling.

### Changes
#### 1. `ClusterGroups.test.tsx`
- **Create Flow**: Added test to verify that clicking the "New Group" button opens the `CreateGroupForm` and renders the appropriate heading.
- **Group List Rendering**: Added verification that custom group names and cluster counts are correctly rendered. Added `isDemoMode: false` mock override so that user-defined groups render instead of preset demo groups.
- **Edit Flow**: Added assertion that clicking the edit pencil button correctly renders `EditGroupForm` for the target group. Changed the previous `getByDisplayValue` check (which failed because group names are immutable unique keys and do not have an editable text input) to look for the Edit Group heading `common.edit: Group A`.
- **Delete Flow**: Verified that clicking the delete icon prompts the confirm dialog, and clicking delete fires the `deleteGroup` callback with the correct group name.

#### 2. `ComputeOverview.test.tsx`
- **CPU & Memory Aggregation**: Added tests that mock multiple clusters with defined resources and assert that total CPU cores and total Memory GB are correctly calculated and formatted.
- **Deduplication Safeguard**: Added verification that calculations do not double-count clusters when raw lists contain context aliases, ensuring `deduplicatedClusters` is the correct source of truth.
- **Empty State Guard**: Verified that the component renders a fallback message (`computeOverview.noComputeData`) and doesn't crash when no cluster metrics are available.

#### 3. `FleetComplianceHeatmap.test.tsx`
- **Kubescape Thresholds**: Asserted that cell background colors properly match Kubescape score rules: Green (`score >= 80`), Amber (`score >= 60`), Red (`score < 60`).
- **Kyverno Thresholds**: Verified Kyverno violation boundaries: Green (`violations <= 3`), Amber (`violations <= 10`), Red (`violations > 10`).
- **Trivy Thresholds**: Confirmed Trivy critical+high vulnerability color mapping: Green (`crit+high <= 1`), Amber (`crit+high <= 5`), Red (`crit+high > 5`).
- **Empty State Safeguard**: Confirmed that empty cluster lists do not crash the component and placeholder cells are correctly rendered instead.

---
### Verification
All unit tests in `src/components/cards` were executed and verified locally. All **294 test files (2631 tests in total)** pass perfectly.

```bash
npx vitest src/components/cards --run
```
```
Test Files  294 passed (294)
     Tests  2631 passed (2631)
```