### PR TITLE
[quality] add render and unit tests for missions deep-link, preflight, and type explainer

### DIFF
--- a/web/src/components/missions/__tests__/MissionToolPrerequisiteNotice.test.tsx
+++ b/web/src/components/missions/__tests__/MissionToolPrerequisiteNotice.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MissionToolPrerequisiteNotice } from '../MissionToolPrerequisiteNotice'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, string>) => {
+      if (opts?.defaultValue) {
+        let result = opts.defaultValue
+        // Simple template replacement for {{tools}} and {{tool}}
+        if (opts.tools) result = result.replace('{{tools}}', opts.tools)
+        if (opts.tool) result = result.replace('{{tool}}', opts.tool)
+        return result
+      }
+      return key
+    },
+  }),
+}))
+
+describe('MissionToolPrerequisiteNotice', () => {
+  it('renders nothing when showNotice is false', () => {
+    const { container } = render(
+      <MissionToolPrerequisiteNotice
+        status="ready"
+        missingTools={[]}
+        requiredTools={['kubectl']}
+        showNotice={false}
+      />
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders checking state with spinner message', () => {
+    render(
+      <MissionToolPrerequisiteNotice
+        status="checking"
+        missingTools={[]}
+        requiredTools={['kubectl']}
+        showNotice={true}
+      />
+    )
+    expect(screen.getByText('Checking for required local tools…')).toBeTruthy()
+  })
+
+  it('renders error state with error message', () => {
+    render(
+      <MissionToolPrerequisiteNotice
+        status="error"
+        missingTools={[]}
+        requiredTools={['kubectl']}
+        errorMessage="Network timeout"
+        showNotice={true}
+      />
+    )
+    expect(screen.getByText('Unable to verify local tools')).toBeTruthy()
+    expect(screen.getByText('Network timeout')).toBeTruthy()
+  })
+
+  it('renders error state with default message when no errorMessage', () => {
+    render(
+      <MissionToolPrerequisiteNotice
+        status="error"
+        missingTools={[]}
+        requiredTools={['kubectl']}
+        showNotice={true}
+      />
+    )
+    expect(screen.getByText('Unable to verify local tools')).toBeTruthy()
+    expect(screen.getByText('The console could not verify required local tools right now.')).toBeTruthy()
+  })
+
+  it('renders ready state listing detected tools', () => {
+    render(
+      <MissionToolPrerequisiteNotice
+        status="ready"
+        missingTools={[]}
+        requiredTools={['kubectl', 'helm']}
+        showNotice={true}
+      />
+    )
+    expect(screen.getByText('Local tools ready')).toBeTruthy()
+    expect(screen.getByText(/kubectl, helm/)).toBeTruthy()
+  })
+
+  it('renders blocked state with disabled-run hint', () => {
+    render(
+      <MissionToolPrerequisiteNotice
+        status="blocked"
+        missingTools={['helm']}
+        requiredTools={['kubectl', 'helm']}
+        showNotice={true}
+      />
+    )
+    expect(screen.getByText('Install local tools before running')).toBeTruthy()
+    expect(screen.getByText(/This mission requires helm/)).toBeTruthy()
+    expect(screen.getByText('Run Mission is disabled until the required tools are installed.')).toBeTruthy()
+  })
+
+  it('renders warning state for non-blocking missing tools', () => {
+    render(
+      <MissionToolPrerequisiteNotice
+        status="warning"
+        missingTools={['helm']}
+        requiredTools={['kubectl', 'helm']}
+        showNotice={true}
+      />
+    )
+    expect(screen.getByText('Local tools recommended')).toBeTruthy()
+    expect(screen.getByText(/local execution steps may still require helm/)).toBeTruthy()
+  })
+
+  it('renders install links for known tools', () => {
+    render(
+      <MissionToolPrerequisiteNotice
+        status="blocked"
+        missingTools={['kubectl', 'helm']}
+        requiredTools={['kubectl', 'helm']}
+        showNotice={true}
+      />
+    )
+    const kubectlLink = screen.getByText('Install kubectl')
+    expect(kubectlLink.closest('a')?.getAttribute('href')).toContain('kubernetes.io')
+    const helmLink = screen.getByText('Install helm')
+    expect(helmLink.closest('a')?.getAttribute('href')).toContain('helm.sh')
+  })
+
+  it('does not render install link for unknown tools', () => {
+    render(
+      <MissionToolPrerequisiteNotice
+        status="blocked"
+        missingTools={['custom-tool']}
+        requiredTools={['custom-tool']}
+        showNotice={true}
+      />
+    )
+    expect(screen.queryByText('Install custom-tool')).toBeNull()
+  })
+})

--- a/web/src/components/missions/__tests__/MissionTypeExplainer.test.tsx
+++ b/web/src/components/missions/__tests__/MissionTypeExplainer.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MissionTypeExplainer } from '../MissionTypeExplainer'
+
+// Mock isDemoMode to control visibility
+const mockIsDemoMode = vi.fn()
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => mockIsDemoMode(),
+}))
+
+vi.mock('../../../lib/cn', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}))
+
+describe('MissionTypeExplainer', () => {
+  beforeEach(() => {
+    mockIsDemoMode.mockReset()
+  })
+
+  it('returns null when not in demo mode', () => {
+    mockIsDemoMode.mockReturnValue(false)
+    const { container } = render(<MissionTypeExplainer />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders in demo mode with expanded content', () => {
+    mockIsDemoMode.mockReturnValue(true)
+    render(<MissionTypeExplainer />)
+    expect(screen.getByText('How AI Missions work')).toBeTruthy()
+    expect(screen.getByText('Install')).toBeTruthy()
+    expect(screen.getByText('Fix')).toBeTruthy()
+    expect(screen.getByText('Mission Control')).toBeTruthy()
+    expect(screen.getByText('Orbit')).toBeTruthy()
+  })
+
+  it('shows descriptions for each mission type when expanded', () => {
+    mockIsDemoMode.mockReturnValue(true)
+    render(<MissionTypeExplainer />)
+    expect(screen.getByText(/Deploy CNCF projects/)).toBeTruthy()
+    expect(screen.getByText(/AI diagnoses issues/)).toBeTruthy()
+    expect(screen.getByText(/Orchestrate multi-project/)).toBeTruthy()
+    expect(screen.getByText(/Recurring maintenance/)).toBeTruthy()
+  })
+
+  it('collapses content when toggle button is clicked', () => {
+    mockIsDemoMode.mockReturnValue(true)
+    render(<MissionTypeExplainer />)
+    const button = screen.getByText('How AI Missions work').closest('button')!
+    fireEvent.click(button)
+    // After collapsing, descriptions should not be visible
+    expect(screen.queryByText(/Deploy CNCF projects/)).toBeNull()
+    expect(screen.queryByText(/AI diagnoses issues/)).toBeNull()
+  })
+
+  it('re-expands when toggle button is clicked again', () => {
+    mockIsDemoMode.mockReturnValue(true)
+    render(<MissionTypeExplainer />)
+    const button = screen.getByText('How AI Missions work').closest('button')!
+    fireEvent.click(button) // collapse
+    fireEvent.click(button) // expand
+    expect(screen.getByText(/Deploy CNCF projects/)).toBeTruthy()
+  })
+
+  it('shows summary paragraph about Mission Control', () => {
+    mockIsDemoMode.mockReturnValue(true)
+    render(<MissionTypeExplainer />)
+    expect(screen.getByText(/Mission Control combines all types/)).toBeTruthy()
+  })
+})

--- a/web/src/components/missions/__tests__/PreflightFailure.test.tsx
+++ b/web/src/components/missions/__tests__/PreflightFailure.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PreflightFailure } from '../PreflightFailure'
+import type { PreflightError } from '../../../lib/missions/preflightCheck'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, string>) => opts?.defaultValue || key,
+  }),
+}))
+
+vi.mock('../../../lib/missions/preflightCheck', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    getRemediationActions: () => [],
+  }
+})
+
+vi.mock('../../../lib/clipboard', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+}))
+
+describe('PreflightFailure', () => {
+  const makeError = (code: string, message: string): PreflightError => ({
+    code: code as PreflightError['code'],
+    message,
+  })
+
+  it('renders with MISSING_CREDENTIALS error code', () => {
+    const error = makeError('MISSING_CREDENTIALS', 'No kubeconfig found')
+    const { container } = render(<PreflightFailure error={error} />)
+    const el = container.querySelector('[data-testid="preflight-failure"]')
+    expect(el).toBeTruthy()
+    expect(el?.getAttribute('data-error-code')).toBe('MISSING_CREDENTIALS')
+    expect(screen.getByText('Missing Credentials')).toBeTruthy()
+    expect(screen.getByText('No kubeconfig found')).toBeTruthy()
+  })
+
+  it('renders with EXPIRED_CREDENTIALS error code', () => {
+    const error = makeError('EXPIRED_CREDENTIALS', 'Token expired')
+    render(<PreflightFailure error={error} />)
+    expect(screen.getByText('Expired Credentials')).toBeTruthy()
+    expect(screen.getByText('Token expired')).toBeTruthy()
+  })
+
+  it('renders with RBAC_DENIED error code', () => {
+    const error = makeError('RBAC_DENIED', 'Access denied to namespace')
+    render(<PreflightFailure error={error} />)
+    expect(screen.getByText('Permission Denied')).toBeTruthy()
+  })
+
+  it('renders with CONTEXT_NOT_FOUND error code', () => {
+    const error = makeError('CONTEXT_NOT_FOUND', 'Context "prod" not found')
+    render(<PreflightFailure error={error} />)
+    expect(screen.getByText('Context Not Found')).toBeTruthy()
+  })
+
+  it('renders with CLUSTER_UNREACHABLE error code', () => {
+    const error = makeError('CLUSTER_UNREACHABLE', 'Connection refused')
+    render(<PreflightFailure error={error} />)
+    expect(screen.getByText('Cluster Unreachable')).toBeTruthy()
+  })
+
+  it('renders with MISSING_TOOLS error code', () => {
+    const error = makeError('MISSING_TOOLS', 'kubectl not found')
+    render(<PreflightFailure error={error} />)
+    expect(screen.getByText('Missing Tools')).toBeTruthy()
+  })
+
+  it('renders with UNKNOWN_EXECUTION_FAILURE error code', () => {
+    const error = makeError('UNKNOWN_EXECUTION_FAILURE', 'Something went wrong')
+    render(<PreflightFailure error={error} />)
+    expect(screen.getByText('Preflight Check Failed')).toBeTruthy()
+  })
+
+  it('shows cluster context when provided', () => {
+    const error = makeError('RBAC_DENIED', 'Access denied')
+    render(<PreflightFailure error={error} context="my-cluster" />)
+    expect(screen.getByText('my-cluster')).toBeTruthy()
+  })
+
+  it('does not show context when not provided', () => {
+    const error = makeError('RBAC_DENIED', 'Access denied')
+    const { container } = render(<PreflightFailure error={error} />)
+    expect(container.textContent).not.toContain('Cluster context:')
+  })
+
+  it('displays the error code badge', () => {
+    const error = makeError('MISSING_CREDENTIALS', 'Missing creds')
+    render(<PreflightFailure error={error} />)
+    expect(screen.getByText('MISSING_CREDENTIALS')).toBeTruthy()
+  })
+})

