### PR TITLE
🐛 fix: resolve MCP bridge test failures on main

### DIFF
--- a/pkg/mcp/bridge.go
+++ b/pkg/mcp/bridge.go
@@ -13,11 +13,21 @@ import (
 	"github.com/kubestellar/console/pkg/safego"
 )
 
+// bridgeClient is the interface that MCP clients must satisfy for use in Bridge.
+// It is defined here (not in client.go) to keep Bridge testable: tests inject
+// mock implementations without spinning up real stdio processes.
+type bridgeClient interface {
+	CallTool(ctx context.Context, name string, args map[string]interface{}) (*CallToolResult, error)
+	Tools() []Tool
+	Stop() error
+	IsReady() bool
+}
+
 // Bridge manages MCP client connections and provides a unified interface
 type Bridge struct {
-	opsClient    *Client
-	deployClient *Client
-	gadgetClient *Client
+	opsClient    bridgeClient
+	deployClient bridgeClient
+	gadgetClient bridgeClient
 	mu           sync.RWMutex
 	config       BridgeConfig
 }
@@ -488,8 +498,6 @@ func (b *Bridge) CallDeployTool(ctx context.Context, name string, args map[strin
 
 	return client.CallTool(ctx, name, args)
 }
-
-
 
 // Status returns the current status of the MCP bridge
 func (b *Bridge) Status() map[string]interface{} {

--- a/pkg/mcp/bridge_test.go
+++ b/pkg/mcp/bridge_test.go
@@ -555,7 +555,7 @@ func TestBridge_GetPods(t *testing.T) {
 				}
 				return tc.mockResponse, nil
 			})
-			bridge.opsClient = mockOps.Client
+			bridge.opsClient = mockOps
 
 			pods, err := bridge.GetPods(context.Background(), tc.cluster, tc.namespace, tc.labelSelector)
 
@@ -648,7 +648,7 @@ func TestBridge_FindPodIssues(t *testing.T) {
 				}
 				return tc.mockResponse, nil
 			})
-			bridge.opsClient = mockOps.Client
+			bridge.opsClient = mockOps
 
 			issues, err := bridge.FindPodIssues(context.Background(), tc.cluster, tc.namespace)
 
@@ -734,7 +734,7 @@ func TestBridge_GetEvents(t *testing.T) {
 				}
 				return tc.mockResponse, nil
 			})
-			bridge.opsClient = mockOps.Client
+			bridge.opsClient = mockOps
 
 			events, err := bridge.GetEvents(context.Background(), tc.cluster, tc.namespace, tc.limit)
 
@@ -819,7 +819,7 @@ func TestBridge_GetWarningEvents(t *testing.T) {
 				}
 				return tc.mockResponse, nil
 			})
-			bridge.opsClient = mockOps.Client
+			bridge.opsClient = mockOps
 
 			events, err := bridge.GetWarningEvents(context.Background(), tc.cluster, tc.namespace, tc.limit)
 
@@ -905,7 +905,7 @@ func TestBridge_GetClusterHealth(t *testing.T) {
 				}
 				return tc.mockResponse, nil
 			})
-			bridge.opsClient = mockOps.Client
+			bridge.opsClient = mockOps
 
 			health, err := bridge.GetClusterHealth(context.Background(), tc.cluster)
 
@@ -974,7 +974,7 @@ func TestBridge_ListClusters(t *testing.T) {
 				}
 				return tc.mockResponse, nil
 			})
-			bridge.opsClient = mockOps.Client
+			bridge.opsClient = mockOps
 
 			clusters, err := bridge.ListClusters(context.Background())
 


### PR DESCRIPTION
Fixes #19065

Fixes the `pkg/mcp` bridge_test failures that were breaking CI on main.

## Root Cause

`Bridge` stored `*Client` (concrete type) for `opsClient`, `deployClient`, and `gadgetClient`. Tests created a `*mockClient` (which embeds `*Client` and overrides `CallTool`) but assigned `mockOps.Client` (the embedded `*Client`) rather than `mockOps` (the `*mockClient` itself). This caused all bridge calls to hit the real `(*Client).CallTool`, which fails with `"failed to send request: stdin is nil"` since no stdio process was started.

## Fix

1. **`bridge.go`**: Introduce a `bridgeClient` interface (`CallTool`, `Tools`, `Stop`, `IsReady`) and change the three client fields in `Bridge` from `*Client` to `bridgeClient`. `*Client` implicitly satisfies this interface, so production code is unaffected.

2. **`bridge_test.go`**: Change all six `bridge.opsClient = mockOps.Client` assignments to `bridge.opsClient = mockOps`, so the mock's `CallTool` override is actually dispatched.

## Tests Fixed

- `TestBridge_GetPods/returns_pods_with_minimal_filters`
- `TestBridge_GetPods/returns_error_when_client_call_fails`
- `TestBridge_GetPods/returns_error_when_result_is_error`
- `TestBridge_ListClusters/returns_multiple_clusters`
- `TestBridge_ListClusters/returns_single_cluster`
- `TestBridge_ListClusters/returns_error_when_client_call_fails`