### PR TITLE
🐛 Gate fatal auth-error red banner by requiresIBM in Quantum Control Panel

### DIFF
--- a/web/src/components/cards/quantum/QuantumControlPanel.tsx
+++ b/web/src/components/cards/quantum/QuantumControlPanel.tsx
@@ -134,11 +134,15 @@ export const QuantumControlPanel: React.FC = () => {
   // Split the auth-status error from the rest. Transient IBM upstream errors
   // (rate-limited / 5xx / timeout / "max retries attempted") shouldn't paint
   // the panel red — those go to a softer yellow banner. Genuine fatal errors
-  // (401 with no transient signature, etc.) still surface as red.
+  // (401 with no transient signature, etc.) still surface as red — but only
+  // when the selected backend actually needs IBM. On a local-only backend
+  // (aer/sim) a stale 401/403 from a prior IBM selection shouldn't paint the
+  // panel red while the user is doing purely local work.
   const fatalError = mutationError ?? statusError
   const classifiedAuthError = authStatusError ? classifyApiError(authStatusError) : null
   const isAuthErrorTransient = classifiedAuthError?.retryable === true
-  const authErrorForBanner = classifiedAuthError && !isAuthErrorTransient ? authStatusError : null
+  const authErrorForBanner =
+    classifiedAuthError && !isAuthErrorTransient && requiresIBM ? authStatusError : null
   const error = fatalError ?? authErrorForBanner
 
   // Three-state credential badge:

--- a/web/src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx
@@ -183,6 +183,17 @@ describe('QuantumControlPanel — error classification', () => {
       screen.queryByText('quantumControlPanel.ibmUpstreamUnavailable'),
     ).toBeNull()
   })
+
+  it('does not render the red banner on a non-IBM backend even if the cached auth error is fatal', () => {
+    // A stale 401 from a prior IBM-backed validation must not surface in the
+    // red banner once the user is on aer/sim doing purely local work.
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({ error: 'invalid api key' }),
+    )
+    render(<QuantumControlPanel />)
+
+    expect(screen.queryByText('invalid api key')).toBeNull()
+  })
 })
 
 describe('QuantumControlPanel — three-state credentials badge', () => {


### PR DESCRIPTION
## Summary

Standalone fix for **Bug 2** from `kubestellar-hive[bot]`'s post-merge review of #15948.

The soft yellow transient banner introduced in #15948 is gated by `requiresIBM`, but the non-retryable auth-error path still feeds the main red banner regardless of selected backend. So if a user hits a 401 / invalid-key on `least` or `qx5`, then switches back to `aer` / `sim`, the scary auth error stays visible during purely local work where IBM isn't in the picture.

Fix: gate `authErrorForBanner` with `requiresIBM` to match the yellow banner's existing gate. `fatalError` (mutation / status) is intentionally unchanged — those still surface on any backend because they reflect real local failures.

This is a small, contained Console-only follow-up. Bug 1 from the same review (the `Stored`-after-clear edge case) requires a workload-side change to expose an explicit `tokenStored` field on `/api/quantum/auth/status`; that work will land separately once the workload PR ships.

## Test plan

- [x] Added a symmetric red-banner gating test alongside the existing yellow non-IBM-backend test in `QuantumControlPanel.test.tsx`.
- [x] `npx vitest run src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx` — 11/11 pass.
- [x] `npx vitest run src/components/cards/quantum src/hooks/useQuantumAuthStatus.test.ts src/hooks/useCachedQuantum-pure.test.ts` — 25/25 pass.
- [ ] Manual: select `qx5` with an invalid token → red banner appears → switch to `aer` → red banner gone (yellow banner already correct).

Refs #15946

🤖 Generated with [Claude Code](https://claude.com/claude-code)