### PR TITLE
[scanner] fix: add unit tests for pkg/models and pkg/settings/types.go

### DIFF
--- a/pkg/ai/init_test.go
+++ b/pkg/ai/init_test.go
@@ -1,0 +1,197 @@
+package ai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitializationFunctionVariables(t *testing.T) {
+	t.Run("GetRegistry is defined", func(t *testing.T) {
+		require.NotNil(t, &GetRegistry, "GetRegistry variable should be defined")
+	})
+
+	t.Run("InitializeProviders is defined", func(t *testing.T) {
+		require.NotNil(t, &InitializeProviders, "InitializeProviders variable should be defined")
+	})
+
+	t.Run("SetClusterContextProviders is defined", func(t *testing.T) {
+		require.NotNil(t, &SetClusterContextProviders, "SetClusterContextProviders variable should be defined")
+	})
+
+	t.Run("GetConfigManager is defined", func(t *testing.T) {
+		require.NotNil(t, &GetConfigManager, "GetConfigManager variable should be defined")
+	})
+}
+
+func TestInitializationFunctionVariables_DefaultNil(t *testing.T) {
+	t.Run("function variables are nil by default", func(t *testing.T) {
+		require.Nil(t, GetRegistry, "GetRegistry should be nil until implemented")
+		require.Nil(t, InitializeProviders, "InitializeProviders should be nil until implemented")
+		require.Nil(t, SetClusterContextProviders, "SetClusterContextProviders should be nil until implemented")
+		require.Nil(t, GetConfigManager, "GetConfigManager should be nil until implemented")
+	})
+}
+
+func TestGetRegistry_Implementation(t *testing.T) {
+	t.Run("can be assigned and called", func(t *testing.T) {
+		originalGetRegistry := GetRegistry
+		defer func() { GetRegistry = originalGetRegistry }()
+
+		called := false
+		GetRegistry = func() Registry {
+			called = true
+			return nil
+		}
+
+		GetRegistry()
+		require.True(t, called, "assigned function should be callable")
+	})
+}
+
+func TestInitializeProviders_Implementation(t *testing.T) {
+	t.Run("can be assigned and called", func(t *testing.T) {
+		originalInitializeProviders := InitializeProviders
+		defer func() { InitializeProviders = originalInitializeProviders }()
+
+		called := false
+		InitializeProviders = func() error {
+			called = true
+			return nil
+		}
+
+		err := InitializeProviders()
+		require.NoError(t, err)
+		require.True(t, called, "assigned function should be callable")
+	})
+
+	t.Run("can return errors", func(t *testing.T) {
+		originalInitializeProviders := InitializeProviders
+		defer func() { InitializeProviders = originalInitializeProviders }()
+
+		InitializeProviders = func() error {
+			return &mockError{msg: "initialization failed"}
+		}
+
+		err := InitializeProviders()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "initialization failed")
+	})
+}
+
+func TestSetClusterContextProviders_Implementation(t *testing.T) {
+	t.Run("can be assigned and called", func(t *testing.T) {
+		originalSetClusterContextProviders := SetClusterContextProviders
+		defer func() { SetClusterContextProviders = originalSetClusterContextProviders }()
+
+		called := false
+		SetClusterContextProviders = func(bridge interface{}, k8sClient interface{}) {
+			called = true
+		}
+
+		SetClusterContextProviders(nil, nil)
+		require.True(t, called, "assigned function should be callable")
+	})
+
+	t.Run("accepts any interface types", func(t *testing.T) {
+		originalSetClusterContextProviders := SetClusterContextProviders
+		defer func() { SetClusterContextProviders = originalSetClusterContextProviders }()
+
+		var capturedBridge, capturedClient interface{}
+		SetClusterContextProviders = func(bridge interface{}, k8sClient interface{}) {
+			capturedBridge = bridge
+			capturedClient = k8sClient
+		}
+
+		mockBridge := &struct{ Name string }{Name: "bridge"}
+		mockClient := &struct{ Type string }{Type: "k8s"}
+
+		SetClusterContextProviders(mockBridge, mockClient)
+
+		require.Equal(t, mockBridge, capturedBridge)
+		require.Equal(t, mockClient, capturedClient)
+	})
+}
+
+func TestGetConfigManager_Implementation(t *testing.T) {
+	t.Run("can be assigned and called", func(t *testing.T) {
+		originalGetConfigManager := GetConfigManager
+		defer func() { GetConfigManager = originalGetConfigManager }()
+
+		called := false
+		GetConfigManager = func() interface{} {
+			called = true
+			return nil
+		}
+
+		GetConfigManager()
+		require.True(t, called, "assigned function should be callable")
+	})
+
+	t.Run("can return config manager instance", func(t *testing.T) {
+		originalGetConfigManager := GetConfigManager
+		defer func() { GetConfigManager = originalGetConfigManager }()
+
+		mockConfig := &struct{ Setting string }{Setting: "value"}
+		GetConfigManager = func() interface{} {
+			return mockConfig
+		}
+
+		result := GetConfigManager()
+		require.Equal(t, mockConfig, result)
+	})
+}
+
+func TestFunctionVariables_ConcurrentAccess(t *testing.T) {
+	t.Run("multiple goroutines can read nil safely", func(t *testing.T) {
+		done := make(chan bool)
+
+		for i := 0; i < 10; i++ {
+			go func() {
+				_ = GetRegistry
+				_ = InitializeProviders
+				_ = SetClusterContextProviders
+				_ = GetConfigManager
+				done <- true
+			}()
+		}
+
+		for i := 0; i < 10; i++ {
+			<-done
+		}
+	})
+}
+
+func TestFunctionVariables_GuardPattern(t *testing.T) {
+	t.Run("nil check before calling GetRegistry", func(t *testing.T) {
+		if GetRegistry != nil {
+			_ = GetRegistry()
+		}
+	})
+
+	t.Run("nil check before calling InitializeProviders", func(t *testing.T) {
+		if InitializeProviders != nil {
+			_ = InitializeProviders()
+		}
+	})
+
+	t.Run("nil check before calling SetClusterContextProviders", func(t *testing.T) {
+		if SetClusterContextProviders != nil {
+			SetClusterContextProviders(nil, nil)
+		}
+	})
+
+	t.Run("nil check before calling GetConfigManager", func(t *testing.T) {
+		if GetConfigManager != nil {
+			_ = GetConfigManager()
+		}
+	})
+}
+
+type mockError struct {
+	msg string
+}
+
+func (e *mockError) Error() string {
+	return e.msg
+}

