### PR TITLE
[scanner] fix: add vCluster and quantum computing community outreach

### DIFF
--- a/community/outreach/quantum-computing-partnership.md
+++ b/community/outreach/quantum-computing-partnership.md
@@ -1,0 +1,211 @@
+# Quantum Computing Community Outreach Plan
+
+**Status**: Draft  
+**Owner**: KubeStellar Console team  
+**Target audience**: IBM Quantum community, Qiskit community (~5k★), quantum computing research institutions  
+**Related Issue**: #18944
+
+## Executive Summary
+
+KubeStellar Console ships a **quantum computing card** (`quantum-kc-demo`) that bridges Kubernetes cluster management with IBM Quantum workloads — surfacing qubit grid status, QASM circuit visualization, quantum system auth status, and a histogram card. This appears to be the **only open-source Kubernetes console with native quantum computing integration**.
+
+The IBM Quantum and Qiskit communities are completely unaware this exists.
+
+## What We Have Built
+
+| Feature | Description | Availability |
+|---------|-------------|-------------|
+| Quantum system status card | Qubit grid visualization, system health, auth status | v0.2+ |
+| QASM circuit viewer | Quantum circuit visualization in the console | v0.2+ |
+| Quantum job histogram | Job execution results histogram | v0.2+ |
+| Multi-cluster quantum view | Cross-cluster quantum workload monitoring | v0.3+ |
+| Demo mode support | Try quantum cards without IBM Quantum account | v0.3+ |
+
+## Why This Story Matters
+
+| Factor | Impact |
+|--------|--------||
+| Only K8s console with quantum integration | Genuinely novel story — no competitors |
+| IBM Quantum expanded access tiers | More teams running quantum workloads on K8s infrastructure |
+| Hybrid classical/quantum computing emerging | HPC/research use case gaining traction |
+| CNCF blog + KubeCon opportunity | High media pickup potential |
+| Quantum computing is hot topic | 2026 is the year of practical quantum applications |
+
+## Proposed Outreach Activities
+
+### Phase 1: Community Introduction (Weeks 1-4)
+
+**Objective**: Make the quantum computing community aware of this integration.
+
+1. **Qiskit Community Post** (Slack/Discord)
+   - Message: "The world's first quantum-aware Kubernetes console"
+   - Content: Integration overview, screenshots, link to console demo
+   - Owner: Console team
+
+2. **Blog Post**: "The World's First Quantum-Aware Kubernetes Console: How KubeStellar Console Bridges Qubits and Clusters"
+   - Platform: Dev.to + kubestellar.io blog
+   - Content: Full technical walkthrough with quantum circuit examples
+   - Co-authoring: Invite IBM Quantum researcher or Qiskit maintainer
+   - Owner: Content team
+
+3. **IBM Quantum Network Outreach**
+   - Action: Reach out to IBM Quantum Network partners program
+   - Content: Integration overview and partnership proposal
+   - Owner: Partnerships team
+
+4. **Demo Video** (5 minutes)
+   - Title: "Managing Quantum Computing Workloads on Kubernetes with KubeStellar Console"
+   - Platform: YouTube + quantum computing community channels
+   - Owner: Video team
+
+**Success metric**: ≥30 upvotes/comments on Qiskit Slack, ≥1 IBM Quantum team member responds positively.
+
+### Phase 2: Content Marketing (Weeks 5-12)
+
+**Objective**: Publish high-quality technical content that positions this as a serious research tool.
+
+1. **Integration Guide**
+   - Platform: docs.kubestellar.io
+   - Content: Dedicated quantum computing integration page
+   - Owner: Docs team
+
+2. **Research Paper/Technical Report**
+   - Title: "Kubernetes as the Control Plane for Hybrid Classical-Quantum Computing Workloads"
+   - Platform: arXiv + CNCF blog
+   - Content: Architecture, use cases, performance analysis
+   - Co-authoring: IBM Research or university quantum computing lab
+   - Owner: Research team
+
+3. **Case Study**: "How we debugged a failing quantum circuit job in Kubernetes"
+   - Platform: Medium
+   - Content: Real-world troubleshooting story
+   - Owner: User advocacy team
+
+4. **console-kb Mission**: "Debugging a failing quantum circuit job in Kubernetes"
+   - Platform: console-kb repository
+   - Content: Step-by-step guided mission walkthrough
+   - Owner: Mission catalog team
+
+**Success metric**: ≥2000 blog post views in first month, ≥1 academic citation or mention.
+
+### Phase 3: Event Presence (Weeks 13-24)
+
+**Objective**: Establish this as a serious research contribution at major conferences.
+
+1. **KubeCon NA 2026 CFP Submission**
+   - Title: "From Containers to Qubits: Kubernetes as the Control Plane for Quantum Computing Workloads"
+   - Format: 30-minute talk
+   - Co-presenting: Console team + IBM Research or quantum-kc-demo maintainers
+   - Owner: Community team
+
+2. **IEEE Quantum Week 2026 Submission**
+   - Title: "Orchestrating Hybrid Classical-Quantum Workloads with Kubernetes"
+   - Format: Research paper or poster
+   - Co-authoring: IBM Research or university partner
+   - Owner: Research team
+
+3. **KubeCon Booth Demo**
+   - Demo: Live quantum circuit visualization and job monitoring
+   - Owner: Booth team
+
+4. **CNCF Blog Feature**
+   - Title: "Managing Quantum Workloads with Kubernetes: A Console Integration Story"
+   - Platform: CNCF official blog
+   - Owner: CNCF liaison
+
+**Success metric**: ≥1 accepted talk or paper, ≥50 booth visitors mention quantum use case.
+
+### Phase 4: Continuous Engagement (Ongoing)
+
+**Objective**: Build long-term relationships with the quantum computing community.
+
+1. **Qiskit Community Calls** (Quarterly)
+   - Demo new quantum card features
+   - Owner: Community team
+
+2. **IBM Quantum Network Membership**
+   - Action: Apply for IBM Quantum Network membership
+   - Owner: Partnerships team
+
+3. **University Partnerships**
+   - Action: Reach out to quantum computing labs at MIT, Stanford, Caltech
+   - Content: Offer console as research tool for quantum workload management
+   - Owner: Academic partnerships team
+
+4. **Joint Webinar** (Q4 2026)
+   - Title: "Hybrid classical-quantum computing on Kubernetes: best practices"
+   - Co-hosting: Marketing + IBM Quantum or Qiskit team
+   - Owner: Marketing team
+
+**Success metric**: ≥2 university labs adopt console for quantum research, ≥1 academic paper mentions console.
+
+## Key Messaging
+
+**For quantum researchers:**
+> "You're already using Kubernetes for your classical HPC workloads. KubeStellar Console is the first Kubernetes dashboard that also understands your quantum circuits — qubit status, circuit visualization, and job monitoring in one place."
+
+**For hybrid computing teams:**
+> "Manage both classical containers and quantum circuits from a single dashboard. See your Kubernetes clusters and IBM Quantum systems side-by-side."
+
+**For the CNCF community:**
+> "This is what the future of computing looks like: Kubernetes orchestrating not just containers, but qubits. KubeStellar Console is leading the way."
+
+## Resources Required
+
+| Item | Estimate | Notes |
+|------|----------|-------|
+| Blog post authoring | 16 hrs | Technical writing + quantum circuit diagrams + review |
+| Research paper authoring | 40 hrs | Literature review + experiments + writing |
+| Demo video production | 12 hrs | Complex technical content + animation |
+| KubeCon travel (co-talk) | $3000 | Airfare + hotel for 1 speaker |
+| IEEE Quantum Week registration | $1000 | Conference registration + travel |
+| Community management | 2 hrs/week | Slack monitoring, Qiskit community engagement |
+
+## Success Metrics (6-month horizon)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Qiskit/IBM Quantum mentions console | ≥2 | Slack posts, blog posts, or GitHub |
+| Academic citations | ≥1 | arXiv or IEEE papers |
+| CNCF blog feature | ≥1 | CNCF official blog |
+| KubeCon/IEEE Quantum Week acceptance | ≥1 | Conference talk or paper |
+| University lab adoptions | ≥2 | Direct outreach tracking |
+| Blog post views | ≥3000 | Analytics tracking |
+
+## Next Steps
+
+1. **This week**: Post introduction in Qiskit community Slack/Discord
+2. **Week 2**: Reach out to IBM Quantum Network partners program
+3. **Week 3**: Draft blog post with quantum circuit examples
+4. **Week 4**: Submit KubeCon NA 2026 CFP
+5. **Week 6**: Submit IEEE Quantum Week 2026 CFP (if deadline allows)
+6. **Week 8**: File console-kb mission for quantum debugging
+
+## Appendix: Sample Qiskit Community Slack Post
+
+**Channel**: Qiskit Slack general or #kubernetes (if exists)
+
+**Message**:
+
+> Hey Qiskit community 👋
+>
+> We just shipped what we believe is the **world's first quantum-aware Kubernetes console** — KubeStellar Console now has native IBM Quantum integration.
+>
+> **What it does**: 
+> • Qubit grid visualization showing system status
+> • QASM circuit viewer directly in the dashboard
+> • Quantum job histogram for execution results
+> • Multi-cluster view showing both K8s clusters and quantum systems
+>
+> **Why this matters**: If you're running hybrid classical-quantum workloads where Kubernetes orchestrates your classical compute and IBM Quantum runs your circuits, this gives you unified visibility.
+>
+> **Availability**: Open source at https://github.com/kubestellar/console. Also has a demo mode at console.kubestellar.io if you want to see the quantum cards without connecting to IBM Quantum.
+>
+> We'd love feedback from the quantum computing community — especially researchers running quantum workloads on K8s infrastructure.
+>
+> Happy to answer questions here or on our Slack (#kubestellar-dev in CNCF workspace).
+
+---
+
+**Fixes**: #18944  
+**Last updated**: June 2026

--- a/community/outreach/vcluster-partnership.md
+++ b/community/outreach/vcluster-partnership.md
@@ -1,0 +1,193 @@
+# vCluster Community Partnership Plan
+
+**Status**: Draft  
+**Owner**: KubeStellar Console team  
+**Target audience**: vCluster / Loft Labs community (loft-sh/vcluster ~6k★), multi-tenancy Kubernetes practitioners  
+**Related Issue**: #18947
+
+## Executive Summary
+
+KubeStellar Console ships a VCluster status card showing virtual cluster health and lifecycle across host clusters. vCluster is one of the most popular tools for Kubernetes multi-tenancy, with 6k+ stars and an active commercial ecosystem (Loft Labs). Zero engagement with the vCluster community has occurred.
+
+## What We Have Built
+
+| Feature | Description | Availability |
+|---------|-------------|-------------|
+| VCluster status card | Virtual cluster health, lifecycle, resource usage | v0.2+ |
+| Multi-cluster vCluster view | Cross-cluster vCluster deployment health | v0.3+ |
+| vCluster resource monitoring | CPU/memory usage per virtual cluster | v0.3+ |
+| Demo mode support | Try vCluster monitoring without cluster connection | v0.3+ |
+
+## Why Partner with vCluster Community
+
+| Factor | Impact |
+|--------|--------|
+| vCluster v0.20+ added multi-cluster federation | Direct alignment with KubeStellar's use case |
+| Loft Labs active partner ecosystem program | Promotes integrations in newsletter |
+| 6k+ GitHub stars with commercial backing | Strong community + enterprise reach |
+| "Multi-tenancy meets multi-cluster" narrative | Compelling story: vCluster isolation + Console visibility |
+
+## Proposed Outreach Activities
+
+### Phase 1: Community Introduction (Weeks 1-4)
+
+**Objective**: Make the vCluster community aware of the console integration.
+
+1. **GitHub Discussion** (`loft-sh/vcluster`)
+   - Title: "KubeStellar Console ships a vCluster monitoring card"
+   - Content: Integration overview, screenshots, link to console demo
+   - Owner: Console team
+
+2. **Loft Labs Ecosystem Submission**
+   - Platform: Loft Labs ecosystem integrations page
+   - Content: Integration listing with screenshots
+   - Owner: Partnerships team
+
+3. **Blog Post**: "Virtual Clusters at Scale: Managing vCluster fleets with KubeStellar Console"
+   - Platform: Dev.to + kubestellar.io blog
+   - Content: Full walkthrough with multi-cluster vCluster management
+   - Owner: Content team
+
+4. **Demo Video** (3 minutes)
+   - Title: "Monitor 50 vClusters across 10 host clusters with KubeStellar Console"
+   - Platform: YouTube + vCluster community channels
+   - Owner: Video team
+
+**Success metric**: ≥15 upvotes/comments on GitHub Discussion, ≥1 Loft Labs team member engagement.
+
+### Phase 2: Content Marketing (Weeks 5-12)
+
+**Objective**: Drive adoption through technical content and DevRel collaboration.
+
+1. **Integration Guide**
+   - Platform: docs.kubestellar.io
+   - Content: Dedicated vCluster integration page
+   - Owner: Docs team
+
+2. **Case Study**: "How we manage 200 vClusters for multi-tenant SaaS with KubeStellar Console"
+   - Platform: Medium
+   - Content: Real-world deployment story
+   - Owner: User advocacy team
+
+3. **Loft Labs DevRel Collaboration**
+   - Action: Reach out to Loft Labs DevRel team for co-marketing
+   - Format: Joint webinar or blog post
+   - Owner: Community team
+
+4. **vCluster Community Meetup Demo** (Next available slot)
+   - Demo: Console vCluster cards and multi-cluster monitoring
+   - Duration: 15 minutes
+   - Owner: Community team
+
+**Success metric**: ≥500 blog post views in first month, ≥1 Loft Labs newsletter mention.
+
+### Phase 3: Event Presence (Weeks 13-24)
+
+**Objective**: Establish console as the vCluster monitoring solution at KubeCon.
+
+1. **KubeCon NA 2026 Co-Talk Proposal**
+   - Title: "Multi-tenancy meets multi-cluster: vCluster isolation + KubeStellar visibility"
+   - Format: 30-minute session
+   - Co-presenting: Console team + Loft Labs DevRel
+   - Owner: Community team
+
+2. **KubeCon Booth Demo**
+   - Demo: Live vCluster fleet management with console monitoring
+   - Owner: Booth team
+
+3. **vCluster Office Hours** (KubeCon)
+   - Session: "Ask us anything: vCluster + KubeStellar Console"
+   - Duration: 30 minutes
+   - Co-hosting: Console team + Loft Labs team (if available)
+
+**Success metric**: ≥1 accepted talk or demo slot, ≥40 booth visitors mention vCluster use case.
+
+### Phase 4: Continuous Engagement (Ongoing)
+
+**Objective**: Make console a first-class citizen in the vCluster ecosystem.
+
+1. **vCluster Slack Presence** (Weekly monitoring)
+   - Monitor vCluster Slack for monitoring questions
+   - Provide console screenshots and links
+   - Owner: Community team
+
+2. **GitHub Issue Monitoring** (Daily)
+   - Tag vCluster monitoring issues with console resource links
+   - Owner: Community team
+
+3. **Quarterly Updates**
+   - Post new vCluster features to community channels
+   - Owner: Product team
+
+4. **Joint Webinar** (Q4 2026)
+   - Title: "vCluster best practices: isolation, federation, and monitoring"
+   - Co-hosting: Marketing + Loft Labs
+   - Owner: Marketing team
+
+**Success metric**: Console mentioned in ≥1 vCluster issue or discussion per month.
+
+## Key Messaging
+
+**For vCluster users:**
+> "You already trust vCluster for multi-tenancy. KubeStellar Console gives you multi-cluster visibility for virtual cluster health, resource usage, and lifecycle — all in one dashboard."
+
+**For multi-tenant platform teams:**
+> "vCluster handles tenant isolation. KubeStellar Console handles cross-cluster monitoring. Together, you get end-to-end visibility for virtual cluster fleets."
+
+**For SaaS platform engineers:**
+> "See all your vClusters across all your host clusters without context-switching. One dashboard, real-time updates, fleet-wide health monitoring."
+
+## Resources Required
+
+| Item | Estimate | Notes |
+|------|----------|-------|
+| Blog post authoring | 10 hrs | Technical writing + screenshots + review |
+| Demo video production | 8 hrs | Scripting + recording + editing |
+| DevRel outreach | 4 hrs | Email coordination with Loft Labs team |
+| KubeCon travel (co-talk) | $3000 | Airfare + hotel for 1 speaker |
+| Community management | 2 hrs/week | Slack monitoring, GitHub Discussions |
+
+## Success Metrics (6-month horizon)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| vCluster repo mentions console | ≥1 | GitHub discussions or ecosystem page |
+| Loft Labs newsletter features console | ≥1 | Newsletter tracking |
+| vCluster users open PRs/issues | ≥3 | GitHub issue/PR tags mentioning vCluster |
+| Blog post views | ≥1500 | Analytics tracking |
+| Console installs with vCluster active | ≥15 | Analytics tracking vCluster CRD detection |
+
+## Next Steps
+
+1. **This week**: Open GitHub Discussion in loft-sh/vcluster
+2. **Week 2**: Submit to Loft Labs ecosystem integrations
+3. **Week 3**: Draft blog post
+4. **Week 4**: Reach out to Loft Labs DevRel team
+
+## Appendix: Sample GitHub Discussion Post
+
+**Repository**: `loft-sh/vcluster`
+
+**Title**: KubeStellar Console ships a vCluster monitoring card
+
+**Message**:
+
+> Hey vCluster community 👋
+>
+> KubeStellar Console ships a vCluster monitoring card with multi-cluster visibility — thought this might be useful for folks running virtual cluster fleets.
+>
+> **What it does**: Real-time visibility for vCluster health, lifecycle status, and resource usage across multiple host clusters — all in one dashboard (no context switching).
+>
+> **Availability**: Open source, works with any kubeconfig contexts where vCluster is installed. Also has a hosted demo mode at console.kubestellar.io if you want to see it without connecting clusters.
+>
+> We'd love feedback from the vCluster community — especially if you're managing 10+ virtual clusters and have ideas for what monitoring views would be most useful.
+>
+> Repo: https://github.com/kubestellar/console  
+> Integration docs: https://docs.kubestellar.io/community/partners/vcluster
+>
+> Happy to answer questions here or on our Slack (#kubestellar-dev in CNCF workspace).
+
+---
+
+**Fixes**: #18947  
+**Last updated**: June 2026


### PR DESCRIPTION
Fixes #18815
Fixes #18947
Fixes #18944

Adds outreach content for AI and container ecosystem projects:

- **vCluster partnership** (#18947): Community outreach plan for Loft Labs vCluster integration, targeting the 6k+ star multi-tenancy community with co-marketing opportunities
- **Quantum computing partnership** (#18944): First-of-its-kind quantum-aware Kubernetes console story targeting IBM Quantum, Qiskit community, and research institutions

Note: The Ollama partnership content (#18815) already exists in the repository at `community/outreach/ollama-partnership.md`.

All content follows the established outreach template with executive summaries, phased outreach plans, success metrics, and community engagement strategies.