### PR TITLE
🐛 fix: add missing Loader2 import in QuantumControlPanel

### DIFF
--- a/web/src/components/cards/quantum/QuantumControlPanel.tsx
+++ b/web/src/components/cards/quantum/QuantumControlPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react'
-import { AlertCircle, Play, Zap, Key, Check, Trash2, ShieldCheck, RefreshCw } from 'lucide-react'
+import { AlertCircle, Play, Zap, Key, Check, Trash2, ShieldCheck, RefreshCw, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../../lib/cn'
 import { useReportCardDataState } from '../CardDataContext'


### PR DESCRIPTION
Fixes #18221

## Summary

PR #18200 ([scanner] add loading states to async action buttons) introduced `<Loader2 />` JSX in `QuantumControlPanel.tsx:695` but did not include `Loader2` in the existing `lucide-react` import on line 2, breaking the frontend build:

```
src/components/cards/quantum/QuantumControlPanel.tsx:695:54 -
  error TS2304: Cannot find name 'Loader2'.

695   {(control.executing || isExecuting) ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
```

## Fix

One-line: add `Loader2` to the existing destructured `lucide-react` import.

```diff
-import { AlertCircle, Play, Zap, Key, Check, Trash2, ShieldCheck, RefreshCw } from 'lucide-react'
+import { AlertCircle, Play, Zap, Key, Check, Trash2, ShieldCheck, RefreshCw, Loader2 } from 'lucide-react'
```

## Test plan

- [x] Reproduces TS2304 without the import; clean with it
- [x] Frontend `tsc -b && vite build` passes locally
- [ ] CI passes