### PR TITLE
[quality] ratchet up 6 Go package coverage thresholds from 0% to measured values

### DIFF
--- a/.github/go-package-coverage-ratchet.txt
+++ b/.github/go-package-coverage-ratchet.txt
@@ -18,15 +18,15 @@ pkg/sanitize 85.0
 pkg/store 42.0
 
 # --- Tier 3: Supporting packages ---
-pkg/kagent 0.0
-pkg/mcp 0.0
+pkg/kagent 85.0
+pkg/mcp 65.0
 pkg/models 0.0
-pkg/stellar 0.0
+pkg/stellar 80.0
 pkg/watcher 70.0
-pkg/settings 0.0
-pkg/rewards 0.0
+pkg/settings 75.0
+pkg/rewards 95.0
 pkg/safego 65.0
-pkg/fileutil 0.0
+pkg/fileutil 50.0
 
 # --- Compliance engines (start at 0, ratchet up as evaluation tests land) ---
 pkg/compliance/fedramp 65.0


### PR DESCRIPTION
## Test Improvement

Ratchets up coverage thresholds for 6 Go packages that had tests but were stuck at 0.0% in the ratchet file. Measured coverage locally with `go test -cover`:

| Package | Old Threshold | Measured Coverage | New Threshold |
|---|---|---|---|
| `pkg/kagent` | 0.0% | 86.2% | 85.0% |
| `pkg/mcp` | 0.0% | 67.2% | 65.0% |
| `pkg/stellar` | 0.0% | 84–100% (sub-pkgs) | 80.0% |
| `pkg/settings` | 0.0% | 77.1% | 75.0% |
| `pkg/rewards` | 0.0% | 100.0% | 95.0% |
| `pkg/fileutil` | 0.0% | 54.2% | 50.0% |

### Not updated (2 packages)

- **`pkg/kagentiprovider`** — stays at 0.0%. Cannot build locally (k8s `client-go` dependency lock issue). Needs CI measurement.
- **`pkg/models`** — stays at 0.0%. Has a duplicate test declaration (`TestUser_JSONSerialization` in `models_test.go:17`) that prevents compilation. Separate fix needed.

Fixes #19617

---
*Filed by quality agent (ACMM L4/L6 — full mode)*