### PR TITLE
fix: replace no-explicit-any with KubectlMessage type to unblock build-gate

### DIFF
--- a/web/src/components/drilldown/views/PodDrillDown.actions.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.actions.tsx
@@ -5,6 +5,7 @@ import { useCanI } from '../../../hooks/usePermissions'
 import { useToast } from '../../ui/Toast'
 import { useTranslation } from 'react-i18next'
 import type { RelatedResource } from './pod-drilldown'
+import type { KubectlMessage } from '../../../hooks/useDrillDownWebSocket'
 
 const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 
@@ -22,7 +23,7 @@ interface UsePodActionsProps {
   annotations: Record<string, string> | null
   ownerChain: RelatedResource[]
   openTrackedWs: () => Promise<WebSocket>
-  parseWsMessage: (event: MessageEvent, context: string) => any
+  parseWsMessage: (event: MessageEvent, context: string) => KubectlMessage | null
 }
 
 export function usePodActions({

--- a/web/src/hooks/useDrillDownWebSocket.ts
+++ b/web/src/hooks/useDrillDownWebSocket.ts
@@ -9,7 +9,7 @@ const DEFAULT_HELM_TIMEOUT_MS = KUBECTL_MEDIUM_TIMEOUT_MS
 // are dropped to prevent OOM from a malicious or malfunctioning agent.
 const MAX_WS_PAYLOAD_BYTES = 5 * 1024 * 1024
 
-interface KubectlMessage {
+export interface KubectlMessage {
   id?: string
   type?: string
   payload?: {


### PR DESCRIPTION
## Summary
- Export `KubectlMessage` interface from `useDrillDownWebSocket.ts`
- Replace `any` return type in `PodDrillDown.actions.tsx` with `KubectlMessage | null`
- This is the single ESLint error (`@typescript-eslint/no-explicit-any`) blocking build-gate on main

## Test plan
- [ ] build-gate CI passes (the only blocker was this 1 error among 2292 lint problems)