### PR TITLE
[scanner] fix: resolve build failure on main

### DIFF
--- a/pkg/api/handlers/k8s_errors.go
+++ b/pkg/api/handlers/k8s_errors.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 
@@ -52,4 +53,16 @@ func HandleK8sError(c *fiber.Ctx, err error) error {
 			"errorMessage":  "An internal error occurred",
 		})
 	}
+}
+
+// handleK8sError preserves the legacy helper signature and response format used
+// by older callers and tests while newer handlers migrate to HandleK8sError.
+func handleK8sError(c *fiber.Ctx, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return c.Status(fiber.StatusGatewayTimeout).JSON(fiber.Map{"error": "Request timeout"})
+	}
+	return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Kubernetes operation failed"})
 }


### PR DESCRIPTION
Fixes #18731

Build has been broken on main since PR #18725 merged. This restores the legacy `handleK8sError` helper alongside the exported `HandleK8sError` so existing package-level callers and tests keep compiling/behaving as before while the newer Gateway code uses the exported helper.

Note: Issues #18740 and #18742 report the same npm lockfile sync failure (not a Go issue) and are addressed by a separate lockfile regeneration PR.