### PR TITLE
🌱 docs: add CNCF ecosystem community outreach content

### DIFF
--- a/docs/docs/content/community/partners/gadget.md
+++ b/docs/docs/content/community/partners/gadget.md
@@ -1,0 +1,43 @@
+# KubeStellar Console + Inspektor Gadget Integration
+
+KubeStellar Console ships a **full Inspektor Gadget integration** with four specialized eBPF observability cards.
+
+## What's Included
+
+### Security Audit Card
+- Real-time security audit findings via eBPF
+- System call tracing and policy violations
+- Multi-cluster security event aggregation
+
+### DNS Trace Card
+- Live DNS query tracing across pods
+- DNS resolution patterns and anomalies
+- Multi-cluster DNS visibility
+
+### Network Trace Card
+- Network packet tracing and flow analysis
+- Connection patterns and protocol debugging
+- Cross-cluster network observability
+
+### Process Trace Card
+- Process execution tracing
+- System activity monitoring
+- Multi-cluster process observability
+
+## Why KubeStellar Console for Inspektor Gadget
+
+- **Multi-cluster eBPF observability** — single pane of glass for runtime security across your fleet
+- **Deep system visibility** — DNS, network, process, and security audit traces unified
+- **CNCF Sandbox integration** — deep partnership with emerging eBPF tooling
+- **Security at scale** — eBPF observability for enterprise deployments
+
+## Learn More
+
+- [Inspektor Gadget](https://www.inspektor-gadget.io) — eBPF observability
+- [Inspektor Gadget on CNCF](https://www.cncf.io/projects/inspektor-gadget/)
+- [eBPF.io](https://ebpf.io) — eBPF reference guide
+- [KubeStellar Console Documentation](https://kubestellar.io/docs)
+
+## How to Get Started
+
+[Join the KubeStellar community](https://cloud-native.slack.com/archives/C097094RZ3M) to explore multi-cluster eBPF observability with Inspektor Gadget.

--- a/docs/docs/content/community/partners/harbor-jaeger-thanos.md
+++ b/docs/docs/content/community/partners/harbor-jaeger-thanos.md
@@ -1,0 +1,41 @@
+# KubeStellar Console + Harbor + Jaeger + Thanos Integration
+
+KubeStellar Console ships dedicated cards for **Harbor** (registry), **Jaeger** (tracing), and **Thanos** (metrics).
+
+## What's Included
+
+### Harbor Card
+- Registry health and project storage usage
+- Image pull success rates across clusters
+- Container image inventory and status
+
+### Jaeger Card
+- Distributed trace collection health
+- Backend status and availability
+- Multi-cluster tracing infrastructure visibility
+
+### Thanos Card
+- Query/store/compactor health
+- HA Prometheus status and metrics
+- Long-term storage visibility
+
+## Why KubeStellar Console for Observability Stack
+
+- **Full-stack observability** — unified view of tracing, metrics, and registry across clusters
+- **Multi-cluster observability** — coordinated visibility across your entire Kubernetes fleet
+- **Enterprise adoption** — streamlined observability for platform teams managing multi-cluster observability stacks
+- **CNCF projects** — deep integrations with Graduated and Incubating CNCF projects
+
+## Learn More
+
+- [Harbor](https://goharbor.io) — container registry
+- [Harbor on CNCF](https://www.cncf.io/projects/harbor/)
+- [Jaeger](https://www.jaegertracing.io) — distributed tracing
+- [Jaeger on CNCF](https://www.cncf.io/projects/jaeger/)
+- [Thanos](https://thanos.io) — HA Prometheus
+- [Thanos on CNCF](https://www.cncf.io/projects/thanos/)
+- [KubeStellar Console Documentation](https://kubestellar.io/docs)
+
+## How to Get Started
+
+[Join the KubeStellar community](https://cloud-native.slack.com/archives/C097094RZ3M) to explore full-stack observability with Harbor, Jaeger, and Thanos.

--- a/docs/docs/content/community/partners/keda.md
+++ b/docs/docs/content/community/partners/keda.md
@@ -1,0 +1,29 @@
+# KubeStellar Console + KEDA Integration
+
+KubeStellar Console ships a **KEDA status card** surfacing KEDA autoscaling health across clusters.
+
+## What's Included
+
+The console provides multi-cluster visibility into:
+- **KEDA ScaledObject health** — autoscaling configuration status
+- **Trigger metrics** — real-time scaling trigger data
+- **Autoscaling events** — scaling activity and history across clusters
+
+This enables platform engineers to monitor event-driven autoscaling at scale across multiple Kubernetes clusters.
+
+## Why KubeStellar Console for KEDA
+
+- **Multi-cluster autoscaling** — single pane of glass for event-driven scaling across fleet
+- **Enterprise adoption** — streamlined observability for platform teams running KEDA at scale
+- **Trigger visibility** — cross-cluster trigger health and performance metrics
+- **CNCF Graduated project** — deep integration with mature event-driven autoscaling
+
+## Learn More
+
+- [KEDA.sh](https://keda.sh) — Kubernetes event-driven autoscaling
+- [KEDA on CNCF](https://www.cncf.io/projects/keda/)
+- [KubeStellar Console Documentation](https://kubestellar.io/docs)
+
+## How to Get Started
+
+[Join the KubeStellar community](https://cloud-native.slack.com/archives/C097094RZ3M) to learn more about KEDA integration and multi-cluster event-driven autoscaling.

--- a/docs/docs/content/community/partners/knative-serverless.md
+++ b/docs/docs/content/community/partners/knative-serverless.md
@@ -1,0 +1,49 @@
+# Knative Serverless Integration
+
+## Overview
+
+KubeStellar Console ships a **Knative status card** (`knative_status`) that surfacing Knative Serving and Eventing health across clusters. Knative is a CNCF Graduated project with a large and active practitioner community building serverless workloads on Kubernetes. The console provides **unique multi-cluster visibility** of Knative deployments and event-driven systems.
+
+## Why This Matters
+
+Serverless-on-Kubernetes is a common pattern for platform engineers and application teams. Knative's CNCF graduation opened co-marketing channels and established the project as a standard for serverless abstractions on Kubernetes. The console's multi-cluster perspective on Knative services fills a visibility gap in existing tooling.
+
+## The Console's Knative Story
+
+The integration enables:
+
+- **Multi-Cluster Service Health**: Monitor Knative Serving services across all clusters in a single view
+- **Event Pipeline Status**: Track Knative Eventing sources, channels, and sinks across infrastructure
+- **Revision Scaling**: Observe autoscaling behavior and traffic distribution across service revisions
+- **Cold Start Diagnostics**: Identify cold-start latency patterns and scaling metrics across clusters
+
+## Outreach Opportunities
+
+### 1. Community Discussion
+Open a Knative GitHub Discussion proposing the console as a monitoring tool for Knative deployments at scale. Highlight multi-cluster capabilities and cross-cluster observability.
+
+### 2. Community Newsletter & Blog
+Submit to:
+- Knative community newsletter and monthly blog roundup
+- CNCF blog for Graduated projects
+- Knative community meetings (propose a demo slot)
+
+### 3. Mission Integration
+Create a `console-kb` mission: "Investigating a cold-start latency issue in Knative Serving across clusters" — guide users through diagnosing performance issues and capacity planning.
+
+### 4. KubeCon Co-Location Demo
+Coordinate with Knative maintainers for joint KubeCon NA 2026 co-location demo, showing how the console bridges Knative operations across edge and cloud clusters.
+
+## Next Steps
+
+1. Open a GitHub Discussion in knative/serving
+2. Reach out to Knative steering committee
+3. Submit to Knative newsletter and CNCF channels
+4. Propose demo/talk slot in Knative community meetings
+5. Create educational mission on cold-start latency debugging
+
+---
+
+**Status**: Ready for community outreach  
+**Target Timeline**: Q2-Q3 2026  
+**Primary Communities**: Knative, serverless-on-Kubernetes practitioners, CNCF Graduated projects

--- a/docs/docs/content/community/partners/knative.md
+++ b/docs/docs/content/community/partners/knative.md
@@ -1,0 +1,27 @@
+# KubeStellar Console + Knative Integration
+
+KubeStellar Console ships a **Knative status card** surfacing Knative Serving and Eventing health across clusters.
+
+## What's Included
+
+The console provides multi-cluster visibility into:
+- **Knative Serving** — deployment health, route status, traffic metrics
+- **Knative Eventing** — broker/trigger health, event delivery status across clusters
+
+This enables platform engineers to monitor serverless workloads at scale across multiple Kubernetes clusters.
+
+## Why KubeStellar Console for Knative
+
+- **Multi-cluster monitoring** — single pane of glass for Knative services across fleet deployments
+- **Enterprise adoption** — streamlined observability for platform teams running Knative at scale
+- **CNCF co-marketing** — deep integration with a CNCF Graduated project
+
+## Learn More
+
+- [Knative.dev](https://knative.dev) — official Knative documentation
+- [Knative Serving on CNCF](https://www.cncf.io/projects/knative/)
+- [KubeStellar Console Documentation](https://kubestellar.io/docs)
+
+## How to Get Started
+
+[Join the KubeStellar community](https://cloud-native.slack.com/archives/C097094RZ3M) to learn more about Knative integration and multi-cluster serverless workflows.

--- a/docs/docs/content/community/partners/opa-gatekeeper.md
+++ b/docs/docs/content/community/partners/opa-gatekeeper.md
@@ -1,0 +1,32 @@
+# KubeStellar Console + OPA / Gatekeeper Integration
+
+KubeStellar Console ships a **full OPA/Gatekeeper integration** with comprehensive policy management UI.
+
+## What's Included
+
+The console provides multi-cluster policy management capabilities:
+- **Cluster-level OPA status** — policy enforcement overview across clusters
+- **Policy drill-down** — individual policy violation analysis and triage
+- **Policy creation** — in-console policy creation with templates
+- **Violation tracking** — policy violations aggregated and tracked across fleet
+
+This is not just a status card — it's a **policy management UI** for OPA/Gatekeeper.
+
+## Why KubeStellar Console for OPA/Gatekeeper
+
+- **Multi-cluster policy management** — unified policy visibility and enforcement across clusters
+- **Policy as Code at scale** — manage policies across your entire Kubernetes fleet in one UI
+- **Enterprise policy adoption** — streamlined policy authoring and violation remediation
+- **CNCF Graduated project** — deep integration with the industry-standard Kubernetes policy engine
+
+## Learn More
+
+- [Open Policy Agent](https://www.openpolicyagent.org) — policy engine
+- [OPA on CNCF](https://www.cncf.io/projects/opa/)
+- [Gatekeeper](https://open-policy-agent.github.io/gatekeeper/) — Kubernetes admission controller
+- [Styra Ecosystem](https://styra.com/ecosystem) — OPA ecosystem integrations
+- [KubeStellar Console Documentation](https://kubestellar.io/docs)
+
+## How to Get Started
+
+[Join the KubeStellar community](https://cloud-native.slack.com/archives/C097094RZ3M) to learn about multi-cluster policy management with OPA and Gatekeeper.

--- a/docs/docs/content/community/partners/quantum-computing.md
+++ b/docs/docs/content/community/partners/quantum-computing.md
@@ -1,0 +1,53 @@
+# Quantum Computing Integration
+
+## Overview
+
+KubeStellar Console ships a **quantum computing card** (`quantum-kc-demo`) that bridges Kubernetes cluster management with IBM Quantum workloads — surfacing qubit grid status, QASM circuit visualization, quantum system auth status, and histogram visualization. This represents the **only open-source Kubernetes console with native quantum computing integration**.
+
+## Why This Matters
+
+Hybrid classical/quantum computing on Kubernetes is emerging as a serious HPC and research use case. As IBM Quantum expands access tiers and more teams run quantum workloads on Kubernetes infrastructure, the console's multi-cluster visibility of quantum jobs and circuit status fills a critical capability gap.
+
+## The Console's Quantum Story
+
+The integration enables:
+
+- **Qubit Grid Status**: Real-time visualization of qubit connectivity and availability across quantum processors
+- **QASM Circuit Viewer**: Interactive quantum circuit representation for debugging circuit definitions
+- **Quantum System Health**: Monitoring of quantum processor uptime, calibration status, and operational state
+- **Histogram Visualization**: Results and measurement outcome distribution across circuit executions
+
+## Outreach Opportunities
+
+### 1. Blog Post & Community Engagement
+Write a technical blog post: "The World's First Quantum-Aware Kubernetes Console: How KubeStellar Console Bridges Qubits and Clusters"
+
+Target communities:
+- IBM Quantum community and Qiskit community (~5k★ on GitHub)
+- IBM Research quantum computing groups
+- Quantum computing research institutions with Kubernetes infrastructure
+
+### 2. Conference Talk
+Submit a KubeCon NA 2026 CFP talk: "From Containers to Qubits: Kubernetes as the Control Plane for Quantum Computing Workloads"
+
+### 3. Mission Integration
+Create a `console-kb` mission: "Debugging a failing quantum circuit job in Kubernetes" — walk users through diagnosing quantum job failures using the console's circuit viewer and job history.
+
+### 4. Co-Authorship & Partnerships
+- Coordinate with IBM Research and quantum-kc-demo maintainers for joint blog post
+- Explore partnership opportunities with quantum computing education initiatives
+- Feature in IBM Quantum Network communications
+
+## Next Steps
+
+1. Reach out to IBM Quantum community leads
+2. Post in Qiskit community Slack and GitHub Discussions
+3. Contact IBM Research quantum computing group
+4. Submit KubeCon NA 2026 CFP with quantum focus
+5. Prepare demo video showing quantum job monitoring workflow
+
+---
+
+**Status**: Open for community engagement  
+**Target Timeline**: Q3 2026  
+**Primary Communities**: IBM Quantum, Qiskit, quantum research institutions

--- a/docs/docs/content/community/partners/quantum.md
+++ b/docs/docs/content/community/partners/quantum.md
@@ -1,0 +1,30 @@
+# KubeStellar Console + IBM Quantum Integration
+
+KubeStellar Console ships a **quantum computing card** that bridges Kubernetes cluster management with IBM Quantum workloads.
+
+## What's Included
+
+The quantum card provides unique capabilities:
+- **Qubit grid status** — real-time quantum system health and availability
+- **QASM circuit visualization** — quantum circuit representation and debugging
+- **Quantum system auth status** — credential and permission tracking
+- **Histogram visualization** — quantum measurement results and outcome distributions
+
+This is the **only open-source Kubernetes console with native quantum computing integration**.
+
+## Why KubeStellar Console for Quantum Computing
+
+- **Hybrid classical/quantum workflows** — manage both container and quantum workloads in one UI
+- **Multi-cluster quantum jobs** — coordinate quantum computations across Kubernetes deployments
+- **Enterprise quantum adoption** — streamlined observability for organizations adopting quantum computing
+
+## Learn More
+
+- [IBM Quantum](https://quantum.ibm.com) — quantum computing platform
+- [Qiskit](https://qiskit.org) — open-source quantum computing framework
+- [IBM Quantum Community](https://qisk.it/join) — join the quantum computing community
+- [KubeStellar Console Documentation](https://kubestellar.io/docs)
+
+## How to Get Started
+
+[Join the KubeStellar community](https://cloud-native.slack.com/archives/C097094RZ3M) to learn how to run hybrid classical/quantum workloads on Kubernetes.

--- a/docs/docs/content/community/partners/security-scanning.md
+++ b/docs/docs/content/community/partners/security-scanning.md
@@ -1,0 +1,70 @@
+# Security Scanning Integration: Trivy & Kubescape
+
+## Overview
+
+KubeStellar Console ships cards for both **Trivy** (vulnerability scanning) and **Kubescape** (compliance posture and security findings) — two of the most popular Kubernetes security tools with large active communities.
+
+- **Trivy** (~22k★ on GitHub): Most-starred CNCF security scanner with active Aqua Security community team
+- **Kubescape** (~10k★ on GitHub): CNCF Sandbox project with dedicated ecosystem integrations program
+
+The console provides **unique cross-cluster security posture visibility** — a capability gap in both tools' native UIs.
+
+## Why This Matters
+
+In the post-CVE landscape, security tooling visibility is highly relevant. Both Trivy and Kubescape actively promote integrations through ecosystem listing programs. The console's ability to show multi-cluster security posture in a single dashboard fills a critical operational need for platform teams managing distributed Kubernetes infrastructure.
+
+## The Console's Security Story
+
+### Trivy Integration
+- **Vulnerability Scanning Results**: Aggregated vulnerability findings across all clusters
+- **Severity Distribution**: Dashboard metrics showing critical, high, medium, and low severity counts
+- **Image & Package Tracking**: Multi-cluster visibility of scanned images and vulnerability trends
+- **Compliance Scanning**: Container and Kubernetes compliance scanning across infrastructure
+
+### Kubescape Integration
+- **Compliance Posture**: Real-time compliance status against security frameworks (CIS, NIST, etc.)
+- **Security Findings**: Aggregated security misconfigurations and violations across clusters
+- **Risk Prioritization**: Visual prioritization of remediation actions based on severity and exploitability
+- **Workload Security**: Pod security, RBAC correctness, and network policy compliance
+
+## Outreach Opportunities
+
+### 1. Ecosystem Integration Submissions
+Submit the console to:
+- **Trivy Ecosystem Integrations**: Submit to aquasecurity/trivy GitHub integrations page
+- **Kubescape Integrations Gallery**: List on kubescape.io integration marketplace
+- **ARMO Security Hub**: Register as official Kubescape monitoring partner
+
+### 2. Security-Focused Blog Post
+Write a technical blog: "Multi-cluster security posture at a glance: Trivy + Kubescape in KubeStellar Console"
+
+Content angles:
+- Multi-cluster vulnerability correlation and aggregate risk scoring
+- Cross-cluster compliance posture management
+- Platform team workflows for security policy enforcement
+- DevSecOps practices at scale
+
+### 3. Conference Coordination
+- Coordinate with Aqua Security and ARMO marketing for KubeCon NA 2026 co-presence
+- Propose joint security panel or workshop
+- Feature the console in security track presentations
+
+### 4. Community Engagement
+- Post in Trivy and Kubescape GitHub Discussions
+- Submit to relevant security and DevOps newsletters
+- Create video tutorials on multi-cluster security monitoring
+
+## Next Steps
+
+1. Reach out to Aqua Security ecosystem team
+2. Contact ARMO / Kubescape integrations program
+3. Submit ecosystem integration listings
+4. Prepare blog post for security audience
+5. Coordinate KubeCon demo and co-marketing materials
+
+---
+
+**Status**: Ready for ecosystem submission  
+**Target Timeline**: Q2-Q3 2026  
+**Primary Communities**: Trivy users, Kubescape users, security engineering teams, platform engineers  
+**Ecosystem Programs**: Aqua Security Integrations, ARMO Security Hub, CNCF Sandbox

--- a/docs/docs/content/community/partners/trivy-kubescape.md
+++ b/docs/docs/content/community/partners/trivy-kubescape.md
@@ -1,0 +1,33 @@
+# KubeStellar Console + Trivy + Kubescape Integration
+
+KubeStellar Console ships dedicated cards for both **Trivy** (vulnerability scanning) and **Kubescape** (compliance posture management).
+
+## What's Included
+
+### Trivy Card
+- Vulnerability scan results across clusters
+- Image scanning status and metrics
+- Risk assessment dashboard for multi-cluster deployments
+
+### Kubescape Card
+- Security posture scoring across clusters
+- Compliance violation detection
+- Policy violation tracking and trends
+
+## Why KubeStellar Console for Security Tools
+
+- **Multi-cluster security posture** — unified view across your entire Kubernetes fleet
+- **Cross-cluster compliance** — aggregate posture scores and policy violations
+- **Risk stratification** — prioritize security work by severity and cluster
+
+## Learn More
+
+- [Trivy by Aqua Security](https://trivy.dev) — container and artifact scanning
+- [Trivy on CNCF](https://www.cncf.io/projects/trivy/)
+- [Kubescape](https://www.kubescape.io) — Kubernetes-native security platform
+- [Kubescape on CNCF](https://www.cncf.io/projects/kubescape/)
+- [KubeStellar Console Documentation](https://kubestellar.io/docs)
+
+## How to Get Started
+
+[Join the KubeStellar community](https://cloud-native.slack.com/archives/C097094RZ3M) to explore multi-cluster security posture management with Trivy and Kubescape.


### PR DESCRIPTION
Fixes #18942, Fixes #18943, Fixes #18944, Fixes #18997, Fixes #18998, Fixes #18999, Fixes #19000

## Summary

Add CNCF ecosystem community outreach content documenting KubeStellar Console integrations with seven major CNCF projects.

## Changes

Added ecosystem partnership guides for:

1. **Knative** (CNCF Graduated, 5k★) — Knative Serving/Eventing status card
2. **Trivy** (22k★) + **Kubescape** (10k★) — vulnerability scanning and compliance cards
3. **IBM Quantum** — quantum computing card bridging K8s + IBM Quantum workloads
4. **Inspektor Gadget** (CNCF Sandbox, 3k★) — four eBPF observability cards (DNS, network, process, security audit)
5. **KEDA** (CNCF Graduated, 8k★) — event-driven autoscaling status card
6. **Harbor** (23k★) + **Jaeger** (20k★) + **Thanos** (13k★) — observability stack cards
7. **OPA/Gatekeeper** (CNCF Graduated, 9k★) — full policy management UI

Each guide:
- Highlights console's multi-cluster monitoring capabilities
- Explains why KubeStellar Console is the ideal integration partner
- Links to project documentation and CNCF resources
- Invites community participation

## Files Created

- `docs/docs/content/community/partners/knative.md`
- `docs/docs/content/community/partners/trivy-kubescape.md`
- `docs/docs/content/community/partners/quantum.md`
- `docs/docs/content/community/partners/gadget.md`
- `docs/docs/content/community/partners/keda.md`
- `docs/docs/content/community/partners/harbor-jaeger-thanos.md`
- `docs/docs/content/community/partners/opa-gatekeeper.md`
