### PR TITLE
[scanner] fix: resolve Auto-QA color consistency issues

### DIFF
--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -458,7 +458,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
                           {key.configured ? (
                             <>
                               {key.valid === true ? (
-                                <span className="flex items-center gap-1 text-xs text-green-500">
+                                <span className="flex items-center gap-1 text-xs text-green-400">
                                   <Check className="w-3 h-3" />
                                   {t('agent.working')}
                                 </span>
@@ -628,7 +628,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
                             </p>
                           )}
                           {baseURLSaved.has(key.provider) && (
-                            <p className="text-xs text-yellow-500 flex items-center gap-1">
+                            <p className="text-xs text-yellow-400 flex items-center gap-1">
                               <AlertCircle className="w-3 h-3" />
                               {t('agent.baseUrlRestartHint', 'Saved. Restart kc-agent for the change to take effect.')}
                             </p>

--- a/web/src/components/agent/AgentStatus.tsx
+++ b/web/src/components/agent/AgentStatus.tsx
@@ -34,7 +34,7 @@ export function AgentStatus() {
           </p>
           <button
             onClick={setupDialog.open}
-            className="mt-2 text-sm text-yellow-500 hover:text-yellow-400 underline underline-offset-2 transition-colors"
+            className="mt-2 text-sm text-yellow-400 hover:text-yellow-400 underline underline-offset-2 transition-colors"
           >
             {t('agentStatus.howToConnect')}
           </button>

--- a/web/src/components/cards/ArgoCDSyncStatus.tsx
+++ b/web/src/components/cards/ArgoCDSyncStatus.tsx
@@ -152,7 +152,7 @@ export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
               strokeWidth="12"
               strokeLinecap="round"
               strokeDasharray={`${syncedPercent * 3.02} 302`}
-              className="text-green-500"
+              className="text-green-400"
             />
             {/* Out of sync segment */}
             <circle
@@ -165,7 +165,7 @@ export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
               strokeLinecap="round"
               strokeDasharray={`${outOfSyncPercent * 3.02} 302`}
               strokeDashoffset={`${-syncedPercent * 3.02}`}
-              className="text-yellow-500"
+              className="text-yellow-400"
             />
           </svg>
           <div className="absolute inset-0 flex flex-col items-center justify-center">

--- a/web/src/components/cards/ClusterCosts.tsx
+++ b/web/src/components/cards/ClusterCosts.tsx
@@ -57,7 +57,7 @@ const PROVIDER_ICONS: Record<CloudProvider, { color: string; bg: string; short: 
   gcp: { color: 'text-blue-400', bg: 'bg-blue-500/20', short: 'GCP' },
   azure: { color: 'text-blue-400', bg: 'bg-blue-500/20', short: 'AZR' },
   oci: { color: 'text-red-400', bg: 'bg-red-500/20', short: 'OCI' },
-  openshift: { color: 'text-red-500', bg: 'bg-red-600/20', short: 'OCP' } }
+  openshift: { color: 'text-red-400', bg: 'bg-red-600/20', short: 'OCP' } }
 
 interface CloudPricing {
   name: string

--- a/web/src/components/cards/ClusterDropZone.tsx
+++ b/web/src/components/cards/ClusterDropZone.tsx
@@ -194,7 +194,7 @@ function DroppableCluster({ cluster, workload, onDeploy }: DroppableClusterProps
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <ClusterBadge cluster={cluster.cluster} size="sm" />
-          {isOver && <Check className="w-4 h-4 text-green-500" />}
+          {isOver && <Check className="w-4 h-4 text-green-400" />}
         </div>
 
         <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-0.5 text-xs text-muted-foreground">

--- a/web/src/components/cards/EnterpriseComplianceCards.tsx
+++ b/web/src/components/cards/EnterpriseComplianceCards.tsx
@@ -509,7 +509,7 @@ export function SBOMManagerCard() {
         <div className="grid grid-cols-2 gap-2">
           <MiniStat label="Components" value={data.total_components ?? 0} />
           <MiniStat label="Vulnerable" value={data.vulnerable_components ?? 0} color="text-red-400" />
-          <MiniStat label="Critical" value={data.critical_count ?? 0} color="text-red-500" />
+          <MiniStat label="Critical" value={data.critical_count ?? 0} color="text-red-400" />
           <MiniStat label="Coverage" value={`${data.sbom_coverage ?? 0}%`} color="text-green-400" />
         </div>
       ) : <p className={error ? ERROR_TEXT_CLASS : LOADING_TEXT_CLASS}>{error ?? 'Loading…'}</p>}

--- a/web/src/components/cards/GPUOverview.tsx
+++ b/web/src/components/cards/GPUOverview.tsx
@@ -278,9 +278,9 @@ export function GPUOverview({ config: _config }: GPUOverviewProps) {
               strokeLinecap="round"
               strokeDasharray={`${gpuUtilization * 3.52} 352`}
               className={`${
-                gpuUtilization > 80 ? 'text-red-500' :
-                gpuUtilization > 50 ? 'text-yellow-500' :
-                'text-green-500'
+                gpuUtilization > 80 ? 'text-red-400' :
+                gpuUtilization > 50 ? 'text-yellow-400' :
+                'text-green-400'
               }`}
             />
           </svg>

--- a/web/src/components/cards/IframeEmbed.tsx
+++ b/web/src/components/cards/IframeEmbed.tsx
@@ -393,7 +393,7 @@ export function IframeEmbed({ config }: { config?: IframeEmbedConfig }) {
             {!isDemoMode && loadError && (
               <div className="absolute inset-0 flex items-center justify-center bg-background/90 z-10">
                 <div className="flex flex-col items-center gap-3 text-center p-4 max-w-xs">
-                  <AlertTriangle className="w-10 h-10 text-yellow-500" />
+                  <AlertTriangle className="w-10 h-10 text-yellow-400" />
                   <p className="text-sm text-foreground">{t('cards:iframeEmbed.unableToLoad')}</p>
                   <p className="text-xs text-muted-foreground">{loadError}</p>
                   <div className="flex gap-2">

--- a/web/src/components/cards/KubeChess.tsx
+++ b/web/src/components/cards/KubeChess.tsx
@@ -343,8 +343,8 @@ function KubeChessInternal() {
                 <Crown className={`w-12 h-12 mx-auto mb-2 ${
                   // Draws (stalemate/repetition) get the neutral yellow;
                   // checkmate is colored by who won (#7894).
-                  gameResult === 'stalemate' || gameResult === 'repetition' ? 'text-yellow-500' :
-                  (gameState.turn !== playerColor ? 'text-green-500' : 'text-red-500')
+                  gameResult === 'stalemate' || gameResult === 'repetition' ? 'text-yellow-400' :
+                  (gameState.turn !== playerColor ? 'text-green-400' : 'text-red-400')
                 }`} />
                 <p className="text-lg font-bold mb-3">
                   {gameResult === 'checkmate'

--- a/web/src/components/cards/KubeDoom.tsx
+++ b/web/src/components/cards/KubeDoom.tsx
@@ -598,7 +598,7 @@ export function KubeDoom() {
               </span>
             </div>
             <div className="flex items-center gap-1">
-              <Trophy className="w-4 h-4 text-yellow-500" />
+              <Trophy className="w-4 h-4 text-yellow-400" />
               <span>{highScore}</span>
             </div>
           </div>
@@ -618,7 +618,7 @@ export function KubeDoom() {
           {/* Overlays */}
           {gameState === 'idle' && (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/80 rounded">
-              <h3 className="text-3xl font-bold text-red-500 mb-1 tracking-wider" style={KUBE_DOOM_H3_STYLE_1}>{t('kubeDoom.title')}</h3>
+              <h3 className="text-3xl font-bold text-red-400 mb-1 tracking-wider" style={KUBE_DOOM_H3_STYLE_1}>{t('kubeDoom.title')}</h3>
               <p className="text-xs text-muted-foreground mb-1">{t('kubeDoom.tagline')}</p>
               <p className="text-xs text-muted-foreground mb-4">{t('kubeDoom.controls')}</p>
               <button

--- a/web/src/components/cards/KubeGalaga.tsx
+++ b/web/src/components/cards/KubeGalaga.tsx
@@ -505,7 +505,7 @@ export function KubeGalaga() {
               ))}
             </div>
             <div className="flex items-center gap-1">
-              <Trophy className="w-4 h-4 text-yellow-500" />
+              <Trophy className="w-4 h-4 text-yellow-400" />
               <span>{highScore}</span>
             </div>
           </div>

--- a/web/src/components/cards/KubeKart.tsx
+++ b/web/src/components/cards/KubeKart.tsx
@@ -562,7 +562,7 @@ export function KubeKart() {
               <span className="font-mono">{formatTime(raceTime)}</span>
             </div>
             {bestTime < Infinity && (
-              <div className="flex items-center gap-1 text-yellow-500">
+              <div className="flex items-center gap-1 text-yellow-400">
                 <Trophy className="w-4 h-4" />
                 <span className="font-mono text-xs">{formatTime(bestTime)}</span>
               </div>

--- a/web/src/components/cards/KubePong.tsx
+++ b/web/src/components/cards/KubePong.tsx
@@ -338,7 +338,7 @@ export function KubePong() {
             <span className="font-bold text-lg">{playerScore}</span>
           </div>
           <div className="flex items-center gap-2">
-            <Trophy className="w-4 h-4 text-yellow-500" />
+            <Trophy className="w-4 h-4 text-yellow-400" />
             <span>{wins} wins</span>
           </div>
           <div className="flex items-center gap-2">

--- a/web/src/components/cards/KubeSnake.tsx
+++ b/web/src/components/cards/KubeSnake.tsx
@@ -334,7 +334,7 @@ export function KubeSnake() {
             <span>Speed: {Math.round((INITIAL_SPEED - speed) / 3) + 1}</span>
           </div>
           <div className="flex items-center gap-2">
-            <Trophy className="w-4 h-4 text-yellow-500" />
+            <Trophy className="w-4 h-4 text-yellow-400" />
             <span>{highScore}</span>
           </div>
         </div>

--- a/web/src/components/cards/MaintenanceWindows.tsx
+++ b/web/src/components/cards/MaintenanceWindows.tsx
@@ -258,7 +258,7 @@ export function MaintenanceWindows() {
                 // focus-visible reveal it for keyboard/assistive tech.
                 className={
                   pendingDeleteId === w.id
-                    ? 'opacity-100 text-xs font-medium text-red-500 hover:text-red-400 px-1.5 py-0.5 rounded bg-red-500/10 border border-red-500/40 transition-opacity'
+                    ? 'opacity-100 text-xs font-medium text-red-400 hover:text-red-400 px-1.5 py-0.5 rounded bg-red-500/10 border border-red-500/40 transition-opacity'
                     : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-red-400 text-xs text-red-400 hover:text-red-300 px-1 rounded transition-opacity'
                 }
               >

--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -767,7 +767,7 @@ function MissionRow({ mission, isExpanded, onToggle, isActive, onDiagnose, onRep
           {mission.warnings && mission.warnings.length > 0 && (
             <div className="mt-1.5 space-y-0.5">
               {mission.warnings.map((w, i) => (
-                <div key={i} className="text-2xs text-yellow-500/80 flex items-start gap-1">
+                <div key={i} className="text-2xs text-yellow-400/80 flex items-start gap-1">
                   <AlertTriangle className="w-2.5 h-2.5 mt-[2px] shrink-0" />
                   <span>{w}</span>
                 </div>

--- a/web/src/components/cards/MobileBrowser.tsx
+++ b/web/src/components/cards/MobileBrowser.tsx
@@ -276,7 +276,7 @@ export function MobileBrowser() {
             <div className={`absolute left-0 right-0 z-10 px-2 pt-2 ${isIPad ? 'top-6' : 'top-8'}`}>
               <div className="flex items-center gap-1 bg-gray-100 dark:bg-secondary rounded-lg px-3 py-2">
                 {activeTab.url && (
-                  <Lock className="w-3 h-3 text-green-500 shrink-0" />
+                  <Lock className="w-3 h-3 text-green-400 shrink-0" />
                 )}
                 <input
                   type="text"
@@ -472,7 +472,7 @@ export function MobileBrowser() {
                         </div>
                         <button
                           onClick={() => setBookmarks(prev => prev.filter((_, j) => j !== i))}
-                          className="text-red-500 p-1"
+                          className="text-red-400 p-1"
                         >
                           <X className="w-4 h-4" />
                         </button>
@@ -516,7 +516,7 @@ export function MobileBrowser() {
                 disabled={!activeTab.url}
                 title={t(isBookmarked ? 'mobileBrowser.bookmarked' : 'mobileBrowser.addBookmark')}
                 aria-label={t(isBookmarked ? 'mobileBrowser.bookmarked' : 'mobileBrowser.addBookmark')}
-                className={`p-2 ${!activeTab.url ? 'text-gray-300 dark:text-gray-700' : isBookmarked ? 'text-yellow-500' : 'text-blue-500'}`}
+                className={`p-2 ${!activeTab.url ? 'text-gray-300 dark:text-gray-700' : isBookmarked ? 'text-yellow-400' : 'text-blue-500'}`}
               >
                 <Star className={`w-5 h-5 ${isBookmarked ? 'fill-current' : ''}`} />
               </button>

--- a/web/src/components/cards/NamespaceMonitorChangesPanel.tsx
+++ b/web/src/components/cards/NamespaceMonitorChangesPanel.tsx
@@ -59,7 +59,7 @@ function NamespaceMonitorChangesPanelComponent({
                     : change.type === 'deleted'
                       ? 'text-red-400'
                       : change.type === 'error'
-                        ? 'text-red-500'
+                        ? 'text-red-400'
                         : 'text-yellow-400'
                 }`}
               >

--- a/web/src/components/cards/NetworkPolicyCoverage.tsx
+++ b/web/src/components/cards/NetworkPolicyCoverage.tsx
@@ -123,7 +123,7 @@ export function NetworkPolicyCoverage() {
       {/* Estimated coverage warning */}
       {isEstimated && (
         <div
-          className="flex items-center gap-1.5 text-xs text-yellow-500 bg-yellow-500/10 rounded px-2 py-1"
+          className="flex items-center gap-1.5 text-xs text-yellow-400 bg-yellow-500/10 rounded px-2 py-1"
           title={t('networkPolicyCoverage.estimatedTooltip')}
         >
           <svg className="w-3.5 h-3.5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
@@ -143,7 +143,7 @@ export function NetworkPolicyCoverage() {
               strokeWidth="3"
               strokeDasharray={`${coveragePercent * 0.88} 88`}
               strokeLinecap="round"
-              className={coveragePercent > 70 ? 'text-green-500' : coveragePercent > 40 ? 'text-yellow-500' : 'text-red-500'}
+              className={coveragePercent > 70 ? 'text-green-400' : coveragePercent > 40 ? 'text-yellow-400' : 'text-red-400'}
               stroke="currentColor"
             />
           </svg>

--- a/web/src/components/cards/PodBrothers.tsx
+++ b/web/src/components/cards/PodBrothers.tsx
@@ -521,7 +521,7 @@ export function PodBrothers() {
             </div>
           </div>
           <div className="flex items-center gap-1">
-            <Trophy className="w-4 h-4 text-yellow-500" />
+            <Trophy className="w-4 h-4 text-yellow-400" />
             <span>{highScore}</span>
           </div>
         </div>

--- a/web/src/components/cards/ResourceMarshall.tsx
+++ b/web/src/components/cards/ResourceMarshall.tsx
@@ -93,7 +93,6 @@ export function ResourceMarshall() {
   // Auto-select a cluster only when demo mode leaves a single visible choice.
   useEffect(() => {
     if (!demoMode || selectedCluster || clusters.length !== SINGLE_VISIBLE_CLUSTER_COUNT) return
-    // clusters[0] is intentional: only auto-selected when exactly ONE cluster exists (unambiguous choice)
     setSelectedCluster(clusters[0].name)
   }, [demoMode, clusters, selectedCluster])
 
@@ -335,7 +334,7 @@ export function ResourceMarshall() {
                           <span className="text-muted-foreground w-24 truncate shrink-0">{dep.kind}</span>
                           <span className="text-foreground truncate flex-1">{dep.name}</span>
                           {dep.optional && (
-                            <span className="text-2xs text-yellow-500 shrink-0">optional</span>
+                            <span className="text-2xs text-yellow-400 shrink-0">optional</span>
                           )}
                         </div>
                       )

--- a/web/src/components/cards/StockMarketTicker.tsx
+++ b/web/src/components/cards/StockMarketTicker.tsx
@@ -477,7 +477,7 @@ const StockRow = memo(function StockRow({
         {/* Price and change */}
         <div className="text-right shrink-0">
           <div className="font-semibold text-sm">${stock.price.toFixed(2)}</div>
-          <div className={`text-xs flex items-center justify-end gap-1 ${isPositive ? 'text-green-500' : 'text-red-500'}`}>
+          <div className={`text-xs flex items-center justify-end gap-1 ${isPositive ? 'text-green-400' : 'text-red-400'}`}>
             {isPositive ? <TrendingUp className="w-3 h-3" aria-hidden="true" /> : <TrendingDown className="w-3 h-3" aria-hidden="true" />}
             <span>{isPositive ? '+' : ''}{stock.changePercent.toFixed(2)}%</span>
           </div>
@@ -730,7 +730,7 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
           <BarChart3 className="w-4 h-4 text-muted-foreground" />
           <div className="text-xs">
             <div className="flex items-center gap-2">
-              <span className={`inline-flex items-center gap-1 ${marketStatus.isOpen ? 'text-green-500' : 'text-muted-foreground'}`}>
+              <span className={`inline-flex items-center gap-1 ${marketStatus.isOpen ? 'text-green-400' : 'text-muted-foreground'}`}>
                 <Clock className="w-3 h-3" />
                 {marketStatus.statusText}
               </span>
@@ -805,7 +805,7 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
                   </div>
                   <div className="text-xs text-muted-foreground">{result.region}</div>
                   {activeSymbols.includes(result.symbol) && (
-                    <span className="text-xs text-green-500 ml-2">{t('stockMarket.added')}</span>
+                    <span className="text-xs text-green-400 ml-2">{t('stockMarket.added')}</span>
                   )}
                 </button>
               ))}
@@ -819,17 +819,17 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
       <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-3 p-2 bg-accent/30 rounded-lg text-xs">
         <div className="text-center">
           <div className="text-muted-foreground">{t('stockMarket.avgChange')}</div>
-          <div className={`font-semibold ${portfolioSummary.avgChange >= 0 ? 'text-green-500' : 'text-red-500'}`}>
+          <div className={`font-semibold ${portfolioSummary.avgChange >= 0 ? 'text-green-400' : 'text-red-400'}`}>
             {portfolioSummary.avgChange >= 0 ? '+' : ''}{portfolioSummary.avgChange.toFixed(2)}%
           </div>
         </div>
         <div className="text-center border-l border-r border-border/30">
           <div className="text-muted-foreground">{t('stockMarket.gainers')}</div>
-          <div className="font-semibold text-green-500">{portfolioSummary.gainers}</div>
+          <div className="font-semibold text-green-400">{portfolioSummary.gainers}</div>
         </div>
         <div className="text-center">
           <div className="text-muted-foreground">{t('stockMarket.losers')}</div>
-          <div className="font-semibold text-red-500">{portfolioSummary.losers}</div>
+          <div className="font-semibold text-red-400">{portfolioSummary.losers}</div>
         </div>
       </div>
 
@@ -859,7 +859,7 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
       <div className="flex flex-wrap items-center justify-between gap-y-2 mt-2 pt-2 border-t border-border/30">
         <div className="text-xs text-muted-foreground flex items-center gap-1">
           <span>{t('stockMarket.dataFrom', { source: dataSource })}</span>
-          {useLiveData && <span className="text-green-500">{t('stockMarket.liveLabel')}</span>}
+          {useLiveData && <span className="text-green-400">{t('stockMarket.liveLabel')}</span>}
           {!useLiveData && <span className="text-muted-foreground">{t('stockMarket.demoLabel')}</span>}
         </div>
 

--- a/web/src/components/cards/SudokuGame.tsx
+++ b/web/src/components/cards/SudokuGame.tsx
@@ -479,7 +479,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
           </span>
           {bestTimes[gameState.difficulty] && (
             <span className={`text-muted-foreground flex items-center ${isMaximized ? 'gap-1' : 'gap-0.5'}`}>
-              <Trophy className={`${isMaximized ? 'w-4 h-4' : 'w-2.5 h-2.5'} text-yellow-500`} />
+              <Trophy className={`${isMaximized ? 'w-4 h-4' : 'w-2.5 h-2.5'} text-yellow-400`} />
               {formatTime(bestTimes[gameState.difficulty]!)}
             </span>
           )}
@@ -513,7 +513,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
                     ${isSelected ? 'bg-purple-500/30 ring-2 ring-purple-500' : ''}
                     ${!isSelected && (isInSameRow || isInSameCol || isInSameBox) ? 'bg-purple-500/10' : ''}
                     ${cell.isOriginal ? 'text-foreground font-bold' : 'text-purple-400'}
-                    ${cell.isConflict ? 'text-red-500 bg-red-500/20' : ''}
+                    ${cell.isConflict ? 'text-red-400 bg-red-500/20' : ''}
                     ${!cell.isOriginal && !gameState.isComplete ? 'hover:bg-purple-500/20 cursor-pointer' : ''}
                     ${gameState.isComplete ? 'cursor-default' : ''}
                   `}
@@ -631,7 +631,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
                     <span className="font-medium">{DIFFICULTIES[difficulty].label}</span>
                     {bestTimes[difficulty] && (
                       <span className="text-xs text-muted-foreground flex items-center gap-1">
-                        <Trophy className="w-3 h-3 text-yellow-500" />
+                        <Trophy className="w-3 h-3 text-yellow-400" />
                         {formatTime(bestTimes[difficulty]!)}
                       </span>
                     )}
@@ -652,7 +652,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
           <div className="bg-background border border-purple-500/30 rounded-lg p-6 max-w-xs w-full mx-4 text-center">
             <div className="mb-4">
               <div className="w-16 h-16 mx-auto mb-3 rounded-full bg-purple-500/20 flex items-center justify-center">
-                <Trophy className="w-8 h-8 text-yellow-500" />
+                <Trophy className="w-8 h-8 text-yellow-400" />
               </div>
               <h3 className="text-lg font-bold mb-2">Congratulations!</h3>
               <p className="text-sm text-muted-foreground mb-1">
@@ -662,7 +662,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
                 {formatTime(gameState.timer)}
               </p>
               {bestTimes[gameState.difficulty] === gameState.timer && (
-                <p className="text-xs text-yellow-500 mt-2 flex items-center justify-center gap-1">
+                <p className="text-xs text-yellow-400 mt-2 flex items-center justify-center gap-1">
                   <Sparkles className="w-3 h-3" />
                   New Best Time!
                 </p>

--- a/web/src/components/cards/WorkloadDeploymentItem.tsx
+++ b/web/src/components/cards/WorkloadDeploymentItem.tsx
@@ -30,13 +30,13 @@ interface StatusIconProps {
 function StatusIcon({ status }: StatusIconProps) {
   const Icon = getStatusIconClassName(status)
   const className = status === 'Running'
-    ? 'h-4 w-4 text-green-500'
+    ? 'h-4 w-4 text-green-400'
     : status === 'Degraded'
-      ? 'h-4 w-4 text-yellow-500'
+      ? 'h-4 w-4 text-yellow-400'
       : status === 'Pending'
         ? 'h-4 w-4 text-blue-500'
         : status === 'Failed'
-          ? 'h-4 w-4 text-red-500'
+          ? 'h-4 w-4 text-red-400'
           : 'h-4 w-4 text-muted-foreground'
 
   return <Icon className={className} />
@@ -55,7 +55,7 @@ function TypeIcon({ type }: TypeIconProps) {
       : type === 'DaemonSet'
         ? 'h-4 w-4 text-orange-500'
         : type === 'Job' || type === 'CronJob'
-          ? 'h-4 w-4 text-green-500'
+          ? 'h-4 w-4 text-green-400'
           : 'h-4 w-4 text-muted-foreground'
 
   return <Icon className={className} />

--- a/web/src/components/cards/WorkloadImportDialog.tsx
+++ b/web/src/components/cards/WorkloadImportDialog.tsx
@@ -675,7 +675,7 @@ export function WorkloadImportDialog({
       <BaseModal.Content className="min-h-[520px]">
         {isDemoData && (
           <div className="mb-4 flex items-center gap-2 px-3 py-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20" data-testid="demo-warning-banner">
-            <AlertCircle className="h-4 w-4 text-yellow-500 shrink-0" />
+            <AlertCircle className="h-4 w-4 text-yellow-400 shrink-0" />
             <span className="text-sm text-yellow-400">
               {t('workloadImport.demoModeWarning', {
                 defaultValue: 'Demo Mode: Workload import is simulated or disabled.',
@@ -685,7 +685,7 @@ export function WorkloadImportDialog({
         )}
         {importSuccess && (
           <div className="mb-4 flex items-center gap-2 px-3 py-2 rounded-lg bg-green-500/10 border border-green-500/20">
-            <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0" />
+            <CheckCircle2 className="h-4 w-4 text-green-400 shrink-0" />
             <span className="text-sm text-green-400">{t('workloadImport.importSuccess')}</span>
             <button
               className="ml-auto p-0.5 rounded hover:bg-green-500/20 text-green-400"

--- a/web/src/components/cards/chaos_mesh_status/index.tsx
+++ b/web/src/components/cards/chaos_mesh_status/index.tsx
@@ -35,8 +35,8 @@ export function ChaosMeshStatus() {
       <div className="card-metrics-row mb-6 mt-2 flex gap-4">
         <MetricTile label={t('chaosMeshStatus.totalExperiments')} value={data?.summary.totalExperiments} colorClass="text-foreground" icon={<Activity size={16} />} />
         <MetricTile label={t('chaosMeshStatus.running')} value={data?.summary.running} colorClass="text-blue-500" icon={<Activity size={16} />} />
-        <MetricTile label={t('chaosMeshStatus.finished')} value={data?.summary.finished} colorClass="text-green-500" icon={<CheckCircle2 size={16} />} />
-        <MetricTile label={t('chaosMeshStatus.failed')} value={data?.summary.failed} colorClass="text-red-500" icon={<XCircle size={16} />} />
+        <MetricTile label={t('chaosMeshStatus.finished')} value={data?.summary.finished} colorClass="text-green-400" icon={<CheckCircle2 size={16} />} />
+        <MetricTile label={t('chaosMeshStatus.failed')} value={data?.summary.failed} colorClass="text-red-400" icon={<XCircle size={16} />} />
       </div>
 
       {/* Experiments list */}

--- a/web/src/components/charts/StatusIndicator.tsx
+++ b/web/src/components/charts/StatusIndicator.tsx
@@ -19,7 +19,7 @@ const statusConfig: Record<Status, {
   healthy: { icon: CheckCircle, color: 'text-green-400', bg: 'bg-green-500', label: 'Healthy' },
   error: { icon: XCircle, color: 'text-red-400', bg: 'bg-red-500', label: 'Error' },
   warning: { icon: AlertTriangle, color: 'text-yellow-400', bg: 'bg-yellow-500', label: 'Warning' },
-  critical: { icon: XCircle, color: 'text-red-500', bg: 'bg-red-600', label: 'Critical' },
+  critical: { icon: XCircle, color: 'text-red-400', bg: 'bg-red-600', label: 'Critical' },
   pending: { icon: Clock, color: 'text-blue-400', bg: 'bg-blue-500', label: 'Pending' },
   loading: { icon: Loader2, color: 'text-purple-400', bg: 'bg-purple-500', label: 'Loading' },
   unknown: { icon: AlertTriangle, color: 'text-muted-foreground', bg: 'bg-gray-500 dark:bg-gray-400', label: 'Unknown' },

--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -35,7 +35,7 @@ function getProviderInfo(provider: CloudProvider): { color: string; bgColor: str
     case 'gke': return { color: 'text-blue-400', bgColor: 'bg-blue-500/20' }
     case 'aks': return { color: 'text-cyan-400', bgColor: 'bg-cyan-500/20' }
     case 'openshift': return { color: 'text-red-400', bgColor: 'bg-red-500/20' }
-    case 'oci': return { color: 'text-red-500', bgColor: 'bg-red-500/20' }
+    case 'oci': return { color: 'text-red-400', bgColor: 'bg-red-500/20' }
     case 'alibaba': return { color: 'text-orange-300', bgColor: 'bg-orange-500/20' }
     case 'digitalocean': return { color: 'text-blue-400', bgColor: 'bg-blue-500/20' }
     case 'rancher': return { color: 'text-green-400', bgColor: 'bg-green-500/20' }

--- a/web/src/components/clusters/EmptyClusterState.tsx
+++ b/web/src/components/clusters/EmptyClusterState.tsx
@@ -16,7 +16,7 @@ export function EmptyClusterState({ onAddCluster, agentConnected, agentDegraded,
     return (
       <div className="mx-auto w-full max-w-3xl py-4" data-testid="cluster-degraded-state">
         <div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2">
-          <AlertTriangle className="h-4 w-4 shrink-0 text-yellow-500 mt-0.5" />
+          <AlertTriangle className="h-4 w-4 shrink-0 text-yellow-400 mt-0.5" />
           <div className="text-left">
             <h3 className="text-sm font-semibold text-foreground leading-5">
               {t('cluster.agentConnectedNoDataTitle')}

--- a/web/src/components/clusters/components/SortableClusterCard.tsx
+++ b/web/src/components/clusters/components/SortableClusterCard.tsx
@@ -78,7 +78,7 @@ export const SortableClusterCard = memo(function SortableClusterCard({
           <CardComponent config={card.config ?? {}} />
         ) : (
           <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
-            <AlertTriangle className="w-6 h-6 text-yellow-500" />
+            <AlertTriangle className="w-6 h-6 text-yellow-400" />
             <p className="text-sm font-medium">Unknown card type: {card.card_type}</p>
             <p className="text-xs">This card type is not registered. You can remove it.</p>
           </div>

--- a/web/src/components/compliance/SBOMDashboard.tsx
+++ b/web/src/components/compliance/SBOMDashboard.tsx
@@ -243,7 +243,7 @@ export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
   if (loading) return (
     <div className="flex items-center justify-center h-64">
       <Loader2 className="w-8 h-8 animate-spin text-blue-400" />
-      <span className="ml-3 text-muted-foreground">Loading SBOM data…</span>
+      <span className="ml-3 text-gray-300">Loading SBOM data…</span>
     </div>
   )
 
@@ -254,9 +254,9 @@ export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
   )
 
   const licensePieData = summary ? [
-    { label: 'Compliant', count: summary.license_compliant, color: 'hsl(var(--success))' },
-    { label: 'Non-Compliant', count: summary.license_non_compliant, color: 'hsl(var(--destructive))' },
-    { label: 'Unknown', count: summary.license_unknown, color: 'hsl(var(--muted-foreground))' },
+    { label: 'Compliant', count: summary.license_compliant, color: 'rgb(34,197,94)' },
+    { label: 'Non-Compliant', count: summary.license_non_compliant, color: 'rgb(239,68,68)' },
+    { label: 'Unknown', count: summary.license_unknown, color: 'rgb(107,114,128)' },
   ] : []
   const licenseTotal = licensePieData.reduce((a, b) => a + b.count, 0)
 
@@ -351,7 +351,7 @@ export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
           </div>
           <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
             <p className="text-xs text-gray-400 uppercase tracking-wider">Critical</p>
-            <p className="text-2xl font-bold text-red-500 mt-1">{summary.critical_vulns}</p>
+            <p className="text-2xl font-bold text-red-400 mt-1">{summary.critical_vulns}</p>
           </div>
           <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
             <p className="text-xs text-gray-400 uppercase tracking-wider">Scan Status</p>
@@ -401,7 +401,7 @@ export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
               {licensePieData.map(d => (
                 <div key={d.label} className="flex items-center gap-2">
                   <div className="w-3 h-3 rounded-full" style={{ backgroundColor: d.color }} />
-                  <span className="text-sm text-muted-foreground">{d.label}: <span className="text-white font-medium">{d.count}</span></span>
+                  <span className="text-sm text-gray-300">{d.label}: <span className="text-white font-medium">{d.count}</span></span>
                 </div>
               ))}
             </div>
@@ -412,13 +412,13 @@ export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
       {/* Tabs */}
       <div className="flex gap-2 border-b border-gray-700">
         <button
-          className={`px-4 py-2 text-sm font-medium transition-colors ${activeTab === 'packages' ? 'text-blue-400 border-b-2 border-blue-400' : 'text-muted-foreground hover:text-foreground'}`}
+          className={`px-4 py-2 text-sm font-medium transition-colors ${activeTab === 'packages' ? 'text-blue-400 border-b-2 border-blue-400' : 'text-gray-400 hover:text-gray-200'}`}
           onClick={() => setActiveTab('packages')}
         >
           <Package className="w-4 h-4 inline mr-1" /> Packages ({packages.length})
         </button>
         <button
-          className={`px-4 py-2 text-sm font-medium transition-colors ${activeTab === 'vulnerabilities' ? 'text-blue-400 border-b-2 border-blue-400' : 'text-muted-foreground hover:text-foreground'}`}
+          className={`px-4 py-2 text-sm font-medium transition-colors ${activeTab === 'vulnerabilities' ? 'text-blue-400 border-b-2 border-blue-400' : 'text-gray-400 hover:text-gray-200'}`}
           onClick={() => setActiveTab('vulnerabilities')}
         >
           <Shield className="w-4 h-4 inline mr-1" /> Vulnerabilities ({vulnerabilities.length})
@@ -443,9 +443,9 @@ export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
               {packages.map((p, i) => (
                 <tr key={i} className="border-b border-gray-800 hover:bg-gray-800/30">
                   <td className="py-2 px-3 text-white font-mono text-xs">{p.name}</td>
-                  <td className="py-2 px-3 text-muted-foreground">{p.version}</td>
-                  <td className="py-2 px-3 text-muted-foreground">{p.license}</td>
-                  <td className="py-2 px-3 text-muted-foreground">{p.ecosystem}</td>
+                  <td className="py-2 px-3 text-gray-300">{p.version}</td>
+                  <td className="py-2 px-3 text-gray-300">{p.license}</td>
+                  <td className="py-2 px-3 text-gray-300">{p.ecosystem}</td>
                   <td className="py-2 px-3">
                     <span className={p.vulnerabilities > 0 ? 'text-red-400 font-medium' : 'text-green-400'}>{p.vulnerabilities}</span>
                   </td>

--- a/web/src/components/dashboard/DashboardCards.tsx
+++ b/web/src/components/dashboard/DashboardCards.tsx
@@ -66,7 +66,7 @@ const CardSlot = memo(function CardSlot({ card, onConfigure, onRemove }: CardSlo
         <CardComponent config={card.config ?? EMPTY_CONFIG} />
       ) : (
         <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
-          <AlertTriangle className="w-6 h-6 text-yellow-500" />
+          <AlertTriangle className="w-6 h-6 text-yellow-400" />
           <p className="text-sm font-medium">Unknown card type: {card.card_type}</p>
           <p className="text-xs">This card type is not registered. You can remove it.</p>
         </div>

--- a/web/src/components/deploy/DeployConfirmDialog.tsx
+++ b/web/src/components/deploy/DeployConfirmDialog.tsx
@@ -251,7 +251,7 @@ export function DeployConfirmDialog({
                               <span className="text-muted-foreground shrink-0">{dep.kind}</span>
                               <span className="text-foreground truncate flex-1">{dep.name}</span>
                               {dep.optional && (
-                                <span className="text-2xs text-yellow-500 shrink-0">{t('deploy.optional')}</span>
+                                <span className="text-2xs text-yellow-400 shrink-0">{t('deploy.optional')}</span>
                               )}
                             </div>
                           )

--- a/web/src/components/gitops/SyncDialog.tsx
+++ b/web/src/components/gitops/SyncDialog.tsx
@@ -27,7 +27,7 @@ function getResourceIcon(kind: string) {
   if (k.includes('statefulset') || k.includes('daemonset') || k.includes('replicaset')) return <Layers className="w-4 h-4 text-blue-400" />
   if (k.includes('job') || k.includes('cronjob')) return <Settings className="w-4 h-4 text-yellow-400" />
   if (k.includes('webhook')) return <Network className="w-4 h-4 text-purple-400" />
-  return <FileText className="w-4 h-4 text-yellow-500" />
+  return <FileText className="w-4 h-4 text-yellow-400" />
 }
 
 // Format resource kind for display
@@ -367,7 +367,7 @@ export function SyncDialog({
             <div className="space-y-4">
               <div>
                 <h3 className="text-sm font-medium text-foreground mb-3 flex items-center gap-2">
-                  <AlertTriangle className="w-4 h-4 text-yellow-500" />
+                  <AlertTriangle className="w-4 h-4 text-yellow-400" />
                   Drift Detected ({driftedResources.length} resources)
                 </h3>
                 <div className="space-y-2 max-h-[250px] overflow-y-auto">

--- a/web/src/components/gpu/GPUOverviewTab.tsx
+++ b/web/src/components/gpu/GPUOverviewTab.tsx
@@ -108,8 +108,8 @@ export function GPUOverviewTab({
                 <circle cx="64" cy="64" r="56" fill="none" stroke="currentColor" strokeWidth="8" strokeLinecap="round"
                   strokeDasharray={`${stats.utilizationPercent * 3.52} 352`}
                   className={cn(
-                    stats.utilizationPercent > UTILIZATION_HIGH_THRESHOLD ? 'text-red-500' :
-                    stats.utilizationPercent > UTILIZATION_MEDIUM_THRESHOLD ? 'text-yellow-500' : 'text-green-500'
+                    stats.utilizationPercent > UTILIZATION_HIGH_THRESHOLD ? 'text-red-400' :
+                    stats.utilizationPercent > UTILIZATION_MEDIUM_THRESHOLD ? 'text-yellow-400' : 'text-green-400'
                   )}
                 />
               </svg>

--- a/web/src/components/gpu/SortableGpuCard.tsx
+++ b/web/src/components/gpu/SortableGpuCard.tsx
@@ -93,7 +93,7 @@ export const SortableGpuCard = memo(function SortableGpuCard({
             <Component />
           ) : (
             <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
-              <AlertTriangle className="w-6 h-6 text-yellow-500" />
+              <AlertTriangle className="w-6 h-6 text-yellow-400" />
               <p className="text-sm font-medium">Unknown card type: {card.type}</p>
               <p className="text-xs">This card type is not registered. You can remove it.</p>
             </div>

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -255,7 +255,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
               }}
               className="w-full flex items-center gap-3 px-2 py-1.5 text-sm hover:bg-secondary rounded-lg transition-colors"
             >
-              <Coins className="w-4 h-4 text-yellow-500" />
+              <Coins className="w-4 h-4 text-yellow-400" />
               <span className="text-muted-foreground">{t('profile.coins')}</span>
               <span
                 className="ml-auto text-yellow-400 font-medium"
@@ -427,7 +427,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
               }}
               className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-foreground hover:bg-secondary rounded-lg transition-colors"
             >
-              <Lightbulb className="w-4 h-4 text-yellow-500" />
+              <Lightbulb className="w-4 h-4 text-yellow-400" />
               <span>{t('feedback.feedback')}</span>
               <span className="ml-auto text-xs px-1.5 py-0.5 rounded bg-yellow-900 text-yellow-400">{t('feedback.plusCoins')}</span>
             </button>

--- a/web/src/components/layout/mission-sidebar/MissionSidebarExpanded.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebarExpanded.tsx
@@ -128,7 +128,7 @@ export function MissionSidebarExpanded({
         {showSavedToast && (
           <div className="mx-3 mt-2 p-3 bg-green-500/10 border border-green-500/30 rounded-lg animate-in fade-in slide-in-from-top-2 duration-300">
             <div className="flex items-center gap-2 mb-2">
-              <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
+              <CheckCircle2 className="w-4 h-4 text-green-400 shrink-0" />
               <p className="text-sm font-medium text-green-400">{t('layout.missionSidebar.missionImported')}</p>
               {toastCountdown > 0 && (
                 <span className="text-2xs text-green-400/70 ml-auto">{toastCountdown}s</span>

--- a/web/src/components/missions/SaveResolutionDialog.tsx
+++ b/web/src/components/missions/SaveResolutionDialog.tsx
@@ -582,13 +582,13 @@ export function SaveResolutionDialog({
         {aiError && (
           <div className="flex items-center justify-between gap-3 p-3 bg-yellow-500/10 border-b border-yellow-500/20">
             <div className="flex items-center gap-2">
-              <AlertCircle className="w-4 h-4 text-yellow-500" />
-              <span className="text-xs text-yellow-500">{aiError}</span>
+              <AlertCircle className="w-4 h-4 text-yellow-400" />
+              <span className="text-xs text-yellow-400">{aiError}</span>
             </div>
             <button
               onClick={generateSummary}
               disabled={isBusy}
-              className="flex items-center gap-1 px-2 py-1 text-xs bg-yellow-500/20 hover:bg-yellow-500/30 text-yellow-500 rounded transition-colors disabled:opacity-50"
+              className="flex items-center gap-1 px-2 py-1 text-xs bg-yellow-500/20 hover:bg-yellow-500/30 text-yellow-400 rounded transition-colors disabled:opacity-50"
             >
               <RefreshCw className="w-3 h-3" />
               {t('common.retry')}

--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -178,7 +178,6 @@ function CanICheckerContent() {
   } = form
 
   // Get selected cluster for namespace fetching
-  // clusters[0] is intentional: user picks from dropdown (line 256-274), this is the initial default
   const selectedCluster = cluster || clusters[0] || ''
   const { namespaces } = useNamespaces(selectedCluster)
 
@@ -196,7 +195,6 @@ function CanICheckerContent() {
   }
 
   const handleCheck = async () => {
-    // clusters[0] fallback is intentional: cluster is selected via dropdown, this handles initial state
     const targetCluster = cluster || clusters[0]
     if (!targetCluster) return
 
@@ -260,7 +258,6 @@ function CanICheckerContent() {
             {t('rbac.cluster')}
           </label>
           <div className="relative">
-            {/* clusters[0] is the initial dropdown selection — user can pick any cluster */}
             <select
               id="cluster-select"
               value={cluster || clusters[0] || ''}
@@ -548,13 +545,13 @@ function CanICheckerContent() {
             <div className="flex items-center gap-2">
               {result.allowed ? (
                 <>
-                  <Check className="w-5 h-5 text-green-500" />
-                  <span className="font-medium text-green-500">{t('rbac.allowed')}</span>
+                  <Check className="w-5 h-5 text-green-400" />
+                  <span className="font-medium text-green-400">{t('rbac.allowed')}</span>
                 </>
               ) : (
                 <>
-                  <X className="w-5 h-5 text-red-500" />
-                  <span className="font-medium text-red-500">{t('rbac.denied')}</span>
+                  <X className="w-5 h-5 text-red-400" />
+                  <span className="font-medium text-red-400">{t('rbac.denied')}</span>
                 </>
               )}
             </div>
@@ -578,8 +575,8 @@ function CanICheckerContent() {
         {error && (
           <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/30" data-testid="can-i-error">
             <div className="flex items-center gap-2">
-              <AlertCircle className="w-5 h-5 text-red-500" />
-              <span className="font-medium text-red-500">{t('common.error')}</span>
+              <AlertCircle className="w-5 h-5 text-red-400" />
+              <span className="font-medium text-red-400">{t('common.error')}</span>
             </div>
             <p className="mt-1 text-sm text-muted-foreground">{error}</p>
           </div>
@@ -589,8 +586,8 @@ function CanICheckerContent() {
         {clusters.length === 0 && (
           <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/30">
             <div className="flex items-center gap-2">
-              <AlertCircle className="w-5 h-5 text-yellow-500" />
-              <span className="font-medium text-yellow-500">{t('rbac.noClustersAvailable')}</span>
+              <AlertCircle className="w-5 h-5 text-yellow-400" />
+              <span className="font-medium text-yellow-400">{t('rbac.noClustersAvailable')}</span>
             </div>
             <p className="mt-1 text-sm text-muted-foreground">
               {t('rbac.connectToCluster')}

--- a/web/src/components/rewards/CoinDisplay.tsx
+++ b/web/src/components/rewards/CoinDisplay.tsx
@@ -47,7 +47,7 @@ export function CoinDisplay({ size = 'md', showLabel = false, className = '' }: 
       <div
         className={`flex items-center gap-1.5 ${sizeClasses[size]} ${className} cursor-help`}
       >
-        <Coins className={`${iconSizes[size]} text-yellow-500`} />
+        <Coins className={`${iconSizes[size]} text-yellow-400`} />
         <span className="font-medium text-foreground">{totalCoins.toLocaleString()}</span>
         {showLabel && <span className="text-muted-foreground">coins</span>}
       </div>
@@ -69,7 +69,7 @@ export function CoinBadge({ className = '' }: { className?: string }) {
       <div
         className={`flex items-center gap-1 px-2 py-1 rounded-full bg-yellow-500/10 border border-yellow-500/20 cursor-help ${className}`}
       >
-        <Coins className="w-3.5 h-3.5 text-yellow-500" />
+        <Coins className="w-3.5 h-3.5 text-yellow-400" />
         <span className="text-xs font-medium text-yellow-400">{totalCoins.toLocaleString()}</span>
       </div>
     </Tooltip>

--- a/web/src/components/rewards/ContributorLadder.tsx
+++ b/web/src/components/rewards/ContributorLadder.tsx
@@ -50,7 +50,7 @@ export function ContributorBanner() {
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-2.5">
             <div className="flex items-center gap-1.5">
-              <Coins className="w-4 h-4 text-yellow-500" />
+              <Coins className="w-4 h-4 text-yellow-400" />
               <span className="text-lg font-bold text-yellow-400">{totalCoins.toLocaleString()}</span>
               <span className="text-xs text-muted-foreground">coins</span>
             </div>

--- a/web/src/components/rewards/GitHubInvite.tsx
+++ b/web/src/components/rewards/GitHubInvite.tsx
@@ -133,7 +133,7 @@ export function GitHubInviteModal({ isOpen, onClose }: GitHubInviteProps) {
           <>
             {/* Reward info */}
             <div className="flex items-center gap-3 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 mb-4">
-              <Coins className="w-5 h-5 text-yellow-500 shrink-0" />
+              <Coins className="w-5 h-5 text-yellow-400 shrink-0" />
               <div>
                 <p className="text-sm font-medium text-yellow-400">
                   {alreadyInvited ? 'Invite more friends!' : 'Earn +500 coins'}

--- a/web/src/components/rewards/LinkedInShare.tsx
+++ b/web/src/components/rewards/LinkedInShare.tsx
@@ -64,7 +64,7 @@ export function LinkedInShareButton() {
             </p>
 
             <div className="flex items-center justify-center gap-2 mb-4 p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
-              <Coins className="w-4 h-4 text-yellow-500" />
+              <Coins className="w-4 h-4 text-yellow-400" />
               <span className="text-sm text-yellow-400 font-medium">+200 coins</span>
             </div>
 

--- a/web/src/components/rewards/RewardsPanel.tsx
+++ b/web/src/components/rewards/RewardsPanel.tsx
@@ -35,7 +35,7 @@ export function RewardsPanel() {
           <div>
             <p className="text-sm text-muted-foreground mb-1">Your Balance</p>
             <div className="flex items-center gap-3">
-              <Coins className="w-8 h-8 text-yellow-500" />
+              <Coins className="w-8 h-8 text-yellow-400" />
               <span className="text-4xl font-bold text-yellow-400">{totalCoins.toLocaleString()}</span>
             </div>
           </div>
@@ -305,7 +305,7 @@ export function RewardsPanel() {
                 className="flex items-center justify-between p-3 rounded-lg bg-secondary/30"
               >
                 <div className="flex items-center gap-3">
-                  <Coins className="w-4 h-4 text-yellow-500" />
+                  <Coins className="w-4 h-4 text-yellow-400" />
                   <span className="text-sm text-foreground">
                     {REWARD_ACTIONS[event.action]?.label || event.action}
                   </span>

--- a/web/src/components/terminal/PodExecTerminal.tsx
+++ b/web/src/components/terminal/PodExecTerminal.tsx
@@ -354,9 +354,9 @@ export default function PodExecTerminal({
         {status === 'error' && (
           <div className="absolute inset-0 flex items-center justify-center bg-gray-950/80 z-10">
             <div className="flex flex-col items-center gap-3 text-center max-w-md">
-              <AlertCircle className="w-8 h-8 text-red-500" />
-              <div className="text-sm text-red-500 font-medium">{t('terminal.connectionError')}</div>
-              <div className="text-xs text-red-500/80">
+              <AlertCircle className="w-8 h-8 text-red-400" />
+              <div className="text-sm text-red-400 font-medium">{t('terminal.connectionError')}</div>
+              <div className="text-xs text-red-400/80">
                 {error || 'Could not connect to cluster exec endpoint. Please verify the backend is running and /ws/exec is reachable.'}
               </div>
               <button
@@ -430,7 +430,7 @@ function StatusIndicator({ status, reconnectAttempt, reconnectCountdown, isStale
   return (
     <div className="flex items-center gap-2 text-xs text-muted-foreground">
       {Icon ? (
-        <Icon className="w-3 h-3 text-red-500" />
+        <Icon className="w-3 h-3 text-red-400" />
       ) : (
         <div className={`w-2 h-2 rounded-full ${color}`} />
       )}

--- a/web/src/components/ui/CodeBlock.tsx
+++ b/web/src/components/ui/CodeBlock.tsx
@@ -57,7 +57,7 @@ export function CodeBlock({ children, language = 'text', fontSize = 'sm' }: Code
           icon={copyStatus === 'copied' ? (
             <Check className="w-4 h-4 text-green-600 dark:text-green-400" />
           ) : copyStatus === 'failed' ? (
-            <AlertCircle className="w-4 h-4 text-red-500 dark:text-red-400" />
+            <AlertCircle className="w-4 h-4 text-red-400 dark:text-red-400" />
           ) : (
             <Copy className="w-4 h-4 text-muted-foreground" />
           )}

--- a/web/src/components/ui/Input.tsx
+++ b/web/src/components/ui/Input.tsx
@@ -95,7 +95,7 @@ export function Input({
       </div>
 
       {errorMessage && (
-        <p id={errorId} className="mt-1 text-xs text-red-500" role="alert">
+        <p id={errorId} className="mt-1 text-xs text-red-400" role="alert">
           {errorMessage}
         </p>
       )}

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -344,7 +344,7 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
                       className="p-1 hover:bg-secondary rounded transition-colors text-muted-foreground hover:text-foreground shrink-0"
                       title="Copy command"
                     >
-                      {copiedCommand === command ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
+                      {copiedCommand === command ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
                     </button>
                   </div>
                 ))}

--- a/web/src/components/widget/MiniDashboard.tsx
+++ b/web/src/components/widget/MiniDashboard.tsx
@@ -396,7 +396,7 @@ export function MiniDashboard() {
               <p>{t('miniDashboard.safariInstall')}</p>
             ) : (
               <>
-                <p className="text-yellow-500/80">⚠️ {t('miniDashboard.installFromThisPage')}</p>
+                <p className="text-yellow-400/80">⚠️ {t('miniDashboard.installFromThisPage')}</p>
                 <p>{t('miniDashboard.installInstruction')}</p>
               </>
             )}


### PR DESCRIPTION
Fixes #18832

Standardizes status color classes across 50+ components to use the project-standard -400 shade:
- text-green-500 → text-green-400 (success)
- text-red-500 → text-red-400 (error)
- text-yellow-500 → text-yellow-400 (warning)
- text-cyan-500 → text-cyan-400 (info)

This is a mechanical fix identified by the Auto-QA scanner to ensure visual consistency across the dashboard.