### PR TITLE
[quality] Add comprehensive tests for team service + feedback requests_sync (47 tests)

### DIFF
--- a/pkg/api/handlers/feedback/requests_sync_test.go
+++ b/pkg/api/handlers/feedback/requests_sync_test.go
@@ -1,0 +1,436 @@
+package feedback
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRequestsSyncTest(t *testing.T, userID uuid.UUID, githubLogin string) (*fiber.App, *FeedbackHandler, *feedbackStoreStub) {
+	t.Helper()
+	stub := &feedbackStoreStub{MockStore: &test.MockStore{}}
+	app, handler := setupFeedbackTest(t, userID, githubLogin, stub)
+
+	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
+	app.Post("/api/feedback/requests/:id/reopen", handler.ReopenRequest)
+	app.Post("/api/feedback/requests/:id/update", handler.RequestUpdate)
+	app.Post("/api/feedback/requests/:id/feedback", handler.SubmitFeedback)
+
+	return app, handler, stub
+}
+
+// --- CloseRequest tests ---
+
+func TestCloseRequest_Unauthenticated(t *testing.T) {
+	stub := &feedbackStoreStub{MockStore: &test.MockStore{}}
+	app := fiber.New()
+	handler := NewFeedbackHandler(stub, FeedbackConfig{})
+	// No userID middleware — simulates unauthenticated request
+	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+uuid.New().String()+"/close", nil)
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestCloseRequest_InvalidUUID(t *testing.T) {
+	userID := uuid.New()
+	app, _, _ := setupRequestsSyncTest(t, userID, "")
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/not-a-uuid/close", nil)
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestCloseRequest_NotFound(t *testing.T) {
+	userID := uuid.New()
+	requestID := uuid.New()
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(nil, nil)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestCloseRequest_AccessDenied(t *testing.T) {
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	requestID := uuid.New()
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	featureReq := &models.FeatureRequest{ID: requestID, UserID: otherUserID}
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(featureReq, nil)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestCloseRequest_Success_NoGitHub(t *testing.T) {
+	userID := uuid.New()
+	requestID := uuid.New()
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	featureReq := &models.FeatureRequest{ID: requestID, UserID: userID, Status: models.RequestStatusOpen}
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(featureReq, nil)
+	stub.MockStore.On("CloseFeatureRequest", requestID, true).Return(nil)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestCloseRequest_GitHubID_NoLogin(t *testing.T) {
+	userID := uuid.New()
+	app, _, _ := setupRequestsSyncTest(t, userID, "") // no githubLogin
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/gh-42/close", nil)
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+// --- ReopenRequest tests ---
+
+func TestReopenRequest_Unauthenticated(t *testing.T) {
+	stub := &feedbackStoreStub{MockStore: &test.MockStore{}}
+	app := fiber.New()
+	handler := NewFeedbackHandler(stub, FeedbackConfig{})
+	app.Post("/api/feedback/requests/:id/reopen", handler.ReopenRequest)
+
+	body := `{"comment":"needs fix"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+uuid.New().String()+"/reopen", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestReopenRequest_EmptyComment(t *testing.T) {
+	userID := uuid.New()
+	app, _, _ := setupRequestsSyncTest(t, userID, "")
+
+	body := `{"comment":""}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+uuid.New().String()+"/reopen", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestReopenRequest_WhitespaceOnlyComment(t *testing.T) {
+	userID := uuid.New()
+	app, _, _ := setupRequestsSyncTest(t, userID, "")
+
+	body := `{"comment":"   "}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+uuid.New().String()+"/reopen", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestReopenRequest_CommentTooLong(t *testing.T) {
+	userID := uuid.New()
+	app, _, _ := setupRequestsSyncTest(t, userID, "")
+
+	longComment := strings.Repeat("a", maxVerificationCommentChars+1)
+	body := `{"comment":"` + longComment + `"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+uuid.New().String()+"/reopen", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestReopenRequest_InvalidBody(t *testing.T) {
+	userID := uuid.New()
+	app, _, _ := setupRequestsSyncTest(t, userID, "")
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+uuid.New().String()+"/reopen", strings.NewReader("{bad json"))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestReopenRequest_NotFound(t *testing.T) {
+	userID := uuid.New()
+	requestID := uuid.New()
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(nil, nil)
+
+	body := `{"comment":"still broken"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/reopen", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestReopenRequest_AccessDenied(t *testing.T) {
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	requestID := uuid.New()
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	featureReq := &models.FeatureRequest{ID: requestID, UserID: otherUserID}
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(featureReq, nil)
+
+	body := `{"comment":"still broken"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/reopen", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestReopenRequest_Success_NoGitHub(t *testing.T) {
+	userID := uuid.New()
+	requestID := uuid.New()
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	featureReq := &models.FeatureRequest{ID: requestID, UserID: userID, Status: models.RequestStatusClosed}
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(featureReq, nil)
+	stub.MockStore.On("UpdateFeatureRequestLatestComment", requestID, "still broken").Return(nil)
+	stub.MockStore.On("UpdateFeatureRequestStatus", requestID, models.RequestStatusTriageAccepted).Return(nil)
+
+	body := `{"comment":"still broken"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/reopen", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// --- RequestUpdate tests ---
+
+func TestRequestUpdate_InvalidUUID(t *testing.T) {
+	userID := uuid.New()
+	app, _, _ := setupRequestsSyncTest(t, userID, "")
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/not-a-uuid/update", nil)
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestRequestUpdate_NotFound(t *testing.T) {
+	userID := uuid.New()
+	requestID := uuid.New()
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(nil, nil)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/update", nil)
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestRequestUpdate_AccessDenied(t *testing.T) {
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	requestID := uuid.New()
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	featureReq := &models.FeatureRequest{ID: requestID, UserID: otherUserID}
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(featureReq, nil)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/update", nil)
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestRequestUpdate_Success_NoGitHub(t *testing.T) {
+	userID := uuid.New()
+	requestID := uuid.New()
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	featureReq := &models.FeatureRequest{ID: requestID, UserID: userID}
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(featureReq, nil)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/update", nil)
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result models.FeatureRequest
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, requestID, result.ID)
+}
+
+// --- SubmitFeedback tests ---
+
+func TestSubmitFeedback_Unauthenticated(t *testing.T) {
+	stub := &feedbackStoreStub{MockStore: &test.MockStore{}}
+	app := fiber.New()
+	handler := NewFeedbackHandler(stub, FeedbackConfig{})
+	app.Post("/api/feedback/requests/:id/feedback", handler.SubmitFeedback)
+
+	body := `{"feedback_type":"positive"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+uuid.New().String()+"/feedback", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestSubmitFeedback_InvalidUUID(t *testing.T) {
+	userID := uuid.New()
+	app, _, _ := setupRequestsSyncTest(t, userID, "")
+
+	body := `{"feedback_type":"positive"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/not-a-uuid/feedback", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestSubmitFeedback_InvalidBody(t *testing.T) {
+	userID := uuid.New()
+	app, _, _ := setupRequestsSyncTest(t, userID, "")
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+uuid.New().String()+"/feedback", strings.NewReader("{bad"))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestSubmitFeedback_InvalidFeedbackType(t *testing.T) {
+	userID := uuid.New()
+	requestID := uuid.New()
+	app, _, _ := setupRequestsSyncTest(t, userID, "")
+
+	body := `{"feedback_type":"unknown"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/feedback", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestSubmitFeedback_NotFound(t *testing.T) {
+	userID := uuid.New()
+	requestID := uuid.New()
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(nil, nil)
+
+	body := `{"feedback_type":"positive"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/feedback", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestSubmitFeedback_AccessDenied(t *testing.T) {
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	requestID := uuid.New()
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	featureReq := &models.FeatureRequest{ID: requestID, UserID: otherUserID}
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(featureReq, nil)
+
+	body := `{"feedback_type":"positive"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/feedback", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestSubmitFeedback_NoPRAvailable(t *testing.T) {
+	userID := uuid.New()
+	requestID := uuid.New()
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	featureReq := &models.FeatureRequest{ID: requestID, UserID: userID, PRNumber: nil}
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(featureReq, nil)
+
+	body := `{"feedback_type":"positive"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/feedback", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestSubmitFeedback_Success(t *testing.T) {
+	userID := uuid.New()
+	requestID := uuid.New()
+	prNum := 42
+	app, _, stub := setupRequestsSyncTest(t, userID, "")
+
+	featureReq := &models.FeatureRequest{ID: requestID, UserID: userID, PRNumber: &prNum}
+	stub.MockStore.On("GetFeatureRequest", requestID).Return(featureReq, nil)
+	stub.MockStore.On("CreatePRFeedback", context.Background(), requestID, userID, models.FeedbackTypePositive).Return(nil)
+
+	body := `{"feedback_type":"positive","comment":"looks good"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/feedback", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+}
+
+func TestReopenRequest_GitHubID_NoLogin(t *testing.T) {
+	userID := uuid.New()
+	app, _, _ := setupRequestsSyncTest(t, userID, "") // no githubLogin
+
+	body := `{"comment":"still broken"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/gh-42/reopen", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}

--- a/pkg/api/handlers/feedback/requests_sync_test.go
+++ b/pkg/api/handlers/feedback/requests_sync_test.go
@@ -1,7 +1,6 @@
 package feedback
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -34,7 +33,6 @@ func TestCloseRequest_Unauthenticated(t *testing.T) {
 	stub := &feedbackStoreStub{MockStore: &test.MockStore{}}
 	app := fiber.New()
 	handler := NewFeedbackHandler(stub, FeedbackConfig{})
-	// No userID middleware — simulates unauthenticated request
 	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
 
 	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+uuid.New().String()+"/close", nil)
@@ -103,7 +101,7 @@ func TestCloseRequest_Success_NoGitHub(t *testing.T) {
 
 func TestCloseRequest_GitHubID_NoLogin(t *testing.T) {
 	userID := uuid.New()
-	app, _, _ := setupRequestsSyncTest(t, userID, "") // no githubLogin
+	app, _, _ := setupRequestsSyncTest(t, userID, "")
 
 	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/gh-42/close", nil)
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -232,6 +230,19 @@ func TestReopenRequest_Success_NoGitHub(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestReopenRequest_GitHubID_NoLogin(t *testing.T) {
+	userID := uuid.New()
+	app, _, _ := setupRequestsSyncTest(t, userID, "")
+
+	body := `{"comment":"still broken"}`
+	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/gh-42/reopen", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 }
 
 // --- RequestUpdate tests ---
@@ -411,7 +422,8 @@ func TestSubmitFeedback_Success(t *testing.T) {
 
 	featureReq := &models.FeatureRequest{ID: requestID, UserID: userID, PRNumber: &prNum}
 	stub.MockStore.On("GetFeatureRequest", requestID).Return(featureReq, nil)
-	stub.MockStore.On("CreatePRFeedback", context.Background(), requestID, userID, models.FeedbackTypePositive).Return(nil)
+	// CreatePRFeedback on MockStore returns nil unconditionally (no m.Called)
+	// so no mock setup needed — just verify the endpoint returns 201
 
 	body := `{"feedback_type":"positive","comment":"looks good"}`
 	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/feedback", strings.NewReader(body))
@@ -420,17 +432,4 @@ func TestSubmitFeedback_Success(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
-}
-
-func TestReopenRequest_GitHubID_NoLogin(t *testing.T) {
-	userID := uuid.New()
-	app, _, _ := setupRequestsSyncTest(t, userID, "") // no githubLogin
-
-	body := `{"comment":"still broken"}`
-	req, _ := http.NewRequest(http.MethodPost, "/api/feedback/requests/gh-42/reopen", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := app.Test(req, fiberTestTimeout)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 }

--- a/pkg/services/team/service_test.go
+++ b/pkg/services/team/service_test.go
@@ -87,15 +87,16 @@ func (m *mockTeamStore) GetUserTeams(ctx context.Context, userID uuid.UUID) ([]m
 	return args.Get(0).([]models.Team), args.Error(1)
 }
 
-// mockUserStore implements store.UserStore (minimal, unused by most tests)
-type mockUserStore struct {
-	mock.Mock
+// newTestService creates a service with a mock team store and nil user store
+// (the user store is not used by any current service methods).
+func newTestService() (Service, *mockTeamStore) {
+	teams := new(mockTeamStore)
+	svc := New(teams, nil)
+	return svc, teams
 }
 
 func TestCreate_Success(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	userID := uuid.New()
@@ -115,9 +116,7 @@ func TestCreate_Success(t *testing.T) {
 }
 
 func TestCreate_DeduplicatesMemberIDs(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	userID := uuid.New()
@@ -144,9 +143,7 @@ func TestCreate_DeduplicatesMemberIDs(t *testing.T) {
 }
 
 func TestCreate_EmptyName(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, _ := newTestService()
 	ctx := context.Background()
 
 	_, err := svc.Create(ctx, uuid.New(), models.CreateTeamRequest{Name: ""})
@@ -155,9 +152,7 @@ func TestCreate_EmptyName(t *testing.T) {
 }
 
 func TestCreate_InvalidMemberID(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, _ := newTestService()
 	ctx := context.Background()
 
 	req := models.CreateTeamRequest{
@@ -171,9 +166,7 @@ func TestCreate_InvalidMemberID(t *testing.T) {
 }
 
 func TestGet_Success(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	teamID := uuid.New()
@@ -190,9 +183,7 @@ func TestGet_Success(t *testing.T) {
 }
 
 func TestGet_NotFound(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	teamID := uuid.New()
@@ -204,9 +195,7 @@ func TestGet_NotFound(t *testing.T) {
 }
 
 func TestDelete_AsCreator(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	userID := uuid.New()
@@ -220,9 +209,7 @@ func TestDelete_AsCreator(t *testing.T) {
 }
 
 func TestDelete_AsAdmin(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	creatorID := uuid.New()
@@ -241,9 +228,7 @@ func TestDelete_AsAdmin(t *testing.T) {
 }
 
 func TestDelete_NoPermission(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	creatorID := uuid.New()
@@ -261,9 +246,7 @@ func TestDelete_NoPermission(t *testing.T) {
 }
 
 func TestDelete_NotFound(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	teamID := uuid.New()
@@ -275,9 +258,7 @@ func TestDelete_NotFound(t *testing.T) {
 }
 
 func TestRemoveMember_AsCreator(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	actorID := uuid.New()
@@ -293,9 +274,7 @@ func TestRemoveMember_AsCreator(t *testing.T) {
 }
 
 func TestRemoveMember_SelfRemove(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	memberID := uuid.New()
@@ -312,9 +291,7 @@ func TestRemoveMember_SelfRemove(t *testing.T) {
 }
 
 func TestRemoveMember_NoPermission(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	creatorID := uuid.New()
@@ -332,17 +309,35 @@ func TestRemoveMember_NoPermission(t *testing.T) {
 	teams.AssertExpectations(t)
 }
 
-func TestAddMember_AsAdmin(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+func TestAddMember_AsCreator(t *testing.T) {
+	svc, teams := newTestService()
 	ctx := context.Background()
 
+	creatorID := uuid.New()
+	newMemberID := uuid.New()
+	teamID := uuid.New()
+
+	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID, CreatedBy: creatorID}, nil)
+	teams.On("AddTeamMember", ctx, teamID, newMemberID, models.TeamRoleMember).Return(nil)
+
+	err := svc.AddMember(ctx, teamID, newMemberID, creatorID, models.TeamRoleMember)
+	require.NoError(t, err)
+	teams.AssertExpectations(t)
+}
+
+func TestAddMember_AsAdmin(t *testing.T) {
+	svc, teams := newTestService()
+	ctx := context.Background()
+
+	creatorID := uuid.New()
 	adminID := uuid.New()
 	newMemberID := uuid.New()
 	teamID := uuid.New()
 
-	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID, CreatedBy: adminID}, nil)
+	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID, CreatedBy: creatorID}, nil)
+	teams.On("ListTeamMembers", ctx, teamID).Return([]models.TeamMemberInfo{
+		{UserID: adminID, Role: models.TeamRoleAdmin},
+	}, nil)
 	teams.On("AddTeamMember", ctx, teamID, newMemberID, models.TeamRoleMember).Return(nil)
 
 	err := svc.AddMember(ctx, teamID, newMemberID, adminID, models.TeamRoleMember)
@@ -351,9 +346,7 @@ func TestAddMember_AsAdmin(t *testing.T) {
 }
 
 func TestAddMember_NoPermission(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	creatorID := uuid.New()
@@ -371,31 +364,27 @@ func TestAddMember_NoPermission(t *testing.T) {
 	teams.AssertExpectations(t)
 }
 
-func TestUpdate_AsAdmin(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+func TestUpdate_AsCreator(t *testing.T) {
+	svc, teams := newTestService()
 	ctx := context.Background()
 
-	adminID := uuid.New()
+	creatorID := uuid.New()
 	teamID := uuid.New()
 	newName := "new-name"
 	req := models.UpdateTeamRequest{Name: &newName}
 
-	existingTeam := &models.Team{ID: teamID, Name: "old-name", CreatedBy: adminID}
+	existingTeam := &models.Team{ID: teamID, Name: "old-name", CreatedBy: creatorID}
 	teams.On("GetTeam", ctx, teamID).Return(existingTeam, nil)
 	teams.On("UpdateTeam", ctx, mock.AnythingOfType("*models.Team")).Return(nil)
 
-	result, err := svc.Update(ctx, teamID, adminID, req)
+	result, err := svc.Update(ctx, teamID, creatorID, req)
 	require.NoError(t, err)
 	assert.Equal(t, "new-name", result.Name)
 	teams.AssertExpectations(t)
 }
 
 func TestUpdate_NoPermission(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	creatorID := uuid.New()
@@ -414,10 +403,26 @@ func TestUpdate_NoPermission(t *testing.T) {
 	teams.AssertExpectations(t)
 }
 
+func TestListMembers_Success(t *testing.T) {
+	svc, teams := newTestService()
+	ctx := context.Background()
+
+	teamID := uuid.New()
+	expected := []models.TeamMemberInfo{
+		{UserID: uuid.New(), Role: models.TeamRoleMember},
+		{UserID: uuid.New(), Role: models.TeamRoleAdmin},
+	}
+	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID}, nil)
+	teams.On("ListTeamMembers", ctx, teamID).Return(expected, nil)
+
+	result, err := svc.ListMembers(ctx, teamID)
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+	teams.AssertExpectations(t)
+}
+
 func TestListMembers_NotFound(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	teamID := uuid.New()
@@ -429,9 +434,7 @@ func TestListMembers_NotFound(t *testing.T) {
 }
 
 func TestList_DelegatesToStore(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	userID := uuid.New()
@@ -445,9 +448,7 @@ func TestList_DelegatesToStore(t *testing.T) {
 }
 
 func TestGetUserTeams_DelegatesToStore(t *testing.T) {
-	teams := new(mockTeamStore)
-	users := new(mockUserStore)
-	svc := New(teams, users)
+	svc, teams := newTestService()
 	ctx := context.Background()
 
 	userID := uuid.New()

--- a/pkg/services/team/service_test.go
+++ b/pkg/services/team/service_test.go
@@ -1,0 +1,461 @@
+package team
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubestellar/console/pkg/models"
+)
+
+// mockTeamStore implements store.TeamStore for testing
+type mockTeamStore struct {
+	mock.Mock
+}
+
+func (m *mockTeamStore) CreateTeam(ctx context.Context, team *models.Team, memberIDs []uuid.UUID) error {
+	args := m.Called(ctx, team, memberIDs)
+	return args.Error(0)
+}
+
+func (m *mockTeamStore) GetTeam(ctx context.Context, id uuid.UUID) (*models.Team, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Team), args.Error(1)
+}
+
+func (m *mockTeamStore) GetTeamWithMembers(ctx context.Context, id uuid.UUID) (*models.TeamWithMembers, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.TeamWithMembers), args.Error(1)
+}
+
+func (m *mockTeamStore) UpdateTeam(ctx context.Context, team *models.Team) error {
+	args := m.Called(ctx, team)
+	return args.Error(0)
+}
+
+func (m *mockTeamStore) DeleteTeam(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *mockTeamStore) ListTeams(ctx context.Context, userID *uuid.UUID, limit, offset int) ([]models.Team, error) {
+	args := m.Called(ctx, userID, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.Team), args.Error(1)
+}
+
+func (m *mockTeamStore) AddTeamMember(ctx context.Context, teamID, userID uuid.UUID, role models.TeamRole) error {
+	args := m.Called(ctx, teamID, userID, role)
+	return args.Error(0)
+}
+
+func (m *mockTeamStore) RemoveTeamMember(ctx context.Context, teamID, userID uuid.UUID) error {
+	args := m.Called(ctx, teamID, userID)
+	return args.Error(0)
+}
+
+func (m *mockTeamStore) UpdateTeamMemberRole(ctx context.Context, teamID, userID uuid.UUID, role models.TeamRole) error {
+	args := m.Called(ctx, teamID, userID, role)
+	return args.Error(0)
+}
+
+func (m *mockTeamStore) ListTeamMembers(ctx context.Context, teamID uuid.UUID) ([]models.TeamMemberInfo, error) {
+	args := m.Called(ctx, teamID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.TeamMemberInfo), args.Error(1)
+}
+
+func (m *mockTeamStore) GetUserTeams(ctx context.Context, userID uuid.UUID) ([]models.Team, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.Team), args.Error(1)
+}
+
+// mockUserStore implements store.UserStore (minimal, unused by most tests)
+type mockUserStore struct {
+	mock.Mock
+}
+
+func TestCreate_Success(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	userID := uuid.New()
+	req := models.CreateTeamRequest{Name: "platform", Description: "Platform team"}
+
+	teams.On("CreateTeam", ctx, mock.AnythingOfType("*models.Team"), mock.AnythingOfType("[]uuid.UUID")).
+		Return(nil)
+
+	team, err := svc.Create(ctx, userID, req)
+	require.NoError(t, err)
+	require.NotNil(t, team)
+	assert.Equal(t, "platform", team.Name)
+	assert.Equal(t, "Platform team", team.Description)
+	assert.Equal(t, userID, team.CreatedBy)
+	assert.Equal(t, 1, team.MemberCount, "creator should be counted as member")
+	teams.AssertExpectations(t)
+}
+
+func TestCreate_DeduplicatesMemberIDs(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	userID := uuid.New()
+	otherID := uuid.New()
+	// Include creator in members list + duplicate otherID
+	req := models.CreateTeamRequest{
+		Name:      "dedup-test",
+		MemberIDs: []string{userID.String(), otherID.String(), otherID.String()},
+	}
+
+	var capturedMemberIDs []uuid.UUID
+	teams.On("CreateTeam", ctx, mock.AnythingOfType("*models.Team"), mock.AnythingOfType("[]uuid.UUID")).
+		Run(func(args mock.Arguments) {
+			capturedMemberIDs = args.Get(2).([]uuid.UUID)
+		}).
+		Return(nil)
+
+	team, err := svc.Create(ctx, userID, req)
+	require.NoError(t, err)
+	// Should have exactly 2 unique IDs: userID and otherID
+	assert.Equal(t, 2, len(capturedMemberIDs))
+	assert.Equal(t, 2, team.MemberCount)
+	teams.AssertExpectations(t)
+}
+
+func TestCreate_EmptyName(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, uuid.New(), models.CreateTeamRequest{Name: ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "team name is required")
+}
+
+func TestCreate_InvalidMemberID(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	req := models.CreateTeamRequest{
+		Name:      "bad-member",
+		MemberIDs: []string{"not-a-uuid"},
+	}
+
+	_, err := svc.Create(ctx, uuid.New(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid member ID")
+}
+
+func TestGet_Success(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	teamID := uuid.New()
+	expected := &models.TeamWithMembers{
+		Team:    models.Team{ID: teamID, Name: "platform"},
+		Members: []models.TeamMemberInfo{},
+	}
+	teams.On("GetTeamWithMembers", ctx, teamID).Return(expected, nil)
+
+	result, err := svc.Get(ctx, teamID)
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+	teams.AssertExpectations(t)
+}
+
+func TestGet_NotFound(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	teamID := uuid.New()
+	teams.On("GetTeamWithMembers", ctx, teamID).Return(nil, nil)
+
+	_, err := svc.Get(ctx, teamID)
+	require.ErrorIs(t, err, ErrNotFound)
+	teams.AssertExpectations(t)
+}
+
+func TestDelete_AsCreator(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	userID := uuid.New()
+	teamID := uuid.New()
+	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID, CreatedBy: userID}, nil)
+	teams.On("DeleteTeam", ctx, teamID).Return(nil)
+
+	err := svc.Delete(ctx, teamID, userID)
+	require.NoError(t, err)
+	teams.AssertExpectations(t)
+}
+
+func TestDelete_AsAdmin(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	creatorID := uuid.New()
+	adminID := uuid.New()
+	teamID := uuid.New()
+
+	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID, CreatedBy: creatorID}, nil)
+	teams.On("ListTeamMembers", ctx, teamID).Return([]models.TeamMemberInfo{
+		{UserID: adminID, Role: models.TeamRoleAdmin},
+	}, nil)
+	teams.On("DeleteTeam", ctx, teamID).Return(nil)
+
+	err := svc.Delete(ctx, teamID, adminID)
+	require.NoError(t, err)
+	teams.AssertExpectations(t)
+}
+
+func TestDelete_NoPermission(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	creatorID := uuid.New()
+	randomID := uuid.New()
+	teamID := uuid.New()
+
+	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID, CreatedBy: creatorID}, nil)
+	teams.On("ListTeamMembers", ctx, teamID).Return([]models.TeamMemberInfo{
+		{UserID: randomID, Role: models.TeamRoleMember}, // member, not admin
+	}, nil)
+
+	err := svc.Delete(ctx, teamID, randomID)
+	require.ErrorIs(t, err, ErrNoPermission)
+	teams.AssertExpectations(t)
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	teamID := uuid.New()
+	teams.On("GetTeam", ctx, teamID).Return(nil, nil)
+
+	err := svc.Delete(ctx, teamID, uuid.New())
+	require.ErrorIs(t, err, ErrNotFound)
+	teams.AssertExpectations(t)
+}
+
+func TestRemoveMember_AsCreator(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	actorID := uuid.New()
+	memberID := uuid.New()
+	teamID := uuid.New()
+
+	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID, CreatedBy: actorID}, nil)
+	teams.On("RemoveTeamMember", ctx, teamID, memberID).Return(nil)
+
+	err := svc.RemoveMember(ctx, teamID, memberID, actorID)
+	require.NoError(t, err)
+	teams.AssertExpectations(t)
+}
+
+func TestRemoveMember_SelfRemove(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	memberID := uuid.New()
+	creatorID := uuid.New()
+	teamID := uuid.New()
+
+	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID, CreatedBy: creatorID}, nil)
+	teams.On("RemoveTeamMember", ctx, teamID, memberID).Return(nil)
+
+	// Member removing themselves — allowed
+	err := svc.RemoveMember(ctx, teamID, memberID, memberID)
+	require.NoError(t, err)
+	teams.AssertExpectations(t)
+}
+
+func TestRemoveMember_NoPermission(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	creatorID := uuid.New()
+	memberID := uuid.New()
+	actorID := uuid.New() // not creator, not the member, not admin
+	teamID := uuid.New()
+
+	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID, CreatedBy: creatorID}, nil)
+	teams.On("ListTeamMembers", ctx, teamID).Return([]models.TeamMemberInfo{
+		{UserID: actorID, Role: models.TeamRoleMember},
+	}, nil)
+
+	err := svc.RemoveMember(ctx, teamID, memberID, actorID)
+	require.ErrorIs(t, err, ErrNoPermission)
+	teams.AssertExpectations(t)
+}
+
+func TestAddMember_AsAdmin(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	adminID := uuid.New()
+	newMemberID := uuid.New()
+	teamID := uuid.New()
+
+	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID, CreatedBy: adminID}, nil)
+	teams.On("AddTeamMember", ctx, teamID, newMemberID, models.TeamRoleMember).Return(nil)
+
+	err := svc.AddMember(ctx, teamID, newMemberID, adminID, models.TeamRoleMember)
+	require.NoError(t, err)
+	teams.AssertExpectations(t)
+}
+
+func TestAddMember_NoPermission(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	creatorID := uuid.New()
+	actorID := uuid.New()
+	newMemberID := uuid.New()
+	teamID := uuid.New()
+
+	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID, CreatedBy: creatorID}, nil)
+	teams.On("ListTeamMembers", ctx, teamID).Return([]models.TeamMemberInfo{
+		{UserID: actorID, Role: models.TeamRoleMember},
+	}, nil)
+
+	err := svc.AddMember(ctx, teamID, newMemberID, actorID, models.TeamRoleMember)
+	require.ErrorIs(t, err, ErrNoPermission)
+	teams.AssertExpectations(t)
+}
+
+func TestUpdate_AsAdmin(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	adminID := uuid.New()
+	teamID := uuid.New()
+	newName := "new-name"
+	req := models.UpdateTeamRequest{Name: &newName}
+
+	existingTeam := &models.Team{ID: teamID, Name: "old-name", CreatedBy: adminID}
+	teams.On("GetTeam", ctx, teamID).Return(existingTeam, nil)
+	teams.On("UpdateTeam", ctx, mock.AnythingOfType("*models.Team")).Return(nil)
+
+	result, err := svc.Update(ctx, teamID, adminID, req)
+	require.NoError(t, err)
+	assert.Equal(t, "new-name", result.Name)
+	teams.AssertExpectations(t)
+}
+
+func TestUpdate_NoPermission(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	creatorID := uuid.New()
+	actorID := uuid.New()
+	teamID := uuid.New()
+	newName := "hacked"
+	req := models.UpdateTeamRequest{Name: &newName}
+
+	teams.On("GetTeam", ctx, teamID).Return(&models.Team{ID: teamID, CreatedBy: creatorID}, nil)
+	teams.On("ListTeamMembers", ctx, teamID).Return([]models.TeamMemberInfo{
+		{UserID: actorID, Role: models.TeamRoleMember},
+	}, nil)
+
+	_, err := svc.Update(ctx, teamID, actorID, req)
+	require.ErrorIs(t, err, ErrNoPermission)
+	teams.AssertExpectations(t)
+}
+
+func TestListMembers_NotFound(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	teamID := uuid.New()
+	teams.On("GetTeam", ctx, teamID).Return(nil, nil)
+
+	_, err := svc.ListMembers(ctx, teamID)
+	require.ErrorIs(t, err, ErrNotFound)
+	teams.AssertExpectations(t)
+}
+
+func TestList_DelegatesToStore(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	userID := uuid.New()
+	expected := []models.Team{{ID: uuid.New(), Name: "team-a"}}
+	teams.On("ListTeams", ctx, &userID, 10, 0).Return(expected, nil)
+
+	result, err := svc.List(ctx, &userID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+	teams.AssertExpectations(t)
+}
+
+func TestGetUserTeams_DelegatesToStore(t *testing.T) {
+	teams := new(mockTeamStore)
+	users := new(mockUserStore)
+	svc := New(teams, users)
+	ctx := context.Background()
+
+	userID := uuid.New()
+	expected := []models.Team{{ID: uuid.New(), Name: "my-team"}}
+	teams.On("GetUserTeams", ctx, userID).Return(expected, nil)
+
+	result, err := svc.GetUserTeams(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+	teams.AssertExpectations(t)
+}


### PR DESCRIPTION
## Test Improvement

Adds comprehensive tests for two untested service/handler layers:

### 1. `pkg/services/team/service_test.go` — 22 unit tests
- **Create**: success, member deduplication, empty name validation, invalid member ID
- **Get**: success, not found
- **Delete**: as creator, as admin, no permission, not found
- **RemoveMember**: as creator, self-remove, no permission
- **AddMember**: as creator, as admin, no permission
- **Update**: as creator, no permission
- **ListMembers**: success, not found
- **List**: delegates to store
- **GetUserTeams**: delegates to store

Uses `mockTeamStore` (testify/mock) satisfying `store.TeamStore` interface. Tests verify permission boundary enforcement (creator vs admin vs regular member).

### 2. `pkg/api/handlers/feedback/requests_sync_test.go` — 25 handler tests
- **CloseRequest**: unauthenticated, invalid UUID, not found, access denied, success (no GitHub), GitHub ID with no login
- **ReopenRequest**: unauthenticated, empty comment, whitespace comment, too long comment, invalid body, not found, access denied, success (no GitHub), GitHub ID with no login
- **RequestUpdate**: invalid UUID, not found, access denied, success (no GitHub)
- **SubmitFeedback**: unauthenticated, invalid UUID, invalid body, invalid feedback type, not found, access denied, no PR, success

Tests cover input validation, auth boundaries, and ownership checks without requiring GitHub API connectivity.

**Total: 47 new tests across 2 files**

Fixes #18981

---
*Filed by quality agent (ACMM L4/L6 — full mode)*