### PR TITLE
[scanner] fix: resolve pkg/agent test build failures

### DIFF
--- a/pkg/agent/gitops_test_helpers_test.go
+++ b/pkg/agent/gitops_test_helpers_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+)
+
+// Mock configuration variables for gitops command mocking.
+var (
+	mockStdout   string
+	mockStderr   string
+	mockExitCode int
+)
+
+// fakeExecCommand mimics exec.Command but calls a helper test function.
+func fakeExecCommand(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{
+		"GO_WANT_HELPER_PROCESS=1",
+		"MOCK_STDOUT=" + mockStdout,
+		"MOCK_STDERR=" + mockStderr,
+		"MOCK_EXIT_CODE=" + strconv.Itoa(mockExitCode),
+		// Prevent coverage warning from polluting stderr
+		"GOCOVERDIR=" + os.TempDir(),
+	}
+	return cmd
+}
+
+// fakeExecCommandContext mimics exec.CommandContext for testing.
+func fakeExecCommandContext(_ context.Context, command string, args ...string) *exec.Cmd {
+	return fakeExecCommand(command, args...)
+}
+
+// TestHelperProcess is the function executed by the fake command.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	stdout := os.Getenv("MOCK_STDOUT")
+	stderr := os.Getenv("MOCK_STDERR")
+	exitCode, _ := strconv.Atoi(os.Getenv("MOCK_EXIT_CODE"))
+	if stdout != "" {
+		fmt.Fprint(os.Stdout, stdout)
+	}
+	if stderr != "" {
+		fmt.Fprint(os.Stderr, stderr)
+	}
+	os.Exit(exitCode)
+}

--- a/pkg/agent/server_gitops_test.go
+++ b/pkg/agent/server_gitops_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -315,7 +314,7 @@ func TestGitopsHandlers(t *testing.T) {
 	// 1. Setup mock execCommand
 	defer func() { execCommand = exec.Command; execCommandContext = exec.CommandContext }()
 	execCommand = fakeExecCommand
-	execCommandContext = fakeExecCommand
+	execCommandContext = fakeExecCommandContext
 
 	originalLookup := gitopsLookupIPAddr
 	defer func() { gitopsLookupIPAddr = originalLookup }()


### PR DESCRIPTION
Fixes #18540

## Changes

- **Add `pkg/agent/gitops_test_helpers_test.go`** — restores mock exec command helpers (`fakeExecCommand`, `fakeExecCommandContext`, `TestHelperProcess`) and mock configuration variables (`mockStdout`, `mockStderr`, `mockExitCode`) that were lost during a prior refactor
- **Fix `pkg/agent/server_gitops_test.go`**:
  - Remove unused `"fmt"` import
  - Fix type mismatch: `execCommandContext = fakeExecCommandContext` (was incorrectly assigned `fakeExecCommand` which has wrong signature)

### Root cause

The mock exec helpers were defined inline in `server_gitops_test.go` but were accidentally removed during a refactor. The `fakeExecCommand` and related vars were still referenced by `TestGitopsHandlers` and `TestGitopsCloneRepoRejectsBlockedResolvedIP`, causing 6 build errors that blocked the entire `pkg/agent` test suite.

---
*Filed by scanner agent*