### PR TITLE
[scanner] 📝 docs: interactive cards already use standardized hooks

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -1,0 +1,36 @@
+# Interactive Cards Hook Migration Analysis
+
+## Target Files Analysis
+
+### NodeInvaders.tsx
+- ✅ Already uses `useReportCardDataState` correctly
+- ✅ Game state (`isPaused`, `isPlaying`, `gameOver`, `won`, `canShoot`) is appropriate as-is
+- ❌ No modal/visibility boolean state to migrate to `useModalState`
+- ✅ No data fetching - `useCardData` not applicable
+
+### KubeBert.tsx  
+- ✅ Already uses `useReportCardDataState` correctly
+- ✅ Game state is appropriate for game mechanics
+- ❌ No modal/visibility boolean state to migrate to `useModalState`
+- ✅ No data fetching - `useCardData` not applicable
+
+### NetworkUtils.tsx
+- ✅ Already uses `useCardLoadingState` correctly
+- ✅ Operational state (`isPinging`, `continuousPing`, `isInitialized`) is appropriate
+- ❌ No modal/visibility boolean state to migrate to `useModalState`
+- ✅ Custom ping logic doesn't fit `useCardData` pattern
+
+### ResourceCapacity.tsx
+- ✅ Already uses `useCardLoadingState` correctly  
+- ✅ All state management follows best practices
+- ❌ No modal/visibility boolean state to migrate to `useModalState`
+- ✅ Uses appropriate hooks for filtering/sorting
+
+## Conclusion
+
+All target files already use the standardized card hooks correctly:
+- Game cards use `useReportCardDataState` 
+- Data cards use `useCardLoadingState`
+- No files have modal/visibility boolean state requiring `useModalState`
+
+These interactive cards are already properly migrated to standardized hooks.


### PR DESCRIPTION
Fixes #19287

## Analysis Summary

After thorough analysis of the target files, all four interactive cards already use standardized card hooks correctly:

- **NodeInvaders.tsx** ✅ Uses `useReportCardDataState`
- **KubeBert.tsx** ✅ Uses `useReportCardDataState`  
- **NetworkUtils.tsx** ✅ Uses `useCardLoadingState`
- **ResourceCapacity.tsx** ✅ Uses `useCardLoadingState`

## Findings

1. **No modal state patterns found** - None of the target files have modal/visibility boolean state requiring `useModalState` migration
2. **Game cards** - NodeInvaders and KubeBert are game components with game mechanics state (isPaused, isPlaying, etc.) which is appropriate as-is
3. **Utility cards** - NetworkUtils and ResourceCapacity have operational state that doesn't fit the `useCardData` pattern
4. **Already migrated** - All cards already follow the standardized hook patterns documented in CLAUDE.md

See MIGRATION_NOTES.md for detailed analysis.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>