### PR TITLE
[quality] Add unit tests for Security tab components

### DIFF
--- a/web/src/components/security/__tests__/SecurityComplianceTab.test.tsx
+++ b/web/src/components/security/__tests__/SecurityComplianceTab.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'security.overallCompliance': 'Overall Compliance',
+        'security.passed': 'passed',
+        'security.failing': 'failing',
+        'security.warnings': 'warnings',
+        'security.passing': 'passing',
+      }
+      return map[key] ?? key
+    },
+  }),
+}))
+
+vi.mock('../../ui/ClusterBadge', () => ({
+  ClusterBadge: ({ cluster }: { cluster: string }) => (
+    <span data-testid="cluster-badge">{cluster}</span>
+  ),
+}))
+
+import { SecurityComplianceTab } from '../SecurityComplianceTab'
+import type { ComplianceCheck } from '../../../mocks/securityData'
+
+const baseStats = {
+  complianceScore: 85,
+  compliancePassed: 12,
+  complianceFailed: 2,
+  complianceWarnings: 1,
+}
+
+const mockComplianceByCategory: Record<string, ComplianceCheck[]> = {
+  'Network Security': [
+    {
+      id: 'ns-1',
+      name: 'Network policies enforced',
+      category: 'Network Security',
+      status: 'pass',
+      description: 'All namespaces have network policies',
+      cluster: 'prod',
+    },
+    {
+      id: 'ns-2',
+      name: 'Egress rules configured',
+      category: 'Network Security',
+      status: 'fail',
+      description: 'Missing egress rules in staging namespace',
+      cluster: 'staging',
+    },
+  ],
+  'Pod Security': [
+    {
+      id: 'ps-1',
+      name: 'Pod security standards',
+      category: 'Pod Security',
+      status: 'warn',
+      description: 'Some pods run without restricted PSS',
+      cluster: 'prod',
+    },
+  ],
+}
+
+describe('SecurityComplianceTab', () => {
+  const defaultProps = {
+    stats: baseStats,
+    complianceByCategory: mockComplianceByCategory,
+    handleRefresh: vi.fn(),
+  }
+
+  it('renders compliance score', () => {
+    render(<SecurityComplianceTab {...defaultProps} />)
+    expect(screen.getByText('85%')).toBeInTheDocument()
+  })
+
+  it('renders passed/failed/warnings counts', () => {
+    render(<SecurityComplianceTab {...defaultProps} />)
+    expect(screen.getByText(/12 passed/)).toBeInTheDocument()
+    expect(screen.getByText(/2 failing/)).toBeInTheDocument()
+    expect(screen.getByText(/1 warnings/)).toBeInTheDocument()
+  })
+
+  it('renders compliance categories', () => {
+    render(<SecurityComplianceTab {...defaultProps} />)
+    expect(screen.getByText('Network Security')).toBeInTheDocument()
+    expect(screen.getByText('Pod Security')).toBeInTheDocument()
+  })
+
+  it('renders check names and descriptions', () => {
+    render(<SecurityComplianceTab {...defaultProps} />)
+    expect(screen.getByText('Network policies enforced')).toBeInTheDocument()
+    expect(screen.getByText('Missing egress rules in staging namespace')).toBeInTheDocument()
+  })
+
+  it('shows passing ratio per category', () => {
+    render(<SecurityComplianceTab {...defaultProps} />)
+    expect(screen.getByText('(1/2 passing)')).toBeInTheDocument()
+    expect(screen.getByText('(0/1 passing)')).toBeInTheDocument()
+  })
+
+  it('calls handleRefresh when refresh button clicked', () => {
+    const handleRefresh = vi.fn()
+    render(<SecurityComplianceTab {...defaultProps} handleRefresh={handleRefresh} />)
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }))
+    expect(handleRefresh).toHaveBeenCalledOnce()
+  })
+
+  it('renders cluster badges in checks', () => {
+    render(<SecurityComplianceTab {...defaultProps} />)
+    const badges = screen.getAllByTestId('cluster-badge')
+    expect(badges.length).toBe(3)
+  })
+
+  it('applies green color class for high compliance score', () => {
+    render(<SecurityComplianceTab {...defaultProps} />)
+    const scoreEl = screen.getByText('85%')
+    expect(scoreEl.className).toContain('text-green')
+  })
+
+  it('applies yellow color class for medium compliance score', () => {
+    render(
+      <SecurityComplianceTab
+        {...defaultProps}
+        stats={{ ...baseStats, complianceScore: 65 }}
+      />
+    )
+    expect(screen.getByText('65%').className).toContain('text-yellow')
+  })
+
+  it('applies red color class for low compliance score', () => {
+    render(
+      <SecurityComplianceTab
+        {...defaultProps}
+        stats={{ ...baseStats, complianceScore: 40 }}
+      />
+    )
+    expect(screen.getByText('40%').className).toContain('text-red')
+  })
+})

