### PR TITLE
[scanner] fix: resolve 32 ESLint errors blocking nightly release

### DIFF
--- a/web/src/components/drilldown/views/PodDrillDown.actions.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.actions.tsx
@@ -8,6 +8,16 @@ import type { RelatedResource } from './pod-drilldown'
 
 const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 
+interface WsMessage {
+  id?: string
+  type?: string
+  payload?: {
+    exitCode?: number
+    error?: string
+    output?: string
+  }
+}
+
 interface UsePodActionsProps {
   cluster: string
   namespace: string
@@ -22,7 +32,7 @@ interface UsePodActionsProps {
   annotations: Record<string, string> | null
   ownerChain: RelatedResource[]
   openTrackedWs: () => Promise<WebSocket>
-  parseWsMessage: (event: MessageEvent, context: string) => unknown
+  parseWsMessage: (event: MessageEvent, context: string) => WsMessage | null
 }
 
 export function usePodActions({

--- a/web/src/components/drilldown/views/PodDrillDown.actions.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.actions.tsx
@@ -22,8 +22,7 @@ interface UsePodActionsProps {
   annotations: Record<string, string> | null
   ownerChain: RelatedResource[]
   openTrackedWs: () => Promise<WebSocket>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- WS messages are untyped JSON
-  parseWsMessage: (event: MessageEvent, context: string) => any
+  parseWsMessage: (event: MessageEvent, context: string) => unknown
 }
 
 export function usePodActions({

--- a/web/src/components/teams/TeamAccessGrants.tsx
+++ b/web/src/components/teams/TeamAccessGrants.tsx
@@ -37,7 +37,7 @@ export function TeamAccessGrants({ teamName, grants, onGrantChanged }: TeamAcces
 
   const { deduplicatedClusters: clusters } = useClusters()
   const safeClusters = clusters || []
-  useGlobalFilters()
+  const _globalFilters = useGlobalFilters()
 
   const [selectedCluster, setSelectedCluster] = useState('')
   const [scope, setScope] = useState<'namespace' | 'cluster'>('namespace')

--- a/web/src/components/teams/TeamAccessGrants.tsx
+++ b/web/src/components/teams/TeamAccessGrants.tsx
@@ -37,7 +37,7 @@ export function TeamAccessGrants({ teamName, grants, onGrantChanged }: TeamAcces
 
   const { deduplicatedClusters: clusters } = useClusters()
   const safeClusters = clusters || []
-  const _globalFilters = useGlobalFilters()
+  useGlobalFilters()
 
   const [selectedCluster, setSelectedCluster] = useState('')
   const [scope, setScope] = useState<'namespace' | 'cluster'>('namespace')

--- a/web/src/components/workloads/__tests__/WorkloadsExtended.test.tsx
+++ b/web/src/components/workloads/__tests__/WorkloadsExtended.test.tsx
@@ -43,10 +43,10 @@ vi.mock('../../../lib/dashboards/DashboardPage', () => ({
   ),
 }))
 
-let mockPodIssues: any[] = []
-let mockDeploymentIssues: any[] = []
-let mockDeployments: any[] = []
-const mockClusters: any[] = []
+const mockPodIssues: unknown[] = []
+const mockDeploymentIssues: unknown[] = []
+const mockDeployments: unknown[] = []
+const mockClusters: unknown[] = []
 let mockIsLoading = false
 let mockIsDemoMode = true
 

--- a/web/src/hooks/useDrasiQueryStream.ts
+++ b/web/src/hooks/useDrasiQueryStream.ts
@@ -217,7 +217,7 @@ export function useDrasiQueryStream(args: Args): UseDrasiQueryStreamResult {
           try {
             payload = JSON.parse(ev.data)
           } catch {
-            return // Non-JSON heartbeats etc.
+            return void 0 // Non-JSON heartbeats etc.
           }
 
           // Lifecycle events update connection state but don't touch the table.
@@ -253,7 +253,7 @@ export function useDrasiQueryStream(args: Args): UseDrasiQueryStreamResult {
 
         es.onerror = async () => {
           // Close the current source and attempt a reconnect backoff loop.
-          try { es?.close() } catch { /* SSE close may throw if already closed */ }
+          try { es?.close() } catch { void 0 /* SSE close may throw if already closed */ }
           sourceRef.current = null
           setConnected(false)
           setErrorOnce('SSE connection error')
@@ -279,7 +279,7 @@ export function useDrasiQueryStream(args: Args): UseDrasiQueryStreamResult {
     return () => {
       aborted = true
       clearTimer()
-      try { es?.close() } catch { /* SSE close may throw if already closed */ }
+      try { es?.close() } catch { void 0 /* SSE close may throw if already closed */ }
       sourceRef.current = null
       setConnected(false)
     }

--- a/web/src/hooks/useStellarSource.ts
+++ b/web/src/hooks/useStellarSource.ts
@@ -425,7 +425,7 @@ export function useStellarSource() {
     try {
       await stellarApi.resolveWatch(id)
     } catch {
-      stellarApi.getWatches().then(setWatches).catch(() => {})
+      stellarApi.getWatches().then(setWatches).catch(() => void 0)
     }
   }, [])
   const dismissWatch = useCallback(async (id: string) => {
@@ -433,7 +433,7 @@ export function useStellarSource() {
     try {
       await stellarApi.dismissWatch(id)
     } catch {
-      stellarApi.getWatches().then(setWatches).catch(() => {})
+      stellarApi.getWatches().then(setWatches).catch(() => void 0)
     }
   }, [])
   const snoozeWatch = useCallback(async (id: string, minutes: number) => {

--- a/web/src/lib/cache/cacheCore.ts
+++ b/web/src/lib/cache/cacheCore.ts
@@ -129,7 +129,7 @@ export class CacheStore<T> {
         this.saveMeta({ consecutiveFailures: 0, lastSuccessfulRefresh: entry.timestamp })
       }
     } catch {
-      // Ignore errors, will use initial data with isLoading=true
+      void 0 // Ignore errors, will use initial data with isLoading=true
     }
   }
 
@@ -157,7 +157,7 @@ export class CacheStore<T> {
     } else {
       try {
         localStorage.setItem(META_PREFIX + this.key, JSON.stringify(meta))
-      } catch { /* localStorage may be full or unavailable */ }
+      } catch { void 0 /* localStorage may be full or unavailable */ }
     }
   }
 
@@ -271,7 +271,7 @@ export class CacheStore<T> {
       const currentPromise = this.storageLoadPromise
       try {
         await currentPromise
-      } catch { /* storage load failure is non-fatal */ }
+      } catch { void 0 /* storage load failure is non-fatal */ }
       if (this.storageLoadPromise === currentPromise) {
         this.storageLoadPromise = null
       }
@@ -341,8 +341,8 @@ export class CacheStore<T> {
 
       await this.saveToStorage(finalData)
       if (this.resetVersion !== fetchVersion) {
-        try { sessionStorage.removeItem(SS_PREFIX + this.key) } catch { /* sessionStorage may be unavailable */ }
-        cacheStorage.delete(this.key).catch(() => {})
+        try { sessionStorage.removeItem(SS_PREFIX + this.key) } catch { void 0 /* sessionStorage may be unavailable */ }
+        cacheStorage.delete(this.key).catch(() => void 0)
         this.fetchingRef = false
         return
       }
@@ -398,7 +398,7 @@ export class CacheStore<T> {
 
   async clear(): Promise<void> {
     await cacheStorage.delete(this.key)
-    try { sessionStorage.removeItem(SS_PREFIX + this.key) } catch { /* sessionStorage may be unavailable */ }
+    try { sessionStorage.removeItem(SS_PREFIX + this.key) } catch { void 0 /* sessionStorage may be unavailable */ }
     preloadedMetaMap.delete(this.key)
     if (workerRpc) {
       workerRpc.setMeta(this.key, { consecutiveFailures: 0 })


### PR DESCRIPTION
Fixes #19157

Resolves 32 ESLint errors across 21 frontend files that were blocking the nightly release workflow.

Fix categories:
- `no-empty`: Added void statements to intentionally empty catch blocks
- `preserve-caught-error`: Preserved original errors with `{ cause }` option
- `no-explicit-any`: Replaced `any` with specific types
- `prefer-const`: Changed `let` to `const` where variables are never reassigned
- `Function` type: Replaced with specific function signatures
- Other: Fixed malformed eslint-disable comments, no-restricted-globals, no-empty-pattern, no-async-promise-executor, no-unsafe-finally, no-unused-expressions, no-constant-binary-expression