### PR TITLE
[scanner] fix: resolve Playwright cross-browser nightly workflow failure

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Run Playwright tests (${{ matrix.browser }})
         run: |
-          npx playwright test --project=${{ matrix.browser }} --retries=3 --timeout=90000 \
+          npx playwright test --project=${{ matrix.browser }} --retries=3 --timeout=120000 \
             --workers=1 \
             e2e/smoke.spec.ts \
             e2e/responsive-regression.spec.ts \
@@ -162,7 +162,7 @@ jobs:
 
       - name: Run mobile tests
         run: |
-          npx playwright test --project=${{ matrix.project }} --retries=3 --timeout=90000 \
+          npx playwright test --project=${{ matrix.project }} --retries=3 --timeout=120000 \
             --workers=1 \
             e2e/smoke.spec.ts \
             e2e/responsive-regression.spec.ts \


### PR DESCRIPTION
Fixes #19579

## Summary

Increased timeout from 90s to 120s for cross-browser and mobile Playwright tests in the nightly workflow.

## Root Cause

The workflow was setting `--timeout=90000` (90 seconds) which matched the project timeout in `playwright.config.ts`, leaving no buffer for slow CI environments. This caused frequent timeouts in Firefox, WebKit, and mobile Safari tests.

## Changes

- Increased `--timeout` from 90000ms to 120000ms in cross-browser test job
- Increased `--timeout` from 90000ms to 120000ms in mobile test job

## Testing

Workflow will be tested on next nightly run or via manual trigger.