### PR TITLE
[scanner] fix: add tests for federation provider action execution

### DIFF
--- a/pkg/agent/federation/providers/clusternet_actions_test.go
+++ b/pkg/agent/federation/providers/clusternet_actions_test.go
@@ -75,3 +75,176 @@ func TestClusternetExecuteUnknownAction(t *testing.T) {
 		t.Error("expected error for unknown action")
 	}
 }
+
+func TestUnstructuredNestedBool(t *testing.T) {
+	tests := []struct {
+		name       string
+		obj        map[string]interface{}
+		fields     []string
+		wantValue  bool
+		wantFound  bool
+		wantErr    bool
+	}{
+		{
+			name: "simple bool field exists and is true",
+			obj: map[string]interface{}{
+				"approved": true,
+			},
+			fields:    []string{"approved"},
+			wantValue: true,
+			wantFound: true,
+			wantErr:   false,
+		},
+		{
+			name: "simple bool field exists and is false",
+			obj: map[string]interface{}{
+				"approved": false,
+			},
+			fields:    []string{"approved"},
+			wantValue: false,
+			wantFound: true,
+			wantErr:   false,
+		},
+		{
+			name: "nested bool field exists",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"approved": true,
+				},
+			},
+			fields:    []string{"spec", "approved"},
+			wantValue: true,
+			wantFound: true,
+			wantErr:   false,
+		},
+		{
+			name: "deeply nested bool field exists",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"enabled": false,
+					},
+				},
+			},
+			fields:    []string{"spec", "template", "enabled"},
+			wantValue: false,
+			wantFound: true,
+			wantErr:   false,
+		},
+		{
+			name:      "field does not exist",
+			obj:       map[string]interface{}{},
+			fields:    []string{"missing"},
+			wantValue: false,
+			wantFound: false,
+			wantErr:   false,
+		},
+		{
+			name: "nested field does not exist",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{},
+			},
+			fields:    []string{"spec", "missing"},
+			wantValue: false,
+			wantFound: false,
+			wantErr:   false,
+		},
+		{
+			name: "field is not bool",
+			obj: map[string]interface{}{
+				"value": "string",
+			},
+			fields:    []string{"value"},
+			wantValue: false,
+			wantFound: false,
+			wantErr:   false,
+		},
+		{
+			name: "intermediate field is not map",
+			obj: map[string]interface{}{
+				"spec": "not-a-map",
+			},
+			fields:    []string{"spec", "approved"},
+			wantValue: false,
+			wantFound: false,
+			wantErr:   false,
+		},
+		{
+			name: "nested field value is not bool",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"approved": 123,
+				},
+			},
+			fields:    []string{"spec", "approved"},
+			wantValue: false,
+			wantFound: false,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotValue, gotFound, gotErr := unstructuredNestedBool(tt.obj, tt.fields...)
+
+			if (gotErr != nil) != tt.wantErr {
+				t.Errorf("unstructuredNestedBool() error = %v, wantErr %v", gotErr, tt.wantErr)
+				return
+			}
+
+			if gotValue != tt.wantValue {
+				t.Errorf("unstructuredNestedBool() gotValue = %v, want %v", gotValue, tt.wantValue)
+			}
+
+			if gotFound != tt.wantFound {
+				t.Errorf("unstructuredNestedBool() gotFound = %v, want %v", gotFound, tt.wantFound)
+			}
+		})
+	}
+}
+
+func TestClusternetApproveCluster_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name             string
+		clusterName      string
+		wantErrSubstring string
+	}{
+		{
+			name:             "empty cluster name",
+			clusterName:      "",
+			wantErrSubstring: "cluster  not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := clusternetApproveCluster(context.Background(), nil, tt.clusterName)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErrSubstring)
+			}
+		})
+	}
+}
+
+func TestClusternetUnregisterCluster_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name             string
+		clusterName      string
+		wantErrSubstring string
+	}{
+		{
+			name:             "empty cluster name",
+			clusterName:      "",
+			wantErrSubstring: "cluster  already removed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := clusternetUnregisterCluster(context.Background(), nil, tt.clusterName)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #19113

Adds comprehensive table-driven tests for Clusternet provider action execution functions to improve coverage:

- `TestUnstructuredNestedBool`: covers helper function with 9 test cases including nested fields, missing fields, type mismatches
- `TestClusternetApproveCluster_ValidationErrors`: validates empty cluster name handling
- `TestClusternetUnregisterCluster_ValidationErrors`: validates empty cluster name handling

Follows existing test patterns from OCM provider tests.