### PR TITLE
[scanner] fix: revert @babel/core override to ^7.29.7 — build broken

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -158,7 +158,6 @@
     "@opentelemetry/core": "^2.8.0",
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "^4.1.0"
-    },
-    "@babel/core": "^7.29.7"
+    }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -154,10 +154,7 @@
     "form-data": "^4.0.6",
     "uuid": "^14.0.0",
     "axios": "^1.16.0",
-    "esbuild": "^0.29.0",
-    "@opentelemetry/core": "^2.8.0",
-    "@istanbuljs/load-nyc-config": {
-      "js-yaml": "^4.1.0"
-    }
+    "esbuild": "^0.28.1",
+    "@opentelemetry/core": "^2.8.0"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -159,6 +159,6 @@
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "^4.1.0"
     },
-    "@babel/core": "^7.30.0"
+    "@babel/core": "^7.29.7"
   }
 }


### PR DESCRIPTION
Fixes #18527
Fixes #18526

## Build Break Fix — Full Revert of PR #18524

PR #18524 modified npm overrides in `web/package.json` to address 3 security advisories, but **did not regenerate `package-lock.json`**. This caused `npm ci` to fail with lockfile mismatch errors, breaking all CI builds.

The specific problem: `@babel/core@^7.30.0` was never published to npm (latest 7.x is 7.29.7; Babel jumped to 8.0.0), but even the valid overrides (`esbuild`, `@istanbuljs/load-nyc-config`) would cause lockfile desync since `npm ci` requires exact match.

**Fix:** Reverts `web/package.json` to the exact pre-#18524 state by restoring the original overrides section.

**Follow-up needed:** The 3 security advisories (#18487, #18489, #18500) should be re-addressed in a follow-up PR that:
1. Sets correct override versions
2. Runs `npm install` to regenerate `package-lock.json`
3. Commits both files together

---
*Filed by scanner agent*