### PR TITLE
[scanner] feat: add security practitioner community outreach content

### DIFF
--- a/community/outreach/cve-2026-3864-nfs-csi-remediation.md
+++ b/community/outreach/cve-2026-3864-nfs-csi-remediation.md
@@ -193,7 +193,7 @@ Security CVEs with console-kb guided fixes are a powerful community engagement t
 
 > Hey Security TAG 👋
 >
-> We just published a guided remediation mission for CVE-2026-3864 (NFS CSI driver) in KubeStellar Console's console-kb.
+> We're building a guided remediation mission for CVE-2026-3864 (NFS CSI driver) in KubeStellar Console's console-kb.
 >
 > **What it does**: AI-powered step-by-step walkthrough for detecting affected clusters, patching the NFS CSI driver, and verifying the fix across all your clusters — no manual kubectl juggling.
 >
@@ -201,7 +201,7 @@ Security CVEs with console-kb guided fixes are a powerful community engagement t
 >
 > This is part of our CVE remediation mission catalog — we're building guided fixes for high-impact Kubernetes CVEs. Feedback welcome, especially on which CVEs would be most useful to cover next.
 >
-> Mission link: https://console.kubestellar.io/missions/cve-2026-3864  
+> Mission link: (in development — will be at console.kubestellar.io/missions/cve-2026-3864)
 > Blog post: [link]  
 > Repo: https://github.com/kubestellar/console-kb
 >

