### PR TITLE
[quality] test: render tests for 6 untested llmd card components

### DIFF
--- a/web/src/components/cards/llmd/__tests__/HardwareLeaderboard.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/HardwareLeaderboard.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useBenchmarkData', () => ({
+  useCachedBenchmarkReports: () => ({ data: [], isDemoFallback: null, isFailed: false, consecutiveFailures: 0, isLoading: false, isRefreshing: false, currentSince: null, lastRefresh: null }),
+  resetBenchmarkStream: vi.fn(),
+}))
+
+vi.mock('../../../../lib/llmd/benchmarkMockData', () => ({
+  generateLeaderboardRows: () => [],
+  CONFIG_COLORS: {},
+  generateBenchmarkReports: vi.fn(),
+  getHardwareShort: vi.fn(),
+  getModelShort: vi.fn(),
+}))
+
+vi.mock('../../../ui/CardSearch', () => ({
+  CardSearch: () => null,
+  useCardSearch: () => ({ searchQuery: '', setSearchQuery: vi.fn() }),
+}))
+
+vi.mock('../../../ui/CardControls', () => ({
+  CardControls: () => null,
+}))
+
+vi.mock('../../../ui/Pagination', () => ({
+  usePagination: (items: unknown[]) => ({
+    paginatedItems: items,
+    currentPage: 1,
+    totalPages: 1,
+    totalItems: (items as unknown[]).length,
+    itemsPerPage: 10,
+    goToPage: vi.fn(),
+    setPerPage: vi.fn(),
+    needsPagination: false,
+  }),
+  Pagination: () => null,
+}))
+
+import HardwareLeaderboard from '../HardwareLeaderboard'
+
+describe('HardwareLeaderboard', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<HardwareLeaderboard />)
+    expect(container).toBeTruthy()
+  })
+
+  it('displays the component title', () => {
+    const { container } = render(<HardwareLeaderboard />)
+    expect(container.textContent).toContain('Hardware Leaderboard')
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/LLMdConfigurator.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/LLMdConfigurator.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useCardDemoState: () => ({ shouldUseDemoData: null, showDemoBadge: null }),
+  useCardLoadingState: () => ({ showEmptyState: false }),
+}))
+
+vi.mock('../../../../lib/llmd/mockData', () => ({
+  getConfiguratorPresets: () => [{
+    id: 'test-preset',
+    name: 'Test Preset',
+    category: 'scheduling' as const,
+    description: 'A test preset',
+    parameters: [
+      { name: 'maxBatchSize', value: 64, min: 1, max: 256, unit: '', description: 'Max batch size' },
+    ],
+    expectedImpact: { ttftImprovement: 30, throughputImprovement: 20, costChange: 5 },
+  }],
+}))
+
+vi.mock('../shared/PortalTooltip', () => ({
+  Acronym: ({ term }: { term: string }) => term,
+}))
+
+vi.mock('../../../../lib/clipboard', () => ({
+  copyToClipboard: vi.fn(),
+}))
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: Record<string, unknown>) => {
+      const { whileHover, whileTap, initial, animate, exit, ...rest } = props
+      return <div {...rest}>{children}</div>
+    },
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+import LLMdConfigurator from '../LLMdConfigurator'
+
+describe('LLMdConfigurator', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<LLMdConfigurator />)
+    expect(container).toBeTruthy()
+  })
+
+  it('displays the component title', () => {
+    const { container } = render(<LLMdConfigurator />)
+    expect(container.textContent).toContain('Configurator')
+  })
+
+  it('renders preset card with name', () => {
+    const { container } = render(<LLMdConfigurator />)
+    expect(container.textContent).toContain('Test Preset')
+  })
+
+  it('shows expected impact metrics', () => {
+    const { container } = render(<LLMdConfigurator />)
+    expect(container.textContent).toContain('-30%')
+    expect(container.textContent).toContain('+20%')
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/LatencyBreakdown.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/LatencyBreakdown.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useBenchmarkData', () => ({
+  useCachedBenchmarkReports: () => ({ data: [], isDemoFallback: null, isFailed: false, consecutiveFailures: 0, isLoading: false, isRefreshing: false, currentSince: null, lastRefresh: null }),
+  resetBenchmarkStream: vi.fn(),
+}))
+
+vi.mock('../../../../lib/llmd/benchmarkDataUtils', () => ({
+  groupByExperiment: () => [],
+  getFilterOptions: () => ({ categories: [], islValues: [], oslValues: [] }),
+}))
+
+vi.mock('../../../charts/LazyEChart', () => ({
+  LazyEChart: () => null,
+}))
+
+vi.mock('../../DynamicCardErrorBoundary', () => ({
+  DynamicCardErrorBoundary: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../../ui/StatusBadge', () => ({
+  StatusBadge: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+import LatencyBreakdown from '../LatencyBreakdown'
+
+describe('LatencyBreakdown', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<LatencyBreakdown />)
+    expect(container).toBeTruthy()
+  })
+
+  it('displays the component title', () => {
+    const { container } = render(<LatencyBreakdown />)
+    expect(container.textContent).toContain('Latency Under Load')
+  })
+
+  it('renders metric tab buttons', () => {
+    const { container } = render(<LatencyBreakdown />)
+    expect(container.textContent).toContain('TTFT p50')
+    expect(container.textContent).toContain('TPOT p50')
+    expect(container.textContent).toContain('p99 Latency')
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/ParetoFrontier.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/ParetoFrontier.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useBenchmarkData', () => ({
+  useCachedBenchmarkReports: () => ({ data: [], isDemoFallback: null, isFailed: false, consecutiveFailures: 0, isLoading: false, isRefreshing: false, currentSince: null, lastRefresh: null }),
+  resetBenchmarkStream: vi.fn(),
+}))
+
+vi.mock('../../../../lib/llmd/benchmarkMockData', () => ({
+  generateBenchmarkReports: () => [],
+  getHardwareShort: () => 'A100',
+  getModelShort: () => 'llama-70b',
+  HARDWARE_COLORS: {},
+}))
+
+vi.mock('../../../../lib/llmd/benchmarkDataUtils', () => ({
+  groupByExperiment: () => [],
+  getFilterOptions: () => ({ categories: [], islValues: [], oslValues: [], models: [], hardwares: [], frameworks: [] }),
+  extractExperimentMeta: () => ({ isl: 0, osl: 0, qps: 0, category: '' }),
+}))
+
+vi.mock('../../../charts/LazyEChart', () => ({
+  LazyEChart: () => null,
+}))
+
+vi.mock('../../DynamicCardErrorBoundary', () => ({
+  DynamicCardErrorBoundary: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../../../lib/download', () => ({
+  downloadDataUrl: vi.fn(),
+}))
+
+import ParetoFrontier from '../ParetoFrontier'
+
+describe('ParetoFrontier', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<ParetoFrontier />)
+    expect(container).toBeTruthy()
+  })
+
+  it('displays the component title', () => {
+    const { container } = render(<ParetoFrontier />)
+    expect(container.textContent).toContain('Performance Frontier')
+  })
+
+  it('shows empty state when no data', () => {
+    const { container } = render(<ParetoFrontier />)
+    expect(container.textContent).toContain('No data')
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/PerformanceTimeline.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/PerformanceTimeline.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useBenchmarkData', () => ({
+  useCachedBenchmarkReports: () => ({ data: [], isDemoFallback: null, isFailed: false, consecutiveFailures: 0, isLoading: false, isRefreshing: false, currentSince: null, lastRefresh: null }),
+  resetBenchmarkStream: vi.fn(),
+}))
+
+vi.mock('../../../../lib/llmd/benchmarkMockData', () => ({
+  generateBenchmarkReports: () => [],
+  getHardwareShort: vi.fn(),
+  getModelShort: vi.fn(),
+}))
+
+vi.mock('../../../../lib/llmd/benchmarkDataUtils', () => ({
+  extractExperimentMeta: () => ({ isl: 0, osl: 0, qps: 0, category: '' }),
+  getFilterOptions: () => ({ categories: [], islValues: [], oslValues: [] }),
+}))
+
+import PerformanceTimeline from '../PerformanceTimeline'
+
+describe('PerformanceTimeline', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<PerformanceTimeline />)
+    expect(container).toBeTruthy()
+  })
+
+  it('displays the component title', () => {
+    const { container } = render(<PerformanceTimeline />)
+    expect(container.textContent).toContain('Sequence Length Impact')
+  })
+
+  it('renders metric mode tabs', () => {
+    const { container } = render(<PerformanceTimeline />)
+    expect(container.textContent).toContain('Throughput')
+    expect(container.textContent).toContain('TTFT p50')
+    expect(container.textContent).toContain('TPOT p50')
+    expect(container.textContent).toContain('p99 Latency')
+  })
+
+  it('shows empty state when no data', () => {
+    const { container } = render(<PerformanceTimeline />)
+    expect(container.textContent).toContain('No data for selected filters')
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/ResourceUtilization.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/ResourceUtilization.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useBenchmarkData', () => ({
+  useCachedBenchmarkReports: () => ({ data: [], isDemoFallback: null, isFailed: false, consecutiveFailures: 0, isLoading: false, isRefreshing: false, currentSince: null, lastRefresh: null }),
+  resetBenchmarkStream: vi.fn(),
+}))
+
+vi.mock('../../../../lib/llmd/benchmarkMockData', () => ({
+  generateBenchmarkReports: () => [],
+  getHardwareShort: vi.fn(),
+  getModelShort: vi.fn(),
+}))
+
+vi.mock('../../../../lib/llmd/benchmarkDataUtils', () => ({
+  groupByExperiment: () => [],
+  getFilterOptions: () => ({ categories: [], islValues: [], oslValues: [] }),
+  CONFIG_TYPE_COLORS: { 'llm-d': '#3b82f6', standalone: '#71717a' },
+}))
+
+vi.mock('../../../charts/LazyEChart', () => ({
+  LazyEChart: () => null,
+}))
+
+vi.mock('../../../ui/RefreshIndicator', () => ({
+  RefreshIndicator: () => null,
+}))
+
+vi.mock('../../../ui/StatusBadge', () => ({
+  StatusBadge: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+import ResourceUtilization from '../ResourceUtilization'
+
+describe('ResourceUtilization', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<ResourceUtilization />)
+    expect(container).toBeTruthy()
+  })
+
+  it('displays the component title', () => {
+    const { container } = render(<ResourceUtilization />)
+    expect(container.textContent).toContain('Experiment Comparison')
+  })
+
+  it('renders metric mode tabs', () => {
+    const { container } = render(<ResourceUtilization />)
+    expect(container.textContent).toContain('Throughput')
+    expect(container.textContent).toContain('TTFT p50')
+    expect(container.textContent).toContain('TPOT p50')
+    expect(container.textContent).toContain('p99 Latency')
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/ThroughputComparison.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/ThroughputComparison.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useBenchmarkData', () => ({
+  useCachedBenchmarkReports: () => ({ data: [], isDemoFallback: null, isFailed: false, consecutiveFailures: 0, isLoading: false, isRefreshing: false, currentSince: null, lastRefresh: null }),
+  resetBenchmarkStream: vi.fn(),
+}))
+
+vi.mock('../../../../lib/llmd/benchmarkDataUtils', () => ({
+  groupByExperiment: () => [],
+  getFilterOptions: () => ({ categories: [], islValues: [], oslValues: [] }),
+}))
+
+vi.mock('../../../charts/LazyEChart', () => ({
+  LazyEChart: () => null,
+}))
+
+vi.mock('../../../ui/StatusBadge', () => ({
+  StatusBadge: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+import ThroughputComparison from '../ThroughputComparison'
+
+describe('ThroughputComparison', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<ThroughputComparison />)
+    expect(container).toBeTruthy()
+  })
+
+  it('displays the component title', () => {
+    const { container } = render(<ThroughputComparison />)
+    expect(container.textContent).toContain('Throughput Scaling')
+  })
+
+  it('shows empty state when no data', () => {
+    const { container } = render(<ThroughputComparison />)
+    expect(container.textContent).toContain('No data available for selected filters')
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds render tests for 6 previously untested exported LLM-d card components, covering the remaining gaps in the `web/src/components/cards/llmd/` directory.

### New test files (6)

| File | Tests | Component covered |
|------|-------|-------------------|
| `HardwareLeaderboard.test.tsx` | 2 | Sortable ranked table of hardware configs |
| `LatencyBreakdown.test.tsx` | 3 | Latency metrics line chart under load |
| `ThroughputComparison.test.tsx` | 3 | Throughput scaling line chart |
| `PerformanceTimeline.test.tsx` | 4 | ISL×OSL performance heatmap |
| `ResourceUtilization.test.tsx` | 3 | Experiment comparison bar chart |
| `LLMdConfigurator.test.tsx` | 4 | Interactive LLM-d tuning configurator |

### Coverage improvement

- Before: 10 of 16 exported components had tests (63%)
- After: 16 of 16 exported components have tests (100%)

All tests follow the established pattern: mock common dependencies (demoMode, analytics, i18n, etc.), mock component-specific data hooks with empty data, and verify render + basic content assertions.

Fixes #19681

---
*Filed by quality agent (ACMM L4/L6 — full mode)*