### PR TITLE
🐛 Address Copilot feedback on Quantum Circuit zoom (follow-up to #15884)

### DIFF
--- a/web/e2e/visual/app-quantum-visual.spec.ts
+++ b/web/e2e/visual/app-quantum-visual.spec.ts
@@ -37,6 +37,16 @@ test.describe('Quantum dashboard cards', () => {
   })
 
   test('circuit viewer renders zoom controls and small zoom levels visibly shrink the diagram', async ({ page }) => {
+    // Clear persisted zoom so the 100% baseline is deterministic regardless of
+    // any prior test run or shared storage state.
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.removeItem('quantum-circuit-zoom')
+      } catch {
+        // localStorage unavailable; baseline still works since component falls back to 100%.
+      }
+    })
+
     await setupQuantumPage(page)
 
     const circuitCard = page
@@ -48,7 +58,7 @@ test.describe('Quantum dashboard cards', () => {
     await circuitCard.scrollIntoViewIfNeeded()
     await expect(circuitCard).toBeVisible({ timeout: CARD_VISIBLE_TIMEOUT_MS })
 
-    // All eight default zoom buttons must be present.
+    // All ten zoom level buttons must be present.
     const zoomLevels = [15, 20, 25, 35, 50, 65, 85, 100, 125, 150]
     for (const pct of zoomLevels) {
       await expect(circuitCard.getByRole('button', { name: `${pct}%`, exact: true })).toBeVisible()

--- a/web/e2e/visual/app-quantum-visual.spec.ts
+++ b/web/e2e/visual/app-quantum-visual.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Locator, type Page } from '@playwright/test'
 import { setupDemoMode } from '../helpers/setup'
+import { CIRCUIT_ZOOM_STORAGE_KEY } from '../../src/components/cards/quantum/QuantumCircuitViewer'
 
 const PAGE_VISIBLE_TIMEOUT_MS = 15_000
 const CARD_VISIBLE_TIMEOUT_MS = 15_000
@@ -39,13 +40,13 @@ test.describe('Quantum dashboard cards', () => {
   test('circuit viewer renders zoom controls and small zoom levels visibly shrink the diagram', async ({ page }) => {
     // Clear persisted zoom so the 100% baseline is deterministic regardless of
     // any prior test run or shared storage state.
-    await page.addInitScript(() => {
+    await page.addInitScript((key: string) => {
       try {
-        window.localStorage.removeItem('quantum-circuit-zoom')
+        window.localStorage.removeItem(key)
       } catch {
         // localStorage unavailable; baseline still works since component falls back to 100%.
       }
-    })
+    }, CIRCUIT_ZOOM_STORAGE_KEY)
 
     await setupQuantumPage(page)
 

--- a/web/e2e/visual/app-quantum-visual.spec.ts
+++ b/web/e2e/visual/app-quantum-visual.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type Locator, type Page } from '@playwright/test'
 import { setupDemoMode } from '../helpers/setup'
-import { CIRCUIT_ZOOM_STORAGE_KEY } from '../../src/components/cards/quantum/QuantumCircuitViewer'
+import { CIRCUIT_ZOOM_STORAGE_KEY } from '../../src/components/cards/quantum/QuantumCircuitViewer.constants'
 
 const PAGE_VISIBLE_TIMEOUT_MS = 15_000
 const CARD_VISIBLE_TIMEOUT_MS = 15_000

--- a/web/src/components/cards/quantum/QuantumCircuitViewer.constants.ts
+++ b/web/src/components/cards/quantum/QuantumCircuitViewer.constants.ts
@@ -1,0 +1,5 @@
+// Constants for QuantumCircuitViewer split into a leaf module so the e2e
+// visual test can import them without pulling in app-level transitive
+// dependencies (logger, vite import.meta.env, etc.) that don't resolve under
+// Playwright's Node runtime.
+export const CIRCUIT_ZOOM_STORAGE_KEY = 'quantum-circuit-zoom'

--- a/web/src/components/cards/quantum/QuantumCircuitViewer.tsx
+++ b/web/src/components/cards/quantum/QuantumCircuitViewer.tsx
@@ -8,10 +8,9 @@ import {
   useQuantumCircuitAscii,
   QUANTUM_CIRCUIT_DEFAULT_POLL_MS,
 } from '../../../hooks/useCachedQuantum'
+import { CIRCUIT_ZOOM_STORAGE_KEY } from './QuantumCircuitViewer.constants'
 
 const CIRCUIT_ASCII_POLLING_INTERVAL_MS = QUANTUM_CIRCUIT_DEFAULT_POLL_MS
-
-export const CIRCUIT_ZOOM_STORAGE_KEY = 'quantum-circuit-zoom'
 const CIRCUIT_ZOOM_DEFAULT_PCT = 100
 const CIRCUIT_ZOOM_PERCENT_DIVISOR = 100
 const CIRCUIT_POPOUT_URL = '/api/quantum/qasm/circuit/ascii'

--- a/web/src/components/cards/quantum/QuantumCircuitViewer.tsx
+++ b/web/src/components/cards/quantum/QuantumCircuitViewer.tsx
@@ -11,7 +11,7 @@ import {
 
 const CIRCUIT_ASCII_POLLING_INTERVAL_MS = QUANTUM_CIRCUIT_DEFAULT_POLL_MS
 
-const CIRCUIT_ZOOM_STORAGE_KEY = 'quantum-circuit-zoom'
+export const CIRCUIT_ZOOM_STORAGE_KEY = 'quantum-circuit-zoom'
 const CIRCUIT_ZOOM_DEFAULT_PCT = 100
 const CIRCUIT_ZOOM_PERCENT_DIVISOR = 100
 const CIRCUIT_POPOUT_URL = '/api/quantum/qasm/circuit/ascii'
@@ -186,6 +186,7 @@ export const QuantumCircuitViewer: React.FC<QuantumCircuitViewerProps> = ({ isDe
                 position: 'relative',
                 width: naturalSize.width > 0 ? `${scaledWidth}px` : undefined,
                 height: naturalSize.height > 0 ? `${scaledHeight}px` : undefined,
+                visibility: naturalSize.width > 0 ? 'visible' : 'hidden',
               }}
             >
               <pre

--- a/web/src/components/cards/quantum/QuantumCircuitViewer.tsx
+++ b/web/src/components/cards/quantum/QuantumCircuitViewer.tsx
@@ -17,6 +17,43 @@ const CIRCUIT_ZOOM_PERCENT_DIVISOR = 100
 const CIRCUIT_POPOUT_URL = '/api/quantum/qasm/circuit/ascii'
 const CIRCUIT_ZOOM_LEVELS_PCT = [15, 20, 25, 35, 50, 65, 85, 100, 125, 150]
 
+const isBrowser = typeof window !== 'undefined'
+
+function snapToNearestZoom(pct: number): number {
+  let nearest = CIRCUIT_ZOOM_LEVELS_PCT[0]
+  let nearestDelta = Math.abs(pct - nearest)
+  for (const level of CIRCUIT_ZOOM_LEVELS_PCT) {
+    const delta = Math.abs(pct - level)
+    if (delta < nearestDelta) {
+      nearest = level
+      nearestDelta = delta
+    }
+  }
+  return nearest
+}
+
+function readPersistedZoom(): number {
+  if (!isBrowser) return CIRCUIT_ZOOM_DEFAULT_PCT
+  try {
+    const stored = window.localStorage.getItem(CIRCUIT_ZOOM_STORAGE_KEY)
+    if (!stored) return CIRCUIT_ZOOM_DEFAULT_PCT
+    const parsed = parseInt(stored, 10)
+    if (!Number.isFinite(parsed) || parsed <= 0) return CIRCUIT_ZOOM_DEFAULT_PCT
+    return snapToNearestZoom(parsed)
+  } catch {
+    return CIRCUIT_ZOOM_DEFAULT_PCT
+  }
+}
+
+function writePersistedZoom(pct: number): void {
+  if (!isBrowser) return
+  try {
+    window.localStorage.setItem(CIRCUIT_ZOOM_STORAGE_KEY, pct.toString())
+  } catch {
+    // localStorage may be blocked (privacy mode, quota); ignore.
+  }
+}
+
 interface QuantumCircuitViewerProps {
   isDemoData?: boolean
 }
@@ -38,16 +75,13 @@ export const QuantumCircuitViewer: React.FC<QuantumCircuitViewerProps> = ({ isDe
     pollInterval: CIRCUIT_ASCII_POLLING_INTERVAL_MS,
   })
 
-  const [zoomLevel, setZoomLevel] = React.useState<number>(() => {
-    const stored = localStorage.getItem(CIRCUIT_ZOOM_STORAGE_KEY)
-    if (!stored) return CIRCUIT_ZOOM_DEFAULT_PCT
-    const parsed = parseInt(stored, 10)
-    return Number.isFinite(parsed) ? parsed : CIRCUIT_ZOOM_DEFAULT_PCT
-  })
+  const [zoomLevel, setZoomLevel] = React.useState<number>(readPersistedZoom)
+  const preRef = React.useRef<HTMLPreElement | null>(null)
+  const [naturalSize, setNaturalSize] = React.useState<{ width: number; height: number }>({ width: 0, height: 0 })
 
   const handleZoomChange = (pct: number) => {
     setZoomLevel(pct)
-    localStorage.setItem(CIRCUIT_ZOOM_STORAGE_KEY, pct.toString())
+    writePersistedZoom(pct)
   }
 
   const handlePopout = () => {
@@ -65,6 +99,18 @@ export const QuantumCircuitViewer: React.FC<QuantumCircuitViewerProps> = ({ isDe
     isRefreshing,
   })
 
+  // Measure the unscaled <pre> so the wrapper can reserve the right scrollable
+  // area at any zoom level. Re-measures whenever the circuit text changes;
+  // CSS transforms do not affect offset dimensions, so the measurement remains
+  // valid across zoom changes.
+  React.useLayoutEffect(() => {
+    if (!preRef.current || !circuitAscii) return
+    setNaturalSize({
+      width: preRef.current.offsetWidth,
+      height: preRef.current.offsetHeight,
+    })
+  }, [circuitAscii])
+
   if (authIsLoading) {
     return (
       <div className="p-4">
@@ -78,6 +124,7 @@ export const QuantumCircuitViewer: React.FC<QuantumCircuitViewerProps> = ({ isDe
       <div className="flex flex-col items-center justify-center p-8 gap-4 text-center">
         <p className="text-gray-500">Please log in to view quantum data</p>
         <button
+          type="button"
           onClick={login}
           className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
         >
@@ -96,6 +143,8 @@ export const QuantumCircuitViewer: React.FC<QuantumCircuitViewerProps> = ({ isDe
   }
 
   const zoomFactor = zoomLevel / CIRCUIT_ZOOM_PERCENT_DIVISOR
+  const scaledWidth = naturalSize.width * zoomFactor
+  const scaledHeight = naturalSize.height * zoomFactor
 
   return (
     <div className="p-4 h-full flex flex-col">
@@ -108,6 +157,7 @@ export const QuantumCircuitViewer: React.FC<QuantumCircuitViewerProps> = ({ isDe
                 {CIRCUIT_ZOOM_LEVELS_PCT.map((pct) => (
                   <button
                     key={pct}
+                    type="button"
                     onClick={() => handleZoomChange(pct)}
                     className={`px-2 py-1 text-xs rounded border transition-colors ${
                       zoomLevel === pct
@@ -121,6 +171,7 @@ export const QuantumCircuitViewer: React.FC<QuantumCircuitViewerProps> = ({ isDe
               </div>
             </div>
             <button
+              type="button"
               onClick={handlePopout}
               className="p-1 hover:bg-secondary rounded transition-colors"
               title="Open circuit in new window"
@@ -130,16 +181,28 @@ export const QuantumCircuitViewer: React.FC<QuantumCircuitViewerProps> = ({ isDe
             </button>
           </div>
           <div className="bg-card rounded border border-border overflow-auto flex-1">
-            <pre
-              className="p-4 m-0 whitespace-pre text-foreground quantum-circuit-display"
+            <div
               style={{
-                display: 'inline-block',
-                transform: `scale(${zoomFactor})`,
-                transformOrigin: 'top left',
+                position: 'relative',
+                width: naturalSize.width > 0 ? `${scaledWidth}px` : undefined,
+                height: naturalSize.height > 0 ? `${scaledHeight}px` : undefined,
               }}
             >
-              {circuitAscii}
-            </pre>
+              <pre
+                ref={preRef}
+                className="p-4 m-0 whitespace-pre text-foreground quantum-circuit-display"
+                style={{
+                  display: 'inline-block',
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  transform: `scale(${zoomFactor})`,
+                  transformOrigin: 'top left',
+                }}
+              >
+                {circuitAscii}
+              </pre>
+            </div>
           </div>
         </>
       ) : (


### PR DESCRIPTION
## Summary

Follow-up to #15884. PR #15884 was merged before a fix-up commit addressing Copilot's review feedback could land, so this PR re-applies those six improvements on top of the merged code.

## What changed

`web/src/components/cards/quantum/QuantumCircuitViewer.tsx`:
- **localStorage hardening** — `readPersistedZoom()` / `writePersistedZoom()` helpers wrap reads/writes in `try/catch` and check `typeof window !== 'undefined'`. Privacy modes, blocked storage, and future SSR contexts no longer throw.
- **Value validation + clamping** — `snapToNearestZoom()` snaps any persisted value to the nearest entry in `CIRCUIT_ZOOM_LEVELS_PCT`. Non-finite or non-positive values fall back to the default. Corrupted storage can no longer produce an unreadable or extreme zoom.
- **`type=\"button\"` on all `<button>` elements** — zoom buttons, popout, login. Prevents accidental form submission if the component is ever rendered inside a `<form>`.
- **Scrollbars now match visible content** — `useLayoutEffect` measures the unscaled `<pre>` (`offsetWidth` / `offsetHeight` are unaffected by `transform`, so the measurement stays valid across zoom changes). The wrapper is sized to `naturalSize * zoomFactor`, and the `<pre>` is `position: absolute` inside it. At small zoom levels the scrollable area now matches the visible content instead of leaving large empty space. Avoiding `font-size` / `lineHeight` because that re-introduces the browser minimum-font-size clamping bug #15884 fixed.

`web/e2e/visual/app-quantum-visual.spec.ts`:
- **Deterministic 100% baseline** — `page.addInitScript` clears `quantum-circuit-zoom` from `localStorage` before navigation, so the baseline screenshot doesn't depend on prior test state.
- **Fix stale comment** — was \"All eight default zoom buttons\", now \"All ten zoom level buttons\".

## Test plan

- [x] Manual verification on local dev server (post-#15884 merge): zoom controls render, 15% visibly shrinks the diagram, scrollbars match visible content, persistence survives reload, popout opens in new tab
- [ ] CI: lint + typecheck pass
- [ ] CI: visual baselines may need re-generation given the layout-box change at small zoom levels

## Why a follow-up PR instead of amending #15884

#15884 was already merged when the fix-up commit was prepared. Cleanest path forward is a separate, self-contained PR that maintainers can review against current `main`.

cc @copilot — replies to your six inline comments are on #15884.