### PR TITLE
🐛 [scanner] fix: resolve test failures from Coverage Suite run #3889

### DIFF
--- a/web/src/components/drilldown/views/PodDrillDown.actions.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.actions.tsx
@@ -444,9 +444,6 @@ Please:
           ws.onmessage = (event: MessageEvent) => {
             const msg = parseWsMessage(event, 'related resources')
             if (!msg) {
-              clearTimeout(timeout)
-              ws.close()
-              resolve(output)
               return
             }
 

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -379,7 +379,6 @@ export function MissionControlDialog({ open, onClose, initialKubaraChart, review
   const MODAL_TOP_INSET_PX = 80 // NAVBAR_HEIGHT_PX (64) + 16px breathing room
 
   return (
-    <>
     <AnimatePresence>
       {open && (
         <>
@@ -753,17 +752,16 @@ export function MissionControlDialog({ open, onClose, initialKubaraChart, review
               </footer>
             )}
           </motion.div>
+
+          <RequestApprovalModal
+            isOpen={approvalModal.isOpen}
+            onClose={approvalModal.close}
+            state={state}
+            installedProjects={mc.installedProjects}
+          />
         </>
       )}
     </AnimatePresence>
-
-    <RequestApprovalModal
-      isOpen={approvalModal.isOpen}
-      onClose={approvalModal.close}
-      state={state}
-      installedProjects={mc.installedProjects}
-    />
-    </>
   )
 }
 


### PR DESCRIPTION
Fixes #19600

Resolves 16 test failures identified in Coverage Suite run #3889.

## Changes

### PodDrillDown.actions.tsx - WebSocket Race Condition Fix
- **Issue**: WebSocket message handler was resolving immediately when `parseWsMessage` returned null, causing tests to fail
- **Fix**: Removed early resolution - now only resolves when message has matching requestId AND payload.output exists
- **Impact**: Fixes 5 failing tests related to WebSocket race conditions

### MissionControlDialog.tsx - Rendering Structure Fix
- **Issue**: Component had extraneous outer fragment wrapper and RequestApprovalModal was rendered outside the AnimatePresence conditional
- **Fix**: 
  - Removed outer fragment wrapper
  - Moved RequestApprovalModal inside AnimatePresence conditional block
- **Impact**: Fixes 11 failing MissionControlDialog tests by ensuring container.firstChild is null when dialog is closed

## Test Coverage
All 16 previously failing tests should now pass:
- 5 PodDrillDown WebSocket race condition tests
- 11 MissionControlDialog rendering tests