### PR TITLE
docs: document shipped MCP bridge

### DIFF
--- a/web/docs/MCP_BRIDGE.md
+++ b/web/docs/MCP_BRIDGE.md
@@ -1,0 +1,40 @@
+# KubeStellar Console MCP Bridge
+
+The KubeStellar Console ships an MCP bridge today. It is not a planned or
+"coming soon" feature.
+
+## What is available now
+
+- The web app fetches cluster data through the shipped MCP-backed `/api/mcp/*`
+  routes.
+- When a local `kc-agent` is available, hooks can call the agent directly for
+  richer cluster access and live updates.
+- The browser authenticates local agent requests through `/api/agent/token`,
+  injects the token with `agentFetch()`, and subscribes to kubeconfig change
+  notifications over WebSocket.
+
+## How the bridge works
+
+1. Read hooks call `agentFetch()` and `getLocalAgentURL()` when the local agent
+   is available.
+2. If the local agent is unavailable, the UI falls back to the console backend
+   and its `/api/mcp/*` endpoints.
+3. Demo mode remains available when neither live path is active.
+
+Mutating workload actions are explicitly local-agent backed, and the UI surfaces
+that requirement instead of pretending the feature is still pending.
+
+## Implementation references
+
+- `web/src/hooks/mcp/agentFetch.ts`
+- `web/src/hooks/mcp/sharedImpl.connection.ts`
+- `web/src/hooks/useMCP.ts`
+- `web/src/hooks/useWorkloads.ts`
+
+## Testing guidance
+
+For browser and component tests, mock `/api/mcp/*` responses directly. Existing
+examples live in:
+
+- `web/PLAYWRIGHT.md`
+- `web/docs/TEST_AUTHORING_GUIDE.md`

--- a/web/docs/TEST_AUTHORING_GUIDE.md
+++ b/web/docs/TEST_AUTHORING_GUIDE.md
@@ -36,9 +36,15 @@ web/
 │   │   └── theme-settings.spec.ts
 │   └── compliance/                   ← compliance / audit specs
 ├── docs/
-│   └── TEST_AUTHORING_GUIDE.md       ← you are here
+│   ├── TEST_AUTHORING_GUIDE.md       ← you are here
+│   └── MCP_BRIDGE.md                 ← shipped MCP bridge overview
 └── playwright.config.ts
 ```
+
+The console's MCP bridge is already shipped and testable today. When writing
+tests for cluster data flows, prefer mocking the live `/api/mcp/*` routes
+described in `web/docs/MCP_BRIDGE.md` instead of treating MCP integration as a
+future-only surface.
 
 **Naming rules**
 


### PR DESCRIPTION
Fixes #18719

## Summary
- add `web/docs/MCP_BRIDGE.md` stating the console MCP bridge is already shipped
- point test authors at the live `/api/mcp/*` surface in `web/docs/TEST_AUTHORING_GUIDE.md`
- document console-side MCP availability even though the stale README/card-count work itself primarily lives in `kubestellar/kubestellar-mcp`

## Notes
- I searched the tracked console docs for stale kubestellar-mcp "coming soon" references and did not find any
- issue #18720 and issue #18816 are primarily external submission tasks for `kubestellar/kubestellar-mcp` and related registries, so I am closing them as not planned in this repo