### PR TITLE
[scanner] fix: add nil guards to MCP client (3 of 11 nilaway violations)

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -333,6 +333,9 @@ func (c *Client) CallTool(ctx context.Context, name string, args map[string]inte
 		return nil, err
 	}
 
+	if result == nil {
+		return nil, fmt.Errorf("nil result from tools/call")
+	}
 	var toolResult CallToolResult
 	if err := json.Unmarshal(result, &toolResult); err != nil {
 		return nil, fmt.Errorf("failed to parse tool result: %w", err)
@@ -355,6 +358,9 @@ func (c *Client) initialize(ctx context.Context) error {
 		return err
 	}
 
+	if result == nil {
+		return fmt.Errorf("nil result from initialize")
+	}
 	var initResult InitializeResult
 	if err := json.Unmarshal(result, &initResult); err != nil {
 		return fmt.Errorf("failed to parse initialize result: %w", err)
@@ -375,6 +381,9 @@ func (c *Client) listTools(ctx context.Context) error {
 		return err
 	}
 
+	if result == nil {
+		return fmt.Errorf("nil result from tools/list")
+	}
 	var toolsResult ToolsListResult
 	if err := json.Unmarshal(result, &toolsResult); err != nil {
 		return fmt.Errorf("failed to parse tools list: %w", err)


### PR DESCRIPTION
Fixes #19065

## Summary

Adds nil-result checks before `json.Unmarshal` in three MCP client methods:
- `CallTool` — guards `result` from `c.call("tools/call", ...)`
- `initialize` — guards `result` from `c.call("initialize", ...)`
- `listTools` — guards `result` from `c.call("tools/list", ...)`

These are 3 of the 11 nilaway violations blocking CI on all open PRs. The `call()` method can return `(nil, nil)` when the JSON-RPC response has no `result` field, which would panic in `json.Unmarshal`.

## CI Context

All open PRs are currently failing the `pr-check` job due to 11 nilaway violations on `main`. This PR fixes the 3 violations in `pkg/mcp/client.go`. Additional PRs will address the remaining 8 violations in other files.