### PR TITLE
[scanner] fix: raise coverage ratchets for compliance and sanitize packages

### DIFF
--- a/.github/go-package-coverage-ratchet.txt
+++ b/.github/go-package-coverage-ratchet.txt
@@ -14,7 +14,7 @@ pkg/k8s 68.5
 # --- Tier 2: Critical integrations ---
 pkg/notifications 0.0
 pkg/kagentiprovider 0.0
-pkg/sanitize 0.0
+pkg/sanitize 85.0
 pkg/store 42.0
 
 # --- Tier 3: Supporting packages ---
@@ -29,19 +29,19 @@ pkg/safego 0.0
 pkg/fileutil 0.0
 
 # --- Compliance engines (start at 0, ratchet up as evaluation tests land) ---
-pkg/compliance/fedramp 0.0
-pkg/compliance/hipaa 0.0
-pkg/compliance/nist80053 0.0
-pkg/compliance/slsa 0.0
-pkg/compliance/sbom 0.0
-pkg/compliance/signing 0.0
-pkg/compliance/licenses 0.0
-pkg/compliance/stig 0.0
-pkg/compliance/baa 0.0
-pkg/compliance/airgap 0.0
-pkg/compliance/sod 0.0
-pkg/compliance/gxp 0.0
-pkg/compliance/changecontrol 0.0
-pkg/compliance/residency 0.0
-pkg/compliance/frameworks 0.0
-pkg/compliance/reports 0.0
+pkg/compliance/fedramp 65.0
+pkg/compliance/hipaa 70.0
+pkg/compliance/nist80053 65.0
+pkg/compliance/slsa 60.0
+pkg/compliance/sbom 60.0
+pkg/compliance/signing 60.0
+pkg/compliance/licenses 55.0
+pkg/compliance/stig 65.0
+pkg/compliance/baa 65.0
+pkg/compliance/airgap 65.0
+pkg/compliance/sod 60.0
+pkg/compliance/gxp 60.0
+pkg/compliance/changecontrol 60.0
+pkg/compliance/residency 65.0
+pkg/compliance/frameworks 70.0
+pkg/compliance/reports 75.0


### PR DESCRIPTION
Fixes #19518, Fixes #19519

Raises coverage ratchet thresholds for compliance packages and pkg/sanitize as identified by quality checks.

## Changes

### pkg/sanitize (0% → 85%)
- Security-critical package for prompt injection prevention
- Comprehensive tests covering both `PromptString` and `PromptStrings` functions
- 6 test functions covering injection markers, role markers, empty input, safe input, and slice handling

### Compliance packages (0% → 55-75%)
All 16 compliance engine packages raised from 0% floor to appropriate thresholds based on test file coverage:

- `pkg/compliance/fedramp`: 65% (engine_test.go, score_test.go, evaluate_test.go)
- `pkg/compliance/hipaa`: 70% (engine_test.go, evaluate_test.go, summary_test.go)
- `pkg/compliance/nist80053`: 65% (engine_test.go, evaluate_test.go, summary_test.go)
- `pkg/compliance/slsa`: 60% (engine_test.go, evaluate_test.go)
- `pkg/compliance/sbom`: 60% (engine_test.go, evaluate_test.go)
- `pkg/compliance/signing`: 60% (engine_test.go, evaluate_test.go)
- `pkg/compliance/licenses`: 55% (engine_test.go, evaluate_test.go)
- `pkg/compliance/stig`: 65% (engine_test.go, evaluate_test.go)
- `pkg/compliance/baa`: 65% (engine_test.go, evaluate_test.go)
- `pkg/compliance/airgap`: 65% (engine_test.go, evaluate_test.go)
- `pkg/compliance/sod`: 60% (engine_test.go)
- `pkg/compliance/gxp`: 60% (engine_test.go)
- `pkg/compliance/changecontrol`: 60% (engine_test.go)
- `pkg/compliance/residency`: 65% (engine_test.go)
- `pkg/compliance/frameworks`: 70% (evaluator_test.go, builtin_models_demo_test.go)
- `pkg/compliance/reports`: 75% (reports_test.go, json_test.go, pdf_test.go, demo_test.go)

## Impact

With 0% floors, any test deletion or coverage regression would pass CI undetected. These new floors lock in existing test quality and prevent regressions without requiring new test work.