### PR TITLE
[scanner] fix: add smoke tests for untested CNCF card components

### DIFF
--- a/web/src/components/cards/artifact_hub_status/artifact_hub_status.test.tsx
+++ b/web/src/components/cards/artifact_hub_status/artifact_hub_status.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { ArtifactHubStatus } from './index'
+
+const mockUseArtifactHubStatus = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('./useArtifactHubStatus', () => ({
+  useArtifactHubStatus: () => mockUseArtifactHubStatus(),
+}))
+
+vi.mock('../../ui/Skeleton', () => ({
+  Skeleton: ({ height }: { height?: number }) => <div data-testid="skeleton" style={{ height }} />,
+}))
+
+function setup(overrides?: Record<string, unknown>) {
+  mockUseArtifactHubStatus.mockReturnValue({
+    data: {
+      health: 'healthy',
+      totalPackages: 0,
+      totalPublishers: 0,
+      totalRepositories: 0,
+    },
+    error: null,
+    showSkeleton: false,
+    showEmptyState: false,
+    ...overrides,
+  })
+}
+
+describe('ArtifactHubStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders skeleton when showSkeleton is true', () => {
+    setup({ showSkeleton: true })
+    render(<ArtifactHubStatus />)
+
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0)
+  })
+
+  it('renders error state when error is present', () => {
+    setup({ error: 'fetch error', showEmptyState: false })
+    render(<ArtifactHubStatus />)
+
+    expect(screen.getByText('artifactHub.fetchError')).toBeTruthy()
+  })
+
+  it('renders empty state when showEmptyState is true', () => {
+    setup({ error: null, showEmptyState: true })
+    render(<ArtifactHubStatus />)
+
+    expect(screen.getByText('artifactHub.noData')).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/backstage_status/backstage_status.test.tsx
+++ b/web/src/components/cards/backstage_status/backstage_status.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { BackstageStatus } from './index'
+
+const mockUseCachedBackstage = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../../hooks/useCachedBackstage', () => ({
+  useCachedBackstage: () => mockUseCachedBackstage(),
+}))
+
+vi.mock('../CardDataContext', () => ({
+  useCardLoadingState: (opts: Record<string, unknown>) => mockUseCardLoadingState(opts),
+}))
+
+vi.mock('../../ui/Skeleton', () => ({
+  Skeleton: ({ height }: { height?: number }) => <div data-testid="skeleton" style={{ height }} />,
+  SkeletonList: () => <div data-testid="skeleton-list" />,
+  SkeletonStats: () => <div data-testid="skeleton-stats" />,
+}))
+
+function setup(overrides?: Record<string, unknown>) {
+  mockUseCachedBackstage.mockReturnValue({
+    data: {
+      health: 'healthy',
+      catalogEntities: 0,
+      components: 0,
+      apis: 0,
+    },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: Date.now(),
+    refetch: vi.fn(),
+    ...overrides,
+  })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+}
+
+describe('BackstageStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders skeleton when loading', () => {
+    setup({ isLoading: true })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false })
+    render(<BackstageStatus />)
+
+    expect(screen.getByTestId('skeleton-stats')).toBeTruthy()
+  })
+
+  it('renders without error when data is loaded', () => {
+    setup()
+    render(<BackstageStatus />)
+
+    expect(screen.queryByTestId('skeleton')).toBeFalsy()
+  })
+})

--- a/web/src/components/cards/containerd_status/containerd_status.test.tsx
+++ b/web/src/components/cards/containerd_status/containerd_status.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { ContainerdStatus } from './index'
+
+const mockUseCachedContainerd = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../../hooks/useCachedContainerd', () => ({
+  useCachedContainerd: () => mockUseCachedContainerd(),
+}))
+
+vi.mock('../CardDataContext', () => ({
+  useCardLoadingState: (opts: Record<string, unknown>) => mockUseCardLoadingState(opts),
+}))
+
+vi.mock('../../ui/Skeleton', () => ({
+  Skeleton: ({ height }: { height?: number }) => <div data-testid="skeleton" style={{ height }} />,
+  SkeletonList: () => <div data-testid="skeleton-list" />,
+  SkeletonStats: () => <div data-testid="skeleton-stats" />,
+}))
+
+function setup(overrides?: Record<string, unknown>) {
+  mockUseCachedContainerd.mockReturnValue({
+    data: {
+      health: 'healthy',
+      summary: {
+        totalContainers: 0,
+        runningContainers: 0,
+        pausedContainers: 0,
+        stoppedContainers: 0,
+      },
+      containers: [],
+    },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: Date.now(),
+    refetch: vi.fn(),
+    ...overrides,
+  })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+}
+
+describe('ContainerdStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders skeleton when loading', () => {
+    setup({ isLoading: true })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false })
+    render(<ContainerdStatus />)
+
+    expect(screen.getByTestId('skeleton-stats')).toBeTruthy()
+  })
+
+  it('renders without error when data is loaded', () => {
+    setup()
+    render(<ContainerdStatus />)
+
+    expect(screen.queryByTestId('skeleton')).toBeFalsy()
+  })
+})

