### PR TITLE
[scanner] fix: standardize color usage across components

### DIFF
--- a/web/src/components/cards/drasi/DrasiNodeCard.tsx
+++ b/web/src/components/cards/drasi/DrasiNodeCard.tsx
@@ -113,7 +113,7 @@ export function NodeControls({
 export function StatusDot({ status, isStopped }: { status: 'ready' | 'error' | 'pending'; isStopped: boolean }) {
   const color = isStopped
     ? 'bg-slate-500'
-    : status === 'ready' ? 'bg-green-400' : status === 'error' ? 'bg-red-400' : 'bg-yellow-400'
+    : status === 'ready' ? 'bg-green-500' : status === 'error' ? 'bg-red-500' : 'bg-yellow-500'
   return (
     <motion.div
       className={`w-2 h-2 rounded-full ${color}`}

--- a/web/src/components/mission-control/fixer-definition-panel/TargetClusterSelector.tsx
+++ b/web/src/components/mission-control/fixer-definition-panel/TargetClusterSelector.tsx
@@ -133,7 +133,7 @@ export function TargetClusterSelector({ selected, onChange }: TargetClusterSelec
                   )}
                   onClick={() => toggleCluster(name)}
                 >
-                  <span className={cn('w-1.5 h-1.5 rounded-full', isHealthy ? 'bg-green-400' : 'bg-yellow-400')} />
+                  <span className={cn('w-1.5 h-1.5 rounded-full', isHealthy ? 'bg-green-500' : 'bg-yellow-500')} />
                   {name}
                   <XIcon className="w-3 h-3 opacity-50 hover:opacity-100" />
                 </button>
@@ -208,7 +208,7 @@ export function TargetClusterSelector({ selected, onChange }: TargetClusterSelec
                 )}
                 onClick={() => toggleCluster(name)}
               >
-                <span className={cn('w-2 h-2 rounded-full shrink-0', isHealthy ? 'bg-green-400' : 'bg-yellow-400')} />
+                <span className={cn('w-2 h-2 rounded-full shrink-0', isHealthy ? 'bg-green-500' : 'bg-yellow-500')} />
                 <span className="truncate">{name}</span>
                 {isSelected && <span className="ml-auto text-primary text-xs">✓</span>}
               </button>


### PR DESCRIPTION
Fixes #19441

Standardizes status indicator colors across components for design system consistency:

- ✅ Success/healthy states now consistently use `bg-green-500`
- ❌ Error/failure states now consistently use `bg-red-500`
- ⚠️ Warning states now consistently use `bg-yellow-500`

**Changed files:**
- `web/src/components/mission-control/fixer-definition-panel/TargetClusterSelector.tsx`
- `web/src/components/cards/drasi/DrasiNodeCard.tsx`

This aligns all affected components with the design system's dominant color conventions identified through codebase analysis.