### PR TITLE
[quality] add SSE transport session registry and console persistence helper tests

### DIFF
--- a/pkg/api/handlers/console_persistence_helpers_test.go
+++ b/pkg/api/handlers/console_persistence_helpers_test.go
@@ -1,0 +1,220 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/apis/v1alpha1"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ---------- requireAdmin ----------
+
+func TestRequireAdmin(t *testing.T) {
+	cases := []struct {
+		name       string
+		userStore  func(uid uuid.UUID) *test.MockStore
+		nilStore   bool
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "nil userStore bypasses check (dev/demo mode)",
+			nilStore:   true,
+			wantStatus: 200,
+			wantBody:   "ok",
+		},
+		{
+			name: "admin user is allowed",
+			userStore: func(uid uuid.UUID) *test.MockStore {
+				ms := new(test.MockStore)
+				ms.On("GetUser", mock.Anything, uid).Return(&models.User{
+					ID:   uid,
+					Role: "admin",
+				}, nil)
+				return ms
+			},
+			wantStatus: 200,
+			wantBody:   "ok",
+		},
+		{
+			name: "non admin user is forbidden",
+			userStore: func(uid uuid.UUID) *test.MockStore {
+				ms := new(test.MockStore)
+				ms.On("GetUser", mock.Anything, uid).Return(&models.User{
+					ID:   uid,
+					Role: "viewer",
+				}, nil)
+				return ms
+			},
+			wantStatus: 403,
+		},
+		{
+			name: "nil user is forbidden",
+			userStore: func(uid uuid.UUID) *test.MockStore {
+				ms := new(test.MockStore)
+				ms.On("GetUser", mock.Anything, uid).Return(nil, nil)
+				return ms
+			},
+			wantStatus: 403,
+		},
+		{
+			name: "store error returns 500",
+			userStore: func(uid uuid.UUID) *test.MockStore {
+				ms := new(test.MockStore)
+				ms.On("GetUser", mock.Anything, uid).Return(nil, errors.New("db down"))
+				return ms
+			},
+			wantStatus: 500,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			userID := uuid.New()
+
+			h := &ConsolePersistenceHandlers{}
+			if !tc.nilStore {
+				h.userStore = tc.userStore(userID)
+			}
+
+			app := fiber.New(fiber.Config{
+				ErrorHandler: func(c *fiber.Ctx, err error) error {
+					code := fiber.StatusInternalServerError
+					var fiberErr *fiber.Error
+					if errors.As(err, &fiberErr) {
+						code = fiberErr.Code
+					}
+					return c.Status(code).JSON(fiber.Map{"error": err.Error()})
+				},
+			})
+			app.Use(func(c *fiber.Ctx) error {
+				c.Locals("userID", userID)
+				return c.Next()
+			})
+			app.Get("/test", func(c *fiber.Ctx) error {
+				if err := h.requireAdmin(c); err != nil {
+					return err
+				}
+				return c.SendString("ok")
+			})
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantStatus, resp.StatusCode)
+		})
+	}
+}
+
+// ---------- setTerminalStatus ----------
+
+func TestSetTerminalStatus(t *testing.T) {
+	cases := []struct {
+		name            string
+		initialHistory  []v1alpha1.DeploymentHistoryEntry
+		phase           string
+		message         string
+		wantRevision    int
+		wantHistoryLen  int
+		wantUpdateCalls int
+	}{
+		{
+			name:            "empty history gets revision 1",
+			initialHistory:  nil,
+			phase:           "Complete",
+			message:         "all done",
+			wantRevision:    1,
+			wantHistoryLen:  1,
+			wantUpdateCalls: 1,
+		},
+		{
+			name: "increments max existing revision",
+			initialHistory: []v1alpha1.DeploymentHistoryEntry{
+				{Revision: 1, Phase: "Failed"},
+				{Revision: 3, Phase: "Failed"},
+			},
+			phase:           "Complete",
+			message:         "success",
+			wantRevision:    4,
+			wantHistoryLen:  3,
+			wantUpdateCalls: 1,
+		},
+		{
+			name:            "caps history at maxDeploymentHistory",
+			initialHistory:  makeHistoryEntries(maxDeploymentHistory),
+			phase:           "Failed",
+			message:         "cap test",
+			wantRevision:    maxDeploymentHistory + 1,
+			wantHistoryLen:  maxDeploymentHistory,
+			wantUpdateCalls: 1,
+		},
+		{
+			name:            "oversized history trimmed to max",
+			initialHistory:  makeHistoryEntries(maxDeploymentHistory + 10),
+			phase:           "Failed",
+			message:         "overflow",
+			wantRevision:    maxDeploymentHistory + 11,
+			wantHistoryLen:  maxDeploymentHistory,
+			wantUpdateCalls: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &ConsolePersistenceHandlers{}
+			wd := &v1alpha1.WorkloadDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-wd"},
+				Status: v1alpha1.WorkloadDeploymentStatus{
+					History: tc.initialHistory,
+				},
+			}
+
+			updateCalls := 0
+			h.setTerminalStatus(wd, tc.phase, tc.message, func(w *v1alpha1.WorkloadDeployment) {
+				updateCalls++
+			})
+
+			assert.Equal(t, tc.phase, wd.Status.Phase)
+			assert.NotNil(t, wd.Status.CompletedAt)
+			require.Len(t, wd.Status.History, tc.wantHistoryLen)
+			assert.Equal(t, tc.wantUpdateCalls, updateCalls)
+
+			// Check the last entry has the expected revision
+			lastEntry := wd.Status.History[len(wd.Status.History)-1]
+			assert.Equal(t, tc.wantRevision, lastEntry.Revision)
+			assert.Equal(t, tc.phase, lastEntry.Phase)
+			assert.Equal(t, tc.message, lastEntry.Message)
+		})
+	}
+}
+
+// makeHistoryEntries creates n history entries with sequential revisions.
+func makeHistoryEntries(n int) []v1alpha1.DeploymentHistoryEntry {
+	entries := make([]v1alpha1.DeploymentHistoryEntry, n)
+	for i := range entries {
+		entries[i] = v1alpha1.DeploymentHistoryEntry{
+			Revision: i + 1,
+			Phase:    "Failed",
+			Message:  "historic failure",
+		}
+	}
+	return entries
+}
+
+// ---------- checkClusterHealth ----------
+
+func TestCheckClusterHealth_NilClient(t *testing.T) {
+	h := &ConsolePersistenceHandlers{k8sClient: nil}
+	result := h.checkClusterHealth(context.Background(), "any-cluster")
+	assert.Equal(t, "unknown", string(result))
+}

