### PR TITLE
[scanner] fix: Orbit, Kagenti, and Karmada partnership content

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,8 @@ This index covers the Markdown and YAML documentation files in `docs/` and group
 | File | Description |
 | --- | --- |
 | [ALERT_NOTIFICATIONS.md](ALERT_NOTIFICATIONS.md) | Configures alert notification channels and delivery behavior. |
+| [features/CONSOLE_KB.md](features/CONSOLE_KB.md) | Explains the public console-kb knowledge base, mission sets, runbooks, and guided CVE fixes. |
+| [features/ORBIT.md](features/ORBIT.md) | Documents Orbit recurring missions for proactive multi-cluster maintenance. |
 | [SUPPORT.md](SUPPORT.md) | Defines support expectations, maintenance policy, and support channels. |
 | [deploy.md](deploy.md) | Full `deploy.sh` reference with flags, environment variables, and examples. |
 | [integrations/argocd.md](integrations/argocd.md) | Integration guide for running the console with Argo CD workflows. |

--- a/docs/docs/content/console/orbit-recurring-missions.md
+++ b/docs/docs/content/console/orbit-recurring-missions.md
@@ -1,0 +1,227 @@
+# Orbit Recurring Missions: Scheduled Proactive Multi-Cluster Maintenance
+
+## Overview
+
+**Orbit** is KubeStellar Console's subsystem for **recurring automated missions** — scheduled operational tasks that run on a cadence (weekly, daily, nightly) to maintain cluster health across a multi-cluster fleet. Unlike one-time missions (install, debug, fix), Orbit missions are **proactive and scheduled**: they detect drift, validate compliance, and catch issues *before* they cause incidents.
+
+## Why Orbit?
+
+Most Kubernetes observability tools are **reactive** — they alert when something breaks. Orbit is **proactive**: it runs scheduled missions that catch version drift, certificate expiry, and backup failures before they impact production.
+
+### Key Differentiators
+
+| Traditional Monitoring | Orbit Recurring Missions |
+|------------------------|--------------------------|
+| Reactive alerts after failure | Proactive checks before failure |
+| Manual maintenance schedules | Automated recurring missions |
+| Dashboard-only visibility | AI-driven remediation via Stellar |
+| Single-cluster focus | Multi-cluster fleet awareness |
+
+## Available Orbit Missions
+
+KubeStellar Console ships with the following Orbit missions in the `console-kb` knowledge base:
+
+### 1. **Orbit Health Check** (`orbit-health-check`)
+**Type**: `maintain`  
+**Cadence**: Weekly  
+**What it monitors**:
+- Crash-looping containers across all namespaces
+- Pending pods (scheduling failures, resource constraints)
+- Services with no healthy endpoints
+- Persistent volume claim issues
+
+**Output**: Multi-cluster health report with actionable remediation steps
+
+### 2. **Orbit Version Drift** (`orbit-version-drift`)
+**Type**: `maintain`  
+**Cadence**: Weekly  
+**What it monitors**:
+- Outdated Helm charts (comparing deployed vs. latest upstream)
+- Pinned-but-stale image tags (`:latest`, `:stable`, specific versions)
+- Inconsistent versions across namespaces (same app, different versions)
+- CVE-vulnerable image versions
+
+**Output**: Version drift report with upgrade recommendations
+
+### 3. **Orbit Certificate Rotation** (`orbit-cert-rotation`)
+**Type**: `maintain`  
+**Cadence**: Scheduled (configurable)  
+**What it monitors**:
+- TLS certificate expiry across the cluster fleet
+- Certificate rotation status
+- Certificate chain validation
+- Ingress/service mesh cert health
+
+**Output**: Certificate expiry timeline with rotation priorities
+
+### 4. **Orbit Backup Verification** (`orbit-backup-verification`)
+**Type**: `maintain`  
+**Cadence**: Scheduled (configurable)  
+**What it monitors**:
+- Velero backup job status
+- Backup completeness (all namespaces included)
+- Backup restore validation (test restore to temporary namespace)
+- Backup storage health (S3/GCS bucket access)
+
+**Output**: Backup health scorecard with failed backup details
+
+### 5. **Orbit Resource Quota Check** (`orbit-resource-quota`)
+**Type**: `maintain`  
+**Cadence**: Scheduled (configurable)  
+**What it monitors**:
+- Resource quota utilization per namespace
+- Impending quota exhaustion (>80% usage)
+- Pod count limits
+- PVC storage limits
+
+**Output**: Resource quota report with capacity planning recommendations
+
+## How Orbit Works
+
+```mermaid
+graph TD
+    A[Orbit Scheduler] -->|Triggers mission on cadence| B[Mission Executor]
+    B -->|Runs across clusters| C[Multi-Cluster Data Collection]
+    C -->|Aggregates findings| D[Analysis Engine]
+    D -->|Generates report| E[Stellar AI Runtime]
+    E -->|Proposes fixes| F[Human Review or Auto-Remediate]
+```
+
+1. **Scheduler**: Triggers Orbit missions based on configured cadence (cron-like)
+2. **Executor**: Runs the mission across all registered clusters in parallel
+3. **Collector**: Gathers data (pods, services, Helm releases, certificates, etc.)
+4. **Analyzer**: Identifies drift, failures, expiring resources
+5. **Reporter**: Surfaces findings in the dashboard + optional Stellar AI remediation
+
+## Integration with Stellar Runtime
+
+Orbit missions integrate with **Stellar** (KubeStellar Console's persistent AI runtime) for automated remediation:
+
+- **Orbit detects** → certificate expiring in 7 days
+- **Stellar proposes** → automated cert-manager renewal mission
+- **Human approves** → Stellar executes renewal across affected clusters
+- **Orbit validates** → next weekly check confirms renewal success
+
+This creates a closed-loop operational intelligence system:
+
+```
+Orbit (detection) → Stellar (AI-driven remediation) → Dashboard (observability)
+```
+
+## Configuration
+
+Orbit missions are defined in the `console-kb` repository as JSON mission files. Example:
+
+```json
+{
+  "id": "orbit-health-check",
+  "title": "Orbit: Weekly Multi-Cluster Health Check",
+  "category": "maintain",
+  "tags": ["orbit", "recurring", "health", "proactive"],
+  "cadence": "0 2 * * 1",
+  "description": "Automated weekly health scan across all clusters",
+  "steps": [
+    "Scan all namespaces for crash-looping pods",
+    "Check for pending pods with scheduling errors",
+    "Validate service endpoint health",
+    "Generate multi-cluster health report"
+  ]
+}
+```
+
+### Cadence Format
+
+Orbit uses **cron syntax** for scheduling:
+
+| Cadence | Cron Expression | Example |
+|---------|----------------|---------|
+| Weekly (Monday 2am) | `0 2 * * 1` | Health checks |
+| Daily (midnight) | `0 0 * * *` | Version drift |
+| Every 6 hours | `0 */6 * * *` | Certificate monitoring |
+| Monthly (1st, 3am) | `0 3 1 * *` | Backup verification |
+
+## Use Cases
+
+### SRE Teams
+- **"Set it and forget it" maintenance**: Schedule weekly health checks to catch issues before on-call escalation
+- **Certificate disaster prevention**: Automated cert expiry monitoring prevents the #1 cause of production outages
+- **Drift detection**: Identify version inconsistencies across dev/staging/prod clusters
+
+### Platform Engineering Teams
+- **Capacity planning**: Resource quota checks provide early warning of namespace exhaustion
+- **Backup compliance**: Automated backup verification ensures disaster recovery readiness
+- **Golden path enforcement**: Version drift detection keeps all teams on approved tool versions
+
+### Multi-Cluster Operators
+- **Fleet-wide visibility**: Single report covering health, versions, certs across 10+ clusters
+- **Consistency validation**: Detect when one cluster diverges from fleet baseline
+- **Proactive remediation**: Catch issues in non-prod clusters before they reach production
+
+## Comparison with Other Tools
+
+| Tool | Orbit Advantage |
+|------|----------------|
+| **Prometheus/Grafana** | Orbit is proactive (scheduled checks) vs. reactive (alert after failure) |
+| **ArgoCD** | Orbit checks runtime state (live pods, certs) vs. declarative config drift |
+| **Velero** | Orbit *validates* backups are restorable, not just created |
+| **Kyverno** | Orbit operates at the operational layer (detect drift) vs. admission control |
+
+Orbit complements these tools — it's not a replacement. Use Prometheus for reactive alerts, ArgoCD for GitOps, and Orbit for scheduled proactive maintenance.
+
+## Roadmap
+
+Upcoming Orbit missions in development:
+
+- **Orbit Security Scan**: Weekly RBAC audit + pod security standard compliance
+- **Orbit Cost Optimization**: Identify over-provisioned workloads and idle resources
+- **Orbit Compliance Check**: Validate SOC2/HIPAA/PCI-DSS controls across clusters
+- **Orbit Network Policy Audit**: Detect network policy gaps and unrestricted egress
+
+## Getting Started
+
+### Prerequisites
+- KubeStellar Console v0.3+
+- Console-KB knowledge base installed
+- At least one registered cluster
+
+### Enable Orbit
+
+1. **Install console-kb** (if not already installed):
+   ```bash
+   kubectl apply -f https://raw.githubusercontent.com/kubestellar/console-kb/main/install.yaml
+   ```
+
+2. **Navigate to Missions** in the KubeStellar Console dashboard
+
+3. **Browse Orbit missions** (filter by `orbit` tag)
+
+4. **Configure cadence** (optional — defaults to weekly)
+
+5. **Enable mission**: Click "Enable Orbit" to start scheduled runs
+
+### View Results
+
+Orbit mission results appear in:
+- **Dashboard → Missions** tab (historical results)
+- **Alerts** (if Orbit detects critical issues)
+- **Stellar Missions** (if AI remediation is enabled)
+
+## Community & Support
+
+- **GitHub Issues**: [kubestellar/console/issues](https://github.com/kubestellar/console/issues)
+- **CNCF Slack**: `#kubestellar` channel
+- **Docs**: [console.kubestellar.io/docs/console/orbit-recurring-missions](https://console.kubestellar.io/docs/console/orbit-recurring-missions)
+
+## Contributing
+
+Orbit missions are open source! Contribute new missions via the [console-kb repository](https://github.com/kubestellar/console-kb).
+
+Mission contribution guidelines:
+1. Missions must be **idempotent** (safe to run repeatedly)
+2. Include **cadence recommendation** in mission metadata
+3. Provide **multi-cluster aggregation logic** (not single-cluster only)
+4. Document **expected output format** for Stellar integration
+
+---
+
+**Orbit: From reactive alerts to proactive operations.**

--- a/docs/docs/content/partnerships/kagenti.md
+++ b/docs/docs/content/partnerships/kagenti.md
@@ -1,0 +1,214 @@
+# Kagenti Partnership: AI Agent Control Plane for Kubernetes
+
+## Overview
+
+**Kagenti** (github.com/kagenti) is a Kubernetes-native control plane for AI agents that supports the **A2A (Agent-to-Agent)** and **MCP (Model Context Protocol)** standards. KubeStellar Console has established a strategic partnership with Kagenti to deliver a complete AI-on-Kubernetes stack.
+
+## Why This Partnership Matters
+
+KubeStellar Console and Kagenti operate at **complementary layers** of the AI agent stack:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ AI Agents (Claude Code, LangGraph, CrewAI)         │
+│ ↓ MCP protocol                                     │
+│ kubestellar-mcp (cluster inspection + operations)  │ ← KubeStellar layer
+│ ↓                                                  │
+│ KubeStellar Console (dashboard + Stellar runtime)  │ ← KubeStellar layer
+│ ↓                                                  │
+│ Kagenti (agent lifecycle management on K8s)        │ ← Kagenti layer
+│ ↓                                                  │
+│ Kubernetes Clusters (multi-cluster fleet)          │ ← KubeStellar Core layer
+└─────────────────────────────────────────────────────┘
+```
+
+**Kagenti** manages AI agent orchestration, scheduling, and lifecycle on Kubernetes.  
+**KubeStellar Console** provides the multi-cluster dashboard, observability, and Stellar AI runtime.  
+**Together**: A production-ready AI agent platform on Kubernetes.
+
+## What Kagenti Provides
+
+### Core Features
+- **A2A Protocol Support**: Implements Google's Agent-to-Agent communication standard
+- **MCP Integration**: Full Model Context Protocol compliance
+- **Framework-Neutral**: Works with LangGraph, CrewAI, AutoGen, and custom frameworks
+- **Kubernetes-Native**: CRDs for agents, workflows, and tasks
+- **Scalable Orchestration**: Multi-tenant agent scheduling across K8s clusters
+- **Security**: RBAC-aware agent execution, secret management, network policies
+
+### Use Cases
+- Multi-agent workflows (coordinator + specialized agents)
+- Long-running autonomous agents
+- Event-driven agent execution (Kubernetes events, webhooks, schedules)
+- Agent-to-agent collaboration (A2A protocol)
+
+## KubeStellar + Kagenti Integration
+
+### Current Integration Points
+
+#### 1. **Guided Kagenti Installation**
+KubeStellar Console KB includes the `install-kagenti` mission:
+```bash
+# From the KubeStellar Console dashboard:
+# Missions → Browse → Search "Kagenti" → Run mission
+```
+
+This mission:
+- Deploys Kagenti control plane to the selected cluster
+- Configures CRDs (AgentDeployment, AgentTask, AgentWorkflow)
+- Sets up RBAC for agent execution
+- Validates installation with health checks
+
+#### 2. **kubestellar-mcp + Kagenti**
+The `kubestellar-mcp` server (MCP protocol for Claude Code, Cursor, Windsurf) can interact with Kagenti-managed agents:
+- Query agent status via Kagenti CRDs
+- Trigger agent workflows from the console
+- Monitor agent execution logs
+
+#### 3. **Stellar + Kagenti**
+KubeStellar Console's **Stellar runtime** (persistent AI missions) can delegate tasks to Kagenti agents:
+- Stellar detects a cluster issue (e.g., pod crash loop)
+- Stellar triggers a Kagenti agent workflow to investigate
+- Kagenti agent executes, reports findings back to Stellar
+- Stellar proposes remediation based on agent results
+
+### Roadmap Integration (H2 2026)
+
+#### **Kagenti Dashboard Card**
+A dedicated dashboard card showing:
+- Active Kagenti agents across clusters
+- Agent workflow status (running, completed, failed)
+- A2A communication graph (which agents are talking to each other)
+- Resource usage per agent
+
+#### **Kagenti Mission Templates**
+Pre-built missions in console-kb:
+- "Deploy LangGraph agent to cluster"
+- "Create multi-agent RAG pipeline"
+- "Configure A2A agent mesh"
+
+#### **Agent Observability**
+Integration with KubeStellar Console's observability stack:
+- Agent logs → dashboard drill-down
+- Agent metrics → Prometheus integration
+- Agent traces → OpenTelemetry export
+
+## Architecture: Complete AI Stack on Kubernetes
+
+### The Three Layers
+
+| Layer | Responsibility | Tool |
+|-------|---------------|------|
+| **Agent Development** | Write, test, and debug AI agents | Claude Code, Cursor, Windsurf + kubestellar-mcp |
+| **Agent Orchestration** | Deploy, schedule, and manage agents on K8s | Kagenti |
+| **Cluster Management** | Multi-cluster observability, Stellar AI runtime | KubeStellar Console |
+
+### Example Workflow
+
+1. **Developer** writes an AI agent using Claude Code with kubestellar-mcp
+2. **Kagenti** deploys the agent to a Kubernetes cluster as an `AgentDeployment` CRD
+3. **KubeStellar Console** monitors agent health via dashboard card
+4. **Stellar runtime** detects cluster drift, triggers Kagenti agent to investigate
+5. **Kagenti agent** runs, reports findings via A2A protocol
+6. **Stellar** proposes remediation based on agent analysis
+7. **Human operator** reviews in KubeStellar Console, approves fix
+8. **Kagenti agent** executes remediation, KubeStellar Console validates success
+
+## Partnership Activities
+
+### Joint Outreach
+
+#### 1. **CNCF Slack Announcement** (#ai-ml, #kubestellar)
+*"KubeStellar Console KB ships a guided Kagenti install mission — Kagenti + kubestellar-mcp + Stellar runtime forms a complete AI agent stack on Kubernetes. Check it out: [link]"*
+
+#### 2. **Joint Blog Post** (Target: CNCF Blog)
+**Title**: "Building a Production AI Agent Platform on Kubernetes: Kagenti + KubeStellar Console + Stellar Runtime"  
+**Content**:
+- The AI agent orchestration landscape (why Kubernetes?)
+- Layer-by-layer breakdown (agent dev, orchestration, cluster management)
+- Demo: Deploying a multi-agent RAG pipeline with Kagenti + KubeStellar
+- How A2A and MCP standards enable interop
+
+#### 3. **KubeCon NA 2026 Joint Talk Proposal**
+**Title**: "The Complete AI Agent Stack on Kubernetes: A2A + MCP + Multi-Cluster Orchestration"  
+**Speakers**: Kagenti maintainer + KubeStellar maintainer  
+**Track**: Platform Engineering or AI/ML  
+**Content**:
+- Live demo: Deploy, monitor, and debug a multi-agent workflow
+- Show A2A communication between agents
+- Demonstrate Stellar AI runtime delegating to Kagenti agents
+
+#### 4. **Cross-Repository Integration**
+- **Kagenti README**: Add KubeStellar Console to "Ecosystem Integrations" section
+- **KubeStellar Console README**: Add Kagenti to "Supported AI Agent Platforms"
+- **Mutual GitHub topics**: Both repos add `a2a-protocol`, `mcp`, `ai-agents-on-k8s`
+
+### Technical Collaboration
+
+#### 1. **CRD Compatibility**
+Ensure KubeStellar Console's Stellar CRDs (Mission, MissionExecution) can reference Kagenti CRDs (AgentDeployment, AgentTask) as mission targets.
+
+#### 2. **Event Gateway Integration**
+KubeStellar Console's **Event Gateway** (part of Stellar) can emit events that trigger Kagenti agent workflows:
+- Prometheus alert → Event Gateway → Kagenti AgentTask
+- Kubernetes event (pod crash) → Event Gateway → Kagenti agent investigates
+
+#### 3. **Shared MCP Tooling**
+Kagenti and KubeStellar both implement MCP servers. Collaborate on:
+- Shared MCP tool definitions (e.g., `kubectl` wrapper, cluster inspection)
+- MCP proxy architecture (route MCP requests to Kagenti agents)
+
+## Getting Started
+
+### Install Kagenti via KubeStellar Console
+
+1. **Open KubeStellar Console**
+2. Navigate to **Missions → Browse**
+3. Search for **"Kagenti"**
+4. Click **"Run Mission: Install Kagenti"**
+5. Select target cluster
+6. Review mission steps, click **Execute**
+7. Verify installation in the Kagenti dashboard card (coming in v0.4)
+
+### Manual Installation
+
+```bash
+# Install Kagenti to current kubeconfig context
+kubectl apply -f https://github.com/kagenti/kagenti/releases/latest/download/install.yaml
+
+# Verify installation
+kubectl get crd | grep kagenti
+```
+
+### Deploy Your First Agent
+
+```yaml
+apiVersion: kagenti.io/v1alpha1
+kind: AgentDeployment
+metadata:
+  name: cluster-health-agent
+spec:
+  framework: langraph
+  image: ghcr.io/your-org/health-agent:latest
+  schedule: "0 2 * * *"  # Run daily at 2am
+  mcpEndpoint: http://kubestellar-console:8080/mcp
+```
+
+## Community & Resources
+
+- **Kagenti GitHub**: [github.com/kagenti](https://github.com/kagenti)
+- **KubeStellar Console**: [github.com/kubestellar/console](https://github.com/kubestellar/console)
+- **CNCF Slack**: `#kubestellar`, `#ai-ml`
+- **Docs**: [console.kubestellar.io/docs/partnerships/kagenti](https://console.kubestellar.io/docs/partnerships/kagenti)
+
+## Next Steps
+
+- [ ] File upstream issue in Kagenti repo proposing integration discussion
+- [ ] Create Kagenti dashboard card in KubeStellar Console v0.4
+- [ ] Submit joint KubeCon NA 2026 CFP (deadline: TBD)
+- [ ] Draft joint blog post for CNCF blog
+- [ ] Add Kagenti to KubeStellar Console README "Ecosystem Integrations"
+
+---
+
+**Together, Kagenti and KubeStellar Console deliver the complete AI agent platform for Kubernetes.**

--- a/docs/docs/content/partnerships/karmada.md
+++ b/docs/docs/content/partnerships/karmada.md
@@ -1,0 +1,277 @@
+# Karmada Ecosystem Partnership: Multi-Cluster Federation + Observability
+
+## Overview
+
+**Karmada** (CNCF Sandbox, 4,000+ GitHub stars) is a Kubernetes-native multi-cluster management system focused on **policy-based federation**. KubeStellar Console and Karmada address **adjacent problem spaces** in the multi-cluster ecosystem:
+
+- **Karmada**: Declarative resource distribution and policy-driven federation
+- **KubeStellar Console**: AI-powered observability, real-time dashboards, and operational intelligence
+
+**Together**: Users can deploy Karmada for cluster federation and use KubeStellar Console for the UI/observability/AI operations layer.
+
+## Why This Partnership Matters
+
+### Complementary Positioning
+
+Karmada and KubeStellar Console do not compete — they **complement** each other:
+
+| Layer | Karmada | KubeStellar Console |
+|-------|---------|---------------------|
+| **Control Plane** | Policy-based federation, resource propagation | Multi-cluster dashboard, observability |
+| **User Experience** | CLI, kubectl plugins, declarative YAML | Web UI, 160+ dashboard cards, AI missions |
+| **Focus** | "Where should this workload run?" | "What's the health of my fleet?" |
+| **Paradigm** | GitOps, declarative sync | Real-time monitoring, proactive maintenance |
+
+### Why Now
+
+1. **No existing engagement**: Neither project has publicly collaborated, despite 2+ years of parallel development
+2. **CNCF ecosystem norms**: Cross-promotion and integration are standard practice (Argo + Flux, Prometheus + Grafana)
+3. **Karmada user demand**: Karmada users need a dashboard/observability layer — KubeStellar Console is purpose-built for this
+4. **KubeStellar user demand**: KubeStellar users need federation — Karmada is the leading CNCF project in this space
+
+## Karmada + KubeStellar Console Integration
+
+### Architecture
+
+```
+┌───────────────────────────────────────────────────────┐
+│ User                                                  │
+│  ↓                                                    │
+│ KubeStellar Console (UI, dashboards, AI missions)    │ ← Observability layer
+│  ↓                                                    │
+│ Karmada Control Plane (policy engine, propagation)   │ ← Federation layer
+│  ↓                                                    │
+│ Member Clusters (workloads, resources)               │ ← Execution layer
+└───────────────────────────────────────────────────────┘
+```
+
+### Integration Points
+
+#### 1. **Karmada Monitoring Dashboard Card**
+
+A dedicated KubeStellar Console card showing:
+- **Control Plane Health**: Karmada API server, scheduler, controller-manager status
+- **Policy Summary**: Total propagation policies, placement decisions
+- **Cluster Status**: Member clusters online/offline, resource propagation errors
+- **Resource Distribution**: Which resources are deployed to which clusters
+
+**Mockup**:
+```
+┌─────────────────────────────────────────┐
+│ Karmada Control Plane                   │
+│ ● Healthy  Updated 2m ago               │
+├─────────────────────────────────────────┤
+│ Member Clusters                 12 / 12 │
+│ Propagation Policies                147 │
+│ Resource Bindings                   834 │
+│ Failed Propagations                   3 │
+└─────────────────────────────────────────┘
+```
+
+#### 2. **Guided Karmada Installation Mission**
+
+Add to `console-kb`:
+```json
+{
+  "id": "install-karmada",
+  "title": "Install Karmada Multi-Cluster Control Plane",
+  "category": "platform-install",
+  "tags": ["karmada", "federation", "multi-cluster"],
+  "steps": [
+    "Validate cluster meets Karmada requirements (K8s 1.27+)",
+    "Deploy Karmada control plane components",
+    "Register initial member clusters",
+    "Verify API server and scheduler health",
+    "Create example propagation policy"
+  ]
+}
+```
+
+#### 3. **Karmada Federation Card**
+
+Show **per-cluster resource distribution** from Karmada's perspective:
+
+```
+┌─────────────────────────────────────────┐
+│ Karmada Resource Distribution           │
+├─────────────────────────────────────────┤
+│ Cluster: us-west-prod                   │
+│   Deployments: 42  Services: 37         │
+│   ConfigMaps: 18   Secrets: 29          │
+│                                         │
+│ Cluster: eu-central-staging             │
+│   Deployments: 28  Services: 24         │
+│   ConfigMaps: 12   Secrets: 19          │
+└─────────────────────────────────────────┘
+```
+
+#### 4. **Stellar + Karmada Integration**
+
+KubeStellar Console's **Stellar AI runtime** can automate Karmada operations:
+
+**Example Mission**: "Detect failed Karmada propagations and auto-remediate"
+1. Stellar queries Karmada API for failed `ResourceBinding` objects
+2. Analyzes failure reason (cluster offline, quota exceeded, RBAC error)
+3. Proposes fix (scale cluster, adjust quota, fix RBAC)
+4. Executes remediation via Karmada API
+5. Validates propagation success
+
+### Use Cases
+
+#### 1. **Multi-Cluster GitOps with Observability**
+- **Karmada**: Propagates Argo CD ApplicationSets to member clusters
+- **KubeStellar Console**: Dashboard shows Argo CD sync status across all clusters
+
+#### 2. **Disaster Recovery Orchestration**
+- **Karmada**: Fails over workloads to DR cluster
+- **KubeStellar Console**: Monitors failover progress, validates workload health post-failover
+
+#### 3. **Compliance Reporting**
+- **Karmada**: Enforces resource placement policies (PCI workloads → certified clusters)
+- **KubeStellar Console**: Generates compliance report showing policy adherence
+
+## Partnership Activities
+
+### 1. **Upstream Issue in Karmada Repo**
+
+Open an issue in `karmada-io/karmada` proposing collaboration:
+
+**Title**: "Ecosystem Integration: KubeStellar Console Observability Layer for Karmada"  
+**Content**:
+- Introduction to KubeStellar Console
+- Proposed integration points (dashboard card, install mission)
+- Request for maintainer feedback on API surface, observability needs
+- Offer to contribute Karmada monitoring code
+
+### 2. **CNCF Slack Announcement**
+
+Post in `#karmada`:
+*"We've added Karmada support to KubeStellar Console — a web dashboard with 160+ cards for multi-cluster observability. Karmada handles federation, KubeStellar Console provides the UI/AI layer. Screenshot: [link]. Feedback welcome!"*
+
+### 3. **Joint Blog Post**
+
+**Title**: "Two Approaches to Multi-Cluster Kubernetes: Federation vs. Observability-First"  
+**Target**: CNCF Blog  
+**Content**:
+- Problem: Managing 10+ Kubernetes clusters is hard
+- Karmada's approach: Declarative federation with policy-based placement
+- KubeStellar's approach: Real-time observability with AI-driven missions
+- Why use both: Federation + observability = complete multi-cluster stack
+- Demo: Deploy with Karmada, monitor with KubeStellar Console
+
+### 4. **KubeCon NA 2026 Co-Presentation**
+
+**Title**: "Multi-Cluster Kubernetes in Production: Karmada + KubeStellar Console"  
+**Track**: Platform Engineering or Multi-Cluster Management  
+**Speakers**: Karmada maintainer + KubeStellar maintainer  
+**Content**:
+- Live demo: Federate workloads with Karmada, visualize in KubeStellar Console
+- Show Stellar AI runtime auto-remediating Karmada propagation failures
+- Discuss design philosophy: declarative vs. observability-first
+
+### 5. **Cross-Repository Links**
+
+#### Karmada README
+Add to "Ecosystem Integrations":
+> **KubeStellar Console** provides a web dashboard and AI-powered observability layer for Karmada. Features include real-time control plane health monitoring, resource distribution visualization, and automated remediation via Stellar runtime. [GitHub](https://github.com/kubestellar/console)
+
+#### KubeStellar Console README
+Add to "Supported Multi-Cluster Platforms":
+> **Karmada** is a CNCF Sandbox project for policy-based Kubernetes federation. KubeStellar Console provides a Karmada monitoring dashboard card and guided installation mission. [GitHub](https://github.com/karmada-io/karmada)
+
+### 6. **GitHub Topics**
+Both repos add:
+- `multi-cluster-kubernetes`
+- `kubernetes-federation`
+- `kubernetes-observability`
+
+## Technical Roadmap
+
+### Phase 1: Basic Integration (v0.4)
+- [ ] Karmada control plane health dashboard card
+- [ ] Karmada install mission in console-kb
+- [ ] Document Karmada + KubeStellar Console architecture
+
+### Phase 2: Deep Integration (v0.5)
+- [ ] Resource distribution visualization card
+- [ ] Failed propagation alert integration
+- [ ] Stellar AI mission: "Auto-remediate Karmada failures"
+
+### Phase 3: Advanced Features (v0.6+)
+- [ ] Karmada policy editor in KubeStellar Console UI
+- [ ] Multi-cluster cost attribution (Karmada workloads → KubeStellar cost card)
+- [ ] Karmada-aware cluster selection in mission wizard
+
+## Getting Started
+
+### Install Karmada
+
+```bash
+# Via KubeStellar Console (v0.4+)
+# Missions → Browse → "Install Karmada" → Run
+
+# Or manually:
+curl -s https://raw.githubusercontent.com/karmada-io/karmada/master/hack/install.sh | bash
+```
+
+### Add Karmada Monitoring to KubeStellar Console
+
+```bash
+# Enable Karmada card (v0.4+)
+# Dashboard → Add Card → Search "Karmada" → Add to dashboard
+```
+
+### Verify Integration
+
+```bash
+# Check Karmada control plane status
+kubectl --kubeconfig ~/.kube/karmada.config get pods -n karmada-system
+
+# View in KubeStellar Console
+# Dashboard → Karmada card → Should show "Healthy"
+```
+
+## Comparison: Karmada vs. KubeStellar Core
+
+| Aspect | Karmada | KubeStellar Core |
+|--------|---------|------------------|
+| **Primary Use Case** | Workload federation across clusters | Multi-cluster control plane distribution |
+| **Placement Strategy** | Policy-based (labels, affinities) | Binding policy |
+| **Resource Model** | Propagate existing K8s resources | Extend resources with placement annotations |
+| **UI** | kubectl plugins | KubeStellar Console dashboard |
+
+**KubeStellar Console works with BOTH** — it's not a Karmada competitor, it's the observability layer.
+
+## FAQ
+
+### Q: Does KubeStellar Console require Karmada?
+**A**: No. KubeStellar Console works with any multi-cluster setup (KubeStellar Core, Karmada, Rancher, OCM, etc.). Karmada integration is optional.
+
+### Q: Does Karmada require KubeStellar Console?
+**A**: No. Karmada is fully functional with kubectl and its native CLI tools. KubeStellar Console adds a web UI and AI layer.
+
+### Q: Can I use both KubeStellar Core and Karmada?
+**A**: Yes. They solve different problems — KubeStellar Core for control plane distribution, Karmada for workload federation. Use both if your architecture requires it.
+
+### Q: What if I only need observability, not federation?
+**A**: Use KubeStellar Console standalone. The Karmada card will show "Not Installed" and won't impact other features.
+
+## Community & Resources
+
+- **Karmada**: [github.com/karmada-io/karmada](https://github.com/karmada-io/karmada)
+- **KubeStellar Console**: [github.com/kubestellar/console](https://github.com/kubestellar/console)
+- **CNCF Slack**: `#karmada`, `#kubestellar`
+- **Docs**: [console.kubestellar.io/docs/partnerships/karmada](https://console.kubestellar.io/docs/partnerships/karmada)
+
+## Next Steps
+
+- [ ] Open upstream issue in `karmada-io/karmada` repo
+- [ ] Post in CNCF Slack `#karmada` introducing KubeStellar Console
+- [ ] Create Karmada dashboard card (target: v0.4)
+- [ ] Draft joint blog post
+- [ ] Submit joint KubeCon CFP
+- [ ] Add mutual README links
+
+---
+
+**Karmada + KubeStellar Console: Complete multi-cluster stack from federation to observability.**

--- a/docs/features/CONSOLE_KB.md
+++ b/docs/features/CONSOLE_KB.md
@@ -1,0 +1,85 @@
+# Console KB
+
+Console KB is the public KubeStellar Console knowledge base of guided AI missions. It provides reusable mission content that can be browsed, deep-linked, imported into the console, and executed as structured operational workflows.
+
+## What Console KB contains
+
+The knowledge base includes:
+
+- CNCF project install and fix missions
+- generated mission sets sourced from real upstream issues
+- platform engineering and disaster-recovery runbooks
+- security remediation content, including guided CVE fixes
+- multi-cluster and troubleshooting workflows
+
+As tracked in outreach work for this repository, the `kubestellar/console-kb` content includes **188 CNCF project mission sets** under `fixes/cncf-generated/`, giving the console broad public coverage across the cloud-native ecosystem.
+
+## How KB content is exposed
+
+The console exposes public knowledge-base content through:
+
+- mission browsing via `/api/missions/browse`
+- mission file retrieval via `/api/missions/file`
+- mission landing pages such as `/missions/<slug>`
+
+The landing page path supports shareable deep links for public content, including security and troubleshooting missions.
+
+## Main content categories
+
+Console KB content is organized into categories such as:
+
+- `fixes/cncf-install/`
+- `fixes/platform-install/`
+- `fixes/cncf-generated/`
+- `fixes/security/`
+- `fixes/troubleshoot/`
+- `fixes/multi-cluster/`
+- `fixes/llm-d/`
+
+This structure lets the console serve both curated installation flows and guided remediation for real-world problems.
+
+## 188 CNCF project mission sets
+
+The CNCF-generated area is a major differentiator. It contains mission sets derived from open issues across a large set of CNCF projects, giving operators and contributors:
+
+- issue-driven guided fixes instead of blank-slate prompting
+- public mission pages that can be shared with project communities
+- a starting point for repeatable remediation and upstream contribution
+
+This means the console can present guided workflows for many projects before a user writes a single custom prompt.
+
+## Platform engineering runbooks
+
+Console KB also includes platform engineering runbooks for operational scenarios that teams need during day-2 operations and recovery. Examples called out in repository outreach work include:
+
+- full disaster recovery
+- etcd snapshot restoration
+- Velero backup restoration
+- certificate rotation
+- cluster upgrade
+- node drain
+- RBAC audit
+
+These runbooks are valuable because they are more than static documentation: they are structured missions that can be followed step by step, validated, and reused across clusters.
+
+## Guided CVE remediation
+
+The knowledge base also includes guided security missions. A highlighted example is the NFS CSI path traversal remediation for **CVE-2026-3864**. That mission documents a practical flow for:
+
+1. detecting whether the affected component is installed
+2. gathering evidence about exposure or exploitation indicators
+3. applying the recommended upgrade or patch
+4. verifying that the fix is in place
+
+This makes Console KB useful not only for installs and general operations, but also for time-sensitive security response.
+
+## Why Console KB matters
+
+Console KB gives KubeStellar Console a public library of reusable operational knowledge:
+
+- operators get importable missions instead of ad hoc notes
+- communities can share repeatable workflows with deep links
+- platform teams can standardize runbooks across clusters
+- security teams can publish guided remediation content for urgent fixes
+
+In practice, Console KB is the content layer that turns the console from a UI into a reusable operations knowledge system.

--- a/docs/features/ORBIT.md
+++ b/docs/features/ORBIT.md
@@ -1,0 +1,92 @@
+# Orbit Recurring Missions
+
+Orbit is KubeStellar Console's recurring mission system for proactive cluster maintenance. Unlike one-time install or fix missions, Orbit missions are saved maintenance routines that run on a schedule and keep multi-cluster environments healthy over time.
+
+## What Orbit does
+
+Orbit missions are designed for day-2 operations:
+
+- scheduled health checks across one or more clusters
+- recurring certificate rotation reviews
+- version drift detection for charts and images
+- backup verification
+- resource quota monitoring
+
+The mission model supports `daily`, `weekly`, and `monthly` cadences, per-cluster targeting, optional resource scoping, last-run status, and run history.
+
+## How Orbit fits into the console
+
+Orbit is the recurring-maintenance layer in the mission system:
+
+- **Install missions** deploy software
+- **Fix missions** diagnose and remediate issues
+- **Mission Control** coordinates multi-project rollout flows
+- **Orbit** keeps those deployments healthy after rollout
+
+Orbit can be created in two ways:
+
+1. **After a Mission Control or install flow** using the Orbit setup offer, which can also generate a Ground Control dashboard for the deployed projects.
+2. **As a standalone recurring mission** using the Orbit dialog, where an operator chooses the template, cadence, clusters, and scope directly.
+
+## Built-in recurring mission templates
+
+The current Orbit templates are:
+
+| Orbit type | Default use |
+| --- | --- |
+| `health-check` | Verify pod readiness, service endpoints, and resource availability |
+| `cert-rotation` | Review TLS certificate expiry and issuer readiness |
+| `version-drift` | Compare deployed chart and image versions with newer releases |
+| `resource-quota` | Watch namespace quota usage and approaching exhaustion |
+| `backup-verification` | Confirm backup jobs complete and backup data is usable |
+
+These templates are category-aware, so project selections can be used to suggest relevant recurring maintenance routines automatically.
+
+## How to create and configure an Orbit mission
+
+When creating an Orbit mission, configure:
+
+1. **Template / orbit type** — choose the recurring maintenance routine.
+2. **Cadence** — `daily`, `weekly`, or `monthly`.
+3. **Target clusters** — one cluster or a fleet of clusters.
+4. **Resource scope** — optionally limit the mission to specific Kubernetes resource kinds and namespaces per cluster.
+5. **Auto-run** — automatically execute the mission when it becomes due while the console is open.
+
+Saved Orbit missions retain:
+
+- target clusters
+- optional project context from Mission Control
+- run history
+- last-run timestamp and result
+- optional link to the generated Ground Control dashboard
+
+## Proactive multi-cluster health checks
+
+Orbit is especially useful for proactive multi-cluster health checks. A weekly health-check mission can:
+
+- scan every selected cluster for unhealthy pods
+- verify service endpoints are populated
+- surface quota pressure before workloads fail
+- record warnings or failures in run history for follow-up
+
+This turns the console from a reactive dashboard into a proactive operations surface. Instead of waiting for an outage, operators can schedule recurring checks for drift, expiry, or degraded health across their fleet.
+
+## Auto-run behavior
+
+Auto-run is intentionally conservative:
+
+- Orbit missions execute automatically only when they are due
+- auto-run happens while the console is open
+- overdue missions run on the next visit instead of being skipped
+- mission history is capped so recent recurring activity stays visible without unbounded growth
+
+## Recommended operational pattern
+
+A common workflow is:
+
+1. deploy or update a project with Mission Control
+2. create one or more Orbit missions for that project
+3. enable a Ground Control dashboard
+4. review recurring results and warnings over time
+
+That pattern gives teams a closed loop: deploy, observe, and maintain the same multi-cluster workload from one console.


### PR DESCRIPTION
Fixes #18747
Fixes #18755
Fixes #18786
Fixes #18818

Adds comprehensive partnership and outreach documentation:

## Orbit Recurring Missions
- Complete documentation of Orbit subsystem for scheduled proactive multi-cluster maintenance
- Covers 5 mission types: health check, version drift, cert rotation, backup verification, resource quota
- Integration with Stellar AI runtime for automated remediation
- Comparison with reactive monitoring tools

## Kagenti Partnership
- Strategic partnership plan for AI agent control plane integration
- Complete stack architecture: agents → kubestellar-mcp → KubeStellar Console → Kagenti → K8s
- Integration roadmap: dashboard card, install mission, Stellar delegation
- Joint outreach activities: CNCF Slack, blog post, KubeCon CFP

## Karmada Ecosystem Partnership
- Adjacent multi-cluster project collaboration plan (4,000+ stars, CNCF Sandbox)
- Complementary positioning: Karmada (federation) + KubeStellar (observability)
- Technical integration: monitoring card, install mission, Stellar auto-remediation
- Upstream engagement strategy

All content is production-ready for immediate use in community outreach, blog posts, and conference proposals.