--- a/web/src/components/security/__tests__/SecurityIssuesTab.test.tsx
+++ b/web/src/components/security/__tests__/SecurityIssuesTab.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'security.allIssues': 'All Issues',
+        'security.highLabel': 'High',
+        'security.mediumLabel': 'Medium',
+        'security.lowLabel': 'Low',
+        'security.filterByType': 'Filter by type',
+        'security.noIssuesFound': 'No issues found',
+        'security.bestPractices': 'Following best practices',
+        'security.privileged': 'Privileged',
+        'security.root': 'Root',
+        'security.hostNetwork': 'Host Network',
+      }
+      return map[key] ?? key
+    },
+  }),
+}))
+
+vi.mock('../../ui/ClusterBadge', () => ({
+  ClusterBadge: ({ cluster }: { cluster: string }) => (
+    <span data-testid="cluster-badge">{cluster}</span>
+  ),
+}))
+
+import { SecurityIssuesTab } from '../SecurityIssuesTab'
+import type { SecurityIssue } from '../../../mocks/securityData'
+
+const baseStats = {
+  total: 5,
+  high: 2,
+  medium: 2,
+  low: 1,
+  typeCounts: { privileged: 2, root: 2, noSecurityContext: 1 },
+}
+
+const mockIssues: SecurityIssue[] = [
+  {
+    type: 'privileged',
+    severity: 'high',
+    resource: 'vllm-engine',
+    namespace: 'default',
+    cluster: 'prod-a',
+    message: 'Container runs in privileged mode',
+  },
+  {
+    type: 'root',
+    severity: 'medium',
+    resource: 'metrics-collector',
+    namespace: 'monitoring',
+    cluster: 'ops',
+    message: 'Container runs as root user',
+  },
+  {
+    type: 'noSecurityContext',
+    severity: 'low',
+    resource: 'web-frontend',
+    namespace: 'web',
+    cluster: 'staging',
+    message: 'No security context defined',
+  },
+]
+
+describe('SecurityIssuesTab', () => {
+  const defaultProps = {
+    stats: baseStats,
+    filteredIssues: mockIssues,
+    severityFilter: 'all',
+    setSeverityFilter: vi.fn(),
+    selectedIssueType: null,
+    setSelectedIssueType: vi.fn(),
+  }
+
+  it('renders severity stat cards', () => {
+    render(<SecurityIssuesTab {...defaultProps} />)
+    expect(screen.getByText('5')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('renders all issues', () => {
+    render(<SecurityIssuesTab {...defaultProps} />)
+    expect(screen.getByText('vllm-engine')).toBeInTheDocument()
+    expect(screen.getByText('metrics-collector')).toBeInTheDocument()
+    expect(screen.getByText('web-frontend')).toBeInTheDocument()
+  })
+
+  it('calls setSeverityFilter when severity button clicked', () => {
+    const setSeverityFilter = vi.fn()
+    render(<SecurityIssuesTab {...defaultProps} setSeverityFilter={setSeverityFilter} />)
+    fireEvent.click(screen.getByText('High'))
+    expect(setSeverityFilter).toHaveBeenCalledWith('high')
+  })
+
+  it('calls setSelectedIssueType when type filter clicked', () => {
+    const setSelectedIssueType = vi.fn()
+    render(<SecurityIssuesTab {...defaultProps} setSelectedIssueType={setSelectedIssueType} />)
+    const buttons = screen.getAllByRole('button')
+    const privilegedBtn = buttons.find(b => b.textContent?.includes('Privileged'))
+    if (privilegedBtn) fireEvent.click(privilegedBtn)
+    expect(setSelectedIssueType).toHaveBeenCalled()
+  })
+
+  it('shows empty state when no issues match type filter', () => {
+    render(
+      <SecurityIssuesTab
+        {...defaultProps}
+        filteredIssues={mockIssues}
+        selectedIssueType="hostNetwork"
+      />
+    )
+    expect(screen.getByText('No issues found')).toBeInTheDocument()
+  })
+
+  it('renders cluster badges for each issue', () => {
+    render(<SecurityIssuesTab {...defaultProps} />)
+    const badges = screen.getAllByTestId('cluster-badge')
+    expect(badges.length).toBe(3)
+    expect(badges[0]).toHaveTextContent('prod-a')
+  })
+
+  it('displays namespace info for issues', () => {
+    render(<SecurityIssuesTab {...defaultProps} />)
+    expect(screen.getByText(/default/)).toBeInTheDocument()
+    expect(screen.getByText(/monitoring/)).toBeInTheDocument()
+  })
+})

--- a/web/src/components/security/__tests__/SecurityRBACTab.test.tsx
+++ b/web/src/components/security/__tests__/SecurityRBACTab.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'security.totalBindings': 'Total Bindings',
+        'security.highRisk': 'High Risk',
+        'security.mediumRisk': 'Medium Risk',
+        'security.lowRisk': 'Low Risk',
+        'security.risk': 'risk',
+        'security.subjects': 'Subjects',
+      }
+      return map[key] ?? key
+    },
+  }),
+}))
+
+vi.mock('../../ui/ClusterBadge', () => ({
+  ClusterBadge: ({ cluster }: { cluster: string }) => (
+    <span data-testid="cluster-badge">{cluster}</span>
+  ),
+}))
+
+import { SecurityRBACTab } from '../SecurityRBACTab'
+import type { RBACBinding } from '../../../mocks/securityData'
+
+const baseStats = {
+  rbacTotal: 10,
+  rbacHighRisk: 3,
+  rbacMedRisk: 4,
+  rbacLowRisk: 3,
+}
+
+const mockBindings: RBACBinding[] = [
+  {
+    name: 'cluster-admin-binding',
+    kind: 'ClusterRole',
+    subjects: [{ kind: 'User', name: 'admin-user' }],
+    cluster: 'prod',
+    permissions: ['*'],
+    riskLevel: 'high',
+  },
+  {
+    name: 'readonly-role',
+    kind: 'Role',
+    subjects: [{ kind: 'ServiceAccount', name: 'monitor-sa' }],
+    cluster: 'staging',
+    namespace: 'monitoring',
+    permissions: ['get', 'list', 'watch'],
+    riskLevel: 'low',
+  },
+  {
+    name: 'deploy-role',
+    kind: 'ClusterRole',
+    subjects: [
+      { kind: 'Group', name: 'developers' },
+      { kind: 'User', name: 'deployer' },
+    ],
+    cluster: 'prod',
+    permissions: ['get', 'list', 'create', 'update', 'delete', 'patch'],
+    riskLevel: 'medium',
+  },
+]
+
+describe('SecurityRBACTab', () => {
+  it('renders RBAC stat cards', () => {
+    render(<SecurityRBACTab stats={baseStats} filteredRBAC={mockBindings} />)
+    expect(screen.getByText('10')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('4')).toBeInTheDocument()
+  })
+
+  it('renders binding names', () => {
+    render(<SecurityRBACTab stats={baseStats} filteredRBAC={mockBindings} />)
+    expect(screen.getByText('cluster-admin-binding')).toBeInTheDocument()
+    expect(screen.getByText('readonly-role')).toBeInTheDocument()
+    expect(screen.getByText('deploy-role')).toBeInTheDocument()
+  })
+
+  it('renders subject names', () => {
+    render(<SecurityRBACTab stats={baseStats} filteredRBAC={mockBindings} />)
+    expect(screen.getByText('admin-user')).toBeInTheDocument()
+    expect(screen.getByText('monitor-sa')).toBeInTheDocument()
+    expect(screen.getByText('developers')).toBeInTheDocument()
+  })
+
+  it('renders cluster badges', () => {
+    render(<SecurityRBACTab stats={baseStats} filteredRBAC={mockBindings} />)
+    const badges = screen.getAllByTestId('cluster-badge')
+    expect(badges.length).toBe(3)
+  })
+
+  it('displays namespace when present', () => {
+    render(<SecurityRBACTab stats={baseStats} filteredRBAC={mockBindings} />)
+    expect(screen.getByText(/monitoring/)).toBeInTheDocument()
+  })
+
+  it('truncates permissions beyond 5 and shows +N more', () => {
+    render(<SecurityRBACTab stats={baseStats} filteredRBAC={mockBindings} />)
+    expect(screen.getByText(/\+1/)).toBeInTheDocument()
+  })
+
+  it('shows risk level badges', () => {
+    render(<SecurityRBACTab stats={baseStats} filteredRBAC={mockBindings} />)
+    expect(screen.getByText(/high risk/)).toBeInTheDocument()
+    expect(screen.getByText(/low risk/)).toBeInTheDocument()
+    expect(screen.getByText(/medium risk/)).toBeInTheDocument()
+  })
+
+  it('renders kind badges for bindings', () => {
+    render(<SecurityRBACTab stats={baseStats} filteredRBAC={mockBindings} />)
+    expect(screen.getAllByText('ClusterRole').length).toBe(2)
+    expect(screen.getByText('Role')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds comprehensive unit tests for the Security module's tab components:

- **SecurityIssuesTab** (132 LoC) — tests severity filters, issue type filters, empty states, cluster badges
- **SecurityRBACTab** (149 LoC) — tests RBAC stat rendering, binding display, permission truncation, risk levels
- **SecurityComplianceTab** (128 LoC) — tests compliance score rendering, color thresholds, category grouping, refresh interaction

These three components had **zero test coverage** despite rendering critical security-related UI that users rely on for cluster security posture assessment.

### Coverage added
- 25 new test cases across 3 test files
- Covers rendering, interaction callbacks, edge cases (empty states, truncation)

Partially addresses #17397

---
*Filed by quality agent (ACMM L4/L6 — full mode)*