--- a/web/src/components/missions/__tests__/missionBrowserDeepLink.test.ts
+++ b/web/src/components/missions/__tests__/missionBrowserDeepLink.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FILLER_WORDS,
+  MIN_WORD_OVERLAP_RATIO,
+  HIGH_CONFIDENCE_THRESHOLD,
+  toWordSet,
+  scoreMission,
+  findBestDeepLinkMatch,
+} from '../missionBrowserDeepLink'
+import type { MissionExport } from '../../../lib/missions/types'
+
+// Mock the getMissionSlug import used by scoreMission
+vi.mock('../browser', () => ({
+  getMissionSlug: (m: MissionExport) =>
+    (m.title || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''),
+}))
+
+import { vi } from 'vitest'
+
+describe('missionBrowserDeepLink', () => {
+  describe('constants', () => {
+    it('FILLER_WORDS contains common stopwords', () => {
+      expect(FILLER_WORDS.has('and')).toBe(true)
+      expect(FILLER_WORDS.has('the')).toBe(true)
+      expect(FILLER_WORDS.has('kubernetes')).toBe(true)
+      expect(FILLER_WORDS.has('k8s')).toBe(true)
+    })
+
+    it('FILLER_WORDS does not include meaningful terms', () => {
+      expect(FILLER_WORDS.has('install')).toBe(false)
+      expect(FILLER_WORDS.has('deploy')).toBe(false)
+      expect(FILLER_WORDS.has('prometheus')).toBe(false)
+    })
+
+    it('MIN_WORD_OVERLAP_RATIO is between 0 and 1', () => {
+      expect(MIN_WORD_OVERLAP_RATIO).toBeGreaterThan(0)
+      expect(MIN_WORD_OVERLAP_RATIO).toBeLessThan(1)
+    })
+
+    it('HIGH_CONFIDENCE_THRESHOLD is above MIN_WORD_OVERLAP_RATIO', () => {
+      expect(HIGH_CONFIDENCE_THRESHOLD).toBeGreaterThan(MIN_WORD_OVERLAP_RATIO)
+    })
+  })
+
+  describe('toWordSet', () => {
+    it('lowercases and splits on non-alphanumeric', () => {
+      const result = toWordSet('Install Open-Policy-Agent')
+      expect(result.has('install')).toBe(true)
+      expect(result.has('open')).toBe(true)
+      expect(result.has('policy')).toBe(true)
+      expect(result.has('agent')).toBe(true)
+    })
+
+    it('removes filler words', () => {
+      const result = toWordSet('Deploy to the Kubernetes cluster')
+      expect(result.has('the')).toBe(false)
+      expect(result.has('to')).toBe(false)
+      expect(result.has('kubernetes')).toBe(false)
+      expect(result.has('deploy')).toBe(true)
+      expect(result.has('cluster')).toBe(true)
+    })
+
+    it('removes single-character tokens', () => {
+      const result = toWordSet('a-b-test')
+      // 'a' and 'b' are either filler or single-char; 'test' should remain
+      expect(result.has('test')).toBe(true)
+    })
+
+    it('deduplicates words', () => {
+      const result = toWordSet('test test test')
+      expect(result.size).toBe(1)
+      expect(result.has('test')).toBe(true)
+    })
+
+    it('returns empty set for empty string', () => {
+      const result = toWordSet('')
+      expect(result.size).toBe(0)
+    })
+
+    it('handles numeric tokens', () => {
+      const result = toWordSet('deploy v2 config')
+      expect(result.has('deploy')).toBe(true)
+      expect(result.has('v2')).toBe(true)
+      expect(result.has('config')).toBe(true)
+    })
+  })
+
+  describe('scoreMission', () => {
+    const makeMission = (title: string, cncfProject?: string): MissionExport =>
+      ({ title, cncfProject } as unknown as MissionExport)
+
+    it('returns 1.0 for exact slug match', () => {
+      const m = makeMission('install-prometheus')
+      const slugWordSet = toWordSet('install-prometheus')
+      expect(scoreMission(m, 'install-prometheus', slugWordSet, true)).toBe(1)
+    })
+
+    it('returns 0.95 for cncfProject match on installer', () => {
+      const m = makeMission('Install and Configure Prometheus', 'prometheus')
+      const slugWordSet = toWordSet('install-prometheus')
+      expect(scoreMission(m, 'install-prometheus', slugWordSet, true)).toBe(0.95)
+    })
+
+    it('does not apply cncfProject shortcut for fixers', () => {
+      const m = makeMission('Fix Prometheus Issues', 'prometheus')
+      const slugWordSet = toWordSet('install-prometheus')
+      const score = scoreMission(m, 'install-prometheus', slugWordSet, false)
+      expect(score).not.toBe(0.95)
+      expect(score).toBeLessThan(1)
+    })
+
+    it('returns fuzzy overlap score for partial word matches', () => {
+      const m = makeMission('Deploy Open Policy Agent OPA')
+      const slugWordSet = toWordSet('deploy-open-policy-agent')
+      const score = scoreMission(m, 'deploy-open-policy-agent', slugWordSet, false)
+      // Should have high overlap since title words match slug words
+      expect(score).toBeGreaterThan(0.5)
+    })
+
+    it('returns 0 when no words overlap', () => {
+      const m = makeMission('completely different title')
+      const slugWordSet = toWordSet('install-prometheus-monitoring')
+      const score = scoreMission(m, 'install-prometheus-monitoring', slugWordSet, false)
+      expect(score).toBe(0)
+    })
+
+    it('returns 0 when slug word set is empty', () => {
+      const m = makeMission('Some Mission')
+      const emptySet = new Set<string>()
+      expect(scoreMission(m, '', emptySet, false)).toBe(0)
+    })
+  })
+
+  describe('findBestDeepLinkMatch', () => {
+    const makeMission = (title: string, cncfProject?: string): MissionExport =>
+      ({ title, cncfProject } as unknown as MissionExport)
+
+    it('returns the best scoring mission above threshold', () => {
+      const missions = [
+        makeMission('Install Prometheus Monitoring'),
+        makeMission('Install Grafana Dashboard'),
+        makeMission('Deploy Redis Cache'),
+      ]
+      const slug = 'install-prometheus-monitoring'
+      const slugWordSet = toWordSet(slug)
+      const { match, score } = findBestDeepLinkMatch(missions, slug, slugWordSet, true)
+      expect(match).toBeDefined()
+      expect(match!.title).toBe('Install Prometheus Monitoring')
+      expect(score).toBeGreaterThan(MIN_WORD_OVERLAP_RATIO)
+    })
+
+    it('returns undefined when no mission exceeds threshold', () => {
+      const missions = [
+        makeMission('Unrelated Topic'),
+        makeMission('Nothing Close'),
+      ]
+      const slug = 'install-prometheus'
+      const slugWordSet = toWordSet(slug)
+      const { match } = findBestDeepLinkMatch(missions, slug, slugWordSet, true)
+      expect(match).toBeUndefined()
+    })
+
+    it('returns highest scoring mission among multiple candidates', () => {
+      const missions = [
+        makeMission('Install Prometheus'),
+        makeMission('Install Prometheus Advanced Monitoring'),
+      ]
+      const slug = 'install-prometheus'
+      const slugWordSet = toWordSet(slug)
+      const { match } = findBestDeepLinkMatch(missions, slug, slugWordSet, true)
+      expect(match).toBeDefined()
+      // Both should match; exact slug match wins
+      expect(match!.title).toBe('Install Prometheus')
+    })
+
+    it('handles empty mission list', () => {
+      const slug = 'install-prometheus'
+      const slugWordSet = toWordSet(slug)
+      const { match, score } = findBestDeepLinkMatch([], slug, slugWordSet, true)
+      expect(match).toBeUndefined()
+      expect(score).toBe(MIN_WORD_OVERLAP_RATIO)
+    })
+
+    it('prefers cncfProject match for installers', () => {
+      const missions = [
+        makeMission('Setup and Configure Advanced Monitoring', 'prometheus'),
+        makeMission('Install Grafana with Prometheus Sources'),
+      ]
+      const slug = 'install-prometheus'
+      const slugWordSet = toWordSet(slug)
+      const { match, score } = findBestDeepLinkMatch(missions, slug, slugWordSet, true)
+      expect(match).toBeDefined()
+      expect(score).toBe(0.95)
+      expect(match!.cncfProject).toBe('prometheus')
+    })
+  })
+})

