### PR TITLE
fix: resolve 26 pre-existing ESLint errors blocking build-gate CI

### DIFF
--- a/web/src/components/drilldown/views/PodDrillDown.actions.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.actions.tsx
@@ -22,7 +22,7 @@ interface UsePodActionsProps {
   annotations: Record<string, string> | null
   ownerChain: RelatedResource[]
   openTrackedWs: () => Promise<WebSocket>
-  parseWsMessage: (event: MessageEvent, context: string) => any
+  parseWsMessage: (event: MessageEvent, context: string) => unknown
 }
 
 export function usePodActions({

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -486,6 +486,7 @@ export function NamespaceManager() {
     if (!isAdmin) return
     if (!selectedNamespace) return
 
+    // eslint-disable-next-line no-restricted-globals -- ConfirmDialog migration tracked separately
     if (!confirm(`Revoke access for ${binding.subjectName}?`)) {
       return
     }

--- a/web/src/components/teams/TeamAccessGrants.tsx
+++ b/web/src/components/teams/TeamAccessGrants.tsx
@@ -37,7 +37,7 @@ export function TeamAccessGrants({ teamName, grants, onGrantChanged }: TeamAcces
 
   const { deduplicatedClusters: clusters } = useClusters()
   const safeClusters = clusters || []
-  const { } = useGlobalFilters()
+  useGlobalFilters()
 
   const [selectedCluster, setSelectedCluster] = useState('')
   const [scope, setScope] = useState<'namespace' | 'cluster'>('namespace')

--- a/web/src/components/workloads/__tests__/WorkloadsExtended.test.tsx
+++ b/web/src/components/workloads/__tests__/WorkloadsExtended.test.tsx
@@ -46,7 +46,7 @@ vi.mock('../../../lib/dashboards/DashboardPage', () => ({
 let mockPodIssues: any[] = []
 let mockDeploymentIssues: any[] = []
 let mockDeployments: any[] = []
-let mockClusters: any[] = []
+const mockClusters: any[] = []
 let mockIsLoading = false
 let mockIsDemoMode = true
 

--- a/web/src/contexts/AlertsDataFetcher.tsx
+++ b/web/src/contexts/AlertsDataFetcher.tsx
@@ -47,7 +47,7 @@ export default function AlertsDataFetcher({ onData }: Props) {
       isLoading,
       error: errorStr,
     })
-  // eslint-disable-next-line react-hooks/exhaustive-deps — onData is stable (useState setter)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gpuNodes, podIssues, clusters, isGPULoading, isPodIssuesLoading, isClustersLoading, gpuError, podIssuesError, clustersError])
 
   return null

--- a/web/src/hooks/mcp/kagenti.ts
+++ b/web/src/hooks/mcp/kagenti.ts
@@ -165,7 +165,7 @@ async function agentFetch<T>(path: string, cluster: string, namespace?: string):
       throw err
     }
     // Classify network/abort errors into friendly messages
-    throw new Error(classifyFetchError(err, path, cluster))
+    throw new Error(classifyFetchError(err, path, cluster), { cause: err })
   }
 }
 

--- a/web/src/hooks/mcp/sharedImpl.state.ts
+++ b/web/src/hooks/mcp/sharedImpl.state.ts
@@ -39,7 +39,7 @@ import type { ClusterInfo } from './types'
 const storedClusters = loadClusterCacheFromStorage()
 // In forced demo mode (Netlify), don't show loading - demo data will be set synchronously
 const hasInitialData = storedClusters.length > 0 || isNetlifyDeployment
-export let clusterCache: ClusterCache = {
+export const clusterCache: ClusterCache = {
   clusters: storedClusters,
   lastUpdated: storedClusters.length > 0 ? new Date() : null,
   isLoading: !hasInitialData, // Don't show loading if we have cached data or are in forced demo mode

--- a/web/src/hooks/useCachedData/agentFetchers.ts
+++ b/web/src/hooks/useCachedData/agentFetchers.ts
@@ -209,7 +209,7 @@ export async function fetchCiliumStatus(): Promise<CiliumStatus | null> {
  * Fetch aggregated Jaeger tracing status from the local agent.
  * Matches backend handler at /jaeger-status.
  */
-export async function fetchJaegerStatus(): Promise<any | null> {
+export async function fetchJaegerStatus(): Promise<unknown> {
   // Rule: Check if agent is available before attempting fetch
   if (isAgentUnavailable()) return null
 

--- a/web/src/hooks/useDrasiQueryStream.ts
+++ b/web/src/hooks/useDrasiQueryStream.ts
@@ -253,7 +253,7 @@ export function useDrasiQueryStream(args: Args): UseDrasiQueryStreamResult {
 
         es.onerror = async () => {
           // Close the current source and attempt a reconnect backoff loop.
-          try { es && es.close() } catch {}
+          try { if (es) es.close() } catch { /* EventSource.close may throw if already closed */ }
           sourceRef.current = null
           setConnected(false)
           setErrorOnce('SSE connection error')

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -428,10 +428,10 @@ export function useFeatureRequests(currentUserId?: string, options?: UseFeatureR
       return data
     } catch (err: unknown) {
       if (err instanceof RateLimitError) {
-        throw new Error('Too many requests — please wait a moment and try again.')
+        throw new Error('Too many requests — please wait a moment and try again.', { cause: err })
       }
       if (err instanceof Error && isFeedbackBodyLimitError(err.message)) {
-        throw new Error(FEEDBACK_ATTACHMENT_LIMIT_ERROR)
+        throw new Error(FEEDBACK_ATTACHMENT_LIMIT_ERROR, { cause: err })
       }
       throw err
     } finally {

--- a/web/src/hooks/useLocalClusterTools.ts
+++ b/web/src/hooks/useLocalClusterTools.ts
@@ -625,7 +625,7 @@ export function useLocalClusterTools() {
       setVclusterInstances([])
       setVclusterClusterStatus([])
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps — fetchTools/fetchVClusterClusterStatus are not memoized
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConnected, isDemoMode, fetchClusters, fetchVClusters])
 
   // Auto-refresh cluster list when a create/delete operation completes

--- a/web/src/hooks/useMissions.connection.ts
+++ b/web/src/hooks/useMissions.connection.ts
@@ -76,7 +76,7 @@ export function createMissionConnectionApi(
       return Promise.resolve()
     }
 
-    return new Promise<void>(async (resolve, reject) => {
+    return new Promise<void>((resolve, reject) => { void (async () => {
       state.setAgentsLoading(true)
 
       const timeout = setTimeout(() => {
@@ -452,7 +452,7 @@ export function createMissionConnectionApi(
         clearTimeout(timeout)
         reject(error)
       }
-    })
+    })() })
   }
 
   return {

--- a/web/src/hooks/useProw.ts
+++ b/web/src/hooks/useProw.ts
@@ -142,11 +142,12 @@ export function useProwJobs(prowCluster = 'prow', namespace = 'prow') {
         setError(err instanceof Error ? err.message : 'Failed to fetch ProwJobs')
       }
     } finally {
-      if (!mountedRef.current) return
-      if (!silent) {
-        setIsLoading(false)
+      if (mountedRef.current) {
+        if (!silent) {
+          setIsLoading(false)
+        }
+        setIsRefreshing(false)
       }
-      setIsRefreshing(false)
     }
   }, []) // state setters and refs are stable; no other reactive deps
 

--- a/web/src/hooks/useStellarSource.ts
+++ b/web/src/hooks/useStellarSource.ts
@@ -75,7 +75,7 @@ export function useStellarSource() {
     try {
       const persisted = localStorage.getItem('kc_selected_agent')
       if (persisted && persisted !== 'none') return { provider: persisted, model: '', source: 'user-default' as const, isCli: true }
-    } catch {}
+    } catch { /* localStorage may be unavailable */ }
     return null
   })
   const [solves, setSolves] = useState<StellarSolve[]>([])
@@ -439,7 +439,7 @@ export function useStellarSource() {
   const snoozeWatch = useCallback(async (id: string, minutes: number) => {
     try {
       await stellarApi.snoozeWatch(id, minutes)
-    } catch {}
+    } catch { /* best-effort snooze */ }
   }, [])
   const dismissCatchUp = useCallback(() => setCatchUp(null), [])
   const startSolve = useCallback(async (eventID: string) => {

--- a/web/src/hooks/versionUtils.ts
+++ b/web/src/hooks/versionUtils.ts
@@ -67,7 +67,8 @@ export async function safeJsonParse<T>(response: Response, label: string): Promi
   } catch (err: unknown) {
     // Guard against malformed JSON even when Content-Type looks correct
     throw new Error(
-      `${label}: failed to parse response as JSON — ${err instanceof Error ? err.message : String(err)}`
+      `${label}: failed to parse response as JSON — ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     )
   }
 }

--- a/web/src/lib/__tests__/cn.test.ts
+++ b/web/src/lib/__tests__/cn.test.ts
@@ -7,7 +7,8 @@ describe('cn', () => {
   })
 
   it('handles conditional classes', () => {
-    expect(cn('base', false && 'hidden', 'end')).toBe('base end')
+    const showHidden = false
+    expect(cn('base', showHidden && 'hidden', 'end')).toBe('base end')
   })
 
   it('handles undefined and null', () => {

--- a/web/src/lib/cache/cacheCore.ts
+++ b/web/src/lib/cache/cacheCore.ts
@@ -157,7 +157,7 @@ export class CacheStore<T> {
     } else {
       try {
         localStorage.setItem(META_PREFIX + this.key, JSON.stringify(meta))
-      } catch {}
+      } catch { /* localStorage may be unavailable */ }
     }
   }
 
@@ -271,7 +271,7 @@ export class CacheStore<T> {
       const currentPromise = this.storageLoadPromise
       try {
         await currentPromise
-      } catch {}
+      } catch { /* storage load failure is non-fatal */ }
       if (this.storageLoadPromise === currentPromise) {
         this.storageLoadPromise = null
       }
@@ -341,8 +341,8 @@ export class CacheStore<T> {
 
       await this.saveToStorage(finalData)
       if (this.resetVersion !== fetchVersion) {
-        try { sessionStorage.removeItem(SS_PREFIX + this.key) } catch {}
-        cacheStorage.delete(this.key).catch(() => {})
+        try { sessionStorage.removeItem(SS_PREFIX + this.key) } catch { /* best-effort cleanup */ }
+        cacheStorage.delete(this.key).catch(() => { /* best-effort cleanup */ })
         this.fetchingRef = false
         return
       }
@@ -398,7 +398,7 @@ export class CacheStore<T> {
 
   async clear(): Promise<void> {
     await cacheStorage.delete(this.key)
-    try { sessionStorage.removeItem(SS_PREFIX + this.key) } catch {}
+    try { sessionStorage.removeItem(SS_PREFIX + this.key) } catch { /* best-effort cleanup */ }
     preloadedMetaMap.delete(this.key)
     if (workerRpc) {
       workerRpc.setMeta(this.key, { consecutiveFailures: 0 })

--- a/web/src/lib/kagentBackend.ts
+++ b/web/src/lib/kagentBackend.ts
@@ -69,7 +69,7 @@ export async function fetchKagentStatus(options: FetchKagentStatusOptions = {}):
   } catch (error: unknown) {
     if (error instanceof DOMException && error.name === 'AbortError') {
       if (options.throwOnError) {
-        throw new Error(`Request timeout after ${timeoutMs / 1000}s: ${KAGENT_STATUS_ENDPOINT}: ${error instanceof Error ? error.message : String(error)}`)
+        throw new Error(`Request timeout after ${timeoutMs / 1000}s: ${KAGENT_STATUS_ENDPOINT}: ${error instanceof Error ? error.message : String(error)}`, { cause: error })
       }
       throw error
     }


### PR DESCRIPTION
## Summary

The build-gate CI workflow (added in #18780) runs `npm run lint` and fails on any ESLint error. However, 26 pre-existing errors across 18 files were already on main, causing **all PR merges to fail** — even with `--admin`.

This PR fixes all 26 errors:

- `no-explicit-any` (2) — replaced `any` with `unknown`
- `no-restricted-globals` (1) — eslint-disable for `confirm()` pending ConfirmDialog migration
- `no-empty-pattern` (1) — removed empty destructuring
- `prefer-const` (2) — `let` → `const` where never reassigned
- Malformed eslint-disable comments (2) — em-dash broke rule name parsing
- `preserve-caught-error` (5) — added `{ cause: err }` to re-thrown errors
- `no-empty` (6) — added comments to empty catch blocks
- `no-unused-expressions` (2) — fixed EventSource cleanup expressions
- `no-async-promise-executor` (1) — wrapped in IIFE
- `no-unsafe-finally` (1) — replaced return with conditional
- `no-constant-binary-expression` (1) — used variable instead of literal

## Test plan

- [ ] build-gate CI passes (lint + build)
- [ ] No runtime behavior changes — all fixes are lint-only