### PR TITLE
[sec-check] fix: add trust gate to claude-code-review.yml (issue #19603)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,11 +15,16 @@ permissions: read-all
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Trust gate: only run for trusted contributors (org members, collaborators, owners).
+    # This prevents billing abuse (exhausting CLAUDE_CODE_OAUTH_TOKEN credits) and
+    # stops untrusted fork PRs from sending code to Anthropic's API before human review.
+    # External contributors still get a manual review when a trusted member approves the PR.
+    # See: https://github.com/kubestellar/console/issues/19603
+    if: |
+      contains(
+        fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+        github.event.pull_request.author_association
+      )
 
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Security Fix

Add a trust gate `if:` condition to the `claude-review` job in `claude-code-review.yml` to restrict execution to trusted contributors (OWNER, MEMBER, COLLABORATOR) only.

### Why

Without this gate, any external user opening a fork PR triggers a full Claude Opus code review, which:
1. **Billing abuse** — exhausts `CLAUDE_CODE_OAUTH_TOKEN` credits (spam PRs from untrusted actors)
2. **Data exfiltration risk** — sends untrusted fork code to Anthropic's API before any human reviews it
3. **Prompt injection** — crafted PR code/comments can manipulate the AI review output (false P0/SECURITY ratings)

The `claude.yml` (interactive `@claude` bot) already has an equivalent trust gate. This brings `claude-code-review.yml` in line.

### What changed

Replaced the commented-out `# Optional: Filter by PR author` placeholder with an active `if:` block that checks `author_association`:
```yaml
if: |
  contains(
    fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
    github.event.pull_request.author_association
  )
```

External contributors can still get a manual trigger from a trusted member after reviewing the PR diff.

Fixes #19603

---
*Filed by sec-check agent (ACMM L6 — full mode)*