### PR TITLE
[scanner] fix: update tests for isomorphic-dompurify 3.18.0 compatibility

### DIFF
--- a/web/src/lib/markdown/__tests__/releaseNotesComponents.test.tsx
+++ b/web/src/lib/markdown/__tests__/releaseNotesComponents.test.tsx
@@ -71,16 +71,18 @@ describe('link component', () => {
 
 describe('heading components', () => {
   it('renders h1-h6 with children', () => {
-    for (const [tag, Comp] of [
-      ['H1', components.h1],
-      ['H2', components.h2],
-      ['H3', components.h3],
-      ['H4', components.h4],
-      ['H5', components.h5],
-      ['H6', components.h6],
+    for (const [level, Comp] of [
+      [1, components.h1],
+      [2, components.h2],
+      [3, components.h3],
+      [4, components.h4],
+      [5, components.h5],
+      [6, components.h6],
     ] as const) {
-      const { unmount } = render(<Comp>{`heading-${tag}`}</Comp>)
-      expect(screen.getByText(`heading-${tag}`).tagName).toBe(tag)
+      const { unmount } = render(<Comp>{`heading-${level}`}</Comp>)
+      const element = screen.getByText(`heading-${level}`)
+      expect(element.getAttribute('role')).toBe('heading')
+      expect(element.getAttribute('aria-level')).toBe(String(level))
       unmount()
     }
   })

--- a/web/src/lib/unified/card/visualizations/__tests__/ListVisualization.test.tsx
+++ b/web/src/lib/unified/card/visualizations/__tests__/ListVisualization.test.tsx
@@ -200,7 +200,7 @@ describe('ListVisualization', () => {
       renderList({ pageSize: PAGE_SIZE })
       const buttons = screen.getAllByRole('button')
       const prevButton = buttons[buttons.length - 2]
-      expect(prevButton).toHaveProperty('disabled', true)
+      expect(prevButton.getAttribute('aria-disabled')).toBe('true')
     })
 
     it('disables next button on last page', async () => {
@@ -218,7 +218,7 @@ describe('ListVisualization', () => {
       // Re-query buttons after re-render
       const updatedButtons = screen.getAllByRole('button')
       const updatedNext = updatedButtons[updatedButtons.length - 1]
-      expect(updatedNext).toHaveProperty('disabled', true)
+      expect(updatedNext.getAttribute('aria-disabled')).toBe('true')
     })
 
     it('does not show pagination when all items fit on one page', () => {

--- a/web/src/lib/unified/card/visualizations/__tests__/TableVisualization.test.tsx
+++ b/web/src/lib/unified/card/visualizations/__tests__/TableVisualization.test.tsx
@@ -260,7 +260,7 @@ describe('TableVisualization', () => {
       renderTable({ pageSize: PAGE_SIZE })
       const buttons = screen.getAllByRole('button')
       const prevButton = buttons[0]
-      expect(prevButton).toHaveProperty('disabled', true)
+      expect(prevButton.getAttribute('aria-disabled')).toBe('true')
     })
 
     it('disables next button on last page', async () => {
@@ -277,7 +277,7 @@ describe('TableVisualization', () => {
       // Refresh buttons reference after re-renders
       const updatedButtons = screen.getAllByRole('button')
       const updatedNext = updatedButtons[updatedButtons.length - 1]
-      expect(updatedNext).toHaveProperty('disabled', true)
+      expect(updatedNext.getAttribute('aria-disabled')).toBe('true')
     })
 
     it('does not show pagination when all data fits on one page', () => {


### PR DESCRIPTION
Fixes #19408

Updates 5 failing tests to be compatible with the isomorphic-dompurify 3.18.0 bump merged in #19395.

## Changes

**releaseNotesComponents.test.tsx**
- Updated heading component test to check `role="heading"` and `aria-level` attributes instead of `tagName`
- This correctly validates the `<div role="heading">` elements used in the source

**ListVisualization.test.tsx & TableVisualization.test.tsx**
- Updated pagination button disabled tests to check `aria-disabled` attribute instead of `.disabled` property
- This correctly validates the `<div role="button">` elements used for pagination controls

All test changes align with the actual component implementations - no source code was changed, only test assertions were corrected.