### PR TITLE
📖 clarify demo mode false positives

### DIFF
--- a/web/src/components/cards/CardErrorFallback.tsx
+++ b/web/src/components/cards/CardErrorFallback.tsx
@@ -5,7 +5,8 @@ import { cn } from '@/lib/cn'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { shouldShowFailureBanner } from './card-wrapper/badgeVisibility'
 
-// Pure error boundary component — no data fetching; demo data not applicable
+// Pure error boundary component — no data fetching or cache subscription, so
+// demo mode does not apply here.
 const REMOVE_CARD_FAILURE_THRESHOLD = 3
 
 type RetryLabelFactory = NonNullable<ComponentProps<typeof DynamicCardErrorBoundary>['fallbackRetryLabel']>

--- a/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
+++ b/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
@@ -23,6 +23,9 @@ export interface InstallCTAFlowProps {
  * 2. ClusterSelectionDialog (when agent connected)
  * 3. ConfirmMissionPromptDialog (review/edit prompt)
  * 4. Manual install guide modal (when agent not connected)
+ *
+ * This component does not fetch card data or own demo-mode state. It is only
+ * rendered by cards that are already in a demo/live state decided upstream.
  */
 export function InstallCTAFlow({ cardType, title }: InstallCTAFlowProps) {
   const { t } = useTranslation(['cards', 'common'])

--- a/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
+++ b/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
@@ -26,6 +26,8 @@ const STATUS_LABEL_KEY: Record<CloudEventResourceState, 'cloudevents.status_read
 
 export function CloudEventsStatus() {
   const { t } = useTranslation('cards')
+  // Demo mode subscription is handled in useCloudEventsStatus via useCache, which
+  // uses useSyncExternalStore(subscribeDemoMode, ...) to re-render on toggles.
   const { data, error, showSkeleton, showEmptyState } = useCloudEventsStatus()
   const [search, setSearch] = useState('')
 


### PR DESCRIPTION
Fixes #19328

## Summary
- document that `CloudEventsStatus` already responds to demo mode through `useCloudEventsStatus()` and `useCache()`
- document that `InstallCTAFlow` is a CTA/modal flow, not a card data fetcher
- document that `CardErrorFallback` is an error boundary wrapper, not a data-fetching component
- leave the freshness-indicator findings for a follow-up, as requested

## Verification
- reviewed `useCloudEventsStatus` and confirmed it uses `useCache`
- reviewed `useCache` and confirmed it subscribes to demo mode through `useSyncExternalStore(subscribeDemoMode, isDemoMode, isDemoMode)`
- reviewed `InstallCTAFlow` and `CardErrorFallback` and confirmed neither owns card demo-mode subscription logic

## Notes
- no runtime behavior changes; this PR documents why the Auto-QA demo-mode findings were false positives
- build/lint are expected to be validated by CI on the PR