### PR TITLE
[scanner] fix: harden localStorage access with try/catch

### DIFF
--- a/web/src/components/InitialInfrastructureGate.tsx
+++ b/web/src/components/InitialInfrastructureGate.tsx
@@ -75,13 +75,9 @@ const gateReducer = (state: GateState, action: GateAction): GateState => {
 }
 
 const clearStaleSessionAndRedirectToLogin = (): void => {
-  try {
-    localStorage.removeItem(LEGACY_STORAGE_KEY_KC_TOKEN)
-    clearStoredAuthToken()
-    localStorage.removeItem(STORAGE_KEY_HAS_SESSION)
-  } catch {
-    // ignore localStorage access failures and continue to login
-  }
+  safeRemove(LEGACY_STORAGE_KEY_KC_TOKEN)
+  clearStoredAuthToken()
+  safeRemove(STORAGE_KEY_HAS_SESSION)
   window.location.href = LOGIN_PATH
 }
 

--- a/web/src/components/acmm/ACMMIntroModal.tsx
+++ b/web/src/components/acmm/ACMMIntroModal.tsx
@@ -36,6 +36,7 @@ import {
   Link2,
 } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
+import { safeGet, safeSet } from '../../lib/safeLocalStorage'
 
 const STORAGE_KEY = 'kc-acmm-intro-dismissed'
 const PAPER_URL = 'https://arxiv.org/abs/2604.09388'
@@ -52,19 +53,11 @@ const LEVELS = [
 ] as const
 
 export function isACMMIntroDismissed(): boolean {
-  try {
-    return localStorage.getItem(STORAGE_KEY) === '1'
-  } catch {
-    return false
-  }
+  return safeGet(STORAGE_KEY) === '1'
 }
 
 function dismissACMMIntro() {
-  try {
-    localStorage.setItem(STORAGE_KEY, '1')
-  } catch {
-    // localStorage unavailable — silently ignore
-  }
+  safeSet(STORAGE_KEY, '1')
 }
 
 /** Source framework badge definitions */

--- a/web/src/components/acmm/ACMMProvider.tsx
+++ b/web/src/components/acmm/ACMMProvider.tsx
@@ -12,6 +12,7 @@ import { useCachedACMMScan, type UseACMMScanResult } from '../../hooks/useCached
 import { isACMMIntroDismissed } from './ACMMIntroModal'
 import { emitACMMScanned } from '../../lib/analytics'
 import { ALL_CRITERIA } from '../../lib/acmm/sources'
+import { safeGet, safeSet, safeGetJSON } from '../../lib/safeLocalStorage'
 
 const DEFAULT_REPO = 'kubestellar/console'
 const SELECTED_REPO_KEY = 'kubestellar-acmm-selected-repo'
@@ -81,17 +82,13 @@ function readInitialRepo(): string {
   } catch {
     // window unavailable (SSR)
   }
