### PR TITLE
feat: scanner respects human assignees on issues

### DIFF
--- a/.github/scanner-config.yml
+++ b/.github/scanner-config.yml
@@ -81,6 +81,13 @@ scanner:
       - build-break
       - needs-investigation
       
+  # Human Assignee Respect
+  assignee_respect:
+    enabled: true
+    # Scanner defers if a human (non-bot) is assigned to the issue.
+    # The scanner-please-take label overrides this check.
+    override_label: scanner-please-take
+
   # Emergency Controls
   emergency:
     # Kill switch: completely disable scanner merges

--- a/.github/workflows/implement-fix.md
+++ b/.github/workflows/implement-fix.md
@@ -48,6 +48,8 @@ Only process issues that have BOTH `ai-fix-requested` AND `triage/accepted` labe
 
 **IMPORTANT: Skip if any of these labels are already present:** `ai-awaiting-fix`, `ai-processing`, `ai-pr-draft`, `ai-pr-ready`. These indicate another workflow (triage-command.yml or copilot-assigned.yml) already assigned Copilot. Do NOT double-assign.
 
+**Human assignee respect:** The `ai-fix-requested` label is NOT added by triage-command.yml when a human (non-bot) is assigned to the issue. This prevents the scanner from racing a human contributor. The `scanner-please-take` label overrides this check.
+
 ## Your Task
 
 **Assign Copilot to work on this issue.**

--- a/.github/workflows/triage-command.yml
+++ b/.github/workflows/triage-command.yml
@@ -59,21 +59,18 @@ jobs:
           REPO="${{ github.repository }}"
           ISSUE="${{ github.event.issue.number }}"
 
-          BOT_SUFFIXES="[bot]"
-          ASSIGNEES=$(gh api "repos/$REPO/issues/$ISSUE" \
-            --jq '[.assignees[].login] | join(",")' 2>/dev/null || echo "")
-          LABELS=$(gh api "repos/$REPO/issues/$ISSUE" \
-            --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+          ISSUE_DATA=$(gh api "repos/$REPO/issues/$ISSUE" 2>/dev/null)
+          ASSIGNEES=$(echo "$ISSUE_DATA" | jq -r '[.assignees[].login] | join(",")')
+          LABELS=$(echo "$ISSUE_DATA" | jq -r '[.labels[].name] | join(",")')
 
           HAS_HUMAN="false"
           if [ -n "$ASSIGNEES" ]; then
             IFS=',' read -ra ADDR <<< "$ASSIGNEES"
             for assignee in "${ADDR[@]}"; do
-              if [[ "$assignee" != *"$BOT_SUFFIXES"* ]]; then
-                HAS_HUMAN="true"
-                echo "Found human assignee: $assignee"
-                break
-              fi
+              case "$assignee" in
+                *\[bot\]) ;; # skip bot accounts
+                *) HAS_HUMAN="true"; echo "Found human assignee: $assignee"; break ;;
+              esac
             done
           fi
 
@@ -119,16 +116,17 @@ jobs:
           ASSIGNEES=$(gh api "repos/$REPO/issues/$ISSUE" \
             --jq '[.assignees[].login | select(endswith("[bot]") | not)] | map("@" + .) | join(", ")' 2>/dev/null || echo "unknown")
 
-          # Still add triage/accepted but NOT ai-fix-requested
+          # Add triage/accepted but NOT ai-fix-requested; remove ai-fix-requested if already present
           gh label create "triage/accepted" --repo "$REPO" --color "0e8a16" \
             --description "Issue has been triaged and accepted" 2>/dev/null || true
           gh issue edit "$ISSUE" --repo "$REPO" --remove-label "needs-triage" 2>/dev/null || true
           gh issue edit "$ISSUE" --repo "$REPO" --remove-label "help wanted" 2>/dev/null || true
+          gh issue edit "$ISSUE" --repo "$REPO" --remove-label "ai-fix-requested" 2>/dev/null || true
           gh issue edit "$ISSUE" --repo "$REPO" --add-label "triage/accepted"
 
           gh issue comment "$ISSUE" --repo "$REPO" --body "**Scanner deferred** — this issue is assigned to a human contributor (${ASSIGNEES}). The scanner will not open a competing PR.
 
