### PR TITLE
[scanner] fix: prevent nil-interface panic in TimelineHandler

### DIFF
--- a/pkg/api/handlers/timeline.go
+++ b/pkg/api/handlers/timeline.go
@@ -86,7 +86,11 @@ type TimelineHandler struct {
 // Accepts the full *k8s.MultiClusterClient at the call-site but stores it as
 // the narrow timelineClient interface so tests can substitute a simple mock.
 func NewTimelineHandler(s store.Store, k8sClient *k8s.MultiClusterClient) *TimelineHandler {
-	return &TimelineHandler{store: s, k8sClient: k8sClient}
+	h := &TimelineHandler{store: s}
+	if k8sClient != nil {
+		h.k8sClient = k8sClient
+	}
+	return h
 }
 
 // SetStellarEventSink wires Stellar's ProcessEvent into the collector loop.


### PR DESCRIPTION
Fixes #19542

## Problem
`NewTimelineHandler(store, nil)` stores a nil `*k8s.MultiClusterClient` as a non-nil interface value. The nil guard in `StartEventCollector` then fails, causing a panic when `collectAll` dereferences the nil pointer.

## Fix
Only assign `k8sClient` to the interface field when the concrete pointer is non-nil. This ensures the zero-value nil interface is preserved, making the existing nil check work correctly.