### PR TITLE
test(card-wrapper): expand CardActionMenu coverage — width/height submenus, callbacks, keyboard nav, CustomEvent coordination

### DIFF
--- a/web/src/components/cards/card-wrapper/CardActionMenu.test.tsx
+++ b/web/src/components/cards/card-wrapper/CardActionMenu.test.tsx
@@ -1,6 +1,20 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+/**
+ * CardActionMenu — comprehensive Vitest + RTL tests (#15539).
+ *
+ * Covers: width/height submenus, callbacks, keyboard navigation,
+ * card-menu-open CustomEvent coordination, outside-click dismiss,
+ * and the existing Escape-key focus-restore test.
+ *
+ * Run from web/:  npx vitest run src/components/cards/card-wrapper/CardActionMenu.test.tsx
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { CardActionMenu } from './CardActionMenu'
+import { copyToClipboard } from '../../../lib/clipboard'
+
+// ---------------------------------------------------------------------------
+// Mocks — same pattern as the original single test
+// ---------------------------------------------------------------------------
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
@@ -22,36 +36,537 @@ vi.mock('../../../hooks/useDashboardContext', () => ({
   useDashboardContextOptional: () => null,
 }))
 
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CARD_ID = 'pod-health'
+const CARD_TYPE = 'pod_health'
+const TRIGGER_LABEL = 'cardWrapper.cardMenuTooltip'
+const MENU_LABEL = 'cardWrapper.cardMenuTooltip'
+
+// Width option values from the source
+const WIDTH_SMALL = 3
+const WIDTH_LARGE = 6
+const WIDTH_FULL = 12
+
+// Height option values from the source
+const HEIGHT_DEFAULT = 2
+const HEIGHT_TALL = 3
+const HEIGHT_MAXIMUM = 6
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Default props for a fully-wired CardActionMenu. */
+function defaultProps(overrides: Partial<{
+  onWidthChange: ReturnType<typeof vi.fn>
+  onHeightChange: ReturnType<typeof vi.fn>
+  onConfigure: ReturnType<typeof vi.fn>
+  onRemove: ReturnType<typeof vi.fn>
+  onShowWidgetExport: ReturnType<typeof vi.fn>
+  cardWidth: number
+  cardHeight: number
+}> = {}) {
+  return {
+    cardId: CARD_ID,
+    cardType: CARD_TYPE,
+    onConfigure: overrides.onConfigure ?? vi.fn(),
+    onRemove: overrides.onRemove ?? vi.fn(),
+    onShowWidgetExport: overrides.onShowWidgetExport ?? vi.fn(),
+    onWidthChange: overrides.onWidthChange ?? vi.fn(),
+    onHeightChange: overrides.onHeightChange ?? vi.fn(),
+    cardWidth: overrides.cardWidth,
+    cardHeight: overrides.cardHeight,
+  }
+}
+
+/** Opens the main three-dot menu by clicking its trigger button. */
+function openMenu() {
+  fireEvent.click(screen.getByRole('button', { name: TRIGGER_LABEL }))
+}
+
+/** Query a menu item by its title attribute (most reliable for nested content). */
+function getItemByTitle(title: string) {
+  return screen.getByTitle(title)
+}
+
+/** Query all role="menuitem" buttons inside a given menu (by aria-label). */
+function getSubMenuItems(menuLabel: string) {
+  const menu = screen.getByRole('menu', { name: menuLabel })
+  return within(menu).getAllByRole('menuitem')
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
 describe('CardActionMenu', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
+  // -------------------------------------------------------------------------
+  // Existing test — Escape key focus restore (preserved from original)
+  // -------------------------------------------------------------------------
+  describe('Escape key', () => {
+    it('wires menu semantics and restores focus on Escape', () => {
+      render(
+        <CardActionMenu
+          cardId={CARD_ID}
+          cardType={CARD_TYPE}
+          onConfigure={vi.fn()}
+          onRemove={vi.fn()}
+          onShowWidgetExport={vi.fn()}
+        />,
+      )
+
+      const trigger = screen.getByRole('button', { name: TRIGGER_LABEL })
+      expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+      expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+      fireEvent.click(trigger)
+
+      const menu = screen.getByRole('menu', { name: MENU_LABEL })
+      expect(trigger).toHaveAttribute('aria-expanded', 'true')
+      expect(trigger).toHaveAttribute('aria-controls', `card-action-menu-${CARD_ID}`)
+      expect(screen.getByRole('menuitem', { name: /common:actions.configure/i })).toHaveFocus()
+
+      fireEvent.keyDown(menu, { key: 'Escape' })
+
+      expect(trigger).toHaveFocus()
+      expect(screen.queryByRole('menu', { name: MENU_LABEL })).not.toBeInTheDocument()
+    })
   })
 
-  it('wires menu semantics and restores focus on Escape', () => {
-    render(
-      <CardActionMenu
-        cardId="pod-health"
-        cardType="pod_health"
-        onConfigure={vi.fn()}
-        onRemove={vi.fn()}
-        onShowWidgetExport={vi.fn()}
-      />
-    )
+  // -------------------------------------------------------------------------
+  // Width submenu
+  // -------------------------------------------------------------------------
+  describe('width submenu', () => {
+    it('opens width submenu and sets aria-expanded on the trigger', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
 
-    const trigger = screen.getByRole('button', { name: 'cardWrapper.cardMenuTooltip' })
-    expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
-    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+      const resizeBtn = getItemByTitle('cardWrapper.resizeTooltip')
+      expect(resizeBtn).toHaveAttribute('aria-expanded', 'false')
 
-    fireEvent.click(trigger)
+      fireEvent.click(resizeBtn)
 
-    const menu = screen.getByRole('menu', { name: 'cardWrapper.cardMenuTooltip' })
-    expect(trigger).toHaveAttribute('aria-expanded', 'true')
-    expect(trigger).toHaveAttribute('aria-controls', 'card-action-menu-pod-health')
-    expect(screen.getByRole('menuitem', { name: /common:actions.configure/i })).toHaveFocus()
+      expect(resizeBtn).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByRole('menu', { name: 'cardWrapper.resizeTooltip' })).toBeInTheDocument()
+    })
 
-    fireEvent.keyDown(menu, { key: 'Escape' })
+    it('fires onWidthChange with the small value (3) and closes both menus', () => {
+      const onWidthChange = vi.fn()
+      render(<CardActionMenu {...defaultProps({ onWidthChange })} />)
+      openMenu()
 
-    expect(trigger).toHaveFocus()
-    expect(screen.queryByRole('menu', { name: 'cardWrapper.cardMenuTooltip' })).not.toBeInTheDocument()
+      fireEvent.click(getItemByTitle('cardWrapper.resizeTooltip'))
+
+      // Width submenu items don't have title attributes — use within() on the submenu
+      const widthOptions = getSubMenuItems('cardWrapper.resizeTooltip')
+      // First option is "small" (value=3)
+      fireEvent.click(widthOptions[0])
+
+      expect(onWidthChange).toHaveBeenCalledTimes(1)
+      expect(onWidthChange).toHaveBeenCalledWith(WIDTH_SMALL)
+
+      // Both submenu and main menu should close
+      expect(screen.queryByRole('menu', { name: MENU_LABEL })).not.toBeInTheDocument()
+    })
+
+    it('fires onWidthChange with the full-width value (12)', () => {
+      const onWidthChange = vi.fn()
+      render(<CardActionMenu {...defaultProps({ onWidthChange })} />)
+      openMenu()
+
+      fireEvent.click(getItemByTitle('cardWrapper.resizeTooltip'))
+
+      const widthOptions = getSubMenuItems('cardWrapper.resizeTooltip')
+      // Last option is "full" (value=12)
+      fireEvent.click(widthOptions[widthOptions.length - 1])
+
+      expect(onWidthChange).toHaveBeenCalledWith(WIDTH_FULL)
+    })
+
+    it('highlights the currently-selected width option with active styling', () => {
+      render(<CardActionMenu {...defaultProps({ cardWidth: WIDTH_LARGE })} />)
+      openMenu()
+
+      fireEvent.click(getItemByTitle('cardWrapper.resizeTooltip'))
+
+      const widthOptions = getSubMenuItems('cardWrapper.resizeTooltip')
+      // WIDTH_LARGE = 6 is the 3rd option (index 2): [3, 4, 6, 8, 12]
+      const activeOption = widthOptions[2]
+      expect(activeOption.className).toContain('text-purple-400')
+      expect(activeOption.className).toContain('bg-purple-500/10')
+
+      // Another option (first = small) should NOT have active styling
+      expect(widthOptions[0].className).not.toContain('text-purple-400')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Height submenu
+  // -------------------------------------------------------------------------
+  describe('height submenu', () => {
+    it('opens height submenu and sets aria-expanded on the trigger', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      const heightBtn = getItemByTitle('cardWrapper.resizeHeightTooltip')
+      expect(heightBtn).toHaveAttribute('aria-expanded', 'false')
+
+      fireEvent.click(heightBtn)
+
+      expect(heightBtn).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByRole('menu', { name: 'cardWrapper.resizeHeightTooltip' })).toBeInTheDocument()
+    })
+
+    it('fires onHeightChange with the tall value (3) and closes both menus', () => {
+      const onHeightChange = vi.fn()
+      render(<CardActionMenu {...defaultProps({ onHeightChange })} />)
+      openMenu()
+
+      fireEvent.click(getItemByTitle('cardWrapper.resizeHeightTooltip'))
+
+      const heightOptions = getSubMenuItems('cardWrapper.resizeHeightTooltip')
+      // Second option is "tall" (value=3): [2, 3, 4, 6]
+      fireEvent.click(heightOptions[1])
+
+      expect(onHeightChange).toHaveBeenCalledTimes(1)
+      expect(onHeightChange).toHaveBeenCalledWith(HEIGHT_TALL)
+
+      expect(screen.queryByRole('menu', { name: MENU_LABEL })).not.toBeInTheDocument()
+    })
+
+    it('fires onHeightChange with the maximum value (6)', () => {
+      const onHeightChange = vi.fn()
+      render(<CardActionMenu {...defaultProps({ onHeightChange })} />)
+      openMenu()
+
+      fireEvent.click(getItemByTitle('cardWrapper.resizeHeightTooltip'))
+
+      const heightOptions = getSubMenuItems('cardWrapper.resizeHeightTooltip')
+      // Last option is "maximum" (value=6)
+      fireEvent.click(heightOptions[heightOptions.length - 1])
+
+      expect(onHeightChange).toHaveBeenCalledWith(HEIGHT_MAXIMUM)
+    })
+
+    it('highlights the currently-selected height option with active styling', () => {
+      render(<CardActionMenu {...defaultProps({ cardHeight: HEIGHT_DEFAULT })} />)
+      openMenu()
+
+      fireEvent.click(getItemByTitle('cardWrapper.resizeHeightTooltip'))
+
+      const heightOptions = getSubMenuItems('cardWrapper.resizeHeightTooltip')
+      // HEIGHT_DEFAULT = 2 is the 1st option (index 0): [2, 3, 4, 6]
+      expect(heightOptions[0].className).toContain('text-purple-400')
+      expect(heightOptions[0].className).toContain('bg-purple-500/10')
+
+      // Tall option (index 1) should NOT have active styling
+      expect(heightOptions[1].className).not.toContain('text-purple-400')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Width/height submenu mutual exclusion
+  // -------------------------------------------------------------------------
+  describe('submenu mutual exclusion', () => {
+    it('opening width submenu closes the height submenu', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      // Open height submenu first
+      fireEvent.click(getItemByTitle('cardWrapper.resizeHeightTooltip'))
+      expect(screen.getByRole('menu', { name: 'cardWrapper.resizeHeightTooltip' })).toBeInTheDocument()
+
+      // Now open width submenu — height should close
+      fireEvent.click(getItemByTitle('cardWrapper.resizeTooltip'))
+      expect(screen.getByRole('menu', { name: 'cardWrapper.resizeTooltip' })).toBeInTheDocument()
+      expect(screen.queryByRole('menu', { name: 'cardWrapper.resizeHeightTooltip' })).not.toBeInTheDocument()
+    })
+
+    it('opening height submenu closes the width submenu', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      // Open width submenu first
+      fireEvent.click(getItemByTitle('cardWrapper.resizeTooltip'))
+      expect(screen.getByRole('menu', { name: 'cardWrapper.resizeTooltip' })).toBeInTheDocument()
+
+      // Now open height submenu — width should close
+      fireEvent.click(getItemByTitle('cardWrapper.resizeHeightTooltip'))
+      expect(screen.getByRole('menu', { name: 'cardWrapper.resizeHeightTooltip' })).toBeInTheDocument()
+      expect(screen.queryByRole('menu', { name: 'cardWrapper.resizeTooltip' })).not.toBeInTheDocument()
+    })
+
+    it('ArrowLeft closes the open width submenu', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      // Open the width submenu
+      fireEvent.click(getItemByTitle('cardWrapper.resizeTooltip'))
+      const widthSubMenu = screen.getByRole('menu', { name: 'cardWrapper.resizeTooltip' })
+      expect(widthSubMenu).toBeInTheDocument()
+
+      // Press ArrowLeft on the submenu
+      fireEvent.keyDown(widthSubMenu, { key: 'ArrowLeft' })
+
+      // The width submenu should close
+      expect(screen.queryByRole('menu', { name: 'cardWrapper.resizeTooltip' })).not.toBeInTheDocument()
+      // Main menu should still be open
+      expect(screen.getByRole('menu', { name: MENU_LABEL })).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Callbacks — Configure, Remove, Copy Link
+  // -------------------------------------------------------------------------
+  describe('callbacks', () => {
+    it('clicking Configure fires onConfigure and closes the menu', () => {
+      const onConfigure = vi.fn()
+      render(<CardActionMenu {...defaultProps({ onConfigure })} />)
+      openMenu()
+
+      fireEvent.click(getItemByTitle('cardWrapper.configureTooltip'))
+
+      expect(onConfigure).toHaveBeenCalledTimes(1)
+      expect(screen.queryByRole('menu', { name: MENU_LABEL })).not.toBeInTheDocument()
+    })
+
+    it('clicking Remove fires onRemove and closes the menu', () => {
+      const onRemove = vi.fn()
+      render(<CardActionMenu {...defaultProps({ onRemove })} />)
+      openMenu()
+
+      fireEvent.click(getItemByTitle('cardWrapper.removeTooltip'))
+
+      expect(onRemove).toHaveBeenCalledTimes(1)
+      expect(screen.queryByRole('menu', { name: MENU_LABEL })).not.toBeInTheDocument()
+    })
+
+    it('clicking Copy Link calls copyToClipboard with the expected URL', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      fireEvent.click(getItemByTitle('cardWrapper.copyLinkTooltip'))
+
+      const expectedUrl = `${window.location.origin}${window.location.pathname}?card=${CARD_TYPE}`
+      expect(copyToClipboard).toHaveBeenCalledTimes(1)
+      expect(copyToClipboard).toHaveBeenCalledWith(expectedUrl)
+
+      // Menu should close after copy
+      expect(screen.queryByRole('menu', { name: MENU_LABEL })).not.toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Keyboard navigation
+  //
+  // The component calls `querySelectorAll('button[role="menuitem"]:not([disabled])')`
+  // on the onKeyDown handler's `e.currentTarget`. In jsdom, `document.activeElement`
+  // tracking requires explicit `.focus()` calls, and the useEffect auto-focus
+  // works because the menu portals into the body. We fire keyDown on the menu div.
+  // -------------------------------------------------------------------------
+  describe('keyboard navigation', () => {
+    it('ArrowDown moves focus to the next menu item', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      const menu = screen.getByRole('menu', { name: MENU_LABEL })
+      const items = within(menu).getAllByRole('menuitem')
+
+      // After opening, useEffect focuses the first item (Configure)
+      expect(items[0]).toHaveFocus()
+
+      fireEvent.keyDown(menu, { key: 'ArrowDown' })
+      expect(items[1]).toHaveFocus()
+    })
+
+    it('ArrowUp moves focus to the previous menu item', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      const menu = screen.getByRole('menu', { name: MENU_LABEL })
+      const items = within(menu).getAllByRole('menuitem')
+
+      // Move down twice, then up once
+      fireEvent.keyDown(menu, { key: 'ArrowDown' })
+      fireEvent.keyDown(menu, { key: 'ArrowDown' })
+      expect(items[2]).toHaveFocus()
+
+      fireEvent.keyDown(menu, { key: 'ArrowUp' })
+      expect(items[1]).toHaveFocus()
+    })
+
+    it('Home key focuses the first menu item', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      const menu = screen.getByRole('menu', { name: MENU_LABEL })
+      const items = within(menu).getAllByRole('menuitem')
+
+      // Move away from first
+      fireEvent.keyDown(menu, { key: 'ArrowDown' })
+      fireEvent.keyDown(menu, { key: 'ArrowDown' })
+
+      fireEvent.keyDown(menu, { key: 'Home' })
+      expect(items[0]).toHaveFocus()
+    })
+
+    it('End key focuses the last menu item', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      const menu = screen.getByRole('menu', { name: MENU_LABEL })
+      const items = within(menu).getAllByRole('menuitem')
+
+      fireEvent.keyDown(menu, { key: 'End' })
+      expect(items[items.length - 1]).toHaveFocus()
+    })
+
+    it('ArrowDown at last item does not move focus past the end', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      const menu = screen.getByRole('menu', { name: MENU_LABEL })
+      const items = within(menu).getAllByRole('menuitem')
+
+      // Jump to end
+      fireEvent.keyDown(menu, { key: 'End' })
+      const lastItem = items[items.length - 1]
+      expect(lastItem).toHaveFocus()
+
+      // Try to go past end
+      fireEvent.keyDown(menu, { key: 'ArrowDown' })
+      expect(lastItem).toHaveFocus()
+    })
+
+    it('ArrowUp at first item does not move focus before the start', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      const menu = screen.getByRole('menu', { name: MENU_LABEL })
+      const items = within(menu).getAllByRole('menuitem')
+
+      expect(items[0]).toHaveFocus()
+
+      fireEvent.keyDown(menu, { key: 'ArrowUp' })
+      expect(items[0]).toHaveFocus()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // CustomEvent coordination (#8556)
+  // -------------------------------------------------------------------------
+  describe('CustomEvent coordination', () => {
+    it('opening the trigger dispatches a card-menu-open event with the cardId', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+
+      const events: CustomEvent[] = []
+      const handler = (e: Event) => events.push(e as CustomEvent)
+      window.addEventListener('card-menu-open', handler)
+
+      openMenu()
+
+      window.removeEventListener('card-menu-open', handler)
+
+      const menuOpenEvents = events.filter((evt) => evt.type === 'card-menu-open')
+      expect(menuOpenEvents).toHaveLength(1)
+      expect(menuOpenEvents[0].detail).toBe(CARD_ID)
+    })
+
+    it('closes this menu when another card dispatches card-menu-open', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      expect(screen.getByRole('menu', { name: MENU_LABEL })).toBeInTheDocument()
+
+      // Another card opens its menu
+      act(() => {
+        window.dispatchEvent(new CustomEvent('card-menu-open', { detail: 'other-card-id' }))
+      })
+
+      expect(screen.queryByRole('menu', { name: MENU_LABEL })).not.toBeInTheDocument()
+    })
+
+    it('does NOT close when the same cardId dispatches card-menu-open', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      expect(screen.getByRole('menu', { name: MENU_LABEL })).toBeInTheDocument()
+
+      // Same card fires again — should stay open
+      act(() => {
+        window.dispatchEvent(new CustomEvent('card-menu-open', { detail: CARD_ID }))
+      })
+
+      expect(screen.getByRole('menu', { name: MENU_LABEL })).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Outside click dismiss
+  // -------------------------------------------------------------------------
+  describe('outside click', () => {
+    it('closes the menu when clicking outside', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+      openMenu()
+
+      expect(screen.getByRole('menu', { name: MENU_LABEL })).toBeInTheDocument()
+
+      // Click on document body (outside the menu and trigger)
+      fireEvent.mouseDown(document.body)
+
+      expect(screen.queryByRole('menu', { name: MENU_LABEL })).not.toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Conditional rendering
+  // -------------------------------------------------------------------------
+  describe('conditional rendering', () => {
+    it('does not render width/height submenu triggers when handlers are absent', () => {
+      render(
+        <CardActionMenu
+          cardId={CARD_ID}
+          cardType={CARD_TYPE}
+          onConfigure={vi.fn()}
+          onRemove={vi.fn()}
+          onShowWidgetExport={vi.fn()}
+        />,
+      )
+      openMenu()
+
+      // Width and height resize triggers should not be in the DOM
+      expect(screen.queryByTitle('cardWrapper.resizeTooltip')).not.toBeInTheDocument()
+      expect(screen.queryByTitle('cardWrapper.resizeHeightTooltip')).not.toBeInTheDocument()
+
+      // But configure and remove should still be present
+      expect(screen.getByTitle('cardWrapper.configureTooltip')).toBeInTheDocument()
+      expect(screen.getByTitle('cardWrapper.removeTooltip')).toBeInTheDocument()
+    })
+
+    it('toggle: clicking trigger twice opens then closes the menu', () => {
+      render(<CardActionMenu {...defaultProps()} />)
+
+      const trigger = screen.getByRole('button', { name: TRIGGER_LABEL })
+      fireEvent.click(trigger)
+      expect(screen.getByRole('menu', { name: MENU_LABEL })).toBeInTheDocument()
+
+      fireEvent.click(trigger)
+      expect(screen.queryByRole('menu', { name: MENU_LABEL })).not.toBeInTheDocument()
+    })
   })
 })

--- a/web/src/components/cards/card-wrapper/CardActionMenu.test.tsx
+++ b/web/src/components/cards/card-wrapper/CardActionMenu.test.tsx
@@ -5,6 +5,8 @@
  * card-menu-open CustomEvent coordination, outside-click dismiss,
  * and the existing Escape-key focus-restore test.
  *
+ * Incorporates all improvements recommended in Copilot review.
+ *
  * Run from web/:  npx vitest run src/components/cards/card-wrapper/CardActionMenu.test.tsx
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -35,6 +37,9 @@ vi.mock('../../../lib/clipboard', () => ({
 vi.mock('../../../hooks/useDashboardContext', () => ({
   useDashboardContextOptional: () => null,
 }))
+
+// Get a strictly-typed reference to the mocked copyToClipboard function
+const mockedCopyToClipboard = vi.mocked(copyToClipboard)
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -207,8 +212,10 @@ describe('CardActionMenu', () => {
       const widthOptions = getSubMenuItems('cardWrapper.resizeTooltip')
       // WIDTH_LARGE = 6 is the 3rd option (index 2): [3, 4, 6, 8, 12]
       const activeOption = widthOptions[2]
+      
+      // Note: Component uses simple conditional class strings for layout.
+      // Assert for core indicator class presence rather than the whole string.
       expect(activeOption.className).toContain('text-purple-400')
-      expect(activeOption.className).toContain('bg-purple-500/10')
 
       // Another option (first = small) should NOT have active styling
       expect(widthOptions[0].className).not.toContain('text-purple-400')
@@ -272,7 +279,6 @@ describe('CardActionMenu', () => {
       const heightOptions = getSubMenuItems('cardWrapper.resizeHeightTooltip')
       // HEIGHT_DEFAULT = 2 is the 1st option (index 0): [2, 3, 4, 6]
       expect(heightOptions[0].className).toContain('text-purple-400')
-      expect(heightOptions[0].className).toContain('bg-purple-500/10')
 
       // Tall option (index 1) should NOT have active styling
       expect(heightOptions[1].className).not.toContain('text-purple-400')
@@ -363,8 +369,8 @@ describe('CardActionMenu', () => {
       fireEvent.click(getItemByTitle('cardWrapper.copyLinkTooltip'))
 
       const expectedUrl = `${window.location.origin}${window.location.pathname}?card=${CARD_TYPE}`
-      expect(copyToClipboard).toHaveBeenCalledTimes(1)
-      expect(copyToClipboard).toHaveBeenCalledWith(expectedUrl)
+      expect(mockedCopyToClipboard).toHaveBeenCalledTimes(1)
+      expect(mockedCopyToClipboard).toHaveBeenCalledWith(expectedUrl)
 
       // Menu should close after copy
       expect(screen.queryByRole('menu', { name: MENU_LABEL })).not.toBeInTheDocument()
@@ -374,10 +380,8 @@ describe('CardActionMenu', () => {
   // -------------------------------------------------------------------------
   // Keyboard navigation
   //
-  // The component calls `querySelectorAll('button[role="menuitem"]:not([disabled])')`
-  // on the onKeyDown handler's `e.currentTarget`. In jsdom, `document.activeElement`
-  // tracking requires explicit `.focus()` calls, and the useEffect auto-focus
-  // works because the menu portals into the body. We fire keyDown on the menu div.
+  // Anchor keyboard navigation assertions to specific menu items rather than
+  // hardcoded indices. This makes them highly resilient to presentational refactors.
   // -------------------------------------------------------------------------
   describe('keyboard navigation', () => {
     it('ArrowDown moves focus to the next menu item', () => {
@@ -385,13 +389,14 @@ describe('CardActionMenu', () => {
       openMenu()
 
       const menu = screen.getByRole('menu', { name: MENU_LABEL })
-      const items = within(menu).getAllByRole('menuitem')
+      const configureItem = getItemByTitle('cardWrapper.configureTooltip')
+      const copyLinkItem = getItemByTitle('cardWrapper.copyLinkTooltip')
 
-      // After opening, useEffect focuses the first item (Configure)
-      expect(items[0]).toHaveFocus()
+      // Auto-focus defaults to first item (Configure)
+      expect(configureItem).toHaveFocus()
 
       fireEvent.keyDown(menu, { key: 'ArrowDown' })
-      expect(items[1]).toHaveFocus()
+      expect(copyLinkItem).toHaveFocus()
     })
 
     it('ArrowUp moves focus to the previous menu item', () => {
@@ -399,15 +404,18 @@ describe('CardActionMenu', () => {
       openMenu()
 
       const menu = screen.getByRole('menu', { name: MENU_LABEL })
-      const items = within(menu).getAllByRole('menuitem')
+      const configureItem = getItemByTitle('cardWrapper.configureTooltip')
+      const copyLinkItem = getItemByTitle('cardWrapper.copyLinkTooltip')
+      const resizeItem = getItemByTitle('cardWrapper.resizeTooltip')
 
-      // Move down twice, then up once
+      // Move down twice (Configure -> Copy Link -> Resize)
       fireEvent.keyDown(menu, { key: 'ArrowDown' })
       fireEvent.keyDown(menu, { key: 'ArrowDown' })
-      expect(items[2]).toHaveFocus()
+      expect(resizeItem).toHaveFocus()
 
+      // Move up once (Resize -> Copy Link)
       fireEvent.keyDown(menu, { key: 'ArrowUp' })
-      expect(items[1]).toHaveFocus()
+      expect(copyLinkItem).toHaveFocus()
     })
 
     it('Home key focuses the first menu item', () => {
@@ -415,14 +423,14 @@ describe('CardActionMenu', () => {
       openMenu()
 
       const menu = screen.getByRole('menu', { name: MENU_LABEL })
-      const items = within(menu).getAllByRole('menuitem')
+      const configureItem = getItemByTitle('cardWrapper.configureTooltip')
 
-      // Move away from first
+      // Move away
       fireEvent.keyDown(menu, { key: 'ArrowDown' })
       fireEvent.keyDown(menu, { key: 'ArrowDown' })
 
       fireEvent.keyDown(menu, { key: 'Home' })
-      expect(items[0]).toHaveFocus()
+      expect(configureItem).toHaveFocus()
     })
 
     it('End key focuses the last menu item', () => {
@@ -430,10 +438,10 @@ describe('CardActionMenu', () => {
       openMenu()
 
       const menu = screen.getByRole('menu', { name: MENU_LABEL })
-      const items = within(menu).getAllByRole('menuitem')
+      const removeItem = getItemByTitle('cardWrapper.removeTooltip')
 
       fireEvent.keyDown(menu, { key: 'End' })
-      expect(items[items.length - 1]).toHaveFocus()
+      expect(removeItem).toHaveFocus()
     })
 
     it('ArrowDown at last item does not move focus past the end', () => {
@@ -441,16 +449,15 @@ describe('CardActionMenu', () => {
       openMenu()
 
       const menu = screen.getByRole('menu', { name: MENU_LABEL })
-      const items = within(menu).getAllByRole('menuitem')
+      const removeItem = getItemByTitle('cardWrapper.removeTooltip')
 
       // Jump to end
       fireEvent.keyDown(menu, { key: 'End' })
-      const lastItem = items[items.length - 1]
-      expect(lastItem).toHaveFocus()
+      expect(removeItem).toHaveFocus()
 
       // Try to go past end
       fireEvent.keyDown(menu, { key: 'ArrowDown' })
-      expect(lastItem).toHaveFocus()
+      expect(removeItem).toHaveFocus()
     })
 
     it('ArrowUp at first item does not move focus before the start', () => {
@@ -458,12 +465,12 @@ describe('CardActionMenu', () => {
       openMenu()
 
       const menu = screen.getByRole('menu', { name: MENU_LABEL })
-      const items = within(menu).getAllByRole('menuitem')
+      const configureItem = getItemByTitle('cardWrapper.configureTooltip')
 
-      expect(items[0]).toHaveFocus()
+      expect(configureItem).toHaveFocus()
 
       fireEvent.keyDown(menu, { key: 'ArrowUp' })
-      expect(items[0]).toHaveFocus()
+      expect(configureItem).toHaveFocus()
     })
   })
 
@@ -478,13 +485,16 @@ describe('CardActionMenu', () => {
       const handler = (e: Event) => events.push(e as CustomEvent)
       window.addEventListener('card-menu-open', handler)
 
-      openMenu()
+      try {
+        openMenu()
 
-      window.removeEventListener('card-menu-open', handler)
-
-      const menuOpenEvents = events.filter((evt) => evt.type === 'card-menu-open')
-      expect(menuOpenEvents).toHaveLength(1)
-      expect(menuOpenEvents[0].detail).toBe(CARD_ID)
+        const menuOpenEvents = events.filter((evt) => evt.type === 'card-menu-open')
+        expect(menuOpenEvents).toHaveLength(1)
+        expect(menuOpenEvents[0].detail).toBe(CARD_ID)
+      } finally {
+        // Enforce cleanup in finally block to prevent global event listener leaks
+        window.removeEventListener('card-menu-open', handler)
+      }
     })
 
     it('closes this menu when another card dispatches card-menu-open', () => {


### PR DESCRIPTION
## Summary

Extends `CardActionMenu.test.tsx` from **1 test (58 lines)** to **27 tests (~570 lines)** covering all behavioral branches of the 430-line component that powers the three-dot menu on every dashboard card.

Fixes #15539

## What is covered

### Width submenu (4 tests)
- Opens submenu with `aria-expanded=true`
- Fires `onWidthChange(3)` for small, `onWidthChange(12)` for full
- Closes both submenu and main menu on option select
- Highlights active width option with purple styling

### Height submenu (4 tests)
- Opens submenu with `aria-expanded=true`
- Fires `onHeightChange(3)` for tall, `onHeightChange(6)` for maximum
- Closes both menus on option select
- Highlights active height option with purple styling

### Submenu mutual exclusion (3 tests)
- Opening width closes height (and vice versa)
- ArrowLeft closes the active submenu without closing the main menu

### Callbacks (3 tests)
- Configure fires `onConfigure` and closes the menu
- Remove fires `onRemove` and closes the menu
- Copy Link calls `copyToClipboard` with the correct URL pattern

### Keyboard navigation (6 tests)
- ArrowDown/ArrowUp move focus between menu items
- Home focuses first item, End focuses last item
- ArrowDown at last / ArrowUp at first clamp correctly

### CustomEvent coordination (3 tests)
- Trigger dispatches `card-menu-open` with `detail=cardId`
- Menu closes when a different card fires `card-menu-open`
- Menu stays open when the same `cardId` fires

### Outside click & conditional rendering (3 tests)
- `mouseDown` outside closes the menu
- Width/height triggers absent when handlers not provided
- Trigger toggle opens then closes

## Test run

```
✓ src/components/cards/card-wrapper/CardActionMenu.test.tsx (27 tests) 298ms
 Test Files  1 passed (1)
      Tests  27 passed (27)
```

## File changes

| File | Change |
|------|--------|
| `web/src/components/cards/card-wrapper/CardActionMenu.test.tsx` | +540 lines (1 → 27 tests) |

## Related

- LFX Mentorship: #4189
- Source component references: #5253, #7869, #8556, #6463
