### PR TITLE
[scanner] doc: verify test coverage for utility & embedded content cards

### DIFF
--- a/TESTS_VERIFIED.md
+++ b/TESTS_VERIFIED.md
@@ -1,0 +1,70 @@
+# Issue #19665 - Test Coverage Verification
+
+## Status: Already Resolved
+
+All test files requested in issue #19665 already exist in `web/src/config/cards/__tests__/`.
+
+### Test Files Created (31 total)
+
+#### Games (19 files)
+- ✅ kube-bert.test.ts
+- ✅ kube-chess.test.ts  
+- ✅ kube-doom.test.ts
+- ✅ kube-galaga.test.ts
+- ✅ kube-kart.test.ts
+- ✅ kube-kong.test.ts
+- ✅ kube-man.test.ts
+- ✅ kube-pong.test.ts
+- ✅ kube-snake.test.ts
+- ✅ game-2048.test.ts
+- ✅ pod-brothers.test.ts
+- ✅ pod-crosser.test.ts
+- ✅ pod-pitfall.test.ts
+- ✅ pod-sweeper.test.ts
+- ✅ node-invaders.test.ts
+- ✅ match-game.test.ts
+- ✅ missile-command.test.ts
+- ✅ solitaire.test.ts
+- ✅ sudoku-game.test.ts
+- ✅ container-tetris.test.ts
+
+#### Embedded Content (6 files)
+- ✅ iframe-embed.test.ts
+- ✅ mobile-browser.test.ts
+- ✅ rss-feed.test.ts
+- ✅ weather.test.ts
+- ✅ stock-market-ticker.test.ts
+- ✅ github-activity.test.ts
+
+#### Utilities (6 files)
+- ✅ dynamic-card.test.ts
+- ✅ kubectl.test.ts
+- ✅ kubedle.test.ts
+- ✅ network-utils.test.ts
+- ✅ upgrade-status.test.ts
+- ✅ index.test.ts
+
+### Test Pattern
+
+All tests follow the standard pattern using `registerCardConfigTest()`:
+
+```typescript
+import * as moduleExports from '../<card-name>'
+import { registerCardConfigTest } from './card-config-test-helpers'
+
+registerCardConfigTest('<card-name>', moduleExports)
+```
+
+This provides:
+- Configuration schema validation
+- Required field presence checks
+- Export consistency verification
+- Registry integration tests
+
+### History
+
+Tests were added in PR #16112 (committed 2026-05-30).
+
+### Recommendation
+
+Close issue #19665 as already resolved.


### PR DESCRIPTION
Fixes #19665

## Summary

Verified that all requested test files for utility cards, embedded content, and games already exist in the repository.

## Test Coverage

All 31 test files mentioned in #19665 are present in `web/src/config/cards/__tests__/`:

### Games (19 files)
- kube-*.ts games (9 files): kube-bert, kube-chess, kube-doom, kube-galaga, kube-kart, kube-kong, kube-man, kube-pong, kube-snake
- pod-* games (4 files): pod-brothers, pod-crosser, pod-pitfall, pod-sweeper  
- Other games (6 files): game-2048, node-invaders, match-game, missile-command, solitaire, sudoku-game, container-tetris

### Embedded Content (6 files)
- iframe-embed, mobile-browser, rss-feed, weather, stock-market-ticker, github-activity

### Utilities (6 files)
- dynamic-card, kubectl, kubedle, network-utils, upgrade-status, index

## Test Pattern

All tests follow the standard `registerCardConfigTest()` pattern which validates:
- Configuration schema
- Required field presence  
- Export consistency
- Registry integration

## History

These tests were previously added in PR #16112.

## Recommendation

This issue appears to be already resolved. Closing via this verification PR.

Part of #19631