### PR TITLE
fix: move TopPods useMemo before early returns

### DIFF
--- a/web/src/components/cards/TopPods.tsx
+++ b/web/src/components/cards/TopPods.tsx
@@ -144,6 +144,14 @@ function TopPodsInternal({ config }: TopPodsProps) {
     defaultLimit: config?.limit || 5,
   })
 
+  // Find max values for visual scaling based on current sort
+  const { maxRestarts, maxCpu, maxMemory, maxGpu } = useMemo(() => ({
+    maxRestarts: Math.max(...pods.map(p => p.restarts), 1),
+    maxCpu: Math.max(...pods.map(p => getEffectiveCpu(p)), 1),
+    maxMemory: Math.max(...pods.map(p => getEffectiveMemory(p)), 1),
+    maxGpu: Math.max(...pods.map(p => p.gpuRequest || 0), 1),
+  }), [pods])
+
   if (showSkeleton) {
     return <CardSkeleton rows={5} type="list" showHeader showSearch />
   }
@@ -165,14 +173,6 @@ function TopPodsInternal({ config }: TopPodsProps) {
       </div>
     )
   }
-
-  // Find max values for visual scaling based on current sort
-  const { maxRestarts, maxCpu, maxMemory, maxGpu } = useMemo(() => ({
-    maxRestarts: Math.max(...pods.map(p => p.restarts), 1),
-    maxCpu: Math.max(...pods.map(p => getEffectiveCpu(p)), 1),
-    maxMemory: Math.max(...pods.map(p => getEffectiveMemory(p)), 1),
-    maxGpu: Math.max(...pods.map(p => p.gpuRequest || 0), 1),
-  }), [pods])
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">


### PR DESCRIPTION
## Summary
- Move the TopPods visual-scaling `useMemo` before all conditional returns.
- Preserve the existing calculation and UI behavior.

## Why
`useMemo` was previously called after the skeleton, empty-state, and error early returns. That means the hook order could differ between renders, violating React's Rules of Hooks and causing the minified React error reported in the issue.

## Testing
- Not run locally; this is a hook-order-only change in a single component.
- Verified the diff only moves the existing `useMemo` block above the early returns.

Closes #16246