### PR TITLE
[scanner] fix: tighten workflow security (permissions, trust gates)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,11 +15,9 @@ permissions: read-all
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Trust gate: only review PRs from the same repository (not forks)
+    # to prevent unauthorized API usage from external PRs
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/hive-interactive.yml
+++ b/.github/workflows/hive-interactive.yml
@@ -182,6 +182,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      actions: write
     steps:
       - name: Dispatch hive fix workflow
         env:


### PR DESCRIPTION
Fixes #19601, Fixes #19602, Fixes #19603

## Security Improvements

This PR addresses three workflow security issues identified by the scanner:

### 1. hive-interactive.yml: Insufficient permissions (#19601)
- **Issue**: The `dispatch-hive-fix` job was attempting to dispatch workflows via `gh api` but only had `contents: read` permission
- **Fix**: Added `actions: write` permission to the job to properly authorize workflow dispatch operations
- **Impact**: Prevents unauthorized workflow dispatch failures while maintaining least-privilege principle

### 2. claude-code-review.yml: Missing trust gate (#19603)
- **Issue**: All PRs were receiving AI code review regardless of author trust status, creating potential API abuse risk
- **Fix**: Added fork guard condition `if: github.event.pull_request.head.repo.full_name == github.repository` to only review PRs from the same repository
- **Impact**: Prevents external fork PRs from consuming API credits and improves security posture

### 3. Workflow permission hardening (#19602)
- **Status**: Addressed through the above changes and confirmed existing workflows already have proper `permissions:` declarations
- **Note**: Three `.lock.yml` files without top-level permissions are auto-generated (gh-aw) and should not be manually edited

## Testing

- [x] Verified syntax with yamllint
- [x] Confirmed permissions follow least-privilege principle
- [x] Validated trust gate patterns match existing secure workflows (e.g., hive-trust-gate.yml, copilot-automation.yml)

## Checklist

- [x] Changes follow security best practices
- [x] Workflow permissions are minimal and scoped appropriately
- [x] Trust gates prevent unauthorized access
- [x] No secrets or sensitive data exposed