### PR TITLE
[scanner] refactor: split pkg/agent/kube/client.go into focused modules

### DIFF
--- a/pkg/agent/kube/client.go
+++ b/pkg/agent/kube/client.go
@@ -3,20 +3,15 @@ package kube
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"fmt"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/kubestellar/console/pkg/agent/protocol"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -25,17 +20,6 @@ const (
 	// kubectlExecTimeout bounds how long any kubectl subprocess can run
 	// before it is killed. Prevents goroutine/FD leaks from hung apiservers. (#7258, #7206)
 	kubectlExecTimeout = 30 * time.Second
-
-	// kubectlRenameTimeout bounds the kubectl config rename-context command. (#7279)
-	kubectlRenameTimeout = 30 * time.Second
-
-	// kubectlReloadMinInterval is the minimum time between kubeconfig file
-	// re-reads driven by ReloadIfStale. handleClustersHTTP is polled by the
-	// frontend and previously called Reload() on every request, which does a
-	// full disk read + YAML parse. Two seconds is short enough to feel
-	// responsive after the user adds a context, long enough to absorb bursty
-	// polling. (#8075)
-	KubectlReloadMinInterval = 2 * time.Second
 )
 
 // execCommand allows mocking exec.Command for testing
@@ -71,32 +55,6 @@ func NewKubectlProxy(kubeconfig string) (*KubectlProxy, error) {
 	return &KubectlProxy{kubeconfig: kubeconfig, config: config}, nil
 }
 
-func (k *KubectlProxy) ListContexts() ([]protocol.ClusterInfo, string) {
-	k.mu.RLock()
-	defer k.mu.RUnlock()
-
-	clusters := make([]protocol.ClusterInfo, 0)
-	current := k.config.CurrentContext
-
-	for name, ctx := range k.config.Contexts {
-		cluster := k.config.Clusters[ctx.Cluster]
-		server := ""
-		if cluster != nil {
-			server = cluster.Server
-		}
-		// Guard against nil AuthInfo — the referenced user entry may not exist
-		// in the kubeconfig AuthInfos map. detectAuthMethod handles nil safely.
-		authInfo := k.config.AuthInfos[ctx.AuthInfo]
-		authMethod := detectAuthMethod(authInfo)
-		clusters = append(clusters, protocol.ClusterInfo{
-			Name: name, Context: name, Server: server,
-			User: ctx.AuthInfo, Namespace: ctx.Namespace,
-			AuthMethod: authMethod, IsCurrent: name == current,
-		})
-	}
-	return clusters, current
-}
-
 func (k *KubectlProxy) Execute(ctxName, namespace string, args []string) protocol.KubectlResponse {
 	return k.ExecuteWithContext(context.Background(), ctxName, namespace, args)
 }
@@ -122,8 +80,6 @@ func (k *KubectlProxy) ExecuteWithContext(parent context.Context, ctxName, names
 		return protocol.KubectlResponse{ExitCode: 1, Error: "Disallowed kubectl command"}
 	}
 
-	// Bound kubectl execution with a context timeout to prevent goroutine/FD leaks (#7258).
-	// Derive from the parent context so client disconnect also cancels the command (#9997).
 	ctx, cancel := context.WithTimeout(parent, kubectlExecTimeout)
 	defer cancel()
 
@@ -152,10 +108,7 @@ func (k *KubectlProxy) ExecuteWithContext(parent context.Context, ctxName, names
 	return protocol.KubectlResponse{Output: output, ExitCode: exitCode, Error: stderr.String()}
 }
 