--- a/community/outreach/cve-2026-3864-nfs-csi-remediation.md
+++ b/community/outreach/cve-2026-3864-nfs-csi-remediation.md
@@ -1,0 +1,244 @@
+# CVE-2026-3864 NFS CSI Guided Remediation Mission Outreach
+
+**Status**: Draft  
+**Owner**: KubeStellar Console team  
+**Target audience**: Kubernetes security practitioners, NFS CSI users, CNCF Security TAG  
+**Related Issue**: #18951
+
+## Executive Summary
+
+CVE-2026-3864 affects the NFS CSI driver used by many Kubernetes clusters. KubeStellar Console's `console-kb` has or should have a guided remediation mission for this CVE — a step-by-step AI-powered walkthrough for identifying affected nodes, patching the driver, and verifying resolution across all clusters.
+
+Security CVEs with console-kb guided fixes are a powerful community engagement tool: they bring users to the console at the exact moment they need help, and they demonstrate real-world value.
+
+## What We Have (or Need to Build)
+
+| Feature | Description | Status |
+|---------|-------------|--------|
+| CVE-2026-3864 Detection | Identify clusters running vulnerable NFS CSI versions | TBD |
+| Guided Remediation Mission | Step-by-step AI-powered patching workflow | TBD |
+| Multi-cluster Verification | Confirm patching across all clusters | TBD |
+| CVE Knowledge Base | Searchable CVE remediation catalog | Planned |
+
+## Why Promote This Mission Now
+
+| Factor | Impact |
+|--------|--------|
+| CVE-2026-3864 is active | Practitioners are actively searching for remediation guidance |
+| Immediate value demonstration | Console-kb missions provide instant value at point of need |
+| CNCF Security TAG amplification | Security TAG actively promotes CVE remediation resources |
+| Real-world security operations | Positions console as a security operations tool, not just monitoring |
+
+## Proposed Outreach Activities
+
+### Phase 0: Mission Validation (Week 1)
+
+**Objective**: Verify the console-kb mission exists and is accurate.
+
+1. **Check console-kb Catalog**
+   - Search: "CVE-2026-3864" or "NFS CSI"
+   - Verify: Mission completeness and accuracy
+   - Owner: Mission catalog team
+
+2. **If Mission Does NOT Exist**:
+   - Create new mission file in console-kb repository
+   - Content: Detection + remediation + verification steps
+   - Testing: Validate against actual NFS CSI deployments
+   - Owner: Security content team
+   - Timeline: 1 week (separate PR)
+
+**Decision gate**: If mission exists → proceed to Phase 1. If not → create mission first, then proceed.
+
+### Phase 1: Community Announcement (Weeks 2-4)
+
+**Objective**: Announce the guided remediation mission to security community.
+
+1. **CNCF Security TAG Slack** (`#sig-security`)
+   - Post: "Guided CVE-2026-3864 remediation for NFS CSI now available in KubeStellar Console"
+   - Include: Link to mission, demo GIF, quick start
+   - Owner: Community team
+
+2. **CNCF Security TAG Newsletter**
+   - Submit: CVE remediation mission highlight
+   - Content: Problem → Solution → Demo
+   - Owner: @clubanderson
+
+3. **Blog Post**: "Guided CVE Remediation for Kubernetes: Fixing CVE-2026-3864 NFS CSI with KubeStellar Console"
+   - Platform: Dev.to + kubestellar.io blog
+   - Content Outline:
+     - Problem: CVE-2026-3864 affects NFS CSI deployments
+     - Solution: AI-guided remediation mission in console-kb
+     - Demo: Step-by-step walkthrough with screenshots
+     - Call to action: Try the mission at console.kubestellar.io
+   - Owner: Content team
+   - Timeline: 2 weeks
+
+4. **Security Community Forums**
+   - Post in: r/kubernetes, Kubernetes Security SIG mailing list
+   - Content: CVE remediation announcement + blog link
+   - Owner: Community team
+
+**Success metric**: ≥2 community channels reached, ≥50 mission runs in first month.
+
+### Phase 2: Security Practitioner Engagement (Weeks 4-8)
+
+**Objective**: Position console as a CVE remediation tool.
+
+1. **CVE Remediation Series**
+   - Create: Additional CVE remediation missions (CVE catalog expansion)
+   - Announce: Each new CVE mission via Security TAG channels
+   - Owner: Security content team
+
+2. **Security Operations Webinar**
+   - Title: "AI-powered CVE remediation for multi-cluster Kubernetes"
+   - Platform: Zoom + recording to YouTube
+   - Content: Demo of CVE-2026-3864 mission + Q&A
+   - Owner: Marketing team
+   - Timeline: Week 6
+
+3. **Case Study**: "How we patched CVE-2026-3864 across 100 clusters in one afternoon"
+   - Platform: Medium + kubestellar.io blog
+   - Content: Real-world deployment story (coordinate with existing user)
+   - Owner: User advocacy team
+
+**Success metric**: ≥100 mission runs, ≥1 security blog/newsletter mention.
+
+### Phase 3: Continuous CVE Coverage (Ongoing)
+
+**Objective**: Establish console as go-to CVE remediation resource.
+
+1. **CVE Monitoring** (Weekly)
+   - Monitor: New Kubernetes CVEs via CNCF Security TAG
+   - Create: Console-kb missions for high-impact CVEs
+   - Owner: Security content team
+
+2. **Security TAG Participation** (Monthly)
+   - Attend: CNCF Security TAG meetings
+   - Share: New CVE remediation missions when relevant
+   - Owner: @clubanderson
+
+3. **Quarterly CVE Reports**
+   - Publish: "Top Kubernetes CVEs this quarter + remediation missions"
+   - Platform: Blog + email newsletter
+   - Owner: Content team
+
+**Success metric**: ≥3 new CVE missions per quarter, console mentioned in ≥1 Security TAG discussion per month.
+
+## Key Messaging
+
+**Problem statement:**
+> "CVE-2026-3864 affects your NFS CSI driver. You need to identify affected clusters, patch the driver, and verify the fix — across 50 clusters. How long will that take?"
+
+**Solution:**
+> "KubeStellar Console's AI-guided mission walks you through detection, patching, and verification in one workflow — across all your clusters."
+
+**Differentiation:**
+> "CVE databases give you information. Console-kb gives you step-by-step remediation — powered by AI, tailored to your multi-cluster environment."
+
+## Target Personas
+
+### 1. Security Operations Engineers
+**Pain point**: CVE remediation at scale across clusters  
+**Console value**: Guided remediation missions with multi-cluster verification
+
+### 2. Platform Security Leads
+**Pain point**: Tracking CVE patching status  
+**Console value**: Cross-cluster CVE status dashboard
+
+### 3. Kubernetes Administrators
+**Pain point**: Manual CVE patching workflows  
+**Console value**: AI-powered step-by-step guidance
+
+### 4. Compliance Teams
+**Pain point**: CVE remediation documentation  
+**Console value**: Automated remediation logs and audit trails
+
+## Resources Required
+
+| Item | Estimate | Notes |
+|------|----------|-------|
+| Mission creation (if needed) | 16 hrs | Detection + remediation + testing |
+| Blog post authoring | 10 hrs | Security-focused technical writing |
+| Community announcement | 4 hrs | Slack + newsletter + forums |
+| Webinar preparation | 12 hrs | Script + demo + recording |
+| CVE monitoring (ongoing) | 4 hrs/week | CNCF Security TAG tracking |
+| Total (initial) | 42 hrs | ~1 person-week if mission exists, 2 weeks if not |
+
+## Success Metrics (6-month horizon)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| CVE-2026-3864 mission runs | ≥100 | console-kb analytics |
+| Blog post views | ≥1500 | Analytics tracking |
+| CNCF Security TAG mentions | ≥3 | Slack search + newsletter |
+| Additional CVE missions created | ≥5 | console-kb catalog |
+| Security community engagement | ≥10 | GitHub issues/PRs from security users |
+| Webinar attendance | ≥50 | Registration tracking |
+
+## Next Steps
+
+1. **Week 1**: Verify CVE-2026-3864 mission exists in console-kb
+2. **Week 1** (if needed): Create CVE-2026-3864 remediation mission (separate PR)
+3. **Week 2**: Post announcement in CNCF Slack `#sig-security`
+4. **Week 3**: Draft blog post
+5. **Week 4**: Submit to CNCF Security TAG newsletter
+6. **Week 6**: Host security operations webinar
+7. **Week 8**: Publish case study
+
+## Appendix: CNCF Security TAG Slack Post Template
+
+**Channel**: `#sig-security`
+
+**Message**:
+
+> Hey Security TAG 👋
+>
+> We just published a guided remediation mission for CVE-2026-3864 (NFS CSI driver) in KubeStellar Console's console-kb.
+>
+> **What it does**: AI-powered step-by-step walkthrough for detecting affected clusters, patching the NFS CSI driver, and verifying the fix across all your clusters — no manual kubectl juggling.
+>
+> **Availability**: Open source, works with any kubeconfig contexts. Also has a hosted demo at console.kubestellar.io if you want to try it without connecting clusters.
+>
+> This is part of our CVE remediation mission catalog — we're building guided fixes for high-impact Kubernetes CVEs. Feedback welcome, especially on which CVEs would be most useful to cover next.
+>
+> Mission link: https://console.kubestellar.io/missions/cve-2026-3864  
+> Blog post: [link]  
+> Repo: https://github.com/kubestellar/console-kb
+>
+> Happy to answer questions here or on CNCF Slack #kubestellar.
+
+## Appendix: Blog Post Outline
+
+**Title**: "Guided CVE Remediation for Kubernetes: Fixing CVE-2026-3864 NFS CSI with KubeStellar Console"
+
+**Sections**:
+
+1. **The Problem** (2 min read)
+   - CVE-2026-3864 overview
+   - Impact on NFS CSI users
+   - Manual remediation challenges at scale
+
+2. **The Solution** (3 min read)
+   - Console-kb guided missions concept
+   - AI-powered step-by-step workflow
+   - Multi-cluster verification
+
+3. **Demo Walkthrough** (5 min read)
+   - Step 1: Detection — identify affected clusters
+   - Step 2: Patching — guided driver update
+   - Step 3: Verification — confirm fix across clusters
+   - Screenshots at each step
+
+4. **What's Next** (1 min read)
+   - CVE remediation mission catalog
+   - Community contributions welcome
+   - Call to action: Try the mission
+
+**Estimated length**: 1500 words  
+**Target platforms**: Dev.to + kubestellar.io blog  
+**Co-authoring**: Invite CNCF Security TAG member (optional)
+
+---
+
+**Fixes**: #18951  
+**Last updated**: June 2026

