### PR TITLE
[scanner] fix: add link to GitHub issue tracker from bug report UI

### DIFF
--- a/web/src/components/feedback/SubmitTab.tsx
+++ b/web/src/components/feedback/SubmitTab.tsx
@@ -424,6 +424,15 @@ export function SubmitForm({
                 ))}
               </ul>
               <div className="text-muted-foreground text-xs mt-1.5 flex flex-wrap gap-1 items-center">
+                <a
+                  href={sanitizeUrl(buildDirectIssueUrl(targetRepo, description))}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-purple-400 hover:text-purple-300 underline underline-offset-2"
+                >
+                  Report on GitHub
+                </a>
+                <span>{' · '}</span>
                 <button
                   type="button"
                   onClick={() => window.open(GITHUB_TOKEN_CREATE_URL, '_blank', 'noopener,noreferrer')}


### PR DESCRIPTION
Fixes #15485

Adds a link to the GitHub issue tracker from the file bug report interface.