### PR TITLE
fix(ci): pin guardrail actions to SHAs and guard body-file usage

### DIFF
--- a/.github/workflows/kb-nightly-validation.yml
+++ b/.github/workflows/kb-nightly-validation.yml
@@ -127,10 +127,17 @@ jobs:
           else
             gh label create "kb-gap" --color "B60205" \
               --description "KB coverage gap detected by nightly validation" 2>/dev/null || true
-            gh issue create \
-              --title "$TITLE" \
-              --label "kb-gap,triage/needed,help wanted" \
-              --body-file kb-gap-report.md
+            if [ -f kb-gap-report.md ]; then
+              gh issue create \
+                --title "$TITLE" \
+                --label "kb-gap,triage/needed,help wanted" \
+                --body-file kb-gap-report.md
+            else
+              gh issue create \
+                --title "$TITLE" \
+                --label "kb-gap,triage/needed,help wanted" \
+                --body "KB Nightly Validation failed. No gap report was generated. See workflow run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            fi
           fi
 
       - name: Upload reports

--- a/.github/workflows/scanner-merge-guardrails.yml
+++ b/.github/workflows/scanner-merge-guardrails.yml
@@ -21,11 +21,11 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@eef61447b9ff4aafe5dcd72e0a28fef7ff2e8c5d # v6.4.0
         
       - name: Check Scanner Merge Eligibility
         id: check
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary

- Pin `actions/checkout` and `actions/github-script` to immutable commit SHAs in `scanner-merge-guardrails.yml` to prevent supply-chain attacks via tag force-push
- Guard `--body-file` usage in `kb-nightly-validation.yml` so the workflow doesn't crash when `kb-gap-report.md` isn't generated

Fixes #18643, Fixes #19072