### PR TITLE
[scanner] fix: replace hardcoded inline colors with design tokens

### DIFF
--- a/web/src/components/compliance/SLSADashboard.tsx
+++ b/web/src/components/compliance/SLSADashboard.tsx
@@ -162,6 +162,13 @@ const LEVEL_BG: Record<number, string> = {
   4: 'bg-emerald-500/20 border-emerald-500/30',
 }
 
+const LEVEL_BAR_COLORS: Record<number, string> = {
+  1: 'bg-yellow-500',
+  2: 'bg-blue-500',
+  3: 'bg-green-500',
+  4: 'bg-emerald-500',
+}
+
 const STATUS_COLORS: Record<string, string> = {
   pass: 'text-green-400',
   fail: 'text-red-400',
@@ -299,8 +306,8 @@ export const SLSADashboardContent = memo(function SLSADashboardContent() {
                   </div>
                   <div className="w-full bg-gray-700 rounded-full h-2">
                     <div
-                      className="h-2 rounded-full transition-all"
-                      style={{ width: `${pct}%`, backgroundColor: level === 1 ? 'rgb(234,179,8)' : level === 2 ? 'rgb(59,130,246)' : level === 3 ? 'rgb(34,197,94)' : 'rgb(16,185,129)' }}
+                      className={`h-2 rounded-full transition-all ${LEVEL_BAR_COLORS[level]}`}
+                      style={{ width: `${pct}%` }}
                     />
                   </div>
                   <p className="text-xs text-gray-400 mt-1">{pct}%</p>

--- a/web/src/components/onboarding/Tour.tsx
+++ b/web/src/components/onboarding/Tour.tsx
@@ -329,13 +329,12 @@ export function TourOverlay() {
         <>
           {/* Static dark backdrop — no animation so it never blinks */}
           <div
-            className="absolute rounded-lg pointer-events-none"
+            className="absolute rounded-lg pointer-events-none shadow-[0_0_0_9999px_rgba(0,0,0,0.75)]"
             style={{
               top: overlay.rect.top - 8,
               left: overlay.rect.left - 8,
               width: overlay.rect.width + 16,
               height: overlay.rect.height + 16,
-              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.75)',
             }}
           />
           {/* Pulsing border highlight — only the border animates, not the backdrop */}


### PR DESCRIPTION
Fixes #19234
Fixes #19235

## Summary

Replaced hardcoded inline color values with design tokens in components:

### Fixed Issues

1. **SLSADashboard.tsx** (line 303): Replaced inline `backgroundColor` with `rgb()` values with a new `LEVEL_BAR_COLORS` constant using Tailwind classes (`bg-yellow-500`, `bg-blue-500`, etc.)

2. **Tour.tsx** (line 338): Replaced inline `boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.75)'` with Tailwind arbitrary utility class `shadow-[0_0_0_9999px_rgba(0,0,0,0.75)]`

### Not Changed (Intentional)

- Chart hex constants in `src/lib/constants/ui.ts` — these are named constants required by ECharts
- Canvas game components (NodeInvaders.tsx, KubeBert.tsx) — canvas API requires raw color strings
- ThemeSection.tsx — uses dynamic theme colors from theme object (intentional for theme previews)
- MarketplaceThumbnail.tsx — already uses CSS variables (`var(--cncf-*)`)
- ClusterReadinessCard.tsx — already uses Tailwind classes dynamically
- BlueprintInfoPanels.tsx — file was refactored, outdated line numbers from scanner

## Changes

- Added `LEVEL_BAR_COLORS` constant in SLSADashboard.tsx
- Replaced inline `style={{ backgroundColor: ... }}` with `className={LEVEL_BAR_COLORS[level]}`
- Moved `boxShadow` from inline style to Tailwind class in Tour.tsx

Both changes maintain the exact same visual appearance while using design system tokens.