### PR TITLE
[quality] add newTestServer helper with functional options for pkg/agent

### DIFF
--- a/pkg/agent/testhelpers_server_smoke_test.go
+++ b/pkg/agent/testhelpers_server_smoke_test.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubestellar/console/pkg/k8s"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+)
+
+// TestNewTestServer_Health verifies the helper produces a Server that can
+// serve the /health endpoint without panicking.
+func TestNewTestServer_Health(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+
+	s.handleHealth(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("handleHealth returned %d, want 200", w.Code)
+	}
+
+	var payload map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if payload["status"] != "ok" {
+		t.Errorf("status = %q, want \"ok\"", payload["status"])
+	}
+}
+
+// TestNewTestServer_WithK8sClient verifies injection of a fake k8s client.
+func TestNewTestServer_WithK8sClient(t *testing.T) {
+	fakeClientset := fakek8s.NewSimpleClientset()
+	k8sClient, _ := k8s.NewMultiClusterClient("")
+	k8sClient.SetClient("test-cluster", fakeClientset)
+
+	s := newTestServer(t, withK8sClient(k8sClient))
+
+	if s.k8sClient == nil {
+		t.Fatal("k8sClient should be set")
+	}
+}
+
+// TestNewTestServer_WithToken verifies the token option enables auth.
+func TestNewTestServer_WithToken(t *testing.T) {
+	s := newTestServer(t, withToken("secret-token"))
+
+	// Build a request without the token — should fail auth
+	req := httptest.NewRequest("GET", "/status", nil)
+	w := httptest.NewRecorder()
+
+	s.handleStatus(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("handleStatus without token returned %d, want 401", w.Code)
+	}
+
+	// Now with token — should pass
+	req2 := httptest.NewRequest("GET", "/status", nil)
+	req2.Header.Set("Authorization", "Bearer secret-token")
+	w2 := httptest.NewRecorder()
+
+	s.handleStatus(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Errorf("handleStatus with valid token returned %d, want 200", w2.Code)
+	}
+}
+
+// TestNewTestServer_WithProvider verifies provider injection.
+func TestNewTestServer_WithProvider(t *testing.T) {
+	mock := &ServerMockProvider{name: "test-provider"}
+	s := newTestServer(t, withProvider(mock))
+
+	providers := s.registry.ListAvailable()
+	found := false
+	for _, p := range providers {
+		if p.Name == "test-provider" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("injected provider not found in registry")
+	}
+}

