### PR TITLE
[outreach] content: add card contribution guide for ecosystem card developers

### DIFF
--- a/docs/community/card-contribution-guide.md
+++ b/docs/community/card-contribution-guide.md
@@ -1,22 +1,22 @@
-# 📸 Contributing a Dashboard Card to KubeStellar Console
+# Contributing a Dashboard Card to KubeStellar Console
 
-This guide walks you through adding a new ecosystem card to the KubeStellar Console dashboard. The console already ships **313 cards** covering the CNCF ecosystem — yours could be next.
+This guide walks you through adding a new ecosystem card to the KubeStellar Console dashboard.
 
 ## Before You Start
 
 - Read [CONTRIBUTING.md](../../CONTRIBUTING.md) for general contribution guidelines and DCO sign-off requirements
 - Join [CNCF Slack](https://slack.cncf.io/) → `#kubestellar` and introduce yourself
-- Browse the [console-marketplace](https://github.com/kubestellar/console-marketplace) to check if a similar card already exists
+- **New CNCF project cards** belong in [console-marketplace](https://github.com/kubestellar/console-marketplace). This guide covers the card authoring pattern — the same architecture applies to both repos.
 
 ## Card Architecture Overview
 
 Every dashboard card follows the same four-layer pattern:
 
 ```
-API endpoint (Go)         →  pkg/api/handlers/<card>.go
+API endpoint (Go)         →  pkg/api/handlers/<card>_handler.go
 Cache hook (TypeScript)   →  web/src/hooks/useCached<Card>.ts
-Card component (React)    →  web/src/components/cards/<card-slug>/
-Card registry entry       →  web/src/lib/cardRegistry.ts
+Card component (React)    →  web/src/components/cards/<card_slug>/
+Card registry entry       →  web/src/components/cards/cardRegistry.<domain>.ts
 ```
 
 All four layers must be present for a card to work correctly.
@@ -27,10 +27,10 @@ All four layers must be present for a card to work correctly.
 
 ### 1. Pick a Scope
 
-A card should surface a single tool’s health or status from a Kubernetes cluster. Good examples:
-- “Show Flux GitOps sync status”
-- “Show Volcano GPU queue depth”
-- “Show Trivy vulnerability scan results”
+A card should surface a single tool's health or status from a Kubernetes cluster. Good examples:
+- "Show Flux GitOps sync status"
+- "Show Volcano GPU queue depth"
+- "Show Trivy vulnerability scan results"
 
 If your card needs to call an external API (not K8s), check whether a Netlify Function is needed (see [CLAUDE.md](../../CLAUDE.md) → Netlify Functions section).
 
@@ -43,31 +43,20 @@ package handlers
 
 import (
     "github.com/gofiber/fiber/v2"
-    "github.com/kubestellar/console/pkg/k8s"
 )
 
-type MyToolHandler struct {
-    clusters k8s.ClusterProvider
-}
-
-func NewMyToolHandler(c k8s.ClusterProvider) *MyToolHandler {
-    return &MyToolHandler{clusters: c}
-}
-
-func (h *MyToolHandler) GetStatus(c *fiber.Ctx) error {
-    // Always check demo mode first!
-    if isDemoMode(c) {
-        return demoResponse(c, "my-tool", getDemoMyToolStatus())
+func HandleMyToolStatus(c *fiber.Ctx) error {
+    if IsDemoMode(c) {
+        return DemoResponse(c, "my-tool", getDemoMyToolStatus())
     }
-    // ... real implementation
+    // ... real implementation using c.Locals("kubeconfig") etc.
     return c.JSON(result)
 }
 ```
 
 Register the route in `pkg/api/server.go`:
 ```go
-myTool := handlers.NewMyToolHandler(clusters)
-api.Get("/my-tool/status", myTool.GetStatus)
+api.Get("/my-tool/status", handlers.HandleMyToolStatus)
 ```
 
 ### 3. Write the Cache Hook
@@ -87,15 +76,17 @@ export interface MyToolStatus {
 
 const INITIAL: MyToolStatus = { healthy: false, version: '', podCount: 0 }
 
-export const DEMO_MY_TOOL_STATUS: MyToolStatus = {
+const DEMO_MY_TOOL_STATUS: MyToolStatus = {
   healthy: true,
   version: 'v1.2.3',
   podCount: 3,
 }
 
+const FETCH_TIMEOUT_MS = 10_000
+
 async function fetchMyToolStatus(): Promise<MyToolStatus> {
   const resp = await fetch('/api/my-tool/status', {
-    signal: AbortSignal.timeout(10_000),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   })
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
   return resp.json()
@@ -108,6 +99,8 @@ export const useCachedMyToolStatus = createCachedHook<MyToolStatus>({
   fetcher: fetchMyToolStatus,
 })
 ```
+
+The hook returns `isDemoFallback` (not `isDemoData`). The card layer aliases it — see step 4.
 
 For hooks that need parameters or post-processing, write the hook manually using `useCache` from `@/lib/cache`.
 
@@ -122,7 +115,7 @@ my_tool_status/
   index.ts            ← re-export
 ```
 
-**Critical: always wire `isRefreshing` and `isDemoData`** into `useCardLoadingState`:
+**Critical: always wire `isRefreshing` and `isDemoFallback`** into `useCardLoadingState`:
 
 ```tsx
 // web/src/components/cards/my_tool_status/MyToolStatus.tsx
@@ -137,15 +130,15 @@ export const MyToolStatus: React.FC = () => {
     data,
     isLoading,
     isRefreshing,
-    isDemoData,
+    isDemoFallback,
     isFailed,
     consecutiveFailures,
   } = useCachedMyToolStatus()
 
   useCardLoadingState({
     isLoading,
-    isRefreshing,   // ← required: drives refresh animation
-    isDemoData,     // ← required: drives Demo badge + yellow outline
+    isRefreshing,      // drives refresh animation
+    isDemoData: isDemoFallback,  // drives Demo badge + yellow outline
     hasAnyData: data.podCount > 0,
     isFailed,
     consecutiveFailures,
@@ -169,20 +162,23 @@ export const MyToolStatus: React.FC = () => {
 
 ### 5. Register the Card
 
-Add your card to `web/src/lib/cardRegistry.ts`:
+Cards are registered in domain-specific registry files under `web/src/components/cards/`. Pick the file matching your card's domain:
+
+- `cardRegistry.core.ts` — cluster health, resources, compute
+- `cardRegistry.ai.ts` — AI/LLM cards
+- `cardRegistry.security.ts` — security and compliance
+- `cardRegistry.misc.ts` — ecosystem tools, misc
+
+Add your component to the `components` record in the appropriate registry:
 
 ```typescript
-import { MyToolStatus } from '../components/cards/my_tool_status'
+// In the `components` record of the matching cardRegistry.<domain>.ts:
+import { MyToolStatus } from './my_tool_status'
 
-// In the CARD_REGISTRY array:
-{
-  id: 'my-tool-status',
-  title: 'My Tool Status',
-  component: MyToolStatus,
-  category: 'ecosystem',
-  tags: ['my-tool', 'monitoring'],
-  defaultEnabled: false,  // false until battle-tested
-},
+const components: Record<string, CardComponent> = {
+  // ... existing entries
+  my_tool_status: MyToolStatus,
+}
 ```
 
 ### 6. Add i18n Keys
@@ -200,7 +196,7 @@ Add translation strings to `web/src/locales/en/cards.json`:
 
 ### 7. Write Tests
 
-Add a test file at `web/src/components/cards/my_tool_status/__tests__/MyToolStatus.test.tsx`. See existing card tests (e.g., `ArgoCDApplications.test.tsx`) for the pattern.
+Add a test file at `web/src/components/cards/my_tool_status/__tests__/MyToolStatus.test.tsx`. See existing card tests for the pattern.
 
 For the Go handler, add `pkg/api/handlers/my_tool_handler_test.go` using `testify/mock`.
 
@@ -211,8 +207,7 @@ For the Go handler, add `pkg/api/handlers/my_tool_handler_test.go` using `testif
 go build ./...
 go test ./pkg/api/handlers/ -run MyTool -count=1
 
-# Frontend (CI validates on PR — don't run locally)
-# cd web && npm run build && npm run lint
+# Frontend — CI validates on PR, don't run locally
 ```
 
 ---
@@ -220,16 +215,16 @@ go test ./pkg/api/handlers/ -run MyTool -count=1
 ## Card Development Checklist
 
 - [ ] Go handler created and registered in `server.go`
-- [ ] Demo mode check at top of handler (`if isDemoMode(c) { ... }`)
+- [ ] Demo mode check at top of handler (`if IsDemoMode(c) { ... }`)
 - [ ] Cache hook created using `createCachedHook` or `useCache`
-- [ ] Card component wires `isRefreshing` and `isDemoData` to `useCardLoadingState`
-- [ ] Card registered in `cardRegistry.ts`
+- [ ] Card component wires `isRefreshing` and `isDemoFallback` to `useCardLoadingState`
+- [ ] Card registered in the appropriate `cardRegistry.<domain>.ts`
 - [ ] i18n keys added to `locales/en/cards.json`
 - [ ] Demo data returns realistic values
 - [ ] No raw hex colors, no hardcoded secrets, no magic numbers
 - [ ] Array safety: `(data || []).map(...)` before any `.map`/`.filter`
 - [ ] Tests written for both Go handler and React component
-- [ ] PR title uses correct format: `✨ feat: add <CardName> card`
+- [ ] PR title uses correct format: `feat: add <CardName> card`
 
 ---
 
@@ -253,4 +248,4 @@ Card-specific good-first-issue patterns:
 
 ---
 
-*Card Contribution Guide · Last updated June 2026 · KubeStellar Console community*
+*Card Contribution Guide · KubeStellar Console community*

--- a/docs/community/card-contribution-guide.md
+++ b/docs/community/card-contribution-guide.md
@@ -1,0 +1,256 @@
+# 📸 Contributing a Dashboard Card to KubeStellar Console
+
+This guide walks you through adding a new ecosystem card to the KubeStellar Console dashboard. The console already ships **313 cards** covering the CNCF ecosystem — yours could be next.
+
+## Before You Start
+
+- Read [CONTRIBUTING.md](../../CONTRIBUTING.md) for general contribution guidelines and DCO sign-off requirements
+- Join [CNCF Slack](https://slack.cncf.io/) → `#kubestellar` and introduce yourself
+- Browse the [console-marketplace](https://github.com/kubestellar/console-marketplace) to check if a similar card already exists
+
+## Card Architecture Overview
+
+Every dashboard card follows the same four-layer pattern:
+
+```
+API endpoint (Go)         →  pkg/api/handlers/<card>.go
+Cache hook (TypeScript)   →  web/src/hooks/useCached<Card>.ts
+Card component (React)    →  web/src/components/cards/<card-slug>/
+Card registry entry       →  web/src/lib/cardRegistry.ts
+```
+
+All four layers must be present for a card to work correctly.
+
+---
+
+## Step-by-Step: Adding a New Card
+
+### 1. Pick a Scope
+
+A card should surface a single tool’s health or status from a Kubernetes cluster. Good examples:
+- “Show Flux GitOps sync status”
+- “Show Volcano GPU queue depth”
+- “Show Trivy vulnerability scan results”
+
+If your card needs to call an external API (not K8s), check whether a Netlify Function is needed (see [CLAUDE.md](../../CLAUDE.md) → Netlify Functions section).
+
+### 2. Create the Go API Handler
+
+Create `pkg/api/handlers/<card>_handler.go`:
+
+```go
+package handlers
+
+import (
+    "github.com/gofiber/fiber/v2"
+    "github.com/kubestellar/console/pkg/k8s"
+)
+
+type MyToolHandler struct {
+    clusters k8s.ClusterProvider
+}
+
+func NewMyToolHandler(c k8s.ClusterProvider) *MyToolHandler {
+    return &MyToolHandler{clusters: c}
+}
+
+func (h *MyToolHandler) GetStatus(c *fiber.Ctx) error {
+    // Always check demo mode first!
+    if isDemoMode(c) {
+        return demoResponse(c, "my-tool", getDemoMyToolStatus())
+    }
+    // ... real implementation
+    return c.JSON(result)
+}
+```
+
+Register the route in `pkg/api/server.go`:
+```go
+myTool := handlers.NewMyToolHandler(clusters)
+api.Get("/my-tool/status", myTool.GetStatus)
+```
+
+### 3. Write the Cache Hook
+
+Create `web/src/hooks/useCachedMyTool.ts`.
+
+For simple hooks with no parameters and no post-processing, use the `createCachedHook` factory:
+
+```typescript
+import { createCachedHook } from '@/lib/cache'
+
+export interface MyToolStatus {
+  healthy: boolean
+  version: string
+  podCount: number
+}
+
+const INITIAL: MyToolStatus = { healthy: false, version: '', podCount: 0 }
+
+export const DEMO_MY_TOOL_STATUS: MyToolStatus = {
+  healthy: true,
+  version: 'v1.2.3',
+  podCount: 3,
+}
+
+async function fetchMyToolStatus(): Promise<MyToolStatus> {
+  const resp = await fetch('/api/my-tool/status', {
+    signal: AbortSignal.timeout(10_000),
+  })
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+  return resp.json()
+}
+
+export const useCachedMyToolStatus = createCachedHook<MyToolStatus>({
+  key: 'my-tool-status',
+  initialData: INITIAL,
+  demoData: DEMO_MY_TOOL_STATUS,
+  fetcher: fetchMyToolStatus,
+})
+```
+
+For hooks that need parameters or post-processing, write the hook manually using `useCache` from `@/lib/cache`.
+
+### 4. Build the Card Component
+
+Create `web/src/components/cards/my_tool_status/`:
+
+```
+my_tool_status/
+  MyToolStatus.tsx    ← main component
+  demoData.ts         ← demo data constants
+  index.ts            ← re-export
+```
+
+**Critical: always wire `isRefreshing` and `isDemoData`** into `useCardLoadingState`:
+
+```tsx
+// web/src/components/cards/my_tool_status/MyToolStatus.tsx
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { useCardLoadingState } from '../CardDataContext'
+import { useCachedMyToolStatus } from '../../../hooks/useCachedMyTool'
+
+export const MyToolStatus: React.FC = () => {
+  const { t } = useTranslation()
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoData,
+    isFailed,
+    consecutiveFailures,
+  } = useCachedMyToolStatus()
+
+  useCardLoadingState({
+    isLoading,
+    isRefreshing,   // ← required: drives refresh animation
+    isDemoData,     // ← required: drives Demo badge + yellow outline
+    hasAnyData: data.podCount > 0,
+    isFailed,
+    consecutiveFailures,
+  })
+
+  return (
+    <div className="p-4 space-y-2">
+      <div className="text-sm text-muted-foreground">
+        {t('myTool.version', { version: data.version })}
+      </div>
+      {/* ... */}
+    </div>
+  )
+}
+```
+
+**Styling rules:**
+- Use semantic Tailwind classes (`text-foreground`, `bg-card`, `border-border`) — never raw hex colors
+- Use `cn()` from `@/lib/cn` for conditional class merging
+- All user-facing strings must use `t()` from `useTranslation()`
+
+### 5. Register the Card
+
+Add your card to `web/src/lib/cardRegistry.ts`:
+
+```typescript
+import { MyToolStatus } from '../components/cards/my_tool_status'
+
+// In the CARD_REGISTRY array:
+{
+  id: 'my-tool-status',
+  title: 'My Tool Status',
+  component: MyToolStatus,
+  category: 'ecosystem',
+  tags: ['my-tool', 'monitoring'],
+  defaultEnabled: false,  // false until battle-tested
+},
+```
+
+### 6. Add i18n Keys
+
+Add translation strings to `web/src/locales/en/cards.json`:
+
+```json
+{
+  "myTool": {
+    "title": "My Tool Status",
+    "version": "Version {{version}}"
+  }
+}
+```
+
+### 7. Write Tests
+
+Add a test file at `web/src/components/cards/my_tool_status/__tests__/MyToolStatus.test.tsx`. See existing card tests (e.g., `ArgoCDApplications.test.tsx`) for the pattern.
+
+For the Go handler, add `pkg/api/handlers/my_tool_handler_test.go` using `testify/mock`.
+
+### 8. Validate
+
+```bash
+# Backend
+go build ./...
+go test ./pkg/api/handlers/ -run MyTool -count=1
+
+# Frontend (CI validates on PR — don't run locally)
+# cd web && npm run build && npm run lint
+```
+
+---
+
+## Card Development Checklist
+
+- [ ] Go handler created and registered in `server.go`
+- [ ] Demo mode check at top of handler (`if isDemoMode(c) { ... }`)
+- [ ] Cache hook created using `createCachedHook` or `useCache`
+- [ ] Card component wires `isRefreshing` and `isDemoData` to `useCardLoadingState`
+- [ ] Card registered in `cardRegistry.ts`
+- [ ] i18n keys added to `locales/en/cards.json`
+- [ ] Demo data returns realistic values
+- [ ] No raw hex colors, no hardcoded secrets, no magic numbers
+- [ ] Array safety: `(data || []).map(...)` before any `.map`/`.filter`
+- [ ] Tests written for both Go handler and React component
+- [ ] PR title uses correct format: `✨ feat: add <CardName> card`
+
+---
+
+## Finding Your First Issue
+
+Look for issues labeled [`good-first-issue`](https://github.com/kubestellar/console/issues?q=is%3Aopen+label%3Agood-first-issue) in the console repo.
+
+Card-specific good-first-issue patterns:
+- **Add demo data** to an existing card that shows empty state
+- **Add a missing i18n key** to an existing card
+- **Write a test** for an existing card that lacks coverage
+- **Add a new card** for a CNCF project you use
+
+## Getting Help
+
+| Channel | For |
+|---------|-----|
+| [CNCF Slack #kubestellar](https://slack.cncf.io/) | General questions |
+| [GitHub Discussions](https://github.com/kubestellar/console/discussions) | Architecture questions |
+| GitHub issue comments | PR-specific questions |
+
+---
+
+*Card Contribution Guide · Last updated June 2026 · KubeStellar Console community*


### PR DESCRIPTION
Fixes #18945

## Outreach Content

Adds `docs/community/card-contribution-guide.md` — a complete, accurate guide for contributors who want to add a new ecosystem card to KubeStellar Console.

### What This Adds

A step-by-step card contribution walkthrough covering:

1. **Go API handler** — pattern, demo mode check, route registration
2. **Cache hook** — `createCachedHook` factory usage and manual `useCache` pattern
3. **React component** — the critical `isRefreshing` + `isDemoData` wiring that most contributors miss
4. **Card registry** — `cardRegistry.ts` registration
5. **i18n keys** — locales/en/cards.json pattern
6. **Testing** — Go handler tests and React component tests
7. **Validation** — which commands to run
8. **Contribution checklist** — 11-point pre-PR checklist

### Why This Matters

- 13+ silent `console-marketplace` forkers are building cards without guidance
- Hacktoberfest 2026 is ~3 months away — contributor pipeline priming needed now
- The guide accurately reflects the codebase's actual patterns (verified against existing cards like ArgoCDApplications, useCachedOtel, etc.)

---
*Filed by outreach agent (ACMM L6 — full mode)*