### PR TITLE
[scanner] test: unit tests for missions components

### DIFF
--- a/web/src/components/missions/__tests__/MissionContentContext.test.tsx
+++ b/web/src/components/missions/__tests__/MissionContentContext.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * MissionContentContext unit tests
+ *
+ * Covers: context creation, provider rendering, and hook error handling.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { MissionContentProvider, useMissionContentContext } from '../MissionContentContext'
+import type { MissionContentContextValue } from '../MissionContentContext'
+
+describe('MissionContentContext', () => {
+  const mockContextValue: MissionContentContextValue = {
+    searchPanel: {
+      activeTab: 'recommended',
+      searchQuery: '',
+      tokenError: null,
+      missionFetchError: null,
+      loadingRecommendations: false,
+      searchProgress: { step: '', detail: '', found: 0, scanned: 0 },
+      hasCluster: false,
+      recommendations: [],
+      filteredRecommendations: [],
+      installerMissions: [],
+      filteredInstallers: [],
+      loadingInstallers: false,
+      installerSearch: '',
+      onInstallerSearchChange: () => {},
+      installerCategoryFilter: '',
+      onInstallerCategoryFilterChange: () => {},
+      installerMaturityFilter: '',
+      onInstallerMaturityFilterChange: () => {},
+      fixerMissions: [],
+      filteredFixers: [],
+      loadingFixers: false,
+      fixerSearch: '',
+      onFixerSearchChange: () => {},
+      fixerTypeFilter: '',
+      onFixerTypeFilterChange: () => {},
+    },
+    filePanel: {
+      selectedPath: null,
+      selectedNode: null,
+      viewMode: 'list',
+      onToggleNode: () => {},
+      onSelectNode: () => {},
+      onClearSelectedPath: () => {},
+    },
+    content: {
+      loading: false,
+      selectedMission: null,
+      rawContent: null,
+      showRaw: false,
+      setShowRaw: () => {},
+      isMissionLoading: false,
+      missionContentError: null,
+      unstructuredContent: null,
+      isScanning: false,
+      scanResult: null,
+      showImproveDialog: false,
+      setShowImproveDialog: () => {},
+      directoryEntries: [],
+      selectNode: async () => {},
+      selectCardMission: async () => {},
+      handleImport: async () => {},
+      handleImportDirectoryEntry: async () => {},
+      handleScanComplete: () => {},
+      handleScanDismiss: () => {},
+      handleCopyLink: async () => false,
+      clearSelectedMission: () => {},
+      resetContentView: () => {},
+    },
+    filteredEntries: [],
+  }
+
+  it('provides context value to children', () => {
+    const TestConsumer = () => {
+      const context = useMissionContentContext()
+      return <div data-testid="consumer">{context.searchPanel.activeTab}</div>
+    }
+
+    const { getByTestId } = render(
+      <MissionContentProvider {...mockContextValue}>
+        <TestConsumer />
+      </MissionContentProvider>
+    )
+
+    expect(getByTestId('consumer')).toHaveTextContent('recommended')
+  })
+
+  it('throws error when useMissionContentContext is used outside provider', () => {
+    const TestComponent = () => {
+      useMissionContentContext()
+      return null
+    }
+
+    // Suppress console.error for this test
+    const consoleError = console.error
+    console.error = () => {}
+
+    expect(() => render(<TestComponent />)).toThrow(
+      'useMissionContentContext must be used within a MissionContentProvider'
+    )
+
+    console.error = consoleError
+  })
+
+  it('renders children when provider is mounted', () => {
+    const { getByTestId } = render(
+      <MissionContentProvider {...mockContextValue}>
+        <div data-testid="child">Test Child</div>
+      </MissionContentProvider>
+    )
+
+    expect(getByTestId('child')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/missions/__tests__/ResolutionErrorBoundary.test.tsx
+++ b/web/src/components/missions/__tests__/ResolutionErrorBoundary.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * ResolutionErrorBoundary unit tests
+ *
+ * Covers: error catching, fallback UI, and recovery behavior.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ResolutionErrorBoundary } from '../ResolutionErrorBoundary'
+
+const ThrowError = ({ shouldThrow }: { shouldThrow: boolean }) => {
+  if (shouldThrow) {
+    throw new Error('Test error')
+  }
+  return <div>No error</div>
+}
+
+describe('ResolutionErrorBoundary', () => {
+  it('renders children when there is no error', () => {
+    render(
+      <ResolutionErrorBoundary>
+        <div data-testid="child">Child content</div>
+      </ResolutionErrorBoundary>
+    )
+
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+    expect(screen.getByTestId('child')).toHaveTextContent('Child content')
+  })
+
+  it('catches errors and displays fallback UI', () => {
+    // Suppress console.error for this test
+    const consoleError = console.error
+    console.error = vi.fn()
+
+    render(
+      <ResolutionErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ResolutionErrorBoundary>
+    )
+
+    expect(screen.getByText('Failed to apply resolution')).toBeInTheDocument()
+    expect(screen.getByText('Test error')).toBeInTheDocument()
+
+    console.error = consoleError
+  })
+
+  it('displays error message when error is caught', () => {
+    const consoleError = console.error
+    console.error = vi.fn()
+
+    render(
+      <ResolutionErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ResolutionErrorBoundary>
+    )
+
+    expect(screen.getByText(/An error occurred while processing the resolution/)).toBeInTheDocument()
+
+    console.error = consoleError
+  })
+
+  it('recovers when "Try again" button is clicked', async () => {
+    const user = userEvent.setup()
+    const consoleError = console.error
+    console.error = vi.fn()
+
+    const { rerender } = render(
+      <ResolutionErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ResolutionErrorBoundary>
+    )
+
+    expect(screen.getByText('Failed to apply resolution')).toBeInTheDocument()
+
+    const tryAgainButton = screen.getByRole('button', { name: /try again/i })
+    await user.click(tryAgainButton)
+
+    // After recovery, re-render with non-throwing component
+    rerender(
+      <ResolutionErrorBoundary>
+        <ThrowError shouldThrow={false} />
+      </ResolutionErrorBoundary>
+    )
+
+    expect(screen.getByText('No error')).toBeInTheDocument()
+    expect(screen.queryByText('Failed to apply resolution')).not.toBeInTheDocument()
+
+    console.error = consoleError
+  })
+})

--- a/web/src/components/missions/__tests__/ResolutionKnowledgePanel.test.tsx
+++ b/web/src/components/missions/__tests__/ResolutionKnowledgePanel.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * ResolutionKnowledgePanel unit tests
+ *
+ * Covers: empty state, personal/shared resolutions, expand/collapse, and action callbacks.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ResolutionKnowledgePanel } from '../ResolutionKnowledgePanel'
+import type { SimilarResolution } from '../../../hooks/useResolutions'
+
+const mockPersonalResolution: SimilarResolution = {
+  id: 'res-1',
+  title: 'Fix database connection',
+  description: 'Restart the database service',
+  similarity: 0.85,
+  source: 'personal',
+  resolution: {
+    id: 'res-1',
+    title: 'Fix database connection',
+    description: 'Restart the database service',
+    steps: { type: 'manual', instructions: ['Restart DB'] },
+    successRate: 0.9,
+    usageCount: 5,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  },
+}
+
+const mockSharedResolution: SimilarResolution = {
+  id: 'res-2',
+  title: 'Fix network timeout',
+  description: 'Increase timeout settings',
+  similarity: 0.75,
+  source: 'shared',
+  resolution: {
+    id: 'res-2',
+    title: 'Fix network timeout',
+    description: 'Increase timeout settings',
+    steps: { type: 'manual', instructions: ['Edit config'] },
+    successRate: 0.8,
+    usageCount: 10,
+    createdAt: '2024-01-02T00:00:00Z',
+    updatedAt: '2024-01-02T00:00:00Z',
+  },
+}
+
+describe('ResolutionKnowledgePanel', () => {
+  it('renders empty state when no resolutions provided', () => {
+    const onApplyResolution = vi.fn()
+    const onSaveNewResolution = vi.fn()
+
+    render(
+      <ResolutionKnowledgePanel
+        relatedResolutions={[]}
+        onApplyResolution={onApplyResolution}
+        onSaveNewResolution={onSaveNewResolution}
+      />
+    )
+
+    expect(screen.getByText('Related Knowledge')).toBeInTheDocument()
+    expect(screen.getByText(/No similar resolutions found/)).toBeInTheDocument()
+    expect(screen.getByText('Save This Resolution')).toBeInTheDocument()
+  })
+
+  it('calls onSaveNewResolution when "Save This Resolution" is clicked', async () => {
+    const user = userEvent.setup()
+    const onApplyResolution = vi.fn()
+    const onSaveNewResolution = vi.fn()
+
+    render(
+      <ResolutionKnowledgePanel
+        relatedResolutions={[]}
+        onApplyResolution={onApplyResolution}
+        onSaveNewResolution={onSaveNewResolution}
+      />
+    )
+
+    const saveButton = screen.getByText('Save This Resolution')
+    await user.click(saveButton)
+
+    expect(onSaveNewResolution).toHaveBeenCalledTimes(1)
+  })
+
+  it('displays personal resolutions when provided', () => {
+    const onApplyResolution = vi.fn()
+    const onSaveNewResolution = vi.fn()
+
+    render(
+      <ResolutionKnowledgePanel
+        relatedResolutions={[mockPersonalResolution]}
+        onApplyResolution={onApplyResolution}
+        onSaveNewResolution={onSaveNewResolution}
+      />
+    )
+
+    expect(screen.getByText('Fix database connection')).toBeInTheDocument()
+    expect(screen.getByText(/From Your History/)).toBeInTheDocument()
+  })
+
+  it('displays shared resolutions when provided', () => {
+    const onApplyResolution = vi.fn()
+    const onSaveNewResolution = vi.fn()
+
+    render(
+      <ResolutionKnowledgePanel
+        relatedResolutions={[mockSharedResolution]}
+        onApplyResolution={onApplyResolution}
+        onSaveNewResolution={onSaveNewResolution}
+      />
+    )
+
+    expect(screen.getByText('Fix network timeout')).toBeInTheDocument()
+  })
+
+  it('separates personal and shared resolutions', () => {
+    const onApplyResolution = vi.fn()
+    const onSaveNewResolution = vi.fn()
+
+    render(
+      <ResolutionKnowledgePanel
+        relatedResolutions={[mockPersonalResolution, mockSharedResolution]}
+        onApplyResolution={onApplyResolution}
+        onSaveNewResolution={onSaveNewResolution}
+      />
+    )
+
+    expect(screen.getByText('Fix database connection')).toBeInTheDocument()
+    expect(screen.getByText('Fix network timeout')).toBeInTheDocument()
+    expect(screen.getByText(/From Your History/)).toBeInTheDocument()
+  })
+})

--- a/web/src/components/missions/browser/__tests__/DirectoryListing.test.tsx
+++ b/web/src/components/missions/browser/__tests__/DirectoryListing.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * DirectoryListing unit tests
+ *
+ * Covers: list/grid view modes, file/directory rendering, and interaction callbacks.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DirectoryListing } from '../DirectoryListing'
+import type { BrowseEntry } from '../../../../lib/missions/types'
+
+const mockEntries: BrowseEntry[] = [
+  {
+    name: 'configs',
+    path: '/root/configs',
+    type: 'directory',
+  },
+  {
+    name: 'mission.yaml',
+    path: '/root/mission.yaml',
+    type: 'file',
+    size: 1024,
+  },
+  {
+    name: 'README.md',
+    path: '/root/README.md',
+    type: 'file',
+    size: 512,
+    description: 'Documentation file',
+  },
+]
+
+describe('DirectoryListing', () => {
+  it('renders entries in list view mode', () => {
+    const onSelect = vi.fn()
+
+    render(
+      <DirectoryListing
+        entries={mockEntries}
+        viewMode="list"
+        onSelect={onSelect}
+      />
+    )
+
+    expect(screen.getByText('configs')).toBeInTheDocument()
+    expect(screen.getByText('mission.yaml')).toBeInTheDocument()
+    expect(screen.getByText('README.md')).toBeInTheDocument()
+  })
+
+  it('renders entries in grid view mode', () => {
+    const onSelect = vi.fn()
+
+    render(
+      <DirectoryListing
+        entries={mockEntries}
+        viewMode="grid"
+        onSelect={onSelect}
+      />
+    )
+
+    expect(screen.getByText('configs')).toBeInTheDocument()
+    expect(screen.getByText('mission.yaml')).toBeInTheDocument()
+    expect(screen.getByText('README.md')).toBeInTheDocument()
+  })
+
+  it('calls onSelect when an entry is clicked', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+
+    render(
+      <DirectoryListing
+        entries={mockEntries}
+        viewMode="list"
+        onSelect={onSelect}
+      />
+    )
+
+    const entry = screen.getByText('mission.yaml')
+    await user.click(entry)
+
+    expect(onSelect).toHaveBeenCalledWith(mockEntries[1])
+  })
+
+  it('displays file sizes when provided', () => {
+    const onSelect = vi.fn()
+
+    render(
+      <DirectoryListing
+        entries={mockEntries}
+        viewMode="list"
+        onSelect={onSelect}
+      />
+    )
+
+    expect(screen.getByText('1.00 KB')).toBeInTheDocument()
+    expect(screen.getByText('512 B')).toBeInTheDocument()
+  })
+
+  it('displays file descriptions when provided', () => {
+    const onSelect = vi.fn()
+
+    render(
+      <DirectoryListing
+        entries={mockEntries}
+        viewMode="list"
+        onSelect={onSelect}
+      />
+    )
+
+    expect(screen.getByText('Documentation file')).toBeInTheDocument()
+  })
+
+  it('renders import button for files when onImport is provided', () => {
+    const onSelect = vi.fn()
+    const onImport = vi.fn()
+
+    render(
+      <DirectoryListing
+        entries={mockEntries}
+        viewMode="list"
+        onSelect={onSelect}
+        onImport={onImport}
+      />
+    )
+
+    const importButtons = screen.getAllByTitle('Import mission')
+    expect(importButtons).toHaveLength(2) // Two files in mockEntries
+  })
+
+  it('calls onImport when import button is clicked', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    const onImport = vi.fn()
+
+    render(
+      <DirectoryListing
+        entries={mockEntries}
+        viewMode="list"
+        onSelect={onSelect}
+        onImport={onImport}
+      />
+    )
+
+    const importButtons = screen.getAllByTitle('Import mission')
+    await user.click(importButtons[0])
+
+    expect(onImport).toHaveBeenCalledWith(mockEntries[1])
+    expect(onSelect).not.toHaveBeenCalled() // Stop propagation works
+  })
+
+  it('does not render import button for directories', () => {
+    const onSelect = vi.fn()
+    const onImport = vi.fn()
+
+    render(
+      <DirectoryListing
+        entries={[mockEntries[0]]} // Only directory
+        viewMode="list"
+        onSelect={onSelect}
+        onImport={onImport}
+      />
+    )
+
+    expect(screen.queryByTitle('Import mission')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/missions/browser/__tests__/RecommendationCard.test.tsx
+++ b/web/src/components/missions/browser/__tests__/RecommendationCard.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * RecommendationCard unit tests
+ *
+ * Covers: card rendering, compact mode, score badges, and interaction callbacks.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RecommendationCard } from '../RecommendationCard'
+import type { MissionMatch } from '../../../../lib/missions/types'
+
+const mockMatch: MissionMatch = {
+  mission: {
+    version: 'v1',
+    title: 'Install Prometheus',
+    description: 'Deploy monitoring stack',
+    type: 'install',
+    tags: ['monitoring', 'observability'],
+    steps: [],
+  },
+  score: 0.85,
+  matchPercent: 85,
+  matchReasons: ['Matches cluster needs'],
+}
+
+const mockClusterMatch: MissionMatch = {
+  ...mockMatch,
+  score: 1.5, // > 1 indicates cluster match
+  matchPercent: 90,
+}
+
+const mockMissionWithMaturity: MissionMatch = {
+  ...mockMatch,
+  mission: {
+    ...mockMatch.mission,
+    metadata: {
+      maturity: 'graduated',
+    },
+  },
+}
+
+describe('RecommendationCard', () => {
+  it('renders mission title and description', () => {
+    const onSelect = vi.fn()
+    const onImport = vi.fn()
+
+    render(
+      <RecommendationCard
+        match={mockMatch}
+        onSelect={onSelect}
+        onImport={onImport}
+      />
+    )
+
+    expect(screen.getByText('Install Prometheus')).toBeInTheDocument()
+  })
+
+  it('displays match percentage badge', () => {
+    const onSelect = vi.fn()
+    const onImport = vi.fn()
+
+    render(
+      <RecommendationCard
+        match={mockMatch}
+        onSelect={onSelect}
+        onImport={onImport}
+      />
+    )
+
+    expect(screen.getByText('85%')).toBeInTheDocument()
+  })
+
+  it('displays mission type', () => {
+    const onSelect = vi.fn()
+    const onImport = vi.fn()
+
+    render(
+      <RecommendationCard
+        match={mockMatch}
+        onSelect={onSelect}
+        onImport={onImport}
+      />
+    )
+
+    expect(screen.getByText('install')).toBeInTheDocument()
+  })
+
+  it('shows cluster match indicator for high scores', () => {
+    const onSelect = vi.fn()
+    const onImport = vi.fn()
+
+    render(
+      <RecommendationCard
+        match={mockClusterMatch}
+        onSelect={onSelect}
+        onImport={onImport}
+      />
+    )
+
+    // CheckCircle icon should be present for cluster matches
+    expect(screen.getByText('90%')).toBeInTheDocument()
+  })
+
+  it('displays maturity badge when available', () => {
+    const onSelect = vi.fn()
+    const onImport = vi.fn()
+
+    render(
+      <RecommendationCard
+        match={mockMissionWithMaturity}
+        onSelect={onSelect}
+        onImport={onImport}
+      />
+    )
+
+    expect(screen.getByText('graduated')).toBeInTheDocument()
+  })
+
+  it('displays match reasons when provided', () => {
+    const onSelect = vi.fn()
+    const onImport = vi.fn()
+
+    render(
+      <RecommendationCard
+        match={mockMatch}
+        onSelect={onSelect}
+        onImport={onImport}
+        compact={true}
+      />
+    )
+
+    expect(screen.getByText('Matches cluster needs')).toBeInTheDocument()
+  })
+
+  it('calls onSelect when card is clicked', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    const onImport = vi.fn()
+
+    render(
+      <RecommendationCard
+        match={mockMatch}
+        onSelect={onSelect}
+        onImport={onImport}
+        compact={true}
+      />
+    )
+
+    const card = screen.getByText('Install Prometheus').closest('div')
+    if (card) {
+      await user.click(card)
+      expect(onSelect).toHaveBeenCalled()
+    }
+  })
+
+  it('renders in compact mode', () => {
+    const onSelect = vi.fn()
+    const onImport = vi.fn()
+
+    const { container } = render(
+      <RecommendationCard
+        match={mockMatch}
+        onSelect={onSelect}
+        onImport={onImport}
+        compact={true}
+      />
+    )
+
+    expect(container.firstChild).toHaveClass('flex')
+  })
+})

--- a/web/src/components/missions/browser/__tests__/TreeNodeItem.test.tsx
+++ b/web/src/components/missions/browser/__tests__/TreeNodeItem.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * TreeNodeItem unit tests
+ *
+ * Covers: node rendering, expand/collapse, file type icons, and external repo metadata.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TreeNodeItem } from '../TreeNodeItem'
+import type { TreeNode } from '../types'
+
+const mockDirectoryNode: TreeNode = {
+  id: 'dir-1',
+  name: 'configs',
+  path: '/root/configs',
+  type: 'directory',
+  source: 'community',
+}
+
+const mockFileNode: TreeNode = {
+  id: 'file-1',
+  name: 'mission.yaml',
+  path: '/root/mission.yaml',
+  type: 'file',
+  source: 'community',
+}
+
+const mockGitHubNode: TreeNode = {
+  id: 'gh-1',
+  name: 'kube-prometheus-stack',
+  path: '/kubara/kube-prometheus-stack',
+  type: 'directory',
+  source: 'github',
+  repoOwner: 'kubara-io',
+  repoName: 'kubara',
+}
+
+const mockLoadingNode: TreeNode = {
+  ...mockDirectoryNode,
+  loading: true,
+}
+
+describe('TreeNodeItem', () => {
+  it('renders directory node with name', () => {
+    render(
+      <TreeNodeItem
+        node={mockDirectoryNode}
+        depth={0}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('configs')).toBeInTheDocument()
+  })
+
+  it('renders file node with name', () => {
+    render(
+      <TreeNodeItem
+        node={mockFileNode}
+        depth={0}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('mission.yaml')).toBeInTheDocument()
+  })
+
+  it('calls onToggle when directory is clicked', async () => {
+    const user = userEvent.setup()
+    const onToggle = vi.fn()
+
+    render(
+      <TreeNodeItem
+        node={mockDirectoryNode}
+        depth={0}
+        isExpanded={false}
+        onToggle={onToggle}
+        onSelect={vi.fn()}
+      />
+    )
+
+    const nodeButton = screen.getByText('configs').closest('button')
+    if (nodeButton) {
+      await user.click(nodeButton)
+      expect(onToggle).toHaveBeenCalledWith(mockDirectoryNode)
+    }
+  })
+
+  it('calls onSelect when file is clicked', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+
+    render(
+      <TreeNodeItem
+        node={mockFileNode}
+        depth={0}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onSelect={onSelect}
+      />
+    )
+
+    const nodeButton = screen.getByText('mission.yaml').closest('button')
+    if (nodeButton) {
+      await user.click(nodeButton)
+      expect(onSelect).toHaveBeenCalledWith(mockFileNode)
+    }
+  })
+
+  it('displays loading spinner for loading nodes', () => {
+    const { container } = render(
+      <TreeNodeItem
+        node={mockLoadingNode}
+        depth={0}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    )
+
+    // Look for loading indicator class or spinner
+    const loadingElement = container.querySelector('[class*="animate-spin"]')
+    expect(loadingElement).toBeInTheDocument()
+  })
+
+  it('applies indentation based on depth', () => {
+    const { container: depth0 } = render(
+      <TreeNodeItem
+        node={mockFileNode}
+        depth={0}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    )
+
+    const { container: depth2 } = render(
+      <TreeNodeItem
+        node={mockFileNode}
+        depth={2}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    )
+
+    // Depth affects padding/margin - containers should differ
+    expect(depth0.innerHTML).not.toBe(depth2.innerHTML)
+  })
+
+  it('renders GitHub source indicator for external repos', () => {
+    render(
+      <TreeNodeItem
+        node={mockGitHubNode}
+        depth={0}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('kube-prometheus-stack')).toBeInTheDocument()
+  })
+
+  it('shows expand/collapse chevron for directories', () => {
+    const { container } = render(
+      <TreeNodeItem
+        node={mockDirectoryNode}
+        depth={0}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    )
+
+    // ChevronRight when collapsed, ChevronDown when expanded
+    const chevron = container.querySelector('svg')
+    expect(chevron).toBeInTheDocument()
+  })
+
+  it('changes chevron direction when expanded', () => {
+    const { container: collapsed } = render(
+      <TreeNodeItem
+        node={mockDirectoryNode}
+        depth={0}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    )
+
+    const { container: expanded } = render(
+      <TreeNodeItem
+        node={mockDirectoryNode}
+        depth={0}
+        isExpanded={true}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    )
+
+    expect(collapsed.innerHTML).not.toBe(expanded.innerHTML)
+  })
+})

--- a/web/src/components/missions/browser/__tests__/VirtualizedMissionGrid.test.tsx
+++ b/web/src/components/missions/browser/__tests__/VirtualizedMissionGrid.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * VirtualizedMissionGrid unit tests
+ *
+ * Covers: grid/list rendering, virtualization setup, and responsive column calculation.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { VirtualizedMissionGrid } from '../VirtualizedMissionGrid'
+
+interface TestItem {
+  id: string
+  title: string
+}
+
+const mockItems: TestItem[] = Array.from({ length: 50 }, (_, i) => ({
+  id: `item-${i}`,
+  title: `Test Item ${i}`,
+}))
+
+describe('VirtualizedMissionGrid', () => {
+  it('renders in grid view mode', () => {
+    const renderItem = (item: TestItem) => (
+      <div key={item.id} data-testid={`item-${item.id}`}>
+        {item.title}
+      </div>
+    )
+
+    render(
+      <VirtualizedMissionGrid
+        items={mockItems}
+        viewMode="grid"
+        renderItem={renderItem}
+        maxColumns={4}
+      />
+    )
+
+    // At least some items should be rendered (virtualization)
+    const renderedItems = screen.queryAllByTestId(/item-item-/)
+    expect(renderedItems.length).toBeGreaterThan(0)
+  })
+
+  it('renders in list view mode', () => {
+    const renderItem = (item: TestItem) => (
+      <div key={item.id} data-testid={`item-${item.id}`}>
+        {item.title}
+      </div>
+    )
+
+    render(
+      <VirtualizedMissionGrid
+        items={mockItems}
+        viewMode="list"
+        renderItem={renderItem}
+        maxColumns={1}
+      />
+    )
+
+    const renderedItems = screen.queryAllByTestId(/item-item-/)
+    expect(renderedItems.length).toBeGreaterThan(0)
+  })
+
+  it('handles empty item list', () => {
+    const renderItem = (item: TestItem) => (
+      <div key={item.id}>{item.title}</div>
+    )
+
+    const { container } = render(
+      <VirtualizedMissionGrid
+        items={[]}
+        viewMode="grid"
+        renderItem={renderItem}
+        maxColumns={4}
+      />
+    )
+
+    expect(container.firstChild).toBeInTheDocument()
+  })
+
+  it('applies custom className to container', () => {
+    const renderItem = (item: TestItem) => (
+      <div key={item.id}>{item.title}</div>
+    )
+
+    const { container } = render(
+      <VirtualizedMissionGrid
+        items={mockItems}
+        viewMode="grid"
+        renderItem={renderItem}
+        maxColumns={4}
+        className="custom-class"
+      />
+    )
+
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+
+  it('applies custom inline style to container', () => {
+    const renderItem = (item: TestItem) => (
+      <div key={item.id}>{item.title}</div>
+    )
+
+    const { container } = render(
+      <VirtualizedMissionGrid
+        items={mockItems}
+        viewMode="grid"
+        renderItem={renderItem}
+        maxColumns={4}
+        style={{ height: '500px' }}
+      />
+    )
+
+    const scrollContainer = container.firstChild as HTMLElement
+    expect(scrollContainer.style.height).toBe('500px')
+  })
+
+  it('uses custom row heights', () => {
+    const renderItem = (item: TestItem) => (
+      <div key={item.id}>{item.title}</div>
+    )
+
+    const { container } = render(
+      <VirtualizedMissionGrid
+        items={mockItems}
+        viewMode="grid"
+        renderItem={renderItem}
+        maxColumns={4}
+        gridRowHeight={400}
+        listRowHeight={60}
+      />
+    )
+
+    expect(container.firstChild).toBeInTheDocument()
+  })
+
+  it('renders with different maxColumns settings', () => {
+    const renderItem = (item: TestItem) => (
+      <div key={item.id}>{item.title}</div>
+    )
+
+    const { rerender } = render(
+      <VirtualizedMissionGrid
+        items={mockItems}
+        viewMode="grid"
+        renderItem={renderItem}
+        maxColumns={2}
+      />
+    )
+
+    expect(screen.queryAllByTestId(/item-item-/).length).toBeGreaterThan(0)
+
+    rerender(
+      <VirtualizedMissionGrid
+        items={mockItems}
+        viewMode="grid"
+        renderItem={renderItem}
+        maxColumns={4}
+      />
+    )
+
+    expect(screen.queryAllByTestId(/item-item-/).length).toBeGreaterThan(0)
+  })
+
+  it('virtualizes large lists efficiently', () => {
+    const largeItemList = Array.from({ length: 1000 }, (_, i) => ({
+      id: `item-${i}`,
+      title: `Test Item ${i}`,
+    }))
+
+    const renderItem = (item: TestItem) => (
+      <div key={item.id} data-testid={`item-${item.id}`}>
+        {item.title}
+      </div>
+    )
+
+    render(
+      <VirtualizedMissionGrid
+        items={largeItemList}
+        viewMode="grid"
+        renderItem={renderItem}
+        maxColumns={4}
+      />
+    )
+
+    const renderedItems = screen.queryAllByTestId(/item-item-/)
+    // Should render fewer items than total due to virtualization
+    expect(renderedItems.length).toBeLessThan(largeItemList.length)
+    expect(renderedItems.length).toBeGreaterThan(0)
+  })
+})

--- a/web/src/components/missions/browser/__tests__/index.test.ts
+++ b/web/src/components/missions/browser/__tests__/index.test.ts
@@ -1,0 +1,85 @@
+/**
+ * browser/index.ts unit tests
+ *
+ * Verifies that all exports are available and re-exported correctly.
+ */
+
+import { describe, it, expect } from 'vitest'
+import * as browserExports from '../index'
+
+describe('browser/index exports', () => {
+  it('exports TreeNode type', () => {
+    expect(browserExports).toHaveProperty('TreeNodeItem')
+  })
+
+  it('exports ViewMode type through BROWSER_TABS', () => {
+    expect(browserExports.BROWSER_TABS).toBeDefined()
+    expect(Array.isArray(browserExports.BROWSER_TABS)).toBe(true)
+  })
+
+  it('exports BROWSER_TABS constant', () => {
+    expect(browserExports.BROWSER_TABS).toHaveLength(4)
+    expect(browserExports.BROWSER_TABS[0]).toHaveProperty('id')
+    expect(browserExports.BROWSER_TABS[0]).toHaveProperty('label')
+    expect(browserExports.BROWSER_TABS[0]).toHaveProperty('icon')
+  })
+
+  it('exports TreeNodeItem component', () => {
+    expect(typeof browserExports.TreeNodeItem).toBe('function')
+  })
+
+  it('exports DirectoryListing component', () => {
+    expect(typeof browserExports.DirectoryListing).toBe('function')
+  })
+
+  it('exports RecommendationCard component', () => {
+    expect(typeof browserExports.RecommendationCard).toBe('function')
+  })
+
+  it('exports EmptyState component', () => {
+    expect(typeof browserExports.EmptyState).toBe('function')
+  })
+
+  it('exports MissionFetchErrorBanner component', () => {
+    expect(typeof browserExports.MissionFetchErrorBanner).toBe('function')
+  })
+
+  it('exports helper functions', () => {
+    expect(typeof browserExports.getMissionSlug).toBe('function')
+    expect(typeof browserExports.getMissionShareUrl).toBe('function')
+    expect(typeof browserExports.buildDirectoryEntryNode).toBe('function')
+    expect(typeof browserExports.updateNodeInTree).toBe('function')
+    expect(typeof browserExports.removeNodeFromTree).toBe('function')
+    expect(typeof browserExports.normalizeMission).toBe('function')
+  })
+
+  it('exports mission cache functions', () => {
+    expect(browserExports.missionCache).toBeDefined()
+    expect(typeof browserExports.notifyCacheListeners).toBe('function')
+    expect(typeof browserExports.startMissionCacheFetch).toBe('function')
+    expect(typeof browserExports.resetMissionCache).toBe('function')
+    expect(typeof browserExports.fetchMissionContent).toBe('function')
+  })
+
+  it('exports recommendation cache functions', () => {
+    expect(typeof browserExports.getCachedRecommendations).toBe('function')
+    expect(typeof browserExports.setCachedRecommendations).toBe('function')
+    expect(typeof browserExports.resetRecommendationCache).toBe('function')
+  })
+
+  it('exports VirtualizedMissionGrid component', () => {
+    expect(typeof browserExports.VirtualizedMissionGrid).toBe('function')
+  })
+
+  it('exports tree fetcher functions', () => {
+    expect(typeof browserExports.fetchTreeChildren).toBe('function')
+    expect(typeof browserExports.fetchDirectoryEntries).toBe('function')
+    expect(typeof browserExports.fetchNodeFileContent).toBe('function')
+    expect(typeof browserExports.getKubaraConfig).toBe('function')
+  })
+
+  it('exports MISSION_FILE_FETCH_TIMEOUT_MS constant', () => {
+    expect(typeof browserExports.MISSION_FILE_FETCH_TIMEOUT_MS).toBe('number')
+    expect(browserExports.MISSION_FILE_FETCH_TIMEOUT_MS).toBeGreaterThan(0)
+  })
+})

--- a/web/src/components/missions/browser/__tests__/missionCache.test.ts
+++ b/web/src/components/missions/browser/__tests__/missionCache.test.ts
@@ -1,0 +1,63 @@
+/**
+ * browser/missionCache.ts unit tests
+ *
+ * Verifies that missionCache re-exports work correctly.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  missionCache,
+  notifyCacheListeners,
+  startMissionCacheFetch,
+  resetMissionCache,
+  fetchMissionContent,
+  MISSION_FILE_FETCH_TIMEOUT_MS,
+  getCachedRecommendations,
+  setCachedRecommendations,
+  resetRecommendationCache,
+  computeClusterFingerprint,
+} from '../missionCache'
+
+describe('browser/missionCache', () => {
+  it('exports missionCache object', () => {
+    expect(missionCache).toBeDefined()
+    expect(typeof missionCache).toBe('object')
+  })
+
+  it('exports notifyCacheListeners function', () => {
+    expect(typeof notifyCacheListeners).toBe('function')
+  })
+
+  it('exports startMissionCacheFetch function', () => {
+    expect(typeof startMissionCacheFetch).toBe('function')
+  })
+
+  it('exports resetMissionCache function', () => {
+    expect(typeof resetMissionCache).toBe('function')
+  })
+
+  it('exports fetchMissionContent function', () => {
+    expect(typeof fetchMissionContent).toBe('function')
+  })
+
+  it('exports MISSION_FILE_FETCH_TIMEOUT_MS constant', () => {
+    expect(typeof MISSION_FILE_FETCH_TIMEOUT_MS).toBe('number')
+    expect(MISSION_FILE_FETCH_TIMEOUT_MS).toBeGreaterThan(0)
+  })
+
+  it('exports getCachedRecommendations function', () => {
+    expect(typeof getCachedRecommendations).toBe('function')
+  })
+
+  it('exports setCachedRecommendations function', () => {
+    expect(typeof setCachedRecommendations).toBe('function')
+  })
+
+  it('exports resetRecommendationCache function', () => {
+    expect(typeof resetRecommendationCache).toBe('function')
+  })
+
+  it('exports computeClusterFingerprint function', () => {
+    expect(typeof computeClusterFingerprint).toBe('function')
+  })
+})

--- a/web/src/components/missions/browser/__tests__/types.test.ts
+++ b/web/src/components/missions/browser/__tests__/types.test.ts
@@ -1,0 +1,131 @@
+/**
+ * browser/types.ts unit tests
+ *
+ * Verifies type definitions and constants.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { BROWSER_TABS } from '../types'
+import type { TreeNode, ViewMode, BrowserTab } from '../types'
+
+describe('browser/types', () => {
+  describe('BROWSER_TABS', () => {
+    it('contains all expected tabs', () => {
+      expect(BROWSER_TABS).toHaveLength(4)
+      
+      const ids = BROWSER_TABS.map(tab => tab.id)
+      expect(ids).toContain('recommended')
+      expect(ids).toContain('installers')
+      expect(ids).toContain('fixes')
+      expect(ids).toContain('schedule')
+    })
+
+    it('each tab has required properties', () => {
+      BROWSER_TABS.forEach(tab => {
+        expect(tab).toHaveProperty('id')
+        expect(tab).toHaveProperty('label')
+        expect(tab).toHaveProperty('icon')
+        
+        expect(typeof tab.id).toBe('string')
+        expect(typeof tab.label).toBe('string')
+        expect(typeof tab.icon).toBe('string')
+      })
+    })
+
+    it('recommended tab has correct properties', () => {
+      const recommendedTab = BROWSER_TABS.find(tab => tab.id === 'recommended')
+      expect(recommendedTab).toBeDefined()
+      expect(recommendedTab?.label).toBe('Recommended')
+    })
+
+    it('installers tab has correct properties', () => {
+      const installersTab = BROWSER_TABS.find(tab => tab.id === 'installers')
+      expect(installersTab).toBeDefined()
+      expect(installersTab?.label).toBe('Installers')
+    })
+
+    it('fixes tab has correct properties', () => {
+      const fixesTab = BROWSER_TABS.find(tab => tab.id === 'fixes')
+      expect(fixesTab).toBeDefined()
+      expect(fixesTab?.label).toBe('Fixes')
+    })
+
+    it('schedule tab has correct properties', () => {
+      const scheduleTab = BROWSER_TABS.find(tab => tab.id === 'schedule')
+      expect(scheduleTab).toBeDefined()
+      expect(scheduleTab?.label).toBe('Schedule Action')
+    })
+  })
+
+  describe('TreeNode type', () => {
+    it('accepts valid file node', () => {
+      const fileNode: TreeNode = {
+        id: 'file-1',
+        name: 'mission.yaml',
+        path: '/root/mission.yaml',
+        type: 'file',
+        source: 'community',
+      }
+      
+      expect(fileNode.type).toBe('file')
+      expect(fileNode.source).toBe('community')
+    })
+
+    it('accepts valid directory node', () => {
+      const dirNode: TreeNode = {
+        id: 'dir-1',
+        name: 'configs',
+        path: '/root/configs',
+        type: 'directory',
+        source: 'github',
+        children: [],
+      }
+      
+      expect(dirNode.type).toBe('directory')
+      expect(dirNode.source).toBe('github')
+    })
+
+    it('accepts node with optional properties', () => {
+      const fullNode: TreeNode = {
+        id: 'full-1',
+        name: 'test',
+        path: '/test',
+        type: 'directory',
+        source: 'local',
+        loaded: true,
+        loading: false,
+        description: 'Test node',
+        isEmpty: false,
+        content: 'cached content',
+        repoOwner: 'owner',
+        repoName: 'repo',
+        infoTooltip: 'Info text',
+      }
+      
+      expect(fullNode.loaded).toBe(true)
+      expect(fullNode.description).toBe('Test node')
+      expect(fullNode.repoOwner).toBe('owner')
+    })
+  })
+
+  describe('ViewMode type', () => {
+    it('accepts grid view mode', () => {
+      const mode: ViewMode = 'grid'
+      expect(mode).toBe('grid')
+    })
+
+    it('accepts list view mode', () => {
+      const mode: ViewMode = 'list'
+      expect(mode).toBe('list')
+    })
+  })
+
+  describe('BrowserTab type', () => {
+    it('accepts all valid tab values', () => {
+      const tabs: BrowserTab[] = ['recommended', 'installers', 'fixes', 'schedule']
+      tabs.forEach(tab => {
+        expect(BROWSER_TABS.map(t => t.id)).toContain(tab)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fixes #19682

Adds unit tests for previously untested utility functions and components in web/src/components/missions/.

## Tests Added

### Main Components
- **MissionContentContext**: Context provider and hook tests
- **ResolutionErrorBoundary**: Error boundary behavior and recovery
- **ResolutionKnowledgePanel**: Knowledge panel rendering and interactions

### Browser Components  
- **DirectoryListing**: List/grid view modes and file interactions
- **RecommendationCard**: Card rendering and match scoring
- **TreeNodeItem**: Tree node rendering and expand/collapse
- **VirtualizedMissionGrid**: Virtualization and responsive layout

### Browser Utilities
- **browser/index.ts**: Export verification
- **browser/missionCache.ts**: Cache re-export verification
- **browser/types.ts**: Type definitions and constants

## Coverage

These tests cover 10 previously untested files, reducing the zero-coverage file count from ~30 to ~20 in the missions directory.