### PR TITLE
[quality] Add Server test helper with functional options for pkg/agent

### DIFF
--- a/pkg/agent/prediction_broadcast_test.go
+++ b/pkg/agent/prediction_broadcast_test.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// TestBroadcastToClients_NoClients verifies broadcast with zero connected
+// clients does not panic.
+func TestBroadcastToClients_NoClients(t *testing.T) {
+	s := newTestServer(t)
+	// Should not panic with empty clients map
+	s.BroadcastToClients("test_event", map[string]string{"key": "value"})
+}
+
+// TestBroadcastToClients_SingleClient verifies a message reaches a connected client.
+func TestBroadcastToClients_SingleClient(t *testing.T) {
+	s := newTestServer(t, WithNoAuth())
+
+	// Set up a WebSocket server that uses our Server's broadcast
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+			return
+		}
+		// Register the client
+		s.clientsMux.Lock()
+		s.clients[conn] = &wsClient{}
+		s.clientsMux.Unlock()
+
+		// Keep connection open until test reads
+		time.Sleep(500 * time.Millisecond)
+		conn.Close()
+	})
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// Connect WebSocket client
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer clientConn.Close()
+
+	// Give server time to register the client
+	time.Sleep(50 * time.Millisecond)
+
+	// Broadcast
+	s.BroadcastToClients("prediction_update", map[string]int{"score": 42})
+
+	// Read the message from client side
+	clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := clientConn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if !strings.Contains(string(msg), "prediction_update") {
+		t.Fatalf("expected message to contain 'prediction_update', got: %s", string(msg))
+	}
+	if !strings.Contains(string(msg), "42") {
+		t.Fatalf("expected message to contain '42', got: %s", string(msg))
+	}
+}
+
+// TestBroadcastToClients_DeadClientRemoved verifies that a closed connection
+// is cleaned up after a failed broadcast.
+func TestBroadcastToClients_DeadClientRemoved(t *testing.T) {
+	s := newTestServer(t, WithNoAuth())
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		// Register the client then immediately close (simulating dead conn)
+		s.clientsMux.Lock()
+		s.clients[conn] = &wsClient{}
+		s.clientsMux.Unlock()
+		conn.Close()
+	})
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	clientConn.Close() // Close immediately
+
+	// Give time for server to register
+	time.Sleep(50 * time.Millisecond)
+
+	// Broadcast should detect the dead client and remove it
+	s.BroadcastToClients("test", "hello")
+
+	// Allow cleanup goroutine
+	time.Sleep(100 * time.Millisecond)
+
+	s.clientsMux.RLock()
+	count := len(s.clients)
+	s.clientsMux.RUnlock()
+
+	if count != 0 {
+		t.Fatalf("expected 0 clients after dead removal, got %d", count)
+	}
+}

