### PR TITLE
feat: add search, filtering, pagination, and accurate event statistics

### DIFF
--- a/web/src/components/drilldown/views/EventsDrillDown.tsx
+++ b/web/src/components/drilldown/views/EventsDrillDown.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect, useCallback, useRef } from 'react'
-import { AlertCircle, RefreshCw, Terminal, Copy, CheckCircle, Server, Layers, ChevronLeft } from 'lucide-react'
+import { AlertCircle, RefreshCw, Terminal, Copy, CheckCircle, Server, Layers, ChevronLeft, ChevronRight, Search, Filter } from 'lucide-react'
 import { StatusIndicator } from '../../charts/StatusIndicator'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { getDemoMode } from '../../../hooks/useDemoMode'
@@ -9,6 +9,7 @@ import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { POLL_INTERVAL_MS, UI_FEEDBACK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 import { agentFetch } from '../../../hooks/mcp/shared'
 import { copyToClipboard } from '../../../lib/clipboard'
+import { cn } from '../../../lib/cn'
 
 interface ClusterEvent {
   type: string
@@ -26,6 +27,11 @@ interface ClusterEvent {
 interface Props {
   data: Record<string, unknown>
 }
+
+/** Events displayed per page. */
+const PAGE_SIZE = 20
+
+type TypeFilter = 'all' | 'Warning' | 'Normal'
 
 // Skeleton component for loading state
 function EventsSkeleton() {
@@ -67,9 +73,10 @@ export function EventsDrillDown({ data }: Props) {
   const [copied, setCopied] = useState(false)
   const refreshIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  // Pagination constants (UI controls will be added in task #8)
-  const currentPage = 1
-  const pageSize = 20
+  // Interactive controls
+  const [currentPage, setCurrentPage] = useState(1)
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all')
+  const [searchQuery, setSearchQuery] = useState('')
 
   // Fetch events from local agent (no auth required)
   const refetch = useCallback(async (silent = false) => {
@@ -120,26 +127,60 @@ export function EventsDrillDown({ data }: Props) {
     }
   }, [refetch])
 
-  // Filter by object name, sort by lastSeen, and paginate
-  const { filteredEvents } = useMemo(() => {
+  // Reset to page 1 when the viewed resource changes so stale page numbers
+  // don't persist across drilldown navigations to different resources.
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [objectName, clusterShort, namespace])
+
+  // Reset to page 1 when filters change so users always see results from the top.
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [typeFilter, searchQuery])
+
+  // Full pre-paginated dataset: apply objectName, type, and search filters then sort.
+  // Stat tiles read from this so they always reflect the complete matching set,
+  // not just the items visible on the current page.
+  const allFilteredSortedEvents = useMemo(() => {
     let result = events
 
-    // Filter by object name if specified
     if (objectName) {
       result = result.filter(e => e.object.toLowerCase().includes(objectName.toLowerCase()))
     }
+    if (typeFilter !== 'all') {
+      result = result.filter(e => e.type === typeFilter)
+    }
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase()
+      result = result.filter(e =>
+        e.reason.toLowerCase().includes(q) ||
+        e.message.toLowerCase().includes(q) ||
+        e.object.toLowerCase().includes(q)
+      )
+    }
 
-    // Sort by lastSeen (descending)
-    result = [...result].sort((a, b) => {
-      return new Date(b.lastSeen || 0).getTime() - new Date(a.lastSeen || 0).getTime()
-    })
+    return [...result].sort((a, b) =>
+      new Date(b.lastSeen || 0).getTime() - new Date(a.lastSeen || 0).getTime()
+    )
+  }, [events, objectName, typeFilter, searchQuery])
 
-    // Paginate
-    const start = (currentPage - 1) * pageSize
-    result = result.slice(start, start + pageSize)
+  // Paginated slice used only for rendering the event list
+  const pagedEvents = useMemo(() => {
+    const start = (currentPage - 1) * PAGE_SIZE
+    return allFilteredSortedEvents.slice(start, start + PAGE_SIZE)
+  }, [allFilteredSortedEvents, currentPage])
 
-    return { filteredEvents: result }
-  }, [events, objectName, currentPage])
+  const totalPages = Math.max(1, Math.ceil(allFilteredSortedEvents.length / PAGE_SIZE))
+
+  const warningCount = allFilteredSortedEvents.filter(e => e.type === 'Warning').length
+  const normalCount = allFilteredSortedEvents.filter(e => e.type === 'Normal').length
+
+  const hasActiveFilters = typeFilter !== 'all' || searchQuery !== ''
+
+  const clearFilters = () => {
+    setTypeFilter('all')
+    setSearchQuery('')
+  }
 
   const copyCommand = () => {
     const cmd = objectName
@@ -228,29 +269,62 @@ export function EventsDrillDown({ data }: Props) {
         </button>
       </div>
 
-      {/* Stats */}
+      {/* Stats — computed from the full filtered set, not from the current page */}
       <div className="grid grid-cols-3 gap-4">
         <div className="p-4 rounded-lg bg-card/50 border border-border">
-          <div className="text-2xl font-bold text-foreground">{filteredEvents.length}</div>
+          <div className="text-2xl font-bold text-foreground">{allFilteredSortedEvents.length}</div>
           <div className="text-sm text-muted-foreground">{t('drilldown.events.totalEvents', 'Total Events')}</div>
         </div>
         <div className="p-4 rounded-lg bg-card/50 border border-border">
-          <div className="text-2xl font-bold text-yellow-400">
-            {filteredEvents.filter(e => e.type === 'Warning').length}
-          </div>
+          <div className="text-2xl font-bold text-yellow-400">{warningCount}</div>
           <div className="text-sm text-muted-foreground">{t('common.warnings', 'Warnings')}</div>
         </div>
         <div className="p-4 rounded-lg bg-card/50 border border-border">
-          <div className="text-2xl font-bold text-green-400">
-            {filteredEvents.filter(e => e.type === 'Normal').length}
-          </div>
+          <div className="text-2xl font-bold text-green-400">{normalCount}</div>
           <div className="text-sm text-muted-foreground">{t('common.normal')}</div>
         </div>
       </div>
 
+      {/* Search and type filter */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[200px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <input
+            type="text"
+            placeholder={t('common.search', 'Search')}
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            className="w-full pl-10 pr-4 py-2 bg-card/50 border border-border rounded-lg text-sm focus:outline-hidden focus:ring-2 focus:ring-primary/50"
+            data-testid="events-search"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Filter className="w-4 h-4 text-muted-foreground" />
+          <select
+            value={typeFilter}
+            onChange={e => setTypeFilter(e.target.value as TypeFilter)}
+            className="bg-card/50 border border-border rounded-lg px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-primary/50"
+            data-testid="events-type-filter"
+          >
+            <option value="all">{t('drilldown.events.allTypes', 'All Types')}</option>
+            <option value="Warning">{t('common.warning', 'Warning')}</option>
+            <option value="Normal">{t('common.normal', 'Normal')}</option>
+          </select>
+        </div>
+        {hasActiveFilters && (
+          <button
+            onClick={clearFilters}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            data-testid="events-clear-filters"
+          >
+            {t('common.clearFilters', 'Clear filters')}
+          </button>
+        )}
+      </div>
+
       {/* Events List */}
       <div className="space-y-2">
-        {filteredEvents.map((event, i) => (
+        {pagedEvents.map((event, i) => (
           <div
             key={i}
             className={`p-4 rounded-lg border-l-4 ${
@@ -283,31 +357,99 @@ export function EventsDrillDown({ data }: Props) {
         ))}
       </div>
 
-      {filteredEvents.length === 0 && (
+      {/* Empty state when filters produce no results */}
+      {allFilteredSortedEvents.length === 0 && (
         <div className="space-y-4">
           <div className="text-center py-6">
-            <p className="text-muted-foreground">{t('drilldown.events.noEventsFoundFor', { name: objectName || clusterShort, defaultValue: `No events found for ${objectName || clusterShort}` })}</p>
-            <p className="text-xs text-muted-foreground mt-1">{t('drilldown.events.eventsExpiredHint', 'Events may have expired or require authentication')}</p>
+            {hasActiveFilters ? (
+              <>
+                <p className="text-muted-foreground">
+                  {t('drilldown.events.noEventsMatchFilters', 'No events match the active filters.')}
+                </p>
+                <button
+                  onClick={clearFilters}
+                  className="mt-2 text-sm text-primary hover:text-primary/80 transition-colors"
+                >
+                  {t('common.clearFilters', 'Clear filters')}
+                </button>
+              </>
+            ) : (
+              <>
+                <p className="text-muted-foreground">{t('drilldown.events.noEventsFoundFor', { name: objectName || clusterShort, defaultValue: `No events found for ${objectName || clusterShort}` })}</p>
+                <p className="text-xs text-muted-foreground mt-1">{t('drilldown.events.eventsExpiredHint', 'Events may have expired or require authentication')}</p>
+              </>
+            )}
           </div>
 
-          {/* Kubectl fallback */}
-          <div className="p-4 rounded-lg bg-card/50 border border-border">
-            <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
-              <Terminal className="w-4 h-4" />
-              {t('drilldown.actions.getEvents', 'Get Events via kubectl')}
-            </h4>
-            <div className="flex items-center justify-between p-2 rounded bg-background/50 font-mono text-xs">
-              <code className="text-muted-foreground truncate">
-                kubectl --context {clusterShort} get events{objectName ? ` --field-selector involvedObject.name=${objectName}` : ''}{namespace ? ` -n ${namespace}` : ' -A'} --sort-by=.lastTimestamp
-              </code>
-              <button
-                onClick={copyCommand}
-                className="ml-2 p-1 hover:bg-card rounded shrink-0"
-                title={t('drilldown.tooltips.copyCommand')}
-              >
-                {copied ? <CheckCircle className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3 text-muted-foreground" />}
-              </button>
+          {/* Kubectl fallback — only shown when no active filters are hiding results */}
+          {!hasActiveFilters && (
+            <div className="p-4 rounded-lg bg-card/50 border border-border">
+              <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
+                <Terminal className="w-4 h-4" />
+                {t('drilldown.actions.getEvents', 'Get Events via kubectl')}
+              </h4>
+              <div className="flex items-center justify-between p-2 rounded bg-background/50 font-mono text-xs">
+                <code className="text-muted-foreground truncate">
+                  kubectl --context {clusterShort} get events{objectName ? ` --field-selector involvedObject.name=${objectName}` : ''}{namespace ? ` -n ${namespace}` : ' -A'} --sort-by=.lastTimestamp
+                </code>
+                <button
+                  onClick={copyCommand}
+                  className="ml-2 p-1 hover:bg-card rounded shrink-0"
+                  title={t('drilldown.tooltips.copyCommand')}
+                >
+                  {copied ? <CheckCircle className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3 text-muted-foreground" />}
+                </button>
+              </div>
             </div>
+          )}
+        </div>
+      )}
+
+      {/* Pagination controls — shown only when there is more than one page */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between pt-2 text-sm text-muted-foreground border-t border-border">
+          <span>
+            {t('drilldown.events.showingRange', {
+              from: (currentPage - 1) * PAGE_SIZE + 1,
+              to: Math.min(currentPage * PAGE_SIZE, allFilteredSortedEvents.length),
+              total: allFilteredSortedEvents.length,
+              defaultValue: `Showing ${(currentPage - 1) * PAGE_SIZE + 1}–${Math.min(currentPage * PAGE_SIZE, allFilteredSortedEvents.length)} of ${allFilteredSortedEvents.length}`,
+            })}
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setCurrentPage(p => p - 1)}
+              disabled={currentPage === 1}
+              aria-label={t('common.previousPage', 'Previous page')}
+              className={cn(
+                'p-1.5 rounded-lg transition-colors',
+                currentPage === 1
+                  ? 'text-muted-foreground/40 cursor-not-allowed'
+                  : 'hover:bg-card text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <span className="px-2 tabular-nums">
+              {t('drilldown.events.pageOf', {
+                page: currentPage,
+                total: totalPages,
+                defaultValue: `Page ${currentPage} of ${totalPages}`,
+              })}
+            </span>
+            <button
+              onClick={() => setCurrentPage(p => p + 1)}
+              disabled={currentPage === totalPages}
+              aria-label={t('common.nextPage', 'Next page')}
+              className={cn(
+                'p-1.5 rounded-lg transition-colors',
+                currentPage === totalPages
+                  ? 'text-muted-foreground/40 cursor-not-allowed'
+                  : 'hover:bg-card text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
           </div>
         </div>
       )}

--- a/web/src/components/drilldown/views/__tests__/EventsDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/EventsDrillDown.test.tsx
@@ -1,20 +1,33 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import React from 'react'
 
-vi.mock('../../../../lib/demoMode', () => ({
-  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
-  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
-  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
-  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
-  isFeatureEnabled: () => true,
+// agentFetch — controlled per-test via mockResolvedValueOnce
+vi.mock('../../../../hooks/mcp/shared', () => ({
+  agentFetch: vi.fn(),
 }))
 
+// getDemoMode returns false by default so the component actually fetches.
+// Individual tests that need demo-mode blocking can override it.
 vi.mock('../../../../hooks/useDemoMode', () => ({
-  getDemoMode: () => true, default: () => true,
-  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
-  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
-  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  getDemoMode: vi.fn().mockReturnValue(false),
+  default: () => false,
+  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => true,
+  isDemoModeForced: false,
+  isNetlifyDeployment: false,
+  canToggleDemoMode: () => true,
+  isDemoToken: () => false,
+  setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => false, getDemoMode: () => false, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => false, hasRealToken: () => true, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
 }))
 
 vi.mock('../../../../lib/analytics', () => ({
@@ -29,7 +42,14 @@ vi.mock('../../../../hooks/useTokenUsage', () => ({
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
-  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  useTranslation: () => ({
+    t: (key: string, opts?: string | Record<string, unknown>) => {
+      if (typeof opts === 'string') return opts
+      if (opts && typeof opts === 'object' && 'defaultValue' in opts) return opts.defaultValue as string
+      return key
+    },
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
   Trans: ({ children }: { children: React.ReactNode }) => children,
 }))
 
@@ -43,25 +63,358 @@ vi.mock('../../../../lib/clipboard', () => ({
 }))
 
 vi.mock('../../../charts/StatusIndicator', () => ({
-  StatusIndicator: ({ status, size }: { status: string; size?: string }) => <div data-testid="status-indicator">{status}</div>,
+  StatusIndicator: ({ status }: { status: string }) => <div data-testid="status-indicator">{status}</div>,
 }))
 
 vi.mock('../../../ui/ClusterBadge', () => ({
-  ClusterBadge: ({ cluster, size }: { cluster: string; size?: string }) => <span data-testid="cluster-badge">{cluster}</span>,
+  ClusterBadge: ({ cluster }: { cluster: string }) => <span data-testid="cluster-badge">{cluster}</span>,
 }))
 
-vi.mock('../../../../hooks/mcp/shared', () => ({
-  agentFetch: vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({ events: [] }) })),
+vi.mock('../../../../lib/cn', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
 }))
 
 import { EventsDrillDown } from '../EventsDrillDown'
+import { agentFetch } from '../../../../hooks/mcp/shared'
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function mkEvent(overrides: Partial<{
+  type: string; reason: string; message: string
+  object: string; namespace: string; cluster: string; count: number; lastSeen: string
+}> = {}) {
+  return {
+    type: 'Normal',
+    reason: 'Started',
+    message: 'Started container',
+    object: 'pod/my-pod',
+    namespace: 'default',
+    cluster: 'c1',
+    count: 1,
+    lastSeen: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+/** Make agentFetch resolve with the given events for the next call. */
+function mockEvents(events: ReturnType<typeof mkEvent>[]) {
+  vi.mocked(agentFetch).mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ events }),
+  } as Response)
+}
+
+/** agentFetch returns a network failure — component shows error/empty state. */
+function mockFetchError() {
+  vi.mocked(agentFetch).mockResolvedValueOnce({
+    ok: false,
+    json: () => Promise.resolve({}),
+  } as Response)
+}
+
+const BASE_DATA = { cluster: 'c1', namespace: 'ns1' }
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('EventsDrillDown', () => {
-  it('renders without crashing', () => {
-    const { container } = render(<EventsDrillDown data={{ cluster: 'c1', namespace: 'ns1', events: [] }} />)
-    expect(container).toBeTruthy()
-    // In demo mode, component skips loading and shows empty state immediately
-    // Check for the "No events found" message or Back button navigation
-    expect(container.textContent).toBeTruthy()
+  beforeEach(() => {
+    vi.mocked(agentFetch).mockReset()
+  })
+
+  it('renders without crashing', async () => {
+    mockFetchError()
+    await act(async () => {
+      render(<EventsDrillDown data={BASE_DATA} />)
+    })
+    expect(document.body).toBeTruthy()
+  })
+
+  describe('stat tiles reflect full filtered set, not the current page', () => {
+    it('shows correct total when events exceed one page', async () => {
+      const events = Array.from({ length: 25 }, (_, i) => mkEvent({ reason: `R${i}` }))
+      mockEvents(events)
+
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      // All 25 are Normal so both Total and Normal tiles show "25" — use getAllByText
+      expect(screen.getAllByText('25').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByText('Total Events')).toBeTruthy()
+    })
+
+    it('shows correct Warning and Normal counts across all pages', async () => {
+      const warnings = Array.from({ length: 15 }, (_, i) => mkEvent({ type: 'Warning', reason: `W${i}` }))
+      const normals  = Array.from({ length: 15 }, (_, i) => mkEvent({ type: 'Normal',  reason: `N${i}` }))
+      mockEvents([...warnings, ...normals])
+
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      // Total = 30
+      expect(screen.getByText('30')).toBeTruthy()
+      // Both warning and normal counts should be 15, not the partial page-1 counts
+      const fifteens = screen.getAllByText('15')
+      expect(fifteens.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('type filter', () => {
+    it('renders the type filter select', async () => {
+      mockEvents([mkEvent()])
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+      expect(screen.getByTestId('events-type-filter')).toBeTruthy()
+    })
+
+    it('filters list and updates stat tile total when Warning is selected', async () => {
+      mockEvents([
+        mkEvent({ type: 'Warning', reason: 'BackOff' }),
+        mkEvent({ type: 'Normal',  reason: 'Started' }),
+        mkEvent({ type: 'Warning', reason: 'Failed' }),
+      ])
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      const select = screen.getByTestId('events-type-filter') as HTMLSelectElement
+      await act(async () => {
+        fireEvent.change(select, { target: { value: 'Warning' } })
+      })
+
+      // Only 2 warnings remain — total and warning tiles both show 2
+      expect(screen.getAllByText('2').length).toBeGreaterThanOrEqual(1)
+      // Normal event should not appear in the list
+      expect(screen.queryByText('Started')).toBeNull()
+    })
+
+    it('shows "Clear filters" button when a filter is active', async () => {
+      mockEvents([mkEvent()])
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      const select = screen.getByTestId('events-type-filter') as HTMLSelectElement
+      await act(async () => {
+        fireEvent.change(select, { target: { value: 'Warning' } })
+      })
+
+      expect(screen.getByTestId('events-clear-filters')).toBeTruthy()
+    })
+
+    it('restores full list when Clear filters is clicked', async () => {
+      mockEvents([
+        mkEvent({ type: 'Warning', reason: 'BackOff' }),
+        mkEvent({ type: 'Normal',  reason: 'Started' }),
+      ])
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      const select = screen.getByTestId('events-type-filter') as HTMLSelectElement
+      await act(async () => {
+        fireEvent.change(select, { target: { value: 'Warning' } })
+      })
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('events-clear-filters'))
+      })
+
+      expect(screen.getByText('BackOff')).toBeTruthy()
+      expect(screen.getByText('Started')).toBeTruthy()
+    })
+  })
+
+  describe('search', () => {
+    it('renders the search input', async () => {
+      mockEvents([mkEvent()])
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+      expect(screen.getByTestId('events-search')).toBeTruthy()
+    })
+
+    it('filters events by reason text', async () => {
+      mockEvents([
+        mkEvent({ reason: 'BackOff',  message: 'back-off restarting failed container' }),
+        mkEvent({ reason: 'Pulled',   message: 'Successfully pulled image' }),
+        mkEvent({ reason: 'Created',  message: 'Created container' }),
+      ])
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      const input = screen.getByTestId('events-search') as HTMLInputElement
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'BackOff' } })
+      })
+
+      expect(screen.getByText('BackOff')).toBeTruthy()
+      expect(screen.queryByText('Pulled')).toBeNull()
+      expect(screen.queryByText('Created')).toBeNull()
+    })
+
+    it('filters events by message text (case-insensitive)', async () => {
+      mockEvents([
+        mkEvent({ reason: 'E1', message: 'OOMKilled container restart' }),
+        mkEvent({ reason: 'E2', message: 'Successfully pulled image' }),
+      ])
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      const input = screen.getByTestId('events-search') as HTMLInputElement
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'oomkilled' } })
+      })
+
+      expect(screen.getByText('E1')).toBeTruthy()
+      expect(screen.queryByText('E2')).toBeNull()
+    })
+
+    it('shows "no events match filters" when search yields nothing', async () => {
+      mockEvents([mkEvent({ reason: 'Pulled' })])
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      const input = screen.getByTestId('events-search') as HTMLInputElement
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'xyzzy-no-match' } })
+      })
+
+      expect(screen.getByText('No events match the active filters.')).toBeTruthy()
+    })
+
+    it('does not show kubectl fallback when filters are active', async () => {
+      mockEvents([mkEvent({ reason: 'Pulled' })])
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      const input = screen.getByTestId('events-search') as HTMLInputElement
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'xyzzy-no-match' } })
+      })
+
+      expect(screen.queryByText('Get Events via kubectl')).toBeNull()
+    })
+  })
+
+  describe('pagination', () => {
+    it('does not render pagination when events fit on one page', async () => {
+      mockEvents(Array.from({ length: 5 }, (_, i) => mkEvent({ reason: `R${i}` })))
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      expect(screen.queryByText(/^Page 1 of/)).toBeNull()
+    })
+
+    it('renders pagination controls when events exceed PAGE_SIZE (20)', async () => {
+      mockEvents(Array.from({ length: 25 }, (_, i) => mkEvent({ reason: `R${i}` })))
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      expect(screen.getByText('Page 1 of 2')).toBeTruthy()
+    })
+
+    it('shows correct range label on page 1', async () => {
+      mockEvents(Array.from({ length: 25 }, (_, i) => mkEvent({ reason: `R${i}` })))
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      expect(screen.getByText('Showing 1–20 of 25')).toBeTruthy()
+    })
+
+    it('advances to page 2 and shows correct range', async () => {
+      mockEvents(Array.from({ length: 25 }, (_, i) =>
+        mkEvent({ reason: `R${i}`, lastSeen: new Date(Date.now() - i * 1000).toISOString() })
+      ))
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('Next page'))
+      })
+
+      expect(screen.getByText('Page 2 of 2')).toBeTruthy()
+      expect(screen.getByText('Showing 21–25 of 25')).toBeTruthy()
+    })
+
+    it('disables Previous button on page 1', async () => {
+      mockEvents(Array.from({ length: 25 }, (_, i) => mkEvent({ reason: `R${i}` })))
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      expect((screen.getByLabelText('Previous page') as HTMLButtonElement).disabled).toBe(true)
+    })
+
+    it('disables Next button on the last page', async () => {
+      mockEvents(Array.from({ length: 25 }, (_, i) =>
+        mkEvent({ reason: `R${i}`, lastSeen: new Date(Date.now() - i * 1000).toISOString() })
+      ))
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('Next page'))
+      })
+
+      expect((screen.getByLabelText('Next page') as HTMLButtonElement).disabled).toBe(true)
+    })
+
+    it('resets to page 1 when type filter changes', async () => {
+      // 25 warnings → page controls appear; switch to Normal → reset to page 1
+      mockEvents(Array.from({ length: 25 }, (_, i) =>
+        mkEvent({ type: 'Warning', reason: `W${i}`, lastSeen: new Date(Date.now() - i * 1000).toISOString() })
+      ))
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      // Advance to page 2
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('Next page'))
+      })
+      expect(screen.getByText('Page 2 of 2')).toBeTruthy()
+
+      // Switch filter → no Normal events exist, but the important thing is page reset
+      const select = screen.getByTestId('events-type-filter')
+      await act(async () => {
+        fireEvent.change(select, { target: { value: 'Normal' } })
+      })
+
+      // Page 2 gone — either empty state or page 1 (no Normal events matches empty state)
+      expect(screen.queryByText('Page 2 of 2')).toBeNull()
+    })
+
+    it('resets to page 1 when search query changes', async () => {
+      mockEvents(Array.from({ length: 25 }, (_, i) =>
+        mkEvent({ reason: `Alpha${i}`, lastSeen: new Date(Date.now() - i * 1000).toISOString() })
+      ))
+      await act(async () => {
+        render(<EventsDrillDown data={BASE_DATA} />)
+      })
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('Next page'))
+      })
+      expect(screen.getByText('Page 2 of 2')).toBeTruthy()
+
+      const input = screen.getByTestId('events-search')
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'Alpha' } })
+      })
+
+      // All 25 Alpha events still match — but page resets to 1
+      expect(screen.getByText('Page 1 of 2')).toBeTruthy()
+    })
   })
 })


### PR DESCRIPTION
## SUMMARY

This PR completes the Events Drilldown experience by adding search, type filtering, and pagination support. It also fixes inaccurate event statistics by calculating counts from the complete filtered dataset rather than the currently displayed page. The primary changes are in `EventsDrillDown.tsx`, with corresponding test coverage added in `EventsDrillDown.test.tsx`.

## FIX

* The Events Drilldown had an unfinished pagination implementation that limited users to the first 20 events despite additional data being available.
* Event statistics were calculated from paginated results, causing Total Events, Warning, and Normal counts to be inaccurate when multiple pages existed.
* Added search and type filtering controls to improve event discovery and analysis.
* Added pagination controls to allow navigation through the full event list.
* Separated filtered event aggregation from paginated rendering so statistics always reflect the complete filtered dataset.
* Reset pagination when the viewed resource or active filters change to avoid stale page states.
* Improved empty-state handling by distinguishing between no available events and no results matching active filters.
* Added comprehensive tests covering statistics, filtering, search, pagination behavior, and page reset scenarios.
