### PR TITLE
[scanner] fix: resolve test failures from coverage suite #3905

### DIFF
--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitor.utils.test.ts
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitor.utils.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest'
 import {
   calculateAggregateMetrics,

--- a/web/src/components/cards/llmd/__tests__/nightlyE2E.constants.test.ts
+++ b/web/src/components/cards/llmd/__tests__/nightlyE2E.constants.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest'
 import {
   computeAvgDurationMin,


### PR DESCRIPTION
Fixes #19672

Fixes the shared root cause that broke render tests across card components and mission components after PR #19662 merged.

## Root Cause

The new test files (`KVCacheMonitor.utils.test.ts` and `nightlyE2E.constants.test.ts`) were running in the default jsdom environment instead of Node.js environment. Since they test pure utility functions that import React types, these tests were polluting the global scope when they ran, affecting subsequent jsdom tests in CI (where tests run sequentially with 1 worker).

## Fix

Added `@vitest-environment node` directive to both test files so they run in Node.js environment instead of jsdom, preventing global scope pollution.

This follows the same pattern as the fix in #19663 which resolved the previous 168 test failure cascade.

## Changes

- Added `// @vitest-environment node` to `KVCacheMonitor.utils.test.ts`
- Added `// @vitest-environment node` to `nightlyE2E.constants.test.ts`