### PR TITLE
fix: name alert threshold constants

### DIFF
--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -15,6 +15,7 @@ import type { NightlyGuideStatus } from '../lib/llmd/nightlyE2EDemoData'
 import type { AlertsMCPData } from './AlertsDataFetcher'
 import type { AlertsContextValue, AlertNotificationBatch, MutationAccumulator } from './AlertsContext.types'
 import { INITIAL_FETCH_DELAY_MS, POLL_INTERVAL_SLOW_MS, SECONDARY_FETCH_DELAY_MS, NIGHTLY_E2E_POLL_INTERVAL_MS } from '../lib/constants/network'
+import { MS_PER_SECOND } from '../lib/constants/time'
 import { PRESET_ALERT_RULES } from '../types/alerts'
 import { safeGet } from '../lib/safeLocalStorage'
 import {
@@ -43,9 +44,9 @@ import { applyMutations, createAlertRulesEngine, generateId, shallowEqualRecords
 const AlertsDataFetcher = safeLazy(() => import('./AlertsDataFetcher'), 'default')
 const MCP_UPDATE_BATCH_FRAME_FALLBACK_MS = 16
 const ALERT_RULES_KEY = 'kc_alert_rules'
-const LOADING_TIMEOUT_MS = 30_000
-const INITIAL_EVALUATION_DELAY_MS = 1000
-const EVALUATION_INTERVAL_MS = 30000
+const ALERTS_LOADING_TIMEOUT_MS = 30 * MS_PER_SECOND
+const INITIAL_EVALUATION_DELAY_MS = MS_PER_SECOND
+const EVALUATION_INTERVAL_MS = 30 * MS_PER_SECOND
 
 const {
   Context: AlertsContext,
@@ -260,7 +261,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
     }
     const timer = setTimeout(() => {
       setLoadingTimedOut(true)
-    }, LOADING_TIMEOUT_MS)
+    }, ALERTS_LOADING_TIMEOUT_MS)
     return () => clearTimeout(timer)
   }, [mcpData.isLoading])
 

--- a/web/src/contexts/alertStorage.ts
+++ b/web/src/contexts/alertStorage.ts
@@ -10,7 +10,7 @@
 import type { Alert } from '../types/alerts'
 import { safeGet, safeSet, safeRemove, safeGetJSON } from '../lib/safeLocalStorage'
 import { STORAGE_KEY_NOTIFIED_ALERT_KEYS } from '../lib/constants'
-import { MS_PER_MINUTE, MS_PER_HOUR } from '../lib/constants/time'
+import { DAYS_PER_MONTH, MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../lib/constants/time'
 
 /** Storage key for alerts */
 export const ALERTS_KEY = 'kc_alerts'
@@ -24,7 +24,7 @@ export const MAX_RESOLVED_ALERTS_AFTER_PRUNE = 50
 /** Maximum age (ms) for dedup entries — evict stale entries older than this.
  *  30 days: persistent-condition keys (certificate_error, cluster_unreachable)
  *  must survive across sessions until the cluster recovers; 24 h was too short. */
-export const NOTIFICATION_DEDUP_MAX_AGE_MS = 30 * 24 * MS_PER_HOUR // 30 days
+export const NOTIFICATION_DEDUP_MAX_AGE_MS = DAYS_PER_MONTH * MS_PER_DAY
 
 /** Hard cap on stored dedup keys to prevent unbounded localStorage growth.
  *  When exceeded, the oldest entries (by timestamp) are evicted first. */
@@ -44,7 +44,7 @@ export const NOTIFICATION_COOLDOWN_BY_SEVERITY: Record<string, number> = {
   info: 4 * MS_PER_HOUR,   // 4 hours — informational, minimal interruption
 }
 /** Fallback cooldown when severity is unknown */
-export const DEFAULT_NOTIFICATION_COOLDOWN_MS = 30 * MS_PER_MINUTE // 30 min
+export const DEFAULT_NOTIFICATION_COOLDOWN_MS = NOTIFICATION_COOLDOWN_BY_SEVERITY.warning
 
 /** Legacy DOMException error code for QuotaExceededError (used by older browsers). */
 const DOM_EXCEPTION_QUOTA_EXCEEDED_CODE = 22

--- a/web/src/lib/constants/units.ts
+++ b/web/src/lib/constants/units.ts
@@ -1,11 +1,11 @@
-/** Bytes per mebibyte (MiB) */
-export const BYTES_PER_MIB = 1024 * 1024
 /** Bytes per kibibyte (KiB) */
 export const BYTES_PER_KIB = 1024
+/** Bytes per mebibyte (MiB) */
+export const BYTES_PER_MIB = BYTES_PER_KIB * BYTES_PER_KIB
 /** Bytes per gibibyte (GiB) */
-export const BYTES_PER_GIB = 1024 * 1024 * 1024
+export const BYTES_PER_GIB = BYTES_PER_KIB * BYTES_PER_MIB
 /** Bytes per tebibyte (TiB) */
-export const BYTES_PER_TIB = 1024 * BYTES_PER_GIB
+export const BYTES_PER_TIB = BYTES_PER_KIB * BYTES_PER_GIB
 /** Mebibytes per gibibyte — Gi → Mi conversion factor */
 export const MIB_PER_GIB = 1024
 /** Kibibytes per mebibyte — Ki → Mi conversion factor */


### PR DESCRIPTION
Fixes #19494

---

### Summary of Changes
- Names alert loading and evaluation timings using shared time constants.
- Reuses the warning notification cooldown as the default cooldown source.
- Builds binary byte constants from `BYTES_PER_KIB` instead of repeating raw `1024` expressions.

---

### Changes Made
- [x] Updated `AlertsContext.tsx` to express alert timing thresholds with `MS_PER_SECOND`.
- [x] Updated `alertStorage.ts` to derive the dedup retention window and default cooldown from existing constants.
- [x] Updated `units.ts` so MiB/GiB/TiB constants are composed from the base KiB constant.
- [x] Kept this PR behavior-preserving and focused on the Auto-QA magic-number finding.

---

### Checklist
- [x] I have reviewed the project's contribution guidelines
- [x] I have tested the changes locally and ensured they work as expected
- [x] I have kept the PR focused on one concern
- [x] All commits are signed with DCO (`git commit -s`)