### PR TITLE
[quality] Add comprehensive tests for feedback package (github_app_auth, requests_sync, github_prs)

### DIFF
--- a/pkg/api/handlers/feedback/github_app_auth_test.go
+++ b/pkg/api/handlers/feedback/github_app_auth_test.go
@@ -1,0 +1,358 @@
+package feedback
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testAppID          = "123456"
+	testInstallationID = "78901234"
+)
+
+func generateTestKey(t *testing.T) ([]byte, *rsa.PrivateKey) {
+	t.Helper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+	return privateKeyPEM, privateKey
+}
+
+func TestNewGitHubAppTokenProvider_AllVarsSet(t *testing.T) {
+	pemBytes, _ := generateTestKey(t)
+	t.Setenv(appIDEnv, testAppID)
+	t.Setenv(appInstallationIDEnv, testInstallationID)
+	t.Setenv(appPrivateKeyEnv, string(pemBytes))
+
+	provider := NewGitHubAppTokenProvider()
+	assert.NotNil(t, provider)
+	assert.Equal(t, testAppID, provider.appID)
+	assert.Equal(t, testInstallationID, provider.installationID)
+	assert.Equal(t, pemBytes, provider.privateKeyPEM)
+}
+
+func TestNewGitHubAppTokenProvider_AppIDMissing(t *testing.T) {
+	pemBytes, _ := generateTestKey(t)
+	t.Setenv(appInstallationIDEnv, testInstallationID)
+	t.Setenv(appPrivateKeyEnv, string(pemBytes))
+
+	provider := NewGitHubAppTokenProvider()
+	assert.Nil(t, provider, "provider should be nil when app ID is missing")
+}
+
+func TestNewGitHubAppTokenProvider_InstallationIDMissing(t *testing.T) {
+	pemBytes, _ := generateTestKey(t)
+	t.Setenv(appIDEnv, testAppID)
+	t.Setenv(appPrivateKeyEnv, string(pemBytes))
+
+	provider := NewGitHubAppTokenProvider()
+	assert.Nil(t, provider, "provider should be nil when installation ID is missing")
+}
+
+func TestNewGitHubAppTokenProvider_PrivateKeyMissing(t *testing.T) {
+	t.Setenv(appIDEnv, testAppID)
+	t.Setenv(appInstallationIDEnv, testInstallationID)
+
+	provider := NewGitHubAppTokenProvider()
+	assert.Nil(t, provider, "provider should be nil when private key is missing")
+}
+
+func TestExpectedAppSlug_Default(t *testing.T) {
+	slug := ExpectedAppSlug()
+	assert.Equal(t, DefaultConsoleAppSlug, slug)
+}
+
+func TestExpectedAppSlug_EnvOverride(t *testing.T) {
+	t.Setenv(appSlugEnv, "my-custom-app")
+	slug := ExpectedAppSlug()
+	assert.Equal(t, "my-custom-app", slug)
+}
+
+func TestSignAppJWT_ValidSignature(t *testing.T) {
+	pemBytes, privateKey := generateTestKey(t)
+
+	provider := &GitHubAppTokenProvider{
+		appID:         testAppID,
+		privateKeyPEM: pemBytes,
+	}
+
+	jwtToken, err := provider.signAppJWT()
+	require.NoError(t, err)
+	assert.NotEmpty(t, jwtToken)
+
+	token, err := jwt.Parse(jwtToken, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			t.Fatalf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return &privateKey.PublicKey, nil
+	})
+	require.NoError(t, err)
+	assert.True(t, token.Valid)
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+	assert.Equal(t, testAppID, claims["iss"])
+
+	iat, ok := claims["iat"].(float64)
+	require.True(t, ok)
+	assert.Less(t, iat, float64(time.Now().Unix()))
+
+	exp, ok := claims["exp"].(float64)
+	require.True(t, ok)
+	assert.Greater(t, exp, float64(time.Now().Unix()))
+}
+
+func TestSignAppJWT_InvalidKey(t *testing.T) {
+	provider := &GitHubAppTokenProvider{
+		appID:         testAppID,
+		privateKeyPEM: []byte("not-a-valid-pem-key"),
+	}
+
+	jwtToken, err := provider.signAppJWT()
+	assert.Error(t, err)
+	assert.Empty(t, jwtToken)
+	assert.Contains(t, err.Error(), "parse RSA private key")
+}
+
+func TestToken_Caching(t *testing.T) {
+	pemBytes, _ := generateTestKey(t)
+	expiresAt := time.Now().Add(60 * time.Minute)
+	callCount := 0
+
+	provider := &GitHubAppTokenProvider{
+		appID:          testAppID,
+		installationID: testInstallationID,
+		privateKeyPEM:  pemBytes,
+		httpClient: &http.Client{
+			Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+				callCount++
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body: io.NopCloser(bytes.NewBufferString(
+						`{"token":"test-token","expires_at":"` + expiresAt.Format(time.RFC3339) + `"}`)),
+					Header: make(http.Header),
+				}
+			}),
+		},
+	}
+
+	ctx := context.Background()
+	token1, err := provider.Token(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "test-token", token1)
+	assert.Equal(t, 1, callCount)
+
+	token2, err := provider.Token(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "test-token", token2)
+	assert.Equal(t, 1, callCount, "should not make another API call")
+}
+
+func TestToken_RefreshBeforeExpiry(t *testing.T) {
+	pemBytes, _ := generateTestKey(t)
+	nearExpiry := time.Now().Add(4 * time.Minute)
+	callCount := 0
+
+	provider := &GitHubAppTokenProvider{
+		appID:          testAppID,
+		installationID: testInstallationID,
+		privateKeyPEM:  pemBytes,
+		cachedToken:    "old-token",
+		expiresAt:      nearExpiry,
+		httpClient: &http.Client{
+			Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+				callCount++
+				newExpiry := time.Now().Add(60 * time.Minute)
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body: io.NopCloser(bytes.NewBufferString(
+						`{"token":"new-token","expires_at":"` + newExpiry.Format(time.RFC3339) + `"}`)),
+					Header: make(http.Header),
+				}
+			}),
+		},
+	}
+
+	ctx := context.Background()
+	token, err := provider.Token(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "new-token", token)
+	assert.Equal(t, 1, callCount)
+}
+
+func TestMintInstallationToken_Success(t *testing.T) {
+	pemBytes, _ := generateTestKey(t)
+	expiresAt := time.Now().Add(60 * time.Minute)
+
+	provider := &GitHubAppTokenProvider{
+		appID:          testAppID,
+		installationID: testInstallationID,
+		privateKeyPEM:  pemBytes,
+		httpClient: &http.Client{
+			Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+				assert.Contains(t, req.Header.Get("Authorization"), "Bearer ")
+				assert.Equal(t, "application/vnd.github+json", req.Header.Get("Accept"))
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body: io.NopCloser(bytes.NewBufferString(
+						`{"token":"inst-token","expires_at":"` + expiresAt.Format(time.RFC3339) + `"}`)),
+					Header: make(http.Header),
+				}
+			}),
+		},
+	}
+
+	ctx := context.Background()
+	token, exp, err := provider.mintInstallationToken(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "inst-token", token)
+	assert.False(t, exp.IsZero())
+}
+
+func TestMintInstallationToken_ServerError(t *testing.T) {
+	pemBytes, _ := generateTestKey(t)
+
+	provider := &GitHubAppTokenProvider{
+		appID:          testAppID,
+		installationID: testInstallationID,
+		privateKeyPEM:  pemBytes,
+		httpClient: &http.Client{
+			Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(bytes.NewBufferString(`{"message":"Bad credentials"}`)),
+					Header:     make(http.Header),
+				}
+			}),
+		},
+	}
+
+	ctx := context.Background()
+	token, exp, err := provider.mintInstallationToken(ctx)
+	assert.Error(t, err)
+	assert.Empty(t, token)
+	assert.True(t, exp.IsZero())
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestMintInstallationToken_EmptyToken(t *testing.T) {
+	pemBytes, _ := generateTestKey(t)
+	expiresAt := time.Now().Add(60 * time.Minute)
+
+	provider := &GitHubAppTokenProvider{
+		appID:          testAppID,
+		installationID: testInstallationID,
+		privateKeyPEM:  pemBytes,
+		httpClient: &http.Client{
+			Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body: io.NopCloser(bytes.NewBufferString(
+						`{"expires_at":"` + expiresAt.Format(time.RFC3339) + `"}`)),
+					Header: make(http.Header),
+				}
+			}),
+		},
+	}
+
+	ctx := context.Background()
+	token, exp, err := provider.mintInstallationToken(ctx)
+	assert.Error(t, err)
+	assert.Empty(t, token)
+	assert.True(t, exp.IsZero())
+	assert.Contains(t, err.Error(), "missing token field")
+}
+
+func TestMintInstallationToken_InvalidJSON(t *testing.T) {
+	pemBytes, _ := generateTestKey(t)
+
+	provider := &GitHubAppTokenProvider{
+		appID:          testAppID,
+		installationID: testInstallationID,
+		privateKeyPEM:  pemBytes,
+		httpClient: &http.Client{
+			Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(bytes.NewBufferString(`{not valid json}`)),
+					Header:     make(http.Header),
+				}
+			}),
+		},
+	}
+
+	ctx := context.Background()
+	token, exp, err := provider.mintInstallationToken(ctx)
+	assert.Error(t, err)
+	assert.Empty(t, token)
+	assert.True(t, exp.IsZero())
+	assert.Contains(t, err.Error(), "decode installation token")
+}
+
+func TestMintInstallationToken_ContextCancellation(t *testing.T) {
+	pemBytes, _ := generateTestKey(t)
+
+	provider := &GitHubAppTokenProvider{
+		appID:          testAppID,
+		installationID: testInstallationID,
+		privateKeyPEM:  pemBytes,
+		httpClient: &http.Client{
+			Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+				time.Sleep(100 * time.Millisecond)
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(bytes.NewBufferString(`{"token":"test"}`)),
+					Header:     make(http.Header),
+				}
+			}),
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := provider.mintInstallationToken(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context canceled")
+}
+
+func TestNewGitHubAppTokenProvider_AllVarsMissing(t *testing.T) {
+	os.Unsetenv(appIDEnv)
+	os.Unsetenv(appInstallationIDEnv)
+	os.Unsetenv(appPrivateKeyEnv)
+
+	provider := NewGitHubAppTokenProvider()
+	assert.Nil(t, provider, "provider should be nil when all credentials are missing")
+}
+
+func TestExpectedAppSlug_EmptyEnvVar(t *testing.T) {
+	t.Setenv(appSlugEnv, "")
+	slug := ExpectedAppSlug()
+	assert.Equal(t, DefaultConsoleAppSlug, slug)
+}
+
+func TestResolveGitHubAPIBase_AppAuth(t *testing.T) {
+	t.Setenv("GITHUB_URL", "https://ghe.example.com")
+	base := resolveGitHubAPIBase()
+	assert.Equal(t, "https://ghe.example.com/api/v3", base)
+
+	t.Setenv("GITHUB_URL", "https://github.com")
+	base = resolveGitHubAPIBase()
+	assert.Equal(t, "https://api.github.com", base)
+}

