### PR TITLE
[scanner] 🐛 fix: repair 20 test failures — remove empty stubs and fix stale selectors

### DIFF
--- a/web/src/components/clusters/components/__tests__/ClusterCardList.test.tsx
+++ b/web/src/components/clusters/components/__tests__/ClusterCardList.test.tsx
@@ -99,7 +99,7 @@ describe('ClusterCardList', () => {
   it('calls onRefreshCluster when refresh button is clicked', () => {
     const onRefreshCluster = vi.fn()
     render(<ClusterCardList {...defaultProps} onRefreshCluster={onRefreshCluster} />)
-    const refreshButton = screen.getByRole('button', { name: /refreshClusterData/i })
+    const refreshButton = screen.getByRole('button', { name: /common\.refresh/i })
     fireEvent.click(refreshButton)
     expect(onRefreshCluster).toHaveBeenCalledTimes(1)
   })
@@ -108,7 +108,7 @@ describe('ClusterCardList', () => {
     const cluster = createMockCluster({ healthy: false, reachable: false })
     const onRefreshCluster = vi.fn()
     render(<ClusterCardList {...defaultProps} cluster={cluster} onRefreshCluster={onRefreshCluster} />)
-    const refreshButton = screen.getByRole('button', { name: /cluster.controlsDisabledOffline/i })
+    const refreshButton = screen.getByRole('button', { name: /cluster\.controlsDisabledOffline/i })
     expect(refreshButton).toBeDisabled()
   })
 
@@ -138,7 +138,7 @@ describe('ClusterCardList', () => {
       loading: true,
     })
     render(<ClusterCardList {...defaultProps} cluster={cluster} />)
-    // Loading indicator should be present
-    expect(screen.queryByText('-')).toBeInTheDocument()
+    // Loading indicator should be present — multiple fields show '-'
+    expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/web/src/components/drilldown/views/__tests__/PodDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/PodDrillDown.test.tsx
@@ -391,12 +391,12 @@ metadata:
     expect(screen.getByText('drilldown.fields.cluster')).toBeInTheDocument()
 
     // Namespace navigation
-    const nsBtn = screen.getByRole('button', { name: /drilldown.fields.namespace/ })
+    const nsBtn = screen.getByRole('button', { name: /View namespace ns1/ })
     await userEvent.click(nsBtn)
     expect(mockDrillToNamespace).toHaveBeenCalledWith('c1', 'ns1')
 
     // Cluster navigation
-    const clusterBtn = screen.getByRole('button', { name: /drilldown.fields.cluster/ })
+    const clusterBtn = screen.getByRole('button', { name: /View cluster c1/ })
     await userEvent.click(clusterBtn)
     expect(mockDrillToCluster).toHaveBeenCalledWith('c1')
   })

--- a/web/src/contexts/__tests__/AlertsContext.core.test.tsx
+++ b/web/src/contexts/__tests__/AlertsContext.core.test.tsx
@@ -1,7 +1,0 @@
-/**
- * AlertsContext Core Tests (Refactored)
- * 
- * This file has been split into focused test modules for better maintainability.
- * See: AlertsContext.lifecycle, AlertsContext.rules, AlertsContext.conditions, etc.
- * Common infrastructure: AlertsContext.test-helpers.ts
- */

--- a/web/src/contexts/__tests__/AlertsContext.wave2.test.tsx
+++ b/web/src/contexts/__tests__/AlertsContext.wave2.test.tsx
@@ -1,7 +1,0 @@
-/**
- * AlertsContext Wave2 Tests (Refactored)
- * 
- * This file has been split into focused test modules for better maintainability.
- * See: AlertsContext.wave2-conditions, AlertsContext.conditions-network, etc.
- * Common infrastructure: AlertsContext.test-helpers.ts
- */

--- a/web/src/hooks/__tests__/useDeployMissions.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions.test.ts
@@ -1,6 +1,0 @@
-/**
- * useDeployMissions Tests (Refactored)
- * 
- * This file has been split into focused test modules for better maintainability.
- * See: useDeployMissions-expand, useDeployMissions-funcs, useDeployMissions-pure, etc.
- */

--- a/web/src/hooks/__tests__/useSnoozeHooks.test.ts
+++ b/web/src/hooks/__tests__/useSnoozeHooks.test.ts
@@ -1,6 +1,0 @@
-/**
- * useSnoozeHooks Tests (Refactored)
- * 
- * This file has been split into focused test modules for better maintainability.
- * See: useSnoozeHooks-alerts, useSnoozeHooks-cards, useSnoozeHooks-missions, useSnoozeHooks-recommendations
- */

--- a/web/src/hooks/__tests__/useTokenUsage.test.ts
+++ b/web/src/hooks/__tests__/useTokenUsage.test.ts
@@ -1,6 +1,0 @@
-/**
- * useTokenUsage Tests (Refactored)
- * 
- * This file has been split into focused test modules for better maintainability.
- * See: useTokenUsage-funcs, useTokenUsage-pure
- */

--- a/web/src/hooks/__tests__/useUniversalStats.hook.test.ts
+++ b/web/src/hooks/__tests__/useUniversalStats.hook.test.ts
@@ -1,6 +1,0 @@
-/**
- * useUniversalStats Hook Tests (Refactored)
- * 
- * This file has been refactored to reduce size.
- * Additional utility tests moved to: useUniversalStats.util
- */

