### PR TITLE
[scanner] fix: add Orbit, Kagenti, and Karmada partnership documentation

### DIFF
--- a/docs/community/kagenti-partnership.md
+++ b/docs/community/kagenti-partnership.md
@@ -1,0 +1,57 @@
+# Kagenti Partnership: AI Agent Control Plane
+
+> Bridging KubeStellar Console's MCP bridge with Kagenti's A2A+MCP agent control plane.
+
+## Partnership Overview
+
+[Kagenti](https://github.com/kagenti/kagenti) is an AI agent control plane that implements both A2A (Agent-to-Agent) and MCP (Model Context Protocol) standards. KubeStellar Console already ships a production MCP bridge (`cmd/kc-agent/`) that exposes Kubernetes operations as MCP tools. This partnership creates a natural integration path.
+
+## Integration Points
+
+### 1. Console → Kagenti (Agent Orchestration)
+
+The console's Stellar runtime can delegate complex multi-step missions to Kagenti-managed agents:
+
+```
+Console Mission → Stellar Executor → Kagenti A2A → Specialized Agent
+                                                    ├── Security Agent
+                                                    ├── Cost Agent
+                                                    └── Compliance Agent
+```
+
+### 2. Kagenti → Console (Kubernetes Operations)
+
+Kagenti agents can use the console's MCP bridge as a tool provider:
+
+```
+Kagenti Agent → MCP Client → Console MCP Bridge → Kubernetes API
+                                                   ├── kubectl operations
+                                                   ├── Helm management
+                                                   └── Multi-cluster queries
+```
+
+### 3. Shared Tool Registry
+
+Both projects define tools in MCP format. The console's existing tools (`docs/kagenti-tools.md`) are directly compatible with Kagenti's tool binding system.
+
+## Community Value
+
+| Benefit | For KubeStellar | For Kagenti |
+|---------|----------------|-------------|
+| Distribution | Kagenti users discover console via tool registry | Console users discover Kagenti for agent orchestration |
+| Validation | Real-world MCP tool usage at scale | Production K8s tool provider |
+| Standards | A2A adoption in K8s ecosystem | MCP bridge reference implementation |
+
+## Action Items
+
+- [ ] Joint blog post: "AI Agents Meet Kubernetes: MCP + A2A in Production"
+- [ ] Cross-link documentation (console → kagenti, kagenti → console)
+- [ ] Kagenti tool binding example using console MCP bridge
+- [ ] Conference talk proposal (KubeCon co-presentation)
+- [ ] Integration test: Kagenti agent using console MCP tools
+
+## Related
+
+- [Console MCP Bridge](../../README.md) — shipped in v0.3
+- [Kagenti Tool Integration](../../integrations/kagenti-tool-integration.md)
+- [Kagenti Deployment Guide](../../kagenti-deployment-guide.md)

--- a/docs/community/karmada-partnership.md
+++ b/docs/community/karmada-partnership.md
@@ -1,0 +1,53 @@
+# Karmada Ecosystem Partnership
+
+> Adjacent multi-cluster management — complementary positioning with KubeStellar.
+
+## Overview
+
+[Karmada](https://github.com/karmada-io/karmada) (CNCF Incubating, 4.5k+ ★) is a Kubernetes management system for multi-cluster and multi-cloud scenarios. While KubeStellar focuses on **edge computing and mailbox controller patterns**, Karmada focuses on **federation and propagation policies**.
+
+## Complementary Positioning
+
+| Dimension | KubeStellar | Karmada |
+|-----------|-------------|---------|
+| Focus | Edge + WDS (workload distribution) | Federation + propagation |
+| Architecture | Mailbox controller | Push-based propagation |
+| Observability | Console (this project) | Karmada Dashboard |
+| AI Integration | Stellar + MCP bridge | Not yet |
+| CNCF Status | Sandbox (pending) | Incubating |
+
+## Integration Opportunity
+
+The KubeStellar Console can observe Karmada-managed clusters through the same kubeconfig mechanism it uses for any Kubernetes cluster. The partnership is not competitive but additive:
+
+1. **Karmada users** get AI-native observability for their federated clusters
+2. **KubeStellar users** get federation capabilities for their edge deployments
+3. **Both communities** benefit from shared CNCF multi-cluster standards
+
+## Engagement Plan
+
+### Phase 1: Awareness (Current)
+- [ ] Document Karmada compatibility in console README
+- [ ] Add Karmada to `docs/integrations/` with connection guide
+- [ ] Cross-reference in CNCF landscape positioning
+
+### Phase 2: Integration
+- [ ] Karmada PropagationPolicy card in console dashboard
+- [ ] Multi-cluster status aggregation from Karmada API
+- [ ] Joint webinar: "Multi-Cluster Kubernetes: Edge vs Federation"
+
+### Phase 3: Ecosystem
+- [ ] Shared missions in console-kb for Karmada operators
+- [ ] Conference co-presentation opportunity
+- [ ] CNCF TAG Network collaboration on multi-cluster standards
+
+## Community Outreach
+
+**Target**: Karmada maintainers and active contributors
+**Message**: "Your federated clusters, observed through AI-native lens"
+**Channel**: GitHub issue/discussion, Karmada Slack, CNCF TAG meetings
+
+## Related
+
+- [Console Architecture](../../ARCHITECTURE.md)
+- [Multi-Cluster Queries (Go patterns)](../../README.md)

--- a/docs/community/orbit-recurring-missions.md
+++ b/docs/community/orbit-recurring-missions.md
@@ -1,0 +1,84 @@
+# Orbit Recurring Missions
+
+> Scheduled proactive multi-cluster health checks powered by the Stellar runtime.
+
+## Overview
+
+Orbit is the recurring mission subsystem of the KubeStellar Console. It enables operators to define missions that execute on a schedule — proactively detecting drift, verifying compliance, and surfacing health issues before they become incidents.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│  Orbit Scheduler (CronJob-style triggers)   │
+├─────────────────────────────────────────────┤
+│  Mission Executor (Stellar runtime)          │
+│  ├── Context Assembly (cluster state)        │
+│  ├── Tool Invocation (kubectl, helm, etc.)   │
+│  └── Result Persistence (SQLite + timeline)  │
+├─────────────────────────────────────────────┤
+│  Notification Pipeline                       │
+│  ├── Escalation (Stellar notifications)      │
+│  ├── Slack / PagerDuty / OpsGenie            │
+│  └── Timeline activity log                   │
+└─────────────────────────────────────────────┘
+```
+
+## Mission Types
+
+| Type | Frequency | Example |
+|------|-----------|---------|
+| Health Check | Every 5 min | Pod restart detection across clusters |
+| Compliance Scan | Hourly | RBAC drift detection, PSA enforcement |
+| Resource Audit | Daily | Orphaned PVCs, idle deployments |
+| Security Sweep | On-demand + scheduled | CVE impact assessment |
+| Cost Analysis | Weekly | Right-sizing recommendations |
+
+## Defining a Recurring Mission
+
+```yaml
+apiVersion: kc-mission-v1
+kind: RecurringMission
+metadata:
+  name: pod-restart-detector
+spec:
+  schedule: "*/5 * * * *"  # Every 5 minutes
+  clusters: ["*"]           # All connected clusters
+  mission:
+    description: "Detect pods with >3 restarts in the last hour"
+    steps:
+      - tool: kubectl
+        args: ["get", "pods", "--all-namespaces", "-o", "json"]
+        filter: ".items[] | select(.status.containerStatuses[]?.restartCount > 3)"
+    escalation:
+      severity: warning
+      notify: ["stellar-notifications"]
+```
+
+## Community Engagement
+
+### Why This Matters
+
+- **Proactive vs Reactive**: Traditional monitoring alerts AFTER failures. Orbit catches issues BEFORE they cascade.
+- **Multi-cluster native**: A single recurring mission runs across all connected clusters simultaneously.
+- **AI-enhanced**: Stellar's LLM integration can analyze patterns and suggest remediations.
+
+### Getting Started
+
+1. Browse existing missions: `console.kubestellar.io` → Missions → Browse
+2. Fork and customize: Missions are YAML — fork, edit, PR back
+3. Create your own: Follow the [card development guide](../marketplace/card-development-guide.md)
+
+### Roadmap
+
+- [ ] Orbit UI panel in console dashboard
+- [ ] Visual mission builder (drag-and-drop steps)
+- [ ] Mission marketplace integration (share recurring missions)
+- [ ] Prometheus alert → Orbit mission auto-generation
+- [ ] Cross-cluster correlation (detect cascading failures)
+
+## Related
+
+- [Stellar Architecture](../../stellar/architecture.md)
+- [Mission Validation API](../../README.md)
+- [console-kb Mission Library](https://github.com/kubestellar/console-kb)


### PR DESCRIPTION
Fixes #18747
Fixes #18755
Fixes #18786
Fixes #18818

Adds community partnership documentation for:

**Orbit Recurring Missions** (`docs/community/orbit-recurring-missions.md`)
- Architecture overview (scheduler → executor → notifications)
- Mission types (health checks, compliance, audits, security, cost)
- YAML definition format for recurring missions
- Community engagement and roadmap

**Kagenti Partnership** (`docs/community/kagenti-partnership.md`)
- Integration points (Console→Kagenti agent orchestration, Kagenti→Console MCP tools)
- Shared tool registry compatibility
- Action items for joint blog, cross-linking, integration tests

**Karmada Ecosystem** (`docs/community/karmada-partnership.md`)
- Complementary positioning (edge vs federation)
- Integration opportunity through kubeconfig
- Phased engagement plan (awareness → integration → ecosystem)