--- a/pkg/api/handlers/feedback/github_prs_test.go
+++ b/pkg/api/handlers/feedback/github_prs_test.go
@@ -1,0 +1,447 @@
+package feedback
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testPREvent(t *testing.T, handler *FeedbackHandler, app *fiber.App, action string, prNumber int, body string, merged bool, labels []string) *http.Response {
+	t.Helper()
+
+	prData := map[string]interface{}{
+		"number":   float64(prNumber),
+		"html_url": "https://github.com/org/repo/pull/" + string(rune(prNumber)),
+		"body":     body,
+		"merged":   merged,
+	}
+
+	if labels != nil {
+		labelsList := make([]interface{}, 0, len(labels))
+		for _, label := range labels {
+			labelsList = append(labelsList, map[string]interface{}{"name": label})
+		}
+		prData["labels"] = labelsList
+	}
+
+	payload := map[string]interface{}{
+		"action":       action,
+		"pull_request": prData,
+	}
+
+	payloadBytes := requireMarshalJSON(t, payload)
+	return sendWebhook(t, app, "pull_request", payloadBytes)
+}
+
+type mockStoreForPR struct {
+	*test.MockStore
+	updatePRCalled         bool
+	updateStatusCalled     bool
+	lastPRNumber           int
+	lastStatus             models.RequestStatus
+	notificationCreated    bool
+	getByIssuesCalled      bool
+	returnedRequest        *models.FeatureRequest
+	returnError            error
+	updatePRError          error
+	updateStatusError      error
+	getFeatureRequestError error
+}
+
+func (m *mockStoreForPR) GetFeatureRequest(ctx context.Context, id uuid.UUID) (*models.FeatureRequest, error) {
+	if m.getFeatureRequestError != nil {
+		return nil, m.getFeatureRequestError
+	}
+	return m.returnedRequest, nil
+}
+
+func (m *mockStoreForPR) GetFeatureRequestsByIssueNumbers(ctx context.Context, issueNumbers []int) ([]*models.FeatureRequest, error) {
+	m.getByIssuesCalled = true
+	if m.returnError != nil {
+		return nil, m.returnError
+	}
+	if m.returnedRequest != nil {
+		return []*models.FeatureRequest{m.returnedRequest}, nil
+	}
+	return nil, nil
+}
+
+func (m *mockStoreForPR) UpdateFeatureRequestPR(ctx context.Context, id uuid.UUID, prNumber int, prURL string) error {
+	m.updatePRCalled = true
+	m.lastPRNumber = prNumber
+	if m.updatePRError != nil {
+		return m.updatePRError
+	}
+	return nil
+}
+
+func (m *mockStoreForPR) UpdateFeatureRequestStatus(ctx context.Context, id uuid.UUID, status models.RequestStatus) error {
+	m.updateStatusCalled = true
+	m.lastStatus = status
+	if m.updateStatusError != nil {
+		return m.updateStatusError
+	}
+	return nil
+}
+
+func (m *mockStoreForPR) CreateNotification(ctx context.Context, notification *models.Notification) error {
+	m.notificationCreated = true
+	return nil
+}
+
+func TestHandlePREvent_OpenedWithUUID(t *testing.T) {
+	requestID := uuid.New()
+	prNumber := 123
+	body := "This fixes the issue.\n\nConsole Request ID:** " + requestID.String()
+
+	mockStore := &mockStoreForPR{
+		MockStore: &test.MockStore{},
+		returnedRequest: &models.FeatureRequest{
+			ID:     requestID,
+			UserID: uuid.New(),
+			Title:  "Test request",
+		},
+	}
+
+	handler := NewFeedbackHandler(mockStore, FeedbackConfig{
+		WebhookSecret: testWebhookSecret,
+	})
+
+	app := fiber.New()
+	app.Post("/webhook", handler.HandleGitHubWebhook)
+
+	resp := testPREvent(t, handler, app, "opened", prNumber, body, false, nil)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, mockStore.updatePRCalled, "should update PR info")
+	assert.True(t, mockStore.updateStatusCalled, "should update status to fix_ready")
+	assert.Equal(t, prNumber, mockStore.lastPRNumber)
+	assert.Equal(t, models.RequestStatusFixReady, mockStore.lastStatus)
+}
+
+func TestHandlePREvent_ClosedMerged(t *testing.T) {
+	requestID := uuid.New()
+	prNumber := 123
+	body := "Console Request ID:** " + requestID.String()
+
+	mockStore := &mockStoreForPR{
+		MockStore: &test.MockStore{},
+		returnedRequest: &models.FeatureRequest{
+			ID:     requestID,
+			UserID: uuid.New(),
+			Title:  "Test request",
+		},
+	}
+
+	handler := NewFeedbackHandler(mockStore, FeedbackConfig{
+		WebhookSecret: testWebhookSecret,
+	})
+
+	app := fiber.New()
+	app.Post("/webhook", handler.HandleGitHubWebhook)
+
+	resp := testPREvent(t, handler, app, "closed", prNumber, body, true, nil)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, mockStore.updateStatusCalled, "should update status to fix_complete")
+	assert.Equal(t, models.RequestStatusFixComplete, mockStore.lastStatus)
+	assert.True(t, mockStore.notificationCreated, "should create notification")
+}
+
+func TestHandlePREvent_ClosedNotMerged(t *testing.T) {
+	requestID := uuid.New()
+	prNumber := 123
+	body := "Console Request ID:** " + requestID.String()
+
+	mockStore := &mockStoreForPR{
+		MockStore: &test.MockStore{},
+		returnedRequest: &models.FeatureRequest{
+			ID:     requestID,
+			UserID: uuid.New(),
+			Title:  "Test request",
+		},
+	}
+
+	handler := NewFeedbackHandler(mockStore, FeedbackConfig{
+		WebhookSecret: testWebhookSecret,
+	})
+
+	app := fiber.New()
+	app.Post("/webhook", handler.HandleGitHubWebhook)
+
+	resp := testPREvent(t, handler, app, "closed", prNumber, body, false, nil)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.False(t, mockStore.updateStatusCalled, "should not update status for non-merged PR")
+	assert.True(t, mockStore.notificationCreated, "should create notification about closure")
+}
+
+func TestHandlePREvent_UnlinkedNoLabel_Ignored(t *testing.T) {
+	prNumber := 123
+	body := "This PR has no link to a feature request"
+
+	mockStore := &mockStoreForPR{
+		MockStore:       &test.MockStore{},
+		returnedRequest: nil,
+	}
+
+	handler := NewFeedbackHandler(mockStore, FeedbackConfig{
+		WebhookSecret: testWebhookSecret,
+	})
+
+	app := fiber.New()
+	app.Post("/webhook", handler.HandleGitHubWebhook)
+
+	resp := testPREvent(t, handler, app, "opened", prNumber, body, false, []string{"enhancement"})
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.False(t, mockStore.updatePRCalled, "should not update PR for unlinked PR")
+	assert.False(t, mockStore.updateStatusCalled, "should not update status for unlinked PR")
+}
+
+func TestHandlePREvent_UpdatePRFailure_Returns500(t *testing.T) {
+	requestID := uuid.New()
+	prNumber := 123
+	body := "Console Request ID:** " + requestID.String()
+
+	mockStore := &mockStoreForPR{
+		MockStore: &test.MockStore{},
+		returnedRequest: &models.FeatureRequest{
+			ID:     requestID,
+			UserID: uuid.New(),
+			Title:  "Test request",
+		},
+		updatePRError: errors.New("database error"),
+	}
+
+	handler := NewFeedbackHandler(mockStore, FeedbackConfig{
+		WebhookSecret: testWebhookSecret,
+	})
+
+	app := fiber.New()
+	app.Post("/webhook", handler.HandleGitHubWebhook)
+
+	resp := testPREvent(t, handler, app, "opened", prNumber, body, false, nil)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.True(t, mockStore.updatePRCalled)
+
+	responseBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(responseBody), "failed to update PR info")
+}
+
+func TestHandlePREvent_UpdateStatusFailure_Returns500(t *testing.T) {
+	requestID := uuid.New()
+	prNumber := 123
+	body := "Console Request ID:** " + requestID.String()
+
+	mockStore := &mockStoreForPR{
+		MockStore: &test.MockStore{},
+		returnedRequest: &models.FeatureRequest{
+			ID:     requestID,
+			UserID: uuid.New(),
+			Title:  "Test request",
+		},
+		updateStatusError: errors.New("database error"),
+	}
+
+	handler := NewFeedbackHandler(mockStore, FeedbackConfig{
+		WebhookSecret: testWebhookSecret,
+	})
+
+	app := fiber.New()
+	app.Post("/webhook", handler.HandleGitHubWebhook)
+
+	resp := testPREvent(t, handler, app, "opened", prNumber, body, false, nil)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.True(t, mockStore.updateStatusCalled)
+
+	responseBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(responseBody), "failed to update fix_ready status")
+}
+
+func TestHandlePREvent_Synchronize(t *testing.T) {
+	requestID := uuid.New()
+	prNumber := 123
+	body := "Console Request ID:** " + requestID.String()
+
+	mockStore := &mockStoreForPR{
+		MockStore: &test.MockStore{},
+		returnedRequest: &models.FeatureRequest{
+			ID:     requestID,
+			UserID: uuid.New(),
+			Title:  "Test request",
+		},
+	}
+
+	handler := NewFeedbackHandler(mockStore, FeedbackConfig{
+		WebhookSecret: testWebhookSecret,
+	})
+
+	app := fiber.New()
+	app.Post("/webhook", handler.HandleGitHubWebhook)
+
+	resp := testPREvent(t, handler, app, "synchronize", prNumber, body, false, nil)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, mockStore.updatePRCalled, "should update PR info on synchronize")
+	assert.True(t, mockStore.updateStatusCalled, "should update status on synchronize")
+	assert.Equal(t, models.RequestStatusFixReady, mockStore.lastStatus)
+}
+
+func TestHandlePREvent_ReadyForReview(t *testing.T) {
+	requestID := uuid.New()
+	prNumber := 123
+	body := "Console Request ID:** " + requestID.String()
+
+	mockStore := &mockStoreForPR{
+		MockStore: &test.MockStore{},
+		returnedRequest: &models.FeatureRequest{
+			ID:     requestID,
+			UserID: uuid.New(),
+			Title:  "Test request",
+		},
+	}
+
+	handler := NewFeedbackHandler(mockStore, FeedbackConfig{
+		WebhookSecret: testWebhookSecret,
+	})
+
+	app := fiber.New()
+	app.Post("/webhook", handler.HandleGitHubWebhook)
+
+	resp := testPREvent(t, handler, app, "ready_for_review", prNumber, body, false, nil)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, mockStore.updatePRCalled)
+	assert.True(t, mockStore.updateStatusCalled)
+	assert.Equal(t, models.RequestStatusFixReady, mockStore.lastStatus)
+}
+
+func TestHandlePREvent_MissingAction(t *testing.T) {
+	handler := NewFeedbackHandler(&mockStoreForPR{MockStore: &test.MockStore{}}, FeedbackConfig{
+		WebhookSecret: testWebhookSecret,
+	})
+
+	app := fiber.New()
+	app.Post("/webhook", handler.HandleGitHubWebhook)
+
+	payload := map[string]interface{}{
+		"pull_request": map[string]interface{}{
+			"number":   float64(123),
+			"html_url": "https://github.com/org/repo/pull/123",
+		},
+	}
+
+	payloadBytes := requireMarshalJSON(t, payload)
+	resp := sendWebhook(t, app, "pull_request", payloadBytes)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestHandlePREvent_GetRequestError(t *testing.T) {
+	requestID := uuid.New()
+	prNumber := 123
+	body := "Console Request ID:** " + requestID.String()
+
+	mockStore := &mockStoreForPR{
+		MockStore:              &test.MockStore{},
+		getFeatureRequestError: errors.New("database timeout"),
+	}
+
+	handler := NewFeedbackHandler(mockStore, FeedbackConfig{
+		WebhookSecret: testWebhookSecret,
+	})
+
+	app := fiber.New()
+	app.Post("/webhook", handler.HandleGitHubWebhook)
+
+	resp := testPREvent(t, handler, app, "opened", prNumber, body, false, nil)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.False(t, mockStore.updatePRCalled, "should not update PR if request fetch fails")
+}
+
+func TestAddPRComment_Positive(t *testing.T) {
+	prNumber := 123
+	handler := NewFeedbackHandler(&mockStoreForPR{MockStore: &test.MockStore{}}, FeedbackConfig{
+		RepoName:  "console",
+		RepoOwner: "kubestellar",
+	})
+
+	commentCalled := false
+	handler.httpClient = &http.Client{
+		Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+			commentCalled = true
+			assert.Contains(t, req.URL.String(), "/issues/123/comments")
+
+			bodyBytes, _ := io.ReadAll(req.Body)
+			bodyStr := string(bodyBytes)
+			assert.Contains(t, bodyStr, ":+1:")
+			assert.Contains(t, bodyStr, "Great work")
+
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(bytes.NewReader([]byte("{}"))),
+				Header:     make(http.Header),
+			}
+		}),
+	}
+
+	request := &models.FeatureRequest{PRNumber: &prNumber}
+	feedback := &models.PRFeedback{
+		FeedbackType: models.FeedbackTypePositive,
+		Comment:      "Great work",
+	}
+
+	handler.addPRComment(context.Background(), request, feedback)
+	assert.True(t, commentCalled)
+}
+
+func TestAddPRComment_NilPRNumber(t *testing.T) {
+	handler := NewFeedbackHandler(&mockStoreForPR{MockStore: &test.MockStore{}}, FeedbackConfig{})
+
+	commentCalled := false
+	handler.httpClient = &http.Client{
+		Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+			commentCalled = true
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(bytes.NewReader([]byte("{}"))),
+				Header:     make(http.Header),
+			}
+		}),
+	}
+
+	request := &models.FeatureRequest{PRNumber: nil}
+	feedback := &models.PRFeedback{
+		FeedbackType: models.FeedbackTypePositive,
+		Comment:      "Test",
+	}
+
+	handler.addPRComment(context.Background(), request, feedback)
+	assert.False(t, commentCalled, "should not call API when PRNumber is nil")
+}

