### PR TITLE
[quality] add unit tests for CORS allowlist and in-memory rate limiter

### DIFF
--- a/web/netlify/functions/__tests__/cors.test.ts
+++ b/web/netlify/functions/__tests__/cors.test.ts
@@ -1,0 +1,361 @@
+// @vitest-environment node
+/**
+ * Unit tests for the shared CORS helper module.
+ *
+ * The CORS module is security-critical: OWASP ZAP flagged
+ * "Cross-Domain Misconfiguration" (#9879) and this helper enforces an
+ * explicit origin allowlist. Every code path needs regression coverage.
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+import {
+  isAllowedOrigin,
+  buildCorsHeaders,
+  handlePreflight,
+  getStrictKubestellarCorsOrigin,
+  buildStrictKubestellarCorsHeaders,
+  STRICT_KUBESTELLAR_ORIGINS,
+} from "../_shared/cors";
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function makeRequest(origin: string | null, method = "GET"): Request {
+  const headers = new Headers();
+  if (origin) {
+    headers.set("origin", origin);
+  }
+  return new Request("https://console.kubestellar.io/api/test", {
+    method,
+    headers,
+  });
+}
+
+// ── isAllowedOrigin ─────────────────────────────────────────────────────
+
+describe("isAllowedOrigin", () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Default to test environment so localhost is allowed
+    process.env.NODE_ENV = "test";
+  });
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  describe("exact-match allowlist", () => {
+    it("accepts production origin", () => {
+      expect(isAllowedOrigin("https://console.kubestellar.io")).toBe(true);
+    });
+
+    it("accepts docs.kubestellar.io", () => {
+      expect(isAllowedOrigin("https://docs.kubestellar.io")).toBe(true);
+    });
+
+    it("accepts kubestellar.io", () => {
+      expect(isAllowedOrigin("https://kubestellar.io")).toBe(true);
+    });
+
+    it("accepts www.kubestellar.io", () => {
+      expect(isAllowedOrigin("https://www.kubestellar.io")).toBe(true);
+    });
+  });
+
+  describe("Netlify preview deploys", () => {
+    it("accepts branch preview deploys", () => {
+      expect(
+        isAllowedOrigin("https://feature-xyz--kubestellar-console.netlify.app"),
+      ).toBe(true);
+    });
+
+    it("accepts PR deploy previews", () => {
+      expect(
+        isAllowedOrigin(
+          "https://deploy-preview-1234--kubestellar-console.netlify.app",
+        ),
+      ).toBe(true);
+    });
+
+    it("accepts docs site preview deploys", () => {
+      expect(
+        isAllowedOrigin("https://fix-docs--kubestellar-docs.netlify.app"),
+      ).toBe(true);
+    });
+
+    it("rejects preview deploys for other sites", () => {
+      expect(
+        isAllowedOrigin("https://feature-xyz--evil-site.netlify.app"),
+      ).toBe(false);
+    });
+  });
+
+  describe("localhost (development only)", () => {
+    it("accepts localhost in test environment", () => {
+      process.env.NODE_ENV = "test";
+      expect(isAllowedOrigin("http://localhost:5174")).toBe(true);
+    });
+
+    it("accepts localhost in development environment", () => {
+      process.env.NODE_ENV = "development";
+      expect(isAllowedOrigin("http://localhost:5174")).toBe(true);
+    });
+
+    it("accepts 127.0.0.1 in development", () => {
+      process.env.NODE_ENV = "development";
+      expect(isAllowedOrigin("http://127.0.0.1:3000")).toBe(true);
+    });
+
+    it("accepts localhost without port", () => {
+      process.env.NODE_ENV = "test";
+      expect(isAllowedOrigin("http://localhost")).toBe(true);
+    });
+
+    it("rejects localhost in production", () => {
+      process.env.NODE_ENV = "production";
+      process.env.NETLIFY_DEV = undefined;
+      expect(isAllowedOrigin("http://localhost:5174")).toBe(false);
+    });
+  });
+
+  describe("rejection cases", () => {
+    it("rejects null origin", () => {
+      expect(isAllowedOrigin(null)).toBe(false);
+    });
+
+    it("rejects undefined origin", () => {
+      expect(isAllowedOrigin(undefined)).toBe(false);
+    });
+
+    it("rejects empty string origin", () => {
+      expect(isAllowedOrigin("")).toBe(false);
+    });
+
+    it("rejects arbitrary origins", () => {
+      expect(isAllowedOrigin("https://evil.example.com")).toBe(false);
+    });
+
+    it("rejects origin with matching suffix but different domain", () => {
+      expect(isAllowedOrigin("https://notkubestellar.io")).toBe(false);
+    });
+
+    it("rejects http version of production origin", () => {
+      expect(isAllowedOrigin("http://console.kubestellar.io")).toBe(false);
+    });
+
+    it("rejects origin with path appended", () => {
+      expect(isAllowedOrigin("https://console.kubestellar.io/evil")).toBe(
+        false,
+      );
+    });
+  });
+});
+
+// ── getStrictKubestellarCorsOrigin ──────────────────────────────────────
+
+describe("getStrictKubestellarCorsOrigin", () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  it("returns origin for console.kubestellar.io", () => {
+    expect(
+      getStrictKubestellarCorsOrigin("https://console.kubestellar.io"),
+    ).toBe("https://console.kubestellar.io");
+  });
+
+  it("returns origin for docs.kubestellar.io", () => {
+    expect(
+      getStrictKubestellarCorsOrigin("https://docs.kubestellar.io"),
+    ).toBe("https://docs.kubestellar.io");
+  });
+
+  it("returns null for Netlify preview (not in strict set)", () => {
+    expect(
+      getStrictKubestellarCorsOrigin(
+        "https://feature--kubestellar-console.netlify.app",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for null origin", () => {
+    expect(getStrictKubestellarCorsOrigin(null)).toBeNull();
+  });
+
+  it("returns localhost in dev mode", () => {
+    process.env.NODE_ENV = "development";
+    expect(
+      getStrictKubestellarCorsOrigin("http://localhost:5174"),
+    ).toBe("http://localhost:5174");
+  });
+
+  it("rejects localhost in production", () => {
+    process.env.NODE_ENV = "production";
+    process.env.NETLIFY_DEV = undefined;
+    expect(
+      getStrictKubestellarCorsOrigin("http://localhost:5174"),
+    ).toBeNull();
+  });
+});
+
+// ── STRICT_KUBESTELLAR_ORIGINS ──────────────────────────────────────────
+
+describe("STRICT_KUBESTELLAR_ORIGINS", () => {
+  it("contains console and docs origins", () => {
+    expect(STRICT_KUBESTELLAR_ORIGINS).toContain(
+      "https://console.kubestellar.io",
+    );
+    expect(STRICT_KUBESTELLAR_ORIGINS).toContain(
+      "https://docs.kubestellar.io",
+    );
+  });
+
+  it("is a readonly tuple", () => {
+    expect(STRICT_KUBESTELLAR_ORIGINS.length).toBe(2);
+  });
+});
+
+// ── buildStrictKubestellarCorsHeaders ───────────────────────────────────
+
+describe("buildStrictKubestellarCorsHeaders", () => {
+  it("includes Allow-Origin for allowed origin", () => {
+    const headers = buildStrictKubestellarCorsHeaders(
+      "https://console.kubestellar.io",
+    );
+    expect(headers["Access-Control-Allow-Origin"]).toBe(
+      "https://console.kubestellar.io",
+    );
+  });
+
+  it("omits Allow-Origin for disallowed origin", () => {
+    const headers = buildStrictKubestellarCorsHeaders(
+      "https://evil.example.com",
+    );
+    expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+  });
+
+  it("always includes Vary: Origin", () => {
+    const headers = buildStrictKubestellarCorsHeaders(null);
+    expect(headers.Vary).toBe("Origin");
+  });
+
+  it("uses default methods and headers", () => {
+    const headers = buildStrictKubestellarCorsHeaders(
+      "https://console.kubestellar.io",
+    );
+    expect(headers["Access-Control-Allow-Methods"]).toBe("GET, OPTIONS");
+    expect(headers["Access-Control-Allow-Headers"]).toBe("Content-Type");
+  });
+
+  it("accepts custom methods and headers options", () => {
+    const headers = buildStrictKubestellarCorsHeaders(
+      "https://console.kubestellar.io",
+      { methods: "POST, OPTIONS", headers: "Authorization" },
+    );
+    expect(headers["Access-Control-Allow-Methods"]).toBe("POST, OPTIONS");
+    expect(headers["Access-Control-Allow-Headers"]).toBe("Authorization");
+  });
+});
+
+// ── buildCorsHeaders ────────────────────────────────────────────────────
+
+describe("buildCorsHeaders", () => {
+  it("echoes allowed origin in Access-Control-Allow-Origin", () => {
+    const req = makeRequest("https://console.kubestellar.io");
+    const headers = buildCorsHeaders(req, { methods: "GET, OPTIONS" });
+    expect(headers["Access-Control-Allow-Origin"]).toBe(
+      "https://console.kubestellar.io",
+    );
+  });
+
+  it("omits Access-Control-Allow-Origin for disallowed origin", () => {
+    const req = makeRequest("https://evil.example.com");
+    const headers = buildCorsHeaders(req, { methods: "GET, OPTIONS" });
+    expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+  });
+
+  it("always includes X-Content-Type-Options: nosniff", () => {
+    const req = makeRequest("https://evil.example.com");
+    const headers = buildCorsHeaders(req, { methods: "GET" });
+    expect(headers["X-Content-Type-Options"]).toBe("nosniff");
+  });
+
+  it("always includes Vary: Origin", () => {
+    const req = makeRequest(null);
+    const headers = buildCorsHeaders(req, { methods: "GET" });
+    expect(headers.Vary).toBe("Origin");
+  });
+
+  it("includes Allow-Methods for allowed origin", () => {
+    const req = makeRequest("https://console.kubestellar.io");
+    const headers = buildCorsHeaders(req, { methods: "POST, OPTIONS" });
+    expect(headers["Access-Control-Allow-Methods"]).toBe("POST, OPTIONS");
+  });
+
+  it("omits Allow-Methods for disallowed origin", () => {
+    const req = makeRequest("https://evil.example.com");
+    const headers = buildCorsHeaders(req, { methods: "POST, OPTIONS" });
+    expect(headers["Access-Control-Allow-Methods"]).toBeUndefined();
+  });
+
+  it("includes Allow-Headers when specified for allowed origin", () => {
+    const req = makeRequest("https://console.kubestellar.io");
+    const headers = buildCorsHeaders(req, {
+      methods: "POST",
+      headers: "Content-Type, Authorization",
+    });
+    expect(headers["Access-Control-Allow-Headers"]).toBe(
+      "Content-Type, Authorization",
+    );
+  });
+
+  it("includes Expose-Headers when specified for allowed origin", () => {
+    const req = makeRequest("https://console.kubestellar.io");
+    const headers = buildCorsHeaders(req, {
+      methods: "GET",
+      exposeHeaders: "X-Custom-Header",
+    });
+    expect(headers["Access-Control-Expose-Headers"]).toBe("X-Custom-Header");
+  });
+});
+
+// ── handlePreflight ─────────────────────────────────────────────────────
+
+describe("handlePreflight", () => {
+  it("returns 204 for allowed origin", () => {
+    const req = makeRequest("https://console.kubestellar.io", "OPTIONS");
+    const res = handlePreflight(req, { methods: "GET, OPTIONS" });
+    expect(res.status).toBe(204);
+  });
+
+  it("returns 403 for disallowed origin", () => {
+    const req = makeRequest("https://evil.example.com", "OPTIONS");
+    const res = handlePreflight(req, { methods: "GET, OPTIONS" });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 for null origin", () => {
+    const req = makeRequest(null, "OPTIONS");
+    const res = handlePreflight(req, { methods: "GET, OPTIONS" });
+    expect(res.status).toBe(403);
+  });
+
+  it("includes CORS headers in response", () => {
+    const req = makeRequest("https://console.kubestellar.io", "OPTIONS");
+    const res = handlePreflight(req, { methods: "POST, OPTIONS" });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://console.kubestellar.io",
+    );
+    expect(res.headers.get("Access-Control-Allow-Methods")).toBe(
+      "POST, OPTIONS",
+    );
+  });
+
+  it("has null body", () => {
+    const req = makeRequest("https://console.kubestellar.io", "OPTIONS");
+    const res = handlePreflight(req, { methods: "GET, OPTIONS" });
+    expect(res.body).toBeNull();
+  });
+});

--- a/web/netlify/functions/__tests__/in-memory-rate-limit.test.ts
+++ b/web/netlify/functions/__tests__/in-memory-rate-limit.test.ts
@@ -1,0 +1,316 @@
+// @vitest-environment node
+/**
+ * Unit tests for the in-memory rate limiter.
+ *
+ * The in-memory rate limiter is used across multiple Netlify Functions as
+ * a first line of defense against abuse (CWE-400). These tests verify
+ * every code path: first request, window expiry, limit enforcement,
+ * consume/no-consume mode, pruning, and client-IP extraction.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  checkInMemoryRateLimit,
+  getClientIp,
+  type InMemoryRateLimitEntry,
+} from "../_shared/inMemoryRateLimit";
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+const MAX_REQUESTS = 3;
+const WINDOW_MS = 60_000;
+
+// ── getClientIp ─────────────────────────────────────────────────────────
+
+describe("getClientIp", () => {
+  it("returns x-nf-client-connection-ip header value", () => {
+    const req = new Request("https://example.com", {
+      headers: { "x-nf-client-connection-ip": "1.2.3.4" },
+    });
+    expect(getClientIp(req)).toBe("1.2.3.4");
+  });
+
+  it("returns default subject when header is missing", () => {
+    const req = new Request("https://example.com");
+    expect(getClientIp(req)).toBe("untrusted-client");
+  });
+});
+
+// ── checkInMemoryRateLimit ──────────────────────────────────────────────
+
+describe("checkInMemoryRateLimit", () => {
+  let rateLimitMap: Map<string, InMemoryRateLimitEntry>;
+
+  beforeEach(() => {
+    rateLimitMap = new Map();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("first request", () => {
+    it("allows the first request and creates an entry", () => {
+      const result = checkInMemoryRateLimit(
+        "user-1",
+        rateLimitMap,
+        MAX_REQUESTS,
+        WINDOW_MS,
+      );
+      expect(result.allowed).toBe(true);
+      expect(result.retryAfterSeconds).toBe(0);
+      expect(rateLimitMap.has("user-1")).toBe(true);
+      expect(rateLimitMap.get("user-1")!.count).toBe(1);
+    });
+
+    it("uses default subject for empty string", () => {
+      const result = checkInMemoryRateLimit(
+        "",
+        rateLimitMap,
+        MAX_REQUESTS,
+        WINDOW_MS,
+      );
+      expect(result.allowed).toBe(true);
+      expect(rateLimitMap.has("untrusted-client")).toBe(true);
+    });
+  });
+
+  describe("under limit", () => {
+    it("allows requests up to the limit", () => {
+      for (let i = 0; i < MAX_REQUESTS; i++) {
+        const result = checkInMemoryRateLimit(
+          "user-1",
+          rateLimitMap,
+          MAX_REQUESTS,
+          WINDOW_MS,
+        );
+        expect(result.allowed).toBe(true);
+      }
+      expect(rateLimitMap.get("user-1")!.count).toBe(MAX_REQUESTS);
+    });
+  });
+
+  describe("at limit", () => {
+    it("denies requests exceeding the limit", () => {
+      // Exhaust the limit
+      for (let i = 0; i < MAX_REQUESTS; i++) {
+        checkInMemoryRateLimit(
+          "user-1",
+          rateLimitMap,
+          MAX_REQUESTS,
+          WINDOW_MS,
+        );
+      }
+
+      // Next request should be denied
+      const result = checkInMemoryRateLimit(
+        "user-1",
+        rateLimitMap,
+        MAX_REQUESTS,
+        WINDOW_MS,
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.retryAfterSeconds).toBeGreaterThan(0);
+    });
+
+    it("returns retryAfterSeconds > 0 when limited", () => {
+      for (let i = 0; i < MAX_REQUESTS; i++) {
+        checkInMemoryRateLimit(
+          "user-1",
+          rateLimitMap,
+          MAX_REQUESTS,
+          WINDOW_MS,
+        );
+      }
+
+      // Advance 30 seconds into the window
+      vi.advanceTimersByTime(30_000);
+
+      const result = checkInMemoryRateLimit(
+        "user-1",
+        rateLimitMap,
+        MAX_REQUESTS,
+        WINDOW_MS,
+      );
+      expect(result.allowed).toBe(false);
+      // Should be ~30 seconds remaining
+      expect(result.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+      expect(result.retryAfterSeconds).toBeLessThanOrEqual(31);
+    });
+  });
+
+  describe("window expiry", () => {
+    it("resets after window expires", () => {
+      // Exhaust the limit
+      for (let i = 0; i < MAX_REQUESTS; i++) {
+        checkInMemoryRateLimit(
+          "user-1",
+          rateLimitMap,
+          MAX_REQUESTS,
+          WINDOW_MS,
+        );
+      }
+
+      // Confirm denied
+      expect(
+        checkInMemoryRateLimit(
+          "user-1",
+          rateLimitMap,
+          MAX_REQUESTS,
+          WINDOW_MS,
+        ).allowed,
+      ).toBe(false);
+
+      // Advance past the window
+      vi.advanceTimersByTime(WINDOW_MS + 1);
+
+      // Should be allowed again
+      const result = checkInMemoryRateLimit(
+        "user-1",
+        rateLimitMap,
+        MAX_REQUESTS,
+        WINDOW_MS,
+      );
+      expect(result.allowed).toBe(true);
+      expect(rateLimitMap.get("user-1")!.count).toBe(1);
+    });
+  });
+
+  describe("consume option", () => {
+    it("does not consume when consume=false on first request", () => {
+      const result = checkInMemoryRateLimit(
+        "user-1",
+        rateLimitMap,
+        MAX_REQUESTS,
+        WINDOW_MS,
+        { consume: false },
+      );
+      expect(result.allowed).toBe(true);
+      expect(rateLimitMap.has("user-1")).toBe(false);
+    });
+
+    it("does not increment count when consume=false", () => {
+      // Make one consumed request
+      checkInMemoryRateLimit(
+        "user-1",
+        rateLimitMap,
+        MAX_REQUESTS,
+        WINDOW_MS,
+      );
+      expect(rateLimitMap.get("user-1")!.count).toBe(1);
+
+      // Check without consuming
+      const result = checkInMemoryRateLimit(
+        "user-1",
+        rateLimitMap,
+        MAX_REQUESTS,
+        WINDOW_MS,
+        { consume: false },
+      );
+      expect(result.allowed).toBe(true);
+      expect(rateLimitMap.get("user-1")!.count).toBe(1);
+    });
+
+    it("does not create entry on window expiry when consume=false", () => {
+      // Create and expire an entry
+      checkInMemoryRateLimit(
+        "user-1",
+        rateLimitMap,
+        MAX_REQUESTS,
+        WINDOW_MS,
+      );
+      vi.advanceTimersByTime(WINDOW_MS + 1);
+
+      const result = checkInMemoryRateLimit(
+        "user-1",
+        rateLimitMap,
+        MAX_REQUESTS,
+        WINDOW_MS,
+        { consume: false },
+      );
+      expect(result.allowed).toBe(true);
+      expect(rateLimitMap.has("user-1")).toBe(false);
+    });
+  });
+
+  describe("subject isolation", () => {
+    it("tracks subjects independently", () => {
+      for (let i = 0; i < MAX_REQUESTS; i++) {
+        checkInMemoryRateLimit(
+          "user-1",
+          rateLimitMap,
+          MAX_REQUESTS,
+          WINDOW_MS,
+        );
+      }
+
+      // user-1 is at limit
+      expect(
+        checkInMemoryRateLimit(
+          "user-1",
+          rateLimitMap,
+          MAX_REQUESTS,
+          WINDOW_MS,
+        ).allowed,
+      ).toBe(false);
+
+      // user-2 should still be allowed
+      expect(
+        checkInMemoryRateLimit(
+          "user-2",
+          rateLimitMap,
+          MAX_REQUESTS,
+          WINDOW_MS,
+        ).allowed,
+      ).toBe(true);
+    });
+  });
+
+  describe("pruning", () => {
+    it("prunes expired entries when map reaches MAX_TRACKED_SUBJECTS", () => {
+      const MAX_TRACKED = 1_000;
+
+      // Fill the map to capacity with expired entries
+      const expiredResetAt = Date.now() - 1;
+      for (let i = 0; i < MAX_TRACKED; i++) {
+        rateLimitMap.set(`expired-${i}`, {
+          count: 1,
+          resetAt: expiredResetAt,
+        });
+      }
+      expect(rateLimitMap.size).toBe(MAX_TRACKED);
+
+      // Next call should trigger pruning
+      checkInMemoryRateLimit(
+        "new-user",
+        rateLimitMap,
+        MAX_REQUESTS,
+        WINDOW_MS,
+      );
+
+      // Expired entries should be removed
+      expect(rateLimitMap.size).toBeLessThan(MAX_TRACKED);
+      expect(rateLimitMap.has("new-user")).toBe(true);
+    });
+
+    it("does not prune when below MAX_TRACKED_SUBJECTS", () => {
+      // Add a few entries
+      const expiredResetAt = Date.now() - 1;
+      rateLimitMap.set("expired-1", { count: 1, resetAt: expiredResetAt });
+      rateLimitMap.set("expired-2", { count: 1, resetAt: expiredResetAt });
+
+      checkInMemoryRateLimit(
+        "new-user",
+        rateLimitMap,
+        MAX_REQUESTS,
+        WINDOW_MS,
+      );
+
+      // Expired entries should still be present (no pruning needed)
+      expect(rateLimitMap.has("expired-1")).toBe(true);
+      expect(rateLimitMap.has("expired-2")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Test Improvement

Fixes #17353

Adds **60 unit tests** covering two untested security-critical shared Netlify modules that had **zero test coverage**:

### 1. `cors.ts` — 46 tests
The CORS origin allowlist module (created in response to OWASP ZAP finding #9879). Tests cover:

| Function | Tests |
|----------|-------|
| `isAllowedOrigin` | Exact-match (production, docs, www), Netlify preview/deploy patterns, docs preview deploys, rejection of other Netlify sites, localhost dev/prod environment gating, null/undefined/empty, arbitrary origins, suffix attacks, HTTP downgrade, path-appended bypass |
| `getStrictKubestellarCorsOrigin` | First-party strict set, Netlify preview rejection, null, localhost dev vs production |
| `STRICT_KUBESTELLAR_ORIGINS` | Contents and readonly tuple length |
| `buildStrictKubestellarCorsHeaders` | Allow-Origin echo/omit, Vary header, default vs custom methods/headers |
| `buildCorsHeaders` | Origin echo/omit, X-Content-Type-Options: nosniff, Vary: Origin, Allow-Methods/Headers/Expose-Headers inclusion and omission |
| `handlePreflight` | 204 for allowed, 403 for disallowed/null, CORS headers in response, null body |

### 2. `inMemoryRateLimit.ts` — 14 tests
The in-memory rate limiter (CWE-400 protection). Tests cover:

| Function | Tests |
|----------|-------|
| `getClientIp` | Netlify header extraction, default subject fallback |
| `checkInMemoryRateLimit` | First request entry creation, empty-string default subject, under-limit allows, at-limit denial with retryAfterSeconds, mid-window retryAfterSeconds calculation, window expiry and reset, consume=false peek mode (first request, existing entry, expired entry), subject isolation, pruning at MAX_TRACKED_SUBJECTS capacity, no-prune below capacity |

### Why this matters

Both modules are security-critical and used across all Netlify Functions:
- **CORS**: enforces origin allowlist that prevents cross-origin leakage (OWASP ZAP flagged this)
- **Rate limiter**: prevents resource exhaustion (CWE-400) as first line of defense

All 60 tests pass locally: `npx vitest run netlify/functions/__tests__/cors.test.ts netlify/functions/__tests__/in-memory-rate-limit.test.ts`

---
*Filed by quality agent (ACMM L4/L6 — full mode)*