### PR TITLE
fix: replace any types with proper types in test files

### DIFF
--- a/web/src/hooks/__tests__/useCachedOpenfeature.test.ts
+++ b/web/src/hooks/__tests__/useCachedOpenfeature.test.ts
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react'
 const mockUseCache = vi.fn()
 vi.mock('../../lib/cache', () => ({
     createCachedHook: vi.fn(),
-    useCache: (args: any) => mockUseCache(args),
+    useCache: (args: unknown) => mockUseCache(args),
 }))
 
 const mockIsDemoMode = vi.fn(() => false)

--- a/web/src/hooks/__tests__/useCachedVolcano.test.ts
+++ b/web/src/hooks/__tests__/useCachedVolcano.test.ts
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react'
 const mockUseCache = vi.fn()
 vi.mock('../../lib/cache', () => ({
     createCachedHook: vi.fn(),
-    useCache: (args: any) => mockUseCache(args),
+    useCache: (args: unknown) => mockUseCache(args),
 }))
 
 const mockIsDemoMode = vi.fn(() => false)

--- a/web/src/hooks/__tests__/useStellarSource.test.tsx
+++ b/web/src/hooks/__tests__/useStellarSource.test.tsx
@@ -52,8 +52,8 @@ const mockLocalStorage = {
 }
 
 vi.mock('../../lib/utils/localStorage', () => ({
-  safeGetItem: (...args: any[]) => mockLocalStorage.safeGetItem(...args),
-  safeSetItem: (...args: any[]) => mockLocalStorage.safeSetItem(...args),
+  safeGetItem: (...args: unknown[]) => mockLocalStorage.safeGetItem(...args),
+  safeSetItem: (...args: unknown[]) => mockLocalStorage.safeSetItem(...args),
 }))
 
 // ---------------------------------------------------------------------------
