### PR TITLE
fix(security): remove secrets:inherit and pin reusable workflow SHA

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,5 +13,4 @@ permissions:
 
 jobs:
   greet:
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
-    secrets: inherit
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@a160acca0bdce1ac6c649e006d680d5f6d53024e


### PR DESCRIPTION
## Problem

The .github/workflows/greetings.yml workflow combines three dangerous properties:

1. **pull_request_target** — runs in base repo context with full access to all repo secrets on fork PRs
2. **secrets: inherit** — forwards every secret (including API keys) to the external reusable workflow
3. **@main** — mutable reference; any commit pushed to kubestellar/infra@main is adopted without review

## Fix

1. Removed `secrets: inherit` — the reusable workflow only needs `github.token` (provided automatically)
2. Pinned reusable workflow to immutable commit SHA (`a160acca0bdce1ac6c649e006d680d5f6d53024e`) instead of mutable `@main`

Fixes #19094