### PR TITLE
[scanner] fix: add comprehensive tests for stellar/tasks.go

### DIFF
--- a/pkg/api/handlers/stellar/providers_test.go
+++ b/pkg/api/handlers/stellar/providers_test.go
@@ -1,379 +1,376 @@
 package stellar
 
 import (
+	"context"
+	"errors"
 	"net"
-	"os"
+	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kubestellar/console/pkg/store"
 )
 
-func Test_parseCIDRs(t *testing.T) {
+const (
+	stellarProvidersRoute         = "/api/stellar/providers"
+	stellarProviderDefaultRoute   = "/api/stellar/providers/:id/default"
+	stellarProviderDeleteRoute    = "/api/stellar/providers/:id"
+	stellarOllamaLoopbackBaseURL  = "http://127.0.0.1:11434/"
+	stellarCloudPublicBaseURL     = "https://8.8.8.8/v1/"
+	stellarCloudLoopbackBaseURL   = "https://127.0.0.1/v1"
+	stellarCloudMetadataBaseURL   = "https://metadata.google.internal/v1"
+	stellarOllamaPrivateBaseURL   = "http://10.1.2.3:11434"
+	stellarExpectedCloudTrimmed   = "https://8.8.8.8/v1"
+	stellarExpectedOllamaTrimmed  = "http://127.0.0.1:11434"
+	stellarProviderLongURLPadding = 32
+)
+
+type providerUpsertErrorStore struct {
+	Store
+}
+
+func (s providerUpsertErrorStore) UpsertProviderConfig(_ context.Context, _ *store.StellarProviderConfig) error {
+	return errors.New("save failed")
+}
+
+type providerDeleteErrorStore struct {
+	Store
+}
+
+func (s providerDeleteErrorStore) DeleteProviderConfig(_ context.Context, _, _ string) error {
+	return errors.New("delete failed")
+}
+
+type providerDefaultErrorStore struct {
+	Store
+}
+
+func (s providerDefaultErrorStore) SetUserDefaultProvider(_ context.Context, _, _ string) error {
+	return errors.New("default failed")
+}
+
+type providerStoreUnavailable struct {
+	Store
+}
+
+func newProvidersHandlerTestApp(t *testing.T, handlerStore Store, authenticated bool) (*fiber.App, string) {
+	t.Helper()
+	t.Setenv("STELLAR_ENCRYPTION_KEY", "stellar-provider-test-key")
+
+	userID := uuid.New()
+	app := fiber.New()
+	if authenticated {
+		app.Use(func(c *fiber.Ctx) error {
+			c.Locals("userID", userID)
+			return c.Next()
+		})
+	}
+
+	handler := NewHandler(handlerStore, nil)
+	app.Get(stellarProvidersRoute, handler.ListProviders)
+	app.Post(stellarProvidersRoute, handler.CreateProvider)
+	app.Delete(stellarProviderDeleteRoute, handler.DeleteProvider)
+	app.Post(stellarProviderDefaultRoute, handler.SetDefaultProvider)
+
+	return app, userID.String()
+}
+
+func TestParseCIDRs(t *testing.T) {
+	cidrs, err := parseCIDRs([]string{"127.0.0.0/8", " ", "::1/128"})
+	require.NoError(t, err)
+	require.Len(t, cidrs, 2)
+	assert.True(t, cidrs[0].Contains(net.ParseIP("127.0.0.1")))
+	assert.True(t, cidrs[1].Contains(net.ParseIP("::1")))
+
+	_, err = parseCIDRs([]string{"not-a-cidr"})
+	require.Error(t, err)
+}
+
+func TestLoadStellarOllamaAllowedCIDRs(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		t.Setenv(stellarOllamaAllowedCIDRsEnv, "")
+		cidrs, err := loadStellarOllamaAllowedCIDRs()
+		require.NoError(t, err)
+		require.Len(t, cidrs, 2)
+		assert.True(t, ipInCIDRs(net.ParseIP("127.0.0.1"), cidrs))
+		assert.True(t, ipInCIDRs(net.ParseIP("::1"), cidrs))
+	})
+
+	t.Run("custom value", func(t *testing.T) {
+		t.Setenv(stellarOllamaAllowedCIDRsEnv, "10.0.0.0/8")
+		cidrs, err := loadStellarOllamaAllowedCIDRs()
+		require.NoError(t, err)
+		require.Len(t, cidrs, 1)
+		assert.True(t, ipInCIDRs(net.ParseIP("10.1.2.3"), cidrs))
+	})
+
+	t.Run("invalid value", func(t *testing.T) {
+		t.Setenv(stellarOllamaAllowedCIDRsEnv, "bad-cidr")
+		_, err := loadStellarOllamaAllowedCIDRs()
+		require.Error(t, err)
+	})
+}
+
+func TestResolveStellarProviderHostIPs(t *testing.T) {
+	ips, err := resolveStellarProviderHostIPs("8.8.8.8")
+	require.NoError(t, err)
+	require.Len(t, ips, 1)
+	assert.Equal(t, "8.8.8.8", ips[0].String())
+
+	ips, err = resolveStellarProviderHostIPs("localhost")
+	require.NoError(t, err)
+	require.NotEmpty(t, ips)
+}
+
+func TestIPInCIDRs(t *testing.T) {
+	cidrs, err := parseCIDRs([]string{"10.0.0.0/8", "2001:db8::/32"})
+	require.NoError(t, err)
+
+	assert.True(t, ipInCIDRs(net.ParseIP("10.1.2.3"), cidrs))
+	assert.True(t, ipInCIDRs(net.ParseIP("2001:db8::1"), cidrs))
+	assert.False(t, ipInCIDRs(net.ParseIP("192.168.1.1"), cidrs))
+}
+
+func TestValidateStellarProviderBaseURLCoverage(t *testing.T) {
+	tooLong := "https://example.com/" + strings.Repeat("a", stellarMaxProviderBaseURLLen+stellarProviderLongURLPadding)
+
 	tests := []struct {
-		name    string
-		input   []string
-		wantErr bool
-		wantLen int
+		name      string
+		provider  string
+		baseURL   string
+		envCIDRs  string
+		wantURL   string
+		wantError string
 	}{
-		{
-			name:    "valid single CIDR",
-			input:   []string{"127.0.0.0/8"},
-			wantErr: false,
-			wantLen: 1,
-		},
-		{
-			name:    "valid multiple CIDRs",
-			input:   []string{"127.0.0.0/8", "::1/128", "10.0.0.0/8"},
-			wantErr: false,
-			wantLen: 3,
-		},
-		{
-			name:    "filters empty strings",
-			input:   []string{"127.0.0.0/8", "", "  ", "10.0.0.0/8"},
-			wantErr: false,
-			wantLen: 2,
-		},
-		{
-			name:    "invalid CIDR",
-			input:   []string{"not-a-cidr"},
-			wantErr: true,
-		},
-		{
-			name:    "invalid IP in CIDR",
-			input:   []string{"999.999.999.999/8"},
-			wantErr: true,
-		},
-		{
-			name:    "empty list",
-			input:   []string{},
-			wantErr: false,
-			wantLen: 0,
-		},
+		{name: "empty allowed", provider: "openai", baseURL: "", wantURL: ""},
+		{name: "too long", provider: "openai", baseURL: tooLong, wantError: "base URL too long"},
+		{name: "contains whitespace", provider: "openai", baseURL: "https://example.com /v1", wantError: "base URL must not contain whitespace"},
+		{name: "invalid url", provider: "openai", baseURL: "://bad", wantError: "invalid base URL"},
+		{name: "credentials blocked", provider: "openai", baseURL: "https://user:pass@example.com", wantError: "base URL must not include user credentials"},
+		{name: "missing host", provider: "openai", baseURL: "https:///v1", wantError: "base URL must include a host"},
+		{name: "ollama requires http", provider: "ollama", baseURL: "https://127.0.0.1:11434", wantError: "ollama base URL must use http://"},
+		{name: "ollama loopback allowed", provider: "ollama", baseURL: stellarOllamaLoopbackBaseURL, wantURL: stellarExpectedOllamaTrimmed},
+		{name: "ollama private blocked", provider: "ollama", baseURL: stellarOllamaPrivateBaseURL, wantError: stellarOllamaAllowedCIDRsEnv},
+		{name: "ollama private allowlisted", provider: "ollama", baseURL: stellarOllamaPrivateBaseURL, envCIDRs: "10.0.0.0/8", wantURL: stellarOllamaPrivateBaseURL},
+		{name: "cloud requires https", provider: "openai", baseURL: "http://8.8.8.8/v1", wantError: "cloud provider base URL must use https://"},
+		{name: "cloud localhost blocked", provider: "openai", baseURL: stellarCloudLoopbackBaseURL, wantError: "cloud provider host resolves to blocked IP"},
+		{name: "cloud metadata blocked", provider: "openai", baseURL: stellarCloudMetadataBaseURL, wantError: "cloud provider base URL cannot use internal hostnames"},
+		{name: "cloud public allowed", provider: "openai", baseURL: stellarCloudPublicBaseURL, wantURL: stellarExpectedCloudTrimmed},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := parseCIDRs(tt.input)
-			if tt.wantErr {
+			if tt.envCIDRs != "" {
+				t.Setenv(stellarOllamaAllowedCIDRsEnv, tt.envCIDRs)
+			}
+
+			got, err := validateStellarProviderBaseURL(tt.provider, tt.baseURL)
+			if tt.wantError != "" {
 				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantError)
 				return
 			}
+
 			require.NoError(t, err)
-			assert.Len(t, result, tt.wantLen)
+			assert.Equal(t, tt.wantURL, got)
 		})
 	}
 }
 
