### PR TITLE
[scanner] fix: resolve Auto-QA color consistency issues

### DIFF
--- a/web/src/components/mission-control/fixer-definition-panel/TargetClusterSelector.tsx
+++ b/web/src/components/mission-control/fixer-definition-panel/TargetClusterSelector.tsx
@@ -87,7 +87,7 @@ export function TargetClusterSelector({ selected, onChange }: TargetClusterSelec
       <label className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
         Target Clusters
       </label>
-      <p className="text-xs text-muted-foreground/60 mt-0.5 mb-1">
+      <p className="text-xs text-muted-foreground mt-0.5 mb-1">
         {isAllSelected
           ? 'All clusters — AI will analyze your full fleet'
           : `${selected.length} cluster${selected.length === 1 ? '' : 's'} selected — AI analysis scoped to these`}
@@ -101,7 +101,7 @@ export function TargetClusterSelector({ selected, onChange }: TargetClusterSelec
           <button
             ref={triggerRef}
             type="button"
-            className="flex w-full items-center justify-between gap-2 rounded-md text-left text-sm text-muted-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            className="flex w-full items-center justify-between gap-2 rounded-md text-left text-sm text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
             onClick={toggleDropdown}
             onKeyDown={handleTriggerKeyDown}
             aria-controls={dropdownId}
@@ -141,7 +141,7 @@ export function TargetClusterSelector({ selected, onChange }: TargetClusterSelec
             })}
             <button
               type="button"
-              className="text-[10px] text-muted-foreground/50 hover:text-foreground"
+              className="text-[10px] text-muted-foreground hover:text-foreground"
               onClick={() => onChange([])}
             >
               Clear

--- a/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
+++ b/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
@@ -91,7 +91,7 @@ export function OpsGenieNotificationSettings({
       {testResult && testResult.type === 'opsgenie' && (
         <div
           className={`flex items-start gap-2 p-3 rounded-lg ${
-            testResult.success ? 'bg-green-500/20 border border-green-500/20' : 'bg-red-500/20 border border-red-500/20'
+            testResult.success ? 'bg-green-500/10 border border-green-500/20' : 'bg-red-500/10 border border-red-500/20'
           }`}
         >
           {testResult.success ? (

--- a/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
+++ b/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
@@ -91,7 +91,7 @@ export function PagerDutyNotificationSettings({
       {testResult && testResult.type === 'pagerduty' && (
         <div
           className={`flex items-start gap-2 p-3 rounded-lg ${
-            testResult.success ? 'bg-green-500/20 border border-green-500/20' : 'bg-red-500/20 border border-red-500/20'
+            testResult.success ? 'bg-green-500/10 border border-green-500/20' : 'bg-red-500/10 border border-red-500/20'
           }`}
         >
           {testResult.success ? (


### PR DESCRIPTION
Fixes #18832

Replaces inconsistent raw color values with semantic Tailwind tokens across multiple components. This PR addresses color consistency issues flagged by Auto-QA.

## Changes

### TargetClusterSelector.tsx
- Replaced `/60` opacity variant with semantic `text-muted-foreground` (line 92)
- Replaced `/50` opacity with semantic `text-muted-foreground` (line 110, 160)

### PersistenceSection.tsx  
- No changes needed - already using semantic tokens correctly

### OpsGenieNotificationSettings.tsx
- Standardized success background: `bg-green-500/20` → `bg-green-500/10` (line 94)
- Standardized error background: `bg-red-500/20` → `bg-red-500/10` (line 94)

### PagerDutyNotificationSettings.tsx
- Standardized success background: `bg-green-500/20` → `bg-green-500/10` (line 94)  
- Standardized error background: `bg-red-500/20` → `bg-red-500/10` (line 94)

All changes follow the project's design system guidelines:
- Use semantic Tailwind classes (text-foreground, bg-primary, etc.)
- Standardize on consistent opacity values (/10, /20, /50)
- Status colors remain at -400 shade (text-green-400, text-red-400)
