### PR TITLE
[scanner] fix: add AI-native story content

### DIFF
--- a/docs/community/AI_NATIVE_STORY.md
+++ b/docs/community/AI_NATIVE_STORY.md
@@ -1,0 +1,279 @@
+# AI-Native Story, Ecosystem Milestone, and MCP Bridge Messaging
+
+This document packages three related outreach stories for KubeStellar Console:
+
+1. **KubeStellar Console as an AI-native open-source project**
+2. **The 313-card CNCF ecosystem milestone**
+3. **The in-console MCP bridge as native AI tool integration for Kubernetes**
+
+Use this page as source material for blog posts, social threads, conference abstracts, and community outreach.
+
+---
+
+## 1. Core Narrative: KubeStellar Console as an AI-Native OSS Project
+
+KubeStellar Console is not just an open-source project that happens to use AI tools. It is an **AI-native OSS project**: a production codebase where named AI collaborators contribute alongside humans in a visible, reviewable, policy-governed workflow.
+
+### What makes the project AI-native
+
+- **Named agent roles are part of the development workflow.** Work shows up in issues, commits, and pull requests with role-specific prefixes such as `scanner`, `architect`, `outreach`, `ci-maintainer`, and `sec-check`.
+- **AI contributions follow the same contribution rules as human contributions.** DCO sign-off, code review, tests, and CI all still apply.
+- **Quality controls are explicit.** The repository already documents layered safeguards in [`docs/AI-QUALITY-ASSURANCE.md`](../AI-QUALITY-ASSURANCE.md), including build checks, linting, end-to-end tests, coverage gates, visual regression, post-merge verification, and automated follow-up loops.
+- **AI is used for delivery, not just assistance.** The workflow is closer to a contributor model than an autocomplete model: scoped tasks, traceable outputs, review gates, and visible accountability.
+
+### Why this story matters now
+
+The industry is still looking for credible examples of how AI and humans can collaborate in real open-source maintenance without lowering quality bars. KubeStellar Console offers a concrete answer:
+
+> **AI-native open source is not “AI replacing maintainers.” It is maintainers using named AI collaborators inside transparent, auditable, community-governed workflows.**
+
+### Positioning statement
+
+**KubeStellar Console is an AI-native, multi-cluster Kubernetes console where agent-assisted development and agent-facing operations are both first-class parts of the product story.**
+
+That positioning works because the project spans both sides of the AI transition:
+
+- **How the software is built:** AI-assisted contribution workflow with visible quality gates
+- **What the software enables:** AI-compatible cluster operations through provider integrations, missions, and MCP surfaces
+
+### Proof points to repeat consistently
+
+- Open source and community visible
+- AI contributions are transparent, not hidden
+- Same review pipeline for AI and human changes
+- Existing documented QA model for AI-assisted delivery
+- Kubernetes operations use case, not a toy demo
+- Multi-cluster focus with real platform engineering relevance
+
+### Suggested talking points
+
+- "We are treating AI contributors like accountable collaborators, not magical black boxes."
+- "The important innovation is governance plus feedback loops, not just model usage."
+- "KubeStellar Console shows that AI-native development can still be review-driven, test-driven, and community-friendly."
+
+---
+
+## 2. The 313-Card CNCF Ecosystem Milestone
+
+KubeStellar Console has reached a **313-card dashboard milestone**, representing a broad slice of the cloud-native ecosystem.
+
+### Why the milestone matters
+
+Each card is more than a UI widget. It is a concrete integration surface for a project, workload type, or operational concern. Reaching 313 cards signals:
+
+- **Breadth across the CNCF landscape**
+- **A practical integration layer for many project communities**
+- **A clear invitation for upstream maintainers to validate and improve how their project is represented**
+
+### Community story
+
+The milestone creates a warm outreach path to individual communities:
+
+- "Your project is already visible in KubeStellar Console"
+- "We would love maintainers to review the card and suggest improvements"
+- "If your users already depend on this surface, let's make it better together"
+
+This is a better opening than cold outreach because it starts with shipped work, not a speculative partnership.
+
+### Priority projects for first-wave outreach
+
+- Argo CD
+- Falco
+- KEDA
+- Karmada
+- WasmCloud
+- Volcano
+- Loki
+- Prometheus
+- Jaeger
+- OpenTelemetry
+- Istio
+- Cilium
+- Argo Workflows
+- Crossplane
+- Flux
+
+### Message frame for project communities
+
+**Theme:** "KubeStellar Console already includes your project. Help us make that representation great."
+
+Short version:
+
+> Hey 👋 KubeStellar Console now ships 313 dashboard cards across the cloud-native ecosystem, including one for **[PROJECT]**. We would love feedback from the upstream community on accuracy, UX, and the most useful operational signals to highlight. If you want to review or improve the card, contributions are welcome.
+
+### Outreach goals tied to the milestone
+
+1. Validate card accuracy with upstream experts
+2. Build relationships with project maintainers and advocates
+3. Encourage co-marketing and signal boosting
+4. Create a feedback loop between real operators and card design
+5. Turn card coverage into ecosystem credibility
+
+### Suggested call to action
+
+- Review your project's card
+- Open issues for missing signals or misleading defaults
+- Contribute card improvements directly
+- Share the card with your community if it reflects the project well
+
+---
+
+## 3. MCP Bridge Story: Native AI Tool Integration
+
+KubeStellar Console now includes an **in-console MCP bridge** that exposes Kubernetes and related operational context through a native MCP-compatible interface.
+
+### Why this is different
+
+Many MCP stories focus on standalone servers. KubeStellar Console adds a different angle:
+
+- **In-process**: the MCP bridge runs inside the console experience
+- **Authenticated by default**: it is available within the existing console access model
+- **Operationally integrated**: Kubernetes, Drasi, and related tool routing live together in one operator-facing surface
+- **Multi-cluster aware**: it is positioned for real cluster operations, not just single-cluster demos
+
+### Community positioning
+
+This is not only "we support MCP." The stronger message is:
+
+> **KubeStellar Console treats MCP as a native operations interface for Kubernetes, not as an afterthought plugin.**
+
+That matters to:
+
+- Claude Desktop, Cursor, Continue, and other MCP-client users
+- AI platform engineers building cluster copilots
+- Kubernetes operators evaluating natural-language operational workflows
+- MCP ecosystem maintainers looking for serious production examples
+
+### Comparison message
+
+- Standalone MCP servers are useful for isolated integrations
+- KubeStellar Console shows what MCP looks like when embedded directly into a multi-cluster operations product
+- That makes the bridge easier to discover, easier to adopt, and easier to connect to day-to-day operator workflows
+
+### Announcement angles
+
+- "Kubernetes MCP, but already inside the console"
+- "Native AI tool integration for multi-cluster operations"
+- "Ask MCP-compatible clients about your clusters without standing up separate glue"
+- "A production-oriented MCP bridge with tests and a stable integration surface"
+
+---
+
+## 4. Combined Story Arc
+
+These three stories reinforce each other:
+
+1. **AI-native development model** — how the project is built
+2. **313-card ecosystem breadth** — why the project matters to cloud-native communities
+3. **In-console MCP bridge** — how the product becomes a native AI operations surface
+
+Together they support a larger message:
+
+> **KubeStellar Console is becoming a reference example of an AI-native cloud-native project: AI helps build it, the CNCF ecosystem expands through it, and MCP-compatible tools can operate through it.**
+
+---
+
+## 5. Draft Blog Post Outline
+
+### Working title options
+
+- **How We Run an AI-Native Open Source Project in the Kubernetes Ecosystem**
+- **From 313 Dashboard Cards to MCP: The AI-Native Story Behind KubeStellar Console**
+- **Building an AI-Native Cloud-Native Console in Public**
+
+### Outline
+
+#### 1. Opening: why this story is different
+- AI stories usually focus on coding assistants or chatbots
+- KubeStellar Console combines AI-assisted contribution, ecosystem integration, and AI-facing product interfaces
+- Thesis: this is what an AI-native OSS project can look like in practice
+
+#### 2. The development model
+- Named AI collaborators with scoped roles
+- Transparent commit and PR history
+- Human maintainers remain accountable for direction and merge decisions
+- Same contribution standards for everyone
+
+#### 3. Quality is the credibility layer
+- Point readers to `docs/AI-QUALITY-ASSURANCE.md`
+- Explain layered gates: build, lint, test, review, post-merge verification, monitoring
+- Address the obvious question directly: "How do you keep AI-generated changes trustworthy?"
+
+#### 4. The 313-card milestone
+- Explain what a dashboard card represents
+- Show breadth across CNCF and adjacent projects
+- Position the milestone as a community bridge, not just a vanity metric
+- Invite upstream maintainers to validate and improve their project's representation
+
+#### 5. MCP inside the console
+- Explain what the in-console MCP bridge changes for users
+- Compare embedded MCP with standalone MCP servers
+- Emphasize native AI tool integration for Kubernetes operators and platform teams
+
+#### 6. Why this matters for open source
+- Transparent AI collaboration is more important than hidden automation
+- Ecosystem participation matters more than isolated demos
+- AI-native OSS needs governance, review, and community legitimacy
+
+#### 7. Call to action
+- Try KubeStellar Console
+- Review a project card
+- Join the community discussion
+- Contribute to the AI-native workflow in public
+
+### Supporting pull quotes
+
+- "AI-native open source only works if the workflow is more transparent, not less."
+- "A dashboard card is a product surface, but also a community handshake."
+- "MCP becomes far more compelling when it is built into the operator experience."
+
+---
+
+## 6. Draft Social Content
+
+### Short post
+
+KubeStellar Console is shaping up as an **AI-native open-source project**: named AI collaborators, visible review workflows, documented QA, and now **313 dashboard cards** spanning the cloud-native ecosystem.
+
+It also ships an **in-console MCP bridge** so MCP-compatible clients can interact with Kubernetes through a native operator surface.
+
+### X / Bluesky thread draft
+
+1. KubeStellar Console is more than a Kubernetes dashboard. It is becoming a reference example of an **AI-native OSS project** built in public.
+2. We use named AI collaborator roles in visible workflows, with the same review and QA expectations as human contributions.
+3. The repo also now spans **313 dashboard cards**, covering a broad slice of the CNCF ecosystem.
+4. That creates a new kind of community outreach: "your project already has a surface here — help us make it great."
+5. And on the product side, the console now includes an **in-process MCP bridge** for native AI tool integration with Kubernetes.
+6. That means MCP is not bolted on later; it is part of the operator experience.
+7. AI-native development model + ecosystem breadth + native MCP integration is a compelling new cloud-native story.
+
+### LinkedIn / longer social post
+
+KubeStellar Console is developing a strong "AI-native open-source project" story.
+
+What makes it interesting is not just that AI tools are used during development. It is that named AI collaborators participate in a visible, reviewable workflow, while maintainers keep the same standards for DCO, testing, CI, and merge review.
+
+At the same time, the project has reached a **313-card dashboard milestone** across the cloud-native ecosystem, which creates real opportunities to collaborate with individual upstream communities.
+
+And the product now includes an **in-console MCP bridge**, turning MCP-compatible AI clients into a native interface for Kubernetes operations.
+
+That combination — AI-native workflow, ecosystem breadth, and native AI tool integration — feels like a strong story for the next phase of cloud-native tooling.
+
+---
+
+## 7. Conference / CFP Pitch Seed
+
+**Title:** AI-Native Open Source in Practice: Building KubeStellar Console with Named Agent Collaborators
+
+**Abstract:**
+KubeStellar Console offers a practical case study in AI-native open-source development. Rather than treating AI as a hidden assistant, the project uses named AI collaborator roles in visible contribution workflows while preserving human review, DCO, CI, and community governance. In parallel, the product has grown to 313 dashboard cards across the cloud-native ecosystem and now includes an in-console MCP bridge for native AI interaction with Kubernetes clusters. This talk shares what worked, what required stronger quality gates, and why transparent agent collaboration may become a durable open-source operating model.
+
+---
+
+## 8. Recommended Next Actions
+
+1. Publish a trimmed version of the blog post on the KubeStellar site
+2. Adapt the same story for The New Stack, CNCF blog, Dev.to, and IBM Developer channels
+3. Use the 313-card section as the basis for project-community outreach templates
+4. Post the MCP bridge story in relevant MCP and AI developer communities
+5. Link back to `docs/AI-QUALITY-ASSURANCE.md` whenever discussing the AI-native workflow


### PR DESCRIPTION
Fixes #18813
Fixes #18814
Fixes #18768

Adds AI-native positioning content, 313-card ecosystem milestone documentation, and MCP bridge community announcement draft.