### PR TITLE
docs: update contributing documentation link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,6 @@ You can also help without opening a PR:
 
 ## Getting Help
 
-- [Documentation](https://console-docs.kubestellar.io)
+- [Documentation](https://kubestellar.io/docs/console/overview/architecture)
 - [Slack - #kubestellar-dev](https://cloud-native.slack.com/archives/C097094RZ3M)
 - [GitHub Issues](https://github.com/kubestellar/console/issues)


### PR DESCRIPTION
## Summary
- update the Getting Help documentation link in CONTRIBUTING.md
- point contributors to the canonical KubeStellar Console architecture docs URL used by README.md

## Test plan
- `git diff --check -- CONTRIBUTING.md`
- verified old URL returns HTTP 301
- verified `https://kubestellar.io/docs/console/overview/architecture` returns HTTP 200

Fixes #16256