### PR TITLE
🐛 Fix Quantum Control Panel render crash from stale cache hydration

### DIFF
--- a/web/src/components/cards/quantum/QuantumControlPanel.tsx
+++ b/web/src/components/cards/quantum/QuantumControlPanel.tsx
@@ -151,11 +151,14 @@ export const QuantumControlPanel: React.FC = () => {
   //      images, network-level failures before the body parses).
   const fatalError = mutationError ?? statusError
   const classifiedFromMessage = authStatusError ? classifyApiError(authStatusError) : null
+  // Guard with `!= null` (covers `undefined` from stale pre-v0.4 cache hydration)
+  // rather than `!== null`. The fetcher coerces fresh responses to `null`, but
+  // cached payloads written before the field existed surface as `undefined`.
   const isAuthErrorTransient =
-    lastIbmError !== null
+    lastIbmError != null
       ? lastIbmError.retryable === true
       : classifiedFromMessage?.retryable === true
-  const hasAuthError = lastIbmError !== null || classifiedFromMessage !== null
+  const hasAuthError = lastIbmError != null || classifiedFromMessage !== null
   const authErrorForBanner =
     hasAuthError && !isAuthErrorTransient && requiresIBM
       ? (lastIbmError?.message ?? authStatusError)

--- a/web/src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx
@@ -298,6 +298,43 @@ describe('QuantumControlPanel — error classification', () => {
     expect(fatal).toBeInTheDocument()
     expect(fatal).toHaveTextContent('invalid api key')
   })
+
+  it('REGRESSION: renders without crashing when stale cache hydrates lastIbmError as undefined', () => {
+    // Stale `authStatus` cached before #15960 deployed predates the
+    // `lastIbmError` field, so `useCache` hydrates the panel with
+    // `lastIbmError: undefined` (not `null`). The fetcher coerces fresh
+    // responses to `null`, but cached entries bypass the fetcher.
+    //
+    // The strict equality guard `lastIbmError !== null` was true for
+    // `undefined`, then `lastIbmError.retryable` threw
+    // `TypeError: Cannot read properties of undefined (reading 'retryable')`
+    // and tripped the card's error boundary. The fix is the looser
+    // `lastIbmError != null` guard, which covers both.
+    mockUseQuantumAuthStatus.mockReturnValue(
+      authHookReturn({
+        data: {
+          authenticated: false,
+          tokenStored: false,
+          // Cast: TypeScript types this `null`, but runtime hydration of a
+          // stale cache entry produces `undefined`. We deliberately bypass
+          // the type to model the real-world payload that crashed the panel.
+          lastIbmError: undefined as unknown as null,
+        },
+      }),
+    )
+    const { container } = render(<QuantumControlPanel />)
+    selectIbmBackend(container)
+
+    // Panel must render — no error boundary, no crash.
+    expect(container.querySelector('select')).toBeInTheDocument()
+    // Without an error signal of any kind, neither banner should render.
+    expect(
+      screen.queryByTestId('quantum-control-panel-transient-banner'),
+    ).toBeNull()
+    expect(
+      screen.queryByTestId('quantum-control-panel-fatal-banner'),
+    ).toBeNull()
+  })
 })
 
 describe('QuantumControlPanel — feedback', () => {


### PR DESCRIPTION
## Summary

Fixes a `Card render error` on the Quantum Control Panel introduced as a regression after PR #15960:

```
TypeError: Cannot read properties of undefined (reading 'retryable')
  at QuantumControlPanel
```

Reproduces for any user whose browser has a cached `authStatus` payload written before #15960 deployed — the cached entry predates the `lastIbmError` field, so `useCache` hydrates with `lastIbmError: undefined`, not `null`. The strict guard `lastIbmError !== null` is `true` for `undefined`, then `lastIbmError.retryable` throws and the error boundary catches it.

## Root cause

`fetchQuantumAuthStatus` coerces fresh responses to `null` via `coerceLastIbmError` (added in #15960). Cached entries bypass the fetcher on initial hydration, so the coercion doesn't apply — and existing tests all pass explicit `null`, so the `undefined` path was never exercised.

## Fix

One-line change at the read site — `!== null` → `!= null` covers both `null` and `undefined`:

```diff
- const isAuthErrorTransient = lastIbmError !== null
+ const isAuthErrorTransient = lastIbmError != null
    ? lastIbmError.retryable === true
    : classifiedFromMessage?.retryable === true
- const hasAuthError = lastIbmError !== null || classifiedFromMessage !== null
+ const hasAuthError = lastIbmError != null || classifiedFromMessage !== null
```

Defensive change at the read site, not the cache layer — once the next successful fetch lands, the cache is normalized to `null` and the guard works either way. Less invasive than retrofitting hydration coercion into `useCache`.

## Regression test

Adds `REGRESSION: renders without crashing when stale cache hydrates lastIbmError as undefined` in `QuantumControlPanel.test.tsx`. Verified locally:

- **Without the fix**: test fails with the exact original error (`Cannot read properties of undefined (reading 'retryable')` at line 156)
- **With the fix**: 19/19 quantum control panel tests pass

## Test plan
- [x] New regression test fails on broken code, passes on fixed code (verified locally via `git stash` round-trip)
- [x] All existing QuantumControlPanel tests still pass (19/19)
- [ ] CI green
- [ ] Manual: load Quantum Control Panel in a browser with stale IndexedDB cache → no error boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)