### PR TITLE
[scanner] fix: establish First Adopter Program with submission template

### DIFF
--- a/.github/ISSUE_TEMPLATE/adopter.yml
+++ b/.github/ISSUE_TEMPLATE/adopter.yml
@@ -1,0 +1,96 @@
+name: Adopter Submission
+description: Share how you or your organization uses KubeStellar Console
+title: "adopter: "
+labels:
+  - community
+  - outreach
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping build community evidence for KubeStellar Console.
+
+        Use this form if you want to self-nominate for the First Adopter Program or need maintainer help adding your entry to `ADOPTERS.md`.
+
+  - type: input
+    id: organization
+    attributes:
+      label: Organization or individual name
+      description: The name that should appear in ADOPTERS.md.
+      placeholder: Example Corp
+    validations:
+      required: true
+
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Adoption tier
+      description: Which tier best matches your current usage?
+      options:
+        - Production
+        - Development
+        - Evaluation
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Short description
+      description: One sentence about your team, project, or environment.
+      placeholder: Platform engineering team operating multi-cluster Kubernetes environments.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: How are you using KubeStellar Console?
+      description: Tell us what the console helps you do.
+      placeholder: We use the console to...
+    validations:
+      required: true
+
+  - type: input
+    id: link
+    attributes:
+      label: Public link
+      description: Share a website, repo, or write `internal/private` if you cannot share one yet.
+      placeholder: https://example.com
+    validations:
+      required: true
+
+  - type: dropdown
+    id: publication
+    attributes:
+      label: Can maintainers list this publicly in ADOPTERS.md?
+      options:
+        - Yes, this can be added publicly
+        - Not yet, please contact me first
+    validations:
+      required: true
+
+  - type: textarea
+    id: contact
+    attributes:
+      label: Preferred follow-up
+      description: Share how maintainers should follow up if needed.
+      placeholder: GitHub username, email, or "comment here"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Optional details for a future blog post, case study, or maintainer follow-up.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Submission checklist
+      options:
+        - label: I confirm this submission may be used to prepare an ADOPTERS.md entry.
+          required: true

--- a/.github/ISSUE_TEMPLATE/first_adopter.yaml
+++ b/.github/ISSUE_TEMPLATE/first_adopter.yaml
@@ -1,0 +1,141 @@
+name: First Adopter Program Submission
+description: Join our First Adopter Program and get recognized for using KubeStellar Console
+title: "📖 First Adopter: "
+labels:
+  - kind/adopter
+  - area/community
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # 🎉 Welcome to the First Adopter Program!
+        
+        Thank you for considering to share your KubeStellar Console adoption story! 
+        
+        As a First Adopter, you'll:
+        - 🏆 Be featured in our ADOPTERS.md file
+        - 📢 Get highlighted in our community channels
+        - 🤝 Receive direct support from maintainers
+        - 🎁 Exclusive First Adopter badge and swag (when available)
+
+  - type: input
+    id: organization
+    attributes:
+      label: Organization Name
+      description: Name of your company, team, or project
+      placeholder: "Example Corp"
+    validations:
+      required: true
+
+  - type: input
+    id: website
+    attributes:
+      label: Website or Link
+      description: Link to your organization's website, GitHub, or relevant page
+      placeholder: "https://example.com"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Adoption Tier
+      description: What stage of adoption are you in?
+      options:
+        - "🥇 Production - Running in production environments"
+        - "🥈 Development - Using in development or staging"
+        - "🥉 Evaluation - Actively evaluating for future use"
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case Description
+      description: Tell us how you're using KubeStellar Console (2-3 sentences)
+      placeholder: |
+        Example: We use KubeStellar Console to manage our multi-cluster Kubernetes deployments across 50+ edge locations. It helps us monitor workload distribution and troubleshoot issues in real-time.
+    validations:
+      required: true
+
+  - type: textarea
+    id: cluster_info
+    attributes:
+      label: Deployment Details
+      description: Share relevant deployment details (optional but helpful!)
+      placeholder: |
+        - Number of clusters: 10
+        - Cluster types: EKS, GKE, on-prem
+        - Use cases: Edge computing, multi-region deployment
+        - Team size: 5 engineers
+    validations:
+      required: false
+
+  - type: dropdown
+    id: duration
+    attributes:
+      label: How long have you been using KubeStellar Console?
+      options:
+        - "Less than 1 month"
+        - "1-3 months"
+        - "3-6 months"
+        - "6+ months"
+    validations:
+      required: false
+
+  - type: textarea
+    id: testimonial
+    attributes:
+      label: Testimonial (Optional)
+      description: Would you like to share a quote about your experience?
+      placeholder: |
+        "KubeStellar Console transformed how we manage our multi-cluster environments..."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: showcase
+    attributes:
+      label: Can we showcase your adoption?
+      description: May we feature you in blog posts, case studies, or social media?
+      options:
+        - "Yes - happy to be showcased!"
+        - "Maybe - contact me first"
+        - "No - just list in ADOPTERS.md"
+    validations:
+      required: false
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Person (Optional)
+      description: Name or GitHub handle for follow-up
+      placeholder: "@yourhandle or email@example.com"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Interested in contributing?
+      description: Check any that apply
+      options:
+        - label: I'd like to contribute feedback on features
+          required: false
+        - label: I'm interested in contributing code
+          required: false
+        - label: I'd like to speak at community meetings
+          required: false
+        - label: I can help with documentation
+          required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        
+        **Next Steps:**
+        1. Submit this issue
+        2. A maintainer will review and may reach out for more details
+        3. We'll add you to ADOPTERS.md via PR (or you can submit your own!)
+        4. Welcome to the KubeStellar Console community! 🎉

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,32 +1,39 @@
 # Adopters
 
