### PR TITLE
fix(agent): avoid secret scanning false positive in GCP key test

### DIFF
--- a/pkg/agent/scrub_test.go
+++ b/pkg/agent/scrub_test.go
@@ -46,13 +46,15 @@ func TestScrubSecrets_AWSAccessKey(t *testing.T) {
 }
 
 func TestScrubSecrets_GCPKey(t *testing.T) {
-	input := "apikey=AIzaSyB1234567890abcdefghijklmnopqrstuv"
+	fakeKey := "AIza" + strings.Repeat("X", 32)
+
+	input := "apikey=" + fakeKey
 	got := ScrubSecrets(input)
+
 	if strings.Contains(got, "AIza") {
 		t.Errorf("expected GCP key to be scrubbed, got %q", got)
 	}
 }
-
 func TestScrubSecrets_BearerToken(t *testing.T) {
 	input := "Authorization: Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3QifQ.eyJpc3MiOiJ0ZXN0In0.signature"
 	got := ScrubSecrets(input)


### PR DESCRIPTION
### 📌 Fixes

Fixes #17128

---

### 📝 Summary of Changes

* Replaced the hardcoded Google API key test fixture in `pkg/agent/scrub_test.go` with a dynamically constructed value.
* Preserved existing test coverage for GCP API key scrubbing while avoiding GitHub Secret Scanning false positives caused by a committed API key-like string literal.
* Related issue: #17128

---

### Changes Made

* [x] Updated the GCP API key test fixture to use a dynamically generated value
* [x] Refactored the test to avoid a hardcoded Google API key-like string literal
* [x] Fixed GitHub Secret Scanning false positives triggered by the test fixture
* [x] Verified existing test coverage continues to validate GCP API key scrubbing behavior

---

### Checklist

Please ensure the following before submitting your PR:

* [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
* [x] I have reviewed the project's contribution guidelines
* [x] New cards target console-marketplace, not this repo
* [ ] isDemoData is wired correctly (not applicable for this change)
* [x] I have written unit tests for the changes (existing test updated)
* [x] I have tested the changes locally and ensured they work as expected
* [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)
<img width="1410" height="276" alt="image" src="https://github.com/user-attachments/assets/9d7ea195-7e90-4d09-b942-6fdea15dd5ea" />

Local verification:

```bash
go test ./pkg/agent -run TestScrubSecrets_GCPKey -v
```

The test passes successfully after the change.

---

### 👀 Reviewer Notes

This change does not modify production behavior.

The updated test continues to exercise the existing GCP API key regex (`AIza[A-Za-z0-9_-]{30,}`) and validates that matching values are scrubbed correctly. The only change is replacing the hardcoded API key-like string literal with a dynamically constructed value to avoid secret-scanning alerts.
