### PR TITLE
fix: add CODEOWNERS to enforce code review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# KubeStellar Console Code Owners
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @kubestellar/console-maintainers


### PR DESCRIPTION
Adds a CODEOWNERS file designating the console-maintainers team as reviewers for all files. This establishes code ownership and helps improve the Code-Review security score by enabling automated reviewer assignment.

Fixes #19621