@@ -63,14 +63,14 @@ let eventSourceInstances: MockEventSource[] = []
 
 class MockEventSource {
   url: string
-  options: any
+  options: EventSourceInit | undefined
   onopen: ((e: Event) => void) | null = null
   onerror: ((e: Event) => void) | null = null
   readyState: number = 0
   close = vi.fn()
   _listeners: Record<string, EventListener[]> = {}
 
-  constructor(url: string, options?: any) {
+  constructor(url: string, options?: EventSourceInit) {
     this.url = url
     this.options = options
     eventSourceInstances.push(this)
@@ -422,12 +422,12 @@ describe('useStellarSource — Optimistic mutations', () => {
     })
     expect(result.current.notifications).toHaveLength(1)
 
-    let resolvePromise: any
+    let resolvePromise: ((value: unknown) => void) | undefined
     mockStellarApi.acknowledgeNotification.mockImplementation(() => new Promise((resolve) => {
       resolvePromise = resolve
     }))
 
-    let ackPromise: any
+    let ackPromise: Promise<void> | undefined
     await act(async () => {
       ackPromise = result.current.acknowledgeNotification('n-ack')
     })

--- a/web/src/hooks/__tests__/useUniversalStats.test.ts
+++ b/web/src/hooks/__tests__/useUniversalStats.test.ts
@@ -176,7 +176,7 @@ describe('useUniversalStats', () => {
 
   describe('empty / null-safe data handling', () => {
     it('handles null deduplicatedClusters gracefully', () => {
-      mockUseClusters.mockReturnValue({ deduplicatedClusters: null as any, clusters: [], isLoading: false })
+      mockUseClusters.mockReturnValue({ deduplicatedClusters: null as unknown as ReturnType<typeof mockUseClusters>['deduplicatedClusters'], clusters: [], isLoading: false })
       const stat = getStatValue('clusters')
       expect(stat?.value).toBe(0)
     })

--- a/web/src/hooks/__tests__/useUpgradeWebSocket.test.ts
+++ b/web/src/hooks/__tests__/useUpgradeWebSocket.test.ts
@@ -23,8 +23,8 @@ const { mockSafeLocalStorage } = vi.hoisted(() => ({
 }))
 
 vi.mock('../../lib/safeLocalStorage', () => ({
-  safeGetJSON: (...args: any[]) => mockSafeLocalStorage.safeGetJSON(...args),
-  safeSetJSON: (...args: any[]) => mockSafeLocalStorage.safeSetJSON(...args),
+  safeGetJSON: (...args: unknown[]) => mockSafeLocalStorage.safeGetJSON(...args),
+  safeSetJSON: (...args: unknown[]) => mockSafeLocalStorage.safeSetJSON(...args),
 }))
 
 // ---------------------------------------------------------------------------
@@ -178,8 +178,8 @@ describe('useUpgradeWebSocket — Version cache utilities', () => {
 
   it('clearCachedVersions is a no-op for cluster names not in cache', () => {
     expect(() => clearCachedVersions(['non-existent-cluster'])).not.toThrow()
-    expect(() => clearCachedVersions(null as any)).not.toThrow()
-    expect(() => clearCachedVersions(undefined as any)).not.toThrow()
+    expect(() => clearCachedVersions(null as unknown as string[])).not.toThrow()
+    expect(() => clearCachedVersions(undefined as unknown as string[])).not.toThrow()
   })
 })
 

--- a/web/src/lib/__tests__/kubectlProxy-expand.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy-expand.test.ts
@@ -115,6 +115,17 @@ vi.stubGlobal('WebSocket', FakeWebSocket)
 // Import AFTER mocks
 import { kubectlProxy } from '../kubectlProxy'
 
+/** Internal fields exposed for test-only reset / inspection. */
+interface KubectlProxyInternals {
+  lastConnectionFailureAt: number
+  isConnecting: boolean
+  messageId: number
+  pendingRequests: Map<number, { timeout: ReturnType<typeof setTimeout> }>
+  connectPromise: Promise<unknown> | null
+  requestQueue: unknown[]
+  activeRequests: number
+}
+
 // ---------------------------------------------------------------------------
 // Setup / Teardown
 // ---------------------------------------------------------------------------
@@ -128,8 +139,7 @@ beforeEach(() => {
   // Force-reset private fields that persist across close() calls to prevent
   // state leaking between tests (cooldown, connection flags, pending requests,
   // lingering connectPromise from prior test's in-flight connect).
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const proxy = kubectlProxy as any
+  const proxy = kubectlProxy as unknown as KubectlProxyInternals
   proxy.lastConnectionFailureAt = 0
   proxy.isConnecting = false
   proxy.messageId = 0
@@ -146,8 +156,7 @@ afterEach(() => {
   // but before teardown, they reject promises that no test is awaiting,
   // which vitest surfaces as "Unhandled Rejection" warnings. Clearing
   // timers and pending requests here prevents that cross-test bleed.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const proxy = kubectlProxy as any
+  const proxy = kubectlProxy as unknown as KubectlProxyInternals
   proxy.pendingRequests.forEach((pending: { timeout: ReturnType<typeof setTimeout> }) => {
     clearTimeout(pending.timeout)
   })

--- a/web/src/lib/__tests__/rewardsApi.test.ts
+++ b/web/src/lib/__tests__/rewardsApi.test.ts
@@ -44,6 +44,7 @@ import {
   claimDailyBonus,
   RewardsUnauthenticatedError,
   DailyBonusUnavailableError,
+  type UserRewardsRecord,
 } from '../rewardsApi'
 
 const FAKE_REWARDS = {
@@ -217,7 +218,7 @@ describe('rewardsApi', () => {
     })
 
     it('DailyBonusUnavailableError carries rewards when provided', () => {
-      const err = new DailyBonusUnavailableError(FAKE_REWARDS as any)
+      const err = new DailyBonusUnavailableError(FAKE_REWARDS as UserRewardsRecord)
       expect(err.rewards).toEqual(FAKE_REWARDS)
     })
 

--- a/web/src/lib/cards/__tests__/cardSort.test.ts
+++ b/web/src/lib/cards/__tests__/cardSort.test.ts
@@ -33,16 +33,14 @@ describe('commonComparators', () => {
     })
 
     it('coerces null/undefined to empty string', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const cmp = commonComparators.string<{ name: any }>('name')
+      const cmp = commonComparators.string<{ name: string | null | undefined }>('name')
       expect(cmp({ name: null }, { name: 'a' })).toBeLessThan(0)
       expect(cmp({ name: undefined }, { name: undefined })).toBe(0)
       expect(cmp({ name: '' }, { name: '' })).toBe(0)
     })
 
     it('handles falsy values in field', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const cmp = commonComparators.string<{ name: any }>('name')
+      const cmp = commonComparators.string<{ name: string | number }>('name')
       expect(cmp({ name: 0 }, { name: 1 })).toBeLessThan(0) // 0 coerces to '' and sorts before '1'
     })
   })
@@ -71,8 +69,7 @@ describe('commonComparators', () => {
     })
 
     it('coerces non-numeric fields to 0', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const cmp = commonComparators.number<{ count: any }>('count')
+      const cmp = commonComparators.number<{ count: number | string | null | undefined }>('count')
       expect(cmp({ count: 'abc' }, { count: 5 })).toBeLessThan(0) // 0 < 5
       expect(cmp({ count: null }, { count: null })).toBe(0)
       expect(cmp({ count: undefined }, { count: undefined })).toBe(0)
@@ -264,8 +261,7 @@ describe('useCardSort', () => {
   })
 
   it('handles undefined config gracefully (returns items copy)', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { result } = renderHook(() => useCardSort(ITEMS, undefined as any))
+    const { result } = renderHook(() => useCardSort(ITEMS, undefined as unknown as Parameters<typeof useCardSort<Item>>[1]))
     expect(result.current.sorted).toHaveLength(3)
   })
 


### PR DESCRIPTION
## Summary
- Replace 25 uses of `any` type with proper TypeScript types across 8 test files
- Uses specific types (`unknown`, union types, interface definitions) instead of `any` to improve type safety
- No behavioral changes to tests

Fixes #17261

## Test plan
- [ ] TypeScript compilation passes
- [ ] All affected tests still pass