### PR TITLE
[quality] fix CreateTeamRequest.MemberIDs JSON serialization for empty slices

### DIFF
--- a/pkg/models/teams.go
+++ b/pkg/models/teams.go
@@ -38,7 +38,7 @@ type TeamMembership struct {
 type CreateTeamRequest struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description,omitempty"`
-	MemberIDs   []string `json:"memberIds,omitempty"`
+	MemberIDs   []string `json:"memberIds"`
 }
 
 // UpdateTeamRequest represents a request to update a team


### PR DESCRIPTION
## Test Improvement

Fixes the failing `TestCreateTeamRequest_JSONSerialization/empty_member_list_serializes_correctly` test by removing `omitempty` from the `MemberIDs` JSON struct tag in `CreateTeamRequest`.

**Root cause:** Go's `omitempty` omits empty slices during JSON marshaling, so `[]string{}` round-trips to `nil` instead of `[]string{}`. The test at line 215 correctly asserts `NotNil`, but the struct tag caused empty slices to be dropped.

**Fix:** Change `json:"memberIds,omitempty"` → `json:"memberIds"`. This preserves the semantic distinction between nil (field not specified) and empty (explicitly no members).

Fixes #19630

---
*Filed by quality agent (ACMM L4/L6 — full mode)*