### PR TITLE
🐛 fix: resolve build errors from import path and cross-package references

### DIFF
--- a/pkg/agent/kube/testing.go
+++ b/pkg/agent/kube/testing.go
@@ -3,7 +3,7 @@ package kube
 import (
 	"strings"
 
-	"github.com/kubestellar/console/pkg/agent/kube/k8s"
+	"github.com/kubestellar/console/pkg/k8s"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 

--- a/pkg/api/handlers/gitops/operators.go
+++ b/pkg/api/handlers/gitops/operators.go
@@ -178,7 +178,7 @@ func (h *GitOpsHandlers) StreamOperators(c *fiber.Ctx) error {
 				// can distinguish "no operators" from "query failed".
 				if fetchErr != nil {
 					slog.Error("[GitOpsOperators] cluster fetch failed", "cluster", clusterName, "error", fetchErr)
-					handlers.WriteSSEEvent(w, sseEventClusterError, fiber.Map{
+					handlers.WriteSSEEvent(w, "cluster_error", fiber.Map{
 						"cluster": clusterName,
 						"error":   "cluster query failed",
 					})
@@ -562,7 +562,7 @@ func (h *GitOpsHandlers) StreamOperatorSubscriptions(c *fiber.Ctx) error {
 				// can distinguish "no subscriptions" from "query failed".
 				if fetchErr != nil {
 					slog.Error("[GitOpsOperators] cluster fetch failed", "cluster", clusterName, "error", fetchErr)
-					handlers.WriteSSEEvent(w, sseEventClusterError, fiber.Map{
+					handlers.WriteSSEEvent(w, "cluster_error", fiber.Map{
 						"cluster": clusterName,
 						"error":   "cluster query failed",
 					})

--- a/pkg/api/startup.go
+++ b/pkg/api/startup.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/kubestellar/console/pkg/api/handlers"
+	"github.com/kubestellar/console/pkg/api/handlers/gitops"
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/fileutil"
 	"github.com/kubestellar/console/pkg/safego"
@@ -278,7 +279,7 @@ func (s *Server) Shutdown() error {
 			s.background.rewardsHandler.StopEviction()
 		}
 		// stop the operator cache and GitHub proxy limiter eviction goroutines.
-		handlers.StopOperatorCacheEvictor()
+		gitops.StopOperatorCacheEvictor()
 		handlers.StopGitHubProxyLimiterEvictor()
 		// #7043 — stop the SSE cache evictor goroutine that was started
 		// lazily by sseCacheSet. Without this the goroutine leaks after


### PR DESCRIPTION
## Summary
- Fix wrong import path in `pkg/agent/kube/testing.go` (`pkg/agent/kube/k8s` → `pkg/k8s`)
- Replace undefined `sseEventClusterError` constant in `gitops/operators.go` with the string literal `"cluster_error"` (the constant is unexported in the `handlers` package, not accessible from the `gitops` sub-package)
- Fix cross-package reference to `StopOperatorCacheEvictor` in `startup.go` — function was moved to `gitops` package but caller still referenced `handlers`
- Fix go vet errors across 33 test files: wrong struct fields, missing imports, duplicate test names, type mismatches, renamed constructors

## Test plan
- [x] `go build ./...` passes cleanly
- [x] `go vet ./...` passes cleanly
- [ ] CI build/lint should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)