### PR TITLE
[scanner] fix: replace inconsistent spacing values with Tailwind utilities

### DIFF
--- a/web/src/components/cards/llmd/LLMdConfigurator.tsx
+++ b/web/src/components/cards/llmd/LLMdConfigurator.tsx
@@ -104,7 +104,7 @@ function ParameterSlider({ param, onChange }: ParameterSliderProps) {
         >
           <motion.div
             className="absolute top-0.5 w-4 h-4 bg-white dark:bg-gray-200 rounded-full"
-            animate={{ left: param.value ? '22px' : '2px' }}
+            animate={{ left: param.value ? '1.375rem' : '0.125rem' }}
           />
         </button>
       </div>


### PR DESCRIPTION
Fixes #19271

## Summary
This PR replaces non-standard inline px spacing values with rem-based equivalents aligned to Tailwind CSS conventions.

## Changed Files
- `web/src/components/widgets/widget-export-modal/WidgetExportModalPreview.tsx`: Converted 19 spacing/font size constants from px to rem
- `web/src/lib/auth.tsx`: Converted banner padding, gap, margin, and font sizes from px to rem
- `web/src/components/cards/llmd/LLMdConfigurator.tsx`: Updated animation values from px to rem
- `web/src/components/cards/IssueActivityChart.tsx`: Changed tooltip dot from 10px to 0.625rem
- `web/src/lib/unified/card/visualizations/__tests__/ChartVisualization.test.tsx`: Changed borderRadius from 6px to 0.375rem

## Conversion Scale Used
- 2px → 0.125rem
- 4px → 0.25rem
- 6px → 0.375rem
- 10px → 0.625rem
- 12px → 0.75rem
- 14px → 0.875rem
- 22px → 1.375rem
- 24px → 1.5rem