### PR TITLE
[scanner] fix: resolve test regressions in middleware JWT and auth cleanup

### DIFF
--- a/pkg/api/handlers/auth/handler_test.go
+++ b/pkg/api/handlers/auth/handler_test.go
@@ -210,7 +210,7 @@ func TestAuthHandler_CleanupExpiredTokens(t *testing.T) {
 	jti2 := uuid.New().String()
 	jti3 := uuid.New().String()
 
-	now := time.Now()
+	now := time.Now().UTC()
 	expiredTime := now.Add(-time.Hour)
 	futureTime := now.Add(time.Hour)
 

--- a/pkg/api/middleware/auth_test.go
+++ b/pkg/api/middleware/auth_test.go
@@ -973,9 +973,14 @@ func TestParseJWT_InvalidClaims(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, token)
 
-	// The token is parsed but claims won't match UserClaims type
-	_, ok := token.Claims.(*UserClaims)
-	assert.False(t, ok, "claims should not be UserClaims type")
+	// ParseJWT always uses &UserClaims{}, so type assertion succeeds,
+	// but UserClaims-specific fields should be zero-value for a standard claims token
+	uc, ok := token.Claims.(*UserClaims)
+	assert.True(t, ok, "claims should be *UserClaims (ParseJWT always uses UserClaims)")
+	if ok {
+		assert.Equal(t, uuid.Nil, uc.UserID, "UserID should be zero-value for standard claims token")
+		assert.Empty(t, uc.GitHubLogin, "GitHubLogin should be zero-value for standard claims token")
+	}
 }
 
 func TestJWTAuth_UserValidation(t *testing.T) {


### PR DESCRIPTION
Fixes #18562

## Changes

Resolves test regressions in middleware JWT and auth cleanup:

### 1. `pkg/api/middleware/auth_test.go` — `TestParseJWT_InvalidClaims`
- **Root cause:** `ParseJWT()` always calls `ParseWithClaims(token, &UserClaims{}, ...)`, so `token.Claims` is always `*UserClaims` — the type assertion always succeeds.
- **Fix:** Changed to assert that UserClaims-specific fields (`UserID`, `GitHubLogin`) are zero-value instead of checking the type assertion result.

### 2. `pkg/api/handlers/auth/handler_test.go` — `TestAuthHandler_CleanupExpiredTokens`
- **Root cause:** Test uses `time.Now()` (local time) but `CleanupExpiredTokens()` uses `time.Now().UTC()` for comparison. In non-UTC timezones, stored local timestamps can compare differently against UTC.
- **Fix:** Changed test to use `time.Now().UTC()` to match the production code's comparison.

### Note
The SSRF audit test failures (part 3 of #18562) are addressed separately in PR #18563.