### PR TITLE
🐛 fix: KB nightly validation schema fixture generation

### DIFF
--- a/scripts/validate-missions-schema-test.sh
+++ b/scripts/validate-missions-schema-test.sh
@@ -9,6 +9,17 @@ VALID_DIR="${TESTDATA_ROOT}/valid"
 INVALID_DIR="${TESTDATA_ROOT}/invalid-missing-version"
 EXPECTED_VERSION_ERROR="must have required property 'version'"
 
+check_schema_validation_available() {
+  local output
+  output=$(./scripts/validate-missions.sh --local "$VALID_DIR" --schema "$SCHEMA_FILE" 2>&1 || true)
+  
+  if [[ "$output" == *"schema validation skipped"* ]]; then
+    echo "ERROR: Schema validation was skipped. AJV tools may not be available or properly configured." >&2
+    echo "$output" >&2
+    exit 2
+  fi
+}
+
 assert_validation_passes() {
   local name="$1"
   local mission_dir="$2"
@@ -46,6 +57,7 @@ assert_validation_fails_with() {
   echo "✓ $name"
 }
 
+check_schema_validation_available
 assert_validation_passes "accepts minimal runtime-valid mission fixture" "$VALID_DIR"
 assert_validation_fails_with "rejects mission missing required version" "$INVALID_DIR" "$EXPECTED_VERSION_ERROR"
 


### PR DESCRIPTION
Fixes #19159

## Problem
The KB Nightly Validation workflow's schema test fixture generation was failing silently. When the AJV schema validation check (`ajv_formats_available()`) failed for any reason, the schema validation was silently skipped without warning the test script. This caused invalid missions (e.g., missing required `version` field) to pass validation during the fixture tests.

## Root Cause
The `validate-missions-schema-test.sh` script was calling `validate-missions.sh` with schema validation enabled, but when `ajv_formats_available()` smoke test failed, the `SCHEMA_FILE` variable was silently cleared in `validate-missions.sh` (lines 276-279), causing the script to return 0 even for invalid missions. The test script had no way to detect that schema validation was skipped.

## Solution
Add an explicit `check_schema_validation_available()` function to `validate-missions-schema-test.sh` that:
1. Runs the valid fixture test and captures output
2. Checks if schema validation was skipped (by detecting "schema validation skipped" in output)
3. Exits with status 2 (configuration error) if schema validation was skipped
4. Ensures schema validation is actually running before proceeding with fixture tests

This prevents false-positive passes for invalid missions and clearly communicates when dependencies are missing or misconfigured.

## Testing
- Schema validation tests now fail if AJV or ajv-formats plugin is unavailable
- Valid missions still pass (smoke test fixture includes all required fields)
- Invalid missions (missing version) are properly rejected when schema validation is available