### PR TITLE
[scanner] fix: use req.Host in WS origin tests to fix persistent CI failures

### DIFF
--- a/pkg/api/middleware/auth_ws_revoke_test.go
+++ b/pkg/api/middleware/auth_ws_revoke_test.go
@@ -51,7 +51,7 @@ func TestValidateWebSocketOrigin_Rejected(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/ws", nil)
 	req.Header.Set("Origin", "https://attacker.example.com")
-	req.Header.Set("Host", "console.kubestellar.io")
+	req.Host = "console.kubestellar.io"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
@@ -66,7 +66,7 @@ func TestValidateWebSocketOrigin_MatchesHost(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/ws", nil)
 	req.Header.Set("Origin", "http://console.kubestellar.io")
-	req.Header.Set("Host", "console.kubestellar.io")
+	req.Host = "console.kubestellar.io"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode,
@@ -147,7 +147,7 @@ func TestIsWSOriginAllowed_HTTPSFromXForwardedProto(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/ws", nil)
 	req.Header.Set("Origin", "https://console.kubestellar.io")
-	req.Header.Set("Host", "console.kubestellar.io")
+	req.Host = "console.kubestellar.io"
 	req.Header.Set("X-Forwarded-Proto", "https")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)


### PR DESCRIPTION
## Fix

In Go's `net/http`, the `Host` header is read from `req.Host`, not from the header map (`req.Header`). Fiber/fasthttp follows the same convention when converting requests in `app.Test()`.

The failing tests were setting Host via `req.Header.Set("Host", ...)` which was silently ignored — Fiber saw the default host instead of `console.kubestellar.io`. This caused:
- `TestValidateWebSocketOrigin_MatchesHost` → always 403 (host mismatch)
- `TestIsWSOriginAllowed_HTTPSFromXForwardedProto` → always 403 (host mismatch)

The fix changes these to `req.Host = "..."`, matching the pattern already used in `websocket_origin_test.go`.

Also fixed the same issue in `TestValidateWebSocketOrigin_Rejected` for correctness (it happened to pass for the wrong reason before).

Fixes #19384