### PR TITLE
[scanner] fix: repair 15 test failures from missing mocks and stale assertions

### DIFF
--- a/web/src/components/cards/workload-monitor/__tests__/ClusterHealthMonitor.test.tsx
+++ b/web/src/components/cards/workload-monitor/__tests__/ClusterHealthMonitor.test.tsx
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, fireEvent, waitFor } from '@testing-library/react'
 
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '', hash: '', state: null }),
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}))
+
 vi.mock('../../../../lib/demoMode', () => ({
   isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
   isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),

--- a/web/src/components/cards/workload-monitor/__tests__/ProwCIMonitor.refresh.test.tsx
+++ b/web/src/components/cards/workload-monitor/__tests__/ProwCIMonitor.refresh.test.tsx
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render } from '@testing-library/react'
 
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '', hash: '', state: null }),
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}))
+
 vi.mock('../../../../lib/demoMode', () => ({
   isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
   isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
@@ -39,6 +45,7 @@ vi.mock('../../../../lib/cn', () => ({
 
 vi.mock('../../CardDataContext', () => ({
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
+  useCardDemoState: () => ({ shouldUseDemoData: false, reason: 'none' }),
 }))
 
 vi.mock('../../../../hooks/useGlobalFilters', () => ({

--- a/web/src/components/stellar/EventCard.test.tsx
+++ b/web/src/components/stellar/EventCard.test.tsx
@@ -13,7 +13,7 @@ vi.mock('./lib/derive', () => ({
   countRelated: () => 0,
   deriveImportance: () => ({ label: 'medium', score: 50 }),
   deriveShortReason: () => 'Pod CrashLoopBackOff',
-  deriveTags: () => [{ label: 'pod', color: '#aaa' }],
+  deriveTags: () => ['pod'],
   importanceColor: () => 'var(--s-warning)',
   countSolveAttempts: () => 0,
   getSolveStatus: () => null,
@@ -67,7 +67,7 @@ describe('EventCard', () => {
         onOpenDetail={onOpenDetail}
       />
     )
-    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByLabelText('Open details for Pod CrashLoopBackOff'))
     expect(onOpenDetail).toHaveBeenCalledWith(baseNotification)
   })
 
@@ -80,7 +80,7 @@ describe('EventCard', () => {
         onOpenDetail={onOpenDetail}
       />
     )
-    fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' })
+    fireEvent.keyDown(screen.getByLabelText('Open details for Pod CrashLoopBackOff'), { key: 'Enter' })
     expect(onOpenDetail).toHaveBeenCalledWith(baseNotification)
   })
 
@@ -123,7 +123,7 @@ describe('EventCard', () => {
         onDismiss={() => {}}
       />
     )
-    // Attempt count badge should exist
-    expect(screen.getByText(/3/)).toBeInTheDocument()
+    // The t() mock returns the key; attemptCount badge uses 'stellar.eventCard.attemptCount'
+    expect(screen.getByText(/attemptCount/)).toBeInTheDocument()
   })
 })

--- a/web/src/components/stellar/EventCard.test.tsx
+++ b/web/src/components/stellar/EventCard.test.tsx
@@ -123,7 +123,7 @@ describe('EventCard', () => {
         onDismiss={() => {}}
       />
     )
-    // The t() mock returns the key; attemptCount badge uses 'stellar.eventCard.attemptCount'
-    expect(screen.getByText(/attemptCount/)).toBeInTheDocument()
+    // The t() mock returns the key as-is; assert the full i18n key to avoid false positives
+    expect(screen.getByText("stellar.eventCard.attemptCount")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Fixes 15 test failures from Coverage Suite run #3691 caused by incomplete mocks and stale test assertions.

### Root causes

1. **ClusterHealthMonitor (4 tests)**: `WorkloadMonitorDiagnose` component uses `useApiKeyCheck()` which calls `useNavigate()` — missing `react-router-dom` mock
2. **ProwCIMonitor (4 tests)**: Same `useNavigate` issue + `ProwCIMonitor` now imports `useCardDemoState` from `CardDataContext` which wasn't in the mock
3. **EventCard (7 tests)**: 
   - `deriveTags` mock returned objects `{label, color}` but component renders tags directly as React children (needs strings)
   - Multiple `role="button"` elements (action buttons + card wrapper) broke `getByRole('button')` — switched to `getByLabelText` 
   - `attemptCount` renders via i18n key, not raw number — assertion updated

### Changes

- `ClusterHealthMonitor.test.tsx`: Add `react-router-dom` mock
- `ProwCIMonitor.refresh.test.tsx`: Add `react-router-dom` mock + `useCardDemoState` export to CardDataContext mock
- `EventCard.test.tsx`: Fix `deriveTags` return type, use aria-label for disambiguation, fix attemptCount assertion

Fixes #17447