### PR TITLE
[quality] add webhook signature validation and payload size boundary tests

### DIFF
--- a/pkg/api/handlers/feedback_github_helpers_test.go
+++ b/pkg/api/handlers/feedback_github_helpers_test.go
@@ -1,0 +1,131 @@
+package handlers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLabelPermissionError_NilError(t *testing.T) {
+	assert.False(t, isLabelPermissionError(nil))
+}
+
+func TestIsLabelPermissionError_Matching(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "403 with label keyword",
+			err:  errors.New("HTTP 403: Resource not accessible - label"),
+			want: true,
+		},
+		{
+			name: "403 label in different context",
+			err:  errors.New("received 403 when creating label on issue"),
+			want: true,
+		},
+		{
+			name: "403 without label",
+			err:  errors.New("HTTP 403: Forbidden"),
+			want: false,
+		},
+		{
+			name: "label without 403",
+			err:  errors.New("failed to set label: timeout"),
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("network timeout"),
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isLabelPermissionError(tc.err))
+		})
+	}
+}
+
+func TestIsInsufficientIssuePermissionError(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "resource not accessible by PAT",
+			body: `{"message":"Resource not accessible by personal access token"}`,
+			want: true,
+		},
+		{
+			name: "case insensitive match",
+			body: `{"message":"RESOURCE NOT ACCESSIBLE BY PERSONAL ACCESS TOKEN"}`,
+			want: true,
+		},
+		{
+			name: "insufficient permission variant",
+			body: `{"message":"Insufficient permission to create issue"}`,
+			want: true,
+		},
+		{
+			name: "insufficient alone without permission",
+			body: `{"message":"Insufficient funds"}`,
+			want: false,
+		},
+		{
+			name: "permission alone without insufficient",
+			body: `{"message":"Check your permission settings"}`,
+			want: false,
+		},
+		{
+			name: "empty body",
+			body: "",
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			body: `{"message":"Not Found"}`,
+			want: false,
+		},
+		{
+			name: "rate limit error",
+			body: `{"message":"API rate limit exceeded"}`,
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isInsufficientIssuePermissionError(tc.body))
+		})
+	}
+}
+
+func TestPipelineLabels_ContainsExpectedEntries(t *testing.T) {
+	expectedLabels := []string{
+		"triage/accepted",
+		"ai-processing",
+		"ai-awaiting-fix",
+		"ai-pr-draft",
+		"ai-pr-ready",
+		"ai-processing-complete",
+	}
+	for _, label := range expectedLabels {
+		t.Run(label, func(t *testing.T) {
+			entry, ok := pipelineLabels[label]
+			assert.True(t, ok, "pipelineLabels should contain %q", label)
+			assert.NotEmpty(t, entry.message, "label %q should have a notification message", label)
+		})
+	}
+}
+
+func TestVcsRevision_DoesNotPanic(t *testing.T) {
+	// vcsRevision() should never panic regardless of environment
+	rev := vcsRevision()
+	// In test environment, it may or may not return a value
+	// but it must not panic and should return a string
+	_ = rev
+}

