### PR TITLE
[scanner] fix: add CNCF readiness documentation

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,44 +1,73 @@
-# Adopters
+# KubeStellar Console Adopters
 
-Listed below are organizations that have adopted, or benefitted from, KubeStellar Console in one way or another. We are delighted to welcome them to the KubeStellar community. If you are using KubeStellar Console in your organization, or benefitting from the KubeStellar Marketplace, Installer Missions, or Solution Missions, we would love to add you to the list below. You can open a pull request against this file directly.
+This document tracks public adopter evidence for KubeStellar Console in a CNCF-friendly format. It distinguishes between:
+
+1. **Reference deployments** maintained by the project,
+2. **Production adopters** willing to be named publicly,
+3. **Evaluation / pilot adopters**, and
+4. **Ecosystem integrations and install-mission adopters** with public evidence.
+
+KubeStellar Console maintainers will preserve all valid entries when restructuring this file. Contributors adding new entries should include a public reference link whenever possible.
+
+## What CNCF reviewers should expect here
+
+For CNCF due diligence, the strongest entries are organizations willing to be listed publicly with:
+
+- a short description of how they use KubeStellar Console,
+- the deployment stage (`production`, `pilot`, `evaluation`, or `ecosystem integration`), and
+- a verifiable public reference such as a case study, issue, pull request, mission page, or blog post.
 
 ## How to Add Yourself
 
-1. Fork this repository
-2. Add your organization to the table below using the schema: `| Organization | Description | Maturity Level | Further Information |`
-3. Open a pull request with the title: `📖 docs: add <Organization> to ADOPTERS.md`
+1. Fork this repository.
+2. Add your organization to the appropriate section below.
+3. Use this schema: `| Organization | Deployment stage | Console use case | Public evidence | Notes |`
+4. Open a pull request titled `📖 docs: add <Organization> to ADOPTERS.md`.
 
-> ⚠️ **Maintainer note**: When opening PRs that restructure this file, always preserve existing adopter entries. Do not replace the file with a blank template.
+## 1. Project-hosted Reference Deployment
 
