### PR TITLE
[scanner] fix: add comprehensive tests for missions/share.go

### DIFF
--- a/pkg/api/handlers/missions/share_github_test.go
+++ b/pkg/api/handlers/missions/share_github_test.go
@@ -1,0 +1,391 @@
+package missions
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShareToGitHub_RequestValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		makeApp    func(t *testing.T) *fiber.App
+		body       string
+		token      string
+		wantStatus int
+		wantError  string
+		validate   func(t *testing.T, body map[string]interface{})
+	}{
+		{
+			name: "missing token",
+			makeApp: func(t *testing.T) *fiber.App {
+				app, _ := setupMissionsTest()
+				return app
+			},
+			body:       `{"repo":"kubestellar/console-kb","filePath":"missions/test.json","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`,
+			wantStatus: http.StatusUnauthorized,
+			wantError:  "X-GitHub-Token header is required",
+		},
+		{
+			name: "payload too large",
+			makeApp: func(t *testing.T) *fiber.App {
+				app := fiber.New(fiber.Config{BodyLimit: missionsGitHubShareMaxBytes + 1024})
+				handler := NewMissionsHandler()
+				handler.RegisterRoutes(app.Group("/api/missions"))
+				return app
+			},
+			body: `{"repo":"kubestellar/console-kb","filePath":"missions/test.json","content":"` +
+				strings.Repeat("a", missionsGitHubShareMaxBytes) +
+				`","branch":"mission-test","message":"add mission"}`,
+			token:      "ghp_test123",
+			wantStatus: http.StatusRequestEntityTooLarge,
+			wantError:  "payload too large",
+			validate: func(t *testing.T, body map[string]interface{}) {
+				assert.Equal(t, float64(missionsGitHubShareMaxBytes), body["maxSize"])
+			},
+		},
+		{
+			name: "invalid JSON body",
+			makeApp: func(t *testing.T) *fiber.App {
+				app, _ := setupMissionsTest()
+				return app
+			},
+			body:       "{",
+			token:      "ghp_test123",
+			wantStatus: http.StatusBadRequest,
+			wantError:  "invalid request body",
+		},
+		{
+			name: "missing required fields",
+			makeApp: func(t *testing.T) *fiber.App {
+				app, _ := setupMissionsTest()
+				return app
+			},
+			body:       `{"repo":"kubestellar/console-kb","branch":"mission-test"}`,
+			token:      "ghp_test123",
+			wantStatus: http.StatusBadRequest,
+			wantError:  "repo, filePath, content, and branch are required",
+		},
+		{
+			name: "repo not allowlisted",
+			makeApp: func(t *testing.T) *fiber.App {
+				app, _ := setupMissionsTest()
+				return app
+			},
+			body:       `{"repo":"attacker/private-repo","filePath":"missions/test.json","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`,
+			token:      "ghp_test123",
+			wantStatus: http.StatusBadRequest,
+			wantError:  "repo is not on the share allowlist",
+			validate: func(t *testing.T, body map[string]interface{}) {
+				assert.Equal(t, []interface{}{"kubestellar/console-kb"}, body["allowed_repos"])
+			},
+		},
+		{
+			name: "repo not allowlisted includes env entries",
+			makeApp: func(t *testing.T) *fiber.App {
+				t.Setenv(allowedShareRepoEnvVar, "MyOrg/Missions")
+				app, _ := setupMissionsTest()
+				return app
+			},
+			body:       `{"repo":"attacker/private-repo","filePath":"missions/test.json","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`,
+			token:      "ghp_test123",
+			wantStatus: http.StatusBadRequest,
+			wantError:  "repo is not on the share allowlist",
+			validate: func(t *testing.T, body map[string]interface{}) {
+				assert.Equal(t, []interface{}{"kubestellar/console-kb", "MyOrg/Missions"}, body["allowed_repos"])
+			},
+		},
+		{
+			name: "invalid file path",
+			makeApp: func(t *testing.T) *fiber.App {
+				app, _ := setupMissionsTest()
+				return app
+			},
+			body:       `{"repo":"kubestellar/console-kb","filePath":"../etc/passwd","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`,
+			token:      "ghp_test123",
+			wantStatus: http.StatusBadRequest,
+			wantError:  "invalid filePath",
+		},
+		{
+			name: "invalid branch",
+			makeApp: func(t *testing.T) *fiber.App {
+				app, _ := setupMissionsTest()
+				return app
+			},
+			body:       `{"repo":"kubestellar/console-kb","filePath":"missions/test.json","content":"dGVzdA==","branch":"bad branch","message":"add mission"}`,
+			token:      "ghp_test123",
+			wantStatus: http.StatusBadRequest,
+			wantError:  "invalid branch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := tt.makeApp(t)
+
+			req, err := http.NewRequest(http.MethodPost, "/api/missions/share/github", strings.NewReader(tt.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			if tt.token != "" {
+				req.Header.Set("X-GitHub-Token", tt.token)
+			}
+
+			resp, err := app.Test(req, 5000)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			var body map[string]interface{}
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+			assert.Equal(t, tt.wantError, body["error"])
+			if tt.validate != nil {
+				tt.validate(t, body)
+			}
+		})
+	}
+}
+
+func TestShareToGitHub_UpstreamFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantStatus int
+		wantError  string
+	}{
+		{
+			name: "fork failure",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/repos/kubestellar/console-kb/forks" {
+					http.Error(w, "boom", http.StatusBadGateway)
+					return
+				}
+				http.NotFound(w, r)
+			},
+			wantStatus: http.StatusBadGateway,
+			wantError:  "GitHub fork failed with status 502",
+		},
+		{
+			name: "fork missing full name",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == "/repos/kubestellar/console-kb/forks" {
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{"full_name": ""})
+					return
+				}
+				http.NotFound(w, r)
+			},
+			wantStatus: http.StatusBadGateway,
+			wantError:  "fork response missing or malformed full_name",
+		},
+		{
+			name: "commit response missing sha",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/repos/kubestellar/console-kb/forks":
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"full_name": "testuser/console-kb",
+					})
+				case "/repos/kubestellar/console-kb":
+					_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": "main"})
+				case "/repos/testuser/console-kb/git/ref/heads/main":
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"object": map[string]string{"sha": "headsha"},
+					})
+				case "/repos/testuser/console-kb/git/refs":
+					w.WriteHeader(http.StatusCreated)
+					_ = json.NewEncoder(w).Encode(map[string]string{"ref": "refs/heads/mission-test"})
+				case "/repos/testuser/console-kb/contents/missions/test.json":
+					w.WriteHeader(http.StatusCreated)
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{"content": map[string]string{}})
+				default:
+					http.NotFound(w, r)
+				}
+			},
+			wantStatus: http.StatusBadGateway,
+			wantError:  "GitHub commit response missing expected content SHA",
+		},
+		{
+			name: "pr response missing url",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/repos/kubestellar/console-kb/forks":
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"full_name": "testuser/console-kb",
+					})
+				case "/repos/kubestellar/console-kb":
+					_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": "main"})
+				case "/repos/testuser/console-kb/git/ref/heads/main":
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"object": map[string]string{"sha": "headsha"},
+					})
+				case "/repos/testuser/console-kb/git/refs":
+					w.WriteHeader(http.StatusCreated)
+					_ = json.NewEncoder(w).Encode(map[string]string{"ref": "refs/heads/mission-test"})
+				case "/repos/testuser/console-kb/contents/missions/test.json":
+					w.WriteHeader(http.StatusCreated)
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{"content": map[string]string{"sha": "commitsha"}})
+				case "/repos/kubestellar/console-kb/pulls":
+					w.WriteHeader(http.StatusCreated)
+					_ = json.NewEncoder(w).Encode(map[string]string{})
+				default:
+					http.NotFound(w, r)
+				}
+			},
+			wantStatus: http.StatusBadGateway,
+			wantError:  "GitHub PR response missing html_url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := httptest.NewServer(tt.handler)
+			defer mock.Close()
+
+			app, handler := setupMissionsTest()
+			handler.githubAPIURL = mock.URL
+
+			req, err := http.NewRequest(http.MethodPost, "/api/missions/share/github", strings.NewReader(
+				`{"repo":"kubestellar/console-kb","filePath":"missions/test.json","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`,
+			))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-GitHub-Token", "ghp_test123")
+
+			resp, err := app.Test(req, 5000)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			var body map[string]interface{}
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+			assert.Equal(t, tt.wantError, body["error"])
+		})
+	}
+}
+
+func TestShareToGitHub_SuccessUsesResolvedDefaultBranchAndExpectedPayloads(t *testing.T) {
+	type requestRecord struct {
+		Method        string
+		Path          string
+		Authorization string
+		Accept        string
+		ContentType   string
+		Body          map[string]interface{}
+	}
+
+	records := make([]requestRecord, 0, 6)
+
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		record := requestRecord{
+			Method:        r.Method,
+			Path:          r.URL.Path,
+			Authorization: r.Header.Get("Authorization"),
+			Accept:        r.Header.Get("Accept"),
+			ContentType:   r.Header.Get("Content-Type"),
+		}
+		if r.Body != nil && r.ContentLength != 0 {
+			defer r.Body.Close()
+			body := make(map[string]interface{})
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			record.Body = body
+		}
+		records = append(records, record)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/kubestellar/console-kb/forks":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"full_name":      "testuser/console-kb",
+				"default_branch": "stale-branch",
+				"parent": map[string]interface{}{
+					"default_branch": "also-stale",
+				},
+			})
+		case "/repos/kubestellar/console-kb":
+			_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": "trunk"})
+		case "/repos/testuser/console-kb/git/ref/heads/trunk":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"object": map[string]string{"sha": "headsha"},
+			})
+		case "/repos/testuser/console-kb/git/refs":
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"Reference already exists"}`))
+		case "/repos/testuser/console-kb/contents/missions/test.json":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": map[string]string{"sha": "commitsha"},
+			})
+		case "/repos/kubestellar/console-kb/pulls":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"html_url": "https://github.com/kubestellar/console-kb/pull/42",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer mock.Close()
+
+	app, handler := setupMissionsTest()
+	handler.githubAPIURL = mock.URL
+
+	req, err := http.NewRequest(http.MethodPost, "/api/missions/share/github", strings.NewReader(
+		`{"repo":"kubestellar/console-kb","filePath":"missions/test.json","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`,
+	))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Token", "ghp_test123")
+
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, true, body["success"])
+	assert.Equal(t, "https://github.com/kubestellar/console-kb/pull/42", body["pr_url"])
+	assert.Equal(t, "testuser/console-kb", body["fork"])
+
+	require.Len(t, records, 6)
+	assert.Equal(t, http.MethodPost, records[0].Method)
+	assert.Equal(t, "/repos/kubestellar/console-kb/forks", records[0].Path)
+	assert.Equal(t, "Bearer ghp_test123", records[0].Authorization)
+	assert.Equal(t, "application/vnd.github.v3+json", records[0].Accept)
+	assert.Equal(t, "application/json", records[0].ContentType)
+
+	assert.Equal(t, http.MethodGet, records[1].Method)
+	assert.Equal(t, "/repos/kubestellar/console-kb", records[1].Path)
+
+	assert.Equal(t, http.MethodGet, records[2].Method)
+	assert.Equal(t, "/repos/testuser/console-kb/git/ref/heads/trunk", records[2].Path)
+
+	assert.Equal(t, http.MethodPost, records[3].Method)
+	assert.Equal(t, "/repos/testuser/console-kb/git/refs", records[3].Path)
+	assert.Equal(t, map[string]interface{}{
+		"ref": "refs/heads/mission-test",
+		"sha": "headsha",
+	}, records[3].Body)
+
+	assert.Equal(t, http.MethodPut, records[4].Method)
+	assert.Equal(t, "/repos/testuser/console-kb/contents/missions/test.json", records[4].Path)
+	assert.Equal(t, map[string]interface{}{
+		"branch":  "mission-test",
+		"content": "dGVzdA==",
+		"message": "add mission",
+	}, records[4].Body)
+
+	assert.Equal(t, http.MethodPost, records[5].Method)
+	assert.Equal(t, "/repos/kubestellar/console-kb/pulls", records[5].Path)
+	assert.Equal(t, map[string]interface{}{
+		"base":  "trunk",
+		"body":  "Mission shared via KubeStellar Console",
+		"head":  "testuser:mission-test",
+		"title": "add mission",
+	}, records[5].Body)
+}

