### PR TITLE
test: add evaluation logic tests for 6 compliance engines

### DIFF
--- a/pkg/compliance/airgap/evaluate_test.go
+++ b/pkg/compliance/airgap/evaluate_test.go
@@ -1,0 +1,196 @@
+package airgap
+
+import (
+	"testing"
+)
+
+// TestSummaryScoreCalculation verifies the air-gap readiness score formula:
+// score = (metRequirements * 100) / totalRequirements
+func TestSummaryScoreCalculation(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	// Demo data: 8 ready out of 10 requirements
+	const expectedMet = 8
+	const expectedTotal = 10
+	expectedScore := (expectedMet * 100) / expectedTotal // = 80
+	if s.MetRequirements != expectedMet {
+		t.Errorf("expected %d met requirements, got %d", expectedMet, s.MetRequirements)
+	}
+	if s.TotalRequirements != expectedTotal {
+		t.Errorf("expected %d total requirements, got %d", expectedTotal, s.TotalRequirements)
+	}
+	if s.OverallScore != expectedScore {
+		t.Errorf("expected score %d, got %d", expectedScore, s.OverallScore)
+	}
+}
+
+// TestSummaryClusterCounts verifies cluster ready/not-ready counting.
+func TestSummaryClusterCounts(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	const expectedTotal = 4
+	const expectedReady = 2
+	const expectedNotReady = 2
+	if s.TotalClusters != expectedTotal {
+		t.Errorf("expected %d total clusters, got %d", expectedTotal, s.TotalClusters)
+	}
+	if s.ReadyClusters != expectedReady {
+		t.Errorf("expected %d ready clusters, got %d", expectedReady, s.ReadyClusters)
+	}
+	if s.NotReadyClusters != expectedNotReady {
+		t.Errorf("expected %d not-ready clusters, got %d", expectedNotReady, s.NotReadyClusters)
+	}
+}
+
+// TestSummaryWithAllReady verifies score is 100 when all requirements are met.
+func TestSummaryWithAllReady(t *testing.T) {
+	e := &Engine{
+		requirements: []Requirement{
+			{ID: "r1", Status: "ready"},
+			{ID: "r2", Status: "ready"},
+			{ID: "r3", Status: "ready"},
+		},
+		clusters: []ClusterReadiness{
+			{Cluster: "c1", Ready: true, Score: 100},
+			{Cluster: "c2", Ready: true, Score: 100},
+		},
+	}
+	s := e.Summary()
+	if s.OverallScore != 100 {
+		t.Errorf("all-ready score: expected 100, got %d", s.OverallScore)
+	}
+	if s.MetRequirements != 3 {
+		t.Errorf("expected 3 met requirements, got %d", s.MetRequirements)
+	}
+	if s.ReadyClusters != 2 {
+		t.Errorf("expected 2 ready clusters, got %d", s.ReadyClusters)
+	}
+	if s.NotReadyClusters != 0 {
+		t.Errorf("expected 0 not-ready clusters, got %d", s.NotReadyClusters)
+	}
+}
+
+// TestSummaryWithAllNotReady verifies score is 0 when no requirements are met.
+func TestSummaryWithAllNotReady(t *testing.T) {
+	e := &Engine{
+		requirements: []Requirement{
+			{ID: "r1", Status: "not_ready"},
+			{ID: "r2", Status: "not_ready"},
+		},
+		clusters: []ClusterReadiness{
+			{Cluster: "c1", Ready: false},
+		},
+	}
+	s := e.Summary()
+	if s.OverallScore != 0 {
+		t.Errorf("all-not-ready score: expected 0, got %d", s.OverallScore)
+	}
+	if s.MetRequirements != 0 {
+		t.Errorf("expected 0 met requirements, got %d", s.MetRequirements)
+	}
+	if s.ReadyClusters != 0 {
+		t.Errorf("expected 0 ready clusters, got %d", s.ReadyClusters)
+	}
+}
+
+// TestSummaryWithEmptyData verifies no panic on empty requirements and clusters.
+func TestSummaryWithEmptyData(t *testing.T) {
+	e := &Engine{
+		requirements: nil,
+		clusters:     nil,
+	}
+	s := e.Summary()
+	if s.OverallScore != 0 {
+		t.Errorf("empty data score: expected 0, got %d", s.OverallScore)
+	}
+	if s.TotalRequirements != 0 {
+		t.Errorf("expected 0 total requirements, got %d", s.TotalRequirements)
+	}
+	if s.TotalClusters != 0 {
+		t.Errorf("expected 0 total clusters, got %d", s.TotalClusters)
+	}
+	if s.EvaluatedAt == "" {
+		t.Error("expected non-empty EvaluatedAt even for empty input")
+	}
+}
+
+// TestSummaryPartialStatusNotCounted verifies "partial" requirements are NOT
+// counted as met (only "ready" counts).
+func TestSummaryPartialStatusNotCounted(t *testing.T) {
+	e := &Engine{
+		requirements: []Requirement{
+			{ID: "r1", Status: "ready"},
+			{ID: "r2", Status: "partial"},
+			{ID: "r3", Status: "not_ready"},
+		},
+		clusters: nil,
+	}
+	s := e.Summary()
+	// Only 1 out of 3 is "ready"
+	const expectedScore = (1 * 100) / 3 // = 33
+	if s.MetRequirements != 1 {
+		t.Errorf("expected 1 met requirement, got %d", s.MetRequirements)
+	}
+	if s.OverallScore != expectedScore {
+		t.Errorf("expected score %d, got %d", expectedScore, s.OverallScore)
+	}
+}
+
+// TestSummaryMixedClusters verifies mixed ready/not-ready cluster counting.
+func TestSummaryMixedClusters(t *testing.T) {
+	e := &Engine{
+		requirements: []Requirement{{ID: "r1", Status: "ready"}},
+		clusters: []ClusterReadiness{
+			{Cluster: "c1", Ready: true},
+			{Cluster: "c2", Ready: false},
+			{Cluster: "c3", Ready: true},
+			{Cluster: "c4", Ready: false},
+			{Cluster: "c5", Ready: true},
+		},
+	}
+	s := e.Summary()
+	if s.TotalClusters != 5 {
+		t.Errorf("expected 5 total clusters, got %d", s.TotalClusters)
+	}
+	if s.ReadyClusters != 3 {
+		t.Errorf("expected 3 ready clusters, got %d", s.ReadyClusters)
+	}
+	if s.NotReadyClusters != 2 {
+		t.Errorf("expected 2 not-ready clusters, got %d", s.NotReadyClusters)
+	}
+}
+
+// TestConcurrentSummaryAccess verifies Summary() is safe for concurrent use.
+func TestConcurrentSummaryAccess(t *testing.T) {
+	e := NewEngine()
+	const goroutines = 10
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			s := e.Summary()
+			if s.TotalClusters == 0 {
+				t.Error("unexpected zero total clusters in concurrent access")
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+}
+
+// TestRequirementCategoryDistribution verifies demo data has multiple categories.
+func TestRequirementCategoryDistribution(t *testing.T) {
+	e := NewEngine()
+	categories := map[string]int{}
+	for _, r := range e.Requirements() {
+		categories[r.Category]++
+	}
+	// Demo data should have at least 3 distinct categories
+	const minCategories = 3
+	if len(categories) < minCategories {
+		t.Errorf("expected at least %d categories, got %d", minCategories, len(categories))
+	}
+}

--- a/pkg/compliance/baa/evaluate_test.go
+++ b/pkg/compliance/baa/evaluate_test.go
@@ -1,0 +1,239 @@
+package baa
+
+import (
+	"testing"
+)
+
+// TestSummaryStatusCounting verifies the BAA status counting logic.
+func TestSummaryStatusCounting(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	const expectedTotal = 6
+	if s.TotalAgreements != expectedTotal {
+		t.Errorf("expected %d total agreements, got %d", expectedTotal, s.TotalAgreements)
+	}
+
+	const expectedActive = 3
+	if s.ActiveAgreements != expectedActive {
+		t.Errorf("expected %d active, got %d", expectedActive, s.ActiveAgreements)
+	}
+
+	// Verify all statuses sum to total
+	sum := s.ActiveAgreements + s.ExpiringSoon + s.Expired + s.Pending
+	if sum != s.TotalAgreements {
+		t.Errorf("status counts sum %d != total %d", sum, s.TotalAgreements)
+	}
+}
+
+// TestSummaryClusterCoverage verifies covered/uncovered cluster counting.
+func TestSummaryClusterCoverage(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	// Demo data covers 5 unique clusters across all agreements
+	const expectedCovered = 5
+	if s.CoveredClusters != expectedCovered {
+		t.Errorf("expected %d covered clusters, got %d", expectedCovered, s.CoveredClusters)
+	}
+
+	const expectedUncovered = 1
+	if s.UncoveredClusters != expectedUncovered {
+		t.Errorf("expected %d uncovered clusters, got %d", expectedUncovered, s.UncoveredClusters)
+	}
+
+	// Covered + uncovered should equal demo fleet size (6)
+	const demoFleetSize = 6
+	if s.CoveredClusters+s.UncoveredClusters != demoFleetSize {
+		t.Errorf("covered (%d) + uncovered (%d) != fleet size %d",
+			s.CoveredClusters, s.UncoveredClusters, demoFleetSize)
+	}
+}
+
+// TestSummaryWithAllActive verifies counts when all agreements are active.
+func TestSummaryWithAllActive(t *testing.T) {
+	e := &Engine{
+		agreements: []Agreement{
+			{ID: "a1", Status: "active", CoveredClusters: []string{"c1"}},
+			{ID: "a2", Status: "active", CoveredClusters: []string{"c2"}},
+			{ID: "a3", Status: "active", CoveredClusters: []string{"c3"}},
+		},
+		alerts: nil,
+	}
+	s := e.Summary()
+	if s.ActiveAgreements != 3 {
+		t.Errorf("expected 3 active, got %d", s.ActiveAgreements)
+	}
+	if s.ExpiringSoon != 0 {
+		t.Errorf("expected 0 expiring, got %d", s.ExpiringSoon)
+	}
+	if s.Expired != 0 {
+		t.Errorf("expected 0 expired, got %d", s.Expired)
+	}
+	if s.Pending != 0 {
+		t.Errorf("expected 0 pending, got %d", s.Pending)
+	}
+	if s.CoveredClusters != 3 {
+		t.Errorf("expected 3 covered clusters, got %d", s.CoveredClusters)
+	}
+}
+
+// TestSummaryWithAllExpired verifies counts when all agreements are expired.
+func TestSummaryWithAllExpired(t *testing.T) {
+	e := &Engine{
+		agreements: []Agreement{
+			{ID: "a1", Status: "expired", CoveredClusters: []string{}},
+			{ID: "a2", Status: "expired", CoveredClusters: []string{}},
+		},
+		alerts: nil,
+	}
+	s := e.Summary()
+	if s.Expired != 2 {
+		t.Errorf("expected 2 expired, got %d", s.Expired)
+	}
+	if s.ActiveAgreements != 0 {
+		t.Errorf("expected 0 active, got %d", s.ActiveAgreements)
+	}
+	if s.CoveredClusters != 0 {
+		t.Errorf("expected 0 covered clusters, got %d", s.CoveredClusters)
+	}
+}
+
+// TestSummaryWithEmptyAgreements verifies no panic on empty input.
+func TestSummaryWithEmptyAgreements(t *testing.T) {
+	e := &Engine{
+		agreements: nil,
+		alerts:     nil,
+	}
+	s := e.Summary()
+	if s.TotalAgreements != 0 {
+		t.Errorf("expected 0 total agreements, got %d", s.TotalAgreements)
+	}
+	if s.CoveredClusters != 0 {
+		t.Errorf("expected 0 covered clusters, got %d", s.CoveredClusters)
+	}
+	if s.ActiveAlerts != 0 {
+		t.Errorf("expected 0 alerts, got %d", s.ActiveAlerts)
+	}
+	if s.EvaluatedAt == "" {
+		t.Error("expected non-empty EvaluatedAt even for empty input")
+	}
+}
+
+// TestSummaryDeduplicatesClusters verifies that overlapping cluster coverage
+// is counted correctly (unique clusters, not duplicates).
+func TestSummaryDeduplicatesClusters(t *testing.T) {
+	e := &Engine{
+		agreements: []Agreement{
+			{ID: "a1", Status: "active", CoveredClusters: []string{"c1", "c2"}},
+			{ID: "a2", Status: "active", CoveredClusters: []string{"c2", "c3"}},
+			{ID: "a3", Status: "active", CoveredClusters: []string{"c1", "c3"}},
+		},
+		alerts: nil,
+	}
+	s := e.Summary()
+	// Should be 3 unique clusters, not 6
+	const expectedUnique = 3
+	if s.CoveredClusters != expectedUnique {
+		t.Errorf("expected %d unique covered clusters, got %d", expectedUnique, s.CoveredClusters)
+	}
+}
+
+// TestSummaryAlertsCounting verifies alerts are counted from the alerts slice.
+func TestSummaryAlertsCounting(t *testing.T) {
+	e := &Engine{
+		agreements: []Agreement{
+			{ID: "a1", Status: "active", CoveredClusters: []string{"c1"}},
+		},
+		alerts: []ExpiryAlert{
+			{AgreementID: "a1", Severity: "critical"},
+			{AgreementID: "a1", Severity: "warning"},
+			{AgreementID: "a1", Severity: "info"},
+		},
+	}
+	s := e.Summary()
+	if s.ActiveAlerts != 3 {
+		t.Errorf("expected 3 active alerts, got %d", s.ActiveAlerts)
+	}
+}
+
+// TestSummaryMixedStatuses verifies correct counting with all status types.
+func TestSummaryMixedStatuses(t *testing.T) {
+	e := &Engine{
+		agreements: []Agreement{
+			{ID: "a1", Status: "active", CoveredClusters: []string{"c1"}},
+			{ID: "a2", Status: "expiring_soon", CoveredClusters: []string{"c2"}},
+			{ID: "a3", Status: "expired", CoveredClusters: []string{}},
+			{ID: "a4", Status: "pending", CoveredClusters: []string{"c3"}},
+			{ID: "a5", Status: "active", CoveredClusters: []string{"c1"}},
+		},
+		alerts: []ExpiryAlert{
+			{AgreementID: "a2", Severity: "warning"},
+		},
+	}
+	s := e.Summary()
+	if s.TotalAgreements != 5 {
+		t.Errorf("expected 5 total, got %d", s.TotalAgreements)
+	}
+	if s.ActiveAgreements != 2 {
+		t.Errorf("expected 2 active, got %d", s.ActiveAgreements)
+	}
+	if s.ExpiringSoon != 1 {
+		t.Errorf("expected 1 expiring, got %d", s.ExpiringSoon)
+	}
+	if s.Expired != 1 {
+		t.Errorf("expected 1 expired, got %d", s.Expired)
+	}
+	if s.Pending != 1 {
+		t.Errorf("expected 1 pending, got %d", s.Pending)
+	}
+	// c1, c2, c3 = 3 unique clusters (c1 appears in a1 and a5)
+	if s.CoveredClusters != 3 {
+		t.Errorf("expected 3 covered clusters, got %d", s.CoveredClusters)
+	}
+	if s.ActiveAlerts != 1 {
+		t.Errorf("expected 1 alert, got %d", s.ActiveAlerts)
+	}
+}
+
+// TestSummaryUnknownStatusIgnored verifies unknown statuses don't increment counts.
+func TestSummaryUnknownStatusIgnored(t *testing.T) {
+	e := &Engine{
+		agreements: []Agreement{
+			{ID: "a1", Status: "active", CoveredClusters: []string{"c1"}},
+			{ID: "a2", Status: "unknown_value", CoveredClusters: []string{"c2"}},
+		},
+		alerts: nil,
+	}
+	s := e.Summary()
+	if s.TotalAgreements != 2 {
+		t.Errorf("expected 2 total, got %d", s.TotalAgreements)
+	}
+	if s.ActiveAgreements != 1 {
+		t.Errorf("expected 1 active, got %d", s.ActiveAgreements)
+	}
+	// Unknown status should not increment any known status counter
+	sum := s.ActiveAgreements + s.ExpiringSoon + s.Expired + s.Pending
+	if sum != 1 {
+		t.Errorf("known status sum should be 1, got %d", sum)
+	}
+}
+
+// TestConcurrentSummaryAccess verifies Summary() is safe for concurrent use.
+func TestConcurrentSummaryAccess(t *testing.T) {
+	e := NewEngine()
+	const goroutines = 10
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			s := e.Summary()
+			if s.TotalAgreements == 0 {
+				t.Error("unexpected zero total agreements in concurrent access")
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+}

--- a/pkg/compliance/licenses/evaluate_test.go
+++ b/pkg/compliance/licenses/evaluate_test.go
@@ -1,0 +1,123 @@
+package licenses
+
+import (
+	"testing"
+)
+
+// TestSummaryExactDemoValues verifies the license demo data is returned accurately.
+func TestSummaryExactDemoValues(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	const expectedPackages = 3847
+	if s.TotalPackages != expectedPackages {
+		t.Errorf("expected %d total packages, got %d", expectedPackages, s.TotalPackages)
+	}
+
+	const expectedAllowed = 3814
+	if s.AllowedPackages != expectedAllowed {
+		t.Errorf("expected %d allowed packages, got %d", expectedAllowed, s.AllowedPackages)
+	}
+
+	const expectedWarned = 24
+	if s.WarnedPackages != expectedWarned {
+		t.Errorf("expected %d warned packages, got %d", expectedWarned, s.WarnedPackages)
+	}
+
+	const expectedDenied = 9
+	if s.DeniedPackages != expectedDenied {
+		t.Errorf("expected %d denied packages, got %d", expectedDenied, s.DeniedPackages)
+	}
+
+	const expectedLicenses = 47
+	if s.UniqueLicenses != expectedLicenses {
+		t.Errorf("expected %d unique licenses, got %d", expectedLicenses, s.UniqueLicenses)
+	}
+
+	const expectedScanned = 37
+	if s.WorkloadsScanned != expectedScanned {
+		t.Errorf("expected %d workloads scanned, got %d", expectedScanned, s.WorkloadsScanned)
+	}
+}
+
+// TestSummaryPackageCountConsistency verifies allowed + warned + denied == total.
+func TestSummaryPackageCountConsistency(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	sum := s.AllowedPackages + s.WarnedPackages + s.DeniedPackages
+	if sum != s.TotalPackages {
+		t.Errorf("allowed (%d) + warned (%d) + denied (%d) = %d != total (%d)",
+			s.AllowedPackages, s.WarnedPackages, s.DeniedPackages, sum, s.TotalPackages)
+	}
+}
+
+// TestSummaryEvaluatedAtNonZero verifies timestamp is populated.
+func TestSummaryEvaluatedAtNonZero(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+	if s.EvaluatedAt.IsZero() {
+		t.Error("expected non-zero EvaluatedAt")
+	}
+}
+
+// TestPackagesReturnsEmptySlice verifies stub returns empty (not nil).
+func TestPackagesReturnsEmptySlice(t *testing.T) {
+	e := NewEngine()
+	pkgs := e.Packages()
+	if pkgs == nil {
+		t.Fatal("Packages() returned nil, expected empty slice")
+	}
+	if len(pkgs) != 0 {
+		t.Errorf("expected 0 packages from stub, got %d", len(pkgs))
+	}
+}
+
+// TestCategoriesReturnsEmptySlice verifies stub returns empty (not nil).
+func TestCategoriesReturnsEmptySlice(t *testing.T) {
+	e := NewEngine()
+	cats := e.Categories()
+	if cats == nil {
+		t.Fatal("Categories() returned nil, expected empty slice")
+	}
+	if len(cats) != 0 {
+		t.Errorf("expected 0 categories from stub, got %d", len(cats))
+	}
+}
+
+// TestRiskConstants verifies risk type constants.
+func TestRiskConstants(t *testing.T) {
+	tests := []struct {
+		name string
+		risk Risk
+		want string
+	}{
+		{"allowed", RiskAllowed, "allowed"},
+		{"warn", RiskWarn, "warn"},
+		{"denied", RiskDenied, "denied"},
+	}
+	for _, tt := range tests {
+		if string(tt.risk) != tt.want {
+			t.Errorf("Risk %s: expected %q, got %q", tt.name, tt.want, string(tt.risk))
+		}
+	}
+}
+
+// TestConcurrentSummaryAccess verifies Summary() is safe for concurrent use.
+func TestConcurrentSummaryAccess(t *testing.T) {
+	e := NewEngine()
+	const goroutines = 10
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			s := e.Summary()
+			if s.TotalPackages == 0 {
+				t.Error("unexpected zero total packages in concurrent access")
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+}

--- a/pkg/compliance/sbom/evaluate_test.go
+++ b/pkg/compliance/sbom/evaluate_test.go
@@ -1,0 +1,103 @@
+package sbom
+
+import (
+	"testing"
+)
+
+// TestSummaryExactDemoValues verifies the SBOM demo data is returned accurately.
+func TestSummaryExactDemoValues(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	const expectedWorkloads = 42
+	if s.TotalWorkloads != expectedWorkloads {
+		t.Errorf("expected %d total workloads, got %d", expectedWorkloads, s.TotalWorkloads)
+	}
+
+	const expectedCoverage = 88
+	if s.SBOMCoverage != expectedCoverage {
+		t.Errorf("expected %d%% SBOM coverage, got %d%%", expectedCoverage, s.SBOMCoverage)
+	}
+
+	const expectedComponents = 3847
+	if s.TotalComponents != expectedComponents {
+		t.Errorf("expected %d total components, got %d", expectedComponents, s.TotalComponents)
+	}
+
+	const expectedVulnerable = 12
+	if s.VulnerableComponents != expectedVulnerable {
+		t.Errorf("expected %d vulnerable components, got %d", expectedVulnerable, s.VulnerableComponents)
+	}
+
+	const expectedCritical = 2
+	if s.CriticalCount != expectedCritical {
+		t.Errorf("expected %d critical, got %d", expectedCritical, s.CriticalCount)
+	}
+
+	const expectedHigh = 5
+	if s.HighCount != expectedHigh {
+		t.Errorf("expected %d high, got %d", expectedHigh, s.HighCount)
+	}
+}
+
+// TestSummaryVulnerableConsistency verifies critical + high <= vulnerable.
+func TestSummaryVulnerableConsistency(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	criticalPlusHigh := s.CriticalCount + s.HighCount
+	if criticalPlusHigh > s.VulnerableComponents {
+		t.Errorf("critical (%d) + high (%d) = %d exceeds vulnerable (%d)",
+			s.CriticalCount, s.HighCount, criticalPlusHigh, s.VulnerableComponents)
+	}
+}
+
+// TestSummaryCoverageRange verifies coverage is a valid percentage.
+func TestSummaryCoverageRange(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	if s.SBOMCoverage < 0 || s.SBOMCoverage > 100 {
+		t.Errorf("SBOM coverage %d out of valid range [0, 100]", s.SBOMCoverage)
+	}
+}
+
+// TestSummaryEvaluatedAtNonZero verifies timestamp is populated.
+func TestSummaryEvaluatedAtNonZero(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+	if s.GeneratedAt.IsZero() {
+		t.Error("expected non-zero GeneratedAt")
+	}
+}
+
+// TestDocumentsReturnsEmptySlice verifies stub returns empty (not nil).
+func TestDocumentsReturnsEmptySlice(t *testing.T) {
+	e := NewEngine()
+	docs := e.Documents()
+	if docs == nil {
+		t.Fatal("Documents() returned nil, expected empty slice")
+	}
+	if len(docs) != 0 {
+		t.Errorf("expected 0 documents from stub, got %d", len(docs))
+	}
+}
+
+// TestConcurrentSummaryAccess verifies Summary() is safe for concurrent use.
+func TestConcurrentSummaryAccess(t *testing.T) {
+	e := NewEngine()
+	const goroutines = 10
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			s := e.Summary()
+			if s.TotalWorkloads == 0 {
+				t.Error("unexpected zero total workloads in concurrent access")
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+}

--- a/pkg/compliance/signing/evaluate_test.go
+++ b/pkg/compliance/signing/evaluate_test.go
@@ -1,0 +1,116 @@
+package signing
+
+import (
+	"testing"
+)
+
+// TestSummaryExactDemoValues verifies the signing demo data is returned accurately.
+func TestSummaryExactDemoValues(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	const expectedTotal = 37
+	if s.TotalImages != expectedTotal {
+		t.Errorf("expected %d total images, got %d", expectedTotal, s.TotalImages)
+	}
+
+	const expectedSigned = 33
+	if s.SignedImages != expectedSigned {
+		t.Errorf("expected %d signed images, got %d", expectedSigned, s.SignedImages)
+	}
+
+	const expectedVerified = 30
+	if s.VerifiedImages != expectedVerified {
+		t.Errorf("expected %d verified images, got %d", expectedVerified, s.VerifiedImages)
+	}
+
+	const expectedUnsigned = 4
+	if s.UnsignedImages != expectedUnsigned {
+		t.Errorf("expected %d unsigned images, got %d", expectedUnsigned, s.UnsignedImages)
+	}
+
+	const expectedViolations = 2
+	if s.PolicyViolations != expectedViolations {
+		t.Errorf("expected %d policy violations, got %d", expectedViolations, s.PolicyViolations)
+	}
+
+	const expectedClusters = 5
+	if s.ClustersCovered != expectedClusters {
+		t.Errorf("expected %d clusters covered, got %d", expectedClusters, s.ClustersCovered)
+	}
+}
+
+// TestSummarySignedPlusUnsignedEqualsTotal verifies image count consistency.
+func TestSummarySignedPlusUnsignedEqualsTotal(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	if s.SignedImages+s.UnsignedImages != s.TotalImages {
+		t.Errorf("signed (%d) + unsigned (%d) != total (%d)",
+			s.SignedImages, s.UnsignedImages, s.TotalImages)
+	}
+}
+
+// TestSummaryVerifiedLessThanOrEqualSigned verifies verified <= signed
+// (you must sign before you can verify).
+func TestSummaryVerifiedLessThanOrEqualSigned(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	if s.VerifiedImages > s.SignedImages {
+		t.Errorf("verified (%d) should be <= signed (%d)",
+			s.VerifiedImages, s.SignedImages)
+	}
+}
+
+// TestSummaryEvaluatedAtNonZero verifies timestamp is populated.
+func TestSummaryEvaluatedAtNonZero(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+	if s.EvaluatedAt.IsZero() {
+		t.Error("expected non-zero EvaluatedAt")
+	}
+}
+
+// TestImagesReturnsEmptySlice verifies stub returns empty (not nil).
+func TestImagesReturnsEmptySlice(t *testing.T) {
+	e := NewEngine()
+	images := e.Images()
+	if images == nil {
+		t.Fatal("Images() returned nil, expected empty slice")
+	}
+	if len(images) != 0 {
+		t.Errorf("expected 0 images from stub, got %d", len(images))
+	}
+}
+
+// TestPoliciesReturnsEmptySlice verifies stub returns empty (not nil).
+func TestPoliciesReturnsEmptySlice(t *testing.T) {
+	e := NewEngine()
+	policies := e.Policies()
+	if policies == nil {
+		t.Fatal("Policies() returned nil, expected empty slice")
+	}
+	if len(policies) != 0 {
+		t.Errorf("expected 0 policies from stub, got %d", len(policies))
+	}
+}
+
+// TestConcurrentSummaryAccess verifies Summary() is safe for concurrent use.
+func TestConcurrentSummaryAccess(t *testing.T) {
+	e := NewEngine()
+	const goroutines = 10
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			s := e.Summary()
+			if s.TotalImages == 0 {
+				t.Error("unexpected zero total images in concurrent access")
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+}

--- a/pkg/compliance/slsa/evaluate_test.go
+++ b/pkg/compliance/slsa/evaluate_test.go
@@ -1,0 +1,138 @@
+package slsa
+
+import (
+	"testing"
+)
+
+// TestSummaryExactDemoValues verifies the SLSA demo data is returned accurately.
+func TestSummaryExactDemoValues(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	const expectedWorkloads = 28
+	if s.TotalWorkloads != expectedWorkloads {
+		t.Errorf("expected %d total workloads, got %d", expectedWorkloads, s.TotalWorkloads)
+	}
+
+	const expectedAttested = 24
+	if s.AttestedWorkloads != expectedAttested {
+		t.Errorf("expected %d attested workloads, got %d", expectedAttested, s.AttestedWorkloads)
+	}
+
+	const expectedVerified = 20
+	if s.VerifiedWorkloads != expectedVerified {
+		t.Errorf("expected %d verified workloads, got %d", expectedVerified, s.VerifiedWorkloads)
+	}
+
+	if s.FleetPosture != Level1 {
+		t.Errorf("expected fleet posture Level1, got %d", s.FleetPosture)
+	}
+}
+
+// TestSummaryLevelDistribution verifies level counts sum to total workloads.
+func TestSummaryLevelDistribution(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	sum := 0
+	for _, count := range s.LevelDistribution {
+		sum += count
+	}
+	if sum != s.TotalWorkloads {
+		t.Errorf("level distribution sum %d != total workloads %d", sum, s.TotalWorkloads)
+	}
+}
+
+// TestSummaryLevelDistributionKeys verifies expected SLSA level keys are present.
+func TestSummaryLevelDistributionKeys(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	expectedKeys := []string{"0", "1", "2", "3", "4"}
+	for _, key := range expectedKeys {
+		if _, ok := s.LevelDistribution[key]; !ok {
+			t.Errorf("level distribution missing key %q", key)
+		}
+	}
+
+	// Verify exact demo counts
+	expected := map[string]int{"0": 2, "1": 6, "2": 10, "3": 8, "4": 2}
+	for level, want := range expected {
+		got := s.LevelDistribution[level]
+		if got != want {
+			t.Errorf("level %s: expected %d, got %d", level, want, got)
+		}
+	}
+}
+
+// TestSummaryAttestedGreaterOrEqualVerified verifies attested >= verified
+// (you must attest before you can verify).
+func TestSummaryAttestedGreaterOrEqualVerified(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+
+	if s.AttestedWorkloads < s.VerifiedWorkloads {
+		t.Errorf("attested (%d) should be >= verified (%d)",
+			s.AttestedWorkloads, s.VerifiedWorkloads)
+	}
+}
+
+// TestSummaryEvaluatedAtNonZero verifies timestamp is populated.
+func TestSummaryEvaluatedAtNonZero(t *testing.T) {
+	e := NewEngine()
+	s := e.Summary()
+	if s.EvaluatedAt.IsZero() {
+		t.Error("expected non-zero EvaluatedAt")
+	}
+}
+
+// TestWorkloadsReturnsEmptySlice verifies stub returns empty (not nil).
+func TestWorkloadsReturnsEmptySlice(t *testing.T) {
+	e := NewEngine()
+	w := e.Workloads()
+	if w == nil {
+		t.Fatal("Workloads() returned nil, expected empty slice")
+	}
+	if len(w) != 0 {
+		t.Errorf("expected 0 workloads from stub, got %d", len(w))
+	}
+}
+
+// TestLevelConstants verifies SLSA level constants have expected integer values.
+func TestLevelConstants(t *testing.T) {
+	tests := []struct {
+		name  string
+		level Level
+		want  int
+	}{
+		{"Level0", Level0, 0},
+		{"Level1", Level1, 1},
+		{"Level2", Level2, 2},
+		{"Level3", Level3, 3},
+		{"Level4", Level4, 4},
+	}
+	for _, tt := range tests {
+		if int(tt.level) != tt.want {
+			t.Errorf("%s: expected %d, got %d", tt.name, tt.want, int(tt.level))
+		}
+	}
+}
+
+// TestConcurrentSummaryAccess verifies Summary() is safe for concurrent use.
+func TestConcurrentSummaryAccess(t *testing.T) {
+	e := NewEngine()
+	const goroutines = 10
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			s := e.Summary()
+			if s.TotalWorkloads == 0 {
+				t.Error("unexpected zero total workloads in concurrent access")
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+}


### PR DESCRIPTION
## Summary
- Add evaluation logic tests for SLSA, Signing, Airgap, SBOM, Licenses, and BAA compliance engines
- Tests cover Summary() with exact demo data validation, edge cases (empty, all-pass, all-fail, mixed), consistency invariants, and concurrent access safety
- For engines with injectable state (Airgap, BAA): tests construct custom Engine structs to verify score/counting logic
- For stub engines (SLSA, Signing, SBOM, Licenses): tests verify exact demo values, invariant relationships, and constant definitions
- Follows pattern established in #17414/#17415

Fixes #17419

## Test plan
- [x] `go test ./pkg/compliance/...` passes
- [ ] Coverage ratchet gates pass