### PR TITLE
[ci-maintainer] fix: add missing store import in pkg/api/audit/webhook_send_test.go

### DIFF
--- a/pkg/api/audit/webhook_send_test.go
+++ b/pkg/api/audit/webhook_send_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kubestellar/console/pkg/store"
 )
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## CI Fix

`pkg/api/audit/webhook_send_test.go:200` references `store.Store` inside `TestSetStore_EnablesAndDisables` but the `store` package was not imported. This causes `go vet ./...` to fail on all three platforms (linux, macos, windows), blocking the **Cross-Platform Build** workflow on every PR branch and main:

```
vet: pkg/api/audit/webhook_send_test.go:200:25: undefined: store
```

### Change

Add the missing import:
```go
"github.com/kubestellar/console/pkg/store"
```

### Evidence

- Cross-Platform Build run 27707945559 (main, 2026-06-17): `go vet` fails on ubuntu, macos, windows
- Cross-Platform Build run 27795167623 (quality/test-cluster-groups-19118): same failure
- 5+ PR branches blocked by the same error

Fixes #19154

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*