-func Test_ipInCIDRs(t *testing.T) {
-	cidrs, err := parseCIDRs([]string{"127.0.0.0/8", "10.0.0.0/16", "::1/128"})
-	require.NoError(t, err)
+func TestProviderHandlersRequireAuthentication(t *testing.T) {
+	providerStore := store.OpenTestDB(t)
+	app, _ := newProvidersHandlerTestApp(t, providerStore, false)
 
 	tests := []struct {
 		name   string
-		ip     string
-		wantIn bool
+		method string
+		path   string
+		body   string
 	}{
-		{"localhost IPv4", "127.0.0.1", true},
-		{"localhost IPv4 edge", "127.255.255.255", true},
-		{"10.0.x.x in range", "10.0.5.10", true},
-		{"10.1.x.x out of range", "10.1.0.1", false},
-		{"localhost IPv6", "::1", true},
-		{"public IP", "8.8.8.8", false},
-		{"private IP not in list", "192.168.1.1", false},
+		{name: "list", method: http.MethodGet, path: stellarProvidersRoute},
+		{name: "create", method: http.MethodPost, path: stellarProvidersRoute, body: `{"provider":"ollama","baseUrl":"http://127.0.0.1:11434"}`},
+		{name: "delete", method: http.MethodDelete, path: "/api/stellar/providers/provider-1"},
+		{name: "set default", method: http.MethodPost, path: "/api/stellar/providers/provider-1/default"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ip := net.ParseIP(tt.ip)
-			require.NotNil(t, ip, "invalid test IP")
-			result := ipInCIDRs(ip, cidrs)
-			assert.Equal(t, tt.wantIn, result)
+			resp := sendStellarJSONRequest(t, app, tt.method, tt.path, tt.body)
+			assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 		})
 	}
 }
 
-func Test_ipInCIDRs_EmptyList(t *testing.T) {
-	ip := net.ParseIP("127.0.0.1")
-	result := ipInCIDRs(ip, []*net.IPNet{})
-	assert.False(t, result, "IP should not match empty CIDR list")
+func TestListProvidersReturnsUserConfigs(t *testing.T) {
+	providerStore := store.OpenTestDB(t)
+	app, userID := newProvidersHandlerTestApp(t, providerStore, true)
+	testCtx := context.Background()
+
+	require.NoError(t, providerStore.UpsertProviderConfig(testCtx, &store.StellarProviderConfig{
+		ID:          "provider-1",
+		UserID:      userID,
+		Provider:    "openai",
+		DisplayName: "OpenAI",
+		BaseURL:     stellarExpectedCloudTrimmed,
+		Model:       "gpt-4.1",
+		APIKeyEnc:   []byte{},
+		IsDefault:   true,
+		IsActive:    true,
+	}))
+
+	resp := sendStellarJSONRequest(t, app, http.MethodGet, stellarProvidersRoute, "")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var payload struct {
+		Global []map[string]any              `json:"global"`
+		User   []store.StellarProviderConfig `json:"user"`
+	}
+	payload = decodeJSONBody[struct {
+		Global []map[string]any              `json:"global"`
+		User   []store.StellarProviderConfig `json:"user"`
+	}](t, resp)
+
+	require.NotEmpty(t, payload.Global)
+	require.Len(t, payload.User, 1)
+	assert.Equal(t, "provider-1", payload.User[0].ID)
+	assert.Equal(t, "openai", payload.User[0].Provider)
 }
 
-func Test_validateStellarProviderBaseURL(t *testing.T) {
-	tests := []struct {
-		name     string
-		provider string
-		url      string
-		wantErr  bool
-		errHint  string
-		setup    func()
-		teardown func()
-	}{
-		{
-			name:     "empty URL is allowed",
-			provider: "anthropic",
-			url:      "",
-			wantErr:  false,
-		},
-		{
-			name:     "whitespace-only URL trimmed to empty",
-			provider: "anthropic",
-			url:      "   ",
-			wantErr:  false,
-		},
-		{
-			name:     "URL too long",
-			provider: "anthropic",
-			url:      "https://" + string(make([]byte, stellarMaxProviderBaseURLLen)),
-			wantErr:  true,
-			errHint:  "too long",
-		},
-		{
-			name:     "URL with spaces",
-			provider: "anthropic",
-			url:      "https://api.example.com with spaces",
-			wantErr:  true,
-			errHint:  "whitespace",
-		},
-		{
-			name:     "URL with tabs",
-			provider: "anthropic",
-			url:      "https://api.example.com\twith\ttabs",
-			wantErr:  true,
-			errHint:  "whitespace",
-		},
-		{
-			name:     "URL with newlines",
-			provider: "anthropic",
-			url:      "https://api.example.com\nwith\nnewlines",
-			wantErr:  true,
-			errHint:  "whitespace",
-		},
-		{
-			name:     "invalid URL syntax",
-			provider: "anthropic",
-			url:      "not a valid url",
-			wantErr:  true,
-			errHint:  "invalid base URL",
-		},
-		{
-			name:     "URL with credentials",
-			provider: "anthropic",
-			url:      "https://user:pass@api.example.com",
-			wantErr:  true,
-			errHint:  "credentials",
-		},
-		{
-			name:     "URL without host",
-			provider: "anthropic",
-			url:      "https://",
-			wantErr:  true,
-			errHint:  "host",
-		},
-		{
-			name:     "ollama with http localhost",
-			provider: "ollama",
-			url:      "http://localhost:11434",
-			wantErr:  false,
-			setup: func() {
-				os.Setenv(stellarOllamaAllowedCIDRsEnv, "127.0.0.0/8,::1/128")
-			},
-			teardown: func() {
-				os.Unsetenv(stellarOllamaAllowedCIDRsEnv)
-			},
-		},
-		{
-			name:     "ollama with https rejected",
-			provider: "ollama",
-			url:      "https://localhost:11434",
-			wantErr:  true,
-			errHint:  "must use http://",
-		},
-		{
-			name:     "ollama with public IP rejected",
-			provider: "ollama",
-			url:      "http://8.8.8.8:11434",
-			wantErr:  true,
-			errHint:  "not in",
-			setup: func() {
-				os.Setenv(stellarOllamaAllowedCIDRsEnv, "127.0.0.0/8,::1/128")
-			},
-			teardown: func() {
-				os.Unsetenv(stellarOllamaAllowedCIDRsEnv)
-			},
-		},
-		{
-			name:     "cloud provider with http rejected",
-			provider: "anthropic",
-			url:      "http://api.anthropic.com",
-			wantErr:  true,
-			errHint:  "must use https://",
-		},
-		{
-			name:     "cloud provider with localhost rejected",
-			provider: "openai",
-			url:      "https://localhost:8080",
-			wantErr:  true,
-			errHint:  "internal hostnames",
-		},
-		{
-			name:     "cloud provider with .internal domain rejected",
-			provider: "openai",
-			url:      "https://api.internal",
-			wantErr:  true,
-			errHint:  "internal hostnames",
-		},
-		{
-			name:     "cloud provider with .local domain rejected",
-			provider: "openai",
-			url:      "https://api.local",
-			wantErr:  true,
-			errHint:  "internal hostnames",
-		},
-		{
-			name:     "cloud provider with metadata service rejected",
-			provider: "openai",
-			url:      "https://metadata.google.internal",
-			wantErr:  true,
-			errHint:  "internal hostnames",
-		},
-		{
-			name:     "trailing slash removed",
-			provider: "anthropic",
-			url:      "https://api.example.com/",
-			wantErr:  false,
-		},
-	}
+func TestCreateProviderPersistsConfig(t *testing.T) {
+	providerStore := store.OpenTestDB(t)
+	app, userID := newProvidersHandlerTestApp(t, providerStore, true)
+	testCtx := context.Background()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.setup != nil {
-				tt.setup()
-			}
-			if tt.teardown != nil {
-				defer tt.teardown()
-			}
+	resp := sendStellarJSONRequest(t, app, http.MethodPost, stellarProvidersRoute, `{
+		"provider":"ollama",
+		"displayName":"Local Ollama",
+		"model":"llama3",
+		"baseUrl":"`+stellarOllamaLoopbackBaseURL+`"
+	}`)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
 
-			result, err := validateStellarProviderBaseURL(tt.provider, tt.url)
+	created := decodeJSONBody[store.StellarProviderConfig](t, resp)
+	assert.Equal(t, userID, created.UserID)
+	assert.Equal(t, "ollama", created.Provider)
+	assert.Equal(t, stellarExpectedOllamaTrimmed, created.BaseURL)
+	assert.Equal(t, "****", created.APIKeyMask)
 
-			if tt.wantErr {
-				require.Error(t, err)
-				if tt.errHint != "" {
-					assert.Contains(t, err.Error(), tt.errHint)
-				}
-				return
-			}
-
-			require.NoError(t, err)
-			if tt.url != "" && tt.url != "   " {
-				assert.NotEmpty(t, result)
-				assert.NotContains(t, result, " ")
-			}
-		})
-	}
+	configs, err := providerStore.GetUserProviderConfigs(testCtx, userID)
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Empty(t, configs[0].APIKeyEnc)
 }
 
