### PR TITLE
[scanner] fix: add confirmation dialog for card removal

### DIFF
--- a/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
+++ b/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
@@ -159,6 +159,8 @@ export function UnifiedDashboard({
   const [isConfigureCardModalOpen, setIsConfigureCardModalOpen] = useState(false)
   const [cardToEdit, setCardToEdit] = useState<ConfigurableCard | null>(null)
   const [showResetConfirm, setShowResetConfirm] = useState(false)
+  const [showRemoveCardConfirm, setShowRemoveCardConfirm] = useState(false)
+  const [cardToRemove, setCardToRemove] = useState<{ id: string; title?: string } | null>(null)
 
   // Persist cards to localStorage when they change.
   //
@@ -228,9 +230,20 @@ export function UnifiedDashboard({
     mutateActiveCards(() => newCards)
   }
 
-  // Handle card removal
+  // Handle card removal - show confirmation first
   const handleRemoveCard = (cardId: string) => {
-    mutateActiveCards((prev) => prev.filter((c) => c.id !== cardId))
+    const card = activeCards.find((c) => c.id === cardId)
+    setCardToRemove({ id: cardId, title: card?.title })
+    setShowRemoveCardConfirm(true)
+  }
+
+  // Handle confirmed card removal
+  const handleRemoveCardConfirmed = () => {
+    if (cardToRemove) {
+      mutateActiveCards((prev) => prev.filter((c) => c.id !== cardToRemove.id))
+    }
+    setShowRemoveCardConfirm(false)
+    setCardToRemove(null)
   }
 
   // Handle card configuration
@@ -599,6 +612,22 @@ export function UnifiedDashboard({
         message={t('confirmDialog.resetDashboardMessage')}
         confirmLabel={t('actions.reset')}
         variant="warning"
+      />
+
+      {/* Remove Card Confirmation Dialog */}
+      <ConfirmDialog
+        isOpen={showRemoveCardConfirm}
+        onClose={() => {
+          setShowRemoveCardConfirm(false)
+          setCardToRemove(null)
+        }}
+        onConfirm={handleRemoveCardConfirmed}
+        title={t('confirmDialog.removeCardTitle')}
+        message={cardToRemove?.title 
+          ? t('confirmDialog.removeCardMessageWithTitle', { title: cardToRemove.title })
+          : t('confirmDialog.removeCardMessage')}
+        confirmLabel={t('actions.remove')}
+        variant="danger"
       />
     </div>
   )

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -5449,7 +5449,10 @@
     "logoutTitle": "Log Out?",
     "logoutMessage": "You will be logged out and all session data will be cleared.",
     "clearTokensTitle": "Clear All Tokens?",
-    "clearTokensMessage": "This will remove all stored tokens including agent and authentication tokens. You will need to log in again."
+    "clearTokensMessage": "This will remove all stored tokens including agent and authentication tokens. You will need to log in again.",
+    "removeCardTitle": "Remove Card?",
+    "removeCardMessageWithTitle": "Are you sure you want to remove \"{{title}}\" from your dashboard? You can add it back later from the card catalog.",
+    "removeCardMessage": "Are you sure you want to remove this card from your dashboard? You can add it back later from the card catalog."
   },
   "saveResolution": "Save Resolution",
   "shareToOrg": "Share to Org",


### PR DESCRIPTION
Fixes #19382

## Changes

Adds a confirmation dialog before card removal in the UnifiedDashboard component. Previously, clicking "Remove" on a card would instantly remove it with no undo option.

### UnifiedDashboard.tsx
- Added `showRemoveCardConfirm` and `cardToRemove` state
- Split `handleRemoveCard` into a two-step flow: request → confirm
- Added `ConfirmDialog` with danger variant (red styling)
- Shows card title in the confirmation message when available

### Note
The `StackContext.tsx:231` finding from the issue is a false positive — it's localStorage cleanup when the user changes selection, not a user-facing destructive action.

**TODO:** Translation keys (`confirmDialog.removeCardTitle`, `removeCardMessage`, `removeCardMessageWithTitle`) need to be added to `web/src/locales/en/common.json`. The `t()` calls will fall back to the key path until then.