### PR TITLE
[scanner] fix: reduce Vitest worker heap to prevent OOM on CI runners

### DIFF
--- a/scripts/unit-test.sh
+++ b/scripts/unit-test.sh
@@ -32,12 +32,12 @@ done
 echo "Running Vitest unit tests..."
 
 # CI runners (ubuntu-latest, 7 GB RAM) can OOM when running 900+ test files.
-# 8192 MB (8 GB) is the new limit after test count grew to 1800+ files.
-# The previous 7168 MB limit caused environment setup slowdowns (17+ min
-# jsdom construction time) and intermittent worker crashes (nightly
-# regression 2026-05-28, issue #16250).
+# With 3 forked workers, each worker needs ~2 GB heap to stay within the 7 GB
+# physical RAM limit (leaving 1 GB for system overhead). The previous 8192 MB
+# limit exceeded physical RAM and caused "Worker exited unexpectedly" OOM
+# crashes (nightly regression 2026-06-25, issue #19580).
 if [ -n "${CI:-}" ]; then
-  export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=8192"
+  export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048"
 fi
 
 # Vitest may exit non-zero due to pool worker termination timeout on CI


### PR DESCRIPTION
Fixes #19580

The nightly unit-test suite failed with "Worker exited unexpectedly" errors. Root cause: the test script set Node heap limit to 8GB per worker with 3 workers (24GB total) on a CI runner with only 7GB physical RAM, causing OOM kills.

Reduced heap limit from 8GB to 2GB per worker, keeping total usage at 6GB (3 workers × 2GB) with 1GB headroom for system overhead.