### PR TITLE
[scanner] fix: resolve gosec security findings in kb/rag

### DIFF
--- a/pkg/kb/rag/embedder.go
+++ b/pkg/kb/rag/embedder.go
@@ -62,7 +62,8 @@ func Quantize(v []float32) []uint64 {
 	code := make([]uint64, (len(v)+63)/64)
 	for i, x := range v {
 		if x >= 0 {
-			code[i/64] |= 1 << uint(i%64)
+			// Safe conversion: i%64 is always in [0,63], well within uint range.
+			code[i/64] |= 1 << uint(i%64) // #nosec G115
 		}
 	}
 	return code

--- a/pkg/kb/rag/hashembedder.go
+++ b/pkg/kb/rag/hashembedder.go
@@ -100,7 +100,9 @@ func (e *HashEmbedder) addFeature(vec []float32, feature string, weight float64)
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(feature))
 	sum := h.Sum64()
-	idx := int(sum % uint64(e.dim))
+	// Safe conversion: sum % uint64(e.dim) is always < e.dim (typically 512),
+	// well within int range even on 32-bit systems.
+	idx := int(sum % uint64(e.dim)) // #nosec G115
 	sign := float32(1)
 	if sum&(1<<63) != 0 {
 		sign = -1


### PR DESCRIPTION
Fixes #19277

## Summary

Resolves gosec security scanner findings (G115 - integer overflow conversion) in the kb/rag package.

## Changes

- **pkg/kb/rag/hashembedder.go:103** - Added `#nosec G115` annotation for safe uint64→int conversion with explanatory comment
- **pkg/kb/rag/embedder.go:65** - Added `#nosec G115` annotation for safe int→uint conversion with explanatory comment

## Rationale

Both conversions are mathematically safe:
1. In `hashembedder.go`, `sum % uint64(e.dim)` is always < e.dim (typically 512), well within int range even on 32-bit systems
2. In `embedder.go`, `i%64` is always in [0,63], well within uint range

The `#nosec` directives are justified with inline comments explaining why these specific conversions are safe.