### PR TITLE
fix: replace inline px spacing with Tailwind utility classes

### DIFF
--- a/web/src/components/stellar/BatchMonitorModal.tsx
+++ b/web/src/components/stellar/BatchMonitorModal.tsx
@@ -9,11 +9,7 @@ const SECONDS_PER_MINUTE = 60
 const MS_PER_SECOND = 1000
 
 const FLEX_MIN_WIDTH_STYLE = { flex: 1, minWidth: 0 } as const
-const BATCH_SUMMARY_BREAKDOWN_ITEM_STYLE = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: 8,
-} as const
+const BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS = 'flex items-center gap-2'
 const BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE = {
   fontFamily: 'var(--s-mono)',
   fontSize: 11,
@@ -688,7 +684,7 @@ export function BatchMonitorModal({
           {/* Breakdown */}
           <div className="flex flex-wrap gap-4">
             {batch.summary.resolved > 0 && (
-              <div style={BATCH_SUMMARY_BREAKDOWN_ITEM_STYLE}>
+              <div className={BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS}>
                 <span aria-hidden="true" style={{ color: 'var(--s-success)', fontSize: 14 }}>✓</span>
                 <span style={BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE}>
                   {batch.summary.resolved} {t('stellar.batch.resolved')}
@@ -696,7 +692,7 @@ export function BatchMonitorModal({
               </div>
             )}
             {batch.summary.failed > 0 && (
-              <div style={BATCH_SUMMARY_BREAKDOWN_ITEM_STYLE}>
+              <div className={BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS}>
                 <span aria-hidden="true" style={{ color: 'var(--s-critical)', fontSize: 14 }}>✗</span>
                 <span style={BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE}>
                   {batch.summary.failed} {t('stellar.batch.failed')}
@@ -704,7 +700,7 @@ export function BatchMonitorModal({
               </div>
             )}
             {batch.summary.skipped > 0 && (
-              <div style={BATCH_SUMMARY_BREAKDOWN_ITEM_STYLE}>
+              <div className={BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS}>
                 <span aria-hidden="true" style={{ color: 'var(--s-text-muted)', fontSize: 14 }}>–</span>
                 <span style={BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE}>
                   {batch.summary.skipped} {t('stellar.batch.skipped')}
@@ -712,7 +708,7 @@ export function BatchMonitorModal({
               </div>
             )}
             {batch.summary.inProgress > 0 && (
-              <div style={BATCH_SUMMARY_BREAKDOWN_ITEM_STYLE}>
+              <div className={BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS}>
                 <span aria-hidden="true" style={{ color: 'var(--s-info)', fontSize: 14 }}>⊙</span>
                 <span style={BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE}>
                   {batch.summary.inProgress} {t('stellar.batch.inProgress')}

--- a/web/src/components/stellar/EventCard.tsx
+++ b/web/src/components/stellar/EventCard.tsx
@@ -76,7 +76,7 @@ const ACTION_CONFIG: Record<string, { labelKey: string; icon: string; color: str
   solve: { labelKey: 'stellar.eventCard.actions.solve', icon: '✦', color: 'var(--s-success)' },
 }
 
-const EVENT_CARD_ACTIONS_STYLE = { display: 'flex', gap: 8, marginTop: 8, flexWrap: 'wrap' } as const
+const EVENT_CARD_ACTIONS_CLASS = 'flex flex-wrap gap-2 mt-2'
 const EVENT_CARD_BUTTON_STYLE = { background: 'none', border: '1px solid var(--s-border-muted)', borderRadius: 'var(--s-rs)', color: 'var(--s-text-muted)', cursor: 'pointer' } as const
 
 function buildActionPrompt(hint: string, notification: StellarNotification): string {
@@ -251,9 +251,7 @@ export function EventCard({
       )}
       {solveStatus && (
         <div className="mt-1.5">
-          <div className="mb-1" style={{
-            display: 'flex', alignItems: 'center', gap: 8,
-          }}>
+          <div className="mb-1 flex items-center gap-2">
             <span className="text-[11px] font-mono" style={{
               fontWeight: 600,
               color: solveStatus.color, flex: 1, minWidth: 0,
@@ -342,7 +340,7 @@ export function EventCard({
               e.stopPropagation()
             }
           }}
-          style={EVENT_CARD_ACTIONS_STYLE}
+          className={EVENT_CARD_ACTIONS_CLASS}
         >
           <button className="px-2 py-0.5 text-[11px]" onClick={onDismiss} style={EVENT_CARD_BUTTON_STYLE}>{t('actions.dismiss')}</button>
           {showRollback && onRollback && (

--- a/web/src/components/stellar/EventsPanel.tsx
+++ b/web/src/components/stellar/EventsPanel.tsx
@@ -321,7 +321,7 @@ export function EventsPanel({
               </span>
               <span style={{ fontSize: 11, color: 'var(--s-text-dim)' }}>→</span>
             </div>
-            <div className="text-xs" style={{ color: 'var(--s-text)', marginTop: 4, lineHeight: 1.5 }}>
+            <div className="mt-1 text-xs leading-normal" style={{ color: 'var(--s-text)' }}>
               {t('stellar.batch.viewBatchMonitor')} — {currentBatch.solvingCount} event{currentBatch.solvingCount === 1 ? '' : 's'} actively solving
             </div>
           </button>
@@ -492,15 +492,7 @@ function Group({
 
 function EmptyState({ icon, text }: { icon: string; text: string }) {
   return (
-    <div style={{
-      flex: 1,
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-      gap: 8,
-      color: 'var(--s-text-dim)',
-    }}>
+    <div className="flex flex-1 flex-col items-center justify-center gap-2" style={{ color: 'var(--s-text-dim)' }}>
       <span style={{ fontSize: 22, opacity: 0.4 }}>{icon}</span>
       <span style={{ fontSize: 12 }}>{text}</span>
     </div>

--- a/web/src/components/stellar/ScheduleActionForm.tsx
+++ b/web/src/components/stellar/ScheduleActionForm.tsx
@@ -19,7 +19,7 @@ export function ScheduleActionForm() {
   const [values, setValues] = useState<Record<string, string>>({})
   const [status, setStatus] = useState<string | null>(null)
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+    <div className="flex flex-col gap-2">
       <input value={cluster} onChange={(e) => setCluster(e.target.value)} placeholder="Cluster" />
       <select value={actionType} onChange={(e) => setActionType(e.target.value)}>
         {Object.entries(ACTION_CONFIGS).map(([key, cfg]) => <option key={key} value={key}>{cfg.label}</option>)}

--- a/web/src/components/stellar/StellarActivityPanel.tsx
+++ b/web/src/components/stellar/StellarActivityPanel.tsx
@@ -113,7 +113,7 @@ export function StellarActivityPanel({ activity, onOpenEvent }: Props) {
               Stellar is watching. Nothing to report yet.
             </div>
           ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <div className="flex flex-col gap-0.5">
               {visible.slice(0, 60).map(entry => {
                 const k = describeKind(entry.kind)
                 // A row is clickable iff it carries an eventId AND a handler

--- a/web/src/components/ui/FeatureHintTooltip.stories.tsx
+++ b/web/src/components/ui/FeatureHintTooltip.stories.tsx
@@ -18,7 +18,7 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <div className="relative flex items-center justify-center" style={{ minHeight: 200, padding: 80 }}>
+      <div className="relative flex min-h-[200px] items-center justify-center p-20">
         <div className="relative inline-block">
           <div className="px-4 py-2 bg-secondary rounded-lg text-sm text-foreground border border-border">
             Anchor Element
@@ -85,7 +85,7 @@ export const LongMessage: Story = {
 export const AllPlacements: Story = {
   args: { message: 'Hint tooltip' },
   render: () => (
-    <div className="grid grid-cols-2 gap-16" style={{ padding: 120 }}>
+    <div className="grid grid-cols-2 gap-16 p-[120px]">
       {(['top', 'bottom', 'left', 'right'] as const).map((placement) => (
         <div key={placement} className="flex flex-col items-center gap-2">
           <span className="text-xs text-muted-foreground mb-4">{placement}</span>


### PR DESCRIPTION
## Summary
- Replace inline style objects with Tailwind utility classes where the style contained only layout properties (flex, gap, margin, padding)
- Convert 6 files across stellar components and stories
- Skip legitimate inline styles: CSS variables (`var(--s-*)`), dynamic/computed values, border widths, shadows, chart/visualization code, code generators, and markdown rendering styles

Most of the scanner's findings (borders, shadows, chart pixels, stellar design system tokens, code generator templates, widget export previews) are legitimate uses that cannot or should not be converted to Tailwind.

Fixes #17263

## Test plan
- [ ] TypeScript compilation passes
- [ ] No visual regressions in Stellar panel components
- [ ] Storybook stories render correctly