### PR TITLE
fix: remove duplicate ADOPTERS.MD causing case-insensitive filesystem collision

### DIFF
--- a/.github/policies/merge-policy.yaml
+++ b/.github/policies/merge-policy.yaml
@@ -8,7 +8,7 @@ rules:
   - name: adopters-human-approval
     description: ADOPTERS.md PRs require explicit maintainer approval
     enforcement: blocking
-    paths: ["ADOPTERS.md", "ADOPTERS.MD"]
+    paths: ["ADOPTERS.md"]
     auto_merge: false
 
   - name: no-direct-main

--- a/ADOPTERS.MD
+++ b/ADOPTERS.MD
@@ -1,5 +1,0 @@
-# Adopters (deprecated)
-
-> ⚠️ **This file has been superseded.** All adopter entries have been migrated to **[ADOPTERS.md](./ADOPTERS.md)** (lowercase). Please open pull requests against `ADOPTERS.md` going forward.
-
-See [ADOPTERS.md](./ADOPTERS.md) for the current adopter list (13 entries).

--- a/docs/ADOPTION-METRICS.md
+++ b/docs/ADOPTION-METRICS.md
@@ -174,7 +174,7 @@ Projects that have endorsed or integrated KubeStellar Console missions:
 | Microcks | Sandbox | [microcks/community#125](https://github.com/microcks/community/pull/125) | Contributed |
 | kcp | Sandbox | [kcp-dev/kcp#3923](https://github.com/kcp-dev/kcp/issues/3923) | Engaged |
 
-> See [ADOPTERS.MD](../ADOPTERS.MD) for the full adopter list.
+> See [ADOPTERS.md](../ADOPTERS.md) for the full adopter list.
 
 ### Community Contributions
 
@@ -250,5 +250,5 @@ Where possible, metrics should be collected via automated scripts:
 
 - [CNCF Incubation Criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md)
 - [CNCF Due Diligence Guidelines](https://github.com/cncf/toc/blob/main/process/due-diligence-guidelines.md)
-- [KubeStellar Console Adopters](../ADOPTERS.MD)
+- [KubeStellar Console Adopters](../ADOPTERS.md)
 - [KubeStellar Community](COMMUNITY.md)

--- a/web/src/components/dashboard/AdopterNudge.test.tsx
+++ b/web/src/components/dashboard/AdopterNudge.test.tsx
@@ -60,7 +60,7 @@ describe('AdopterNudge Component', () => {
     render(<AdopterNudge />)
     fireEvent.click(screen.getByText('Add your organization'))
     expect(openSpy).toHaveBeenCalledWith(
-      expect.stringContaining('ADOPTERS.MD'),
+      expect.stringContaining('ADOPTERS.md'),
       '_blank',
       expect.any(String),
     )

--- a/web/src/components/dashboard/AdopterNudge.tsx
+++ b/web/src/components/dashboard/AdopterNudge.tsx
@@ -1,7 +1,7 @@
 /**
  * Adopter Nudge — shown after a user has been using the console for 3+ days.
  *
- * Prompts engaged users to add their company/project to ADOPTERS.MD.
+ * Prompts engaged users to add their company/project to ADOPTERS.md.
  * Only shows for localhost users who have connected kc-agent at least
  * ADOPTER_NUDGE_DELAY_DAYS ago.
  */
@@ -24,7 +24,7 @@ import {
 import { isNetlifyDeployment } from '../../lib/demoMode'
 
 const ADOPTERS_EDIT_URL =
-  'https://github.com/kubestellar/console/edit/main/ADOPTERS.MD'
+  'https://github.com/kubestellar/console/edit/main/ADOPTERS.md'
 
 /** Number of days after first agent connection before showing the nudge */
 const ADOPTER_NUDGE_DELAY_DAYS = 3


### PR DESCRIPTION
## Summary
- Remove deprecated `ADOPTERS.MD` (uppercase) which collides with `ADOPTERS.md` on case-insensitive filesystems (macOS, Windows)
- Fresh clones on macOS show a phantom `modified: ADOPTERS.MD` immediately after checkout
- Updated all references in `AdopterNudge.tsx`, its test, `ADOPTION-METRICS.md`, and `merge-policy.yaml` to use `ADOPTERS.md`

## Test plan
- [ ] Fresh clone on macOS shows clean `git status`
- [ ] AdopterNudge "Add your organization" link points to correct file

Reported-by: Jun Duan