### PR TITLE
docs: add ecosystem outreach strategy for WasmCloud, Crossplane, Dapr, and security communities

### DIFF
--- a/docs/ECOSYSTEM-OUTREACH.md
+++ b/docs/ECOSYSTEM-OUTREACH.md
@@ -1,0 +1,140 @@
+# KubeStellar Console Ecosystem Outreach Plan
+
+## Overview
+
+KubeStellar Console ships integrations with several CNCF and cloud-native ecosystem projects but had minimal documented community engagement strategy. This outreach plan addresses four key ecosystem opportunities with high overlap potential.
+
+## Ecosystem Partnerships
+
+### 1. WasmCloud CNCF Incubating
+**Status**: Content published at [docs.kubestellar.io/community/partners/wasmcloud](https://docs.kubestellar.io/community/partners/wasmcloud)
+
+**Console Features**:
+- Actor health monitoring across clusters
+- Provider connectivity tracking
+- Multi-cluster WebAssembly runtime visibility
+
+**Outreach Goals**:
+- Co-promote at KubeCon NA 2026 (multi-cluster WebAssembly narrative)
+- Coordinate joint blog post or ecosystem demo
+- Feature console in WasmCloud ecosystem tools page
+
+**Engagement Channels**:
+- WasmCloud project GitHub and discussions
+- CNCF Slack `#wasmcloud`
+- WasmCloud community meetings
+
+### 2. Crossplane CNCF Graduated
+**Status**: Content published at [docs.kubestellar.io/community/partners/crossplane](https://docs.kubestellar.io/community/partners/crossplane)
+
+**Console Features**:
+- Composite Resource (XR) health tracking
+- Provider connectivity monitoring across clusters
+- Composition deployment audit trail
+
+**Outreach Goals**:
+- Build console card for Crossplane XR health (separate development issue)
+- Validate use cases with Crossplane community
+- Present integrated solution at Crossplane community meetings
+
+**Engagement Channels**:
+- Crossplane Slack `#integrations` channel
+- Crossplane community meetings (bi-weekly)
+- CNCF Platform Engineering TAG
+
+### 3. Dapr CNCF Graduated
+**Status**: Content published at [docs.kubestellar.io/community/partners/dapr](https://docs.kubestellar.io/community/partners/dapr)
+
+**Console Features**:
+- Sidecar injection monitoring across clusters
+- Pub/sub component health tracking
+- Distributed tracing correlation across cluster boundaries
+
+**Outreach Goals**:
+- Develop Dapr health card for console (separate development issue)
+- Create `console-kb` mission for debugging Dapr injection failures
+- Feature in CNCF TAG Runtime discussions
+
+**Engagement Channels**:
+- Dapr GitHub discussions
+- Dapr community standup (weekly)
+- CNCF TAG Runtime Slack
+
+### 4. Security Practitioner Community
+**Status**: Content published at [docs.kubestellar.io/community/partners/security-ecosystem](https://docs.kubestellar.io/community/partners/security-ecosystem)
+
+**Console Features**:
+- **SPIFFE/SPIRE**: Cross-cluster identity audit, workload certificate lifecycle tracking
+- **TUF**: Supply chain verification, artifact signature validation
+- **Trestle/OpenSCAP**: Compliance baseline tracking, control assessment
+- **Falco**: Runtime security monitoring, policy violation alerts
+
+**Outreach Goals**:
+- Publish blog series: "Unified Security Posture for Multi-Cluster Kubernetes"
+- Post in CNCF Security TAG `#general` Slack
+- Feature in SPIFFE community newsletter
+- Create security-focused missions in `console-kb`
+- Propose KubeCon talk: "Observability for Security: Multi-Cluster Audit with KubeStellar"
+
+**Engagement Channels**:
+- CNCF Security TAG Slack and meetings
+- SPIFFE community Slack and newsletter
+- TUF project GitHub
+- Trestle/OSCAL community
+- Falco community Slack
+
+## Implementation Timeline
+
+| Phase | Quarter | Actions |
+|-------|---------|---------|
+| **Phase 1: Documentation** | Q2 2026 | ✅ Publish outreach content pages in docs |
+| **Phase 2: Community Engagement** | Q3 2026 | Open GitHub discussions, Slack posts in project communities |
+| **Phase 3: Feature Development** | Q3-Q4 2026 | Build new cards (Crossplane, Dapr), security content |
+| **Phase 4: Event Presence** | Q4 2026 | KubeCon NA 2026 co-presence, talks, demos |
+| **Phase 5: Ongoing** | 2026+ | Maintain content, share success stories, join governance |
+
+## Metrics & Success Criteria
+
+### Awareness
+- Community members discover console via partner project docs/tools pages
+- Blog posts reach 1K+ readers in target communities
+- GitHub discussion threads show partner team participation
+
+### Engagement
+- Console cards used in demo environments
+- Community contributes Dapr/Crossplane use case missions
+- Security practitioners adopt multi-cluster audit workflows
+
+### Partnership Depth
+- Maintainer representation in partner project meetings
+- Reciprocal features in partner project documentation
+- Joint conference presence (talks, booth, workshops)
+
+## Responsible Teams
+
+- **Content**: KubeStellar docs/community team (owner: @clubanderson)
+- **Development**: Console feature team (cards, missions)
+- **Events**: KubeStellar conference/marketing team
+- **Community**: Maintainers and ecosystem liaisons
+
+## How to Help
+
+Community members can contribute to outreach efforts:
+
+1. **Share Use Cases** — Tell us about your multi-cluster SPIFFE, Dapr, or Crossplane deployments
+2. **Test Integration** — Try console cards with these ecosystem projects and provide feedback
+3. **Propose Content** — Submit blog post ideas or mission concepts
+4. **Event Participation** — Join community calls, represent KubeStellar at conferences
+5. **Code Contributions** — Develop new cards, improve existing ones
+
+See [COMMUNITY.md](./COMMUNITY.md) for how to get involved.
+
+## References
+
+- **Docs**: [KubeStellar Ecosystem Partnerships](https://docs.kubestellar.io/community/partners)
+- **Governance**: [GOVERNANCE.md](../GOVERNANCE.md)
+- **Contributing**: [How to Contribute](../CONTRIBUTING.md)
+
+---
+
+**Last Updated**: June 2026


### PR DESCRIPTION
Fixes #18817
Fixes #18820
Fixes #18821
Fixes #18822

## Summary

Adds comprehensive ecosystem outreach strategy and partnership documentation for four major CNCF ecosystem projects with significant overlap to KubeStellar Console:

### Content Added

1. **docs/ECOSYSTEM-OUTREACH.md** (console repo) — Master outreach plan with timeline, metrics, and engagement strategies
2. **docs/content/community/partners/wasmcloud.md** (docs repo) — WasmCloud integration overview and co-promotion opportunities
3. **docs/content/community/partners/crossplane.md** (docs repo) — Crossplane platform engineering synergy and card development roadmap
4. **docs/content/community/partners/dapr.md** (docs repo) — Dapr multi-cluster sidecar visibility and integration opportunities
5. **docs/content/community/partners/security-ecosystem.md** (docs repo) — SPIFFE, TUF, Trestle, Falco security practitioner guide

### Key Initiatives

- **WasmCloud**: Co-promotion at KubeCon NA 2026, joint ecosystem content
- **Crossplane**: Card development for XR health monitoring, platform engineering outreach
- **Dapr**: Sidecar health dashboard, distributed tracing across clusters
- **Security**: Blog series, CNCF Security TAG engagement, compliance automation

### Community Engagement

- Slack channels, project meetings, GitHub discussions
- Blog posts and thought leadership content
- Console missions (`console-kb`) for troubleshooting workflows
- KubeCon 2026 presence and co-marketing

See ECOSYSTEM-OUTREACH.md for full implementation timeline and success metrics.