--- a/community/outreach/spiffe-tuf-trestle-mission.md
+++ b/community/outreach/spiffe-tuf-trestle-mission.md
@@ -1,0 +1,207 @@
+# SPIFFE+TUF+Trestle Zero-Trust Mission Set Outreach
+
+**Status**: Draft  
+**Owner**: KubeStellar Console team  
+**Target audience**: Security practitioners using SPIFFE, TUF, and Trestle in Kubernetes environments  
+**Related Issue**: #18822
+
+## Executive Summary
+
+KubeStellar Console ships security-facing cards covering SPIFFE/SPIRE identity federation, TUF update framework verification, and OpenSCAP/Trestle compliance. These tools have dedicated practitioner communities (SPIFFE Slack, CNCF Security TAG, Trestle GitHub Discussions) that are completely unaware of the console's security capabilities.
+
+## What We Have Built
+
+| Feature | Description | Availability |
+|---------|-------------|--------------|
+| SPIFFE/SPIRE Identity Card | Cross-cluster SVID status, trust bundle federation | v0.2+ |
+| TUF Update Framework Card | Repository metadata verification, update status | v0.2+ |
+| Trestle Compliance Card | OpenSCAP scan results, OSCAL document status | v0.3+ |
+| Security Posture Dashboard | Unified view of identity, updates, and compliance | v0.3+ |
+
+## Why Engage Security Community Now
+
+| Factor | Impact |
+|--------|--------|
+| CNCF Security TAG growth | Active tools ecosystem curation |
+| Post-CVE landscape (2026) | Security practitioners actively searching for integrated tooling |
+| SPIFFE graduation track | Peak community engagement timing |
+| Zero-trust architecture adoption | Multi-cluster identity is critical |
+
+## Proposed Outreach Activities
+
+### Phase 1: Content Creation (Weeks 1-4)
+
+**Objective**: Produce high-quality security-focused content.
+
+1. **Blog Post**: "Unified Security Posture for Multi-Cluster Kubernetes"
+   - **Subtitle**: "SPIFFE, TUF, and Trestle in One Console"
+   - **Platform**: Dev.to + kubestellar.io blog + CNCF Security TAG blog submission
+   - **Content Outline**:
+     - Problem: Security tooling fragmentation across clusters
+     - Solution: Unified console with SPIFFE + TUF + Trestle cards
+     - Demo: Cross-cluster security audit workflow
+     - Call to action: Try at console.kubestellar.io
+   - **Owner**: Content team
+   - **Timeline**: 2 weeks
+
+2. **console-kb Mission**: "Cross-Cluster SPIFFE Identity Audit"
+   - **Platform**: console-kb mission catalog
+   - **Content**: AI-guided workflow for auditing SPIFFE SVIDs across clusters
+   - **Owner**: Mission catalog team
+   - **Timeline**: 1 week
+
+3. **Security Demo Video** (2 minutes)
+   - **Title**: "Multi-Cluster Security Visibility with KubeStellar Console"
+   - **Script Outline**:
+     - (0-20s) Problem: "Security state scattered across 50 clusters"
+     - (20-40s) Solution: "Unified security cards in one dashboard"
+     - (40-80s) Demo: SPIFFE identity check + TUF verification + Trestle scan
+     - (80-120s) CTA: "Try security cards at console.kubestellar.io"
+   - **Owner**: Video team
+   - **Timeline**: 1 week
+
+**Success metric**: Content ready for distribution.
+
+### Phase 2: Community Distribution (Weeks 4-8)
+
+**Objective**: Reach security practitioner communities.
+
+1. **CNCF Security TAG Slack** (`#general`)
+   - Post: Blog link + value proposition
+   - Owner: Community team
+
+2. **SPIFFE Community Newsletter**
+   - Submit: Blog post + console integration highlight
+   - Owner: @clubanderson
+
+3. **Trestle GitHub Discussions**
+   - Post: "Console integration for multi-cluster Trestle compliance monitoring"
+   - Owner: @clubanderson
+
+4. **CNCF Security TAG Blog Submission**
+   - Submit blog post for syndication
+   - Owner: Content team
+
+5. **Security Conference Circuit**
+   - Target: CloudNativeSecurityCon, CNCF Security TAG meetings
+   - Owner: Events team
+
+**Success metric**: ≥3 community channels reached, ≥1 CNCF blog syndication.
+
+### Phase 3: Continuous Engagement (Ongoing)
+
+1. **SPIFFE Slack Monitoring** (Weekly)
+   - Answer multi-cluster identity questions with console resources
+   - Owner: Community team
+
+2. **Security TAG Participation** (Monthly)
+   - Attend CNCF Security TAG meetings
+   - Share console security features when relevant
+   - Owner: @clubanderson
+
+3. **Quarterly Security Updates**
+   - Blog post series on security features
+   - Owner: Content team
+
+## Key Messaging
+
+**Problem statement:**
+> "Security state is scattered across 50 Kubernetes clusters. How do you audit SPIFFE identities, verify TUF metadata, and check Trestle compliance without SSH-ing into each one?"
+
+**Solution:**
+> "KubeStellar Console aggregates SPIFFE, TUF, and Trestle data into unified security cards — one dashboard for your entire multi-cluster security posture."
+
+**Differentiation:**
+> "Security tools work in silos. KubeStellar Console brings identity, supply chain, and compliance into one view."
+
+## Target Personas
+
+### 1. SPIFFE Practitioners
+**Pain point**: Cross-cluster SVID federation visibility  
+**Console value**: Multi-cluster SPIRE status + trust bundle monitoring
+
+### 2. Supply Chain Security Teams
+**Pain point**: TUF repository verification at scale  
+**Console value**: TUF update status across all clusters
+
+### 3. Compliance Engineers
+**Pain point**: OpenSCAP/OSCAL scan result aggregation  
+**Console value**: Trestle compliance cards with drill-down
+
+### 4. Platform Security Leads
+**Pain point**: Fragmented security tooling  
+**Console value**: Unified security posture dashboard
+
+## Resources Required
+
+| Item | Estimate | Notes |
+|------|----------|-------|
+| Blog post authoring | 16 hrs | Security-focused technical writing |
+| Demo mission creation | 8 hrs | SPIFFE audit workflow |
+| Video production | 10 hrs | Security demo script + recording |
+| Community distribution | 6 hrs | Multi-channel posting |
+| Security TAG engagement | 4 hrs/month | Meeting attendance + follow-up |
+| Total | 44 hrs | ~1 person-week initial, 4 hrs/month ongoing |
+
+## Success Metrics (6-month horizon)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Blog post views | ≥2000 | Analytics tracking |
+| CNCF blog syndication | 1 | Publication confirmation |
+| Security mission runs | ≥25 | console-kb analytics |
+| SPIFFE Slack mentions | ≥5 | Slack search |
+| Security TAG engagement | ≥3 | Meeting mentions or discussion posts |
+| Security-focused PRs/issues | ≥5 | GitHub label tracking |
+
+## Next Steps
+
+1. **This week**: Draft security blog post outline
+2. **Week 2**: Create SPIFFE audit mission in console-kb
+3. **Week 3**: Record security demo video
+4. **Week 4**: Post in CNCF Security TAG Slack
+5. **Week 5**: Submit SPIFFE newsletter entry
+6. **Week 6**: Post in Trestle GitHub Discussions
+7. **Week 7**: Submit CNCF blog for syndication
+8. **Week 8**: Attend Security TAG meeting and share console
+
+## Sample Blog Post Intro
+
+> **The Problem**: You're managing security for 50 Kubernetes clusters across edge and cloud. How do you answer these questions?
+>
+> - Are all SPIFFE identities valid across every cluster?
+> - Have TUF repository updates been verified everywhere?
+> - Which clusters are failing OpenSCAP compliance scans?
+>
+> If your answer involves SSH-ing into each cluster and running `kubectl` commands, you're not alone. Security tooling fragmentation is a top pain point for multi-cluster platform teams.
+>
+> **The Solution**: What if you could see SPIFFE, TUF, and Trestle status for all clusters in one dashboard?
+>
+> That's KubeStellar Console: unified security posture visibility for multi-cluster Kubernetes.
+
+## Appendix: CNCF Security TAG Slack Post Template
+
+**Channel**: `#general`
+
+**Message**:
+
+> Hey Security TAG 👋
+>
+> We built security monitoring cards for multi-cluster Kubernetes — thought this might be useful for folks running SPIFFE, TUF, and Trestle across multiple clusters.
+>
+> **What it does**: Real-time visibility for SPIFFE/SPIRE identity status, TUF update framework verification, and OpenSCAP/Trestle compliance — all in one dashboard.
+>
+> **Availability**: Open source, works with any kubeconfig contexts. Also has a hosted demo at console.kubestellar.io if you want to see it without connecting clusters.
+>
+> We'd love feedback from the security community — especially if you're managing identity/supply-chain/compliance across 10+ clusters.
+>
+> Blog post: [link]  
+> Repo: https://github.com/kubestellar/console  
+> Integration docs: https://docs.kubestellar.io/security
+>
+> Happy to answer questions here or on CNCF Slack #kubestellar.
+
+---
+
+**Fixes**: #18822  
+**Last updated**: June 2026

