### PR TITLE
[scanner] fix: add tests for audit subsystem

### DIFF
--- a/pkg/api/audit/audit_test.go
+++ b/pkg/api/audit/audit_test.go
@@ -2,12 +2,18 @@ package audit
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+
+	"github.com/kubestellar/console/pkg/store"
 )
 
 // captureLog replaces the default slog logger with a JSON logger that writes
@@ -109,5 +115,109 @@ func TestLogUnauthorizedAttempt(t *testing.T) {
 
 	if entry["action"] != ActionUnauthorizedAttempt {
 		t.Errorf("action = %v, want %v", entry["action"], ActionUnauthorizedAttempt)
+	}
+}
+
+type auditStoreStub struct {
+	store.Store
+	userID string
+	action string
+	detail string
+	calls  int
+	err    error
+}
+
+func (s *auditStoreStub) InsertAuditLog(_ context.Context, userID, action, detail string) error {
+	s.calls++
+	s.userID = userID
+	s.action = action
+	s.detail = detail
+	return s.err
+}
+
+func TestLogPersistsAuditEntry(t *testing.T) {
+	originalStore := getStore()
+	defer SetStore(originalStore)
+
+	stub := &auditStoreStub{}
+	SetStore(stub)
+
+	app := fiber.New()
+	actorID := uuid.New()
+	app.Put("/api/settings", func(c *fiber.Ctx) error {
+		c.Locals("userID", actorID)
+		Log(c, ActionSaveSettings, "settings", "global", "saved", "ok")
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	req := httptest.NewRequest("PUT", "/api/settings", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+	_, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+
+	if stub.calls != 1 {
+		t.Fatalf("InsertAuditLog calls = %d, want 1", stub.calls)
+	}
+	if stub.userID != actorID.String() {
+		t.Fatalf("userID = %q, want %q", stub.userID, actorID.String())
+	}
+	if stub.action != ActionSaveSettings {
+		t.Fatalf("action = %q, want %q", stub.action, ActionSaveSettings)
+	}
+
+	var detail map[string]string
+	if err := json.Unmarshal([]byte(stub.detail), &detail); err != nil {
+		t.Fatalf("json.Unmarshal(detail) error = %v", err)
+	}
+	if detail["target_type"] != "settings" {
+		t.Errorf("target_type = %q, want %q", detail["target_type"], "settings")
+	}
+	if detail["target_id"] != "global" {
+		t.Errorf("target_id = %q, want %q", detail["target_id"], "global")
+	}
+	if detail["path"] != "/api/settings" {
+		t.Errorf("path = %q, want %q", detail["path"], "/api/settings")
+	}
+	if detail["method"] != "PUT" {
+		t.Errorf("method = %q, want %q", detail["method"], "PUT")
+	}
+	if detail["details"] != "saved ok" {
+		t.Errorf("details = %q, want %q", detail["details"], "saved ok")
+	}
+}
+
+func TestLogStoreFailureLogsError(t *testing.T) {
+	originalStore := getStore()
+	defer SetStore(originalStore)
+
+	stub := &auditStoreStub{err: errors.New("insert failed")}
+	SetStore(stub)
+
+	app := fiber.New()
+	app.Post("/api/login", func(c *fiber.Ctx) error {
+		Log(c, ActionAuthFailed, "session", "current")
+		return c.SendStatus(fiber.StatusUnauthorized)
+	})
+
+	var buf bytes.Buffer
+	captureLog(&buf, func() {
+		req := httptest.NewRequest("POST", "/api/login", nil)
+		_, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("app.Test() error = %v", err)
+		}
+	})
+
+	if stub.calls != 1 {
+		t.Fatalf("InsertAuditLog calls = %d, want 1", stub.calls)
+	}
+	logText := buf.String()
+	if !strings.Contains(logText, "audit: failed to persist audit entry") {
+		t.Fatalf("log output %q does not contain persistence failure message", logText)
+	}
+	if !strings.Contains(logText, "\"level\":\"ERROR\"") {
+		t.Fatalf("log output %q does not contain error level", logText)
 	}
 }

--- a/pkg/api/audit/elastic_test.go
+++ b/pkg/api/audit/elastic_test.go
@@ -62,3 +62,53 @@ func TestElasticDestination_DefaultIndex(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, elasticDefaultIndex, dest.index)
 }
+
+func TestElasticDestination_Provider(t *testing.T) {
+	dest := &ElasticDestination{}
+	assert.Equal(t, ProviderElastic, dest.Provider())
+}
+
+func TestElasticDestination_SendWithoutURLReturnsUnsupported(t *testing.T) {
+	dest := &ElasticDestination{index: "test-index"}
+	err := dest.Send(context.Background(), []PipelineEvent{{ID: "evt-1"}})
+	assert.ErrorIs(t, err, ErrDestinationUnsupported)
+}
+
+func TestElasticDestination_SendEmptyEventsSkipsRequest(t *testing.T) {
+	allowLoopbackDestinations(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be called for empty events")
+	}))
+	defer srv.Close()
+
+	dest, err := NewElasticDestination(srv.URL, "test-index", srv.Client())
+	require.NoError(t, err)
+
+	assert.NoError(t, dest.Send(context.Background(), nil))
+	assert.NoError(t, dest.Send(context.Background(), []PipelineEvent{}))
+}
+
+func TestElasticDestination_SendErrorStatus(t *testing.T) {
+	allowLoopbackDestinations(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	dest, err := NewElasticDestination(srv.URL, "test-index", srv.Client())
+	require.NoError(t, err)
+
+	err = dest.Send(context.Background(), []PipelineEvent{{ID: "evt-1"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 502")
+}
+
+func TestNewElasticDestination_AppendsBulkPath(t *testing.T) {
+	allowLoopbackDestinations(t)
+
+	dest, err := NewElasticDestination("http://localhost:9200/root/", "test-index", nil)
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(dest.url, "/root/_bulk"))
+}

--- a/pkg/api/audit/syslog_test.go
+++ b/pkg/api/audit/syslog_test.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -88,4 +89,84 @@ func TestSyslogDestination_RequiresAddr(t *testing.T) {
 	_, err := NewSyslogDestination("tcp", "", "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "addr is required")
+}
+
+func TestSyslogDestination_Provider(t *testing.T) {
+	dest := &SyslogDestination{}
+	assert.Equal(t, ProviderSyslog, dest.Provider())
+}
+
+func TestSyslogDestination_Defaults(t *testing.T) {
+	orig := syslogHostValidator
+	syslogHostValidator = func(_ string) error { return nil }
+	t.Cleanup(func() { syslogHostValidator = orig })
+
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer conn.Close()
+
+	dest, err := NewSyslogDestination("", conn.LocalAddr().String(), "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dest.Close()) })
+
+	assert.Equal(t, syslogDefaultNetwork, dest.network)
+	assert.Equal(t, syslogDefaultTag, dest.tag)
+}
+
+func TestSyslogDestination_RejectsUnsupportedNetwork(t *testing.T) {
+	_, err := NewSyslogDestination("http", "127.0.0.1:514", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported network")
+}
+
+func TestSyslogDestination_ValidationError(t *testing.T) {
+	orig := syslogHostValidator
+	syslogHostValidator = func(_ string) error { return errors.New("blocked host") }
+	t.Cleanup(func() { syslogHostValidator = orig })
+
+	_, err := NewSyslogDestination("tcp", "collector.example.com:514", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "blocked host")
+}
+
+func TestSyslogDestination_SendClosedWriter(t *testing.T) {
+	dest := &SyslogDestination{}
+	err := dest.Send(context.Background(), []PipelineEvent{{ID: "closed"}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDestinationUnsupported)
+}
+
+func TestSyslogDestination_SendCanceledContext(t *testing.T) {
+	orig := syslogHostValidator
+	syslogHostValidator = func(_ string) error { return nil }
+	t.Cleanup(func() { syslogHostValidator = orig })
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, acceptErr := ln.Accept()
+		if acceptErr == nil {
+			_ = conn.Close()
+		}
+	}()
+
+	dest, err := NewSyslogDestination("tcp", ln.Addr().String(), "test-tag")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dest.Close()) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = dest.Send(ctx, []PipelineEvent{{ID: "syslog-cancelled", Timestamp: time.Now().UTC()}})
+	require.ErrorIs(t, err, context.Canceled)
+	<-done
+}
+
+func TestSyslogDestination_CloseIsIdempotent(t *testing.T) {
+	dest := &SyslogDestination{}
+	require.NoError(t, dest.Close())
 }


### PR DESCRIPTION
Fixes #18547

## Changes

Adds unit tests for the audit subsystem to improve coverage.

---
*Filed by scanner agent*