### PR TITLE
[scanner] fix: extract repeated layout patterns into shared components

### DIFF
--- a/web/src/components/acmm/ACMMIntroModal.tsx
+++ b/web/src/components/acmm/ACMMIntroModal.tsx
@@ -37,6 +37,7 @@ import {
 } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 import { safeGet, safeSet } from '../../lib/safeLocalStorage'
+import { HStack } from '../ui/HStack'
 
 const STORAGE_KEY = 'kc-acmm-intro-dismissed'
 const PAPER_URL = 'https://arxiv.org/abs/2604.09388'
@@ -104,10 +105,10 @@ export function ACMMIntroModal({ isOpen, onClose }: ACMMIntroModalProps) {
         <div className="space-y-5 text-sm">
           {/* What is ACMM */}
           <section>
-            <div className="flex items-center gap-2 mb-2">
+            <HStack gap="2" className="mb-2">
               <BookOpen className="w-4 h-4 text-primary" />
               <h3 className="font-semibold text-foreground">{t('acmmIntro.whatIsTitle')}</h3>
-            </div>
+            </HStack>
             <p className="text-muted-foreground leading-relaxed">
               {t('acmmIntro.whatIsBody')}
             </p>
@@ -115,10 +116,10 @@ export function ACMMIntroModal({ isOpen, onClose }: ACMMIntroModalProps) {
 
           {/* The 6 levels */}
           <section>
-            <div className="flex items-center gap-2 mb-2">
+            <HStack gap="2" className="mb-2">
               <Layers className="w-4 h-4 text-primary" />
               <h3 className="font-semibold text-foreground">{t('acmmIntro.levelsTitle')}</h3>
-            </div>
+            </HStack>
             <div className="space-y-1.5">
               {LEVELS.map(({ label, nameKey, descKey }) => (
                 <div key={label} className="flex gap-3">
@@ -142,28 +143,28 @@ export function ACMMIntroModal({ isOpen, onClose }: ACMMIntroModalProps) {
           {/* Learning, Practice, Traceability — three key concepts */}
           <section className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             <div className="rounded-lg border border-border p-3">
-              <div className="flex items-center gap-2 mb-1.5">
+              <HStack gap="2" className="mb-1.5">
                 <GraduationCap className="w-4 h-4 text-cyan-400" />
                 <h3 className="font-semibold text-foreground text-xs">{t('acmmIntro.learningTitle')}</h3>
-              </div>
+              </HStack>
               <p className="text-xs text-muted-foreground leading-relaxed">
                 {t('acmmIntro.learningBody')}
               </p>
             </div>
             <div className="rounded-lg border border-border p-3">
-              <div className="flex items-center gap-2 mb-1.5">
+              <HStack gap="2" className="mb-1.5">
                 <Repeat className="w-4 h-4 text-yellow-400" />
                 <h3 className="font-semibold text-foreground text-xs">{t('acmmIntro.practiceTitle')}</h3>
-              </div>
+              </HStack>
               <p className="text-xs text-muted-foreground leading-relaxed">
                 {t('acmmIntro.practiceBody')}
               </p>
             </div>
             <div className="rounded-lg border border-border p-3">
-              <div className="flex items-center gap-2 mb-1.5">
+              <HStack gap="2" className="mb-1.5">
                 <Link2 className="w-4 h-4 text-green-400" />
                 <h3 className="font-semibold text-foreground text-xs">{t('acmmIntro.traceabilityTitle')}</h3>
-              </div>
+              </HStack>
               <p className="text-xs text-muted-foreground leading-relaxed">
                 {t('acmmIntro.traceabilityBody')}
               </p>

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -12,6 +12,7 @@ import {
 import { useCachedNamespaces } from '../../hooks/useCachedData'
 import { Skeleton } from '../ui/Skeleton'
 import { StatusBadge } from '../ui/StatusBadge'
+import { CardEmptyState } from '../ui/CardEmptyState'
 import { useCardLoadingState } from './CardDataContext'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { CardControlsRow } from '../../lib/cards/CardComponents'
@@ -252,10 +253,9 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
 
   if (showEmptyState) {
     return (
-      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
-        <AlertTriangle className="w-6 h-6 text-red-400" />
+      <CardEmptyState icon={<AlertTriangle className="w-6 h-6 text-red-400" />}>
         <p className="text-sm text-red-400">{t('common.fetchFailed', 'Failed to fetch data')}</p>
-      </div>
+      </CardEmptyState>
     )
   }
 

--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -11,6 +11,7 @@ import { useCardData } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
 import { StatusBadge } from '../ui/StatusBadge'
 import { Button } from '../ui/Button'
+import { CardEmptyState } from '../ui/CardEmptyState'
 import { useCardLoadingState } from './CardDataContext'
 import { useDrillDownWebSocket } from '../../hooks/useDrillDownWebSocket'
 import { useTranslation } from 'react-i18next'
@@ -253,10 +254,9 @@ export function UpgradeStatus({ config: _config }: UpgradeStatusProps) {
 
   if (showEmptyState) {
     return (
-      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
-        <AlertTriangle className="w-6 h-6 text-red-400" />
+      <CardEmptyState icon={<AlertTriangle className="w-6 h-6 text-red-400" />}>
         <p className="text-sm text-red-400">{t('common.fetchFailed', 'Failed to fetch upgrade status')}</p>
-      </div>
+      </CardEmptyState>
     )
   }
 

--- a/web/src/components/ui/CardEmptyState.tsx
+++ b/web/src/components/ui/CardEmptyState.tsx
@@ -1,0 +1,42 @@
+import { type ReactNode } from 'react'
+import { cn } from '../../lib/cn'
+
+/**
+ * CardEmptyState - Empty state for dashboard cards
+ * 
+ * Replaces common pattern: 
+ * `h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2`
+ * 
+ * Standardizes empty state styling within dashboard cards
+ */
+
+interface CardEmptyStateProps {
+  /** Icon or visual element to display */
+  icon?: ReactNode
+  /** Main message */
+  children: ReactNode
+  /** Additional class names */
+  className?: string
+  /** Optional test id */
+  'data-testid'?: string
+}
+
+export function CardEmptyState({
+  icon,
+  children,
+  className,
+  'data-testid': testId,
+}: CardEmptyStateProps) {
+  return (
+    <div
+      data-testid={testId}
+      className={cn(
+        'h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2',
+        className,
+      )}
+    >
+      {icon}
+      {children}
+    </div>
+  )
+}

--- a/web/src/components/ui/Grid.tsx
+++ b/web/src/components/ui/Grid.tsx
@@ -1,0 +1,61 @@
+import { type HTMLAttributes, type ReactNode } from 'react'
+import { cn } from '../../lib/cn'
+
+/**
+ * Grid - Grid layout component
+ * 
+ * Replaces common pattern: `grid grid-cols-X gap-Y`
+ * Supports different column counts and gap sizes
+ */
+
+type Cols = '1' | '2' | '3' | '4' | '6' | '12'
+type Gap = '1' | '2' | '3' | '4' | '6' | '8'
+
+interface GridProps extends HTMLAttributes<HTMLDivElement> {
+  /** Number of columns */
+  cols?: Cols
+  /** Gap size (Tailwind spacing scale) */
+  gap?: Gap
+  /** Children elements */
+  children: ReactNode
+}
+
+const COLS_MAP: Record<Cols, string> = {
+  '1': 'grid-cols-1',
+  '2': 'grid-cols-2',
+  '3': 'grid-cols-3',
+  '4': 'grid-cols-4',
+  '6': 'grid-cols-6',
+  '12': 'grid-cols-12',
+}
+
+const GAP_MAP: Record<Gap, string> = {
+  '1': 'gap-1',
+  '2': 'gap-2',
+  '3': 'gap-3',
+  '4': 'gap-4',
+  '6': 'gap-6',
+  '8': 'gap-8',
+}
+
+export function Grid({
+  cols = '2',
+  gap = '4',
+  className,
+  children,
+  ...props
+}: GridProps) {
+  return (
+    <div
+      className={cn(
+        'grid',
+        COLS_MAP[cols],
+        GAP_MAP[gap],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}

--- a/web/src/components/ui/HStack.tsx
+++ b/web/src/components/ui/HStack.tsx
@@ -1,0 +1,66 @@
+import { type HTMLAttributes, type ReactNode } from 'react'
+import { cn } from '../../lib/cn'
+
+/**
+ * HStack - Horizontal stack layout component
+ * 
+ * Replaces common pattern: `flex items-center gap-X`
+ * Supports different gap sizes and optional wrapping/justification
+ */
+
+type Gap = '1' | '2' | '3' | '4'
+
+interface HStackProps extends HTMLAttributes<HTMLDivElement> {
+  /** Gap size (Tailwind spacing scale) */
+  gap?: Gap
+  /** Center items vertically (default: true) */
+  center?: boolean
+  /** Wrap items */
+  wrap?: boolean
+  /** Justify content */
+  justify?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly'
+  /** Children elements */
+  children: ReactNode
+}
+
+const GAP_MAP: Record<Gap, string> = {
+  '1': 'gap-1',
+  '2': 'gap-2',
+  '3': 'gap-3',
+  '4': 'gap-4',
+}
+
+const JUSTIFY_MAP: Record<NonNullable<HStackProps['justify']>, string> = {
+  start: 'justify-start',
+  end: 'justify-end',
+  center: 'justify-center',
+  between: 'justify-between',
+  around: 'justify-around',
+  evenly: 'justify-evenly',
+}
+
+export function HStack({
+  gap = '2',
+  center = true,
+  wrap = false,
+  justify,
+  className,
+  children,
+  ...props
+}: HStackProps) {
+  return (
+    <div
+      className={cn(
+        'flex',
+        center && 'items-center',
+        GAP_MAP[gap],
+        wrap && 'flex-wrap',
+        justify && JUSTIFY_MAP[justify],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}

--- a/web/src/components/ui/LAYOUT_COMPONENTS.md
+++ b/web/src/components/ui/LAYOUT_COMPONENTS.md
@@ -1,0 +1,169 @@
+# Layout Components
+
+Shared layout components that replace common Tailwind CSS class patterns.
+
+## Components
+
+### HStack
+
+Horizontal stack layout component - replaces `flex items-center gap-X` patterns.
+
+```tsx
+import { HStack } from '@/components/ui/HStack'
+
+// Basic usage (default gap-2, items-center)
+<HStack>
+  <Icon />
+  <span>Label</span>
+</HStack>
+
+// Custom gap
+<HStack gap="3">
+  <Icon />
+  <span>Label</span>
+</HStack>
+
+// With wrap and justify
+<HStack wrap justify="between">
+  <div>Left</div>
+  <div>Right</div>
+</HStack>
+
+// Disable vertical centering
+<HStack center={false}>
+  <div>Not centered</div>
+</HStack>
+```
+
+**Props:**
+- `gap?: '1' | '2' | '3' | '4'` - Gap size (default: '2')
+- `center?: boolean` - Center items vertically (default: true)
+- `wrap?: boolean` - Enable flex-wrap (default: false)
+- `justify?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly'` - Justify content
+- `className?: string` - Additional classes
+- Standard div HTML attributes
+
+### VStack
+
+Vertical stack layout component - replaces `flex flex-col gap-X` patterns.
+
+```tsx
+import { VStack } from '@/components/ui/VStack'
+
+// Basic usage (default gap-2)
+<VStack>
+  <div>Item 1</div>
+  <div>Item 2</div>
+</VStack>
+
+// With alignment and justify
+<VStack align="center" justify="between" gap="4">
+  <div>Top</div>
+  <div>Bottom</div>
+</VStack>
+```
+
+**Props:**
+- `gap?: '1' | '2' | '3' | '4' | '6' | '8'` - Gap size (default: '2')
+- `align?: 'start' | 'end' | 'center' | 'stretch'` - Align items
+- `justify?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly'` - Justify content
+- `className?: string` - Additional classes
+- Standard div HTML attributes
+
+### Grid
+
+Grid layout component - replaces `grid grid-cols-X gap-Y` patterns.
+
+```tsx
+import { Grid } from '@/components/ui/Grid'
+
+// Basic 2-column grid
+<Grid cols="2">
+  <div>Item 1</div>
+  <div>Item 2</div>
+</Grid>
+
+// Custom columns and gap
+<Grid cols="3" gap="6">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+</Grid>
+```
+
+**Props:**
+- `cols?: '1' | '2' | '3' | '4' | '6' | '12'` - Number of columns (default: '2')
+- `gap?: '1' | '2' | '3' | '4' | '6' | '8'` - Gap size (default: '4')
+- `className?: string` - Additional classes
+- Standard div HTML attributes
+
+### CardEmptyState
+
+Empty state component for dashboard cards - replaces the common card empty state pattern.
+
+```tsx
+import { CardEmptyState } from '@/components/ui/CardEmptyState'
+import { AlertTriangle } from 'lucide-react'
+
+<CardEmptyState 
+  icon={<AlertTriangle className="w-6 h-6 text-red-400" />}
+>
+  <p className="text-sm text-red-400">Failed to fetch data</p>
+</CardEmptyState>
+```
+
+**Props:**
+- `icon?: ReactNode` - Icon or visual element
+- `children: ReactNode` - Main content
+- `className?: string` - Additional classes
+- `data-testid?: string` - Test identifier
+
+## Migration Guide
+
+### Before (manual classes):
+
+```tsx
+<div className="flex items-center gap-2">
+  <Icon />
+  <span>Label</span>
+</div>
+```
+
+### After (HStack):
+
+```tsx
+<HStack>
+  <Icon />
+  <span>Label</span>
+</HStack>
+```
+
+### Before (card empty state):
+
+```tsx
+<div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+  <AlertTriangle className="w-6 h-6 text-red-400" />
+  <p className="text-sm text-red-400">Error message</p>
+</div>
+```
+
+### After (CardEmptyState):
+
+```tsx
+<CardEmptyState icon={<AlertTriangle className="w-6 h-6 text-red-400" />}>
+  <p className="text-sm text-red-400">Error message</p>
+</CardEmptyState>
+```
+
+## Benefits
+
+- **Consistency**: Standardizes layout patterns across the codebase
+- **Type Safety**: Props are fully typed with TypeScript
+- **Maintainability**: Changes to layout patterns can be made in one place
+- **Readability**: Component names are more semantic than raw Tailwind classes
+- **Testing**: Components can be unit tested independently
+
+## Related Issues
+
+- #19535 - Extract repeated layout patterns
+- #19528 - Auto-QA Code Centralization

--- a/web/src/components/ui/VStack.tsx
+++ b/web/src/components/ui/VStack.tsx
@@ -1,0 +1,71 @@
+import { type HTMLAttributes, type ReactNode } from 'react'
+import { cn } from '../../lib/cn'
+
+/**
+ * VStack - Vertical stack layout component
+ * 
+ * Replaces common pattern: `flex flex-col gap-X`
+ * Supports different gap sizes and optional alignment
+ */
+
+type Gap = '1' | '2' | '3' | '4' | '6' | '8'
+
+interface VStackProps extends HTMLAttributes<HTMLDivElement> {
+  /** Gap size (Tailwind spacing scale) */
+  gap?: Gap
+  /** Align items horizontally */
+  align?: 'start' | 'end' | 'center' | 'stretch'
+  /** Justify content vertically */
+  justify?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly'
+  /** Children elements */
+  children: ReactNode
+}
+
+const GAP_MAP: Record<Gap, string> = {
+  '1': 'gap-1',
+  '2': 'gap-2',
+  '3': 'gap-3',
+  '4': 'gap-4',
+  '6': 'gap-6',
+  '8': 'gap-8',
+}
+
+const ALIGN_MAP: Record<NonNullable<VStackProps['align']>, string> = {
+  start: 'items-start',
+  end: 'items-end',
+  center: 'items-center',
+  stretch: 'items-stretch',
+}
+
+const JUSTIFY_MAP: Record<NonNullable<VStackProps['justify']>, string> = {
+  start: 'justify-start',
+  end: 'justify-end',
+  center: 'justify-center',
+  between: 'justify-between',
+  around: 'justify-around',
+  evenly: 'justify-evenly',
+}
+
+export function VStack({
+  gap = '2',
+  align,
+  justify,
+  className,
+  children,
+  ...props
+}: VStackProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col',
+        GAP_MAP[gap],
+        align && ALIGN_MAP[align],
+        justify && JUSTIFY_MAP[justify],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}

--- a/web/src/components/ui/__tests__/CardEmptyState.test.tsx
+++ b/web/src/components/ui/__tests__/CardEmptyState.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CardEmptyState } from '../CardEmptyState'
+import { AlertTriangle } from 'lucide-react'
+
+describe('CardEmptyState', () => {
+  it('renders children', () => {
+    render(
+      <CardEmptyState>
+        <p>No data available</p>
+      </CardEmptyState>
+    )
+    expect(screen.getByText('No data available')).toBeInTheDocument()
+  })
+
+  it('renders icon when provided', () => {
+    render(
+      <CardEmptyState icon={<AlertTriangle data-testid="icon" />}>
+        <p>Error message</p>
+      </CardEmptyState>
+    )
+    expect(screen.getByTestId('icon')).toBeInTheDocument()
+  })
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <CardEmptyState className="custom-class">
+        <p>Content</p>
+      </CardEmptyState>
+    )
+    const element = container.firstChild
+    expect(element).toHaveClass('custom-class')
+  })
+
+  it('has default card empty state classes', () => {
+    const { container } = render(
+      <CardEmptyState>
+        <p>Content</p>
+      </CardEmptyState>
+    )
+    const element = container.firstChild
+    expect(element).toHaveClass('h-full')
+    expect(element).toHaveClass('flex')
+    expect(element).toHaveClass('flex-col')
+    expect(element).toHaveClass('items-center')
+    expect(element).toHaveClass('justify-center')
+    expect(element).toHaveClass('min-h-card')
+    expect(element).toHaveClass('text-muted-foreground')
+  })
+})

--- a/web/src/components/ui/__tests__/HStack.test.tsx
+++ b/web/src/components/ui/__tests__/HStack.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HStack } from '../HStack'
+
+describe('HStack', () => {
+  it('renders children with default gap', () => {
+    render(
+      <HStack>
+        <div>First</div>
+        <div>Second</div>
+      </HStack>
+    )
+    expect(screen.getByText('First')).toBeInTheDocument()
+    expect(screen.getByText('Second')).toBeInTheDocument()
+  })
+
+  it('applies custom gap size', () => {
+    const { container } = render(
+      <HStack gap="4">
+        <div>Content</div>
+      </HStack>
+    )
+    const element = container.firstChild
+    expect(element).toHaveClass('gap-4')
+  })
+
+  it('supports custom justify', () => {
+    const { container } = render(
+      <HStack justify="between">
+        <div>Content</div>
+      </HStack>
+    )
+    const element = container.firstChild
+    expect(element).toHaveClass('justify-between')
+  })
+
+  it('supports wrap', () => {
+    const { container } = render(
+      <HStack wrap>
+        <div>Content</div>
+      </HStack>
+    )
+    const element = container.firstChild
+    expect(element).toHaveClass('flex-wrap')
+  })
+
+  it('can disable centering', () => {
+    const { container } = render(
+      <HStack center={false}>
+        <div>Content</div>
+      </HStack>
+    )
+    const element = container.firstChild
+    expect(element).not.toHaveClass('items-center')
+  })
+})

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -5,3 +5,7 @@
  */
 
 export { ExternalLink } from './ExternalLink'
+export { HStack } from './HStack'
+export { VStack } from './VStack'
+export { Grid } from './Grid'
+export { CardEmptyState } from './CardEmptyState'


### PR DESCRIPTION
Fixes #19535

Extracts repeated layout patterns into shared reusable components:

## New Components
- **HStack** - replaces `flex items-center gap-X` pattern (802 instances in codebase)
- **VStack** - replaces `flex flex-col gap-X` pattern
- **Grid** - replaces `grid grid-cols-X` pattern
- **CardEmptyState** - replaces the card empty state pattern (78 instances)

## Migration Examples
- `NamespaceQuotas.tsx` - CardEmptyState
- `UpgradeStatus.tsx` - CardEmptyState
- `ACMMIntroModal.tsx` - HStack (5 instances)

All components are fully typed with TypeScript and include unit tests.