### PR TITLE
fix: guard typed-nil event summaries

### DIFF
--- a/pkg/agent/server_events_stream.go
+++ b/pkg/agent/server_events_stream.go
@@ -22,9 +22,9 @@ const (
 	sseWatchTimeout      = 10 * time.Minute // server-side watch timeout before re-establishing
 
 	// Event forwarding concurrency limits
-	maxConcurrentForwards    = 32              // max parallel event forwards to Stellar backend
-	forwardTimeout           = 10 * time.Second // HTTP request timeout for event forwarding
-	semaphoreAcquireTimeout  = 1 * time.Second  // max wait time to acquire semaphore before dropping event
+	maxConcurrentForwards   = 32               // max parallel event forwards to Stellar backend
+	forwardTimeout          = 10 * time.Second // HTTP request timeout for event forwarding
+	semaphoreAcquireTimeout = 1 * time.Second  // max wait time to acquire semaphore before dropping event
 )
 
 // sseEvent is the JSON envelope sent over the SSE stream for each Kubernetes event.
@@ -163,7 +163,7 @@ type sseEventSummary struct {
 func summarizeEvent(evt watch.Event, cluster string) sseEventSummary {
 	summary := sseEventSummary{Cluster: cluster}
 	ev, ok := evt.Object.(*corev1.Event)
-	if !ok {
+	if !ok || ev == nil {
 		return summary
 	}
 	summary.Type = ev.Type
@@ -218,9 +218,9 @@ func (s *Server) forwardEventToStellar(event sseEventSummary) {
 		defer func() { <-s.stellarForwardSem }() // Release semaphore when done
 	case <-ctx.Done():
 		// Timeout waiting for semaphore — drop event to prevent backlog
-		slog.Warn("stellar: dropped event (semaphore timeout)", 
-			"cluster", event.Cluster, 
-			"namespace", event.Namespace, 
+		slog.Warn("stellar: dropped event (semaphore timeout)",
+			"cluster", event.Cluster,
+			"namespace", event.Namespace,
 			"reason", event.Reason)
 		return
 	}

--- a/pkg/agent/server_sse_test.go
+++ b/pkg/agent/server_sse_test.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -49,6 +50,19 @@ func newTestServerForSSE(t *testing.T, contexts map[string]*api.Context) (*Serve
 		agentToken:     "",
 	}
 	return srv, k8sMock
+}
+
+func TestSummarizeEventTypedNilObject(t *testing.T) {
+	var ev *corev1.Event
+
+	summary := summarizeEvent(watch.Event{Type: watch.Added, Object: ev}, "cluster-a")
+
+	if summary.Cluster != "cluster-a" {
+		t.Fatalf("Cluster = %q, want cluster-a", summary.Cluster)
+	}
+	if summary.Type != "" || summary.Reason != "" || summary.Message != "" || summary.Object != "" || summary.Namespace != "" || summary.LastSeen != "" {
+		t.Fatalf("typed-nil event should return only cluster summary, got %#v", summary)
+	}
 }
 
 func TestHandleNodesStreamSSE_StreamsEvents(t *testing.T) {


### PR DESCRIPTION
## Summary

- guard `summarizeEvent` against typed-nil `*corev1.Event` objects
- return the existing minimal cluster summary for nil/non-event objects
- add a focused regression test for the typed-nil path

Fixes #17247.

## Verification

- `go test $(find pkg/agent -maxdepth 1 -name '*.go' ! -name '*_test.go' ! -name '*_windows.go' | sort) pkg/agent/server_sse_test.go -run TestSummarizeEventTypedNilObject`
- `git diff --check`

Note: `go test ./pkg/agent -run TestSummarizeEventTypedNilObject` is currently blocked on `main` by unrelated `server_lifecycle_test.go` compile errors around `newTestServer` / `withContexts`; the focused command above compiles the package production files plus this regression test only.
