### PR TITLE
[scanner] test: add unit tests for stellar dedup keys and provider URL validation

### DIFF
--- a/pkg/stellar/providers/provider_url_validation_test.go
+++ b/pkg/stellar/providers/provider_url_validation_test.go
@@ -18,7 +18,7 @@ func TestValidateProviderURL(t *testing.T) {
 		{name: "valid http URL", url: "http://localhost:8080", wantErr: false},
 		{name: "valid https with path", url: "https://api.example.com/v1/chat", wantErr: false},
 		{name: "invalid scheme ftp", url: "ftp://files.example.com", wantErr: true, errMsg: "URL scheme must be http or https"},
-		{name: "missing scheme", url: "example.com", wantErr: true, errMsg: "URL must have a host"},
+		{name: "missing scheme", url: "example.com", wantErr: true, errMsg: "URL scheme must be http or https"},
 		{name: "scheme only no host", url: "https://", wantErr: true, errMsg: "URL must have a host"},
 	}
 

--- a/pkg/stellar/providers/provider_url_validation_test.go
+++ b/pkg/stellar/providers/provider_url_validation_test.go
@@ -1,0 +1,42 @@
+package providers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateProviderURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+		errMsg  string
+	}{
+		{name: "empty URL is valid", url: "", wantErr: false},
+		{name: "whitespace-only URL is valid", url: "   ", wantErr: false},
+		{name: "valid https URL", url: "https://api.example.com", wantErr: false},
+		{name: "valid http URL", url: "http://localhost:8080", wantErr: false},
+		{name: "valid https with path", url: "https://api.example.com/v1/chat", wantErr: false},
+		{name: "invalid scheme ftp", url: "ftp://files.example.com", wantErr: true, errMsg: "URL scheme must be http or https"},
+		{name: "missing scheme", url: "example.com", wantErr: true, errMsg: "URL must have a host"},
+		{name: "scheme only no host", url: "https://", wantErr: true, errMsg: "URL must have a host"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProviderURL(tt.url, "test-provider")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errMsg)
+				}
+				if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error = %q, want substring %q", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/stellar/watcher/dedup_test.go
+++ b/pkg/stellar/watcher/dedup_test.go
@@ -2,7 +2,7 @@ package watcher
 
 import "testing"
 
-func TestDedupKeyEvent(t *testing.T) {
+func TestDedupKeyEvent_TableDriven(t *testing.T) {
 	tests := []struct {
 		cluster, namespace, resource, reason string
 		want                                 string
@@ -20,7 +20,7 @@ func TestDedupKeyEvent(t *testing.T) {
 	}
 }
 
-func TestDedupKeyCrash(t *testing.T) {
+func TestDedupKeyCrash_TableDriven(t *testing.T) {
 	tests := []struct {
 		cluster, namespace, pod, container string
 		want                              string
@@ -37,7 +37,7 @@ func TestDedupKeyCrash(t *testing.T) {
 	}
 }
 
-func TestDedupKeyNodeNotReady(t *testing.T) {
+func TestDedupKeyNodeNotReady_TableDriven(t *testing.T) {
 	tests := []struct {
 		cluster, nodeName string
 		want              string

--- a/pkg/stellar/watcher/dedup_test.go
+++ b/pkg/stellar/watcher/dedup_test.go
@@ -1,0 +1,55 @@
+package watcher
+
+import "testing"
+
+func TestDedupKeyEvent(t *testing.T) {
+	tests := []struct {
+		cluster, namespace, resource, reason string
+		want                                 string
+	}{
+		{"prod", "default", "my-pod", "CrashLoopBackOff", "ev:prod:default:my-pod:CrashLoopBackOff"},
+		{"", "", "", "", "ev::::"},
+		{"c1", "ns", "deploy-abc", "FailedScheduling", "ev:c1:ns:deploy-abc:FailedScheduling"},
+	}
+	for _, tt := range tests {
+		got := DedupKeyEvent(tt.cluster, tt.namespace, tt.resource, tt.reason)
+		if got != tt.want {
+			t.Errorf("DedupKeyEvent(%q,%q,%q,%q) = %q, want %q",
+				tt.cluster, tt.namespace, tt.resource, tt.reason, got, tt.want)
+		}
+	}
+}
+
+func TestDedupKeyCrash(t *testing.T) {
+	tests := []struct {
+		cluster, namespace, pod, container string
+		want                              string
+	}{
+		{"prod", "default", "my-pod-abc", "main", "crash:prod:default:my-pod-abc:main"},
+		{"", "", "", "", "crash::::"},
+	}
+	for _, tt := range tests {
+		got := DedupKeyCrash(tt.cluster, tt.namespace, tt.pod, tt.container)
+		if got != tt.want {
+			t.Errorf("DedupKeyCrash(%q,%q,%q,%q) = %q, want %q",
+				tt.cluster, tt.namespace, tt.pod, tt.container, got, tt.want)
+		}
+	}
+}
+
+func TestDedupKeyNodeNotReady(t *testing.T) {
+	tests := []struct {
+		cluster, nodeName string
+		want              string
+	}{
+		{"prod", "node-1", "node-notready:prod:node-1"},
+		{"", "", "node-notready::"},
+	}
+	for _, tt := range tests {
+		got := DedupKeyNodeNotReady(tt.cluster, tt.nodeName)
+		if got != tt.want {
+			t.Errorf("DedupKeyNodeNotReady(%q,%q) = %q, want %q",
+				tt.cluster, tt.nodeName, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds unit test files for two previously untested Go source files, addressing part of #17441 (137 Go source files lack corresponding test files).

### New tests

1. **`pkg/stellar/watcher/dedup_test.go`** — Table-driven tests for all three dedup key generators:
   - `DedupKeyEvent` — event dedup keys
   - `DedupKeyCrash` — crash dedup keys
   - `DedupKeyNodeNotReady` — node-not-ready dedup keys

2. **`pkg/stellar/providers/provider_url_validation_test.go`** — Tests for `ValidateProviderURL` covering:
   - Empty/whitespace input (valid)
   - Valid http/https URLs
   - Invalid scheme (ftp)
   - Missing scheme/host

### Impact

Small step toward improving Go test coverage. These are pure functions with no external dependencies, making them ideal starting points.

Partial fix for #17441