### PR TITLE
🐛 Run cache-test earlier in full Playwright suite

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -207,11 +207,14 @@ echo ""
 
 declare -a PLAYWRIGHT_SCRIPTS=(
   "scripts/console-error-scan.sh"
+  # Keep cache-test early while the shared preview runner is still fresh.
+  # It is sensitive to accumulated Chromium/V8/IndexedDB pressure from the
+  # long navigation and performance suites (#16245).
+  "scripts/cache-test.sh"
   "scripts/nav-test.sh"
   "scripts/perf-test.sh"
   "scripts/ui-compliance-test.sh"
   "scripts/deploy-test.sh"
-  "scripts/cache-test.sh"
   "scripts/benchmark-test.sh"
   "scripts/ai-ml-test.sh"
   "scripts/a11y-test.sh"


### PR DESCRIPTION
## Summary

- move `cache-test` earlier in `PLAYWRIGHT_SCRIPTS`, immediately after `console-error-scan`
- document why the cache suite should run while the shared preview runner is still relatively fresh
- leave timeouts and all test commands unchanged

## Rationale

`cache-test` is sensitive to accumulated Chromium/V8/IndexedDB pressure when the full nightly suite runs many long Playwright suites sequentially on one shared runner. Running it before the heavier `nav-test` and `perf-test` suites matches the recommendation in #16245 and should reduce false failures without weakening the assertion threshold further.

## Testing

- Not run locally: the full Playwright nightly suite requires the project CI environment and is long-running.
- Verified the PR diff only reorders the `PLAYWRIGHT_SCRIPTS` array and adds explanatory comments.

Closes #16245