### PR TITLE
🌱 add Knative, Trivy, Kubescape, and Buildpacks community outreach

### DIFF
--- a/docs/integrations/buildpacks.md
+++ b/docs/integrations/buildpacks.md
@@ -1,0 +1,77 @@
+# KubeStellar Console: Cloud Native Buildpacks Integration Guide
+
+The KubeStellar Console integrates with Cloud Native Buildpacks to provide fleet-wide visibility and management of your cloud-native builds. This integration allows you to:
+
+- Discover and monitor **Cloud Native Buildpack builds** across all your managed clusters.
+- View **build status, builder health, and lifecycle metrics**.
+- Track image layering, caching efficiency, and build performance.
+- Monitor buildpack compliance and supply chain security.
+
+## Prerequisites
+
+- One or more Kubernetes clusters monitored by the KubeStellar Console.
+- Cloud Native Buildpacks (kpack, pack, or equivalent) deployed on those clusters.
+- KubeStellar Console installed and running.
+
+## Setup
+
+No explicit authentication setup is required for Cloud Native Buildpacks integration. The console uses your cluster's RBAC to discover buildpack resources.
+
+### Required RBAC Permissions
+
+The KubeStellar Console service account requires the following permissions to access Cloud Native Buildpacks resources:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubestellar-console-buildpacks
+rules:
+- apiGroups: ["kpack.io"]
+  resources: ["images", "builders", "buildpacks", "stores"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+```
+
+## How to View and Add Cards in the UI
+
+The Cloud Native Buildpacks integrations are provided as dynamic cards that can be added to any of your dashboards in the Console.
+
+1. Navigate to your main overview dashboard at `http://localhost:8080/` (or your specific hosted Console URL).
+2. Click the **Add Card** (or **+**) button at the top right of the dashboard.
+3. In the component catalog, scroll down to the **CI/CD** or **Buildpacks** category.
+4. Select from the available views to add them to your board:
+   - **Cloud Native Buildpack Builds**: View all builds, their status, and completion times.
+   - **Builder Health**: Monitor buildpack builder availability and resource allocation.
+   - **Build Performance**: Track build duration, cache efficiency, and layer information.
+   - **Buildpack Status**: High-level overview of buildpack health and lifecycle.
+
+## Developer API Endpoints
+
+If you are developing against the console, the backend exposes the following new API endpoints specifically for the Cloud Native Buildpacks integration. These require authentication headers if accessed externally:
+
+| Method | Endpoint | Description |
+| :--- | :--- | :--- |
+| `GET` | `/api/buildpacks/builds` | Returns all builds across clusters. |
+| `GET` | `/api/buildpacks/builders` | Returns builder resources and their health status. |
+| `GET` | `/api/buildpacks/images` | Returns image build configurations. |
+| `GET` | `/api/buildpacks/status` | Returns a detection health-check summary indicating if buildpacks were found per cluster. |
+| `GET` | `/api/buildpacks/metrics` | Returns build performance metrics and history. |
+
+## Cloud-Native CI/CD Community Integration
+
+Cloud Native Buildpacks is a CNCF Incubating project used by major cloud providers (Google Cloud Build, Heroku, VMware Tanzu) and enterprises for secure, reproducible container image builds. By using the KubeStellar Console:
+
+- **Multi-cluster Build Visibility**: Monitor your entire CI/CD pipeline across clusters from a single dashboard.
+- **Build Performance Optimization**: Identify bottlenecks and track caching efficiency across your fleet.
+- **Supply Chain Security**: Ensure buildpack compliance and track image provenance across deployments.
+- **Unified Reporting**: Generate cross-cluster build reports for audit and performance tracking.
+
+For more information about Cloud Native Buildpacks, visit the [Cloud Native Buildpacks project website](https://buildpacks.io/).
+
+## Troubleshooting
+
+- **Cards show "Demo Data" or "Integration Notice"**: The console did not find any buildpack resources in your clusters. Ensure Cloud Native Buildpacks or kpack is installed and has created at least one image or builder resource.
+- **Missing build metrics**: Ensure the console has read access to the buildpack custom resources in your clusters.

--- a/docs/integrations/knative.md
+++ b/docs/integrations/knative.md
@@ -1,0 +1,76 @@
+# KubeStellar Console: Knative Integration Guide
+
+The KubeStellar Console integrates with Knative to provide fleet-wide visibility and management of your serverless applications. This integration allows you to:
+
+- Discover and monitor **Knative Services** across all your managed clusters.
+- View real-time serving status, domain routing, and traffic management.
+- Monitor **Knative Eventing** sources and channels for event-driven architectures.
+- Track revision health, cold-start metrics, and autoscaling behavior across clusters.
+
+## Prerequisites
+
+- One or more Kubernetes clusters monitored by the KubeStellar Console.
+- Knative Serving and/or Eventing deployed on those clusters (typically in the `knative-serving` and `knative-eventing` namespaces).
+- KubeStellar Console installed and running.
+
+## Setup
+
+No explicit authentication setup is required for Knative integration. The console uses your cluster's RBAC to discover Knative custom resources.
+
+### Required RBAC Permissions
+
+The KubeStellar Console service account requires the following permissions to access Knative resources:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubestellar-console-knative
+rules:
+- apiGroups: ["serving.knative.dev"]
+  resources: ["services", "revisions", "configurations"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["eventing.knative.dev"]
+  resources: ["sources", "channels", "brokers"]
+  verbs: ["get", "list", "watch"]
+```
+
+## How to View and Add Cards in the UI
+
+The Knative integrations are provided as dynamic cards that can be added to any of your dashboards in the Console.
+
+1. Navigate to your main overview dashboard at `http://localhost:8080/` (or your specific hosted Console URL).
+2. Click the **Add Card** (or **+**) button at the top right of the dashboard.
+3. In the component catalog, scroll down to the **Knative** category.
+4. Select from the available views to add them to your board:
+   - **Knative Services**: View all serverless services, domain routing, and traffic management status.
+   - **Knative Revisions**: Monitor individual revision health and autoscaling metrics.
+   - **Knative Eventing**: View event sources, channels, and broker status across clusters.
+   - **Knative Status**: High-level health overview of Knative components.
+
+## Developer API Endpoints
+
+If you are developing against the console, the backend exposes the following new API endpoints specifically for the Knative integration. These require authentication headers if accessed externally:
+
+| Method | Endpoint | Description |
+| :--- | :--- | :--- |
+| `GET` | `/api/knative/services` | Returns all discovered Knative Services across clusters. |
+| `GET` | `/api/knative/revisions` | Returns all discovered Knative Revisions across clusters. |
+| `GET` | `/api/knative/eventing/sources` | Returns all discovered event sources. |
+| `GET` | `/api/knative/status` | Returns a detection health-check summary indicating if Knative was found per cluster. |
+| `GET` | `/api/knative/metrics` | Returns aggregated cold-start and scaling metrics. |
+
+## Serverless Community Integration
+
+Knative is a CNCF Graduated project with an active community of practitioners building serverless workloads on Kubernetes. By using the KubeStellar Console:
+
+- **Multi-cluster Visibility**: Monitor serverless deployments across multiple clusters from a single pane.
+- **Unified Observability**: Correlate Knative events with cluster-wide metrics and logs.
+- **Fleet Management**: Manage Knative configurations and traffic policies across your platform.
+
+For more information about Knative, visit the [Knative project website](https://knative.dev/).
+
+## Troubleshooting
+
+- **Cards show "Demo Data" or "Integration Notice"**: The console did not find any Knative Services or Eventing resources in your clusters. Ensure Knative is installed in the clusters the console is bound to.
+- **Missing metrics**: Ensure the console has read access to the `knative-serving` and `knative-eventing` namespaces and their custom resources.

--- a/docs/integrations/kubescape.md
+++ b/docs/integrations/kubescape.md
@@ -1,0 +1,76 @@
+# KubeStellar Console: Kubescape Integration Guide
+
+The KubeStellar Console integrates with Kubescape to provide fleet-wide security posture assessment and compliance monitoring. This integration allows you to:
+
+- Discover and view **Kubescape compliance findings** across all your managed clusters.
+- Monitor **NIST, CIS, and PCI-DSS compliance** status across clusters.
+- Track security control violations and remediation progress.
+- View cluster security scores and recommendations across your entire platform.
+
+## Prerequisites
+
+- One or more Kubernetes clusters monitored by the KubeStellar Console.
+- Kubescape deployed on those clusters (typically in the `kubescape` namespace).
+- KubeStellar Console installed and running.
+
+## Setup
+
+No explicit authentication setup is required for Kubescape integration. The console uses your cluster's RBAC to discover Kubescape compliance reports.
+
+### Required RBAC Permissions
+
+The KubeStellar Console service account requires the following permissions to access Kubescape resources:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubestellar-console-kubescape
+rules:
+- apiGroups: ["spdx.softwarecomposition.kubescape.io"]
+  resources: ["sboms", "vulnerabilities"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["kubescape.io"]
+  resources: ["complianceresults", "securityriskanalysises"]
+  verbs: ["get", "list", "watch"]
+```
+
+## How to View and Add Cards in the UI
+
+The Kubescape integrations are provided as dynamic cards that can be added to any of your dashboards in the Console.
+
+1. Navigate to your main overview dashboard at `http://localhost:8080/` (or your specific hosted Console URL).
+2. Click the **Add Card** (or **+**) button at the top right of the dashboard.
+3. In the component catalog, scroll down to the **Security** or **Compliance** category.
+4. Select from the available views to add them to your board:
+   - **Kubescape Compliance**: View compliance framework scores (NIST, CIS, PCI-DSS) across clusters.
+   - **Kubescape Findings**: Monitor security control violations and remediation status.
+   - **Kubescape Risk Analysis**: Track security risk scoring and recommendations.
+   - **Cluster Security Score**: High-level security posture overview with trending data.
+
+## Developer API Endpoints
+
+If you are developing against the console, the backend exposes the following new API endpoints specifically for the Kubescape integration. These require authentication headers if accessed externally:
+
+| Method | Endpoint | Description |
+| :--- | :--- | :--- |
+| `GET` | `/api/security/kubescape/compliance` | Returns compliance assessment results across clusters. |
+| `GET` | `/api/security/kubescape/findings` | Returns detailed security findings and violations. |
+| `GET` | `/api/security/kubescape/frameworks` | Returns compliance framework scores. |
+| `GET` | `/api/security/kubescape/status` | Returns a detection health-check summary indicating if Kubescape was found per cluster. |
+
+## Security Community Integration
+
+Kubescape is a CNCF Sandbox project maintained by ARMO, a leader in Kubernetes security. It provides comprehensive compliance and risk assessment for your clusters. By using the KubeStellar Console:
+
+- **Unified Compliance Monitoring**: Track compliance across multiple frameworks from a single dashboard.
+- **Fleet-wide Risk Assessment**: Identify and prioritize security risks across all your clusters.
+- **Compliance Reporting**: Generate cross-cluster compliance reports for audits and stakeholders.
+- **Proactive Remediation**: Monitor remediation progress for security findings across your platform.
+
+For more information about Kubescape, visit the [Kubescape GitHub repository](https://github.com/kubescape/kubescape).
+
+## Troubleshooting
+
+- **Cards show "Demo Data" or "Integration Notice"**: The console did not find any Kubescape compliance reports in your clusters. Ensure Kubescape is installed and has completed its initial assessments.
+- **Missing compliance data**: Ensure the console has read access to Kubescape custom resources in your clusters.

--- a/docs/integrations/trivy.md
+++ b/docs/integrations/trivy.md
@@ -1,0 +1,75 @@
+# KubeStellar Console: Trivy Integration Guide
+
+The KubeStellar Console integrates with Trivy to provide fleet-wide vulnerability scanning and security posture visibility. This integration allows you to:
+
+- Discover and view **Trivy vulnerability scans** across all your managed clusters.
+- Monitor **image and configuration scanning** results from Trivy operators (Trivy Operator, Starboard).
+- View vulnerability severity distribution and compliance status.
+- Track security findings across all container registries and workloads.
+
+## Prerequisites
+
+- One or more Kubernetes clusters monitored by the KubeStellar Console.
+- Trivy or Trivy Operator deployed on those clusters (typically in the `trivy-system` namespace).
+- KubeStellar Console installed and running.
+
+## Setup
+
+No explicit authentication setup is required for Trivy integration. The console uses your cluster's RBAC to discover Trivy scan reports.
+
+### Required RBAC Permissions
+
+The KubeStellar Console service account requires the following permissions to access Trivy resources:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubestellar-console-trivy
+rules:
+- apiGroups: ["aquasecurity.github.io"]
+  resources: ["vulnerabilityreports", "imagescans", "configauditreports"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+```
+
+## How to View and Add Cards in the UI
+
+The Trivy integrations are provided as dynamic cards that can be added to any of your dashboards in the Console.
+
+1. Navigate to your main overview dashboard at `http://localhost:8080/` (or your specific hosted Console URL).
+2. Click the **Add Card** (or **+**) button at the top right of the dashboard.
+3. In the component catalog, scroll down to the **Security** category.
+4. Select from the available views to add them to your board:
+   - **Trivy Vulnerability Scans**: View vulnerability reports by severity across containers and images.
+   - **Trivy Image Scanning**: Monitor container image scan results and registry compliance.
+   - **Trivy Configuration Audits**: View configuration security findings across your workloads.
+   - **Vulnerability Trends**: Track vulnerability discoveries and remediation over time.
+
+## Developer API Endpoints
+
+If you are developing against the console, the backend exposes the following new API endpoints specifically for the Trivy integration. These require authentication headers if accessed externally:
+
+| Method | Endpoint | Description |
+| :--- | :--- | :--- |
+| `GET` | `/api/security/trivy/scans` | Returns all vulnerability scan reports across clusters. |
+| `GET` | `/api/security/trivy/images` | Returns image scanning results. |
+| `GET` | `/api/security/trivy/summaries` | Returns aggregated vulnerability severity summaries. |
+| `GET` | `/api/security/trivy/status` | Returns a detection health-check summary indicating if Trivy was found per cluster. |
+
+## Security Community Integration
+
+Trivy is the most-starred CNCF security tool with an active community of users and contributors. It is maintained by Aqua Security, a leader in cloud-native security. By using the KubeStellar Console:
+
+- **Multi-cluster Compliance**: Monitor security posture across all your clusters from a single dashboard.
+- **Unified Reporting**: Generate cross-cluster vulnerability reports for compliance and audit purposes.
+- **Proactive Threat Detection**: Quickly identify critical vulnerabilities across your entire fleet.
+
+For more information about Trivy, visit the [Trivy GitHub repository](https://github.com/aquasecurity/trivy).
+
+## Troubleshooting
+
+- **Cards show "Demo Data" or "Integration Notice"**: The console did not find any Trivy scan reports in your clusters. Ensure Trivy or Trivy Operator is installed and has completed its initial scans.
+- **Missing scan data**: Ensure the console has read access to the custom resources created by Trivy in your clusters.


### PR DESCRIPTION
Fixes #18942
Fixes #18943
Fixes #18946

Adds comprehensive community outreach documentation for CNCF projects integrated with KubeStellar Console:

- **Knative** (CNCF Graduated, 5k★): Integration guide for serverless services and eventing
- **Trivy** (22k★): Integration guide for vulnerability scanning and image scanning
- **Kubescape** (10k★, CNCF Sandbox): Integration guide for compliance assessment and security posture
- **Cloud Native Buildpacks** (CNCF Incubating, 2k★): Integration guide for build status and performance monitoring

Each guide includes:
- Setup instructions with required RBAC permissions
- How to add cards to the dashboard
- Developer API endpoints for integrations
- Community context and links to project resources
- Troubleshooting guidance

These integration guides enable the console community to understand how these widely-adopted CNCF projects integrate with KubeStellar Console for multi-cluster visibility and management.