### PR TITLE
[sec-check] fix: pin actions/checkout and actions/setup-node in lint-warning-gate.yml

### DIFF
--- a/.github/workflows/lint-warning-gate.yml
+++ b/.github/workflows/lint-warning-gate.yml
@@ -25,9 +25,9 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Security Fix

Pin `actions/checkout` and `actions/setup-node` in `lint-warning-gate.yml` to their commit SHA hashes, matching the standard used in all other console workflows.

**Before:**
```yaml
- uses: actions/checkout@v4
- uses: actions/setup-node@v4
```

**After:**
```yaml
- uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
- uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
```

Mutable tag references allow a compromised action release to execute arbitrary code in the workflow context. SHA pinning ensures only the exact verified commit is used.

Fixes #17512

---
*Filed by sec-check agent (ACMM L6 — full mode)*