### PR TITLE
fix: add animate-spin to refresh icons during loading state

### DIFF
--- a/web/src/components/cards/workload-monitor/ClusterHealthMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/ClusterHealthMonitor.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import {
   Server, AlertTriangle, CheckCircle, XCircle,
-  RefreshCw, Loader2, ChevronDown, ChevronRight,
+  RefreshCw, ChevronDown, ChevronRight,
   Box, Activity } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { useClusters } from '../../../hooks/useMCP'
@@ -232,9 +232,7 @@ export function ClusterHealthMonitor({ config: _config }: ClusterHealthMonitorPr
           className="p-1 rounded hover:bg-secondary transition-colors"
           title={t('common:common.refresh')}
         >
-          {isRefreshing
-            ? <Loader2 className="w-3.5 h-3.5 text-green-400 animate-spin" />
-            : <RefreshCw className="w-3.5 h-3.5 text-muted-foreground" />}
+          <RefreshCw className={`w-3.5 h-3.5 ${isRefreshing ? 'text-green-400 animate-spin' : 'text-muted-foreground'}`} />
         </button>
       </div>
 

--- a/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
@@ -7,7 +7,7 @@ import { useMemo, useState, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import {
   Cpu, Network, Activity, Layers, Server,
-  RefreshCw, Loader2, ChevronDown, ChevronRight, Filter,
+  RefreshCw, ChevronDown, ChevronRight, Filter,
   AlertTriangle
 } from 'lucide-react'
 import { ALERT_SEVERITY_ORDER } from '../../../types/alerts'
@@ -593,9 +593,7 @@ export function LLMdStackMonitor({ config: _config }: LLMdStackMonitorProps) {
           className="p-1 rounded hover:bg-secondary transition-colors"
           title={t('common.refresh')}
         >
-          {isRefreshing
-            ? <Loader2 className="w-3.5 h-3.5 text-purple-400 animate-spin" />
-            : <RefreshCw className="w-3.5 h-3.5 text-muted-foreground" />}
+          <RefreshCw className={`w-3.5 h-3.5 ${isRefreshing ? 'text-purple-400 animate-spin' : 'text-muted-foreground'}`} />
         </button>
       </div>
 

--- a/web/src/components/cards/workload-monitor/ProwCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/ProwCIMonitor.tsx
@@ -1,6 +1,6 @@
 import {
   Activity, AlertTriangle, CheckCircle, XCircle,
-  Clock, RefreshCw, Loader2, Play, Pause } from 'lucide-react'
+  Clock, RefreshCw, Play, Pause } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
 import { CardControls } from '../../ui/CardControls'
@@ -206,9 +206,7 @@ export function ProwCIMonitor({ config: _config }: ProwCIMonitorProps) {
           className="p-1 rounded hover:bg-secondary transition-colors"
           title={t('common.refresh')}
         >
-          {isRefreshing
-            ? <Loader2 className="w-3.5 h-3.5 text-blue-400 animate-spin" />
-            : <RefreshCw className="w-3.5 h-3.5 text-muted-foreground" />}
+          <RefreshCw className={`w-3.5 h-3.5 ${isRefreshing ? 'text-blue-400 animate-spin' : 'text-muted-foreground'}`} />
         </button>
       </div>
 

--- a/web/src/components/cards/workload-monitor/WorkloadMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitor.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Package, RefreshCw, Loader2, AlertTriangle, Search } from 'lucide-react'
+import { Package, RefreshCw, AlertTriangle, Search } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
@@ -267,9 +267,7 @@ export function WorkloadMonitor({ config }: WorkloadMonitorProps) {
               className="p-1 rounded hover:bg-secondary transition-colors"
               title={t('common.refresh')}
             >
-              {monitorRefreshing
-                ? <Loader2 className="w-3.5 h-3.5 text-purple-400 animate-spin" />
-                : <RefreshCw className="w-3.5 h-3.5 text-muted-foreground" />}
+              <RefreshCw className={`w-3.5 h-3.5 ${monitorRefreshing ? 'text-purple-400 animate-spin' : 'text-muted-foreground'}`} />
             </button>
           </div>
 

--- a/web/src/components/drilldown/views/LogsDrillDown.tsx
+++ b/web/src/components/drilldown/views/LogsDrillDown.tsx
@@ -280,9 +280,7 @@ export function LogsDrillDown({ data }: Props) {
             disabled={isLoading}
             className="px-3 py-2 rounded-lg bg-primary text-primary-foreground text-sm flex items-center gap-2 disabled:opacity-50"
           >
-            {isLoading
-              ? <Loader2 className="w-4 h-4 animate-spin" />
-              : <RefreshCw className="w-4 h-4" />}
+            <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
             {t('drilldown.logs.refresh')}
           </button>
         </div>


### PR DESCRIPTION
## Summary
- Replace inconsistent `Loader2`/`RefreshCw` icon swap pattern with a single `RefreshCw` that conditionally applies `animate-spin` during loading
- Aligns 4 workload monitor cards (ClusterHealth, LLMdStack, ProwCI, Workload) and the LogsDrillDown with the pattern already used by `RefreshIndicator`, `DashboardHeader`, `UnifiedDashboard`, and other shared components
- Removes unused `Loader2` imports from 4 files

Fixes #17418

## Test plan
- [ ] TypeScript compilation passes
- [ ] Refresh icons spin during loading in workload monitor cards
- [ ] Refresh icon spins during loading in logs drilldown
- [ ] No animation when not loading
- [ ] Visual consistency with DashboardHeader and other shared components