### PR TITLE
[scanner] fix: add tests for federation providers and action functions

### DIFF
--- a/pkg/agent/federation/providers/capi_actions_http_test.go
+++ b/pkg/agent/federation/providers/capi_actions_http_test.go
@@ -1,0 +1,92 @@
+package providers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func TestExecuteCAPIScaleMachineDeployment_HTTP(t *testing.T) {
+	const path = "/apis/cluster.x-k8s.io/v1beta1/namespaces/default/machinedeployments/md-workers"
+
+	t.Run("updates replicas", func(t *testing.T) {
+		server, cfg, state := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			path: {"apiVersion": "cluster.x-k8s.io/v1beta1", "kind": "MachineDeployment", "metadata": map[string]interface{}{"name": "md-workers", "namespace": "default"}, "spec": map[string]interface{}{"replicas": float64(2)}},
+		}, nil)
+		defer server.Close()
+
+		result, err := executeCAPIScaleMachineDeployment(context.Background(), cfg, federation.ActionRequest{ActionID: capiActionScaleMachineDeployment, Payload: map[string]interface{}{"name": "md-workers", "namespace": "default", "replicas": float64(5)}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.OK || result.Already {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+
+		updated := state.object(path)
+		spec := updated["spec"].(map[string]interface{})
+		if spec["replicas"].(float64) != 5 {
+			t.Fatalf("expected replicas to be 5, got %#v", spec["replicas"])
+		}
+	})
+}
+
+func TestExecuteCAPIDeleteCluster_HTTP(t *testing.T) {
+	const path = "/apis/cluster.x-k8s.io/v1beta1/namespaces/default/clusters/cluster-1"
+
+	t.Run("deletes cluster", func(t *testing.T) {
+		server, cfg, state := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			path: {"apiVersion": "cluster.x-k8s.io/v1beta1", "kind": "Cluster", "metadata": map[string]interface{}{"name": "cluster-1", "namespace": "default"}},
+		}, nil)
+		defer server.Close()
+
+		result, err := executeCAPIDeleteCluster(context.Background(), cfg, federation.ActionRequest{ActionID: capiActionDeleteCluster, ClusterName: "cluster-1", Payload: map[string]interface{}{"namespace": "default"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.OK || result.Already {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+		if state.object(path) != nil {
+			t.Fatal("expected cluster to be removed")
+		}
+	})
+
+	t.Run("returns already when cluster missing", func(t *testing.T) {
+		server, cfg, _ := newTestKubeAPIServer(t, nil, nil)
+		defer server.Close()
+
+		result, err := executeCAPIDeleteCluster(context.Background(), cfg, federation.ActionRequest{ActionID: capiActionDeleteCluster, ClusterName: "cluster-1", Payload: map[string]interface{}{"namespace": "default"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Already {
+			t.Fatalf("expected already result, got %+v", result)
+		}
+	})
+}
+
+func TestExecuteCAPIRetryProvisioning_HTTP(t *testing.T) {
+	const path = "/apis/cluster.x-k8s.io/v1beta1/namespaces/default/clusters/cluster-1"
+
+	server, cfg, state := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+		path: {"apiVersion": "cluster.x-k8s.io/v1beta1", "kind": "Cluster", "metadata": map[string]interface{}{"name": "cluster-1", "namespace": "default"}},
+	}, nil)
+	defer server.Close()
+
+	result, err := executeCAPIRetryProvisioning(context.Background(), cfg, federation.ActionRequest{ActionID: capiActionRetryProvisioning, ClusterName: "cluster-1", Payload: map[string]interface{}{"namespace": "default"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OK {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+
+	updated := state.object(path)
+	metadata := updated["metadata"].(map[string]interface{})
+	annotations := metadata["annotations"].(map[string]interface{})
+	if annotations[capiRetryAnnotation] == "" {
+		t.Fatalf("expected %s annotation to be set", capiRetryAnnotation)
+	}
+}

--- a/pkg/agent/federation/providers/clusternet_actions_http_test.go
+++ b/pkg/agent/federation/providers/clusternet_actions_http_test.go
@@ -1,0 +1,80 @@
+package providers
+
+import (
+	"context"
+	"testing"
+)
+
+func TestClusternetApproveCluster_HTTP(t *testing.T) {
+	const clusterPath = "/apis/clusters.clusternet.io/v1beta1/managedclusters/edge-1"
+
+	t.Run("approves cluster", func(t *testing.T) {
+		server, cfg, state := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			clusterPath: {"apiVersion": "clusters.clusternet.io/v1beta1", "kind": "ManagedCluster", "metadata": map[string]interface{}{"name": "edge-1"}, "spec": map[string]interface{}{"approved": false}},
+		}, nil)
+		defer server.Close()
+
+		result, err := clusternetApproveCluster(context.Background(), cfg, "edge-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.OK || result.Already {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+		updated := state.object(clusterPath)
+		approved := updated["spec"].(map[string]interface{})["approved"].(bool)
+		if !approved {
+			t.Fatal("expected spec.approved to be true")
+		}
+	})
+
+	t.Run("returns already when approved", func(t *testing.T) {
+		server, cfg, _ := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			clusterPath: {"apiVersion": "clusters.clusternet.io/v1beta1", "kind": "ManagedCluster", "metadata": map[string]interface{}{"name": "edge-1"}, "spec": map[string]interface{}{"approved": true}},
+		}, nil)
+		defer server.Close()
+
+		result, err := clusternetApproveCluster(context.Background(), cfg, "edge-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Already {
+			t.Fatalf("expected already result, got %+v", result)
+		}
+	})
+}
+
+func TestClusternetUnregisterCluster_HTTP(t *testing.T) {
+	const clusterPath = "/apis/clusters.clusternet.io/v1beta1/managedclusters/edge-1"
+
+	t.Run("deletes cluster", func(t *testing.T) {
+		server, cfg, state := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			clusterPath: {"apiVersion": "clusters.clusternet.io/v1beta1", "kind": "ManagedCluster", "metadata": map[string]interface{}{"name": "edge-1"}},
+		}, nil)
+		defer server.Close()
+
+		result, err := clusternetUnregisterCluster(context.Background(), cfg, "edge-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.OK || result.Already {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+		if state.object(clusterPath) != nil {
+			t.Fatal("expected cluster to be deleted")
+		}
+	})
+
+	t.Run("returns already when missing", func(t *testing.T) {
+		server, cfg, _ := newTestKubeAPIServer(t, nil, nil)
+		defer server.Close()
+
+		result, err := clusternetUnregisterCluster(context.Background(), cfg, "edge-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Already {
+			t.Fatalf("expected already result, got %+v", result)
+		}
+	})
+}

--- a/pkg/agent/federation/providers/karmada_actions_http_test.go
+++ b/pkg/agent/federation/providers/karmada_actions_http_test.go
@@ -1,0 +1,124 @@
+package providers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func TestExecuteKarmadaJoinCluster_HTTP(t *testing.T) {
+	const clusterPath = "/apis/cluster.karmada.io/v1alpha1/clusters/member-1"
+	const collectionPath = "/apis/cluster.karmada.io/v1alpha1/clusters"
+
+	t.Run("creates cluster", func(t *testing.T) {
+		server, cfg, state := newTestKubeAPIServer(t, nil, nil)
+		defer server.Close()
+
+		result, err := executeKarmadaJoinCluster(context.Background(), cfg, federation.ActionRequest{ActionID: karmadaActionJoinCluster, ClusterName: "member-1", Payload: map[string]interface{}{"apiEndpoint": "https://member-1:6443"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.OK || result.Already {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+		created := state.object(clusterPath)
+		if created == nil {
+			t.Fatalf("expected object at %s", clusterPath)
+		}
+		spec := created["spec"].(map[string]interface{})
+		if spec["apiEndpoint"].(string) != "https://member-1:6443" || spec["syncMode"].(string) != "Pull" {
+			t.Fatalf("unexpected created spec: %#v", spec)
+		}
+		_ = collectionPath
+	})
+
+	t.Run("returns already when cluster exists", func(t *testing.T) {
+		server, cfg, _ := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			clusterPath: {"apiVersion": "cluster.karmada.io/v1alpha1", "kind": "Cluster", "metadata": map[string]interface{}{"name": "member-1"}},
+		}, nil)
+		defer server.Close()
+
+		result, err := executeKarmadaJoinCluster(context.Background(), cfg, federation.ActionRequest{ActionID: karmadaActionJoinCluster, ClusterName: "member-1", Payload: map[string]interface{}{"apiEndpoint": "https://member-1:6443"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Already {
+			t.Fatalf("expected already result, got %+v", result)
+		}
+	})
+}
+
+func TestExecuteKarmadaUnjoinCluster_HTTP(t *testing.T) {
+	const clusterPath = "/apis/cluster.karmada.io/v1alpha1/clusters/member-1"
+
+	t.Run("deletes cluster", func(t *testing.T) {
+		server, cfg, state := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			clusterPath: {"apiVersion": "cluster.karmada.io/v1alpha1", "kind": "Cluster", "metadata": map[string]interface{}{"name": "member-1"}},
+		}, nil)
+		defer server.Close()
+
+		result, err := executeKarmadaUnjoinCluster(context.Background(), cfg, federation.ActionRequest{ActionID: karmadaActionUnjoinCluster, ClusterName: "member-1"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.OK || result.Already {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+		if state.object(clusterPath) != nil {
+			t.Fatal("expected cluster to be deleted")
+		}
+	})
+
+	t.Run("returns already when missing", func(t *testing.T) {
+		server, cfg, _ := newTestKubeAPIServer(t, nil, nil)
+		defer server.Close()
+
+		result, err := executeKarmadaUnjoinCluster(context.Background(), cfg, federation.ActionRequest{ActionID: karmadaActionUnjoinCluster, ClusterName: "member-1"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Already {
+			t.Fatalf("expected already result, got %+v", result)
+		}
+	})
+}
+
+func TestExecuteKarmadaTaintCluster_HTTP(t *testing.T) {
+	const clusterPath = "/apis/cluster.karmada.io/v1alpha1/clusters/member-1"
+
+	t.Run("adds taint", func(t *testing.T) {
+		server, cfg, state := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			clusterPath: {"apiVersion": "cluster.karmada.io/v1alpha1", "kind": "Cluster", "metadata": map[string]interface{}{"name": "member-1"}, "spec": map[string]interface{}{}},
+		}, nil)
+		defer server.Close()
+
+		result, err := executeKarmadaTaintCluster(context.Background(), cfg, federation.ActionRequest{ActionID: karmadaActionTaintCluster, ClusterName: "member-1", Payload: map[string]interface{}{"key": "dedicated", "value": "gpu", "effect": "NoSchedule"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.OK || result.Already {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+		updated := state.object(clusterPath)
+		taints := updated["spec"].(map[string]interface{})["taints"].([]interface{})
+		if len(taints) != 1 {
+			t.Fatalf("expected 1 taint, got %d", len(taints))
+		}
+	})
+
+	t.Run("returns already when taint exists", func(t *testing.T) {
+		server, cfg, _ := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			clusterPath: {"apiVersion": "cluster.karmada.io/v1alpha1", "kind": "Cluster", "metadata": map[string]interface{}{"name": "member-1"}, "spec": map[string]interface{}{"taints": []interface{}{map[string]interface{}{"key": "dedicated", "value": "gpu", "effect": "NoSchedule"}}}},
+		}, nil)
+		defer server.Close()
+
+		result, err := executeKarmadaTaintCluster(context.Background(), cfg, federation.ActionRequest{ActionID: karmadaActionTaintCluster, ClusterName: "member-1", Payload: map[string]interface{}{"key": "dedicated", "value": "gpu", "effect": "NoSchedule"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Already {
+			t.Fatalf("expected already result, got %+v", result)
+		}
+	})
+}

--- a/pkg/agent/federation/providers/kubeadmiral_read_test.go
+++ b/pkg/agent/federation/providers/kubeadmiral_read_test.go
@@ -1,0 +1,120 @@
+package providers
+
+import (
+	"context"
+	"testing"
+)
+
+func TestKubeAdmiralReadClusters(t *testing.T) {
+	ts, cfg := fakeAPIServer(t, map[string]interface{}{
+		"/apis/core.kubeadmiral.io/v1alpha1/federatedclusters": map[string]interface{}{
+			"kind":       "FederatedClusterList",
+			"apiVersion": "core.kubeadmiral.io/v1alpha1",
+			"items": []interface{}{
+				map[string]interface{}{
+					"metadata": map[string]interface{}{"name": "member-1", "labels": map[string]interface{}{"region": "us-east"}},
+					"spec":     map[string]interface{}{"apiEndpoint": "https://member-1:6443"},
+					"status": map[string]interface{}{"conditions": []interface{}{
+						map[string]interface{}{"type": "Ready", "status": "True"},
+					}},
+				},
+				map[string]interface{}{
+					"metadata": map[string]interface{}{"name": "member-2"},
+					"status": map[string]interface{}{"conditions": []interface{}{
+						map[string]interface{}{"type": "Ready", "status": "False"},
+					}},
+				},
+			},
+		},
+	})
+	defer ts.Close()
+
+	clusters, err := (&kubeAdmiralProvider{}).ReadClusters(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ReadClusters returned error: %v", err)
+	}
+	if len(clusters) != 2 {
+		t.Fatalf("expected 2 clusters, got %d", len(clusters))
+	}
+	if clusters[0].Name != "member-1" || clusters[0].Available != "True" {
+		t.Fatalf("unexpected first cluster: %+v", clusters[0])
+	}
+	if clusters[1].Name != "member-2" || clusters[1].Available != "False" {
+		t.Fatalf("unexpected second cluster: %+v", clusters[1])
+	}
+}
+
+func TestKubeAdmiralReadGroups(t *testing.T) {
+	ts, cfg := fakeAPIServer(t, map[string]interface{}{
+		"/apis/core.kubeadmiral.io/v1alpha1/federatedclusters": map[string]interface{}{
+			"kind": "FederatedClusterList",
+			"items": []interface{}{
+				map[string]interface{}{"metadata": map[string]interface{}{"name": "member-1", "labels": map[string]interface{}{"region": "us-east", "env": "prod"}}},
+				map[string]interface{}{"metadata": map[string]interface{}{"name": "member-2", "labels": map[string]interface{}{"region": "us-east"}}},
+			},
+		},
+	})
+	defer ts.Close()
+
+	groups, err := (&kubeAdmiralProvider{}).ReadGroups(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ReadGroups returned error: %v", err)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 synthetic groups, got %d", len(groups))
+	}
+
+	foundRegion := false
+	foundEnv := false
+	for _, group := range groups {
+		switch group.Name {
+		case "region=us-east":
+			foundRegion = true
+			if len(group.Members) != 2 {
+				t.Fatalf("expected 2 members in region group, got %d", len(group.Members))
+			}
+		case "env=prod":
+			foundEnv = true
+			if len(group.Members) != 1 || group.Members[0] != "member-1" {
+				t.Fatalf("unexpected env group members: %#v", group.Members)
+			}
+		}
+	}
+	if !foundRegion || !foundEnv {
+		t.Fatalf("missing expected groups: foundRegion=%v foundEnv=%v", foundRegion, foundEnv)
+	}
+}
+
+func TestKubeAdmiralReadPendingJoins(t *testing.T) {
+	ts, cfg := fakeAPIServer(t, map[string]interface{}{
+		"/apis/core.kubeadmiral.io/v1alpha1/federatedclusters": map[string]interface{}{
+			"kind": "FederatedClusterList",
+			"items": []interface{}{
+				map[string]interface{}{
+					"metadata": map[string]interface{}{"name": "pending-member", "creationTimestamp": "2026-01-01T00:00:00Z"},
+					"status": map[string]interface{}{"conditions": []interface{}{
+						map[string]interface{}{"type": "Ready", "status": "False"},
+					}},
+				},
+				map[string]interface{}{
+					"metadata": map[string]interface{}{"name": "joined-member", "creationTimestamp": "2026-01-01T00:00:00Z"},
+					"status": map[string]interface{}{"conditions": []interface{}{
+						map[string]interface{}{"type": "Ready", "status": "True"},
+					}},
+				},
+			},
+		},
+	})
+	defer ts.Close()
+
+	pending, err := (&kubeAdmiralProvider{}).ReadPendingJoins(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ReadPendingJoins returned error: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending join, got %d", len(pending))
+	}
+	if pending[0].ClusterName != "pending-member" {
+		t.Fatalf("expected pending-member, got %s", pending[0].ClusterName)
+	}
+}

--- a/pkg/agent/federation/providers/liqo_read_test.go
+++ b/pkg/agent/federation/providers/liqo_read_test.go
@@ -1,0 +1,95 @@
+package providers
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLiqoReadClusters(t *testing.T) {
+	ts, cfg := fakeAPIServer(t, map[string]interface{}{
+		"/apis/discovery.liqo.io/v1alpha1/foreignclusters": map[string]interface{}{
+			"kind":       "ForeignClusterList",
+			"apiVersion": "discovery.liqo.io/v1alpha1",
+			"items": []interface{}{
+				map[string]interface{}{
+					"metadata": map[string]interface{}{"name": "peer-1"},
+					"spec":     map[string]interface{}{"controlPlaneEndpoint": "https://peer-1:6443"},
+					"status": map[string]interface{}{"peeringConditions": []interface{}{
+						map[string]interface{}{"type": "OutgoingPeering", "status": "Active"},
+					}},
+				},
+				map[string]interface{}{
+					"metadata": map[string]interface{}{"name": "peer-2"},
+					"spec":     map[string]interface{}{"foreignAuthURL": "https://peer-2:9443/auth"},
+					"status": map[string]interface{}{"peeringConditions": []interface{}{
+						map[string]interface{}{"type": "OutgoingPeering", "status": "Pending"},
+					}},
+				},
+			},
+		},
+	})
+	defer ts.Close()
+
+	clusters, err := (&liqoProvider{}).ReadClusters(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ReadClusters returned error: %v", err)
+	}
+	if len(clusters) != 2 {
+		t.Fatalf("expected 2 clusters, got %d", len(clusters))
+	}
+	if clusters[0].State != "joined" || clusters[1].State != "pending" {
+		t.Fatalf("unexpected states: %#v", clusters)
+	}
+	if clusters[1].APIServerURL != "https://peer-2:9443/auth" {
+		t.Fatalf("expected foreignAuthURL fallback, got %s", clusters[1].APIServerURL)
+	}
+}
+
+func TestLiqoReadGroups(t *testing.T) {
+	ts, cfg := fakeAPIServer(t, map[string]interface{}{
+		"/apis/discovery.liqo.io/v1alpha1/foreignclusters": map[string]interface{}{
+			"kind": "ForeignClusterList",
+			"items": []interface{}{
+				map[string]interface{}{"metadata": map[string]interface{}{"name": "peer-1"}, "status": map[string]interface{}{"peeringConditions": []interface{}{map[string]interface{}{"type": "OutgoingPeering", "status": "Active"}}}},
+				map[string]interface{}{"metadata": map[string]interface{}{"name": "peer-2"}, "status": map[string]interface{}{"peeringConditions": []interface{}{map[string]interface{}{"type": "IncomingPeering", "status": "Active"}}}},
+				map[string]interface{}{"metadata": map[string]interface{}{"name": "peer-3"}, "status": map[string]interface{}{"peeringConditions": []interface{}{map[string]interface{}{"type": "OutgoingPeering", "status": "Pending"}}}},
+			},
+		},
+	})
+	defer ts.Close()
+
+	groups, err := (&liqoProvider{}).ReadGroups(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ReadGroups returned error: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 peers group, got %d", len(groups))
+	}
+	if groups[0].Name != "peers" || len(groups[0].Members) != 2 {
+		t.Fatalf("unexpected group: %+v", groups[0])
+	}
+}
+
+func TestLiqoReadPendingJoins(t *testing.T) {
+	ts, cfg := fakeAPIServer(t, map[string]interface{}{
+		"/apis/discovery.liqo.io/v1alpha1/foreignclusters": map[string]interface{}{
+			"kind": "ForeignClusterList",
+			"items": []interface{}{
+				map[string]interface{}{"metadata": map[string]interface{}{"name": "peer-1", "creationTimestamp": "2026-01-01T00:00:00Z"}, "status": map[string]interface{}{"peeringConditions": []interface{}{map[string]interface{}{"type": "OutgoingPeering", "status": "Pending"}}}},
+				map[string]interface{}{"metadata": map[string]interface{}{"name": "peer-2", "creationTimestamp": "2026-01-01T00:00:00Z"}, "status": map[string]interface{}{"peeringConditions": []interface{}{map[string]interface{}{"type": "OutgoingPeering", "status": "Active"}}}},
+			},
+		},
+	})
+	defer ts.Close()
+
+	pending, err := (&liqoProvider{}).ReadPendingJoins(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ReadPendingJoins returned error: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending join, got %d", len(pending))
+	}
+	if pending[0].ClusterName != "peer-1" {
+		t.Fatalf("expected peer-1, got %s", pending[0].ClusterName)
+	}
+}

--- a/pkg/agent/federation/providers/ocm_actions_http_test.go
+++ b/pkg/agent/federation/providers/ocm_actions_http_test.go
@@ -1,0 +1,126 @@
+package providers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func TestExecuteOCMApproveCSR_HTTP(t *testing.T) {
+	const csrPath = "/apis/certificates.k8s.io/v1/certificatesigningrequests/csr-1"
+
+	t.Run("approves pending csr", func(t *testing.T) {
+		server, cfg, state := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			csrPath: {"apiVersion": "certificates.k8s.io/v1", "kind": "CertificateSigningRequest", "metadata": map[string]interface{}{"name": "csr-1"}, "status": map[string]interface{}{"conditions": []interface{}{}}},
+		}, nil)
+		defer server.Close()
+
+		result, err := executeOCMApproveCSR(context.Background(), cfg, federation.ActionRequest{ActionID: ocmActionApproveCSR, Payload: map[string]interface{}{"csrName": "csr-1"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.OK || result.Already {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+
+		updated := state.object(csrPath)
+		conditions := updated["status"].(map[string]interface{})["conditions"].([]interface{})
+		if len(conditions) != 1 {
+			t.Fatalf("expected 1 condition, got %d", len(conditions))
+		}
+		condition := conditions[0].(map[string]interface{})
+		if condition["type"].(string) != "Approved" {
+			t.Fatalf("unexpected condition: %#v", condition)
+		}
+	})
+
+	t.Run("returns already for approved csr", func(t *testing.T) {
+		server, cfg, _ := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			csrPath: {"apiVersion": "certificates.k8s.io/v1", "kind": "CertificateSigningRequest", "metadata": map[string]interface{}{"name": "csr-1"}, "status": map[string]interface{}{"conditions": []interface{}{map[string]interface{}{"type": "Approved", "status": "True"}}}},
+		}, nil)
+		defer server.Close()
+
+		result, err := executeOCMApproveCSR(context.Background(), cfg, federation.ActionRequest{ActionID: ocmActionApproveCSR, Payload: map[string]interface{}{"csrName": "csr-1"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Already {
+			t.Fatalf("expected already result, got %+v", result)
+		}
+	})
+}
+
+func TestExecuteOCMAcceptCluster_HTTP(t *testing.T) {
+	const clusterPath = "/apis/cluster.open-cluster-management.io/v1/managedclusters/spoke-1"
+
+	t.Run("accepts cluster", func(t *testing.T) {
+		server, cfg, state := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			clusterPath: {"apiVersion": "cluster.open-cluster-management.io/v1", "kind": "ManagedCluster", "metadata": map[string]interface{}{"name": "spoke-1"}, "spec": map[string]interface{}{"hubAcceptsClient": false}},
+		}, nil)
+		defer server.Close()
+
+		result, err := executeOCMAcceptCluster(context.Background(), cfg, federation.ActionRequest{ActionID: ocmActionAcceptCluster, ClusterName: "spoke-1"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.OK || result.Already {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+		updated := state.object(clusterPath)
+		accepted := updated["spec"].(map[string]interface{})["hubAcceptsClient"].(bool)
+		if !accepted {
+			t.Fatal("expected hubAcceptsClient to be true")
+		}
+	})
+
+	t.Run("returns already when accepted", func(t *testing.T) {
+		server, cfg, _ := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			clusterPath: {"apiVersion": "cluster.open-cluster-management.io/v1", "kind": "ManagedCluster", "metadata": map[string]interface{}{"name": "spoke-1"}, "spec": map[string]interface{}{"hubAcceptsClient": true}},
+		}, nil)
+		defer server.Close()
+
+		result, err := executeOCMAcceptCluster(context.Background(), cfg, federation.ActionRequest{ActionID: ocmActionAcceptCluster, ClusterName: "spoke-1"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Already {
+			t.Fatalf("expected already result, got %+v", result)
+		}
+	})
+}
+
+func TestExecuteOCMDetachCluster_HTTP(t *testing.T) {
+	const clusterPath = "/apis/cluster.open-cluster-management.io/v1/managedclusters/spoke-1"
+
+	t.Run("deletes cluster", func(t *testing.T) {
+		server, cfg, state := newTestKubeAPIServer(t, map[string]map[string]interface{}{
+			clusterPath: {"apiVersion": "cluster.open-cluster-management.io/v1", "kind": "ManagedCluster", "metadata": map[string]interface{}{"name": "spoke-1"}},
+		}, nil)
+		defer server.Close()
+
+		result, err := executeOCMDetachCluster(context.Background(), cfg, federation.ActionRequest{ActionID: ocmActionDetachCluster, ClusterName: "spoke-1"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.OK || result.Already {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+		if state.object(clusterPath) != nil {
+			t.Fatal("expected cluster to be removed")
+		}
+	})
+
+	t.Run("returns already when missing", func(t *testing.T) {
+		server, cfg, _ := newTestKubeAPIServer(t, nil, nil)
+		defer server.Close()
+
+		result, err := executeOCMDetachCluster(context.Background(), cfg, federation.ActionRequest{ActionID: ocmActionDetachCluster, ClusterName: "spoke-1"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Already {
+			t.Fatalf("expected already result, got %+v", result)
+		}
+	})
+}

--- a/pkg/agent/federation/providers/test_server_test.go
+++ b/pkg/agent/federation/providers/test_server_test.go
@@ -1,0 +1,203 @@
+package providers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+type testKubeAPIServer struct {
+	t        *testing.T
+	mu       sync.Mutex
+	objects  map[string]map[string]interface{}
+	statuses map[string]int
+}
+
+func newTestKubeAPIServer(t *testing.T, objects map[string]map[string]interface{}, statuses map[string]int) (*httptest.Server, *rest.Config, *testKubeAPIServer) {
+	t.Helper()
+
+	state := &testKubeAPIServer{
+		t:        t,
+		objects:  make(map[string]map[string]interface{}, len(objects)),
+		statuses: statuses,
+	}
+	for path, obj := range objects {
+		state.objects[path] = deepCopyMap(t, obj)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		state.handle(w, r)
+	}))
+
+	return server, &rest.Config{
+		Host: server.URL,
+		ContentConfig: rest.ContentConfig{
+			ContentType:        "application/json",
+			AcceptContentTypes: "application/json",
+		},
+	}, state
+}
+
+func (s *testKubeAPIServer) handle(w http.ResponseWriter, r *http.Request) {
+	s.t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+
+	if status, ok := s.statuses[r.Method+" "+r.URL.Path]; ok {
+		writeStatusResponse(w, status, r.URL.Path)
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	switch r.Method {
+	case http.MethodGet:
+		obj, ok := s.objects[r.URL.Path]
+		if !ok {
+			writeStatusResponse(w, http.StatusNotFound, r.URL.Path)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(obj)
+	case http.MethodPost:
+		var obj map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&obj); err != nil {
+			writeStatusResponse(w, http.StatusBadRequest, r.URL.Path)
+			return
+		}
+		name := nestedString(obj, "metadata", "name")
+		if name == "" {
+			writeStatusResponse(w, http.StatusBadRequest, r.URL.Path)
+			return
+		}
+		objectPath := strings.TrimSuffix(r.URL.Path, "/") + "/" + name
+		if _, exists := s.objects[objectPath]; exists {
+			writeStatusResponse(w, http.StatusConflict, objectPath)
+			return
+		}
+		s.objects[objectPath] = obj
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(obj)
+	case http.MethodPatch:
+		current, ok := s.objects[r.URL.Path]
+		if !ok {
+			writeStatusResponse(w, http.StatusNotFound, r.URL.Path)
+			return
+		}
+		var patch map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+			writeStatusResponse(w, http.StatusBadRequest, r.URL.Path)
+			return
+		}
+		mergeMaps(current, patch)
+		s.objects[r.URL.Path] = current
+		_ = json.NewEncoder(w).Encode(current)
+	case http.MethodDelete:
+		if _, ok := s.objects[r.URL.Path]; !ok {
+			writeStatusResponse(w, http.StatusNotFound, r.URL.Path)
+			return
+		}
+		delete(s.objects, r.URL.Path)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"kind": "Status", "status": "Success", "code": http.StatusOK})
+	case http.MethodPut:
+		basePath := strings.TrimSuffix(r.URL.Path, "/approval")
+		if _, ok := s.objects[basePath]; !ok {
+			writeStatusResponse(w, http.StatusNotFound, basePath)
+			return
+		}
+		var obj map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&obj); err != nil {
+			writeStatusResponse(w, http.StatusBadRequest, r.URL.Path)
+			return
+		}
+		s.objects[basePath] = obj
+		_ = json.NewEncoder(w).Encode(obj)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *testKubeAPIServer) object(path string) map[string]interface{} {
+	s.t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	obj, ok := s.objects[path]
+	if !ok {
+		return nil
+	}
+	return deepCopyMap(s.t, obj)
+}
+
+func writeStatusResponse(w http.ResponseWriter, code int, path string) {
+	reason := "Unknown"
+	message := "request failed"
+	switch code {
+	case http.StatusNotFound:
+		reason = "NotFound"
+		message = "404 not found"
+	case http.StatusConflict:
+		reason = "Conflict"
+		message = "the object has been modified"
+	case http.StatusBadRequest:
+		reason = "BadRequest"
+		message = "bad request"
+	}
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"kind":    "Status",
+		"status":  "Failure",
+		"message": message + ": " + path,
+		"reason":  reason,
+		"code":    code,
+	})
+}
+
+func mergeMaps(dst, patch map[string]interface{}) {
+	for key, value := range patch {
+		patchMap, patchIsMap := value.(map[string]interface{})
+		dstMap, dstIsMap := dst[key].(map[string]interface{})
+		if patchIsMap && dstIsMap {
+			mergeMaps(dstMap, patchMap)
+			continue
+		}
+		dst[key] = value
+	}
+}
+
+func deepCopyMap(t *testing.T, src map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshal deep copy: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal deep copy: %v", err)
+	}
+	return out
+}
+
+func nestedString(obj map[string]interface{}, fields ...string) string {
+	current := obj
+	for i, field := range fields {
+		value, ok := current[field]
+		if !ok {
+			return ""
+		}
+		if i == len(fields)-1 {
+			str, _ := value.(string)
+			return str
+		}
+		next, ok := value.(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		current = next
+	}
+	return ""
+}


### PR DESCRIPTION
Fixes #18548
Fixes #18549

## Changes

Adds unit tests for federation providers (kubeadmiral, liqo) and federation action functions.

---
*Filed by scanner agent*