-          To hand this off to the scanner instead, add the \`scanner-please-take\` label."
+To hand this off to the scanner instead, add the \`scanner-please-take\` label."
 
       - name: Add rocket reaction to issue
         if: steps.check_perms.outputs.authorized == 'true'
@@ -334,21 +332,18 @@ jobs:
           REPO="${{ github.repository }}"
           ISSUE="${{ github.event.issue.number }}"
 
-          BOT_SUFFIXES="[bot]"
-          ASSIGNEES=$(gh api "repos/$REPO/issues/$ISSUE" \
-            --jq '[.assignees[].login] | join(",")' 2>/dev/null || echo "")
-          LABELS=$(gh api "repos/$REPO/issues/$ISSUE" \
-            --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+          ISSUE_DATA=$(gh api "repos/$REPO/issues/$ISSUE" 2>/dev/null)
+          ASSIGNEES=$(echo "$ISSUE_DATA" | jq -r '[.assignees[].login] | join(",")')
+          LABELS=$(echo "$ISSUE_DATA" | jq -r '[.labels[].name] | join(",")')
 
           HAS_HUMAN="false"
           if [ -n "$ASSIGNEES" ]; then
             IFS=',' read -ra ADDR <<< "$ASSIGNEES"
             for assignee in "${ADDR[@]}"; do
-              if [[ "$assignee" != *"$BOT_SUFFIXES"* ]]; then
-                HAS_HUMAN="true"
-                echo "Found human assignee: $assignee"
-                break
-              fi
+              case "$assignee" in
+                *\[bot\]) ;; # skip bot accounts
+                *) HAS_HUMAN="true"; echo "Found human assignee: $assignee"; break ;;
+              esac
             done
           fi
 
@@ -392,9 +387,12 @@ jobs:
           ASSIGNEES=$(gh api "repos/$REPO/issues/$ISSUE" \
             --jq '[.assignees[].login | select(endswith("[bot]") | not)] | map("@" + .) | join(", ")' 2>/dev/null || echo "unknown")
 
+          # Remove ai-fix-requested if already present
+          gh issue edit "$ISSUE" --repo "$REPO" --remove-label "ai-fix-requested" 2>/dev/null || true
+
           gh issue comment "$ISSUE" --repo "$REPO" --body "**Scanner deferred** — this issue is assigned to a human contributor (${ASSIGNEES}). The scanner will not open a competing PR.
 
-          To hand this off to the scanner instead, add the \`scanner-please-take\` label."
+To hand this off to the scanner instead, add the \`scanner-please-take\` label."
 
       - name: Add rocket reaction to issue
         if: steps.check_perms.outputs.authorized == 'true'

--- a/.github/workflows/triage-command.yml
+++ b/.github/workflows/triage-command.yml
@@ -50,8 +50,43 @@ jobs:
           gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             -X POST -f content='+1'
 
-      - name: Add triage and AI labels
+      - name: Check for human assignee
         if: steps.check_perms.outputs.authorized == 'true'
+        id: check_assignee
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          ISSUE="${{ github.event.issue.number }}"
+
+          BOT_SUFFIXES="[bot]"
+          ASSIGNEES=$(gh api "repos/$REPO/issues/$ISSUE" \
+            --jq '[.assignees[].login] | join(",")' 2>/dev/null || echo "")
+          LABELS=$(gh api "repos/$REPO/issues/$ISSUE" \
+            --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+
+          HAS_HUMAN="false"
+          if [ -n "$ASSIGNEES" ]; then
+            IFS=',' read -ra ADDR <<< "$ASSIGNEES"
+            for assignee in "${ADDR[@]}"; do
+              if [[ "$assignee" != *"$BOT_SUFFIXES"* ]]; then
+                HAS_HUMAN="true"
+                echo "Found human assignee: $assignee"
+                break
+              fi
+            done
+          fi
+
+          # scanner-please-take label overrides the human assignee check
+          if echo "$LABELS" | grep -q "scanner-please-take"; then
+            echo "scanner-please-take label found — overriding human assignee check"
+            HAS_HUMAN="false"
+          fi
+
+          echo "has_human=$HAS_HUMAN" >> $GITHUB_OUTPUT
+
+      - name: Add triage and AI labels
+        if: steps.check_perms.outputs.authorized == 'true' && steps.check_assignee.outputs.has_human != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -73,6 +108,27 @@ jobs:
             --add-label "ai-fix-requested"
 
           echo "Triaged issue #$ISSUE: removed needs-triage, added triage/accepted + ai-fix-requested"
+
+      - name: Comment deferring to human assignee
+        if: steps.check_perms.outputs.authorized == 'true' && steps.check_assignee.outputs.has_human == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          ISSUE="${{ github.event.issue.number }}"
+          ASSIGNEES=$(gh api "repos/$REPO/issues/$ISSUE" \
+            --jq '[.assignees[].login | select(endswith("[bot]") | not)] | map("@" + .) | join(", ")' 2>/dev/null || echo "unknown")
+
+          # Still add triage/accepted but NOT ai-fix-requested
+          gh label create "triage/accepted" --repo "$REPO" --color "0e8a16" \
+            --description "Issue has been triaged and accepted" 2>/dev/null || true
+          gh issue edit "$ISSUE" --repo "$REPO" --remove-label "needs-triage" 2>/dev/null || true
+          gh issue edit "$ISSUE" --repo "$REPO" --remove-label "help wanted" 2>/dev/null || true
+          gh issue edit "$ISSUE" --repo "$REPO" --add-label "triage/accepted"
+
+          gh issue comment "$ISSUE" --repo "$REPO" --body "**Scanner deferred** — this issue is assigned to a human contributor (${ASSIGNEES}). The scanner will not open a competing PR.
+
+          To hand this off to the scanner instead, add the \`scanner-please-take\` label."
 
       - name: Add rocket reaction to issue
         if: steps.check_perms.outputs.authorized == 'true'
@@ -269,8 +325,43 @@ jobs:
             echo "::warning::User $ACTOR lacks write permission (has: $PERMISSION)"
           fi
 
-      - name: Add AI labels
+      - name: Check for human assignee
         if: steps.check_perms.outputs.authorized == 'true'
+        id: check_assignee
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          ISSUE="${{ github.event.issue.number }}"
+
+          BOT_SUFFIXES="[bot]"
+          ASSIGNEES=$(gh api "repos/$REPO/issues/$ISSUE" \
+            --jq '[.assignees[].login] | join(",")' 2>/dev/null || echo "")
+          LABELS=$(gh api "repos/$REPO/issues/$ISSUE" \
+            --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+
+          HAS_HUMAN="false"
+          if [ -n "$ASSIGNEES" ]; then
+            IFS=',' read -ra ADDR <<< "$ASSIGNEES"
+            for assignee in "${ADDR[@]}"; do
+              if [[ "$assignee" != *"$BOT_SUFFIXES"* ]]; then
+                HAS_HUMAN="true"
+                echo "Found human assignee: $assignee"
+                break
+              fi
+            done
+          fi
+
+          # scanner-please-take label overrides the human assignee check
+          if echo "$LABELS" | grep -q "scanner-please-take"; then
+            echo "scanner-please-take label found — overriding human assignee check"
+            HAS_HUMAN="false"
+          fi
+
+          echo "has_human=$HAS_HUMAN" >> $GITHUB_OUTPUT
+
+      - name: Add AI labels
+        if: steps.check_perms.outputs.authorized == 'true' && steps.check_assignee.outputs.has_human != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -290,6 +381,20 @@ jobs:
             --add-label "ai-fix-requested"
 
           echo "Label-triggered triage for issue #$ISSUE: added ai-fix-requested"
+
+      - name: Comment deferring to human assignee
+        if: steps.check_perms.outputs.authorized == 'true' && steps.check_assignee.outputs.has_human == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          ISSUE="${{ github.event.issue.number }}"
+          ASSIGNEES=$(gh api "repos/$REPO/issues/$ISSUE" \
+            --jq '[.assignees[].login | select(endswith("[bot]") | not)] | map("@" + .) | join(", ")' 2>/dev/null || echo "unknown")
+
+          gh issue comment "$ISSUE" --repo "$REPO" --body "**Scanner deferred** — this issue is assigned to a human contributor (${ASSIGNEES}). The scanner will not open a competing PR.
+
+          To hand this off to the scanner instead, add the \`scanner-please-take\` label."
 
       - name: Add rocket reaction to issue
         if: steps.check_perms.outputs.authorized == 'true'


### PR DESCRIPTION
## Summary
- Scanner now checks for human (non-bot) assignees before adding `ai-fix-requested` label
- Both triage paths (comment and label) defer to human contributors
- `scanner-please-take` label overrides the check when a human wants to hand off to the scanner
- Posts a comment explaining the deferral with override instructions

## How it works
When `triage/accepted` is added (via label or `/triage accepted` comment), the workflow checks if any non-bot user is assigned. If so, it adds `triage/accepted` but **skips** `ai-fix-requested`, preventing the scanner from picking up the issue. A comment is posted explaining the deferral.

Build-break issues filed by the scanner itself are unaffected — they have no human assignee by default.

## Test plan
- [ ] Assign a human to an issue, add `triage/accepted` — verify `ai-fix-requested` is NOT added
- [ ] Add `scanner-please-take` label to same issue — verify scanner picks it up
- [ ] Unassigned issue with `triage/accepted` — verify `ai-fix-requested` IS added (no behavior change)
- [ ] Bot-only assigned issue — verify scanner still picks it up

Fixes #19074

🤖 Generated with [Claude Code](https://claude.com/claude-code)