### PR TITLE
[scanner] 🐛 fix: add missing time constants barrel export

### DIFF
--- a/web/src/lib/constants/index.ts
+++ b/web/src/lib/constants/index.ts
@@ -3,6 +3,7 @@
  */
 export * from './network'
 export * from './storage'
+export * from './time'
 export * from './ui'
 export * from './units'
 export * from './status-colors'


### PR DESCRIPTION
Fixes #19258 (partial — import errors)

Adds missing `export * from './time'` to the constants barrel file (`web/src/lib/constants/index.ts`). After PR #19253 extracted time constants into `time.ts`, the barrel wasn't updated, causing 5+ tests to fail to load:
- `AlertsContext.core.test.tsx`
- `AlertsContext.wave2.test.tsx`
- `useDeployMissions.test.ts`
- `useSnoozeHooks.test.ts`
- `useTokenUsage.test.ts`