### PR TITLE
 docs: promote console marketplace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The hosted demo is a self-contained showcase: it serves canned demo data and int
 
 KubeStellar Console can be extended with community dashboard content from the [console-marketplace](https://github.com/kubestellar/console-marketplace). The marketplace hosts dashboards, card presets, and themes for Kubernetes operations, AI/ML, security, GitOps, networking, and CNCF project integrations without adding custom code to the core console bundle.
 
-- Browse 150+ ready-made card templates and dashboard presets in [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace)
+- Browse community dashboards, card presets, and themes in [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace)
 - Share your own dashboard cards or presets through the marketplace repository
 - Start from the [marketplace contribution guide](https://github.com/kubestellar/console-marketplace/blob/main/CONTRIBUTING.md) when adding new community content
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ The hosted demo is a self-contained showcase: it serves canned demo data and int
 
 > **Note**: `kc-agent` is **not** consumed by the hosted demo at [console.kubestellar.io](https://console.kubestellar.io). It bridges your **self-hosted** console (running at `localhost:8080`) to your kubeconfig contexts and to AI providers. If you want the convenience of the hosted UI plus your real cluster data, you currently have to run the console locally.
 
+## Extend with the Marketplace
+
+KubeStellar Console can be extended with community dashboard content from the [console-marketplace](https://github.com/kubestellar/console-marketplace). The marketplace hosts dashboards, card presets, and themes for Kubernetes operations, AI/ML, security, GitOps, networking, and CNCF project integrations without adding custom code to the core console bundle.
+
+- Browse 150+ ready-made card templates and dashboard presets in [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace)
+- Share your own dashboard cards or presets through the marketplace repository
+- Start from the [marketplace contribution guide](https://github.com/kubestellar/console-marketplace/blob/main/CONTRIBUTING.md) when adding new community content
+
 ## Local install (self-host)
 
 The quickest path to a working console with your own data. `start.sh` downloads the pre-built console binary and a pre-built `kc-agent`, starts both, and opens [http://localhost:8080](http://localhost:8080):

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This index covers the Markdown and YAML documentation files in `docs/` and group
 - [Deployment guide](deploy.md) — `deploy.sh` reference and deployment flags
 - [Troubleshooting](troubleshooting.md) — operational troubleshooting reference
 - [Release process](RELEASING.md) — release workflow and packaging notes
+- [Console marketplace](https://github.com/kubestellar/console-marketplace) — community dashboards, card presets, and themes
 
 ## For developers
 
@@ -67,5 +68,6 @@ This index covers the Markdown and YAML documentation files in `docs/` and group
 | [COMMUNITY.md](COMMUNITY.md) | Community channels, engagement guidance, and project participation information. |
 | [HOMEBREW.md](HOMEBREW.md) | Explains Homebrew support status for the console and kc-agent. |
 | [RELEASING.md](RELEASING.md) | Release-process reference for maintainers packaging and publishing releases. |
+| [console-marketplace](https://github.com/kubestellar/console-marketplace) | Community contribution hub for dashboard exports, card presets, and themes. |
 | [cncf-insights/2026-05-27.md](cncf-insights/2026-05-27.md) | Snapshot report of CNCF landscape intelligence from 2026-05-27. |
 | [security/SELF-ASSESSMENT.md](security/SELF-ASSESSMENT.md) | Project security self-assessment and related review notes. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,6 @@ This index covers the Markdown and YAML documentation files in `docs/` and group
 | [COMMUNITY.md](COMMUNITY.md) | Community channels, engagement guidance, and project participation information. |
 | [HOMEBREW.md](HOMEBREW.md) | Explains Homebrew support status for the console and kc-agent. |
 | [RELEASING.md](RELEASING.md) | Release-process reference for maintainers packaging and publishing releases. |
-| [console-marketplace](https://github.com/kubestellar/console-marketplace) | Community contribution hub for dashboard exports, card presets, and themes. |
 | [cncf-insights/2026-05-27.md](cncf-insights/2026-05-27.md) | Snapshot report of CNCF landscape intelligence from 2026-05-27. |
+| [console-marketplace](https://github.com/kubestellar/console-marketplace) | Community contribution hub for dashboard exports, card presets, and themes. |
 | [security/SELF-ASSESSMENT.md](security/SELF-ASSESSMENT.md) | Project security self-assessment and related review notes. |


### PR DESCRIPTION
﻿###  Fixes

Fixes kubestellar/kubestellar#3824

---

###  Summary of Changes

- Adds a visible Marketplace CTA to the main Console README.
- Points users and contributors to `kubestellar/console-marketplace` for dashboards, card presets, and themes.
- Adds the marketplace to the docs index so it is easier to discover from contributor-facing docs.

---

### Changes Made

- [x] Updated `README.md` with an "Extend with the Marketplace" section.
- [x] Updated `docs/README.md` with marketplace links in key entry points and contributor docs.
- [x] Kept this PR docs-only; no runtime code or card components were changed.

---

### Checklist

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [x] isDemoData is wired correctly (cards show Demo badge when using demo data) — not applicable, docs-only change
- [x] I have written unit tests for the changes (if applicable) — not applicable, docs-only change
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)
