### PR TITLE
🐛 Default Quantum Execution Histogram sort to Pattern

### DIFF
--- a/web/src/components/cards/quantum/QuantumHistogramCard.tsx
+++ b/web/src/components/cards/quantum/QuantumHistogramCard.tsx
@@ -100,7 +100,7 @@ function HistogramMetadata({
 export function QuantumHistogramCard() {
   const { t } = useTranslation(['cards', 'common'])
   const { isAuthenticated, login, isLoading: authIsLoading } = useAuth()
-  const [sortBy, setSortBy] = useState<HistogramSort>('count')
+  const [sortBy, setSortBy] = useState<HistogramSort>('pattern')
   const [refreshInterval, setRefreshInterval] = useState(HISTOGRAM_DEFAULT_POLL_MS)
   const {
     data,


### PR DESCRIPTION
## Summary
- Flip the Quantum Execution Histogram card's initial sort from **Frequency** → **Pattern** (`QuantumHistogramCard.tsx:103`).
- One-line change; toggle buttons still work — only the mount default changes.

## Why
Pattern order shows every bit-string bucket along the x-axis in deterministic order, so the random-noise distribution across all outcomes is immediately visible when the dashboard loads. Frequency order collapses to a top-N ranked view that hides the long noisy tail, which is exactly the visual signal that makes the quantum demo compelling.

## Test plan
- [ ] Load `/quantum`, confirm histogram opens with Pattern button highlighted and bars laid out by bit-string order
- [ ] Click "Frequency" — bars re-sort by descending count
- [ ] Click "Pattern" again — bars return to bit-string order
- [ ] Hard reload (clear cache) — still defaults to Pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)