--- a/pkg/models/teams_test.go
+++ b/pkg/models/teams_test.go
@@ -1,0 +1,551 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTeamRole_Constants(t *testing.T) {
+	require.Equal(t, TeamRole("admin"), TeamRoleAdmin)
+	require.Equal(t, TeamRole("member"), TeamRoleMember)
+}
+
+func TestTeam_JSONSerialization(t *testing.T) {
+	t.Run("marshal includes expected fields", func(t *testing.T) {
+		teamID := uuid.New()
+		creatorID := uuid.New()
+		now := time.Now().UTC()
+
+		team := Team{
+			ID:          teamID,
+			Name:        "Platform Team",
+			Description: "Core platform engineering",
+			CreatedBy:   creatorID,
+			MemberCount: 5,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+
+		data, err := json.Marshal(team)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, teamID.String(), m["id"])
+		require.Equal(t, "Platform Team", m["name"])
+		require.Equal(t, "Core platform engineering", m["description"])
+		require.Equal(t, creatorID.String(), m["createdBy"])
+		require.Equal(t, float64(5), m["memberCount"])
+	})
+
+	t.Run("omitempty description is absent when empty", func(t *testing.T) {
+		team := Team{
+			ID:          uuid.New(),
+			Name:        "Team Without Description",
+			CreatedBy:   uuid.New(),
+			MemberCount: 0,
+			CreatedAt:   time.Now(),
+			UpdatedAt:   time.Now(),
+		}
+
+		data, err := json.Marshal(team)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		_, hasDescription := m["description"]
+		require.False(t, hasDescription, "empty description should be omitted")
+	})
+
+	t.Run("round-trip preserves all fields", func(t *testing.T) {
+		original := Team{
+			ID:          uuid.New(),
+			Name:        "Security Team",
+			Description: "Security operations and compliance",
+			CreatedBy:   uuid.New(),
+			MemberCount: 3,
+			CreatedAt:   time.Now().UTC(),
+			UpdatedAt:   time.Now().UTC(),
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded Team
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, original.ID, decoded.ID)
+		require.Equal(t, original.Name, decoded.Name)
+		require.Equal(t, original.Description, decoded.Description)
+		require.Equal(t, original.CreatedBy, decoded.CreatedBy)
+		require.Equal(t, original.MemberCount, decoded.MemberCount)
+	})
+
+	t.Run("empty team has zero member count", func(t *testing.T) {
+		team := Team{
+			ID:        uuid.New(),
+			Name:      "Empty Team",
+			CreatedBy: uuid.New(),
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+
+		data, err := json.Marshal(team)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, float64(0), m["memberCount"])
+	})
+}
+
+func TestTeamMembership_JSONSerialization(t *testing.T) {
+	t.Run("marshal includes expected fields", func(t *testing.T) {
+		membershipID := uuid.New()
+		teamID := uuid.New()
+		userID := uuid.New()
+		now := time.Now().UTC()
+
+		membership := TeamMembership{
+			ID:        membershipID,
+			TeamID:    teamID,
+			UserID:    userID,
+			Role:      TeamRoleAdmin,
+			CreatedAt: now,
+		}
+
+		data, err := json.Marshal(membership)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, membershipID.String(), m["id"])
+		require.Equal(t, teamID.String(), m["teamId"])
+		require.Equal(t, userID.String(), m["userId"])
+		require.Equal(t, "admin", m["role"])
+	})
+
+	t.Run("member role serializes correctly", func(t *testing.T) {
+		membership := TeamMembership{
+			ID:        uuid.New(),
+			TeamID:    uuid.New(),
+			UserID:    uuid.New(),
+			Role:      TeamRoleMember,
+			CreatedAt: time.Now(),
+		}
+
+		data, err := json.Marshal(membership)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, "member", m["role"])
+	})
+
+	t.Run("round-trip preserves all fields", func(t *testing.T) {
+		original := TeamMembership{
+			ID:        uuid.New(),
+			TeamID:    uuid.New(),
+			UserID:    uuid.New(),
+			Role:      TeamRoleAdmin,
+			CreatedAt: time.Now().UTC(),
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded TeamMembership
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, original.ID, decoded.ID)
+		require.Equal(t, original.TeamID, decoded.TeamID)
+		require.Equal(t, original.UserID, decoded.UserID)
+		require.Equal(t, original.Role, decoded.Role)
+	})
+}
+
+func TestCreateTeamRequest_JSONSerialization(t *testing.T) {
+	t.Run("deserialize with all fields", func(t *testing.T) {
+		payload := `{
+			"name": "DevOps Team",
+			"description": "DevOps and automation",
+			"memberIds": ["user1", "user2", "user3"]
+		}`
+
+		var req CreateTeamRequest
+		require.NoError(t, json.Unmarshal([]byte(payload), &req))
+
+		require.Equal(t, "DevOps Team", req.Name)
+		require.Equal(t, "DevOps and automation", req.Description)
+		require.Equal(t, []string{"user1", "user2", "user3"}, req.MemberIDs)
+	})
+
+	t.Run("omitempty fields can be absent", func(t *testing.T) {
+		payload := `{"name": "Minimal Team"}`
+
+		var req CreateTeamRequest
+		require.NoError(t, json.Unmarshal([]byte(payload), &req))
+
+		require.Equal(t, "Minimal Team", req.Name)
+		require.Empty(t, req.Description)
+		require.Nil(t, req.MemberIDs)
+	})
+
+	t.Run("empty member list serializes correctly", func(t *testing.T) {
+		req := CreateTeamRequest{
+			Name:      "Team",
+			MemberIDs: []string{},
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var decoded CreateTeamRequest
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.NotNil(t, decoded.MemberIDs)
+		require.Empty(t, decoded.MemberIDs)
+	})
+}
+
+func TestUpdateTeamRequest_JSONSerialization(t *testing.T) {
+	t.Run("update name only", func(t *testing.T) {
+		name := "Updated Team Name"
+		req := UpdateTeamRequest{Name: &name}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, "Updated Team Name", m["name"])
+		_, hasDescription := m["description"]
+		require.False(t, hasDescription)
+	})
+
+	t.Run("update description only", func(t *testing.T) {
+		desc := "New description"
+		req := UpdateTeamRequest{Description: &desc}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, "New description", m["description"])
+		_, hasName := m["name"]
+		require.False(t, hasName)
+	})
+
+	t.Run("update both fields", func(t *testing.T) {
+		name := "New Name"
+		desc := "New Description"
+		req := UpdateTeamRequest{
+			Name:        &name,
+			Description: &desc,
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var decoded UpdateTeamRequest
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.NotNil(t, decoded.Name)
+		require.Equal(t, "New Name", *decoded.Name)
+		require.NotNil(t, decoded.Description)
+		require.Equal(t, "New Description", *decoded.Description)
+	})
+
+	t.Run("nil pointers omit fields", func(t *testing.T) {
+		req := UpdateTeamRequest{}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Empty(t, m)
+	})
+}
+
+func TestAddTeamMemberRequest_JSONSerialization(t *testing.T) {
+	t.Run("admin role", func(t *testing.T) {
+		req := AddTeamMemberRequest{
+			UserID: "user123",
+			Role:   TeamRoleAdmin,
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, "user123", m["userId"])
+		require.Equal(t, "admin", m["role"])
+	})
+
+	t.Run("member role", func(t *testing.T) {
+		req := AddTeamMemberRequest{
+			UserID: "user456",
+			Role:   TeamRoleMember,
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var decoded AddTeamMemberRequest
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, "user456", decoded.UserID)
+		require.Equal(t, TeamRoleMember, decoded.Role)
+	})
+
+	t.Run("deserialize from JSON payload", func(t *testing.T) {
+		payload := `{"userId": "abc-123", "role": "member"}`
+
+		var req AddTeamMemberRequest
+		require.NoError(t, json.Unmarshal([]byte(payload), &req))
+
+		require.Equal(t, "abc-123", req.UserID)
+		require.Equal(t, TeamRoleMember, req.Role)
+	})
+}
+
+func TestTeamWithMembers_JSONSerialization(t *testing.T) {
+	t.Run("embedded team fields are present", func(t *testing.T) {
+		teamID := uuid.New()
+		userID1 := uuid.New()
+		userID2 := uuid.New()
+
+		twm := TeamWithMembers{
+			Team: Team{
+				ID:          teamID,
+				Name:        "Full Team",
+				Description: "Team with members",
+				CreatedBy:   uuid.New(),
+				MemberCount: 2,
+				CreatedAt:   time.Now(),
+				UpdatedAt:   time.Now(),
+			},
+			Members: []TeamMemberInfo{
+				{
+					UserID:      userID1,
+					GitHubLogin: "alice",
+					AvatarURL:   "https://avatar.url/alice",
+					Role:        TeamRoleAdmin,
+					Email:       "alice@example.com",
+				},
+				{
+					UserID:      userID2,
+					GitHubLogin: "bob",
+					Role:        TeamRoleMember,
+				},
+			},
+		}
+
+		data, err := json.Marshal(twm)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, teamID.String(), m["id"])
+		require.Equal(t, "Full Team", m["name"])
+		require.Equal(t, "Team with members", m["description"])
+		require.NotNil(t, m["members"])
+
+		members := m["members"].([]interface{})
+		require.Len(t, members, 2)
+
+		member1 := members[0].(map[string]interface{})
+		require.Equal(t, userID1.String(), member1["userId"])
+		require.Equal(t, "alice", member1["githubLogin"])
+		require.Equal(t, "admin", member1["role"])
+	})
+
+	t.Run("empty member list serializes as empty array", func(t *testing.T) {
+		twm := TeamWithMembers{
+			Team: Team{
+				ID:        uuid.New(),
+				Name:      "Empty Team",
+				CreatedBy: uuid.New(),
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			Members: []TeamMemberInfo{},
+		}
+
+		data, err := json.Marshal(twm)
+		require.NoError(t, err)
+
+		var decoded TeamWithMembers
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.NotNil(t, decoded.Members)
+		require.Empty(t, decoded.Members)
+	})
+
+	t.Run("round-trip preserves structure", func(t *testing.T) {
+		original := TeamWithMembers{
+			Team: Team{
+				ID:          uuid.New(),
+				Name:        "Test Team",
+				CreatedBy:   uuid.New(),
+				MemberCount: 1,
+				CreatedAt:   time.Now().UTC(),
+				UpdatedAt:   time.Now().UTC(),
+			},
+			Members: []TeamMemberInfo{
+				{
+					UserID:      uuid.New(),
+					GitHubLogin: "testuser",
+					Role:        TeamRoleMember,
+				},
+			},
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded TeamWithMembers
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, original.Team.ID, decoded.Team.ID)
+		require.Equal(t, original.Team.Name, decoded.Team.Name)
+		require.Len(t, decoded.Members, 1)
+		require.Equal(t, original.Members[0].UserID, decoded.Members[0].UserID)
+		require.Equal(t, original.Members[0].Role, decoded.Members[0].Role)
+	})
+}
+
+func TestTeamMemberInfo_JSONSerialization(t *testing.T) {
+	t.Run("all fields present", func(t *testing.T) {
+		userID := uuid.New()
+		info := TeamMemberInfo{
+			UserID:      userID,
+			GitHubLogin: "johndoe",
+			AvatarURL:   "https://example.com/avatar.png",
+			Role:        TeamRoleAdmin,
+			Email:       "john@example.com",
+		}
+
+		data, err := json.Marshal(info)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, userID.String(), m["userId"])
+		require.Equal(t, "johndoe", m["githubLogin"])
+		require.Equal(t, "https://example.com/avatar.png", m["avatarUrl"])
+		require.Equal(t, "admin", m["role"])
+		require.Equal(t, "john@example.com", m["email"])
+	})
+
+	t.Run("omitempty fields absent when empty", func(t *testing.T) {
+		info := TeamMemberInfo{
+			UserID:      uuid.New(),
+			GitHubLogin: "minimaluser",
+			Role:        TeamRoleMember,
+		}
+
+		data, err := json.Marshal(info)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		_, hasAvatar := m["avatarUrl"]
+		require.False(t, hasAvatar, "empty avatarUrl should be omitted")
+		_, hasEmail := m["email"]
+		require.False(t, hasEmail, "empty email should be omitted")
+	})
+}
+
+func TestTeam_EdgeCases(t *testing.T) {
+	t.Run("zero-valued UUID is serialized", func(t *testing.T) {
+		team := Team{
+			ID:        uuid.UUID{},
+			Name:      "Team",
+			CreatedBy: uuid.UUID{},
+			CreatedAt: time.Time{},
+			UpdatedAt: time.Time{},
+		}
+
+		data, err := json.Marshal(team)
+		require.NoError(t, err)
+
+		var decoded Team
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, uuid.UUID{}, decoded.ID)
+		assert.Equal(t, uuid.UUID{}, decoded.CreatedBy)
+	})
+
+	t.Run("negative member count is preserved", func(t *testing.T) {
+		team := Team{
+			ID:          uuid.New(),
+			Name:        "Team",
+			CreatedBy:   uuid.New(),
+			MemberCount: -1,
+			CreatedAt:   time.Now(),
+			UpdatedAt:   time.Now(),
+		}
+
+		data, err := json.Marshal(team)
+		require.NoError(t, err)
+
+		var decoded Team
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, -1, decoded.MemberCount)
+	})
+}
+
+func TestTeamMembership_EdgeCases(t *testing.T) {
+	t.Run("empty role string is preserved", func(t *testing.T) {
+		membership := TeamMembership{
+			ID:        uuid.New(),
+			TeamID:    uuid.New(),
+			UserID:    uuid.New(),
+			Role:      TeamRole(""),
+			CreatedAt: time.Now(),
+		}
+
+		data, err := json.Marshal(membership)
+		require.NoError(t, err)
+
+		var decoded TeamMembership
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, TeamRole(""), decoded.Role)
+	})
+
+	t.Run("invalid role value is preserved", func(t *testing.T) {
+		membership := TeamMembership{
+			ID:        uuid.New(),
+			TeamID:    uuid.New(),
+			UserID:    uuid.New(),
+			Role:      TeamRole("superadmin"),
+			CreatedAt: time.Now(),
+		}
+
+		data, err := json.Marshal(membership)
+		require.NoError(t, err)
+
+		var decoded TeamMembership
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, TeamRole("superadmin"), decoded.Role)
+	})
+}

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -1,0 +1,530 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUser_JSONSerialization(t *testing.T) {
+	t.Run("marshal includes all fields", func(t *testing.T) {
+		userID := uuid.New()
+		now := time.Now().UTC()
+		user := User{
+			ID:          userID,
+			GitHubID:    "123456",
+			GitHubLogin: "testuser",
+			Email:       "test@example.com",
+			SlackID:     "U123ABC",
+			AvatarURL:   "https://avatar.url",
+			Role:        UserRoleAdmin,
+			Onboarded:   true,
+			CreatedAt:   now,
+			LastLogin:   &now,
+		}
+
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, userID.String(), m["id"])
+		require.Equal(t, "123456", m["github_id"])
+		require.Equal(t, "testuser", m["github_login"])
+		require.Equal(t, "test@example.com", m["email"])
+		require.Equal(t, "U123ABC", m["slack_id"])
+		require.Equal(t, "https://avatar.url", m["avatar_url"])
+		require.Equal(t, "admin", m["role"])
+		require.Equal(t, true, m["onboarded"])
+	})
+
+	t.Run("omitempty fields absent when empty", func(t *testing.T) {
+		user := User{
+			ID:          uuid.New(),
+			GitHubID:    "123",
+			GitHubLogin: "minimal",
+			Role:        UserRoleViewer,
+			Onboarded:   false,
+			CreatedAt:   time.Now(),
+		}
+
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		_, hasEmail := m["email"]
+		require.False(t, hasEmail, "empty email should be omitted")
+		_, hasSlack := m["slack_id"]
+		require.False(t, hasSlack, "empty slack_id should be omitted")
+		_, hasAvatar := m["avatar_url"]
+		require.False(t, hasAvatar, "empty avatar_url should be omitted")
+		_, hasLastLogin := m["last_login"]
+		require.False(t, hasLastLogin, "nil last_login should be omitted")
+	})
+
+	t.Run("round-trip preserves structure", func(t *testing.T) {
+		now := time.Now().UTC()
+		original := User{
+			ID:          uuid.New(),
+			GitHubID:    "999",
+			GitHubLogin: "roundtrip",
+			Email:       "roundtrip@example.com",
+			Role:        UserRoleEditor,
+			Onboarded:   true,
+			CreatedAt:   now,
+			LastLogin:   &now,
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded User
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, original.ID, decoded.ID)
+		require.Equal(t, original.GitHubID, decoded.GitHubID)
+		require.Equal(t, original.GitHubLogin, decoded.GitHubLogin)
+		require.Equal(t, original.Email, decoded.Email)
+		require.Equal(t, original.Role, decoded.Role)
+		require.Equal(t, original.Onboarded, decoded.Onboarded)
+	})
+
+	t.Run("nil last_login omitted in JSON", func(t *testing.T) {
+		user := User{
+			ID:          uuid.New(),
+			GitHubID:    "123",
+			GitHubLogin: "noLogin",
+			Role:        UserRoleViewer,
+			CreatedAt:   time.Now(),
+			LastLogin:   nil,
+		}
+
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		_, hasLastLogin := m["last_login"]
+		require.False(t, hasLastLogin)
+	})
+
+	t.Run("pointer last_login serializes when set", func(t *testing.T) {
+		loginTime := time.Now().UTC()
+		user := User{
+			ID:          uuid.New(),
+			GitHubID:    "456",
+			GitHubLogin: "withLogin",
+			Role:        UserRoleViewer,
+			CreatedAt:   time.Now(),
+			LastLogin:   &loginTime,
+		}
+
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var decoded User
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.NotNil(t, decoded.LastLogin)
+		require.WithinDuration(t, loginTime, *decoded.LastLogin, time.Second)
+	})
+}
+
+func TestUser_IdentityConstruction(t *testing.T) {
+	t.Run("minimal user identity is valid", func(t *testing.T) {
+		user := User{
+			ID:          uuid.New(),
+			GitHubID:    "12345",
+			GitHubLogin: "basicuser",
+			Role:        UserRoleViewer,
+			CreatedAt:   time.Now(),
+		}
+
+		require.NotEqual(t, uuid.Nil, user.ID)
+		require.NotEmpty(t, user.GitHubID)
+		require.NotEmpty(t, user.GitHubLogin)
+		require.NotEmpty(t, user.Role)
+	})
+
+	t.Run("user with all optional fields", func(t *testing.T) {
+		now := time.Now()
+		user := User{
+			ID:          uuid.New(),
+			GitHubID:    "99999",
+			GitHubLogin: "fulluser",
+			Email:       "full@example.com",
+			SlackID:     "U999",
+			AvatarURL:   "https://example.com/avatar.png",
+			Role:        UserRoleAdmin,
+			Onboarded:   true,
+			CreatedAt:   now,
+			LastLogin:   &now,
+		}
+
+		require.NotEmpty(t, user.Email)
+		require.NotEmpty(t, user.SlackID)
+		require.NotEmpty(t, user.AvatarURL)
+		require.True(t, user.Onboarded)
+		require.NotNil(t, user.LastLogin)
+	})
+
+	t.Run("zero-valued UUID is serializable", func(t *testing.T) {
+		user := User{
+			ID:          uuid.UUID{},
+			GitHubID:    "123",
+			GitHubLogin: "user",
+			Role:        UserRoleViewer,
+			CreatedAt:   time.Time{},
+		}
+
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var decoded User
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, uuid.UUID{}, decoded.ID)
+	})
+}
+
+func TestOnboardingResponse_JSONSerialization(t *testing.T) {
+	t.Run("marshal includes all fields", func(t *testing.T) {
+		respID := uuid.New()
+		userID := uuid.New()
+		now := time.Now().UTC()
+
+		resp := OnboardingResponse{
+			ID:          respID,
+			UserID:      userID,
+			QuestionKey: "role",
+			Answer:      "SRE",
+			CreatedAt:   now,
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, respID.String(), m["id"])
+		require.Equal(t, userID.String(), m["user_id"])
+		require.Equal(t, "role", m["question_key"])
+		require.Equal(t, "SRE", m["answer"])
+	})
+
+	t.Run("round-trip preserves fields", func(t *testing.T) {
+		original := OnboardingResponse{
+			ID:          uuid.New(),
+			UserID:      uuid.New(),
+			QuestionKey: "cluster_count",
+			Answer:      "10-50",
+			CreatedAt:   time.Now().UTC(),
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded OnboardingResponse
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, original.ID, decoded.ID)
+		require.Equal(t, original.UserID, decoded.UserID)
+		require.Equal(t, original.QuestionKey, decoded.QuestionKey)
+		require.Equal(t, original.Answer, decoded.Answer)
+	})
+
+	t.Run("empty answer is preserved", func(t *testing.T) {
+		resp := OnboardingResponse{
+			ID:          uuid.New(),
+			UserID:      uuid.New(),
+			QuestionKey: "optional_question",
+			Answer:      "",
+			CreatedAt:   time.Now(),
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var decoded OnboardingResponse
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, "", decoded.Answer)
+	})
+}
+
+func TestOnboardingQuestion_JSONSerialization(t *testing.T) {
+	t.Run("marshal includes all fields", func(t *testing.T) {
+		q := OnboardingQuestion{
+			Key:         "role",
+			Question:    "What's your primary role?",
+			Description: "This helps us customize your dashboard",
+			Options:     []string{"SRE", "DevOps", "Developer"},
+			MultiSelect: false,
+		}
+
+		data, err := json.Marshal(q)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, "role", m["key"])
+		require.Equal(t, "What's your primary role?", m["question"])
+		require.Equal(t, "This helps us customize your dashboard", m["description"])
+		require.NotNil(t, m["options"])
+		require.False(t, m["multi_select"].(bool))
+	})
+
+	t.Run("omitempty description absent when empty", func(t *testing.T) {
+		q := OnboardingQuestion{
+			Key:      "simple",
+			Question: "Simple question?",
+			Options:  []string{"Yes", "No"},
+		}
+
+		data, err := json.Marshal(q)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		_, hasDescription := m["description"]
+		require.False(t, hasDescription, "empty description should be omitted")
+	})
+
+	t.Run("multi-select question", func(t *testing.T) {
+		q := OnboardingQuestion{
+			Key:         "features",
+			Question:    "Which features interest you?",
+			Options:     []string{"Feature A", "Feature B", "Feature C"},
+			MultiSelect: true,
+		}
+
+		data, err := json.Marshal(q)
+		require.NoError(t, err)
+
+		var decoded OnboardingQuestion
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.True(t, decoded.MultiSelect)
+		require.Len(t, decoded.Options, 3)
+	})
+
+	t.Run("empty options list is preserved", func(t *testing.T) {
+		q := OnboardingQuestion{
+			Key:      "freetext",
+			Question: "Your thoughts?",
+			Options:  []string{},
+		}
+
+		data, err := json.Marshal(q)
+		require.NoError(t, err)
+
+		var decoded OnboardingQuestion
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.NotNil(t, decoded.Options)
+		require.Empty(t, decoded.Options)
+	})
+}
+
+func TestGetOnboardingQuestions_Structure(t *testing.T) {
+	questions := GetOnboardingQuestions()
+	require.NotEmpty(t, questions, "should return at least one question")
+
+	t.Run("all questions have required fields", func(t *testing.T) {
+		for _, q := range questions {
+			require.NotEmpty(t, q.Key, "question key should not be empty")
+			require.NotEmpty(t, q.Question, "question text should not be empty")
+			require.NotEmpty(t, q.Options, "options should not be empty")
+		}
+	})
+
+	t.Run("question keys are unique", func(t *testing.T) {
+		keys := make(map[string]bool)
+		for _, q := range questions {
+			require.False(t, keys[q.Key], "duplicate question key: %s", q.Key)
+			keys[q.Key] = true
+		}
+	})
+
+	t.Run("expected questions are present", func(t *testing.T) {
+		keySet := make(map[string]bool)
+		for _, q := range questions {
+			keySet[q.Key] = true
+		}
+
+		expectedKeys := []string{
+			"role",
+			"focus_layer",
+			"cluster_count",
+			"daily_challenge",
+			"gitops",
+			"monitoring_priority",
+			"data_preference",
+			"gpu_workloads",
+			"alert_threshold",
+			"regulated",
+		}
+
+		for _, key := range expectedKeys {
+			require.True(t, keySet[key], "expected question key not found: %s", key)
+		}
+	})
+
+	t.Run("role question has expected structure", func(t *testing.T) {
+		var roleQuestion *OnboardingQuestion
+		for _, q := range questions {
+			if q.Key == "role" {
+				roleQuestion = &q
+				break
+			}
+		}
+
+		require.NotNil(t, roleQuestion, "role question should exist")
+		require.Equal(t, "What's your primary role?", roleQuestion.Question)
+		require.NotEmpty(t, roleQuestion.Description)
+		require.Contains(t, roleQuestion.Options, "SRE")
+		require.Contains(t, roleQuestion.Options, "DevOps")
+	})
+
+	t.Run("gpu_workloads question is boolean choice", func(t *testing.T) {
+		var gpuQuestion *OnboardingQuestion
+		for _, q := range questions {
+			if q.Key == "gpu_workloads" {
+				gpuQuestion = &q
+				break
+			}
+		}
+
+		require.NotNil(t, gpuQuestion)
+		require.Len(t, gpuQuestion.Options, 2)
+		require.Contains(t, gpuQuestion.Options, "Yes")
+		require.Contains(t, gpuQuestion.Options, "No")
+	})
+}
+
+func TestUser_EdgeCases(t *testing.T) {
+	t.Run("user with empty strings for optional fields", func(t *testing.T) {
+		user := User{
+			ID:          uuid.New(),
+			GitHubID:    "123",
+			GitHubLogin: "user",
+			Email:       "",
+			SlackID:     "",
+			AvatarURL:   "",
+			Role:        UserRoleViewer,
+			CreatedAt:   time.Now(),
+		}
+
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		_, hasEmail := m["email"]
+		_, hasSlack := m["slack_id"]
+		_, hasAvatar := m["avatar_url"]
+
+		assert.False(t, hasEmail, "empty email should be omitted")
+		assert.False(t, hasSlack, "empty slack_id should be omitted")
+		assert.False(t, hasAvatar, "empty avatar_url should be omitted")
+	})
+
+	t.Run("onboarded false is serialized", func(t *testing.T) {
+		user := User{
+			ID:          uuid.New(),
+			GitHubID:    "123",
+			GitHubLogin: "newuser",
+			Role:        UserRoleViewer,
+			Onboarded:   false,
+			CreatedAt:   time.Now(),
+		}
+
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, false, m["onboarded"])
+	})
+
+	t.Run("empty role is preserved", func(t *testing.T) {
+		user := User{
+			ID:          uuid.New(),
+			GitHubID:    "123",
+			GitHubLogin: "norole",
+			Role:        UserRole(""),
+			CreatedAt:   time.Now(),
+		}
+
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var decoded User
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, UserRole(""), decoded.Role)
+	})
+
+	t.Run("invalid role value is preserved", func(t *testing.T) {
+		user := User{
+			ID:          uuid.New(),
+			GitHubID:    "123",
+			GitHubLogin: "invalidrole",
+			Role:        UserRole("superuser"),
+			CreatedAt:   time.Now(),
+		}
+
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var decoded User
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, UserRole("superuser"), decoded.Role)
+	})
+}
+
+func TestOnboardingQuestion_EdgeCases(t *testing.T) {
+	t.Run("question with single option", func(t *testing.T) {
+		q := OnboardingQuestion{
+			Key:      "single",
+			Question: "Only one choice?",
+			Options:  []string{"Only Option"},
+		}
+
+		data, err := json.Marshal(q)
+		require.NoError(t, err)
+
+		var decoded OnboardingQuestion
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Len(t, decoded.Options, 1)
+	})
+
+	t.Run("question with many options", func(t *testing.T) {
+		opts := make([]string, 20)
+		for i := range opts {
+			opts[i] = "Option " + string(rune('A'+i))
+		}
+
+		q := OnboardingQuestion{
+			Key:      "many",
+			Question: "Choose from many?",
+			Options:  opts,
+		}
+
+		data, err := json.Marshal(q)
+		require.NoError(t, err)
+
+		var decoded OnboardingQuestion
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Len(t, decoded.Options, 20)
+	})
+}

