### PR TITLE
fix: stale Helm release history after successful rollback

### DIFF
--- a/web/src/components/drilldown/views/HelmReleaseDrillDown.tsx
+++ b/web/src/components/drilldown/views/HelmReleaseDrillDown.tsx
@@ -169,7 +169,7 @@ export function HelmReleaseDrillDown({ data }: Props) {
     if (result.success) {
       // Refresh data after rollback
       fetchReleaseInfo()
-      fetchHistory()
+      fetchHistory(true)
     }
   }
 
@@ -228,8 +228,8 @@ export function HelmReleaseDrillDown({ data }: Props) {
   }
 
   // Fetch release history
-  const fetchHistory = async () => {
-    if (!agentConnected || releaseHistory) return
+  const fetchHistory = async (force = false) => {
+    if (!agentConnected || (releaseHistory && !force)) return
     setHistoryLoading(true)
     try {
       const output = await runHelm(['history', releaseName, '-n', namespace, '-o', 'json'])

--- a/web/src/components/drilldown/views/HelmReleaseDrillDown.tsx
+++ b/web/src/components/drilldown/views/HelmReleaseDrillDown.tsx
@@ -252,8 +252,9 @@ export function HelmReleaseDrillDown({ data }: Props) {
       }
     } catch {
       setReleaseHistory([])
+    } finally {
+      setHistoryLoading(false)
     }
-    setHistoryLoading(false)
   }
 
   // Fetch release resources (manifest)


### PR DESCRIPTION
# SUMMARY

This PR fixes an issue in the Helm Release drilldown where the History tab continued to display stale revision data after a successful rollback. The change updates the history refresh logic in `HelmReleaseDrillDown.tsx` to ensure fresh revision data is fetched when a rollback completes, while preserving the existing caching behavior for normal tab navigation.

# FIX

```ts 
//After
const fetchHistory = async (force = false) => {
  if (!agentConnected || (releaseHistory && !force)) return
  ...
}

if (result.success) {
  fetchReleaseInfo()
  fetchHistory(true)
}
```

