### PR TITLE
test: stabilize nightly mobile navigation checks

### DIFF
--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -72,6 +72,7 @@ const FOCUSABLE_SELECTOR = [
 ].join(', ')
 const WEBKIT_FOCUSABLE_SELECTOR = [
   'a[href]',
+  'button:not([disabled])',
   'input:not([disabled])',
   'select:not([disabled])',
   'textarea:not([disabled])',

--- a/web/e2e/responsive-regression.spec.ts
+++ b/web/e2e/responsive-regression.spec.ts
@@ -163,21 +163,12 @@ test.describe('Responsive Breakpoint Tests', () => {
             .or(page.locator('button[aria-label*="menu" i]'))
             .or(page.locator('[data-testid="sidebar-toggle"]'))
             .or(page.getByTestId('navbar-home-btn'))
+            .or(page.locator('nav a:visible, nav button:visible'))
 
-          const hasHamburger = await mobileNav.first().isVisible({ timeout: MOBILE_NAV_PROBE_TIMEOUT_MS }).catch(() => false)
-
-          // Either a primary navbar control is present OR nav items are visible.
-          // On narrow viewports the app can collapse into a compact header with
-          // a home button before the full nav items render, and that still
-          // satisfies "navigation is accessible" for this regression guard.
-          if (!hasHamburger) {
-            const navItems = page.locator('nav a, nav button')
-            const navCount = await navItems.count()
-            expect(
-              navCount,
-              `No navigation accessible at ${viewport.name} viewport`
-            ).toBeGreaterThan(0)
-          }
+          await expect(
+            mobileNav.first(),
+            `No navigation accessible at ${viewport.name} viewport`
+          ).toBeVisible({ timeout: MOBILE_NAV_PROBE_TIMEOUT_MS })
         } else {
           // On larger viewports, main nav should be visible
           const nav = page.locator('nav')

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -16,6 +16,8 @@ const MIN_BODY_TEXT_LEN = 50
 const MIN_DASHBOARD_TEXT_LEN = 100
 /** Short timeout for optional UI probes (theme toggle, demo badge, etc.). */
 const OPTIONAL_PROBE_TIMEOUT_MS = 3_000
+const MOBILE_SIDEBAR_MAX_WIDTH_PX = 768
+const HAMBURGER_PROBE_TIMEOUT_MS = 2_000
 
 /**
  * Smoke Tests for KubeStellar Console
@@ -86,8 +88,6 @@ test.describe('Smoke Tests', () => {
         .or(page.locator('button[aria-label*="menu" i]'))
         .first()
       const viewportSize = page.viewportSize()
-      const MOBILE_SIDEBAR_MAX_WIDTH_PX = 768
-      const HAMBURGER_PROBE_TIMEOUT_MS = 2_000
       if (viewportSize && viewportSize.width < MOBILE_SIDEBAR_MAX_WIDTH_PX) {
         const hamburgerVisible = await hamburger
           .isVisible({ timeout: HAMBURGER_PROBE_TIMEOUT_MS })
@@ -159,6 +159,22 @@ test.describe('Smoke Tests', () => {
       // entry can be flaky across Firefox/WebKit. In-app navigation exercises
       // the actual router path without relying on preview-server rewrites.
       await page.goto('/', { waitUntil: 'domcontentloaded' })
+      const sidebar = page.getByTestId('sidebar')
+      const viewportSize = page.viewportSize()
+      if (viewportSize && viewportSize.width < MOBILE_SIDEBAR_MAX_WIDTH_PX) {
+        const hamburger = page
+          .locator('[data-testid="mobile-menu-toggle"]')
+          .or(page.locator('button[aria-label*="menu" i]'))
+          .first()
+        const hamburgerVisible = await hamburger
+          .isVisible({ timeout: HAMBURGER_PROBE_TIMEOUT_MS })
+          .catch(() => false)
+        if (hamburgerVisible) {
+          await hamburger.evaluate((el) => (el as HTMLElement).click())
+          await expect(sidebar).toBeVisible({ timeout: 3000 })
+        }
+      }
+
       const settingsLink = page.locator('[data-testid="sidebar-primary-nav"] a[href="/settings"], [data-testid="sidebar"] a[href="/settings"]').first()
       // WebKit/mobile browsers need more time for sidebar elements to hydrate
       await expect(settingsLink).toBeVisible({ timeout: 20000 })


### PR DESCRIPTION
Fixes #19499

---

## Summary of Changes

- Stabilizes mobile/WebKit navigation checks from the nightly Playwright run.
- Opens the mobile sidebar before clicking the Settings link in the smoke navigation test.
- Makes the responsive nav guard wait for a visible mobile/nav control instead of counting hidden elements.
- Includes buttons in the WebKit dashboard focus candidate list so navbar controls are covered.

---

## Changes Made

- [x] Updated `web/e2e/smoke.spec.ts` for mobile sidebar navigation.
- [x] Updated `web/e2e/responsive-regression.spec.ts` to assert visible nav controls.
- [x] Updated `web/e2e/Dashboard.spec.ts` for WebKit focusable controls.
- [x] Kept this PR test-only; no runtime UI behavior changed.

---

## Checklist

- [x] I reviewed the contribution guidelines.
- [x] I used a coding agent to generate/review this code.
- [x] New cards target `console-marketplace`, not this repo — not applicable, test-only change.
- [x] I have tested the changes locally where possible.
- [x] All commits are signed with DCO (`git commit -s`).