### PR TITLE
[scanner] 🐛 fix: repair ClusterCardList test selectors for refresh button

### DIFF
--- a/web/src/components/clusters/components/__tests__/ClusterCardList.test.tsx
+++ b/web/src/components/clusters/components/__tests__/ClusterCardList.test.tsx
@@ -99,7 +99,7 @@ describe('ClusterCardList', () => {
   it('calls onRefreshCluster when refresh button is clicked', () => {
     const onRefreshCluster = vi.fn()
     render(<ClusterCardList {...defaultProps} onRefreshCluster={onRefreshCluster} />)
-    const refreshButton = screen.getByRole('button', { name: /common\.refresh/i })
+    const refreshButton = screen.getAllByRole('button', { name: /common\.refresh/i }).find(el => el.tagName === 'BUTTON')!
     fireEvent.click(refreshButton)
     expect(onRefreshCluster).toHaveBeenCalledTimes(1)
   })
@@ -108,7 +108,7 @@ describe('ClusterCardList', () => {
     const cluster = createMockCluster({ healthy: false, reachable: false })
     const onRefreshCluster = vi.fn()
     render(<ClusterCardList {...defaultProps} cluster={cluster} onRefreshCluster={onRefreshCluster} />)
-    const refreshButton = screen.getByRole('button', { name: /cluster\.controlsDisabledOffline/i })
+    const refreshButton = screen.getAllByRole('button', { name: /cluster\.controlsDisabledOffline/i }).find(el => el.tagName === 'BUTTON')!
     expect(refreshButton).toBeDisabled()
   })
 


### PR DESCRIPTION
Fixes #19279

Repairs 2 failing tests in ClusterCardList.test.tsx that have stale selectors after PR #19270 changed component structure.

The `ActionTooltipWrapper` now carries `role="button"` on its outer `<span>` (added in PR #19270), causing `getByRole('button', { name: /common\.refresh/i })` to match **both** the wrapper span and the inner `<button>` — throwing *"Found multiple elements with role 'button'"*.

The fix mirrors the pattern already used in `ClusterCardFull.test.tsx`: switch from `getByRole` to `getAllByRole(...).find(el => el.tagName === 'BUTTON')!` so only the actual `<button>` element is targeted.