### PR TITLE
[quality] Expand Server test helper with functional options for handler testing

### DIFF
--- a/pkg/agent/server_health_handler_test.go
+++ b/pkg/agent/server_health_handler_test.go
@@ -1,0 +1,147 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// handleHealth — unauthenticated health probe
+// ---------------------------------------------------------------------------
+
+func TestHandleHealth_GET_ReturnsOKJSON(t *testing.T) {
+	srv := newTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := serveAndRecord(srv.handleHealth, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("expected status=ok, got %q", body["status"])
+	}
+	if body["version"] != Version {
+		t.Errorf("expected version=%q, got %q", Version, body["version"])
+	}
+	// Health should only expose status + version (not telemetry)
+	if len(body) != 2 {
+		t.Errorf("expected 2 fields, got %d: %v", len(body), body)
+	}
+}
+
+func TestHandleHealth_OPTIONS_ReturnsNoContent(t *testing.T) {
+	srv := newTestServer(t)
+	req := httptest.NewRequest(http.MethodOptions, "/health", nil)
+	rec := serveAndRecord(srv.handleHealth, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rec.Code)
+	}
+}
+
+func TestHandleHealth_CORS_AllowedOrigin(t *testing.T) {
+	srv := newTestServer(t, withAllowedOrigins("http://console.example.com"))
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Origin", "http://console.example.com")
+	rec := serveAndRecord(srv.handleHealth, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	got := rec.Header().Get("Access-Control-Allow-Origin")
+	if got != "http://console.example.com" {
+		t.Errorf("expected CORS header %q, got %q", "http://console.example.com", got)
+	}
+}
+
+func TestHandleHealth_CORS_DisallowedOrigin(t *testing.T) {
+	srv := newTestServer(t, withAllowedOrigins("http://console.example.com"))
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Origin", "http://evil.example.com")
+	rec := serveAndRecord(srv.handleHealth, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	got := rec.Header().Get("Access-Control-Allow-Origin")
+	if got != "" {
+		t.Errorf("expected no CORS header for disallowed origin, got %q", got)
+	}
+}
+
+func TestHandleHealth_NoAuth_Required(t *testing.T) {
+	// Health endpoint must be accessible without a token (for load balancer
+	// probes and service discovery).
+	srv := newTestServer(t, withToken("secret-token"))
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	// Deliberately not setting Authorization header
+	rec := serveAndRecord(srv.handleHealth, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("health should not require auth, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleStatus — authenticated status probe
+// ---------------------------------------------------------------------------
+
+func TestHandleStatus_RequiresAuth(t *testing.T) {
+	srv := newTestServer(t,
+		withToken("my-secret"),
+		withContexts("cluster-a"),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rec := serveAndRecord(srv.handleStatus, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without token, got %d", rec.Code)
+	}
+}
+
+func TestHandleStatus_ValidToken_ReturnsPayload(t *testing.T) {
+	srv := newTestServer(t,
+		withToken("my-secret"),
+		withContexts("cluster-a", "cluster-b"),
+	)
+
+	req := authRequest(
+		httptest.NewRequest(http.MethodGet, "/status", nil),
+		"my-secret",
+	)
+	rec := serveAndRecord(srv.handleStatus, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var payload map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload["status"] != "ok" {
+		t.Errorf("expected status=ok, got %v", payload["status"])
+	}
+	clusters, ok := payload["clusters"].(float64)
+	if !ok || clusters != 2 {
+		t.Errorf("expected clusters=2, got %v", payload["clusters"])
+	}
+}
+
+func TestHandleStatus_OPTIONS_ReturnsNoContent(t *testing.T) {
+	srv := newTestServer(t, withToken("tok"))
+	req := httptest.NewRequest(http.MethodOptions, "/status", nil)
+	rec := serveAndRecord(srv.handleStatus, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rec.Code)
+	}
+}

--- a/pkg/agent/server_test_helpers_test.go
+++ b/pkg/agent/server_test_helpers_test.go
@@ -2,11 +2,15 @@ package agent
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sort"
 	"testing"
+	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/kubestellar/console/pkg/k8s"
 )
 
@@ -45,18 +49,79 @@ func withContexts(names ...string) serverTestOption {
 	}
 }
 
+// withToken returns an option that configures a shared secret for
+// authentication. Handlers that call s.validateToken will require a
+// matching "Bearer <token>" Authorization header.
+func withToken(token string) serverTestOption {
+	return func(s *Server) {
+		s.agentToken = token
+		s.tokenExplicit = true
+	}
+}
+
+// withAllowedOrigins returns an option that sets the server's allowed
+// origins list for CORS checks.
+func withAllowedOrigins(origins ...string) serverTestOption {
+	return func(s *Server) {
+		s.allowedOrigins = origins
+	}
+}
+
+// withRegistry returns an option that sets the server's AI provider
+// registry. Use GetRegistry() or a custom *Registry for testing.
+func withRegistry(r *Registry) serverTestOption {
+	return func(s *Server) {
+		s.registry = r
+	}
+}
+
+// withSkipKeyValidation returns an option that disables real API key
+// validation, useful for handler tests that don't need network access.
+func withSkipKeyValidation() serverTestOption {
+	return func(s *Server) {
+		s.SkipKeyValidation = true
+	}
+}
+
 // newTestServer creates a minimal *Server for lifecycle and unit tests.
-// Pass serverTestOption values (e.g. withContexts) to configure optional
-// fields. The server has a valid stopCh and no real API server connections.
+// Pass serverTestOption values (e.g. withContexts, withToken) to configure
+// optional fields. The server has a valid stopCh, initialized maps, and no
+// real API server connections. All internal maps and channels are non-nil
+// to prevent nil-pointer panics in handler code paths.
 func newTestServer(t *testing.T, opts ...serverTestOption) *Server {
 	t.Helper()
 	s := &Server{
-		stopCh: make(chan struct{}),
+		stopCh:             make(chan struct{}),
+		clients:            make(map[*websocket.Conn]*wsClient),
+		activeChatCtxs:     make(map[string]activeChatEntry),
+		dryRunSessions:     make(map[string]bool),
+		resourceRetryState: make(map[string]clusterResourceRetryState),
+		allowedOrigins:     []string{"http://localhost", "https://localhost"},
+		registry:           &Registry{providers: make(map[string]AIProvider)},
+		sessionStart:       time.Now(),
+		todayDate:          time.Now().Format("2006-01-02"),
+		upgrader:           websocket.Upgrader{},
+		stellarForwardSem:  make(chan struct{}, 32),
 	}
 	for _, opt := range opts {
 		opt(s)
 	}
 	return s
+}
+
+// authRequest adds a Bearer token Authorization header to an HTTP request.
+// Useful when testing authenticated handler endpoints.
+func authRequest(req *http.Request, token string) *http.Request {
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req
+}
+
+// serveAndRecord invokes a handler function with the given request and
+// returns the recorded response. Reduces boilerplate for httptest usage.
+func serveAndRecord(handler http.HandlerFunc, req *http.Request) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+	return rec
 }
 
 // writeTestKubeconfig2 is a copy of writeTestKubeconfig from server_federation_test.go


### PR DESCRIPTION
Fixes #17147

## Test Improvement

Extends `newTestServer()` in `pkg/agent/server_test_helpers_test.go` to initialize all internal maps/channels (`clients`, `activeChatCtxs`, `dryRunSessions`, `resourceRetryState`, `stellarForwardSem`) preventing nil-pointer panics when handler code paths access them.

### New functional options added:
- `withToken(token)` — configure auth secret for `validateToken`
- `withAllowedOrigins(origins...)` — configure CORS allowed origins
- `withRegistry(r)` — inject AI provider registry
- `withSkipKeyValidation()` — disable real API key validation

### New test utilities:
- `authRequest(req, token)` — adds Bearer token header
- `serveAndRecord(handler, req)` — reduces httptest boilerplate

### Proof-of-concept handler tests (`server_health_handler_test.go`):
- `TestHandleHealth_GET_ReturnsOKJSON` — verifies minimal response
- `TestHandleHealth_OPTIONS_ReturnsNoContent` — preflight handling
- `TestHandleHealth_CORS_AllowedOrigin` — CORS header present
- `TestHandleHealth_CORS_DisallowedOrigin` — CORS header absent
- `TestHandleHealth_NoAuth_Required` — health stays unauthenticated
- `TestHandleStatus_RequiresAuth` — 401 without token
- `TestHandleStatus_ValidToken_ReturnsPayload` — authenticated path
- `TestHandleStatus_OPTIONS_ReturnsNoContent` — preflight handling

This helper unlocks httptest-based handler tests for all 31 currently-untested `server_*` files without requiring real Kubernetes connections or AI providers.

---
*Filed by quality agent (ACMM L4/L6 — full mode)*