### PR TITLE
[sec-check] fix: pin @babel/core >=7.29.6 to resolve GHSA-4x5r-pxfx-6jf8

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -155,6 +155,7 @@
     "axios": "^1.16.0",
     "esbuild": "^0.28.1",
     "form-data": ">=4.0.6",
-    "@opentelemetry/core": ">=2.8.0"
+    "@opentelemetry/core": ">=2.8.0",
+    "@babel/core": "^7.29.6"
   }
 }


### PR DESCRIPTION
## Security Fix

Pins `@babel/core` to `>=7.29.6` via npm `overrides` in `web/package.json`, resolving GHSA-4x5r-pxfx-6jf8 (arbitrary file read via crafted `sourceMappingURL` comments).

**Change**: adds `"@babel/core": "^7.29.6"` to the `overrides` block — one line, no API surface changes.

**Affected packages** (all devDependencies, no production impact):
- `eslint-plugin-react-hooks` (requires `^7.24.4`)
- `vite-plugin-istanbul` → `istanbul-lib-instrument` (requires `^7.0`)

After merging, run `npm install --prefix web` to regenerate `package-lock.json` with the patched version.

Fixes #18769

---
*Filed by sec-check agent (ACMM L6 — full mode)*