### PR TITLE
[scanner] fix: resolve 8 test failures in LocalClusterControls and buildpacks-coverage

### DIFF
--- a/web/src/components/clusters/components/LocalClusterControls.test.tsx
+++ b/web/src/components/clusters/components/LocalClusterControls.test.tsx
@@ -24,10 +24,11 @@ vi.mock('../../../hooks/useLocalClusterTools', () => ({
 describe('LocalClusterControls', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockLocalClusters = [
+    mockLocalClusters.length = 0
+    mockLocalClusters.push(
       { name: 'kubeflex', tool: 'kind', status: 'running' as const },
       { name: 'minikube', tool: 'minikube', status: 'stopped' as const },
-    ]
+    )
     mockClusterLifecycle.mockResolvedValue(undefined)
   })
 
@@ -75,7 +76,7 @@ describe('LocalClusterControls', () => {
   })
 
   it('maps k3s provider to k3d when no local cluster match exists', async () => {
-    mockLocalClusters = []
+    mockLocalClusters.length = 0
 
     render(
       <LocalClusterControls clusterName="k3s-cluster" provider="k3s" unreachable={false} />,
@@ -89,7 +90,8 @@ describe('LocalClusterControls', () => {
   })
 
   it('disables controls when cluster is unreachable and not locally detected', () => {
-    mockLocalClusters = [{ name: 'other', tool: 'kind', status: 'running' as const }]
+    mockLocalClusters.length = 0
+    mockLocalClusters.push({ name: 'other', tool: 'kind', status: 'running' as const })
 
     render(
       <LocalClusterControls clusterName="kind-missing" provider="kind" unreachable={true} />,

--- a/web/src/hooks/mcp/buildpacks.ts
+++ b/web/src/hooks/mcp/buildpacks.ts
@@ -206,6 +206,8 @@ export function useBuildpackImages(cluster?: string) {
           setConsecutiveFailures(0)
           setLastRefresh(Date.now())
           setIsDemoData(false)
+          setIsLoading(false)
+          setIsRefreshing(false)
           return
         }
         if (!response.ok) {

--- a/web/src/lib/unified/dashboard/DashboardGrid.tsx
+++ b/web/src/lib/unified/dashboard/DashboardGrid.tsx
@@ -259,7 +259,10 @@ function DashboardCardWrapper({
   }, [onConfigureCard, placement.id])
 
   // Fallback: component-only cards (no config file) render directly via CardWrapper
-  const DirectComponent = !cardConfig && cardTypeKey ? getCardComponent(cardTypeKey) : undefined
+  const DirectComponent = useMemo(
+    () => (!cardConfig && cardTypeKey ? getCardComponent(cardTypeKey) : undefined),
+    [cardConfig, cardTypeKey]
+  )
 
   if (!cardConfig && !DirectComponent) {
     return (

--- a/web/src/lib/unified/dashboard/DashboardGrid.tsx
+++ b/web/src/lib/unified/dashboard/DashboardGrid.tsx
@@ -259,10 +259,7 @@ function DashboardCardWrapper({
   }, [onConfigureCard, placement.id])
 
   // Fallback: component-only cards (no config file) render directly via CardWrapper
-  const DirectComponent = useMemo(
-    () => (!cardConfig && cardTypeKey ? getCardComponent(cardTypeKey) : undefined),
-    [cardConfig, cardTypeKey]
-  )
+  const DirectComponent = !cardConfig && cardTypeKey ? getCardComponent(cardTypeKey) : undefined
 
   if (!cardConfig && !DirectComponent) {
     return (


### PR DESCRIPTION
Fixes #19438

Resolves 8 test failures from Coverage Suite run #3861:

**LocalClusterControls.test.tsx (7 failures)**
- Root cause: `vi.mock()` factory captures the `mockLocalClusters` array reference at module evaluation time. When tests reassign with `=`, they create new arrays the mock doesn't see.
- Fix: Use array mutation (`.length = 0` + `.push()`) instead of reassignment to preserve the original reference.

**buildpacks.ts (1 failure — 404 handler)**
- Added explicit `setIsLoading(false)` and `setIsRefreshing(false)` in the 404 handler before the early `return` for defensive state cleanup.