### PR TITLE
fix: wrap technical abbreviations with TechnicalAcronym tooltips

### DIFF
--- a/web/src/components/cards/EnterpriseComplianceCards.tsx
+++ b/web/src/components/cards/EnterpriseComplianceCards.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { authFetch, safeJson } from '../../lib/api'
 import { useCache } from '../../lib/cache'
+import { TechnicalAcronym } from '../shared/TechnicalAcronym'
 
 // ── Shared helpers ──────────────────────────────────────────────────────
 
@@ -61,7 +62,7 @@ export function ScoreRing({ score, size = 64 }: { score: number; size?: number }
 }
 
 function CardShell({ title, icon: Icon, children, onClick }: {
-  title: string; icon: React.ComponentType<{ className?: string }>; children: React.ReactNode; onClick?: () => void
+  title: React.ReactNode; icon: React.ComponentType<{ className?: string }>; children: React.ReactNode; onClick?: () => void
 }) {
   return (
     <div
@@ -462,7 +463,7 @@ export function RBACAuditCard() {
   const nav = useNavigate()
   const { data, error } = useSummaryData<Record<string, number>>('/api/identity/rbac/summary')
   return (
-    <CardShell title="RBAC Audit" icon={Lock} onClick={() => nav('/enterprise/rbac-audit')}>
+    <CardShell title={<><TechnicalAcronym term="RBAC" /> Audit</>} icon={Lock} onClick={() => nav('/enterprise/rbac-audit')}>
       {data ? (
         <div className="flex items-center gap-4">
           <ScoreRing score={data.compliance_score ?? 0} />

--- a/web/src/components/cards/ISO27001Audit.tsx
+++ b/web/src/components/cards/ISO27001Audit.tsx
@@ -15,6 +15,7 @@ import { CardClusterFilter, CardSearchInput, CardSkeleton } from '../../lib/card
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
+import { wrapAbbreviations } from '../shared/TechnicalAcronym'
 import { useState } from 'react'
 
 // ── Demo Data ──────────────────────────────────────────────────────
@@ -309,7 +310,7 @@ export function ISO27001Audit({ config }: ISO27001AuditProps) {
                     }`}>{f.severity}</span>
                   </div>
                   <div className="flex items-center gap-1.5 mt-0.5 text-muted-foreground">
-                    <span className="truncate">{f.category}</span>
+                    <span className="truncate">{wrapAbbreviations(f.category)}</span>
                     <span>·</span>
                     <span className="text-blue-400">{f.cluster}</span>
                   </div>

--- a/web/src/components/compliance/RBACAuditDashboard.tsx
+++ b/web/src/components/compliance/RBACAuditDashboard.tsx
@@ -11,6 +11,7 @@ import { Select } from '../ui/Select'
 import { DashboardHeader } from '../shared/DashboardHeader'
 import { RotatingTip } from '../ui/RotatingTip'
 import { DashboardHealthIndicator } from '../dashboard/DashboardHealthIndicator'
+import { TechnicalAcronym } from '../shared/TechnicalAcronym'
 
 interface RBACBinding {
   id: string; name: string; kind: string; subject_kind: string
@@ -121,7 +122,7 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
   return (
     <div className="space-y-6 p-6">
       <DashboardHeader
-        title="RBAC Audit & Least-Privilege Analysis"
+        title={<><TechnicalAcronym term="RBAC" /> Audit & Least-Privilege Analysis</>}
         subtitle="Role binding audit, over-privilege detection, and compliance scoring"
         isFetching={loading}
         onRefresh={fetchData}
@@ -143,7 +144,7 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
             <div className="flex items-center gap-3">
               <Activity className="w-5 h-5 text-blue-400" />
               <div>
-                <div className="text-sm font-medium text-foreground">RBAC System Status</div>
+                <div className="text-sm font-medium text-foreground"><TechnicalAcronym term="RBAC" /> System Status</div>
                 <div className="text-xs text-muted-foreground">
                   {summary.over_privileged === 0 && summary.unused_bindings === 0
                     ? 'All bindings follow least-privilege principles'

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -9,6 +9,7 @@ import { authFetch } from '../../lib/api'
 import { DashboardHeader } from '../shared/DashboardHeader'
 import { RotatingTip } from '../ui/RotatingTip'
 import { Select } from '../ui/Select'
+import { TechnicalAcronym } from '../shared/TechnicalAcronym'
 
 interface SoDRule {
   id: string; name: string; description: string; role_a: string; role_b: string
@@ -101,7 +102,7 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
     <div className="space-y-6">
       <DashboardHeader
         title="Segregation of Duties"
-        subtitle="Detect conflicting privilege assignments across RBAC roles"
+        subtitle={<>Detect conflicting privilege assignments across <TechnicalAcronym term="RBAC" /> roles</>}
         isFetching={loading}
         onRefresh={fetchData}
         autoRefresh={autoRefresh}

--- a/web/src/components/deploy/DeployConfirmDialog.tsx
+++ b/web/src/components/deploy/DeployConfirmDialog.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../hooks/useDependencies'
 import { cn } from '../../lib/cn'
 import { useTranslation } from 'react-i18next'
+import { wrapAbbreviations } from '../shared/TechnicalAcronym'
 
 interface DeployConfirmDialogProps {
   isOpen: boolean
@@ -231,7 +232,7 @@ export function DeployConfirmDialog({
                         ? <ChevronDown className="w-3 h-3 text-muted-foreground shrink-0" />
                         : <ChevronRight className="w-3 h-3 text-muted-foreground shrink-0" />}
                       <GroupIcon className="w-3.5 h-3.5 text-purple-400 shrink-0" />
-                      <span className="text-sm text-foreground flex-1">{group.label}</span>
+                      <span className="text-sm text-foreground flex-1">{wrapAbbreviations(group.label)}</span>
                       <span className="text-xs text-muted-foreground px-1.5 py-0.5 rounded bg-secondary">
                         {group.deps.length}
                       </span>


### PR DESCRIPTION
## Summary
- Wrap technical abbreviations (RBAC, etc.) in `TechnicalAcronym` component for hover tooltips
- Improves operator usefulness for users unfamiliar with Kubernetes terminology
- Applied across 5 files: RBACAuditDashboard, SegregationOfDuties, EnterpriseComplianceCards, DeployConfirmDialog, ISO27001Audit

Fixes #17395

## Test plan
- [ ] TypeScript compilation passes
- [ ] Tooltips appear on hover over abbreviations