### PR TITLE
[scanner] fix: resolve test failures from coverage suite run #3786

### DIFF
--- a/web/src/components/pods/__tests__/Pods.test.tsx
+++ b/web/src/components/pods/__tests__/Pods.test.tsx
@@ -205,7 +205,7 @@ describe('Pods Component', () => {
   it('renders the action buttons (Restart, Logs, Delete)', () => {
     renderPods()
     expect(screen.getByLabelText('common.restart')).toBeTruthy()
-    expect(screen.getByLabelText('View logs')).toBeTruthy()
+    expect(screen.getByLabelText('common.logs')).toBeTruthy()
     expect(screen.getByLabelText('common.delete')).toBeTruthy()
   })
 
@@ -228,10 +228,9 @@ describe('Pods Component', () => {
 
   it('calls drillToPod when Logs is clicked', () => {
     renderPods()
-    const logsBtn = screen.getByLabelText('View logs')
+    const logsBtn = screen.getByLabelText('common.logs')
     fireEvent.click(logsBtn)
     // Check if drillToPod was called with tab: 'logs'
-    // Note: we added tab: 'logs' to the drillToPod call in implementation
     expect(drillToPodSpy).toHaveBeenCalledWith('ctx/prod', 'default', 'my-pod', { tab: 'logs' })
   })
 

--- a/web/src/lib/modals/__tests__/ModalSections-coverage.test.tsx
+++ b/web/src/lib/modals/__tests__/ModalSections-coverage.test.tsx
@@ -36,10 +36,11 @@ vi.mock('../../constants/network', () => ({
 }))
 
 vi.mock('../../../components/ui/Button', () => ({
-  Button: ({ children, onClick, icon, title, ...props }: Record<string, unknown>) => (
+  Button: ({ children, onClick, icon, iconRight, title, ...props }: Record<string, unknown>) => (
     <button onClick={onClick as () => void} title={title as string} {...props}>
       {icon as React.ReactNode}
       {children as React.ReactNode}
+      {iconRight as React.ReactNode}
     </button>
   ),
 }))

--- a/web/src/lib/modals/__tests__/ModalSections.test.tsx
+++ b/web/src/lib/modals/__tests__/ModalSections.test.tsx
@@ -23,10 +23,11 @@ vi.mock('../../clipboard', () => ({
 
 // Mock Button component
 vi.mock('../../../components/ui/Button', () => ({
-  Button: ({ children, onClick, icon, ...props }: Record<string, unknown>) => (
+  Button: ({ children, onClick, icon, iconRight, ...props }: Record<string, unknown>) => (
     <button onClick={onClick as () => void} {...props}>
       {icon as React.ReactNode}
       {children as React.ReactNode}
+      {iconRight as React.ReactNode}
     </button>
   ),
 }))


### PR DESCRIPTION
Fixes #18573

## Summary

Fixes 8 test failures from Coverage Suite run #3786 triggered by PR #18559.

### Root causes:
1. **Button mock missing `iconRight` render** — `CollapsibleSection` passes badge content via `iconRight` prop to `Button`, but test mocks only rendered `icon` and `children`. Fixed in both `ModalSections.test.tsx` and `ModalSections-coverage.test.tsx`.

2. **Stale aria-label in Pods test** — Component uses `t('common.logs')` for the logs button, but the test expected the old hardcoded `'View logs'` string. Updated to match the i18n key.

### Files changed:
- `web/src/lib/modals/__tests__/ModalSections.test.tsx` — Button mock now renders `iconRight`
- `web/src/lib/modals/__tests__/ModalSections-coverage.test.tsx` — Same fix
- `web/src/components/pods/__tests__/Pods.test.tsx` — Updated Logs button aria-label assertion