### PR TITLE
test: add Vitest unit tests for youtube-playlist and medium-blog Netlify functions

### DIFF
--- a/web/netlify/functions/__tests__/medium-blog.test.ts
+++ b/web/netlify/functions/__tests__/medium-blog.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Vitest unit tests for medium-blog.mts Netlify function (#15655, Part of #4189).
+ *
+ * Covers CORS origin handling, RSS parsing with CDATA, cutoff date filtering,
+ * HTML stripping via DOMPurify, oversized response handling, and upstream
+ * failure modes that currently return 502.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  readJson,
+} from "./netlify-handler-helpers";
+
+import handler from "../medium-blog.mts";
+
+// Named constants for HTTP status codes to prevent magic numbers
+const HTTP_STATUS_OK = 200;
+const HTTP_STATUS_NO_CONTENT = 204;
+const HTTP_STATUS_BAD_GATEWAY = 502;
+
+/** Maximum upstream response size matching the handler constant */
+const MAX_RESPONSE_BYTES = 512 * 1024;
+
+/** Allowed production origin for CORS echoing */
+const PROD_ORIGIN = "https://console.kubestellar.io";
+
+const mockFetch = vi.fn();
+
+// ── Sample Data ──────────────────────────────────────────────────────────────
+
+/** Builds a minimal RSS <item> block with CDATA wrapping (Medium's format) */
+function buildRSSItem(opts: {
+  title: string;
+  link: string;
+  pubDate: string;
+  description?: string;
+  contentEncoded?: string;
+}): string {
+  const descBlock = opts.description
+    ? `<description><![CDATA[${opts.description}]]></description>`
+    : "";
+  const contentBlock = opts.contentEncoded
+    ? `<content:encoded><![CDATA[${opts.contentEncoded}]]></content:encoded>`
+    : "";
+  return `<item>
+    <title><![CDATA[${opts.title}]]></title>
+    <link>${opts.link}</link>
+    <pubDate>${opts.pubDate}</pubDate>
+    ${descBlock}
+    ${contentBlock}
+  </item>`;
+}
+
+/** A valid RSS feed with recent posts (after CUTOFF_DATE 2026-04-07) */
+const SAMPLE_RSS_FEED = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    ${buildRSSItem({
+      title: "KubeStellar v1.0 Released",
+      link: "https://medium.com/@kubestellar/v1-released",
+      pubDate: "Tue, 15 Apr 2026 12:00:00 GMT",
+      description: "<p>We are excited to announce the release of <b>KubeStellar v1.0</b>!</p>",
+    })}
+    ${buildRSSItem({
+      title: "Multi-Cluster at Scale",
+      link: "https://medium.com/@kubestellar/multi-cluster",
+      pubDate: "Mon, 14 Apr 2026 10:00:00 GMT",
+      contentEncoded: "<h2>Scaling Kubernetes</h2><p>Learn how to manage clusters at scale.</p>",
+    })}
+  </channel>
+</rss>`;
+
+/** An RSS feed where all items predate the cutoff */
+const OLD_POSTS_RSS_FEED = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    ${buildRSSItem({
+      title: "Ancient Post",
+      link: "https://medium.com/@kubestellar/ancient",
+      pubDate: "Mon, 01 Jan 2024 10:00:00 GMT",
+      description: "This is very old.",
+    })}
+  </channel>
+</rss>`;
+
+/** An empty RSS feed with no <item> blocks */
+const EMPTY_RSS_FEED = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel></channel></rss>`;
+
+// ── Response Shapes ──────────────────────────────────────────────────────────
+
+interface MediumSuccessResponse {
+  posts: Array<{
+    title: string;
+    link: string;
+    published: string;
+    preview: string;
+  }>;
+  feedUrl: string;
+  channelUrl: string;
+}
+
+interface MediumErrorResponse {
+  error: string;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("medium-blog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("CORS & Preflight", () => {
+    it("returns 204 for OPTIONS preflight", async () => {
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "OPTIONS",
+        headers: { Origin: PROD_ORIGIN },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_NO_CONTENT);
+      expect(res.headers.get("access-control-allow-methods")).toContain("GET");
+      expect(res.headers.get("access-control-allow-methods")).toContain("OPTIONS");
+    });
+
+    it("echoes allowed origin in CORS response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(SAMPLE_RSS_FEED, {
+          status: 200,
+          headers: { "content-length": String(SAMPLE_RSS_FEED.length) },
+        })
+      );
+
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "GET",
+        headers: { Origin: PROD_ORIGIN },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_OK);
+      expect(res.headers.get("access-control-allow-origin")).toBe(PROD_ORIGIN);
+    });
+
+    it("falls back to default origin for disallowed origin", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(SAMPLE_RSS_FEED, {
+          status: 200,
+          headers: { "content-length": String(SAMPLE_RSS_FEED.length) },
+        })
+      );
+
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "GET",
+        headers: { Origin: "https://evil.example.com" },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_OK);
+      expect(res.headers.get("access-control-allow-origin")).toBe(PROD_ORIGIN);
+    });
+  });
+
+  describe("Success Path & Feed Parsing", () => {
+    it("parses valid RSS feed with CDATA-wrapped titles and descriptions", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(SAMPLE_RSS_FEED, {
+          status: 200,
+          headers: { "content-length": String(SAMPLE_RSS_FEED.length) },
+        })
+      );
+
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "GET",
+        headers: { Origin: PROD_ORIGIN },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_OK);
+
+      const body = await readJson<MediumSuccessResponse>(res);
+      expect(body.posts).toHaveLength(2);
+      expect(body.posts[0].title).toBe("KubeStellar v1.0 Released");
+      expect(body.posts[0].link).toBe("https://medium.com/@kubestellar/v1-released");
+      expect(body.feedUrl).toContain("medium.com/feed/@kubestellar");
+      expect(body.channelUrl).toContain("medium.com/@kubestellar");
+    });
+
+    it("strips HTML tags from preview text", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(SAMPLE_RSS_FEED, {
+          status: 200,
+          headers: { "content-length": String(SAMPLE_RSS_FEED.length) },
+        })
+      );
+
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "GET",
+        headers: { Origin: PROD_ORIGIN },
+      });
+      const res = await handler(req);
+      const body = await readJson<MediumSuccessResponse>(res);
+
+      // First post uses <description> with <p> and <b> tags
+      expect(body.posts[0].preview).not.toContain("<p>");
+      expect(body.posts[0].preview).not.toContain("<b>");
+      expect(body.posts[0].preview).toContain("KubeStellar v1.0");
+
+      // Second post uses <content:encoded> with <h2> and <p> tags
+      expect(body.posts[1].preview).not.toContain("<h2>");
+      expect(body.posts[1].preview).not.toContain("<p>");
+      expect(body.posts[1].preview).toContain("Scaling Kubernetes");
+    });
+
+    it("filters out posts published before the cutoff date", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(OLD_POSTS_RSS_FEED, {
+          status: 200,
+          headers: { "content-length": String(OLD_POSTS_RSS_FEED.length) },
+        })
+      );
+
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "GET",
+        headers: { Origin: PROD_ORIGIN },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_OK);
+
+      const body = await readJson<MediumSuccessResponse>(res);
+      expect(body.posts).toHaveLength(0);
+    });
+
+    it("returns empty posts array when feed has no items", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(EMPTY_RSS_FEED, {
+          status: 200,
+          headers: { "content-length": String(EMPTY_RSS_FEED.length) },
+        })
+      );
+
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "GET",
+        headers: { Origin: PROD_ORIGIN },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_OK);
+
+      const body = await readJson<MediumSuccessResponse>(res);
+      expect(body.posts).toEqual([]);
+    });
+  });
+
+  describe("Error Handling (502 Contracts)", () => {
+    it("returns 502 when upstream returns 4xx status", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response("", { status: 404, statusText: "Not Found" })
+      );
+
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "GET",
+        headers: { Origin: PROD_ORIGIN },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_BAD_GATEWAY);
+
+      const body = await readJson<MediumErrorResponse>(res);
+      expect(body.error).toBe("upstream request failed");
+    });
+
+    it("returns 502 when upstream returns 5xx status", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response("", { status: 503, statusText: "Service Unavailable" })
+      );
+
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "GET",
+        headers: { Origin: PROD_ORIGIN },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_BAD_GATEWAY);
+
+      const body = await readJson<MediumErrorResponse>(res);
+      expect(body.error).toBe("upstream request failed");
+    });
+
+    it("returns 502 when content-length exceeds MAX_RESPONSE_BYTES", async () => {
+      const oversizedLength = MAX_RESPONSE_BYTES + 1;
+      mockFetch.mockResolvedValueOnce(
+        new Response("x", {
+          status: 200,
+          headers: { "content-length": String(oversizedLength) },
+        })
+      );
+
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "GET",
+        headers: { Origin: PROD_ORIGIN },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_BAD_GATEWAY);
+
+      const body = await readJson<MediumErrorResponse>(res);
+      expect(body.error).toBe("upstream response too large");
+    });
+
+    it("returns 502 when response body exceeds MAX_RESPONSE_BYTES", async () => {
+      const oversizedBody = "a".repeat(MAX_RESPONSE_BYTES + 1);
+      mockFetch.mockResolvedValueOnce(
+        new Response(oversizedBody, {
+          status: 200,
+          headers: { "content-length": "0" },
+        })
+      );
+
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "GET",
+        headers: { Origin: PROD_ORIGIN },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_BAD_GATEWAY);
+
+      const body = await readJson<MediumErrorResponse>(res);
+      expect(body.error).toBe("upstream response too large");
+    });
+
+    it("returns 502 when network fetch throws an error", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("DNS resolution failed"));
+
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "GET",
+        headers: { Origin: PROD_ORIGIN },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_BAD_GATEWAY);
+
+      const body = await readJson<MediumErrorResponse>(res);
+      expect(body.error).toBe("Failed to fetch blog");
+    });
+  });
+
+  describe("Response Headers", () => {
+    it("includes Cache-Control public, max-age=3600 on success", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(SAMPLE_RSS_FEED, {
+          status: 200,
+          headers: { "content-length": String(SAMPLE_RSS_FEED.length) },
+        })
+      );
+
+      const req = new Request("https://console.kubestellar.io/.netlify/functions/medium-blog", {
+        method: "GET",
+        headers: { Origin: PROD_ORIGIN },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_OK);
+      expect(res.headers.get("cache-control")).toBe("public, max-age=3600");
+      expect(res.headers.get("content-type")).toBe("application/json");
+    });
+  });
+});

--- a/web/netlify/functions/__tests__/medium-blog.test.ts
+++ b/web/netlify/functions/__tests__/medium-blog.test.ts
@@ -10,15 +10,18 @@ import {
   readJson,
 } from "./netlify-handler-helpers";
 
-import handler from "../medium-blog.mts";
+import handler, { MAX_RESPONSE_BYTES } from "../medium-blog.mts";
 
 // Named constants for HTTP status codes to prevent magic numbers
 const HTTP_STATUS_OK = 200;
 const HTTP_STATUS_NO_CONTENT = 204;
 const HTTP_STATUS_BAD_GATEWAY = 502;
 
-/** Maximum upstream response size matching the handler constant */
-const MAX_RESPONSE_BYTES = 512 * 1024;
+/**
+ * Oversized response test threshold: exactly one byte above the max so the test
+ * continues to validate the intended boundary condition dynamically.
+ */
+const TEST_OVERSIZED_RESPONSE_BYTES = MAX_RESPONSE_BYTES + 1;
 
 /** Allowed production origin for CORS echoing */
 const PROD_ORIGIN = "https://console.kubestellar.io";
@@ -201,6 +204,7 @@ describe("medium-blog", () => {
         headers: { Origin: PROD_ORIGIN },
       });
       const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_OK);
       const body = await readJson<MediumSuccessResponse>(res);
 
       // First post uses <description> with <p> and <b> tags
@@ -287,7 +291,7 @@ describe("medium-blog", () => {
     });
 
     it("returns 502 when content-length exceeds MAX_RESPONSE_BYTES", async () => {
-      const oversizedLength = MAX_RESPONSE_BYTES + 1;
+      const oversizedLength = TEST_OVERSIZED_RESPONSE_BYTES;
       mockFetch.mockResolvedValueOnce(
         new Response("x", {
           status: 200,
@@ -307,7 +311,7 @@ describe("medium-blog", () => {
     });
 
     it("returns 502 when response body exceeds MAX_RESPONSE_BYTES", async () => {
-      const oversizedBody = "a".repeat(MAX_RESPONSE_BYTES + 1);
+      const oversizedBody = "a".repeat(TEST_OVERSIZED_RESPONSE_BYTES);
       mockFetch.mockResolvedValueOnce(
         new Response(oversizedBody, {
           status: 200,

--- a/web/netlify/functions/__tests__/youtube-playlist.test.ts
+++ b/web/netlify/functions/__tests__/youtube-playlist.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Vitest unit tests for youtube-playlist.mts Netlify function (#15655, Part of #4189).
+ *
+ * Covers Invidious API primary path, RSS fallback, feed parsing,
+ * oversized response handling, and upstream failure modes.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  TEST_CORS_ORIGIN,
+  makeNetlifyRequest,
+  readJson,
+} from "./netlify-handler-helpers";
+
+import handler from "../youtube-playlist.mts";
+
+// Named constants for HTTP status codes to prevent magic numbers
+const HTTP_STATUS_OK = 200;
+const HTTP_STATUS_NO_CONTENT = 204;
+const HTTP_STATUS_FORBIDDEN = 403;
+const HTTP_STATUS_BAD_GATEWAY = 502;
+
+/** Maximum upstream response size matching the handler constant */
+const MAX_RESPONSE_BYTES = 512_000;
+
+const mockFetch = vi.fn();
+
+// ── Sample Data ──────────────────────────────────────────────────────────────
+
+/** Simulates a valid Invidious API JSON response */
+const SAMPLE_INVIDIOUS_RESPONSE = {
+  videos: [
+    { videoId: "abc123", title: "Getting Started with KubeStellar" },
+    { videoId: "def456", title: "KubeStellar Architecture Deep Dive" },
+  ],
+};
+
+/** Simulates a valid YouTube Atom RSS feed with <entry> blocks */
+const SAMPLE_ATOM_FEED = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+      xmlns:media="http://search.yahoo.com/mrss/">
+  <entry>
+    <yt:videoId>rss001</yt:videoId>
+    <title>KubeStellar Demo</title>
+    <media:description>A demo video</media:description>
+    <published>2026-05-20T10:00:00Z</published>
+  </entry>
+  <entry>
+    <yt:videoId>rss002</yt:videoId>
+    <title>KubeStellar Tutorial</title>
+    <published>2026-05-21T10:00:00Z</published>
+  </entry>
+</feed>`;
+
+/** Atom feed with no <entry> blocks */
+const EMPTY_ATOM_FEED = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"></feed>`;
+
+// ── Response Shapes ──────────────────────────────────────────────────────────
+
+interface PlaylistSuccessResponse {
+  videos: Array<{ id: string; title: string; description?: string; published?: string }>;
+  playlistId: string;
+  playlistUrl: string;
+}
+
+interface PlaylistErrorResponse {
+  error: string;
+  videos?: unknown[];
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("youtube-playlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("CORS & Preflight", () => {
+    it("returns 204 for OPTIONS preflight from allowed origin", async () => {
+      const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist", {
+        method: "OPTIONS",
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_NO_CONTENT);
+    });
+
+    it("returns 403 for OPTIONS preflight from disallowed origin", async () => {
+      const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist", {
+        method: "OPTIONS",
+        origin: "https://evil.example.com",
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_FORBIDDEN);
+    });
+  });
+
+  describe("Invidious API Primary Path", () => {
+    it("returns videos from the first successful Invidious instance", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify(SAMPLE_INVIDIOUS_RESPONSE), {
+          status: 200,
+          headers: { "content-length": "200" },
+        })
+      );
+
+      const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_OK);
+
+      const body = await readJson<PlaylistSuccessResponse>(res);
+      expect(body.videos).toHaveLength(2);
+      expect(body.videos[0].id).toBe("abc123");
+      expect(body.videos[0].title).toBe("Getting Started with KubeStellar");
+      expect(body.videos[1].id).toBe("def456");
+      expect(body.playlistId).toBeTruthy();
+      expect(body.playlistUrl).toContain("youtube.com/playlist");
+    });
+
+    it("skips Invidious instance with empty videos array and falls back", async () => {
+      // First Invidious instance returns empty videos array
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ videos: [] }), {
+          status: 200,
+          headers: { "content-length": "20" },
+        })
+      );
+      // Second Invidious instance also empty
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ videos: [] }), {
+          status: 200,
+          headers: { "content-length": "20" },
+        })
+      );
+      // Third Invidious instance also empty
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ videos: [] }), {
+          status: 200,
+          headers: { "content-length": "20" },
+        })
+      );
+      // RSS fallback succeeds
+      mockFetch.mockResolvedValueOnce(
+        new Response(SAMPLE_ATOM_FEED, {
+          status: 200,
+          headers: { "content-length": String(SAMPLE_ATOM_FEED.length) },
+        })
+      );
+
+      const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_OK);
+
+      const body = await readJson<PlaylistSuccessResponse>(res);
+      expect(body.videos).toHaveLength(2);
+      expect(body.videos[0].id).toBe("rss001");
+      expect(body.videos[0].title).toBe("KubeStellar Demo");
+    });
+
+    it("skips Invidious instances with oversized content-length", async () => {
+      const oversizedLength = MAX_RESPONSE_BYTES + 1;
+      // All 3 Invidious instances return oversized content-length
+      for (let i = 0; i < 3; i++) {
+        mockFetch.mockResolvedValueOnce(
+          new Response(JSON.stringify(SAMPLE_INVIDIOUS_RESPONSE), {
+            status: 200,
+            headers: { "content-length": String(oversizedLength) },
+          })
+        );
+      }
+      // RSS fallback succeeds
+      mockFetch.mockResolvedValueOnce(
+        new Response(SAMPLE_ATOM_FEED, {
+          status: 200,
+          headers: { "content-length": String(SAMPLE_ATOM_FEED.length) },
+        })
+      );
+
+      const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_OK);
+
+      const body = await readJson<PlaylistSuccessResponse>(res);
+      expect(body.videos[0].id).toBe("rss001");
+    });
+  });
+
+  describe("RSS Feed Fallback Path", () => {
+    /** Helper: make all 3 Invidious instances fail, then return given RSS response */
+    function mockAllInvidiousFailed(): void {
+      for (let i = 0; i < 3; i++) {
+        mockFetch.mockRejectedValueOnce(new Error("Invidious timeout"));
+      }
+    }
+
+    it("parses Atom feed entries with description and published fields", async () => {
+      mockAllInvidiousFailed();
+      mockFetch.mockResolvedValueOnce(
+        new Response(SAMPLE_ATOM_FEED, {
+          status: 200,
+          headers: { "content-length": String(SAMPLE_ATOM_FEED.length) },
+        })
+      );
+
+      const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_OK);
+
+      const body = await readJson<PlaylistSuccessResponse>(res);
+      expect(body.videos).toHaveLength(2);
+      expect(body.videos[0].id).toBe("rss001");
+      expect(body.videos[0].title).toBe("KubeStellar Demo");
+      expect(body.videos[0].description).toBe("A demo video");
+      expect(body.videos[0].published).toBe("2026-05-20T10:00:00Z");
+      // Second entry has no media:description → undefined
+      expect(body.videos[1].description).toBeUndefined();
+    });
+
+    it("returns 502 with empty videos array when RSS feed has no entries", async () => {
+      mockAllInvidiousFailed();
+      mockFetch.mockResolvedValueOnce(
+        new Response(EMPTY_ATOM_FEED, {
+          status: 200,
+          headers: { "content-length": String(EMPTY_ATOM_FEED.length) },
+        })
+      );
+
+      const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_BAD_GATEWAY);
+
+      const body = await readJson<PlaylistErrorResponse>(res);
+      expect(body.error).toBe("All video sources unavailable");
+      expect(body.videos).toEqual([]);
+    });
+
+    it("returns 502 when RSS upstream returns non-ok status", async () => {
+      mockAllInvidiousFailed();
+      mockFetch.mockResolvedValueOnce(
+        new Response("", { status: 500, statusText: "Internal Server Error" })
+      );
+
+      const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_BAD_GATEWAY);
+
+      const body = await readJson<PlaylistErrorResponse>(res);
+      expect(body.error).toBe("All video sources unavailable");
+    });
+
+    it("returns 502 when RSS response body exceeds size limit", async () => {
+      mockAllInvidiousFailed();
+      const oversizedLength = MAX_RESPONSE_BYTES + 1;
+      mockFetch.mockResolvedValueOnce(
+        new Response("x".repeat(1000), {
+          status: 200,
+          headers: { "content-length": String(oversizedLength) },
+        })
+      );
+
+      const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_BAD_GATEWAY);
+
+      const body = await readJson<PlaylistErrorResponse>(res);
+      expect(body.error).toBe("Upstream response too large");
+      expect(body.videos).toEqual([]);
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("returns 502 when all fetch sources throw network errors", async () => {
+      // 3 Invidious + 1 RSS all fail
+      mockFetch.mockRejectedValue(new Error("Network unreachable"));
+
+      const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_BAD_GATEWAY);
+
+      const body = await readJson<PlaylistErrorResponse>(res);
+      expect(body.error).toBe("Internal server error");
+    });
+  });
+
+  describe("Response Headers", () => {
+    it("includes Cache-Control public, max-age=300 on success", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify(SAMPLE_INVIDIOUS_RESPONSE), {
+          status: 200,
+          headers: { "content-length": "200" },
+        })
+      );
+
+      const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
+      const res = await handler(req);
+      expect(res.status).toBe(HTTP_STATUS_OK);
+      expect(res.headers.get("cache-control")).toBe("public, max-age=300");
+      expect(res.headers.get("content-type")).toBe("application/json");
+    });
+  });
+});

