### PR TITLE
[quality] add Server test helper and initial handler tests

### DIFF
--- a/pkg/agent/server_health_test.go
+++ b/pkg/agent/server_health_test.go
@@ -1,0 +1,102 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleHealth_ReturnsOK(t *testing.T) {
+	s := newTestServer(t)
+
+	rec := httptest.NewRecorder()
+	req := testRequestNoAuth(t, http.MethodGet, "/health")
+
+	s.handleHealth(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("expected status=ok, got %q", body["status"])
+	}
+}
+
+func TestHandleHealth_CORS_Preflight(t *testing.T) {
+	s := newTestServer(t)
+
+	rec := httptest.NewRecorder()
+	req := testRequestNoAuth(t, http.MethodOptions, "/health")
+
+	s.handleHealth(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for OPTIONS, got %d", rec.Code)
+	}
+}
+
+func TestHandleStatus_Authenticated(t *testing.T) {
+	s := newTestServer(t)
+
+	rec := httptest.NewRecorder()
+	req := testRequest(t, http.MethodGet, "/status")
+
+	s.handleStatus(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("expected status=ok, got %q", body["status"])
+	}
+}
+
+func TestHandleStatus_Unauthenticated(t *testing.T) {
+	s := newTestServer(t)
+
+	rec := httptest.NewRecorder()
+	req := testRequestNoAuth(t, http.MethodGet, "/status")
+
+	s.handleStatus(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestHandleStatus_CORS_Preflight(t *testing.T) {
+	s := newTestServer(t)
+
+	rec := httptest.NewRecorder()
+	req := testRequestNoAuth(t, http.MethodOptions, "/status")
+
+	s.handleStatus(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for OPTIONS, got %d", rec.Code)
+	}
+}
+
+func TestHandleStatus_NoToken_OpenMode(t *testing.T) {
+	s := newTestServer(t, withNoToken())
+
+	rec := httptest.NewRecorder()
+	req := testRequestNoAuth(t, http.MethodGet, "/status")
+
+	s.handleStatus(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 in open mode, got %d", rec.Code)
+	}
+}

--- a/pkg/agent/server_routes_test.go
+++ b/pkg/agent/server_routes_test.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRegisterRoutes_HealthEndpoint(t *testing.T) {
+	s := newTestServer(t)
+
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+
+	// Verify health endpoint is registered and responds
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from /health via mux, got %d", rec.Code)
+	}
+}
+
+func TestRegisterRoutes_StatusEndpointRequiresAuth(t *testing.T) {
+	s := newTestServer(t)
+
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 from /status without auth, got %d", rec.Code)
+	}
+}
+
+func TestRegisterRoutes_StatusEndpointWithAuth(t *testing.T) {
+	s := newTestServer(t)
+
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	req.Header.Set("Authorization", "Bearer test-token-secret")
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from /status with auth, got %d", rec.Code)
+	}
+}

