### PR TITLE
🌱 De-brittle quantum unit-test assertions

### DIFF
--- a/web/src/components/cards/quantum/QuantumHistogramCard.tsx
+++ b/web/src/components/cards/quantum/QuantumHistogramCard.tsx
@@ -67,7 +67,7 @@ function formatExecutionTime(timestamp: string | null): string | null {
 
 function HistogramLoadingState() {
   return (
-    <div className="p-4 flex flex-col gap-4" data-testid="quantum-skeleton">
+    <div className="p-4 flex flex-col gap-4" data-testid="quantum-histogram-skeleton">
       <div className="flex items-center justify-between gap-3">
         <Skeleton variant="text" width={HISTOGRAM_SKELETON_TITLE_WIDTH_PX} height={HISTOGRAM_SKELETON_TITLE_HEIGHT_PX} />
         <Skeleton variant="circular" width={HISTOGRAM_SKELETON_ACTION_SIZE_PX} height={HISTOGRAM_SKELETON_ACTION_SIZE_PX} />

--- a/web/src/components/cards/quantum/QuantumHistogramCard.tsx
+++ b/web/src/components/cards/quantum/QuantumHistogramCard.tsx
@@ -67,7 +67,7 @@ function formatExecutionTime(timestamp: string | null): string | null {
 
 function HistogramLoadingState() {
   return (
-    <div className="p-4 flex flex-col gap-4">
+    <div className="p-4 flex flex-col gap-4" data-testid="quantum-skeleton">
       <div className="flex items-center justify-between gap-3">
         <Skeleton variant="text" width={HISTOGRAM_SKELETON_TITLE_WIDTH_PX} height={HISTOGRAM_SKELETON_TITLE_HEIGHT_PX} />
         <Skeleton variant="circular" width={HISTOGRAM_SKELETON_ACTION_SIZE_PX} height={HISTOGRAM_SKELETON_ACTION_SIZE_PX} />

--- a/web/src/components/cards/quantum/QuantumStatus.tsx
+++ b/web/src/components/cards/quantum/QuantumStatus.tsx
@@ -50,7 +50,7 @@ export const QuantumStatus: React.FC<QuantumStatusProps> = ({ isDemoData = false
 
   if (authIsLoading) {
     return (
-      <div className="p-4 space-y-3" data-testid="quantum-skeleton">
+      <div className="p-4 space-y-3" data-testid="quantum-status-skeleton">
         <Skeleton variant="text" width="80%" height={20} />
         <Skeleton variant="text" width="60%" height={20} />
         <Skeleton variant="text" width="70%" height={20} />
@@ -74,7 +74,7 @@ export const QuantumStatus: React.FC<QuantumStatusProps> = ({ isDemoData = false
 
   if (showSkeleton) {
     return (
-      <div className="p-4 space-y-3" data-testid="quantum-skeleton">
+      <div className="p-4 space-y-3" data-testid="quantum-status-skeleton">
         <Skeleton variant="text" width="80%" height={20} />
         <Skeleton variant="text" width="60%" height={20} />
         <Skeleton variant="text" width="70%" height={20} />

--- a/web/src/components/cards/quantum/QuantumStatus.tsx
+++ b/web/src/components/cards/quantum/QuantumStatus.tsx
@@ -50,7 +50,7 @@ export const QuantumStatus: React.FC<QuantumStatusProps> = ({ isDemoData = false
 
   if (authIsLoading) {
     return (
-      <div className="p-4 space-y-3">
+      <div className="p-4 space-y-3" data-testid="quantum-skeleton">
         <Skeleton variant="text" width="80%" height={20} />
         <Skeleton variant="text" width="60%" height={20} />
         <Skeleton variant="text" width="70%" height={20} />
@@ -74,7 +74,7 @@ export const QuantumStatus: React.FC<QuantumStatusProps> = ({ isDemoData = false
 
   if (showSkeleton) {
     return (
-      <div className="p-4 space-y-3">
+      <div className="p-4 space-y-3" data-testid="quantum-skeleton">
         <Skeleton variant="text" width="80%" height={20} />
         <Skeleton variant="text" width="60%" height={20} />
         <Skeleton variant="text" width="70%" height={20} />

--- a/web/src/components/cards/quantum/__tests__/QuantumHistogramCard.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumHistogramCard.test.tsx
@@ -104,9 +104,9 @@ describe('QuantumHistogramCard', () => {
   it('renders loading skeleton while auth is loading', () => {
     mockUseAuth.mockReturnValue(defaultAuthReturn({ isLoading: true, isAuthenticated: false }))
 
-    const { container } = render(<QuantumHistogramCard />)
+    render(<QuantumHistogramCard />)
 
-    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0)
+    expect(screen.getByTestId('quantum-skeleton')).toBeInTheDocument()
     expect(screen.queryByTestId('lazy-echart')).toBeNull()
   })
 
@@ -115,9 +115,9 @@ describe('QuantumHistogramCard', () => {
       defaultHookReturn({ isLoading: true, data: null }),
     )
 
-    const { container } = render(<QuantumHistogramCard />)
+    render(<QuantumHistogramCard />)
 
-    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0)
+    expect(screen.getByTestId('quantum-skeleton')).toBeInTheDocument()
     expect(screen.queryByTestId('lazy-echart')).toBeNull()
   })
 
@@ -179,13 +179,9 @@ describe('QuantumHistogramCard', () => {
     )
 
     await waitFor(() => {
-      const reportedDemo = report.mock.calls.some(
-        (call) =>
-          call[0] &&
-          typeof call[0] === 'object' &&
-          (call[0] as { isDemoData?: boolean }).isDemoData === true,
+      expect(report).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true }),
       )
-      expect(reportedDemo).toBe(true)
     })
   })
 

--- a/web/src/components/cards/quantum/__tests__/QuantumHistogramCard.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumHistogramCard.test.tsx
@@ -62,10 +62,14 @@ function defaultAuthReturn(overrides: Record<string, unknown> = {}) {
   }
 }
 
-// Stable epoch fixed at 2026-05-08T14:00:00Z (matches DEMO_HISTOGRAM.timestamp)
-// to avoid time-dependent test output. Override per-test if a specific
-// freshness window matters.
-const STABLE_LAST_REFRESH_MS = 1_778_421_600_000
+// Stable epoch derived from DEMO_HISTOGRAM.timestamp so the two stay in sync
+// if the demo timestamp ever changes. Override per-test if a specific
+// freshness window matters. Asserted at module load to fail fast if the
+// timestamp ever becomes unparseable.
+const STABLE_LAST_REFRESH_MS = Date.parse(DEMO_HISTOGRAM.timestamp ?? '')
+if (!Number.isFinite(STABLE_LAST_REFRESH_MS)) {
+  throw new Error('DEMO_HISTOGRAM.timestamp must be a parseable ISO string')
+}
 
 function defaultHookReturn(
   overrides: Partial<{
@@ -106,7 +110,7 @@ describe('QuantumHistogramCard', () => {
 
     render(<QuantumHistogramCard />)
 
-    expect(screen.getByTestId('quantum-skeleton')).toBeInTheDocument()
+    expect(screen.getByTestId('quantum-histogram-skeleton')).toBeInTheDocument()
     expect(screen.queryByTestId('lazy-echart')).toBeNull()
   })
 
@@ -117,7 +121,7 @@ describe('QuantumHistogramCard', () => {
 
     render(<QuantumHistogramCard />)
 
-    expect(screen.getByTestId('quantum-skeleton')).toBeInTheDocument()
+    expect(screen.getByTestId('quantum-histogram-skeleton')).toBeInTheDocument()
     expect(screen.queryByTestId('lazy-echart')).toBeNull()
   })
 

--- a/web/src/components/cards/quantum/__tests__/QuantumStatus.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumStatus.test.tsx
@@ -77,9 +77,9 @@ describe('QuantumStatus', () => {
       defaultHookReturn({ isLoading: true, data: null }),
     )
 
-    const { container } = render(<QuantumStatus />)
+    render(<QuantumStatus />)
 
-    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0)
+    expect(screen.getByTestId('quantum-skeleton')).toBeInTheDocument()
     expect(screen.queryByText('Refresh Interval')).toBeNull()
   })
 
@@ -110,13 +110,9 @@ describe('QuantumStatus', () => {
     )
 
     await waitFor(() => {
-      const reportedDemo = report.mock.calls.some(
-        (call) =>
-          call[0] &&
-          typeof call[0] === 'object' &&
-          (call[0] as { isDemoData?: boolean }).isDemoData === true,
+      expect(report).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true }),
       )
-      expect(reportedDemo).toBe(true)
     })
   })
 

--- a/web/src/components/cards/quantum/__tests__/QuantumStatus.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumStatus.test.tsx
@@ -79,7 +79,7 @@ describe('QuantumStatus', () => {
 
     render(<QuantumStatus />)
 
-    expect(screen.getByTestId('quantum-skeleton')).toBeInTheDocument()
+    expect(screen.getByTestId('quantum-status-skeleton')).toBeInTheDocument()
     expect(screen.queryByText('Refresh Interval')).toBeNull()
   })
 


### PR DESCRIPTION
## Summary

Closes the deferral on PR #17333 ([Copilot comment 1](https://github.com/kubestellar/console/pull/17333#discussion_r3384571884), [Copilot comment 2](https://github.com/kubestellar/console/pull/17333#discussion_r3384571898)). Two test files used patterns that would silently break on unrelated refactors:

- **`.animate-pulse` class-counting assertions** for loading state → replaced with `getByTestId('quantum-skeleton')`. Adds `data-testid="quantum-skeleton"` to the loading-state wrapper divs in `QuantumStatus` (auth-loading + showSkeleton branches) and `QuantumHistogramCard` (`HistogramLoadingState`).
- **Manual `.some()` scan with type-cast** for demo-data reporting → replaced with `expect.objectContaining({ isDemoData: true })`, which matches the same call but reads cleaner and gives a usable diff message on failure.

Only the two test files that had these patterns are touched. The peers (`QuantumQubitGrid.test.tsx`, `QuantumCircuitViewer.test.tsx`, `QuantumControlPanel.test.tsx`) use different assertion shapes and need no changes.

## Stacked on #17333

This branch was created from `test/quantum-coverage-and-baselines` (the branch backing PR #17333), so it includes #17333's commits as a prefix. **#17333 must merge first.** Once it does, the GitHub diff on this PR will collapse to just this commit's changes.

If you want to review both together: pull `test/quantum-debrittle-assertions` and diff against #17333's tip — the new commit is the only one this PR contributes.

## Test plan
- [x] `npx vitest run src/components/cards/quantum/__tests__/QuantumStatus.test.tsx src/components/cards/quantum/__tests__/QuantumHistogramCard.test.tsx` — 14/14 pass
- [ ] CI visual-regression.yml passes — `data-testid` attributes are HTML-only and don't render pixels, so the baselines from #17333 should match unchanged
- [ ] CI coverage-gate.yml passes