### PR TITLE
[scanner] fix: add top-level permissions to pre-merge-gate and copilot-dco workflows

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  pull-requests: read
+
 jobs:
   copilot-dco:
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/pre-merge-gate.yml
+++ b/.github/workflows/pre-merge-gate.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: pre-merge-${{ github.head_ref || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Fixes #19446

## Summary

Adds explicit top-level `permissions` blocks to two workflow files that were inheriting default (potentially over-broad) token permissions:

- `.github/workflows/pre-merge-gate.yml` → `contents: read`
- `.github/workflows/copilot-dco.yml` → `pull-requests: read`

This satisfies the OpenSSF Scorecard TokenPermissions check and follows the principle of least privilege.