### PR TITLE
[scanner] fix: add console-kb CNCF mission sets community engagement content

### DIFF
--- a/docs/docs/content/community/console-kb-mission-engagement.md
+++ b/docs/docs/content/community/console-kb-mission-engagement.md
@@ -207,13 +207,13 @@ Would the maintainers be interested in reviewing these for potential inclusion i
 ## Anti-Spam Guidelines
 
 **Before ANY outreach action, verify**:
-1. ✅ No existing PR/issue on target repository from @clubanderson
+1. ✅ No existing PR/issue on target repository from KubeStellar maintainers
 2. ✅ Repository is active (commits within last 6 months)
 3. ✅ CONTRIBUTING.md allows community resource submissions
 4. ✅ Message is tailored to specific project (no copy-paste spam)
 5. ✅ Respect each community's preferred communication channels
 
-**One action per target, ever.** See [outreach-antispam.md](../hive/outreach-antispam.md) for full ruleset.
+**One action per target, ever.**
 
 ---
 
@@ -245,12 +245,10 @@ Document real-world mission usage: "How We Used Console Missions to Deploy Istio
 
 ## Links & Resources
 
-- **Mission Browser** (coming soon): console.kubestellar.io/missions
+- **Mission Browser** (coming soon): [console.kubestellar.io/missions](https://console.kubestellar.io/missions)
 - **Console-KB Repository**: https://github.com/kubestellar/console-kb
-- **AI Missions Documentation**: [ai-missions-setup.md](../console/ai-missions-setup.md)
-- **Mission Control Overview**: [mission-control-overview.md](../news/mission-control-overview.md)
 - **CNCF Landscape**: https://landscape.cncf.io
-- **KubeStellar Community**: [Join the community](./index.md)
+- **KubeStellar Community**: https://kubestellar.io/community
 
 ---
 

--- a/docs/docs/content/community/console-kb-mission-engagement.md
+++ b/docs/docs/content/community/console-kb-mission-engagement.md
@@ -1,0 +1,259 @@
+---
+title: Console-KB Mission Sets Community Engagement
+description: Strategies to drive community adoption of console-kb's 188 CNCF project mission sets
+---
+
+# Console-KB Mission Sets: Community Engagement Strategy
+
+## Overview
+
+The [console-kb repository](https://github.com/kubestellar/console-kb) contains **188 CNCF project mission sets** — the most comprehensive library of AI-powered, guided operational runbooks for the Kubernetes ecosystem available in any open-source project.
+
+These mission sets cover the breadth of the CNCF landscape, including:
+- **GitOps & CD**: ArgoCD, Flux, Tekton, Spinnaker
+- **Service Mesh**: Istio, Linkerd, Consul
+- **Observability**: Prometheus, Grafana, OpenTelemetry, Jaeger
+- **Policy & Security**: Kyverno, OPA, Falco, cert-manager
+- **Storage**: Rook, Longhorn, OpenEBS, Vitess
+- **Networking**: Cilium, Calico, CoreDNS
+- **And 100+ more CNCF projects**
+
+Each mission set provides:
+- Step-by-step installation commands
+- Verification checks
+- Upgrade procedures
+- Troubleshooting guides
+- Uninstall instructions
+- Multi-cluster deployment patterns
+
+---
+
+## The Engagement Gap
+
+Despite this milestone achievement, there has been **zero public announcement** to:
+- CNCF project communities (Slack channels, mailing lists, GitHub Discussions)
+- The broader SRE and platform engineering audience
+- CNCF blog or ecosystem publications
+- KubeCon and cloud-native conferences
+
+This represents a significant missed opportunity to:
+1. Drive adoption among downstream users who need these runbooks
+2. Build relationships with CNCF project maintainers
+3. Establish KubeStellar Console as a key resource for the ecosystem
+4. Gather feedback to improve mission quality and coverage
+
+---
+
+## Community Engagement Strategy
+
+### 1. CNCF Blog Post
+
+**Title**: "188 Guided Runbooks for the CNCF Ecosystem: KubeStellar Console's Mission Library"
+
+**Target Audience**: Platform engineers, SREs, DevOps teams, CNCF project users
+
+**Key Points**:
+- Quantifiable milestone: 188 mission sets covering the CNCF landscape
+- What makes these different: AI-powered, multi-cluster aware, guided workflows
+- Real-world use cases: installation, upgrades, troubleshooting across clusters
+- Open source and community-driven: contributors welcome
+- Link to mission browser at console.kubestellar.io/missions
+
+**Distribution**:
+- Submit to [CNCF Blog](https://www.cncf.io/blog/) (ecosystem tooling category)
+- Cross-post to KubeStellar Medium blog
+- Share on LinkedIn with #CNCF, #Kubernetes hashtags
+- Post in cloud-native Slack communities
+
+### 2. CNCF Project Community Outreach
+
+**Approach**: Engage individual CNCF project communities with mission-specific value
+
+**Template Message** (for Slack channels like #argo-cd, #flux, #prometheus):
+
+```
+👋 We've created comprehensive AI-powered mission sets for [PROJECT_NAME] in the KubeStellar Console knowledge base (console-kb).
+
+These include:
+• Guided installation workflows
+• Multi-cluster deployment patterns  
+• Upgrade procedures
+• Troubleshooting runbooks
+• Common failure scenarios and fixes
+
+📦 [X] mission sets for [PROJECT_NAME]: https://console.kubestellar.io/missions?filter=[PROJECT]
+
+The missions are open source and we'd love feedback from the [PROJECT] community. Happy to collaborate on improving coverage or accuracy.
+
+🔗 Repo: https://github.com/kubestellar/console-kb
+```
+
+**Prioritize These Projects** (largest communities):
+1. ArgoCD (#argo-cd)
+2. Prometheus (#prometheus-operator)
+3. Istio (#istio)
+4. Flux (#flux)
+5. Cilium (#cilium)
+6. Kyverno (#kyverno)
+7. OpenTelemetry (#opentelemetry)
+8. Crossplane (#crossplane)
+9. Helm (#helm-users)
+10. Cert-manager (#cert-manager)
+
+**Timing**: Stagger messages across 2-3 weeks to avoid appearing spammy
+
+### 3. Create Console-KB Mission Index Page
+
+**URL**: console.kubestellar.io/missions
+
+**Features**:
+- Searchable/filterable catalog of all 188 mission sets
+- Group by CNCF project category (GitOps, Observability, Security, etc.)
+- Show mission count per project
+- Link to mission YAML files and documentation
+- "Contribute a Mission" call-to-action
+
+**SEO Value**:
+- Captures search traffic for "[CNCF project] installation guide"
+- Positions console.kubestellar.io as authoritative resource
+- Builds organic backlinks from project documentation
+
+### 4. CNCF Project Repository Engagement
+
+**Approach**: File helpful issues/discussions on CNCF project repos linking mission sets as community resources
+
+**Example Issue Template**:
+
+```markdown
+## Suggested Resource: Guided Mission Sets
+
+The KubeStellar Console knowledge base includes comprehensive mission sets for [PROJECT_NAME]:
+
+- Installation and configuration guides
+- Multi-cluster deployment patterns
+- Upgrade workflows
+- Troubleshooting runbooks
+
+These could be valuable additions to the [PROJECT] documentation or linked as community resources.
+
+📦 Mission sets: https://console.kubestellar.io/missions?filter=[PROJECT]
+🔗 Repository: https://github.com/kubestellar/console-kb
+
+Would the maintainers be interested in reviewing these for potential inclusion in the official docs or community resources section?
+```
+
+**Selection Criteria**:
+- Only file on projects with active maintainer engagement
+- Respect each project's CONTRIBUTING.md guidelines
+- Don't file unless missions are high quality and verified
+- One issue per project maximum (no spam)
+
+### 5. KubeCon and Conference Presence
+
+**Opportunities**:
+- KubeCon NA 2026 talk proposal (#18810): Feature mission library prominently
+- CNCF project maintainer track talks: Mention as resource for operators
+- Hallway track / booth: Demo mission browser with live cluster examples
+- Lightning talks: "188 Ways to Deploy CNCF Projects"
+
+**Materials Needed**:
+- Mission browser demo environment
+- Printed QR codes linking to console.kubestellar.io/missions
+- Slide deck showcasing mission variety and multi-cluster capabilities
+- Swag featuring CNCF project logos + "Powered by Console-KB Missions"
+
+### 6. Metrics and Feedback Collection
+
+**Track These Metrics**:
+- Mission browser page views (Google Analytics)
+- console-kb GitHub stars and forks
+- Mission execution counts (if telemetry enabled)
+- Community feedback (GitHub issues, Slack mentions)
+- Referral traffic from CNCF project documentation
+
+**Feedback Channels**:
+- GitHub Discussions in console-kb repo
+- `#kubestellar-dev` Slack channel
+- Survey embedded in mission browser: "Was this mission helpful?"
+- Monthly community call segment: "Mission of the Month" showcase
+
+---
+
+## Success Metrics
+
+### Short-term (1-3 months)
+- [ ] CNCF blog post published
+- [ ] 10+ CNCF project communities engaged (Slack posts, GitHub issues)
+- [ ] Mission browser index page live at console.kubestellar.io/missions
+- [ ] 500+ unique visitors to mission browser
+- [ ] 50+ GitHub stars/forks on console-kb
+
+### Medium-term (3-6 months)
+- [ ] 5+ CNCF project docs link to console-kb missions as community resource
+- [ ] 1,000+ mission browser page views
+- [ ] KubeCon talk accepted featuring mission library
+- [ ] 3+ community contributors submit new missions
+- [ ] Referral traffic from at least 10 different CNCF project sites
+
+### Long-term (6-12 months)
+- [ ] 200+ mission sets (continuous growth)
+- [ ] 5,000+ mission browser page views
+- [ ] Featured in CNCF newsletter or Kubeweekly
+- [ ] 10+ community contributors
+- [ ] Mission library cited in SRE/DevOps blogs and newsletters
+
+---
+
+## Anti-Spam Guidelines
+
+**Before ANY outreach action, verify**:
+1. ✅ No existing PR/issue on target repository from @clubanderson
+2. ✅ Repository is active (commits within last 6 months)
+3. ✅ CONTRIBUTING.md allows community resource submissions
+4. ✅ Message is tailored to specific project (no copy-paste spam)
+5. ✅ Respect each community's preferred communication channels
+
+**One action per target, ever.** See [outreach-antispam.md](../hive/outreach-antispam.md) for full ruleset.
+
+---
+
+## Contributor Opportunities
+
+**How to Get Involved**:
+
+### Add Missing Mission Sets
+Browse the [CNCF Landscape](https://landscape.cncf.io) and identify projects without mission coverage. Submit a PR to console-kb with new mission YAML files.
+
+### Improve Existing Missions
+- Test missions on real clusters and file issues for inaccuracies
+- Add multi-cluster deployment variations
+- Expand troubleshooting sections with common failure scenarios
+- Add upgrade/rollback procedures
+
+### Translate Missions
+Help internationalize mission sets for non-English speaking communities.
+
+### Write Case Studies
+Document real-world mission usage: "How We Used Console Missions to Deploy Istio Across 50 Clusters"
+
+**Get Started**:
+- 📖 [Contributing Guide](https://github.com/kubestellar/console-kb/blob/main/CONTRIBUTING.md)
+- 💬 [#kubestellar-dev Slack](https://cloud-native.slack.com/archives/C097094RZ3M)
+- 🐛 [File an Issue](https://github.com/kubestellar/console-kb/issues)
+
+---
+
+## Links & Resources
+
+- **Mission Browser** (coming soon): console.kubestellar.io/missions
+- **Console-KB Repository**: https://github.com/kubestellar/console-kb
+- **AI Missions Documentation**: [ai-missions-setup.md](../console/ai-missions-setup.md)
+- **Mission Control Overview**: [mission-control-overview.md](../news/mission-control-overview.md)
+- **CNCF Landscape**: https://landscape.cncf.io
+- **KubeStellar Community**: [Join the community](./index.md)
+
+---
+
+*Last updated: June 2026*  
+*Issue reference: [#18949](https://github.com/kubestellar/console/issues/18949)*  
+*Maintained by the KubeStellar outreach team*


### PR DESCRIPTION
Fixes #18949

Adds community engagement content for console-kb's 188 CNCF project mission sets to drive downstream user adoption.

## Changes
- Created `docs/docs/content/community/console-kb-mission-engagement.md` with comprehensive community engagement strategy
- Outlines 6 engagement approaches: CNCF blog post, project community outreach, mission index page, repository engagement, conference presence, and metrics collection
- Includes success metrics (short/medium/long-term), anti-spam guidelines, and contributor opportunities
- Documents template messages, prioritized projects, and actionable next steps

## Context
The console-kb repository contains 188 CNCF project mission sets (guided AI-powered runbooks covering ArgoCD, Flux, Istio, Prometheus, and 100+ more projects). Despite this milestone, there has been zero public announcement to CNCF communities, the SRE/platform engineering audience, or the CNCF blog.

This document provides a strategic framework to:
1. Drive adoption among downstream users who need these runbooks
2. Build relationships with CNCF project maintainers
3. Establish KubeStellar Console as a key resource for the ecosystem
4. Gather feedback to improve mission quality and coverage