### PR TITLE
[scanner] fix: fail schema test when AJV unavailable instead of silently skipping

### DIFF
--- a/scripts/validate-missions-schema-test.sh
+++ b/scripts/validate-missions-schema-test.sh
@@ -9,12 +9,44 @@ VALID_DIR="${TESTDATA_ROOT}/valid"
 INVALID_DIR="${TESTDATA_ROOT}/invalid-missing-version"
 EXPECTED_VERSION_ERROR="must have required property 'version'"
 
+# ── Prerequisite check ──────────────────────────────────────────────
+# AJV must be available for schema validation tests to be meaningful.
+# If AJV is missing or non-functional, exit with code 2 (configuration error)
+# rather than silently skipping schema checks and giving false positives.
+if ! command -v ajv &>/dev/null; then
+  echo "✗ CONFIGURATION ERROR: 'ajv' CLI not found in PATH."
+  echo "  Schema validation tests require ajv-cli. Install with:"
+  echo "    npm ci --ignore-scripts --prefix .github/kb-scripts"
+  echo "  Then add to PATH:"
+  echo "    export PATH=\".github/kb-scripts/node_modules/.bin:\$PATH\""
+  exit 2
+fi
+
+# Smoke-test that ajv can actually validate against the schema with formats
+SMOKE_FILE=$(mktemp)
+trap 'rm -f "$SMOKE_FILE"' EXIT
+echo '{"version":"kc-mission-v1","title":"AJV smoke test","steps":[{"title":"Step 1","description":"Smoke test"}]}' > "$SMOKE_FILE"
+
+if ! ajv validate --spec=draft7 -s "$SCHEMA_FILE" -d "$SMOKE_FILE" -c ajv-formats >/dev/null 2>&1; then
+  echo "✗ CONFIGURATION ERROR: ajv cannot validate against schema with ajv-formats plugin."
+  echo "  The schema file may have changed or the ajv-formats plugin is unavailable."
+  echo "  Schema: $SCHEMA_FILE"
+  exit 2
+fi
+
 assert_validation_passes() {
   local name="$1"
   local mission_dir="$2"
   local output
 
   if output=$(./scripts/validate-missions.sh --local "$mission_dir" --schema "$SCHEMA_FILE" 2>&1); then
+    # Verify that schema validation was actually performed (not silently skipped)
+    if echo "$output" | grep -qi "schema validation skipped"; then
+      echo "✗ $name"
+      echo "  Schema validation was silently skipped — this is a false positive."
+      echo "$output"
+      exit 2
+    fi
     echo "✓ $name"
     return
   fi
@@ -32,7 +64,9 @@ assert_validation_fails_with() {
 
   if output=$(./scripts/validate-missions.sh --local "$mission_dir" --schema "$SCHEMA_FILE" 2>&1); then
     echo "✗ $name"
-    echo "Expected schema validation to fail."
+    echo "Expected schema validation to fail, but it passed."
+    echo "  This may indicate schema validation was silently skipped."
+    echo "$output"
     exit 1
   fi
 


### PR DESCRIPTION
Fixes #19159

## Summary

The schema validation test script (`scripts/validate-missions-schema-test.sh`) was giving false positives when AJV was unavailable — the `validate-missions.sh` script silently skipped schema validation, causing invalid missions to pass all checks.

## Changes

- Added prerequisite check: fail with exit code 2 if `ajv` CLI is not in PATH
- Added smoke test: verify ajv can actually validate with the ajv-formats plugin before running tests
- Added skip detection: if `validate-missions.sh` reports "schema validation skipped", treat it as a configuration error
- Improved error messages to guide CI debugging

## Note on #19072

Issue #19072 requires changes to `.github/workflows/kb-nightly-validation.yml` which cannot be pushed via the current OAuth token (missing `workflow` scope). The fix is documented in that issue — a maintainer needs to add a `[ -f kb-gap-report.md ]` guard in the "File issue on failure" step.