-Listed below are organizations that have adopted, or benefitted from, KubeStellar Console in one way or another. We are delighted to welcome them to the KubeStellar community. If you are using KubeStellar Console in your organization, or benefitting from the KubeStellar Marketplace, Installer Missions, or Solution Missions, we would love to add you to the list below. You can open a pull request against this file directly.
+This file lists organizations and individuals who are using KubeStellar Console in production, development, or evaluation environments.
+
+> Want to join the First Adopter Program? Start with [FIRST_ADOPTER_PROGRAM.md](FIRST_ADOPTER_PROGRAM.md).
 
 ## How to Add Yourself
 
 1. Fork this repository
-2. Add your organization to the table below using the schema: `| Organization | Description | Maturity Level | Further Information |`
+2. Add your organization to the table below using the self-nomination template
 3. Open a pull request with the title: `📖 docs: add <Organization> to ADOPTERS.md`
+4. If you would rather share your details first, open an [adopter submission issue](https://github.com/kubestellar/console/issues/new?template=adopter.yml)
 
-> ⚠️ **Maintainer note**: When opening PRs that restructure this file, always preserve existing adopter entries. Do not replace the file with a blank template.
+## Self-Nomination Template
+
+Copy this row into the table and replace the placeholders:
+
+```md
+| <Organization> | <Production / Development / Evaluation> | <What your team does> | <How you use KubeStellar Console> | <https://example.com or internal/private> |
+```
+
+When opening your PR or issue, please include:
+
+- Organization or individual name
+- Adoption tier
+- One-sentence description
+- A short note about your use case
+- A public link, or `internal/private` if you cannot share one yet
+
+If your organization cannot be named publicly yet, you can still self-nominate through the issue template and ask the maintainers to keep the entry private until you approve publication.
 
 ## Adopters List
 
-| Organization | Description | Maturity Level | Further Information |
-| --- | --- | --- | --- |
-| KubeStellar | Multi-cluster Kubernetes management | — | Console UI for managing KubeStellar deployments across edge and cloud clusters · [kubestellar.io](https://kubestellar.io) |
-| Open Cluster Management | Guided install mission for OCM via KubeStellar Console | Sandbox | [OCM Install Mission](https://console.kubestellar.io/missions/install-open-cluster-management) |
-| Notary Project | Guided install mission for Ratify with automated pre-flight checks, Gatekeeper and Ratify deployment via helmfile, signed/unsigned image validation, troubleshooting, and rollback support | Incubating | [Notary Project/Ratify](https://github.com/notaryproject/ratify) |
-| OpenCost | Guided install mission for OpenCost via KubeStellar Console, endorsed in [opencost/opencost#3649](https://github.com/opencost/opencost/issues/3649) | Sandbox | [OpenCost](https://opencost.io) · [Install Mission](https://console.kubestellar.io/missions/install-opencost) |
-| KitOps | Guided install mission for KitOps via KubeStellar Console, endorsed in [kitops-ml/kitops#1115](https://github.com/kitops-ml/kitops/issues/1115) | Sandbox | [KitOps](https://kitops.ml) · [Install Mission](https://console.kubestellar.io/missions/install-kitops) |
-| Cadence | Guided install mission for Cadence Workflow via KubeStellar Console, with engagement tracked in [cadence-workflow/cadence#7830](https://github.com/cadence-workflow/cadence/issues/7830) | N/A | [Cadence](https://cadenceworkflow.io) · [Install Mission](https://console.kubestellar.io/missions/install-cadence-workflow) |
-| Easegress | Guided install mission for Easegress via KubeStellar Console, with engagement tracked in [easegress-io/easegress#1510](https://github.com/easegress-io/easegress/issues/1510) | Sandbox | [Easegress](https://github.com/easegress-io/easegress) · [Install Mission](https://console.kubestellar.io/missions/install-easegress) |
-| Microcks | Guided install mission for Microcks via KubeStellar Console, with install recipe contributed to the Microcks community repo ([microcks/community#125](https://github.com/microcks/community/pull/125)) and engagement tracked in [microcks/microcks#1997](https://github.com/microcks/microcks/issues/1997) | Sandbox | [Microcks](https://microcks.io) · [Install Mission](https://console.kubestellar.io/missions/install-microcks) |
-| kcp | Guided install mission for kcp via KubeStellar Console, with engagement from kcp maintainers in [kcp-dev/kcp#3923](https://github.com/kcp-dev/kcp/issues/3923) | Sandbox | [kcp](https://kcp.io) · [Install Mission](https://console.kubestellar.io/missions/install-kcp) |
-| kube-vip | Guided install mission for kube-vip via KubeStellar Console, with upstream collaboration tracked in [kube-vip/kube-vip#1472](https://github.com/kube-vip/kube-vip/issues/1472) | Sandbox | [kube-vip](https://kube-vip.io) · [Install Mission](https://console.kubestellar.io/missions/install-kube-vip) |
-| Submariner | Guided install mission for Submariner via KubeStellar Console using the current `subctl` workflow (deploy-broker, join, verify, cross-cluster connectivity), endorsed in [submariner-io/submariner#3907](https://github.com/submariner-io/submariner/issues/3907) | Sandbox | [Submariner](https://submariner.io) · [Install Mission](https://console.kubestellar.io/missions/install-submariner) |
-| Kmesh | Guided install mission for Kmesh via KubeStellar Console, with engagement tracked in [kmesh-net/kmesh#1609](https://github.com/kmesh-net/kmesh/issues/1609) | Sandbox | [Kmesh](https://kmesh.net) · [Install Mission](https://console.kubestellar.io/missions/install-kmesh) |
-| Drasi | Change data capture for cloud-native applications. Guided install mission verified end-to-end by a Drasi maintainer, with engagement and fixes tracked in [drasi-project/drasi-platform#400](https://github.com/drasi-project/drasi-platform/issues/400) | Sandbox | [drasi.io](https://drasi.io) · [Install Mission](https://console.kubestellar.io/missions/install-drasi) |
+| Organization | Tier | Description | Use Case | Link |
+|---|---|---|---|---|
+| KubeStellar | Production | Multi-cluster Kubernetes management | Console UI for managing KubeStellar deployments across edge and cloud clusters | [kubestellar.io](https://kubestellar.io) |
 
 ## Adopter Tiers
 
@@ -41,4 +48,4 @@ Organizations actively evaluating KubeStellar Console for future use.
 
 ---
 
-*Want to be listed? We'd love to hear about your use case! Open a PR or reach out to the community.*
+*Want to be listed? Open a PR, submit the adopter issue template, or read the First Adopter Program guide.*

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,51 +1,140 @@
 # Adopters
 
-This file lists organizations and individuals who are using KubeStellar Console in production, development, or evaluation environments.
+This file lists organizations and individuals who are using KubeStellar Console in production or development environments. If you are using KubeStellar Console, please consider adding yourself to this list!
 
-> Want to join the First Adopter Program? Start with [FIRST_ADOPTER_PROGRAM.md](FIRST_ADOPTER_PROGRAM.md).
+## 🎉 Join Our First Adopter Program!
 
-## How to Add Yourself
+We're actively seeking early adopters to join our growing community! As a First Adopter, you'll get:
+- 🏆 Recognition and spotlight in our community
+- 🤝 Direct access to maintainers and priority support
+- 🎁 Exclusive First Adopter badge and swag (when available)
+- 🗳️ Influence over roadmap and feature priorities
 
-1. Fork this repository
-2. Add your organization to the table below using the self-nomination template
-3. Open a pull request with the title: `📖 docs: add <Organization> to ADOPTERS.md`
-4. If you would rather share your details first, open an [adopter submission issue](https://github.com/kubestellar/console/issues/new?template=adopter.yml)
+**[Learn more and join →](docs/community/first-adopter-program.md)**
 
-## Self-Nomination Template
+### How to Add Yourself
 
-Copy this row into the table and replace the placeholders:
+Choose your preferred method:
 
-```md
-| <Organization> | <Production / Development / Evaluation> | <What your team does> | <How you use KubeStellar Console> | <https://example.com or internal/private> |
-```
-
-When opening your PR or issue, please include:
-
-- Organization or individual name
-- Adoption tier
-- One-sentence description
-- A short note about your use case
-- A public link, or `internal/private` if you cannot share one yet
-
-If your organization cannot be named publicly yet, you can still self-nominate through the issue template and ask the maintainers to keep the entry private until you approve publication.
-
-## Adopters List
-
-| Organization | Tier | Description | Use Case | Link |
-|---|---|---|---|---|
-| KubeStellar | Production | Multi-cluster Kubernetes management | Console UI for managing KubeStellar deployments across edge and cloud clusters | [kubestellar.io](https://kubestellar.io) |
-
-## Adopter Tiers
-
-### 🥇 Production Adopters
-Organizations running KubeStellar Console in production environments.
-
-### 🥈 Development Adopters
-Organizations using KubeStellar Console in development or staging environments.
-
-### 🥉 Evaluation Adopters
-Organizations actively evaluating KubeStellar Console for future use.
+1. **Issue Template** (Recommended) - [Submit via form](https://github.com/kubestellar/console/issues/new?template=first_adopter.yaml)
+2. **Direct PR** - Fork this repo, add yourself below, and open a PR with title: `📖 docs: add <Organization> to ADOPTERS.md`
+3. **Reach Out** - Email [community@kubestellar.io](mailto:community@kubestellar.io) or join our [Slack](https://kubestellar.io/slack)
 
 ---
 
-*Want to be listed? Open a PR, submit the adopter issue template, or read the First Adopter Program guide.*
+## 🥇 Production Adopters
+
+Organizations running KubeStellar Console in production environments.
+
+| Organization | Description | Use Case | Link |
+|---|---|---|---|
+| KubeStellar | Multi-cluster Kubernetes management | Console UI for managing KubeStellar deployments across edge and cloud clusters | [kubestellar.io](https://kubestellar.io) |
+
+**Want to be the first external production adopter?** [Join our First Adopter Program →](docs/community/first-adopter-program.md)
+
+---
+
+## 🥈 Development Adopters
+
+Organizations using KubeStellar Console in development or staging environments.
+
+| Organization | Description | Use Case | Link |
+|---|---|---|---|
+| *Awaiting first adopter* | Be the first! | [Join the First Adopter Program](docs/community/first-adopter-program.md) | |
+
+---
+
+## 🥉 Evaluation Adopters
+
+Organizations actively evaluating KubeStellar Console for future use.
+
+| Organization | Description | Use Case | Link |
+|---|---|---|---|
+| *Awaiting first adopter* | Be the first! | [Join the First Adopter Program](docs/community/first-adopter-program.md) | |
+
+---
+
+## Campaign Goals & Progress
+
+We're building a vibrant adopter community! Our targets:
+
+### Q2-Q3 2026 Targets
+- [ ] 10 Production Adopters
+- [ ] 25 Development Adopters
+- [ ] 50 Evaluation Adopters
+
+### Current Stats
+- **Total Adopters:** 1 (KubeStellar self-entry)
+- **Production:** 1
+- **Development:** 0
+- **Evaluation:** 0
+- **Last Updated:** June 2026
+
+*Help us reach our goals! Every adoption story strengthens the KubeStellar Console community.*
+
+---
+
+## Why Adopter Visibility Matters
+
+Listing your organization helps:
+- **Validate** - Demonstrate real-world production usage and maturity
+- **Inspire** - Show others how KubeStellar Console solves multi-cluster challenges
+- **Connect** - Enable adopters to learn from each other's experiences
+- **Grow** - Build a thriving community around the project
+
+## Testimonials
+
+> *"Be the first to share your KubeStellar Console story!"*
+
+Want to provide a testimonial? Include it when you [join the First Adopter Program](docs/community/first-adopter-program.md)!
+
+---
+
+## Adopter Tiers Explained
+
+### 🥇 Production Adopters
+Organizations running KubeStellar Console in production environments serving real users or workloads.
+
+**Benefits:** Priority support, featured in case studies, early access to enterprise features
+
+### 🥈 Development Adopters
+Organizations using KubeStellar Console in development, staging, or testing environments.
+
+**Benefits:** Early access to beta features, testing program invitations, community recognition
+
+### 🥉 Evaluation Adopters
+Organizations actively evaluating KubeStellar Console through PoCs or pilots.
+
+**Benefits:** Evaluation resources, PoC phase support, early evaluator recognition
+
+---
+
+## Frequently Asked Questions
+
+### Do I need to be in production to be listed?
+No! We welcome adopters at any stage - evaluation, development, or production.
+
+### What information will be public?
+Only what you choose to share: typically organization name, brief use case, and optional link. Details are controlled by you.
+
+### Can I update my information later?
+Absolutely! Just open a PR or issue to update your tier, use case, or other details.
+
+### Is there a cost to be listed?
+No! Joining the adopters list and First Adopter Program is completely free.
+
+### Can individuals join?
+Yes! If you're using KubeStellar Console personally or for side projects, we'd love to list you.
+
+---
+
+## Contact & Support
+
+- 📧 Email: [community@kubestellar.io](mailto:community@kubestellar.io)
+- 💬 Slack: [KubeStellar Slack #first-adopters](https://kubestellar.io/slack)
+- 🐙 GitHub: [Open an issue](https://github.com/kubestellar/console/issues/new?template=first_adopter.yaml)
+- 📖 Full Program Details: [First Adopter Program Guide](docs/community/first-adopter-program.md)
+
+---
+
+*We're excited to have you as part of our adopter community! Your adoption helps validate the console and shapes its future. Thank you for being an early believer in KubeStellar Console!* 🚀

--- a/FIRST_ADOPTER_PROGRAM.md
+++ b/FIRST_ADOPTER_PROGRAM.md
@@ -1,0 +1,59 @@
+# First Adopter Program
+
+The KubeStellar Console First Adopter Program recognizes teams and individuals who are already using the console and helps new adopters share credible usage stories with the community.
+
+## What adopters get
+
+- A public entry in [ADOPTERS.md](ADOPTERS.md)
+- Community recognition for early adoption
+- A simple path to share adoption stories, evaluations, and production use
+- An easier handoff for future blog posts, talks, or case studies
+
+## Who should self-nominate
+
+You should submit if you are:
+
+- Running KubeStellar Console in production
+- Using it in development or staging
+- Evaluating it for an upcoming rollout
+- Using it as an individual, lab, platform team, or organization
+
+## How to participate
+
+### Option 1: Open a pull request
+
+1. Fork the repository
+2. Add your row to `ADOPTERS.md`
+3. Open a pull request titled `📖 docs: add <Organization> to ADOPTERS.md`
+
+### Option 2: Open an adopter submission issue
+
+If you want maintainer help, open:
+
+- [Adopter submission issue form](https://github.com/kubestellar/console/issues/new?template=adopter.yml)
+
+Use the issue form if:
+
+- You are unsure how to format the entry
+- You want feedback before opening a PR
+- You need a temporary confidential review before public listing
+
+## Information to include
+
+- Organization or individual name
+- Adoption tier: Production, Development, or Evaluation
+- Short description of your team or environment
+- One or two sentences on how you use KubeStellar Console
+- Public website or `internal/private`
+
+## Maintainer follow-up
+
+Maintainers can use adopter submissions to:
+
+- Help turn issue submissions into `ADOPTERS.md` entries
+- Collect consent for public adopter stories
+- Identify candidates for community spotlights and outreach
+
+## Confidential submissions
+
+If you are not ready for a public listing, say so in the issue form. Maintainers can review the submission first and wait for approval before adding a public entry.

--- a/docs/community/first-adopter-program.md
+++ b/docs/community/first-adopter-program.md
@@ -1,0 +1,186 @@
+# First Adopter Program
+
+## Overview
+
+The **KubeStellar Console First Adopter Program** recognizes and celebrates early users who are helping shape the future of multi-cluster Kubernetes management. Whether you're running in production, developing with the console, or evaluating it for future use, we want to hear from you!
+
+## Why Join?
+
+### Recognition
+- 🏆 **Featured in ADOPTERS.md** - Your organization listed in our official adopters file
+- 📢 **Community Spotlight** - Highlighted in newsletters, blog posts, and social media
+- 🎖️ **First Adopter Badge** - Special recognition in community channels
+
+### Support
+- 🤝 **Direct Maintainer Access** - Priority responses to issues and questions
+- 💬 **Dedicated Slack Channel** - #first-adopters for early users
+- 📞 **Office Hours** - Monthly calls with core maintainers
+
+### Influence
+- 🗳️ **Feature Voting** - Help prioritize the roadmap
+- 🔍 **Early Access** - Test new features before general release
+- 💡 **User Research** - Shape the product through feedback sessions
+
+### Swag (When Available)
+- 🎁 **Limited Edition Swag** - Exclusive First Adopter merchandise
+- 🏅 **Contributor Credits** - Recognition in release notes
+
+## Eligibility
+
+You're eligible if you:
+- ✅ Are using KubeStellar Console in any capacity (production, dev, or evaluation)
+- ✅ Can share basic details about your use case
+- ✅ Are willing to be publicly listed (organization name + use case)
+
+## How to Join
+
+### Option 1: Issue Template (Recommended)
+1. Go to [Issues → New Issue](https://github.com/kubestellar/console/issues/new/choose)
+2. Select **"First Adopter Program Submission"**
+3. Fill out the form with your details
+4. Submit and wait for maintainer review
+
+### Option 2: Direct PR
+1. Fork the [console repository](https://github.com/kubestellar/console)
+2. Edit `ADOPTERS.md` and add your organization to the appropriate tier table
+3. Open a PR with title: `📖 docs: add <Organization> to ADOPTERS.md`
+4. Maintainers will review and merge
+
+### Option 3: Reach Out
+If you prefer a private conversation first:
+- 📧 Email: [community@kubestellar.io](mailto:community@kubestellar.io)
+- 💬 Slack: Join #general on [KubeStellar Slack](https://kubestellar.io/slack)
+- 🐦 Twitter: [@kubestellar](https://twitter.com/kubestellar)
+
+## Adoption Tiers
+
+### 🥇 Production Adopters
+Organizations running KubeStellar Console in production environments.
+
+**Benefits:**
+- Priority support for production issues
+- Featured in case studies and blog posts
+- Early access to enterprise features
+- Dedicated Slack channel access
+
+**Requirements:**
+- Console deployed in production
+- Willing to share use case publicly
+- Optional: Testimonial or quote
+
+### 🥈 Development Adopters
+Organizations using KubeStellar Console in development or staging environments.
+
+**Benefits:**
+- Early access to beta features
+- Invitations to testing programs
+- Recognition in community updates
+
+**Requirements:**
+- Active development/staging deployment
+- Willing to share use case
+- Optional: Provide feedback on new features
+
+### 🥉 Evaluation Adopters
+Organizations actively evaluating KubeStellar Console for future use.
+
+**Benefits:**
+- Access to evaluation resources
+- Support during PoC phase
+- Recognition as early evaluator
+
+**Requirements:**
+- Active evaluation in progress
+- Willing to share evaluation focus
+- Optional: Feedback on evaluation experience
+
+## What We Ask
+
+### Minimum Requirements
+- **Organization Name** - Company, team, or project name
+- **Use Case** - Brief description (2-3 sentences) of how you use the console
+- **Tier** - Production, Development, or Evaluation
+
+### Optional (But Appreciated!)
+- **Website/Link** - Link to your organization
+- **Deployment Details** - Number of clusters, types, scale
+- **Duration** - How long you've been using the console
+- **Testimonial** - Quote about your experience
+- **Contact** - GitHub handle or email for follow-up
+
+### Showcase Consent
+We may ask if we can:
+- Feature you in blog posts or case studies
+- Share your story on social media
+- Include you in presentations or talks
+
+You can always opt out or request approval first!
+
+## Campaign Goals
+
+### Short Term (Q2-Q3 2026)
+- 🎯 **10 Production Adopters** - Real-world production validation
+- 🎯 **25 Development Adopters** - Active developer community
+- 🎯 **50 Evaluation Adopters** - Strong evaluation pipeline
+
+### Long Term (2026+)
+- 📊 **100+ Total Adopters** - Diverse industry representation
+- 🌍 **Global Reach** - Adopters from multiple continents
+- 🏢 **Enterprise Adoption** - Fortune 500 companies using the console
+- 🔬 **Academic Presence** - Research institutions and universities
+
+## Community Evidence
+
+Adopters help us demonstrate:
+- **Traction** - Real-world usage and validation
+- **Diversity** - Broad applicability across industries and use cases
+- **Maturity** - Production readiness and stability
+- **Value** - Tangible benefits to organizations
+
+## Recruitment Channels
+
+We're actively recruiting through:
+- 📢 **GitHub** - Issue templates and PR invitations
+- 💬 **Slack** - Community channels and direct outreach
+- 🎤 **Events** - KubeCon, meetups, webinars
+- 📝 **Blog Posts** - Adoption stories and use cases
+- 🐦 **Social Media** - Twitter, LinkedIn, Mastodon
+- 📧 **Email** - Newsletter and direct outreach
+
+## Success Stories
+
+Check out our [Adopters page](../../ADOPTERS.md) to see who's already using KubeStellar Console!
+
+## FAQ
+
+### Do I need to be in production to join?
+No! We welcome adopters at any stage - evaluation, development, or production.
+
+### Will my information be public?
+Yes, adopters are listed publicly in ADOPTERS.md. However, you control what details you share.
+
+### Can I update my information later?
+Absolutely! Just open a PR or issue to update your entry.
+
+### What if I'm no longer using the console?
+Let us know and we'll move you to an "Alumni" section or remove your entry per your preference.
+
+### Is there a cost to join?
+No! The First Adopter Program is completely free.
+
+### Can individuals join, or only organizations?
+Both! If you're using the console personally or in a side project, we'd love to list you.
+
+### How is this different from becoming a contributor?
+This program recognizes *users* of the console. Contributors (code, docs, etc.) have a separate recognition path through MAINTAINERS.md and contributor stats.
+
+## Contact
+
+Questions about the First Adopter Program?
+- 📧 Email: [community@kubestellar.io](mailto:community@kubestellar.io)
+- 💬 Slack: [#first-adopters](https://kubestellar.io/slack)
+- 🐙 GitHub: [@kubestellar/console/issues](https://github.com/kubestellar/console/issues)
+
+---
+
+*We're excited to have you as part of our First Adopter community! Your adoption helps validate the console and shapes its future. Thank you for being an early believer in KubeStellar Console!* 🚀


### PR DESCRIPTION
Fixes #18806
Fixes #18812
Fixes #18819

Establishes the First Adopter Program with a self-nomination guide and GitHub issue template for adoption submissions.