--- a/pkg/settings/types_test.go
+++ b/pkg/settings/types_test.go
@@ -1,0 +1,638 @@
+package settings
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultSettings(t *testing.T) {
+	t.Run("returns non-nil settings", func(t *testing.T) {
+		s := DefaultSettings()
+		require.NotNil(t, s)
+	})
+
+	t.Run("sets expected default values", func(t *testing.T) {
+		s := DefaultSettings()
+
+		require.Equal(t, 1, s.Version)
+		require.Equal(t, "medium", s.Settings.AIMode)
+		require.Equal(t, "kubestellar", s.Settings.Theme)
+		require.Equal(t, "browser", s.Settings.Widget.SelectedWidget)
+	})
+
+	t.Run("prediction settings have sensible defaults", func(t *testing.T) {
+		s := DefaultSettings()
+		p := s.Settings.Predictions
+
+		require.True(t, p.AIEnabled)
+		require.Equal(t, 60, p.Interval)
+		require.Equal(t, 60, p.MinConfidence)
+		require.Equal(t, 10, p.MaxPredictions)
+		require.False(t, p.ConsensusMode)
+	})
+
+	t.Run("prediction thresholds have defaults", func(t *testing.T) {
+		s := DefaultSettings()
+		th := s.Settings.Predictions.Thresholds
+
+		require.Equal(t, 3, th.HighRestartCount)
+		require.Equal(t, 80, th.CPUPressure)
+		require.Equal(t, 85, th.MemoryPressure)
+		require.Equal(t, 90, th.GPUMemoryPressure)
+	})
+
+	t.Run("token usage settings have defaults", func(t *testing.T) {
+		s := DefaultSettings()
+		tu := s.Settings.TokenUsage
+
+		require.Equal(t, 500000000, tu.Limit)
+		require.Equal(t, 0.7, tu.WarningThreshold)
+		require.Equal(t, 0.9, tu.CriticalThreshold)
+		require.Equal(t, 1.0, tu.StopThreshold)
+	})
+
+	t.Run("accessibility settings default to false", func(t *testing.T) {
+		s := DefaultSettings()
+		acc := s.Settings.Accessibility
+
+		require.False(t, acc.ColorBlindMode)
+		require.False(t, acc.ReduceMotion)
+		require.False(t, acc.HighContrast)
+	})
+
+	t.Run("encrypted settings are empty", func(t *testing.T) {
+		s := DefaultSettings()
+		require.NotNil(t, s.Encrypted)
+		require.Nil(t, s.Encrypted.APIKeys)
+		require.Nil(t, s.Encrypted.GitHubToken)
+		require.Nil(t, s.Encrypted.FeedbackGitHubToken)
+		require.Nil(t, s.Encrypted.Notifications)
+	})
+}
+
+func TestDefaultAllSettings(t *testing.T) {
+	t.Run("returns non-nil settings", func(t *testing.T) {
+		s := DefaultAllSettings()
+		require.NotNil(t, s)
+	})
+
+	t.Run("mirrors defaults from DefaultSettings", func(t *testing.T) {
+		s := DefaultAllSettings()
+
+		require.Equal(t, "medium", s.AIMode)
+		require.Equal(t, "kubestellar", s.Theme)
+		require.Equal(t, "browser", s.Widget.SelectedWidget)
+		require.Equal(t, 60, s.Predictions.Interval)
+		require.Equal(t, 500000000, s.TokenUsage.Limit)
+	})
+
+	t.Run("initializes empty maps and structs", func(t *testing.T) {
+		s := DefaultAllSettings()
+
+		require.NotNil(t, s.APIKeys)
+		require.Empty(t, s.APIKeys)
+		require.NotNil(t, s.Notifications)
+		require.Empty(t, s.Notifications.SlackWebhookURL)
+	})
+
+	t.Run("has no feedback token by default", func(t *testing.T) {
+		s := DefaultAllSettings()
+
+		require.Empty(t, s.FeedbackGitHubToken)
+		require.False(t, s.HasFeedbackToken)
+		require.Empty(t, s.FeedbackGitHubTokenSource)
+	})
+}
+
+func TestSettingsFile_JSONSerialization(t *testing.T) {
+	t.Run("round-trip preserves structure", func(t *testing.T) {
+		original := &SettingsFile{
+			Version:      1,
+			LastModified: "2024-01-15T10:00:00Z",
+			Settings: PlaintextSettings{
+				AIMode: "high",
+				Predictions: PredictionSettings{
+					AIEnabled:     true,
+					Interval:      120,
+					MinConfidence: 70,
+				},
+				Theme: "dark",
+			},
+			KeyFingerprint: "abc123",
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded SettingsFile
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, original.Version, decoded.Version)
+		require.Equal(t, original.LastModified, decoded.LastModified)
+		require.Equal(t, original.Settings.AIMode, decoded.Settings.AIMode)
+		require.Equal(t, original.Settings.Theme, decoded.Settings.Theme)
+		require.Equal(t, original.KeyFingerprint, decoded.KeyFingerprint)
+	})
+
+	t.Run("CustomThemes preserves raw JSON", func(t *testing.T) {
+		customThemes := json.RawMessage(`[{"name":"MyTheme","colors":{}}]`)
+		sf := &SettingsFile{
+			Version: 1,
+			Settings: PlaintextSettings{
+				CustomThemes: customThemes,
+			},
+		}
+
+		data, err := json.Marshal(sf)
+		require.NoError(t, err)
+
+		var decoded SettingsFile
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.NotNil(t, decoded.Settings.CustomThemes)
+		require.JSONEq(t, string(customThemes), string(decoded.Settings.CustomThemes))
+	})
+}
+
+func TestAllSettings_ClientSafeCopy(t *testing.T) {
+	t.Run("removes FeedbackGitHubToken", func(t *testing.T) {
+		original := &AllSettings{
+			AIMode:              "medium",
+			FeedbackGitHubToken: "ghp_secrettoken123",
+			APIKeys: map[string]APIKeyEntry{
+				"anthropic": {APIKey: "sk-ant-key"},
+			},
+		}
+
+		safe := original.ClientSafeCopy()
+
+		require.Empty(t, safe.FeedbackGitHubToken, "token should be removed")
+		require.True(t, safe.HasFeedbackToken, "HasFeedbackToken should be true")
+		require.Equal(t, original.AIMode, safe.AIMode)
+		require.Equal(t, original.APIKeys, safe.APIKeys)
+	})
+
+	t.Run("sets HasFeedbackToken to false when no token", func(t *testing.T) {
+		original := &AllSettings{
+			AIMode:              "low",
+			FeedbackGitHubToken: "",
+		}
+
+		safe := original.ClientSafeCopy()
+
+		require.Empty(t, safe.FeedbackGitHubToken)
+		require.False(t, safe.HasFeedbackToken)
+	})
+
+	t.Run("returns nil for nil input", func(t *testing.T) {
+		var original *AllSettings = nil
+		safe := original.ClientSafeCopy()
+		require.Nil(t, safe)
+	})
+
+	t.Run("does not modify original", func(t *testing.T) {
+		original := &AllSettings{
+			AIMode:              "medium",
+			FeedbackGitHubToken: "secret",
+		}
+
+		safe := original.ClientSafeCopy()
+
+		require.Equal(t, "secret", original.FeedbackGitHubToken, "original should not be modified")
+		require.Empty(t, safe.FeedbackGitHubToken)
+	})
+
+	t.Run("preserves all non-sensitive fields", func(t *testing.T) {
+		original := &AllSettings{
+			AIMode: "high",
+			Predictions: PredictionSettings{
+				AIEnabled: true,
+				Interval:  90,
+			},
+			TokenUsage: TokenUsageSettings{
+				Limit: 1000000,
+			},
+			Theme: "nord",
+			Accessibility: AccessibilitySettings{
+				HighContrast: true,
+			},
+			Profile: ProfileSettings{
+				Email: "user@example.com",
+			},
+			Widget: WidgetSettings{
+				SelectedWidget: "cli",
+			},
+			FeedbackGitHubToken:       "token",
+			FeedbackGitHubTokenSource: "settings",
+		}
+
+		safe := original.ClientSafeCopy()
+
+		require.Equal(t, original.AIMode, safe.AIMode)
+		require.Equal(t, original.Predictions, safe.Predictions)
+		require.Equal(t, original.TokenUsage, safe.TokenUsage)
+		require.Equal(t, original.Theme, safe.Theme)
+		require.Equal(t, original.Accessibility, safe.Accessibility)
+		require.Equal(t, original.Profile, safe.Profile)
+		require.Equal(t, original.Widget, safe.Widget)
+		require.Equal(t, original.FeedbackGitHubTokenSource, safe.FeedbackGitHubTokenSource)
+	})
+}
+
+func TestAllSettings_PreserveFeedbackTokenFrom(t *testing.T) {
+	t.Run("preserves token and source from existing", func(t *testing.T) {
+		existing := &AllSettings{
+			FeedbackGitHubToken:       "ghp_existingtoken",
+			FeedbackGitHubTokenSource: "env",
+			HasFeedbackToken:          true,
+		}
+
+		incoming := &AllSettings{
+			AIMode: "updated",
+		}
+
+		incoming.PreserveFeedbackTokenFrom(existing)
+
+		require.Equal(t, "ghp_existingtoken", incoming.FeedbackGitHubToken)
+		require.Equal(t, "env", incoming.FeedbackGitHubTokenSource)
+		require.True(t, incoming.HasFeedbackToken)
+	})
+
+	t.Run("sets HasFeedbackToken false when existing has no token", func(t *testing.T) {
+		existing := &AllSettings{
+			FeedbackGitHubToken:       "",
+			FeedbackGitHubTokenSource: "",
+		}
+
+		incoming := &AllSettings{
+			AIMode: "low",
+		}
+
+		incoming.PreserveFeedbackTokenFrom(existing)
+
+		require.Empty(t, incoming.FeedbackGitHubToken)
+		require.Empty(t, incoming.FeedbackGitHubTokenSource)
+		require.False(t, incoming.HasFeedbackToken)
+	})
+
+	t.Run("no-op when incoming is nil", func(t *testing.T) {
+		existing := &AllSettings{
+			FeedbackGitHubToken: "token",
+		}
+
+		var incoming *AllSettings = nil
+		incoming.PreserveFeedbackTokenFrom(existing)
+	})
+
+	t.Run("no-op when existing is nil", func(t *testing.T) {
+		incoming := &AllSettings{
+			AIMode: "medium",
+		}
+
+		var existing *AllSettings = nil
+		incoming.PreserveFeedbackTokenFrom(existing)
+
+		require.Empty(t, incoming.FeedbackGitHubToken)
+	})
+}
+
+func TestResolveGitHubTokenEnv(t *testing.T) {
+	t.Run("prefers FEEDBACK_GITHUB_TOKEN", func(t *testing.T) {
+		os.Setenv("FEEDBACK_GITHUB_TOKEN", "ghp_feedback")
+		os.Setenv("GITHUB_TOKEN", "ghp_generic")
+		defer func() {
+			os.Unsetenv("FEEDBACK_GITHUB_TOKEN")
+			os.Unsetenv("GITHUB_TOKEN")
+		}()
+
+		token := ResolveGitHubTokenEnv()
+		require.Equal(t, "ghp_feedback", token)
+	})
+
+	t.Run("falls back to GITHUB_TOKEN", func(t *testing.T) {
+		os.Unsetenv("FEEDBACK_GITHUB_TOKEN")
+		os.Setenv("GITHUB_TOKEN", "ghp_generic")
+		defer os.Unsetenv("GITHUB_TOKEN")
+
+		token := ResolveGitHubTokenEnv()
+		require.Equal(t, "ghp_generic", token)
+	})
+
+	t.Run("returns empty when neither is set", func(t *testing.T) {
+		os.Unsetenv("FEEDBACK_GITHUB_TOKEN")
+		os.Unsetenv("GITHUB_TOKEN")
+
+		token := ResolveGitHubTokenEnv()
+		require.Empty(t, token)
+	})
+
+	t.Run("empty FEEDBACK_GITHUB_TOKEN falls back to GITHUB_TOKEN", func(t *testing.T) {
+		os.Setenv("FEEDBACK_GITHUB_TOKEN", "")
+		os.Setenv("GITHUB_TOKEN", "ghp_fallback")
+		defer func() {
+			os.Unsetenv("FEEDBACK_GITHUB_TOKEN")
+			os.Unsetenv("GITHUB_TOKEN")
+		}()
+
+		token := ResolveGitHubTokenEnv()
+		require.Equal(t, "ghp_fallback", token)
+	})
+}
+
+func TestGitHubTokenSource_Constants(t *testing.T) {
+	require.Equal(t, "settings", GitHubTokenSourceSettings)
+	require.Equal(t, "env", GitHubTokenSourceEnv)
+}
+
+func TestEncryptedField_JSONSerialization(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		ef := EncryptedField{
+			Ciphertext: "base64encrypteddata==",
+			IV:         "base64iv==",
+		}
+
+		data, err := json.Marshal(ef)
+		require.NoError(t, err)
+
+		var decoded EncryptedField
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, ef.Ciphertext, decoded.Ciphertext)
+		require.Equal(t, ef.IV, decoded.IV)
+	})
+
+	t.Run("empty fields serialize", func(t *testing.T) {
+		ef := EncryptedField{}
+
+		data, err := json.Marshal(ef)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, "", m["ciphertext"])
+		require.Equal(t, "", m["iv"])
+	})
+}
+
+func TestAPIKeyEntry_JSONSerialization(t *testing.T) {
+	t.Run("with model override", func(t *testing.T) {
+		entry := APIKeyEntry{
+			APIKey: "sk-key123",
+			Model:  "claude-3-opus",
+		}
+
+		data, err := json.Marshal(entry)
+		require.NoError(t, err)
+
+		var decoded APIKeyEntry
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, entry.APIKey, decoded.APIKey)
+		require.Equal(t, entry.Model, decoded.Model)
+	})
+
+	t.Run("without model override", func(t *testing.T) {
+		entry := APIKeyEntry{
+			APIKey: "sk-key456",
+		}
+
+		data, err := json.Marshal(entry)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		require.Equal(t, "sk-key456", m["apiKey"])
+		_, hasModel := m["model"]
+		require.False(t, hasModel, "empty model should be omitted")
+	})
+}
+
+func TestNotificationSecrets_JSONSerialization(t *testing.T) {
+	t.Run("all fields present", func(t *testing.T) {
+		ns := NotificationSecrets{
+			SlackWebhookURL: "https://hooks.slack.com/xxx",
+			SlackChannel:    "#alerts",
+			EmailSMTPHost:   "smtp.example.com",
+			EmailSMTPPort:   587,
+			EmailFrom:       "alerts@example.com",
+			EmailTo:         "oncall@example.com",
+			EmailUsername:   "smtp_user",
+			EmailPassword:   "smtp_pass",
+		}
+
+		data, err := json.Marshal(ns)
+		require.NoError(t, err)
+
+		var decoded NotificationSecrets
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, ns.SlackWebhookURL, decoded.SlackWebhookURL)
+		require.Equal(t, ns.SlackChannel, decoded.SlackChannel)
+		require.Equal(t, ns.EmailSMTPHost, decoded.EmailSMTPHost)
+		require.Equal(t, ns.EmailSMTPPort, decoded.EmailSMTPPort)
+		require.Equal(t, ns.EmailFrom, decoded.EmailFrom)
+		require.Equal(t, ns.EmailTo, decoded.EmailTo)
+		require.Equal(t, ns.EmailUsername, decoded.EmailUsername)
+		require.Equal(t, ns.EmailPassword, decoded.EmailPassword)
+	})
+
+	t.Run("omitempty fields absent when empty", func(t *testing.T) {
+		ns := NotificationSecrets{
+			SlackWebhookURL: "https://hooks.slack.com/yyy",
+		}
+
+		data, err := json.Marshal(ns)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		_, hasChannel := m["slackChannel"]
+		_, hasHost := m["emailSMTPHost"]
+
+		assert.False(t, hasChannel)
+		assert.False(t, hasHost)
+	})
+}
+
+func TestPredictionSettings_JSONSerialization(t *testing.T) {
+	t.Run("round-trip preserves all fields", func(t *testing.T) {
+		ps := PredictionSettings{
+			AIEnabled:      false,
+			Interval:       120,
+			MinConfidence:  80,
+			MaxPredictions: 5,
+			ConsensusMode:  true,
+			Thresholds: PredictionThresholds{
+				HighRestartCount:  5,
+				CPUPressure:       90,
+				MemoryPressure:    95,
+				GPUMemoryPressure: 85,
+			},
+		}
+
+		data, err := json.Marshal(ps)
+		require.NoError(t, err)
+
+		var decoded PredictionSettings
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, ps.AIEnabled, decoded.AIEnabled)
+		require.Equal(t, ps.Interval, decoded.Interval)
+		require.Equal(t, ps.MinConfidence, decoded.MinConfidence)
+		require.Equal(t, ps.MaxPredictions, decoded.MaxPredictions)
+		require.Equal(t, ps.ConsensusMode, decoded.ConsensusMode)
+		require.Equal(t, ps.Thresholds, decoded.Thresholds)
+	})
+}
+
+func TestTokenUsageSettings_JSONSerialization(t *testing.T) {
+	t.Run("round-trip preserves thresholds", func(t *testing.T) {
+		tus := TokenUsageSettings{
+			Limit:             100000,
+			WarningThreshold:  0.6,
+			CriticalThreshold: 0.85,
+			StopThreshold:     0.95,
+		}
+
+		data, err := json.Marshal(tus)
+		require.NoError(t, err)
+
+		var decoded TokenUsageSettings
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, tus.Limit, decoded.Limit)
+		require.Equal(t, tus.WarningThreshold, decoded.WarningThreshold)
+		require.Equal(t, tus.CriticalThreshold, decoded.CriticalThreshold)
+		require.Equal(t, tus.StopThreshold, decoded.StopThreshold)
+	})
+
+	t.Run("float precision is preserved", func(t *testing.T) {
+		tus := TokenUsageSettings{
+			WarningThreshold: 0.777,
+		}
+
+		data, err := json.Marshal(tus)
+		require.NoError(t, err)
+
+		var decoded TokenUsageSettings
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.InDelta(t, 0.777, decoded.WarningThreshold, 0.0001)
+	})
+}
+
+func TestAccessibilitySettings_JSONSerialization(t *testing.T) {
+	t.Run("all boolean flags serialize correctly", func(t *testing.T) {
+		acc := AccessibilitySettings{
+			ColorBlindMode: true,
+			ReduceMotion:   true,
+			HighContrast:   false,
+		}
+
+		data, err := json.Marshal(acc)
+		require.NoError(t, err)
+
+		var decoded AccessibilitySettings
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.True(t, decoded.ColorBlindMode)
+		require.True(t, decoded.ReduceMotion)
+		require.False(t, decoded.HighContrast)
+	})
+}
+
+func TestPlaintextSettings_JSONSerialization(t *testing.T) {
+	t.Run("round-trip with CustomThemes", func(t *testing.T) {
+		customThemes := json.RawMessage(`[{"name":"Custom","colors":{"bg":"#000"}}]`)
+		ps := PlaintextSettings{
+			AIMode:       "low",
+			Theme:        "custom-dark",
+			CustomThemes: customThemes,
+		}
+
+		data, err := json.Marshal(ps)
+		require.NoError(t, err)
+
+		var decoded PlaintextSettings
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, ps.AIMode, decoded.AIMode)
+		require.Equal(t, ps.Theme, decoded.Theme)
+		require.JSONEq(t, string(customThemes), string(decoded.CustomThemes))
+	})
+
+	t.Run("CustomThemes omitempty when nil", func(t *testing.T) {
+		ps := PlaintextSettings{
+			AIMode: "medium",
+		}
+
+		data, err := json.Marshal(ps)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		_, hasCustomThemes := m["customThemes"]
+		assert.False(t, hasCustomThemes)
+	})
+}
+
+func TestAllSettings_JSONRoundTrip(t *testing.T) {
+	t.Run("full settings round-trip", func(t *testing.T) {
+		original := &AllSettings{
+			AIMode: "high",
+			Predictions: PredictionSettings{
+				AIEnabled:     true,
+				Interval:      60,
+				MinConfidence: 70,
+			},
+			TokenUsage: TokenUsageSettings{
+				Limit:             1000000,
+				WarningThreshold:  0.8,
+				CriticalThreshold: 0.9,
+				StopThreshold:     1.0,
+			},
+			Theme: "dracula",
+			Accessibility: AccessibilitySettings{
+				HighContrast: true,
+			},
+			Profile: ProfileSettings{
+				Email:   "test@example.com",
+				SlackID: "U123",
+			},
+			Widget: WidgetSettings{
+				SelectedWidget: "browser",
+			},
+			APIKeys: map[string]APIKeyEntry{
+				"anthropic": {APIKey: "sk-ant-123", Model: "claude-3-opus"},
+			},
+			FeedbackGitHubToken:       "ghp_token",
+			HasFeedbackToken:          true,
+			FeedbackGitHubTokenSource: "settings",
+			Notifications: NotificationSecrets{
+				SlackWebhookURL: "https://hooks.slack.com/xxx",
+			},
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded AllSettings
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.Equal(t, original.AIMode, decoded.AIMode)
+		require.Equal(t, original.Theme, decoded.Theme)
+		require.Equal(t, original.FeedbackGitHubToken, decoded.FeedbackGitHubToken)
+		require.Equal(t, original.HasFeedbackToken, decoded.HasFeedbackToken)
+		require.Equal(t, original.FeedbackGitHubTokenSource, decoded.FeedbackGitHubTokenSource)
+		require.Len(t, decoded.APIKeys, 1)
+		require.Equal(t, original.Notifications.SlackWebhookURL, decoded.Notifications.SlackWebhookURL)
+	})
+}


### PR DESCRIPTION
Fixes #19611

## Test Improvement

Adds unit tests for previously untested model and settings types:

### `pkg/models/teams_test.go`
- Team struct JSON serialization and round-trip tests
- TeamMembership role mapping tests (admin/member)
- Edge cases: empty teams, nil fields, zero-valued UUIDs

### `pkg/models/user_test.go`
- User identity construction and field validation
- JSON serialization with omitempty field tests
- GetOnboardingQuestions() validation

### `pkg/settings/types_test.go`
- DefaultSettings() and DefaultAllSettings() default value tests
- AllSettings.ClientSafeCopy() token removal and safety
- JSON round-trips for all settings types

### `pkg/ai/init_test.go`
- Function variable existence and invocation tests
- Error handling for InitializeProviders

---
*Filed by scanner agent*