### PR TITLE
[scanner] fix: address 3 security advisories in devDependencies

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -154,7 +154,11 @@
     "form-data": "^4.0.6",
     "uuid": "^14.0.0",
     "axios": "^1.16.0",
-    "esbuild": "^0.28.1",
-    "@opentelemetry/core": "^2.8.0"
+    "esbuild": "^0.29.0",
+    "@opentelemetry/core": "^2.8.0",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^4.1.0"
+    },
+    "@babel/core": "^7.30.0"
   }
 }


### PR DESCRIPTION
Fixes #18487, Fixes #18489, Fixes #18500

Updates/overrides vulnerable devDependencies:

- **#18487**: @babel/core ≤7.29.0 arbitrary file read via sourceMappingURL (GHSA-4x5r-pxfx-6jf8)
- **#18489**: js-yaml@3.14.2 quadratic DoS in @istanbuljs/load-nyc-config (GHSA-h67p-54hq-rp68)
- **#18500**: esbuild HIGH advisory in storybook devDep (GHSA-gv7w-rqvm-qjhr, GHSA-g7r4-m6w7-qqqr)

**Changes**:
- `esbuild`: `^0.28.1` → `^0.29.0` (fixes #18500)
- `@istanbuljs/load-nyc-config.js-yaml`: → `^4.1.0` (fixes #18489)
- `@babel/core`: → `^7.30.0` (fixes #18487)

All are devDependencies only — no production impact.