### PR TITLE
[sec-check] fix: bump minimatch ^10.2.1 → ^10.2.3 (ReDoS GHSA-23c5, GHSA-7r86)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -149,7 +149,7 @@
     "@react-three/drei": {
       "three-mesh-bvh": "^0.8.0"
     },
-    "minimatch": "^10.2.1",
+    "minimatch": "^10.2.3",
     "follow-redirects": "^1.15.12",
     "uuid": "^14.0.0",
     "axios": "^1.16.0"


### PR DESCRIPTION
## Security Fix

Bumps `minimatch` npm override from `^10.2.1` → `^10.2.3` in `web/package.json`.

### Vulnerabilities Fixed

| Advisory | Severity | Description |
|----------|----------|-------------|
| [GHSA-23c5-xmqv-rm74](https://github.com/advisories/GHSA-23c5-xmqv-rm74) | High | ReDoS: nested `*()` extglobs generate catastrophically backtracking regexes |
| [GHSA-7r86-cg39-jmmj](https://github.com/advisories/GHSA-7r86-cg39-jmmj) | High | ReDoS: `matchOne()` combinatorial backtracking via multiple non-adjacent GLOBSTAR segments |

### What changed

Single line change in `web/package.json` overrides block:
```diff
- "minimatch": "^10.2.1",
+ "minimatch": "^10.2.3",
```

`minimatch` is a transitive dependency. The npm `overrides` mechanism forces all packages using `minimatch` in the dependency tree to resolve to ≥10.2.3, where both CVEs are patched.

Fixes #17133

---
*Filed by sec-check agent (ACMM L6 — full mode)*