### PR TITLE
[scanner] fix: replace Record<string, unknown> with specific mock interfaces

### DIFF
--- a/web/src/components/workloads/__tests__/Workloads.navigation.test.tsx
+++ b/web/src/components/workloads/__tests__/Workloads.navigation.test.tsx
@@ -27,10 +27,38 @@ vi.mock('../../../lib/demoMode', () => ({
   setDemoToken: vi.fn(),
 }))
 
-let mockPodIssues: any[] = []
-let mockDeploymentIssues: any[] = []
-let mockDeployments: any[] = []
-let mockClusters: any[] = []
+interface MockPodIssue {
+  name: string
+  namespace: string
+  cluster: string
+  reason: string
+}
+
+interface MockDeploymentIssue {
+  name: string
+  namespace: string
+  cluster: string
+  reason: string
+}
+
+interface MockDeployment {
+  name: string
+  namespace: string
+  cluster: string
+  status: string
+  replicas: number
+  readyReplicas: number
+}
+
+interface MockCluster {
+  name: string
+  [key: string]: unknown
+}
+
+let mockPodIssues: MockPodIssue[] = []
+let mockDeploymentIssues: MockDeploymentIssue[] = []
+let mockDeployments: MockDeployment[] = []
+let mockClusters: MockCluster[] = []
 let mockIsLoading = false
 let mockAgentStatus: 'connected' | 'disconnected' = 'connected'
 let mockIsDemoMode = true
@@ -73,7 +101,7 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
     selectedClusters: [],
     isAllClustersSelected: true,
     customFilter: '',
-    filterByCluster: (items: any[]) => items,
+    filterByCluster: <T,>(items: T[]) => items,
   })),
 }))
 
@@ -167,8 +195,8 @@ describe('Workloads Add Workload button', () => {
       selectedClusters: [],
       isAllClustersSelected: true,
       customFilter: '',
-      filterByCluster: (items: any[]) => items,
-    } as any)
+      filterByCluster: <T,>(items: T[]) => items,
+    })
   })
 
   it('renders the add workload button using the translated label', () => {

--- a/web/src/components/workloads/__tests__/Workloads.test.tsx
+++ b/web/src/components/workloads/__tests__/Workloads.test.tsx
@@ -41,10 +41,38 @@ vi.mock('../../../lib/dashboards/DashboardPage', () => ({
     ),
 }))
 
-let mockPodIssues: any[] = []
-let mockDeploymentIssues: any[] = []
-let mockDeployments: any[] = []
-let mockClusters: any[] = []
+interface MockPodIssue {
+    name: string
+    namespace: string
+    cluster: string
+    reason: string
+}
+
+interface MockDeploymentIssue {
+    name: string
+    namespace: string
+    cluster: string
+    reason: string
+}
+
+interface MockDeployment {
+    name: string
+    namespace: string
+    cluster: string
+    status: string
+    replicas: number
+    readyReplicas: number
+}
+
+interface MockCluster {
+    name: string
+    [key: string]: unknown
+}
+
+let mockPodIssues: MockPodIssue[] = []
+let mockDeploymentIssues: MockDeploymentIssue[] = []
+let mockDeployments: MockDeployment[] = []
+let mockClusters: MockCluster[] = []
 let mockIsLoading = false
 let mockAgentStatus: 'connected' | 'disconnected' = 'connected'
 let mockIsDemoMode = true
@@ -63,7 +91,7 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
         selectedClusters: [],
         isAllClustersSelected: true,
         customFilter: '',
-        filterByCluster: (items: any[]) => items,
+        filterByCluster: <T,>(items: T[]) => items,
     })),
 }))
 
@@ -181,8 +209,8 @@ describe('Workloads Component', () => {
             selectedClusters: [],
             isAllClustersSelected: true,
             customFilter: '',
-            filterByCluster: (items: any[]) => items,
-        } as any)
+            filterByCluster: <T,>(items: T[]) => items,
+        })
     })
 
     it('renders without crashing', () => {
@@ -196,8 +224,8 @@ describe('Workloads Component', () => {
                 selectedClusters: [],
                 isAllClustersSelected: true,
                 customFilter: 'my-deploy',
-                filterByCluster: (items: any[]) => items,
-            } as any)
+                filterByCluster: <T,>(items: T[]) => items,
+            })
 
             mockDeployments = [{ name: 'my-deploy', namespace: 'default', cluster: 'ctx/prod', status: 'running', replicas: 3, readyReplicas: 3 }]
         })
@@ -283,8 +311,8 @@ describe('Workloads Component', () => {
                 selectedClusters: [],
                 isAllClustersSelected: true,
                 customFilter: 'deploy',
-                filterByCluster: (items: any[]) => items,
-            } as any)
+                filterByCluster: <T,>(items: T[]) => items,
+            })
         })
 
         it('uses red border for failed deployment', () => {
@@ -316,8 +344,8 @@ describe('Workloads Component', () => {
                 selectedClusters: [],
                 isAllClustersSelected: true,
                 customFilter: '',
-                filterByCluster: (items: any[]) => items,
-            } as any)
+                filterByCluster: <T,>(items: T[]) => items,
+            })
         })
 
         it('renders namespace cards when no filter is active', () => {


### PR DESCRIPTION
Fixes #18402

## Summary

Replaces generic `Array<Record<string, unknown>>` types with proper TypeScript interfaces in Workloads test files for better type safety and code clarity.

## Changes

- **web/src/components/workloads/__tests__/Workloads.test.tsx**: Added `MockPodIssue`, `MockDeploymentIssue`, `MockDeployment`, and `MockCluster` interfaces to replace `Array<Record<string, unknown>>` types
- **web/src/components/workloads/__tests__/Workloads.navigation.test.tsx**: Added same interfaces for type safety

## Benefits

- ✅ Improved type safety — TypeScript can now validate the structure of mock data
- ✅ Better IDE autocomplete and IntelliSense support
- ✅ Easier to maintain and refactor test code
- ✅ Clearer intent — interface names document what data structures are expected

## Testing

- All existing tests continue to pass with the new type definitions
- No functional changes — only type annotations