### PR TITLE
🐛 fix: improve error handling in hooks with swallowed catch blocks

### DIFF
--- a/web/src/hooks/useCardHistory.ts
+++ b/web/src/hooks/useCardHistory.ts
@@ -22,7 +22,7 @@ function safeJsonParse<T>(raw: string, fallback: T, context: string): T {
   try {
     return JSON.parse(raw) as T
   } catch (err) {
-    console.warn(`[useCardHistory] Failed to parse ${context}, using default`, err)
+    console.error(`[useCardHistory] Failed to parse ${context}, using default`, err)
     return fallback
   }
 }

--- a/web/src/hooks/useDashboardCards.ts
+++ b/web/src/hooks/useDashboardCards.ts
@@ -24,7 +24,7 @@ function safeJsonParse<T>(raw: string, fallback: T, context: string): T {
   try {
     return JSON.parse(raw) as T
   } catch (err) {
-    console.warn(`[useDashboardCards] Failed to parse ${context}, using default`, err)
+    console.error(`[useDashboardCards] Failed to parse ${context}, using default`, err)
     return fallback
   }
 }

--- a/web/src/hooks/useDeployMissions.types.ts
+++ b/web/src/hooks/useDeployMissions.types.ts
@@ -78,7 +78,7 @@ export function safeJsonParse<T>(raw: string, fallback: T, context: string): T {
   try {
     return JSON.parse(raw) as T
   } catch (err) {
-    console.warn(`[useDeployMissions] Failed to parse ${context}, using default`, err)
+    console.error(`[useDeployMissions] Failed to parse ${context}, using default`, err)
     return fallback
   }
 }

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -65,7 +65,7 @@ function safeJsonParse<T>(raw: string, fallback: T, context: string): T {
     return JSON.parse(raw) as T
   } catch (err) {
     // Non-critical: malformed optional cache data; log for debugging and fall back to default
-    console.warn(`[useKubescape] Failed to parse ${context}, using default`, err)
+    console.error(`[useKubescape] Failed to parse ${context}, using default`, err)
     return fallback
   }
 }

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -69,7 +69,7 @@ function safeJsonParse<T>(raw: string, fallback: T, context: string): T {
     return JSON.parse(raw) as T
   } catch (err) {
     // Non-critical: malformed optional cache data; log for debugging and fall back to default
-    console.warn(`[useKyverno] Failed to parse ${context}, using default`, err)
+    console.error(`[useKyverno] Failed to parse ${context}, using default`, err)
     return fallback
   }
 }

--- a/web/src/hooks/useLastRoute.ts
+++ b/web/src/hooks/useLastRoute.ts
@@ -13,7 +13,7 @@ function safeJsonParse<T>(raw: string, fallback: T, context: string): T {
   try {
     return JSON.parse(raw) as T
   } catch (err) {
-    console.warn(`[useLastRoute] Failed to parse ${context}, using default`, err)
+    console.error(`[useLastRoute] Failed to parse ${context}, using default`, err)
     return fallback
   }
 }

--- a/web/src/hooks/useRBACFindings.ts
+++ b/web/src/hooks/useRBACFindings.ts
@@ -63,7 +63,7 @@ function safeJsonParse<T>(raw: string, fallback: T, context: string): T {
   try {
     return JSON.parse(raw) as T
   } catch (err) {
-    console.warn(`[useRBACFindings] Failed to parse ${context}, using default`, err)
+    console.error(`[useRBACFindings] Failed to parse ${context}, using default`, err)
     return fallback
   }
 }

--- a/web/src/hooks/useStackDiscovery.ts
+++ b/web/src/hooks/useStackDiscovery.ts
@@ -23,7 +23,7 @@ function safeJsonParse<T>(value: string, fallback: T, context: string): T {
   try {
     return JSON.parse(value) as T
   } catch (err) {
-    console.warn(`[useStackDiscovery] Ignoring malformed JSON for ${context}:`, err)
+    console.error(`[useStackDiscovery] Ignoring malformed JSON for ${context}:`, err)
     return fallback
   }
 }

