### PR TITLE
[scanner] fix: resolve 45 test failures in card component tests

### DIFF
--- a/web/src/components/cards/NamespaceQuotas.test.tsx
+++ b/web/src/components/cards/NamespaceQuotas.test.tsx
@@ -58,8 +58,10 @@ vi.mock('../../hooks/useDemoMode', async (importOriginal) => {
 })
 
 const mockUseCardLoadingState = vi.fn()
+const mockUseCardDemoState = vi.fn()
 vi.mock('./CardDataContext', () => ({
   useCardLoadingState: (opts: Record<string, unknown>) => mockUseCardLoadingState(opts),
+  useCardDemoState: (opts: Record<string, unknown>) => mockUseCardDemoState(opts),
 }))
 
 vi.mock('../ui/Skeleton', () => ({
@@ -143,6 +145,12 @@ function setupMocks(overrides: {
 
   mockUseDemoMode.mockReturnValue({
     isDemoMode: overrides.isDemoMode ?? false,
+  })
+
+  mockUseCardDemoState.mockReturnValue({
+    shouldUseDemoData: overrides.isDemoMode ?? false,
+    reason: overrides.isDemoMode ? 'global-demo-mode' : null,
+    showDemoBadge: overrides.isDemoMode ?? false,
   })
 
   mockUseCardLoadingState.mockReturnValue({

--- a/web/src/components/cards/__tests__/ClusterGroups.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterGroups.test.tsx
@@ -63,9 +63,11 @@ vi.mock('react-i18next', async () => {
 })
 
 const mockUseCardLoadingState = vi.fn()
+const mockUseCardDemoState = vi.fn()
 vi.mock('../CardDataContext', () => ({
   useReportCardDataState: vi.fn(),
   useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
+  useCardDemoState: (opts: unknown) => mockUseCardDemoState(opts),
 }))
 
 const mockUseClusters = vi.fn()
@@ -115,6 +117,11 @@ describe('ClusterGroups', () => {
       isPersisted: false,
     })
     mockUseFederationAwareness.mockReturnValue({ groups: [] })
+    mockUseCardDemoState.mockReturnValue({
+      shouldUseDemoData: true,
+      reason: 'global-demo-mode',
+      showDemoBadge: true,
+    })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockUseClusters.mockReturnValue({
       clusters: [],

--- a/web/src/components/cards/__tests__/ResourceCapacity.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceCapacity.test.tsx
@@ -40,9 +40,11 @@ vi.mock('react-i18next', async () => {
 })
 
 const mockUseCardLoadingState = vi.fn()
+const mockUseCardDemoState = vi.fn()
 vi.mock('../CardDataContext', () => ({
   useReportCardDataState: vi.fn(),
   useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
+  useCardDemoState: (opts: unknown) => mockUseCardDemoState(opts),
 }))
 
 const mockGPUNodes = vi.fn()
@@ -75,6 +77,11 @@ describe('ResourceCapacity', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    mockUseCardDemoState.mockReturnValue({
+      shouldUseDemoData: true,
+      reason: 'global-demo-mode',
+      showDemoBadge: true,
+    })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
     mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })

--- a/web/src/components/drilldown/views/__tests__/PodDrillDown.actions.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/PodDrillDown.actions.test.tsx
@@ -9,7 +9,7 @@ vi.mock('../../../../hooks/useMissions', () => ({
 vi.mock('../../../../hooks/useDrillDown', () => ({
   useDrillDown: () => ({
     drillTo: vi.fn(),
-    closeDrillDown: vi.fn()
+    close: vi.fn()
   })
 }))
 


### PR DESCRIPTION
Fixes #19589

Resolves 45 test failures in Coverage Suite run #3886.

## Root Cause

The card components (NamespaceQuotas, ClusterGroups, ResourceCapacity) all use `useCardDemoState({ requires: 'agent' })` from CardDataContext, but their test files only mocked `useCardLoadingState` — not `useCardDemoState` — causing all tests to fail when components called the unmocked hook.

PodDrillDown.actions.test.tsx used the wrong method name (`closeDrillDown` instead of `close`).

## Changes

| File | Fix |
|------|-----|
| `NamespaceQuotas.test.tsx` | Added missing `useCardDemoState` mock |
| `ClusterGroups.test.tsx` | Added missing `useCardDemoState` mock |
| `ResourceCapacity.test.tsx` | Added missing `useCardDemoState` mock |
| `PodDrillDown.actions.test.tsx` | Fixed `useDrillDown` mock: `close` not `closeDrillDown` |