### PR TITLE
🐛 [scanner] fix: handle null images in buildpacks coverage test

### DIFF
--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
@@ -177,7 +177,7 @@ describe('buildpacks coverage part 1', () => {
   })
 
   it('null images in response: defaults to empty array', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ images: null }) })
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ images: null }) })
     const { result, unmount } = renderHook(() => useBuildpackImages(uc()))
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.images).toEqual([])

--- a/web/src/hooks/mcp/buildpacks.ts
+++ b/web/src/hooks/mcp/buildpacks.ts
@@ -257,7 +257,7 @@ export function useBuildpackImages(cluster?: string) {
     const cacheAge = now - buildpackCache.timestamp
     const cacheValid =
       !cluster &&
-      buildpackCache.data.length > 0 &&
+      buildpackCache.timestamp > 0 &&
       cacheAge < BUILDPACK_CACHE_TTL_MS
 
     if (cacheValid) {


### PR DESCRIPTION
Fixes #19334

This PR fixes the failing test in the buildpacks-coverage test suite by making two changes:

1. **Test fix**: Added missing `status: 200` property to the mock fetch response in the "null images in response" test. The hook checks `response.status === 404`, so the mock needs a status property.

2. **Hook fix**: Fixed infinite loop caused by empty array not being considered valid cached data. Changed cache validation from `buildpackCache.data.length > 0` to `buildpackCache.timestamp > 0`. An empty array is valid cached data and should not trigger repeated refetches.

**Root cause**: When the API returned `null` for images (which correctly defaulted to `[]` via `data.images || []`), the empty array was cached, but the cache validation logic considered it invalid because `length === 0`. This caused the useEffect to repeatedly call `refetch()`, creating an infinite loop manifested as "Maximum update depth exceeded" errors.

**Testing**: All 5 tests in buildpacks-coverage.test.ts now pass.