--- a/web/src/components/cards/grpc_status/grpc_status.test.tsx
+++ b/web/src/components/cards/grpc_status/grpc_status.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { GrpcStatus } from './index'
+
+const mockUseCachedGrpc = vi.fn()
+const mockUseReportCardDataState = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../../hooks/useCachedGrpc', () => ({
+  useCachedGrpc: () => mockUseCachedGrpc(),
+}))
+
+vi.mock('../CardDataContext', () => ({
+  useReportCardDataState: (opts: Record<string, unknown>) => mockUseReportCardDataState(opts),
+}))
+
+vi.mock('../../ui/Skeleton', () => ({
+  Skeleton: ({ height }: { height?: number }) => <div data-testid="skeleton" style={{ height }} />,
+  SkeletonList: () => <div data-testid="skeleton-list" />,
+  SkeletonStats: () => <div data-testid="skeleton-stats" />,
+}))
+
+function setup(overrides?: Record<string, unknown>) {
+  mockUseCachedGrpc.mockReturnValue({
+    data: {
+      health: 'healthy',
+      services: [],
+      stats: {
+        totalServices: 0,
+        totalRequests: 0,
+        avgLatencyMs: 0,
+        errorRate: 0,
+      },
+    },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: Date.now(),
+    refetch: vi.fn(),
+    ...overrides,
+  })
+  mockUseReportCardDataState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+}
+
+describe('GrpcStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders skeleton when loading', () => {
+    setup({ isLoading: true })
+    mockUseReportCardDataState.mockReturnValue({ showSkeleton: true, showEmptyState: false })
+    render(<GrpcStatus />)
+
+    expect(screen.getByTestId('skeleton-stats')).toBeTruthy()
+  })
+
+  it('renders without error when data is loaded', () => {
+    setup()
+    render(<GrpcStatus />)
+
+    expect(screen.queryByTestId('skeleton')).toBeFalsy()
+  })
+})

--- a/web/src/components/cards/linkerd_status/linkerd_status.test.tsx
+++ b/web/src/components/cards/linkerd_status/linkerd_status.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { LinkerdStatus } from './index'
+
+const mockUseCachedLinkerd = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../../hooks/useCachedLinkerd', () => ({
+  useCachedLinkerd: () => mockUseCachedLinkerd(),
+}))
+
+vi.mock('../CardDataContext', () => ({
+  useCardLoadingState: (opts: Record<string, unknown>) => mockUseCardLoadingState(opts),
+}))
+
+vi.mock('../../ui/Skeleton', () => ({
+  Skeleton: ({ height }: { height?: number }) => <div data-testid="skeleton" style={{ height }} />,
+  SkeletonList: () => <div data-testid="skeleton-list" />,
+  SkeletonStats: () => <div data-testid="skeleton-stats" />,
+}))
+
+function setup(overrides?: Record<string, unknown>) {
+  mockUseCachedLinkerd.mockReturnValue({
+    data: {
+      health: 'healthy',
+      meshedPods: 0,
+      totalPods: 0,
+      successRate: 0,
+      rps: 0,
+    },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: Date.now(),
+    refetch: vi.fn(),
+    ...overrides,
+  })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+}
+
+describe('LinkerdStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders skeleton when loading', () => {
+    setup({ isLoading: true })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false })
+    render(<LinkerdStatus />)
+
+    expect(screen.getByTestId('skeleton-stats')).toBeTruthy()
+  })
+
+  it('renders without error when data is loaded', () => {
+    setup()
+    render(<LinkerdStatus />)
+
+    expect(screen.queryByTestId('skeleton')).toBeFalsy()
+  })
+})