--- a/web/src/hooks/useStellarSource.ts
+++ b/web/src/hooks/useStellarSource.ts
@@ -36,7 +36,7 @@ function parseStellarEvent<T>(event: Event, eventName: string): T | null {
   try {
     return JSON.parse((event as MessageEvent).data) as T
   } catch (err) {
-    console.warn(`stellar: malformed ${eventName} event JSON`, err)
+    console.error(`stellar: malformed ${eventName} event JSON`, err)
     return null
   }
 }
@@ -145,7 +145,7 @@ export function useStellarSource() {
       setConnectionError(null)
       return
     }
-    console.warn('stellar: refreshState partial failure —', failures.length, 'of', STELLAR_REFRESH_REQUEST_COUNT, 'calls failed')
+    console.error('stellar: refreshState partial failure —', failures.length, 'of', STELLAR_REFRESH_REQUEST_COUNT, 'calls failed')
     const firstFailure = failures[0]
     setOperationalError(
       firstFailure.status === 'rejected' ? firstFailure.reason : null,
@@ -164,7 +164,7 @@ export function useStellarSource() {
     try {
       await refreshState()
     } catch (err) {
-      console.warn('stellar: batch refresh failed:', err)
+      console.error('stellar: batch refresh failed:', err)
       setOperationalError(err, 'Failed to refresh Stellar state')
     } finally {
       batchRefreshInFlightRef.current = false
@@ -214,7 +214,7 @@ export function useStellarSource() {
         [notif.id]: { solveId: 'pending', eventId: notif.id, step: 'reading', message: 'Auto-solve triggered — Stellar is investigating…', actionsTaken: 0, status: 'running' },
       })
       stellarApi.startSolve(notif.id).catch(err => {
-        console.warn('stellar: auto-solve for critical event failed:', notif.id, err)
+        console.error('stellar: auto-solve for critical event failed:', notif.id, err)
         setOperationalError(err, 'Failed to auto-solve critical event')
         setSolveProgress(prev => {
           const copy = { ...prev }
@@ -330,7 +330,7 @@ export function useStellarSource() {
       try {
         await refreshState()
       } catch (err) {
-        console.warn('stellar: init failed:', err)
+        console.error('stellar: init failed:', err)
         setOperationalError(err, 'Failed to initialize Stellar state')
       }
       scheduleNextBatch()

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -66,7 +66,7 @@ function safeJsonParse<T>(raw: string, fallback: T, context: string): T {
   try {
     return JSON.parse(raw) as T
   } catch (err) {
-    console.warn(`[useTrivy] Failed to parse ${context}, using default`, err)
+    console.error(`[useTrivy] Failed to parse ${context}, using default`, err)
     return fallback
   }
 }


### PR DESCRIPTION
Fixes #19598

Improves error handling in hooks that previously only used `console.warn` in catch blocks. Changes to `console.error` to make errors more observable during debugging while maintaining graceful fallback behavior.

## Changes

Updated error logging from `console.warn` to `console.error` in `safeJsonParse` functions across 10 hooks:

- `useDashboardCards.ts`
- `useRBACFindings.ts`
- `useTrivy.ts`
- `useCardHistory.ts`
- `useLastRoute.ts`
- `useDeployMissions.types.ts`
- `useKyverno.ts`
- `useKubescape.ts`
- `useStackDiscovery.ts`
- `useStellarSource.ts`

## Rationale

These hooks handle localStorage/JSON parse failures that can fail gracefully with default values. The previous `console.warn` made these errors easy to miss during debugging. Using `console.error` follows the established pattern used by other hooks in the codebase (e.g., `useSnoozedCards`, `useSnoozedAlerts`, `useClusterGroups`, `useTrestle`).

The change ensures errors are:
- ✅ More visible in browser console (console.error styling)
- ✅ Properly logged with full error context
- ✅ Still gracefully handled with fallback defaults
- ✅ Consistent with existing codebase patterns

No functional changes - this is purely a logging improvement.