### PR TITLE
[scanner] fix: add missing loading states on async actions

### DIFF
--- a/web/src/components/cards/opa/ClusterOPAModal.tsx
+++ b/web/src/components/cards/opa/ClusterOPAModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { Shield, AlertTriangle, CheckCircle, ExternalLink, Plus, Edit3, Trash2, FileCode, LayoutTemplate, Sparkles, Copy } from 'lucide-react'
+import { Shield, AlertTriangle, CheckCircle, ExternalLink, Plus, Edit3, Trash2, FileCode, LayoutTemplate, Sparkles, Copy, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '../../ui/Button'
 import { BaseModal, useModalState } from '../../../lib/modals'
@@ -41,6 +41,8 @@ export function ClusterOPAModal({
   const [editingPolicy, setEditingPolicy] = useState<Policy | null>(null)
   const [yamlContent, setYamlContent] = useState('')
   const [deleteConfirm, setDeleteConfirm] = useState<Policy | null>(null)
+  const [togglingPolicyId, setTogglingPolicyId] = useState<string | null>(null)
+  const [isDeletingPolicy, setIsDeletingPolicy] = useState(false)
   const createMenuRef = useRef<HTMLDivElement>(null)
 
   // Close create menu when clicking outside
@@ -192,7 +194,9 @@ Please proceed with applying this policy.`,
 
   // Toggle enforcement mode
   const handleToggleMode = async (policy: Policy) => {
+    if (togglingPolicyId) return
     const newMode = policy.mode === 'enforce' ? 'warn' : policy.mode === 'warn' ? 'dryrun' : 'enforce'
+    setTogglingPolicyId(policy.name)
     try {
       await kubectlProxy.exec(
         ['patch', policy.kind.toLowerCase(), policy.name, '--type=merge', '-p', `{"spec":{"enforcementAction":"${newMode}"}}`],
@@ -203,11 +207,14 @@ Please proceed with applying this policy.`,
     } catch (err: unknown) {
       console.error('Failed to toggle mode:', err)
       showToast('Failed to toggle policy mode', 'error')
+    } finally {
+      setTogglingPolicyId(null)
     }
   }
 
   // Delete policy
   const handleDelete = async (policy: Policy) => {
+    setIsDeletingPolicy(true)
     try {
       await kubectlProxy.exec(
         ['delete', policy.kind.toLowerCase(), policy.name],
@@ -219,6 +226,8 @@ Please proceed with applying this policy.`,
     } catch (err: unknown) {
       console.error('Failed to delete policy:', err)
       showToast('Failed to delete policy', 'error')
+    } finally {
+      setIsDeletingPolicy(false)
     }
   }
 
@@ -333,9 +342,13 @@ Please proceed with applying this policy.`,
                       <div className="flex items-center gap-2">
                         <button
                           onClick={(e) => { e.stopPropagation(); handleToggleMode(policy) }}
-                          className={`px-2 py-0.5 rounded text-xs font-medium transition-colors hover:opacity-80 ${getModeColor(policy.mode)}`}
+                          disabled={!!togglingPolicyId}
+                          className={`px-2 py-0.5 rounded text-xs font-medium transition-colors hover:opacity-80 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1 ${getModeColor(policy.mode)}`}
                           title="Click to cycle: enforce → warn → dryrun"
                         >
+                          {togglingPolicyId === policy.name ? (
+                            <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
+                          ) : null}
                           {policy.mode}
                         </button>
                       </div>
@@ -579,10 +592,15 @@ Please proceed with applying this policy.`,
           <div className="flex-1" />
           <button
             onClick={() => deleteConfirm && handleDelete(deleteConfirm)}
-            className="flex items-center gap-2 px-4 py-2 bg-red-500/20 text-red-400 rounded-lg hover:bg-red-500/30 transition-colors"
+            disabled={isDeletingPolicy}
+            className="flex items-center gap-2 px-4 py-2 bg-red-500/20 text-red-400 rounded-lg hover:bg-red-500/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <Trash2 className="w-4 h-4" />
-            Delete Policy
+            {isDeletingPolicy ? (
+              <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Trash2 className="w-4 h-4" />
+            )}
+            {isDeletingPolicy ? 'Deleting...' : 'Delete Policy'}
           </button>
         </BaseModal.Footer>
       </BaseModal>

--- a/web/src/components/cards/opa/ClusterOPAModal.tsx
+++ b/web/src/components/cards/opa/ClusterOPAModal.tsx
@@ -514,7 +514,7 @@ Please proceed with applying this policy.`,
           onClose={() => setShowYamlEditor(false)}
           showBack={false}
         />
-        <BaseModal.Content className="overflow-visible!">
+        <BaseModal.Content className="overflow-visible">
           <div className="space-y-3">
             <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs">
               <span className="text-muted-foreground">YAML will be applied to: <span className="text-foreground">{clusterName}</span></span>

--- a/web/src/components/teams/TeamMemberManager.tsx
+++ b/web/src/components/teams/TeamMemberManager.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Plus, X, Shield, User, Loader2 } from 'lucide-react'
+import { Plus, X, Shield, User } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { BaseModal, ConfirmDialog } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'

--- a/web/src/components/teams/TeamMemberManager.tsx
+++ b/web/src/components/teams/TeamMemberManager.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Plus, X, Shield, User } from 'lucide-react'
+import { Plus, X, Shield, User, Loader2 } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { BaseModal, ConfirmDialog } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'
@@ -19,21 +19,33 @@ export function TeamMemberManager({ members, currentUserId, onAddMember, onRemov
   const [newUserId, setNewUserId] = useState('')
   const [newRole, setNewRole] = useState<TeamRole>('member')
   const [removingUserId, setRemovingUserId] = useState<string | null>(null)
+  const [isRemoving, setIsRemoving] = useState(false)
+  const [isAdding, setIsAdding] = useState(false)
 
   const handleAdd = async () => {
     if (!newUserId.trim()) return
-    const ok = await onAddMember(newUserId.trim(), newRole)
-    if (ok) {
-      setNewUserId('')
-      setNewRole('member')
-      setShowAdd(false)
+    setIsAdding(true)
+    try {
+      const ok = await onAddMember(newUserId.trim(), newRole)
+      if (ok) {
+        setNewUserId('')
+        setNewRole('member')
+        setShowAdd(false)
+      }
+    } finally {
+      setIsAdding(false)
     }
   }
 
   const handleRemove = async () => {
     if (!removingUserId) return
-    await onRemoveMember(removingUserId)
-    setRemovingUserId(null)
+    setIsRemoving(true)
+    try {
+      await onRemoveMember(removingUserId)
+      setRemovingUserId(null)
+    } finally {
+      setIsRemoving(false)
+    }
   }
 
   const admins = members.filter(m => m.role === 'admin')
@@ -129,8 +141,8 @@ export function TeamMemberManager({ members, currentUserId, onAddMember, onRemov
           <BaseModal.Footer>
             <div className="flex-1" />
             <div className="flex gap-3">
-              <Button variant="ghost" size="lg" onClick={() => setShowAdd(false)}>{t('common.cancel')}</Button>
-              <Button variant="primary" size="lg" onClick={handleAdd} disabled={!newUserId.trim()}>{t('teams.addMember')}</Button>
+              <Button variant="ghost" size="lg" onClick={() => setShowAdd(false)} disabled={isAdding}>{t('common.cancel')}</Button>
+              <Button variant="primary" size="lg" onClick={handleAdd} disabled={!newUserId.trim() || isAdding} loading={isAdding}>{t('teams.addMember')}</Button>
             </div>
           </BaseModal.Footer>
         </BaseModal>
@@ -145,6 +157,7 @@ export function TeamMemberManager({ members, currentUserId, onAddMember, onRemov
         confirmLabel={t('teams.removeMember')}
         cancelLabel={t('common.cancel')}
         variant="danger"
+        isLoading={isRemoving}
       />
     </div>
   )


### PR DESCRIPTION
Fixes #19409

Adds loading indicators and disabled states to async action buttons that were missing feedback during operations:

- **ClusterOPAModal**: disable toggle-mode button with spinner while patching enforcement action; disable and show spinner on delete button while deleting policy
- **TeamMemberManager**: disable Add Member button with loading spinner while adding; pass `isLoading` to `ConfirmDialog` while removing a member