### PR TITLE
[scanner] test: add unit tests for lib/constants/time.ts

### DIFF
--- a/web/src/lib/constants/__tests__/time.test.ts
+++ b/web/src/lib/constants/__tests__/time.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MS_PER_SECOND,
+  SECONDS_PER_MINUTE,
+  MINUTES_PER_HOUR,
+  HOURS_PER_DAY,
+  MS_PER_MINUTE,
+  MS_PER_HOUR,
+  MS_PER_DAY,
+  DAYS_PER_MONTH,
+  DAYS_PER_YEAR,
+  SECONDS_PER_HOUR,
+  SECONDS_PER_DAY,
+  HOURS_PER_MONTH,
+  MS_PER_MONTH,
+  MS_PER_YEAR,
+} from '../time'
+
+describe('time constants', () => {
+  describe('base units', () => {
+    it('defines milliseconds per second', () => {
+      expect(MS_PER_SECOND).toBe(1_000)
+    })
+
+    it('defines seconds per minute', () => {
+      expect(SECONDS_PER_MINUTE).toBe(60)
+    })
+
+    it('defines minutes per hour', () => {
+      expect(MINUTES_PER_HOUR).toBe(60)
+    })
+
+    it('defines hours per day', () => {
+      expect(HOURS_PER_DAY).toBe(24)
+    })
+
+    it('defines days per month (30-day approximation)', () => {
+      expect(DAYS_PER_MONTH).toBe(30)
+    })
+
+    it('defines days per year (365-day approximation)', () => {
+      expect(DAYS_PER_YEAR).toBe(365)
+    })
+  })
+
+  describe('derived millisecond constants', () => {
+    it('calculates MS_PER_MINUTE correctly', () => {
+      expect(MS_PER_MINUTE).toBe(60_000)
+      expect(MS_PER_MINUTE).toBe(MS_PER_SECOND * SECONDS_PER_MINUTE)
+    })
+
+    it('calculates MS_PER_HOUR correctly', () => {
+      expect(MS_PER_HOUR).toBe(3_600_000)
+      expect(MS_PER_HOUR).toBe(MS_PER_MINUTE * MINUTES_PER_HOUR)
+    })
+
+    it('calculates MS_PER_DAY correctly', () => {
+      expect(MS_PER_DAY).toBe(86_400_000)
+      expect(MS_PER_DAY).toBe(MS_PER_HOUR * HOURS_PER_DAY)
+    })
+
+    it('calculates MS_PER_MONTH correctly (30-day approximation)', () => {
+      expect(MS_PER_MONTH).toBe(2_592_000_000)
+      expect(MS_PER_MONTH).toBe(MS_PER_DAY * DAYS_PER_MONTH)
+    })
+
+    it('calculates MS_PER_YEAR correctly (365-day approximation)', () => {
+      expect(MS_PER_YEAR).toBe(31_536_000_000)
+      expect(MS_PER_YEAR).toBe(MS_PER_DAY * DAYS_PER_YEAR)
+    })
+  })
+
+  describe('derived second constants', () => {
+    it('calculates SECONDS_PER_HOUR correctly', () => {
+      expect(SECONDS_PER_HOUR).toBe(3_600)
+      expect(SECONDS_PER_HOUR).toBe(SECONDS_PER_MINUTE * MINUTES_PER_HOUR)
+    })
+
+    it('calculates SECONDS_PER_DAY correctly', () => {
+      expect(SECONDS_PER_DAY).toBe(86_400)
+      expect(SECONDS_PER_DAY).toBe(SECONDS_PER_HOUR * HOURS_PER_DAY)
+    })
+  })
+
+  describe('derived hour constants', () => {
+    it('calculates HOURS_PER_MONTH correctly (30-day approximation)', () => {
+      expect(HOURS_PER_MONTH).toBe(720)
+      expect(HOURS_PER_MONTH).toBe(HOURS_PER_DAY * DAYS_PER_MONTH)
+    })
+  })
+
+  describe('constant relationships', () => {
+    it('maintains consistent minute conversions', () => {
+      expect(MS_PER_MINUTE / MS_PER_SECOND).toBe(SECONDS_PER_MINUTE)
+    })
+
+    it('maintains consistent hour conversions', () => {
+      expect(MS_PER_HOUR / MS_PER_MINUTE).toBe(MINUTES_PER_HOUR)
+      expect(SECONDS_PER_HOUR / SECONDS_PER_MINUTE).toBe(MINUTES_PER_HOUR)
+    })
+
+    it('maintains consistent day conversions', () => {
+      expect(MS_PER_DAY / MS_PER_HOUR).toBe(HOURS_PER_DAY)
+      expect(SECONDS_PER_DAY / SECONDS_PER_HOUR).toBe(HOURS_PER_DAY)
+    })
+
+    it('maintains consistent month conversions', () => {
+      expect(MS_PER_MONTH / MS_PER_DAY).toBe(DAYS_PER_MONTH)
+      expect(HOURS_PER_MONTH / HOURS_PER_DAY).toBe(DAYS_PER_MONTH)
+    })
+
+    it('maintains consistent year conversions', () => {
+      expect(MS_PER_YEAR / MS_PER_DAY).toBe(DAYS_PER_YEAR)
+    })
+  })
+
+  describe('practical usage scenarios', () => {
+    it('converts 2.5 hours to milliseconds', () => {
+      const twoAndHalfHours = 2.5 * MS_PER_HOUR
+      expect(twoAndHalfHours).toBe(9_000_000)
+    })
+
+    it('converts 45 minutes to milliseconds', () => {
+      const fortyFiveMinutes = 45 * MS_PER_MINUTE
+      expect(fortyFiveMinutes).toBe(2_700_000)
+    })
+
+    it('converts 7 days to milliseconds', () => {
+      const sevenDays = 7 * MS_PER_DAY
+      expect(sevenDays).toBe(604_800_000)
+    })
+
+    it('converts 90 seconds to minutes (decimal)', () => {
+      const ninetySeconds = 90
+      const minutes = ninetySeconds / SECONDS_PER_MINUTE
+      expect(minutes).toBe(1.5)
+    })
+
+    it('converts milliseconds to seconds (timestamp scenario)', () => {
+      const timestamp = Date.now()
+      const seconds = Math.floor(timestamp / MS_PER_SECOND)
+      expect(seconds).toBeLessThan(timestamp)
+      expect(seconds * MS_PER_SECOND).toBeLessThanOrEqual(timestamp)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('all constants are positive integers or computed from integers', () => {
+      expect(MS_PER_SECOND).toBeGreaterThan(0)
+      expect(SECONDS_PER_MINUTE).toBeGreaterThan(0)
+      expect(MINUTES_PER_HOUR).toBeGreaterThan(0)
+      expect(HOURS_PER_DAY).toBeGreaterThan(0)
+      expect(DAYS_PER_MONTH).toBeGreaterThan(0)
+      expect(DAYS_PER_YEAR).toBeGreaterThan(0)
+    })
+
+    it('all constants are numbers', () => {
+      expect(typeof MS_PER_SECOND).toBe('number')
+      expect(typeof SECONDS_PER_MINUTE).toBe('number')
+      expect(typeof MINUTES_PER_HOUR).toBe('number')
+      expect(typeof HOURS_PER_DAY).toBe('number')
+      expect(typeof MS_PER_MINUTE).toBe('number')
+      expect(typeof MS_PER_HOUR).toBe('number')
+      expect(typeof MS_PER_DAY).toBe('number')
+      expect(typeof DAYS_PER_MONTH).toBe('number')
+      expect(typeof DAYS_PER_YEAR).toBe('number')
+      expect(typeof SECONDS_PER_HOUR).toBe('number')
+      expect(typeof SECONDS_PER_DAY).toBe('number')
+      expect(typeof HOURS_PER_MONTH).toBe('number')
+      expect(typeof MS_PER_MONTH).toBe('number')
+      expect(typeof MS_PER_YEAR).toBe('number')
+    })
+
+    it('constants are not NaN', () => {
+      expect(Number.isNaN(MS_PER_SECOND)).toBe(false)
+      expect(Number.isNaN(MS_PER_MINUTE)).toBe(false)
+      expect(Number.isNaN(MS_PER_HOUR)).toBe(false)
+      expect(Number.isNaN(MS_PER_DAY)).toBe(false)
+      expect(Number.isNaN(MS_PER_MONTH)).toBe(false)
+      expect(Number.isNaN(MS_PER_YEAR)).toBe(false)
+    })
+
+    it('constants are finite', () => {
+      expect(Number.isFinite(MS_PER_SECOND)).toBe(true)
+      expect(Number.isFinite(MS_PER_MINUTE)).toBe(true)
+      expect(Number.isFinite(MS_PER_HOUR)).toBe(true)
+      expect(Number.isFinite(MS_PER_DAY)).toBe(true)
+      expect(Number.isFinite(MS_PER_MONTH)).toBe(true)
+      expect(Number.isFinite(MS_PER_YEAR)).toBe(true)
+    })
+  })
+
+  describe('approximation validity', () => {
+    it('month approximation is within reasonable bounds', () => {
+      // 30 days is between shortest (28) and longest (31) months
+      expect(DAYS_PER_MONTH).toBeGreaterThanOrEqual(28)
+      expect(DAYS_PER_MONTH).toBeLessThanOrEqual(31)
+    })
+
+    it('year approximation excludes leap years', () => {
+      // Standard year without leap day
+      expect(DAYS_PER_YEAR).toBe(365)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #19501

Adds comprehensive unit tests for lib/constants/time.ts to improve test coverage.

## Coverage
- All base time unit constants (MS_PER_SECOND, SECONDS_PER_MINUTE, etc.)
- Derived millisecond, second, and hour constants
- Mathematical relationships between constants
- Practical usage scenarios
- Edge cases (NaN, finite, type checks)
- Approximation validity for months and years