-func Test_loadStellarOllamaAllowedCIDRs(t *testing.T) {
-	tests := []struct {
-		name    string
-		envVal  string
-		wantLen int
-		wantErr bool
-	}{
-		{
-			name:    "default when env not set",
-			envVal:  "",
-			wantLen: 2, // 127.0.0.0/8 and ::1/128
-			wantErr: false,
-		},
-		{
-			name:    "custom single CIDR",
-			envVal:  "10.0.0.0/8",
-			wantLen: 1,
-			wantErr: false,
-		},
-		{
-			name:    "custom multiple CIDRs",
-			envVal:  "127.0.0.0/8,10.0.0.0/16,::1/128",
-			wantLen: 3,
-			wantErr: false,
-		},
-		{
-			name:    "invalid CIDR",
-			envVal:  "not-valid",
-			wantLen: 0,
-			wantErr: true,
-		},
-	}
+func TestCreateProviderValidationAndStoreFailures(t *testing.T) {
+	t.Run("invalid json", func(t *testing.T) {
+		providerStore := store.OpenTestDB(t)
+		app, _ := newProvidersHandlerTestApp(t, providerStore, true)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.envVal != "" {
-				os.Setenv(stellarOllamaAllowedCIDRsEnv, tt.envVal)
-				defer os.Unsetenv(stellarOllamaAllowedCIDRsEnv)
-			} else {
-				os.Unsetenv(stellarOllamaAllowedCIDRsEnv)
-			}
+		resp := sendStellarJSONRequest(t, app, http.MethodPost, stellarProvidersRoute, `{"provider":`)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		payload := decodeJSONBody[map[string]string](t, resp)
+		assert.Equal(t, "invalid JSON", payload["error"])
+	})
 
-			result, err := loadStellarOllamaAllowedCIDRs()
+	t.Run("invalid base url", func(t *testing.T) {
+		providerStore := store.OpenTestDB(t)
+		app, _ := newProvidersHandlerTestApp(t, providerStore, true)
 
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
+		resp := sendStellarJSONRequest(t, app, http.MethodPost, stellarProvidersRoute, `{"provider":"openai","baseUrl":"`+stellarCloudLoopbackBaseURL+`"}`)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		payload := decodeJSONBody[map[string]string](t, resp)
+		assert.Equal(t, "invalid baseUrl", payload["error"])
+	})
 
-			require.NoError(t, err)
-			assert.Len(t, result, tt.wantLen)
-		})
-	}
+	t.Run("provider store unavailable", func(t *testing.T) {
+		providerStore := store.OpenTestDB(t)
+		app, _ := newProvidersHandlerTestApp(t, providerStoreUnavailable{Store: providerStore}, true)
+
+		resp := sendStellarJSONRequest(t, app, http.MethodPost, stellarProvidersRoute, `{"provider":"ollama","baseUrl":"`+stellarExpectedOllamaTrimmed+`"}`)
+		require.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+		payload := decodeJSONBody[map[string]string](t, resp)
+		assert.Equal(t, "provider store unavailable", payload["error"])
+	})
+
+	t.Run("save failure", func(t *testing.T) {
+		providerStore := store.OpenTestDB(t)
+		app, _ := newProvidersHandlerTestApp(t, providerUpsertErrorStore{Store: providerStore}, true)
+
+		resp := sendStellarJSONRequest(t, app, http.MethodPost, stellarProvidersRoute, `{"provider":"ollama","baseUrl":"`+stellarExpectedOllamaTrimmed+`"}`)
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		payload := decodeJSONBody[map[string]string](t, resp)
+		assert.Equal(t, "failed to save provider", payload["error"])
+	})
 }
 
