### PR TITLE
fix: extract hardcoded colors to named constants

### DIFF
--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -94,12 +94,15 @@ export function isJWTExpired(token: string): boolean {
 function showExpiryWarningBanner(onRefresh: () => void): void {
   if (document.getElementById('session-expiry-warning')) return
 
-  /* Spacing constants for DOM-based banner (Tailwind unavailable in imperative DOM) */
+  /* Spacing & color constants for DOM-based banner (Tailwind unavailable in imperative DOM) */
   const BANNER_BOTTOM_PX = '24px'
   const BANNER_GAP_PX = '12px'
   const BANNER_PAD_V_PX = '12px'
   const BANNER_PAD_H_PX = '20px'
   const BANNER_RADIUS_PX = '8px'
+  const WARN_BG = 'rgba(234,179,8,0.15)'       // yellow-500 at 15% opacity
+  const WARN_BORDER = 'rgba(234,179,8,0.4)'     // yellow-500 at 40% opacity
+  const WARN_TEXT = '#fbbf24'                    // amber-400 text
   const BTN_MARGIN_LEFT_PX = '8px'
   const BTN_PAD_V_PX = '4px'
   const BTN_PAD_H_PX = '12px'
@@ -110,10 +113,10 @@ function showExpiryWarningBanner(onRefresh: () => void): void {
     position: fixed; bottom: ${BANNER_BOTTOM_PX}; left: 50%; transform: translateX(-50%); z-index: 99999;
     display: flex; align-items: center; gap: ${BANNER_GAP_PX};
     padding: ${BANNER_PAD_V_PX} ${BANNER_PAD_H_PX};
-    background: rgba(234,179,8,0.15);
-    border: 1px solid rgba(234,179,8,0.4);
+    background: ${WARN_BG};
+    border: 1px solid ${WARN_BORDER};
     border-radius: ${BANNER_RADIUS_PX}; backdrop-filter: blur(8px);
-    color: #fbbf24; font-family: system-ui, sans-serif; font-size: 14px;
+    color: ${WARN_TEXT}; font-family: system-ui, sans-serif; font-size: 14px;
     animation: slideUp 0.3s ease-out;
   `
   banner.innerHTML = `

--- a/web/src/lib/chartColors.ts
+++ b/web/src/lib/chartColors.ts
@@ -1,10 +1,20 @@
 /**
  * Chart color utilities for accessing CSS custom properties
- * 
+ *
  * These functions provide access to the chart color design tokens
  * defined in index.css. Use these instead of hardcoded hex values
  * to ensure consistency with the theme system.
  */
+
+/** Chart fallback colors — used when CSS custom properties are unavailable */
+const CHART_PURPLE = '#9333ea'  // chart-color-1: primary accent
+const CHART_BLUE = '#3b82f6'    // chart-color-2: info / secondary
+const CHART_GREEN = '#10b981'   // chart-color-3: success
+const CHART_AMBER = '#f59e0b'   // chart-color-4: warning
+const CHART_RED = '#ef4444'     // chart-color-5: error / danger
+const CHART_CYAN = '#06b6d4'    // chart-color-6: supplementary
+const CHART_VIOLET = '#8b5cf6'  // chart-color-7: alt purple
+const CHART_TEAL = '#14b8a6'    // chart-color-8: alt green
 
 /**
  * Get a chart color by index (1-8)
@@ -27,14 +37,14 @@ export function getChartColor(index: number): string {
   
   // Fallback to default values matching index.css
   const fallbacks: Record<number, string> = {
-    1: '#9333ea', // purple
-    2: '#3b82f6', // blue
-    3: '#10b981', // green
-    4: '#f59e0b', // amber/warning
-    5: '#ef4444', // red
-    6: '#06b6d4', // cyan
-    7: '#8b5cf6', // purple
-    8: '#14b8a6', // teal
+    1: CHART_PURPLE,
+    2: CHART_BLUE,
+    3: CHART_GREEN,
+    4: CHART_AMBER,
+    5: CHART_RED,
+    6: CHART_CYAN,
+    7: CHART_VIOLET,
+    8: CHART_TEAL,
   }
   
   return fallbacks[colorIndex] || fallbacks[1]

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -38,6 +38,8 @@ export const CHART_TOOLTIP_CONTENT_STYLE_GRAY: React.CSSProperties = {
   border: `1px solid ${UNIFIED_CHART_TOOLTIP_BORDER}`,
   borderRadius: UNIFIED_CHART_TOOLTIP_RADIUS,
 }
+/** Semi-transparent black used for chart emphasis shadows */
+export const EMPHASIS_SHADOW_COLOR = 'rgba(0,0,0,0.5)'
 export const CHART_GRID_STROKE = '#333'
 export const CHART_AXIS_STROKE = '#333'
 export const CHART_TICK_COLOR = '#888'

--- a/web/src/lib/unified/card/visualizations/ChartVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/ChartVisualization.tsx
@@ -8,7 +8,7 @@
 import { useMemo } from 'react'
 import { LazyEChart } from '../../../../components/charts/LazyEChart'
 import type { CardContentChart, CardChartSeries, CardAxisConfig } from '../../types'
-import { CHART_TOOLTIP_CONTENT_STYLE_GRAY } from '../../../constants'
+import { CHART_TOOLTIP_CONTENT_STYLE_GRAY, EMPHASIS_SHADOW_COLOR } from '../../../constants'
 
 export interface ChartVisualizationProps {
   /** Content configuration */
@@ -409,7 +409,7 @@ function DonutChartRenderer({
       })),
       label: { show: false },
       emphasis: {
-        itemStyle: { shadowBlur: 10, shadowOffsetX: 0, shadowColor: 'rgba(0,0,0,0.5)' },
+        itemStyle: { shadowBlur: 10, shadowOffsetX: 0, shadowColor: EMPHASIS_SHADOW_COLOR },
       },
     }],
   }), [typedData, showLegend])