--- a/web/src/components/missions/__tests__/useMissionWatchedSources.test.ts
+++ b/web/src/components/missions/__tests__/useMissionWatchedSources.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useMissionWatchedSources } from '../useMissionWatchedSources'
+
+const mockShowToast = vi.fn()
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}))
+
+let mockStorage: Record<string, string> = {}
+vi.stubGlobal('localStorage', {
+  getItem: vi.fn((key: string) => mockStorage[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => { mockStorage[key] = value }),
+})
+
+describe('useMissionWatchedSources', () => {
+  beforeEach(() => {
+    mockStorage = {}
+    mockShowToast.mockClear()
+  })
+
+  it('initializes with empty arrays when localStorage is empty', () => {
+    const { result } = renderHook(() => useMissionWatchedSources())
+    expect(result.current.watchedRepos).toEqual([])
+    expect(result.current.watchedPaths).toEqual([])
+  })
+
+  it('initializes from localStorage when data exists', () => {
+    mockStorage['kc_mission_watched_repos'] = '["org/repo1"]'
+    mockStorage['kc_mission_watched_paths'] = '["/path/a"]'
+    const { result } = renderHook(() => useMissionWatchedSources())
+    expect(result.current.watchedRepos).toEqual(['org/repo1'])
+    expect(result.current.watchedPaths).toEqual(['/path/a'])
+  })
+
+  it('handleAddRepo adds a repo and shows toast', () => {
+    const { result } = renderHook(() => useMissionWatchedSources())
+    act(() => {
+      result.current.handleAddRepo('org/new-repo')
+    })
+    expect(result.current.watchedRepos).toEqual(['org/new-repo'])
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringContaining('org/new-repo'),
+      'success'
+    )
+    expect(mockStorage['kc_mission_watched_repos']).toBe('["org/new-repo"]')
+  })
+
+  it('handleRemoveRepo removes a repo and shows toast', () => {
+    mockStorage['kc_mission_watched_repos'] = '["a","b"]'
+    const { result } = renderHook(() => useMissionWatchedSources())
+    act(() => {
+      result.current.handleRemoveRepo('a')
+    })
+    expect(result.current.watchedRepos).toEqual(['b'])
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringContaining('a'),
+      'info'
+    )
+  })
+
+  it('handleAddPath adds a path and shows toast', () => {
+    const { result } = renderHook(() => useMissionWatchedSources())
+    act(() => {
+      result.current.handleAddPath('/new/path')
+    })
+    expect(result.current.watchedPaths).toEqual(['/new/path'])
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringContaining('/new/path'),
+      'success'
+    )
+  })
+
+  it('handleRemovePath removes a path and shows toast', () => {
+    mockStorage['kc_mission_watched_paths'] = '["/x","/y"]'
+    const { result } = renderHook(() => useMissionWatchedSources())
+    act(() => {
+      result.current.handleRemovePath('/x')
+    })
+    expect(result.current.watchedPaths).toEqual(['/y'])
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringContaining('/x'),
+      'info'
+    )
+  })
+
+  it('exposes addingRepo/addingPath toggle state', () => {
+    const { result } = renderHook(() => useMissionWatchedSources())
+    expect(result.current.addingRepo).toBe(false)
+    expect(result.current.addingPath).toBe(false)
+    act(() => {
+      result.current.setAddingRepo(true)
+      result.current.setAddingPath(true)
+    })
+    expect(result.current.addingRepo).toBe(true)
+    expect(result.current.addingPath).toBe(true)
+  })
+
+  it('exposes newRepoValue/newPathValue input state', () => {
+    const { result } = renderHook(() => useMissionWatchedSources())
+    expect(result.current.newRepoValue).toBe('')
+    expect(result.current.newPathValue).toBe('')
+    act(() => {
+      result.current.setNewRepoValue('test')
+      result.current.setNewPathValue('/test')
+    })
+    expect(result.current.newRepoValue).toBe('test')
+    expect(result.current.newPathValue).toBe('/test')
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds unit and render tests for 4 previously untested files in `web/src/components/missions/`:

### New test files

| File | Tests | Coverage |
|------|-------|----------|
| `missionBrowserDeepLink.test.ts` | 18 tests | `toWordSet`, `scoreMission`, `findBestDeepLinkMatch` — fuzzy matching, exact slug, cncfProject shortcuts |
| `PreflightFailure.test.tsx` | 10 tests | All 7 error code renderings, context display, error code badge |
| `MissionTypeExplainer.test.tsx` | 6 tests | Demo mode gate, expand/collapse toggle, mission type descriptions |
| `MissionToolPrerequisiteNotice.test.tsx` | 9 tests | All status states (checking, error, ready, blocked, warning), install links |
| `useMissionWatchedSources.test.ts` | 8 tests | Hook state, add/remove repos/paths, localStorage persistence, toast notifications |

### Why

These files contain critical pure logic (deep-link fuzzy matching with scoring) and user-facing preflight/tool-check UI with multiple render states. No tests existed previously, creating regression risk for the mission browser's deep-link resolution and error reporting.

Fixes #19649

---
*Filed by quality agent (ACMM L4/L6 — full mode)*