### PR TITLE
fix: add dark mode variants to light-only color classes

### DIFF
--- a/web/src/components/missions/MissionBrowserRecommendedTab.tsx
+++ b/web/src/components/missions/MissionBrowserRecommendedTab.tsx
@@ -117,7 +117,7 @@ export function MissionBrowserRecommendedTab({
               <p className="text-muted-foreground">
                 The fix browser needs a GitHub personal access token to fetch missions. Add one to
                 your{' '}
-                <code className="px-1.5 py-0.5 bg-white/10 rounded text-xs font-mono">.env</code>{' '}
+                <code className="px-1.5 py-0.5 bg-gray-200 dark:bg-white/10 rounded text-xs font-mono">.env</code>{' '}
                 file and restart the console:
               </p>
               <ol className="text-muted-foreground list-decimal list-inside space-y-1.5 ml-1">
@@ -131,14 +131,14 @@ export function MissionBrowserRecommendedTab({
                     Create a GitHub personal access token
                   </a>{' '}
                   (only{' '}
-                  <code className="px-1 py-0.5 bg-white/10 rounded text-xs font-mono">
+                  <code className="px-1 py-0.5 bg-gray-200 dark:bg-white/10 rounded text-xs font-mono">
                     public_repo
                   </code>{' '}
                   scope needed)
                 </li>
                 <li>
                   Add it to your{' '}
-                  <code className="px-1 py-0.5 bg-white/10 rounded text-xs font-mono">.env</code>{' '}
+                  <code className="px-1 py-0.5 bg-gray-200 dark:bg-white/10 rounded text-xs font-mono">.env</code>{' '}
                   file:
                   <pre className="mt-1 px-3 py-2 bg-black/40 rounded text-xs font-mono text-purple-300 select-all">
                     GITHUB_TOKEN=ghp_your_token_here

--- a/web/src/components/pods/Pods.tsx
+++ b/web/src/components/pods/Pods.tsx
@@ -330,7 +330,7 @@ export function Pods() {
                         disabled={backendActionUnavailable}
                         className={backendActionUnavailable
                           ? 'p-1.5 rounded-md text-muted-foreground opacity-50 cursor-not-allowed'
-                          : 'p-1.5 hover:bg-white/10 rounded-md text-muted-foreground hover:text-blue-400 transition-colors'}
+                          : 'p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-md text-muted-foreground hover:text-blue-400 transition-colors'}
                         aria-label={t('common.restart', 'Restart')}
                         title={backendActionUnavailable ? backendUnavailableMessage : t('common.restart', 'Restart')}
                       >
@@ -341,7 +341,7 @@ export function Pods() {
                     <PortalTooltip content={t('common.logs', 'Logs')}>
                       <button
                         onClick={(e) => issue.cluster && handleShowLogs(e, issue.cluster, issue.namespace, issue.name)}
-                        className="p-1.5 hover:bg-white/10 rounded-md text-muted-foreground hover:text-purple-400 transition-colors"
+                        className="p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-md text-muted-foreground hover:text-purple-400 transition-colors"
                         aria-label="View logs"
                       >
                         <Terminal className="w-4 h-4" />
@@ -354,7 +354,7 @@ export function Pods() {
                         disabled={backendActionUnavailable}
                         className={backendActionUnavailable
                           ? 'p-1.5 rounded-md text-muted-foreground opacity-50 cursor-not-allowed'
-                          : 'p-1.5 hover:bg-white/10 rounded-md text-muted-foreground hover:text-red-400 transition-colors'}
+                          : 'p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-md text-muted-foreground hover:text-red-400 transition-colors'}
                         aria-label={t('common.delete', 'Delete')}
                         title={backendActionUnavailable ? backendUnavailableMessage : t('common.delete', 'Delete')}
                       >


### PR DESCRIPTION
## Summary
- Add `bg-gray-200 dark:bg-white/10` to inline `<code>` elements in MissionBrowserRecommendedTab (3 instances) so they're visible in light mode
- Add `hover:bg-black/5 dark:hover:bg-white/10` to pod action buttons in Pods.tsx (3 instances) for proper light-mode hover states
- Reviewed all 14 flagged locations; the remaining 8 use `bg-gray-500/*` (theme-agnostic mid-range), `bg-white` (radio dot on purple — intentional), or `bg-white/90` (logo backdrop — intentional) and need no changes

Fixes #17396

## Test plan
- [ ] TypeScript compilation passes
- [ ] No visual regressions in dark mode
- [ ] Light mode still renders correctly