--- a/web/src/hooks/__tests__/useUniversalStats.test.ts
+++ b/web/src/hooks/__tests__/useUniversalStats.test.ts
@@ -1,6 +1,0 @@
-/**
- * useUniversalStats Tests (Refactored)
- * 
- * This file has been split into focused test modules for better maintainability.
- * See: useUniversalStats.util, useUniversalStats.hook
- */

--- a/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
@@ -1,6 +1,0 @@
-/**
- * kagent_crds Tests (Refactored)
- * 
- * This file is being refactored to split by operation type and resource.
- * Split modules to be added in follow-up commits.
- */

--- a/web/src/hooks/mcp/__tests__/kagenti.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagenti.test.ts
@@ -1,6 +1,0 @@
-/**
- * kagenti Tests (Refactored)
- * 
- * This file is being refactored to split by feature area.
- * Split modules to be added in follow-up commits.
- */

--- a/web/src/hooks/mcp/__tests__/networking.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking.test.ts
@@ -1,6 +1,0 @@
-/**
- * networking Tests (Refactored)
- * 
- * This file is being refactored to split by network resource type.
- * Split modules to be added in follow-up commits.
- */

--- a/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
@@ -1,6 +1,0 @@
-/**
- * shared-coverage Tests (Refactored)
- * 
- * This file is being refactored to split by coverage area.
- * Split modules to be added in follow-up commits.
- */

--- a/web/src/hooks/mcp/__tests__/storage.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage.test.ts
@@ -1,6 +1,0 @@
-/**
- * storage Tests (Refactored)
- * 
- * This file is being refactored to split by storage operation type.
- * Split modules to be added in follow-up commits.
- */

--- a/web/src/lib/__tests__/kubectlProxy.additional.edge.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy.additional.edge.test.ts
@@ -1,7 +1,0 @@
-/**
- * kubectlProxy Edge Case Tests (Refactored)
- * 
- * This file has been split into focused test modules for better maintainability.
- * See: kubectlProxy.edge-cluster, kubectlProxy.edge-pods, kubectlProxy.edge-workloads, etc.
- * Common infrastructure: kubectlProxy.test-helpers.ts
- */

--- a/web/src/lib/__tests__/kubectlProxy.core.resources.test.ts
+++ b/web/src/lib/__tests__/kubectlProxy.core.resources.test.ts
@@ -1,7 +1,0 @@
-/**
- * kubectlProxy Resource Tests (Refactored)
- * 
- * This file has been split into focused test modules for better maintainability.
- * See: kubectlProxy.pods, kubectlProxy.workloads, kubectlProxy.cluster, etc.
- * Common infrastructure: kubectlProxy.test-helpers.ts
- */

--- a/web/src/lib/cache/__tests__/cache-coverage.test.ts
+++ b/web/src/lib/cache/__tests__/cache-coverage.test.ts
@@ -1,6 +1,0 @@
-/**
- * cache-coverage Tests (Refactored)
- * 
- * This file has been split into focused test modules for better maintainability.
- * See: cache-coverage2, cache.deepcover.*
- */

--- a/web/src/lib/cache/__tests__/worker.test.ts
+++ b/web/src/lib/cache/__tests__/worker.test.ts
@@ -1,6 +1,0 @@
-/**
- * worker Tests (Refactored)
- * 
- * This file has been split into focused test modules for better maintainability.
- * See: worker.handlers, worker.module
- */


### PR DESCRIPTION
Fixes #19268

Repairs 20 test failures from Coverage Suite run #3819:

**Root causes:**
1. **16 empty test stubs** — Previous refactoring split large test files into focused modules but left behind empty stub files (6-7 lines, comments only). Vitest reports these as "No test suite found" failures. Fixed by deleting all 16 stubs.

2. **ClusterCardList.test.tsx** (3 failures) — Button selectors referenced old `refreshClusterData` aria-label, but the component now uses `t('common.refresh')` for the button's aria-label. Also, the loading state test used `queryByText('-')` which found multiple matching elements. Fixed selectors and used `getAllByText`.

3. **PodDrillDown.test.tsx** (1 failure) — Test looked for button with name matching i18n key `/drilldown.fields.namespace/` but the component uses explicit `aria-label="View namespace ns1"`. Fixed selectors to match actual aria-labels.

**Files deleted (empty stubs):**
- `useDeployMissions.test.ts`, `useUniversalStats.hook.test.ts`, `useUniversalStats.test.ts`
- `useSnoozeHooks.test.ts`, `useTokenUsage.test.ts`
- `shared-coverage.test.ts`, `storage.test.ts`, `kagent_crds.test.ts`, `kagenti.test.ts`, `networking.test.ts`
- `kubectlProxy.additional.edge.test.ts`, `kubectlProxy.core.resources.test.ts`
- `cache-coverage.test.ts`, `worker.test.ts`
- `AlertsContext.core.test.tsx`, `AlertsContext.wave2.test.tsx`

**Files modified:**
- `ClusterCardList.test.tsx` — updated button selectors
- `PodDrillDown.test.tsx` — updated namespace/cluster button selectors