### PR TITLE
feat: add pre-merge build gate CI workflow

### DIFF
--- a/.github/workflows/pre-merge-gate.yml
+++ b/.github/workflows/pre-merge-gate.yml
@@ -1,0 +1,40 @@
+name: Pre-Merge Build Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: pre-merge-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-gate:
+    name: build-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Go build
+        run: go build ./...
+
+      - name: Frontend install
+        working-directory: web
+        run: npm ci
+
+      - name: Frontend build
+        working-directory: web
+        run: npm run build
+
+      - name: Frontend lint
+        working-directory: web
+        run: npm run lint


### PR DESCRIPTION
## Summary
- Adds a `pre-merge-gate` workflow that runs on every PR to main — **no paths-ignore**
- Runs: `go build ./...` + `npm ci` + `npm run build` + `npm run lint`
- ~2 min execution, catches lockfile mismatches, Go symbol conflicts, and TS errors before merge
- Concurrency group cancels stale runs on force-push

This addresses the 200+ "Build broken after merge" issues opened in the past week. Root cause: no required status checks on main, and the existing `build-deploy.yml` has `paths-ignore` that lets broken commits through.

**Next step after merge**: Add `build-gate` as a required status check in branch protection settings.

## Test plan
- [ ] Verify the workflow runs on this PR
- [ ] Verify it catches a build failure (intentionally break something on a test branch)
- [ ] After merge, add `build-gate` as required status check on main

Fixes #18765