### PR TITLE
✨ Consume tokenStored + lastIbmError from quantum-kc-demo v0.4.0

### DIFF
--- a/web/src/components/cards/quantum/QuantumControlPanel.tsx
+++ b/web/src/components/cards/quantum/QuantumControlPanel.tsx
@@ -112,7 +112,6 @@ export const QuantumControlPanel: React.FC = () => {
     data: authStatus,
     isRefreshing: isAuthRefreshing,
     error: authStatusError,
-    lastRefresh: lastAuthRefresh,
     refetch: refetchAuthStatus,
   } = useQuantumAuthStatus({
     isAuthenticated,
@@ -122,6 +121,8 @@ export const QuantumControlPanel: React.FC = () => {
   })
 
   const ibmAuthenticated = authStatus.authenticated
+  const ibmTokenStored = authStatus.tokenStored
+  const lastIbmError = authStatus.lastIbmError
 
   // Mark the session as validated whenever a successful auth check returns
   // authenticated:true. This is what flips the badge from "Stored" → "Configured".
@@ -138,23 +139,41 @@ export const QuantumControlPanel: React.FC = () => {
   // when the selected backend actually needs IBM. On a local-only backend
   // (aer/sim) a stale 401/403 from a prior IBM selection shouldn't paint the
   // panel red while the user is doing purely local work.
+  //
+  // Classification source:
+  //   1. Prefer the workload's structured `lastIbmError` (v0.4.0+). The
+  //      backend has the raw exception and classifies it authoritatively.
+  //   2. Fall back to client-side `classifyApiError` against the error
+  //      string when the workload didn't provide `lastIbmError` (older
+  //      images, network-level failures before the body parses).
   const fatalError = mutationError ?? statusError
-  const classifiedAuthError = authStatusError ? classifyApiError(authStatusError) : null
-  const isAuthErrorTransient = classifiedAuthError?.retryable === true
+  const classifiedFromMessage = authStatusError ? classifyApiError(authStatusError) : null
+  const isAuthErrorTransient =
+    lastIbmError !== null
+      ? lastIbmError.retryable === true
+      : classifiedFromMessage?.retryable === true
+  const hasAuthError = lastIbmError !== null || classifiedFromMessage !== null
   const authErrorForBanner =
-    classifiedAuthError && !isAuthErrorTransient && requiresIBM ? authStatusError : null
+    hasAuthError && !isAuthErrorTransient && requiresIBM
+      ? (lastIbmError?.message ?? authStatusError)
+      : null
   const error = fatalError ?? authErrorForBanner
 
-  // Three-state credential badge:
-  //   configured — validation succeeded in this browser session
-  //   stored     — token likely exists on backend but unvalidated this session
-  //   none       — no token saved
-  const hasHistoricalValidation = lastAuthRefresh !== null
-  const tokenLikelyStored = hasHistoricalValidation || ibmAuthenticated
+  // Three-state credential badge, driven by the workload's explicit
+  // `tokenStored` field (v0.4.0+ — see web/src/hooks/useCachedQuantum.ts):
+  //   configured — validation succeeded in this browser session.
+  //   stored     — workload reports a token saved (auth.json on emptyDir
+  //                OR Qiskit account file on the PV) but we have not
+  //                validated it this session.
+  //   none       — workload reports no token saved.
+  //
+  // Pre-v0.4 workloads omit `tokenStored`; the fetcher coerces the missing
+  // field to `false`, so the badge sits at "Not configured" until the
+  // first successful validation, which is harmless and self-healing.
   const ibmCredentialState: 'configured' | 'stored' | 'none' =
     sessionValidatedAt !== null
       ? 'configured'
-      : tokenLikelyStored
+      : ibmTokenStored
         ? 'stored'
         : 'none'
 
@@ -415,14 +434,22 @@ export const QuantumControlPanel: React.FC = () => {
       </h3>
 
       {error && !isDemoFallback && (
-          <div className="mb-4 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 flex items-start gap-2">
+          <div
+            data-testid="quantum-control-panel-fatal-banner"
+            role="alert"
+            className="mb-4 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 flex items-start gap-2"
+          >
             <AlertCircle className="w-4 h-4 text-red-600 dark:text-red-400 mt-0.5 flex-shrink-0" />
             <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
           </div>
       )}
 
       {isAuthErrorTransient && requiresIBM && !isDemoFallback && (
-          <div className="mb-4 p-3 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 flex items-start gap-2">
+          <div
+            data-testid="quantum-control-panel-transient-banner"
+            role="status"
+            className="mb-4 p-3 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 flex items-start gap-2"
+          >
             <AlertCircle className="w-4 h-4 text-yellow-600 dark:text-yellow-400 mt-0.5 flex-shrink-0" />
             <p className="text-sm text-yellow-700 dark:text-yellow-300">
               {t('quantumControlPanel.ibmUpstreamUnavailable')}

--- a/web/src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx
@@ -174,9 +174,12 @@ describe('QuantumControlPanel — error classification', () => {
     const { container } = render(<QuantumControlPanel />)
     selectIbmBackend(container)
 
-    expect(
-      screen.getByTestId('quantum-control-panel-transient-banner'),
-    ).toBeInTheDocument()
+    // Both the banner element AND its rendered copy are checked: testid alone
+    // would silently pass if the banner were rendered empty or with the wrong
+    // i18n key.
+    const transient = screen.getByTestId('quantum-control-panel-transient-banner')
+    expect(transient).toBeInTheDocument()
+    expect(transient).toHaveTextContent('quantumControlPanel.ibmUpstreamUnavailable')
     // The classified-transient error must NOT also surface in the red banner.
     expect(
       screen.queryByTestId('quantum-control-panel-fatal-banner'),
@@ -190,9 +193,9 @@ describe('QuantumControlPanel — error classification', () => {
     const { container } = render(<QuantumControlPanel />)
     selectIbmBackend(container)
 
-    expect(
-      screen.getByTestId('quantum-control-panel-fatal-banner'),
-    ).toBeInTheDocument()
+    const fatal = screen.getByTestId('quantum-control-panel-fatal-banner')
+    expect(fatal).toBeInTheDocument()
+    expect(fatal).toHaveTextContent('invalid api key')
     expect(
       screen.queryByTestId('quantum-control-panel-transient-banner'),
     ).toBeNull()
@@ -246,9 +249,9 @@ describe('QuantumControlPanel — error classification', () => {
     const { container } = render(<QuantumControlPanel />)
     selectIbmBackend(container)
 
-    expect(
-      screen.getByTestId('quantum-control-panel-transient-banner'),
-    ).toBeInTheDocument()
+    const transient = screen.getByTestId('quantum-control-panel-transient-banner')
+    expect(transient).toBeInTheDocument()
+    expect(transient).toHaveTextContent('quantumControlPanel.ibmUpstreamUnavailable')
     expect(
       screen.queryByTestId('quantum-control-panel-fatal-banner'),
     ).toBeNull()

--- a/web/src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx
@@ -100,7 +100,11 @@ function authHookReturn(
   }> = {},
 ) {
   return {
-    data: { authenticated: false } as QuantumAuthStatus,
+    data: {
+      authenticated: false,
+      tokenStored: false,
+      lastIbmError: null,
+    } as QuantumAuthStatus,
     isLoading: false,
     isRefreshing: false,
     isDemoData: false,
@@ -111,6 +115,25 @@ function authHookReturn(
     refetch: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   }
+}
+
+/**
+ * Force the control panel onto a non-IBM (local-only) backend before
+ * assertions. Use in tests that verify "stale IBM error must NOT surface
+ * on local backends" so they don't depend on the component's default
+ * backend value remaining `aer`.
+ */
+function selectNonIbmBackend(container: HTMLElement) {
+  const select = container.querySelector('select') as HTMLSelectElement
+  fireEvent.change(select, { target: { value: 'aer' } })
+}
+
+/**
+ * Force the control panel onto an IBM-requiring backend (qx5).
+ */
+function selectIbmBackend(container: HTMLElement) {
+  const select = container.querySelector('select') as HTMLSelectElement
+  fireEvent.change(select, { target: { value: 'qx5' } })
 }
 
 describe('QuantumControlPanel — auth-status polling gating', () => {
@@ -149,27 +172,29 @@ describe('QuantumControlPanel — error classification', () => {
       authHookReturn({ error: 'max retries attempted; service unavailable' }),
     )
     const { container } = render(<QuantumControlPanel />)
-    const select = container.querySelector('select') as HTMLSelectElement
-    fireEvent.change(select, { target: { value: 'qx5' } })
+    selectIbmBackend(container)
 
     expect(
-      screen.getByText('quantumControlPanel.ibmUpstreamUnavailable'),
+      screen.getByTestId('quantum-control-panel-transient-banner'),
     ).toBeInTheDocument()
     // The classified-transient error must NOT also surface in the red banner.
-    expect(screen.queryByText(/max retries attempted/i)).toBeNull()
+    expect(
+      screen.queryByTestId('quantum-control-panel-fatal-banner'),
+    ).toBeNull()
   })
 
-  it('renders the red banner for fatal (non-retryable) auth errors', () => {
+  it('renders the red banner for fatal (non-retryable) auth errors on an IBM backend', () => {
     mockUseQuantumAuthStatus.mockReturnValue(
       authHookReturn({ error: 'invalid api key' }),
     )
     const { container } = render(<QuantumControlPanel />)
-    const select = container.querySelector('select') as HTMLSelectElement
-    fireEvent.change(select, { target: { value: 'qx5' } })
+    selectIbmBackend(container)
 
-    expect(screen.getByText('invalid api key')).toBeInTheDocument()
     expect(
-      screen.queryByText('quantumControlPanel.ibmUpstreamUnavailable'),
+      screen.getByTestId('quantum-control-panel-fatal-banner'),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('quantum-control-panel-transient-banner'),
     ).toBeNull()
   })
 
@@ -177,22 +202,78 @@ describe('QuantumControlPanel — error classification', () => {
     mockUseQuantumAuthStatus.mockReturnValue(
       authHookReturn({ error: 'service unavailable 503' }),
     )
-    render(<QuantumControlPanel />)
+    const { container } = render(<QuantumControlPanel />)
+    selectNonIbmBackend(container)
 
     expect(
-      screen.queryByText('quantumControlPanel.ibmUpstreamUnavailable'),
+      screen.queryByTestId('quantum-control-panel-transient-banner'),
     ).toBeNull()
   })
 
   it('does not render the red banner on a non-IBM backend even if the cached auth error is fatal', () => {
     // A stale 401 from a prior IBM-backed validation must not surface in the
     // red banner once the user is on aer/sim doing purely local work.
+    // Backend is set explicitly via selectNonIbmBackend so this test does
+    // not depend on the component's default backend remaining `aer`.
     mockUseQuantumAuthStatus.mockReturnValue(
       authHookReturn({ error: 'invalid api key' }),
     )
-    render(<QuantumControlPanel />)
+    const { container } = render(<QuantumControlPanel />)
+    selectNonIbmBackend(container)
 
-    expect(screen.queryByText('invalid api key')).toBeNull()
+    expect(
+      screen.queryByTestId('quantum-control-panel-fatal-banner'),
+    ).toBeNull()
+  })
+
+  it('drives the yellow banner from authStatus.lastIbmError.retryable when present (v0.4.0+ workload)', () => {
+    // When the workload provides a structured lastIbmError, the Console
+    // should classify off `retryable`, not the error message string.
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({
+        data: {
+          authenticated: false,
+          tokenStored: true,
+          lastIbmError: {
+            code: 'rate_limited',
+            message: 'rate limit exceeded',
+            retryable: true,
+          },
+        },
+        // Note: no `error` field — workload returned 200 with structured payload.
+      }),
+    )
+    const { container } = render(<QuantumControlPanel />)
+    selectIbmBackend(container)
+
+    expect(
+      screen.getByTestId('quantum-control-panel-transient-banner'),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('quantum-control-panel-fatal-banner'),
+    ).toBeNull()
+  })
+
+  it('drives the red banner from authStatus.lastIbmError when retryable:false', () => {
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({
+        data: {
+          authenticated: false,
+          tokenStored: true,
+          lastIbmError: {
+            code: 'unknown',
+            message: 'invalid api key',
+            retryable: false,
+          },
+        },
+      }),
+    )
+    const { container } = render(<QuantumControlPanel />)
+    selectIbmBackend(container)
+
+    const fatal = screen.getByTestId('quantum-control-panel-fatal-banner')
+    expect(fatal).toBeInTheDocument()
+    expect(fatal).toHaveTextContent('invalid api key')
   })
 })
 
@@ -203,30 +284,45 @@ describe('QuantumControlPanel — three-state credentials badge', () => {
     mockUseQuantumSystemStatus.mockReturnValue(statusHookReturn())
   })
 
-  it('shows "Not configured" key when there is no token and no historical validation', () => {
+  it('shows "Not configured" when workload reports tokenStored:false', () => {
     mockUseQuantumAuthStatus.mockReturnValue(
-      authHookReturn({ data: { authenticated: false }, lastRefresh: null }),
+      authHookReturn({
+        data: {
+          authenticated: false,
+          tokenStored: false,
+          lastIbmError: null,
+        },
+      }),
     )
     render(<QuantumControlPanel />)
     expect(screen.getByText('quantumControlPanel.credsNone')).toBeInTheDocument()
   })
 
-  it('shows "Stored" key when cache has a historical successful validation but session has not re-confirmed', () => {
+  it('shows "Stored" when workload reports tokenStored:true but session has not re-confirmed', () => {
+    // Common scenario: post-pod-restart. The Qiskit account file on the PV
+    // survives, so the workload reports tokenStored:true even though
+    // validation hasn't run this session.
     mockUseQuantumAuthStatus.mockReturnValue(
       authHookReturn({
-        data: { authenticated: false },
-        lastRefresh: Date.now() - 60_000,
+        data: {
+          authenticated: false,
+          tokenStored: true,
+          lastIbmError: null,
+        },
       }),
     )
     render(<QuantumControlPanel />)
     expect(screen.getByText('quantumControlPanel.credsStored')).toBeInTheDocument()
   })
 
-  it('shows "Configured" key once the session observes authenticated:true', () => {
+  it('shows "Configured" once the session observes authenticated:true', () => {
     mockUseQuantumAuthStatus.mockReturnValue(
       authHookReturn({
-        data: { authenticated: true },
-        lastRefresh: Date.now(),
+        data: {
+          authenticated: true,
+          tokenStored: true,
+          lastIbmError: null,
+        },
       }),
     )
     render(<QuantumControlPanel />)
@@ -236,8 +332,11 @@ describe('QuantumControlPanel — three-state credentials badge', () => {
   it('renders a Validate-now button when the badge is in Stored state', () => {
     mockUseQuantumAuthStatus.mockReturnValue(
       authHookReturn({
-        data: { authenticated: false },
-        lastRefresh: Date.now() - 60_000,
+        data: {
+          authenticated: false,
+          tokenStored: true,
+          lastIbmError: null,
+        },
       }),
     )
     render(<QuantumControlPanel />)
@@ -247,11 +346,58 @@ describe('QuantumControlPanel — three-state credentials badge', () => {
   it('does not render a Validate-now button when the badge is Configured', () => {
     mockUseQuantumAuthStatus.mockReturnValue(
       authHookReturn({
-        data: { authenticated: true },
-        lastRefresh: Date.now(),
+        data: {
+          authenticated: true,
+          tokenStored: true,
+          lastIbmError: null,
+        },
       }),
     )
     render(<QuantumControlPanel />)
     expect(screen.queryByLabelText('quantumControlPanel.validateNow')).toBeNull()
+  })
+
+  it('REGRESSION (Bug 1 from PR #15948 review): after credentials clear, badge drops to "Not configured" — not "Stored"', () => {
+    // Pre-v0.4 the Console inferred tokenLikelyStored from lastRefresh!=null
+    // OR authenticated:true. After a `clear`, the workload returns
+    // {authenticated:false} which is still a successful fetch — so
+    // lastRefresh updated, the inference flipped to true, and the badge
+    // fell back to "Stored". That bug is structurally impossible now: the
+    // workload reports tokenStored explicitly, and after clear it's false
+    // regardless of the cache's lastRefresh state.
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({
+        data: {
+          authenticated: false,
+          tokenStored: false,
+          lastIbmError: null,
+        },
+        lastRefresh: Date.now(), // recent successful fetch — pre-v0.4 trap
+      }),
+    )
+    render(<QuantumControlPanel />)
+    expect(screen.getByText('quantumControlPanel.credsNone')).toBeInTheDocument()
+    expect(screen.queryByText('quantumControlPanel.credsStored')).toBeNull()
+  })
+
+  it('treats a pre-v0.4 workload (no tokenStored field) as "Not configured" until next validation', () => {
+    // The fetcher coerces missing tokenStored to false. Until the next
+    // successful auth check flips authenticated:true (which sets
+    // sessionValidatedAt and moves the badge to Configured), the badge
+    // sits at "Not configured" — harmless and self-healing.
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({
+        data: {
+          authenticated: false,
+          // Simulate an older workload by leaving tokenStored at its
+          // coerced default and lastIbmError at null.
+          tokenStored: false,
+          lastIbmError: null,
+        },
+        lastRefresh: Date.now() - 60_000,
+      }),
+    )
+    render(<QuantumControlPanel />)
+    expect(screen.getByText('quantumControlPanel.credsNone')).toBeInTheDocument()
   })
 })

--- a/web/src/hooks/__tests__/useCachedQuantum-pure.test.ts
+++ b/web/src/hooks/__tests__/useCachedQuantum-pure.test.ts
@@ -162,6 +162,73 @@ describe('fetchQuantumAuthStatus', () => {
     expect(result.lastIbmError).toBeNull()
   })
 
+  describe('lastIbmError boundary validation', () => {
+    // The fetcher must coerce malformed `lastIbmError` payloads to null so
+    // downstream UI doesn't suppress the message-text classifier fallback
+    // while having no usable structured payload to render.
+    const malformedCases: Array<[string, unknown]> = [
+      ['missing retryable field', { code: 'rate_limited', message: 'foo' }],
+      ['missing message field', { code: 'rate_limited', retryable: true }],
+      ['missing code field', { message: 'foo', retryable: true }],
+      ['retryable not a boolean', { code: 'rate_limited', message: 'foo', retryable: 'true' }],
+      ['code not a string', { code: 429, message: 'foo', retryable: true }],
+      ['message not a string', { code: 'rate_limited', message: 42, retryable: true }],
+      ['payload is a string', 'service unavailable'],
+      ['payload is a number', 503],
+      ['payload is an array', ['rate_limited']],
+    ]
+
+    for (const [label, malformed] of malformedCases) {
+      it(`coerces to null when payload is malformed: ${label}`, async () => {
+        ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            authenticated: false,
+            tokenStored: true,
+            lastIbmError: malformed,
+          }),
+        })
+        const result = await fetchQuantumAuthStatus()
+        expect(result.lastIbmError).toBeNull()
+      })
+    }
+
+    it('accepts an unrecognized code value (forward-compat with future workload codes)', async () => {
+      // If a future workload adds a new error code we don't know about,
+      // we should still surface its message + retryable flag rather than
+      // silently dropping the structured payload.
+      ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          authenticated: false,
+          tokenStored: true,
+          lastIbmError: {
+            code: 'future_code_we_do_not_know_about',
+            message: 'something happened',
+            retryable: true,
+          },
+        }),
+      })
+      const result = await fetchQuantumAuthStatus()
+      expect(result.lastIbmError).not.toBeNull()
+      expect(result.lastIbmError?.message).toBe('something happened')
+      expect(result.lastIbmError?.retryable).toBe(true)
+    })
+
+    it('accepts explicit null (workload says "no error")', async () => {
+      ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          authenticated: true,
+          tokenStored: true,
+          lastIbmError: null,
+        }),
+      })
+      const result = await fetchQuantumAuthStatus()
+      expect(result.lastIbmError).toBeNull()
+    })
+  })
+
   it('throws on non-ok response', async () => {
     ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: false,

--- a/web/src/hooks/__tests__/useCachedQuantum-pure.test.ts
+++ b/web/src/hooks/__tests__/useCachedQuantum-pure.test.ts
@@ -93,7 +93,12 @@ describe('fetchQuantumAuthStatus', () => {
       json: async () => ({ authenticated: true }),
     })
     const result = await fetchQuantumAuthStatus()
-    expect(result).toEqual({ authenticated: true })
+    // Pre-v0.4 workload — only `authenticated` is set; new fields coerce to safe defaults.
+    expect(result).toEqual({
+      authenticated: true,
+      tokenStored: false,
+      lastIbmError: null,
+    })
   })
 
   it('returns authenticated false when response says false', async () => {
@@ -102,7 +107,11 @@ describe('fetchQuantumAuthStatus', () => {
       json: async () => ({ authenticated: false }),
     })
     const result = await fetchQuantumAuthStatus()
-    expect(result).toEqual({ authenticated: false })
+    expect(result).toEqual({
+      authenticated: false,
+      tokenStored: false,
+      lastIbmError: null,
+    })
   })
 
   it('returns authenticated false when field is missing', async () => {
@@ -111,7 +120,46 @@ describe('fetchQuantumAuthStatus', () => {
       json: async () => ({}),
     })
     const result = await fetchQuantumAuthStatus()
-    expect(result).toEqual({ authenticated: false })
+    expect(result).toEqual({
+      authenticated: false,
+      tokenStored: false,
+      lastIbmError: null,
+    })
+  })
+
+  it('passes through tokenStored and lastIbmError from a v0.4.0+ workload response', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        authenticated: false,
+        tokenStored: true,
+        lastIbmError: {
+          code: 'rate_limited',
+          message: 'rate limit exceeded',
+          retryable: true,
+        },
+      }),
+    })
+    const result = await fetchQuantumAuthStatus()
+    expect(result).toEqual({
+      authenticated: false,
+      tokenStored: true,
+      lastIbmError: {
+        code: 'rate_limited',
+        message: 'rate limit exceeded',
+        retryable: true,
+      },
+    })
+  })
+
+  it('coerces missing tokenStored field to false (older workload compat)', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ authenticated: true }),
+    })
+    const result = await fetchQuantumAuthStatus()
+    expect(result.tokenStored).toBe(false)
+    expect(result.lastIbmError).toBeNull()
   })
 
   it('throws on non-ok response', async () => {

--- a/web/src/hooks/__tests__/useQuantumAuthStatus.test.ts
+++ b/web/src/hooks/__tests__/useQuantumAuthStatus.test.ts
@@ -33,7 +33,11 @@ describe('useQuantumAuthStatus', () => {
       useQuantumAuthStatus({ isAuthenticated: false }),
     )
 
-    expect(result.current.data).toEqual({ authenticated: false })
+    expect(result.current.data).toEqual({
+      authenticated: false,
+      tokenStored: false,
+      lastIbmError: null,
+    })
     expect(result.current.isLoading).toBe(false)
     expect(result.current.isRefreshing).toBe(false)
     expect(result.current.isDemoData).toBe(false)

--- a/web/src/hooks/useCachedQuantum.ts
+++ b/web/src/hooks/useCachedQuantum.ts
@@ -78,8 +78,40 @@ export interface QuantumSystemStatus {
   version_info?: QuantumVersionInfo
 }
 
+/**
+ * Structured upstream-error channel returned by the quantum-kc-demo workload
+ * (v0.4.0+). Absent on older workloads, in which case the Console falls back
+ * to message-text classification via `classifyApiError`.
+ */
+export interface QuantumIbmError {
+  code:
+    | 'rate_limited'
+    | 'service_unavailable'
+    | 'timeout'
+    | 'account_not_found'
+    | 'unknown'
+  message: string
+  retryable: boolean
+}
+
 export interface QuantumAuthStatus {
   authenticated: boolean
+  /**
+   * Whether a saved token exists on the workload backend (auth.json on
+   * emptyDir OR Qiskit's account file on the PV — either present = `true`).
+   *
+   * Provided by quantum-kc-demo v0.4.0+. Older workloads omit this field;
+   * the fetcher coerces missing values to `false`. The badge sits at "Not
+   * configured" against an older workload until the next successful
+   * validation flips `authenticated:true` — harmless and self-healing.
+   */
+  tokenStored: boolean
+  /**
+   * Structured payload describing the most recent IBM-side validation
+   * error, when one occurred. `null` when validation succeeded or was not
+   * attempted. Provided by v0.4.0+ workloads.
+   */
+  lastIbmError: QuantumIbmError | null
 }
 
 export interface QuantumCircuitAsciiData {
@@ -139,6 +171,8 @@ c: 2/═══════════╩══╩═
 
 const DEFAULT_AUTH_STATUS: QuantumAuthStatus = {
   authenticated: false,
+  tokenStored: false,
+  lastIbmError: null,
 }
 
 async function fetchQuantumJson<T>(endpoint: string): Promise<T> {
@@ -162,9 +196,19 @@ async function fetchQuantumStatus(): Promise<QuantumSystemStatus> {
 }
 
 async function fetchQuantumAuthStatus(): Promise<QuantumAuthStatus> {
-  const response = await fetchQuantumJson<{ authenticated?: boolean }>(QUANTUM_AUTH_STATUS_ENDPOINT)
+  const response = await fetchQuantumJson<{
+    authenticated?: boolean
+    tokenStored?: boolean
+    lastIbmError?: QuantumIbmError | null
+  }>(QUANTUM_AUTH_STATUS_ENDPOINT)
+  // Coerce missing v0.4.0 fields to safe defaults so this hook works
+  // against pre-v0.4 workloads. `tokenStored:false` is the conservative
+  // choice; the Console badge falls back to "Not configured" until
+  // `authenticated:true` arrives, which self-heals on first valid check.
   return {
     authenticated: response.authenticated === true,
+    tokenStored: response.tokenStored === true,
+    lastIbmError: response.lastIbmError ?? null,
   }
 }
 

--- a/web/src/hooks/useCachedQuantum.ts
+++ b/web/src/hooks/useCachedQuantum.ts
@@ -195,20 +195,53 @@ async function fetchQuantumStatus(): Promise<QuantumSystemStatus> {
   return fetchQuantumJson<QuantumSystemStatus>(QUANTUM_STATUS_ENDPOINT)
 }
 
+/**
+ * Validate a `lastIbmError` payload from the workload at the fetcher
+ * boundary. Returns the value typed as `QuantumIbmError` if the shape is
+ * complete and well-formed; returns `null` for any malformed payload.
+ *
+ * This is defensive coercion: TypeScript types lie about JSON, and
+ * downstream UI code interprets a non-null `lastIbmError` as "the workload
+ * told us something authoritative" — suppressing the message-text
+ * `classifyApiError` fallback. A partial object (e.g. `{code: 'rate_limited'}`
+ * with no `retryable`) would silently disable that fallback while also
+ * having nothing useful to render. Treating partial payloads as `null`
+ * keeps the fallback alive.
+ *
+ * Unrecognized `code` values are accepted as-is (typed back to the union
+ * via cast) so a future workload version that adds a new code doesn't
+ * silently lose its error classification on older Console builds.
+ */
+function coerceLastIbmError(raw: unknown): QuantumIbmError | null {
+  if (raw === null || raw === undefined) return null
+  if (typeof raw !== 'object') return null
+  const obj = raw as Record<string, unknown>
+  if (typeof obj.code !== 'string') return null
+  if (typeof obj.message !== 'string') return null
+  if (typeof obj.retryable !== 'boolean') return null
+  return {
+    code: obj.code as QuantumIbmError['code'],
+    message: obj.message,
+    retryable: obj.retryable,
+  }
+}
+
 async function fetchQuantumAuthStatus(): Promise<QuantumAuthStatus> {
   const response = await fetchQuantumJson<{
-    authenticated?: boolean
-    tokenStored?: boolean
-    lastIbmError?: QuantumIbmError | null
+    authenticated?: unknown
+    tokenStored?: unknown
+    lastIbmError?: unknown
   }>(QUANTUM_AUTH_STATUS_ENDPOINT)
-  // Coerce missing v0.4.0 fields to safe defaults so this hook works
-  // against pre-v0.4 workloads. `tokenStored:false` is the conservative
-  // choice; the Console badge falls back to "Not configured" until
-  // `authenticated:true` arrives, which self-heals on first valid check.
+  // Coerce missing or malformed v0.4.0 fields to safe defaults so this
+  // hook works against pre-v0.4 workloads AND defends against a
+  // misbehaving workload returning a partial `lastIbmError` payload.
+  // `tokenStored:false` is the conservative choice; the Console badge
+  // falls back to "Not configured" until `authenticated:true` arrives,
+  // which self-heals on first valid check.
   return {
     authenticated: response.authenticated === true,
     tokenStored: response.tokenStored === true,
-    lastIbmError: response.lastIbmError ?? null,
+    lastIbmError: coerceLastIbmError(response.lastIbmError),
   }
 }
 


### PR DESCRIPTION
## Summary

Replaces the client-side `tokenLikelyStored` inference with the explicit `tokenStored` field that quantum-kc-demo `v0.4.0` now returns on `/api/quantum/auth/status`. Also threads through the new structured `lastIbmError` payload so the workload's authoritative classification drives the yellow transient banner instead of message-text matching.

**Closes Bug 1** from `kubestellar-hive[bot]`'s post-merge review of #15948 — *"the new Stored state can be shown even when no credentials exist."* That bug was a symptom of inferring storage state from the cache's `lastSuccessfulRefresh`: a fetch returning `{authenticated:false}` after a `clear` is still a successful fetch, so `lastRefresh` updated and the badge fell back to "Stored". With v0.4.0 the workload reports `tokenStored` explicitly, and after `clear` it's `false` regardless of cache state.

The workload-side change shipped in `KPRoche/quantum-kc-demo` v0.4.0 (image `ghcr.io/kproche/quantum-kc-demo:v0.4.0`, deployed and verified live on the kind-quantum cluster). This PR consumes those new fields on the Console side.

## What changed

**`useCachedQuantum.ts`:**
- Adds `tokenStored: boolean` and `lastIbmError: QuantumIbmError | null` to the `QuantumAuthStatus` interface.
- `fetchQuantumAuthStatus()` coerces missing `tokenStored` to `false` so pre-v0.4 workloads still work — badge sits at "Not configured" until next successful validation, harmless and self-healing.

**`QuantumControlPanel.tsx`:**
- Replaces `tokenLikelyStored = lastAuthRefresh !== null || ibmAuthenticated` with the explicit `ibmTokenStored = authStatus.tokenStored`.
- Drops the now-unused `lastAuthRefresh` destructure and `hasHistoricalValidation` derived value.
- Prefers `authStatus.lastIbmError.retryable` over `classifyApiError(authStatusError)` when classifying for the yellow banner. Keeps `classifyApiError` as a fallback for older workloads and pre-body network errors.

**Backward compatibility:** older workloads (pre-v0.4) that omit `tokenStored` and `lastIbmError` are handled — `tokenStored` coerces to `false`, the existing `classifyApiError` fallback covers banner classification. The badge sits at "Not configured" against an old workload until the first successful validation.

## Tests

- 6 quantum test files, **50/50 passing locally** (`vitest run src/components/cards/quantum src/hooks/__tests__/useQuantumAuthStatus.test.ts src/hooks/__tests__/useCachedQuantum-pure.test.ts`).
- New test cases:
  - Bug 1 regression: `tokenStored:false` + recent `lastRefresh` must yield "Not configured", not "Stored".
  - Pre-v0.4 compat: workload omitting `tokenStored` is treated as "Not configured".
  - Yellow banner driven by `lastIbmError.retryable:true` (v0.4.0+ workload, no error string).
  - Red banner driven by `lastIbmError.retryable:false`.
  - Updated fetcher pure tests for the new return shape, plus a v0.4.0+ passthrough case and a coercion case.

## Addresses Copilot nits from #15957

1. **Explicit backend selection.** The non-IBM red-banner test now calls `selectNonIbmBackend(container)` explicitly rather than relying on the component's default backend remaining `aer`. Mirrors the existing `selectIbmBackend()` helper used for IBM-backend tests.
2. **Stable selectors.** Banner assertions now target `data-testid="quantum-control-panel-fatal-banner"` and `quantum-control-panel-transient-banner` instead of the raw error text or i18n key. Future banner-content refactors won't silently invalidate the tests. Added matching `role="alert"` / `role="status"` attributes for accessibility.

## Test plan

- [x] `vitest run src/components/cards/quantum src/hooks/__tests__/useQuantumAuthStatus.test.ts src/hooks/__tests__/useCachedQuantum-pure.test.ts` — all green
- [ ] Visual regression baseline (`app-quantum-control-panel-demo.png`) unchanged — banner JSX only added test-ids/roles, no visual changes
- [ ] Manual: connect to quantum-kc-demo v0.4.0 cluster, verify badge transitions: clear → "Not configured", save token → "Configured", restart pod → "Stored", validate-now → "Configured"

Refs #15946, #15948, #15957
🤖 Generated with [Claude Code](https://claude.com/claude-code)