### PR TITLE
[sec-check] fix: add K8s name validation to non-MCP handler entry points

### DIFF
--- a/pkg/api/handlers/gateway.go
+++ b/pkg/api/handlers/gateway.go
@@ -50,6 +50,10 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	if err := validateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(c.Context(), gatewayDefaultTimeout)
 	defer cancel()
 
@@ -90,6 +94,10 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 	// Optional filters
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
+
+	if err := validateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), gatewayDefaultTimeout)
 	defer cancel()
@@ -166,6 +174,13 @@ func (h *GatewayHandlers) GetGateway(c *fiber.Ctx) error {
 	namespace := c.Params("namespace")
 	name := c.Params("name")
 
+	if err := validateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+	if err := validateK8sName("name", name); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(c.Context(), gatewayDefaultTimeout)
 	defer cancel()
 
@@ -193,6 +208,13 @@ func (h *GatewayHandlers) GetHTTPRoute(c *fiber.Ctx) error {
 	cluster := c.Params("cluster")
 	namespace := c.Params("namespace")
 	name := c.Params("name")
+
+	if err := validateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+	if err := validateK8sName("name", name); err != nil {
+		return err
+	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), gatewayDefaultTimeout)
 	defer cancel()

--- a/pkg/api/handlers/mcs.go
+++ b/pkg/api/handlers/mcs.go
@@ -49,6 +49,10 @@ func (h *MCSHandlers) ListServiceExports(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	if err := validateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(c.Context(), mcsDefaultTimeout)
 	defer cancel()
 
@@ -84,6 +88,10 @@ func (h *MCSHandlers) ListServiceImports(c *fiber.Ctx) error {
 	// Optional filters
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
+
+	if err := validateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), mcsDefaultTimeout)
 	defer cancel()
@@ -155,6 +163,13 @@ func (h *MCSHandlers) GetServiceExport(c *fiber.Ctx) error {
 	namespace := c.Params("namespace")
 	name := c.Params("name")
 
+	if err := validateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+	if err := validateK8sName("name", name); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(c.Context(), mcsDefaultTimeout)
 	defer cancel()
 
@@ -182,6 +197,13 @@ func (h *MCSHandlers) GetServiceImport(c *fiber.Ctx) error {
 	cluster := c.Params("cluster")
 	namespace := c.Params("namespace")
 	name := c.Params("name")
+
+	if err := validateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+	if err := validateK8sName("name", name); err != nil {
+		return err
+	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), mcsDefaultTimeout)
 	defer cancel()

--- a/pkg/api/handlers/namespaces.go
+++ b/pkg/api/handlers/namespaces.go
@@ -71,6 +71,9 @@ func (h *NamespaceHandler) ListNamespaces(c *fiber.Ctx) error {
 	if cluster == "" {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster parameter required")
 	}
+	if err := validateK8sName("cluster", cluster); err != nil {
+		return err
+	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), nsDefaultTimeout)
 	defer cancel()
@@ -109,6 +112,12 @@ func (h *NamespaceHandler) GetNamespaceAccess(c *fiber.Ctx) error {
 	name := c.Params("name")
 	if cluster == "" || name == "" {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster and namespace name are required")
+	}
+	if err := validateK8sName("cluster", cluster); err != nil {
+		return err
+	}
+	if err := validateK8sName("namespace", name); err != nil {
+		return err
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), nsDefaultTimeout)

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -234,6 +234,10 @@ func (h *RBACHandler) ListK8sServiceAccounts(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	if err := validateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(c.Context(), k8s.RBACDefaultTimeout)
 	defer cancel()
 
@@ -324,6 +328,10 @@ func (h *RBACHandler) ListK8sRoles(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	includeSystem := c.Query("includeSystem") == "true"
 
+	if err := validateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(c.Context(), k8s.RBACDefaultTimeout)
 	defer cancel()
 
@@ -371,6 +379,10 @@ func (h *RBACHandler) ListK8sRoleBindings(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 	includeSystem := c.Query("includeSystem") == "true"
+
+	if err := validateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), k8s.RBACDefaultTimeout)
 	defer cancel()
@@ -435,6 +447,9 @@ func (h *RBACHandler) ListK8sUsers(c *fiber.Ctx) error {
 	if cluster == "" {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster parameter required")
 	}
+	if err := validateK8sName("cluster", cluster); err != nil {
+		return err
+	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), k8s.RBACDefaultTimeout)
 	defer cancel()
@@ -469,6 +484,9 @@ func (h *RBACHandler) ListOpenShiftUsers(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	if cluster == "" {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster parameter required")
+	}
+	if err := validateK8sName("cluster", cluster); err != nil {
+		return err
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), rbacAnalysisTimeout)

--- a/pkg/api/handlers/validation.go
+++ b/pkg/api/handlers/validation.go
@@ -1,8 +1,11 @@
 package handlers
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/gofiber/fiber/v2"
 )
 
 // cronFieldCount is the number of fields in a standard cron expression.
@@ -60,4 +63,27 @@ func IsValidK8sVersion(version string) bool {
 		return false
 	}
 	return k8sVersionPattern.MatchString(version)
+}
+
+// validateK8sName checks that a non-empty string is a valid Kubernetes resource name.
+// Empty values are allowed (they mean "all" in query param context). Returns a
+// 400 fiber error with the parameter name in the message when invalid.
+func validateK8sName(param, value string) error {
+	if value == "" {
+		return nil
+	}
+	if !IsValidK8sName(value) {
+		return fiber.NewError(fiber.StatusBadRequest,
+			fmt.Sprintf("invalid %s: must be a valid Kubernetes resource name (lowercase alphanumeric, '-', '.')", param))
+	}
+	return nil
+}
+
+// validateClusterAndNamespace is a convenience helper that validates both the
+// cluster and namespace query parameters in a single call.
+func validateClusterAndNamespace(cluster, namespace string) error {
+	if err := validateK8sName("cluster", cluster); err != nil {
+		return err
+	}
+	return validateK8sName("namespace", namespace)
 }


### PR DESCRIPTION
## Problem

Four handler files (`mcs.go`, `gateway.go`, `rbac.go`, `namespaces.go`) accept `cluster`, `namespace`, and `name` from URL params or query strings and pass them directly to Kubernetes client calls **without any format validation**.

The MCP handlers (`mcp/resources.go`, `mcp/workloads.go`, `mcp/cluster.go`) and GPU handler (`gpu.go`) already validate via their own `mcpValidate*` functions — but **15 entry points** across these 4 files were missed.

**Impact**: Malformed or malicious K8s resource names reach the Kubernetes API before being rejected, producing confusing internal error messages instead of clean 400 responses.

## Solution

This PR takes two steps:

### 1. Add validation helpers to `pkg/api/handlers/validation.go`

Two small wrappers around the existing `IsValidK8sName()` that return proper `fiber.Error` 400 responses:

- **`validateK8sName(param, value string) error`** — validates a single parameter (empty values pass through, matching the existing MCP pattern for optional query params)
- **`validateClusterAndNamespace(cluster, namespace string) error`** — convenience helper for the common case

### 2. Apply to 15 handler entry points

| File | Handlers patched | Validations added |
|------|-----------------|-------------------|
| `mcs.go` | 4 | `validateClusterAndNamespace` + `validateK8sName("name")` |
| `gateway.go` | 4 | `validateClusterAndNamespace` + `validateK8sName("name")` |
| `rbac.go` | 5 | `validateClusterAndNamespace` / `validateK8sName("cluster")` |
| `namespaces.go` | 2 | `validateK8sName("cluster")` + `validateK8sName("namespace")` |

### Design decisions

- **Reuses `IsValidK8sName`** — was already defined in `validation.go` with the correct regex (`k8sNamePattern`). Adding error-returning wrappers avoids duplicating the regex or the length constant.
- **Empty values pass validation** — consistent with the MCP handler pattern. Optional query params (e.g. `?cluster=` meaning all clusters) are not rejected; mandatory URL params are caught by existing empty-string checks or downstream K8s calls.
- **Cluster-only handlers** (`ListK8sUsers`, `ListOpenShiftUsers`, `ListNamespaces`) call `validateK8sName("cluster", cluster)` directly.
- **`workloads.go`** — this file was removed upstream and is not part of this change. The original recommendation referenced a file (`workloads/handler.go`) that never existed in the upstream.

## Testing

- All 5 changed files parse cleanly (`gofmt -e`)
- The existing `IsValidK8sName` in `validation.go` and its regex `k8sNamePattern` are already used elsewhere in the codebase
- Existing empty-string checks (e.g. `if cluster == ""`) remain unchanged

## Related

Reuses validation infrastructure from:
- `pkg/api/handlers/validation.go:49-54` — `IsValidK8sName()`
- `pkg/api/handlers/validation.go:20` — `k8sNamePattern`

Extends the pattern used by:
- `pkg/api/handlers/mcp/validate.go` — MCP handlers use equivalent `mcpValidateName` / `mcpValidateClusterAndNamespace` in their own package

Signed-off-by: AdeshDeshmukh <adeshkd123@gmail.com>