### PR TITLE
[scanner] fix: replace hardcoded colors with semantic design tokens

### DIFF
--- a/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
+++ b/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
@@ -68,7 +68,7 @@ export function OpsGenieNotificationSettings({
             opsgenieApiKeyConfigured: e.target.value.trim().length > 0,
           })}
           placeholder="e.g. xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-primary"
         />
         {hasStoredApiKey && (
           <p className="mt-1 text-xs text-green-400">
@@ -83,15 +83,15 @@ export function OpsGenieNotificationSettings({
       <button
         onClick={handleTestOpsGenie}
         disabled={isLoading}
-        className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors disabled:opacity-50"
+        className="px-4 py-2 text-sm rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
       >
         {isLoading ? t('settings.notifications.opsgenie.testing') : t('settings.notifications.opsgenie.testNotification', 'Test OpsGenie')}
       </button>
 
       {testResult && testResult.type === 'opsgenie' && (
         <div
-          className={`flex items-start gap-2 p-3 rounded-lg ${
-            testResult.success ? 'bg-green-500/20 border border-green-500/20' : 'bg-red-500/20 border border-red-500/20'
+          className={`flex items-start gap-2 p-3 rounded-lg border ${
+            testResult.success ? 'bg-green-500/10 border-green-500/20' : 'bg-red-500/10 border-red-500/20'
           }`}
         >
           {testResult.success ? (

--- a/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
+++ b/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
@@ -68,7 +68,7 @@ export function PagerDutyNotificationSettings({
             pagerdutyRoutingKeyConfigured: e.target.value.trim().length > 0,
           })}
           placeholder="e.g. a1b2c3d4e5f6..."
-          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-primary"
         />
         {hasStoredRoutingKey && (
           <p className="mt-1 text-xs text-green-400">
@@ -83,15 +83,15 @@ export function PagerDutyNotificationSettings({
       <button
         onClick={handleTestPagerDuty}
         disabled={isLoading}
-        className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors disabled:opacity-50"
+        className="px-4 py-2 text-sm rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
       >
         {isLoading ? t('settings.notifications.pagerduty.testing') : t('settings.notifications.pagerduty.testNotification', 'Test PagerDuty')}
       </button>
 
       {testResult && testResult.type === 'pagerduty' && (
         <div
-          className={`flex items-start gap-2 p-3 rounded-lg ${
-            testResult.success ? 'bg-green-500/20 border border-green-500/20' : 'bg-red-500/20 border border-red-500/20'
+          className={`flex items-start gap-2 p-3 rounded-lg border ${
+            testResult.success ? 'bg-green-500/10 border-green-500/20' : 'bg-red-500/10 border-red-500/20'
           }`}
         >
           {testResult.success ? (

--- a/web/src/components/settings/sections/PersistenceSection.tsx
+++ b/web/src/components/settings/sections/PersistenceSection.tsx
@@ -137,11 +137,11 @@ export function PersistenceSection() {
           aria-checked={localConfig.enabled}
           aria-label={t('settings.persistence.enablePersistence')}
           className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-            localConfig.enabled ? 'bg-purple-500' : 'bg-secondary'
+            localConfig.enabled ? 'bg-primary' : 'bg-secondary'
           }`}
         >
           <span
-            className={`inline-block h-4 w-4 transform rounded-full bg-white dark:bg-gray-100 transition-transform ${
+            className={`inline-block h-4 w-4 transform rounded-full border border-border bg-background transition-transform ${
               localConfig.enabled ? 'translate-x-6' : 'translate-x-1'
             }`}
           />
@@ -196,7 +196,7 @@ export function PersistenceSection() {
                 onClick={() => setLocalConfig(prev => ({ ...prev, syncMode: 'primary-only' }))}
                 className={`flex-1 px-3 py-2 rounded-lg border ${
                   localConfig.syncMode === 'primary-only'
-                    ? 'bg-purple-500/20 border-purple-500 text-purple-400'
+                    ? 'bg-primary/10 border-primary/30 text-primary'
                     : 'bg-secondary border-border text-muted-foreground'
                 }`}
               >
@@ -206,7 +206,7 @@ export function PersistenceSection() {
                 onClick={() => setLocalConfig(prev => ({ ...prev, syncMode: 'active-passive' }))}
                 className={`flex-1 px-3 py-2 rounded-lg border ${
                   localConfig.syncMode === 'active-passive'
-                    ? 'bg-purple-500/20 border-purple-500 text-purple-400'
+                    ? 'bg-primary/10 border-primary/30 text-primary'
                     : 'bg-secondary border-border text-muted-foreground'
                 }`}
               >
@@ -322,7 +322,7 @@ export function PersistenceSection() {
             <div className="flex justify-end">
               <button
                 onClick={handleSave}
-                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-500 text-white hover:bg-purple-600"
+                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90"
               >
                 <Check className="w-4 h-4" />
                 {t('settings.persistence.saveChanges')}


### PR DESCRIPTION
Fixes #18832

Replaces hardcoded hex colors and non-semantic Tailwind color classes with semantic design tokens for theme consistency.