### PR TITLE
🐛 Fix quantum-proxy validator rejecting real Control Panel payloads

### DIFF
--- a/web/netlify/functions/__tests__/quantum-proxy.test.ts
+++ b/web/netlify/functions/__tests__/quantum-proxy.test.ts
@@ -330,39 +330,7 @@ describe("quantum-proxy", () => {
       expect(body.error).toBe("Request body must be a JSON object");
     });
 
-    it("returns 400 when POST request body is missing 'circuit' for /execute", async () => {
-      const req = new Request("https://example.test/.netlify/functions/quantum-proxy/execute", {
-        method: "POST",
-        headers: {
-          Origin: TEST_CORS_ORIGIN,
-          authorization: "Bearer token",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ otherKey: "val" }),
-      });
-      const res = await handler(req, contextWithEnv);
-      expect(res.status).toBe(HTTP_STATUS_BAD_REQUEST);
-      const body = await readJson<{ error: string }>(res);
-      expect(body.error).toBe('Request body must be an object with a non-empty "circuit" string');
-    });
-
-    it("returns 400 when POST request body for /loop/stop is not empty", async () => {
-      const req = new Request("https://example.test/.netlify/functions/quantum-proxy/loop/stop", {
-        method: "POST",
-        headers: {
-          Origin: TEST_CORS_ORIGIN,
-          authorization: "Bearer token",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ loop_id: "demo" }),
-      });
-      const res = await handler(req, contextWithEnv);
-      expect(res.status).toBe(HTTP_STATUS_BAD_REQUEST);
-      const body = await readJson<{ error: string }>(res);
-      expect(body.error).toBe("Request body for /loop/stop must be empty");
-    });
-
-    it("proxies POST request successfully to upstream when validation passes", async () => {
+    it("proxies POST request to upstream with the panel's real body shape", async () => {
       const fetchMock = vi.fn().mockResolvedValue(
         new Response(JSON.stringify({ job_id: "upstream-job-42" }), {
           status: HTTP_STATUS_CREATED,
@@ -378,7 +346,7 @@ describe("quantum-proxy", () => {
           authorization: "Bearer token",
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ circuit: "OPENQASM 2.0; qreg q[1];" }),
+        body: JSON.stringify({ backend: "aer_simulator", shots: 1024, qasm_file: "bell.qasm" }),
       });
       const res = await handler(req, contextWithEnv);
 
@@ -390,7 +358,30 @@ describe("quantum-proxy", () => {
       const firstCallInit = fetchMock.mock.calls[0][1] as RequestInit;
       expect(firstCallInit.method).toBe("POST");
       const passedBody = JSON.parse(firstCallInit.body as string);
-      expect(passedBody.circuit).toBe("OPENQASM 2.0; qreg q[1];");
+      expect(passedBody.qasm_file).toBe("bell.qasm");
+      expect(passedBody.shots).toBe(1024);
+    });
+
+    it("accepts empty body on /loop/start (panel sends none)", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ status: "started" }), {
+          status: HTTP_STATUS_OK,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const req = new Request("https://example.test/.netlify/functions/quantum-proxy/loop/start", {
+        method: "POST",
+        headers: {
+          Origin: TEST_CORS_ORIGIN,
+          authorization: "Bearer token",
+          "Content-Type": "application/json",
+        },
+      });
+      const res = await handler(req, contextWithEnv);
+      expect(res.status).toBe(HTTP_STATUS_OK);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it("returns 502 when upstream response content-length header exceeds MAX_RESPONSE_BYTES", async () => {

--- a/web/netlify/functions/quantum-proxy.mts
+++ b/web/netlify/functions/quantum-proxy.mts
@@ -82,8 +82,6 @@ const PROXY_TIMEOUT_MS = 15_000;
 const MAX_PROXY_BODY_BYTES = 1_048_576;
 const MAX_RESPONSE_BYTES = 1_048_576;
 const ALLOWED_METHODS = new Set(["GET", "POST"]);
-const CIRCUIT_POST_PATHS = new Set(["/execute", "/loop/start"]);
-const LOOP_STOP_PATH = "/loop/stop";
 const OVERSIZED_RESPONSE_ERROR = "Upstream response too large";
 
 function isAllowedPath(path: string): boolean {
@@ -102,7 +100,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function validatePostBody(path: string, requestBody: string): string | null {
+function validatePostBody(requestBody: string): string | null {
   const trimmedBody = requestBody.trim();
   let parsedBody: unknown;
 
@@ -114,16 +112,6 @@ function validatePostBody(path: string, requestBody: string): string | null {
 
   if (!isPlainObject(parsedBody)) {
     return "Request body must be a JSON object";
-  }
-
-  if (CIRCUIT_POST_PATHS.has(path)) {
-    if (Object.keys(parsedBody).length !== 1 || typeof parsedBody.circuit !== "string" || parsedBody.circuit.trim() === "") {
-      return 'Request body must be an object with a non-empty "circuit" string';
-    }
-  }
-
-  if (path === LOOP_STOP_PATH && Object.keys(parsedBody).length !== 0) {
-    return "Request body for /loop/stop must be empty";
   }
 
   return null;
@@ -321,7 +309,7 @@ export default async (req: Request, context: Context): Promise<Response> => {
     }
     const requestBody = req.method === "GET" ? undefined : await req.text();
     if (req.method === "POST" && requestBody !== undefined) {
-      const validationError = validatePostBody(path, requestBody);
+      const validationError = validatePostBody(requestBody);
       if (validationError) {
         return new Response(JSON.stringify({ error: validationError }), {
           status: 400,


### PR DESCRIPTION
## Summary

- Remove the hallucinated `{circuit: string}` body-shape check from `quantum-proxy.mts` `validatePostBody()`
- The check rejected every real Quantum Control Panel POST to `/execute` and `/loop/start` on the hosted site (HTTP 400)
- Path allowlist, `isPlainObject` check, request/response size caps, and rate limit all preserved

Fixes #15819 (regression from #15254)

## Why

The validator added in #15254 required POSTs to `/execute` and `/loop/start` to match `{ circuit: "<string>" }`. The quantum-kc-demo backend has no `circuit` field — `QuantumControlPanel.tsx` sends `{backend, shots, qasm_file}` to `/execute` and an empty body to `/loop/start`. Result: every Execute click and Loop toggle on console.kubestellar.io returned 400.

The Go backend (`pkg/api/handlers/quantum_proxy.go`) doesn't enforce this shape, so local dev was unaffected — only the Netlify-hosted site broke.

The schema check adds ~no security value: the actual quantum-kc-demo backend validates its own inputs. Keeping the path allowlist, JSON-object check, and 1 MB body cap preserves all the real defenses.

## What changed

`web/netlify/functions/quantum-proxy.mts`:
- Drop `CIRCUIT_POST_PATHS` constant and the `if (CIRCUIT_POST_PATHS.has(path)) { ... }` block
- Drop the `LOOP_STOP_PATH` empty-body requirement (the panel sends empty bodies for both `/loop/start` and `/loop/stop`; rejecting non-empty would also misalign with the backend)
- Keep `isPlainObject` check, path allowlist, body size cap, response size cap

## Test plan

- [ ] `validatePostBody` reproducer (see issue) confirms the real payloads now pass
- [ ] Existing Vitest suite for `quantum-proxy` (if any) passes
- [ ] Manual: deploy preview → click Execute on Quantum Control Panel → 200 + job submitted
- [ ] Manual: deploy preview → toggle Loop Mode ON then OFF → 200 on both
- [ ] Local dev unchanged: `./startup-oauth.sh` Quantum Demo continues to work end-to-end
