### PR TITLE
[sec-check] fix: bump dompurify ^3.4.10 + pin @opentelemetry/core ^2.8.0 (GHSA-vxr8-fq34-vvx9, GHSA-8988-4f7v-96qf)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -74,7 +74,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "clsx": "^2.1.1",
-    "dompurify": "^3.4.8",
+    "dompurify": "^3.4.10",
     "echarts": "^6.1.0",
     "framer-motion": "^12.40.0",
     "i18next": "^26.3.1",
@@ -154,6 +154,7 @@
     "form-data": "^4.0.6",
     "uuid": "^14.0.0",
     "axios": "^1.16.0",
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "@opentelemetry/core": "^2.8.0"
   }
 }


### PR DESCRIPTION
## Security Fix

Two dependency security fixes bundled in one atomic commit:

### 1. dompurify ^3.4.8 → ^3.4.10 (GHSA-vxr8-fq34-vvx9)

**Severity**: low — CWE-693 Protection Mechanism Failure
**Advisory**: [GHSA-vxr8-fq34-vvx9](https://github.com/advisories/GHSA-vxr8-fq34-vvx9)

A Trusted Types policy set before `clearConfig()` survives the reset and can poison later `RETURN_TRUSTED_TYPE` output. `dompurify` is a **direct production dependency** used to sanitize SVG markup in `BlueprintReport.ts` and `ClusterLocations.tsx`. While the repo doesn't currently use `RETURN_TRUSTED_TYPE` mode, keeping the primary XSS defence library current is a hygiene requirement.

### 2. `@opentelemetry/core` override ^2.8.0 (GHSA-8988-4f7v-96qf)

**Severity**: medium (CVSS 5.3) — CWE-770 Allocation Without Limits
**Advisory**: [GHSA-8988-4f7v-96qf](https://github.com/advisories/GHSA-8988-4f7v-96qf)

Unbounded memory allocation in the W3C Baggage propagation parser. Maliciously crafted `baggage` HTTP headers can cause heap exhaustion. The production dependency chain is:

```
@netlify/blobs@10.7.9 (production dep)
  └── @netlify/otel@6.0.3
        └── @opentelemetry/core@2.7.1  ← was vulnerable (needs >=2.8.0)
```

`@netlify/otel@6.0.3` is the latest release and has not yet updated its peer dep. The `overrides` entry forces npm to resolve to the patched `2.8.0`.

### Changes

| File | Change |
|------|--------|
| `web/package.json` | `dompurify` `^3.4.8` → `^3.4.10` |
| `web/package.json` | Add `overrides["@opentelemetry/core"]` `^2.8.0` |

Fixes #18476
Fixes #18477

---
*Filed by sec-check agent (ACMM L6 — full mode)*