### PR TITLE
🐛 fix: replace js-yaml namespace imports with named imports for tree-shaking

### DIFF
--- a/web/src/components/cards/drasi/DrasiModals.tsx
+++ b/web/src/components/cards/drasi/DrasiModals.tsx
@@ -13,7 +13,7 @@ import React, { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import { X, Download, Settings, Trash2, Plus, Check } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import * as yaml from 'js-yaml'
+import { dump } from 'js-yaml'
 import { StreamLanguage } from '@codemirror/language'
 import { cypher } from '@codemirror/legacy-modes/mode/cypher'
 import { oneDark } from '@codemirror/theme-one-dark'
@@ -200,7 +200,7 @@ export function SourceConfigModal({
   const handleDownloadYaml = () => {
     if (!source) return
     const doc = { apiVersion: 'v1', kind: 'Source', name: source.name, spec: { kind: source.kind } }
-    downloadText(`${source.name}.yaml`, yaml.dump(doc), 'text/yaml')
+    downloadText(`${source.name}.yaml`, dump(doc), 'text/yaml')
   }
 
   return (
@@ -302,7 +302,7 @@ export function QueryConfigModal({
         sources: query.sourceIds.map(id => ({ id })),
       },
     }
-    downloadText(`${query.name}.yaml`, yaml.dump(doc), 'text/yaml')
+    downloadText(`${query.name}.yaml`, dump(doc), 'text/yaml')
   }
 
   return (

--- a/web/src/components/missions/ShareMissionDialog.tsx
+++ b/web/src/components/missions/ShareMissionDialog.tsx
@@ -15,7 +15,7 @@ import {
   AlertTriangle,
   Shield,
   Loader2 } from 'lucide-react'
-import * as yaml from 'js-yaml'
+import { dump } from 'js-yaml'
 import type { Resolution } from '../../hooks/useResolutions'
 import type { MissionExport, FileScanResult } from '../../lib/missions/types'
 import { fullScan } from '../../lib/missions/scanner/index'
@@ -63,7 +63,7 @@ function resolutionToMissionExport(resolution: Resolution): MissionExport {
 const YAML_INDENT = 2
 
 function missionToYaml(mission: MissionExport): string {
-  return yaml.dump(mission, {
+  return dump(mission, {
     indent: YAML_INDENT,
     lineWidth: -1,
     noRefs: true,

--- a/web/src/lib/missions/fileParser.ts
+++ b/web/src/lib/missions/fileParser.ts
@@ -7,7 +7,7 @@
  * or returns an unstructured preview for AI-assisted conversion.
  */
 
-import * as yaml from 'js-yaml'
+import { dump, load, loadAll } from 'js-yaml'
 import type { MissionExport, MissionStep } from './types'
 import { validateMissionExport } from './types'
 import {
@@ -314,7 +314,7 @@ function wrapCRsAsMission(crDocuments: Record<string, unknown>[]): ParseResult {
       description: project
         ? `Apply ${kind} resource for ${project.displayName}`
         : `Apply ${kind} resource (${doc.apiVersion})`,
-      yaml: yaml.dump(doc, { indent: 2, lineWidth: -1 }),
+      yaml: dump(doc, { indent: 2, lineWidth: -1 }),
       command: `kubectl apply -f ${name ? name + '.yaml' : '<filename>.yaml'}`,
     }
   })
@@ -365,7 +365,7 @@ function extractFrontmatter(content: string): FrontmatterResult {
   const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/)
   if (!match) return { frontmatter: null, body: content }
   try {
-    const parsed = yaml.load(match[1]) as Record<string, unknown>
+    const parsed = load(match[1]) as Record<string, unknown>
     return { frontmatter: parsed, body: match[2] }
   } catch {
     return { frontmatter: null, body: content }
@@ -452,12 +452,12 @@ function stripCodeBlocks(text: string): string {
 /** Safely load all YAML documents from a multi-document string */
 function loadAllYamlDocuments(content: string): unknown[] {
   try {
-    const docs = yaml.loadAll(content)
+    const docs = loadAll(content)
     return (docs || []).filter((doc: unknown) => doc !== null && doc !== undefined)
   } catch {
     // If loadAll fails, try single document
     try {
-      const single = yaml.load(content)
+      const single = load(content)
       if (single !== null && single !== undefined) {
         return [single]
       }

--- a/web/src/lib/yamlMask.ts
+++ b/web/src/lib/yamlMask.ts
@@ -37,7 +37,7 @@
  * by tests in `__tests__/yamlMask.test.ts`.
  */
 
-import * as yaml from 'js-yaml'
+import { dump, loadAll } from 'js-yaml'
 
 /** Sentinel string used in place of secret values when masking. Same
  * width as the per-key reveal placeholder on the Data tabs so masked
@@ -97,7 +97,7 @@ export function maskKubernetesYamlData(yamlInput: string): string {
     // loadAll handles multi-document YAML transparently — single docs
     // come back as a 1-element array. Use the safe loader (default in
     // js-yaml v4+) to avoid arbitrary code execution from custom tags.
-    docs = yaml.loadAll(yamlInput)
+    docs = loadAll(yamlInput)
   } catch {
     // Parse failure on a security helper must never silently expose
     // secrets — return the hard-mask sentinel so the user sees an
@@ -112,7 +112,7 @@ export function maskKubernetesYamlData(yamlInput: string): string {
     // dumpAll for multi-doc, single dump for single-doc, so we don't
     // emit a stray `---` for single-resource YAML.
     if (maskedDocs.length === 1) {
-      return yaml.dump(maskedDocs[0], {
+      return dump(maskedDocs[0], {
         // noRefs avoids emitting `&anchor` references for repeated
         // values; the placeholder is repeated by design and we don't
         // want kubectl-style YAML cluttered with `&id001`.
@@ -124,7 +124,7 @@ export function maskKubernetesYamlData(yamlInput: string): string {
     }
     return maskedDocs
       .map(d =>
-        yaml.dump(d, { noRefs: true, lineWidth: -1 }),
+        dump(d, { noRefs: true, lineWidth: -1 }),
       )
       .join('---\n')
   } catch {


### PR DESCRIPTION
Fixes #19440

Replaces `import * as yaml from 'js-yaml'` with tree-shakeable named imports in:
- web/src/lib/missions/fileParser.ts
- web/src/lib/yamlMask.ts
- web/src/components/missions/ShareMissionDialog.tsx
- web/src/components/cards/drasi/DrasiModals.tsx

Using named imports (`import { dump, load, loadAll }`) enables better tree-shaking for bundle optimization.