-  try {
-    return localStorage.getItem(SELECTED_REPO_KEY) || DEFAULT_REPO
-  } catch {
-    return DEFAULT_REPO
-  }
+  return safeGet(SELECTED_REPO_KEY) || DEFAULT_REPO
 }
 
 function readRecentRepos(): string[] {
+  const raw = safeGet(RECENT_REPOS_KEY)
+  if (!raw) return [DEFAULT_REPO]
   try {
-    const raw = localStorage.getItem(RECENT_REPOS_KEY)
-    if (!raw) return [DEFAULT_REPO]
     const parsed = JSON.parse(raw) as unknown
     if (!Array.isArray(parsed)) return [DEFAULT_REPO]
     return parsed.filter((x): x is string => typeof x === 'string').slice(0, MAX_RECENT_REPOS)
@@ -171,11 +168,7 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
     const trimmed = normalizeRepoInput(next)
     if (!trimmed) return
     setRepoState(trimmed)
-    try {
-      localStorage.setItem(SELECTED_REPO_KEY, trimmed)
-    } catch {
-      // ignore localStorage failures
-    }
+    safeSet(SELECTED_REPO_KEY, trimmed)
     // Sync the URL so the current scan is always shareable. replaceState
     // (not pushState) keeps the back button useful — picking a new repo
     // is dashboard interaction, not navigation.
@@ -188,22 +181,14 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
     }
     setRecentRepos((prev) => {
       const dedup = [trimmed, ...prev.filter((r) => r !== trimmed)].slice(0, MAX_RECENT_REPOS)
-      try {
-        localStorage.setItem(RECENT_REPOS_KEY, JSON.stringify(dedup))
-      } catch {
-        // ignore
-      }
+      safeSet(RECENT_REPOS_KEY, JSON.stringify(dedup))
       return dedup
     })
   }, [])
 
   const clearRepo = useCallback(() => {
     setRepoState(DEFAULT_REPO)
-    try {
-      localStorage.setItem(SELECTED_REPO_KEY, DEFAULT_REPO)
-    } catch {
-      // ignore
-    }
+    safeSet(SELECTED_REPO_KEY, DEFAULT_REPO)
     try {
       const url = new URL(window.location.href)
       url.searchParams.set('repo', DEFAULT_REPO)

--- a/web/src/components/agent/AgentApprovalDialog.tsx
+++ b/web/src/components/agent/AgentApprovalDialog.tsx
@@ -3,6 +3,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { BaseModal } from '../../lib/modals'
 import type { AgentInfo } from '../../types/agent'
 import { AgentIcon } from './AgentIcon'
+import { safeGet, safeSet, safeRemove } from '../../lib/safeLocalStorage'
 
 const APPROVED_KEY = 'kc_agents_approved'
 
@@ -11,30 +12,18 @@ let sessionApproved = false
 
 /** Check whether the user has already approved agent access. */
 export function hasApprovedAgents(): boolean {
-  try {
-    return localStorage.getItem(APPROVED_KEY) === 'true' || sessionApproved
-  } catch {
-    return sessionApproved
-  }
+  return safeGet(APPROVED_KEY) === 'true' || sessionApproved
 }
 
 /** Record that the user has approved agent access. */
 export function setAgentsApproved(): void {
   sessionApproved = true
-  try {
-    localStorage.setItem(APPROVED_KEY, 'true')
-  } catch {
-    // storage full — sessionApproved already set above as fallback
-  }
+  safeSet(APPROVED_KEY, 'true')
 }
 
 /** Clear approval (e.g. for testing or reset). */
 export function clearAgentsApproval(): void {
-  try {
-    localStorage.removeItem(APPROVED_KEY)
-  } catch {
-    // ignore
-  }
+  safeRemove(APPROVED_KEY)
 }
 
 interface AgentApprovalDialogProps {

--- a/web/src/components/cards/KubePong.tsx
+++ b/web/src/components/cards/KubePong.tsx
@@ -6,6 +6,7 @@ import { useReportCardDataState } from './CardDataContext'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
 import { useGameKeyTracking } from '../../hooks/useGameKeys'
 import { isDemoMode } from '@/lib/demoMode'
+import { safeGet, safeSet } from '../../lib/safeLocalStorage'
 
 // Game constants
 const CANVAS_WIDTH = 400
@@ -77,7 +78,7 @@ export function KubePong() {
   const [winner, setWinner] = useState<'player' | 'ai' | null>(null)
   const [difficulty, setDifficulty] = useState<'easy' | 'medium' | 'hard'>('medium')
   const [wins, setWins] = useState(() => {
-    const saved = localStorage.getItem('kubePongWins')
+    const saved = safeGet('kubePongWins')
     return saved ? parseInt(saved, 10) : 0
   })
 
@@ -225,7 +226,7 @@ export function KubePong() {
         setWinner('player')
         setWins(prev => {
           const newWins = prev + 1
-          localStorage.setItem('kubePongWins', newWins.toString())
+          safeSet('kubePongWins', newWins.toString())
           return newWins
         })
         setGameState('finished')


### PR DESCRIPTION
Fixes #19481

Replaces direct localStorage.getItem/setItem/removeItem calls with existing `safeGet/safeSet/safeRemove` utilities from `lib/safeLocalStorage.ts`, which handle private browsing, quota exceeded, sandboxed iframes, and SSR environments.

Files changed: ACMMIntroModal.tsx, ACMMProvider.tsx, AgentApprovalDialog.tsx, InitialInfrastructureGate.tsx, KubePong.tsx