### PR TITLE
[scanner] fix: resolve Go build failure — handleK8sError case mismatch in gateway.go

### DIFF
--- a/pkg/api/handlers/gateway.go
+++ b/pkg/api/handlers/gateway.go
@@ -61,7 +61,7 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 		// Get gateways for specific cluster
 		gateways, err := h.k8sClient.ListGatewaysForCluster(ctx, cluster, namespace)
 		if err != nil {
-			return handleK8sError(c, err)
+			return HandleK8sError(c, err)
 		}
 		return c.JSON(fiber.Map{
 			"items":      gateways,
@@ -78,7 +78,7 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 			slog.Warn("partial gateway list failure", "error", err)
 			return c.JSON(list)
 		}
-		return handleK8sError(c, err)
+		return HandleK8sError(c, err)
 	}
 
 	return c.JSON(list)
@@ -106,7 +106,7 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 		// Get routes for specific cluster
 		routes, err := h.k8sClient.ListHTTPRoutesForCluster(ctx, cluster, namespace)
 		if err != nil {
-			return handleK8sError(c, err)
+			return HandleK8sError(c, err)
 		}
 		return c.JSON(fiber.Map{
 			"items":      routes,
@@ -123,7 +123,7 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 			slog.Warn("partial httproute list failure", "error", err)
 			return c.JSON(list)
 		}
-		return handleK8sError(c, err)
+		return HandleK8sError(c, err)
 	}
 
 	return c.JSON(list)
@@ -141,7 +141,7 @@ func (h *GatewayHandlers) GetGatewayAPIStatus(c *fiber.Ctx) error {
 
 	clusters, _, err := h.k8sClient.HealthyClusters(ctx)
 	if err != nil {
-		return handleK8sError(c, err)
+		return HandleK8sError(c, err)
 	}
 
 	type clusterGatewayStatus struct {
@@ -186,7 +186,7 @@ func (h *GatewayHandlers) GetGateway(c *fiber.Ctx) error {
 
 	gateways, err := h.k8sClient.ListGatewaysForCluster(ctx, cluster, namespace)
 	if err != nil {
-		return handleK8sError(c, err)
+		return HandleK8sError(c, err)
 	}
 
 	for _, gw := range gateways {
@@ -221,7 +221,7 @@ func (h *GatewayHandlers) GetHTTPRoute(c *fiber.Ctx) error {
 
 	routes, err := h.k8sClient.ListHTTPRoutesForCluster(ctx, cluster, namespace)
 	if err != nil {
-		return handleK8sError(c, err)
+		return HandleK8sError(c, err)
 	}
 
 	for _, route := range routes {


### PR DESCRIPTION
Fixes #18697, Fixes #18701, Fixes #18702, Fixes #18703, Fixes #18704, Fixes #18705, Fixes #18706, Fixes #18717

## Root Cause

Two issues breaking the build on main:

### 1. Go Build: `handleK8sError` undefined (fixed in this PR)
`pkg/api/handlers/gateway.go` was calling `handleK8sError` (lowercase) but the function in `k8s_errors.go` is `HandleK8sError` (exported/uppercase). Changed all 7 call sites to use `HandleK8sError`.

### 2. npm: package-lock.json out of sync (separate PR #18724)
`package.json` overrides (e.g., `@babel/core ^7.29.6`) were added by PR #18685 without regenerating the lockfile. Being fixed in a companion PR via Copilot coding agent.