### PR TITLE
[scanner] fix: stabilize Playwright mobile/webkit navigation tests

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -103,6 +103,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
       <div className="flex items-center gap-2 md:gap-3 shrink-0">
         {/* Hamburger menu - mobile only */}
         <button
+          data-testid="mobile-menu-toggle"
           onClick={toggleMobileSidebar}
           className="p-2 min-w-[44px] min-h-[44px] flex md:hidden items-center justify-center rounded-lg transition-colors hover:bg-black/5 dark:hover:bg-white/10 cursor-pointer"
           aria-label={config.isMobileOpen ? t('navbar.closeMenu') : t('navbar.openMenu')}


### PR DESCRIPTION
Fixes #19375

## Problem

The Playwright Cross-Browser (Nightly) workflow failed on 3 jobs:
- Mobile (mobile-safari): navigation tests timing out
- Cross-Browser (webkit): keyboard navigation and responsive tests failing
- Mobile (mobile-chrome): sidebar link not visible on mobile viewport

## Root Cause

1. The hamburger menu button in `Navbar.tsx` was missing `data-testid="mobile-menu-toggle"`, causing test locators to fail on mobile viewports
2. The responsive-regression test used fragile `.or()` chains instead of the reliable testid
3. The smoke test used `nav button[aria-label*="home"]` which is unreliable on webkit

## Changes

- **`web/src/components/layout/navbar/Navbar.tsx`**: Added `data-testid="mobile-menu-toggle"` to the hamburger menu button
- **`web/e2e/responsive-regression.spec.ts`**: Updated navigation test to use `getByTestId('mobile-menu-toggle')` with `navbar-home-btn` fallback, more resilient mobile nav detection
- **`web/e2e/smoke.spec.ts`**: Improved logo navigation test to use in-app routing instead of direct URL entry (avoids webkit preview-server flakiness)

## Testing

These changes fix the specific test failures observed in workflow run #27939921246. The fixes target mobile/webkit browser compatibility without weakening the assertions.