### PR TITLE
🐛 Soft transient banner + 3-state badge for Quantum Control Panel

### DIFF
--- a/web/e2e/visual/app-quantum-visual.spec.ts
+++ b/web/e2e/visual/app-quantum-visual.spec.ts
@@ -37,6 +37,19 @@ test.describe('Quantum dashboard cards', () => {
     await expectCardScreenshot(histogramCard, 'app-quantum-histogram-card.png')
   })
 
+  test('control panel renders three-state credentials badge and IBM-only backends only when stored', async ({ page }) => {
+    await setupQuantumPage(page)
+
+    const controlPanelCard = page
+      .locator('h3:has-text("Quantum Demonstration Controls")')
+      .first()
+      .locator('xpath=ancestor::*[@data-card-type][1]')
+
+    // Demo mode: hook is forceDemo, so lastRefresh is null and authenticated is false →
+    // badge state should be "Not configured" (the `quantumControlPanel.credsNone` key in tests).
+    await expectCardScreenshot(controlPanelCard, 'app-quantum-control-panel-demo.png')
+  })
+
   test('circuit viewer renders zoom controls and small zoom levels visibly shrink the diagram', async ({ page }) => {
     // Clear persisted zoom so the 100% baseline is deterministic regardless of
     // any prior test run or shared storage state.

--- a/web/src/components/cards/quantum/QuantumControlPanel.tsx
+++ b/web/src/components/cards/quantum/QuantumControlPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react'
-import { AlertCircle, Play, Zap, Key, Check, Trash2 } from 'lucide-react'
+import { AlertCircle, Play, Zap, Key, Check, Trash2, ShieldCheck, RefreshCw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../../lib/cn'
 import { useReportCardDataState } from '../CardDataContext'
@@ -9,6 +9,7 @@ import { useQASMFiles } from '../../../hooks/useQASMFiles'
 import { useAuth } from '../../../lib/auth'
 import { useDrillDown } from '../../../hooks/useDrillDown'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { classifyApiError } from '../../../lib/errorHandling'
 import {
   useQuantumSystemStatus,
   useQuantumAuthStatus,
@@ -36,6 +37,11 @@ const LARGE_CIRCUIT_QASM = 'expt32.qasm'
 const LOOP_MODE_STATUS_SYNC_DELAY_MS = 100
 const EXECUTION_STATUS_POLL_DELAY_MS = 500
 const CONTROL_PANEL_POLL_MS = QUANTUM_STATUS_DEFAULT_POLL_MS
+
+// Backends that talk to IBM Quantum's upstream API. `aer` and `sim` run
+// purely locally on the quantum-kc-demo pod; the three below all hit IBM
+// and so are the only ones for which `/api/quantum/auth/status` is meaningful.
+const BACKENDS_REQUIRING_IBM: ReadonlySet<string> = new Set(['qx5', 'least', 'aer_noise'])
 
 const DEMO_DATA: ControlState = {
   backend: 'aer',
@@ -71,6 +77,11 @@ export const QuantumControlPanel: React.FC = () => {
   const [showClearCredentialsDialog, setShowClearCredentialsDialog] = useState(false)
   const [isClearing, setIsClearing] = useState(false)
   const [statusTab, setStatusTab] = useState<'system' | 'job'>('system')
+  // Marks the wall-clock time of the last `authenticated:true` we observed in
+  // THIS browser session. Persisted cache entries from a prior session don't
+  // count — after a pod restart or page reload we want to drop back to
+  // "Stored" until validation succeeds again.
+  const [sessionValidatedAt, setSessionValidatedAt] = useState<number | null>(null)
 
   // Custom QASM support
   const [showCustomQasmModal, setShowCustomQasmModal] = useState(false)
@@ -79,6 +90,7 @@ export const QuantumControlPanel: React.FC = () => {
 
   const forceDemo = isQuantumForcedToDemo()
   const hasInitializedControlRef = useRef(false)
+  const requiresIBM = BACKENDS_REQUIRING_IBM.has(control.backend)
 
   // Fetch available QASM files
   const { files: qasmFiles, isLoading: qasmFilesLoading } = useQASMFiles(undefined, forceDemo)
@@ -100,22 +112,54 @@ export const QuantumControlPanel: React.FC = () => {
     data: authStatus,
     isRefreshing: isAuthRefreshing,
     error: authStatusError,
+    lastRefresh: lastAuthRefresh,
     refetch: refetchAuthStatus,
   } = useQuantumAuthStatus({
     isAuthenticated,
     forceDemo,
     pollInterval: CONTROL_PANEL_POLL_MS,
+    autoRefresh: requiresIBM,
   })
 
   const ibmAuthenticated = authStatus.authenticated
-  const error = mutationError ?? statusError ?? authStatusError
+
+  // Mark the session as validated whenever a successful auth check returns
+  // authenticated:true. This is what flips the badge from "Stored" → "Configured".
+  useEffect(() => {
+    if (ibmAuthenticated && !isAuthRefreshing) {
+      setSessionValidatedAt(Date.now())
+    }
+  }, [ibmAuthenticated, isAuthRefreshing])
+
+  // Split the auth-status error from the rest. Transient IBM upstream errors
+  // (rate-limited / 5xx / timeout / "max retries attempted") shouldn't paint
+  // the panel red — those go to a softer yellow banner. Genuine fatal errors
+  // (401 with no transient signature, etc.) still surface as red.
+  const fatalError = mutationError ?? statusError
+  const classifiedAuthError = authStatusError ? classifyApiError(authStatusError) : null
+  const isAuthErrorTransient = classifiedAuthError?.retryable === true
+  const authErrorForBanner = classifiedAuthError && !isAuthErrorTransient ? authStatusError : null
+  const error = fatalError ?? authErrorForBanner
+
+  // Three-state credential badge:
+  //   configured — validation succeeded in this browser session
+  //   stored     — token likely exists on backend but unvalidated this session
+  //   none       — no token saved
+  const hasHistoricalValidation = lastAuthRefresh !== null
+  const tokenLikelyStored = hasHistoricalValidation || ibmAuthenticated
+  const ibmCredentialState: 'configured' | 'stored' | 'none' =
+    sessionValidatedAt !== null
+      ? 'configured'
+      : tokenLikelyStored
+        ? 'stored'
+        : 'none'
 
   useReportCardDataState({
     isLoading: isAuthenticated ? isLoading && status === null : false,
     isRefreshing: isRefreshing || isAuthRefreshing,
     isDemoData: isAuthenticated ? isDemoFallback : false,
     hasData: isAuthenticated ? status !== null : false,
-    isFailed: isStatusFailed || error !== null,
+    isFailed: isStatusFailed || fatalError !== null,
     consecutiveFailures,
   })
 
@@ -200,6 +244,7 @@ export const QuantumControlPanel: React.FC = () => {
         throw new Error(errorData.error || 'Failed to clear credentials')
       }
 
+      setSessionValidatedAt(null)
       await refetchAuthStatus()
       setShowClearCredentialsDialog(false)
       setMutationError(null)
@@ -372,6 +417,15 @@ export const QuantumControlPanel: React.FC = () => {
           </div>
       )}
 
+      {isAuthErrorTransient && requiresIBM && !isDemoFallback && (
+          <div className="mb-4 p-3 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 flex items-start gap-2">
+            <AlertCircle className="w-4 h-4 text-yellow-600 dark:text-yellow-400 mt-0.5 flex-shrink-0" />
+            <p className="text-sm text-yellow-700 dark:text-yellow-300">
+              {t('quantumControlPanel.ibmUpstreamUnavailable')}
+            </p>
+          </div>
+      )}
+
       <div className="space-y-4">
           {/* IBM Credentials Button with Clear Option */}
           <div className="flex gap-2 items-stretch">
@@ -383,18 +437,38 @@ export const QuantumControlPanel: React.FC = () => {
                 <Key className="w-4 h-4 text-blue-600 dark:text-blue-400" />
                 <span className="text-sm font-medium text-gray-700 dark:text-gray-300">IBM Credentials</span>
               </div>
-              <div className={`flex items-center gap-1 text-xs font-semibold ${ibmAuthenticated ? 'text-green-600 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'}`}>
-                {ibmAuthenticated ? (
+              <div className={cn('flex items-center gap-1 text-xs font-semibold',
+                ibmCredentialState === 'configured' && 'text-green-600 dark:text-green-400',
+                ibmCredentialState === 'stored' && 'text-blue-600 dark:text-blue-400',
+                ibmCredentialState === 'none' && 'text-gray-500 dark:text-gray-400',
+              )}>
+                {ibmCredentialState === 'configured' && (
+                  <>
+                    <ShieldCheck className="w-3 h-3" />
+                    {t('quantumControlPanel.credsConfigured')}
+                  </>
+                )}
+                {ibmCredentialState === 'stored' && (
                   <>
                     <Check className="w-3 h-3" />
-                    Configured
+                    {t('quantumControlPanel.credsStored')}
                   </>
-                ) : (
-                  'Not configured'
                 )}
+                {ibmCredentialState === 'none' && t('quantumControlPanel.credsNone')}
               </div>
             </button>
-            {ibmAuthenticated && (
+            {ibmCredentialState === 'stored' && (
+              <button
+                onClick={() => { void refetchAuthStatus() }}
+                disabled={isAuthRefreshing}
+                className="px-3 py-2 rounded-lg border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/20 hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors disabled:opacity-50 flex items-center"
+                title={t('quantumControlPanel.validateNow')}
+                aria-label={t('quantumControlPanel.validateNow')}
+              >
+                <RefreshCw className={cn('w-4 h-4 text-blue-600 dark:text-blue-400', isAuthRefreshing && 'animate-spin')} />
+              </button>
+            )}
+            {ibmCredentialState !== 'none' && (
               <button
                 onClick={() => setShowClearCredentialsDialog(true)}
                 disabled={isClearing}
@@ -457,7 +531,7 @@ export const QuantumControlPanel: React.FC = () => {
                   <option value="aer">{t('quantumControlPanel.backendOptions.aerSimulator')}</option>
                   <option value="sim">QASM Simulator</option>
                   <option value="qx5">IBM 5-qubit</option>
-                  {ibmAuthenticated && (
+                  {ibmCredentialState !== 'none' && (
                     <>
                       <option value="least">IBM Least Busy (Real Hardware)</option>
                       <option value="aer_noise" disabled={is32Qubit}>

--- a/web/src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { QuantumAuthStatus, QuantumSystemStatus } from '../../../../hooks/useCachedQuantum'
+
+const mockUseQuantumSystemStatus = vi.fn()
+const mockUseQuantumAuthStatus = vi.fn()
+
+vi.mock('../../../../hooks/useCachedQuantum', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../hooks/useCachedQuantum')>()
+  return {
+    ...actual,
+    useQuantumSystemStatus: (opts: Parameters<typeof actual.useQuantumSystemStatus>[0]) =>
+      mockUseQuantumSystemStatus(opts),
+    useQuantumAuthStatus: (opts: Parameters<typeof actual.useQuantumAuthStatus>[0]) =>
+      mockUseQuantumAuthStatus(opts),
+  }
+})
+
+vi.mock('../../../../lib/demoMode', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../lib/demoMode')>()
+  return {
+    ...actual,
+    isQuantumForcedToDemo: vi.fn(() => false),
+  }
+})
+
+const mockUseAuth = vi.fn()
+vi.mock('../../../../lib/auth', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+const mockOpenDrillDown = vi.fn()
+const mockCloseDrillDown = vi.fn()
+vi.mock('../../../../hooks/useDrillDown', () => ({
+  useDrillDown: () => ({
+    open: mockOpenDrillDown,
+    close: mockCloseDrillDown,
+  }),
+}))
+
+vi.mock('../../../../hooks/useQASMFiles', () => ({
+  useQASMFiles: () => ({
+    files: [{ name: 'bell.qasm' }],
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+import { QuantumControlPanel } from '../QuantumControlPanel'
+import { DEMO_QUANTUM_STATUS } from '../../../../hooks/useCachedQuantum'
+
+function defaultAuthReturn(overrides: Record<string, unknown> = {}) {
+  return {
+    isAuthenticated: true,
+    isLoading: false,
+    login: vi.fn(),
+    token: null,
+    ...overrides,
+  }
+}
+
+function statusHookReturn(
+  overrides: Partial<{
+    data: QuantumSystemStatus | null
+    isLoading: boolean
+    isRefreshing: boolean
+    isDemoData: boolean
+    error: string | null
+    isFailed: boolean
+    consecutiveFailures: number
+    lastRefresh: number | null
+    refetch: () => Promise<void>
+  }> = {},
+) {
+  return {
+    data: DEMO_QUANTUM_STATUS,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: Date.now(),
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+function authHookReturn(
+  overrides: Partial<{
+    data: QuantumAuthStatus
+    isLoading: boolean
+    isRefreshing: boolean
+    isDemoData: boolean
+    error: string | null
+    isFailed: boolean
+    consecutiveFailures: number
+    lastRefresh: number | null
+    refetch: () => Promise<void>
+  }> = {},
+) {
+  return {
+    data: { authenticated: false } as QuantumAuthStatus,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+describe('QuantumControlPanel — auth-status polling gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAuth.mockReturnValue(defaultAuthReturn())
+    mockUseQuantumSystemStatus.mockReturnValue(statusHookReturn())
+    mockUseQuantumAuthStatus.mockReturnValue(authHookReturn())
+  })
+
+  it('passes autoRefresh: false to auth-status hook when default backend is aer', () => {
+    render(<QuantumControlPanel />)
+    expect(mockUseQuantumAuthStatus).toHaveBeenCalled()
+    const lastCall = mockUseQuantumAuthStatus.mock.calls.at(-1)?.[0]
+    expect(lastCall?.autoRefresh).toBe(false)
+  })
+
+  it('passes autoRefresh: true once user selects an IBM backend (qx5)', () => {
+    const { container } = render(<QuantumControlPanel />)
+    const select = container.querySelector('select') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'qx5' } })
+    const lastCall = mockUseQuantumAuthStatus.mock.calls.at(-1)?.[0]
+    expect(lastCall?.autoRefresh).toBe(true)
+  })
+})
+
+describe('QuantumControlPanel — error classification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAuth.mockReturnValue(defaultAuthReturn())
+    mockUseQuantumSystemStatus.mockReturnValue(statusHookReturn())
+  })
+
+  it('renders the soft yellow transient banner (not red) for retryable IBM errors when on an IBM backend', () => {
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({ error: 'max retries attempted; service unavailable' }),
+    )
+    const { container } = render(<QuantumControlPanel />)
+    const select = container.querySelector('select') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'qx5' } })
+
+    expect(
+      screen.getByText('quantumControlPanel.ibmUpstreamUnavailable'),
+    ).toBeInTheDocument()
+    // The classified-transient error must NOT also surface in the red banner.
+    expect(screen.queryByText(/max retries attempted/i)).toBeNull()
+  })
+
+  it('renders the red banner for fatal (non-retryable) auth errors', () => {
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({ error: 'invalid api key' }),
+    )
+    const { container } = render(<QuantumControlPanel />)
+    const select = container.querySelector('select') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'qx5' } })
+
+    expect(screen.getByText('invalid api key')).toBeInTheDocument()
+    expect(
+      screen.queryByText('quantumControlPanel.ibmUpstreamUnavailable'),
+    ).toBeNull()
+  })
+
+  it('does not render the transient banner on a non-IBM backend even if the cached error is transient', () => {
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({ error: 'service unavailable 503' }),
+    )
+    render(<QuantumControlPanel />)
+
+    expect(
+      screen.queryByText('quantumControlPanel.ibmUpstreamUnavailable'),
+    ).toBeNull()
+  })
+})
+
+describe('QuantumControlPanel — three-state credentials badge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAuth.mockReturnValue(defaultAuthReturn())
+    mockUseQuantumSystemStatus.mockReturnValue(statusHookReturn())
+  })
+
+  it('shows "Not configured" key when there is no token and no historical validation', () => {
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({ data: { authenticated: false }, lastRefresh: null }),
+    )
+    render(<QuantumControlPanel />)
+    expect(screen.getByText('quantumControlPanel.credsNone')).toBeInTheDocument()
+  })
+
+  it('shows "Stored" key when cache has a historical successful validation but session has not re-confirmed', () => {
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({
+        data: { authenticated: false },
+        lastRefresh: Date.now() - 60_000,
+      }),
+    )
+    render(<QuantumControlPanel />)
+    expect(screen.getByText('quantumControlPanel.credsStored')).toBeInTheDocument()
+  })
+
+  it('shows "Configured" key once the session observes authenticated:true', () => {
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({
+        data: { authenticated: true },
+        lastRefresh: Date.now(),
+      }),
+    )
+    render(<QuantumControlPanel />)
+    expect(screen.getByText('quantumControlPanel.credsConfigured')).toBeInTheDocument()
+  })
+
+  it('renders a Validate-now button when the badge is in Stored state', () => {
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({
+        data: { authenticated: false },
+        lastRefresh: Date.now() - 60_000,
+      }),
+    )
+    render(<QuantumControlPanel />)
+    expect(screen.getByLabelText('quantumControlPanel.validateNow')).toBeInTheDocument()
+  })
+
+  it('does not render a Validate-now button when the badge is Configured', () => {
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({
+        data: { authenticated: true },
+        lastRefresh: Date.now(),
+      }),
+    )
+    render(<QuantumControlPanel />)
+    expect(screen.queryByLabelText('quantumControlPanel.validateNow')).toBeNull()
+  })
+})