--- a/pkg/api/handlers/missions/share_slack_test.go
+++ b/pkg/api/handlers/missions/share_slack_test.go
@@ -1,0 +1,242 @@
+package missions
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveAllowedShareRepos(t *testing.T) {
+	t.Run("defaults only", func(t *testing.T) {
+		t.Setenv(allowedShareRepoEnvVar, "")
+
+		allowed := resolveAllowedShareRepos()
+
+		require.Equal(t, []string{"kubestellar/console-kb"}, allowed)
+	})
+
+	t.Run("appends trimmed env entries", func(t *testing.T) {
+		t.Setenv(allowedShareRepoEnvVar, " MyOrg/Missions , , another/repo ")
+
+		allowed := resolveAllowedShareRepos()
+
+		require.Equal(t, []string{
+			"kubestellar/console-kb",
+			"MyOrg/Missions",
+			"another/repo",
+		}, allowed)
+	})
+}
+
+func TestIsRepoAllowedForShareWithList_CaseInsensitive(t *testing.T) {
+	allowed := []string{"Kubestellar/Console-KB", "MyOrg/Missions"}
+
+	assert.True(t, isRepoAllowedForShareWithList("kubestellar/console-kb", allowed))
+	assert.True(t, isRepoAllowedForShareWithList("KUBESTELLAR/CONSOLE-KB", allowed))
+	assert.True(t, isRepoAllowedForShareWithList("myorg/missions", allowed))
+	assert.False(t, isRepoAllowedForShareWithList("attacker/evil", allowed))
+}
+
+func TestValidateSlackWebhookURL_StrictValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantErr string
+	}{
+		{
+			name:   "valid webhook",
+			rawURL: "https://hooks.slack.com/services/T000/B000/XXX",
+		},
+		{
+			name:    "empty webhook",
+			rawURL:  "",
+			wantErr: "webhook URL is required",
+		},
+		{
+			name:    "invalid URL",
+			rawURL:  "://bad",
+			wantErr: "webhook URL is not a valid URL",
+		},
+		{
+			name:    "http rejected",
+			rawURL:  "http://hooks.slack.com/services/T000/B000/XXX",
+			wantErr: "webhook URL must use https",
+		},
+		{
+			name:    "userinfo rejected",
+			rawURL:  "https://attacker@hooks.slack.com/services/T000/B000/XXX",
+			wantErr: "webhook URL must not include userinfo",
+		},
+		{
+			name:    "prefix attack rejected",
+			rawURL:  "https://hooks.slack.com.evil.com/services/T000/B000/XXX",
+			wantErr: "webhook URL host must be hooks.slack.com",
+		},
+		{
+			name:    "subdomain rejected",
+			rawURL:  "https://api.hooks.slack.com/services/T000/B000/XXX",
+			wantErr: "webhook URL host must be hooks.slack.com",
+		},
+		{
+			name:    "port rejected",
+			rawURL:  "https://hooks.slack.com:443/services/T000/B000/XXX",
+			wantErr: "webhook URL must not specify a port",
+		},
+		{
+			name:    "wrong path rejected",
+			rawURL:  "https://hooks.slack.com/api/T000/B000/XXX",
+			wantErr: "webhook URL path must begin with /services/",
+		},
+		{
+			name:    "path escape rejected",
+			rawURL:  "https://hooks.slack.com/@attacker.evil",
+			wantErr: "webhook URL path must begin with /services/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSlackWebhookURL(tt.rawURL)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestShareToSlack_ValidationAndUpstreamFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		httpClient *http.Client
+		wantStatus int
+		wantError  string
+	}{
+		{
+			name:       "invalid JSON body",
+			body:       "{",
+			wantStatus: http.StatusBadRequest,
+			wantError:  "invalid request body",
+		},
+		{
+			name:       "invalid webhook",
+			body:       `{"webhookUrl":"https://evil.com/webhook","text":"hello"}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "invalid webhook URL",
+		},
+		{
+			name:       "missing text",
+			body:       `{"webhookUrl":"https://hooks.slack.com/services/T000/B000/XXX"}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "text is required",
+		},
+		{
+			name:       "oversized text",
+			body:       `{"webhookUrl":"https://hooks.slack.com/services/T000/B000/XXX","text":"` + strings.Repeat("a", slackMaxTextBytes+1) + `"}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "text exceeds maximum size (10240 bytes)",
+		},
+		{
+			name: "transport error",
+			body: `{"webhookUrl":"https://hooks.slack.com/services/T000/B000/XXX","text":"hello"}`,
+			httpClient: &http.Client{
+				Transport: &mockTransport{handler: func(*http.Request) (*http.Response, error) {
+					return nil, errors.New("boom")
+				}},
+			},
+			wantStatus: http.StatusBadGateway,
+			wantError:  "slack webhook request failed",
+		},
+		{
+			name: "non-200 upstream",
+			body: `{"webhookUrl":"https://hooks.slack.com/services/T000/B000/XXX","text":"hello"}`,
+			httpClient: &http.Client{
+				Transport: &mockTransport{handler: func(*http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusInternalServerError,
+						Body:       io.NopCloser(strings.NewReader("fail")),
+						Header:     make(http.Header),
+					}, nil
+				}},
+			},
+			wantStatus: http.StatusBadGateway,
+			wantError:  "slack returned status 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app, handler := setupMissionsTest()
+			if tt.httpClient != nil {
+				handler.httpClient = tt.httpClient
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "/api/missions/share/slack", strings.NewReader(tt.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req, 5000)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			var body map[string]interface{}
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+			require.Equal(t, tt.wantError, body["error"])
+		})
+	}
+}
+
+func TestShareToSlack_SendsExpectedPayload(t *testing.T) {
+	var (
+		gotMethod      string
+		gotContentType string
+		gotPayload     map[string]string
+	)
+
+	slackMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+
+		defer r.Body.Close()
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotPayload))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer slackMock.Close()
+
+	app, handler := setupMissionsTest()
+	handler.httpClient = &http.Client{
+		Transport: &mockTransport{handler: func(req *http.Request) (*http.Response, error) {
+			req.URL.Scheme = "http"
+			req.URL.Host = strings.TrimPrefix(slackMock.URL, "http://")
+			return http.DefaultTransport.RoundTrip(req)
+		}},
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "/api/missions/share/slack", strings.NewReader(
+		`{"webhookUrl":"https://hooks.slack.com/services/T000/B000/XXX","text":"mission ready"}`,
+	))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, true, body["success"])
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "application/json", gotContentType)
+	assert.Equal(t, map[string]string{"text": "mission ready"}, gotPayload)
+}


### PR DESCRIPTION
Fixes #18759

Adds comprehensive test coverage for the missions share endpoint including auth validation, security checks, and edge cases.

Validation:
- `go build ./pkg/api/handlers/...`
- targeted `go test ./pkg/api/handlers/missions -run 'TestResolveAllowedShareRepos|TestIsRepoAllowedForShareWithList_CaseInsensitive|TestValidateSlackWebhookURL_StrictValidation|TestShareToSlack_ValidationAndUpstreamFailures|TestShareToSlack_SendsExpectedPayload|TestShareToGitHub_RequestValidation|TestShareToGitHub_UpstreamFailures|TestShareToGitHub_SuccessUsesResolvedDefaultBranchAndExpectedPayloads' -count=1 -timeout 120s`

Note: the broader `go test ./pkg/api/handlers/... -count=1 -timeout 120s` suite still has unrelated pre-existing failures in other handler packages and existing missions tests.