--- a/pkg/agent/server_health_providercheck_test.go
+++ b/pkg/agent/server_health_providercheck_test.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubestellar/console/pkg/agent/protocol"
+)
+
+// TestHandleProviderCheck_MissingName verifies that /provider/check without
+// a "name" query param returns 400.
+func TestHandleProviderCheck_MissingName(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/provider/check", nil)
+	req.Header.Set("Authorization", TestAuthHeader())
+	w := httptest.NewRecorder()
+
+	s.handleProviderCheck(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var payload protocol.ErrorPayload
+	if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if payload.Code != "missing_name" {
+		t.Fatalf("expected code missing_name, got %q", payload.Code)
+	}
+}
+
+// TestHandleProviderCheck_UnknownProvider verifies that requesting a
+// non-existent provider returns 404 with ready=false.
+func TestHandleProviderCheck_UnknownProvider(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/provider/check?name=nonexistent", nil)
+	req.Header.Set("Authorization", TestAuthHeader())
+	w := httptest.NewRecorder()
+
+	s.handleProviderCheck(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp protocol.ProviderCheckResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.Ready {
+		t.Fatal("expected Ready=false for unknown provider")
+	}
+	if resp.State != "failed" {
+		t.Fatalf("expected state=failed, got %q", resp.State)
+	}
+}
+
+// TestHandleProviderCheck_Unauthorized verifies auth is enforced.
+func TestHandleProviderCheck_Unauthorized(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/provider/check?name=test", nil)
+	// No Authorization header
+	w := httptest.NewRecorder()
+
+	s.handleProviderCheck(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+// TestHandleProviderCheck_CORS_Preflight verifies OPTIONS returns 204.
+func TestHandleProviderCheck_CORS_Preflight(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodOptions, "/provider/check", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+
+	s.handleProviderCheck(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+}

--- a/pkg/agent/server_test_helper_test.go
+++ b/pkg/agent/server_test_helper_test.go
@@ -1,0 +1,250 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/kubestellar/console/pkg/k8s"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// TestServerOption is a functional option for configuring a test Server.
+type TestServerOption func(*Server)
+
+// newTestServer creates a minimally-configured Server suitable for handler
+// unit tests. By default it sets up:
+//   - an empty kubeconfig with a "test-ctx" context
+//   - an empty k8s.MultiClusterClient with fake typed+dynamic clients for "test-ctx"
+//   - an empty AIProvider registry
+//   - allowedOrigins: ["*"]
+//   - agentToken: "test-token" (explicit)
+//   - initialized maps/channels required to avoid nil panics
+//
+// Use TestServerOption functions to override defaults.
+func newTestServer(t *testing.T, opts ...TestServerOption) *Server {
+	t.Helper()
+
+	// Default kubeconfig with one context
+	kubecfg := &api.Config{
+		CurrentContext: "test-ctx",
+		Contexts: map[string]*api.Context{
+			"test-ctx": {Cluster: "test-cluster", AuthInfo: "test-user"},
+		},
+		Clusters: map[string]*api.Cluster{
+			"test-cluster": {Server: "https://127.0.0.1:6443"},
+		},
+		AuthInfos: map[string]*api.AuthInfo{
+			"test-user": {},
+		},
+	}
+
+	// Default k8s client with fake backends
+	k8sClient, _ := k8s.NewMultiClusterClient("")
+	scheme := runtime.NewScheme()
+	k8sClient.SetDynamicClient("test-ctx", fake.NewSimpleDynamicClient(scheme))
+	k8sClient.SetClient("test-ctx", fakek8s.NewSimpleClientset())
+
+	s := &Server{
+		kubectl: &KubectlProxy{
+			config:     kubecfg,
+			kubeconfig: "/tmp/test-kubeconfig",
+		},
+		k8sClient:          k8sClient,
+		registry:           &Registry{providers: make(map[string]AIProvider)},
+		allowedOrigins:     []string{"*"},
+		agentToken:         "test-token",
+		tokenExplicit:      true,
+		clients:            make(map[*websocket.Conn]*wsClient),
+		activeChatCtxs:     make(map[string]activeChatEntry),
+		dryRunSessions:     make(map[string]bool),
+		stopCh:             make(chan struct{}),
+		resourceRetryState: make(map[string]clusterResourceRetryState),
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+// WithAllowedOrigins overrides the default allowed origins.
+func WithAllowedOrigins(origins []string) TestServerOption {
+	return func(s *Server) {
+		s.allowedOrigins = origins
+	}
+}
+
+// WithToken sets the agent auth token. Use "" for unauthenticated handlers.
+func WithToken(token string) TestServerOption {
+	return func(s *Server) {
+		s.agentToken = token
+		s.tokenExplicit = token != ""
+	}
+}
+
+// WithNoAuth disables token authentication (empty token, not explicit).
+func WithNoAuth() TestServerOption {
+	return func(s *Server) {
+		s.agentToken = ""
+		s.tokenExplicit = false
+	}
+}
+
+// WithRegistry sets a custom provider registry.
+func WithRegistry(r *Registry) TestServerOption {
+	return func(s *Server) {
+		s.registry = r
+	}
+}
+
+// WithProvider registers an AI provider in the server's registry.
+func WithProvider(p AIProvider) TestServerOption {
+	return func(s *Server) {
+		s.registry.Register(p)
+	}
+}
+
+// WithK8sClient overrides the default k8s multi-cluster client.
+func WithK8sClient(c *k8s.MultiClusterClient) TestServerOption {
+	return func(s *Server) {
+		s.k8sClient = c
+	}
+}
+
+// WithKubeconfig overrides the default kubectl proxy kubeconfig.
+func WithKubeconfig(cfg *api.Config) TestServerOption {
+	return func(s *Server) {
+		s.kubectl = &KubectlProxy{config: cfg, kubeconfig: "/tmp/test-kubeconfig"}
+	}
+}
+
+// WithMultiContext sets up a kubeconfig with multiple contexts and matching
+// fake k8s clients for each.
+func WithMultiContext(contexts ...string) TestServerOption {
+	return func(s *Server) {
+		cfg := &api.Config{
+			CurrentContext: contexts[0],
+			Contexts:       make(map[string]*api.Context),
+			Clusters:       make(map[string]*api.Cluster),
+			AuthInfos:      make(map[string]*api.AuthInfo),
+		}
+		k8sClient, _ := k8s.NewMultiClusterClient("")
+		scheme := runtime.NewScheme()
+
+		for _, ctx := range contexts {
+			cfg.Contexts[ctx] = &api.Context{Cluster: ctx, AuthInfo: ctx}
+			cfg.Clusters[ctx] = &api.Cluster{Server: "https://127.0.0.1:6443"}
+			cfg.AuthInfos[ctx] = &api.AuthInfo{}
+			k8sClient.SetDynamicClient(ctx, fake.NewSimpleDynamicClient(scheme))
+			k8sClient.SetClient(ctx, fakek8s.NewSimpleClientset())
+		}
+		s.kubectl = &KubectlProxy{config: cfg, kubeconfig: "/tmp/test-kubeconfig"}
+		s.k8sClient = k8sClient
+	}
+}
+
+// WithPredictionWorker sets up a prediction worker (can be nil to skip).
+func WithPredictionWorker(pw *PredictionWorker) TestServerOption {
+	return func(s *Server) {
+		s.predictionWorker = pw
+	}
+}
+
+// WithMetricsHistory sets the metrics history instance.
+func WithMetricsHistory(mh *MetricsHistory) TestServerOption {
+	return func(s *Server) {
+		s.metricsHistory = mh
+	}
+}
+
+// WithDeviceTracker sets the device tracker instance.
+func WithDeviceTracker(dt *DeviceTracker) TestServerOption {
+	return func(s *Server) {
+		s.deviceTracker = dt
+	}
+}
+
+// WithSessionTokenQuota sets the per-session token quota.
+func WithSessionTokenQuota(quota int64) TestServerOption {
+	return func(s *Server) {
+		s.sessionTokenQuota = quota
+	}
+}
+
+// WithDryRunSession marks a session as dry-run.
+func WithDryRunSession(sessionID string) TestServerOption {
+	return func(s *Server) {
+		s.dryRunSessions[sessionID] = true
+	}
+}
+
+// TestAuthHeader returns the default Bearer token for authenticated test requests.
+func TestAuthHeader() string {
+	return "Bearer test-token"
+}
+
+// --- Smoke tests for the helper itself ---
+
+func TestNewTestServer_Smoke(t *testing.T) {
+	s := newTestServer(t)
+	if s == nil {
+		t.Fatal("newTestServer returned nil")
+	}
+	if s.agentToken != "test-token" {
+		t.Fatalf("expected default token, got %q", s.agentToken)
+	}
+	if s.kubectl == nil || s.kubectl.config == nil {
+		t.Fatal("kubectl proxy not initialized")
+	}
+	if s.k8sClient == nil {
+		t.Fatal("k8sClient not initialized")
+	}
+	if s.registry == nil {
+		t.Fatal("registry not initialized")
+	}
+	if s.clients == nil {
+		t.Fatal("clients map not initialized")
+	}
+	if s.stopCh == nil {
+		t.Fatal("stopCh not initialized")
+	}
+}
+
+func TestNewTestServer_WithOptions(t *testing.T) {
+	s := newTestServer(t,
+		WithToken("custom-token"),
+		WithMultiContext("ctx-a", "ctx-b", "ctx-c"),
+		WithAllowedOrigins([]string{"http://localhost:3000"}),
+	)
+	if s.agentToken != "custom-token" {
+		t.Fatalf("expected custom-token, got %q", s.agentToken)
+	}
+	contexts, _ := s.kubectl.ListContexts()
+	if len(contexts) != 3 {
+		t.Fatalf("expected 3 contexts, got %d", len(contexts))
+	}
+	if s.allowedOrigins[0] != "http://localhost:3000" {
+		t.Fatalf("expected custom origin, got %v", s.allowedOrigins)
+	}
+}
+
+func TestNewTestServer_WithNoAuth(t *testing.T) {
+	s := newTestServer(t, WithNoAuth())
+	if s.agentToken != "" {
+		t.Fatalf("expected empty token, got %q", s.agentToken)
+	}
+	if s.tokenExplicit {
+		t.Fatal("expected tokenExplicit=false")
+	}
+}
+
+func TestNewTestServer_WithDryRun(t *testing.T) {
+	s := newTestServer(t, WithDryRunSession("sess-123"))
+	if !s.dryRunSessions["sess-123"] {
+		t.Fatal("expected session to be in dry-run mode")
+	}
+}


### PR DESCRIPTION
## Test Improvement

Introduces a `newTestServer()` helper function in `pkg/agent` that provides a functional-options pattern for constructing minimally-configured `Server` instances in unit tests.

### What this adds:
- **`server_test_helper_test.go`** — Core helper with `newTestServer(t, ...opts)` and 12 option functions:
  - `WithToken`, `WithNoAuth`, `WithAllowedOrigins`
  - `WithK8sClient`, `WithKubeconfig`, `WithMultiContext`
  - `WithProvider`, `WithRegistry`
  - `WithPredictionWorker`, `WithMetricsHistory`, `WithDeviceTracker`
  - `WithSessionTokenQuota`, `WithDryRunSession`
- **`server_health_providercheck_test.go`** — 4 tests for `handleProviderCheck` (previously untested)
- **`prediction_broadcast_test.go`** — 3 tests for `BroadcastToClients` (previously untested)

### Why:
All 31 untested handler files in `pkg/agent/` require a constructed `Server` struct with mock dependencies. This helper eliminates the boilerplate and makes it trivial to add new handler tests.

## Related Issue
Fixes #17147

---
*Filed by quality agent (hold-gated mode). Human review required.*