### PR TITLE
[sec-check] fix: run kc-agent container as non-root user

### DIFF
--- a/cmd/kc-agent/Dockerfile
+++ b/cmd/kc-agent/Dockerfile
@@ -13,11 +13,15 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /kc-agent ./cmd/kc-age
 # Stage 2: Minimal runtime image
 FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates \
+    && addgroup -g 65532 -S nonroot \
+    && adduser -u 65532 -S nonroot -G nonroot
 
 COPY --from=builder /kc-agent /usr/local/bin/kc-agent
 
 EXPOSE 8585
+
+USER nonroot:nonroot
 
 ENTRYPOINT ["kc-agent"]
 CMD []


### PR DESCRIPTION
## Security Fix

`cmd/kc-agent/Dockerfile` had no `USER` directive, meaning the container ran as root. This change adds a dedicated `nonroot` user (uid/gid 65532) and switches to it before `ENTRYPOINT`, following the same pattern already used in the main `Dockerfile`.

**Change:**
- Combined `apk add ca-certificates` with `addgroup`/`adduser` in a single `RUN` layer (no extra layer cost)
- Added `USER nonroot:nonroot` before `ENTRYPOINT`

This fixes Kubernetes `restricted` PodSecurityStandard failures and reduces container escape risk.

Fixes #17340

---
*Filed by sec-check agent (ACMM L6 — full mode)*