### PR TITLE
[sec-check] fix: pin fast-json-patch>=3.1.1 and uuid>=11.1.1 in CI scripts (GHSA-8gh8-hqwg-xf34, GHSA-w5hq-g745-h8pq)

### DIFF
--- a/.github/ga4-scripts/package-lock.json
+++ b/.github/ga4-scripts/package-lock.json
@@ -563,17 +563,16 @@
       "license": "BSD"
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/webidl-conversions": {

--- a/.github/ga4-scripts/package.json
+++ b/.github/ga4-scripts/package.json
@@ -5,5 +5,8 @@
   "description": "GA4 analytics helper dependencies for GitHub Actions workflows",
   "dependencies": {
     "googleapis": "144.0.0"
+  },
+  "overrides": {
+    "uuid": "^11.1.1"
   }
 }

--- a/.github/kb-scripts/package-lock.json
+++ b/.github/kb-scripts/package-lock.json
@@ -122,21 +122,9 @@
       "license": "MIT"
     },
     "node_modules/fast-json-patch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {

--- a/.github/kb-scripts/package.json
+++ b/.github/kb-scripts/package.json
@@ -6,5 +6,8 @@
   "dependencies": {
     "ajv-cli": "5.0.0",
     "ajv-formats": "2.1.1"
+  },
+  "overrides": {
+    "fast-json-patch": "^3.1.1"
   }
 }


### PR DESCRIPTION
## Security Fix

Pins two vulnerable transitive CI-script dependencies detected by Scorecard (OSV scan, alert #16):

### fast-json-patch: 2.2.1 → 3.1.1
**File**: `.github/kb-scripts/package.json`
**CVE**: CVE-2021-4279 / [GHSA-8gh8-hqwg-xf34](https://github.com/advisories/GHSA-8gh8-hqwg-xf34)
**CVSS**: 7.3 (High) — Prototype Pollution (CWE-1321)

`ajv-cli@5.0.0` (a KB validation tool) required `fast-json-patch: ^2.0.0`, resolving to `2.2.1` which is affected by prototype pollution. Added npm `overrides` to force resolution to `^3.1.1`. `npm install --package-lock-only` confirmed `0 vulnerabilities`.

### uuid: 9.0.1 → 11.1.1
**File**: `.github/ga4-scripts/package.json`
**CVE**: CVE-2026-41907 / [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)
**CVSS**: 7.5 — Out-of-bounds write (CWE-787/CWE-1285)

`googleapis@144.0.0` transitively resolved `uuid@9.0.1` which lacks bounds checking in `v3()`/`v5()`/`v6()` APIs. Added npm `overrides` to force `^11.1.1`. `npm install --package-lock-only` confirmed `0 vulnerabilities`.

Both package-lock.json files are regenerated in this PR.

Fixes #17321

---
*Filed by sec-check agent (ACMM L6 — full mode)*