### PR TITLE
🐛 fix: resolve unlinked Terms of Service on login screen

### DIFF
--- a/web/src/components/auth/Login.test.tsx
+++ b/web/src/components/auth/Login.test.tsx
@@ -68,6 +68,12 @@ describe('Login Component', () => {
     expect(screen.getByText('KubeStellar')).toBeInTheDocument()
   })
 
+  it('does not render a terms of service footer', () => {
+    renderLogin()
+    expect(screen.queryByText('login.termsOfServicePrefix')).not.toBeInTheDocument()
+    expect(screen.queryByText('login.termsOfServiceLink')).not.toBeInTheDocument()
+  })
+
   describe('OAuth setup wizard (backendUp && !oauthConfigured)', () => {
     beforeEach(() => {
       oauthProbeResult = { backendUp: true, oauthConfigured: false }

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -19,9 +19,6 @@ import { sanitizeUrl } from '@/lib/utils/sanitizeUrl'
 // The Suspense fallback (spinner) shows while loading.
 const GlobeAnimation = safeLazy(() => import('../animations/globe'), 'GlobeAnimation')
 
-// Apache 2.0 license is the project's effective terms; link opens in a new tab (#8376).
-const TERMS_OF_SERVICE_URL = 'https://github.com/kubestellar/console/blob/main/LICENSE'
-
 // GitHub Developer Settings URL for creating OAuth Apps.
 const GITHUB_DEVELOPER_SETTINGS_URL = 'https://github.com/settings/developers'
 
@@ -583,18 +580,6 @@ export function Login() {
             </div>
           )}
 
-          {/* Footer */}
-          <div className="text-center text-sm text-muted-foreground mt-8">
-            {t('login.termsOfServicePrefix')}{' '}
-            <a
-              href={TERMS_OF_SERVICE_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-foreground transition-colors"
-            >
-              {t('login.termsOfServiceLink')}
-            </a>
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Fixes #19075

The login screen showed a "Terms of Service" footer that linked to the Apache 2.0 `LICENSE` file — not an actual Terms of Service document. This was misleading to users who expected a legal contract for using the website.

## Changes

- **`web/src/components/auth/Login.tsx`**: Removed the misleading ToS footer div and the unused `TERMS_OF_SERVICE_URL` constant. Since no actual Terms of Service document exists for this project, removing the footer is the correct fix.
- **`web/src/components/auth/Login.test.tsx`**: Added a regression test to ensure the ToS footer remains absent.

## Before / After

**Before**: Footer on login page said "By signing in, you agree to our [Terms of Service]" linking to the Apache 2.0 license file.

**After**: Footer removed — no misleading legal claim is shown to users.