--- a/pkg/api/handlers/feedback_github_webhook_test.go
+++ b/pkg/api/handlers/feedback_github_webhook_test.go
@@ -1,0 +1,170 @@
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- verifyWebhookSignature unit tests (direct function, no HTTP) ---
+
+func TestVerifyWebhookSignature_ValidSignature(t *testing.T) {
+	handler := &FeedbackHandler{webhookSecret: testWebhookSecret}
+	payload := []byte(`{"action":"opened"}`)
+	sig := signWebhookPayload(payload, testWebhookSecret)
+
+	assert.True(t, handler.verifyWebhookSignature(payload, sig))
+}
+
+func TestVerifyWebhookSignature_EmptySignature(t *testing.T) {
+	handler := &FeedbackHandler{webhookSecret: testWebhookSecret}
+	assert.False(t, handler.verifyWebhookSignature([]byte(`{}`), ""))
+}
+
+func TestVerifyWebhookSignature_TooShortSignature(t *testing.T) {
+	handler := &FeedbackHandler{webhookSecret: testWebhookSecret}
+	assert.False(t, handler.verifyWebhookSignature([]byte(`{}`), "sha2"))
+}
+
+func TestVerifyWebhookSignature_WrongSecret(t *testing.T) {
+	handler := &FeedbackHandler{webhookSecret: testWebhookSecret}
+	payload := []byte(`{"action":"opened"}`)
+	sig := signWebhookPayload(payload, "wrong-secret")
+
+	assert.False(t, handler.verifyWebhookSignature(payload, sig))
+}
+
+func TestVerifyWebhookSignature_TamperedPayload(t *testing.T) {
+	handler := &FeedbackHandler{webhookSecret: testWebhookSecret}
+	payload := []byte(`{"action":"opened"}`)
+	sig := signWebhookPayload(payload, testWebhookSecret)
+
+	tampered := []byte(`{"action":"opened","injected":true}`)
+	assert.False(t, handler.verifyWebhookSignature(tampered, sig))
+}
+
+// --- HandleGitHubWebhook additional integration tests ---
+
+func TestWebhook_NoSecretConfigured_Returns503(t *testing.T) {
+	// Handler with empty webhook secret should reject all webhooks
+	stubStore := &feedbackStoreStub{MockStore: &test.MockStore{}}
+	handler := NewFeedbackHandler(stubStore, FeedbackConfig{
+		WebhookSecret: "", // not configured
+	})
+	app := fiber.New()
+	app.Post("/webhook", handler.HandleGitHubWebhook)
+
+	payload := []byte(`{"action":"opened"}`)
+	req, err := http.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestWebhook_UnknownEventType_Returns200Ignored(t *testing.T) {
+	app, _ := setupWebhookTest(t)
+
+	payload := requireMarshalJSON(t, map[string]interface{}{
+		"action":    "completed",
+		"check_run": map[string]interface{}{},
+	})
+
+	resp := sendWebhook(t, app, "check_run", payload)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body := readBody(t, resp)
+	assert.Contains(t, body, "ignored")
+}
+
+func TestWebhook_OversizedPayload_Returns413(t *testing.T) {
+	app, _ := setupWebhookTest(t)
+
+	// Create payload > 1 MB (the webhook limit)
+	bigPayload := make([]byte, (1<<20)+1)
+	for i := range bigPayload {
+		bigPayload[i] = 'A'
+	}
+	sig := signWebhookPayload(bigPayload, testWebhookSecret)
+
+	req, err := http.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(bigPayload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hub-Signature-256", sig)
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+}
+
+func TestWebhook_ExactlyMaxPayload_NotRejectedBySize(t *testing.T) {
+	app, _ := setupWebhookTest(t)
+
+	// Exactly 1 MB should NOT be rejected by the size check
+	payload := []byte(`{"action":"ping"}`)
+	padding := make([]byte, (1<<20)-len(payload))
+	for i := range padding {
+		padding[i] = ' '
+	}
+	fullPayload := append(payload[:len(payload)-1], padding...)
+	fullPayload = append(fullPayload, '}')
+
+	sig := signWebhookPayload(fullPayload, testWebhookSecret)
+
+	req, err := http.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(fullPayload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hub-Signature-256", sig)
+	req.Header.Set("X-GitHub-Event", "ping")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.NotEqual(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+}
+
+func TestWebhook_MissingSignatureHeader_Returns401(t *testing.T) {
+	app, _ := setupWebhookTest(t)
+
+	payload := []byte(`{"action":"opened"}`)
+	req, err := http.NewRequest(http.MethodPost, "/webhook", strings.NewReader(string(payload)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	// Deliberately omit X-Hub-Signature-256
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestWebhook_DeploymentStatusEvent_MissingFields_ReturnsOK(t *testing.T) {
+	app, _ := setupWebhookTest(t)
+
+	// deployment_status event with minimal payload
+	payload := requireMarshalJSON(t, map[string]interface{}{
+		"action": "created",
+	})
+
+	resp := sendWebhook(t, app, "deployment_status", payload)
+	defer resp.Body.Close()
+
+	// handleDeploymentStatus should handle gracefully without crashing
+	// (returns nil or error based on implementation)
+	assert.Contains(t, []int{http.StatusOK, http.StatusBadRequest}, resp.StatusCode)
+}


### PR DESCRIPTION
## Test Improvement

Adds **28 new tests** across two files for the feedback webhook handler and helper functions in `pkg/api/handlers/`.

### `feedback_github_webhook_test.go` (11 tests)

| Test | What it verifies |
|------|-----------------|
| `TestVerifyWebhookSignature_ValidSignature` | Correct HMAC passes verification |
| `TestVerifyWebhookSignature_EmptySignature` | Empty signature string rejected |
| `TestVerifyWebhookSignature_TooShortSignature` | Signature < 7 chars rejected |
| `TestVerifyWebhookSignature_WrongSecret` | Different secret produces failed verification |
| `TestVerifyWebhookSignature_TamperedPayload` | Modified body fails signature check |
| `TestWebhook_NoSecretConfigured_Returns503` | Returns 503 when GITHUB_WEBHOOK_SECRET not set |
| `TestWebhook_UnknownEventType_Returns200Ignored` | Unhandled event types return 200 with \"ignored\" |
| `TestWebhook_OversizedPayload_Returns413` | Payloads > 1 MB rejected with 413 |
| `TestWebhook_ExactlyMaxPayload_NotRejectedBySize` | Exactly 1 MB boundary not rejected |
| `TestWebhook_MissingSignatureHeader_Returns401` | Missing X-Hub-Signature-256 header → 401 |
| `TestWebhook_DeploymentStatusEvent_MissingFields_ReturnsOK` | deployment_status with missing fields handled gracefully |

### `feedback_github_helpers_test.go` (17 tests)

| Test | What it verifies |
|------|-----------------|
| `TestIsLabelPermissionError_*` (6 cases) | Permission error detection for label fallback logic |
| `TestIsInsufficientIssuePermissionError` (8 cases) | PAT permission error detection for issue creation fallback |
| `TestPipelineLabels_ContainsExpectedEntries` (6 labels) | Pipeline label map integrity |
| `TestVcsRevision_DoesNotPanic` | No-panic smoke test |

### Why

These cover security-critical code paths in the feedback webhook subsystem:
- Signature verification prevents webhook spoofing
- Payload size limits prevent denial-of-service
- Permission error detection controls auth fallback behavior (incorrect matching could silently drop issues)

Relates to #17313

---
*Filed by quality agent (ACMM L4/L6 — full mode)*