### PR TITLE
🐛 fix: increase WebKit timeouts for nightly cross-browser tests

### DIFF
--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -22,6 +22,7 @@ const HEADER_ASSERT_TIMEOUT_MS = 20_000
 const ERROR_FALLBACK_TIMEOUT_MS = 20_000
 const CARD_DATA_TIMEOUT_MS = 15_000
 const ACCESSIBILITY_ASSERT_TIMEOUT_MS = 20_000
+const WEBKIT_FOCUS_ASSERT_TIMEOUT_MS = 30_000
 const HOVER_EFFECT_TIMEOUT_MS = 5_000
 const ADD_CARD_MODAL_TIMEOUT_MS = 15_000
 const INITIAL_PAGE_VISIBLE_TIMEOUT_MS = 30_000
@@ -543,10 +544,12 @@ test.describe('Dashboard Page', () => {
         // WebKit mirrors Safari's reduced keyboard-access mode for plain Tab.
         // Alt+Tab exercises the full in-page focus order so buttons remain reachable.
         await page.keyboard.press(tabKey)
+        // WebKit needs extra time for focus state to stabilize in CI environments
+        const focusTimeout = browserName === 'webkit' ? WEBKIT_FOCUS_ASSERT_TIMEOUT_MS : 15_000
         await expect(
           page.locator(`[data-e2e-focus-order="${expectedElement.index}"]`),
           `Expected keyboard navigation to focus ${expectedElement.label}`,
-        ).toBeFocused()
+        ).toBeFocused({ timeout: focusTimeout })
       }
     })
 

--- a/web/e2e/responsive-regression.spec.ts
+++ b/web/e2e/responsive-regression.spec.ts
@@ -28,7 +28,7 @@ const ROOT_VISIBLE_TIMEOUT_MS = 10_000
 /** Minimum body text length to consider the page non-blank. */
 const MIN_BODY_TEXT_LEN = 20
 /** Timeout (ms) for hamburger/sidebar-toggle visibility probe. */
-const MOBILE_NAV_PROBE_TIMEOUT_MS = 5_000
+const MOBILE_NAV_PROBE_TIMEOUT_MS = 10_000
 /** Max viewport width (px) below which mobile/hamburger nav is expected. */
 const MOBILE_NAV_MAX_WIDTH_PX = 1024
 

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -160,7 +160,8 @@ test.describe('Smoke Tests', () => {
       // the actual router path without relying on preview-server rewrites.
       await page.goto('/', { waitUntil: 'domcontentloaded' })
       const settingsLink = page.locator('[data-testid="sidebar-primary-nav"] a[href="/settings"], [data-testid="sidebar"] a[href="/settings"]').first()
-      await expect(settingsLink).toBeVisible({ timeout: 10000 })
+      // WebKit/mobile browsers need more time for sidebar elements to hydrate
+      await expect(settingsLink).toBeVisible({ timeout: 20000 })
       await settingsLink.click({ force: true })
 
       await expect(page).toHaveURL(/\/settings(?:[?#].*)?$/, { timeout: 10000 })


### PR DESCRIPTION
Fixes #19453

## Problem

The Playwright nightly workflow was failing consistently on WebKit-based browsers (webkit, mobile-safari, mobile-chrome) due to timeout issues:

1. **Dashboard keyboard navigation**: Focus state assertions timing out at 15s
2. **Smoke test navigation**: Settings link visibility timing out at 10s  
3. **Responsive regression**: Mobile navigation probe timing out at 5s

These failures occurred across all 3 retry attempts, indicating the timeouts were genuinely too short for WebKit's rendering pipeline in CI environments (not random flakiness).

## Root Cause

WebKit browsers exhibit slower focus state updates and DOM hydration compared to Chromium/Firefox in headless CI. The tests were using conservative timeouts (5-15s) that work fine for faster browsers, but WebKit needs more time for:
- Focus ring rendering to stabilize after keyboard navigation
- Sidebar elements to hydrate after page load
- Mobile navigation UI to mount and become visible

## Solution

Increased timeouts specifically for the failing assertions:

| Test | Element | Before | After | Browser Scope |
|------|---------|--------|-------|---------------|
| Dashboard keyboard nav | `toBeFocused()` | 15s (implicit) | 30s | webkit only |
| Smoke settings link | `toBeVisible()` | 10s | 20s | all (mobile/webkit affected) |
| Responsive nav probe | `isVisible()` | 5s | 10s | all (mobile viewports) |

The Dashboard fix is webkit-conditional (`browserName === 'webkit'`) to avoid unnecessarily slowing down Firefox/Chromium runs.

## Testing

- All changes are in test files only — no production code affected
- Timeouts are still well within the 90s per-test limit set by the workflow
- Increased values (10-30s) are conservative but not excessive for CI environments

## Why Not Workflow-Level Fixes?

Previous investigation comments suggested increasing `--retries` at the workflow level, but:
- Retries don't fix genuine timeout issues (all 3 retries failed identically)
- The workflow already has `--retries=3` and `--timeout=90000`
- The problem is assertion-level timeouts, not test-level timeouts
- Fixing at the test level is more surgical and doesn't slow down passing tests