### PR TITLE
[scanner] fix: add Harbor, Jaeger, KEDA, OPA, and Inspektor Gadget community outreach

### DIFF
--- a/docs/docs/content/community/outreach/harbor.md
+++ b/docs/docs/content/community/outreach/harbor.md
@@ -1,0 +1,28 @@
+# Harbor Registry Integration
+
+KubeStellar Console ships a dedicated **Harbor status card** that surfaces container registry health, image pull success rates, and project storage usage across your multi-cluster deployments.
+
+## About Harbor
+
+[Harbor](https://goharbor.io/) is a CNCF Graduated container registry project used by enterprise organizations worldwide (VMware, Ant Group, and many others). With 23k+ GitHub stars, Harbor represents a massive practitioner community building container supply chain solutions.
+
+## Console Integration
+
+The `harbor_status` card in KubeStellar Console provides:
+- Harbor registry health and availability metrics
+- Image pull success rates across clusters
+- Project storage usage and quotas
+- Cross-cluster registry synchronization status
+
+## Engagement Opportunities
+
+- Discuss Harbor + KubeStellar console integration in [Harbor community discussions](https://github.com/goharbor/harbor/discussions)
+- Submit to CNCF Container Registry Working Group
+- Blog post: "Full-stack observability across clusters: Harbor + Jaeger + Thanos in KubeStellar Console"
+- Co-presence at KubeCon for enterprise users evaluating dashboard integrations
+
+## More Information
+
+- [Harbor Project](https://goharbor.io/)
+- [Harbor GitHub](https://github.com/goharbor/harbor)
+- [KubeStellar Console](https://console.kubestellar.io/)

--- a/docs/docs/content/community/outreach/inspektor-gadget.md
+++ b/docs/docs/content/community/outreach/inspektor-gadget.md
@@ -1,0 +1,30 @@
+# Inspektor Gadget eBPF Security Integration
+
+KubeStellar Console ships a **full Inspektor Gadget integration** with four specialized eBPF-powered cards for runtime security observability across your multi-cluster deployments.
+
+## About Inspektor Gadget
+
+[Inspektor Gadget](https://www.inspektor-gadget.io/) is a CNCF Sandbox project providing eBPF-based tools for runtime security and observability on Kubernetes. Maintained by Microsoft and the community, Inspektor Gadget enables security engineers to trace DNS queries, network packets, process execution, and security audit events at the kernel level across entire clusters.
+
+## Console Integration
+
+KubeStellar Console's Inspektor Gadget card suite provides:
+- **SecurityAuditCard** — Real-time security audit findings via eBPF, surfacing policy violations and suspicious activities
+- **DNSTraceCard** — Live DNS query tracing across pods, enabling visibility into service discovery and external communications
+- **NetworkTraceCard** — Network packet tracing and flow analysis, tracking inter-pod and pod-to-external communications
+- **ProcessTraceCard** — Process execution tracing, capturing all process creation events across clusters
+
+This represents a unique **multi-cluster eBPF observability dashboard** — a single pane of glass for runtime security and network observability across fleets.
+
+## Engagement Opportunities
+
+- Open discussion on [Inspektor Gadget GitHub](https://github.com/inspektor-gadget/inspektor-gadget/discussions): "Console integration for multi-cluster eBPF observability"
+- Submit to CNCF Security TAG for amplification
+- Blog post: "eBPF Security at Scale: DNS, Network, Process + Security Audit across K8s clusters in KubeStellar Console"
+- KubeCon NA 2026 co-demo with Inspektor Gadget maintainers
+
+## More Information
+
+- [Inspektor Gadget Project](https://www.inspektor-gadget.io/)
+- [Inspektor Gadget GitHub](https://github.com/inspektor-gadget/inspektor-gadget)
+- [KubeStellar Console](https://console.kubestellar.io/)

--- a/docs/docs/content/community/outreach/jaeger.md
+++ b/docs/docs/content/community/outreach/jaeger.md
@@ -1,0 +1,28 @@
+# Jaeger Distributed Tracing Integration
+
+KubeStellar Console ships a dedicated **Jaeger status card** that monitors distributed trace collection health and backend status across your multi-cluster deployments.
+
+## About Jaeger
+
+[Jaeger](https://www.jaegertracing.io/) is a CNCF Graduated distributed tracing platform used by organizations managing microservices at scale. With 20k+ GitHub stars, Jaeger is the industry standard for observability in cloud-native architectures.
+
+## Console Integration
+
+The `jaeger_status` card in KubeStellar Console provides:
+- Jaeger backend health and collector status
+- Trace collection health metrics
+- Cross-cluster tracing pipeline visibility
+- Integration with multi-cluster observability stack
+
+## Engagement Opportunities
+
+- Discuss Jaeger + KubeStellar console integration in [Jaeger community discussions](https://github.com/jaegertracing/jaeger/discussions)
+- Submit to CNCF Observability Working Group
+- Blog post: "Full-stack observability across clusters: Jaeger + Thanos + Harbor in KubeStellar Console"
+- KubeCon co-demo showcasing multi-cluster distributed tracing
+
+## More Information
+
+- [Jaeger Project](https://www.jaegertracing.io/)
+- [Jaeger GitHub](https://github.com/jaegertracing/jaeger)
+- [KubeStellar Console](https://console.kubestellar.io/)

--- a/docs/docs/content/community/outreach/keda.md
+++ b/docs/docs/content/community/outreach/keda.md
@@ -1,0 +1,28 @@
+# KEDA Event-Driven Autoscaling Integration
+
+KubeStellar Console ships a **KEDA status card** that surfaces ScaledObject health, trigger metrics, and autoscaling events across your multi-cluster deployments.
+
+## About KEDA
+
+[KEDA](https://keda.sh/) (Kubernetes Event Driven Autoscaling) is a CNCF Graduated project that enables event-driven autoscaling for Kubernetes workloads. With 8k+ GitHub stars and adoption by Azure, Red Hat, and AWS, KEDA is the standard for connecting Kubernetes autoscaling to external event sources.
+
+## Console Integration
+
+The `keda_status` card in KubeStellar Console provides:
+- ScaledObject health and status across clusters
+- Trigger metrics and autoscaling event history
+- Multi-cluster autoscaling trigger health visibility
+- Integration with event-driven workload management
+
+## Engagement Opportunities
+
+- Open discussion on [KEDA GitHub](https://github.com/kedacore/keda/discussions): "KubeStellar Console ships KEDA status card for multi-cluster autoscaling visibility"
+- Post in KEDA community channels (Slack, GitHub Discussions)
+- Blog post: "Event-Driven Autoscaling at Scale: Monitoring KEDA across multi-cluster deployments"
+- Target: platform teams managing KEDA at scale
+
+## More Information
+
+- [KEDA Project](https://keda.sh/)
+- [KEDA GitHub](https://github.com/kedacore/keda)
+- [KubeStellar Console](https://console.kubestellar.io/)

--- a/docs/docs/content/community/outreach/opa-gatekeeper.md
+++ b/docs/docs/content/community/outreach/opa-gatekeeper.md
@@ -1,0 +1,32 @@
+# OPA/Gatekeeper Policy Management Integration
+
+KubeStellar Console ships a **full OPA/Gatekeeper policy management UI** with comprehensive multi-cluster policy oversight and enforcement capabilities.
+
+## About OPA/Gatekeeper
+
+[Open Policy Agent (OPA)](https://www.openpolicyagent.org/) and [Gatekeeper](https://open-policy-agent.github.io/gatekeeper/) are CNCF Graduated projects providing policy-as-code for Kubernetes. With 9k+ GitHub stars, OPA/Gatekeeper is the industry standard for Kubernetes policy enforcement and the default policy engine in enterprise distributions.
+
+## Console Integration
+
+KubeStellar Console's OPA/Gatekeeper suite provides:
+- **ClusterOPAModal** — Cluster-level OPA status and policy enforcement overview
+- **PolicyDetailModal** — Drill-down into individual policy violations with context
+- **CreatePolicyModal** — In-console policy creation with pre-built templates and best practices
+
+This is not just a status card — it's a **multi-cluster policy management UI** with policy templates and violation drill-down, filling a significant gap in the OPA ecosystem.
+
+## Engagement Opportunities
+
+- Open discussion in [OPA community Slack](https://slack.cncf.io/) (#open-policy-agent channel)
+- Submit to [Styra ecosystem integrations listing](https://styra.com/ecosystem)
+- Blog post: "Policy-as-Code at Scale: Multi-cluster OPA/Gatekeeper management with KubeStellar Console"
+- Demo at OPA community meeting
+- Target: enterprise teams managing policy enforcement across clusters
+
+## More Information
+
+- [OPA Project](https://www.openpolicyagent.org/)
+- [OPA GitHub](https://github.com/open-policy-agent/opa)
+- [Gatekeeper GitHub](https://github.com/open-policy-agent/gatekeeper)
+- [Styra (OPA Commercial Sponsor)](https://styra.com/)
+- [KubeStellar Console](https://console.kubestellar.io/)

--- a/docs/docs/content/community/outreach/thanos.md
+++ b/docs/docs/content/community/outreach/thanos.md
@@ -1,0 +1,28 @@
+# Thanos High-Availability Prometheus Integration
+
+KubeStellar Console ships a dedicated **Thanos status card** that monitors query, store, and compactor health for high-availability Prometheus deployments across your multi-cluster infrastructure.
+
+## About Thanos
+
+[Thanos](https://thanos.io/) is a CNCF Incubating project that extends Prometheus with multi-cluster querying, long-term storage, and high availability. With 13k+ GitHub stars, Thanos powers observability at massive scale for organizations managing large Kubernetes deployments.
+
+## Console Integration
+
+The `thanos_status` card in KubeStellar Console provides:
+- Thanos query, store, and compactor health
+- HA Prometheus status across clusters
+- Long-term metric storage visibility
+- Multi-cluster query pipeline health
+
+## Engagement Opportunities
+
+- Discuss Thanos + KubeStellar console integration in [Thanos community discussions](https://github.com/thanos-io/thanos/discussions)
+- Submit to CNCF Observability Working Group
+- Blog post: "Full-stack observability across clusters: Jaeger + Thanos + Harbor in KubeStellar Console"
+- KubeCon co-demo on multi-cluster observability with HA Prometheus
+
+## More Information
+
+- [Thanos Project](https://thanos.io/)
+- [Thanos GitHub](https://github.com/thanos-io/thanos)
+- [KubeStellar Console](https://console.kubestellar.io/)


### PR DESCRIPTION
Fixes #18997
Fixes #18998
Fixes #18999
Fixes #19000

Adds community outreach content for Harbor, Jaeger, Thanos, Inspektor Gadget, KEDA, and OPA/Gatekeeper CNCF project integrations.

**Changes:**
- Added `/docs/docs/content/community/outreach/harbor.md` — Harbor registry status card outreach
- Added `/docs/docs/content/community/outreach/jaeger.md` — Jaeger distributed tracing card outreach  
- Added `/docs/docs/content/community/outreach/thanos.md` — Thanos HA Prometheus card outreach
- Added `/docs/docs/content/community/outreach/inspektor-gadget.md` — Inspektor Gadget eBPF security cards outreach
- Added `/docs/docs/content/community/outreach/keda.md` — KEDA autoscaling card outreach
- Added `/docs/docs/content/community/outreach/opa-gatekeeper.md` — OPA/Gatekeeper policy management UI outreach

Each document describes the console integration, highlights the CNCF project's significance, and suggests engagement opportunities (community discussions, blog posts, KubeCon co-demos, CNCF working group submissions).

Signed-off-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;