### PR TITLE
[scanner] test: unit tests for cluster & namespace cards

### DIFF
--- a/web/src/config/cards/__tests__/cluster-comparison.test.ts
+++ b/web/src/config/cards/__tests__/cluster-comparison.test.ts
@@ -1,4 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { clusterComparisonConfig } from '../cluster-comparison'
 import * as moduleExports from '../cluster-comparison'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('cluster-comparison', moduleExports)
+
+describe('cluster-comparison configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(clusterComparisonConfig.type).toBe('cluster_comparison')
+    expect(clusterComparisonConfig.title).toBe('Cluster Comparison')
+    expect(clusterComparisonConfig.category).toBe('cluster-health')
+    expect(clusterComparisonConfig.description).toBe('Compare metrics across clusters')
+  })
+
+  it('validates appearance fields', () => {
+    expect(clusterComparisonConfig.icon).toBe('GitCompare')
+    expect(clusterComparisonConfig.iconColor).toBe('text-blue-400')
+    expect(clusterComparisonConfig.defaultWidth).toBe(12)
+    expect(clusterComparisonConfig.defaultHeight).toBe(4)
+  })
+
+  it('validates data source configuration', () => {
+    expect(clusterComparisonConfig.dataSource.type).toBe('hook')
+    expect(clusterComparisonConfig.dataSource.hook).toBe('useClusterComparison')
+  })
+
+  it('validates content configuration', () => {
+    expect(clusterComparisonConfig.content.type).toBe('table')
+    expect(clusterComparisonConfig.content.columns).toBeDefined()
+    expect(clusterComparisonConfig.content.columns).toHaveLength(6)
+    expect(clusterComparisonConfig.content.columns?.[0].field).toBe('cluster')
+    expect(clusterComparisonConfig.content.columns?.[0].primary).toBe(true)
+  })
+
+  it('validates empty state configuration', () => {
+    expect(clusterComparisonConfig.emptyState?.icon).toBe('GitCompare')
+    expect(clusterComparisonConfig.emptyState?.title).toBe('No Clusters')
+    expect(clusterComparisonConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(clusterComparisonConfig.loadingState?.type).toBe('table')
+    expect(clusterComparisonConfig.loadingState?.rows).toBe(4)
+  })
+
+  it('validates metadata fields', () => {
+    expect(clusterComparisonConfig.isDemoData).toBe(false)
+    expect(clusterComparisonConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/cluster-costs.test.ts
+++ b/web/src/config/cards/__tests__/cluster-costs.test.ts
@@ -1,4 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { AMBER_500, BLUE_500, GREEN_500 } from '../../../lib/theme/chartColors'
+import { clusterCostsConfig } from '../cluster-costs'
 import * as moduleExports from '../cluster-costs'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('cluster-costs', moduleExports)
+
+describe('cluster-costs configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(clusterCostsConfig.type).toBe('cluster_costs')
+    expect(clusterCostsConfig.title).toBe('Cluster Costs')
+    expect(clusterCostsConfig.category).toBe('cost')
+    expect(clusterCostsConfig.description).toBe('Cost allocation by cluster')
+  })
+
+  it('validates appearance fields', () => {
+    expect(clusterCostsConfig.icon).toBe('DollarSign')
+    expect(clusterCostsConfig.iconColor).toBe('text-green-400')
+    expect(clusterCostsConfig.defaultWidth).toBe(8)
+    expect(clusterCostsConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(clusterCostsConfig.dataSource.type).toBe('hook')
+    expect(clusterCostsConfig.dataSource.hook).toBe('useClusterCosts')
+  })
+
+  it('validates content configuration', () => {
+    expect(clusterCostsConfig.content.type).toBe('chart')
+    expect(clusterCostsConfig.content.chartType).toBe('bar')
+    expect(clusterCostsConfig.content.dataKey).toBe('clusters')
+    expect(clusterCostsConfig.content.xAxis).toBe('cluster')
+    expect(clusterCostsConfig.content.yAxis).toEqual(['compute', 'storage', 'network'])
+    expect(clusterCostsConfig.content.colors).toEqual([BLUE_500, GREEN_500, AMBER_500])
+  })
+
+  it('validates empty state configuration', () => {
+    expect(clusterCostsConfig.emptyState?.icon).toBe('DollarSign')
+    expect(clusterCostsConfig.emptyState?.title).toBe('No Cost Data')
+    expect(clusterCostsConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(clusterCostsConfig.loadingState?.type).toBe('chart')
+  })
+
+  it('validates metadata fields', () => {
+    expect(clusterCostsConfig.isDemoData).toBe(false)
+    expect(clusterCostsConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/cluster-delta-detector.test.ts
+++ b/web/src/config/cards/__tests__/cluster-delta-detector.test.ts
@@ -1,4 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { clusterDeltaDetectorConfig } from '../cluster-delta-detector'
 import * as moduleExports from '../cluster-delta-detector'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('cluster-delta-detector', moduleExports)
+
+describe('cluster-delta-detector configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(clusterDeltaDetectorConfig.type).toBe('cluster_delta_detector')
+    expect(clusterDeltaDetectorConfig.title).toBe('Cluster Delta Detector')
+    expect(clusterDeltaDetectorConfig.category).toBe('insights')
+    expect(clusterDeltaDetectorConfig.description).toBe('Detects differences between clusters sharing the same workloads')
+  })
+
+  it('validates appearance fields', () => {
+    expect(clusterDeltaDetectorConfig.icon).toBe('GitCompare')
+    expect(clusterDeltaDetectorConfig.iconColor).toBe('text-blue-400')
+    expect(clusterDeltaDetectorConfig.defaultWidth).toBe(8)
+    expect(clusterDeltaDetectorConfig.defaultHeight).toBe(4)
+  })
+
+  it('validates data source configuration', () => {
+    expect(clusterDeltaDetectorConfig.dataSource.type).toBe('hook')
+    expect(clusterDeltaDetectorConfig.dataSource.hook).toBe('useMultiClusterInsights')
+  })
+
+  it('validates content configuration', () => {
+    expect(clusterDeltaDetectorConfig.content.type).toBe('custom')
+  })
+
+  it('validates empty state configuration', () => {
+    expect(clusterDeltaDetectorConfig.emptyState?.icon).toBe('GitCompare')
+    expect(clusterDeltaDetectorConfig.emptyState?.title).toBe('No cluster deltas detected')
+    expect(clusterDeltaDetectorConfig.emptyState?.message).toBe('Shared workloads are consistent across clusters')
+    expect(clusterDeltaDetectorConfig.emptyState?.variant).toBe('neutral')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(clusterDeltaDetectorConfig.loadingState?.type).toBe('chart')
+  })
+
+  it('validates metadata fields', () => {
+    expect(clusterDeltaDetectorConfig.isDemoData).toBe(false)
+    expect(clusterDeltaDetectorConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/cluster-focus.test.ts
+++ b/web/src/config/cards/__tests__/cluster-focus.test.ts
@@ -1,4 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { clusterFocusConfig } from '../cluster-focus'
 import * as moduleExports from '../cluster-focus'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('cluster-focus', moduleExports)
+
+describe('cluster-focus configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(clusterFocusConfig.type).toBe('cluster_focus')
+    expect(clusterFocusConfig.title).toBe('Cluster Focus')
+    expect(clusterFocusConfig.category).toBe('cluster-health')
+    expect(clusterFocusConfig.description).toBe('Focused view of selected cluster')
+  })
+
+  it('validates appearance fields', () => {
+    expect(clusterFocusConfig.icon).toBe('Target')
+    expect(clusterFocusConfig.iconColor).toBe('text-purple-400')
+    expect(clusterFocusConfig.defaultWidth).toBe(8)
+    expect(clusterFocusConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(clusterFocusConfig.dataSource.type).toBe('hook')
+    expect(clusterFocusConfig.dataSource.hook).toBe('useClusterFocus')
+  })
+
+  it('validates content configuration', () => {
+    expect(clusterFocusConfig.content.type).toBe('stats-grid')
+    expect(clusterFocusConfig.content.stats).toBeDefined()
+    expect(clusterFocusConfig.content.stats).toHaveLength(4)
+    expect(clusterFocusConfig.content.stats?.[0].field).toBe('nodes')
+    expect(clusterFocusConfig.content.stats?.[1].field).toBe('pods')
+    expect(clusterFocusConfig.content.stats?.[2].field).toBe('cpu')
+    expect(clusterFocusConfig.content.stats?.[3].field).toBe('memory')
+  })
+
+  it('validates empty state configuration', () => {
+    expect(clusterFocusConfig.emptyState?.icon).toBe('Target')
+    expect(clusterFocusConfig.emptyState?.title).toBe('Select Cluster')
+    expect(clusterFocusConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(clusterFocusConfig.loadingState?.type).toBe('stats')
+    expect(clusterFocusConfig.loadingState?.count).toBe(4)
+  })
+
+  it('validates metadata fields', () => {
+    expect(clusterFocusConfig.isDemoData).toBe(false)
+    expect(clusterFocusConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/cluster-groups.test.ts
+++ b/web/src/config/cards/__tests__/cluster-groups.test.ts
@@ -1,4 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { clusterGroupsConfig } from '../cluster-groups'
 import * as moduleExports from '../cluster-groups'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('cluster-groups', moduleExports)
+
+describe('cluster-groups configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(clusterGroupsConfig.type).toBe('cluster_groups')
+    expect(clusterGroupsConfig.title).toBe('Cluster Groups')
+    expect(clusterGroupsConfig.category).toBe('cluster-health')
+    expect(clusterGroupsConfig.description).toBe('Manage cluster groupings')
+  })
+
+  it('validates projects configuration', () => {
+    expect(clusterGroupsConfig.projects).toBeDefined()
+    expect(clusterGroupsConfig.projects).toEqual(['kubestellar'])
+  })
+
+  it('validates appearance fields', () => {
+    expect(clusterGroupsConfig.icon).toBe('Layers')
+    expect(clusterGroupsConfig.iconColor).toBe('text-blue-400')
+    expect(clusterGroupsConfig.defaultWidth).toBe(4)
+    expect(clusterGroupsConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(clusterGroupsConfig.dataSource.type).toBe('hook')
+    expect(clusterGroupsConfig.dataSource.hook).toBe('useClusterGroups')
+  })
+
+  it('validates content configuration', () => {
+    expect(clusterGroupsConfig.content.type).toBe('list')
+    expect(clusterGroupsConfig.content.pageSize).toBe(8)
+    expect(clusterGroupsConfig.content.columns).toBeDefined()
+    expect(clusterGroupsConfig.content.columns).toHaveLength(3)
+    expect(clusterGroupsConfig.content.columns?.[0].field).toBe('name')
+    expect(clusterGroupsConfig.content.columns?.[0].primary).toBe(true)
+  })
+
+  it('validates empty state configuration', () => {
+    expect(clusterGroupsConfig.emptyState?.icon).toBe('Layers')
+    expect(clusterGroupsConfig.emptyState?.title).toBe('No Groups')
+    expect(clusterGroupsConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(clusterGroupsConfig.loadingState?.type).toBe('list')
+    expect(clusterGroupsConfig.loadingState?.rows).toBe(4)
+  })
+
+  it('validates metadata fields', () => {
+    expect(clusterGroupsConfig.isDemoData).toBe(false)
+    expect(clusterGroupsConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/cluster-health-monitor.test.ts
+++ b/web/src/config/cards/__tests__/cluster-health-monitor.test.ts
@@ -1,4 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { clusterHealthMonitorConfig } from '../cluster-health-monitor'
 import * as moduleExports from '../cluster-health-monitor'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('cluster-health-monitor', moduleExports)
+
+describe('cluster-health-monitor configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(clusterHealthMonitorConfig.type).toBe('cluster_health_monitor')
+    expect(clusterHealthMonitorConfig.title).toBe('Cluster Monitor')
+    expect(clusterHealthMonitorConfig.category).toBe('cluster-health')
+    expect(clusterHealthMonitorConfig.description).toBe('Comprehensive cluster health')
+  })
+
+  it('validates appearance fields', () => {
+    expect(clusterHealthMonitorConfig.icon).toBe('HeartPulse')
+    expect(clusterHealthMonitorConfig.iconColor).toBe('text-red-400')
+    expect(clusterHealthMonitorConfig.defaultWidth).toBe(6)
+    expect(clusterHealthMonitorConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(clusterHealthMonitorConfig.dataSource.type).toBe('hook')
+    expect(clusterHealthMonitorConfig.dataSource.hook).toBe('useClusterHealthMonitor')
+  })
+
+  it('validates content configuration', () => {
+    expect(clusterHealthMonitorConfig.content.type).toBe('custom')
+    expect(clusterHealthMonitorConfig.content.component).toBe('ClusterHealthView')
+  })
+
+  it('validates empty state configuration', () => {
+    expect(clusterHealthMonitorConfig.emptyState?.icon).toBe('HeartPulse')
+    expect(clusterHealthMonitorConfig.emptyState?.title).toBe('No Clusters')
+    expect(clusterHealthMonitorConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(clusterHealthMonitorConfig.loadingState?.type).toBe('custom')
+  })
+
+  it('validates metadata fields', () => {
+    expect(clusterHealthMonitorConfig.isDemoData).toBe(false)
+    expect(clusterHealthMonitorConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/cluster-health.test.ts
+++ b/web/src/config/cards/__tests__/cluster-health.test.ts
@@ -1,4 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { clusterHealthConfig } from '../cluster-health'
 import * as moduleExports from '../cluster-health'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('cluster-health', moduleExports)
+
+describe('cluster-health configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(clusterHealthConfig.type).toBe('cluster_health')
+    expect(clusterHealthConfig.title).toBe('Cluster Health')
+    expect(clusterHealthConfig.category).toBe('cluster-health')
+    expect(clusterHealthConfig.description).toBe('Health status of all connected Kubernetes clusters')
+  })
+
+  it('validates appearance fields', () => {
+    expect(clusterHealthConfig.icon).toBe('Activity')
+    expect(clusterHealthConfig.iconColor).toBe('text-green-400')
+    expect(clusterHealthConfig.defaultWidth).toBe(4)
+    expect(clusterHealthConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(clusterHealthConfig.dataSource).toBeDefined()
+    expect(clusterHealthConfig.dataSource.type).toBe('hook')
+    expect(clusterHealthConfig.dataSource.hook).toBe('useClusters')
+  })
+
+  it('validates stats configuration', () => {
+    expect(clusterHealthConfig.stats).toBeDefined()
+    expect(clusterHealthConfig.stats).toHaveLength(3)
+    
+    const healthyStat = clusterHealthConfig.stats?.[0]
+    expect(healthyStat?.id).toBe('healthy')
+    expect(healthyStat?.icon).toBe('CheckCircle')
+    expect(healthyStat?.color).toBe('text-green-400')
+    expect(healthyStat?.label).toBe('Healthy')
+    
+    const unhealthyStat = clusterHealthConfig.stats?.[1]
+    expect(unhealthyStat?.id).toBe('unhealthy')
+    expect(unhealthyStat?.icon).toBe('XCircle')
+    
+    const offlineStat = clusterHealthConfig.stats?.[2]
+    expect(offlineStat?.id).toBe('offline')
+    expect(offlineStat?.icon).toBe('WifiOff')
+  })
+
+  it('validates filters configuration', () => {
+    expect(clusterHealthConfig.filters).toBeDefined()
+    expect(clusterHealthConfig.filters).toHaveLength(1)
+    expect(clusterHealthConfig.filters?.[0].field).toBe('search')
+    expect(clusterHealthConfig.filters?.[0].type).toBe('text')
+    expect(clusterHealthConfig.filters?.[0].searchFields).toEqual(['name', 'context', 'server'])
+  })
+
+  it('validates content configuration', () => {
+    expect(clusterHealthConfig.content.type).toBe('list')
+    expect(clusterHealthConfig.content.pageSize).toBe(10)
+    expect(clusterHealthConfig.content.itemClick).toBe('drill')
+    expect(clusterHealthConfig.content.columns).toBeDefined()
+    expect(clusterHealthConfig.content.columns).toHaveLength(4)
+  })
+
+  it('validates drillDown configuration', () => {
+    expect(clusterHealthConfig.drillDown).toBeDefined()
+    expect(clusterHealthConfig.drillDown?.action).toBe('openClusterDetail')
+    expect(clusterHealthConfig.drillDown?.params).toEqual(['name'])
+  })
+
+  it('validates empty state configuration', () => {
+    expect(clusterHealthConfig.emptyState).toBeDefined()
+    expect(clusterHealthConfig.emptyState?.icon).toBe('Server')
+    expect(clusterHealthConfig.emptyState?.title).toBe('No clusters connected')
+    expect(clusterHealthConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(clusterHealthConfig.loadingState).toBeDefined()
+    expect(clusterHealthConfig.loadingState?.type).toBe('list')
+    expect(clusterHealthConfig.loadingState?.rows).toBe(5)
+  })
+
+  it('validates metadata fields', () => {
+    expect(clusterHealthConfig.isDemoData).toBe(false)
+    expect(clusterHealthConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/cluster-locations.test.ts
+++ b/web/src/config/cards/__tests__/cluster-locations.test.ts
@@ -1,4 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { clusterLocationsConfig } from '../cluster-locations'
 import * as moduleExports from '../cluster-locations'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('cluster-locations', moduleExports)
+
+describe('cluster-locations configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(clusterLocationsConfig.type).toBe('cluster_locations')
+    expect(clusterLocationsConfig.title).toBe('Cluster Locations')
+    expect(clusterLocationsConfig.category).toBe('cluster-health')
+    expect(clusterLocationsConfig.description).toBe('Geographic distribution of clusters')
+  })
+
+  it('validates appearance fields', () => {
+    expect(clusterLocationsConfig.icon).toBe('MapPin')
+    expect(clusterLocationsConfig.iconColor).toBe('text-red-400')
+    expect(clusterLocationsConfig.defaultWidth).toBe(8)
+    expect(clusterLocationsConfig.defaultHeight).toBe(4)
+  })
+
+  it('validates data source configuration', () => {
+    expect(clusterLocationsConfig.dataSource.type).toBe('hook')
+    expect(clusterLocationsConfig.dataSource.hook).toBe('useClusterLocations')
+  })
+
+  it('validates content configuration', () => {
+    expect(clusterLocationsConfig.content.type).toBe('custom')
+    expect(clusterLocationsConfig.content.component).toBe('ClusterMap')
+  })
+
+  it('validates empty state configuration', () => {
+    expect(clusterLocationsConfig.emptyState?.icon).toBe('MapPin')
+    expect(clusterLocationsConfig.emptyState?.title).toBe('No Location Data')
+    expect(clusterLocationsConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(clusterLocationsConfig.loadingState?.type).toBe('custom')
+  })
+
+  it('validates metadata fields', () => {
+    expect(clusterLocationsConfig.isDemoData).toBe(false)
+    expect(clusterLocationsConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/cluster-metrics.test.ts
+++ b/web/src/config/cards/__tests__/cluster-metrics.test.ts
@@ -1,4 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { CYAN_500, PURPLE_400 } from '../../../lib/theme/chartColors'
+import { clusterMetricsConfig } from '../cluster-metrics'
 import * as moduleExports from '../cluster-metrics'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('cluster-metrics', moduleExports)
+
+describe('cluster-metrics configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(clusterMetricsConfig.type).toBe('cluster_metrics')
+    expect(clusterMetricsConfig.title).toBe('Cluster Metrics')
+    expect(clusterMetricsConfig.category).toBe('compute')
+    expect(clusterMetricsConfig.description).toBe('CPU and memory metrics over time')
+  })
+
+  it('validates appearance fields', () => {
+    expect(clusterMetricsConfig.icon).toBe('Activity')
+    expect(clusterMetricsConfig.iconColor).toBe('text-blue-400')
+    expect(clusterMetricsConfig.defaultWidth).toBe(6)
+    expect(clusterMetricsConfig.defaultHeight).toBe(4)
+  })
+
+  it('validates data source configuration', () => {
+    expect(clusterMetricsConfig.dataSource.type).toBe('hook')
+    expect(clusterMetricsConfig.dataSource.hook).toBe('useCachedClusterMetrics')
+  })
+
+  it('validates stats configuration', () => {
+    expect(clusterMetricsConfig.stats).toBeDefined()
+    expect(clusterMetricsConfig.stats).toHaveLength(2)
+    
+    const cpuStat = clusterMetricsConfig.stats?.[0]
+    expect(cpuStat?.id).toBe('currentCpu')
+    expect(cpuStat?.icon).toBe('Cpu')
+    expect(cpuStat?.label).toBe('CPU')
+    
+    const memoryStat = clusterMetricsConfig.stats?.[1]
+    expect(memoryStat?.id).toBe('currentMemory')
+    expect(memoryStat?.icon).toBe('MemoryStick')
+    expect(memoryStat?.label).toBe('Memory')
+  })
+
+  it('validates content configuration', () => {
+    expect(clusterMetricsConfig.content.type).toBe('chart')
+    expect(clusterMetricsConfig.content.chartType).toBe('area')
+    expect(clusterMetricsConfig.content.height).toBe(250)
+    expect(clusterMetricsConfig.content.showLegend).toBe(true)
+    expect(clusterMetricsConfig.content.xAxis?.field).toBe('time')
+    expect(clusterMetricsConfig.content.yAxis?.label).toBe('Usage %')
+    expect(clusterMetricsConfig.content.series).toHaveLength(2)
+    expect(clusterMetricsConfig.content.series?.[0].field).toBe('cpu')
+    expect(clusterMetricsConfig.content.series?.[0].color).toBe(CYAN_500)
+    expect(clusterMetricsConfig.content.series?.[1].field).toBe('memory')
+    expect(clusterMetricsConfig.content.series?.[1].color).toBe(PURPLE_400)
+  })
+
+  it('validates empty state configuration', () => {
+    expect(clusterMetricsConfig.emptyState?.icon).toBe('Activity')
+    expect(clusterMetricsConfig.emptyState?.title).toBe('No metrics data')
+    expect(clusterMetricsConfig.emptyState?.variant).toBe('neutral')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(clusterMetricsConfig.loadingState?.type).toBe('chart')
+    expect(clusterMetricsConfig.loadingState?.rows).toBe(1)
+    expect(clusterMetricsConfig.loadingState?.showSearch).toBe(false)
+  })
+
+  it('validates metadata fields', () => {
+    expect(clusterMetricsConfig.isDemoData).toBe(false)
+    expect(clusterMetricsConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/cluster-network.test.ts
+++ b/web/src/config/cards/__tests__/cluster-network.test.ts
@@ -1,4 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { clusterNetworkConfig } from '../cluster-network'
 import * as moduleExports from '../cluster-network'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('cluster-network', moduleExports)
+
+describe('cluster-network configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(clusterNetworkConfig.type).toBe('cluster_network')
+    expect(clusterNetworkConfig.title).toBe('Cluster Network')
+    expect(clusterNetworkConfig.category).toBe('network')
+    expect(clusterNetworkConfig.description).toBe('Network topology visualization')
+  })
+
+  it('validates appearance fields', () => {
+    expect(clusterNetworkConfig.icon).toBe('Network')
+    expect(clusterNetworkConfig.iconColor).toBe('text-cyan-400')
+    expect(clusterNetworkConfig.defaultWidth).toBe(8)
+    expect(clusterNetworkConfig.defaultHeight).toBe(4)
+  })
+
+  it('validates data source configuration', () => {
+    expect(clusterNetworkConfig.dataSource.type).toBe('hook')
+    expect(clusterNetworkConfig.dataSource.hook).toBe('useClusterNetwork')
+  })
+
+  it('validates content configuration', () => {
+    expect(clusterNetworkConfig.content.type).toBe('custom')
+    expect(clusterNetworkConfig.content.component).toBe('NetworkTopology')
+  })
+
+  it('validates empty state configuration', () => {
+    expect(clusterNetworkConfig.emptyState?.icon).toBe('Network')
+    expect(clusterNetworkConfig.emptyState?.title).toBe('No Network Data')
+    expect(clusterNetworkConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(clusterNetworkConfig.loadingState?.type).toBe('custom')
+  })
+
+  it('validates metadata fields', () => {
+    expect(clusterNetworkConfig.isDemoData).toBe(false)
+    expect(clusterNetworkConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/cluster-resource-tree.test.ts
+++ b/web/src/config/cards/__tests__/cluster-resource-tree.test.ts
@@ -1,4 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { clusterResourceTreeConfig } from '../cluster-resource-tree'
 import * as moduleExports from '../cluster-resource-tree'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('cluster-resource-tree', moduleExports)
+
+describe('cluster-resource-tree configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(clusterResourceTreeConfig.type).toBe('cluster_resource_tree')
+    expect(clusterResourceTreeConfig.title).toBe('Resource Tree')
+    expect(clusterResourceTreeConfig.category).toBe('cluster-health')
+    expect(clusterResourceTreeConfig.description).toBe('Hierarchical view of cluster resources')
+  })
+
+  it('validates appearance fields', () => {
+    expect(clusterResourceTreeConfig.icon).toBe('GitBranch')
+    expect(clusterResourceTreeConfig.iconColor).toBe('text-purple-400')
+    expect(clusterResourceTreeConfig.defaultWidth).toBe(12)
+    expect(clusterResourceTreeConfig.defaultHeight).toBe(5)
+  })
+
+  it('validates data source configuration', () => {
+    expect(clusterResourceTreeConfig.dataSource.type).toBe('hook')
+    expect(clusterResourceTreeConfig.dataSource.hook).toBe('useClusterResourceTree')
+  })
+
+  it('validates content configuration', () => {
+    expect(clusterResourceTreeConfig.content.type).toBe('custom')
+    expect(clusterResourceTreeConfig.content.component).toBe('ResourceTree')
+  })
+
+  it('validates empty state configuration', () => {
+    expect(clusterResourceTreeConfig.emptyState?.icon).toBe('GitBranch')
+    expect(clusterResourceTreeConfig.emptyState?.title).toBe('No Resources')
+    expect(clusterResourceTreeConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(clusterResourceTreeConfig.loadingState?.type).toBe('custom')
+  })
+
+  it('validates metadata fields', () => {
+    expect(clusterResourceTreeConfig.isDemoData).toBe(false)
+    expect(clusterResourceTreeConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/compute-overview.test.ts
+++ b/web/src/config/cards/__tests__/compute-overview.test.ts
@@ -1,4 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { computeOverviewConfig } from '../compute-overview'
 import * as moduleExports from '../compute-overview'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('compute-overview', moduleExports)
+
+describe('compute-overview configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(computeOverviewConfig.type).toBe('compute_overview')
+    expect(computeOverviewConfig.title).toBe('Compute Overview')
+    expect(computeOverviewConfig.category).toBe('compute')
+    expect(computeOverviewConfig.description).toBe('Compute resource summary')
+  })
+
+  it('validates appearance fields', () => {
+    expect(computeOverviewConfig.icon).toBe('Cpu')
+    expect(computeOverviewConfig.iconColor).toBe('text-blue-400')
+    expect(computeOverviewConfig.defaultWidth).toBe(4)
+    expect(computeOverviewConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(computeOverviewConfig.dataSource.type).toBe('hook')
+    expect(computeOverviewConfig.dataSource.hook).toBe('useComputeOverview')
+  })
+
+  it('validates content configuration', () => {
+    expect(computeOverviewConfig.content.type).toBe('stats-grid')
+    expect(computeOverviewConfig.content.stats).toBeDefined()
+    expect(computeOverviewConfig.content.stats).toHaveLength(3)
+    expect(computeOverviewConfig.content.stats?.[0].field).toBe('nodes')
+    expect(computeOverviewConfig.content.stats?.[1].field).toBe('cpuUsage')
+    expect(computeOverviewConfig.content.stats?.[2].field).toBe('memoryUsage')
+  })
+
+  it('validates empty state configuration', () => {
+    expect(computeOverviewConfig.emptyState?.icon).toBe('Cpu')
+    expect(computeOverviewConfig.emptyState?.title).toBe('No Data')
+    expect(computeOverviewConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(computeOverviewConfig.loadingState?.type).toBe('stats')
+    expect(computeOverviewConfig.loadingState?.count).toBe(3)
+  })
+
+  it('validates metadata fields', () => {
+    expect(computeOverviewConfig.isDemoData).toBe(false)
+    expect(computeOverviewConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/hardware-health.test.ts
+++ b/web/src/config/cards/__tests__/hardware-health.test.ts
@@ -1,4 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { hardwareHealthConfig } from '../hardware-health'
 import * as moduleExports from '../hardware-health'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('hardware-health', moduleExports)
+
+describe('hardware-health configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(hardwareHealthConfig.type).toBe('hardware_health')
+    expect(hardwareHealthConfig.title).toBe('Hardware Health')
+    expect(hardwareHealthConfig.category).toBe('cluster-health')
+    expect(hardwareHealthConfig.description).toBe('Track hardware device disappearances on SuperMicro/HGX nodes')
+  })
+
+  it('validates appearance fields', () => {
+    expect(hardwareHealthConfig.icon).toBe('Cpu')
+    expect(hardwareHealthConfig.iconColor).toBe('text-red-400')
+    expect(hardwareHealthConfig.defaultWidth).toBe(6)
+    expect(hardwareHealthConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(hardwareHealthConfig.dataSource.type).toBe('hook')
+    expect(hardwareHealthConfig.dataSource.hook).toBe('useHardwareHealth')
+  })
+
+  it('validates content configuration', () => {
+    expect(hardwareHealthConfig.content.type).toBe('list')
+    expect(hardwareHealthConfig.content.pageSize).toBe(5)
+    expect(hardwareHealthConfig.content.columns).toBeDefined()
+    expect(hardwareHealthConfig.content.columns).toHaveLength(5)
+    expect(hardwareHealthConfig.content.columns?.[0].field).toBe('nodeName')
+    expect(hardwareHealthConfig.content.columns?.[0].primary).toBe(true)
+    expect(hardwareHealthConfig.content.columns?.[4].render).toBe('severity-badge')
+  })
+
+  it('validates empty state configuration', () => {
+    expect(hardwareHealthConfig.emptyState?.icon).toBe('CheckCircle')
+    expect(hardwareHealthConfig.emptyState?.title).toBe('All Healthy')
+    expect(hardwareHealthConfig.emptyState?.variant).toBe('success')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(hardwareHealthConfig.loadingState?.type).toBe('list')
+    expect(hardwareHealthConfig.loadingState?.rows).toBe(3)
+  })
+
+  it('validates metadata fields', () => {
+    expect(hardwareHealthConfig.isDemoData).toBe(false)
+    expect(hardwareHealthConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/namespace-events.test.ts
+++ b/web/src/config/cards/__tests__/namespace-events.test.ts
@@ -1,4 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { namespaceEventsConfig } from '../namespace-events'
 import * as moduleExports from '../namespace-events'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('namespace-events', moduleExports)
+
+describe('namespace-events configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(namespaceEventsConfig.type).toBe('namespace_events')
+    expect(namespaceEventsConfig.title).toBe('Namespace Events')
+    expect(namespaceEventsConfig.category).toBe('events')
+    expect(namespaceEventsConfig.description).toBe('Events in selected namespace')
+  })
+
+  it('validates appearance fields', () => {
+    expect(namespaceEventsConfig.icon).toBe('Activity')
+    expect(namespaceEventsConfig.iconColor).toBe('text-cyan-400')
+    expect(namespaceEventsConfig.defaultWidth).toBe(6)
+    expect(namespaceEventsConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(namespaceEventsConfig.dataSource.type).toBe('hook')
+    expect(namespaceEventsConfig.dataSource.hook).toBe('useNamespaceEvents')
+  })
+
+  it('validates content configuration', () => {
+    expect(namespaceEventsConfig.content.type).toBe('list')
+    expect(namespaceEventsConfig.content.pageSize).toBe(10)
+    expect(namespaceEventsConfig.content.columns).toBeDefined()
+    expect(namespaceEventsConfig.content.columns).toHaveLength(4)
+    expect(namespaceEventsConfig.content.columns?.[0].field).toBe('type')
+    expect(namespaceEventsConfig.content.columns?.[2].primary).toBe(true)
+  })
+
+  it('validates empty state configuration', () => {
+    expect(namespaceEventsConfig.emptyState?.icon).toBe('Activity')
+    expect(namespaceEventsConfig.emptyState?.title).toBe('No Events')
+    expect(namespaceEventsConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(namespaceEventsConfig.loadingState?.type).toBe('list')
+    expect(namespaceEventsConfig.loadingState?.rows).toBe(5)
+  })
+
+  it('validates metadata fields', () => {
+    expect(namespaceEventsConfig.isDemoData).toBe(false)
+    expect(namespaceEventsConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/namespace-monitor.test.ts
+++ b/web/src/config/cards/__tests__/namespace-monitor.test.ts
@@ -1,4 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { namespaceMonitorConfig } from '../namespace-monitor'
 import * as moduleExports from '../namespace-monitor'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('namespace-monitor', moduleExports)
+
+describe('namespace-monitor configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(namespaceMonitorConfig.type).toBe('namespace_monitor')
+    expect(namespaceMonitorConfig.title).toBe('Namespace Monitor')
+    expect(namespaceMonitorConfig.category).toBe('namespaces')
+    expect(namespaceMonitorConfig.description).toBe('Real-time namespace health monitoring')
+  })
+
+  it('validates appearance fields', () => {
+    expect(namespaceMonitorConfig.icon).toBe('Monitor')
+    expect(namespaceMonitorConfig.iconColor).toBe('text-green-400')
+    expect(namespaceMonitorConfig.defaultWidth).toBe(8)
+    expect(namespaceMonitorConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(namespaceMonitorConfig.dataSource.type).toBe('hook')
+    expect(namespaceMonitorConfig.dataSource.hook).toBe('useNamespaceMonitor')
+  })
+
+  it('validates content configuration', () => {
+    expect(namespaceMonitorConfig.content.type).toBe('stats-grid')
+    expect(namespaceMonitorConfig.content.stats).toBeDefined()
+    expect(namespaceMonitorConfig.content.stats).toHaveLength(4)
+    expect(namespaceMonitorConfig.content.stats?.[0].field).toBe('healthy')
+    expect(namespaceMonitorConfig.content.stats?.[1].field).toBe('warning')
+    expect(namespaceMonitorConfig.content.stats?.[2].field).toBe('critical')
+    expect(namespaceMonitorConfig.content.stats?.[3].field).toBe('unknown')
+  })
+
+  it('validates empty state configuration', () => {
+    expect(namespaceMonitorConfig.emptyState?.icon).toBe('Monitor')
+    expect(namespaceMonitorConfig.emptyState?.title).toBe('No Data')
+    expect(namespaceMonitorConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(namespaceMonitorConfig.loadingState?.type).toBe('stats')
+    expect(namespaceMonitorConfig.loadingState?.count).toBe(4)
+  })
+
+  it('validates metadata fields', () => {
+    expect(namespaceMonitorConfig.isDemoData).toBe(false)
+    expect(namespaceMonitorConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/namespace-overview.test.ts
+++ b/web/src/config/cards/__tests__/namespace-overview.test.ts
@@ -1,4 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { namespaceOverviewConfig } from '../namespace-overview'
 import * as moduleExports from '../namespace-overview'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('namespace-overview', moduleExports)
+
+describe('namespace-overview configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(namespaceOverviewConfig.type).toBe('namespace_overview')
+    expect(namespaceOverviewConfig.title).toBe('Namespace Overview')
+    expect(namespaceOverviewConfig.category).toBe('namespaces')
+    expect(namespaceOverviewConfig.description).toBe('Namespace resource summary')
+  })
+
+  it('validates appearance fields', () => {
+    expect(namespaceOverviewConfig.icon).toBe('FolderOpen')
+    expect(namespaceOverviewConfig.iconColor).toBe('text-blue-400')
+    expect(namespaceOverviewConfig.defaultWidth).toBe(6)
+    expect(namespaceOverviewConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(namespaceOverviewConfig.dataSource.type).toBe('hook')
+    expect(namespaceOverviewConfig.dataSource.hook).toBe('useNamespaceOverview')
+  })
+
+  it('validates content configuration', () => {
+    expect(namespaceOverviewConfig.content.type).toBe('stats-grid')
+    expect(namespaceOverviewConfig.content.stats).toBeDefined()
+    expect(namespaceOverviewConfig.content.stats).toHaveLength(4)
+    expect(namespaceOverviewConfig.content.stats?.[0].field).toBe('pods')
+    expect(namespaceOverviewConfig.content.stats?.[1].field).toBe('deployments')
+    expect(namespaceOverviewConfig.content.stats?.[2].field).toBe('services')
+    expect(namespaceOverviewConfig.content.stats?.[3].field).toBe('configmaps')
+  })
+
+  it('validates empty state configuration', () => {
+    expect(namespaceOverviewConfig.emptyState?.icon).toBe('FolderOpen')
+    expect(namespaceOverviewConfig.emptyState?.title).toBe('Select Namespace')
+    expect(namespaceOverviewConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(namespaceOverviewConfig.loadingState?.type).toBe('stats')
+    expect(namespaceOverviewConfig.loadingState?.count).toBe(4)
+  })
+
+  it('validates metadata fields', () => {
+    expect(namespaceOverviewConfig.isDemoData).toBe(false)
+    expect(namespaceOverviewConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/namespace-quotas.test.ts
+++ b/web/src/config/cards/__tests__/namespace-quotas.test.ts
@@ -1,4 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { namespaceQuotasConfig } from '../namespace-quotas'
 import * as moduleExports from '../namespace-quotas'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('namespace-quotas', moduleExports)
+
+describe('namespace-quotas configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(namespaceQuotasConfig.type).toBe('namespace_quotas')
+    expect(namespaceQuotasConfig.title).toBe('Namespace Quotas')
+    expect(namespaceQuotasConfig.category).toBe('namespaces')
+    expect(namespaceQuotasConfig.description).toBe('Resource quota usage by namespace')
+  })
+
+  it('validates appearance fields', () => {
+    expect(namespaceQuotasConfig.icon).toBe('Gauge')
+    expect(namespaceQuotasConfig.iconColor).toBe('text-yellow-400')
+    expect(namespaceQuotasConfig.defaultWidth).toBe(5)
+    expect(namespaceQuotasConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(namespaceQuotasConfig.dataSource.type).toBe('hook')
+    expect(namespaceQuotasConfig.dataSource.hook).toBe('useNamespaceQuotas')
+  })
+
+  it('validates content configuration', () => {
+    expect(namespaceQuotasConfig.content.type).toBe('list')
+    expect(namespaceQuotasConfig.content.pageSize).toBe(8)
+    expect(namespaceQuotasConfig.content.columns).toBeDefined()
+    expect(namespaceQuotasConfig.content.columns).toHaveLength(4)
+    expect(namespaceQuotasConfig.content.columns?.[0].field).toBe('resource')
+    expect(namespaceQuotasConfig.content.columns?.[0].primary).toBe(true)
+    expect(namespaceQuotasConfig.content.columns?.[3].render).toBe('progress-bar')
+  })
+
+  it('validates empty state configuration', () => {
+    expect(namespaceQuotasConfig.emptyState?.icon).toBe('Gauge')
+    expect(namespaceQuotasConfig.emptyState?.title).toBe('No Quotas')
+    expect(namespaceQuotasConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(namespaceQuotasConfig.loadingState?.type).toBe('list')
+    expect(namespaceQuotasConfig.loadingState?.rows).toBe(5)
+  })
+
+  it('validates metadata fields', () => {
+    expect(namespaceQuotasConfig.isDemoData).toBe(false)
+    expect(namespaceQuotasConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/namespace-rbac.test.ts
+++ b/web/src/config/cards/__tests__/namespace-rbac.test.ts
@@ -1,4 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { namespaceRbacConfig } from '../namespace-rbac'
 import * as moduleExports from '../namespace-rbac'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('namespace-rbac', moduleExports)
+
+describe('namespace-rbac configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(namespaceRbacConfig.type).toBe('namespace_rbac')
+    expect(namespaceRbacConfig.title).toBe('Namespace RBAC')
+    expect(namespaceRbacConfig.category).toBe('security')
+    expect(namespaceRbacConfig.description).toBe('RBAC permissions in namespace')
+  })
+
+  it('validates appearance fields', () => {
+    expect(namespaceRbacConfig.icon).toBe('Shield')
+    expect(namespaceRbacConfig.iconColor).toBe('text-red-400')
+    expect(namespaceRbacConfig.defaultWidth).toBe(6)
+    expect(namespaceRbacConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(namespaceRbacConfig.dataSource.type).toBe('hook')
+    expect(namespaceRbacConfig.dataSource.hook).toBe('useNamespaceRBAC')
+  })
+
+  it('validates content configuration', () => {
+    expect(namespaceRbacConfig.content.type).toBe('list')
+    expect(namespaceRbacConfig.content.pageSize).toBe(10)
+    expect(namespaceRbacConfig.content.columns).toBeDefined()
+    expect(namespaceRbacConfig.content.columns).toHaveLength(4)
+    expect(namespaceRbacConfig.content.columns?.[0].field).toBe('subject')
+    expect(namespaceRbacConfig.content.columns?.[0].primary).toBe(true)
+  })
+
+  it('validates empty state configuration', () => {
+    expect(namespaceRbacConfig.emptyState?.icon).toBe('Shield')
+    expect(namespaceRbacConfig.emptyState?.title).toBe('No RBAC')
+    expect(namespaceRbacConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(namespaceRbacConfig.loadingState?.type).toBe('list')
+    expect(namespaceRbacConfig.loadingState?.rows).toBe(5)
+  })
+
+  it('validates metadata fields', () => {
+    expect(namespaceRbacConfig.isDemoData).toBe(false)
+    expect(namespaceRbacConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/namespace-status.test.ts
+++ b/web/src/config/cards/__tests__/namespace-status.test.ts
@@ -1,4 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { namespaceStatusConfig } from '../namespace-status'
 import * as moduleExports from '../namespace-status'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('namespace-status', moduleExports)
+
+describe('namespace-status configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(namespaceStatusConfig.type).toBe('namespace_status')
+    expect(namespaceStatusConfig.title).toBe('Namespaces')
+    expect(namespaceStatusConfig.category).toBe('namespaces')
+    expect(namespaceStatusConfig.description).toBe('Kubernetes Namespaces across clusters')
+  })
+
+  it('validates appearance fields', () => {
+    expect(namespaceStatusConfig.icon).toBe('FolderOpen')
+    expect(namespaceStatusConfig.iconColor).toBe('text-blue-400')
+    expect(namespaceStatusConfig.defaultWidth).toBe(6)
+    expect(namespaceStatusConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(namespaceStatusConfig.dataSource.type).toBe('hook')
+    expect(namespaceStatusConfig.dataSource.hook).toBe('useNamespaces')
+  })
+
+  it('validates filters configuration', () => {
+    expect(namespaceStatusConfig.filters).toBeDefined()
+    expect(namespaceStatusConfig.filters).toHaveLength(2)
+    expect(namespaceStatusConfig.filters?.[0].field).toBe('search')
+    expect(namespaceStatusConfig.filters?.[0].type).toBe('text')
+    expect(namespaceStatusConfig.filters?.[1].field).toBe('cluster')
+    expect(namespaceStatusConfig.filters?.[1].type).toBe('cluster-select')
+  })
+
+  it('validates content configuration', () => {
+    expect(namespaceStatusConfig.content.type).toBe('list')
+    expect(namespaceStatusConfig.content.pageSize).toBe(10)
+    expect(namespaceStatusConfig.content.columns).toBeDefined()
+    expect(namespaceStatusConfig.content.columns).toHaveLength(4)
+    expect(namespaceStatusConfig.content.columns?.[1].primary).toBe(true)
+  })
+
+  it('validates empty state configuration', () => {
+    expect(namespaceStatusConfig.emptyState?.icon).toBe('FolderOpen')
+    expect(namespaceStatusConfig.emptyState?.title).toBe('No Namespaces')
+    expect(namespaceStatusConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(namespaceStatusConfig.loadingState?.type).toBe('list')
+    expect(namespaceStatusConfig.loadingState?.rows).toBe(5)
+    expect(namespaceStatusConfig.loadingState?.showSearch).toBe(true)
+  })
+
+  it('validates metadata fields', () => {
+    expect(namespaceStatusConfig.isDemoData).toBe(true)
+    expect(namespaceStatusConfig.isLive).toBe(true)
+  })
+})

--- a/web/src/config/cards/__tests__/node-status.test.ts
+++ b/web/src/config/cards/__tests__/node-status.test.ts
@@ -1,4 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { nodeStatusConfig } from '../node-status'
 import * as moduleExports from '../node-status'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
 registerCardConfigTest('node-status', moduleExports)
+
+describe('node-status configuration coverage', () => {
+  it('validates all required fields', () => {
+    expect(nodeStatusConfig.type).toBe('node_status')
+    expect(nodeStatusConfig.title).toBe('Node Status')
+    expect(nodeStatusConfig.category).toBe('compute')
+    expect(nodeStatusConfig.description).toBe('Kubernetes Nodes across clusters')
+  })
+
+  it('validates appearance fields', () => {
+    expect(nodeStatusConfig.icon).toBe('Server')
+    expect(nodeStatusConfig.iconColor).toBe('text-purple-400')
+    expect(nodeStatusConfig.defaultWidth).toBe(6)
+    expect(nodeStatusConfig.defaultHeight).toBe(3)
+  })
+
+  it('validates data source configuration', () => {
+    expect(nodeStatusConfig.dataSource.type).toBe('hook')
+    expect(nodeStatusConfig.dataSource.hook).toBe('useNodes')
+  })
+
+  it('validates filters configuration', () => {
+    expect(nodeStatusConfig.filters).toBeDefined()
+    expect(nodeStatusConfig.filters).toHaveLength(2)
+    expect(nodeStatusConfig.filters?.[0].field).toBe('search')
+    expect(nodeStatusConfig.filters?.[0].searchFields).toEqual(['name', 'cluster', 'status'])
+    expect(nodeStatusConfig.filters?.[1].type).toBe('cluster-select')
+  })
+
+  it('validates content configuration', () => {
+    expect(nodeStatusConfig.content.type).toBe('list')
+    expect(nodeStatusConfig.content.pageSize).toBe(10)
+    expect(nodeStatusConfig.content.columns).toBeDefined()
+    expect(nodeStatusConfig.content.columns).toHaveLength(6)
+    expect(nodeStatusConfig.content.columns?.[1].primary).toBe(true)
+  })
+
+  it('validates empty state configuration', () => {
+    expect(nodeStatusConfig.emptyState?.icon).toBe('Server')
+    expect(nodeStatusConfig.emptyState?.title).toBe('No Nodes')
+    expect(nodeStatusConfig.emptyState?.variant).toBe('info')
+  })
+
+  it('validates loading state configuration', () => {
+    expect(nodeStatusConfig.loadingState?.type).toBe('list')
+    expect(nodeStatusConfig.loadingState?.rows).toBe(5)
+    expect(nodeStatusConfig.loadingState?.showSearch).toBe(true)
+  })
+
+  it('validates metadata fields', () => {
+    expect(nodeStatusConfig.isDemoData).toBe(true)
+    expect(nodeStatusConfig.isLive).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #19671

Adds comprehensive unit tests for ~20 cluster management, node, and namespace card configuration files to achieve >80% line coverage.

### Cluster Cards (11 files)
- cluster-comparison, cluster-costs, cluster-delta-detector, cluster-focus, cluster-groups
- cluster-health-monitor, cluster-health, cluster-locations, cluster-metrics, cluster-network, cluster-resource-tree

### Namespace Cards (6 files)
- namespace-events, namespace-monitor, namespace-overview, namespace-quotas, namespace-rbac, namespace-status

### Node/Compute Cards (3 files)
- node-status, compute-overview, hardware-health