### PR TITLE
[scanner] fix: resolve nil pointer panic in Go test suite

### DIFF
--- a/pkg/k8s/client_clusters.go
+++ b/pkg/k8s/client_clusters.go
@@ -64,6 +64,9 @@ type ClusterHealth struct {
 }
 
 func (m *MultiClusterClient) ListClusters(ctx context.Context) ([]ClusterInfo, error) {
+	if m == nil {
+		return nil, ErrNoClusterConfigured
+	}
 	m.mu.RLock()
 	rawConfig := m.rawConfig
 	inClusterConfig := m.inClusterConfig
@@ -158,6 +161,9 @@ func (m *MultiClusterClient) ListClusters(ctx context.Context) ([]ClusterInfo, e
 // via multiple kubeconfig contexts (e.g. "vllm-d" and
 // "default/api-fmaas-vllm-d-fmaas-res-ibm-com:6443/...").
 func (m *MultiClusterClient) DeduplicatedClusters(ctx context.Context) ([]ClusterInfo, error) {
+	if m == nil {
+		return nil, ErrNoClusterConfigured
+	}
 	clusters, err := m.ListClusters(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #19520

## Problem
The Go test suite on main was failing with a nil pointer panic when `MultiClusterClient.ListClusters` was called on a nil receiver in admission webhook and Lima handler tests. This blocked ALL Go coverage enforcement on main.

## Fix
Added nil receiver checks to `ListClusters()` and `DeduplicatedClusters()` in `pkg/k8s/client_clusters.go`. When the receiver is nil, both methods now return `ErrNoClusterConfigured` instead of panicking.

## Verification
- All Lima handler tests pass
- All Webhook handler tests pass
- All k8s package tests pass
- Nil pointer panic resolved