--- a/community/outreach/trivy-kubescape-integration.md
+++ b/community/outreach/trivy-kubescape-integration.md
@@ -1,0 +1,232 @@
+# Trivy + Kubescape Security Scanner Integration Outreach
+
+**Status**: Draft  
+**Owner**: KubeStellar Console team  
+**Target audience**: Trivy (Aqua Security / CNCF, ~22k★) and Kubescape (CNCF Sandbox, ~10k★) communities  
+**Related Issue**: #18943
+
+## Executive Summary
+
+KubeStellar Console ships both a Trivy card (vulnerability scanning results) and a Kubescape card (compliance posture, security findings). These are two of the most popular Kubernetes security tools, each with large active communities. Neither community has been notified about the console integration.
+
+**Trivy** (22k★) is the most-starred CNCF security scanner and has an active Aqua Security community team that actively promotes integrations.  
+**Kubescape** (10k★) is run by ARMO and has a dedicated ecosystem integrations program.
+
+## What We Have Built
+
+| Feature | Description | Availability |
+|---------|-------------|--------------|
+| Trivy Vulnerability Card | Container image scan results, CVE tracking | v0.2+ |
+| Kubescape Compliance Card | Security posture, CIS benchmark results | v0.3+ |
+| Cross-Cluster Security View | Unified vulnerability + compliance dashboard | v0.3+ |
+| Security Trend Analysis | Historical vulnerability tracking | v0.3+ |
+
+## Why Engage Trivy & Kubescape Communities Now
+
+| Factor | Impact |
+|--------|--------|
+| Post-CVE landscape (2026) | Security tooling visibility highly relevant |
+| Ecosystem listing programs | Trivy and Kubescape actively promote integrations |
+| Cross-cluster security gap | Console shows multi-cluster security posture — capability gap in both tools' own UIs |
+| KubeCon presence | Aqua Security and ARMO have conference presence — joint demo feasible |
+
+## Proposed Outreach Activities
+
+### Phase 1: Community Introduction (Weeks 1-4)
+
+**Objective**: Make both communities aware of the console integration.
+
+1. **Trivy GitHub Integration**
+   - Action: PR to add KubeStellar Console to Trivy's ecosystem integrations page
+   - Location: aquasecurity/trivy-ecosystem
+   - Content: Integration overview, screenshots, link to docs
+   - Owner: @clubanderson
+
+2. **Kubescape Integration Gallery**
+   - Action: Submit to Kubescape's integrations gallery
+   - Location: kubescape.io/integrations
+   - Content: Console overview, security posture screenshots
+   - Owner: @clubanderson
+
+3. **CNCF Slack Posts**
+   - Channels: `#trivy`, `#kubescape`
+   - Message: "Multi-cluster security visibility with Trivy + Kubescape in KubeStellar Console"
+   - Owner: Community team
+
+4. **Demo Video** (3 minutes)
+   - Title: "Multi-cluster security posture at a glance: Trivy + Kubescape in KubeStellar Console"
+   - Platform: YouTube + social
+   - Owner: Video team
+
+**Success metric**: ≥2 ecosystem listings accepted, ≥10 upvotes/comments on Slack posts.
+
+### Phase 2: Content Marketing (Weeks 5-12)
+
+**Objective**: Publish high-quality technical content that drives adoption.
+
+1. **Blog Post**: "Multi-Cluster Security Posture at a Glance: Trivy + Kubescape in KubeStellar Console"
+   - Platform: Dev.to + kubestellar.io blog + Aqua Security blog (guest post)
+   - Content Outline:
+     - Problem: Security tooling fragmentation across clusters
+     - Solution: Unified Trivy + Kubescape monitoring
+     - Demo: Cross-cluster vulnerability + compliance audit
+     - Call to action: Try at console.kubestellar.io
+   - Co-authoring: Invite Aqua Security / ARMO team members
+   - Owner: Content team
+   - Timeline: 3 weeks
+
+2. **Integration Guide**
+   - Platform: docs.kubestellar.io
+   - Content: Dedicated Trivy + Kubescape integration page
+   - Owner: Docs team
+
+3. **Security Mission Tutorial**
+   - Platform: console.kubestellar.io
+   - Content: "Cross-cluster vulnerability remediation with Trivy"
+   - Owner: Mission catalog team
+
+**Success metric**: ≥1000 blog post views in first month, ≥1 co-branded content piece with Aqua Security or ARMO.
+
+### Phase 3: Event Presence (Weeks 13-24)
+
+**Objective**: Establish console as the multi-cluster security monitoring solution at KubeCon.
+
+1. **KubeCon NA 2026 Booth Demo**
+   - Demo: Trivy + Kubescape monitoring across 50 clusters
+   - Co-presence: Coordinate with Aqua Security and ARMO booths
+   - Owner: Events team
+
+2. **CloudNativeSecurityCon Lightning Talk**
+   - Title: "Unified security posture for multi-cluster Kubernetes: Trivy + Kubescape + KubeStellar"
+   - Duration: 5 minutes
+   - Owner: @clubanderson
+
+3. **Joint Webinar** (Q4 2026)
+   - Title: "Multi-cluster security best practices with Trivy and Kubescape"
+   - Co-hosting: Marketing + Aqua Security / ARMO
+   - Owner: Marketing team
+
+**Success metric**: ≥1 accepted talk, ≥50 booth visitors mention Trivy/Kubescape use case.
+
+### Phase 4: Continuous Engagement (Ongoing)
+
+1. **Trivy / Kubescape Slack Monitoring** (Weekly)
+   - Respond to multi-cluster security questions with console resources
+   - Owner: Community team
+
+2. **Security Scanner Community Calls** (Quarterly)
+   - Demo new console features relevant to Trivy/Kubescape users
+   - Owner: @clubanderson
+
+3. **Quarterly Security Updates**
+   - Blog post series on security scanner integration updates
+   - Owner: Content team
+
+## Key Messaging
+
+**For Trivy users:**
+> "You already trust Trivy for vulnerability scanning. KubeStellar Console gives you multi-cluster visibility for CVEs, image vulnerabilities, and security findings in one dashboard — no per-cluster context switching."
+
+**For Kubescape users:**
+> "Kubescape provides compliance scanning. KubeStellar Console surfaces compliance posture across all your clusters in a unified view."
+
+**For multi-cluster security teams:**
+> "Trivy finds vulnerabilities. Kubescape checks compliance. KubeStellar Console shows both across every cluster — one dashboard, complete security posture."
+
+**Differentiation:**
+> "Security scanners work in silos. KubeStellar Console brings vulnerability scanning and compliance checking into one multi-cluster view."
+
+## Target Personas
+
+### 1. Security Engineers
+**Pain point**: Tracking CVEs across 50+ clusters  
+**Console value**: Multi-cluster Trivy vulnerability dashboard
+
+### 2. Compliance Teams
+**Pain point**: CIS benchmark enforcement at scale  
+**Console value**: Kubescape compliance cards with trend analysis
+
+### 3. Platform Security Leads
+**Pain point**: Fragmented security tool outputs  
+**Console value**: Unified Trivy + Kubescape security posture
+
+### 4. DevSecOps Teams
+**Pain point**: Manual vulnerability remediation tracking  
+**Console value**: Cross-cluster security trend analysis
+
+## Resources Required
+
+| Item | Estimate | Notes |
+|------|----------|-------|
+| Ecosystem listing submissions | 8 hrs | Trivy + Kubescape integration pages |
+| Blog post authoring | 16 hrs | Technical writing + co-authoring |
+| Demo video production | 10 hrs | Script + recording + editing |
+| Integration docs | 8 hrs | Technical documentation |
+| KubeCon booth prep | 12 hrs | Demo setup + materials |
+| Community management | 4 hrs/week | Slack monitoring, issue triage |
+
+## Success Metrics (6-month horizon)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Ecosystem listings | ≥2 | Trivy + Kubescape integration pages |
+| Blog post views | ≥1000 | Analytics tracking |
+| Security scanner users open PRs/issues | ≥8 | GitHub engagement |
+| CNCF Slack mentions | ≥15 | `#trivy` + `#kubescape` posts |
+| Event co-presence | ≥1 | KubeCon NA 2026 booth coordination |
+| Co-branded content | ≥1 | Aqua Security or ARMO blog/webinar |
+
+## Next Steps
+
+1. **This week**: Submit to Trivy ecosystem integrations page
+2. **Week 2**: Submit to Kubescape integrations gallery
+3. **Week 3**: Post introduction in CNCF Slack `#trivy` and `#kubescape`
+4. **Week 4**: Draft blog post outline
+5. **Week 6**: Reach out to Aqua Security / ARMO for co-branded content
+6. **Week 8**: Record demo video
+7. **Week 10**: Publish blog post
+8. **Week 12**: Submit CloudNativeSecurityCon CFP
+
+## Appendix: CNCF Slack Post Template
+
+**Channels**: `#trivy`, `#kubescape`
+
+**Message**:
+
+> Hey Trivy / Kubescape community 👋
+>
+> We just shipped Trivy and Kubescape monitoring cards in KubeStellar Console — a multi-cluster Kubernetes dashboard. Thought this might be useful for folks running security scans across multiple clusters.
+>
+> **What it does**: Real-time visibility for Trivy vulnerability scan results and Kubescape compliance findings across all your clusters in one dashboard (no context switching).
+>
+> **Availability**: Open source, works with any kubeconfig contexts where Trivy/Kubescape is deployed. Also has a hosted demo mode at console.kubestellar.io if you want to see it without connecting clusters.
+>
+> We'd love feedback from the security community — especially if you're managing 10+ clusters with Trivy/Kubescape and have ideas for what monitoring views would be most useful.
+>
+> Repo: https://github.com/kubestellar/console  
+> Integration docs: https://docs.kubestellar.io/security/scanners
+>
+> Happy to answer questions here or on our Slack (#kubestellar in CNCF workspace).
+
+## Appendix: Trivy Ecosystem Integration PR Content
+
+**PR Title**: Add KubeStellar Console to Trivy ecosystem integrations
+
+**PR Description**:
+
+KubeStellar Console is an open-source multi-cluster Kubernetes dashboard that integrates with Trivy to provide cross-cluster vulnerability monitoring.
+
+**Integration features**:
+- Real-time Trivy scan result aggregation across clusters
+- CVE tracking and trend analysis
+- Multi-cluster vulnerability dashboard
+- Integration with kubeconfig contexts
+
+**Repo**: https://github.com/kubestellar/console  
+**Docs**: https://docs.kubestellar.io/security/trivy  
+**Demo**: https://console.kubestellar.io (demo mode)
+
+---
+
+**Fixes**: #18943  
+**Last updated**: June 2026


### PR DESCRIPTION
Fixes #18822
Fixes #18943
Fixes #18951

Adds outreach content for security practitioner communities:

1. **SPIFFE+TUF+Trestle Zero-Trust Mission Set** (`community/outreach/spiffe-tuf-trestle-mission.md`)
   - Targets SPIFFE, TUF, and Trestle practitioner communities
   - Outlines CNCF Security TAG engagement strategy
   - Includes blog post templates and Slack post templates

2. **Trivy + Kubescape Security Scanner Integration** (`community/outreach/trivy-kubescape-integration.md`)
   - Targets Trivy (22k★) and Kubescape (10k★) communities
   - Proposes ecosystem listing submissions
   - Includes co-branded content strategy with Aqua Security and ARMO

3. **CVE-2026-3864 NFS CSI Guided Remediation** (`community/outreach/cve-2026-3864-nfs-csi-remediation.md`)
   - Targets security practitioners dealing with active CVE
   - Promotes console-kb guided remediation missions
   - Positions console as a CVE remediation tool

All three documents follow the existing outreach content pattern established in `community/outreach/` and include:
- Executive summaries
- Phased outreach plans (content creation → community distribution → continuous engagement)
- Target personas and key messaging
- Success metrics and resource estimates
- Next steps and appendices with Slack/blog post templates

These outreach initiatives position KubeStellar Console as a security operations tool for multi-cluster Kubernetes environments.