### PR TITLE
[scanner] fix: resolve 20 test failures from Coverage Suite run #3893

### DIFF
--- a/web/src/components/drilldown/views/PodDrillDown.actions.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.actions.tsx
@@ -434,16 +434,13 @@ Please:
             resolve(output || '')
           }, 10000)
 
-          ws.onopen = () => {
-            ws.send(JSON.stringify({
-              id: requestId,
-              type: 'kubectl',
-              payload: { context: cluster, args }
-            }))
-          }
+          // Set up handlers before sending so no messages are missed
           ws.onmessage = (event: MessageEvent) => {
             const msg = parseWsMessage(event, 'related resources')
             if (!msg) {
+              clearTimeout(timeout)
+              ws.close()
+              resolve(output || '')
               return
             }
 
@@ -459,6 +456,13 @@ Please:
             ws.close()
             resolve(output || '')
           }
+
+          // openTrackedWs resolves with an already-open connection; send immediately
+          ws.send(JSON.stringify({
+            id: requestId,
+            type: 'kubectl',
+            payload: { context: cluster, args }
+          }))
         })
       }
 

--- a/web/src/components/mission-control/__tests__/mission-control-dialog.test.tsx
+++ b/web/src/components/mission-control/__tests__/mission-control-dialog.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../missionPlanCodec', () => ({
 vi.mock('../../../lib/modals/useModalNavigation', () => ({
   useModalFocusTrap: vi.fn(),
   useModalNavigation: vi.fn(),
+  useModalState: vi.fn(() => ({ isOpen: false, open: vi.fn(), close: vi.fn(), toggle: vi.fn(), setIsOpen: vi.fn() })),
 }))
 
 vi.mock('../../../lib/auth', () => ({

--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
@@ -71,6 +71,11 @@ vi.mock('../../../lib/constants', async (importOriginal) => {
   return { ...actual, STORAGE_KEY_TOKEN: 'token' }
 })
 
+vi.mock('../../../lib/authToken', () => ({
+  getStoredAuthToken: vi.fn().mockImplementation(async () => localStorage.getItem('token')),
+  getStoredAuthTokenSync: vi.fn().mockImplementation(() => localStorage.getItem('token')),
+}))
+
 import { useBuildpackImages } from '../buildpacks'
 
 let cnt = 0

--- a/web/src/hooks/useStackDiscovery.ts
+++ b/web/src/hooks/useStackDiscovery.ts
@@ -23,7 +23,7 @@ function safeJsonParse<T>(value: string, fallback: T, context: string): T {
   try {
     return JSON.parse(value) as T
   } catch (err) {
-    console.error(`[useStackDiscovery] Ignoring malformed JSON for ${context}:`, err)
+    console.warn(`[useStackDiscovery] Ignoring malformed JSON for ${context}:`, err)
     return fallback
   }
 }


### PR DESCRIPTION
Fixes #19614

Resolves 20 test failures across 4 test files:
- PodDrillDown.actions.test.tsx (6)
- mission-control-dialog.test.tsx (11)
- useStackDiscovery.test.ts (1)
- buildpacks-coverage.test.ts (2)