### PR TITLE
[scanner] fix: resolve 168 test failures from coverage suite run #3903

### DIFF
--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -128,29 +128,29 @@ if (isBrowserEnvironment) {
       dispatchEvent: vi.fn(),
     })),
   })
+
+  // Mock IntersectionObserver
+  Object.defineProperty(globalThis, 'IntersectionObserver', {
+    writable: true,
+    value: class IntersectionObserver {
+      constructor() {}
+      disconnect() {}
+      observe() {}
+      takeRecords() {
+        return []
+      }
+      unobserve() {}
+    },
+  })
+
+  // Mock ResizeObserver
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    writable: true,
+    value: class ResizeObserver {
+      constructor() {}
+      disconnect() {}
+      observe() {}
+      unobserve() {}
+    },
+  })
 }
-
-// Mock IntersectionObserver
-Object.defineProperty(globalThis, 'IntersectionObserver', {
-  writable: true,
-  value: class IntersectionObserver {
-    constructor() {}
-    disconnect() {}
-    observe() {}
-    takeRecords() {
-      return []
-    }
-    unobserve() {}
-  },
-})
-
-// Mock ResizeObserver
-Object.defineProperty(globalThis, 'ResizeObserver', {
-  writable: true,
-  value: class ResizeObserver {
-    constructor() {}
-    disconnect() {}
-    observe() {}
-    unobserve() {}
-  },
-})


### PR DESCRIPTION
Fixes #19660

## Root Cause

The test setup file (`web/src/test/setup.ts`) was defining `IntersectionObserver` and `ResizeObserver` mocks on `globalThis` unconditionally, even when running in Node.js environment (for tests with `// @vitest-environment node` directive).

When the new Netlify function tests added in PR #19652 ran with Node environment, the setup file still executed but in Node.js context. This added browser APIs to the Node.js global scope, corrupting state that affected subsequent jsdom tests in CI (where tests run sequentially with 1 worker due to `maxWorkers: 1`).

## Fix

Moved the `IntersectionObserver` and `ResizeObserver` mock definitions inside the existing `if (isBrowserEnvironment)` guard (lines 94-156). This ensures they only run in jsdom/browser environments, not in Node.js environment.

The `isBrowserEnvironment` check (`typeof window !== 'undefined'`) already existed in the file and was used for other browser-specific mocks like `localStorage` and `matchMedia`. The IntersectionObserver and ResizeObserver mocks were the only ones incorrectly defined outside this guard.