--- a/web/netlify/functions/__tests__/youtube-playlist.test.ts
+++ b/web/netlify/functions/__tests__/youtube-playlist.test.ts
@@ -6,12 +6,11 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  TEST_CORS_ORIGIN,
   makeNetlifyRequest,
   readJson,
 } from "./netlify-handler-helpers";
 
-import handler from "../youtube-playlist.mts";
+import handler, { MAX_RESPONSE_BYTES } from "../youtube-playlist.mts";
 
 // Named constants for HTTP status codes to prevent magic numbers
 const HTTP_STATUS_OK = 200;
@@ -19,8 +18,11 @@ const HTTP_STATUS_NO_CONTENT = 204;
 const HTTP_STATUS_FORBIDDEN = 403;
 const HTTP_STATUS_BAD_GATEWAY = 502;
 
-/** Maximum upstream response size matching the handler constant */
-const MAX_RESPONSE_BYTES = 512_000;
+/**
+ * Oversized response test threshold: exactly one byte above the max so the test
+ * continues to validate the intended boundary condition dynamically.
+ */
+const TEST_OVERSIZED_RESPONSE_BYTES = MAX_RESPONSE_BYTES + 1;
 
 const mockFetch = vi.fn();
 
@@ -103,12 +105,16 @@ describe("youtube-playlist", () => {
 
   describe("Invidious API Primary Path", () => {
     it("returns videos from the first successful Invidious instance", async () => {
-      mockFetch.mockResolvedValueOnce(
-        new Response(JSON.stringify(SAMPLE_INVIDIOUS_RESPONSE), {
-          status: 200,
-          headers: { "content-length": "200" },
-        })
-      );
+      mockFetch.mockImplementation(async (input) => {
+        const url = typeof input === "string" ? input : (input as Request).url || input.toString();
+        if (url.includes("/api/v1/playlists/")) {
+          return new Response(JSON.stringify(SAMPLE_INVIDIOUS_RESPONSE), {
+            status: 200,
+            headers: { "content-length": "200" },
+          });
+        }
+        return new Response("", { status: 404 });
+      });
 
       const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
       const res = await handler(req);
@@ -124,34 +130,22 @@ describe("youtube-playlist", () => {
     });
 
     it("skips Invidious instance with empty videos array and falls back", async () => {
-      // First Invidious instance returns empty videos array
-      mockFetch.mockResolvedValueOnce(
-        new Response(JSON.stringify({ videos: [] }), {
-          status: 200,
-          headers: { "content-length": "20" },
-        })
-      );
-      // Second Invidious instance also empty
-      mockFetch.mockResolvedValueOnce(
-        new Response(JSON.stringify({ videos: [] }), {
-          status: 200,
-          headers: { "content-length": "20" },
-        })
-      );
-      // Third Invidious instance also empty
-      mockFetch.mockResolvedValueOnce(
-        new Response(JSON.stringify({ videos: [] }), {
-          status: 200,
-          headers: { "content-length": "20" },
-        })
-      );
-      // RSS fallback succeeds
-      mockFetch.mockResolvedValueOnce(
-        new Response(SAMPLE_ATOM_FEED, {
-          status: 200,
-          headers: { "content-length": String(SAMPLE_ATOM_FEED.length) },
-        })
-      );
+      mockFetch.mockImplementation(async (input) => {
+        const url = typeof input === "string" ? input : (input as Request).url || input.toString();
+        if (url.includes("/api/v1/playlists/")) {
+          return new Response(JSON.stringify({ videos: [] }), {
+            status: 200,
+            headers: { "content-length": "20" },
+          });
+        }
+        if (url.includes("/feeds/videos.xml")) {
+          return new Response(SAMPLE_ATOM_FEED, {
+            status: 200,
+            headers: { "content-length": String(SAMPLE_ATOM_FEED.length) },
+          });
+        }
+        return new Response("", { status: 404 });
+      });
 
       const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
       const res = await handler(req);
@@ -164,23 +158,22 @@ describe("youtube-playlist", () => {
     });
 
     it("skips Invidious instances with oversized content-length", async () => {
-      const oversizedLength = MAX_RESPONSE_BYTES + 1;
-      // All 3 Invidious instances return oversized content-length
-      for (let i = 0; i < 3; i++) {
-        mockFetch.mockResolvedValueOnce(
-          new Response(JSON.stringify(SAMPLE_INVIDIOUS_RESPONSE), {
+      mockFetch.mockImplementation(async (input) => {
+        const url = typeof input === "string" ? input : (input as Request).url || input.toString();
+        if (url.includes("/api/v1/playlists/")) {
+          return new Response(JSON.stringify(SAMPLE_INVIDIOUS_RESPONSE), {
             status: 200,
-            headers: { "content-length": String(oversizedLength) },
-          })
-        );
-      }
-      // RSS fallback succeeds
-      mockFetch.mockResolvedValueOnce(
-        new Response(SAMPLE_ATOM_FEED, {
-          status: 200,
-          headers: { "content-length": String(SAMPLE_ATOM_FEED.length) },
-        })
-      );
+            headers: { "content-length": String(TEST_OVERSIZED_RESPONSE_BYTES) },
+          });
+        }
+        if (url.includes("/feeds/videos.xml")) {
+          return new Response(SAMPLE_ATOM_FEED, {
+            status: 200,
+            headers: { "content-length": String(SAMPLE_ATOM_FEED.length) },
+          });
+        }
+        return new Response("", { status: 404 });
+      });
 
       const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
       const res = await handler(req);
@@ -192,21 +185,25 @@ describe("youtube-playlist", () => {
   });
 
   describe("RSS Feed Fallback Path", () => {
-    /** Helper: make all 3 Invidious instances fail, then return given RSS response */
-    function mockAllInvidiousFailed(): void {
-      for (let i = 0; i < 3; i++) {
-        mockFetch.mockRejectedValueOnce(new Error("Invidious timeout"));
-      }
+    /** Helper: make all Invidious instance calls fail, then return specific RSS response */
+    function mockAllInvidiousFailed(rssResponse?: Response): void {
+      mockFetch.mockImplementation(async (input) => {
+        const url = typeof input === "string" ? input : (input as Request).url || input.toString();
+        if (url.includes("/api/v1/playlists/")) {
+          throw new Error("Invidious timeout");
+        }
+        if (url.includes("/feeds/videos.xml")) {
+          return rssResponse || new Response(SAMPLE_ATOM_FEED, {
+            status: 200,
+            headers: { "content-length": String(SAMPLE_ATOM_FEED.length) },
+          });
+        }
+        return new Response("", { status: 404 });
+      });
     }
 
     it("parses Atom feed entries with description and published fields", async () => {
       mockAllInvidiousFailed();
-      mockFetch.mockResolvedValueOnce(
-        new Response(SAMPLE_ATOM_FEED, {
-          status: 200,
-          headers: { "content-length": String(SAMPLE_ATOM_FEED.length) },
-        })
-      );
 
       const req = makeNetlifyRequest("/.netlify/functions/youtube-playlist");
       const res = await handler(req);
@@ -223,8 +220,7 @@ describe("youtube-playlist", () => {
     });
 
     it("returns 502 with empty videos array when RSS feed has no entries", async () => {
-      mockAllInvidiousFailed();
-      mockFetch.mockResolvedValueOnce(
+      mockAllInvidiousFailed(
         new Response(EMPTY_ATOM_FEED, {
           status: 200,
           headers: { "content-length": String(EMPTY_ATOM_FEED.length) },
@@ -241,8 +237,7 @@ describe("youtube-playlist", () => {
     });
 
     it("returns 502 when RSS upstream returns non-ok status", async () => {
-      mockAllInvidiousFailed();
-      mockFetch.mockResolvedValueOnce(
+      mockAllInvidiousFailed(
         new Response("", { status: 500, statusText: "Internal Server Error" })
       );
 
@@ -255,12 +250,10 @@ describe("youtube-playlist", () => {
     });
 
     it("returns 502 when RSS response body exceeds size limit", async () => {
-      mockAllInvidiousFailed();
-      const oversizedLength = MAX_RESPONSE_BYTES + 1;
-      mockFetch.mockResolvedValueOnce(
+      mockAllInvidiousFailed(
         new Response("x".repeat(1000), {
           status: 200,
-          headers: { "content-length": String(oversizedLength) },
+          headers: { "content-length": String(TEST_OVERSIZED_RESPONSE_BYTES) },
         })
       );
 

--- a/web/netlify/functions/medium-blog.mts
+++ b/web/netlify/functions/medium-blog.mts
@@ -24,7 +24,7 @@ const MAX_POSTS = 3;
 const PREVIEW_MAX_LEN = 200;
 
 /** Maximum upstream response size (512 KB) — reject unexpectedly large feeds */
-const MAX_RESPONSE_BYTES = 512 * 1024;
+export const MAX_RESPONSE_BYTES = 512 * 1024;
 
 const ALLOWED_ORIGINS = [
   "https://console.kubestellar.io",

--- a/web/netlify/functions/youtube-playlist.mts
+++ b/web/netlify/functions/youtube-playlist.mts
@@ -10,7 +10,7 @@ import { buildCorsHeaders, handlePreflight } from "./_shared"
 
 const PLAYLIST_ID = "PL1ALKGr_qZKc-xehA_8iUCdiKsCo6p6nD";
 const FEED_URL = `https://www.youtube.com/feeds/videos.xml?playlist_id=${PLAYLIST_ID}`;
-const MAX_RESPONSE_BYTES = 512_000; // 512 KB — playlist data is typically < 100 KB
+export const MAX_RESPONSE_BYTES = 512_000; // 512 KB — playlist data is typically < 100 KB
 
 interface PlaylistVideo {
   id: string;


### PR DESCRIPTION
Closes #15655

## Summary
This PR adds comprehensive Vitest unit test suites for the `youtube-playlist.mts` and `medium-blog.mts` Netlify functions, closing a critical test coverage gap for two homepage-facing content feed endpoints.

## youtube-playlist.mts (11 tests)
- **CORS Preflight**: Validates 204 for allowed origins and 403 for disallowed origins
- **Invidious API Primary Path**: Verifies correct video mapping from the first successful instance, empty-array fallback to RSS, and oversized response skipping
- **RSS Feed Fallback**: Tests Atom feed parsing with description/published fields, empty feed → 502 with `videos:[]`, non-ok upstream → 502, oversized RSS → 502
- **Error Handling**: All fetch sources reject → 502 "Internal server error"
- **Response Headers**: Verifies `Cache-Control: public, max-age=300`

## medium-blog.mts (13 tests)
- **CORS**: Origin echoing for allowed origins, fallback to `https://console.kubestellar.io` for disallowed
- **Feed Parsing**: CDATA-wrapped titles and `content:encoded`, HTML tag stripping via DOMPurify, cutoff date filtering (pre-2026-04-07 excluded)
- **Error Contracts (502)**: Upstream 4xx → 502, 5xx → 502, oversized content-length → 502, oversized body → 502, network failure → 502 "Failed to fetch blog"
- **Response Headers**: Verifies `Cache-Control: public, max-age=3600`

## Verification
- `youtube-playlist.test.ts`: **11/11 tests pass** ✓
- `medium-blog.test.ts`: **13/13 tests pass** ✓
- Full Netlify test suite: **21/21 files, 211/211 tests pass** ✓

Related mentorship issue: LFX Mentorship: AI-Driven Test Coverage Architect for KubeStellar Console #4189