### PR TITLE
[scanner] fix: resolve eslint error blocking CI

### DIFF
--- a/web/src/components/clusters/components/LocalClusterControls.test.tsx
+++ b/web/src/components/clusters/components/LocalClusterControls.test.tsx
@@ -7,7 +7,7 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }))
 
-let mockLocalClusters = [
+const mockLocalClusters = [
   { name: 'kubeflex', tool: 'kind', status: 'running' as const },
   { name: 'minikube', tool: 'minikube', status: 'stopped' as const },
 ]


### PR DESCRIPTION
Fixes the single eslint error that causes build-gate to fail on all open PRs.

**Error fixed:**
```
/web/src/components/clusters/components/LocalClusterControls.test.tsx
  10:5  error  'mockLocalClusters' is never reassigned. Use 'const' instead  prefer-const
```

**Change:**
Changed `mockLocalClusters` from `let` to `const` on line 10. The variable is never reassigned (only mutated via `.length = 0` and `.push()`, which is allowed with `const`).

Once merged, PRs #19449, #19448, and all other open PRs should pass build-gate.