### PR TITLE
[scanner] fix: resolve Playwright cross-browser nightly test failures

### DIFF
--- a/web/e2e/Sidebar.spec.ts
+++ b/web/e2e/Sidebar.spec.ts
@@ -119,20 +119,14 @@ test.describe('Sidebar Navigation', () => {
       // Navigate away first — clicking the home link while already on "/"
       // would not exercise any real routing behavior.
       await page.goto('/clusters')
-      
-      // Firefox-specific: Wait for /clusters route before asserting URL/content.
-      // In Firefox, there's a race where the auth context hasn't finished init,
-      // causing navigation issues. Use waitForURL() to ensure the route has loaded. (#18304, #18396)
-      await page.waitForURL('**/clusters', { timeout: SIDEBAR_TIMEOUT_MS })
-      await expect(page.getByTestId('dashboard-title')).toContainText('My Clusters', { timeout: SIDEBAR_TIMEOUT_MS })
+      await page.waitForLoadState('domcontentloaded')
       await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
+      await expectDashboardNavigation(page, '/clusters', 'My Clusters')
 
       const dashboardLink = page.locator('[data-testid="sidebar-primary-nav"] a[href="/"], [data-testid="sidebar"] a[href="/"]').first()
       await expect(dashboardLink).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
-      
-      // Click and wait for navigation
       await dashboardLink.click({ force: true })
-      await page.waitForURL('**/', { timeout: SIDEBAR_TIMEOUT_MS })
+      await page.waitForLoadState('domcontentloaded')
 
       await expectDashboardNavigation(page, '/', 'Dashboard')
     })
@@ -142,10 +136,8 @@ test.describe('Sidebar Navigation', () => {
 
       const clustersLink = page.locator('[data-testid="sidebar-primary-nav"] a[href="/clusters"], [data-testid="sidebar"] a[href="/clusters"]').first()
       await expect(clustersLink).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
-      await Promise.all([
-        page.waitForURL('**/clusters', { timeout: SIDEBAR_TIMEOUT_MS }),
-        clustersLink.click({ force: true }),
-      ])
+      await clustersLink.click({ force: true })
+      await page.waitForLoadState('domcontentloaded')
 
       await expectDashboardNavigation(page, '/clusters', 'My Clusters')
     })
@@ -155,10 +147,8 @@ test.describe('Sidebar Navigation', () => {
 
       const deployLink = page.locator('[data-testid="sidebar-primary-nav"] a[href="/deploy"], [data-testid="sidebar"] a[href="/deploy"]').first()
       await expect(deployLink).toBeVisible({ timeout: SIDEBAR_TIMEOUT_MS })
-      await Promise.all([
-        page.waitForURL('**/deploy', { timeout: SIDEBAR_TIMEOUT_MS }),
-        deployLink.click({ force: true }),
-      ])
+      await deployLink.click({ force: true })
+      await page.waitForLoadState('domcontentloaded')
 
       await expectDashboardNavigation(page, '/deploy', 'Deploy')
     })

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -157,11 +157,9 @@ test.describe('Smoke Tests', () => {
       // Navigate to a non-home route
       await page.goto('/settings')
       
-      // Firefox-specific: Wait for /settings route before asserting page content.
-      // In Firefox, there's a race where ProtectedRoute hasn't finished auth init yet,
-      // causing a redirect to home. Using waitForURL() ensures the route is fully loaded
-      // before we assert on page content. (#18304, #18396)
-      await page.waitForURL('**/settings', { timeout: 10000 })
+      // Use regex-based URL assertion for cross-browser compatibility.
+      // Glob-based waitForURL('**/settings') fails on Firefox/WebKit. (#18588)
+      await expect(page).toHaveURL(/\/settings/, { timeout: 10000 })
       await expect(page.locator('h1:has-text("Settings")')).toBeVisible({ timeout: 10000 })
 
       // Click the logo button (has aria-label "Go to home dashboard").


### PR DESCRIPTION
Fixes #18588

Resolves Playwright cross-browser nightly test failures affecting all non-Chromium browsers (webkit, firefox, mobile-safari, mobile-chrome).

**Root cause:** `Promise.all([page.waitForURL(glob), link.click()])` uses glob pattern matching in `waitForURL` which has browser-specific behavior that fails on Firefox/WebKit.

**Fix:** Replace with sequential `click()` + `waitForLoadState('domcontentloaded')`. The `expectDashboardNavigation()` helper already provides robust URL validation using `expect.poll()` without glob pattern issues.