### PR TITLE
🌱 Sync workflows from kubestellar/infra

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -9,4 +9,5 @@ permissions:
 
 jobs:
   label:
-    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@5c7fdcdde035388fa2df43d860d2372c2dd3e3ed  # main
+    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@main
+    secrets: inherit

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,25 +12,14 @@ on:
   pull_request_target:
     types: [opened]
 
-# No broad workflow-level permissions — each job declares only what it needs.
-# pull_request_target runs with write access to the base repo; the if-guard below
-# ensures only PRs from the same repository (not forks) proceed, preventing
-# untrusted PR head code from being executed with elevated permissions.
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   ai-fix:
-    if: >-
-      github.event_name != 'pull_request_target' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    # Scoped to minimum permissions required by the reusable AI-fix workflow:
-    # - contents:write  — to push commits on the fix branch
-    # - issues:write   — to comment on and close the issue
-    # - pull-requests:write — to open and update the fix PR
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@5c7fdcdde035388fa2df43d860d2372c2dd3e3ed  # main
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   assignment-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@5c7fdcdde035388fa2df43d860d2372c2dd3e3ed  # main
+    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@main

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,7 +10,11 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-# No broad workflow-level permissions — each job declares only what it needs.
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  statuses: write
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -18,20 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
-    if: >-
-      github.event_name != 'pull_request_target' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    # Scoped to minimum permissions required by the reusable automation workflow:
-    # - contents:write  — to push fixup commits to the PR branch
-    # - pull-requests:write — to add review comments and labels
-    # - issues:write   — to post issue comments
-    # - statuses:write — to set commit status checks
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      statuses: write
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@5c7fdcdde035388fa2df43d860d2372c2dd3e3ed  # main
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,11 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# Least-privilege: only grant read access; reusable workflow cannot exceed this ceiling
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
   copilot-dco:
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@5c7fdcdde035388fa2df43d860d2372c2dd3e3ed  # main
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -10,4 +10,5 @@ permissions:
 
 jobs:
   feedback:
-    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@5c7fdcdde035388fa2df43d860d2372c2dd3e3ed  # main
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
+    secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   greet:
-    if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@5c7fdcdde035388fa2df43d860d2372c2dd3e3ed  # main
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
+    secrets: inherit

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -11,4 +11,5 @@ permissions:
 
 jobs:
   label-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@5c7fdcdde035388fa2df43d860d2372c2dd3e3ed  # main
+    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
+    secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,8 +11,9 @@ permissions:
   security-events: write
   contents: read
   actions: read
+  id-token: write
 
 jobs:
   analysis:
-    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@5c7fdcdde035388fa2df43d860d2372c2dd3e3ed  # main
-    # No secrets passed — reusable workflow only needs GITHUB_TOKEN (automatic)
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
+    secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,4 +10,5 @@ permissions:
 
 jobs:
   stale:
-    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@5c7fdcdde035388fa2df43d860d2372c2dd3e3ed  # main
+    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@main
+    secrets: inherit


### PR DESCRIPTION
This PR syncs the caller workflows from `kubestellar/infra`.

These workflows call reusable workflows from `kubestellar/infra`:

**Standard Workflows:**
- `add-help-wanted.yml` - Add help-wanted label to issues
- `assignment-helper.yml` - Handle issue assignments
- `feedback.yml` - Collect feedback
- `greetings.yml` - Welcome new contributors
- `label-helper.yml` - Manage labels
- `pr-verifier.yml` - Verify PR contents
- `pr-verify-title.yml` - Verify PR title format
- `scorecard.yml` - Security scorecard
- `stale.yml` - Mark stale issues/PRs

**Agentic Workflows (Copilot Integration):**
- `ai-fix.yml` - Assign Copilot to issues with `ai-fix-requested` label
- `copilot-automation.yml` - Automate Copilot PR processing (DCO, labels)
- `copilot-dco.yml` - Override DCO for Copilot PRs

Auto-generated by workflow sync