--- a/pkg/agent/testhelpers_test.go
+++ b/pkg/agent/testhelpers_test.go
@@ -1,0 +1,113 @@
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	api "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// testServerOption configures a test Server instance.
+type testServerOption func(*Server)
+
+// newTestServer creates a minimal Server suitable for handler testing.
+// It sets up safe defaults (empty maps, closed-channel stopCh, etc.)
+// so tests can focus on the specific behavior under test.
+func newTestServer(t *testing.T, opts ...testServerOption) *Server {
+	t.Helper()
+
+	s := &Server{
+		config: Config{Port: 0},
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool { return true },
+		},
+		kubectl: &KubectlProxy{
+			config: &api.Config{
+				Contexts: map[string]*api.Context{
+					"test-ctx": {Cluster: "test-cluster", AuthInfo: "test-user"},
+				},
+				CurrentContext: "test-ctx",
+			},
+		},
+		registry:                &Registry{providers: make(map[string]AIProvider)},
+		clients:                 make(map[*websocket.Conn]*wsClient),
+		allowedOrigins:          []string{"http://localhost", "https://localhost"},
+		agentToken:              "test-token-secret",
+		tokenExplicit:           true,
+		activeChatCtxs:          make(map[string]activeChatEntry),
+		dryRunSessions:          make(map[string]bool),
+		stopCh:                  make(chan struct{}),
+		resourceRetryState:      make(map[string]clusterResourceRetryState),
+		missionExecutionTimeout: defaultMissionExecutionTimeout,
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+// withToken sets a custom agent token for authentication testing.
+func withToken(token string) testServerOption {
+	return func(s *Server) {
+		s.agentToken = token
+	}
+}
+
+// withNoToken disables token authentication (open mode).
+func withNoToken() testServerOption {
+	return func(s *Server) {
+		s.agentToken = ""
+		s.tokenExplicit = false
+	}
+}
+
+// withKubeContexts sets custom kubeconfig contexts on the kubectl proxy.
+func withKubeContexts(contexts map[string]*api.Context, current string) testServerOption {
+	return func(s *Server) {
+		s.kubectl = &KubectlProxy{
+			config: &api.Config{
+				Contexts:       contexts,
+				CurrentContext: current,
+			},
+		}
+	}
+}
+
+// withRegistry sets a custom AI provider registry.
+func withRegistry(r *Registry) testServerOption {
+	return func(s *Server) {
+		s.registry = r
+	}
+}
+
+// withAllowedOrigins overrides the allowed CORS origins.
+func withAllowedOrigins(origins []string) testServerOption {
+	return func(s *Server) {
+		s.allowedOrigins = origins
+	}
+}
+
+// withEventProcessor sets a custom event processor callback.
+func withEventProcessor(ep EventProcessor) testServerOption {
+	return func(s *Server) {
+		s.eventProcessor = ep
+	}
+}
+
+// testRequest creates an HTTP request with the test server's auth token.
+func testRequest(t *testing.T, method, path string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	req.Header.Set("Authorization", "Bearer test-token-secret")
+	return req
+}
+
+// testRequestNoAuth creates an HTTP request without authentication.
+func testRequestNoAuth(t *testing.T, method, path string) *http.Request {
+	t.Helper()
+	return httptest.NewRequest(method, path, nil)
+}


### PR DESCRIPTION
## Test Improvement

Introduces `pkg/agent/testhelpers_test.go` with a `newTestServer()` function and functional options pattern that creates a minimal `Server` struct suitable for `httptest`-based handler testing without requiring real Kubernetes connections or AI providers.

### What's included:

**Test helper (`testhelpers_test.go`):**
- `newTestServer(t, opts...)` — creates a Server with safe defaults (empty maps, mock kubeconfig, test token)
- `withToken(token)` — custom auth token
- `withNoToken()` — open/unauthenticated mode
- `withKubeContexts(contexts, current)` — custom kubeconfig contexts
- `withRegistry(r)` — custom AI provider registry
- `withAllowedOrigins(origins)` — custom CORS origins
- `withEventProcessor(ep)` — custom event processor
- `testRequest(t, method, path)` — pre-authenticated request helper
- `testRequestNoAuth(t, method, path)` — unauthenticated request helper

**Handler tests (`server_health_test.go`):**
- `TestHandleHealth_ReturnsOK` — verifies health endpoint returns 200 + JSON
- `TestHandleHealth_CORS_Preflight` — OPTIONS returns 204
- `TestHandleStatus_Authenticated` — authenticated status returns full payload
- `TestHandleStatus_Unauthenticated` — rejects without token
- `TestHandleStatus_CORS_Preflight` — OPTIONS passthrough
- `TestHandleStatus_NoToken_OpenMode` — open mode allows unauthenticated access

**Route registration tests (`server_routes_test.go`):**
- Verifies health/status endpoints are registered and respond correctly through ServeMux

### Impact

This unlocks httptest-based testing for all 14+ `server_*` handler files listed in #17147 by providing a reusable, minimal Server fixture.

Fixes #17147

---
*Filed by quality agent (ACMM L4/L6 — full mode)*