### PR TITLE
🐛 fix: extract inline rgba colors in canvas card components

### DIFF
--- a/web/src/components/cards/KubeBert.tsx
+++ b/web/src/components/cards/KubeBert.tsx
@@ -22,6 +22,19 @@ const LEVEL_TRANSITION_DELAY_MS = 1000
 /** Minimum enemy spawn interval in milliseconds — prevents the game from becoming unplayable at high levels */
 const MIN_ENEMY_SPAWN_INTERVAL_MS = 1000
 
+// ─── Canvas Colors (extracted from inline rgba/rgb strings) ─────────────────
+const KUBEBERT_TILE_STROKE = 'rgba(255,255,255,0.15)'
+const KUBEBERT_FACE_SHADOW = 'rgba(0,0,0,0.2)'
+const KUBEBERT_CHARACTER_OUTLINE = 'rgba(0,0,0,0.3)'
+const KUBEBERT_LABEL_TEXT = 'rgba(255,255,255,0.6)'
+const KUBEBERT_LEVEL_COMPLETE_FLASH = 'rgba(0, 212, 170, 0.15)'
+const KUBEBERT_LEVEL_COMPLETE_TEXT = '#00d4aa'
+const KUBEBERT_CHARACTER_EYES = '#000'
+const KUBEBERT_CHARACTER_NOSE = '#ff8800'
+const KUBEBERT_CHARACTER_CROWN_BG = '#326ce5'
+const KUBEBERT_CHARACTER_CROWN_OUTLINE = '#fff'
+const KUBEBERT_GAMEOVER_TEXT = '#fff'
+
 
 // Tile colors by state
 const TILE_COLORS = {
@@ -81,7 +94,7 @@ function drawTile(
   ctx.closePath()
   ctx.fillStyle = topColor
   ctx.fill()
-  ctx.strokeStyle = 'rgba(255,255,255,0.15)'
+  ctx.strokeStyle = KUBEBERT_TILE_STROKE
   ctx.lineWidth = 1
   ctx.stroke()
 
@@ -94,7 +107,7 @@ function drawTile(
   ctx.closePath()
   ctx.fillStyle = leftColor
   ctx.fill()
-  ctx.strokeStyle = 'rgba(0,0,0,0.2)'
+  ctx.strokeStyle = KUBEBERT_FACE_SHADOW
   ctx.stroke()
 
   // Right face
@@ -106,12 +119,12 @@ function drawTile(
   ctx.closePath()
   ctx.fillStyle = rightColor
   ctx.fill()
-  ctx.strokeStyle = 'rgba(0,0,0,0.2)'
+  ctx.strokeStyle = KUBEBERT_FACE_SHADOW
   ctx.stroke()
 
   // Label on top face
   if (label) {
-    ctx.fillStyle = 'rgba(255,255,255,0.6)'
+    ctx.fillStyle = KUBEBERT_LABEL_TEXT
     ctx.font = `${Math.max(8, tileW / 5)}px monospace`
     ctx.textAlign = 'center'
     ctx.textBaseline = 'middle'
@@ -137,13 +150,13 @@ function drawCharacter(
     ctx.arc(x, charY, size * 0.7, 0, Math.PI * 2)
     ctx.fillStyle = color
     ctx.fill()
-    ctx.strokeStyle = 'rgba(0,0,0,0.3)'
+    ctx.strokeStyle = KUBEBERT_CHARACTER_OUTLINE
     ctx.lineWidth = 1
     ctx.stroke()
 
     // Eyes
     const eyeSize = size * 0.15
-    ctx.fillStyle = '#000'
+    ctx.fillStyle = KUBEBERT_CHARACTER_EYES
     ctx.beginPath()
     ctx.arc(x - size * 0.25, charY - size * 0.15, eyeSize, 0, Math.PI * 2)
     ctx.fill()
@@ -156,15 +169,15 @@ function drawCharacter(
     ctx.moveTo(x, charY + size * 0.05)
     ctx.lineTo(x + size * 0.4, charY + size * 0.2)
     ctx.lineTo(x, charY + size * 0.35)
-    ctx.fillStyle = '#ff8800'
+    ctx.fillStyle = KUBEBERT_CHARACTER_NOSE
     ctx.fill()
 
     // Kubernetes wheel on top (little crown)
     ctx.beginPath()
     ctx.arc(x, charY - size * 0.7, size * 0.2, 0, Math.PI * 2)
-    ctx.fillStyle = '#326ce5'
+    ctx.fillStyle = KUBEBERT_CHARACTER_CROWN_BG
     ctx.fill()
-    ctx.strokeStyle = '#fff'
+    ctx.strokeStyle = KUBEBERT_CHARACTER_CROWN_OUTLINE
     ctx.lineWidth = 1
     ctx.stroke()
   } else {
@@ -176,13 +189,13 @@ function drawCharacter(
     ctx.closePath()
     ctx.fillStyle = color
     ctx.fill()
-    ctx.strokeStyle = 'rgba(0,0,0,0.3)'
+    ctx.strokeStyle = KUBEBERT_CHARACTER_OUTLINE
     ctx.lineWidth = 1
     ctx.stroke()
 
     // Enemy eyes
     const eyeSize = size * 0.1
-    ctx.fillStyle = '#fff'
+    ctx.fillStyle = KUBEBERT_CHARACTER_CROWN_OUTLINE
     ctx.beginPath()
     ctx.arc(x - size * 0.15, charY, eyeSize, 0, Math.PI * 2)
     ctx.fill()
@@ -514,7 +527,7 @@ export function KubeBert() {
 
     // Draw "@#!?" speech bubble when hit (game over state)
     if (gameStateRef.current === 'gameover') {
-      ctx.fillStyle = '#fff'
+      ctx.fillStyle = KUBEBERT_GAMEOVER_TEXT
       ctx.font = `bold ${Math.max(12, tileW / 3)}px monospace`
       ctx.textAlign = 'center'
       ctx.fillText('@#!?', px, py - tileW * 0.8)
@@ -522,9 +535,9 @@ export function KubeBert() {
 
     // Level complete flash
     if (gameStateRef.current === 'levelComplete') {
-      ctx.fillStyle = 'rgba(0, 212, 170, 0.15)'
+      ctx.fillStyle = KUBEBERT_LEVEL_COMPLETE_FLASH
       ctx.fillRect(0, 0, w, h)
-      ctx.fillStyle = '#00d4aa'
+      ctx.fillStyle = KUBEBERT_LEVEL_COMPLETE_TEXT
       ctx.font = `bold ${Math.max(16, w / 15)}px monospace`
       ctx.textAlign = 'center'
       ctx.fillText(`Level ${levelRef.current} Complete!`, w / 2, h / 2)

--- a/web/src/components/cards/NodeInvaders.tsx
+++ b/web/src/components/cards/NodeInvaders.tsx
@@ -29,6 +29,20 @@ const INVADER_MIN_MOVE_TICKS = 5
 const INVADER_BASE_MOVE_TICKS = 20
 const INVADER_ALIVE_TICK_DIVISOR = 2
 
+// ─── Canvas Colors (extracted from inline rgba strings) ─────────────────────
+const NODE_INVADERS_BG = '#0a0a1a'
+const NODE_INVADERS_STARS = '#ffffff'
+const NODE_INVADERS_SHIELD_TEAL = (alpha: number) => `rgba(0, 255, 0, ${alpha})`
+const NODE_INVADERS_SHIELD_PATTERN = (alpha: number) => `rgba(0, 200, 0, ${alpha})`
+const NODE_INVADERS_INVADER_RED = '#ff6b6b'
+const NODE_INVADERS_INVADER_YELLOW = '#ffd93d'
+const NODE_INVADERS_INVADER_GREEN = '#6bcb77'
+const NODE_INVADERS_INVADER_EYES = '#000'
+const NODE_INVADERS_PLAYER_SHIP = '#00bfff'
+const NODE_INVADERS_PLAYER_COCKPIT = '#87ceeb'
+const NODE_INVADERS_BULLET_PLAYER = '#00ff00'
+const NODE_INVADERS_BULLET_ENEMY = '#ff0000'
+
 interface Player {
   x: number
   lives: number
@@ -134,11 +148,11 @@ export function NodeInvaders(_props: CardComponentProps) {
     ctx.scale(scale, scale)
 
     // Background
-    ctx.fillStyle = '#0a0a1a'
+    ctx.fillStyle = NODE_INVADERS_BG
     ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT)
 
     // Stars
-    ctx.fillStyle = '#ffffff'
+    ctx.fillStyle = NODE_INVADERS_STARS
     for (let i = 0; i < 30; i++) {
       ctx.fillRect((i * 47) % CANVAS_WIDTH, (i * 31) % CANVAS_HEIGHT, 1, 1)
     }
@@ -147,10 +161,10 @@ export function NodeInvaders(_props: CardComponentProps) {
     for (const s of shields) {
       if (s.health <= 0) continue
       const alpha = s.health / 4
-      ctx.fillStyle = `rgba(0, 255, 0, ${alpha})`
+      ctx.fillStyle = NODE_INVADERS_SHIELD_TEAL(alpha)
       ctx.fillRect(s.x, s.y, 30, 20)
       // Shield pattern
-      ctx.fillStyle = `rgba(0, 200, 0, ${alpha})`
+      ctx.fillStyle = NODE_INVADERS_SHIELD_PATTERN(alpha)
       ctx.fillRect(s.x + 10, s.y + 15, 10, 5)
     }
 
@@ -159,7 +173,7 @@ export function NodeInvaders(_props: CardComponentProps) {
       if (!inv.alive) continue
 
       // Different colors for different types
-      const colors = ['#ff6b6b', '#ffd93d', '#6bcb77']
+      const colors = [NODE_INVADERS_INVADER_RED, NODE_INVADERS_INVADER_YELLOW, NODE_INVADERS_INVADER_GREEN]
       ctx.fillStyle = colors[inv.type]
 
       // Invader body (node shape)
@@ -167,7 +181,7 @@ export function NodeInvaders(_props: CardComponentProps) {
       ctx.fillRect(inv.x, inv.y + 6, INVADER_WIDTH, INVADER_HEIGHT - 12)
 
       // Eyes
-      ctx.fillStyle = '#000'
+      ctx.fillStyle = NODE_INVADERS_INVADER_EYES
       ctx.fillRect(inv.x + 5, inv.y + 6, 4, 4)
       ctx.fillRect(inv.x + INVADER_WIDTH - 9, inv.y + 6, 4, 4)
 
@@ -178,7 +192,7 @@ export function NodeInvaders(_props: CardComponentProps) {
     }
 
     // Draw player (kubectl ship)
-    ctx.fillStyle = '#00bfff'
+    ctx.fillStyle = NODE_INVADERS_PLAYER_SHIP
     // Ship body
     ctx.beginPath()
     ctx.moveTo(player.x + PLAYER_WIDTH / 2, CANVAS_HEIGHT - 40)
@@ -189,12 +203,12 @@ export function NodeInvaders(_props: CardComponentProps) {
     // Ship base
     ctx.fillRect(player.x + 5, CANVAS_HEIGHT - 20, PLAYER_WIDTH - 10, 8)
     // Cockpit
-    ctx.fillStyle = '#87ceeb'
+    ctx.fillStyle = NODE_INVADERS_PLAYER_COCKPIT
     ctx.fillRect(player.x + PLAYER_WIDTH / 2 - 3, CANVAS_HEIGHT - 35, 6, 6)
 
     // Draw bullets
     for (const b of bullets) {
-      ctx.fillStyle = b.isPlayer ? '#00ff00' : '#ff0000'
+      ctx.fillStyle = b.isPlayer ? NODE_INVADERS_BULLET_PLAYER : NODE_INVADERS_BULLET_ENEMY
       ctx.fillRect(b.x - 2, b.y, 4, b.isPlayer ? 10 : 8)
     }
 


### PR DESCRIPTION
Fixes #19464

Extract hardcoded rgba/rgb color strings from canvas drawing code into named constants at the top of each component file. This improves maintainability and follows the existing pattern in the codebase.

**Changes:**
- **KubeBert.tsx**: Added 11 color constants for tiles, characters, and UI elements
- **NodeInvaders.tsx**: Added 12 color constants for shields, invaders, and player ship

**Acceptance criteria met:**
✅ Canvas colors defined as named constants
✅ No hardcoded rgba strings in drawing functions
✅ Visual rendering unchanged