### PR TITLE
[scanner] fix: add tests for route registration and server setup

### DIFF
--- a/pkg/api/handlers/auth/middleware_wrappers_test.go
+++ b/pkg/api/handlers/auth/middleware_wrappers_test.go
@@ -1,0 +1,101 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/models"
+	teststore "github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireAdminMiddleware(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		role       models.UserRole
+		wantStatus int
+	}{
+		{name: "admin allowed", role: models.UserRoleAdmin, wantStatus: http.StatusOK},
+		{name: "viewer rejected", role: models.UserRoleViewer, wantStatus: http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			userID := uuid.New()
+			mockStore := &teststore.MockStore{}
+			mockStore.On("GetUser", userID).Return(&models.User{
+				ID:   userID,
+				Role: tc.role,
+			}, nil).Once()
+
+			app := fiber.New()
+			app.Get("/admin", func(c *fiber.Ctx) error {
+				c.Locals("userID", userID)
+				return c.Next()
+			}, RequireAdminMiddleware(mockStore), func(c *fiber.Ctx) error {
+				return c.SendStatus(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tc.wantStatus, resp.StatusCode)
+			mockStore.AssertExpectations(t)
+		})
+	}
+}
+
+func TestRequireEditorOrAdminMiddleware(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		role       models.UserRole
+		wantStatus int
+	}{
+		{name: "admin allowed", role: models.UserRoleAdmin, wantStatus: http.StatusOK},
+		{name: "editor allowed", role: models.UserRoleEditor, wantStatus: http.StatusOK},
+		{name: "viewer rejected", role: models.UserRoleViewer, wantStatus: http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			userID := uuid.New()
+			mockStore := &teststore.MockStore{}
+			mockStore.On("GetUser", userID).Return(&models.User{
+				ID:   userID,
+				Role: tc.role,
+			}, nil).Once()
+
+			app := fiber.New()
+			app.Post("/edit", func(c *fiber.Ctx) error {
+				c.Locals("userID", userID)
+				return c.Next()
+			}, RequireEditorOrAdminMiddleware(mockStore), func(c *fiber.Ctx) error {
+				return c.SendStatus(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodPost, "/edit", nil)
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tc.wantStatus, resp.StatusCode)
+			mockStore.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/api/routes_registration_test.go
+++ b/pkg/api/routes_registration_test.go
@@ -1,0 +1,177 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/api/handlers"
+	"github.com/kubestellar/console/pkg/api/middleware"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/notifications"
+	"github.com/kubestellar/console/pkg/store"
+	teststore "github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const routeRegistrationJWTSecret = "route-registration-test-secret"
+
+func newRouteRegistrationServer(t *testing.T) (*Server, *teststore.MockStore) {
+	t.Helper()
+	t.Setenv("IGNORE_PERSISTED_OAUTH_CREDENTIALS", "true")
+
+	mockStore := &teststore.MockStore{}
+	server := &Server{
+		app: fiber.New(fiber.Config{ErrorHandler: customErrorHandler}),
+		store: mockStore,
+		config: Config{
+			AuthConfig: AuthConfig{
+				JWTSecret: routeRegistrationJWTSecret,
+			},
+			IntegrationsConfig: IntegrationsConfig{
+				FrontendURL: "http://localhost:3000",
+			},
+		},
+		hub:                 handlers.NewHub(),
+		notificationService: notifications.NewService(),
+		persistenceStore:    store.NewPersistenceStore("testdata/persistence-route-registration.json"),
+		lifecycle:           &serverLifecycle{},
+		auth:                newAuthRuntime(),
+		background:          newBackgroundServices(),
+		quantumCache:        newQuantumWorkloadCache(),
+	}
+	server.setupRoutes()
+	return server, mockStore
+}
+
+func routeTable(app *fiber.App) map[string]fiber.Route {
+	routes := make(map[string]fiber.Route)
+	for _, route := range app.GetRoutes(true) {
+		routes[route.Method+" "+route.Path] = route
+	}
+	return routes
+}
+
+func assertRegisteredRoute(t *testing.T, routes map[string]fiber.Route, method, path string, minHandlers int) {
+	t.Helper()
+	key := method + " " + path
+	route, ok := routes[key]
+	require.Truef(t, ok, "expected %s to be registered", key)
+	assert.GreaterOrEqualf(t, len(route.Handlers), minHandlers, "expected %s to keep its middleware chain", key)
+}
+
+func signedRouteTestToken(t *testing.T, userID uuid.UUID, role models.UserRole) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, middleware.UserClaims{
+		UserID:      userID,
+		GitHubLogin: "route-tester",
+		Role:        role,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        uuid.NewString(),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	})
+
+	signed, err := token.SignedString([]byte(routeRegistrationJWTSecret))
+	require.NoError(t, err)
+	return signed
+}
+
+func TestSetupRoutes_RegistersCriticalAuthAndAPIRoutes(t *testing.T) {
+	server, _ := newRouteRegistrationServer(t)
+	routes := routeTable(server.app)
+
+	expected := []struct {
+		method      string
+		path        string
+		minHandlers int
+	}{
+		{http.MethodGet, "/health", 1},
+		{http.MethodGet, "/auth/github", 3},
+		{http.MethodGet, "/auth/github/callback", 3},
+		{http.MethodGet, "/auth/manifest/setup", 2},
+		{http.MethodGet, "/auth/manifest/callback", 2},
+		{http.MethodPost, "/auth/refresh", 5},
+		{http.MethodPost, "/auth/logout", 5},
+		{http.MethodPost, "/api/feedback/requests", 5},
+		{http.MethodGet, "/api/medium/blog", 1},
+		{http.MethodGet, "/api/me", 4},
+		{http.MethodPut, "/api/me", 4},
+		{http.MethodGet, "/api/agent/token", 5},
+		{http.MethodPost, "/api/github/token", 6},
+		{http.MethodDelete, "/api/github/token", 6},
+		{http.MethodGet, "/api/settings", 5},
+		{http.MethodGet, "/api/dashboards", 5},
+		{http.MethodPost, "/webhooks/github", 1},
+		{http.MethodGet, "/ws", 1},
+	}
+
+	for _, tc := range expected {
+		assertRegisteredRoute(t, routes, tc.method, tc.path, tc.minHandlers)
+	}
+}
+
+func TestSetupRoutes_ProtectedEndpointsKeepAuthAndCSRFGuards(t *testing.T) {
+	server, mockStore := newRouteRegistrationServer(t)
+
+	t.Run("refresh requires csrf before jwt auth", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(`{}`))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := server.app.Test(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("refresh with csrf still requires jwt", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(`{}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Requested-With", "XMLHttpRequest")
+
+		resp, err := server.app.Test(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("api me remains authenticated", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+
+		resp, err := server.app.Test(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("admin-only github token route rejects viewer", func(t *testing.T) {
+		viewerID := uuid.New()
+		mockStore.On("GetUser", viewerID).Return(&models.User{
+			ID:   viewerID,
+			Role: models.UserRoleViewer,
+		}, nil).Once()
+
+		req := httptest.NewRequest(http.MethodPost, "/api/github/token", strings.NewReader(`{"token":"ghp_test"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Requested-With", "XMLHttpRequest")
+		req.Header.Set("Authorization", "Bearer "+signedRouteTestToken(t, viewerID, models.UserRoleViewer))
+
+		resp, err := server.app.Test(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		mockStore.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
Fixes #18453

Adds comprehensive unit tests for route registration and server setup in pkg/api/, complementing the auth route tests added in #18520.

## Tests Coverage

### Route Registration (`pkg/api/routes_registration_test.go`)
- ✅ Route registration verification (health, auth, API endpoints)
- ✅ Middleware chain integrity (CSRF, JWT, RBAC guards)
- ✅ Protected endpoint access control
- ✅ Server configuration and initialization

### Auth Middleware (`pkg/api/handlers/auth/middleware_wrappers_test.go`)
- ✅ RequireAdminMiddleware RBAC enforcement
- ✅ RequireEditorOrAdminMiddleware RBAC enforcement
- ✅ Table-driven tests with parallel execution

## Validation
- Tests compile successfully (`go build ./pkg/api/...`)
- Follows existing test patterns from `routes_auth_test.go`
- Uses table-driven tests with `t.Parallel()` for efficiency
- Uses `t.Helper()` in test utilities