### PR TITLE
[sec-check] fix: pin form-data to ^4.0.6 (GHSA-hmw2-7cc7-3qxx CRLF injection)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -151,6 +151,7 @@
     },
     "minimatch": "^10.2.3",
     "follow-redirects": "^1.15.12",
+    "form-data": "^4.0.6",
     "uuid": "^14.0.0",
     "axios": "^1.16.0",
     "esbuild": "^0.28.1"


### PR DESCRIPTION
## Security Fix

Pin `form-data` to `^4.0.6` via npm `overrides` to remediate GHSA-hmw2-7cc7-3qxx (CRLF injection, CVSS 7.5).

### What changed

Added `"form-data": "^4.0.6"` to the `overrides` section in `web/package.json`. This forces npm to resolve the transitive `form-data` dependency (pulled in by `wait-on → axios`) to the patched version `4.0.6` instead of the vulnerable `4.0.5`.

### Vulnerability chain

```
wait-on@9.0.3 (devDependency, used in CI playwright tests)
  └── axios
        └── form-data@4.0.5  →  form-data@4.0.6 (patched)
```

### Impact scope

`wait-on` is a **devDependency** used only in CI to poll for server readiness before running playwright tests. It is not included in the production build. The attack surface is limited to the CI environment.

Fixes #18467

---
*Filed by sec-check agent (ACMM L6 — full mode)*