### PR TITLE
[scanner] 🌱 refactor: extract magic timer values to named constants

### DIFF
--- a/web/src/components/animations/globe/Cluster.tsx
+++ b/web/src/components/animations/globe/Cluster.tsx
@@ -10,6 +10,7 @@ const COLORS = {
   highlight: "#00C2FF",
   success: "#00E396",
   background: "#0a0f1c",
+const NODE_ACTIVATION_INTERVAL_MS = 3000
 }
 
 // Cluster visualization with dynamic elements
@@ -56,7 +57,7 @@ const Cluster = ({
         () => Math.floor(Math.random() * nodeCount)
       )
       setActiveNodes(randomNodes)
-    }, 3000)
+    }, NODE_ACTIVATION_INTERVAL_MS)
 
     return () => clearInterval(interval)
   }, [nodeCount])

--- a/web/src/components/animations/globe/Cluster.tsx
+++ b/web/src/components/animations/globe/Cluster.tsx
@@ -10,8 +10,9 @@ const COLORS = {
   highlight: "#00C2FF",
   success: "#00E396",
   background: "#0a0f1c",
-const NODE_ACTIVATION_INTERVAL_MS = 3000
 }
+
+const NODE_ACTIVATION_INTERVAL_MS = 3000
 
 // Cluster visualization with dynamic elements
 interface ClusterProps {

--- a/web/src/components/cards/KubeMan.tsx
+++ b/web/src/components/cards/KubeMan.tsx
@@ -10,6 +10,7 @@ import { useGameKeys } from '../../hooks/useGameKeys'
 const CELL_SIZE = 16
 const MAZE_WIDTH = 19
 const MAZE_HEIGHT = 21
+const POWER_MODE_DURATION_MS = 5000
 
 // Ghost names and behaviors
 type GhostName = 'Blinky' | 'Pinky' | 'Inky' | 'Clyde'
@@ -445,7 +446,7 @@ export function KubeMan(_props: CardComponentProps) {
             powerTimerRef.current = setTimeout(() => {
               setPowerMode(false)
               setGhosts(gs => gs.map(g => ({ ...g, scared: false })))
-            }, 5000)
+            }, POWER_MODE_DURATION_MS)
           }
         }
       }

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -43,6 +43,7 @@ type ClusterNamespaceStatus = 'unavailable' | 'accessDenied'
 
 // Cache for namespace data per cluster - persists across filter changes
 const namespaceCache = new Map<string, NamespaceDetails[]>()
+const AUTO_REFRESH_INTERVAL_MS = 30000
 
 function buildFallbackNamespaces(namespaces: string[], cluster: string): NamespaceDetails[] {
   return Array.from(new Set(namespaces.filter(Boolean)))
@@ -413,7 +414,7 @@ export function NamespaceManager() {
   useEffect(() => {
     const interval = setInterval(() => {
       fetchNamespaces(true)
-    }, 30000)
+    }, AUTO_REFRESH_INTERVAL_MS)
     return () => clearInterval(interval)
   }, [fetchNamespaces])
 


### PR DESCRIPTION
Fixes #19245

Extracts bare numeric timeout/interval values to named constants in 3 production source files.

**Changes:**
- `web/src/components/animations/globe/Cluster.tsx`: `NODE_ACTIVATION_INTERVAL_MS = 3000`
- `web/src/components/cards/KubeMan.tsx`: `POWER_MODE_DURATION_MS = 5000`
- `web/src/components/namespaces/NamespaceManager.tsx`: `AUTO_REFRESH_INTERVAL_MS = 30000`

**Not addressed (out of scope / false positives):**
- Values already extracted to constants (majority of issue findings)
- z-index values (UI layering, not thresholds)
- Port numbers in demo URLs (e.g., localhost:3000)
- Issue reference numbers in comments (#6055, #7788, etc.)
- Test files (test environments have different concerns)