--- a/web/src/hooks/useCachedQuantum.ts
+++ b/web/src/hooks/useCachedQuantum.ts
@@ -20,6 +20,7 @@ interface UseQuantumCacheOptions {
   isAuthenticated: boolean
   forceDemo?: boolean
   pollInterval?: number
+  autoRefresh?: boolean
 }
 
 interface UseCachedQuantumResult<T> {
@@ -267,12 +268,13 @@ export function useQuantumAuthStatus({
   isAuthenticated,
   forceDemo = false,
   pollInterval = QUANTUM_STATUS_DEFAULT_POLL_MS,
+  autoRefresh,
 }: UseQuantumCacheOptions): UseCachedQuantumResult<QuantumAuthStatus> {
   const result = useCache<QuantumAuthStatus>({
     key: QUANTUM_AUTH_STATUS_CACHE_KEY,
     category: 'realtime',
     refreshInterval: pollInterval,
-    autoRefresh: !isGlobalQuantumPollingPaused(),
+    autoRefresh: (autoRefresh ?? true) && !isGlobalQuantumPollingPaused(),
     enabled: isAuthenticated && !forceDemo,
     initialData: DEFAULT_AUTH_STATUS,
     demoData: DEFAULT_AUTH_STATUS,

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -213,7 +213,13 @@
     "qasmFiles": {
       "loadingFiles": "Loading files...",
       "customQasm": "Custom QASM..."
-    }
+    },
+    "credsConfigured": "Configured",
+    "credsStored": "Stored",
+    "credsNone": "Not configured",
+    "validateNow": "Validate now",
+    "validating": "Validating…",
+    "ibmUpstreamUnavailable": "IBM Quantum is temporarily unavailable. We'll keep retrying — your saved credentials are unaffected."
   },
   "titles": {
     "cluster_health": "Cluster Health",


### PR DESCRIPTION
Fixes #15946

## Summary
- Suppress `/api/quantum/auth/status` auto-poll on local backends (`aer`, `sim`); only `qx5`, `least`, `aer_noise` need IBM. Adds optional `autoRefresh` flag to `useQuantumAuthStatus` so manual fetch (validate-on-save, "Validate now" button) still works on any backend.
- Classify auth errors with the existing `classifyApiError` helper. Retryable categories (network / timeout / service_unavailable / rate_limited) render a soft yellow "IBM Quantum temporarily unavailable" banner instead of the alarming red error containing raw upstream JSON. `useReportCardDataState.isFailed` is keyed off `fatalError` so transient blips don't paint the card wrapper.
- Replace the binary credentials badge with three states:
  - 🛡️ **Configured** (green) — validation succeeded in this browser session.
  - ✓ **Stored** (blue) — token likely on backend but unvalidated this session (post-pod-restart, non-IBM backend, transient blip).
  - **Not configured** (gray) — no token saved.

  Critical for the persistent-volume case: after a pod restart the badge defaults to **Stored** and only flips to **Configured** when the *current* session observes `authenticated: true`.
- Add a "Validate now" `RefreshCw` button next to the Stored badge so users can manually trigger a one-shot check without switching backend.
- Widen IBM-only backend dropdown options and the trash-icon clear gate to non-`none` states, so users with stored creds can pick `least` / `aer_noise` (which then triggers validation).
- Reset `sessionValidatedAt` on credentials clear.

## Test plan
- [x] `cd web && npx vitest run src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx` (10 new tests pass)
- [x] `cd web && npx vitest run src/components/cards/quantum src/hooks/__tests__/useQuantumAuthStatus.test.ts src/hooks/__tests__/useCachedQuantum-pure.test.ts` (43 tests pass)
- [ ] Visual regression baselines for `app-quantum-control-panel-demo.png` — generate on CI runner via `npm run test:visual:update`
- [ ] Manual: select `aer`, no errors, no polling. Save a real IBM token, switch to `least`, observe Configured badge within one poll. Force a 503 from `/api/quantum/auth/status` while on `least`, observe yellow banner not red. Click trash → badge reverts to Not configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)