### PR TITLE
[outreach] content: blog post — CVE-2026-3864 guided remediation via KubeStellar console-kb

### DIFF
--- a/docs/blog/2026-cve-2026-3864-nfs-csi-consolekb-remediation.md
+++ b/docs/blog/2026-cve-2026-3864-nfs-csi-consolekb-remediation.md
@@ -1,0 +1,170 @@
+---
+title: "Guided CVE Remediation in KubeStellar Console KB: Walk-through of CVE-2026-3864 (NFS CSI Path Traversal)"
+date: 2026-06-17
+authors:
+  - kubestellar-team
+tags:
+  - security
+  - cve
+  - kubernetes
+  - nfs
+  - csi
+  - multi-cluster
+  - platform-engineering
+draft: true
+---
+
+# Guided CVE Remediation in KubeStellar Console KB
+## Walk-through: CVE-2026-3864 — NFS CSI Driver Path Traversal
+
+> **Draft** — ready for review by security team. Related: #18739
+
+KubeStellar Console KB now ships a production-quality guided remediation mission for **CVE-2026-3864** — a CVSS 6.5 Medium path traversal vulnerability in the Kubernetes NFS CSI driver. This post walks through what the vulnerability is, how to detect it, and how the console-kb mission guides you to a fix.
+
+---
+
+## What Is CVE-2026-3864?
+
+**Affected component**: `kubernetes-csi/csi-driver-nfs` (all versions prior to v4.13.1)  
+**CVSS score**: 6.5 Medium  
+**Attack type**: Path traversal via crafted `volumeHandle`  
+**Fixed in**: [v4.13.1](https://github.com/kubernetes-csi/csi-driver-nfs/releases/tag/v4.13.1)
+
+The NFS CSI driver performs insufficient validation of the `subDir` parameter in PersistentVolume identifiers. An attacker with PersistentVolume creation privileges can craft a `volumeHandle` containing `../` path traversal sequences. When the CSI driver processes the volume during cleanup, it follows the traversal path and may **delete or modify unintended directories on the NFS server** — including directories belonging to other tenants.
+
+This vulnerability is particularly dangerous in multi-tenant clusters and shared NFS environments where different teams share the same NFS server but should be isolated from each other.
+
+---
+
+## Who Is Affected?
+
+You are affected if:
+1. The `nfs.csi.k8s.io` CSI driver is deployed in your cluster
+2. The deployed version is older than v4.13.1
+3. Tenants with PersistentVolume creation privileges exist (standard in almost every production cluster)
+
+Standalone NFS mounts (`hostPath` or static PVs) are **not** affected by this CVE.
+
+---
+
+## The KubeStellar Console KB Mission
+
+The console-kb mission `fix-cve-2026-3864` provides a four-step guided remediation that runs in approximately 10 minutes:
+
+### Step 1: Detect — Is the NFS CSI driver installed?
+
+```bash
+kubectl get csidrivers nfs.csi.k8s.io 2>/dev/null \
+  && echo 'NFS CSI driver is installed' \
+  || echo 'NFS CSI driver not found — not affected'
+```
+
+If the driver is not installed, you stop here. No action needed.
+
+### Step 2: Version Check — Are you running a vulnerable version?
+
+```bash
+kubectl get pods -n kube-system -l app.kubernetes.io/name=csi-driver-nfs \
+  -o jsonpath='{.items[0].spec.containers[0].image}'
+helm list -n kube-system | grep csi-driver-nfs
+```
+
+Versions older than `v4.13.1` are vulnerable.
+
+### Step 3: Forensics — Scan for Exploitation
+
+This is where the mission adds real value beyond a standard upgrade guide:
+
+```bash
+kubectl get pv -o json | jq -r '
+  .items[] 
+  | select(.spec.csi.driver == "nfs.csi.k8s.io") 
+  | select(.spec.csi.volumeHandle | test("\\.\\.")) 
+  | "SUSPICIOUS: \(.metadata.name) — volumeHandle: \(.spec.csi.volumeHandle)"
+'
+```
+
+If any PersistentVolumes contain `..` in their `volumeHandle`, they may have been crafted to exploit this vulnerability. **Investigate before upgrading** — an upgrade doesn't undo directory deletions that already occurred.
+
+### Step 4: Remediate — Upgrade to v4.13.1
+
+**Via Helm (recommended):**
+
+```bash
+helm repo add csi-driver-nfs \
+  https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
+helm repo update
+helm upgrade csi-driver-nfs csi-driver-nfs/csi-driver-nfs \
+  --namespace kube-system \
+  --version 4.13.1
+```
+
+> ⚠️ Note: Starting from v4.11.0 the Helm chart version does NOT use a `v` prefix. Use `4.13.1`, not `v4.13.1`.
+
+**Via kubectl manifests:**
+
+```bash
+curl -skSL \
+  https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/v4.13.1/deploy/install-driver.sh \
+  | bash -s v4.13.1 --
+```
+
+---
+
+## Multi-Cluster Considerations
+
+For teams running multi-cluster Kubernetes with KubeStellar, the CVE-2026-3864 exposure multiplies: if the same NFS server is accessible from multiple clusters (a common pattern in data center deployments), a single crafted PV in any cluster could affect the shared NFS namespace.
+
+The console-kb mission is designed to run across your entire fleet:
+1. **Run Step 1-2** on each cluster to identify which ones have the vulnerable driver
+2. **Run Step 3** on each cluster independently — crafted PVs don't propagate, so each cluster needs its own forensic scan
+3. **Run Step 4** on each affected cluster in turn
+
+KubeStellar's multi-cluster dashboard lets you see the NFS CSI driver version across all clusters at a glance from the storage cards.
+
+---
+
+## Try the Mission
+
+**Import directly into KubeStellar Console:**
+
+```
+console.kubestellar.io/missions/fix-cve-2026-3864
+```
+
+Or start in demo mode to preview the steps without a live cluster:
+
+```bash
+git clone https://github.com/kubestellar/console
+cd console && ./start-dev.sh
+# Open http://localhost:5174/missions/fix-cve-2026-3864
+```
+
+---
+
+## Why Guided CVE Remediation Matters
+
+Most CVE advisories link to a GitHub release and a one-liner upgrade command. That works when everything is clean. The KubeStellar Console KB approach adds:
+
+1. **Detection before action** — verify the driver is actually installed before alerting
+2. **Forensics** — detect whether exploitation occurred before upgrading (upgrading doesn't fix already-deleted directories)
+3. **Version-aware instructions** — the Helm v-prefix gotcha catches many operators by surprise
+4. **Interactive execution** — the mission runner shows live output from each command, not just a script to paste blindly
+
+As KubeStellar Console KB grows, this pattern extends to every new CVE affecting commonly deployed CNCF storage, networking, and security components.
+
+---
+
+## What's in console-kb?
+
+The `kubestellar/console-kb` repository now contains:
+- **1,600+ AI mission fixes** across 12+ categories
+- **188 CNCF project directories** with missions sourced from real open issues
+- **9 operational runbooks** for disaster recovery, etcd snapshots, Velero restores, cert rotation, and more
+- **CVE fixes** for Kubernetes ecosystem vulnerabilities
+
+All missions are importable directly into KubeStellar Console. Browse at [console.kubestellar.io/kb](https://console.kubestellar.io/kb).
+
+---
+
+*This blog post is a draft. Intended publish targets: KubeStellar blog, CNCF blog, and cross-posted to CNCF Slack #kubernetes-csi and #security.*


### PR DESCRIPTION
## Outreach Content

Blog post draft announcing the CVE-2026-3864 (NFS CSI path traversal) guided remediation mission in `kubestellar/console-kb`.

### What this covers
- CVE-2026-3864 description: CVSS 6.5 Medium, NFS CSI driver path traversal via crafted volumeHandle, fixed in v4.13.1
- 4-step guided mission: detect → version check → **forensics (exploitation scan)** → remediate
- Multi-cluster angle: why shared NFS servers across clusters multiply the exposure
- How to import the mission (`console.kubestellar.io/missions/fix-cve-2026-3864`)
- Context on what's in console-kb (1,600+ fixes, 188 CNCF projects, 9 runbooks)

### Why publish this

The CVE-2026-3864 fix is in console-kb right now but zero practitioners know about it. This post:
1. Drives traffic from the security/kubernetes community to KubeStellar Console KB
2. Demonstrates the value of guided CVE remediation (vs. a raw GitHub release note)
3. Seeds the CNCF blog submission pipeline

### Publish targets (after merge + review)
- KubeStellar blog (kubestellar.io/blog)
- CNCF blog
- Cross-post to CNCF Slack `#kubernetes-csi`, `#security`, r/kubernetes, r/netsec

Related: #18739

---
*Filed by outreach agent (ACMM L6 — full mode)*