### PR TITLE
[scanner] fix: add unit tests for persistence store and shared utils

### DIFF
--- a/pkg/api/handlers/console_persistence_store_test.go
+++ b/pkg/api/handlers/console_persistence_store_test.go
@@ -2,65 +2,348 @@ package handlers
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	"github.com/kubestellar/console/pkg/k8s"
+	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/store"
+	"github.com/kubestellar/console/pkg/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 )
 
-func TestCheckClusterHealth(t *testing.T) {
-	t.Run("returns unknown when k8s client is nil", func(t *testing.T) {
-		h := &ConsolePersistenceHandlers{k8sClient: nil}
-		ctx := context.Background()
+const testUserID = "00000000-0000-0000-0000-000000000001"
 
-		health := h.checkClusterHealth(ctx, "test-cluster")
-		assert.Equal(t, store.ClusterHealthUnknown, health)
-	})
-
-	t.Run("returns unknown when cluster not found", func(t *testing.T) {
-		// This test verifies the logic path when a cluster is not in the list
-		// We can't easily test with a real k8s client, but we can test the handler structure
-		h := &ConsolePersistenceHandlers{}
-
-		// With nil client, should return unknown
-		health := h.checkClusterHealth(context.Background(), "non-existent-cluster")
-		assert.Equal(t, store.ClusterHealthUnknown, health)
-	})
+// MockK8sClient is a mock implementation of k8s.K8sClient for persistence tests
+type MockK8sClient struct {
+	mock.Mock
 }
 
-func TestCheckClusterHealthLogic(t *testing.T) {
-	t.Run("healthy cluster logic", func(t *testing.T) {
-		// Test the cluster health determination logic
-		clusters := []k8s.ClusterInfo{
-			{Name: "healthy-cluster", Healthy: true},
-			{Name: "unhealthy-cluster", Healthy: false},
-		}
+func (m *MockK8sClient) ListClusters(ctx context.Context) ([]k8s.ClusterInfo, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]k8s.ClusterInfo), args.Error(1)
+}
 
-		// Simulate the logic from checkClusterHealth
-		findHealth := func(clusterName string) store.ClusterHealth {
-			for _, cluster := range clusters {
-				if cluster.Name == clusterName {
-					if cluster.Healthy {
-						return store.ClusterHealthHealthy
-					}
-					return store.ClusterHealthUnreachable
-				}
+func (m *MockK8sClient) GetDynamicClient(clusterName string) (dynamic.Interface, error) {
+	args := m.Called(clusterName)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(dynamic.Interface), args.Error(1)
+}
+
+func (m *MockK8sClient) GetRestConfig(clusterName string) (*rest.Config, error) {
+	args := m.Called(clusterName)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*rest.Config), args.Error(1)
+}
+
+func (m *MockK8sClient) ListNamespaces(ctx context.Context, cluster string) ([]k8s.NamespaceInfo, error) {
+	return nil, nil
+}
+
+func (m *MockK8sClient) ListPods(ctx context.Context, cluster, namespace string) ([]k8s.PodInfo, error) {
+	return nil, nil
+}
+
+func (m *MockK8sClient) ListNodes(ctx context.Context, cluster string) ([]k8s.NodeInfo, error) {
+	return nil, nil
+}
+
+func (m *MockK8sClient) GetClusterHealth(ctx context.Context, cluster string) (*k8s.ClusterHealth, error) {
+	return nil, nil
+}
+
+func (m *MockK8sClient) DeployWorkload(ctx context.Context, sourceCluster, sourceNamespace, workloadName string, targets []string, replicas int32, opts *k8s.DeployOptions) (*k8s.DeployResult, error) {
+	return nil, nil
+}
+
+// MockPersistenceStore is a mock implementation of store.PersistenceStore
+type MockPersistenceStore struct {
+	mock.Mock
+}
+
+func (m *MockPersistenceStore) IsEnabled() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m *MockPersistenceStore) GetActiveCluster(ctx context.Context) (string, error) {
+	args := m.Called(ctx)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockPersistenceStore) GetNamespace() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockPersistenceStore) GetActiveClient(ctx context.Context) (dynamic.Interface, *rest.Config, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, nil, args.Error(2)
+	}
+	if args.Get(1) == nil {
+		return args.Get(0).(dynamic.Interface), nil, args.Error(2)
+	}
+	return args.Get(0).(dynamic.Interface), args.Get(1).(*rest.Config), args.Error(2)
+}
+
+func TestRequireAdmin(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupUserID   bool
+		userStoreNil  bool
+		mockUser      *models.User
+		mockError     error
+		expectedCode  int
+		expectedError string
+	}{
+		{
+			name:         "NoUserStore_SkipCheck",
+			userStoreNil: true,
+			setupUserID:  true,
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "AdminUser_Allowed",
+			setupUserID:  true,
+			mockUser:     &models.User{ID: uuid.MustParse(testUserID), Role: models.UserRoleAdmin},
+			mockError:    nil,
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:          "ViewerUser_Forbidden",
+			setupUserID:   true,
+			mockUser:      &models.User{ID: uuid.MustParse(testUserID), Role: models.UserRoleViewer},
+			mockError:     nil,
+			expectedCode:  http.StatusForbidden,
+			expectedError: "Console admin access required",
+		},
+		{
+			name:          "NilUser_Forbidden",
+			setupUserID:   true,
+			mockUser:      nil,
+			mockError:     nil,
+			expectedCode:  http.StatusForbidden,
+			expectedError: "Console admin access required",
+		},
+		{
+			name:          "DBError_InternalServerError",
+			setupUserID:   true,
+			mockError:     errors.New("database connection failed"),
+			expectedCode:  http.StatusInternalServerError,
+			expectedError: "Failed to verify admin role",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := fiber.New()
+			var mockStore *test.MockStore
+			var h *ConsolePersistenceHandlers
+
+			if tt.userStoreNil {
+				h = &ConsolePersistenceHandlers{}
+			} else {
+				mockStore = new(test.MockStore)
+				userID := uuid.MustParse(testUserID)
+				mockStore.On("GetUser", userID).Return(tt.mockUser, tt.mockError).Once()
+				h = &ConsolePersistenceHandlers{userStore: mockStore}
 			}
-			return store.ClusterHealthUnknown
-		}
 
-		assert.Equal(t, store.ClusterHealthHealthy, findHealth("healthy-cluster"))
-		assert.Equal(t, store.ClusterHealthUnreachable, findHealth("unhealthy-cluster"))
-		assert.Equal(t, store.ClusterHealthUnknown, findHealth("non-existent"))
-	})
+			app.Get("/test", func(c *fiber.Ctx) error {
+				if tt.setupUserID {
+					c.Locals("userID", uuid.MustParse(testUserID))
+				}
+				err := h.RequireAdmin(c)
+				if err != nil {
+					return err
+				}
+				return c.SendStatus(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedCode, resp.StatusCode)
+
+			if !tt.userStoreNil && mockStore != nil {
+				mockStore.AssertExpectations(t)
+			}
+		})
+	}
+}
+
+func TestCheckClusterHealth(t *testing.T) {
+	tests := []struct {
+		name           string
+		clusterName    string
+		k8sClientNil   bool
+		mockClusters   []k8s.ClusterInfo
+		mockError      error
+		expectedHealth store.ClusterHealth
+	}{
+		{
+			name:           "NoK8sClient_ReturnsUnknown",
+			clusterName:    "test-cluster",
+			k8sClientNil:   true,
+			expectedHealth: store.ClusterHealthUnknown,
+		},
+		{
+			name:        "HealthyCluster_ReturnsHealthy",
+			clusterName: "healthy-cluster",
+			mockClusters: []k8s.ClusterInfo{
+				{Name: "healthy-cluster", Healthy: true},
+			},
+			expectedHealth: store.ClusterHealthHealthy,
+		},
+		{
+			name:        "UnhealthyCluster_ReturnsUnreachable",
+			clusterName: "unhealthy-cluster",
+			mockClusters: []k8s.ClusterInfo{
+				{Name: "unhealthy-cluster", Healthy: false},
+			},
+			expectedHealth: store.ClusterHealthUnreachable,
+		},
+		{
+			name:        "ClusterNotFound_ReturnsUnknown",
+			clusterName: "nonexistent-cluster",
+			mockClusters: []k8s.ClusterInfo{
+				{Name: "other-cluster", Healthy: true},
+			},
+			expectedHealth: store.ClusterHealthUnknown,
+		},
+		{
+			name:           "ListClustersError_ReturnsUnknown",
+			clusterName:    "test-cluster",
+			mockError:      errors.New("failed to list clusters"),
+			expectedHealth: store.ClusterHealthUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			var h *ConsolePersistenceHandlers
+
+			if tt.k8sClientNil {
+				h = &ConsolePersistenceHandlers{}
+			} else {
+				mockK8s := new(MockK8sClient)
+				mockK8s.On("ListClusters", ctx).Return(tt.mockClusters, tt.mockError).Once()
+				h = &ConsolePersistenceHandlers{k8sClient: mockK8s}
+			}
+
+			health := h.checkClusterHealth(ctx, tt.clusterName)
+			assert.Equal(t, tt.expectedHealth, health)
+
+			if !tt.k8sClientNil && h.k8sClient != nil {
+				mockK8s := h.k8sClient.(*MockK8sClient)
+				mockK8s.AssertExpectations(t)
+			}
+		})
+	}
+}
+
+func TestGetClusterClient(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusterName   string
+		k8sClientNil  bool
+		mockClient    dynamic.Interface
+		mockConfig    *rest.Config
+		clientError   error
+		configError   error
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "NoK8sClient_ReturnsError",
+			clusterName:   "test-cluster",
+			k8sClientNil:  true,
+			expectError:   true,
+			errorContains: noClusterAccessMsg,
+		},
+		{
+			name:        "Success_ReturnsBoth",
+			clusterName: "prod-cluster",
+			mockClient:  fake.NewSimpleDynamicClient(scheme.Scheme),
+			mockConfig:  &rest.Config{Host: "https://prod-api:6443"},
+			expectError: false,
+		},
+		{
+			name:          "ClientError_ReturnsError",
+			clusterName:   "error-cluster",
+			clientError:   errors.New("failed to create client"),
+			expectError:   true,
+			errorContains: "failed to create client",
+		},
+		{
+			name:          "ConfigError_ReturnsError",
+			clusterName:   "config-error-cluster",
+			mockClient:    fake.NewSimpleDynamicClient(scheme.Scheme),
+			configError:   errors.New("failed to get config"),
+			expectError:   true,
+			errorContains: "failed to get rest config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var h *ConsolePersistenceHandlers
+
+			if tt.k8sClientNil {
+				h = &ConsolePersistenceHandlers{}
+			} else {
+				mockK8s := new(MockK8sClient)
+				mockK8s.On("GetDynamicClient", tt.clusterName).Return(tt.mockClient, tt.clientError).Maybe()
+				if tt.clientError == nil {
+					mockK8s.On("GetRestConfig", tt.clusterName).Return(tt.mockConfig, tt.configError).Once()
+				}
+				h = &ConsolePersistenceHandlers{k8sClient: mockK8s}
+			}
+
+			client, config, err := h.getClusterClient(tt.clusterName)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				assert.Nil(t, client)
+				assert.Nil(t, config)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, client)
+				assert.NotNil(t, config)
+				assert.Equal(t, tt.mockConfig, config)
+			}
+
+			if !tt.k8sClientNil && h.k8sClient != nil {
+				mockK8s := h.k8sClient.(*MockK8sClient)
+				mockK8s.AssertExpectations(t)
+			}
+		})
+	}
 }
 
 func TestStopWatcher(t *testing.T) {
 	t.Run("stop watcher when watcher is nil", func(t *testing.T) {
 		h := &ConsolePersistenceHandlers{}
-
-		// Should not panic
 		assert.NotPanics(t, func() {
 			h.StopWatcher()
 		})
@@ -68,10 +351,7 @@ func TestStopWatcher(t *testing.T) {
 
 	t.Run("stop watcher sets watcher to nil", func(t *testing.T) {
 		h := &ConsolePersistenceHandlers{}
-		// Create a mock watcher (we can't easily create a real one without k8s)
-		// but we can verify the nil assignment logic
 		h.watcher = nil
-
 		h.StopWatcher()
 		assert.Nil(t, h.watcher)
 	})

--- a/pkg/api/handlers/console_persistence_store_unit_test.go
+++ b/pkg/api/handlers/console_persistence_store_unit_test.go
@@ -1,0 +1,306 @@
+package handlers
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/apis/v1alpha1"
+	"github.com/kubestellar/console/pkg/k8s"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/store"
+	pkgtest "github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+const requireAdminRoute = "/require-admin"
+
+func newRequireAdminTestApp(t *testing.T, handler *ConsolePersistenceHandlers, userID uuid.UUID) *fiber.App {
+	t.Helper()
+
+	app := fiber.New()
+	app.Get(requireAdminRoute, func(c *fiber.Ctx) error {
+		c.Locals("userID", userID)
+		if err := handler.RequireAdmin(c); err != nil {
+			return err
+		}
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+
+	return app
+}
+
+func performRequireAdminRequest(t *testing.T, app *fiber.App) (int, string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, requireAdminRoute, nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return resp.StatusCode, string(body)
+}
+
+func TestRequireAdmin(t *testing.T) {
+	adminUserID := uuid.New()
+	viewerUserID := uuid.New()
+	missingUserID := uuid.New()
+	errorUserID := uuid.New()
+
+	mockStore := new(pkgtest.MockStore)
+	mockStore.On("GetUser", adminUserID).Return(&models.User{ID: adminUserID, Role: models.UserRoleAdmin}, nil).Once()
+	mockStore.On("GetUser", viewerUserID).Return(&models.User{ID: viewerUserID, Role: models.UserRoleViewer}, nil).Once()
+	mockStore.On("GetUser", missingUserID).Return((*models.User)(nil), nil).Once()
+	mockStore.On("GetUser", errorUserID).Return((*models.User)(nil), assert.AnError).Once()
+
+	tests := []struct {
+		name          string
+		handler       *ConsolePersistenceHandlers
+		userID        uuid.UUID
+		wantStatus    int
+		wantBodyParts []string
+	}{
+		{
+			name:       "allows requests when user store is not configured",
+			handler:    &ConsolePersistenceHandlers{},
+			userID:     uuid.New(),
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "allows admin user",
+			handler:    &ConsolePersistenceHandlers{userStore: mockStore},
+			userID:     adminUserID,
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:          "rejects non admin user",
+			handler:       &ConsolePersistenceHandlers{userStore: mockStore},
+			userID:        viewerUserID,
+			wantStatus:    http.StatusForbidden,
+			wantBodyParts: []string{"Console admin access required"},
+		},
+		{
+			name:          "rejects missing user",
+			handler:       &ConsolePersistenceHandlers{userStore: mockStore},
+			userID:        missingUserID,
+			wantStatus:    http.StatusForbidden,
+			wantBodyParts: []string{"Console admin access required"},
+		},
+		{
+			name:          "surfaces store errors as internal server errors",
+			handler:       &ConsolePersistenceHandlers{userStore: mockStore},
+			userID:        errorUserID,
+			wantStatus:    http.StatusInternalServerError,
+			wantBodyParts: []string{"Failed to verify admin role"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newRequireAdminTestApp(t, tt.handler, tt.userID)
+			statusCode, body := performRequireAdminRequest(t, app)
+
+			assert.Equal(t, tt.wantStatus, statusCode)
+			for _, wantBodyPart := range tt.wantBodyParts {
+				assert.Contains(t, body, wantBodyPart)
+			}
+		})
+	}
+
+	mockStore.AssertExpectations(t)
+}
+
+func TestCheckClusterHealth(t *testing.T) {
+	freshK8sClient := newStoreBackedK8sClient(t)
+
+	tests := []struct {
+		name        string
+		handler     *ConsolePersistenceHandlers
+		clusterName string
+		want        store.ClusterHealth
+	}{
+		{
+			name:        "returns unknown when k8s client is missing",
+			handler:     &ConsolePersistenceHandlers{},
+			clusterName: "test-cluster",
+			want:        store.ClusterHealthUnknown,
+		},
+		{
+			name:        "returns unreachable when cluster exists but is not marked healthy",
+			handler:     &ConsolePersistenceHandlers{k8sClient: freshK8sClient},
+			clusterName: "test-cluster",
+			want:        store.ClusterHealthUnreachable,
+		},
+		{
+			name:        "returns unknown for clusters missing from kubeconfig",
+			handler:     &ConsolePersistenceHandlers{k8sClient: freshK8sClient},
+			clusterName: "does-not-exist",
+			want:        store.ClusterHealthUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.handler.checkClusterHealth(context.Background(), tt.clusterName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetClusterClient(t *testing.T) {
+	freshK8sClient := newStoreBackedK8sClient(t)
+
+	tests := []struct {
+		name          string
+		handler       *ConsolePersistenceHandlers
+		clusterName   string
+		wantErr       string
+		wantConfigURL string
+	}{
+		{
+			name:        "returns service unavailable when cluster access is missing",
+			handler:     &ConsolePersistenceHandlers{},
+			clusterName: "test-cluster",
+			wantErr:     noClusterAccessMsg,
+		},
+		{
+			name:          "returns client and config for known cluster",
+			handler:       &ConsolePersistenceHandlers{k8sClient: freshK8sClient},
+			clusterName:   "test-cluster",
+			wantConfigURL: "https://test-cluster:6443",
+		},
+		{
+			name:        "returns error for unknown cluster context",
+			handler:     &ConsolePersistenceHandlers{k8sClient: freshK8sClient},
+			clusterName: "missing-cluster",
+			wantErr:     "missing-cluster",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, config, err := tt.handler.getClusterClient(tt.clusterName)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, client)
+				assert.Nil(t, config)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotNil(t, client)
+			assert.NotNil(t, config)
+			assert.Equal(t, tt.wantConfigURL, config.Host)
+		})
+	}
+}
+
+func TestStartWatcher(t *testing.T) {
+	t.Run("skips watcher start when persistence is disabled", func(t *testing.T) {
+		persistenceStore := store.NewPersistenceStore("")
+		handler := &ConsolePersistenceHandlers{persistenceStore: persistenceStore}
+
+		err := handler.StartWatcher(context.Background())
+		require.NoError(t, err)
+		assert.Nil(t, handler.watcher)
+	})
+
+	t.Run("fails when persistence is enabled but no cluster client is configured", func(t *testing.T) {
+		persistenceStore := store.NewPersistenceStore("")
+		err := persistenceStore.UpdateConfig(store.PersistenceConfig{
+			Enabled:        true,
+			PrimaryCluster: "test-cluster",
+			Namespace:      store.DefaultNamespace,
+			SyncMode:       "primary-only",
+		})
+		require.NoError(t, err)
+
+		handler := &ConsolePersistenceHandlers{persistenceStore: persistenceStore}
+		err = handler.StartWatcher(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), noClusterAccessMsg)
+	})
+}
+
+func TestStopWatcherWithNilWatcher(t *testing.T) {
+	handler := &ConsolePersistenceHandlers{}
+	assert.NotPanics(t, func() {
+		handler.StopWatcher()
+	})
+}
+
+func TestSetTerminalStatusUsesHighestExistingRevision(t *testing.T) {
+	handler := &ConsolePersistenceHandlers{}
+	startedAt := nowMetaTime()
+	completedAt := nowMetaTime()
+	workloadDeployment := newWorkloadDeploymentWithHistory(startedAt, completedAt)
+
+	updateCalls := 0
+	handler.setTerminalStatus(workloadDeployment, "Complete", "deployment finished", func(*v1alpha1.WorkloadDeployment) {
+		updateCalls++
+	})
+
+	require.Equal(t, 1, updateCalls)
+	require.Len(t, workloadDeployment.Status.History, 3)
+	assert.Equal(t, 8, workloadDeployment.Status.History[2].Revision)
+	assert.Equal(t, startedAt, workloadDeployment.Status.History[2].StartedAt)
+	assert.Equal(t, "deployment finished", workloadDeployment.Status.History[2].Message)
+	assert.NotNil(t, workloadDeployment.Status.CompletedAt)
+	assert.Equal(t, "Complete", workloadDeployment.Status.Phase)
+}
+
+func newStoreBackedK8sClient(t *testing.T) *k8s.MultiClusterClient {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	rawConfig := api.Config{
+		Clusters: map[string]*api.Cluster{
+			"test-cluster": {Server: "https://test-cluster:6443"},
+		},
+		Contexts: map[string]*api.Context{
+			"test-cluster": {Cluster: "test-cluster", AuthInfo: "test-user"},
+		},
+		AuthInfos: map[string]*api.AuthInfo{
+			"test-user": {},
+		},
+		CurrentContext: "test-cluster",
+	}
+	kubeconfigPath := filepath.Join(tempDir, "kubeconfig")
+	require.NoError(t, clientcmd.WriteToFile(rawConfig, kubeconfigPath))
+
+	client, err := k8s.NewMultiClusterClient(kubeconfigPath)
+	require.NoError(t, err)
+
+	return client
+}
+
+func nowMetaTime() *metav1.Time {
+	now := metav1.Now()
+	return &now
+}
+
+func newWorkloadDeploymentWithHistory(startedAt, completedAt *metav1.Time) *v1alpha1.WorkloadDeployment {
+	return &v1alpha1.WorkloadDeployment{
+		Status: v1alpha1.WorkloadDeploymentStatus{
+			Phase:     "InProgress",
+			StartedAt: startedAt,
+			History: []v1alpha1.DeploymentHistoryEntry{
+				{Revision: 2, StartedAt: startedAt, CompletedAt: completedAt, Phase: "Failed", Message: "first"},
+				{Revision: 7, StartedAt: startedAt, CompletedAt: completedAt, Phase: "Failed", Message: "second"},
+			},
+		},
+	}
+}

--- a/pkg/api/handlers/shared_utils_test.go
+++ b/pkg/api/handlers/shared_utils_test.go
@@ -1,9 +1,12 @@
 package handlers
 
 import (
+	"encoding/json"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
@@ -11,289 +14,219 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const parsePageParamsRoute = "/page-params"
+
+type pageParamsResponse struct {
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
+
+func newParsePageParamsTestApp(t *testing.T) *fiber.App {
+	t.Helper()
+
+	app := fiber.New()
+	app.Get(parsePageParamsRoute, func(c *fiber.Ctx) error {
+		limit, offset, err := ParsePageParams(c)
+		if err != nil {
+			return err
+		}
+		return c.JSON(pageParamsResponse{Limit: limit, Offset: offset})
+	})
+
+	return app
+}
+
 func TestParsePageParams(t *testing.T) {
+	app := newParsePageParamsTestApp(t)
+	limitTooLarge := maxClientPageLimit + 1
+
 	tests := []struct {
-		name        string
-		queryLimit  string
-		queryOffset string
-		wantLimit   int
-		wantOffset  int
-		wantErr     bool
-		errContains string
+		name          string
+		query         string
+		wantStatus    int
+		wantResponse  *pageParamsResponse
+		wantBodyParts []string
 	}{
 		{
-			name:       "NoParams",
-			wantLimit:  0,
-			wantOffset: 0,
-			wantErr:    false,
+			name:         "uses defaults when query parameters are absent",
+			query:        "",
+			wantStatus:   http.StatusOK,
+			wantResponse: &pageParamsResponse{Limit: 0, Offset: 0},
 		},
 		{
-			name:       "ValidLimitAndOffset",
-			queryLimit: "50",
-			queryOffset: "100",
-			wantLimit:  50,
-			wantOffset: 100,
-			wantErr:    false,
+			name:         "accepts zero and boundary values",
+			query:        "?limit=1000&offset=0",
+			wantStatus:   http.StatusOK,
+			wantResponse: &pageParamsResponse{Limit: maxClientPageLimit, Offset: 0},
 		},
 		{
-			name:        "InvalidLimit",
-			queryLimit:  "abc",
-			wantErr:     true,
-			errContains: "invalid limit",
+			name:         "accepts positive values",
+			query:        "?limit=25&offset=12",
+			wantStatus:   http.StatusOK,
+			wantResponse: &pageParamsResponse{Limit: 25, Offset: 12},
 		},
 		{
-			name:        "NegativeLimit",
-			queryLimit:  "-5",
-			wantErr:     true,
-			errContains: "invalid limit",
+			name:          "rejects negative limit",
+			query:         "?limit=-1",
+			wantStatus:    http.StatusBadRequest,
+			wantBodyParts: []string{"invalid limit"},
 		},
 		{
-			name:        "LimitTooLarge",
-			queryLimit:  "2000",
-			wantErr:     true,
-			errContains: "limit too large",
+			name:          "rejects non numeric limit",
+			query:         "?limit=abc",
+			wantStatus:    http.StatusBadRequest,
+			wantBodyParts: []string{"invalid limit"},
 		},
 		{
-			name:        "InvalidOffset",
-			queryOffset: "xyz",
-			wantErr:     true,
-			errContains: "invalid offset",
+			name:          "rejects oversized limit",
+			query:         "?limit=" + strconv.Itoa(limitTooLarge),
+			wantStatus:    http.StatusBadRequest,
+			wantBodyParts: []string{"limit too large"},
 		},
 		{
-			name:        "NegativeOffset",
-			queryOffset: "-10",
-			wantErr:     true,
-			errContains: "invalid offset",
+			name:          "rejects negative offset",
+			query:         "?offset=-5",
+			wantStatus:    http.StatusBadRequest,
+			wantBodyParts: []string{"invalid offset"},
 		},
 		{
-			name:       "MaxAllowedLimit",
-			queryLimit: "1000",
-			wantLimit:  1000,
-			wantErr:    false,
+			name:          "rejects non numeric offset",
+			query:         "?offset=bad",
+			wantStatus:    http.StatusBadRequest,
+			wantBodyParts: []string{"invalid offset"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			app := fiber.New()
-			app.Get("/test", func(c *fiber.Ctx) error {
-				limit, offset, err := ParsePageParams(c)
-				if err != nil {
-					return err
-				}
-				return c.JSON(fiber.Map{"limit": limit, "offset": offset})
-			})
-
-			url := "/test"
-			if tt.queryLimit != "" || tt.queryOffset != "" {
-				url += "?"
-				if tt.queryLimit != "" {
-					url += "limit=" + tt.queryLimit
-				}
-				if tt.queryOffset != "" {
-					if tt.queryLimit != "" {
-						url += "&"
-					}
-					url += "offset=" + tt.queryOffset
-				}
-			}
-
-			req := httptest.NewRequest("GET", url, nil)
+			req := httptest.NewRequest(http.MethodGet, parsePageParamsRoute+tt.query, nil)
 			resp, err := app.Test(req)
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			if tt.wantErr {
-				assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
-				body, err := io.ReadAll(resp.Body)
-				require.NoError(t, err)
-				assert.Contains(t, string(body), tt.errContains)
-			} else {
-				assert.Equal(t, fiber.StatusOK, resp.StatusCode)
-				body, err := io.ReadAll(resp.Body)
-				require.NoError(t, err)
-				assert.Contains(t, string(body), `"limit"`)
-				assert.Contains(t, string(body), `"offset"`)
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
+			if tt.wantResponse != nil {
+				var got pageParamsResponse
+				require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+				assert.Equal(t, *tt.wantResponse, got)
+				return
+			}
+
+			bodyBytes, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			body := string(bodyBytes)
+			for _, wantBodyPart := range tt.wantBodyParts {
+				assert.Contains(t, body, wantBodyPart)
 			}
 		})
 	}
 }
 
 func TestResolveGitHubAPIBase(t *testing.T) {
+	originalValue, hadOriginal := os.LookupEnv("GITHUB_URL")
+	if hadOriginal {
+		defer func() {
+			require.NoError(t, os.Setenv("GITHUB_URL", originalValue))
+		}()
+	} else {
+		defer func() {
+			require.NoError(t, os.Unsetenv("GITHUB_URL"))
+		}()
+	}
+
 	tests := []struct {
-		name        string
-		githubURL   string
-		wantAPIBase string
+		name      string
+		githubURL string
+		want      string
 	}{
 		{
-			name:        "EmptyEnvVar",
-			githubURL:   "",
-			wantAPIBase: "https://api.github.com",
+			name:      "defaults to public github api when env is unset",
+			githubURL: "",
+			want:      githubAPIBase,
 		},
 		{
-			name:        "PublicGitHub",
-			githubURL:   "https://github.com",
-			wantAPIBase: "https://api.github.com",
+			name:      "maps bare github host to public api",
+			githubURL: "github.com",
+			want:      githubAPIBase,
 		},
 		{
-			name:        "BareGitHubHost",
-			githubURL:   "github.com",
-			wantAPIBase: "https://api.github.com",
+			name:      "maps www github host to public api",
+			githubURL: " https://www.github.com/ ",
+			want:      githubAPIBase,
 		},
 		{
-			name:        "WWWGitHub",
-			githubURL:   "www.github.com",
-			wantAPIBase: "https://api.github.com",
+			name:      "appends ghe api path for bare enterprise host",
+			githubURL: "github.enterprise.example.com",
+			want:      "https://github.enterprise.example.com/api/v3",
 		},
 		{
-			name:        "APIGitHub",
-			githubURL:   "api.github.com",
-			wantAPIBase: "https://api.github.com",
-		},
-		{
-			name:        "GHEWithHTTPS",
-			githubURL:   "https://github.example.com",
-			wantAPIBase: "https://github.example.com/api/v3",
-		},
-		{
-			name:        "GHEBareHost",
-			githubURL:   "github.example.com",
-			wantAPIBase: "https://github.example.com/api/v3",
-		},
-		{
-			name:        "GHEWithHTTP",
-			githubURL:   "http://github.internal",
-			wantAPIBase: "http://github.internal/api/v3",
-		},
-		{
-			name:        "GHEWithTrailingSlash",
-			githubURL:   "https://github.corp.com/",
-			wantAPIBase: "https://github.corp.com/api/v3",
+			name:      "preserves http scheme for enterprise host",
+			githubURL: "http://ghe.example.com/",
+			want:      "http://ghe.example.com/api/v3",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.githubURL != "" {
-				t.Setenv("GITHUB_URL", tt.githubURL)
+			if tt.githubURL == "" {
+				require.NoError(t, os.Unsetenv("GITHUB_URL"))
 			} else {
-				os.Unsetenv("GITHUB_URL")
+				require.NoError(t, os.Setenv("GITHUB_URL", tt.githubURL))
 			}
 
-			result := ResolveGitHubAPIBase()
-			assert.Equal(t, tt.wantAPIBase, result)
+			assert.Equal(t, tt.want, ResolveGitHubAPIBase())
 		})
 	}
 }
 
 func TestExtractHost(t *testing.T) {
 	tests := []struct {
-		name     string
-		raw      string
-		wantHost string
-		wantErr  bool
+		name    string
+		raw     string
+		want    string
+		wantErr bool
 	}{
 		{
-			name:     "FullURL",
-			raw:      "https://github.com/path",
-			wantHost: "github.com",
-			wantErr:  false,
+			name: "extracts lowercase hostname from full url",
+			raw:  "https://GitHub.example.com:8443/api/v3",
+			want: "github.example.com",
 		},
 		{
-			name:     "BareHost",
-			raw:      "github.com",
-			wantHost: "github.com",
-			wantErr:  false,
+			name: "extracts lowercase hostname from bare host",
+			raw:  "GITHUB.COM",
+			want: "github.com",
 		},
 		{
-			name:     "WithPort",
-			raw:      "https://github.com:443/path",
-			wantHost: "github.com",
-			wantErr:  false,
-		},
-		{
-			name:     "HTTPProtocol",
-			raw:      "http://internal.corp",
-			wantHost: "internal.corp",
-			wantErr:  false,
-		},
-		{
-			name:     "WithSubdomain",
-			raw:      "api.github.com",
-			wantHost: "api.github.com",
-			wantErr:  false,
-		},
-		{
-			name:    "EmptyString",
-			raw:     "",
-			wantErr: true,
-		},
-		{
-			name:    "WhitespaceOnly",
+			name:    "rejects empty input",
 			raw:     "   ",
 			wantErr: true,
 		},
 		{
-			name:     "LowercaseConversion",
-			raw:      "GitHub.COM",
-			wantHost: "github.com",
-			wantErr:  false,
+			name:    "rejects malformed urls",
+			raw:     "http://[::1",
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			host, err := ExtractHost(tt.raw)
+			got, err := ExtractHost(tt.raw)
 			if tt.wantErr {
 				assert.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.wantHost, host)
+				return
 			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
 func TestGetEnvOrDefault(t *testing.T) {
-	tests := []struct {
-		name       string
-		key        string
-		defaultVal string
-		envVal     string
-		wantResult string
-	}{
-		{
-			name:       "EnvVarSet",
-			key:        "TEST_VAR_1",
-			defaultVal: "default",
-			envVal:     "custom",
-			wantResult: "custom",
-		},
-		{
-			name:       "EnvVarEmpty",
-			key:        "TEST_VAR_2",
-			defaultVal: "default",
-			envVal:     "",
-			wantResult: "default",
-		},
-		{
-			name:       "EnvVarUnset",
-			key:        "TEST_VAR_3",
-			defaultVal: "default",
-			wantResult: "default",
-		},
-	}
+	t.Setenv("SHARED_UTILS_TEST_VALUE", "configured")
+	t.Setenv("SHARED_UTILS_EMPTY_VALUE", "")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.envVal != "" {
-				t.Setenv(tt.key, tt.envVal)
-			} else {
-				os.Unsetenv(tt.key)
-			}
-
-			result := GetEnvOrDefault(tt.key, tt.defaultVal)
-			assert.Equal(t, tt.wantResult, result)
-		})
-	}
+	assert.Equal(t, "configured", GetEnvOrDefault("SHARED_UTILS_TEST_VALUE", "fallback"))
+	assert.Equal(t, "fallback", GetEnvOrDefault("SHARED_UTILS_MISSING_VALUE", "fallback"))
+	assert.Equal(t, "fallback", GetEnvOrDefault("SHARED_UTILS_EMPTY_VALUE", "fallback"))
 }


### PR DESCRIPTION
Fixes #18481

Adds comprehensive unit tests for console_persistence_store.go and shared_utils.go.