### PR TITLE
[scanner] fix: add fork guard to ai-fix.yml

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   ai-fix:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}


### PR DESCRIPTION
Fixes #19428

Adds fork guard condition to ai-fix.yml to prevent fork PRs from gaining write permissions.

The workflow now includes the security condition:
```yaml
if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
```

This ensures that only PRs from the repository itself (not forks) can trigger the workflow with write permissions to contents, issues, and pull-requests.