### PR TITLE
[scanner] fix: use typed constants in TestGetDemoWorkloads to unbreak main

### DIFF
--- a/pkg/api/handlers/workloads/helpers_test.go
+++ b/pkg/api/handlers/workloads/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/apis/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -86,8 +87,8 @@ func TestGetDemoWorkloads(t *testing.T) {
 		if w.Name == "nginx-ingress" {
 			foundNginx = true
 			assert.Equal(t, "ingress-system", w.Namespace)
-			assert.Equal(t, "Deployment", w.Type)
-			assert.Equal(t, "Running", w.Status)
+			assert.Equal(t, v1alpha1.WorkloadTypeDeployment, w.Type)
+			assert.Equal(t, v1alpha1.WorkloadStatusRunning, w.Status)
 			break
 		}
 	}


### PR DESCRIPTION
## Fix: Main branch Go Tests failure

The `TestGetDemoWorkloads` test in `pkg/api/handlers/workloads/helpers_test.go` was comparing plain `string` literals against `v1alpha1.WorkloadType` and `v1alpha1.WorkloadStatus` typed values, causing type mismatch assertion failures.

### Changes
- Import `v1alpha1` package in the test file
- Replace `"Deployment"` with `v1alpha1.WorkloadTypeDeployment`
- Replace `"Running"` with `v1alpha1.WorkloadStatusRunning`

**P0 fix** — this is blocking all PRs on main.

Signed-off-by: clubanderson <clubanderson@users.noreply.github.com>