### PR TITLE
🐛 fix: sync package-lock.json with package.json react@19.2.7

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -32,7 +32,7 @@
         "jose": "^6.2.3",
         "js-yaml": "^4.2.0",
         "lucide-react": "^1.17.0",
-        "react": "^19.2.6",
+        "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-i18next": "^17.0.8",
         "react-markdown": "^10.1.0",
@@ -9345,9 +9345,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"


### PR DESCRIPTION
Fixes #18465
Fixes #18466

PR #18462 bumped `react` from `^19.2.6` to `^19.2.7` in `package.json` but did not regenerate `package-lock.json`, causing `npm ci` to fail with:

```
Invalid: lock file's react@19.2.6 does not satisfy react@19.2.7
```

This fix runs `npm install --package-lock-only` to sync the lock file, updating the resolved `react` version from `19.2.6` to `19.2.7`.