### PR TITLE
[scanner] fix: add launch post content for Show HN and r/kubernetes

### DIFF
--- a/docs/community/LAUNCH_POST.md
+++ b/docs/community/LAUNCH_POST.md
@@ -1,0 +1,78 @@
+# Launch post drafts
+
+## Show HN draft
+
+**Suggested title**
+
+Show HN: KubeStellar Console — AI-powered multi-cluster Kubernetes dashboard (zero install)
+
+**Draft body**
+
+I built an open source Kubernetes console for exploring multiple clusters and 250+ CNCF projects from one place.
+
+You can try it immediately at **https://console.kubestellar.io** — no cluster, no install, and no config required because the hosted demo ships with built-in demo data.
+
+A few things that make it different:
+
+- **Multi-cluster view** for workloads, platform signals, and project health in one UI
+- **250+ CNCF ecosystem integrations** including tools like Argo CD, Flux, KEDA, Cilium, and more
+- **AI missions** that guide setup and operational workflows step by step
+- **Cache-first UX** designed to feel fast on repeat visits
+- **Open source** and self-hostable when you want to connect your own clusters
+
+The goal was to make Kubernetes exploration easier: you should be able to evaluate the product in a browser first, then self-host it when you want real cluster data.
+
+Try it: https://console.kubestellar.io  
+Source: https://github.com/kubestellar/console
+
+I would especially love feedback from platform engineers, SREs, and anyone managing more than one cluster.
+
+## r/kubernetes draft
+
+**Suggested title**
+
+I made a zero-install multi-cluster Kubernetes console you can try in your browser
+
+**Draft body**
+
+We have been working on **KubeStellar Console**, an open source multi-cluster Kubernetes dashboard that now has a hosted demo at **https://console.kubestellar.io**.
+
+The goal is simple: let people evaluate the console instantly before they decide whether to self-host it.
+
+What it includes:
+
+- A **zero-install hosted demo** with built-in demo data
+- A **multi-cluster console** for browsing workloads, dashboards, and ecosystem signals
+- Coverage for **250+ CNCF projects**
+- **AI mission flows** for guided setup and operational tasks
+- A self-hosted path if you want to connect your own kubeconfig contexts and AI keys
+
+If you want to kick the tires without touching your laptop or cluster, the hosted demo is the fastest path:
+
+**https://console.kubestellar.io**
+
+And if you want the code or want to self-host it:
+
+**https://github.com/kubestellar/console**
+
+I would love feedback on:
+
+1. Whether the hosted demo makes the project easier to evaluate
+2. Which multi-cluster views or integrations matter most in day-to-day operations
+3. What would make you trust a console enough to connect it to real clusters
+
+## Key talking points
+
+- Lead with the **hosted demo link** so readers can try it before reading more
+- Emphasize **zero install, zero config, browser-only evaluation**
+- Position it as a **multi-cluster console**, not just a single-cluster dashboard
+- Call out **250+ CNCF projects** and recognizable integrations such as Argo CD, Flux, and KEDA
+- Mention **AI missions** as guided workflows, not vague AI hype
+- Make the handoff clear: **hosted demo for evaluation, self-host for real cluster access**
+- Ask for concrete feedback from **platform engineers, SREs, and Kubernetes operators**
+
+## Optional cross-post notes
+
+- Best timing from the issue notes: Tuesday through Thursday morning in US time
+- Reuse the same hosted demo link and source link in every channel
+- Keep the Reddit version slightly more practical and feedback-oriented than the HN version


### PR DESCRIPTION
Fixes #18690
Fixes #18807

Adds `docs/community/LAUNCH_POST.md` with draft Show HN and r/kubernetes launch content plus key talking points.

README already has a clear "Try it now" section pointing to https://console.kubestellar.io, so no additional README change was required.