### PR TITLE
[scanner] fix: add missing safeRemove import and remove unused safeGetJSON import

### DIFF
--- a/web/src/components/InitialInfrastructureGate.tsx
+++ b/web/src/components/InitialInfrastructureGate.tsx
@@ -10,6 +10,7 @@ import { getUserSafeErrorMessage } from '../lib/errors/handleError'
 import { stellarApi } from '../services/stellar'
 import { StatusBadge } from './ui/StatusBadge'
 import { Button } from './ui/Button'
+import { safeRemove } from '../lib/safeLocalStorage'
 
 const INITIAL_HANDSHAKE_TIMEOUT_MS = 15_000
 const INITIAL_HANDSHAKE_TIMEOUT_SECONDS = INITIAL_HANDSHAKE_TIMEOUT_MS / 1000

--- a/web/src/components/acmm/ACMMProvider.tsx
+++ b/web/src/components/acmm/ACMMProvider.tsx
@@ -12,7 +12,7 @@ import { useCachedACMMScan, type UseACMMScanResult } from '../../hooks/useCached
 import { isACMMIntroDismissed } from './ACMMIntroModal'
 import { emitACMMScanned } from '../../lib/analytics'
 import { ALL_CRITERIA } from '../../lib/acmm/sources'
-import { safeGet, safeSet, safeGetJSON } from '../../lib/safeLocalStorage'
+import { safeGet, safeSet } from '../../lib/safeLocalStorage'
 
 const DEFAULT_REPO = 'kubestellar/console'
 const SELECTED_REPO_KEY = 'kubestellar-acmm-selected-repo'


### PR DESCRIPTION
Fixes #19485, Fixes #19486, Fixes #19487

PR #19483 replaced direct localStorage calls with safeLocalStorage utilities but missed the import of `safeRemove` in InitialInfrastructureGate.tsx and left an unused `safeGetJSON` import in ACMMProvider.tsx.