### PR TITLE
fix: preserve empty Bearer token validation

### DIFF
--- a/web/netlify/functions/__tests__/jwt-validation.test.ts
+++ b/web/netlify/functions/__tests__/jwt-validation.test.ts
@@ -218,18 +218,16 @@ describe("validateBearerToken", () => {
       expect(result.error).toMatch(/Bearer/i);
     });
 
-    it("rejects header with empty Bearer token (trims to no space)", async () => {
-      // "Bearer " trims trailing space → "Bearer" → doesn't start with "Bearer <space>"
+    it("rejects header with empty Bearer token", async () => {
       const result = await validateBearerToken("Bearer ", TEST_SECRET);
       expect(result.valid).toBe(false);
-      expect(result.error).toMatch(/must start with/i);
+      expect(result.error).toMatch(/empty/i);
     });
 
-    it("rejects header that trims to bearer keyword only", async () => {
-      // Multiple trailing spaces all get removed by trim() → same as "Bearer "
+    it("rejects header that has only whitespace after the Bearer prefix", async () => {
       const result = await validateBearerToken("Bearer    ", TEST_SECRET);
       expect(result.valid).toBe(false);
-      expect(result.error).toMatch(/must start with/i);
+      expect(result.error).toMatch(/empty/i);
     });
   });
 

--- a/web/netlify/functions/_shared/jwt-validation.ts
+++ b/web/netlify/functions/_shared/jwt-validation.ts
@@ -162,7 +162,7 @@ export async function validateBearerToken(
     return { valid: false, error: "Authorization header is required" };
   }
 
-  const trimmed = authHeader.trim();
+  const trimmed = authHeader.trimStart();
   const bearerPrefix = "Bearer ";
 
   if (!trimmed.startsWith(bearerPrefix)) {


### PR DESCRIPTION
## Summary

- Preserve leading-whitespace tolerance for Authorization headers by trimming only the start before checking the `Bearer ` prefix.
- Treat `Bearer ` and `Bearer    ` as syntactically valid Bearer headers with an empty token, returning the existing empty-token error.
- Update the JWT validation unit expectations for empty Bearer tokens after the broader coverage merged in #17356.

## Checks

- `npm run test -- --run netlify/functions/__tests__/jwt-validation.test.ts`
- `npx eslint netlify/functions/_shared/jwt-validation.ts netlify/functions/__tests__/jwt-validation.test.ts`
- `NODE_OPTIONS=--max-old-space-size=6144 npm run build`
- `git diff --check`