### PR TITLE
[sec-check] fix: add rate limiting to bonus-points.mts and youtube-playlist.mts (CWE-770)

### DIFF
--- a/web/netlify/functions/bonus-points.mts
+++ b/web/netlify/functions/bonus-points.mts
@@ -16,7 +16,7 @@ import { enforceSimpleRateLimit } from "./_shared/rate-limit";
 const BONUS_REPO = "kubestellar/console";
 const BONUS_LABEL = "bonus-points";
 const BONUS_AUTHORIZED_USER = "clubanderson";
-const BONUS_TITLE_REGEX = /^\[bonus\]\s+@(\S+)\s+(\d+)\s*(.*)/i;
+const BONUS_TITLE_REGEX = /^\[bonus\]\s+@(\S+)\s+\+(\d+)\s*(.*)/i;
 
 /** GitHub username validation — alphanumeric, hyphens allowed, 1-39 chars (#14500) */
 const GITHUB_LOGIN_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,38})?$/;
@@ -167,7 +167,11 @@ export default async (req: Request) => {
       JSON.stringify({ error: "Rate limit exceeded" }),
       {
         status: 429,
-        headers: { ...headers, "Retry-After": String(rate.retryAfterSeconds) },
+        headers: {
+          ...headers,
+          "Retry-After": String(rate.retryAfterSeconds),
+          "Cache-Control": "no-store",
+        },
       }
     );
   }

--- a/web/netlify/functions/bonus-points.mts
+++ b/web/netlify/functions/bonus-points.mts
@@ -9,18 +9,29 @@
  * Query: GET /api/rewards/bonus?login=rishi-jat
  */
 
+import { getStore } from "@netlify/blobs";
 import { buildCorsHeaders, handlePreflight } from "./_shared";
+import { enforceSimpleRateLimit } from "./_shared/rate-limit";
 
 const BONUS_REPO = "kubestellar/console";
 const BONUS_LABEL = "bonus-points";
 const BONUS_AUTHORIZED_USER = "clubanderson";
-const BONUS_TITLE_REGEX = /^\[bonus\]\s+@(\S+)\s+\+(\d+)\s*(.*)/i;
+const BONUS_TITLE_REGEX = /^\[bonus\]\s+@(\S+)\s+(\d+)\s*(.*)/i;
 
 /** GitHub username validation — alphanumeric, hyphens allowed, 1-39 chars (#14500) */
 const GITHUB_LOGIN_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,38})?$/;
 
+/** Blob cache store name */
+const CACHE_STORE_NAME = "bonus-points-cache";
+/** Cache key for all bonus issues */
+const CACHE_KEY = "all-bonus-issues";
 /** Cache TTL — 15 minutes */
 const CACHE_TTL_MS = 15 * 60 * 1000;
+
+/** Rate limit store and config */
+const RATE_LIMIT_STORE_NAME = "bonus-points-rate-limit";
+const RATE_LIMIT_MAX_REQUESTS = 30;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 
 /** Timeout for GitHub API requests */
 const GITHUB_API_TIMEOUT_MS = 10_000;
@@ -35,13 +46,10 @@ interface BonusEntry {
   state: string;
 }
 
