### PR TITLE
[scanner] fix: downgrade React Compiler lint rules to warnings

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -19,6 +19,11 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      // React Compiler rules (new in eslint-plugin-react-hooks v7) —
+      // downgrade to warnings until codebase is incrementally migrated.
+      'react-hooks/purity': 'warn',
+      'react-hooks/set-state-in-effect': 'warn',
+      'react-hooks/static-components': 'warn',
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },


### PR DESCRIPTION
## Summary

Fixes the Release workflow failure caused by `eslint-plugin-react-hooks` v7 introducing new React Compiler rules (`purity`, `set-state-in-effect`, `static-components`) at error level via `recommended.rules`.

The codebase has ~788 violations of these new rules. This PR downgrades them to `'warn'` to unblock the release pipeline while preserving visibility for incremental migration.

### Changes
- `web/eslint.config.js`: Add explicit `'warn'` overrides for `react-hooks/purity`, `react-hooks/set-state-in-effect`, and `react-hooks/static-components`

### Root Cause
The existing config spreads `reactHooks.configs.recommended.rules` which in v7 includes these rules at `'error'` level. Previously (v5/v6), the recommended config only had `rules-of-hooks` and `exhaustive-deps`.

Fixes #17485