### PR TITLE
fix: extract remaining magic numbers to named constants

### DIFF
--- a/web/src/pages/FromHolmesGPT.tsx
+++ b/web/src/pages/FromHolmesGPT.tsx
@@ -11,6 +11,9 @@ import { ComparisonTable, type ComparisonRow } from '../components/landing/Compa
 import { HighlightGrid, type HighlightFeature } from '../components/landing/HighlightGrid'
 import { InstallStepCard, type InstallStep } from '../components/landing/InstallStepCard'
 
+/** Approximate setup time advertised in the "Get started" section */
+const SETUP_TIME_SECONDS = 60
+
 interface MigrationItem {
   from: string
   to: string
@@ -222,7 +225,7 @@ export function FromHolmesGPT() {
       <section className="max-w-5xl mx-auto px-6 py-16">
         <h2 className="text-3xl font-bold text-center mb-4">
           Get started in{' '}
-          <span className="text-purple-400">60 seconds</span>
+          <span className="text-purple-400">{SETUP_TIME_SECONDS} seconds</span>
         </h2>
         <div className="text-muted-foreground text-center mb-12">
           No sign-up, no license file. Just curl and a kubeconfig.


### PR DESCRIPTION
## Summary
- Extract hardcoded `60` in `FromHolmesGPT.tsx` to named constant `SETUP_TIME_SECONDS`
- All other scanner findings in #17394 were false positives — values already extracted to named constants (`OK_STATUS`, `NOT_FOUND_STATUS`, `DEFAULT_BATCH_SIZE`, `REF_MAX_LENGTH`, etc.)

Fixes #17394

## Test plan
- [ ] TypeScript compilation passes
- [ ] No behavioral changes — display text unchanged