--- a/pkg/agent/testhelpers_server_test.go
+++ b/pkg/agent/testhelpers_server_test.go
@@ -1,0 +1,144 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/kubestellar/console/pkg/k8s"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// ── Test Server Builder ─────────────────────────────────────────────────────
+//
+// newTestServer constructs a minimal *Server suitable for httptest-based
+// handler tests. It applies functional options so each test only specifies
+// the dependencies it actually exercises.
+//
+// Usage:
+//
+//	s := newTestServer(t, withK8sClient(myClient), withRegistry(myReg))
+//	req := httptest.NewRequest("GET", "/health", nil)
+//	w := httptest.NewRecorder()
+//	s.handleHealth(w, req)
+
+type testServerOption func(*Server)
+
+// newTestServer creates a *Server with sane defaults for testing.
+// All channels, maps, and mutexes are initialized to prevent nil-pointer
+// panics. Pass options to override specific dependencies.
+func newTestServer(t *testing.T, opts ...testServerOption) *Server {
+	t.Helper()
+
+	// Minimal kubectl proxy with empty config (no real kubeconfig needed)
+	kubectlProxy := &KubectlProxy{
+		config: &api.Config{
+			Contexts: map[string]*api.Context{
+				"test-context": {Cluster: "test-cluster", AuthInfo: "test-user"},
+			},
+			CurrentContext: "test-context",
+		},
+	}
+
+	s := &Server{
+		kubectl:                 kubectlProxy,
+		registry:                &Registry{providers: make(map[string]AIProvider)},
+		allowedOrigins:          []string{"*"},
+		clients:                 make(map[*websocket.Conn]*wsClient),
+		activeChatCtxs:          make(map[string]activeChatEntry),
+		dryRunSessions:          make(map[string]bool),
+		resourceRetryState:      make(map[string]clusterResourceRetryState),
+		stopCh:                  make(chan struct{}),
+		missionExecutionTimeout: defaultMissionExecutionTimeout,
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+// ── Options ─────────────────────────────────────────────────────────────────
+
+// withToken sets a shared-secret token on the server and marks it explicit.
+func withToken(token string) testServerOption {
+	return func(s *Server) {
+		s.agentToken = token
+		s.tokenExplicit = true
+	}
+}
+
+// withNoToken disables token authentication (open mode).
+func withNoToken() testServerOption {
+	return func(s *Server) {
+		s.agentToken = ""
+		s.tokenExplicit = false
+	}
+}
+
+// withAllowedOrigins overrides the default wildcard origin list.
+func withAllowedOrigins(origins ...string) testServerOption {
+	return func(s *Server) {
+		s.allowedOrigins = origins
+	}
+}
+
+// withK8sClient injects a *k8s.MultiClusterClient (typically backed by
+// k8s.io/client-go/kubernetes/fake).
+func withK8sClient(client *k8s.MultiClusterClient) testServerOption {
+	return func(s *Server) {
+		s.k8sClient = client
+	}
+}
+
+// withKubectlProxy overrides the default empty KubectlProxy.
+func withKubectlProxy(kp *KubectlProxy) testServerOption {
+	return func(s *Server) {
+		s.kubectl = kp
+	}
+}
+
+// withRegistry overrides the default empty provider registry.
+func withRegistry(r *Registry) testServerOption {
+	return func(s *Server) {
+		s.registry = r
+	}
+}
+
+// withProvider is a convenience that registers a single provider into the
+// server's registry. Can be called multiple times.
+func withProvider(p AIProvider) testServerOption {
+	return func(s *Server) {
+		s.registry.Register(p)
+	}
+}
+
+// withMetricsHistory injects a MetricsHistory for prediction/metrics tests.
+func withMetricsHistory(mh *MetricsHistory) testServerOption {
+	return func(s *Server) {
+		s.metricsHistory = mh
+	}
+}
+
+// withDeviceTracker injects a DeviceTracker for GPU/hardware tests.
+func withDeviceTracker(dt *DeviceTracker) testServerOption {
+	return func(s *Server) {
+		s.deviceTracker = dt
+	}
+}
+
+// withSkipKeyValidation disables key validation (useful for AI handler tests
+// that don't care about provider readiness).
+func withSkipKeyValidation() testServerOption {
+	return func(s *Server) {
+		s.SkipKeyValidation = true
+	}
+}
+
+// withEventProcessor injects a custom EventProcessor (Stellar integration).
+func withEventProcessor(ep EventProcessor) testServerOption {
+	return func(s *Server) {
+		s.eventProcessor = ep
+	}
+}


### PR DESCRIPTION
## Test Improvement

Adds a reusable `newTestServer(t, ...opts)` helper to `pkg/agent/` that constructs a minimal `*Server` with all maps, channels, and mutexes initialized. This prevents nil-pointer panics and eliminates the boilerplate repeated across 20+ test files.

### What's included:

**`testhelpers_server_test.go`** — the builder:
- `newTestServer(t, ...opts)` with sane defaults (empty kubeconfig, wildcard CORS, empty registry)
- Functional options: `withToken`, `withNoToken`, `withK8sClient`, `withKubectlProxy`, `withRegistry`, `withProvider`, `withMetricsHistory`, `withDeviceTracker`, `withSkipKeyValidation`, `withEventProcessor`, `withAllowedOrigins`

**`testhelpers_server_smoke_test.go`** — validation:
- `TestNewTestServer_Health` — proves the helper can serve `/health`
- `TestNewTestServer_WithK8sClient` — verifies k8s client injection
- `TestNewTestServer_WithToken` — confirms auth enforcement works
- `TestNewTestServer_WithProvider` — confirms provider registration

### Why this matters:
Unlocks httptest-based handler tests for 31 untested `server_*.go` files that all require a constructed `Server` struct with mock dependencies.

## Related Issue
Fixes #17147

---
*Filed by quality agent (hold-gated mode). Human review required.*