### PR TITLE
[outreach] restore Drasi adopter entry lost when #18161 replaced ADOPTERS.md template

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -8,11 +8,14 @@ This file lists organizations and individuals who are using KubeStellar Console 
 2. Add your organization to the table below
 3. Open a pull request with the title: `📖 docs: add <Organization> to ADOPTERS.md`
 
+> ⚠️ **Maintainer note**: When opening PRs that restructure this file, always preserve existing adopter entries. Do not replace the file with a blank template.
+
 ## Adopters List
 
 | Organization | Description | Use Case | Link |
 |---|---|---|---|
 | KubeStellar | Multi-cluster Kubernetes management | Console UI for managing KubeStellar deployments across edge and cloud clusters | [kubestellar.io](https://kubestellar.io) |
+| Drasi | Change data capture for cloud-native applications | Guided install mission for Drasi verified end-to-end by a Drasi maintainer, with engagement and fixes tracked in [drasi-project/drasi-platform#400](https://github.com/drasi-project/drasi-platform/issues/400) | [drasi.io](https://drasi.io) · [Install Mission](https://console.kubestellar.io/missions/install-drasi) |
 
 ## Adopter Tiers
 


### PR DESCRIPTION
## Outreach Content — Adopter Recovery

Restores the **Drasi** adopter entry that was lost when PR #18161 replaced the entire ADOPTERS.md file with a new template.

### Background

- PR #10938 (merged 2026-04-29) added Drasi to ADOPTERS.md ✅
- PR #18161 (merged later) initialized a new ADOPTERS.md program template, **overwriting the Drasi entry** ❌
- Current `main` shows only 1 self-entry

### What this PR does

1. **Restores Drasi entry** — the Drasi maintainer verified the install mission end-to-end (see `drasi-project/drasi-platform#400`). No re-approval needed; this was already merged.
2. **Adds a maintainer note** to ADOPTERS.md warning that file restructuring PRs must preserve existing adopter entries — preventing the same issue from recurring.

### Drasi entry
| Drasi | Change data capture for cloud-native apps | Guided install mission verified end-to-end by Drasi maintainer, tracked in drasi-project/drasi-platform#400 | drasi.io |

### Model Pack
Model Pack (#9114) was closed with `hold` pending maintainer approval. A separate follow-up in `modelpack/model-csi-driver#30` is needed before that entry can be re-added.

Related: #18730 (adopter recovery issue), supersedes #10938

---
*Filed by outreach agent (ACMM L6 — full mode)*