### PR TITLE
[scanner] fix: recognize first contributors and engage forker communities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,39 @@ New monitoring cards for CNCF projects (Karmada, Falco, KEDA, etc.) belong in [*
 
 PRs that add new card components to `web/src/components/cards/` will be redirected to console-marketplace.
 
+## Documentation Forkers: You're Welcome Here! 📚
+
+If you've forked [kubestellar/docs](https://github.com/kubestellar/docs) to write content, adapt documentation for your clusters, or build tutorials, we'd love to have you contribute to KubeStellar Console as well. Your documentation expertise translates directly to:
+
+- **Console-KB Missions** — write operational guides that help users master the console
+- **Contributor Documentation** — improve `CONTRIBUTING.md` and setup guides
+- **UI Translation & Localization** — help expand console translations (v0.4 goal)
+- **Cards & Dashboards** — document new monitoring cards and best practices
+
+**Getting started:**
+1. Read this `CONTRIBUTING.md` section on [Getting Started Locally](#getting-started-locally)
+2. Check out [console-kb](https://github.com/kubestellar/console-kb) for mission writing patterns
+3. Look for issues labeled `good-first-issue` or `documentation` in this repo
+4. Join [#kubestellar-dev on Slack](https://cloud-native.slack.com/archives/C097094RZ3M) to discuss your ideas
+
+## Marketplace Builders: Publish Your Work! 🎨
+
+If you've forked [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace) to build custom dashboards, card presets, or themes for your clusters, your work deserves to be shared with the community.
+
+**Why submit your marketplace item:**
+- Share your creation with 1000+ console users
+- Get feedback and contributions from users of your item
+- Build your portfolio as a KubeStellar community creator
+- Help the community benefit from your innovation
+
+**Submitting a marketplace item:**
+1. Fork [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace)
+2. Add your dashboard, card preset, or theme following the [marketplace structure](https://github.com/kubestellar/console-marketplace#submitting-a-new-item)
+3. Open a PR describing what you've built and who it's for
+4. Share a screenshot or demo link in the PR
+
+**Got questions?** Ask on [#kubestellar-dev](https://cloud-native.slack.com/archives/C097094RZ3M) or open an issue in the marketplace repo.
+
 ## Repo Inventory Files
 
 The repo-root [`INVENTORY.md`](INVENTORY.md) tracks the component, route, modal, and drill-down inventory that the Auto-QA workflow cross-checks against the source tree.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,33 @@
+# KubeStellar Console Contributors
+
+## ✨ First Wave of External Contributors
+
+We celebrate our first wave of external contributors who opened PRs on the same day — a rare alignment signal and critical moment for community growth.
+
+### 2026 Contributors
+
+- **[@bmvinay7](https://github.com/bmvinay7)** — First external contributor [#18264]
+- **[@AdeshDeshmukh](https://github.com/AdeshDeshmukh)** — First wave contributor [#18373]
+
+## About This File
+
+This file honors contributors who have made significant contributions to the KubeStellar Console project. For a complete list of all contributors, see the [GitHub contributors graph](https://github.com/kubestellar/console/graphs/contributors).
+
+## Contributor Spotlight
+
+Early contributors who get merged quickly become long-term contributors. If you've submitted a PR and want to be recognized, we'd love to hear about it!
+
+### How to Contribute
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on:
+- Submitting issues and feature requests
+- Opening pull requests
+- Writing tests
+- Contributing documentation
+- Non-code contributions (design, translations, community support)
+
+### Getting Help
+
+- [Documentation](https://kubestellar.io/docs/console/overview/)
+- [Slack - #kubestellar-dev](https://cloud-native.slack.com/archives/C097094RZ3M)
+- [GitHub Issues](https://github.com/kubestellar/console/issues)


### PR DESCRIPTION
Fixes #18782
Fixes #18790
Fixes #18791

## Summary

This PR addresses three outreach opportunities to grow the KubeStellar contributor community:

### #18782 — First External Contributors
Created **CONTRIBUTORS.md** to recognize @bmvinay7 and @AdeshDeshmukh as the first wave of external contributors to KubeStellar Console. This establishes a contributor spotlight to celebrate and onboard early contributors who are critical to long-term community health.

### #18790 — Engage Docs Forkers
Added a new **"Documentation Forkers: You're Welcome Here!"** section to CONTRIBUTING.md. This directly targets the 89 forkers of kubestellar/docs with a clear value proposition:
- They already understand the project well
- Their writing skills are needed for console-kb missions, CONTRIBUTING.md, and i18n translation (v0.4)
- Console-kb and locale files are accessible entry points

### #18791 — Marketplace Builders
Added a new **"Marketplace Builders: Publish Your Work!"** section to CONTRIBUTING.md to activate the 13 silent forkers of console-marketplace. This encourages builders to:
- Share their creations with 1000+ console users
- Get feedback and contributions from users
- Help the community benefit from their innovation

## Changes

- **CONTRIBUTORS.md** (new) — First external contributor spotlight
- **CONTRIBUTING.md** — Added two new sections welcoming docs and marketplace contributors