### PR TITLE
[quality] add Server test helper with functional options + health handler tests

### DIFF
--- a/pkg/agent/server_health_test.go
+++ b/pkg/agent/server_health_test.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHandleHealth_OK verifies the unauthenticated /health endpoint returns
+// status: ok with the current version.
+func TestHandleHealth_OK(t *testing.T) {
+	s := NewTestServerHelper(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Origin", "http://localhost")
+	w := httptest.NewRecorder()
+
+	s.handleHealth(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp["status"] != "ok" {
+		t.Errorf("expected status=ok, got %q", resp["status"])
+	}
+}
+
+// TestHandleHealth_CORS_Preflight verifies OPTIONS returns 204.
+func TestHandleHealth_CORS_Preflight(t *testing.T) {
+	s := NewTestServerHelper(t)
+
+	req := httptest.NewRequest(http.MethodOptions, "/health", nil)
+	req.Header.Set("Origin", "http://localhost")
+	w := httptest.NewRecorder()
+
+	s.handleHealth(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+}
+
+// TestHandleStatus_Unauthorized verifies /status rejects unauthenticated requests.
+func TestHandleStatus_Unauthorized(t *testing.T) {
+	s := NewTestServerHelper(t, WithAgentToken("secret-token"))
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	req.Header.Set("Origin", "http://localhost")
+	// No Authorization header
+	w := httptest.NewRecorder()
+
+	s.handleStatus(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleStatus_Authenticated verifies /status returns JSON when authenticated.
+func TestHandleStatus_Authenticated(t *testing.T) {
+	s := NewTestServerHelper(t, WithAgentToken("my-token"))
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	req.Header.Set("Origin", "http://localhost")
+	req.Header.Set("Authorization", "Bearer my-token")
+	w := httptest.NewRecorder()
+
+	s.handleStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body=%s", w.Code, w.Body.String())
+	}
+	// Should be valid JSON
+	var payload map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if payload["status"] != "ok" {
+		t.Errorf("expected status=ok, got %v", payload["status"])
+	}
+}
+
+// TestHandleProviderCheck_MissingName verifies 400 when name param is absent.
+func TestHandleProviderCheck_MissingName(t *testing.T) {
+	s := NewTestServerHelper(t, WithAgentToken("tok"))
+
+	req := httptest.NewRequest(http.MethodGet, "/provider/check", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+
+	s.handleProviderCheck(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleProviderCheck_Unauthorized verifies 401 without token.
+func TestHandleProviderCheck_Unauthorized(t *testing.T) {
+	s := NewTestServerHelper(t, WithAgentToken("tok"))
+
+	req := httptest.NewRequest(http.MethodGet, "/provider/check?name=test", nil)
+	// No Authorization header
+	w := httptest.NewRecorder()
+
+	s.handleProviderCheck(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/pkg/agent/testhelpers_test.go
+++ b/pkg/agent/testhelpers_test.go
@@ -1,0 +1,181 @@
+package agent
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/kubestellar/console/pkg/k8s"
+)
+
+// TestServerOption is a functional option for configuring a test Server.
+type TestServerOption func(*Server)
+
+// NewTestServerHelper constructs a minimal *Server suitable for handler-level
+// unit tests. It wires safe defaults (closed stopCh, empty maps, empty
+// registry) so callers only need to supply options relevant to the handler
+// under test.
+//
+// Usage:
+//
+//	s := NewTestServerHelper(t,
+//	    WithAgentToken("test-token"),
+//	    WithAllowedOrigins("http://localhost"),
+//	)
+//	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+//	w := httptest.NewRecorder()
+//	s.handleHealth(w, req)
+func NewTestServerHelper(t *testing.T, opts ...TestServerOption) *Server {
+	t.Helper()
+
+	s := &Server{
+		config: Config{
+			Port:           0,
+			AllowedOrigins: []string{"http://localhost"},
+		},
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool { return true },
+		},
+		clients:            make(map[*websocket.Conn]*wsClient),
+		allowedOrigins:     []string{"http://localhost"},
+		activeChatCtxs:     make(map[string]activeChatEntry),
+		dryRunSessions:     make(map[string]bool),
+		resourceRetryState: make(map[string]clusterResourceRetryState),
+		registry:           &Registry{providers: make(map[string]AIProvider)},
+		stopCh:             make(chan struct{}),
+		sessionStart:       time.Now(),
+		todayDate:          time.Now().Format("2006-01-02"),
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+// WithAgentToken sets the agent token for authentication-aware tests.
+func WithAgentToken(token string) TestServerOption {
+	return func(s *Server) {
+		s.agentToken = token
+		s.tokenExplicit = token != ""
+	}
+}
+
+// WithAllowedOrigins overrides the allowed origins list for CORS tests.
+func WithAllowedOrigins(origins ...string) TestServerOption {
+	return func(s *Server) {
+		s.allowedOrigins = origins
+	}
+}
+
+// WithRegistry injects a custom Registry (e.g., with mock providers).
+func WithRegistry(r *Registry) TestServerOption {
+	return func(s *Server) {
+		s.registry = r
+	}
+}
+
+// WithK8sClient injects a MultiClusterClient for tests that exercise
+// cluster-aware handlers.
+func WithK8sClient(c *k8s.MultiClusterClient) TestServerOption {
+	return func(s *Server) {
+		s.k8sClient = c
+	}
+}
+
+// WithKubectlProxy injects a KubectlProxy for tests that need kubectl
+// operations (ListContexts, etc.).
+func WithKubectlProxy(k *KubectlProxy) TestServerOption {
+	return func(s *Server) {
+		s.kubectl = k
+	}
+}
+
+// WithMetricsHistory injects a MetricsHistory for prediction/metrics tests.
+func WithMetricsHistory(mh *MetricsHistory) TestServerOption {
+	return func(s *Server) {
+		s.metricsHistory = mh
+	}
+}
+
+// WithPredictionWorker injects a PredictionWorker for prediction handler tests.
+func WithPredictionWorker(pw *PredictionWorker) TestServerOption {
+	return func(s *Server) {
+		s.predictionWorker = pw
+	}
+}
+
+// WithInsightWorker injects an InsightWorker for insight handler tests.
+func WithInsightWorker(iw *InsightWorker) TestServerOption {
+	return func(s *Server) {
+		s.insightWorker = iw
+	}
+}
+
+// WithDeviceTracker injects a DeviceTracker for device handler tests.
+func WithDeviceTracker(dt *DeviceTracker) TestServerOption {
+	return func(s *Server) {
+		s.deviceTracker = dt
+	}
+}
+
+// WithLocalClusterManager injects a LocalClusterManager for local cluster
+// handler tests.
+func WithLocalClusterManager(lcm *LocalClusterManager) TestServerOption {
+	return func(s *Server) {
+		s.localClusters = lcm
+	}
+}
+
+// WithSessionTokenQuota sets a session token quota for quota-related tests.
+func WithSessionTokenQuota(quota int64) TestServerOption {
+	return func(s *Server) {
+		s.sessionTokenQuota = quota
+	}
+}
+
+// WithEventProcessor injects an EventProcessor for Stellar integration tests.
+func WithEventProcessor(ep EventProcessor) TestServerOption {
+	return func(s *Server) {
+		s.eventProcessor = ep
+	}
+}
+
+// WithStellarForwardSem sets the Stellar forward semaphore capacity.
+func WithStellarForwardSem(capacity int) TestServerOption {
+	return func(s *Server) {
+		s.stellarForwardSem = make(chan struct{}, capacity)
+	}
+}
+
+// MockBroadcast returns a broadcast function that records calls and a function
+// to retrieve the recorded messages. Useful for testing handlers that invoke
+// the WebSocket broadcast path.
+func MockBroadcast(t *testing.T) (func(string, interface{}), func() []BroadcastMessage) {
+	t.Helper()
+	var mu sync.Mutex
+	var msgs []BroadcastMessage
+	fn := func(msgType string, payload interface{}) {
+		mu.Lock()
+		defer mu.Unlock()
+		msgs = append(msgs, BroadcastMessage{Type: msgType, Payload: payload})
+	}
+	get := func() []BroadcastMessage {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]BroadcastMessage, len(msgs))
+		copy(out, msgs)
+		return out
+	}
+	return fn, get
+}
+
+// BroadcastMessage captures a single broadcast call for assertions.
+type BroadcastMessage struct {
+	Type    string
+	Payload interface{}
+}


### PR DESCRIPTION
## Test Improvement

Introduces `NewTestServerHelper` in `testhelpers_test.go` — a shared, reusable test helper using the functional options pattern that enables httptest-based handler tests without real Kubernetes connections or AI providers.

### What's included:

**`pkg/agent/testhelpers_test.go`** — the helper with options:
- `WithAgentToken` — authentication-aware tests
- `WithAllowedOrigins` — CORS tests
- `WithRegistry` — mock AI provider tests
- `WithK8sClient` — cluster-aware handler tests
- `WithKubectlProxy` — kubectl operation tests
- `WithMetricsHistory`, `WithPredictionWorker`, `WithInsightWorker` — subsystem tests
- `WithDeviceTracker`, `WithLocalClusterManager` — device/cluster tests
- `WithSessionTokenQuota` — quota tests
- `WithEventProcessor`, `WithStellarForwardSem` — Stellar integration tests
- `MockBroadcast` — captures broadcast calls for assertions

**`pkg/agent/server_health_test.go`** — 6 handler tests demonstrating usage:
- `TestHandleHealth_OK` — basic health check
- `TestHandleHealth_CORS_Preflight` — OPTIONS handling
- `TestHandleStatus_Unauthorized` — auth enforcement
- `TestHandleStatus_Authenticated` — successful status response
- `TestHandleProviderCheck_MissingName` — validation
- `TestHandleProviderCheck_Unauthorized` — auth enforcement

### Impact

This unlocks testing for 31 previously untested handler files in `pkg/agent/` that all require a constructed `Server` struct.

Fixes #17147

---
*Filed by quality agent (ACMM L4/L6 — full mode)*