### PR TITLE
fix: premature WebSocket resolution in PodDrillDown related resources

### DIFF
--- a/web/src/components/drilldown/views/PodDrillDown.actions.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.actions.tsx
@@ -452,10 +452,10 @@ Please:
 
             if (msg.id === requestId && msg.payload?.output) {
               output = msg.payload.output
+              clearTimeout(timeout)
+              ws.close()
+              resolve(output)
             }
-            clearTimeout(timeout)
-            ws.close()
-            resolve(output)
           }
           ws.onerror = () => {
             clearTimeout(timeout)


### PR DESCRIPTION
## SUMMARY

This PR fixes a race condition in the Related Resources WebSocket flow where `runKubectl` could resolve before receiving the response associated with the current request. The issue affected the Pod Drilldown Related Resources tab, causing resource data to be missing when unrelated WebSocket messages arrived first.

The changes are contained in `web/src/components/drilldown/views/PodDrillDown.actions.tsx`, specifically within the `runKubectl` helper used by the Related Resources view.

## FIX

```ts
if (msg.id === requestId && msg.payload?.output) {
  output = msg.payload.output
}
clearTimeout(timeout)
ws.close()
resolve(output)

//After
if (msg.id === requestId && msg.payload?.output) {
  output = msg.payload.output
  clearTimeout(timeout)
  ws.close()
  resolve(output)
}
```

