### PR TITLE
[scanner] fix: add missing ARIA labels and dialog roles

### DIFF
--- a/web/src/components/agent/AgentInstallGuide.tsx
+++ b/web/src/components/agent/AgentInstallGuide.tsx
@@ -114,6 +114,9 @@ export function AgentInstallGuide({
   return createPortal(
     <div
       className="fixed inset-0 z-modal flex items-center justify-center bg-black/60 backdrop-blur-xs"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="install-guide-title"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}

--- a/web/src/components/clusters/components/ClusterGrid.common.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.common.tsx
@@ -53,6 +53,7 @@ export function ActionTooltipWrapper({
       onClick={(event) => event.stopPropagation()}
       onMouseDown={(event) => event.stopPropagation()}
       onKeyDown={handleKeyDown}
+      aria-label={tooltip}
     >
       <Tooltip content={tooltip}>{children}</Tooltip>
     </span>

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -632,6 +632,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                                   onClick={e => { e.stopPropagation(); void copyScreenshotToClipboard(s.preview, i) }}
                                   className="p-1.5 rounded-md bg-secondary/80 text-foreground hover:bg-secondary transition-colors"
                                   title="Copy to clipboard"
+                                  aria-label="Copy screenshot to clipboard"
                                 >
                                   {copiedIndex === i ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
                                 </button>
@@ -641,6 +642,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                                 onClick={e => { e.stopPropagation(); removeScreenshot(i) }}
                                 className="p-1.5 rounded-md bg-secondary/80 text-red-400 hover:bg-red-500/20 transition-colors"
                                 title="Remove attachment"
+                                aria-label="Remove screenshot"
                               >
                                 <Trash2 className="w-3.5 h-3.5" />
                               </button>


### PR DESCRIPTION
Fixes #19411

- Adds aria-label to ActionTooltipWrapper button element in ClusterGrid.common.tsx
- Adds role="dialog" and aria-modal="true" to AgentInstallGuide modal container
- Adds aria-label to screenshot copy and remove buttons in FeedbackModal

Improves screen reader accessibility per Auto-QA A11y audit.