### PR TITLE
[scanner] 🐛 fix: address KB validation gaps

### DIFF
--- a/.github/kb-scripts/package.json
+++ b/.github/kb-scripts/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "KB validation helper dependencies for GitHub Actions workflows",
   "dependencies": {
+    "ajv": "8.20.0",
     "ajv-formats": "2.1.1"
   },
   "overrides": {

--- a/.github/kb-scripts/validate-json-schema.cjs
+++ b/.github/kb-scripts/validate-json-schema.cjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
+
+const [, , schemaPath, dataPath] = process.argv;
+
+if (!schemaPath || !dataPath) {
+  console.error('Usage: validate-json-schema.cjs <schema.json> <data.json>');
+  process.exit(2);
+}
+
+const readJson = (filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+try {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+
+  const validate = ajv.compile(readJson(schemaPath));
+  const valid = validate(readJson(dataPath));
+
+  if (!valid) {
+    console.error(ajv.errorsText(validate.errors, { separator: '\n' }));
+    process.exit(1);
+  }
+} catch (error) {
+  console.error(error.message);
+  process.exit(2);
+}

--- a/.github/workflows/kb-nightly-validation.yml
+++ b/.github/workflows/kb-nightly-validation.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Install pinned AJV tools for schema validation
         run: npm ci --ignore-scripts --prefix .github/kb-scripts
 
-      - name: Add AJV tools to PATH
-        run: echo "$GITHUB_WORKSPACE/.github/kb-scripts/node_modules/.bin" >> "$GITHUB_PATH"
-
       - name: Test mission schema validation path
         run: |
           chmod +x scripts/validate-missions-schema-test.sh

--- a/scripts/validate-missions-schema-test.sh
+++ b/scripts/validate-missions-schema-test.sh
@@ -13,24 +13,23 @@ EXPECTED_VERSION_ERROR="must have required property 'version'"
 # AJV must be available for schema validation tests to be meaningful.
 # If AJV is missing or non-functional, exit with code 2 (configuration error)
 # rather than silently skipping schema checks and giving false positives.
-if ! command -v ajv &>/dev/null; then
-  echo "✗ CONFIGURATION ERROR: 'ajv' CLI not found in PATH."
-  echo "  Schema validation tests require ajv-cli. Install with:"
+if ! command -v node &>/dev/null; then
+  echo "✗ CONFIGURATION ERROR: 'node' not found in PATH."
+  echo "  Schema validation tests require Node.js. Install helper dependencies with:"
   echo "    npm ci --ignore-scripts --prefix .github/kb-scripts"
-  echo "  Then add to PATH:"
-  echo "    export PATH=\".github/kb-scripts/node_modules/.bin:\$PATH\""
   exit 2
 fi
 
 # Smoke-test that ajv can actually validate against the schema with formats
-SMOKE_FILE=$(mktemp)
+SMOKE_FILE=$(mktemp --suffix=.json)
 trap 'rm -f "$SMOKE_FILE"' EXIT
 echo '{"version":"kc-mission-v1","title":"AJV smoke test","steps":[{"title":"Step 1","description":"Smoke test"}]}' > "$SMOKE_FILE"
 
-if ! ajv validate --spec=draft7 -s "$SCHEMA_FILE" -d "$SMOKE_FILE" -c ajv-formats >/dev/null 2>&1; then
-  echo "✗ CONFIGURATION ERROR: ajv cannot validate against schema with ajv-formats plugin."
+if ! ajv_out=$(node .github/kb-scripts/validate-json-schema.cjs "$SCHEMA_FILE" "$SMOKE_FILE" 2>&1); then
+  echo "✗ CONFIGURATION ERROR: AJV cannot validate against schema with ajv-formats plugin."
   echo "  The schema file may have changed or the ajv-formats plugin is unavailable."
   echo "  Schema: $SCHEMA_FILE"
+  echo "$ajv_out"
   exit 2
 fi
 

--- a/scripts/validate-missions.sh
+++ b/scripts/validate-missions.sh
@@ -38,7 +38,7 @@ CARD_INSTALL_MAP_FILE="web/src/lib/cards/cardInstallMap.ts"
 VERBOSE=false
 LOCAL_DIR=""
 SCHEMA_FILE=""
-AJV_FORMATS_PLUGIN="ajv-formats"
+AJV_VALIDATOR=".github/kb-scripts/validate-json-schema.cjs"
 AJV_TMP_DIR=".validate-missions-ajv-${BASHPID}"
 
 require_option_value() {
@@ -249,10 +249,7 @@ ajv_formats_available() {
   local smoke_file
   smoke_file=$(write_ajv_input "plugin-check" '{"version":"kc-mission-v1","title":"AJV plugin check","steps":[{"title":"Step 1","description":"Schema smoke test"}]}')
 
-  ajv validate --spec=draft7 \
-    -s "$SCHEMA_FILE" \
-    -d "$smoke_file" \
-    -c "$AJV_FORMATS_PLUGIN" >/dev/null 2>&1
+  node "$AJV_VALIDATOR" "$SCHEMA_FILE" "$smoke_file" >/dev/null 2>&1
 }
 
 trap cleanup_ajv_tmp_dir EXIT
@@ -270,11 +267,14 @@ if [[ -n "$SCHEMA_FILE" ]]; then
     echo "ERROR: Schema file not found: $SCHEMA_FILE" >&2
     exit 2
   fi
-  if ! command -v ajv &>/dev/null; then
-    echo -e "${YELLOW:-}WARNING: --schema given but 'ajv' not found; schema validation skipped (run 'npm install -g ajv-cli ajv-formats').${RESET:-}"
+  if ! command -v node &>/dev/null; then
+    echo -e "${YELLOW:-}WARNING: --schema given but 'node' not found; schema validation skipped.${RESET:-}"
+    SCHEMA_FILE=""
+  elif [[ ! -f "$AJV_VALIDATOR" ]]; then
+    echo -e "${YELLOW:-}WARNING: --schema given but '$AJV_VALIDATOR' is missing; schema validation skipped.${RESET:-}"
     SCHEMA_FILE=""
   elif ! ajv_formats_available; then
-    echo -e "${YELLOW:-}WARNING: --schema given but '${AJV_FORMATS_PLUGIN}' is not available; schema validation skipped.${RESET:-}"
+    echo -e "${YELLOW:-}WARNING: --schema given but AJV helper dependencies are not available; schema validation skipped.${RESET:-}"
     SCHEMA_FILE=""
   fi
 fi
@@ -405,12 +405,12 @@ validate_mission() {
     mission_issues+=("INFO: Version references found: $(echo $version_refs | tr '\n' ' ')")
   fi
 
-  # ── JSON Schema validation via ajv-cli ────────────────────────
-  if [[ -n "$SCHEMA_FILE" ]] && command -v ajv &>/dev/null; then
+  # ── JSON Schema validation via AJV ────────────────────────
+  if [[ -n "$SCHEMA_FILE" ]] && command -v node &>/dev/null; then
     local schema_payload ajv_input_file ajv_out
     schema_payload=$(build_schema_validation_payload "$normalized")
     ajv_input_file=$(write_ajv_input "mission" "$schema_payload")
-    if ! ajv_out=$(ajv validate --spec=draft7 -s "$SCHEMA_FILE" -d "$ajv_input_file" -c "$AJV_FORMATS_PLUGIN" 2>&1); then
+    if ! ajv_out=$(node "$AJV_VALIDATOR" "$SCHEMA_FILE" "$ajv_input_file" 2>&1); then
       local ajv_err
       ajv_err=$(echo "$ajv_out" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g')
       mission_issues+=("CRITICAL: Schema validation failed after normalization — ${ajv_err}")


### PR DESCRIPTION
Fixes #19260

Addresses KB validation gaps detected on 2026-06-20.

Repairs the KB nightly validation setup so the mission schema smoke test can run before gap tracking.

**Changes:**
- Adds a small local Node/AJV schema validator under `.github/kb-scripts`
- Uses that helper from the mission validation scripts instead of expecting an `ajv` CLI on PATH
- Keeps the workflow install step focused on pinned helper dependencies

**Testing:**
- The KB nightly validation workflow will now use the local Node validator
- Schema validation checks in validate-missions.sh and validate-missions-schema-test.sh will use the local validator