### PR TITLE
[quality] add 9 tested packages to coverage ratchet tracking

### DIFF
--- a/.github/go-package-coverage-ratchet.txt
+++ b/.github/go-package-coverage-ratchet.txt
@@ -28,6 +28,17 @@ pkg/rewards 95.0
 pkg/safego 65.0
 pkg/fileutil 50.0
 
+# --- Tier 3: Previously untracked (have tests, need ratchet baseline) ---
+pkg/ai 0.0
+pkg/apis 0.0
+pkg/client 0.0
+pkg/gpu 0.0
+pkg/kb 0.0
+pkg/ssrf 0.0
+pkg/services/stellar 0.0
+pkg/services/team 0.0
+pkg/services/user 0.0
+
 # --- Compliance engines (start at 0, ratchet up as evaluation tests land) ---
 pkg/compliance/fedramp 65.0
 pkg/compliance/hipaa 70.0


### PR DESCRIPTION
## Test Improvement

Adds 9 Go packages to `.github/go-package-coverage-ratchet.txt` that have existing test files but were not being tracked by the coverage ratchet gate. All start at 0.0% as a safe baseline — the ratchet will automatically tighten as coverage improves.

### Packages added

| Package | Test Files | Ratchet |
|---------|-----------|---------|
| `pkg/ai` | `init_test.go`, `provider_test.go` | 0.0% |
| `pkg/apis` | `v1alpha1/argocd_types_test.go` | 0.0% |
| `pkg/client` | `http_test.go` | 0.0% |
| `pkg/gpu` | `scraper_test.go` | 0.0% |
| `pkg/kb` | `kb_test.go`, `rag/bm25_test.go` | 0.0% |
| `pkg/ssrf` | `ssrf_test.go` | 0.0% |
| `pkg/services/stellar` | `service_test.go` | 0.0% |
| `pkg/services/team` | `service_test.go` | 0.0% |
| `pkg/services/user` | `service_test.go` | 0.0% |

### Why

Without ratchet tracking, coverage for these packages could regress silently. Adding them at 0.0% ensures no immediate CI failures while establishing a floor that ratchets upward.

Fixes #19623

---
*Filed by quality agent (ACMM L4/L6 — full mode)*