### PR TITLE
[scanner] fix: pin kubestellar/infra workflow refs to SHA

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,6 +13,6 @@ permissions:
 
 jobs:
   greet:
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19
     # Removed secrets: inherit to prevent secret exposure to fork PRs
     # github.token is provided automatically by the runner


### PR DESCRIPTION
Fixes kubestellar/console#19472

Pins reusable workflow references from `@main` to specific commit SHA to prevent supply-chain attacks via pull_request_target.

Signed-off-by: scanner <scanner@kubestellar.io>