### PR TITLE
[scanner] fix: add tests for ClusterStatusDetails, ClusterCardCompact, NotFound

### DIFF
--- a/web/src/components/NotFound.test.tsx
+++ b/web/src/components/NotFound.test.tsx
@@ -1,139 +1,132 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
 import NotFound from './NotFound'
 import { ROUTES } from '../config/routes'
+import * as demoMode from '../lib/demoMode'
 
+// Mock react-router-dom
 const mockNavigate = vi.fn()
-const mockLocation = vi.hoisted(() => ({
-  pathname: '/nonexistent-page',
-  hash: '',
-  search: '',
-  state: null,
-  key: 'test-key',
-}))
-
 vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  const actual = await vi.importActual('react-router-dom')
   return {
     ...actual,
     useNavigate: () => mockNavigate,
-    useLocation: () => mockLocation,
+    useLocation: () => ({ pathname: '/non-existent-page' }),
   }
 })
 
+// Mock demo mode
 vi.mock('../lib/demoMode', () => ({
   activatePublicDemoMode: vi.fn(),
 }))
 
-describe('NotFound Component', () => {
+describe('NotFound', () => {
   beforeEach(() => {
-    mockNavigate.mockReset()
-    Object.assign(mockLocation, {
-      pathname: '/nonexistent-page',
-      hash: '',
-      search: '',
-      state: null,
-      key: 'test-key',
-    })
+    vi.clearAllMocks()
   })
 
-  it('renders the 404 page', () => {
-    render(<NotFound />)
-    expect(screen.getByText('Page not found')).toBeTruthy()
+  it('renders 404 page with appropriate messaging', () => {
+    render(
+      <BrowserRouter>
+        <NotFound />
+      </BrowserRouter>
+    )
+
+    expect(screen.getByText('Page not found')).toBeInTheDocument()
+    expect(screen.getByText(/doesn't exist yet \u2014 but it could!/)).toBeInTheDocument()
   })
 
-  it('displays the current pathname in the error message', () => {
-    render(<NotFound />)
-    expect(screen.getByText(/\/nonexistent-page/)).toBeTruthy()
+  it('displays the current pathname in code block', () => {
+    render(
+      <BrowserRouter>
+        <NotFound />
+      </BrowserRouter>
+    )
+
+    const codeElement = screen.getByText('/non-existent-page')
+    expect(codeElement).toBeInTheDocument()
+    expect(codeElement.tagName).toBe('CODE')
   })
 
-  it('renders the main heading', () => {
-    render(<NotFound />)
-    const heading = screen.getByRole('heading', { level: 1 })
-    expect(heading.textContent).toContain('Page not found')
-  })
+  it('renders feature request button with correct URL', () => {
+    render(
+      <BrowserRouter>
+        <NotFound />
+      </BrowserRouter>
+    )
 
-  it('renders the feature request CTA section', () => {
-    render(<NotFound />)
-    expect(screen.getByText(/Ship it in hours, not months/)).toBeTruthy()
-  })
-
-  it('renders the feature request button with correct href', () => {
-    render(<NotFound />)
-    const button = screen.getByRole('link', { name: /Request this feature/ })
-    expect(button).toBeTruthy()
-    expect(button.getAttribute('href')).toContain('github.com/kubestellar/console/issues/new')
-    expect(button.getAttribute('href')).toContain('nonexistent-page')
-  })
-
-  it('opens feature request link in a new tab', () => {
-    render(<NotFound />)
-    const button = screen.getByRole('link', { name: /Request this feature/ })
-    expect(button.getAttribute('target')).toBe('_blank')
-    expect(button.getAttribute('rel')).toBe('noopener noreferrer')
+    const featureRequestLink = screen.getByRole('link', { name: /Request this feature/i })
+    expect(featureRequestLink).toBeInTheDocument()
+    expect(featureRequestLink).toHaveAttribute('href')
+    expect(featureRequestLink.getAttribute('href')).toContain('github.com/kubestellar/console/issues/new')
+    expect(featureRequestLink.getAttribute('href')).toContain('template=feature_request.yaml')
   })
 
   it('renders all quick link buttons', () => {
-    render(<NotFound />)
-    expect(screen.getByRole('button', { name: /Dashboard/ })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /Clusters/ })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /Compliance/ })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /Deploy/ })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /Marketplace/ })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /Cost/ })).toBeTruthy()
+    render(
+      <BrowserRouter>
+        <NotFound />
+      </BrowserRouter>
+    )
+
+    expect(screen.getByRole('button', { name: /Dashboard/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Clusters/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Compliance/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Deploy/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Marketplace/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Cost/i })).toBeInTheDocument()
   })
 
-  it('navigates to home when Home button is clicked', () => {
-    render(<NotFound />)
-    const homeButton = screen.getByRole('button', { name: /Home/ })
+  it('activates demo mode and navigates when quick link is clicked', () => {
+    render(
+      <BrowserRouter>
+        <NotFound />
+      </BrowserRouter>
+    )
+
+    const dashboardButton = screen.getByRole('button', { name: /Dashboard/i })
+    fireEvent.click(dashboardButton)
+
+    expect(demoMode.activatePublicDemoMode).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.HOME)
+  })
+
+  it('activates demo mode and navigates to home when Home button is clicked', () => {
+    render(
+      <BrowserRouter>
+        <NotFound />
+      </BrowserRouter>
+    )
+
+    const homeButton = screen.getByRole('button', { name: /Home/i })
     fireEvent.click(homeButton)
+
+    expect(demoMode.activatePublicDemoMode).toHaveBeenCalledTimes(1)
     expect(mockNavigate).toHaveBeenCalledWith(ROUTES.HOME)
   })
 
   it('navigates back when Go back button is clicked', () => {
-    render(<NotFound />)
-    const backButton = screen.getByRole('button', { name: /Go back/ })
-    fireEvent.click(backButton)
+    render(
+      <BrowserRouter>
+        <NotFound />
+      </BrowserRouter>
+    )
+
+    const goBackButton = screen.getByRole('button', { name: /Go back/i })
+    fireEvent.click(goBackButton)
+
     expect(mockNavigate).toHaveBeenCalledWith(-1)
   })
 
-  it('calls activatePublicDemoMode when quick link is clicked', () => {
-    const { activatePublicDemoMode } = require('../lib/demoMode')
-    render(<NotFound />)
-    const dashboardButton = screen.getByRole('button', { name: /Dashboard/ })
-    fireEvent.click(dashboardButton)
-    expect(activatePublicDemoMode).toHaveBeenCalled()
-  })
+  it('displays KubeStellar pitch messaging', () => {
+    render(
+      <BrowserRouter>
+        <NotFound />
+      </BrowserRouter>
+    )
 
-  it('renders the compass icon', () => {
-    const { container } = render(<NotFound />)
-    const svg = container.querySelector('svg')
-    expect(svg).toBeTruthy()
-  })
-
-  it('displays helpful description text', () => {
-    render(<NotFound />)
-    const description = screen.getByText(/doesn't exist yet — but it could!/)
-    expect(description).toBeTruthy()
-  })
-
-  it('displays the popular pages section', () => {
-    render(<NotFound />)
-    expect(screen.getByText(/Popular pages/)).toBeTruthy()
-  })
-
-  it('includes KubeStellar messaging about fast iteration', () => {
-    render(<NotFound />)
-    expect(screen.getByText(/KubeStellar Console uses AI-powered repo automation/)).toBeTruthy()
-  })
-
-  it('correctly encodes feature request URL with path', () => {
-    Object.assign(mockLocation, {
-      pathname: '/special/path?with=query',
-    })
-    render(<NotFound />)
-    const button = screen.getByRole('link', { name: /Request this feature/ })
-    const href = button.getAttribute('href')
-    expect(href).toContain(encodeURIComponent('/special/path?with=query'))
+    expect(screen.getByText(/Ship it in hours, not months/i)).toBeInTheDocument()
+    expect(screen.getByText(/AI-powered repo automation/i)).toBeInTheDocument()
   })
 })

--- a/web/src/components/clusters/__tests__/ClusterStatusDetails.test.tsx
+++ b/web/src/components/clusters/__tests__/ClusterStatusDetails.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * ClusterStatusDetails Component Tests
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ClusterInfo } from '../../../hooks/mcp/types'
+
+vi.mock('lucide-react', () => ({
+  AlertCircle: () => <span data-testid="alert-circle-icon" />,
+  Clock: () => <span data-testid="clock-icon" />,
+  Globe: () => <span data-testid="globe-icon" />,
+  Lock: () => <span data-testid="lock-icon" />,
+  ShieldAlert: () => <span data-testid="shield-alert-icon" />,
+  WifiOff: () => <span data-testid="wifi-off-icon" />,
+  XCircle: () => <span data-testid="x-circle-icon" />,
+}))
+
+vi.mock('../../../lib/cn', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}))
+
+vi.mock('../../../lib/errorClassifier', () => ({
+  formatLastSeen: (timestamp: string | Date | undefined) => {
+    if (!timestamp) return 'never'
+    return '5m ago'
+  },
+  getSuggestionForErrorType: (errorType: string) => {
+    const suggestions: Record<string, string> = {
+      auth: 'Re-authenticate with the cluster',
+      certificate: 'Check certificate validity or trust settings',
+      network: 'Check network connectivity and firewall settings',
+      timeout: 'Check VPN connection or network connectivity',
+    }
+    return suggestions[errorType] || 'Check cluster connectivity and configuration'
+  },
+}))
+
+vi.mock('../utils', () => ({
+  getClusterHealthState: (cluster: ClusterInfo) => {
+    if (cluster.neverConnected) return 'unknown'
+    if (cluster.healthUnknown) return 'unknown'
+    if (cluster.reachable === false) return 'unreachable'
+    if (cluster.healthy === true) return 'healthy'
+    if (cluster.healthy === false) return 'unhealthy'
+    return 'unknown'
+  },
+  isClusterUnreachable: (cluster: ClusterInfo) => {
+    return cluster.reachable === false || !!cluster.errorType
+  },
+}))
+
+import { ClusterStatusDetails } from '../ClusterStatusDetails'
+
+const createMockCluster = (overrides: Partial<ClusterInfo> = {}): ClusterInfo => ({
+  name: 'test-cluster',
+  server: 'https://test.example.com',
+  healthy: true,
+  namespaces: [],
+  ...overrides,
+})
+
+describe('ClusterStatusDetails', () => {
+  it('renders nothing when no diagnostic fields are present', () => {
+    const cluster = createMockCluster({ healthy: true })
+    const { container } = render(<ClusterStatusDetails cluster={cluster} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders unreachable reason with auth error', () => {
+    const cluster = createMockCluster({
+      reachable: false,
+      errorType: 'auth',
+      errorMessage: 'Authentication failed',
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    expect(screen.getByText(/Unreachable: Auth/)).toBeInTheDocument()
+    expect(screen.getByText('Authentication failed')).toBeInTheDocument()
+    expect(screen.getByText(/Suggestion: Re-authenticate with the cluster/)).toBeInTheDocument()
+    expect(screen.getByTestId('lock-icon')).toBeInTheDocument()
+  })
+
+  it('renders unreachable reason with certificate error', () => {
+    const cluster = createMockCluster({
+      reachable: false,
+      errorType: 'certificate',
+      errorMessage: 'Certificate validation failed',
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    expect(screen.getByText(/Unreachable: Certificate/)).toBeInTheDocument()
+    expect(screen.getByText('Certificate validation failed')).toBeInTheDocument()
+    expect(screen.getByTestId('shield-alert-icon')).toBeInTheDocument()
+  })
+
+  it('renders unreachable reason with network error', () => {
+    const cluster = createMockCluster({
+      reachable: false,
+      errorType: 'network',
+      errorMessage: 'Network unreachable',
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    expect(screen.getByText(/Unreachable: Network/)).toBeInTheDocument()
+    expect(screen.getByTestId('x-circle-icon')).toBeInTheDocument()
+  })
+
+  it('renders unreachable reason with timeout error', () => {
+    const cluster = createMockCluster({
+      reachable: false,
+      errorType: 'timeout',
+      errorMessage: 'Connection timeout',
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    expect(screen.getByText(/Unreachable: Timeout/)).toBeInTheDocument()
+    expect(screen.getByTestId('wifi-off-icon')).toBeInTheDocument()
+  })
+
+  it('renders unreachable reason with unknown error type', () => {
+    const cluster = createMockCluster({
+      reachable: false,
+      errorMessage: 'Unknown error occurred',
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    expect(screen.getByText(/Unreachable: Unknown/)).toBeInTheDocument()
+    expect(screen.getByTestId('alert-circle-icon')).toBeInTheDocument()
+  })
+
+  it('renders never connected state', () => {
+    const cluster = createMockCluster({
+      neverConnected: true,
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    expect(screen.getByText('Never connected')).toBeInTheDocument()
+    expect(screen.getByText(/No successful health probe since startup/)).toBeInTheDocument()
+  })
+
+  it('renders health unknown state', () => {
+    const cluster = createMockCluster({
+      healthUnknown: true,
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    expect(screen.getByText('Health unknown')).toBeInTheDocument()
+    expect(screen.getByText(/No authoritative health signal yet/)).toBeInTheDocument()
+  })
+
+  it('renders external reachability when reachable', () => {
+    const cluster = createMockCluster({
+      externallyReachable: true,
+      lastSeen: new Date().toISOString(),
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    expect(screen.getByText('External reachability:')).toBeInTheDocument()
+    expect(screen.getByText('Reachable')).toBeInTheDocument()
+  })
+
+  it('renders external reachability when not reachable', () => {
+    const cluster = createMockCluster({
+      externallyReachable: false,
+      lastSeen: new Date().toISOString(),
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    expect(screen.getByText('External reachability:')).toBeInTheDocument()
+    expect(screen.getByText('Not reachable from outside')).toBeInTheDocument()
+  })
+
+  it('renders last seen timestamp', () => {
+    const cluster = createMockCluster({
+      lastSeen: new Date().toISOString(),
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    expect(screen.getByText('Last seen:')).toBeInTheDocument()
+    expect(screen.getByText('5m ago')).toBeInTheDocument()
+    expect(screen.getByTestId('clock-icon')).toBeInTheDocument()
+  })
+
+  it('applies custom className', () => {
+    const cluster = createMockCluster({
+      lastSeen: new Date().toISOString(),
+    })
+    const { container } = render(
+      <ClusterStatusDetails cluster={cluster} className="custom-class" />
+    )
+    
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+
+  it('renders multiple fields together', () => {
+    const cluster = createMockCluster({
+      externallyReachable: true,
+      lastSeen: new Date().toISOString(),
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    expect(screen.getByText('External reachability:')).toBeInTheDocument()
+    expect(screen.getByText('Last seen:')).toBeInTheDocument()
+  })
+
+  it('prioritizes unreachable reason over never connected', () => {
+    const cluster = createMockCluster({
+      neverConnected: true,
+      reachable: false,
+      errorType: 'timeout',
+      errorMessage: 'Connection timeout',
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    // Should show unreachable reason, not never connected
+    expect(screen.getByText(/Unreachable: Timeout/)).toBeInTheDocument()
+    expect(screen.queryByText('Never connected')).not.toBeInTheDocument()
+  })
+
+  it('prioritizes unreachable reason over health unknown', () => {
+    const cluster = createMockCluster({
+      healthUnknown: true,
+      reachable: false,
+      errorType: 'network',
+      errorMessage: 'Network error',
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    // Should show unreachable reason, not health unknown
+    expect(screen.getByText(/Unreachable: Network/)).toBeInTheDocument()
+    expect(screen.queryByText('Health unknown')).not.toBeInTheDocument()
+  })
+
+  it('renders with status role and aria-label', () => {
+    const cluster = createMockCluster({
+      lastSeen: new Date().toISOString(),
+    })
+    render(<ClusterStatusDetails cluster={cluster} />)
+    
+    const statusPanel = screen.getByRole('status')
+    expect(statusPanel).toHaveAttribute('aria-label', 'Cluster status details')
+  })
+})

--- a/web/src/components/clusters/components/__tests__/ClusterCardCompact.test.tsx
+++ b/web/src/components/clusters/components/__tests__/ClusterCardCompact.test.tsx
@@ -67,6 +67,36 @@ describe('ClusterCardCompact', () => {
     expect(healthyIndicator).toBeInTheDocument()
   })
 
+  it('displays unreachable icon for offline cluster', () => {
+    const cluster = createMockCluster({ healthy: false, unreachable: true })
+    const { container } = render(<ClusterCardCompact {...defaultProps} cluster={cluster} />)
+    expect(container.querySelector('[class*="WifiOff"]')).toBeTruthy()
+  })
+
+  it('displays alert icon for unhealthy cluster', () => {
+    const cluster = createMockCluster({ healthy: false, unreachable: false })
+    const { container } = render(<ClusterCardCompact {...defaultProps} cluster={cluster} />)
+    expect(container.querySelector('[class*="AlertCircle"]')).toBeTruthy()
+  })
+
+  it('displays token expired icon when token is expired', () => {
+    const cluster = createMockCluster({ tokenExpiry: new Date('2020-01-01').toISOString() })
+    const { container } = render(<ClusterCardCompact {...defaultProps} cluster={cluster} />)
+    expect(container.querySelector('[class*="KeyRound"]')).toBeTruthy()
+  })
+
+  it('displays current cluster star icon', () => {
+    const cluster = createMockCluster({ isCurrent: true })
+    const { container } = render(<ClusterCardCompact {...defaultProps} cluster={cluster} />)
+    expect(container.querySelector('[class*="Star"]')).toBeTruthy()
+  })
+
+  it('displays alias badge when cluster has aliases', () => {
+    const cluster = createMockCluster({ aliases: ['alias1', 'alias2'] })
+    render(<ClusterCardCompact {...defaultProps} cluster={cluster} />)
+    expect(screen.getByText('+2')).toBeInTheDocument()
+  })
+
   it('calls onSelectCluster when card is clicked', () => {
     const onSelectCluster = vi.fn()
     render(<ClusterCardCompact {...defaultProps} onSelectCluster={onSelectCluster} />)
@@ -80,6 +110,14 @@ describe('ClusterCardCompact', () => {
     render(<ClusterCardCompact {...defaultProps} onSelectCluster={onSelectCluster} />)
     const card = screen.getByRole('button', { name: /Select cluster test-context/i })
     fireEvent.keyDown(card, { key: 'Enter' })
+    expect(onSelectCluster).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onSelectCluster when Space key is pressed', () => {
+    const onSelectCluster = vi.fn()
+    render(<ClusterCardCompact {...defaultProps} onSelectCluster={onSelectCluster} />)
+    const card = screen.getByRole('button', { name: /Select cluster test-context/i })
+    fireEvent.keyDown(card, { key: ' ' })
     expect(onSelectCluster).toHaveBeenCalledTimes(1)
   })
 
@@ -98,9 +136,26 @@ describe('ClusterCardCompact', () => {
     expect(screen.queryByTestId('remove-cluster-button')).not.toBeInTheDocument()
   })
 
+  it('displays dash for stats when cluster data is not loaded', () => {
+    const cluster = createMockCluster({
+      nodeCount: undefined,
+      cpuCores: undefined,
+      podCount: undefined,
+    })
+    render(<ClusterCardCompact {...defaultProps} cluster={cluster} />)
+    const dashes = screen.getAllByText('-')
+    expect(dashes.length).toBeGreaterThan(0)
+  })
+
   it('renders drag handle when provided', () => {
     const dragHandle = <div data-testid="drag-handle">Drag</div>
     render(<ClusterCardCompact {...defaultProps} dragHandle={dragHandle} />)
     expect(screen.getByTestId('drag-handle')).toBeInTheDocument()
+  })
+
+  it('displays GPU count of 0 when no GPUs are present', () => {
+    const cluster = createMockCluster({ nodeCount: 3, cpuCores: 12, podCount: 50 })
+    render(<ClusterCardCompact {...defaultProps} cluster={cluster} gpuInfo={undefined} />)
+    expect(screen.getByText('0')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Fixes #19241

Adds test coverage for 3 components that were identified as lacking tests:

- **ClusterStatusDetails** (243 lines) — Tests error types (auth, cert, network, timeout), never connected, health unknown, external reachability, last seen, priority rules, accessibility
- **ClusterCardCompact** (161 lines) — Tests rendering, stats display, health indicators, keyboard interactions, remove button logic, drag handles
- **NotFound** (109 lines) — Tests 404 rendering, quick links, navigation, demo mode activation, feature request URL

Part of #18599