### PR TITLE
[scanner] 🐛 fix: remove duplicate test and unused import blocking nightly release

### DIFF
--- a/pkg/api/handlers/missions/share_test.go
+++ b/pkg/api/handlers/missions/share_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -131,29 +130,6 @@ func TestMissions_ShareToSlack_TextTooLarge(t *testing.T) {
 	var result map[string]interface{}
 	require.NoError(t, json.Unmarshal(body, &result))
 	assert.Contains(t, result["error"], "exceeds maximum size")
-}
-
-func TestMissions_ShareToSlack_EmptyText(t *testing.T) {
-	app, _ := setupMissionsTest()
-
-	payload := map[string]string{
-		"webhookUrl": "https://hooks.slack.com/services/T00/B00/XXX",
-		"text":       "",
-	}
-	payloadBytes, _ := json.Marshal(payload)
-
-	req, err := http.NewRequest("POST", "/api/missions/share/slack", strings.NewReader(string(payloadBytes)))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := app.Test(req, 5000)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-
-	body, _ := io.ReadAll(resp.Body)
-	var result map[string]interface{}
-	require.NoError(t, json.Unmarshal(body, &result))
-	assert.Contains(t, result["error"], "text is required")
 }
 
 func TestMissions_ResolveAllowedShareRepos(t *testing.T) {


### PR DESCRIPTION
Fixes #18426

Partial fix addressing compilation errors in `pkg/api/handlers/missions/` that block the nightly release:

**Changes:**
- Remove duplicate `TestMissions_ShareToSlack_EmptyText` function from `share_test.go` (already defined in `share_error_test.go` — Go disallows duplicate function names in the same package)
- Remove unused `"github.com/gofiber/fiber/v2"` import from `share_test.go`

These two issues cause the entire missions test package to fail compilation, which cascades to fail:
- `TestMissions_BrowseConsoleKB_EmbeddedFallback`
- `TestMissions_GetMissionFile_EmbeddedFallback`
- `TestGetKBScores_UpstreamError`

**Remaining nightly failures** (separate root causes, tracked in #18426 comments):
- AI provider tests (Claude, Codex, Gemini) — separate package
- KC-Agent URL normalization — separate package
- Import cycle in `pkg/k8s/gpu` — requires architectural decision