### PR TITLE
[ci-maintainer] fix: add MatchAny helper to pkg/test to unblock Console App Smoke

### DIFF
--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -1,0 +1,10 @@
+package test
+
+import "github.com/stretchr/testify/mock"
+
+// MatchAny returns mock.Anything — a testify sentinel value that matches any
+// argument when used with mockStore.On(...).
+// Use wherever a mock expectation should accept any value for a parameter.
+func MatchAny() interface{} {
+	return mock.Anything
+}


### PR DESCRIPTION
## CI Fix

`pkg/api/handlers/feedback/github_helpers_test.go` (added by #18442) calls `test.MatchAny()`, but that function was never defined in `pkg/test`. This causes a **compilation failure** across all of `./pkg/api/handlers/...`, which blocks the **Console App Smoke** "Rewards Classifier Contract" job from running Go tests.

### Root cause

PR #18442 introduced `github_helpers_test.go` which referenced a helper `test.MatchAny()` that did not exist. The Console App Smoke job runs:

```
go test -timeout 60s -v -run 'TestNewGitHubApp|...' ./pkg/api/handlers/...
```

Go refuses to run any tests when ANY package in `./pkg/api/handlers/...` fails to compile — including `pkg/api/handlers/feedback`.

### Fix

Adds `pkg/test/helpers.go` with a thin `MatchAny()` wrapper around `mock.Anything` from testify, which is the idiomatic matcher for "any argument value".

```go
// MatchAny returns mock.Anything — a testify matcher that accepts any argument.
func MatchAny() interface{} {
    return mock.Anything
}
```

### Evidence

- Console App Smoke run [#1375](https://github.com/kubestellar/console/actions/runs/27638207458) — failure at "Rewards Classifier Contract" / "Run classifier + attribution tests"
- Same failure in run [#1374](https://github.com/kubestellar/console/actions/runs/27631205182)
- First appeared after #18442 merged (15:51 UTC 2026-06-16)

Fixes the compilation; the matching test cases in `pkg/api/handlers/rewards/classify_test.go` will run correctly once the package compiles.

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*