### PR TITLE
[scanner] fix: update tests for js-yaml 5.0.0 compatibility

### DIFF
--- a/web/src/components/clusters/components/LocalClusterControls.test.tsx
+++ b/web/src/components/clusters/components/LocalClusterControls.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import { LocalClusterControls } from './LocalClusterControls'
 
 vi.mock('react-i18next', () => ({
@@ -29,6 +29,10 @@ describe('LocalClusterControls', () => {
       { name: 'minikube', tool: 'minikube', status: 'stopped' },
     ]
     mockClusterLifecycle.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    cleanup()
   })
 
   it('renders null for unsupported providers', () => {

--- a/web/src/lib/__tests__/yamlMask.test.ts
+++ b/web/src/lib/__tests__/yamlMask.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { maskKubernetesYamlData, YAML_MASK_PLACEHOLDER } from '../yamlMask'
+import * as yaml from 'js-yaml'
 
 /**
  * Pin behavior of the resource-agnostic Kubernetes YAML masker.
@@ -81,7 +82,6 @@ describe('maskKubernetesYamlData', () => {
     // The output must still be parseable as valid YAML — re-parse it
     // to prove no stray indented lines were emitted.
     expect(() => {
-      const yaml = require('js-yaml')
       yaml.load(masked)
     }).not.toThrow()
     // Key name preserved


### PR DESCRIPTION
Fixes #19418

Updates test files to be compatible with js-yaml v5.0.0:
- yamlMask.test.ts: Replace require() with namespace import for js-yaml  
- LocalClusterControls.test.tsx: Add proper cleanup in afterEach

The test failures were caused by the js-yaml upgrade from 4.2.0 to 5.0.0 (PR #19394), which removed the default export and callback form of loadAll().