### PR TITLE
[scanner] test: unit tests for llmd card components

### DIFF
--- a/web/src/components/cards/llmd/__tests__/HardwareLeaderboard.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/HardwareLeaderboard.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useBenchmarkData', () => ({
+  useCachedBenchmarkReports: () => ({
+    data: [],
+    isDemoFallback: true,
+    isFailed: false,
+    consecutiveFailures: 0,
+    isLoading: false,
+    isRefreshing: false,
+    currentSince: null,
+  }),
+}))
+
+vi.mock('../../../../lib/llmd/benchmarkMockData', () => ({
+  generateLeaderboardRows: () => [],
+  CONFIG_COLORS: {},
+}))
+
+import HardwareLeaderboard from '../HardwareLeaderboard'
+
+describe('HardwareLeaderboard', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<HardwareLeaderboard />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitor.types.test.ts
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitor.types.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import type {
+  AggregationMode,
+  ViewMode,
+  MetricType,
+  PodMetricHistory,
+  PodHistoryMap,
+  AggregateMetrics,
+} from '../KVCacheMonitor.types'
+
+describe('KVCacheMonitor.types', () => {
+  describe('type guards and constants', () => {
+    it('AggregationMode accepts aggregated and disaggregated', () => {
+      const modes: AggregationMode[] = ['aggregated', 'disaggregated']
+      expect(modes).toHaveLength(2)
+    })
+
+    it('ViewMode accepts gauges, horseshoe, and heatmap', () => {
+      const views: ViewMode[] = ['gauges', 'horseshoe', 'heatmap']
+      expect(views).toHaveLength(3)
+    })
+
+    it('MetricType accepts util and hitRate', () => {
+      const metrics: MetricType[] = ['util', 'hitRate']
+      expect(metrics).toHaveLength(2)
+    })
+  })
+
+  describe('PodMetricHistory interface', () => {
+    it('stores util and hitRate arrays', () => {
+      const history: PodMetricHistory = {
+        util: [50, 60, 70],
+        hitRate: [90, 91, 92],
+      }
+      expect(history.util).toHaveLength(3)
+      expect(history.hitRate).toHaveLength(3)
+    })
+  })
+
+  describe('PodHistoryMap type', () => {
+    it('maps pod names to metric histories', () => {
+      const map: PodHistoryMap = {
+        'pod-0': { util: [50], hitRate: [90] },
+        'pod-1': { util: [60], hitRate: [85] },
+      }
+      expect(Object.keys(map)).toHaveLength(2)
+      expect(map['pod-0'].util[0]).toBe(50)
+    })
+  })
+
+  describe('AggregateMetrics interface', () => {
+    it('contains aggregate statistics fields', () => {
+      const metrics: AggregateMetrics = {
+        avgUtil: 55.5,
+        totalUsed: 120,
+        totalCapacity: 200,
+        avgHitRate: 88.3,
+      }
+      expect(metrics.avgUtil).toBe(55.5)
+      expect(metrics.totalCapacity).toBe(200)
+    })
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitorChart.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitorChart.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  ComposedChart: ({ children }: any) => <div>{children}</div>,
+  Line: () => null,
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}))
+
+import KVCacheMonitorChart from '../KVCacheMonitorChart'
+
+describe('KVCacheMonitorChart', () => {
+  const mockT = ((key: string, fallback?: string) => fallback || key) as any
+
+  it('renders without crashing with empty data', () => {
+    const { container } = render(
+      <KVCacheMonitorChart
+        podHistory={{}}
+        selectedPod={null}
+        selectedMetrics={['util']}
+        t={mockT}
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+
+  it('renders with pod history data', () => {
+    const podHistory = {
+      'pod-0': {
+        util: [50, 60, 70],
+        hitRate: [90, 91, 92],
+      },
+    }
+    const { container } = render(
+      <KVCacheMonitorChart
+        podHistory={podHistory}
+        selectedPod="pod-0"
+        selectedMetrics={['util', 'hitRate']}
+        t={mockT}
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitorDetailPanel.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitorDetailPanel.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../KVCacheMonitorChart', () => ({
+  default: () => <div data-testid="kvcache-chart">Chart</div>,
+}))
+
+import KVCacheMonitorDetailPanel from '../KVCacheMonitorDetailPanel'
+
+describe('KVCacheMonitorDetailPanel', () => {
+  const mockT = ((key: string, fallback?: string) => fallback || key) as any
+
+  it('renders nothing when no selected pod', () => {
+    const { container } = render(
+      <KVCacheMonitorDetailPanel
+        selectedPod={null}
+        panelPosition={null}
+        stats={[]}
+        podHistory={{}}
+        selectedMetrics={['util']}
+        onToggleMetric={vi.fn()}
+        onClose={vi.fn()}
+        isDemoData={false}
+        t={mockT}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders panel when pod is selected', () => {
+    const stats = [
+      {
+        cluster: 'test',
+        namespace: 'default',
+        podName: 'pod-0',
+        utilizationPercent: 75,
+        hitRate: 0.9,
+        evictionRate: 0.01,
+        totalCapacityGB: 80,
+        usedGB: 60,
+        lastUpdated: new Date(),
+      },
+    ]
+    const { getByTestId } = render(
+      <KVCacheMonitorDetailPanel
+        selectedPod="pod-0"
+        panelPosition={{ x: 100, y: 100 }}
+        stats={stats}
+        podHistory={{ 'pod-0': { util: [75], hitRate: [90] } }}
+        selectedMetrics={['util']}
+        onToggleMetric={vi.fn()}
+        onClose={vi.fn()}
+        isDemoData={false}
+        t={mockT}
+      />
+    )
+    expect(getByTestId('kvcache-chart')).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitorHeader.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitorHeader.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('lucide-react', () => ({
+  Grid3x3: () => <span>Grid</span>,
+  Gauge: () => <span>Gauge</span>,
+  Activity: () => <span>Activity</span>,
+}))
+
+import KVCacheMonitorHeader from '../KVCacheMonitorHeader'
+
+describe('KVCacheMonitorHeader', () => {
+  const mockT = ((key: string, fallback?: string) => fallback || key) as any
+
+  it('renders without crashing', () => {
+    const { container } = render(
+      <KVCacheMonitorHeader
+        viewMode="gauges"
+        aggregationMode="aggregated"
+        selectedStack={null}
+        isDemoMode={true}
+        onViewModeToggle={vi.fn()}
+        onAggregationModeChange={vi.fn()}
+        t={mockT}
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+
+  it('renders with selected stack', () => {
+    const stack = {
+      cluster: 'test',
+      namespace: 'llmd',
+      name: 'test-stack',
+      components: {
+        prefill: [],
+        decode: [],
+        both: [],
+      },
+    }
+    const { container } = render(
+      <KVCacheMonitorHeader
+        viewMode="heatmap"
+        aggregationMode="disaggregated"
+        selectedStack={stack as any}
+        isDemoMode={false}
+        onViewModeToggle={vi.fn()}
+        onAggregationModeChange={vi.fn()}
+        t={mockT}
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/LLMdConfigurator.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/LLMdConfigurator.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useStackDiscovery', () => ({
+  useStackDiscovery: () => ({ stacks: [], selectedStack: null, setSelectedStack: vi.fn() }),
+}))
+
+vi.mock('../../../../hooks/useLLMdConfigData', () => ({
+  useLLMdConfigData: () => ({ configs: [], isLoading: false }),
+}))
+
+import LLMdConfigurator from '../LLMdConfigurator'
+
+describe('LLMdConfigurator', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<LLMdConfigurator />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/LLMdFlowNodes.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/LLMdFlowNodes.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { NODE_POSITIONS, CONNECTIONS, COLORS, PremiumNode } from '../LLMdFlowNodes'
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    circle: ({ children, ...props }: any) => <circle {...props}>{children}</circle>,
+    path: ({ children, ...props }: any) => <path {...props}>{children}</path>,
+    g: ({ children, ...props }: any) => <g {...props}>{children}</g>,
+  },
+}))
+
+vi.mock('./shared/colorUtils', () => ({
+  getLoadColors: (load: number) => ({
+    start: '#f59e0b',
+    end: '#ef4444',
+    glow: '#f59e0b',
+  }),
+  getHorseshoeColor: (value: number) => '#22c55e',
+}))
+
+describe('LLMdFlowNodes', () => {
+  describe('NODE_POSITIONS', () => {
+    it('has positions for all expected nodes', () => {
+      expect(NODE_POSITIONS.client).toBeDefined()
+      expect(NODE_POSITIONS.gateway).toBeDefined()
+      expect(NODE_POSITIONS.epp).toBeDefined()
+      expect(NODE_POSITIONS.prefill0).toBeDefined()
+      expect(NODE_POSITIONS.decode0).toBeDefined()
+    })
+
+    it('positions have x and y coordinates', () => {
+      expect(NODE_POSITIONS.client.x).toBeGreaterThanOrEqual(0)
+      expect(NODE_POSITIONS.client.y).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  describe('CONNECTIONS', () => {
+    it('has expected connections', () => {
+      expect(CONNECTIONS.length).toBeGreaterThan(0)
+    })
+
+    it('each connection has required fields', () => {
+      CONNECTIONS.forEach(conn => {
+        expect(conn.from).toBeDefined()
+        expect(conn.to).toBeDefined()
+        expect(conn.type).toBeDefined()
+        expect(conn.trafficPercent).toBeGreaterThanOrEqual(0)
+      })
+    })
+
+    it('traffic percentages are valid', () => {
+      CONNECTIONS.forEach(conn => {
+        expect(conn.trafficPercent).toBeGreaterThanOrEqual(0)
+        expect(conn.trafficPercent).toBeLessThanOrEqual(100)
+      })
+    })
+  })
+
+  describe('COLORS', () => {
+    it('has colors for connection types', () => {
+      expect(COLORS.prefill).toBeDefined()
+      expect(COLORS.decode).toBeDefined()
+      expect(COLORS['kv-transfer']).toBeDefined()
+    })
+
+    it('colors are hex strings', () => {
+      expect(COLORS.prefill).toMatch(/^#[0-9a-f]{6}$/i)
+      expect(COLORS.decode).toMatch(/^#[0-9a-f]{6}$/i)
+    })
+  })
+
+  describe('PremiumNode', () => {
+    it('renders without crashing', () => {
+      const { container } = render(
+        <svg>
+          <PremiumNode
+            id="client"
+            label="Client"
+            nodeColor="#3b82f6"
+            uniqueId="test-client"
+            nodePositions={NODE_POSITIONS}
+          />
+        </svg>
+      )
+      expect(container.querySelector('circle')).toBeTruthy()
+    })
+
+    it('returns null for unknown node id', () => {
+      const { container } = render(
+        <svg>
+          <PremiumNode
+            id="unknown"
+            label="Unknown"
+            nodeColor="#3b82f6"
+            uniqueId="test-unknown"
+            nodePositions={NODE_POSITIONS}
+          />
+        </svg>
+      )
+      expect(container.querySelector('circle')).toBeNull()
+    })
+
+    it('renders with metrics', () => {
+      const { container } = render(
+        <svg>
+          <PremiumNode
+            id="prefill0"
+            label="Prefill 0"
+            metrics={{ load: 75, queueDepth: 10 }}
+            nodeColor="#9333ea"
+            uniqueId="test-prefill"
+            nodePositions={NODE_POSITIONS}
+          />
+        </svg>
+      )
+      expect(container.querySelector('circle')).toBeTruthy()
+    })
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/LatencyBreakdown.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/LatencyBreakdown.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  BarChart: ({ children }: any) => <div>{children}</div>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  Cell: () => null,
+}))
+
+import LatencyBreakdown from '../LatencyBreakdown'
+
+describe('LatencyBreakdown', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<LatencyBreakdown />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/NightlyE2EDetailPanel.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/NightlyE2EDetailPanel.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  LineChart: ({ children }: any) => <div>{children}</div>,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}))
+
+import NightlyE2EDetailPanel from '../NightlyE2EDetailPanel'
+
+describe('NightlyE2EDetailPanel', () => {
+  const mockT = ((key: string, fallback?: string) => fallback || key) as any
+
+  it('renders without crashing when no guide selected', () => {
+    const { container } = render(
+      <NightlyE2EDetailPanel
+        selectedGuide={null}
+        allRuns={[]}
+        onClose={vi.fn()}
+        t={mockT}
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+
+  it('renders with selected guide', () => {
+    const guide = {
+      model: 'llama-3-70b',
+      gpuType: 'H100',
+      gpuCount: 4,
+      platform: 'OCP',
+      recentRuns: [],
+    }
+    const { container } = render(
+      <NightlyE2EDetailPanel
+        selectedGuide={guide as any}
+        allRuns={[]}
+        onClose={vi.fn()}
+        t={mockT}
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/NightlyE2EGuideRow.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/NightlyE2EGuideRow.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  LineChart: ({ children }: any) => <div>{children}</div>,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+}))
+
+vi.mock('lucide-react', () => ({
+  TrendingUp: () => <span>TrendingUp</span>,
+  TrendingDown: () => <span>TrendingDown</span>,
+  Minus: () => <span>Minus</span>,
+  ChevronRight: () => <span>ChevronRight</span>,
+}))
+
+import NightlyE2EGuideRow from '../NightlyE2EGuideRow'
+
+describe('NightlyE2EGuideRow', () => {
+  const mockT = ((key: string, fallback?: string) => fallback || key) as any
+
+  it('renders without crashing', () => {
+    const guide = {
+      model: 'llama-3-70b',
+      gpuType: 'H100',
+      gpuCount: 4,
+      platform: 'OCP',
+      recentRuns: [],
+      passRate: 0.9,
+      avgDurationMin: 45,
+      lastRun: null,
+    }
+    const { container } = render(
+      <NightlyE2EGuideRow
+        guide={guide as any}
+        onClick={vi.fn()}
+        t={mockT}
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+
+  it('renders with recent runs data', () => {
+    const guide = {
+      model: 'mistral-7b',
+      gpuType: 'A100',
+      gpuCount: 2,
+      platform: 'GKE',
+      recentRuns: [
+        { status: 'completed', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T01:00:00Z' },
+      ],
+      passRate: 1.0,
+      avgDurationMin: 30,
+      lastRun: { status: 'completed', createdAt: '2026-01-01T00:00:00Z' },
+    }
+    const { container } = render(
+      <NightlyE2EGuideRow
+        guide={guide as any}
+        onClick={vi.fn()}
+        t={mockT}
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/ParetoFrontier.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/ParetoFrontier.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  ComposedChart: ({ children }: any) => <div>{children}</div>,
+  Line: () => null,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}))
+
+import ParetoFrontier from '../ParetoFrontier'
+
+describe('ParetoFrontier', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<ParetoFrontier />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/PerformanceTimeline.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/PerformanceTimeline.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  LineChart: ({ children }: any) => <div>{children}</div>,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}))
+
+import PerformanceTimeline from '../PerformanceTimeline'
+
+describe('PerformanceTimeline', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<PerformanceTimeline />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/ResourceUtilization.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/ResourceUtilization.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  BarChart: ({ children }: any) => <div>{children}</div>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}))
+
+import ResourceUtilization from '../ResourceUtilization'
+
+describe('ResourceUtilization', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<ResourceUtilization />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/llmd/__tests__/ThroughputComparison.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/ThroughputComparison.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useReportCardDataState: vi.fn(),
+  useCardLoadingState: vi.fn(),
+}))
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  BarChart: ({ children }: any) => <div>{children}</div>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}))
+
+import ThroughputComparison from '../ThroughputComparison'
+
+describe('ThroughputComparison', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<ThroughputComparison />)
+    expect(container).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Fixes #19681

Adds unit tests for previously untested utility functions and components in web/src/components/cards/llmd/.

## Changes

- KVCacheMonitor.types.test.ts: Type definitions and interfaces
- HardwareLeaderboard.test.tsx: Sortable leaderboard table component  
- KVCacheMonitorChart.test.tsx: Time-series chart visualization
- KVCacheMonitorDetailPanel.test.tsx: Detail panel with metrics
- KVCacheMonitorHeader.test.tsx: Header with view mode controls
- LLMdConfigurator.test.tsx: Stack configuration component
- LLMdFlowNodes.test.tsx: Flow diagram nodes and connections
- LatencyBreakdown.test.tsx: Latency breakdown visualization
- NightlyE2EDetailPanel.test.tsx: E2E test detail panel
- NightlyE2EGuideRow.test.tsx: E2E guide row component
- ParetoFrontier.test.tsx: Pareto frontier chart
- PerformanceTimeline.test.tsx: Performance timeline chart
- ResourceUtilization.test.tsx: Resource utilization charts
- ThroughputComparison.test.tsx: Throughput comparison charts

All tests follow existing project patterns with appropriate mocks for dependencies like react-i18next, recharts, and card context providers.