--- a/pkg/api/handlers/sse_transport_test.go
+++ b/pkg/api/handlers/sse_transport_test.go
@@ -1,0 +1,463 @@
+package handlers
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testConcurrentRegistrations = 64
+	testConcurrentCancelCalls   = 16
+	testCancelWaitTimeout       = 100 * time.Millisecond
+)
+
+func resetSSEGlobalState(t *testing.T) uint64 {
+	t.Helper()
+
+	sseSessionsMu.Lock()
+	defer sseSessionsMu.Unlock()
+
+	start := sseSessionSeq
+	sseSessions = make(map[uuid.UUID]map[uint64]context.CancelFunc)
+
+	return start
+}
+
+func registryUserCount(t *testing.T) int {
+	t.Helper()
+
+	sseSessionsMu.Lock()
+	defer sseSessionsMu.Unlock()
+
+	return len(sseSessions)
+}
+
+func registrySessionCountForUser(t *testing.T, userID uuid.UUID) int {
+	t.Helper()
+
+	sseSessionsMu.Lock()
+	defer sseSessionsMu.Unlock()
+
+	return len(sseSessions[userID])
+}
+
+func registryHasUser(t *testing.T, userID uuid.UUID) bool {
+	t.Helper()
+
+	sseSessionsMu.Lock()
+	defer sseSessionsMu.Unlock()
+
+	_, ok := sseSessions[userID]
+	return ok
+}
+
+func registryHasSession(t *testing.T, userID uuid.UUID, id uint64) bool {
+	t.Helper()
+
+	sseSessionsMu.Lock()
+	defer sseSessionsMu.Unlock()
+
+	sessions, ok := sseSessions[userID]
+	if !ok {
+		return false
+	}
+
+	_, exists := sessions[id]
+	return exists
+}
+
+func currentSSESessionSeq(t *testing.T) uint64 {
+	t.Helper()
+
+	sseSessionsMu.Lock()
+	defer sseSessionsMu.Unlock()
+
+	return sseSessionSeq
+}
+
+func assertContextCancelled(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(testCancelWaitTimeout):
+		t.Fatal("expected context to be cancelled")
+	}
+}
+
+func assertContextNotCancelled(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("expected context to remain active")
+	default:
+	}
+}
+
+func TestRegisterSSESession(t *testing.T) {
+	testCases := []struct {
+		name string
+		run  func(t *testing.T, start uint64)
+	}{
+		{
+			name: "register single session returns next relative ID and creates user map",
+			run: func(t *testing.T, start uint64) {
+				userID := uuid.New()
+
+				id := registerSSESession(userID, func() {})
+
+				require.Equal(t, start+1, id)
+				assert.True(t, registryHasUser(t, userID))
+				assert.Equal(t, 1, registrySessionCountForUser(t, userID))
+				assert.True(t, registryHasSession(t, userID, id))
+			},
+		},
+		{
+			name: "register multiple sessions for same user returns incrementing IDs",
+			run: func(t *testing.T, start uint64) {
+				userID := uuid.New()
+
+				firstID := registerSSESession(userID, func() {})
+				secondID := registerSSESession(userID, func() {})
+				thirdID := registerSSESession(userID, func() {})
+
+				assert.Equal(t, start+1, firstID)
+				assert.Equal(t, start+2, secondID)
+				assert.Equal(t, start+3, thirdID)
+				assert.Equal(t, 3, registrySessionCountForUser(t, userID))
+			},
+		},
+		{
+			name: "register sessions for different users creates separate maps",
+			run: func(t *testing.T, start uint64) {
+				firstUserID := uuid.New()
+				secondUserID := uuid.New()
+
+				firstID := registerSSESession(firstUserID, func() {})
+				secondID := registerSSESession(secondUserID, func() {})
+
+				assert.Equal(t, start+1, firstID)
+				assert.Equal(t, start+2, secondID)
+				assert.Equal(t, 2, registryUserCount(t))
+				assert.Equal(t, 1, registrySessionCountForUser(t, firstUserID))
+				assert.Equal(t, 1, registrySessionCountForUser(t, secondUserID))
+			},
+		},
+		{
+			name: "IDs are monotonically increasing across users",
+			run: func(t *testing.T, _ uint64) {
+				firstUserID := uuid.New()
+				secondUserID := uuid.New()
+
+				firstID := registerSSESession(firstUserID, func() {})
+				secondID := registerSSESession(secondUserID, func() {})
+				thirdID := registerSSESession(firstUserID, func() {})
+
+				assert.Less(t, firstID, secondID)
+				assert.Less(t, secondID, thirdID)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			start := resetSSEGlobalState(t)
+			testCase.run(t, start)
+		})
+	}
+}
+
+func TestUnregisterSSESession(t *testing.T) {
+	testCases := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "unregister existing session removes it",
+			run: func(t *testing.T) {
+				userID := uuid.New()
+
+				firstID := registerSSESession(userID, func() {})
+				secondID := registerSSESession(userID, func() {})
+
+				unregisterSSESession(userID, firstID)
+
+				assert.False(t, registryHasSession(t, userID, firstID))
+				assert.True(t, registryHasSession(t, userID, secondID))
+				assert.Equal(t, 1, registrySessionCountForUser(t, userID))
+			},
+		},
+		{
+			name: "unregister last session for user cleans up user map",
+			run: func(t *testing.T) {
+				userID := uuid.New()
+
+				id := registerSSESession(userID, func() {})
+
+				unregisterSSESession(userID, id)
+
+				assert.False(t, registryHasUser(t, userID))
+				assert.Equal(t, 0, registryUserCount(t))
+			},
+		},
+		{
+			name: "unregister non existent session is safe",
+			run: func(t *testing.T) {
+				userID := uuid.New()
+
+				id := registerSSESession(userID, func() {})
+
+				assert.NotPanics(t, func() {
+					unregisterSSESession(userID, id+1000)
+				})
+				assert.True(t, registryHasSession(t, userID, id))
+				assert.Equal(t, 1, registrySessionCountForUser(t, userID))
+			},
+		},
+		{
+			name: "unregister non existent user is safe",
+			run: func(t *testing.T) {
+				userID := uuid.New()
+
+				assert.NotPanics(t, func() {
+					unregisterSSESession(userID, 1)
+				})
+				assert.False(t, registryHasUser(t, userID))
+				assert.Equal(t, 0, registryUserCount(t))
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resetSSEGlobalState(t)
+			testCase.run(t)
+		})
+	}
+}
+
+func TestCancelUserSSEStreams(t *testing.T) {
+	testCases := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "cancels all contexts for a user and removes user from registry",
+			run: func(t *testing.T) {
+				userID := uuid.New()
+
+				ctxOne, cancelOne := context.WithCancel(context.Background())
+				ctxTwo, cancelTwo := context.WithCancel(context.Background())
+				ctxThree, cancelThree := context.WithCancel(context.Background())
+
+				registerSSESession(userID, cancelOne)
+				registerSSESession(userID, cancelTwo)
+				registerSSESession(userID, cancelThree)
+
+				CancelUserSSEStreams(userID)
+
+				assertContextCancelled(t, ctxOne)
+				assertContextCancelled(t, ctxTwo)
+				assertContextCancelled(t, ctxThree)
+				assert.False(t, registryHasUser(t, userID))
+			},
+		},
+		{
+			name: "safe to call for user with no streams",
+			run: func(t *testing.T) {
+				userID := uuid.New()
+
+				assert.NotPanics(t, func() {
+					CancelUserSSEStreams(userID)
+				})
+				assert.False(t, registryHasUser(t, userID))
+			},
+		},
+		{
+			name: "does not affect other users streams",
+			run: func(t *testing.T) {
+				targetUserID := uuid.New()
+				otherUserID := uuid.New()
+
+				targetCtx, targetCancel := context.WithCancel(context.Background())
+				otherCtx, otherCancel := context.WithCancel(context.Background())
+
+				registerSSESession(targetUserID, targetCancel)
+				otherID := registerSSESession(otherUserID, otherCancel)
+
+				CancelUserSSEStreams(targetUserID)
+
+				assertContextCancelled(t, targetCtx)
+				assertContextNotCancelled(t, otherCtx)
+				assert.False(t, registryHasUser(t, targetUserID))
+				assert.True(t, registryHasUser(t, otherUserID))
+				assert.True(t, registryHasSession(t, otherUserID, otherID))
+
+				otherCancel()
+				assertContextCancelled(t, otherCtx)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resetSSEGlobalState(t)
+			testCase.run(t)
+		})
+	}
+}
+
+func TestSSETransportConstants(t *testing.T) {
+	durationCases := []struct {
+		name string
+		got  time.Duration
+		want time.Duration
+	}{
+		{
+			name: "sseOverallDeadline is 30 seconds",
+			got:  sseOverallDeadline,
+			want: 30 * time.Second,
+		},
+		{
+			name: "ssePerClusterTimeout is 10 seconds",
+			got:  ssePerClusterTimeout,
+			want: 10 * time.Second,
+		},
+		{
+			name: "sseSlowClusterTimeout is 3 seconds",
+			got:  sseSlowClusterTimeout,
+			want: 3 * time.Second,
+		},
+	}
+
+	for _, testCase := range durationCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.want, testCase.got)
+		})
+	}
+
+	limitCases := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{
+			name: "defaultWarningEventsLimit is 50",
+			got:  defaultWarningEventsLimit,
+			want: 50,
+		},
+		{
+			name: "maxWarningEventsLimit is 500",
+			got:  maxWarningEventsLimit,
+			want: 500,
+		},
+	}
+
+	for _, testCase := range limitCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.want, testCase.got)
+		})
+	}
+}
+
+func TestSSESessionRegistryConcurrentRegister(t *testing.T) {
+	start := resetSSEGlobalState(t)
+	userID := uuid.New()
+
+	startCh := make(chan struct{})
+	idsCh := make(chan uint64, testConcurrentRegistrations)
+
+	var wg sync.WaitGroup
+	for range testConcurrentRegistrations {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-startCh
+			idsCh <- registerSSESession(userID, func() {})
+		}()
+	}
+
+	close(startCh)
+	wg.Wait()
+	close(idsCh)
+
+	ids := make([]uint64, 0, testConcurrentRegistrations)
+	for id := range idsCh {
+		ids = append(ids, id)
+	}
+
+	require.Len(t, ids, testConcurrentRegistrations)
+
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i] < ids[j]
+	})
+
+	for index, id := range ids {
+		assert.Equal(t, start+uint64(index)+1, id)
+	}
+
+	assert.Equal(t, testConcurrentRegistrations, registrySessionCountForUser(t, userID))
+	assert.Equal(t, start+testConcurrentRegistrations, currentSSESessionSeq(t))
+}
+
+func TestSSESessionRegistryConcurrentRegisterAndCancel(t *testing.T) {
+	resetSSEGlobalState(t)
+
+	userID := uuid.New()
+	startCh := make(chan struct{})
+	ctxCh := make(chan context.Context, testConcurrentRegistrations)
+
+	var registerWG sync.WaitGroup
+	for range testConcurrentRegistrations {
+		registerWG.Add(1)
+		go func() {
+			defer registerWG.Done()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			ctxCh <- ctx
+
+			<-startCh
+			registerSSESession(userID, cancel)
+		}()
+	}
+
+	var cancelWG sync.WaitGroup
+	cancelWG.Add(1)
+	go func() {
+		defer cancelWG.Done()
+		<-startCh
+		for range testConcurrentCancelCalls {
+			CancelUserSSEStreams(userID)
+		}
+	}()
+
+	assert.NotPanics(t, func() {
+		close(startCh)
+		registerWG.Wait()
+		cancelWG.Wait()
+	})
+
+	close(ctxCh)
+
+	CancelUserSSEStreams(userID)
+
+	contexts := make([]context.Context, 0, testConcurrentRegistrations)
+	for ctx := range ctxCh {
+		contexts = append(contexts, ctx)
+	}
+
+	require.Len(t, contexts, testConcurrentRegistrations)
+	for _, ctx := range contexts {
+		assertContextCancelled(t, ctx)
+	}
+
+	assert.False(t, registryHasUser(t, userID))
+}


