### PR TITLE
[scanner] fix: add keyboard accessibility to clickable cluster components

### DIFF
--- a/web/src/components/clusters/components/ClusterGrid.common.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.common.tsx
@@ -38,11 +38,21 @@ export function ActionTooltipWrapper({
   tooltip: string
   children: ReactNode
 }) {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+  }
+
   return (
     <span
       className="inline-flex"
+      role="button"
+      tabIndex={0}
       onClick={(event) => event.stopPropagation()}
       onMouseDown={(event) => event.stopPropagation()}
+      onKeyDown={handleKeyDown}
     >
       <Tooltip content={tooltip}>{children}</Tooltip>
     </span>


### PR DESCRIPTION
Fixes #19078

Adds role="button", tabIndex={0}, and onKeyDown handler to ActionTooltipWrapper span for keyboard accessibility parity. This ensures users navigating via keyboard can interact with clickable elements that previously only responded to mouse clicks.