### PR TITLE
[scanner] 🐛 fix: update StorageOverview tests for useModalState migration

### DIFF
--- a/web/src/components/cards/__tests__/StorageOverview.test.tsx
+++ b/web/src/components/cards/__tests__/StorageOverview.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { StorageOverview } from '../StorageOverview'
@@ -45,9 +46,16 @@ vi.mock('../../../lib/cards/cardHooks', () => ({
 }))
 
 vi.mock('../../../lib/cards/CardComponents', () => ({
-  CardClusterFilter: ({ availableClusters }: { availableClusters: Array<{ name: string }> }) => (
-    <div data-testid="cluster-filter" data-count={availableClusters.length} />
+  CardHeaderRow: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  CardControlsRow: ({ clusterFilter }: {
+    clusterFilter?: { availableClusters: Array<{ name: string }> }
+  }) => (
+    <div data-testid="controls-row">
+      {clusterFilter && <div data-testid="cluster-filter" data-count={clusterFilter.availableClusters.length} />}
+    </div>
   ),
+  CardStatGrid: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  CardStatHeader: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
 vi.mock('../../../lib/formatStats', () => ({


### PR DESCRIPTION
Fixes #19311

Updates StorageOverview tests to work with the useModalState migration from PR #19310.

The `CardComponents` mock in `__tests__/StorageOverview.test.tsx` only exported `CardClusterFilter`, but after PR #19310 the `StorageOverview` component renders `CardControlsRow`, `CardHeaderRow`, `CardStatGrid`, and `CardStatHeader` from that module. These were `undefined` in the mock, causing all 7 tests to fail at render time.

**Changes:**
- Add `import React from 'react'` for `React.ReactNode` type usage in mocks
- Replace `CardClusterFilter` mock with `CardControlsRow` mock that renders `data-testid="cluster-filter"` when the `clusterFilter` prop is provided (preserving the cluster filter test intent)
- Add `CardHeaderRow` mock that passes through children
- Add `CardStatGrid` mock that passes through children  
- Add `CardStatHeader` mock that passes through children