### PR TITLE
[quality] fix: use modernc.org/sqlite in migration tests for CGO-free builds

### DIFF
--- a/pkg/store/migrations/runner_test.go
+++ b/pkg/store/migrations/runner_test.go
@@ -5,11 +5,11 @@ import (
 	"database/sql"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 func TestRun_CreatesTrackingTable(t *testing.T) {
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestRun_CreatesTrackingTable(t *testing.T) {
 }
 
 func TestRun_Idempotent(t *testing.T) {
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Test Improvement

Replaces `github.com/mattn/go-sqlite3` with `modernc.org/sqlite` in `pkg/store/migrations/runner_test.go`.

The `go-sqlite3` driver requires CGO, which isn't available in many CI environments (CGO_ENABLED=0). The rest of the codebase uses `modernc.org/sqlite` (pure Go). This mismatch causes both migration tests to always fail:

```
Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub
```

### Changes
- Import `_ "modernc.org/sqlite"` instead of `_ "github.com/mattn/go-sqlite3"`
- Change driver name from `"sqlite3"` to `"sqlite"` (modernc's registered name)

Fixes #18580

---
*Filed by quality agent (ACMM L4/L6 — full mode)*