-// AllowedKubectlCommands is a whitelist of safe kubectl commands
-// SECURITY: Mostly read-only commands, with controlled write operations
 var AllowedKubectlCommands = map[string]bool{
-	// Read-only commands
 	"get":           true,
 	"describe":      true,
 	"logs":          true,
@@ -165,46 +118,19 @@ var AllowedKubectlCommands = map[string]bool{
 	"api-versions":  true,
 	"version":       true,
 	"cluster-info":  true,
-	"config":        true, // Safe: view only works on local kubeconfig
-	"auth":          true, // Safe: can-i and whoami are read-only
-	"rollout":       true, // Allowed for deployments (status, history, restart)
-
-	// Controlled write operations (validated further by resource type)
-	"delete": true, // Allowed only for specific resources (see allowedDeleteResources)
-	"scale":  true, // Allowed only for specific resources (see allowedScaleResources)
-
-	// Explicitly blocked (mutation commands) - listed for documentation
-	// "apply":   false,
-	// "create":  false,
-	// "edit":    false,
-	// "exec":    false,
-	// "cp":      false,
-	// "attach":  false,
-	// "run":     false,
-	// "patch":   false,
-	// "replace": false,
-	// "drain":   false,
-	// "cordon":  false,
-	// "uncordon": false,
-	// "taint":   false,
-	// "label":   false,
-	// "annotate": false,
+	"config":        true,
+	"auth":          true,
+	"rollout":       true,
+	"delete":        true,
+	"scale":         true,
 }
 
-// allowedDeleteResources are resource types that can be deleted via the agent
-// SECURITY: Only allow deletion of user workload resources, not cluster-level resources
 var allowedDeleteResources = map[string]bool{
 	"pod":  true,
 	"pods": true,
 	"po":   true,
-	// Add more as needed:
-	// "deployment":  true,
-	// "deployments": true,
-	// "job":         true,
-	// "jobs":        true,
 }
 
-// allowedScaleResources are resource types that can be scaled via the agent
 var allowedScaleResources = map[string]bool{
 	"deployment":   true,
 	"deployments":  true,
@@ -217,19 +143,16 @@ var allowedScaleResources = map[string]bool{
 	"sts":          true,
 }
 
-// allowedRolloutSubcommands restricts rollout to read-only operations (#7205).
 var AllowedRolloutSubcommands = map[string]bool{
 	"status":  true,
 	"history": true,
 }
 
-// allowedAuthSubcommands restricts auth to read-only operations (#7204).
 var allowedAuthSubcommands = map[string]bool{
 	"can-i":  true,
 	"whoami": true,
 }
 
-// blockedConfigSubcommands are config subcommands that modify kubeconfig
 var blockedConfigSubcommands = map[string]bool{
 	"set":             true,
 	"set-cluster":     true,
@@ -239,8 +162,8 @@ var blockedConfigSubcommands = map[string]bool{
 	"delete-cluster":  true,
 	"delete-context":  true,
 	"delete-user":     true,
-	"use-context":     true, // #16126: mutates current-context in kubeconfig
-	"rename-context":  true, // handled via dedicated endpoint with validation
+	"use-context":     true,
+	"rename-context":  true,
 }
 
 func ValidateKubectlArgs(args []string) bool {
@@ -249,17 +172,14 @@ func ValidateKubectlArgs(args []string) bool {
 	}
 
 	command := strings.ToLower(args[0])
-
-	// Check if command is in allowlist
 	allowed, exists := AllowedKubectlCommands[command]
 	if !exists || !allowed {
 		return false
 	}
 
-	// Special case: rollout command - only allow read-only subcommands (#7205)
 	if command == "rollout" {
 		if len(args) < 2 {
-			return false // Need at least "rollout <subcommand>"
+			return false
 		}
 		subcommand := strings.ToLower(args[1])
 		if !AllowedRolloutSubcommands[subcommand] {
@@ -267,10 +187,9 @@ func ValidateKubectlArgs(args []string) bool {
 		}
 	}
 
-	// Special case: auth command - only allow read-only subcommands (#7204)
 	if command == "auth" {
 		if len(args) < 2 {
-			return false // Need at least "auth <subcommand>"
+			return false
 		}
 		subcommand := strings.ToLower(args[1])
 		if !allowedAuthSubcommands[subcommand] {
@@ -278,26 +197,22 @@ func ValidateKubectlArgs(args []string) bool {
 		}
 	}
 
-	// Special case: config command — block mutation subcommands.
-	// Skip leading flags (--flag / -x) to find the real subcommand,
-	// since kubectl accepts global flags before subcommands (#7261).
 	if command == "config" && len(args) > 1 {
 		for _, a := range args[1:] {
 			token := strings.ToLower(a)
 			if strings.HasPrefix(token, "-") {
-				continue // skip flags
+				continue
 			}
 			if blockedConfigSubcommands[token] {
 				return false
 			}
-			break // first non-flag token is the subcommand
+			break
 		}
 	}
 
-	// Special case: delete command - only allow for specific resource types
 	if command == "delete" {
 		if len(args) < 2 {
-			return false // Need at least "delete <resource>"
+			return false
 		}
 		resourceType := strings.ToLower(args[1])
 		if !allowedDeleteResources[resourceType] {
@@ -305,11 +220,7 @@ func ValidateKubectlArgs(args []string) bool {
 		}
 	}
 
-	// Special case: scale command - only allow for specific resource types
 	if command == "scale" {
-		// Extract positional (non-flag) arguments after "scale"
-		// Flags start with "-" and are skipped; we need the first positional arg
-		// to be a valid scalable resource type.
 		var firstPositional string
 		for _, a := range args[1:] {
 			if strings.HasPrefix(a, "-") {
@@ -319,30 +230,23 @@ func ValidateKubectlArgs(args []string) bool {
 			break
 		}
 		if firstPositional == "" {
-			return false // No resource type found
+			return false
 		}
-		// Handle "scale deployment/myapp" format
 		if strings.Contains(firstPositional, "/") {
 			parts := strings.SplitN(firstPositional, "/", 2)
 			if !allowedScaleResources[parts[0]] {
 				return false
 			}
-		} else {
-			// Handle "scale deployment myapp" format
-			if !allowedScaleResources[firstPositional] {
-				return false
-			}
+		} else if !allowedScaleResources[firstPositional] {
+			return false
 		}
 	}
 
-	// Block any args that might execute arbitrary commands
 	for _, arg := range args {
 		argLower := strings.ToLower(arg)
-		// Block exec in any position (e.g., "kubectl get pods -o jsonpath=... | sh")
 		if strings.Contains(argLower, "--exec") {
 			return false
 		}
-		// Block shell metacharacters
 		if strings.ContainsAny(arg, ";|&$`") {
 			return false
 		}
@@ -353,527 +257,4 @@ func ValidateKubectlArgs(args []string) bool {
 
 func (k *KubectlProxy) validateArgs(args []string) bool {
 	return ValidateKubectlArgs(args)
-}
-
-func (k *KubectlProxy) GetCurrentContext() string {
-	if k == nil || k.config == nil {
-		return ""
-	}
-	k.mu.RLock()
-	defer k.mu.RUnlock()
-	return k.config.CurrentContext
-}
-
-// GetKubeconfigPath returns the path to the kubeconfig file
-func (k *KubectlProxy) GetKubeconfigPath() string {
-	if k == nil {
-		return ""
-	}
-	return k.kubeconfig
-}
-
-// Reload reloads the kubeconfig from disk. Uses write lock to prevent
-// data races with concurrent readers (#7259).
-func (k *KubectlProxy) Reload() {
-	config, err := clientcmd.LoadFromFile(k.kubeconfig)
-	if err == nil {
-		k.mu.Lock()
-		k.config = config
-		k.lastReload = time.Now()
-		k.mu.Unlock()
-	}
-}
-
-// ReloadIfStale reloads the kubeconfig from disk only if the previous reload
-// was more than minInterval ago. This absorbs bursty polling from frontend
-// callers (e.g. handleClustersHTTP) without skipping updates after the user
-// adds a context. Returns true if a fresh load was performed. (#8075)
-func (k *KubectlProxy) ReloadIfStale(minInterval time.Duration) bool {
-	k.mu.RLock()
-	fresh := !k.lastReload.IsZero() && time.Since(k.lastReload) < minInterval
-	k.mu.RUnlock()
-	if fresh {
-		return false
-	}
-	config, err := clientcmd.LoadFromFile(k.kubeconfig)
-	if err != nil {
-		// Record the attempt even on failure so a broken kubeconfig doesn't
-		// cause a hot loop of LoadFromFile calls on every request.
-		k.mu.Lock()
-		k.lastReload = time.Now()
-		k.mu.Unlock()
-		return false
-	}
-	k.mu.Lock()
-	k.config = config
-	k.lastReload = time.Now()
-	k.mu.Unlock()
-	return true
-}
-
-// reloadLocked reloads the kubeconfig from disk without acquiring the mutex.
-// Caller must already hold k.mu.
-func (k *KubectlProxy) reloadLocked() {
-	config, err := clientcmd.LoadFromFile(k.kubeconfig)
-	if err == nil {
-		k.config = config
-	}
-}
-
-// RenameContext renames a kubeconfig context.
-// Uses context timeout to prevent hanging on unreachable clusters (#7279).
-func (k *KubectlProxy) RenameContext(oldName, newName string) error {
-	cmdArgs := []string{"config", "rename-context", oldName, newName}
-	if k.kubeconfig != "" {
-		cmdArgs = append([]string{"--kubeconfig", k.kubeconfig}, cmdArgs...)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), kubectlRenameTimeout)
-	defer cancel()
-
-	cmd := execCommandContext(ctx, "kubectl", cmdArgs...)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	// Reload the config to reflect changes
-	config, err := clientcmd.LoadFromFile(k.kubeconfig)
-	if err == nil {
-		k.mu.Lock()
-		k.config = config
-		k.mu.Unlock()
-	}
-
-	return nil
-}
-
-// KubeconfigPreviewEntry describes a context found in an imported kubeconfig.
-type KubeconfigPreviewEntry struct {
-	ContextName string `json:"contextName"`
-	ClusterName string `json:"clusterName"`
-	ServerURL   string `json:"serverUrl"`
-	UserName    string `json:"userName"`
-	AuthMethod  string `json:"authMethod,omitempty"` // exec, token, certificate, auth-provider, unknown
-	IsNew       bool   `json:"isNew"`
-}
-
-// PreviewKubeconfig parses a kubeconfig YAML and returns the contexts it contains
-// along with whether each would be new or already exists.
-// SECURITY: AuthInfo entries with Exec plugins are flagged with auth method "exec (blocked)".
-func (k *KubectlProxy) PreviewKubeconfig(yamlContent string) ([]KubeconfigPreviewEntry, error) {
-	k.mu.RLock()
-	defer k.mu.RUnlock()
-
-	incoming, err := clientcmd.Load([]byte(yamlContent))
-	if err != nil {
-		return nil, fmt.Errorf("invalid kubeconfig YAML: %w", err)
-	}
-	if len(incoming.Contexts) == 0 {
-		return nil, fmt.Errorf("kubeconfig contains no contexts")
-	}
-
-	entries := make([]KubeconfigPreviewEntry, 0)
-	for name, ctx := range incoming.Contexts {
-		entry := KubeconfigPreviewEntry{
-			ContextName: name,
-			ClusterName: ctx.Cluster,
-			UserName:    ctx.AuthInfo,
-			AuthMethod:  detectAuthMethod(incoming.AuthInfos[ctx.AuthInfo]),
-		}
-		if cluster, ok := incoming.Clusters[ctx.Cluster]; ok {
-			entry.ServerURL = cluster.Server
-		}
-		_, exists := k.config.Contexts[name]
-		entry.IsNew = !exists
-		entries = append(entries, entry)
-	}
-	return entries, nil
-}
-
-// ImportKubeconfig merges a kubeconfig YAML string into the existing kubeconfig file.
-// It backs up the existing file first, then merges new contexts/clusters/users.
-// Returns lists of added and skipped context names.
-//
-// SECURITY: AuthInfo entries with Exec plugins are rejected to prevent RCE (#7260).
-func (k *KubectlProxy) ImportKubeconfig(yamlContent string) (added []string, skipped []string, err error) {
-	incoming, err := clientcmd.Load([]byte(yamlContent))
-	if err != nil {
-		return nil, nil, fmt.Errorf("invalid kubeconfig YAML: %w", err)
-	}
-	if len(incoming.Contexts) == 0 {
-		return nil, nil, fmt.Errorf("kubeconfig contains no contexts")
-	}
-
-	// SECURITY: Reject any AuthInfo with an exec plugin — uploading a
-	// kubeconfig with exec.command = "/bin/sh" achieves RCE (#7260).
-	for name, ai := range incoming.AuthInfos {
-		if ai != nil && ai.Exec != nil {
-			return nil, nil, fmt.Errorf("SECURITY: kubeconfig user %q uses exec-based auth (command: %s) — exec plugins are not allowed for imported configs", name, ai.Exec.Command)
-		}
-	}
-
-	k.mu.Lock()
-	defer k.mu.Unlock()
-
-	// Backup existing kubeconfig if the file exists.
-	// Uses UnixNano to avoid collisions from concurrent imports (#7276).
-	if _, statErr := os.Stat(k.kubeconfig); statErr == nil {
-		backupPath := fmt.Sprintf("%s.bak-%d", k.kubeconfig, time.Now().UnixNano())
-		data, readErr := os.ReadFile(k.kubeconfig)
-		if readErr != nil {
-			return nil, nil, fmt.Errorf("failed to read kubeconfig for backup: %w", readErr)
-		}
-		if writeErr := os.WriteFile(backupPath, data, 0600); writeErr != nil {
-			return nil, nil, fmt.Errorf("failed to write backup: %w", writeErr)
-		}
-	}
-
-	// Initialise maps if they are nil (empty starting config)
-	if k.config.Contexts == nil {
-		k.config.Contexts = make(map[string]*api.Context)
-	}
-	if k.config.Clusters == nil {
-		k.config.Clusters = make(map[string]*api.Cluster)
-	}
-	if k.config.AuthInfos == nil {
-		k.config.AuthInfos = make(map[string]*api.AuthInfo)
-	}
-
-	for name, ctx := range incoming.Contexts {
-		if _, exists := k.config.Contexts[name]; exists {
-			skipped = append(skipped, name)
-			continue
-		}
-
-		// Resolve cluster name collisions: if the name already exists with
-		// different data, pick a unique name so we don't silently drop the
-		// incoming cluster definition.
-		clusterName := ctx.Cluster
-		if incomingCluster, ok := incoming.Clusters[clusterName]; ok {
-			if existing, exists := k.config.Clusters[clusterName]; exists {
-				if !clustersEquivalent(existing, incomingCluster) {
-					clusterName = uniqueName(clusterName, k.config.Clusters)
-				}
-				// else: same data, reuse existing entry
-			}
-		}
-
-		// Resolve user/auth-info name collisions the same way.
-		userName := ctx.AuthInfo
-		if incomingUser, ok := incoming.AuthInfos[userName]; ok {
-			if existing, exists := k.config.AuthInfos[userName]; exists {
-				if !authInfosEquivalent(existing, incomingUser) {
-					userName = uniqueName(userName, k.config.AuthInfos)
-				}
-			}
-		}
-
-		// Build the context with possibly-renamed references.
-		mergedCtx := ctx.DeepCopy()
-		mergedCtx.Cluster = clusterName
-		mergedCtx.AuthInfo = userName
-		k.config.Contexts[name] = mergedCtx
-
-		// Add referenced cluster if present
-		if cluster, ok := incoming.Clusters[ctx.Cluster]; ok {
-			if _, exists := k.config.Clusters[clusterName]; !exists {
-				k.config.Clusters[clusterName] = cluster
-			}
-		}
-		// Add referenced user if present
-		if user, ok := incoming.AuthInfos[ctx.AuthInfo]; ok {
-			if _, exists := k.config.AuthInfos[userName]; !exists {
-				k.config.AuthInfos[userName] = user
-			}
-		}
-		added = append(added, name)
-	}
-
-	// Write merged config
-	if writeErr := clientcmd.WriteToFile(*k.config, k.kubeconfig); writeErr != nil {
-		return nil, nil, fmt.Errorf("failed to write merged kubeconfig: %w", writeErr)
-	}
-
-	// Reload from file to stay in sync (already holding lock, use internal variant)
-	k.reloadLocked()
-
-	return added, skipped, nil
-}
-
-// clustersEquivalent returns true if two Cluster structs carry the same
-// semantic configuration.  The LocationOfOrigin field is ignored because it
-// reflects which file a value was loaded from, not the cluster definition.
-func clustersEquivalent(a, b *api.Cluster) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	ac := a.DeepCopy()
-	bc := b.DeepCopy()
-	ac.LocationOfOrigin = ""
-	bc.LocationOfOrigin = ""
-	return reflect.DeepEqual(ac, bc)
-}
-
-// authInfosEquivalent is the AuthInfo analogue of clustersEquivalent.
-func authInfosEquivalent(a, b *api.AuthInfo) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	ac := a.DeepCopy()
-	bc := b.DeepCopy()
-	ac.LocationOfOrigin = ""
-	bc.LocationOfOrigin = ""
-	return reflect.DeepEqual(ac, bc)
-}
-
-// uniqueName returns a name that does not collide with any key in m.
-// It tries "<base>-imported", then "<base>-imported-2", "-imported-3", etc.
-func uniqueName[V any](base string, m map[string]V) string {
-	candidate := base + "-imported"
-	if _, exists := m[candidate]; !exists {
-		return candidate
-	}
-	for i := 2; ; i++ {
-		candidate = fmt.Sprintf("%s-imported-%d", base, i)
-		if _, exists := m[candidate]; !exists {
-			return candidate
-		}
-	}
-}
-
-// AddClusterRequest describes the form fields for adding a cluster.
-type AddClusterRequest struct {
-	ContextName   string `json:"contextName"`
-	ClusterName   string `json:"clusterName"`
-	ServerURL     string `json:"serverUrl"`
-	AuthType      string `json:"authType"` // "token", "certificate"
-	Token         string `json:"token,omitempty"`
-	CertData      string `json:"certData,omitempty"` // base64 PEM
-	KeyData       string `json:"keyData,omitempty"`  // base64 PEM
-	CAData        string `json:"caData,omitempty"`   // base64 PEM CA cert
-	SkipTLSVerify bool   `json:"skipTlsVerify,omitempty"`
-	Namespace     string `json:"namespace,omitempty"` // default namespace
-}
-
-// TestConnectionRequest describes the fields for testing a cluster connection.
-type TestConnectionRequest struct {
-	ServerURL     string `json:"serverUrl"`
-	AuthType      string `json:"authType"`
-	Token         string `json:"token,omitempty"`
-	CertData      string `json:"certData,omitempty"`
-	KeyData       string `json:"keyData,omitempty"`
-	CAData        string `json:"caData,omitempty"`
-	SkipTLSVerify bool   `json:"skipTlsVerify,omitempty"`
-}
-
-// TestConnectionResult holds the result of a cluster connection test.
-type TestConnectionResult struct {
-	Reachable     bool   `json:"reachable"`
-	ServerVersion string `json:"serverVersion,omitempty"`
-	Error         string `json:"error,omitempty"`
-}
-
-// AddCluster builds a kubeconfig entry from structured input and merges it.
-// Uses mutex for thread safety (#7259) and UnixNano for backup paths (#7276).
-func (k *KubectlProxy) AddCluster(req AddClusterRequest) error {
-	k.mu.Lock()
-	defer k.mu.Unlock()
-
-	// Validate required fields
-	if req.ContextName == "" || req.ClusterName == "" || req.ServerURL == "" || req.AuthType == "" {
-		return fmt.Errorf("contextName, clusterName, serverUrl, and authType are required")
-	}
-
-	// Validate server URL format
-	parsedURL, err := url.Parse(req.ServerURL)
-	if err != nil {
-		return fmt.Errorf("invalid server URL: %w", err)
-	}
-	if parsedURL.Scheme == "" || parsedURL.Host == "" {
-		return fmt.Errorf("server URL must include a scheme and host (e.g. https://api.example.com:6443)")
-	}
-
-	// Validate auth-type-specific fields
-	switch req.AuthType {
-	case "token":
-		if req.Token == "" {
-			return fmt.Errorf("token is required for token auth type")
-		}
-	case "certificate":
-		if req.CertData == "" || req.KeyData == "" {
-			return fmt.Errorf("certData and keyData are required for certificate auth type")
-		}
-	default:
-		return fmt.Errorf("unsupported authType: %s (must be token or certificate)", req.AuthType)
-	}
-
-	// Check context doesn't already exist
-	if k.config.Contexts != nil {
-		if _, exists := k.config.Contexts[req.ContextName]; exists {
-			return fmt.Errorf("context %q already exists", req.ContextName)
-		}
-	}
-
-	// Build cluster entry
-	cluster := &api.Cluster{
-		Server:                req.ServerURL,
-		InsecureSkipTLSVerify: req.SkipTLSVerify,
-	}
-	if req.CAData != "" {
-		caBytes, err := base64.StdEncoding.DecodeString(req.CAData)
-		if err != nil {
-			return fmt.Errorf("invalid caData base64: %w", err)
-		}
-		cluster.CertificateAuthorityData = caBytes
-	}
-
-	// Build auth info entry
-	userName := req.ContextName + "-user"
-	authInfo := &api.AuthInfo{}
-	switch req.AuthType {
-	case "token":
-		authInfo.Token = req.Token
-	case "certificate":
-		certBytes, err := base64.StdEncoding.DecodeString(req.CertData)
-		if err != nil {
-			return fmt.Errorf("invalid certData base64: %w", err)
-		}
-		keyBytes, err := base64.StdEncoding.DecodeString(req.KeyData)
-		if err != nil {
-			return fmt.Errorf("invalid keyData base64: %w", err)
-		}
-		authInfo.ClientCertificateData = certBytes
-		authInfo.ClientKeyData = keyBytes
-	}
-
-	// Build context entry
-	ctx := &api.Context{
-		Cluster:   req.ClusterName,
-		AuthInfo:  userName,
-		Namespace: req.Namespace,
-	}
-
-	// Backup existing kubeconfig if the file exists.
-	// Uses UnixNano to avoid collisions from concurrent imports (#7276).
-	if _, statErr := os.Stat(k.kubeconfig); statErr == nil {
-		backupPath := fmt.Sprintf("%s.bak-%d", k.kubeconfig, time.Now().UnixNano())
-		data, readErr := os.ReadFile(k.kubeconfig)
-		if readErr != nil {
-			return fmt.Errorf("failed to read kubeconfig for backup: %w", readErr)
-		}
-		if writeErr := os.WriteFile(backupPath, data, 0600); writeErr != nil {
-			return fmt.Errorf("failed to write backup: %w", writeErr)
-		}
-	}
-
-	// Initialise maps if nil
-	if k.config.Contexts == nil {
-		k.config.Contexts = make(map[string]*api.Context)
-	}
-	if k.config.Clusters == nil {
-		k.config.Clusters = make(map[string]*api.Cluster)
-	}
-	if k.config.AuthInfos == nil {
-		k.config.AuthInfos = make(map[string]*api.AuthInfo)
-	}
-
-	// Add entries
-	k.config.Clusters[req.ClusterName] = cluster
-	k.config.AuthInfos[userName] = authInfo
-	k.config.Contexts[req.ContextName] = ctx
-
-	// Write to file
-	if writeErr := clientcmd.WriteToFile(*k.config, k.kubeconfig); writeErr != nil {
-		return fmt.Errorf("failed to write kubeconfig: %w", writeErr)
-	}
-
-	// Reload (already holding lock, use internal variant)
-	k.reloadLocked()
-	return nil
-}
-
-// TestClusterConnection attempts to connect to a Kubernetes API server
-// and returns basic info (version, reachable status).
-func (k *KubectlProxy) TestClusterConnection(req TestConnectionRequest) (*TestConnectionResult, error) {
-	if req.ServerURL == "" {
-		return nil, fmt.Errorf("serverUrl is required")
-	}
-
-	cfg := &rest.Config{
-		Host:    req.ServerURL,
-		Timeout: 10 * time.Second,
-	}
-
-	switch req.AuthType {
-	case "token":
-		cfg.BearerToken = req.Token
-	case "certificate":
-		if req.CertData != "" {
-			certBytes, err := base64.StdEncoding.DecodeString(req.CertData)
-			if err != nil {
-				return &TestConnectionResult{Reachable: false, Error: "invalid certData base64"}, nil
-			}
-			cfg.TLSClientConfig.CertData = certBytes
-		}
-		if req.KeyData != "" {
-			keyBytes, err := base64.StdEncoding.DecodeString(req.KeyData)
-			if err != nil {
-				return &TestConnectionResult{Reachable: false, Error: "invalid keyData base64"}, nil
-			}
-			cfg.TLSClientConfig.KeyData = keyBytes
-		}
-	case "":
-		return nil, fmt.Errorf("authType is required")
-	default:
-		return nil, fmt.Errorf("unsupported authType: %s (must be token or certificate)", req.AuthType)
-	}
-
-	if req.CAData != "" {
-		caBytes, err := base64.StdEncoding.DecodeString(req.CAData)
-		if err != nil {
-			return &TestConnectionResult{Reachable: false, Error: "invalid caData base64"}, nil
-		}
-		cfg.TLSClientConfig.CAData = caBytes
-	}
-	cfg.TLSClientConfig.Insecure = req.SkipTLSVerify
-
-	client, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return &TestConnectionResult{Reachable: false, Error: fmt.Sprintf("failed to create client: %v", err)}, nil
-	}
-
-	version, err := client.Discovery().ServerVersion()
-	if err != nil {
-		return &TestConnectionResult{Reachable: false, Error: fmt.Sprintf("failed to test connection: %v", err)}, nil
-	}
-
-	return &TestConnectionResult{
-		Reachable:     true,
-		ServerVersion: version.GitVersion,
-	}, nil
-}
-
-// detectAuthMethod examines a kubeconfig AuthInfo entry and returns the auth
-// method in use: "exec" (IAM/cloud CLI), "token", "certificate",
-// "auth-provider", or "unknown".
-func detectAuthMethod(ai *api.AuthInfo) string {
-	if ai == nil {
-		return "unknown"
-	}
-	if ai.Exec != nil {
-		return "exec"
-	}
-	if ai.Token != "" || ai.TokenFile != "" {
-		return "token"
-	}
-	if len(ai.ClientCertificateData) > 0 || ai.ClientCertificate != "" {
-		return "certificate"
-	}
-	if ai.AuthProvider != nil {
-		return "auth-provider"
-	}
-	return "unknown"
 }

--- a/pkg/agent/kube/client_connection.go
+++ b/pkg/agent/kube/client_connection.go
@@ -1,0 +1,101 @@
+package kube
+
+import (
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+const testClusterConnectionTimeout = 10 * time.Second
+
+type TestConnectionRequest struct {
+	ServerURL     string `json:"serverUrl"`
+	AuthType      string `json:"authType"`
+	Token         string `json:"token,omitempty"`
+	CertData      string `json:"certData,omitempty"`
+	KeyData       string `json:"keyData,omitempty"`
+	CAData        string `json:"caData,omitempty"`
+	SkipTLSVerify bool   `json:"skipTlsVerify,omitempty"`
+}
+
+type TestConnectionResult struct {
+	Reachable     bool   `json:"reachable"`
+	ServerVersion string `json:"serverVersion,omitempty"`
+	Error         string `json:"error,omitempty"`
+}
+
+func (k *KubectlProxy) TestClusterConnection(req TestConnectionRequest) (*TestConnectionResult, error) {
+	if req.ServerURL == "" {
+		return nil, fmt.Errorf("serverUrl is required")
+	}
+
+	cfg := &rest.Config{Host: req.ServerURL, Timeout: testClusterConnectionTimeout}
+
+	switch req.AuthType {
+	case "token":
+		cfg.BearerToken = req.Token
+	case "certificate":
+		if req.CertData != "" {
+			certBytes, err := base64.StdEncoding.DecodeString(req.CertData)
+			if err != nil {
+				return &TestConnectionResult{Reachable: false, Error: "invalid certData base64"}, nil
+			}
+			cfg.TLSClientConfig.CertData = certBytes
+		}
+		if req.KeyData != "" {
+			keyBytes, err := base64.StdEncoding.DecodeString(req.KeyData)
+			if err != nil {
+				return &TestConnectionResult{Reachable: false, Error: "invalid keyData base64"}, nil
+			}
+			cfg.TLSClientConfig.KeyData = keyBytes
+		}
+	case "":
+		return nil, fmt.Errorf("authType is required")
+	default:
+		return nil, fmt.Errorf("unsupported authType: %s (must be token or certificate)", req.AuthType)
+	}
+
+	if req.CAData != "" {
+		caBytes, err := base64.StdEncoding.DecodeString(req.CAData)
+		if err != nil {
+			return &TestConnectionResult{Reachable: false, Error: "invalid caData base64"}, nil
+		}
+		cfg.TLSClientConfig.CAData = caBytes
+	}
+	cfg.TLSClientConfig.Insecure = req.SkipTLSVerify
+
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return &TestConnectionResult{Reachable: false, Error: fmt.Sprintf("failed to create client: %v", err)}, nil
+	}
+
+	version, err := client.Discovery().ServerVersion()
+	if err != nil {
+		return &TestConnectionResult{Reachable: false, Error: fmt.Sprintf("failed to test connection: %v", err)}, nil
+	}
+
+	return &TestConnectionResult{Reachable: true, ServerVersion: version.GitVersion}, nil
+}
+
+func detectAuthMethod(ai *api.AuthInfo) string {
+	if ai == nil {
+		return "unknown"
+	}
+	if ai.Exec != nil {
+		return "exec"
+	}
+	if ai.Token != "" || ai.TokenFile != "" {
+		return "token"
+	}
+	if len(ai.ClientCertificateData) > 0 || ai.ClientCertificate != "" {
+		return "certificate"
+	}
+	if ai.AuthProvider != nil {
+		return "auth-provider"
+	}
+	return "unknown"
+}

--- a/pkg/agent/kube/client_context.go
+++ b/pkg/agent/kube/client_context.go
@@ -1,0 +1,120 @@
+package kube
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/kubestellar/console/pkg/agent/protocol"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	kubectlRenameTimeout     = 30 * time.Second
+	KubectlReloadMinInterval = 2 * time.Second
+)
+
+func (k *KubectlProxy) ListContexts() ([]protocol.ClusterInfo, string) {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	clusters := make([]protocol.ClusterInfo, 0)
+	current := k.config.CurrentContext
+
+	for name, ctx := range k.config.Contexts {
+		cluster := k.config.Clusters[ctx.Cluster]
+		server := ""
+		if cluster != nil {
+			server = cluster.Server
+		}
+		authInfo := k.config.AuthInfos[ctx.AuthInfo]
+		authMethod := detectAuthMethod(authInfo)
+		clusters = append(clusters, protocol.ClusterInfo{
+			Name: name, Context: name, Server: server,
+			User: ctx.AuthInfo, Namespace: ctx.Namespace,
+			AuthMethod: authMethod, IsCurrent: name == current,
+		})
+	}
+	return clusters, current
+}
+
+func (k *KubectlProxy) GetCurrentContext() string {
+	if k == nil || k.config == nil {
+		return ""
+	}
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	return k.config.CurrentContext
+}
+
+func (k *KubectlProxy) GetKubeconfigPath() string {
+	if k == nil {
+		return ""
+	}
+	return k.kubeconfig
+}
+
+func (k *KubectlProxy) Reload() {
+	config, err := clientcmd.LoadFromFile(k.kubeconfig)
+	if err == nil {
+		k.mu.Lock()
+		k.config = config
+		k.lastReload = time.Now()
+		k.mu.Unlock()
+	}
+}
+
+func (k *KubectlProxy) ReloadIfStale(minInterval time.Duration) bool {
+	k.mu.RLock()
+	fresh := !k.lastReload.IsZero() && time.Since(k.lastReload) < minInterval
+	k.mu.RUnlock()
+	if fresh {
+		return false
+	}
+	config, err := clientcmd.LoadFromFile(k.kubeconfig)
+	if err != nil {
+		k.mu.Lock()
+		k.lastReload = time.Now()
+		k.mu.Unlock()
+		return false
+	}
+	k.mu.Lock()
+	k.config = config
+	k.lastReload = time.Now()
+	k.mu.Unlock()
+	return true
+}
+
+func (k *KubectlProxy) reloadLocked() {
+	config, err := clientcmd.LoadFromFile(k.kubeconfig)
+	if err == nil {
+		k.config = config
+	}
+}
+
+func (k *KubectlProxy) RenameContext(oldName, newName string) error {
+	cmdArgs := []string{"config", "rename-context", oldName, newName}
+	if k.kubeconfig != "" {
+		cmdArgs = append([]string{"--kubeconfig", k.kubeconfig}, cmdArgs...)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), kubectlRenameTimeout)
+	defer cancel()
+
+	cmd := execCommandContext(ctx, "kubectl", cmdArgs...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	config, err := clientcmd.LoadFromFile(k.kubeconfig)
+	if err == nil {
+		k.mu.Lock()
+		k.config = config
+		k.mu.Unlock()
+	}
+
+	return nil
+}

--- a/pkg/agent/kube/client_onboarding.go
+++ b/pkg/agent/kube/client_onboarding.go
@@ -1,0 +1,270 @@
+package kube
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"os"
+	"reflect"
+	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+type KubeconfigPreviewEntry struct {
+	ContextName string `json:"contextName"`
+	ClusterName string `json:"clusterName"`
+	ServerURL   string `json:"serverUrl"`
+	UserName    string `json:"userName"`
+	AuthMethod  string `json:"authMethod,omitempty"`
+	IsNew       bool   `json:"isNew"`
+}
+
+type AddClusterRequest struct {
+	ContextName   string `json:"contextName"`
+	ClusterName   string `json:"clusterName"`
+	ServerURL     string `json:"serverUrl"`
+	AuthType      string `json:"authType"`
+	Token         string `json:"token,omitempty"`
+	CertData      string `json:"certData,omitempty"`
+	KeyData       string `json:"keyData,omitempty"`
+	CAData        string `json:"caData,omitempty"`
+	SkipTLSVerify bool   `json:"skipTlsVerify,omitempty"`
+	Namespace     string `json:"namespace,omitempty"`
+}
+
+func (k *KubectlProxy) PreviewKubeconfig(yamlContent string) ([]KubeconfigPreviewEntry, error) {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	incoming, err := clientcmd.Load([]byte(yamlContent))
+	if err != nil {
+		return nil, fmt.Errorf("invalid kubeconfig YAML: %w", err)
+	}
+	if len(incoming.Contexts) == 0 {
+		return nil, fmt.Errorf("kubeconfig contains no contexts")
+	}
+
+	entries := make([]KubeconfigPreviewEntry, 0)
+	for name, ctx := range incoming.Contexts {
+		entry := KubeconfigPreviewEntry{ContextName: name, ClusterName: ctx.Cluster, UserName: ctx.AuthInfo, AuthMethod: detectAuthMethod(incoming.AuthInfos[ctx.AuthInfo])}
+		if cluster, ok := incoming.Clusters[ctx.Cluster]; ok {
+			entry.ServerURL = cluster.Server
+		}
+		_, exists := k.config.Contexts[name]
+		entry.IsNew = !exists
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+func (k *KubectlProxy) ImportKubeconfig(yamlContent string) (added []string, skipped []string, err error) {
+	incoming, err := clientcmd.Load([]byte(yamlContent))
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid kubeconfig YAML: %w", err)
+	}
+	if len(incoming.Contexts) == 0 {
+		return nil, nil, fmt.Errorf("kubeconfig contains no contexts")
+	}
+
+	for name, ai := range incoming.AuthInfos {
+		if ai != nil && ai.Exec != nil {
+			return nil, nil, fmt.Errorf("SECURITY: kubeconfig user %q uses exec-based auth (command: %s) — exec plugins are not allowed for imported configs", name, ai.Exec.Command)
+		}
+	}
+
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	if err := backupKubeconfig(k.kubeconfig); err != nil {
+		return nil, nil, err
+	}
+	ensureConfigMaps(k.config)
+
+	for name, ctx := range incoming.Contexts {
+		if _, exists := k.config.Contexts[name]; exists {
+			skipped = append(skipped, name)
+			continue
+		}
+
+		clusterName := ctx.Cluster
+		if incomingCluster, ok := incoming.Clusters[clusterName]; ok {
+			if existing, exists := k.config.Clusters[clusterName]; exists && !clustersEquivalent(existing, incomingCluster) {
+				clusterName = uniqueName(clusterName, k.config.Clusters)
+			}
+		}
+
+		userName := ctx.AuthInfo
+		if incomingUser, ok := incoming.AuthInfos[userName]; ok {
+			if existing, exists := k.config.AuthInfos[userName]; exists && !authInfosEquivalent(existing, incomingUser) {
+				userName = uniqueName(userName, k.config.AuthInfos)
+			}
+		}
+
+		mergedCtx := ctx.DeepCopy()
+		mergedCtx.Cluster = clusterName
+		mergedCtx.AuthInfo = userName
+		k.config.Contexts[name] = mergedCtx
+
+		if cluster, ok := incoming.Clusters[ctx.Cluster]; ok {
+			if _, exists := k.config.Clusters[clusterName]; !exists {
+				k.config.Clusters[clusterName] = cluster
+			}
+		}
+		if user, ok := incoming.AuthInfos[ctx.AuthInfo]; ok {
+			if _, exists := k.config.AuthInfos[userName]; !exists {
+				k.config.AuthInfos[userName] = user
+			}
+		}
+		added = append(added, name)
+	}
+
+	if writeErr := clientcmd.WriteToFile(*k.config, k.kubeconfig); writeErr != nil {
+		return nil, nil, fmt.Errorf("failed to write merged kubeconfig: %w", writeErr)
+	}
+
+	k.reloadLocked()
+	return added, skipped, nil
+}
+
+func (k *KubectlProxy) AddCluster(req AddClusterRequest) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	if req.ContextName == "" || req.ClusterName == "" || req.ServerURL == "" || req.AuthType == "" {
+		return fmt.Errorf("contextName, clusterName, serverUrl, and authType are required")
+	}
+
+	parsedURL, err := url.Parse(req.ServerURL)
+	if err != nil {
+		return fmt.Errorf("invalid server URL: %w", err)
+	}
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return fmt.Errorf("server URL must include a scheme and host (e.g. https://api.example.com:6443)")
+	}
+
+	switch req.AuthType {
+	case "token":
+		if req.Token == "" {
+			return fmt.Errorf("token is required for token auth type")
+		}
+	case "certificate":
+		if req.CertData == "" || req.KeyData == "" {
+			return fmt.Errorf("certData and keyData are required for certificate auth type")
+		}
+	default:
+		return fmt.Errorf("unsupported authType: %s (must be token or certificate)", req.AuthType)
+	}
+
+	if k.config.Contexts != nil {
+		if _, exists := k.config.Contexts[req.ContextName]; exists {
+			return fmt.Errorf("context %q already exists", req.ContextName)
+		}
+	}
+
+	cluster := &api.Cluster{Server: req.ServerURL, InsecureSkipTLSVerify: req.SkipTLSVerify}
+	if req.CAData != "" {
+		caBytes, err := base64.StdEncoding.DecodeString(req.CAData)
+		if err != nil {
+			return fmt.Errorf("invalid caData base64: %w", err)
+		}
+		cluster.CertificateAuthorityData = caBytes
+	}
+
+	userName := req.ContextName + "-user"
+	authInfo := &api.AuthInfo{}
+	switch req.AuthType {
+	case "token":
+		authInfo.Token = req.Token
+	case "certificate":
+		certBytes, err := base64.StdEncoding.DecodeString(req.CertData)
+		if err != nil {
+			return fmt.Errorf("invalid certData base64: %w", err)
+		}
+		keyBytes, err := base64.StdEncoding.DecodeString(req.KeyData)
+		if err != nil {
+			return fmt.Errorf("invalid keyData base64: %w", err)
+		}
+		authInfo.ClientCertificateData = certBytes
+		authInfo.ClientKeyData = keyBytes
+	}
+
+	ctx := &api.Context{Cluster: req.ClusterName, AuthInfo: userName, Namespace: req.Namespace}
+
+	if err := backupKubeconfig(k.kubeconfig); err != nil {
+		return err
+	}
+	ensureConfigMaps(k.config)
+	k.config.Clusters[req.ClusterName] = cluster
+	k.config.AuthInfos[userName] = authInfo
+	k.config.Contexts[req.ContextName] = ctx
+
+	if writeErr := clientcmd.WriteToFile(*k.config, k.kubeconfig); writeErr != nil {
+		return fmt.Errorf("failed to write kubeconfig: %w", writeErr)
+	}
+
+	k.reloadLocked()
+	return nil
+}
+
+func backupKubeconfig(kubeconfigPath string) error {
+	if _, statErr := os.Stat(kubeconfigPath); statErr == nil {
+		backupPath := fmt.Sprintf("%s.bak-%d", kubeconfigPath, time.Now().UnixNano())
+		data, readErr := os.ReadFile(kubeconfigPath)
+		if readErr != nil {
+			return fmt.Errorf("failed to read kubeconfig for backup: %w", readErr)
+		}
+		if writeErr := os.WriteFile(backupPath, data, 0o600); writeErr != nil {
+			return fmt.Errorf("failed to write backup: %w", writeErr)
+		}
+	}
+	return nil
+}
+
+func ensureConfigMaps(config *api.Config) {
+	if config.Contexts == nil {
+		config.Contexts = make(map[string]*api.Context)
+	}
+	if config.Clusters == nil {
+		config.Clusters = make(map[string]*api.Cluster)
+	}
+	if config.AuthInfos == nil {
+		config.AuthInfos = make(map[string]*api.AuthInfo)
+	}
+}
+
+func clustersEquivalent(a, b *api.Cluster) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	ac := a.DeepCopy()
+	bc := b.DeepCopy()
+	ac.LocationOfOrigin = ""
+	bc.LocationOfOrigin = ""
+	return reflect.DeepEqual(ac, bc)
+}
+
+func authInfosEquivalent(a, b *api.AuthInfo) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	ac := a.DeepCopy()
+	bc := b.DeepCopy()
+	ac.LocationOfOrigin = ""
+	bc.LocationOfOrigin = ""
+	return reflect.DeepEqual(ac, bc)
+}
+
+func uniqueName[V any](base string, m map[string]V) string {
+	candidate := base + "-imported"
+	if _, exists := m[candidate]; !exists {
+		return candidate
+	}
+	for i := 2; ; i++ {
+		candidate = fmt.Sprintf("%s-imported-%d", base, i)
+		if _, exists := m[candidate]; !exists {
+			return candidate
+		}
+	}
+}

--- a/pkg/agent/kube/client_providers.go
+++ b/pkg/agent/kube/client_providers.go
@@ -1,0 +1,322 @@
+package kube
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const minikubeStatusTimeout = 5 * time.Second
+
+func (m *LocalClusterManager) detectKind() *LocalClusterTool {
+	path, err := findExecutablePath("kind")
+	if err != nil {
+		return nil
+	}
+	tool := &LocalClusterTool{Name: "kind", Installed: true, Path: path}
+	cmd := execCommand("kind", "version")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err == nil {
+		version := strings.TrimSpace(out.String())
+		if parts := strings.Fields(version); len(parts) >= 2 {
+			tool.Version = strings.TrimPrefix(parts[1], "v")
+		}
+	}
+	return tool
+}
+
+func (m *LocalClusterManager) detectK3d() *LocalClusterTool {
+	path, err := findExecutablePath("k3d")
+	if err != nil {
+		return nil
+	}
+	tool := &LocalClusterTool{Name: "k3d", Installed: true, Path: path}
+	cmd := execCommand("k3d", "version")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err == nil {
+		lines := strings.Split(out.String(), "\n")
+		if len(lines) > 0 {
+			if matches := k3dVersionRegexp.FindStringSubmatch(lines[0]); len(matches) > 1 {
+				tool.Version = matches[1]
+			}
+		}
+	}
+	return tool
+}
+
+func (m *LocalClusterManager) detectMinikube() *LocalClusterTool {
+	path, err := findExecutablePath("minikube")
+	if err != nil {
+		return nil
+	}
+	tool := &LocalClusterTool{Name: "minikube", Installed: true, Path: path}
+	cmd := execCommand("minikube", "version", "--short")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err == nil {
+		tool.Version = strings.TrimPrefix(strings.TrimSpace(out.String()), "v")
+	}
+	return tool
+}
+
+func (m *LocalClusterManager) listKindClusters() []LocalCluster {
+	clusters := make([]LocalCluster, 0)
+	cmd := execCommand("kind", "get", "clusters")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return clusters
+	}
+	for _, name := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if name != "" {
+			clusters = append(clusters, LocalCluster{Name: name, Tool: "kind", Status: "running"})
+		}
+	}
+	return clusters
+}
+
+func (m *LocalClusterManager) listK3dClusters() []LocalCluster {
+	clusters := make([]LocalCluster, 0)
+	cmd := execCommand("k3d", "cluster", "list", "--no-headers")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return clusters
+	}
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 1 {
+			clusters = append(clusters, LocalCluster{Name: fields[0], Tool: "k3d", Status: "running"})
+		}
+	}
+	return clusters
+}
+
+func (m *LocalClusterManager) listMinikubeClusters() []LocalCluster {
+	clusters := make([]LocalCluster, 0)
+	cmd := execCommand("minikube", "profile", "list", "-o", "json")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return clusters
+	}
+	output := out.String()
+	if !strings.Contains(output, "valid") {
+		return clusters
+	}
+	matches := minikubeProfileNameRegexp.FindAllStringSubmatch(output, -1)
+	for _, match := range matches {
+		if len(match) > 1 {
+			name := match[1]
+			clusters = append(clusters, LocalCluster{Name: name, Tool: "minikube", Status: minikubeProfileStatus(name)})
+		}
+	}
+	return clusters
+}
+
+func minikubeProfileStatus(name string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), minikubeStatusTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "minikube", "status", "-p", name, "-o", "json")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil && out.Len() == 0 {
+		return "unknown"
+	}
+	raw := bytes.TrimSpace(out.Bytes())
+	if len(raw) == 0 {
+		return "unknown"
+	}
+	type statusEntry struct {
+		Host      string `json:"Host"`
+		Kubelet   string `json:"Kubelet"`
+		APIServer string `json:"APIServer"`
+	}
+	var entries []statusEntry
+	if raw[0] == '[' {
+		if err := json.Unmarshal(raw, &entries); err != nil {
+			return "unknown"
+		}
+	} else {
+		var single statusEntry
+		if err := json.Unmarshal(raw, &single); err != nil {
+			return "unknown"
+		}
+		entries = append(entries, single)
+	}
+	if len(entries) == 0 {
+		return "unknown"
+	}
+	for _, e := range entries {
+		if !strings.EqualFold(e.Host, "Running") {
+			return "stopped"
+		}
+	}
+	return "running"
+}
+
+func (m *LocalClusterManager) createKindCluster(name string) error {
+	cmd := execCommand("kind", "create", "cluster", "--name", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("kind create failed: %s", stderr.String())
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) createK3dCluster(name string) error {
+	cmd := execCommand("k3d", "cluster", "create", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("k3d create failed: %s", stderr.String())
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) createMinikubeCluster(name string) error {
+	cmd := execCommand("minikube", "start", "--profile", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("minikube start failed: %s", stderr.String())
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) startKindCluster(name string) error {
+	containers, err := listKindContainers(name)
+	if err != nil {
+		return fmt.Errorf("failed to list kind cluster containers: %w", err)
+	}
+	if len(containers) == 0 {
+		return fmt.Errorf("no containers found for kind cluster %q", name)
+	}
+	for _, c := range containers {
+		cmd := execCommand("docker", "start", c)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to start container %q: %s", c, stderr.String())
+		}
+	}
+	return nil
+}
+
+func listKindContainers(name string) ([]string, error) {
+	labelFilter := fmt.Sprintf("label=io.x-k8s.kind.cluster=%s", name)
+	cmd := execCommand("docker", "ps", "-a", "--filter", labelFilter, "--format", "{{.Names}}")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("docker ps failed: %s", stderr.String())
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			names = append(names, line)
+		}
+	}
+	return names, nil
+}
+
+func (m *LocalClusterManager) startK3dCluster(name string) error {
+	cmd := execCommand("k3d", "cluster", "start", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("k3d start failed: %s", stderr.String())
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) startMinikubeCluster(name string) error {
+	cmd := execCommand("minikube", "start", "--profile", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("minikube start failed: %s", stderr.String())
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) stopKindCluster(name string) error {
+	containers, err := listKindContainers(name)
+	if err != nil {
+		return fmt.Errorf("failed to list kind cluster containers: %w", err)
+	}
+	if len(containers) == 0 {
+		return fmt.Errorf("no containers found for kind cluster %q", name)
+	}
+	for _, c := range containers {
+		cmd := execCommand("docker", "stop", c)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to stop container %q: %s", c, stderr.String())
+		}
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) stopK3dCluster(name string) error {
+	cmd := execCommand("k3d", "cluster", "stop", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("k3d stop failed: %s", stderr.String())
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) stopMinikubeCluster(name string) error {
+	cmd := execCommand("minikube", "stop", "--profile", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("minikube stop failed: %s", stderr.String())
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) deleteKindCluster(name string) error {
+	cmd := execCommand("kind", "delete", "cluster", "--name", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("kind delete failed: %s", stderr.String())
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) deleteK3dCluster(name string) error {
+	cmd := execCommand("k3d", "cluster", "delete", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("k3d delete failed: %s", stderr.String())
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) deleteMinikubeCluster(name string) error {
+	cmd := execCommand("minikube", "delete", "--profile", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("minikube delete failed: %s", stderr.String())
+	}
+	return nil
+}

--- a/pkg/agent/kube/discovery.go
+++ b/pkg/agent/kube/discovery.go
@@ -2,8 +2,6 @@ package kube
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -15,30 +13,23 @@ import (
 	"time"
 )
 
-// Progress percentage constants for cluster creation/deletion phases
 const (
-	progressValidating = 10  // Pre-flight checks (Docker daemon, tool availability)
-	progressCreating   = 30  // Cluster creation command dispatched
-	progressDeleting   = 30  // Cluster deletion command dispatched
-	progressConnecting = 50  // Connection/disconnect operation in progress
-	progressDone       = 100 // Operation completed successfully
-	progressFailed     = 0   // Operation failed
+	progressValidating = 10
+	progressCreating   = 30
+	progressDeleting   = 30
+	progressConnecting = 50
+	progressDone       = 100
+	progressFailed     = 0
 )
 
-// vCluster CLI operation timeouts
 const (
-	vclusterListTimeout    = 15 * time.Second  // Timeout for listing vClusters
-	vclusterCreateTimeout  = 120 * time.Second // Timeout for creating a vCluster
-	vclusterConnectTimeout = 30 * time.Second  // Timeout for connecting/disconnecting a vCluster
-	vclusterDeleteTimeout  = 60 * time.Second  // Timeout for deleting a vCluster
+	vclusterListTimeout    = 15 * time.Second
+	vclusterCreateTimeout  = 120 * time.Second
+	vclusterConnectTimeout = 30 * time.Second
+	vclusterDeleteTimeout  = 60 * time.Second
 )
-
-// minikubeStatusTimeout bounds the `minikube status -p <name>` fan-out per
-// profile so a hung minikube doesn't stall the whole local-clusters listing.
-const minikubeStatusTimeout = 5 * time.Second
 
 var (
-	// execCommand is already declared in kubectl.go
 	lookPath                  = exec.LookPath
 	statFile                  = os.Stat
 	userHomeDir               = os.UserHomeDir
@@ -47,9 +38,9 @@ var (
 	minikubeProfileNameRegexp = regexp.MustCompile(`"Name":\s*"([^"]+)"`)
 	vclusterVersionRegexp     = regexp.MustCompile(`v?([\d.]+)`)
 	semverRegexp              = regexp.MustCompile(`v?([\d]+\.[\d]+\.[\d]+)`)
+	dns1123LabelRegexp        = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 )
 
-// LocalClusterTool represents a detected local cluster tool
 type LocalClusterTool struct {
 	Name      string `json:"name"`
 	Installed bool   `json:"installed"`
@@ -57,23 +48,20 @@ type LocalClusterTool struct {
 	Path      string `json:"path,omitempty"`
 }
 
-// LocalCluster represents a local cluster instance
 type LocalCluster struct {
 	Name   string `json:"name"`
 	Tool   string `json:"tool"`
-	Status string `json:"status"` // "running", "stopped", "unknown"
+	Status string `json:"status"`
 }
 
-// VClusterInstance represents a vCluster instance
 type VClusterInstance struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
-	Status    string `json:"status"`    // "Running", "Paused", etc.
-	Connected bool   `json:"connected"` // whether kubeconfig context exists
-	Context   string `json:"context"`   // kubeconfig context name if connected
+	Status    string `json:"status"`
+	Connected bool   `json:"connected"`
+	Context   string `json:"context"`
 }
 
-// vclusterListEntry mirrors the JSON output from `vcluster list --output json`
 type vclusterListEntry struct {
 	Name      string `json:"Name"`
 	Namespace string `json:"Namespace"`
@@ -82,36 +70,22 @@ type vclusterListEntry struct {
 	Context   string `json:"Context"`
 }
 
-// LocalClusterManager handles local cluster operations
 type LocalClusterManager struct {
 	broadcast func(msgType string, payload interface{})
 }
 
-// NewLocalClusterManager creates a new manager with an optional broadcast callback
-// for sending real-time progress updates to connected WebSocket clients.
 func NewLocalClusterManager(broadcast func(string, interface{})) *LocalClusterManager {
 	return &LocalClusterManager{broadcast: broadcast}
 }
 
-// broadcastProgress sends a progress update to all connected clients.
-// If no broadcast function is configured, a debug-level log is emitted
-// so progress events are traceable rather than silently swallowed (#7782).
 func (m *LocalClusterManager) broadcastProgress(tool, name, status, message string, progress int) {
 	if m.broadcast == nil {
-		slog.Debug("[LocalCluster] no broadcast listener, progress event dropped",
-			"tool", tool, "name", name, "status", status, "progress", progress)
+		slog.Debug("[LocalCluster] no broadcast listener, progress event dropped", "tool", tool, "name", name, "status", status, "progress", progress)
 		return
 	}
-	m.broadcast("local_cluster_progress", map[string]interface{}{
-		"tool":     tool,
-		"name":     name,
-		"status":   status,
-		"message":  message,
-		"progress": progress,
-	})
+	m.broadcast("local_cluster_progress", map[string]interface{}{"tool": tool, "name": name, "status": status, "message": message, "progress": progress})
 }
 
-// checkDockerRunning verifies the Docker daemon is reachable (required by kind/k3d)
 func (m *LocalClusterManager) checkDockerRunning() error {
 	cmd := execCommand("docker", "info")
 	var stderr bytes.Buffer
@@ -185,7 +159,6 @@ func findExecutablePath(name string) (string, error) {
 	if path, err := lookPath(name); err == nil {
 		return path, nil
 	}
-
 	for _, candidate := range standardToolCandidates(name) {
 		info, err := statFile(candidate)
 		if err != nil {
@@ -195,7 +168,6 @@ func findExecutablePath(name string) (string, error) {
 			return candidate, nil
 		}
 	}
-
 	return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
 }
 
@@ -214,15 +186,10 @@ func (m *LocalClusterManager) detectNamedTool(name string) *LocalClusterTool {
 		if err != nil {
 			return nil
 		}
-		return &LocalClusterTool{
-			Name:      strings.ToLower(strings.TrimSpace(name)),
-			Installed: true,
-			Path:      path,
-		}
+		return &LocalClusterTool{Name: strings.ToLower(strings.TrimSpace(name)), Installed: true, Path: path}
 	}
 }
 
-// DetectTools returns installed local cluster tools for the Local Clusters UI.
 func (m *LocalClusterManager) DetectTools() []LocalClusterTool {
 	allTools := m.DetectNamedTools([]string{"kind", "k3d", "minikube", "vcluster"})
 	tools := make([]LocalClusterTool, 0, len(allTools))
@@ -234,10 +201,6 @@ func (m *LocalClusterManager) DetectTools() []LocalClusterTool {
 	return tools
 }
 
-// DetectNamedTools detects the requested tools in order, including tools that
-// are not part of the local-cluster UI (for example kubectl and helm for AI
-// mission preflight checks). Missing tools are included with Installed=false so
-// callers can render a complete checklist.
 func (m *LocalClusterManager) DetectNamedTools(names []string) []LocalClusterTool {
 	tools := make([]LocalClusterTool, 0, len(names))
 	seen := make(map[string]struct{}, len(names))
@@ -250,265 +213,23 @@ func (m *LocalClusterManager) DetectNamedTools(names []string) []LocalClusterToo
 			continue
 		}
 		seen[normalized] = struct{}{}
-
 		if tool := m.detectNamedTool(normalized); tool != nil {
 			tools = append(tools, *tool)
 			continue
 		}
-
 		tools = append(tools, LocalClusterTool{Name: normalized, Installed: false})
 	}
-
 	return tools
 }
 
-func (m *LocalClusterManager) detectKind() *LocalClusterTool {
-	path, err := findExecutablePath("kind")
-	if err != nil {
-		return nil
-	}
-
-	tool := &LocalClusterTool{
-		Name:      "kind",
-		Installed: true,
-		Path:      path,
-	}
-
-	// Get version
-	cmd := execCommand("kind", "version")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err == nil {
-		// Parse "kind v0.20.0 go1.21.0 darwin/arm64"
-		version := strings.TrimSpace(out.String())
-		if parts := strings.Fields(version); len(parts) >= 2 {
-			tool.Version = strings.TrimPrefix(parts[1], "v")
-		}
-	}
-
-	return tool
-}
-
-func (m *LocalClusterManager) detectK3d() *LocalClusterTool {
-	path, err := findExecutablePath("k3d")
-	if err != nil {
-		return nil
-	}
-
-	tool := &LocalClusterTool{
-		Name:      "k3d",
-		Installed: true,
-		Path:      path,
-	}
-
-	// Get version
-	cmd := execCommand("k3d", "version")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err == nil {
-		// Parse "k3d version v5.6.0\nk3s version v1.27.4-k3s1 (default)"
-		lines := strings.Split(out.String(), "\n")
-		if len(lines) > 0 {
-			if matches := k3dVersionRegexp.FindStringSubmatch(lines[0]); len(matches) > 1 {
-				tool.Version = matches[1]
-			}
-		}
-	}
-
-	return tool
-}
-
-func (m *LocalClusterManager) detectMinikube() *LocalClusterTool {
-	path, err := findExecutablePath("minikube")
-	if err != nil {
-		return nil
-	}
-
-	tool := &LocalClusterTool{
-		Name:      "minikube",
-		Installed: true,
-		Path:      path,
-	}
-
-	// Get version
-	cmd := execCommand("minikube", "version", "--short")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err == nil {
-		// Parse "v1.31.0"
-		version := strings.TrimSpace(out.String())
-		tool.Version = strings.TrimPrefix(version, "v")
-	}
-
-	return tool
-}
-
-// ListClusters returns all local clusters for all detected tools
 func (m *LocalClusterManager) ListClusters() []LocalCluster {
-	clusters := []LocalCluster{}
-
-	// List kind clusters
+	clusters := make([]LocalCluster, 0)
 	clusters = append(clusters, m.listKindClusters()...)
-
-	// List k3d clusters
 	clusters = append(clusters, m.listK3dClusters()...)
-
-	// List minikube clusters
 	clusters = append(clusters, m.listMinikubeClusters()...)
-
 	return clusters
 }
 
-func (m *LocalClusterManager) listKindClusters() []LocalCluster {
-	clusters := []LocalCluster{}
-
-	cmd := execCommand("kind", "get", "clusters")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		return clusters
-	}
-
-	for _, name := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-		if name != "" {
-			clusters = append(clusters, LocalCluster{
-				Name:   name,
-				Tool:   "kind",
-				Status: "running", // kind clusters are always running if listed
-			})
-		}
-	}
-
-	return clusters
-}
-
-func (m *LocalClusterManager) listK3dClusters() []LocalCluster {
-	clusters := []LocalCluster{}
-
-	cmd := execCommand("k3d", "cluster", "list", "--no-headers")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		return clusters
-	}
-
-	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-		if line == "" {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) >= 1 {
-			clusters = append(clusters, LocalCluster{
-				Name:   fields[0],
-				Tool:   "k3d",
-				Status: "running",
-			})
-		}
-	}
-
-	return clusters
-}
-
-func (m *LocalClusterManager) listMinikubeClusters() []LocalCluster {
-	clusters := []LocalCluster{}
-
-	cmd := execCommand("minikube", "profile", "list", "-o", "json")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		return clusters
-	}
-
-	// Extract profile names from the JSON output. `minikube profile list`
-	// uses a nested structure with a "valid" array; we only need the names,
-	// then we fan out one `minikube status` call per profile to get the
-	// real running state (#7984).
-	output := out.String()
-	if !strings.Contains(output, "valid") {
-		return clusters
-	}
-	matches := minikubeProfileNameRegexp.FindAllStringSubmatch(output, -1)
-	for _, match := range matches {
-		if len(match) <= 1 {
-			continue
-		}
-		name := match[1]
-		clusters = append(clusters, LocalCluster{
-			Name:   name,
-			Tool:   "minikube",
-			Status: minikubeProfileStatus(name),
-		})
-	}
-
-	return clusters
-}
-
-// minikubeProfileStatus returns a normalized status string ("running",
-// "stopped", "unknown") for a single minikube profile by shelling out to
-// `minikube status -p <name> -o json`. Previously this was hardcoded to
-// "unknown" (#7984) so operators could not tell from the UI whether a
-// profile was running.
-func minikubeProfileStatus(name string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), minikubeStatusTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "minikube", "status", "-p", name, "-o", "json")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		// Exit code 1-7 means "not running" in some form; still parse the
-		// stdout if present because minikube writes JSON even on non-zero
-		// exits. Fall through to the parser below.
-		if out.Len() == 0 {
-			return "unknown"
-		}
-	}
-
-	// `minikube status -o json` emits either a single object or an array of
-	// objects (multi-node). Try array first, fall back to object.
-	raw := bytes.TrimSpace(out.Bytes())
-	if len(raw) == 0 {
-		return "unknown"
-	}
-	type statusEntry struct {
-		Host      string `json:"Host"`
-		Kubelet   string `json:"Kubelet"`
-		APIServer string `json:"APIServer"`
-	}
-	var entries []statusEntry
-	if raw[0] == '[' {
-		if err := json.Unmarshal(raw, &entries); err != nil {
-			return "unknown"
-		}
-	} else {
-		var single statusEntry
-		if err := json.Unmarshal(raw, &single); err != nil {
-			return "unknown"
-		}
-		entries = append(entries, single)
-	}
-	if len(entries) == 0 {
-		return "unknown"
-	}
-
-	// A profile is "running" only when every node reports Host=Running and
-	// either Kubelet=Running or APIServer=Running (workers don't run
-	// apiserver). Anything else collapses to "stopped".
-	for _, e := range entries {
-		if !strings.EqualFold(e.Host, "Running") {
-			return "stopped"
-		}
-	}
-	return "running"
-}
-
-// dns1123LabelRegexp matches valid DNS-1123 labels (RFC 1123 section 2.1).
-// Max 63 chars, lowercase alphanumeric, may contain hyphens but not at
-// start or end.
-var dns1123LabelRegexp = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
-
-// validateClusterName ensures the name is a valid DNS-1123 label before
-// any exec call runs, preventing orphaned Docker containers from partial
-// creates and flag-injection edge cases (#7249).
 func validateClusterName(name string) error {
 	if name == "" {
 		return fmt.Errorf("cluster name must not be empty")
@@ -519,25 +240,17 @@ func validateClusterName(name string) error {
 	return nil
 }
 
-// CreateCluster creates a new local cluster with phased progress broadcasting
 func (m *LocalClusterManager) CreateCluster(tool, name string) error {
 	if err := validateClusterName(name); err != nil {
 		return err
 	}
-
-	// Phase 1: Validating prerequisites
 	m.broadcastProgress(tool, name, "validating", "Checking prerequisites...", progressValidating)
-
-	// Docker pre-flight check for tools that require it
 	if tool == "kind" || tool == "k3d" {
 		if err := m.checkDockerRunning(); err != nil {
 			return err
 		}
 	}
-
-	// Phase 2: Creating the cluster
 	m.broadcastProgress(tool, name, "creating", fmt.Sprintf("Creating %s cluster '%s'...", tool, name), progressCreating)
-
 	switch tool {
 	case "kind":
 		return m.createKindCluster(name)
@@ -550,45 +263,12 @@ func (m *LocalClusterManager) CreateCluster(tool, name string) error {
 	}
 }
 
-func (m *LocalClusterManager) createKindCluster(name string) error {
-	cmd := execCommand("kind", "create", "cluster", "--name", name)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("kind create failed: %s", stderr.String())
-	}
-	return nil
-}
-
-func (m *LocalClusterManager) createK3dCluster(name string) error {
-	cmd := execCommand("k3d", "cluster", "create", name)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("k3d create failed: %s", stderr.String())
-	}
-	return nil
-}
-
-func (m *LocalClusterManager) createMinikubeCluster(name string) error {
-	cmd := execCommand("minikube", "start", "--profile", name)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("minikube start failed: %s", stderr.String())
-	}
-	return nil
-}
-
-// StartCluster starts a stopped local cluster with phased progress broadcasting
 func (m *LocalClusterManager) StartCluster(tool, name string) error {
 	if err := validateClusterName(name); err != nil {
 		return err
 	}
 	m.broadcastProgress(tool, name, "validating", fmt.Sprintf("Preparing to start cluster '%s'...", name), progressValidating)
-
 	m.broadcastProgress(tool, name, "starting", fmt.Sprintf("Starting %s cluster '%s'...", tool, name), progressCreating)
-
 	switch tool {
 	case "kind":
 		return m.startKindCluster(name)
@@ -601,76 +281,12 @@ func (m *LocalClusterManager) StartCluster(tool, name string) error {
 	}
 }
 
-func (m *LocalClusterManager) startKindCluster(name string) error {
-	containers, err := listKindContainers(name)
-	if err != nil {
-		return fmt.Errorf("failed to list kind cluster containers: %w", err)
-	}
-	if len(containers) == 0 {
-		return fmt.Errorf("no containers found for kind cluster %q", name)
-	}
-	for _, c := range containers {
-		cmd := execCommand("docker", "start", c)
-		var stderr bytes.Buffer
-		cmd.Stderr = &stderr
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to start container %q: %s", c, stderr.String())
-		}
-	}
-	return nil
-}
-
-// listKindContainers returns all Docker container names that belong to the
-// given kind cluster, by querying the kind cluster label. This avoids the
-// previous fixed-loop limit of 10 worker nodes.
-func listKindContainers(name string) ([]string, error) {
-	labelFilter := fmt.Sprintf("label=io.x-k8s.kind.cluster=%s", name)
-	cmd := execCommand("docker", "ps", "-a", "--filter", labelFilter, "--format", "{{.Names}}")
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("docker ps failed: %s", stderr.String())
-	}
-	var names []string
-	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			names = append(names, line)
-		}
-	}
-	return names, nil
-}
-
-func (m *LocalClusterManager) startK3dCluster(name string) error {
-	cmd := execCommand("k3d", "cluster", "start", name)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("k3d start failed: %s", stderr.String())
-	}
-	return nil
-}
-
-func (m *LocalClusterManager) startMinikubeCluster(name string) error {
-	cmd := execCommand("minikube", "start", "--profile", name)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("minikube start failed: %s", stderr.String())
-	}
-	return nil
-}
-
-// StopCluster stops a running local cluster with phased progress broadcasting
 func (m *LocalClusterManager) StopCluster(tool, name string) error {
 	if err := validateClusterName(name); err != nil {
 		return err
 	}
 	m.broadcastProgress(tool, name, "validating", fmt.Sprintf("Preparing to stop cluster '%s'...", name), progressValidating)
-
 	m.broadcastProgress(tool, name, "stopping", fmt.Sprintf("Stopping %s cluster '%s'...", tool, name), progressCreating)
-
 	switch tool {
 	case "kind":
 		return m.stopKindCluster(name)
@@ -683,56 +299,12 @@ func (m *LocalClusterManager) StopCluster(tool, name string) error {
 	}
 }
 
-func (m *LocalClusterManager) stopKindCluster(name string) error {
-	containers, err := listKindContainers(name)
-	if err != nil {
-		return fmt.Errorf("failed to list kind cluster containers: %w", err)
-	}
-	if len(containers) == 0 {
-		return fmt.Errorf("no containers found for kind cluster %q", name)
-	}
-	for _, c := range containers {
-		cmd := execCommand("docker", "stop", c)
-		var stderr bytes.Buffer
-		cmd.Stderr = &stderr
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to stop container %q: %s", c, stderr.String())
-		}
-	}
-	return nil
-}
-
-func (m *LocalClusterManager) stopK3dCluster(name string) error {
-	cmd := execCommand("k3d", "cluster", "stop", name)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("k3d stop failed: %s", stderr.String())
-	}
-	return nil
-}
-
-func (m *LocalClusterManager) stopMinikubeCluster(name string) error {
-	cmd := execCommand("minikube", "stop", "--profile", name)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("minikube stop failed: %s", stderr.String())
-	}
-	return nil
-}
-
-// DeleteCluster deletes a local cluster with phased progress broadcasting
 func (m *LocalClusterManager) DeleteCluster(tool, name string) error {
 	if err := validateClusterName(name); err != nil {
 		return err
 	}
-	// Phase 1: Validating
 	m.broadcastProgress(tool, name, "validating", fmt.Sprintf("Preparing to delete cluster '%s'...", name), progressValidating)
-
-	// Phase 2: Deleting
 	m.broadcastProgress(tool, name, "deleting", fmt.Sprintf("Deleting %s cluster '%s'...", tool, name), progressDeleting)
-
 	switch tool {
 	case "kind":
 		return m.deleteKindCluster(name)
@@ -743,34 +315,4 @@ func (m *LocalClusterManager) DeleteCluster(tool, name string) error {
 	default:
 		return fmt.Errorf("unsupported tool: %s", tool)
 	}
-}
-
-func (m *LocalClusterManager) deleteKindCluster(name string) error {
-	cmd := execCommand("kind", "delete", "cluster", "--name", name)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("kind delete failed: %s", stderr.String())
-	}
-	return nil
-}
-
-func (m *LocalClusterManager) deleteK3dCluster(name string) error {
-	cmd := execCommand("k3d", "cluster", "delete", name)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("k3d delete failed: %s", stderr.String())
-	}
-	return nil
-}
-
-func (m *LocalClusterManager) deleteMinikubeCluster(name string) error {
-	cmd := execCommand("minikube", "delete", "--profile", name)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("minikube delete failed: %s", stderr.String())
-	}
-	return nil
 }


### PR DESCRIPTION
Fixes #19082
Fixes #19083
Fixes #19084
Fixes #19085

Extracts context/reload, connection testing, LocalClusterManager providers, and kubeconfig import/onboarding from the monolithic client.go into focused module files.