-func Test_resolveStellarProviderHostIPs(t *testing.T) {
-	tests := []struct {
-		name    string
-		host    string
-		wantErr bool
-		minIPs  int
-	}{
-		{
-			name:    "IPv4 address",
-			host:    "127.0.0.1",
-			wantErr: false,
-			minIPs:  1,
-		},
-		{
-			name:    "IPv6 address",
-			host:    "::1",
-			wantErr: false,
-			minIPs:  1,
-		},
-		{
-			name:    "localhost resolves",
-			host:    "localhost",
-			wantErr: false,
-			minIPs:  1,
-		},
-		{
-			name:    "invalid hostname",
-			host:    "this-hostname-definitely-does-not-exist-12345.invalid",
-			wantErr: true,
-		},
-	}
+func TestDeleteProviderAndSetDefault(t *testing.T) {
+	providerStore := store.OpenTestDB(t)
+	app, userID := newProvidersHandlerTestApp(t, providerStore, true)
+	testCtx := context.Background()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := resolveStellarProviderHostIPs(tt.host)
+	require.NoError(t, providerStore.UpsertProviderConfig(testCtx, &store.StellarProviderConfig{
+		ID:          "provider-a",
+		UserID:      userID,
+		Provider:    "openai",
+		DisplayName: "OpenAI",
+		BaseURL:     stellarExpectedCloudTrimmed,
+		Model:       "gpt-4.1",
+		APIKeyEnc:   []byte{},
+		IsDefault:   true,
+		IsActive:    true,
+	}))
+	require.NoError(t, providerStore.UpsertProviderConfig(testCtx, &store.StellarProviderConfig{
+		ID:          "provider-b",
+		UserID:      userID,
+		Provider:    "anthropic",
+		DisplayName: "Anthropic",
+		BaseURL:     "https://api.anthropic.com",
+		Model:       "claude-sonnet-4.5",
+		APIKeyEnc:   []byte{},
+		IsDefault:   false,
+		IsActive:    true,
+	}))
 
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
+	resp := sendStellarJSONRequest(t, app, http.MethodPost, "/api/stellar/providers/provider-b/default", "")
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 
-			require.NoError(t, err)
-			assert.GreaterOrEqual(t, len(result), tt.minIPs)
-			for _, ip := range result {
-				assert.NotNil(t, ip)
-			}
-		})
-	}
+	defaultProvider, err := providerStore.GetUserDefaultProvider(testCtx, userID)
+	require.NoError(t, err)
+	require.NotNil(t, defaultProvider)
+	assert.Equal(t, "provider-b", defaultProvider.ID)
+
+	resp = sendStellarJSONRequest(t, app, http.MethodDelete, "/api/stellar/providers/provider-a", "")
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	configs, err := providerStore.GetUserProviderConfigs(testCtx, userID)
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Equal(t, "provider-b", configs[0].ID)
+}
+
+func TestDeleteProviderAndSetDefaultStoreFailures(t *testing.T) {
+	t.Run("delete failure", func(t *testing.T) {
+		providerStore := store.OpenTestDB(t)
+		app, _ := newProvidersHandlerTestApp(t, providerDeleteErrorStore{Store: providerStore}, true)
+
+		resp := sendStellarJSONRequest(t, app, http.MethodDelete, "/api/stellar/providers/provider-1", "")
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		payload := decodeJSONBody[map[string]string](t, resp)
+		assert.Equal(t, "delete failed", payload["error"])
+	})
+
+	t.Run("default failure", func(t *testing.T) {
+		providerStore := store.OpenTestDB(t)
+		app, _ := newProvidersHandlerTestApp(t, providerDefaultErrorStore{Store: providerStore}, true)
+
+		resp := sendStellarJSONRequest(t, app, http.MethodPost, "/api/stellar/providers/provider-1/default", "")
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		payload := decodeJSONBody[map[string]string](t, resp)
+		assert.Equal(t, "failed to set default", payload["error"])
+	})
 }

