### PR TITLE
🌱 test: add unit tests for Drasi proxy SSRF prevention helpers

### DIFF
--- a/pkg/api/handlers/mcp/drasi_proxy_test.go
+++ b/pkg/api/handlers/mcp/drasi_proxy_test.go
@@ -884,7 +884,7 @@ func TestStripDrasiControlQuery(t *testing.T) {
 		{
 			name:  "params without values",
 			input: []byte("foo&target&bar"),
-			want:  "bar&foo",
+			want:  "bar=&foo=",
 		},
 	}
 

--- a/pkg/api/handlers/mcp/drasi_proxy_test.go
+++ b/pkg/api/handlers/mcp/drasi_proxy_test.go
@@ -501,3 +501,524 @@ func TestDrasiProxyDialContext_EmptyDNSResult(t *testing.T) {
 		t.Fatal("expected error for unresolvable host, got nil")
 	}
 }
+
+// TestNormalizeDrasiHost tests the normalizeDrasiHost SSRF prevention helper.
+func TestNormalizeDrasiHost(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "already normalized",
+			input: "example.com",
+			want:  "example.com",
+		},
+		{
+			name:  "uppercase to lowercase",
+			input: "EXAMPLE.COM",
+			want:  "example.com",
+		},
+		{
+			name:  "mixed case to lowercase",
+			input: "ExAmPlE.CoM",
+			want:  "example.com",
+		},
+		{
+			name:  "leading whitespace",
+			input: "  example.com",
+			want:  "example.com",
+		},
+		{
+			name:  "trailing whitespace",
+			input: "example.com  ",
+			want:  "example.com",
+		},
+		{
+			name:  "leading and trailing whitespace",
+			input: "  example.com  ",
+			want:  "example.com",
+		},
+		{
+			name:  "ipv6 with brackets",
+			input: "[::1]",
+			want:  "::1",
+		},
+		{
+			name:  "ipv6 full address with brackets",
+			input: "[2001:db8::1]",
+			want:  "2001:db8::1",
+		},
+		{
+			name:  "ipv6 without brackets",
+			input: "::1",
+			want:  "::1",
+		},
+		{
+			name:  "ipv4 address",
+			input: "127.0.0.1",
+			want:  "127.0.0.1",
+		},
+		{
+			name:  "localhost",
+			input: "LOCALHOST",
+			want:  "localhost",
+		},
+		{
+			name:  "localhost with whitespace and brackets",
+			input: " [LOCALHOST] ",
+			want:  "localhost",
+		},
+		{
+			name:  "ipv6 loopback with brackets and whitespace",
+			input: " [::1] ",
+			want:  "::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeDrasiHost(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestIsAllowedDrasiHost tests the isAllowedDrasiHost SSRF prevention helper.
+func TestIsAllowedDrasiHost(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVar  string
+		host    string
+		want    bool
+	}{
+		{
+			name:   "empty env var returns false",
+			envVar: "",
+			host:   "localhost",
+			want:   false,
+		},
+		{
+			name:   "exact match case insensitive",
+			envVar: "LOCALHOST",
+			host:   "localhost",
+			want:   true,
+		},
+		{
+			name:   "exact match reverse case",
+			envVar: "localhost",
+			host:   "LOCALHOST",
+			want:   true,
+		},
+		{
+			name:   "single entry allowed",
+			envVar: "drasi-server.example.com",
+			host:   "drasi-server.example.com",
+			want:   true,
+		},
+		{
+			name:   "multiple entries comma separated first match",
+			envVar: "localhost,drasi-server.example.com,192.168.1.10",
+			host:   "localhost",
+			want:   true,
+		},
+		{
+			name:   "multiple entries comma separated middle match",
+			envVar: "localhost,drasi-server.example.com,192.168.1.10",
+			host:   "drasi-server.example.com",
+			want:   true,
+		},
+		{
+			name:   "multiple entries comma separated last match",
+			envVar: "localhost,drasi-server.example.com,192.168.1.10",
+			host:   "192.168.1.10",
+			want:   true,
+		},
+		{
+			name:   "no match in list",
+			envVar: "localhost,drasi-server.example.com",
+			host:   "evil.com",
+			want:   false,
+		},
+		{
+			name:   "whitespace in env var entries",
+			envVar: " localhost , drasi-server.example.com , 192.168.1.10 ",
+			host:   "drasi-server.example.com",
+			want:   true,
+		},
+		{
+			name:   "whitespace in host input",
+			envVar: "localhost,drasi-server.example.com",
+			host:   "  drasi-server.example.com  ",
+			want:   true,
+		},
+		{
+			name:   "ipv6 with brackets in env",
+			envVar: "[::1],drasi-server.example.com",
+			host:   "::1",
+			want:   true,
+		},
+		{
+			name:   "ipv6 without brackets in env",
+			envVar: "::1,drasi-server.example.com",
+			host:   "[::1]",
+			want:   true,
+		},
+		{
+			name:   "127.0.0.1 allowed",
+			envVar: "127.0.0.1,localhost",
+			host:   "127.0.0.1",
+			want:   true,
+		},
+		{
+			name:   "partial match does not allow",
+			envVar: "example.com",
+			host:   "sub.example.com",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(drasiAllowedHostsEnv, tt.envVar)
+			got := isAllowedDrasiHost(tt.host)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestIsLocalhostDrasiHost tests the isLocalhostDrasiHost SSRF prevention helper.
+func TestIsLocalhostDrasiHost(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{
+			name: "localhost",
+			host: "localhost",
+			want: true,
+		},
+		{
+			name: "localhost uppercase",
+			host: "LOCALHOST",
+			want: true,
+		},
+		{
+			name: "localhost.localdomain",
+			host: "localhost.localdomain",
+			want: true,
+		},
+		{
+			name: "localhost.localdomain uppercase",
+			host: "LOCALHOST.LOCALDOMAIN",
+			want: true,
+		},
+		{
+			name: "127.0.0.1",
+			host: "127.0.0.1",
+			want: true,
+		},
+		{
+			name: "127.0.0.2",
+			host: "127.0.0.2",
+			want: true,
+		},
+		{
+			name: "127.1.2.3",
+			host: "127.1.2.3",
+			want: true,
+		},
+		{
+			name: "ipv6 loopback",
+			host: "::1",
+			want: true,
+		},
+		{
+			name: "ipv6 loopback with brackets",
+			host: "[::1]",
+			want: true,
+		},
+		{
+			name: "ipv6 loopback full form",
+			host: "0000:0000:0000:0000:0000:0000:0000:0001",
+			want: true,
+		},
+		{
+			name: "public ip",
+			host: "8.8.8.8",
+			want: false,
+		},
+		{
+			name: "private ip 10.x",
+			host: "10.0.0.1",
+			want: false,
+		},
+		{
+			name: "private ip 192.168.x",
+			host: "192.168.1.1",
+			want: false,
+		},
+		{
+			name: "private ip 172.16.x",
+			host: "172.16.0.1",
+			want: false,
+		},
+		{
+			name: "public hostname",
+			host: "example.com",
+			want: false,
+		},
+		{
+			name: "subdomain localhost is not loopback",
+			host: "sub.localhost",
+			want: false,
+		},
+		{
+			name: "localhost prefix is not loopback",
+			host: "localhost.example.com",
+			want: false,
+		},
+		{
+			name: "ipv6 public address",
+			host: "2001:db8::1",
+			want: false,
+		},
+		{
+			name: "empty string",
+			host: "",
+			want: false,
+		},
+		{
+			name: "whitespace around localhost",
+			host: "  localhost  ",
+			want: true,
+		},
+		{
+			name: "whitespace around ipv6 loopback",
+			host: "  ::1  ",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isLocalhostDrasiHost(tt.host)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestStripDrasiControlQuery tests the stripDrasiControlQuery helper.
+func TestStripDrasiControlQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		want  string
+	}{
+		{
+			name:  "empty query string",
+			input: []byte(""),
+			want:  "",
+		},
+		{
+			name:  "only target param",
+			input: []byte("target=server"),
+			want:  "",
+		},
+		{
+			name:  "only url param",
+			input: []byte("url=http://example.com"),
+			want:  "",
+		},
+		{
+			name:  "only cluster param",
+			input: []byte("cluster=prow"),
+			want:  "",
+		},
+		{
+			name:  "all control params",
+			input: []byte("target=server&url=http://example.com&cluster=prow"),
+			want:  "",
+		},
+		{
+			name:  "control params with other params",
+			input: []byte("target=server&url=http://example.com&foo=bar&baz=qux"),
+			want:  "baz=qux&foo=bar",
+		},
+		{
+			name:  "preserves non-control params",
+			input: []byte("foo=bar&baz=qux"),
+			want:  "baz=qux&foo=bar",
+		},
+		{
+			name:  "mixed control and non-control",
+			input: []byte("foo=bar&target=server&baz=qux&url=http://example.com"),
+			want:  "baz=qux&foo=bar",
+		},
+		{
+			name:  "multi-value params preserved",
+			input: []byte("foo=bar&foo=baz&target=server"),
+			want:  "foo=bar&foo=baz",
+		},
+		{
+			name:  "url encoded values preserved",
+			input: []byte("name=hello+world&target=server&url=http%3A%2F%2Fexample.com"),
+			want:  "name=hello+world",
+		},
+		{
+			name:  "malformed query string passthrough",
+			input: []byte("%%%invalid"),
+			want:  "%%%invalid",
+		},
+		{
+			name:  "empty values preserved",
+			input: []byte("foo=&target=server&bar=value"),
+			want:  "bar=value&foo=",
+		},
+		{
+			name:  "params without values",
+			input: []byte("foo&target&bar"),
+			want:  "bar&foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripDrasiControlQuery(tt.input)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+// TestParseQueryParams tests the parseQueryParams helper.
+func TestParseQueryParams(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  map[string]string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  map[string]string{},
+		},
+		{
+			name:  "single param",
+			input: "foo=bar",
+			want:  map[string]string{"foo": "bar"},
+		},
+		{
+			name:  "multiple params",
+			input: "foo=bar&baz=qux",
+			want:  map[string]string{"foo": "bar", "baz": "qux"},
+		},
+		{
+			name:  "multi-value param takes first value",
+			input: "foo=bar&foo=baz&foo=qux",
+			want:  map[string]string{"foo": "bar"},
+		},
+		{
+			name:  "url encoded values",
+			input: "name=hello+world&path=%2Fapi%2Fv1",
+			want:  map[string]string{"name": "hello world", "path": "/api/v1"},
+		},
+		{
+			name:  "empty value",
+			input: "foo=&bar=value",
+			want:  map[string]string{"foo": "", "bar": "value"},
+		},
+		{
+			name:  "param without value",
+			input: "foo&bar=value",
+			want:  map[string]string{"foo": "", "bar": "value"},
+		},
+		{
+			name:  "malformed query string returns empty",
+			input: "%%%invalid",
+			want:  map[string]string{},
+		},
+		{
+			name:  "special characters in values",
+			input: "query=select+*+from+table&filter=name%3D%27test%27",
+			want:  map[string]string{"query": "select * from table", "filter": "name='test'"},
+		},
+		{
+			name:  "numeric values",
+			input: "page=1&limit=100",
+			want:  map[string]string{"page": "1", "limit": "100"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseQueryParams(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestUpstreamStatus tests the upstreamStatus helper.
+func TestUpstreamStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: 0,
+		},
+		{
+			name: "error without Status method",
+			err:  assert.AnError,
+			want: 0,
+		},
+		{
+			name: "error with Status method",
+			err:  &mockStatusError{status: 404},
+			want: 404,
+		},
+		{
+			name: "error with Status method 500",
+			err:  &mockStatusError{status: 500},
+			want: 500,
+		},
+		{
+			name: "error with Status method 403",
+			err:  &mockStatusError{status: 403},
+			want: 403,
+		},
+		{
+			name: "error with Status method 0",
+			err:  &mockStatusError{status: 0},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := upstreamStatus(tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// mockStatusError is a test helper implementing the statusGetter interface.
+type mockStatusError struct {
+	status int
+}
+
+func (e *mockStatusError) Error() string {
+	return "mock error"
+}
+
+func (e *mockStatusError) Status() int {
+	return e.status
+}


### PR DESCRIPTION
Fixes #19571

Adds comprehensive unit tests for 6 previously untested SSRF prevention helper functions in `pkg/api/handlers/mcp/drasi_proxy.go`:

1. **`normalizeDrasiHost`** — tests whitespace trimming, bracket stripping, case folding, IPv6 handling, empty strings
2. **`isAllowedDrasiHost`** — tests env var parsing, case insensitivity, comma-separated lists, whitespace handling, bracket normalization
3. **`isLocalhostDrasiHost`** — tests localhost variants, loopback IPs (127.0.0.1, ::1), non-loopback IPs, edge cases
4. **`stripDrasiControlQuery`** — tests removal of proxy control params (target/url/cluster) while preserving other params
5. **`parseQueryParams`** — tests multi-value params, URL encoding, empty values, malformed input
6. **`upstreamStatus`** — tests interface extraction from K8s API errors, non-matching error types

All 6 functions are security-critical SSRF prevention helpers that previously had zero direct test coverage. Tests follow existing codebase patterns (testify/assert, table-driven tests).