### PR TITLE
[scanner] fix: add Crossplane, Dapr, and Knative CNCF graduated community outreach

### DIFF
--- a/community/outreach/knative-partnership.md
+++ b/community/outreach/knative-partnership.md
@@ -1,0 +1,230 @@
+# Knative Community Partnership Plan
+
+**Status**: Draft  
+**Owner**: KubeStellar Console team  
+**Target audience**: Knative project (CNCF Graduated, knative/serving ~5k★), serverless-on-Kubernetes community  
+**Related Issue**: #18942
+
+## Executive Summary
+
+KubeStellar Console ships a Knative status card (`knative_status`) surfacing Knative Serving and Eventing health across clusters. Knative is a CNCF Graduated project with a large practitioner community. **Zero engagement has been made** with the Knative community about this integration. This document outlines a partnership strategy to position KubeStellar Console as the multi-cluster monitoring frontend for Knative deployments.
+
+## What We Have Built
+
+KubeStellar Console Knative integration shipped in v0.2 and matured in v0.3:
+
+| Feature | Description |
+|---------|-------------|
+| Knative Serving Status Card | Service readiness, route configuration, revision health across clusters |
+| Knative Eventing Card | Broker, channel, and trigger status with event flow visibility |
+| Multi-Cluster Knative Overview | Cross-cluster Knative control plane health and service count |
+| Cold-Start Latency Monitoring | Track serverless function cold-start performance |
+
+## Why Partner with Knative
+
+| Factor | Impact |
+|--------|--------|
+| Knative CNCF Graduated | CNCF co-marketing channels now available |
+| Serverless-on-K8s adoption | Platform engineering teams deploying serverless workloads |
+| Console already ships Knative card | Integration is production-ready — needs community awareness |
+| Multi-cluster visibility gap | Knative community lacks multi-cluster monitoring tools |
+| KubeCon 2026 serverless track | High-visibility event for Knative-related content |
+
+## Proposed Outreach Activities
+
+### Phase 1: Community Introduction (Weeks 1-4)
+
+**Objective**: Make the Knative community aware of the console integration.
+
+1. **GitHub Discussion** (`knative/serving`)
+   - Title: "Ecosystem integration: KubeStellar Console monitors Knative Serving/Eventing across clusters"
+   - Content: Integration overview, screenshots, demo link
+   - Owner: @clubanderson
+
+2. **Knative Slack Post** (`#general`)
+   - Message: "Console integration exists for multi-cluster Knative monitoring — feedback wanted"
+   - Include: Screenshots of Knative cards, link to console.kubestellar.io demo
+   - Owner: @clubanderson
+
+3. **Knative Ecosystem Page PR**
+   - Action: Add KubeStellar Console to Knative docs
+   - Link: integration docs + console repo
+   - Owner: Console team
+
+4. **Demo Video** (2 minutes)
+   - Title: "Monitoring 50 Knative Services across 10 clusters with KubeStellar Console"
+   - Platform: YouTube + Knative community channels
+   - Owner: Video team
+
+**Success metric**: ≥15 upvotes/comments on GitHub Discussion, ≥1 Knative maintainer responds positively.
+
+### Phase 2: Content Marketing (Weeks 5-12)
+
+**Objective**: Publish technical content that drives Knative user adoption of the console.
+
+1. **Blog Post**: "Multi-Cluster Serverless Visibility: Knative Serving + KubeStellar Console"
+   - Platform: Dev.to + kubestellar.io blog
+   - Content: Walkthrough of deploying Knative services and monitoring with console
+   - Co-authoring: Invite Knative maintainer
+   - Owner: @clubanderson
+
+2. **console-kb Mission**: "Investigating Cold-Start Latency in Knative Serving"
+   - Platform: console-kb mission catalog
+   - Content: Step-by-step troubleshooting guide for Knative performance issues
+   - Owner: Mission catalog team
+
+3. **Integration Guide**
+   - Platform: docs.kubestellar.io
+   - Content: Dedicated Knative integration page with setup and troubleshooting
+   - Owner: Docs team
+
+4. **Knative Community Newsletter Submission**
+   - Submit: Console integration announcement
+   - Owner: Content team
+
+**Success metric**: ≥800 blog post views in first month, ≥10 console installs with Knative integration active.
+
+### Phase 3: Event Presence (Weeks 13-24)
+
+**Objective**: Establish console as the Knative monitoring solution at KubeCon.
+
+1. **KubeCon NA 2026 Serverless Track Talk**
+   - Title: "Multi-cluster serverless observability: Knative + KubeStellar Console"
+   - Format: 30-minute session
+   - Co-presenting: @clubanderson + Knative maintainer (if available)
+   - Owner: @clubanderson
+
+2. **KubeCon Booth Demo**
+   - Demo: Live Knative service deployment and monitoring across clusters
+   - Owner: Booth team
+
+3. **Knative Community Meeting Demo**
+   - Demo: Console Knative cards and multi-cluster visibility
+   - Duration: 15 minutes
+   - Owner: @clubanderson
+
+4. **Serverless Practitioners Meetup Co-location**
+   - Co-hosting: Knative community + KubeStellar
+   - Topic: "Serverless at scale on Kubernetes"
+   - Owner: Community team
+
+**Success metric**: ≥1 accepted talk or demo slot, ≥40 booth visitors mention Knative use case.
+
+### Phase 4: Continuous Engagement (Ongoing)
+
+**Objective**: Make console a first-class citizen in the Knative ecosystem.
+
+1. **Knative Community Call Participation** (Quarterly)
+   - Demo new serverless monitoring features
+   - Owner: @clubanderson
+
+2. **Knative Slack Presence** (Weekly monitoring)
+   - Respond to monitoring questions in `#general` with console resources
+   - Owner: Community team
+
+3. **Joint Webinar** (Q4 2026)
+   - Title: "Serverless best practices: Knative deployment and monitoring"
+   - Co-hosting: Marketing + Knative maintainer
+   - Owner: Marketing team
+
+4. **ADOPTERS.md Entry** (One-time)
+   - Add Knative as ecosystem adopter with integration details
+   - Owner: Console team
+
+**Success metric**: Console mentioned in ≥1 Knative issue or discussion per month.
+
+## Key Messaging
+
+**For Knative users:**
+> "Monitor Knative Serving and Eventing across all your clusters without context-switching. See service health, cold-start latency, and event flow in one dashboard."
+
+**For serverless teams:**
+> "Knative handles serverless runtime. KubeStellar Console handles multi-cluster visibility. Together, you get end-to-end observability for serverless-on-Kubernetes."
+
+**For platform engineering teams:**
+> "See Knative service status, revision health, and eventing broker status across 20+ clusters in real-time — no SSH required."
+
+## Resources Required
+
+| Item | Estimate | Notes |
+|------|----------|-------|
+| Blog post authoring | 14 hrs | Technical writing + screenshots + review |
+| Demo video production | 8 hrs | Scripting + recording + editing |
+| console-kb mission creation | 10 hrs | YAML + docs + testing |
+| KubeCon travel | $3000 | Airfare + hotel for 1 speaker |
+| Booth materials | $400 | Knative-specific demo setup + one-pagers |
+| Community management | 3 hrs/week | Slack monitoring, GitHub discussions |
+
+## Success Metrics (6-month horizon)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Knative project links back to console | ≥1 | GitHub ecosystem page or blog |
+| Knative users open PRs/issues | ≥5 | GitHub issue/PR tags mentioning Knative use case |
+| console-kb mission runs | ≥15 | Analytics tracking Knative mission completions |
+| CNCF Slack mentions | ≥8 | `#knative` posts referencing console |
+| Event talk acceptance | ≥1 | KubeCon NA 2026 or Knative community call |
+| Console installs with Knative active | ≥20 | Analytics tracking Knative CRD detection |
+
+## Next Steps
+
+1. **This week**: Open GitHub Discussion in knative/serving
+2. **Week 2**: Post introduction in Knative Slack #general with screenshots
+3. **Week 3**: Submit ecosystem page PR to Knative docs
+4. **Week 4**: Draft blog post and submit KubeCon CFP
+
+## Appendix: Sample GitHub Discussion Post
+
+**Repository**: `knative/serving`
+
+**Title**: Ecosystem integration: KubeStellar Console monitors Knative Serving/Eventing across clusters
+
+**Content**:
+
+> Hey Knative community 👋
+>
+> KubeStellar Console (https://github.com/kubestellar/console) ships production-ready Knative monitoring cards — thought this might be useful for folks running serverless workloads across multiple clusters.
+>
+> **What it does**: Multi-cluster visibility for Knative Serving (service health, revision status, route config, cold-start latency) and Eventing (broker/channel/trigger status, event flow) — all in one dashboard.
+>
+> **What we built**:
+> - Knative Serving status card (service readiness, revision health)
+> - Knative Eventing card (broker/channel/trigger monitoring)
+> - Multi-cluster overview (cross-cluster Knative control plane health)
+> - Cold-start latency tracking
+>
+> **Availability**: Open source, works with any kubeconfig contexts where Knative is installed. Also has a hosted demo mode at console.kubestellar.io if you want to see it without connecting clusters.
+>
+> We'd love feedback from the Knative community — especially if you're managing 10+ clusters with serverless workloads and have ideas for what monitoring views would be most useful.
+>
+> **Screenshots**: [link to screenshots in issue/PR]  
+> **Repo**: https://github.com/kubestellar/console  
+> **Integration docs**: https://docs.kubestellar.io/community/partners/knative
+>
+> Happy to answer questions here or on our Slack (#kubestellar-dev in CNCF workspace).
+
+## Appendix: Sample Knative Slack Post
+
+**Channel**: `#general`
+
+**Message**:
+
+> Hey Knative community 👋
+>
+> We've shipped Knative Serving & Eventing monitoring cards in KubeStellar Console — multi-cluster visibility for serverless workloads on Kubernetes.
+>
+> **What it monitors**: Service health, revision status, cold-start latency, broker/channel/trigger status across all your clusters in one dashboard.
+>
+> **Open source**: Works with any kubeconfig contexts. Demo mode available at console.kubestellar.io (no cluster connection needed).
+>
+> We'd love feedback on what monitoring views would be most helpful for Knative users managing multi-cluster deployments.
+>
+> Repo: https://github.com/kubestellar/console  
+> Integration docs: https://docs.kubestellar.io/community/partners/knative
+>
+> Questions? Happy to chat here or in #kubestellar-dev!
+
+---
+
+**Fixes**: #18942  
+**Last updated**: June 2026


### PR DESCRIPTION
Fixes #18820
Fixes #18821
Fixes #18942

Adds community outreach partnership plans for three CNCF Graduated projects:

## Changes

### Knative Partnership Plan (NEW)
- Created `community/outreach/knative-partnership.md`
- Comprehensive 4-phase outreach strategy for Knative (CNCF Graduated, 5k★)
- Leverages existing Knative status card shipped in console v0.2+
- Includes GitHub Discussion templates, Slack messaging, KubeCon presence plan
- Proposes console-kb mission: "Investigating Cold-Start Latency in Knative Serving"

### Crossplane Partnership Plan (EXISTING - referenced)
- Plan already exists at `community/outreach/crossplane-partnership.md`
- Addresses issue #18820 (Crossplane CNCF Graduated, 9k★)
- Proposes validation-first approach before building integration

### Dapr Partnership Plan (EXISTING - referenced)
- Plan already exists at `community/outreach/dapr-partnership.md`
- Addresses issue #18821 (Dapr CNCF Graduated, 23k★)
- Focuses on multi-cluster sidecar health monitoring opportunity

## Impact

All three projects are CNCF Graduated with significant community reach:
- **Crossplane**: 9k+ stars, platform engineering audience
- **Dapr**: 23k+ stars, distributed app runtime community
- **Knative**: 5k+ stars, serverless-on-Kubernetes practitioners

These partnership plans provide a structured approach to:
1. Community validation and engagement
2. Content marketing and co-authoring
3. Event presence (KubeCon 2026, community calls)
4. Continuous ecosystem partnership

The console already ships Knative integration (v0.2+) — this PR formalizes the outreach strategy to make the Knative community aware of the existing capability. Crossplane and Dapr plans take a validation-first approach before committing engineering resources.