--- a/pkg/api/handlers/stellar/tasks_test.go
+++ b/pkg/api/handlers/stellar/tasks_test.go
@@ -1,0 +1,328 @@
+package stellar
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubestellar/console/pkg/store"
+)
+
+const (
+	stellarTasksRoute       = "/api/stellar/tasks"
+	stellarTaskStatusRoute  = "/api/stellar/tasks/:id/status"
+	stellarTaskDueAtRFC3339 = "2026-06-17T20:00:00Z"
+)
+
+type taskCreateErrorStore struct {
+	Store
+}
+
+func (s taskCreateErrorStore) CreateTask(_ context.Context, _ *store.StellarTask) (string, error) {
+	return "", errors.New("create failed")
+}
+
+type taskListErrorStore struct {
+	Store
+}
+
+func (s taskListErrorStore) GetOpenTasks(_ context.Context, _ string) ([]store.StellarTask, error) {
+	return nil, errors.New("list failed")
+}
+
+type taskUpdateErrorStore struct {
+	Store
+}
+
+func (s taskUpdateErrorStore) UpdateTaskStatus(_ context.Context, _, _, _ string) error {
+	return errors.New("update failed")
+}
+
+func newTasksHandlerTestApp(t *testing.T, handlerStore Store, authenticated bool) (*fiber.App, string) {
+	t.Helper()
+
+	userID := uuid.New()
+	app := fiber.New()
+	if authenticated {
+		app.Use(func(c *fiber.Ctx) error {
+			c.Locals("userID", userID)
+			return c.Next()
+		})
+	}
+
+	handler := NewHandler(handlerStore, nil)
+	app.Get(stellarTasksRoute, handler.ListTasks)
+	app.Post(stellarTasksRoute, handler.CreateTask)
+	app.Patch(stellarTaskStatusRoute, handler.UpdateTaskStatus)
+
+	return app, userID.String()
+}
+
+func sendStellarJSONRequest(t *testing.T, app *fiber.App, method, path string, body string) *http.Response {
+	t.Helper()
+
+	req, err := http.NewRequest(method, path, bytes.NewReader([]byte(body)))
+	require.NoError(t, err)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := app.Test(req, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = resp.Body.Close()
+	})
+
+	return resp
+}
+
+func decodeJSONBody[T any](t *testing.T, resp *http.Response) T {
+	t.Helper()
+
+	var payload T
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	return payload
+}
+
+func TestTaskHandlersRequireAuthentication(t *testing.T) {
+	tasksStore := store.OpenTestDB(t)
+	app, _ := newTasksHandlerTestApp(t, tasksStore, false)
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{name: "list", method: http.MethodGet, path: stellarTasksRoute},
+		{name: "create", method: http.MethodPost, path: stellarTasksRoute, body: `{"title":"Investigate rollout"}`},
+		{name: "update", method: http.MethodPatch, path: "/api/stellar/tasks/task-1/status", body: `{"status":"done"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := sendStellarJSONRequest(t, app, tt.method, tt.path, tt.body)
+			assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		})
+	}
+}
+
+func TestListTasksReturnsOpenTasksForCurrentUser(t *testing.T) {
+	tasksStore := store.OpenTestDB(t)
+	app, userID := newTasksHandlerTestApp(t, tasksStore, true)
+	testCtx := context.Background()
+
+	_, err := tasksStore.CreateTask(testCtx, &store.StellarTask{
+		ID:       "task-open",
+		UserID:   userID,
+		Title:    "Open task",
+		Status:   "open",
+		Priority: 2,
+	})
+	require.NoError(t, err)
+
+	_, err = tasksStore.CreateTask(testCtx, &store.StellarTask{
+		ID:       "task-blocked",
+		UserID:   userID,
+		Title:    "Blocked task",
+		Status:   "blocked",
+		Priority: 1,
+	})
+	require.NoError(t, err)
+
+	_, err = tasksStore.CreateTask(testCtx, &store.StellarTask{
+		ID:       "task-done",
+		UserID:   userID,
+		Title:    "Done task",
+		Status:   "done",
+		Priority: 3,
+	})
+	require.NoError(t, err)
+
+	_, err = tasksStore.CreateTask(testCtx, &store.StellarTask{
+		ID:       "other-user-task",
+		UserID:   "other-user",
+		Title:    "Other user task",
+		Status:   "open",
+		Priority: 1,
+	})
+	require.NoError(t, err)
+
+	resp := sendStellarJSONRequest(t, app, http.MethodGet, stellarTasksRoute, "")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var payload struct {
+		Items []store.StellarTask `json:"items"`
+	}
+	payload = decodeJSONBody[struct {
+		Items []store.StellarTask `json:"items"`
+	}](t, resp)
+
+	require.Len(t, payload.Items, 2)
+	assert.Equal(t, "task-blocked", payload.Items[0].ID)
+	assert.Equal(t, "task-open", payload.Items[1].ID)
+}
+
+func TestListTasksReturnsInternalServerErrorWhenStoreFails(t *testing.T) {
+	baseStore := store.OpenTestDB(t)
+	app, _ := newTasksHandlerTestApp(t, taskListErrorStore{Store: baseStore}, true)
+
+	resp := sendStellarJSONRequest(t, app, http.MethodGet, stellarTasksRoute, "")
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	payload := decodeJSONBody[map[string]string](t, resp)
+	assert.Equal(t, "failed to load tasks", payload["error"])
+}
+
+func TestCreateTaskValidation(t *testing.T) {
+	tasksStore := store.OpenTestDB(t)
+	app, _ := newTasksHandlerTestApp(t, tasksStore, true)
+
+	tests := []struct {
+		name         string
+		body         string
+		wantStatus   int
+		wantErrorMsg string
+	}{
+		{name: "invalid json", body: `{"title":`, wantStatus: http.StatusBadRequest, wantErrorMsg: "invalid JSON body"},
+		{name: "missing title", body: `{"description":"x"}`, wantStatus: http.StatusBadRequest, wantErrorMsg: "title is required"},
+		{name: "blank title", body: `{"title":"   "}`, wantStatus: http.StatusBadRequest, wantErrorMsg: "title is required"},
+		{name: "invalid dueAt", body: `{"title":"Investigate","dueAt":"not-rfc3339"}`, wantStatus: http.StatusBadRequest, wantErrorMsg: "dueAt must be RFC3339"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := sendStellarJSONRequest(t, app, http.MethodPost, stellarTasksRoute, tt.body)
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			payload := decodeJSONBody[map[string]string](t, resp)
+			assert.Equal(t, tt.wantErrorMsg, payload["error"])
+		})
+	}
+}
+
+func TestCreateTaskPersistsNormalizedValues(t *testing.T) {
+	tasksStore := store.OpenTestDB(t)
+	app, userID := newTasksHandlerTestApp(t, tasksStore, true)
+	testCtx := context.Background()
+
+	resp := sendStellarJSONRequest(t, app, http.MethodPost, stellarTasksRoute, `{
+		"sessionId":"  sess-1  ",
+		"cluster":"  cluster-a  ",
+		"title":"  Investigate rollout  ",
+		"description":"  Review logs  ",
+		"priority":99,
+		"parentId":"  task-parent  ",
+		"dueAt":"`+stellarTaskDueAtRFC3339+`"
+	}`)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	created := decodeJSONBody[store.StellarTask](t, resp)
+	assert.Equal(t, userID, created.UserID)
+	assert.Equal(t, "sess-1", created.SessionID)
+	assert.Equal(t, "cluster-a", created.Cluster)
+	assert.Equal(t, "Investigate rollout", created.Title)
+	assert.Equal(t, "Review logs", created.Description)
+	assert.Equal(t, "open", created.Status)
+	assert.Equal(t, 5, created.Priority)
+	assert.Equal(t, "user", created.Source)
+	assert.Equal(t, "task-parent", created.ParentID)
+	require.NotNil(t, created.DueAt)
+	assert.Equal(t, stellarTaskDueAtRFC3339, created.DueAt.UTC().Format(time.RFC3339))
+	assert.Equal(t, "{}", created.ContextJSON)
+
+	items, err := tasksStore.GetOpenTasks(testCtx, userID)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, created.ID, items[0].ID)
+}
+
+func TestCreateTaskReturnsInternalServerErrorWhenStoreFails(t *testing.T) {
+	baseStore := store.OpenTestDB(t)
+	app, _ := newTasksHandlerTestApp(t, taskCreateErrorStore{Store: baseStore}, true)
+
+	resp := sendStellarJSONRequest(t, app, http.MethodPost, stellarTasksRoute, `{"title":"Investigate rollout"}`)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	payload := decodeJSONBody[map[string]string](t, resp)
+	assert.Equal(t, "failed to create task", payload["error"])
+}
+
+func TestUpdateTaskStatusValidation(t *testing.T) {
+	tasksStore := store.OpenTestDB(t)
+	app, _ := newTasksHandlerTestApp(t, tasksStore, true)
+
+	tests := []struct {
+		name         string
+		path         string
+		body         string
+		wantStatus   int
+		wantErrorMsg string
+	}{
+		{name: "invalid json", path: "/api/stellar/tasks/task-1/status", body: `{"status":`, wantStatus: http.StatusBadRequest, wantErrorMsg: "invalid JSON body"},
+		{name: "invalid status", path: "/api/stellar/tasks/task-1/status", body: `{"status":"paused"}`, wantStatus: http.StatusBadRequest, wantErrorMsg: "invalid status"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := sendStellarJSONRequest(t, app, http.MethodPatch, tt.path, tt.body)
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			payload := decodeJSONBody[map[string]string](t, resp)
+			assert.Equal(t, tt.wantErrorMsg, payload["error"])
+		})
+	}
+}
+
+func TestUpdateTaskStatusReturnsUpdatedItems(t *testing.T) {
+	tasksStore := store.OpenTestDB(t)
+	app, userID := newTasksHandlerTestApp(t, tasksStore, true)
+	testCtx := context.Background()
+
+	taskID, err := tasksStore.CreateTask(testCtx, &store.StellarTask{
+		UserID:   userID,
+		Title:    "Investigate rollout",
+		Status:   "open",
+		Priority: 4,
+	})
+	require.NoError(t, err)
+
+	resp := sendStellarJSONRequest(t, app, http.MethodPatch, "/api/stellar/tasks/"+taskID+"/status", `{"status":"IN_PROGRESS"}`)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var payload struct {
+		ID     string              `json:"id"`
+		Status string              `json:"status"`
+		Items  []store.StellarTask `json:"items"`
+	}
+	payload = decodeJSONBody[struct {
+		ID     string              `json:"id"`
+		Status string              `json:"status"`
+		Items  []store.StellarTask `json:"items"`
+	}](t, resp)
+
+	assert.Equal(t, taskID, payload.ID)
+	assert.Equal(t, "in_progress", payload.Status)
+	require.Len(t, payload.Items, 1)
+	assert.Equal(t, "in_progress", payload.Items[0].Status)
+}
+
+func TestUpdateTaskStatusReturnsInternalServerErrorWhenStoreFails(t *testing.T) {
+	baseStore := store.OpenTestDB(t)
+	app, _ := newTasksHandlerTestApp(t, taskUpdateErrorStore{Store: baseStore}, true)
+
+	resp := sendStellarJSONRequest(t, app, http.MethodPatch, "/api/stellar/tasks/task-1/status", `{"status":"done"}`)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	payload := decodeJSONBody[map[string]string](t, resp)
+	assert.Equal(t, "failed to update task status", payload["error"])
+}

--- a/pkg/api/handlers/stellar_tasks_test.go
+++ b/pkg/api/handlers/stellar_tasks_test.go
@@ -1,0 +1,267 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubestellar/console/pkg/store"
+)
+
+const (
+	stellarTaskDefaultPriority    = 5
+	stellarTaskDefaultSource      = "user"
+	stellarTaskDefaultSessionID   = "default"
+	stellarTaskExpectedListCount  = 2
+	stellarTaskOutOfRangePriority = 99
+)
+
+type stellarTaskListResponse struct {
+	Items []store.StellarTask `json:"items"`
+}
+
+type stellarTaskStatusResponse struct {
+	ID     string              `json:"id"`
+	Status string              `json:"status"`
+	Items  []store.StellarTask `json:"items"`
+}
+
+type stellarTaskErrorResponse struct {
+	Error string `json:"error"`
+}
+
+func createStellarTaskRequest(t *testing.T, app *fiber.App, body any) store.StellarTask {
+	t.Helper()
+
+	payload, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "/api/stellar/tasks", bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var created store.StellarTask
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&created))
+	return created
+}
+
+func listStellarTasksRequest(t *testing.T, app *fiber.App) stellarTaskListResponse {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, "/api/stellar/tasks", nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var payload stellarTaskListResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	return payload
+}
+
+func TestStellarListTasks_ReturnsEmptyListInitially(t *testing.T) {
+	app, _ := newStellarTestApp(t)
+
+	payload := listStellarTasksRequest(t, app)
+	require.NotNil(t, payload.Items)
+	assert.Empty(t, payload.Items)
+}
+
+func TestStellarCreateTask_PersistsAndNormalizesPayload(t *testing.T) {
+	app, _ := newStellarTestApp(t)
+
+	dueAt := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second)
+	created := createStellarTaskRequest(t, app, map[string]any{
+		"sessionId":   "  ",
+		"cluster":     " prod-a ",
+		"title":       "  Investigate OOM kills  ",
+		"description": "  Check memory limits  ",
+		"priority":    stellarTaskOutOfRangePriority,
+		"source":      "  ",
+		"parentId":    " parent-1 ",
+		"dueAt":       dueAt.Format(time.RFC3339),
+		"contextJson": "  ",
+	})
+
+	assert.NotEmpty(t, created.ID)
+	assert.Equal(t, stellarTaskDefaultSessionID, created.SessionID)
+	assert.Equal(t, "prod-a", created.Cluster)
+	assert.Equal(t, "Investigate OOM kills", created.Title)
+	assert.Equal(t, "Check memory limits", created.Description)
+	assert.Equal(t, "open", created.Status)
+	assert.Equal(t, stellarTaskDefaultPriority, created.Priority)
+	assert.Equal(t, stellarTaskDefaultSource, created.Source)
+	assert.Equal(t, "parent-1", created.ParentID)
+	require.NotNil(t, created.DueAt)
+	assert.True(t, created.DueAt.Equal(dueAt))
+	assert.Equal(t, "{}", created.ContextJSON)
+}
+
+func TestStellarCreateTask_RejectsInvalidPayloads(t *testing.T) {
+	app, _ := newStellarTestApp(t)
+
+	testCases := []struct {
+		name          string
+		body          []byte
+		expectedError string
+	}{
+		{
+			name:          "invalid json",
+			body:          []byte(`not json`),
+			expectedError: "invalid JSON body",
+		},
+		{
+			name:          "missing title",
+			body:          []byte(`{"description":"missing title"}`),
+			expectedError: "title is required",
+		},
+		{
+			name:          "whitespace title",
+			body:          []byte(`{"title":"   "}`),
+			expectedError: "title is required",
+		},
+		{
+			name:          "invalid dueAt",
+			body:          []byte(`{"title":"Investigate","dueAt":"not-rfc3339"}`),
+			expectedError: "dueAt must be RFC3339",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, "/api/stellar/tasks", bytes.NewReader(tc.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req, stellarTestFiberTimeoutMs)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+			var payload stellarTaskErrorResponse
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+			assert.Equal(t, tc.expectedError, payload.Error)
+		})
+	}
+}
+
+func TestStellarListTasks_ReturnsOnlyOpenTasks(t *testing.T) {
+	app, _ := newStellarTestApp(t)
+
+	firstTask := createStellarTaskRequest(t, app, map[string]any{"title": "Task A", "priority": 2})
+	secondTask := createStellarTaskRequest(t, app, map[string]any{"title": "Task B", "priority": 1})
+	doneTask := createStellarTaskRequest(t, app, map[string]any{"title": "Task Done", "priority": 3})
+
+	updateReq, err := http.NewRequest(http.MethodPatch, "/api/stellar/tasks/"+doneTask.ID+"/status", bytes.NewReader([]byte(`{"status":"done"}`)))
+	require.NoError(t, err)
+	updateReq.Header.Set("Content-Type", "application/json")
+
+	updateResp, err := app.Test(updateReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	defer updateResp.Body.Close()
+	require.Equal(t, http.StatusOK, updateResp.StatusCode)
+
+	payload := listStellarTasksRequest(t, app)
+	require.Len(t, payload.Items, stellarTaskExpectedListCount)
+	assert.Equal(t, secondTask.ID, payload.Items[0].ID)
+	assert.Equal(t, firstTask.ID, payload.Items[1].ID)
+}
+
+func TestStellarUpdateTaskStatus_TransitionsAndFiltersItems(t *testing.T) {
+	app, _ := newStellarTestApp(t)
+
+	testCases := []struct {
+		name              string
+		requestStatus     string
+		expectedStatus    string
+		expectTaskPresent bool
+	}{
+		{name: "in progress", requestStatus: "IN_PROGRESS", expectedStatus: "in_progress", expectTaskPresent: true},
+		{name: "blocked", requestStatus: "blocked", expectedStatus: "blocked", expectTaskPresent: true},
+		{name: "done", requestStatus: "done", expectedStatus: "done", expectTaskPresent: false},
+		{name: "dismissed", requestStatus: "dismissed", expectedStatus: "dismissed", expectTaskPresent: false},
+		{name: "reopened", requestStatus: "open", expectedStatus: "open", expectTaskPresent: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := createStellarTaskRequest(t, app, map[string]any{"title": tc.name})
+
+			req, err := http.NewRequest(http.MethodPatch, "/api/stellar/tasks/"+task.ID+"/status", bytes.NewReader([]byte(`{"status":"`+tc.requestStatus+`"}`)))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req, stellarTestFiberTimeoutMs)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var payload stellarTaskStatusResponse
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+			assert.Equal(t, task.ID, payload.ID)
+			assert.Equal(t, tc.expectedStatus, payload.Status)
+			assert.Equal(t, tc.expectTaskPresent, taskIDPresent(payload.Items, task.ID))
+		})
+	}
+}
+
+func TestStellarUpdateTaskStatus_RejectsInvalidPayloads(t *testing.T) {
+	app, _ := newStellarTestApp(t)
+	task := createStellarTaskRequest(t, app, map[string]any{"title": "Task to validate"})
+
+	testCases := []struct {
+		name          string
+		body          []byte
+		expectedError string
+	}{
+		{
+			name:          "invalid json",
+			body:          []byte(`not json`),
+			expectedError: "invalid JSON body",
+		},
+		{
+			name:          "invalid status",
+			body:          []byte(`{"status":"later"}`),
+			expectedError: "invalid status",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPatch, "/api/stellar/tasks/"+task.ID+"/status", bytes.NewReader(tc.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req, stellarTestFiberTimeoutMs)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+			var payload stellarTaskErrorResponse
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+			assert.Equal(t, tc.expectedError, payload.Error)
+		})
+	}
+}
+
+func taskIDPresent(items []store.StellarTask, id string) bool {
+	for _, item := range items {
+		if item.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/api/handlers/stellar_test.go
+++ b/pkg/api/handlers/stellar_test.go
@@ -1,0 +1,376 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/store"
+)
+
+const (
+	stellarTestFiberTimeoutMs = 5000
+	stellarTestEventWait      = 100 * time.Millisecond
+)
+
+func newStellarTestApp(t *testing.T) (*fiber.App, store.Store) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "stellar-test.db")
+	sqlStore, err := store.NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlStore.Close() })
+	testUserID := uuid.New()
+	require.NoError(t, sqlStore.CreateUser(context.Background(), &models.User{
+		ID:          testUserID,
+		GitHubLogin: "stellar-test-user",
+		Role:        models.UserRoleAdmin,
+	}))
+	require.NoError(t, sqlStore.UpdateStellarPreferences(context.Background(), &store.StellarPreferences{
+		UserID:          testUserID.String(),
+		DefaultProvider: "auto",
+		ExecutionMode:   "hybrid",
+		Timezone:        "UTC",
+		ProactiveMode:   true,
+		PinnedClusters:  []string{},
+	}))
+
+	ollamaServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/tags":
+			_, _ = w.Write([]byte(`{"models":[{"name":"llama3:latest"}]}`))
+		case "/api/chat":
+			_, _ = w.Write([]byte(`{"message":{"content":"Test answer"},"prompt_eval_count":5,"eval_count":10,"model":"llama3:latest"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(ollamaServer.Close)
+	t.Setenv("OLLAMA_BASE_URL", ollamaServer.URL)
+
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("userID", testUserID)
+		c.Locals("githubLogin", "stellar-test-user")
+		return c.Next()
+	})
+
+	h := NewStellarHandler(sqlStore, nil)
+	app.Get("/api/stellar/preferences", h.GetPreferences)
+	app.Put("/api/stellar/preferences", h.UpdatePreferences)
+	app.Get("/api/stellar/missions", h.ListMissions)
+	app.Get("/api/stellar/missions/:id", h.GetMission)
+	app.Post("/api/stellar/missions", h.CreateMission)
+	app.Put("/api/stellar/missions/:id", h.UpdateMission)
+	app.Delete("/api/stellar/missions/:id", h.DeleteMission)
+	app.Get("/api/stellar/actions", h.ListActions)
+	app.Post("/api/stellar/actions", h.CreateAction)
+	app.Post("/api/stellar/actions/:id/approve", h.ApproveAction)
+	app.Get("/api/stellar/state", h.GetState)
+	app.Get("/api/stellar/digest", h.GetDigest)
+	app.Post("/api/stellar/ask", h.Ask)
+	app.Get("/api/stellar/notifications", h.ListNotifications)
+	app.Post("/api/stellar/notifications/:id/read", h.MarkNotificationRead)
+	app.Post("/api/stellar/notifications/:id/investigate", h.MarkNotificationInvestigating)
+	app.Post("/api/stellar/notifications/:id/resolve", h.ResolveNotification)
+	app.Post("/api/stellar/notifications/:id/dismiss", h.DismissNotification)
+	app.Get("/api/stellar/watches", h.ListWatches)
+	app.Post("/api/stellar/watches", h.CreateWatch)
+	app.Post("/api/stellar/watches/:id/resolve", h.ResolveWatch)
+	app.Get("/api/stellar/tasks", h.ListTasks)
+	app.Post("/api/stellar/tasks", h.CreateTask)
+	app.Patch("/api/stellar/tasks/:id/status", h.UpdateTaskStatus)
+	app.Get("/api/stellar/observations", h.ListObservations)
+	app.Get("/api/stellar/stream", h.Stream)
+	app.Post("/api/stellar/events", h.IngestEvent)
+
+	return app, sqlStore
+}
+
+func TestStellarPreferencesRoundTrip(t *testing.T) {
+	app, _ := newStellarTestApp(t)
+
+	getReq, err := http.NewRequest(http.MethodGet, "/api/stellar/preferences", nil)
+	require.NoError(t, err)
+	getResp, err := app.Test(getReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, getResp.StatusCode)
+	var defaults map[string]any
+	require.NoError(t, json.NewDecoder(getResp.Body).Decode(&defaults))
+	assert.Equal(t, "hybrid", defaults["executionMode"])
+	assert.Equal(t, true, defaults["proactiveMode"])
+
+	updateBody := map[string]any{
+		"defaultProvider": "ollama",
+		"executionMode":   "local-only",
+		"timezone":        "Asia/Kolkata",
+		"proactiveMode":   false,
+		"pinnedClusters":  []string{"prod-a", "staging-a"},
+	}
+	raw, _ := json.Marshal(updateBody)
+	putReq, err := http.NewRequest(http.MethodPut, "/api/stellar/preferences", bytes.NewReader(raw))
+	require.NoError(t, err)
+	putReq.Header.Set("Content-Type", "application/json")
+	putResp, err := app.Test(putReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, putResp.StatusCode)
+}
+
+func TestStellarMissionAndActionFlow(t *testing.T) {
+	app, _ := newStellarTestApp(t)
+
+	createMissionBody := map[string]any{
+		"name":           "overnight-watch",
+		"goal":           "Watch production overnight and summarize drift, failures, and alerts.",
+		"schedule":       "0 1 * * *",
+		"triggerType":    "cron",
+		"providerPolicy": "hybrid-fallback",
+		"memoryScope":    "mission",
+		"enabled":        true,
+		"toolBindings":   []string{"kubernetes", "prometheus"},
+	}
+	rawMission, _ := json.Marshal(createMissionBody)
+	createMissionReq, err := http.NewRequest(http.MethodPost, "/api/stellar/missions", bytes.NewReader(rawMission))
+	require.NoError(t, err)
+	createMissionReq.Header.Set("Content-Type", "application/json")
+	createMissionResp, err := app.Test(createMissionReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createMissionResp.StatusCode)
+
+	scheduledAt := time.Now().UTC().Add(-1 * time.Minute).Format(time.RFC3339)
+	createActionBody := map[string]any{
+		"description": "Scale worker deployment",
+		"actionType":  "ScaleDeployment",
+		"parameters": map[string]any{
+			"deployment": "worker",
+			"replicas":   5,
+		},
+		"cluster":     "prod-a",
+		"namespace":   "default",
+		"scheduledAt": scheduledAt,
+	}
+	rawAction, _ := json.Marshal(createActionBody)
+	createActionReq, err := http.NewRequest(http.MethodPost, "/api/stellar/actions", bytes.NewReader(rawAction))
+	require.NoError(t, err)
+	createActionReq.Header.Set("Content-Type", "application/json")
+	createActionResp, err := app.Test(createActionReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createActionResp.StatusCode)
+	var createdAction map[string]any
+	require.NoError(t, json.NewDecoder(createActionResp.Body).Decode(&createdAction))
+	actionID, ok := createdAction["id"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, actionID)
+
+	approveReq, err := http.NewRequest(http.MethodPost, "/api/stellar/actions/"+actionID+"/approve", bytes.NewReader([]byte(`{}`)))
+	require.NoError(t, err)
+	approveReq.Header.Set("Content-Type", "application/json")
+	approveResp, err := app.Test(approveReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, approveResp.StatusCode)
+}
+
+func TestStellarAskStateDigestAndNotifications(t *testing.T) {
+	app, _ := newStellarTestApp(t)
+
+	askBody := map[string]any{
+		"prompt": "What should I look at first?",
+	}
+	rawAsk, _ := json.Marshal(taskBody)
+	askReq, err := http.NewRequest(http.MethodPost, "/api/stellar/ask", bytes.NewReader(rawAsk))
+	require.NoError(t, err)
+	askReq.Header.Set("Content-Type", "application/json")
+	askResp, err := app.Test(taskReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, taskResp.StatusCode)
+
+	stateReq, err := http.NewRequest(http.MethodGet, "/api/stellar/state", nil)
+	require.NoError(t, err)
+	stateResp, err := app.Test(stateReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, stateResp.StatusCode)
+
+	digestReq, err := http.NewRequest(http.MethodGet, "/api/stellar/digest", nil)
+	require.NoError(t, err)
+	digestResp, err := app.Test(digestReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, digestResp.StatusCode)
+
+	notifReq, err := http.NewRequest(http.MethodGet, "/api/stellar/notifications", nil)
+	require.NoError(t, err)
+	notifResp, err := app.Test(notifReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, notifResp.StatusCode)
+	var payload map[string]any
+	require.NoError(t, json.NewDecoder(notifResp.Body).Decode(&payload))
+	items, _ := payload["items"].([]any)
+	if len(items) > 0 {
+		item, _ := items[0].(map[string]any)
+		id, _ := item["id"].(string)
+		if id != "" {
+			readReq, reqErr := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+id+"/read", nil)
+			require.NoError(t, reqErr)
+			readResp, readErr := app.Test(readReq, stellarTestFiberTimeoutMs)
+			require.NoError(t, readErr)
+			require.Equal(t, http.StatusNoContent, readResp.StatusCode)
+		}
+	}
+}
+
+func TestBroadcastToClientsScopesEventsByUser(t *testing.T) {
+	h := NewStellarHandler(nil, nil)
+
+	userChannel := make(chan SSEEvent, 4)
+	otherChannel := make(chan SSEEvent, 4)
+	adminChannel := make(chan SSEEvent, 4)
+
+	h.registerSSEClient("user", "user-a", false, userChannel)
+	h.registerSSEClient("other", "user-b", false, otherChannel)
+	h.registerSSEClient("admin", "admin-user", true, adminChannel)
+
+	h.broadcastToClients(SSEEvent{Type: "notification", Data: &store.StellarNotification{UserID: "user-a", Title: "owned"}})
+	require.Eventually(t, func() bool { return len(userChannel) == 1 }, stellarTestEventWait, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return len(adminChannel) == 1 }, stellarTestEventWait, 10*time.Millisecond)
+	assert.Len(t, otherChannel, 0)
+
+	assert.Equal(t, "notification", (<-userChannel).Type)
+	assert.Equal(t, "notification", (<-adminChannel).Type)
+
+	h.broadcastToClients(newUserScopedSSEEvent("user-b", "action_update", map[string]string{"id": "a1", "status": "done"}))
+	require.Eventually(t, func() bool { return len(otherChannel) == 1 }, stellarTestEventWait, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return len(adminChannel) == 1 }, stellarTestEventWait, 10*time.Millisecond)
+	assert.Len(t, userChannel, 0)
+
+	assert.Equal(t, "action_update", (<-otherChannel).Type)
+	assert.Equal(t, "action_update", (<-adminChannel).Type)
+
+	h.broadcastToClients(SSEEvent{Type: "notification", Data: &store.StellarNotification{UserID: stellarSystemUserID, Title: "system"}})
+	require.Eventually(t, func() bool { return len(adminChannel) == 1 }, stellarTestEventWait, 10*time.Millisecond)
+	assert.Len(t, userChannel, 0)
+	assert.Len(t, otherChannel, 0)
+	assert.Equal(t, "notification", (<-adminChannel).Type)
+}
+
+func TestStellarNotificationStateTransitions(t *testing.T) {
+	app, st := newStellarTestApp(t)
+	sqlStore, ok := st.(*store.SQLiteStore)
+	require.True(t, ok)
+
+	items, err := sqlStore.ListStellarUserIDs(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+	userID := items[0]
+
+	notification := &store.StellarNotification{
+		UserID:    userID,
+		Type:      "event",
+		Severity:  "critical",
+		Title:     "CrashLoopBackOff — default/api-7c9d",
+		Body:      "timeout after 30s waiting for DB pool",
+		Cluster:   "prod-a",
+		Namespace: "default",
+		DedupeKey: "ev:Pod:api-7c9d",
+	}
+	require.NoError(t, sqlStore.CreateStellarNotification(context.Background(), notification))
+
+	investigateReq, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+notification.ID+"/investigate", bytes.NewReader([]byte(`{"investigationSummary":"pulling logs"}`)))
+	require.NoError(t, err)
+	investigateReq.Header.Set("Content-Type", "application/json")
+	investigateResp, err := app.Test(investigateReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, investigateResp.StatusCode)
+
+	var investigating store.StellarNotification
+	require.NoError(t, json.NewDecoder(investigateResp.Body).Decode(&investigating))
+	assert.Equal(t, "investigating", investigating.Status)
+	assert.Equal(t, "pulling logs", investigating.InvestigationSummary)
+	assert.False(t, investigating.Read)
+
+	resolveReq, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+notification.ID+"/resolve", bytes.NewReader([]byte(`{"resolutionNote":"restarted deployment"}`)))
+	require.NoError(t, err)
+	resolveReq.Header.Set("Content-Type", "application/json")
+	resolveResp, err := app.Test(resolveReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resolveResp.StatusCode)
+
+	var resolved store.StellarNotification
+	require.NoError(t, json.NewDecoder(resolveResp.Body).Decode(&resolved))
+	assert.Equal(t, "resolved", resolved.Status)
+	assert.Equal(t, "restarted deployment", resolved.ResolutionNote)
+	assert.True(t, resolved.Read)
+	assert.NotNil(t, resolved.BatchTimestamp)
+
+	notification2 := &store.StellarNotification{
+		UserID:    userID,
+		Type:      "event",
+		Severity:  "warning",
+		Title:     "FailedScheduling — default/api",
+		Body:      "insufficient cpu",
+		Cluster:   "prod-a",
+		Namespace: "default",
+		DedupeKey: "ev:Pod:api",
+	}
+	require.NoError(t, sqlStore.CreateStellarNotification(context.Background(), notification2))
+
+	dismissReq, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+notification2.ID+"/dismiss", bytes.NewReader([]byte(`{"dismissalReason":"duplicate event"}`)))
+	require.NoError(t, err)
+	dismissReq.Header.Set("Content-Type", "application/json")
+	dismissResp, err := app.Test(dismissReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, dismissResp.StatusCode)
+
+	var dismissed store.StellarNotification
+	require.NoError(t, json.NewDecoder(dismissResp.Body).Decode(&dismissed))
+	assert.Equal(t, "dismissed", dismissed.Status)
+	assert.Equal(t, "duplicate event", dismissed.DismissalReason)
+	assert.True(t, dismissed.Read)
+}
+
+func TestStellarResolveWatchReturnsJSON(t *testing.T) {
+	app, _ := newStellarTestApp(t)
+
+	createBody := map[string]any{
+		"cluster":      "prod-a",
+		"namespace":    "default",
+		"resourceKind": "Deployment",
+		"resourceName": "api",
+		"reason":       "recurring failures",
+	}
+	rawCreate, _ := json.Marshal(createBody)
+	createReq, err := http.NewRequest(http.MethodPost, "/api/stellar/watches", bytes.NewReader(rawCreate))
+	require.NoError(t, err)
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := app.Test(createReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	var created map[string]any
+	require.NoError(t, json.NewDecoder(createResp.Body).Decode(&created))
+	watchID, ok := created["id"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, watchID)
+
+	resolveReq, err := http.NewRequest(http.MethodPost, "/api/stellar/watches/"+watchID+"/resolve", bytes.NewReader([]byte(`{}`)))
+	require.NoError(t, err)
+	resolveReq.Header.Set("Content-Type", "application/json")
+	resolveResp, err := app.Test(resolveReq, stellarTestFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resolveResp.StatusCode)
+
+	var resolved map[string]any
+	require.NoError(t, json.NewDecoder(resolveResp.Body).Decode(&resolved))
+	assert.Equal(t, watchID, resolved["id"])
+	assert.Equal(t, "resolved", resolved["status"])
+	assert.NotNil(t, resolved["inactivityTimeoutMs"])
+}


### PR DESCRIPTION
Fixes #18826

Adds comprehensive task CRUD coverage for `pkg/api/handlers/stellar_tasks.go` and registers the task routes in the shared Stellar test app.

Validation:
- `go test ./pkg/store -run 'Test(CreateTask|GetOpenTasks|UpdateTaskStatus)' -count=1 -timeout 120s`
- `go build ./pkg/api/handlers/...` currently fails on `main` due unrelated pre-existing `pkg/k8s` import-cycle and `pkg/api/handlers/missions` build issues.
- `go test ./pkg/api/handlers/... -count=1 -timeout 120s` currently fails on the same unrelated pre-existing baseline issues.