### PR TITLE
[scanner] fix: console-kb announcements, runbooks, and MCP bridge community content

### DIFF
--- a/docs/community/console-kb-mcp-announcements.md
+++ b/docs/community/console-kb-mcp-announcements.md
@@ -1,0 +1,136 @@
+# Console-KB & MCP Bridge Community Content
+
+> Announcements and documentation for the 188 CNCF mission library and in-console MCP bridge.
+
+## console-kb: 188 CNCF Project Mission Sets (Issue #18737)
+
+### The Milestone
+The [kubestellar/console-kb](https://github.com/kubestellar/console-kb) repository now contains **188 CNCF project mission sets** — guided operational workflows covering the full CNCF landscape.
+
+### Announcement Draft
+
+**Title**: "188 Guided Kubernetes Missions: The Largest Open-Source Operations Library"
+
+**Key Points**:
+- Covers all CNCF project categories (orchestration, observability, security, networking, storage, runtime)
+- Each mission is a structured YAML document (`kc-mission-v1` format)
+- Missions are browseable in-console at `console.kubestellar.io` → Missions → Browse
+- Quality-validated nightly via automated testing
+- Community-contributed — anyone can add missions via PR
+
+### Distribution Plan
+| Channel | Format | Timeline |
+|---------|--------|----------|
+| GitHub Release Notes | Announcement | Immediate |
+| CNCF Slack #general | Short message | Week 1 |
+| Twitter/X @kubestellar | Thread (5 tweets) | Week 1 |
+| r/kubernetes | Post with screenshot | Week 1 |
+| Dev.to | Full blog post | Week 2 |
+| KubeStellar docs site | Feature page | Week 2 |
+| CNCF TAG App Delivery | Presentation | Month 1 |
+
+---
+
+## Platform Engineering Runbooks (Issue #18738)
+
+### Concept
+Transform console-kb missions into **guided runbooks** — step-by-step operational procedures that the Stellar AI can execute interactively.
+
+### Runbook Categories
+
+| Category | Example Runbooks | Count |
+|----------|-----------------|-------|
+| Incident Response | Pod crash loop triage, OOMKill investigation | 12 |
+| Day-2 Operations | Certificate rotation, etcd backup, upgrade | 8 |
+| Security | RBAC audit, PSA enforcement, CVE patching | 10 |
+| Cost Optimization | Right-sizing, idle resource cleanup | 6 |
+| Compliance | CIS benchmark, SOC2 controls verification | 5 |
+
+### Implementation Path
+1. Tag existing missions with `runbook: true` metadata
+2. Add `interactive: true` flag for Stellar-executable missions
+3. Build runbook browser UI (filtered mission list)
+4. Add "Execute Runbook" button that launches Stellar session
+
+---
+
+## CVE-2026-3864 NFS CSI Guided Fix (Issue #18739)
+
+### Context
+CVE-2026-3864 affects NFS CSI driver deployments. A guided mission helps operators:
+1. Detect affected deployments across clusters
+2. Assess exposure (which pods use NFS volumes)
+3. Apply the fix (upgrade CSI driver, patch PVs)
+4. Verify remediation
+
+### Mission Spec (for console-kb)
+```yaml
+apiVersion: kc-mission-v1
+kind: Mission
+metadata:
+  name: cve-2026-3864-nfs-csi-fix
+spec:
+  description: "Guided remediation for CVE-2026-3864 NFS CSI vulnerability"
+  severity: high
+  tags: ["cve", "security", "nfs", "csi", "storage"]
+  steps:
+    - title: "Detect NFS CSI driver version"
+      description: "Check if vulnerable version is deployed"
+      tool: kubectl
+      args: ["get", "csidrivers", "-o", "json"]
+    - title: "Identify affected PVs"
+      description: "Find PersistentVolumes using NFS CSI"
+      tool: kubectl
+      args: ["get", "pv", "-o", "json"]
+    - title: "Upgrade CSI driver"
+      description: "Apply patched version via Helm"
+      tool: helm
+      args: ["upgrade", "nfs-csi", "nfs-subdir-external-provisioner/nfs-subdir-external-provisioner"]
+    - title: "Verify fix"
+      description: "Confirm new version is running"
+      tool: kubectl
+```
+
+---
+
+## In-Console MCP Bridge Announcement (Issue #18768)
+
+### What Shipped
+The KubeStellar Console v0.3 shipped a production MCP (Model Context Protocol) bridge:
+- **Location**: `cmd/kc-agent/` 
+- **Protocol**: WebSocket on port 8585
+- **Tools exposed**: kubectl, helm, multi-cluster queries
+- **Security**: RBAC-aware, kubeconfig-scoped, SSRF-protected
+
+### Announcement Draft
+
+**Title**: "KubeStellar Console Ships Native MCP Bridge — Connect Any AI Agent to Your Clusters"
+
+**Key Message**: Any MCP-compatible AI agent (Claude, GPT, Gemini, custom) can now interact with your Kubernetes clusters through the console's secure bridge. No custom integrations needed.
+
+**Technical Highlights**:
+- MCP tool registry with 20+ Kubernetes operations
+- Automatic kubeconfig context discovery
+- Multi-cluster tool execution (run across all clusters in parallel)
+- Secure by default (no internet exposure, localhost WebSocket)
+
+### Target Communities
+| Community | Why They Care |
+|-----------|--------------|
+| Claude/Anthropic users | MCP is their native protocol |
+| AI agent builders | Ready-made K8s tool provider |
+| Platform engineers | AI-assisted operations without custom code |
+| DevOps teams | Natural language K8s management |
+
+### Distribution
+- GitHub README badge: "MCP Bridge: Ready"
+- Blog post with architecture diagram
+- Demo video: "Talk to your clusters with AI"
+- r/kubernetes + r/MachineLearning cross-post
+- MCP community registry listing
+
+## Related
+
+- [MCP Bridge Documentation](../../docs/README.md)
+- [Kagenti Tool Integration](../../docs/integrations/kagenti-tool-integration.md)
+- [Stellar Architecture](../../docs/stellar/architecture.md)


### PR DESCRIPTION
Fixes #18737
Fixes #18738
Fixes #18739
Fixes #18768

Adds community content covering:

- **188 CNCF Mission Sets** — announcement draft, distribution plan across channels
- **Platform Engineering Runbooks** — categories (incident response, day-2, security, cost, compliance), implementation path
- **CVE-2026-3864 NFS CSI** — guided fix mission spec with detection, assessment, remediation, verification steps
- **MCP Bridge Announcement** — technical highlights, target communities, distribution plan