### PR TITLE
[scanner] fix: add repository topics for discoverability (#19404)

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,14 @@
+# These settings are synced to GitHub by https://probot.github.io/apps/settings/
+# Repository topics for discoverability
+repository:
+  topics:
+    - kubernetes
+    - kubestellar
+    - console
+    - dashboard
+    - multicluster
+    - edge-computing
+    - cloud-native
+    - cncf
+    - react
+    - nextjs


### PR DESCRIPTION
## Summary

Fixes #19404 — GitHub repository topics absent, zero discoverability.

## Changes

Adds `.github/settings.yml` with repository topics. When the [Probot Settings app](https://probot.github.io/apps/settings/) is installed, these topics are automatically synced to the repository, making it discoverable via searches for:

- `kubernetes`, `kubestellar`, `console`, `dashboard`
- `multicluster`, `edge-computing`, `cloud-native`, `cncf`
- `react`, `nextjs`

## Why a settings.yml?

Direct API access to set topics is not available in this environment. The `.github/settings.yml` approach is the standard declarative, code-reviewed, and auditable way to manage repository metadata — ensuring topics stay consistent and are tracked in version control.

> **Note for maintainers:** If the Probot Settings app is not yet installed, topics can also be set manually via the repository Settings page → Topics, using the list above.