--- a/web/src/lib/unified/stats/UnifiedStatBlock.tsx
+++ b/web/src/lib/unified/stats/UnifiedStatBlock.tsx
@@ -17,6 +17,9 @@ import type { UnifiedStatBlockProps } from '../types'
 import { resolveStatValue } from './valueResolvers'
 import { useIsModeSwitching } from '../demo'
 
+/** Tailwind arbitrary shadow class for demo-mode glow (yellow-500 at 15% opacity) */
+const DEMO_GLOW_SHADOW = 'shadow-[0_0_12px_rgba(234,179,8,0.15)]'
+
 // Icon mapping for dynamic rendering
 const ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   Server, CheckCircle2, XCircle, WifiOff, Box, Cpu, MemoryStick, HardDrive, Zap, Layers,
@@ -107,7 +110,7 @@ export function UnifiedStatBlock({
         relative glass p-4 rounded-lg transition-colors
         ${showPulse ? 'animate-pulse' : ''}
         ${isClickable ? 'cursor-pointer hover:bg-secondary/50' : ''}
-        ${isDemo ? 'border border-yellow-500/30 bg-yellow-500/5 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''}
+        ${isDemo ? `border border-yellow-500/30 bg-yellow-500/5 ${DEMO_GLOW_SHADOW}` : ''}
       `}
       onClick={() => {
         if (isClickable && config.onClick) {


### PR DESCRIPTION
## Summary
- Extract hardcoded hex colors in chartColors.ts to named constants with semantic comments
- Replace inline rgba values in ChartVisualization.tsx and auth.tsx with named constants
- Extract demo-mode glow shadow in UnifiedStatBlock.tsx to a named constant
- Add `EMPHASIS_SHADOW_COLOR` to shared UI constants
- Skip WhiteLabel.tsx (intentional defaults for whitelabel config)

Fixes #17286

## Test plan
- [ ] TypeScript compilation passes
- [ ] Chart colors render correctly
- [ ] Session expiry banner displays with correct warning colors
- [ ] Demo-mode stat blocks show yellow glow
- [ ] No visual regressions