### PR TITLE
[scanner] fix: resolve pkg/store test failures

### DIFF
--- a/pkg/store/sqlite_auth.go
+++ b/pkg/store/sqlite_auth.go
@@ -13,10 +13,14 @@ import (
 // RevokeToken persists a revoked token JTI with its expiration time.
 // INSERT OR IGNORE ensures re-revoking a token cannot silently extend
 // its expiry — the first revocation is authoritative (#7731).
+//
+// expiresAt is normalised to UTC before storage so that the string
+// representation written by the SQLite driver is directly comparable with
+// the UTC timestamp used in CleanupExpiredTokens (#18560).
 func (s *SQLiteStore) RevokeToken(ctx context.Context, jti string, expiresAt time.Time) error {
 	_, err := s.db.ExecContext(ctx,
 		`INSERT OR IGNORE INTO revoked_tokens (jti, expires_at) VALUES (?, ?)`,
-		jti, expiresAt,
+		jti, expiresAt.UTC(),
 	)
 	return err
 }
@@ -48,8 +52,12 @@ func (s *SQLiteStore) CleanupExpiredTokens(ctx context.Context) (int64, error) {
 // StoreOAuthState persists an OAuth state token with the given time-to-live.
 // The state is a single-use CSRF token; ConsumeOAuthState must be called once
 // to validate and delete it on the callback.
+//
+// Both created_at and expires_at are stored as UTC so that string comparisons
+// in CleanupExpiredOAuthStates work correctly regardless of the server's local
+// timezone (#18560).
 func (s *SQLiteStore) StoreOAuthState(ctx context.Context, state string, ttl time.Duration) error {
-	now := time.Now()
+	now := time.Now().UTC()
 	expiresAt := now.Add(ttl)
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO oauth_states (state, created_at, expires_at) VALUES (?, ?, ?)`,


### PR DESCRIPTION
Fixes #18560

## Root cause

`RevokeToken` and `StoreOAuthState` stored `time.Time` values without normalizing to UTC. The SQLite driver serialized these values using the server's local timezone (e.g. `2026-06-17T02:17:10-04:00` in EDT). `CleanupExpiredTokens` and `CleanupExpiredOAuthStates` then compared against `time.Now().UTC()`, which produces a UTC string (e.g. `2026-06-17T05:17:10Z`).

SQLite compares `DATETIME` values as strings. So `"02:17:10-04:00"` compared against `"05:17:10Z"` evaluates to `"02:17..." < "05:17..."` — marking a token that expires 2 hours in the future as already expired. This caused cleanup to delete more rows than expected, and the tests failed with `expected: 1, actual: 2` / `expected: 2, actual: 3`.

## Fix

Normalize all `time.Time` values to UTC before passing them to `INSERT` statements in `RevokeToken` and `StoreOAuthState`. This ensures stored strings and the cleanup-query parameter share the same format, making SQLite string comparison correct.

```go
// Before (bug: stores in local timezone)
jti, expiresAt

// After (fix: stores in UTC)
jti, expiresAt.UTC()
```

Same fix applied to `created_at` and `expires_at` in `StoreOAuthState`.

## Tests affected

- `TestTokenRevocation/CleanupExpiredTokens_removes_expired_entries` — now returns `1` as expected
- `TestCleanupExpiredOAuthStates` — now returns `2` as expected

The three swap-test failures (`TestGetUserPendingSwaps`, `TestGetDueSwaps`, `TestSnoozeSwap`) were already resolved on `main` by a prior commit that added the required user → dashboard → card fixture chain.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>