### PR TITLE
[quality] fix: remove duplicate TestUser_JSONSerialization preventing pkg/models compilation

### DIFF
--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -14,53 +14,8 @@ func TestUserRole_Constants(t *testing.T) {
 	require.Equal(t, UserRole("viewer"), UserRoleViewer)
 }
 
-func TestUser_JSONSerialization(t *testing.T) {
-	t.Run("marshal includes expected fields", func(t *testing.T) {
-		user := User{
-			GitHubID:    "12345",
-			GitHubLogin: "testuser",
-			Email:       "test@example.com",
-			Role:        UserRoleAdmin,
-			Onboarded:   true,
-		}
-
-		data, err := json.Marshal(user)
-		require.NoError(t, err)
-
-		var m map[string]interface{}
-		require.NoError(t, json.Unmarshal(data, &m))
-
-		require.Equal(t, "12345", m["github_id"])
-		require.Equal(t, "testuser", m["github_login"])
-		require.Equal(t, "test@example.com", m["email"])
-		require.Equal(t, "admin", m["role"])
-		require.Equal(t, true, m["onboarded"])
-	})
-
-	t.Run("omitempty fields are absent when empty", func(t *testing.T) {
-		user := User{
-			GitHubID:    "12345",
-			GitHubLogin: "testuser",
-			Role:        UserRoleViewer,
-		}
-
-		data, err := json.Marshal(user)
-		require.NoError(t, err)
-
-		var m map[string]interface{}
-		require.NoError(t, json.Unmarshal(data, &m))
-
-		// email, slack_id, avatar_url are omitempty
-		_, hasEmail := m["email"]
-		require.False(t, hasEmail, "empty email should be omitted")
-		_, hasSlack := m["slack_id"]
-		require.False(t, hasSlack, "empty slack_id should be omitted")
-		_, hasAvatar := m["avatar_url"]
-		require.False(t, hasAvatar, "empty avatar_url should be omitted")
-		_, hasLastLogin := m["last_login"]
-		require.False(t, hasLastLogin, "nil last_login should be omitted")
-	})
-}
+// TestUser_JSONSerialization lives in user_test.go with more comprehensive
+// subtests (round-trip, nil/pointer last_login, etc.).
 
 func TestDashboard_JSONSerialization(t *testing.T) {
 	t.Run("layout is preserved as raw JSON", func(t *testing.T) {


### PR DESCRIPTION
## Test Improvement

Removes the duplicate `TestUser_JSONSerialization` function from `pkg/models/models_test.go`. The same function name exists in both `models_test.go` and `user_test.go`, which prevents `go test ./pkg/models/...` from compiling:

```
./models_test.go:17:6: TestUser_JSONSerialization redeclared in this block
    ./user_test.go:13:6: other declaration of TestUser_JSONSerialization
```

The `user_test.go` version is strictly more comprehensive (5 subtests covering round-trip, nil/pointer last_login, etc.) vs the `models_test.go` version (2 subtests). The duplicate in `models_test.go` is removed; a comment points to the canonical location.

This unblocks the `pkg/models` coverage ratchet — currently stuck at 0.0% because tests can't compile.

Fixes #19617 (partially — addresses the `pkg/models` compilation blocker)

---
*Filed by quality agent (ACMM L4/L6 — full mode)*