### PR TITLE
🌱 test: address team handler review feedback

### DIFF
--- a/pkg/api/handlers/teams.go
+++ b/pkg/api/handlers/teams.go
@@ -70,7 +70,6 @@ func (h *TeamHandler) GetTeam(c *fiber.Ctx) error {
 
 	teamResp, err := h.svc.Get(c.UserContext(), teamID)
 	if err != nil {
-		// Now 'team' correctly refers to the imported package
 		if err == team.ErrNotFound {
 			return fiber.NewError(fiber.StatusNotFound, "Team not found")
 		}

--- a/pkg/api/handlers/teams.go
+++ b/pkg/api/handlers/teams.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"strings"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/kubestellar/console/pkg/api/audit"
@@ -46,7 +48,7 @@ func (h *TeamHandler) CreateTeam(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
 	}
 
-	if req.Name == "" {
+	if strings.TrimSpace(req.Name) == "" {
 		return fiber.NewError(fiber.StatusBadRequest, "Team name is required")
 	}
 
@@ -68,7 +70,7 @@ func (h *TeamHandler) GetTeam(c *fiber.Ctx) error {
 
 	teamResp, err := h.svc.Get(c.UserContext(), teamID)
 	if err != nil {
-        // Now 'team' correctly refers to the imported package
+		// Now 'team' correctly refers to the imported package
 		if err == team.ErrNotFound {
 			return fiber.NewError(fiber.StatusNotFound, "Team not found")
 		}
@@ -95,6 +97,9 @@ func (h *TeamHandler) UpdateTeam(c *fiber.Ctx) error {
 	if err != nil {
 		if err == team.ErrNotFound {
 			return fiber.NewError(fiber.StatusNotFound, "Team not found")
+		}
+		if err == team.ErrNoPermission {
+			return fiber.NewError(fiber.StatusForbidden, "Permission denied")
 		}
 		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 	}
@@ -231,27 +236,36 @@ func (h *TeamHandler) ListAllTeams(c *fiber.Ctx) error {
 	}
 	return c.JSON(teams)
 }
+
 // Add the handler implementation
 func (h *TeamHandler) UpdateTeamMemberRole(c *fiber.Ctx) error {
-    teamID, err := uuid.Parse(c.Params("id"))
-    if err != nil { return fiber.NewError(fiber.StatusBadRequest, "Invalid team ID") }
+	teamID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid team ID")
+	}
 
-    memberID, err := uuid.Parse(c.Params("userId"))
-    if err != nil { return fiber.NewError(fiber.StatusBadRequest, "Invalid user ID") }
+	memberID, err := uuid.Parse(c.Params("userId"))
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid user ID")
+	}
 
-    var req struct {
-        Role models.TeamRole `json:"role"`
-    }
-    if err := c.BodyParser(&req); err != nil {
-        return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
-    }
+	var req struct {
+		Role models.TeamRole `json:"role"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
+	}
 
-    actorID := middleware.GetUserID(c)
-    if err := h.svc.UpdateMemberRole(c.UserContext(), teamID, memberID, actorID, req.Role); err != nil {
-        if err == team.ErrNotFound { return fiber.NewError(fiber.StatusNotFound, "Team not found") }
-        if err == team.ErrNoPermission { return fiber.NewError(fiber.StatusForbidden, "Permission denied") }
-        return fiber.NewError(fiber.StatusInternalServerError, err.Error())
-    }
+	actorID := middleware.GetUserID(c)
+	if err := h.svc.UpdateMemberRole(c.UserContext(), teamID, memberID, actorID, req.Role); err != nil {
+		if err == team.ErrNotFound {
+			return fiber.NewError(fiber.StatusNotFound, "Team not found")
+		}
+		if err == team.ErrNoPermission {
+			return fiber.NewError(fiber.StatusForbidden, "Permission denied")
+		}
+		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+	}
 
-    return c.SendStatus(fiber.StatusNoContent)
+	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/pkg/api/handlers/teams_test.go
+++ b/pkg/api/handlers/teams_test.go
@@ -626,9 +626,9 @@ func TestTeamHandler_ListAllTeams(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			app, handler := setupTeamHandlerTest(uuid.New(), tt.service)
-			app.Get("/admin/teams", handler.ListAllTeams)
+			app.Get("/teams", handler.ListAllTeams)
 
-			resp := performTeamRequest(t, app, http.MethodGet, "/admin/teams"+tt.queryStr, "")
+			resp := performTeamRequest(t, app, http.MethodGet, "/teams"+tt.queryStr, "")
 			assert.Equal(t, tt.wantStatus, resp.StatusCode)
 
 			if tt.assertBody != nil {
@@ -862,9 +862,9 @@ func TestTeamHandler_GetUserTeams(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			app, handler := setupTeamHandlerTest(userID, tt.service)
-			app.Get("/users/me/teams", handler.GetUserTeams)
+			app.Get("/teams/mine", handler.GetUserTeams)
 
-			resp := performTeamRequest(t, app, http.MethodGet, "/users/me/teams", "")
+			resp := performTeamRequest(t, app, http.MethodGet, "/teams/mine", "")
 			assert.Equal(t, tt.wantStatus, resp.StatusCode)
 
 			if tt.assertBody != nil {
@@ -934,6 +934,14 @@ func TestTeamHandler_UpdateTeam(t *testing.T) {
 				return nil, team.ErrNotFound
 			}},
 			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "permission denied",
+			body: `{"name":"NewName"}`,
+			service: &mockTeamService{updateFunc: func(context.Context, uuid.UUID, uuid.UUID, models.UpdateTeamRequest) (*models.Team, error) {
+				return nil, team.ErrNoPermission
+			}},
+			wantStatus: http.StatusForbidden,
 		},
 		{
 			name: "service error",

--- a/pkg/services/team/service.go
+++ b/pkg/services/team/service.go
@@ -32,7 +32,7 @@ type Service interface {
 	ListMembers(ctx context.Context, teamID uuid.UUID) ([]models.TeamMemberInfo, error)
 	GetUserTeams(ctx context.Context, userID uuid.UUID) ([]models.Team, error)
 	Update(ctx context.Context, teamID uuid.UUID, actorID uuid.UUID, req models.UpdateTeamRequest) (*models.Team, error)
-    AddMember(ctx context.Context, teamID, userID, actorID uuid.UUID, role models.TeamRole) error
+	AddMember(ctx context.Context, teamID, userID, actorID uuid.UUID, role models.TeamRole) error
 }
 
 type service struct {
@@ -57,21 +57,21 @@ func (s *service) Create(ctx context.Context, userID uuid.UUID, req models.Creat
 	}
 
 	uniqueMembers := make(map[uuid.UUID]bool)
-    uniqueMembers[userID] = true // Explicitly add the creator
+	uniqueMembers[userID] = true // Explicitly add the creator
 
-    for _, idStr := range req.MemberIDs {
-        uid, err := uuid.Parse(idStr)
-        if err != nil {
-            return nil, fmt.Errorf("invalid member ID %q: %w", idStr, err)
-        }
-        uniqueMembers[uid] = true
-    }
+	for _, idStr := range req.MemberIDs {
+		uid, err := uuid.Parse(idStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid member ID %q: %w", idStr, err)
+		}
+		uniqueMembers[uid] = true
+	}
 
-    // Convert back to slice
-    memberIDs := make([]uuid.UUID, 0, len(uniqueMembers))
-    for uid := range uniqueMembers {
-        memberIDs = append(memberIDs, uid)
-    }
+	// Convert back to slice
+	memberIDs := make([]uuid.UUID, 0, len(uniqueMembers))
+	for uid := range uniqueMembers {
+		memberIDs = append(memberIDs, uid)
+	}
 
 	if err := s.teams.CreateTeam(ctx, team, memberIDs); err != nil {
 		return nil, err
@@ -147,7 +147,6 @@ func (s *service) List(ctx context.Context, userID *uuid.UUID, limit, offset int
 	return s.teams.ListTeams(ctx, userID, limit, offset)
 }
 
-
 func (s *service) RemoveMember(ctx context.Context, teamID, userID, actorID uuid.UUID) error {
 	tm, err := s.teams.GetTeam(ctx, teamID)
 	if err != nil {
@@ -178,7 +177,6 @@ func (s *service) RemoveMember(ctx context.Context, teamID, userID, actorID uuid
 	return s.teams.RemoveTeamMember(ctx, teamID, userID)
 }
 
-
 func (s *service) ListMembers(ctx context.Context, teamID uuid.UUID) ([]models.TeamMemberInfo, error) {
 	team, err := s.teams.GetTeam(ctx, teamID)
 	if err != nil {
@@ -194,33 +192,39 @@ func (s *service) GetUserTeams(ctx context.Context, userID uuid.UUID) ([]models.
 	return s.teams.GetUserTeams(ctx, userID)
 }
 func (s *service) isTeamAdmin(ctx context.Context, team *models.Team, actorID uuid.UUID) (bool, error) {
-    if team.CreatedBy == actorID {
-        return true, nil
-    }
-    members, err := s.teams.ListTeamMembers(ctx, team.ID)
-    if err != nil {
-        return false, err
-    }
-    for _, m := range members {
-        if m.UserID == actorID && m.Role == models.TeamRoleAdmin {
-            return true, nil
-        }
-    }
-    return false, nil
+	if team.CreatedBy == actorID {
+		return true, nil
+	}
+	members, err := s.teams.ListTeamMembers(ctx, team.ID)
+	if err != nil {
+		return false, err
+	}
+	for _, m := range members {
+		if m.UserID == actorID && m.Role == models.TeamRoleAdmin {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
-
-
 func (s *service) AddMember(ctx context.Context, teamID, userID, actorID uuid.UUID, role models.TeamRole) error {
-    team, err := s.teams.GetTeam(ctx, teamID)
-    if err != nil { return err }
-    if team == nil { return ErrNotFound }
+	team, err := s.teams.GetTeam(ctx, teamID)
+	if err != nil {
+		return err
+	}
+	if team == nil {
+		return ErrNotFound
+	}
 
-    isAdmin, err := s.isTeamAdmin(ctx, team, actorID)
-    if err != nil { return err }
-    if !isAdmin { return ErrNoPermission }
+	isAdmin, err := s.isTeamAdmin(ctx, team, actorID)
+	if err != nil {
+		return err
+	}
+	if !isAdmin {
+		return ErrNoPermission
+	}
 
-    return s.teams.AddTeamMember(ctx, teamID, userID, role)
+	return s.teams.AddTeamMember(ctx, teamID, userID, role)
 }
 func (s *service) Update(ctx context.Context, teamID uuid.UUID, actorID uuid.UUID, req models.UpdateTeamRequest) (*models.Team, error) {
 	team, err := s.teams.GetTeam(ctx, teamID)
@@ -250,6 +254,21 @@ func (s *service) Update(ctx context.Context, teamID uuid.UUID, actorID uuid.UUI
 	return team, nil
 }
 func (s *service) UpdateMemberRole(ctx context.Context, teamID uuid.UUID, userID uuid.UUID, actorID uuid.UUID, role models.TeamRole) error {
-	// Implement your role update logic or use a temporary stub return:
-	return nil
+	team, err := s.teams.GetTeam(ctx, teamID)
+	if err != nil {
+		return err
+	}
+	if team == nil {
+		return ErrNotFound
+	}
+
+	isAdmin, err := s.isTeamAdmin(ctx, team, actorID)
+	if err != nil {
+		return err
+	}
+	if !isAdmin {
+		return ErrNoPermission
+	}
+
+	return s.teams.UpdateTeamMemberRole(ctx, teamID, userID, role)
 }

--- a/pkg/services/team/service_test.go
+++ b/pkg/services/team/service_test.go
@@ -13,31 +13,34 @@ import (
 // mockTeamStore is a minimal mock that satisfies store.TeamStore for the
 // methods used by Service. Unused interface methods panic if called.
 type mockTeamStore struct {
-	team              *models.Team
-	teamWithMembers   *models.TeamWithMembers
-	teams             []models.Team
-	members           []models.TeamMemberInfo
-	userTeams         []models.Team
-	createErr         error
-	getErr            error
-	getWithMembersErr error
-	updateErr         error
-	deleteErr         error
-	listErr           error
-	addMemberErr      error
-	removeMemberErr   error
-	updateMemberErr   error
-	listMembersErr    error
-	getUserTeamsErr   error
-	createdTeam       *models.Team
-	createdMemberIDs  []uuid.UUID
-	updatedTeam       *models.Team
-	deletedTeamID     uuid.UUID
-	addedTeamID       uuid.UUID
-	addedUserID       uuid.UUID
-	addedRole         models.TeamRole
-	removedTeamID     uuid.UUID
-	removedUserID     uuid.UUID
+	team                *models.Team
+	teamWithMembers     *models.TeamWithMembers
+	teams               []models.Team
+	members             []models.TeamMemberInfo
+	userTeams           []models.Team
+	createErr           error
+	getErr              error
+	getWithMembersErr   error
+	updateErr           error
+	deleteErr           error
+	listErr             error
+	addMemberErr        error
+	removeMemberErr     error
+	updateMemberErr     error
+	listMembersErr      error
+	getUserTeamsErr     error
+	createdTeam         *models.Team
+	createdMemberIDs    []uuid.UUID
+	updatedTeam         *models.Team
+	deletedTeamID       uuid.UUID
+	addedTeamID         uuid.UUID
+	addedUserID         uuid.UUID
+	addedRole           models.TeamRole
+	removedTeamID       uuid.UUID
+	removedUserID       uuid.UUID
+	updatedMemberTeamID uuid.UUID
+	updatedMemberUserID uuid.UUID
+	updatedMemberRole   models.TeamRole
 }
 
 func (m *mockTeamStore) CreateTeam(_ context.Context, team *models.Team, memberIDs []uuid.UUID) error {
@@ -81,7 +84,10 @@ func (m *mockTeamStore) RemoveTeamMember(_ context.Context, teamID, userID uuid.
 	return m.removeMemberErr
 }
 
-func (m *mockTeamStore) UpdateTeamMemberRole(_ context.Context, _, _ uuid.UUID, _ models.TeamRole) error {
+func (m *mockTeamStore) UpdateTeamMemberRole(_ context.Context, teamID, userID uuid.UUID, role models.TeamRole) error {
+	m.updatedMemberTeamID = teamID
+	m.updatedMemberUserID = userID
+	m.updatedMemberRole = role
 	return m.updateMemberErr
 }
 
@@ -538,5 +544,85 @@ func TestUpdate_NoPermission(t *testing.T) {
 	_, err := svc.Update(context.Background(), teamID, regularUserID, models.UpdateTeamRequest{Name: &newName})
 	if !errors.Is(err, ErrNoPermission) {
 		t.Fatalf("expected ErrNoPermission, got %v", err)
+	}
+}
+
+// TestUpdateMemberRole_NotFound tests that UpdateMemberRole returns ErrNotFound
+// when the team does not exist.
+func TestUpdateMemberRole_NotFound(t *testing.T) {
+	svc := New(&mockTeamStore{team: nil}, &mockUserStore{})
+	err := svc.UpdateMemberRole(context.Background(), uuid.New(), uuid.New(), uuid.New(), models.TeamRoleAdmin)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// TestUpdateMemberRole_ByCreator tests that team creators can update member roles.
+func TestUpdateMemberRole_ByCreator(t *testing.T) {
+	creatorID := uuid.New()
+	teamID := uuid.New()
+	memberID := uuid.New()
+	mock := &mockTeamStore{team: &models.Team{ID: teamID, CreatedBy: creatorID}}
+	svc := New(mock, &mockUserStore{})
+
+	err := svc.UpdateMemberRole(context.Background(), teamID, memberID, creatorID, models.TeamRoleAdmin)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.updatedMemberTeamID != teamID {
+		t.Fatalf("expected UpdateTeamMemberRole called with team %v, got %v", teamID, mock.updatedMemberTeamID)
+	}
+	if mock.updatedMemberUserID != memberID {
+		t.Fatalf("expected UpdateTeamMemberRole called with user %v, got %v", memberID, mock.updatedMemberUserID)
+	}
+	if mock.updatedMemberRole != models.TeamRoleAdmin {
+		t.Fatalf("expected role %v, got %v", models.TeamRoleAdmin, mock.updatedMemberRole)
+	}
+}
+
+// TestUpdateMemberRole_ByAdmin tests that team admins can update member roles.
+func TestUpdateMemberRole_ByAdmin(t *testing.T) {
+	creatorID := uuid.New()
+	adminID := uuid.New()
+	teamID := uuid.New()
+	memberID := uuid.New()
+	mock := &mockTeamStore{
+		team: &models.Team{ID: teamID, CreatedBy: creatorID},
+		members: []models.TeamMemberInfo{
+			{UserID: adminID, Role: models.TeamRoleAdmin},
+		},
+	}
+	svc := New(mock, &mockUserStore{})
+
+	err := svc.UpdateMemberRole(context.Background(), teamID, memberID, adminID, models.TeamRoleMember)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.updatedMemberRole != models.TeamRoleMember {
+		t.Fatalf("expected role %v, got %v", models.TeamRoleMember, mock.updatedMemberRole)
+	}
+}
+
+// TestUpdateMemberRole_NoPermission tests that regular members cannot update
+// another member's role.
+func TestUpdateMemberRole_NoPermission(t *testing.T) {
+	creatorID := uuid.New()
+	regularUserID := uuid.New()
+	teamID := uuid.New()
+	memberID := uuid.New()
+	mock := &mockTeamStore{
+		team: &models.Team{ID: teamID, CreatedBy: creatorID},
+		members: []models.TeamMemberInfo{
+			{UserID: regularUserID, Role: models.TeamRoleMember},
+		},
+	}
+	svc := New(mock, &mockUserStore{})
+
+	err := svc.UpdateMemberRole(context.Background(), teamID, memberID, regularUserID, models.TeamRoleAdmin)
+	if !errors.Is(err, ErrNoPermission) {
+		t.Fatalf("expected ErrNoPermission, got %v", err)
+	}
+	if mock.updatedMemberUserID != uuid.Nil {
+		t.Fatal("UpdateTeamMemberRole should not be called without permission")
 	}
 }


### PR DESCRIPTION
## Summary
- align team handler tests with production routes for `ListAllTeams` and `GetUserTeams`
- add coverage for `UpdateTeam` permission-denied handling
- return 403 from `UpdateTeam` when the service reports `team.ErrNoPermission`
- reject whitespace-only team names, matching the existing handler test expectation

## Context
Follow-up to review comments on #19511 after it was merged. The route changes address Copilot comments about `/teams` and `/teams/mine`; the update permission case exposed a real handler mapping gap.

## Netlify parity
No matching `web/netlify/functions` team-management endpoint exists, so there is no Netlify function to update for this Go handler behavior.

## Tests
- `go test ./pkg/api/handlers -run '^TestTeamHandler_(ListAllTeams|GetUserTeams|UpdateTeam)$'`\n- `go test ./pkg/api/handlers -run '^TestTeamHandler'`\n- `git diff --check -- pkg/api/handlers/teams.go pkg/api/handlers/teams_test.go`\n\nNote: `go test ./pkg/api/handlers` still fails on current main in an unrelated admission webhook test path with a nil pointer panic from `MultiClusterClient.ListClusters`.