### PR TITLE
fix: remove duplicate aria-label on GPU namespace items

### DIFF
--- a/web/src/components/cards/GPUNamespaceAllocations.tsx
+++ b/web/src/components/cards/GPUNamespaceAllocations.tsx
@@ -230,7 +230,6 @@ function GPUNamespaceAllocationsInternal({ config: _config }: GPUNamespaceAlloca
           <div
             key={ns.namespace}
             role="button"
-            aria-label={`View GPU details for namespace ${ns.namespace}`}
             tabIndex={0}
             onClick={() => drillToGPUNamespace(ns.namespace, {
               gpuRequested: ns.gpuRequested,


### PR DESCRIPTION
## Summary

- PR #17539 added i18n `aria-label` attributes but left the original hardcoded `aria-label` in place
- This caused `TS17001: JSX elements cannot have multiple attributes with the same name` on line 249
- Removed the hardcoded `aria-label` on line 233, keeping the i18n version on line 249

Fixes #17540, Fixes #17541, Fixes #17542