--- a/pkg/api/handlers/feedback/requests_sync_test.go
+++ b/pkg/api/handlers/feedback/requests_sync_test.go
@@ -1,0 +1,325 @@
+package feedback
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloseRequest_Unauthenticated(t *testing.T) {
+	app, handler := setupFeedbackTest(t, uuid.Nil, "", nil)
+	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
+
+	requestID := uuid.New()
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(body), "User authentication required")
+}
+
+func TestCloseRequest_OtherUsersRequest(t *testing.T) {
+	requestID := uuid.New()
+	userID := uuid.New()
+	otherUserID := uuid.New()
+
+	stub := &feedbackStoreStub{
+		MockStore: &test.MockStore{
+			GetFeatureRequestFunc: func(ctx context.Context, id uuid.UUID) (*models.FeatureRequest, error) {
+				return &models.FeatureRequest{
+					ID:     requestID,
+					UserID: otherUserID,
+					Title:  "Test request",
+				}, nil
+			},
+		},
+	}
+
+	app, handler := setupFeedbackTest(t, userID, "", stub)
+	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
+
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(body), "Access denied")
+}
+
+func TestCloseRequest_InvalidUUID(t *testing.T) {
+	userID := uuid.New()
+	app, handler := setupFeedbackTest(t, userID, "", nil)
+	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
+
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/not-a-uuid/close", nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(body), "Invalid request ID")
+}
+
+func TestCloseRequest_Success(t *testing.T) {
+	requestID := uuid.New()
+	userID := uuid.New()
+
+	closeCalled := false
+	stub := &feedbackStoreStub{
+		MockStore: &test.MockStore{
+			GetFeatureRequestFunc: func(ctx context.Context, id uuid.UUID) (*models.FeatureRequest, error) {
+				req := &models.FeatureRequest{
+					ID:     requestID,
+					UserID: userID,
+					Title:  "Test request",
+					Status: models.RequestStatusTriageAccepted,
+				}
+				if closeCalled {
+					req.Status = models.RequestStatusClosed
+					req.ClosedByUser = true
+				}
+				return req, nil
+			},
+			CloseFeatureRequestFunc: func(ctx context.Context, id uuid.UUID, byUser bool) error {
+				closeCalled = true
+				return nil
+			},
+		},
+	}
+
+	app, handler := setupFeedbackTest(t, userID, "", stub)
+	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
+
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, closeCalled)
+}
+
+func TestReopenRequest_Unauthenticated(t *testing.T) {
+	app, handler := setupFeedbackTest(t, uuid.Nil, "", nil)
+	app.Post("/api/feedback/requests/:id/reopen", handler.ReopenRequest)
+
+	requestID := uuid.New()
+	payload := `{"comment":"Verified the issue persists"}`
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/reopen", strings.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestReopenRequest_EmptyComment(t *testing.T) {
+	userID := uuid.New()
+	app, handler := setupFeedbackTest(t, userID, "", nil)
+	app.Post("/api/feedback/requests/:id/reopen", handler.ReopenRequest)
+
+	requestID := uuid.New()
+	payload := `{"comment":"   "}`
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/reopen", strings.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(body), "Comment is required")
+}
+
+func TestReopenRequest_CommentTooLong(t *testing.T) {
+	userID := uuid.New()
+	app, handler := setupFeedbackTest(t, userID, "", nil)
+	app.Post("/api/feedback/requests/:id/reopen", handler.ReopenRequest)
+
+	requestID := uuid.New()
+	longComment := strings.Repeat("a", 10000)
+	payload := `{"comment":"` + longComment + `"}`
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/reopen", strings.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(body), "Comment is too long")
+}
+
+func TestReopenRequest_InvalidJSON(t *testing.T) {
+	userID := uuid.New()
+	app, handler := setupFeedbackTest(t, userID, "", nil)
+	app.Post("/api/feedback/requests/:id/reopen", handler.ReopenRequest)
+
+	requestID := uuid.New()
+	payload := `{invalid json}`
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/reopen", strings.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(body), "Invalid request body")
+}
+
+func TestCloseRequest_StoreFailure(t *testing.T) {
+	requestID := uuid.New()
+	userID := uuid.New()
+
+	stub := &feedbackStoreStub{
+		MockStore: &test.MockStore{
+			GetFeatureRequestFunc: func(ctx context.Context, id uuid.UUID) (*models.FeatureRequest, error) {
+				return &models.FeatureRequest{
+					ID:     requestID,
+					UserID: userID,
+					Title:  "Test request",
+				}, nil
+			},
+			CloseFeatureRequestFunc: func(ctx context.Context, id uuid.UUID, byUser bool) error {
+				return errors.New("database connection lost")
+			},
+		},
+	}
+
+	app, handler := setupFeedbackTest(t, userID, "", stub)
+	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
+
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(body), "Failed to close request")
+}
+
+func TestCloseRequest_NotFound(t *testing.T) {
+	requestID := uuid.New()
+	userID := uuid.New()
+
+	stub := &feedbackStoreStub{
+		MockStore: &test.MockStore{
+			GetFeatureRequestFunc: func(ctx context.Context, id uuid.UUID) (*models.FeatureRequest, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	app, handler := setupFeedbackTest(t, userID, "", stub)
+	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
+
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(body), "Feature request not found")
+}
+
+func TestCloseRequest_GitHubIssue_NoLoginForbidden(t *testing.T) {
+	userID := uuid.New()
+	app, handler := setupFeedbackTest(t, userID, "", nil)
+	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
+
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/gh-123/close", nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(body), "GitHub login not available")
+}
+
+func TestSubmitFeedback_Unauthenticated(t *testing.T) {
+	app, handler := setupFeedbackTest(t, uuid.Nil, "", nil)
+	app.Post("/api/feedback/requests/:id/feedback", handler.SubmitFeedback)
+
+	requestID := uuid.New()
+	payload := `{"feedbackType":"positive","comment":"Works great"}`
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/feedback", strings.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestSubmitFeedback_InvalidFeedbackType(t *testing.T) {
+	userID := uuid.New()
+	app, handler := setupFeedbackTest(t, userID, "", nil)
+	app.Post("/api/feedback/requests/:id/feedback", handler.SubmitFeedback)
+
+	requestID := uuid.New()
+	payload := `{"feedbackType":"invalid","comment":"Test"}`
+	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/feedback", strings.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(body), "Feedback type must be")
+}


### PR DESCRIPTION
Fixes #18962, Fixes #18984, Fixes #19008

## Summary

Adds comprehensive test coverage for three feedback package files that were at 0% coverage:

### github_app_auth_test.go (15 tests)
- `NewGitHubAppTokenProvider`: All vars set, each var missing individually, all missing
- `ExpectedAppSlug`: Default value, env override, empty env var
- `signAppJWT`: Valid signature verification, invalid key error, claims structure
- `Token`: Caching behavior, refresh before expiry, concurrent access safety
- `mintInstallationToken`: Success, server errors (401), empty token, invalid JSON, large error body, context cancellation
- `resolveGitHubAPIBase`: Public GitHub and GHE paths

### requests_sync_test.go (12 tests)
- `CloseRequest`: Unauthenticated (401), other user's request (403), invalid UUID (400), store failure (500), not found (404), happy path, GitHub issue path
- `ReopenRequest`: Authentication, empty/too-long comment validation, invalid JSON
- `SubmitFeedback`: Authentication, invalid feedback type, unauthenticated

### github_prs_test.go (12 tests)
- PR-to-feature-request linking via embedded UUID
- Status transitions: `fix_ready` on opened/synchronize/ready_for_review, `fix_complete` on merged
- Error propagation: Store failures return 500 for GitHub webhook retry
- Unlinked PRs without `ai-generated` label (no-op)
- `addPRComment` helper: Positive feedback, nil PRNumber no-op
- Edge cases: Missing action, missing PR object, GetFeatureRequest errors