--- a/web/src/components/cards/nats_status/nats_status.test.tsx
+++ b/web/src/components/cards/nats_status/nats_status.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { NatsStatus } from './index'
+
+const mockUseCachedNats = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../../hooks/useCachedNats', () => ({
+  useCachedNats: () => mockUseCachedNats(),
+}))
+
+vi.mock('../CardDataContext', () => ({
+  useCardLoadingState: (opts: Record<string, unknown>) => mockUseCardLoadingState(opts),
+}))
+
+vi.mock('../../ui/Skeleton', () => ({
+  Skeleton: ({ height }: { height?: number }) => <div data-testid="skeleton" style={{ height }} />,
+  SkeletonList: () => <div data-testid="skeleton-list" />,
+  SkeletonStats: () => <div data-testid="skeleton-stats" />,
+}))
+
+function setup(overrides?: Record<string, unknown>) {
+  mockUseCachedNats.mockReturnValue({
+    data: {
+      health: 'healthy',
+      servers: [],
+      streams: [],
+      consumers: [],
+    },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: Date.now(),
+    refetch: vi.fn(),
+    ...overrides,
+  })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+}
+
+describe('NatsStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders skeleton when loading', () => {
+    setup({ isLoading: true })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false })
+    render(<NatsStatus />)
+
+    expect(screen.getByTestId('skeleton-stats')).toBeTruthy()
+  })
+
+  it('renders without error when data is loaded', () => {
+    setup()
+    render(<NatsStatus />)
+
+    expect(screen.queryByTestId('skeleton')).toBeFalsy()
+  })
+})

--- a/web/src/components/cards/rook_status/rook_status.test.tsx
+++ b/web/src/components/cards/rook_status/rook_status.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { RookStatus } from './index'
+
+const mockUseCachedRook = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../../hooks/useCachedRook', () => ({
+  useCachedRook: () => mockUseCachedRook(),
+}))
+
+vi.mock('../CardDataContext', () => ({
+  useCardLoadingState: (opts: Record<string, unknown>) => mockUseCardLoadingState(opts),
+}))
+
+vi.mock('../../ui/Skeleton', () => ({
+  Skeleton: ({ height }: { height?: number }) => <div data-testid="skeleton" style={{ height }} />,
+  SkeletonList: () => <div data-testid="skeleton-list" />,
+  SkeletonStats: () => <div data-testid="skeleton-stats" />,
+}))
+
+function setup(overrides?: Record<string, unknown>) {
+  mockUseCachedRook.mockReturnValue({
+    data: {
+      health: 'healthy',
+      clusters: [],
+      osds: [],
+    },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: Date.now(),
+    refetch: vi.fn(),
+    ...overrides,
+  })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+}
+
+describe('RookStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders skeleton when loading', () => {
+    setup({ isLoading: true })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false })
+    render(<RookStatus />)
+
+    expect(screen.getByTestId('skeleton-stats')).toBeTruthy()
+  })
+
+  it('renders without error when data is loaded', () => {
+    setup()
+    render(<RookStatus />)
+
+    expect(screen.queryByTestId('skeleton')).toBeFalsy()
+  })
+})

--- a/web/src/components/cards/spiffe_status/spiffe_status.test.tsx
+++ b/web/src/components/cards/spiffe_status/spiffe_status.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { SpiffeStatus } from './index'
+
+const mockUseCachedSpiffe = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../../hooks/useCachedSpiffe', () => ({
+  useCachedSpiffe: () => mockUseCachedSpiffe(),
+}))
+
+vi.mock('../CardDataContext', () => ({
+  useCardLoadingState: (opts: Record<string, unknown>) => mockUseCardLoadingState(opts),
+}))
+
+vi.mock('../../ui/Skeleton', () => ({
+  Skeleton: ({ height }: { height?: number }) => <div data-testid="skeleton" style={{ height }} />,
+  SkeletonList: () => <div data-testid="skeleton-list" />,
+  SkeletonStats: () => <div data-testid="skeleton-stats" />,
+}))
+
+function setup(overrides?: Record<string, unknown>) {
+  mockUseCachedSpiffe.mockReturnValue({
+    data: {
+      health: 'healthy',
+      identities: [],
+      bundles: [],
+    },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: Date.now(),
+    refetch: vi.fn(),
+    ...overrides,
+  })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+}
+
+describe('SpiffeStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders skeleton when loading', () => {
+    setup({ isLoading: true })
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false })
+    render(<SpiffeStatus />)
+
+    expect(screen.getByTestId('skeleton-stats')).toBeTruthy()
+  })
+
+  it('renders without error when data is loaded', () => {
+    setup()
+    render(<SpiffeStatus />)
+
+    expect(screen.queryByTestId('skeleton')).toBeFalsy()
+  })
+})


### PR DESCRIPTION
Adds minimal export-existence smoke tests for 8 previously untested CNCF card components to eliminate zero-coverage gaps.

**Test files added:**
- artifact_hub_status.test.tsx
- backstage_status.test.tsx
- containerd_status.test.tsx
- grpc_status.test.tsx
- linkerd_status.test.tsx
- nats_status.test.tsx
- rook_status.test.tsx
- spiffe_status.test.tsx

The remaining untested components can be addressed in follow-up PRs.

Fixes #19629