-## Adopters List
+| Organization | Deployment stage | Console use case | Public evidence | Notes |
+| --- | --- | --- | --- | --- |
+| KubeStellar | Reference deployment | Hosted console UI, mission catalog, and community demonstration environment | [console.kubestellar.io](https://console.kubestellar.io) · [kubestellar.io](https://kubestellar.io) | Maintainer-operated reference environment; not counted as an external adopter |
 
-| Organization | Description | Maturity Level | Further Information |
-| --- | --- | --- | --- |
-| KubeStellar | Multi-cluster Kubernetes management | — | Console UI for managing KubeStellar deployments across edge and cloud clusters · [kubestellar.io](https://kubestellar.io) |
-| Open Cluster Management | Guided install mission for OCM via KubeStellar Console | Sandbox | [OCM Install Mission](https://console.kubestellar.io/missions/install-open-cluster-management) |
-| Notary Project | Guided install mission for Ratify with automated pre-flight checks, Gatekeeper and Ratify deployment via helmfile, signed/unsigned image validation, troubleshooting, and rollback support | Incubating | [Notary Project/Ratify](https://github.com/notaryproject/ratify) |
-| OpenCost | Guided install mission for OpenCost via KubeStellar Console, endorsed in [opencost/opencost#3649](https://github.com/opencost/opencost/issues/3649) | Sandbox | [OpenCost](https://opencost.io) · [Install Mission](https://console.kubestellar.io/missions/install-opencost) |
-| KitOps | Guided install mission for KitOps via KubeStellar Console, endorsed in [kitops-ml/kitops#1115](https://github.com/kitops-ml/kitops/issues/1115) | Sandbox | [KitOps](https://kitops.ml) · [Install Mission](https://console.kubestellar.io/missions/install-kitops) |
-| Cadence | Guided install mission for Cadence Workflow via KubeStellar Console, with engagement tracked in [cadence-workflow/cadence#7830](https://github.com/cadence-workflow/cadence/issues/7830) | N/A | [Cadence](https://cadenceworkflow.io) · [Install Mission](https://console.kubestellar.io/missions/install-cadence-workflow) |
-| Easegress | Guided install mission for Easegress via KubeStellar Console, with engagement tracked in [easegress-io/easegress#1510](https://github.com/easegress-io/easegress/issues/1510) | Sandbox | [Easegress](https://github.com/easegress-io/easegress) · [Install Mission](https://console.kubestellar.io/missions/install-easegress) |
-| Microcks | Guided install mission for Microcks via KubeStellar Console, with install recipe contributed to the Microcks community repo ([microcks/community#125](https://github.com/microcks/community/pull/125)) and engagement tracked in [microcks/microcks#1997](https://github.com/microcks/microcks/issues/1997) | Sandbox | [Microcks](https://microcks.io) · [Install Mission](https://console.kubestellar.io/missions/install-microcks) |
-| kcp | Guided install mission for kcp via KubeStellar Console, with engagement from kcp maintainers in [kcp-dev/kcp#3923](https://github.com/kcp-dev/kcp/issues/3923) | Sandbox | [kcp](https://kcp.io) · [Install Mission](https://console.kubestellar.io/missions/install-kcp) |
-| kube-vip | Guided install mission for kube-vip via KubeStellar Console, with upstream collaboration tracked in [kube-vip/kube-vip#1472](https://github.com/kube-vip/kube-vip/issues/1472) | Sandbox | [kube-vip](https://kube-vip.io) · [Install Mission](https://console.kubestellar.io/missions/install-kube-vip) |
-| Submariner | Guided install mission for Submariner via KubeStellar Console using the current `subctl` workflow (deploy-broker, join, verify, cross-cluster connectivity), endorsed in [submariner-io/submariner#3907](https://github.com/submariner-io/submariner/issues/3907) | Sandbox | [Submariner](https://submariner.io) · [Install Mission](https://console.kubestellar.io/missions/install-submariner) |
-| Kmesh | Guided install mission for Kmesh via KubeStellar Console, with engagement tracked in [kmesh-net/kmesh#1609](https://github.com/kmesh-net/kmesh/issues/1609) | Sandbox | [Kmesh](https://kmesh.net) · [Install Mission](https://console.kubestellar.io/missions/install-kmesh) |
-| Drasi | Change data capture for cloud-native applications. Guided install mission verified end-to-end by a Drasi maintainer, with engagement and fixes tracked in [drasi-project/drasi-platform#400](https://github.com/drasi-project/drasi-platform/issues/400) | Sandbox | [drasi.io](https://drasi.io) · [Install Mission](https://console.kubestellar.io/missions/install-drasi) |
+## 2. Public Production Adopters
 
-## Adopter Tiers
+The project is actively collecting named production references for CNCF due diligence.
 
-### 🥇 Production Adopters
-Organizations running KubeStellar Console in production environments.
+| Organization | Deployment stage | Console use case | Public evidence | Notes |
+| --- | --- | --- | --- | --- |
+| _Seeking public production references_ | — | Outreach is tracked in [#18783](https://github.com/kubestellar/console/issues/18783) | — | Add named production users here once permission is granted |
 
-### 🥈 Development Adopters
-Organizations using KubeStellar Console in development or staging environments.
+## 3. Public Pilot / Evaluation Adopters
 
-### 🥉 Evaluation Adopters
-Organizations actively evaluating KubeStellar Console for future use.
+Use this section for organizations that are evaluating, piloting, or testing KubeStellar Console in their own environments and are comfortable being named publicly.
 
----
+| Organization | Deployment stage | Console use case | Public evidence | Notes |
+| --- | --- | --- | --- | --- |
+| _Seeking public pilot references_ | — | Outreach is tracked in [#18773](https://github.com/kubestellar/console/issues/18773) | — | Add named pilot or staging users here as they are confirmed |
 
-*Want to be listed? We'd love to hear about your use case! Open a PR or reach out to the community.*
+## 4. Ecosystem Integrations and Install-Mission Adopters
+
+These entries demonstrate real ecosystem engagement, install-mission usage, and public collaboration with upstream communities. They are valuable CNCF evidence, but they should be distinguished from named production operators.
+
+| Organization / Project | Deployment stage | Console use case | Public evidence | Notes |
+| --- | --- | --- | --- | --- |
+| Open Cluster Management | Ecosystem integration | Guided install mission for OCM via KubeStellar Console | [OCM Install Mission](https://console.kubestellar.io/missions/install-open-cluster-management) | CNCF Sandbox project |
+| Notary Project | Ecosystem integration | Guided install mission for Ratify with pre-flight checks, policy wiring, validation, troubleshooting, and rollback support | [Notary Project / Ratify](https://github.com/notaryproject/ratify) | CNCF Incubating project |
+| OpenCost | Ecosystem integration | Guided install mission and upstream endorsement for OpenCost workflows | [OpenCost](https://opencost.io) · [opencost/opencost#3649](https://github.com/opencost/opencost/issues/3649) | CNCF Sandbox project |
+| KitOps | Ecosystem integration | Guided install mission and upstream endorsement for KitOps | [KitOps](https://kitops.ml) · [kitops-ml/kitops#1115](https://github.com/kitops-ml/kitops/issues/1115) | CNCF Sandbox project |
+| Cadence | Ecosystem integration | Guided install mission with public upstream engagement | [Cadence](https://cadenceworkflow.io) · [cadence-workflow/cadence#7830](https://github.com/cadence-workflow/cadence/issues/7830) | Non-CNCF project |
+| Easegress | Ecosystem integration | Guided install mission with public upstream engagement | [Easegress](https://github.com/easegress-io/easegress) · [easegress-io/easegress#1510](https://github.com/easegress-io/easegress/issues/1510) | CNCF Sandbox project |
+| Microcks | Ecosystem integration | Guided install mission with contribution into the Microcks community repo | [Microcks](https://microcks.io) · [microcks/community#125](https://github.com/microcks/community/pull/125) · [microcks/microcks#1997](https://github.com/microcks/microcks/issues/1997) | CNCF Sandbox project |
+| kcp | Ecosystem integration | Guided install mission with maintainer engagement | [kcp](https://kcp.io) · [kcp-dev/kcp#3923](https://github.com/kcp-dev/kcp/issues/3923) | CNCF Sandbox project |
+| kube-vip | Ecosystem integration | Guided install mission with upstream collaboration | [kube-vip](https://kube-vip.io) · [kube-vip/kube-vip#1472](https://github.com/kube-vip/kube-vip/issues/1472) | CNCF project |
+| Submariner | Ecosystem integration | Guided install mission covering `subctl` broker, join, verify, and connectivity workflows | [Submariner](https://submariner.io) · [submariner-io/submariner#3907](https://github.com/submariner-io/submariner/issues/3907) | CNCF Sandbox project |
+| Kmesh | Ecosystem integration | Guided install mission with public community engagement | [Kmesh](https://kmesh.net) · [kmesh-net/kmesh#1609](https://github.com/kmesh-net/kmesh/issues/1609) | CNCF Sandbox project |
+| Drasi | Ecosystem integration | Guided install mission verified end-to-end by a Drasi maintainer | [drasi.io](https://drasi.io) · [drasi-project/drasi-platform#400](https://github.com/drasi-project/drasi-platform/issues/400) | CNCF Sandbox project |
+
+## 5. Maintenance Notes
+
+- Keep entries factual and publicly supportable.
+- Do not label an organization as `production` without permission or a public reference.
+- Preserve older evidence links when adding new detail.
+- Cross-reference [docs/ADOPTION-METRICS.md](docs/ADOPTION-METRICS.md) and [docs/community/CNCF_READINESS.md](docs/community/CNCF_READINESS.md) when preparing CNCF applications.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,108 +1,133 @@
 # KubeStellar Console Project Governance
 
-KubeStellar Console is a sub-project of [KubeStellar](https://github.com/kubestellar/kubestellar) and follows the same governance model. This document describes how the Console project is run.
+KubeStellar Console is a sub-project of [KubeStellar](https://github.com/kubestellar/kubestellar). This document describes how the Console project makes decisions, delegates responsibilities, and maintains a healthy community as it prepares for CNCF Sandbox and incubation reviews.
 
-- [Values](#values)
-- [Maintainers](#maintainers)
-- [Code of Conduct Enforcement](#code-of-conduct)
-- [Security Response Team](#security-response-team)
-- [Voting](#voting)
-- [Modifying this Charter](#modifying-this-charter)
+## Governance Goals
 
-## Values
+The project is governed to keep technical direction, community stewardship, and operational responsibility transparent.
 
-The KubeStellar Console project and its leadership embrace the following values:
+We prioritize:
 
- * *Openness*: Communication and decision-making happens in the open and is
-   discoverable for future reference. As much as possible, all discussions and
-   work take place in public forums and open repositories.
- * *Fairness*: All stakeholders have the opportunity to provide feedback and
-   submit contributions, which will be considered on their merits.
- * *Community over Product or Company*: Sustaining and growing our community
-   takes priority over shipping code or sponsors' organizational goals. Each
-   contributor participates in the project as an individual.
- * *Inclusivity*: We innovate through different perspectives and skill sets,
-   which can only be accomplished in a welcoming and respectful environment.
- * *Participation*: Responsibilities within the project are earned through
-   participation, and there is a clear path up the contributor ladder into
-   leadership positions.
+- **Openness** — discussion, design, and roadmap work happen in public wherever possible.
+- **Fairness** — contributors are evaluated on the quality of their work and collaboration.
+- **Community over any single vendor** — maintainers act in the interest of the project and its users.
+- **Inclusion** — the project follows the [Code of Conduct](CODE_OF_CONDUCT.md) and aims to create a welcoming environment.
+- **Merit with accountability** — additional responsibility is earned through sustained contribution and trusted stewardship.
 
-## Maintainers
+## Project Scope
 
-KubeStellar Console Maintainers have write access to the [project GitHub repository](https://github.com/kubestellar/console).
-They can merge their own patches or patches from others. The current maintainers
-can be found as top-level approvers in [OWNERS](OWNERS). Maintainers collectively
-manage the project's resources and contributors.
+KubeStellar Console covers the source, documentation, release process, website-hosted console experience, and related community workflows in the [`kubestellar/console`](https://github.com/kubestellar/console) repository.
 
-This privilege is granted with some expectation of responsibility: maintainers
-are people who care about the KubeStellar Console project and want to help it grow and
-improve. A maintainer is not just someone who can make changes, but someone who
-has demonstrated their ability to collaborate with the team, get the most
-knowledgeable people to review code and docs, contribute high-quality code, and
-follow through to fix issues (in code or tests).
+## Roles
+
+### Contributors
+
+Anyone who reports issues, proposes improvements, reviews code, improves documentation, or submits pull requests is a contributor.
+
+### Reviewers
+
+Reviewers are trusted contributors who regularly provide technical or documentation feedback. Reviewers help maintain code quality, validate architectural direction, and mentor new contributors.
+
+### Maintainers
+
+Maintainers are the project stewards for KubeStellar Console. They are responsible for:
+
+- reviewing and merging pull requests,
+- curating the roadmap and release priorities,
+- triaging issues and community escalations,
+- protecting security-sensitive and conduct-sensitive workflows,
+- keeping documentation, governance, and operational practices current.
+
+The current maintainer roster is recorded in:
+
+- [OWNERS](OWNERS) for repository approval rights, and
+- [MAINTAINERS.md](MAINTAINERS.md) for public maintainer names and affiliations.
+
+### Security Response Team
+
+The maintainers appoint a Security Response Team to coordinate confidential reports and disclosure. The team may consist of the maintainers themselves. Its operating policy is defined in [SECURITY.md](SECURITY.md).
+
+## Decision-Making Process
+
+### Day-to-Day Decisions
+
+KubeStellar Console uses **lazy consensus** for routine decisions. A change may proceed when it is proposed publicly, receives appropriate review, and no maintainer raises a blocking concern within a reasonable review window.
+
+Examples include:
+
+- routine bug fixes,
+- documentation updates,
+- refactors that do not materially change project direction,
+- issue triage and release housekeeping.
+
+### Escalated Decisions
+
+A maintainer should call for explicit consensus when a proposal affects project direction, compatibility, governance, release policy, security posture, or community process.
+
+Examples include:
+
+- adopting or removing major dependencies,
+- changing contributor or release policy,
+- altering governance or maintainer expectations,
+- making roadmap commitments tied to CNCF milestones.
+
+### Voting
+
+When consensus is unclear, maintainers may hold a vote on the public developer mailing list or, for sensitive matters, the private maintainer list.
+
+- **Simple majority of maintainers** is required for routine formal votes.
+- **Two-thirds majority of maintainers** is required to remove a maintainer or amend this governance document.
+
+## Maintainer Expectations
+
+Maintainers are expected to:
+
+- act in the best interests of the project and its community,
+- review code and documentation constructively and promptly,
+- keep the main branch healthy and release processes reliable,
+- handle conflicts, security reports, and conduct matters responsibly,
+- help the project maintain CNCF-ready governance and community evidence.
+
+Maintainers may merge their own changes when normal review expectations are satisfied, but they should seek review from another maintainer for substantial or policy-sensitive changes.
 
 ## Becoming a Maintainer
 
-To become a Maintainer you need to demonstrate the following:
+A prospective maintainer should demonstrate:
 
-  * commitment to the project:
-    * participate in discussions, contributions, code and documentation reviews
-      for 3 months or more,
-    * perform reviews for 5 non-trivial pull requests,
-    * contribute 5 non-trivial pull requests and have them merged,
-  * ability to write quality code and/or documentation,
-  * ability to collaborate with the team,
-  * understanding of how the team works (policies, processes for testing and code review, etc),
-  * understanding of the project's code base and coding and documentation style.
+- sustained contributions for at least three months,
+- at least five non-trivial pull requests merged,
+- at least five non-trivial pull request reviews,
+- strong collaboration and communication habits,
+- familiarity with project architecture, testing expectations, and documentation standards.
 
-A new Maintainer must be proposed by an existing maintainer by sending a message to the
-[developer mailing list](https://groups.google.com/g/kubestellar-dev). A simple majority
-vote of existing Maintainers approves the application.
+A new maintainer is proposed by an existing maintainer on the [developer mailing list](https://groups.google.com/g/kubestellar-dev). Appointment requires a simple majority vote of current maintainers.
 
-### Removing a Maintainer
+## Maintainer Inactivity or Removal
 
-Maintainers may resign at any time if they feel that they will not be able to
-continue fulfilling their project duties.
+Maintainers may resign at any time.
 
-Maintainers may also be removed after being inactive, failure to fulfill their
-Maintainer responsibilities, violating the Code of Conduct, or other reasons.
-Inactivity is defined as a period of very low or no activity in the project for
-a year or more, with no definite schedule to return to full Maintainer activity.
+A maintainer may be considered inactive after roughly one year of minimal or no project activity without a communicated return plan. Maintainers may also be removed for failure to fulfill responsibilities, Code of Conduct violations, or other serious cause. Removal requires a two-thirds vote of the remaining maintainers.
 
-A Maintainer may be removed at any time by a 2/3 vote of the remaining maintainers.
+## Community Meetings and Records
 
-## Meetings
+KubeStellar Console participates in the broader KubeStellar community process.
 
-Time zones permitting, Maintainers are expected to participate in the public
-community call meeting. Maintainers will also have closed meetings in order to
-discuss security reports or Code of Conduct violations.
+- Community discussion happens through [docs/COMMUNITY.md](docs/COMMUNITY.md).
+- Public agenda items may be proposed on Slack, GitHub, or the mailing list.
+- Sensitive conduct and security matters may be handled in private maintainer channels.
 
-## Code of Conduct
+Where possible, decisions and rationale should be recorded in issues, pull requests, mailing-list threads, roadmap updates, or public meeting notes.
 
-[Code of Conduct](CODE_OF_CONDUCT.md)
-violations by community members will be discussed and resolved
-on the [private Maintainer mailing list](https://groups.google.com/u/1/g/kubestellar-dev-private).
+## Code of Conduct Enforcement
 
-## Security Response Team
+All participants are expected to follow [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
-The Maintainers will appoint a Security Response Team to handle security reports.
-This committee may simply consist of the Maintainer Council themselves. The Security
-Response Team is responsible for handling all reports of security holes and breaches
-according to the [security policy](SECURITY.md).
+Conduct reports for the project may be sent to the [private KubeStellar maintainers list](mailto:kubestellar-dev-private@googlegroups.com). Maintainers will review reports promptly and coordinate with CNCF processes when required.
 
-## Voting
+## Security Coordination
 
-While most business in KubeStellar Console is conducted by "lazy consensus", periodically
-the Maintainers may need to vote on specific actions or changes.
-A vote can be taken on [the developer mailing list](https://groups.google.com/g/kubestellar-dev) or
-[the private Maintainer mailing list](https://groups.google.com/u/1/g/kubestellar-dev-private)
-for security or conduct matters.
+Security reports must follow [SECURITY.md](SECURITY.md). Public issues should not be used for undisclosed vulnerabilities.
 
-Most votes require a simple majority of all Maintainers to succeed. Maintainers
-can be removed by a 2/3 majority vote of all Maintainers, and changes to this
-Governance require a 2/3 vote of all Maintainers.
+## Amendments
 
-## Modifying this Charter
-
-Changes to this Governance and its supporting documents may be approved by a
-2/3 vote of the Maintainers.
+Changes to this governance document require a two-thirds vote of maintainers.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,40 +1,76 @@
-<!--security-start-->
+# Security Policy
+
+KubeStellar Console takes security reports seriously. This document describes how to report a vulnerability, what information to include, and how the project coordinates response and disclosure.
+
+## Supported Scope
+
+This policy applies to the KubeStellar Console codebase, release artifacts, hosted console experience, and project-managed integrations in the [`kubestellar/console`](https://github.com/kubestellar/console) repository.
+
+## Reporting a Vulnerability
+
+Please **do not file public GitHub issues** for suspected vulnerabilities.
+
+Use one of these channels instead:
+
+- **Primary:** [kubestellar-security-announce@googlegroups.com](mailto:kubestellar-security-announce@googlegroups.com)
+- **Announcements:** [kubestellar-security-announce Google Group](https://groups.google.com/u/1/g/kubestellar-security-announce)
+
+When reporting, include as much of the following as possible:
+
+- affected component, feature, or endpoint,
+- reproduction steps or proof of concept,
+- expected impact and attack prerequisites,
+- affected versions, deployment mode, or environment,
+- any proposed mitigation or patch, if available.
+
+If you are unsure whether something is a security issue, contact the security list first and the maintainers will help triage it.
+
+## When to Use This Process
+
+Use the private security process when:
+
+- you believe you found a vulnerability in KubeStellar Console,
+- you are unsure whether a bug has security impact,
+- a dependency vulnerability may materially affect KubeStellar Console users.
+
+Do not use this process for:
+
+- general support requests,
+- feature requests,
+- non-security bugs,
+- configuration help without a vulnerability component.
+
+## Response Targets
+
+The KubeStellar security response team aims to:
+
+- acknowledge reports within **3 working days**, and
+- keep reporters informed as triage, fix development, and disclosure planning proceed.
+
+Confidential report details are shared only with the people needed to investigate and remediate the issue.
+
+## Disclosure Process
+
+The security response team coordinates disclosure timing with the reporter.
+
+Our preferred process is:
+
+1. validate the report,
+2. identify mitigation or a fix,
+3. prepare a coordinated disclosure,
+4. publish the fix and advisory as soon as practical.
+
+Disclosure timing can range from immediate disclosure for already-public issues to a short coordination window when a fix must be prepared and validated first. For straightforward vulnerabilities with a clear mitigation, the project targets disclosure within about one week of the initial report.
+
+## Related Security Documentation
+
+Additional security material lives in this repository:
+
+- [GOVERNANCE.md](GOVERNANCE.md) — security response ownership and maintainer authority
+- [SECURITY_CONTACTS](SECURITY_CONTACTS) — project security contacts
+- [docs/INCIDENT-RESPONSE.md](docs/INCIDENT-RESPONSE.md) — incident-handling guidance
+- [docs/security/HARDCODED_URLS.md](docs/security/HARDCODED_URLS.md) — credentials and hardcoded URL policy
+
 ## Security Announcements
 
-Join the [kubestellar-security-announce](https://groups.google.com/u/1/g/kubestellar-security-announce) group for emails about security and major API announcements.
-
-## Report a Vulnerability
-
-We're extremely grateful for security researchers and users that report vulnerabilities to the KubeStellar Open Source Community. All reports are thoroughly investigated by a set of community volunteers.
-
-You can also email the private [kubestellar-security-announce@googlegroups.com](mailto:kubestellar-security-announce@googlegroups.com) list with the security details and the details expected for [all KubeStellar Console bug reports](https://github.com/kubestellar/console/issues/new).
-
-### When Should I Report a Vulnerability?
-
-- You think you discovered a potential security vulnerability in KubeStellar Console
-- You are unsure how a vulnerability affects KubeStellar Console
-- You think you discovered a vulnerability in another project that KubeStellar Console depends on
-    - For projects with their own vulnerability reporting and disclosure process, please report it directly there
-
-### When Should I NOT Report a Vulnerability?
-
-- You need help tuning KubeStellar Console components for security
-- You need help applying security related updates
-- Your issue is not security related
-
-## Security Vulnerability Response
-
-Each report is acknowledged and analyzed by the maintainers of KubeStellar within 3 working days.
-
-Any vulnerability information shared with Security Response Committee stays within the KubeStellar project and will not be disseminated to other projects unless it is necessary to get the issue fixed.
-
-As the security issue moves from triage, to identified fix, to release planning we will keep the reporter updated.
-
-## Public Disclosure Timing
-
-A public disclosure date is negotiated by the KubeStellar Security Response Committee and the bug submitter. We prefer to fully disclose the bug as soon as possible once a user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it's already publicly known) to a few weeks. For a vulnerability with a straightforward mitigation, we expect report date to disclosure date to be on the order of 7 days. The KubeStellar maintainers hold the final say when setting a disclosure date.
-
-## Hardcoded URLs and Credentials Policy
-
-For documentation on intentionally hardcoded URLs and the credentials handling policy, see [docs/security/HARDCODED_URLS.md](docs/security/HARDCODED_URLS.md).
-<!--security-end-->
+Join the [kubestellar-security-announce](https://groups.google.com/u/1/g/kubestellar-security-announce) group for security advisories and major security-related project announcements.

--- a/docs/community/CNCF_READINESS.md
+++ b/docs/community/CNCF_READINESS.md
@@ -1,0 +1,79 @@
+# CNCF Readiness Checklist
+
+This checklist consolidates the documentation and evidence needed for KubeStellar Console's CNCF Sandbox readiness work and the Q4 2026 incubation evidence package.
+
+**Snapshot date:** 2026-06-17
+
+## Issue Mapping
+
+- [#18674](https://github.com/kubestellar/console/issues/18674) — CNCF Landscape listing verification
+- [#18773](https://github.com/kubestellar/console/issues/18773) — Sandbox application readiness
+- [#18783](https://github.com/kubestellar/console/issues/18783) — Incubation community evidence package
+
+## Readiness Summary
+
+| Area | Status | Evidence / Next step |
+| --- | --- | --- |
+| Governance charter | ✅ Ready | [GOVERNANCE.md](../../GOVERNANCE.md) defines roles, lazy consensus, voting, maintainer expectations, and amendment rules |
+| Code of conduct | ✅ Ready | [CODE_OF_CONDUCT.md](../../CODE_OF_CONDUCT.md) adopts the CNCF Code of Conduct and reporting paths |
+| Security policy | ✅ Ready | [SECURITY.md](../../SECURITY.md) defines private reporting, response targets, and disclosure expectations |
+| Maintainer roster | ✅ Ready | [MAINTAINERS.md](../../MAINTAINERS.md) and [OWNERS](../../OWNERS) identify current maintainers and approvers |
+| Community channels | ✅ Ready | [docs/COMMUNITY.md](../COMMUNITY.md) lists Slack, mailing lists, discussions, and meeting process |
+| Roadmap alignment | ✅ Ready | [ROADMAP.md](../../ROADMAP.md) includes Sandbox/incubation goals and community-health prerequisites |
+| Adopters structure | ✅ Structured, evidence still growing | [ADOPTERS.md](../../ADOPTERS.md) now separates reference deployment, production, pilot, and ecosystem evidence |
+| Adoption metrics | ⚠️ Needs data collection | [docs/ADOPTION-METRICS.md](../ADOPTION-METRICS.md) exists but still contains `TBD` placeholders |
+| Production adopter references | ⚠️ In progress | Public production references still need outreach and permission before they can be added to [ADOPTERS.md](../../ADOPTERS.md) |
+| Human contributor ratio | ⚠️ In progress | Track against roadmap health targets before incubation filing |
+| CNCF Landscape listing | ⚠️ Verified gap | GitHub code search in `cncf/landscape` on 2026-06-17 did not find `KubeStellar Console` or `kubestellar`; open an external landscape PR after maintainer confirmation |
+| CNCF application draft | ⚠️ Not started here | Sandbox/incubation submission narrative still needs a dedicated TOC application draft |
+
+## Checklist
+
+### 1. Required project-policy documents
+
+- [x] [LICENSE](../../LICENSE)
+- [x] [CODE_OF_CONDUCT.md](../../CODE_OF_CONDUCT.md)
+- [x] [GOVERNANCE.md](../../GOVERNANCE.md)
+- [x] [SECURITY.md](../../SECURITY.md)
+- [x] [MAINTAINERS.md](../../MAINTAINERS.md)
+- [x] [OWNERS](../../OWNERS)
+- [x] [ROADMAP.md](../../ROADMAP.md)
+
+### 2. Community and governance evidence
+
+- [x] Public community channels documented in [docs/COMMUNITY.md](../COMMUNITY.md)
+- [x] Maintainer nomination and removal process documented in [GOVERNANCE.md](../../GOVERNANCE.md)
+- [x] Code of Conduct enforcement path documented in [CODE_OF_CONDUCT.md](../../CODE_OF_CONDUCT.md)
+- [ ] Publish or link recurring public meeting notes for easy reviewer access
+- [ ] Document PR triage SLA adoption progress (see [docs/plans/PR-TRIAGE-SLA.md](../plans/PR-TRIAGE-SLA.md))
+
+### 3. Adoption evidence
+
+- [x] Public adopter index maintained in [ADOPTERS.md](../../ADOPTERS.md)
+- [x] Reference deployment publicly documented
+- [x] Ecosystem integration evidence preserved with links to public issues, PRs, or mission pages
+- [ ] Add at least 3 named public production adopters with permission
+- [ ] Add named pilot / staging adopters where public references exist
+- [ ] Replace placeholders in [docs/ADOPTION-METRICS.md](../ADOPTION-METRICS.md) with measured data
+
+### 4. Security and due-diligence evidence
+
+- [x] Private vulnerability intake path documented
+- [x] Response-time expectations documented
+- [x] Disclosure coordination described
+- [x] Additional security docs linked from the policy
+- [ ] Track third-party audit request and outcome for incubation readiness
+
+### 5. CNCF-specific follow-ups
+
+- [ ] Draft the Sandbox submission narrative and TOC checklist response
+- [ ] Prepare incubation evidence package using adoption metrics, community metrics, and contributor-ratio data
+- [ ] Verify / add KubeStellar Console entry in the CNCF Landscape under the appropriate category
+- [ ] Add the landscape PR or accepted listing link back into this checklist once available
+
+## Recommended Next Actions
+
+1. Fill the remaining `TBD` values in [docs/ADOPTION-METRICS.md](../ADOPTION-METRICS.md).
+2. Collect written permission from at least three production users to be named in [ADOPTERS.md](../../ADOPTERS.md).
+3. Open the external `cncf/landscape` update once maintainers confirm the desired category and card wording.
+4. Draft the Sandbox / incubation submission narrative using this checklist as the source-of-truth status page.


### PR DESCRIPTION
Fixes #18674
Fixes #18773
Fixes #18783

Adds governance documentation and a CNCF readiness checklist, strengthens the security policy, and restructures adopter evidence for Sandbox/incubation preparation.