-interface CachedBonusData {
-  /** Map of login -> entries */
+interface BlobCacheEntry {
   byLogin: Record<string, BonusEntry[]>;
   fetchedAt: number;
 }
-
-let cache: CachedBonusData | null = null;
 
 async function readCappedJson<T>(response: Response): Promise<T> {
   const contentLength = parseInt(response.headers.get("content-length") || "0", 10);
@@ -60,8 +68,6 @@ async function readCappedJson<T>(response: Response): Promise<T> {
 async function fetchAllBonusIssues(): Promise<Record<string, BonusEntry[]>> {
   const byLogin: Record<string, BonusEntry[]> = {};
 
-  // Use GitHub API without auth — bonus-points issues are public
-  // Fall back to GITHUB_TOKEN if available for higher rate limits
   const headers: Record<string, string> = {
     Accept: "application/vnd.github.v3+json",
   };
@@ -110,6 +116,29 @@ async function fetchAllBonusIssues(): Promise<Record<string, BonusEntry[]>> {
   return byLogin;
 }
 
+async function readBlobCache(): Promise<Record<string, BonusEntry[]> | null> {
+  try {
+    const store = getStore(CACHE_STORE_NAME);
+    const raw = await store.get(CACHE_KEY, { type: "json" }) as BlobCacheEntry | null;
+    if (raw && raw.fetchedAt && Date.now() - raw.fetchedAt < CACHE_TTL_MS) {
+      return raw.byLogin;
+    }
+  } catch {
+    // cache miss — proceed to fetch
+  }
+  return null;
+}
+
+async function writeBlobCache(byLogin: Record<string, BonusEntry[]>): Promise<void> {
+  try {
+    const store = getStore(CACHE_STORE_NAME);
+    const entry: BlobCacheEntry = { byLogin, fetchedAt: Date.now() };
+    await store.setJSON(CACHE_KEY, entry);
+  } catch {
+    // best-effort
+  }
+}
+
 export default async (req: Request) => {
   const headers: Record<string, string> = {
     ...buildCorsHeaders(req, { methods: "GET, OPTIONS" }),
@@ -119,6 +148,28 @@ export default async (req: Request) => {
 
   if (req.method === "OPTIONS") {
     return handlePreflight(req, { methods: "GET, OPTIONS" });
+  }
+
+  const clientIp =
+    req.headers.get("x-nf-client-connection-ip") ??
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "unknown";
+
+  const rate = await enforceSimpleRateLimit({
+    storeName: RATE_LIMIT_STORE_NAME,
+    prefix: "bonus-points:",
+    subject: clientIp,
+    maxRequests: RATE_LIMIT_MAX_REQUESTS,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+  });
+  if (rate.limited) {
+    return new Response(
+      JSON.stringify({ error: "Rate limit exceeded" }),
+      {
+        status: 429,
+        headers: { ...headers, "Retry-After": String(rate.retryAfterSeconds) },
+      }
+    );
   }
 
   const url = new URL(req.url);
@@ -139,13 +190,16 @@ export default async (req: Request) => {
   }
 
   try {
-    // Check cache
-    if (!cache || Date.now() - cache.fetchedAt > CACHE_TTL_MS) {
-      const byLogin = await fetchAllBonusIssues();
-      cache = { byLogin, fetchedAt: Date.now() };
+    // Try Netlify Blobs cache first (persists across Lambda containers)
+    let byLogin = await readBlobCache();
+    if (!byLogin) {
+      byLogin = await fetchAllBonusIssues();
+      writeBlobCache(byLogin).catch((err) => {
+        console.warn("[bonus-points] blob cache write failed:", err instanceof Error ? err.message : err);
+      });
     }
 
-    const entries = cache.byLogin[login] || [];
+    const entries = byLogin[login] || [];
     const totalPoints = entries.reduce((sum, e) => sum + e.points, 0);
 
     return new Response(
@@ -174,7 +228,4 @@ export const _testOnly = {
   MAX_RESPONSE_BYTES,
   GITHUB_LOGIN_REGEX,
   CACHE_TTL_MS,
-  resetCache: () => {
-    cache = null;
-  },
 };

--- a/web/netlify/functions/youtube-playlist.mts
+++ b/web/netlify/functions/youtube-playlist.mts
@@ -7,10 +7,19 @@
  */
 
 import { buildCorsHeaders, handlePreflight } from "./_shared"
+import { enforceSimpleRateLimit } from "./_shared/rate-limit"
 
 const PLAYLIST_ID = "PL1ALKGr_qZKc-xehA_8iUCdiKsCo6p6nD";
 const FEED_URL = `https://www.youtube.com/feeds/videos.xml?playlist_id=${PLAYLIST_ID}`;
 export const MAX_RESPONSE_BYTES = 512_000; // 512 KB — playlist data is typically < 100 KB
+
+/** Rate limit: 30 requests per minute per IP (CWE-770, #17152) */
+const RATE_LIMIT_STORE_NAME = "youtube-playlist-rate-limit";
+const RATE_LIMIT_MAX_REQUESTS = 30;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+
+/** YouTube video ID: exactly 11 chars of [A-Za-z0-9_-] */
+const YOUTUBE_VIDEO_ID_RE = /^[A-Za-z0-9_-]{11}$/;
 
 interface PlaylistVideo {
   id: string;
@@ -34,7 +43,7 @@ function parseAtomFeed(xml: string): PlaylistVideo[] {
     const description = entry.match(/<media:description>([^<]*)<\/media:description>/)?.[1] ?? "";
     const published = entry.match(/<published>([^<]+)<\/published>/)?.[1] ?? "";
 
-    if (videoId) {
+    if (videoId && YOUTUBE_VIDEO_ID_RE.test(videoId)) {
       videos.push({
         id: videoId,
         title,
@@ -63,6 +72,28 @@ export default async (req: Request) => {
     });
   }
 
+  const clientIp =
+    req.headers.get("x-nf-client-connection-ip") ??
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "unknown";
+
+  const rate = await enforceSimpleRateLimit({
+    storeName: RATE_LIMIT_STORE_NAME,
+    prefix: "youtube-playlist:",
+    subject: clientIp,
+    maxRequests: RATE_LIMIT_MAX_REQUESTS,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+  });
+  if (rate.limited) {
+    return new Response(
+      JSON.stringify({ error: "Rate limit exceeded", videos: [] }),
+      {
+        status: 429,
+        headers: { ...headers, "Retry-After": String(rate.retryAfterSeconds) },
+      }
+    );
+  }
+
   try {
     // Primary: Invidious API (reliable, no auth required)
     const invidiousInstances = [
@@ -88,18 +119,23 @@ export default async (req: Request) => {
           }
           const data = JSON.parse(rawText) as { videos?: Array<{ videoId: string; title: string }> };
           if (data.videos && data.videos.length > 0) {
-            const videos: PlaylistVideo[] = data.videos.map((v) => ({
-              id: v.videoId,
-              title: v.title,
-            }));
-            return new Response(
-              JSON.stringify({
-                videos,
-                playlistId: PLAYLIST_ID,
-                playlistUrl: `https://www.youtube.com/playlist?list=${PLAYLIST_ID}`,
-              }),
-              { status: 200, headers }
-            );
+            // Validate videoIds returned by third-party Invidious instances (#17152)
+            const videos: PlaylistVideo[] = data.videos
+              .filter((v) => YOUTUBE_VIDEO_ID_RE.test(v.videoId))
+              .map((v) => ({
+                id: v.videoId,
+                title: v.title,
+              }));
+            if (videos.length > 0) {
+              return new Response(
+                JSON.stringify({
+                  videos,
+                  playlistId: PLAYLIST_ID,
+                  playlistUrl: `https://www.youtube.com/playlist?list=${PLAYLIST_ID}`,
+                }),
+                { status: 200, headers }
+              );
+            }
           }
         }
       } catch {

--- a/web/netlify/functions/youtube-playlist.mts
+++ b/web/netlify/functions/youtube-playlist.mts
@@ -89,7 +89,11 @@ export default async (req: Request) => {
       JSON.stringify({ error: "Rate limit exceeded", videos: [] }),
       {
         status: 429,
-        headers: { ...headers, "Retry-After": String(rate.retryAfterSeconds) },
+        headers: {
+          ...headers,
+          "Retry-After": String(rate.retryAfterSeconds),
+          "Cache-Control": "no-store",
+        },
       }
     );
   }


### PR DESCRIPTION
## Security Fix

Adds per-IP rate limiting (30 req/min) and Netlify Blobs caching to two Netlify functions that made outbound API calls with no incoming throttle.

### bonus-points.mts — GitHub API quota exhaustion (CWE-770)

**Before:** In-memory module-level cache (`let cache`) resets on every cold Lambda invocation. No rate limiting. Each cache-miss triggers a live GitHub API call:
`GET /repos/kubestellar/console/issues?labels=bonus-points&per_page=100`

**After:**
- `enforceSimpleRateLimit` (30 req/min per IP, Netlify Blobs-backed)
- Netlify Blobs cache replaces in-memory-only cache — persists across Lambda containers, preventing repeated GitHub API calls under horizontal scale-out
- Returns `429 Too Many Requests` with `Retry-After` header

### youtube-playlist.mts — Invidious API abuse + video ID validation (CWE-770)

**Before:** No rate limiting. Each request makes up to 4 outbound calls (3 Invidious instances + YouTube RSS). Invidious `videoId` values from untrusted third-party servers were forwarded to clients without validation.

**After:**
- `enforceSimpleRateLimit` (30 req/min per IP)
- Returns `429 Too Many Requests` with `Retry-After` header
- `videoId` values from Invidious responses validated against `YOUTUBE_VIDEO_ID_RE = /^[A-Za-z0-9_-]{11}$/` before being included in the response

### Changes

| File | Change |
|---|---|
| `bonus-points.mts` | + rate limit, + Blobs cache, remove resetCache test export |
| `youtube-playlist.mts` | + rate limit, + videoId validation |

Fixes #17152

---
*Filed by sec-check agent (ACMM L6 — full mode)*