### PR TITLE
[scanner] fix: add kagentiprovider Discover and Invoke handler tests

### DIFF
--- a/pkg/kagentiprovider/client_additional_test.go
+++ b/pkg/kagentiprovider/client_additional_test.go
@@ -1,0 +1,185 @@
+package kagentiprovider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewKagentiClientFromEnvReturnsNilWhenDetectionFails(t *testing.T) {
+	t.Setenv("KAGENTI_AGENT_URL", "")
+	t.Setenv("KAGENTI_AGENT_NAME", "")
+	t.Setenv("KAGENTI_AGENT_NAMESPACE", "")
+	t.Setenv("KAGENTI_CONTROLLER_URL", "")
+	t.Setenv("KAGENTI_NAMESPACE", "missing-ns")
+	t.Setenv("KAGENTI_SERVICE_NAME", "missing-svc")
+	t.Setenv("KAGENTI_SERVICE_PORT", "65535")
+	t.Setenv("KAGENTI_SERVICE_PROTOCOL", "http")
+
+	client := NewKagentiClientFromEnv()
+	assert.Nil(t, client)
+}
+
+func TestDecodeAgentListInvalidShape(t *testing.T) {
+	got, err := decodeAgentList(strings.NewReader(`{"agents":"nope"}`))
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "unsupported list response shape")
+}
+
+func TestWrapperMethods(t *testing.T) {
+	t.Run("Status delegates to StatusWithContext", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/health" {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		client := NewKagentiClient(server.URL)
+		ok, err := client.Status()
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("ListAgents delegates to ListAgentsWithContext", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v1/agents" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`[{"name":"agent-one","namespace":"team-a"}]`))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		client := NewKagentiClient(server.URL)
+		agents, err := client.ListAgents()
+		require.NoError(t, err)
+		require.Len(t, agents, 1)
+		assert.Equal(t, "agent-one", agents[0].Name)
+	})
+
+	t.Run("Detect delegates to DetectWithContext", func(t *testing.T) {
+		t.Setenv("KAGENTI_NAMESPACE", "probe-ns")
+		t.Setenv("KAGENTI_SERVICE_NAME", "probe-svc")
+		t.Setenv("KAGENTI_SERVICE_PORT", "7777")
+		t.Setenv("KAGENTI_SERVICE_PROTOCOL", "http")
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Host == "probe-svc.probe-ns.svc:7777" && r.URL.Path == "/health" {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		client := &KagentiClient{httpClient: newReroutedHTTPClient(t, server.URL)}
+		assert.Equal(t, "http://probe-svc.probe-ns.svc:7777", client.Detect())
+	})
+}
+
+func TestStatusWithContextAllPathsFail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewKagentiClient(server.URL)
+	ok, err := client.StatusWithContext(context.Background())
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Contains(t, err.Error(), "failed for all known endpoints")
+}
+
+func TestStatusWithContextDirectAgentAllPathsFail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := &KagentiClient{
+		directAgentURL: strings.TrimRight(server.URL, "/"),
+		httpClient:     &http.Client{Timeout: defaultClientTimeout},
+	}
+	ok, err := client.StatusWithContext(context.Background())
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Contains(t, err.Error(), "direct agent health check failed")
+}
+
+func TestListAgentsWithContextAllPathsFail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream unavailable"))
+	}))
+	defer server.Close()
+
+	client := NewKagentiClient(server.URL)
+	agents, err := client.ListAgentsWithContext(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, agents)
+	assert.Contains(t, err.Error(), "/api/agents")
+	assert.Contains(t, err.Error(), "502")
+}
+
+func TestListAgentsWithContextInvalidJSONFallsThrough(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/agents" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"items":"invalid"}`))
+			return
+		}
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream unavailable"))
+	}))
+	defer server.Close()
+
+	client := NewKagentiClient(server.URL)
+	agents, err := client.ListAgentsWithContext(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, agents)
+	assert.Contains(t, err.Error(), "/api/agents")
+}
+
+func TestInvokeControllerModeReturnsLastFallbackError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("stream unavailable"))
+	}))
+	defer server.Close()
+
+	client := NewKagentiClient(server.URL)
+	body, err := client.Invoke(context.Background(), "team-a", "agent-one", "test", "", nil)
+	require.Error(t, err)
+	assert.Nil(t, body)
+	assert.Contains(t, err.Error(), "/api/chat/team-a/agent-one/stream")
+	assert.Contains(t, err.Error(), "502")
+}
+
+func TestInvokeDirectAgentModeReturnsLastFallbackError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("try later"))
+	}))
+	defer server.Close()
+
+	client := &KagentiClient{
+		directAgentURL: strings.TrimRight(server.URL, "/"),
+		httpClient:     &http.Client{Timeout: defaultClientTimeout},
+	}
+
+	body, err := client.Invoke(context.Background(), "", "", "msg", "", nil)
+	require.Error(t, err)
+	assert.Nil(t, body)
+	assert.Contains(t, err.Error(), "503")
+	assert.Contains(t, err.Error(), "try later")
+}

