### PR TITLE
[scanner] fix: migrate remaining cards to standardized card hooks

### DIFF
--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -19,8 +19,7 @@ import {
   type ClusterGroup,
   type ClusterGroupKind } from '../../hooks/useClusterGroups'
 import { useClusters } from '../../hooks/useMCP'
-import { useCardLoadingState } from './CardDataContext'
-import { useDemoMode } from '../../hooks/useDemoMode'
+import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../ui/StatusBadge'
 import { ConfirmDialog, useModalState } from '../../lib/modals'
@@ -50,7 +49,7 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
   const { showToast } = useToast()
   const { groups: liveGroups, createGroup, updateGroup, deleteGroup, isPersisted } = useClusterGroups()
   const { deduplicatedClusters: clusters, isLoading, isRefreshing, isFailed, consecutiveFailures } = useClusters()
-  const { isDemoMode: demoMode } = useDemoMode()
+  const { shouldUseDemoData } = useCardDemoState({ requires: 'agent' })
   const federation = useFederationAwareness()
 
   // Build the built-in "all-healthy-clusters" group from current cluster state for live mode
@@ -71,7 +70,7 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
     icon: fg.kind,
   }))
 
-  const groups = demoMode ? DEMO_GROUPS : [builtInGroup, ...federationGroups, ...liveGroups]
+  const groups = shouldUseDemoData ? DEMO_GROUPS : [builtInGroup, ...federationGroups, ...liveGroups]
   const { isOpen: isCreating, open: openCreateForm, close: closeCreateForm } = useModalState()
   // Track which group is pending delete confirmation (#5197)
   const [deleteConfirmName, setDeleteConfirmName] = useState<string | null>(null)
@@ -82,7 +81,7 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
     isLoading: isLoading && !hasData,
     isRefreshing,
     hasAnyData: hasData,
-    isDemoData: demoMode,
+    isDemoData: shouldUseDemoData,
     isFailed,
     consecutiveFailures })
   const [editingGroup, setEditingGroup] = useState<string | null>(null)

--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -122,7 +122,7 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
             </span>
           )}
         </div>
-        {!demoMode && (
+        {!shouldUseDemoData && (
           <button
             onClick={openCreateForm}
             className="flex items-center gap-1 px-2 py-1 text-xs rounded-md bg-blue-500/20 text-blue-400 hover:bg-blue-500/30 transition-colors"

--- a/web/src/components/cards/KubeKong.tsx
+++ b/web/src/components/cards/KubeKong.tsx
@@ -4,7 +4,7 @@ import { RotateCcw, Trophy, Pause, Play } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { CardComponentProps } from './cardRegistry'
 import { useCardExpanded } from './CardWrapper'
-import { useReportCardDataState } from './CardDataContext'
+import { useReportCardDataState, useCardDemoState } from './CardDataContext'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
 import { useGameKeyTracking } from '../../hooks/useGameKeys'
 import { safeGet, safeSet } from '../../lib/safeLocalStorage'
@@ -99,7 +99,8 @@ function getPlatformY(platform: Platform, x: number): number {
 
 export function KubeKong(_props: CardComponentProps) {
   const { t } = useTranslation('cards')
-  useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
+  const { showDemoBadge } = useCardDemoState({ requires: 'none' })
+  useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: showDemoBadge })
   const { isExpanded } = useCardExpanded()
   const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -13,8 +13,7 @@ import { useCachedNamespaces } from '../../hooks/useCachedData'
 import { Skeleton } from '../ui/Skeleton'
 import { StatusBadge } from '../ui/StatusBadge'
 import { CardEmptyState } from '../ui/CardEmptyState'
-import { useCardLoadingState } from './CardDataContext'
-import { useDemoMode } from '../../hooks/useDemoMode'
+import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 import { CardControlsRow } from '../../lib/cards/CardComponents'
 import { useCardData, type SortDirection } from '../../lib/cards/cardHooks'
 import { useTranslation } from 'react-i18next'
@@ -38,7 +37,7 @@ import {
 
 export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
   const { t } = useTranslation(['cards', 'common'])
-  const { isDemoMode } = useDemoMode()
+  const { showDemoBadge } = useCardDemoState({ requires: 'agent' })
   const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed: clustersFailed, consecutiveFailures: clustersFailures } = useClusters()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || 'all')
   const [selectedNamespace, setSelectedNamespace] = useState<string>(config?.namespace || 'all')
@@ -75,7 +74,7 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
     isLoading: isInitialLoading || isFetchingData,
     isRefreshing: clustersRefreshing || namespacesRefreshing,
     hasAnyData: allClusters.length > 0 || resourceQuotas.length > 0 || limitRanges.length > 0,
-    isDemoData: isDemoMode || isDemoFallback,
+    isDemoData: showDemoBadge || isDemoFallback,
     isFailed: clustersFailed,
     consecutiveFailures: clustersFailures,
   })

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -333,7 +333,7 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
         paginatedQuotas={paginatedQuotas as QuotaUsage[]}
         paginatedLimits={paginatedLimits as LimitRangeItem[]}
         uniqueQuotas={uniqueQuotas}
-        isDemoData={isDemoMode || isDemoFallback}
+        isDemoData={showDemoBadge || isDemoFallback}
         isFetchingData={isFetchingData}
         onEditQuota={openEditModal}
         onDeleteQuota={setDeleteConfirm}

--- a/web/src/components/cards/ResourceCapacity.tsx
+++ b/web/src/components/cards/ResourceCapacity.tsx
@@ -11,8 +11,7 @@ import { CardControls, SortDirection } from '../ui/CardControls'
 import { Pagination, usePagination } from '../ui/Pagination'
 import { ClusterFilterDropdown } from '../ui/ClusterFilterDropdown'
 import { useChartFilters } from '../../lib/cards/cardHooks'
-import { useCardLoadingState } from './CardDataContext'
-import { useDemoMode } from '../../hooks/useDemoMode'
+import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 import { CardEmptyState } from '../../lib/cards/CardComponents'
 
 interface ResourceCapacityProps {
@@ -43,7 +42,7 @@ export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
   const { deduplicatedClusters: allClusters, isLoading, isRefreshing, lastRefresh, isFailed, consecutiveFailures, error } = useClusters()
   const { nodes: gpuNodes, isRefreshing: gpuRefreshing, isDemoFallback } = useCachedGPUNodes()
   const { drillToResources } = useDrillDownActions()
-  const { isDemoMode } = useDemoMode()
+  const { shouldUseDemoData } = useCardDemoState({ requires: 'agent' })
   const {
     selectedClusters: globalSelectedClusters,
     isAllClustersSelected } = useGlobalFilters()
@@ -61,7 +60,7 @@ export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
     isFailed,
     consecutiveFailures,
     errorMessage: error ?? undefined,
-    isDemoData: isDemoMode || isDemoFallback })
+    isDemoData: shouldUseDemoData || isDemoFallback })
 
   // Local cluster filter
   const {


### PR DESCRIPTION
Fixes #19529, Fixes #19531

Replaces #19547 which was closed due to merge conflicts after recent merges of #19551 (useModal hook) and #19552 (layout patterns).

## Changes

Migrated 4 cards to use `useCardDemoState` hook instead of direct `useDemoMode` calls:

1. **ClusterGroups** - Replace `isDemoMode` with `shouldUseDemoData`
2. **ResourceCapacity** - Replace `isDemoMode` with `shouldUseDemoData`
3. **NamespaceQuotas** - Replace `isDemoMode` with `showDemoBadge`
4. **KubeKong** - Add `useCardDemoState({ requires: 'none' })` for demo-only game card