### PR TITLE
🐛 Fix Stellar SSE stream nil-pointer panic on /api/stellar/stream

### DIFF
--- a/pkg/api/handlers/stellar_observations.go
+++ b/pkg/api/handlers/stellar_observations.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
-	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/safego"
 	"github.com/kubestellar/console/pkg/stellar/prompts"
@@ -396,7 +395,7 @@ func (h *StellarHandler) Stream(c *fiber.Ctx) error {
 		clientCh := make(chan SSEEvent, 32)
 		isAdmin := false
 		if userStore, ok := h.store.(store.Store); ok {
-			resolvedUser, resolveErr := userStore.GetUser(streamCtx, middleware.GetUserID(c))
+			resolvedUser, resolveErr := userStore.GetUser(streamCtx, userID)
 			isAdmin = resolveErr == nil && resolvedUser != nil && resolvedUser.Role == models.UserRoleAdmin
 		}
 		h.registerSSEClient(connID, userID, isAdmin, clientCh)

--- a/pkg/api/handlers/stellar_observations.go
+++ b/pkg/api/handlers/stellar_observations.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/safego"
@@ -388,15 +389,21 @@ func (h *StellarHandler) Stream(c *fiber.Ctx) error {
 	c.Set("Content-Type", "text/event-stream")
 	c.Set("Cache-Control", "no-cache")
 	c.Set("Connection", "keep-alive")
+	// Parse userID into a UUID up-front, in the safe parent-handler scope. The
+	// SetBodyStreamWriter callback runs in a goroutine after the request ctx is
+	// recycled, so we cannot read c.Locals (or call middleware.GetUserID) there.
+	userUUID, parseErr := uuid.Parse(userID)
 	streamCtx, streamCancel := context.WithCancel(c.UserContext())
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
 		defer streamCancel()
 		connID := fmt.Sprintf("%s-%d", userID, time.Now().UnixNano())
 		clientCh := make(chan SSEEvent, 32)
 		isAdmin := false
-		if userStore, ok := h.store.(store.Store); ok {
-			resolvedUser, resolveErr := userStore.GetUser(streamCtx, userID)
-			isAdmin = resolveErr == nil && resolvedUser != nil && resolvedUser.Role == models.UserRoleAdmin
+		if parseErr == nil {
+			if userStore, ok := h.store.(store.Store); ok {
+				resolvedUser, resolveErr := userStore.GetUser(streamCtx, userUUID)
+				isAdmin = resolveErr == nil && resolvedUser != nil && resolvedUser.Role == models.UserRoleAdmin
+			}
 		}
 		h.registerSSEClient(connID, userID, isAdmin, clientCh)
 		defer h.unregisterSSEClient(connID)


### PR DESCRIPTION
Fixes #17226

## Summary
- Stellar SSE stream handler crashed the backend with SIGSEGV on every connection — the SSE goroutine called `middleware.GetUserID(c)` after fasthttp had already recycled the `*RequestCtx`, so `c.Locals("userID")` dereferenced a nil internal map.
- `userID` is already captured into a local variable at `stellar_observations.go:376` via `h.requireUser(c)`. Reuse the captured value inside the `SetBodyStreamWriter` callback instead of re-deriving it from the released request context.
- Drops the now-unused `middleware` import.

## Regression from
#17008 — "🔒 Scope Stellar observations per-user on SSE stream (CWE-200)" added the admin lookup that made the unsafe `GetUserID(c)` call.

## Stack trace (from local repro)
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1c497f6]

goroutine 682 [running]:
github.com/valyala/fasthttp.(*RequestCtx).UserValue(...)
        .../fasthttp@v1.58.0/server.go:709
github.com/gofiber/fiber/v2.(*Ctx).Locals(...)
        .../fiber/v2@v2.52.13/ctx.go:985 +0x36
github.com/kubestellar/console/pkg/api/middleware.GetUserID(...)
        .../pkg/api/middleware/auth.go:721
github.com/kubestellar/console/pkg/api/handlers.(*StellarHandler).Stream.func1(...)
        .../pkg/api/handlers/stellar_observations.go:399 +0x205
github.com/valyala/fasthttp.NewStreamReader.func1()
        .../fasthttp@v1.58.0/stream.go:44 +0x39
created by github.com/valyala/fasthttp.NewStreamReader in goroutine 86
```

## Test plan
- [ ] CI passes (build + lint)
- [ ] `./startup-oauth.sh` no longer panics on `GET /api/stellar/stream`
- [ ] Stellar dashboard stream loads notifications + state without backend crash
- [ ] Admin SSE filtering still works (admins continue to receive admin-scoped events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)