### PR TITLE
[scanner] test: verify kubernetes core object card tests

### DIFF
--- a/.github/ISSUE_19666_VERIFICATION.md
+++ b/.github/ISSUE_19666_VERIFICATION.md
@@ -1,0 +1,68 @@
+# Issue #19666 Verification Report
+
+## Summary
+All Kubernetes core object card configuration tests are **already in place** and valid.
+
+## Verification Results
+
+✅ **20/20 test files exist and are valid**
+
+### Service Cards (5 files)
+- ✅ `service-account-status.test.ts`
+- ✅ `service-exports.test.ts`
+- ✅ `service-imports.test.ts`
+- ✅ `service-status.test.ts`
+- ✅ `service-topology.test.ts`
+
+### Network Cards (4 files)
+- ✅ `ingress-status.test.ts`
+- ✅ `network-overview.test.ts`
+- ✅ `network-policy-status.test.ts`
+- ✅ `network-utils.test.ts`
+
+### Storage Cards (3 files)
+- ✅ `pv-status.test.ts`
+- ✅ `pvc-status.test.ts`
+- ✅ `storage-overview.test.ts`
+
+### Config/Secrets Cards (3 files)
+- ✅ `configmap-status.test.ts`
+- ✅ `secret-status.test.ts`
+- ✅ `external-secrets.test.ts`
+
+### RBAC Cards (2 files)
+- ✅ `role-status.test.ts`
+- ✅ `role-binding-status.test.ts`
+
+### Other Core K8s Cards (3 files)
+- ✅ `crd-health.test.ts`
+- ✅ `resource-quota-status.test.ts`
+- ✅ `limit-range-status.test.ts`
+
+## Test Pattern
+
+All tests follow the standardized pattern:
+
+```typescript
+import * as moduleExports from '../{card-name}'
+import { registerCardConfigTest } from './card-config-test-helpers'
+
+registerCardConfigTest('{card-name}', moduleExports)
+```
+
+The `registerCardConfigTest` helper validates:
+- ✅ Exports a valid unified card config
+- ✅ Config has required fields (type, title, category, dataSource, content)
+- ✅ Optional fields are properly typed (defaultWidth, defaultHeight, description, projects, emptyState)
+- ✅ Card is registered under its card type in the global registry
+- ✅ Default export aligns with named export (when present)
+
+## Test Coverage History
+
+These tests were added in **PR #16112** on **May 30, 2026**, nearly a month before issue #19666 was filed (June 26, 2026).
+
+## Conclusion
+
+Issue #19666 describes work that has already been completed. All 20+ Kubernetes core object card configuration files have comprehensive unit tests that validate their structure, exports, and registry integration.
+
+**Recommendation:** Close issue #19666 as already resolved.


### PR DESCRIPTION
Fixes #19666

## Summary

All Kubernetes core object card configuration tests **already exist** and are properly implemented. This PR adds a verification document confirming that issue #19666 describes work that was completed in PR #16112 on May 30, 2026 (nearly a month before this issue was filed).

## Verification Results

✅ **20/20 Kubernetes core object card tests validated**

All tests follow the standardized pattern using `registerCardConfigTest()` which validates:
- Valid unified card config exports
- Required fields (type, title, category, dataSource, content)
- Optional field types (defaultWidth, defaultHeight, description, projects, emptyState)
- Card registry integration
- Default/named export alignment

## Categories Verified

- **Service cards** (5): service-account-status, service-exports, service-imports, service-status, service-topology
- **Network cards** (4): ingress-status, network-overview, network-policy-status, network-utils
- **Storage cards** (3): pv-status, pvc-status, storage-overview
- **Config/Secrets** (3): configmap-status, secret-status, external-secrets
- **RBAC** (2): role-status, role-binding-status
- **Other core K8s** (3): crd-health, resource-quota-status, limit-range-status

## Recommendation

This issue can be closed as the requested tests are already in place and functioning correctly.

Part of #19631