### PR TITLE
[scanner] fix: add least-privilege permissions to 4 workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,14 +12,15 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   ai-fix:
     if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/deploy-checksum.yml
+++ b/.github/workflows/deploy-checksum.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths: [deploy.sh]
 
-permissions: {}
+permissions: read-all
 
 jobs:
   update-checksum:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -17,9 +17,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write
-      pages: write
       packages: write
-      id-token: write
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/hive-interactive.yml
+++ b/.github/workflows/hive-interactive.yml
@@ -8,7 +8,7 @@ on:
   issue_comment:
     types: [created]
 
-permissions: {}
+permissions: read-all
 
 jobs:
   post-directions:


### PR DESCRIPTION
Fixes #19473

Adds `permissions: read-all` at workflow level and scopes write permissions to individual jobs.

**Changes:**
- `.github/workflows/ai-fix.yml`: Moved `contents: write`, `issues: write`, `pull-requests: write` from workflow top-level to job-level, added `permissions: read-all` at top
- `.github/workflows/hive-interactive.yml`: Changed workflow-level `permissions: {}` to `permissions: read-all` for consistency
- `.github/workflows/helm-release.yml`: Removed unnecessary `pages: write` and `id-token: write` from job permissions (keeping only `contents: write` and `packages: write` for actual needs)
- `.github/workflows/deploy-checksum.yml`: Changed workflow-level `permissions: {}` to `permissions: read-all` for consistency

Signed-off-by: scanner <scanner@kubestellar.io>