--- a/pkg/kagentiprovider/client_test.go
+++ b/pkg/kagentiprovider/client_test.go
@@ -318,7 +318,7 @@ func TestDiscover(t *testing.T) {
 
 	t.Run("escapes namespace and agent name", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "/api/a2a/team%2Fa/agent%20one/.well-known/agent.json", r.URL.Path)
+			assert.Equal(t, "/api/a2a/team%2Fa/agent%20one/.well-known/agent.json", r.URL.EscapedPath())
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"name":"agent one","description":"demo"}`))
 		}))

--- a/pkg/kagentiprovider/config_additional_test.go
+++ b/pkg/kagentiprovider/config_additional_test.go
@@ -1,0 +1,230 @@
+package kagentiprovider
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNewKubernetesConfigManagerFromEnv(t *testing.T) {
+	originalHost, hasHost := os.LookupEnv("KUBERNETES_SERVICE_HOST")
+	originalPort, hasPort := os.LookupEnv("KUBERNETES_SERVICE_PORT")
+	t.Cleanup(func() {
+		if hasHost {
+			t.Setenv("KUBERNETES_SERVICE_HOST", originalHost)
+		} else {
+			_ = os.Unsetenv("KUBERNETES_SERVICE_HOST")
+		}
+		if hasPort {
+			t.Setenv("KUBERNETES_SERVICE_PORT", originalPort)
+		} else {
+			_ = os.Unsetenv("KUBERNETES_SERVICE_PORT")
+		}
+	})
+
+	_ = os.Unsetenv("KUBERNETES_SERVICE_HOST")
+	_ = os.Unsetenv("KUBERNETES_SERVICE_PORT")
+
+	manager, err := NewKubernetesConfigManagerFromEnv()
+	if err == nil {
+		t.Fatalf("expected in-cluster config error, got manager %#v", manager)
+	}
+}
+
+func TestKubernetesConfigManagerGetStatusWithoutMatchingKey(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "kagenti-backend", Namespace: "kagenti-system"},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: "backend",
+							Env:  []corev1.EnvVar{{Name: llmProviderEnvVarName, Value: "openai"}},
+						}},
+					},
+				},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: defaultKagentiLLMSecretName, Namespace: "kagenti-system"},
+			Data: map[string][]byte{
+				"ANTHROPIC_API_KEY": []byte("sk-anthropic"),
+			},
+		},
+	)
+
+	manager := newKubernetesConfigManager(client, "kagenti-system", "kagenti-backend", defaultKagentiLLMSecretName)
+	status, err := manager.GetStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetStatus returned error: %v", err)
+	}
+	if status.APIKeyConfigured {
+		t.Fatal("expected APIKeyConfigured to be false")
+	}
+}
+
+func TestKubernetesConfigManagerGetStatusWithoutSecret(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "kagenti-backend", Namespace: "kagenti-system"},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "backend"}}},
+				},
+			},
+		},
+	)
+
+	manager := newKubernetesConfigManager(client, "kagenti-system", "kagenti-backend", defaultKagentiLLMSecretName)
+	status, err := manager.GetStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetStatus returned error: %v", err)
+	}
+	if status.LLMProvider != "" {
+		t.Fatalf("expected empty provider, got %q", status.LLMProvider)
+	}
+	if status.APIKeyConfigured {
+		t.Fatal("expected APIKeyConfigured to be false")
+	}
+	if len(status.ConfiguredProviders) != 0 {
+		t.Fatalf("expected no configured providers, got %v", status.ConfiguredProviders)
+	}
+}
+
+func TestKubernetesConfigManagerUpdateConfigUnsupportedProvider(t *testing.T) {
+	manager := newKubernetesConfigManager(fake.NewSimpleClientset(), "kagenti-system", "kagenti-backend", defaultKagentiLLMSecretName)
+
+	_, err := manager.UpdateConfig(context.Background(), ConfigUpdate{LLMProvider: "unknown"})
+	if err == nil {
+		t.Fatal("expected unsupported provider error")
+	}
+	if !errors.Is(err, ErrUnsupportedLLMProvider) {
+		t.Fatalf("expected ErrUnsupportedLLMProvider, got %v", err)
+	}
+}
+
+func TestKubernetesConfigManagerUpdateConfigRequiresExistingProviderKey(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "kagenti-backend", Namespace: "kagenti-system"},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "backend"}}},
+				},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            defaultKagentiLLMSecretName,
+				Namespace:       "kagenti-system",
+				ResourceVersion: "1",
+			},
+			Data: map[string][]byte{
+				"GEMINI_API_KEY": []byte("gemini-secret"),
+			},
+		},
+	)
+
+	manager := newKubernetesConfigManager(client, "kagenti-system", "kagenti-backend", defaultKagentiLLMSecretName)
+	_, err := manager.UpdateConfig(context.Background(), ConfigUpdate{LLMProvider: "openai"})
+	if err == nil {
+		t.Fatal("expected error when selected provider has no stored key")
+	}
+	if !errors.Is(err, ErrAPIKeyRequired) {
+		t.Fatalf("expected ErrAPIKeyRequired, got %v", err)
+	}
+}
+
+func TestKubernetesConfigManagerUpdateConfigReusesExistingKey(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "kagenti-backend", Namespace: "kagenti-system"},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: "backend",
+							Env:  []corev1.EnvVar{{Name: llmProviderEnvVarName, Value: "openai"}},
+						}},
+					},
+				},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            defaultKagentiLLMSecretName,
+				Namespace:       "kagenti-system",
+				ResourceVersion: "1",
+			},
+			Data: map[string][]byte{
+				"OPENAI_API_KEY": []byte("existing-openai-key"),
+			},
+		},
+	)
+
+	manager := newKubernetesConfigManager(client, "kagenti-system", "kagenti-backend", defaultKagentiLLMSecretName)
+	status, err := manager.UpdateConfig(context.Background(), ConfigUpdate{LLMProvider: "openai"})
+	if err != nil {
+		t.Fatalf("UpdateConfig returned error: %v", err)
+	}
+	if !status.APIKeyConfigured {
+		t.Fatal("expected APIKeyConfigured to remain true")
+	}
+	if status.LLMProvider != "openai" {
+		t.Fatalf("expected provider openai, got %q", status.LLMProvider)
+	}
+}
+
+func TestSetDeploymentLLMProviderNoContainers(t *testing.T) {
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "kagenti-backend", Namespace: "kagenti-system"}}
+
+	err := setDeploymentLLMProvider(deployment, "openai")
+	if err == nil {
+		t.Fatal("expected error for empty container list")
+	}
+}
+
+func TestSetDeploymentLLMProviderUpdatesExistingEnv(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "kagenti-backend", Namespace: "kagenti-system"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "backend",
+						Env:  []corev1.EnvVar{{Name: llmProviderEnvVarName, Value: "openai"}},
+					}},
+				},
+			},
+		},
+	}
+
+	if err := setDeploymentLLMProvider(deployment, "anthropic"); err != nil {
+		t.Fatalf("setDeploymentLLMProvider returned error: %v", err)
+	}
+	if got := extractLLMProvider(deployment); got != "anthropic" {
+		t.Fatalf("expected provider anthropic, got %q", got)
+	}
+	if deployment.Spec.Template.Annotations[rolloutRestartAnnotation] == "" {
+		t.Fatal("expected rollout annotation to be set")
+	}
+}
+
+func TestStringSliceContains(t *testing.T) {
+	if stringSliceContains([]string{"openai"}, "") {
+		t.Fatal("expected empty target to return false")
+	}
+	if stringSliceContains([]string{"openai"}, "anthropic") {
+		t.Fatal("expected missing target to return false")
+	}
+	if !stringSliceContains([]string{"openai", "anthropic"}, "anthropic") {
+		t.Fatal("expected present target to return true")
+	}
+}


### PR DESCRIPTION
Fixes #18707

Adds test coverage for kagentiprovider Discover and Invoke handlers, plus related wrapper and config edge cases, increasing coverage from 54% toward the target.