### PR DESCRIPTION
Fixes #18490

## Test Improvement

Adds 25+ unit tests covering two previously untested handler modules (1,203 lines combined, 0% test coverage):

### `sse_transport_test.go` — SSE session registry tests (420-line module)

| Function | Tests Added |
|----------|-------------|
| `registerSSESession` | Single registration, multi-user maps, incrementing IDs, monotonic across users |
| `unregisterSSESession` | Remove existing, user map cleanup on last session, safety on non-existent session/user |
| `CancelUserSSEStreams` | Cancel all contexts, user isolation (other users unaffected), no-op safety |
| Constants | `sseOverallDeadline` (30s), `ssePerClusterTimeout` (10s), `sseSlowClusterTimeout` (3s), warning event limits |
| Concurrent access | 64-goroutine concurrent registration, register + cancel race condition test |

The SSE session registry manages per-user stream lifecycle and is called from auth logout handlers. A regression could leak SSE connections or fail to cancel streams on logout.

### `console_persistence_helpers_test.go` — persistence handler tests

| Function | Tests Added |
|----------|-------------|
| `requireAdmin` | nil store bypass (dev/demo), admin allowed, non-admin 403, nil user 403, store error 500 |
| `setTerminalStatus` | Empty history → revision 1, revision increment from max, history capped at 50, oversized trim, update callback invoked |
| `checkClusterHealth` | nil k8sClient → ClusterHealthUnknown |

The `requireAdmin` function is security-critical (RBAC check for persistence endpoints). `setTerminalStatus` manages deployment history with a cap to prevent unbounded growth in etcd.

---
*Filed by quality agent (ACMM L4/L6 — full mode)*