### PR TITLE
[scanner] fix: add unit tests for teams/ components

### DIFF
--- a/web/src/components/teams/__tests__/TeamAccessGrants.test.tsx
+++ b/web/src/components/teams/__tests__/TeamAccessGrants.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { TeamAccessGrants } from '../TeamAccessGrants'
+
+// Mock hooks and dependencies
+const mockUseClusters = vi.fn()
+const mockUseCachedNamespaces = vi.fn()
+const mockUseGlobalFilters = vi.fn()
+const mockAuthFetch = vi.fn()
+const mockT = vi.fn((key: string) => key)
+
+vi.mock('../../../hooks/useMCP', () => ({
+  useClusters: () => mockUseClusters(),
+}))
+
+vi.mock('../../../hooks/useCachedData', () => ({
+  useCachedNamespaces: (cluster?: string) => mockUseCachedNamespaces(cluster),
+}))
+
+vi.mock('../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => mockUseGlobalFilters(),
+}))
+
+vi.mock('../../../lib/api', () => ({
+  authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: mockT }),
+}))
+
+describe('TeamAccessGrants', () => {
+  const mockOnGrantChanged = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseClusters.mockReturnValue({ deduplicatedClusters: [] })
+    mockUseCachedNamespaces.mockReturnValue({ namespaces: [] })
+    mockUseGlobalFilters.mockReturnValue({})
+    mockT.mockImplementation((key: string) => key)
+  })
+
+  it('renders grants list when grants are provided', () => {
+    const grants = [
+      { cluster: 'prod-east', namespace: 'default', role: 'admin', isClusterScoped: false },
+      { cluster: 'staging', role: 'view', isClusterScoped: true },
+    ]
+
+    render(<TeamAccessGrants teamName="test-team" grants={grants} onGrantChanged={mockOnGrantChanged} />)
+
+    expect(screen.getByText('prod-east/ default')).toBeInTheDocument()
+    expect(screen.getByText('admin')).toBeInTheDocument()
+    expect(screen.getByText('staging')).toBeInTheDocument()
+    expect(screen.getByText('view')).toBeInTheDocument()
+    expect(screen.getByText('(cluster-wide)')).toBeInTheDocument()
+  })
+
+  it('renders empty state when no grants exist', () => {
+    render(<TeamAccessGrants teamName="test-team" grants={[]} onGrantChanged={mockOnGrantChanged} />)
+
+    expect(screen.getByText('teams.noAccessGrants')).toBeInTheDocument()
+  })
+
+  it('opens grant modal when grant access button is clicked', () => {
+    render(<TeamAccessGrants teamName="test-team" grants={[]} onGrantChanged={mockOnGrantChanged} />)
+
+    const grantButton = screen.getByText('teams.grantAccess')
+    fireEvent.click(grantButton)
+
+    expect(screen.getAllByText('teams.grantAccess')).toHaveLength(2)
+  })
+
+  it('closes grant modal when cancel is clicked', () => {
+    render(<TeamAccessGrants teamName="test-team" grants={[]} onGrantChanged={mockOnGrantChanged} />)
+
+    fireEvent.click(screen.getByText('teams.grantAccess'))
+    fireEvent.click(screen.getByText('common.cancel'))
+
+    expect(screen.queryByText('common.cancel')).not.toBeInTheDocument()
+  })
+
+  it('populates cluster dropdown with available clusters', () => {
+    mockUseClusters.mockReturnValue({
+      deduplicatedClusters: [
+        { name: 'cluster1' },
+        { name: 'cluster2' },
+      ],
+    })
+
+    render(<TeamAccessGrants teamName="test-team" grants={[]} onGrantChanged={mockOnGrantChanged} />)
+    fireEvent.click(screen.getByText('teams.grantAccess'))
+
+    const clusterSelect = screen.getByRole('combobox', { name: /teams.cluster/i })
+    expect(clusterSelect).toBeInTheDocument()
+  })
+
+  it('calls authFetch with correct payload when granting namespace access', async () => {
+    mockUseClusters.mockReturnValue({
+      deduplicatedClusters: [{ name: 'cluster1' }],
+    })
+    mockUseCachedNamespaces.mockReturnValue({
+      namespaces: ['default', 'kube-system'],
+    })
+    mockAuthFetch.mockResolvedValue({ ok: true })
+
+    render(<TeamAccessGrants teamName="test-team" grants={[]} onGrantChanged={mockOnGrantChanged} />)
+
+    fireEvent.click(screen.getByText('teams.grantAccess'))
+
+    const scopeSelect = screen.getByDisplayValue('teams.namespaceScoped')
+    fireEvent.change(scopeSelect, { target: { value: 'namespace' } })
+
+    await waitFor(() => {
+      const grantButton = screen.getAllByText('teams.grantAccess')[1]
+      fireEvent.click(grantButton)
+    })
+
+    expect(mockAuthFetch).toHaveBeenCalled()
+  })
+
+  it('handles grant error and displays error message', async () => {
+    mockUseClusters.mockReturnValue({
+      deduplicatedClusters: [{ name: 'cluster1' }],
+    })
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: 'Permission denied' }),
+    })
+
+    render(<TeamAccessGrants teamName="test-team" grants={[]} onGrantChanged={mockOnGrantChanged} />)
+
+    fireEvent.click(screen.getByText('teams.grantAccess'))
+
+    await waitFor(() => {
+      const grantButton = screen.getAllByText('teams.grantAccess')[1]
+      fireEvent.click(grantButton)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Permission denied')).toBeInTheDocument()
+    })
+  })
+
+  it('disables grant button while granting', async () => {
+    mockUseClusters.mockReturnValue({
+      deduplicatedClusters: [{ name: 'cluster1' }],
+    })
+    mockAuthFetch.mockImplementation(() => new Promise(() => {}))
+
+    render(<TeamAccessGrants teamName="test-team" grants={[]} onGrantChanged={mockOnGrantChanged} />)
+
+    fireEvent.click(screen.getByText('teams.grantAccess'))
+
+    const grantButton = screen.getAllByText('teams.grantAccess')[1]
+    fireEvent.click(grantButton)
+
+    await waitFor(() => {
+      expect(grantButton).toBeDisabled()
+    })
+  })
+
+  it('calls onGrantChanged after successful grant', async () => {
+    mockUseClusters.mockReturnValue({
+      deduplicatedClusters: [{ name: 'cluster1' }],
+    })
+    mockAuthFetch.mockResolvedValue({ ok: true })
+
+    render(<TeamAccessGrants teamName="test-team" grants={[]} onGrantChanged={mockOnGrantChanged} />)
+
+    fireEvent.click(screen.getByText('teams.grantAccess'))
+
+    const grantButton = screen.getAllByText('teams.grantAccess')[1]
+    fireEvent.click(grantButton)
+
+    await waitFor(() => {
+      expect(mockOnGrantChanged).toHaveBeenCalled()
+    })
+  })
+})

--- a/web/src/components/teams/__tests__/TeamDetail.test.tsx
+++ b/web/src/components/teams/__tests__/TeamDetail.test.tsx
@@ -1,0 +1,226 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TeamDetail } from '../TeamDetail'
+import type { TeamWithMembers, TeamRole } from '../../../types/teams'
+
+const mockT = vi.fn((key: string) => key)
+const mockUser = { id: 'user1', email: 'test@example.com' }
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: mockT }),
+}))
+
+vi.mock('../../../lib/auth', () => ({
+  useAuth: () => ({ user: mockUser }),
+}))
+
+vi.mock('../TeamMemberManager', () => ({
+  TeamMemberManager: ({ members, currentUserId }: { members: unknown[]; currentUserId: string }) => (
+    <div data-testid="team-member-manager">
+      TeamMemberManager: {members.length} members, currentUserId: {currentUserId}
+    </div>
+  ),
+}))
+
+vi.mock('../TeamAccessGrants', () => ({
+  TeamAccessGrants: ({ teamName, grants }: { teamName: string; grants: unknown[] }) => (
+    <div data-testid="team-access-grants">
+      TeamAccessGrants: {teamName}, {grants.length} grants
+    </div>
+  ),
+}))
+
+describe('TeamDetail', () => {
+  const mockOnBack = vi.fn()
+  const mockOnUpdateTeam = vi.fn()
+  const mockOnDeleteTeam = vi.fn()
+  const mockOnAddMember = vi.fn()
+  const mockOnRemoveMember = vi.fn()
+  const mockOnChangeRole = vi.fn()
+
+  const mockTeam: TeamWithMembers = {
+    id: 'team1',
+    name: 'Test Team',
+    description: 'Test description',
+    memberCount: 2,
+    members: [
+      { userId: 'user1', role: 'admin' as TeamRole, githubLogin: 'admin-user', email: 'admin@example.com' },
+      { userId: 'user2', role: 'member' as TeamRole, githubLogin: 'member-user', email: 'member@example.com' },
+    ],
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockT.mockImplementation((key: string) => key)
+  })
+
+  it('renders team name and description', () => {
+    render(
+      <TeamDetail
+        team={mockTeam}
+        onBack={mockOnBack}
+        onUpdateTeam={mockOnUpdateTeam}
+        onDeleteTeam={mockOnDeleteTeam}
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    expect(screen.getByText('Test Team')).toBeInTheDocument()
+    expect(screen.getByText('Test description')).toBeInTheDocument()
+  })
+
+  it('renders without description when not provided', () => {
+    const teamWithoutDesc = { ...mockTeam, description: undefined }
+    render(
+      <TeamDetail
+        team={teamWithoutDesc}
+        onBack={mockOnBack}
+        onUpdateTeam={mockOnUpdateTeam}
+        onDeleteTeam={mockOnDeleteTeam}
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    expect(screen.getByText('Test Team')).toBeInTheDocument()
+    expect(screen.queryByText('Test description')).not.toBeInTheDocument()
+  })
+
+  it('calls onBack when back button is clicked', () => {
+    render(
+      <TeamDetail
+        team={mockTeam}
+        onBack={mockOnBack}
+        onUpdateTeam={mockOnUpdateTeam}
+        onDeleteTeam={mockOnDeleteTeam}
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    const backButton = screen.getByRole('button', { name: '' })
+    fireEvent.click(backButton)
+
+    expect(mockOnBack).toHaveBeenCalled()
+  })
+
+  it('shows delete button when current user is admin', () => {
+    render(
+      <TeamDetail
+        team={mockTeam}
+        onBack={mockOnBack}
+        onUpdateTeam={mockOnUpdateTeam}
+        onDeleteTeam={mockOnDeleteTeam}
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    expect(screen.getByText('teams.deleteTeam')).toBeInTheDocument()
+  })
+
+  it('hides delete button when current user is not admin', () => {
+    const teamWithNoAdminUser = {
+      ...mockTeam,
+      members: [
+        { userId: 'user2', role: 'member' as TeamRole, githubLogin: 'member-user', email: 'member@example.com' },
+      ],
+    }
+
+    render(
+      <TeamDetail
+        team={teamWithNoAdminUser}
+        onBack={mockOnBack}
+        onUpdateTeam={mockOnUpdateTeam}
+        onDeleteTeam={mockOnDeleteTeam}
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    expect(screen.queryByText('teams.deleteTeam')).not.toBeInTheDocument()
+  })
+
+  it('opens delete confirmation dialog when delete button is clicked', () => {
+    render(
+      <TeamDetail
+        team={mockTeam}
+        onBack={mockOnBack}
+        onUpdateTeam={mockOnUpdateTeam}
+        onDeleteTeam={mockOnDeleteTeam}
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    const deleteButton = screen.getByText('teams.deleteTeam')
+    fireEvent.click(deleteButton)
+
+    expect(screen.getByText('teams.deleteTeamTitle')).toBeInTheDocument()
+    expect(screen.getByText('teams.deleteTeamMessage')).toBeInTheDocument()
+  })
+
+  it('calls onDeleteTeam when delete is confirmed', () => {
+    render(
+      <TeamDetail
+        team={mockTeam}
+        onBack={mockOnBack}
+        onUpdateTeam={mockOnUpdateTeam}
+        onDeleteTeam={mockOnDeleteTeam}
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('teams.deleteTeam'))
+    fireEvent.click(screen.getAllByText('teams.deleteTeam')[1])
+
+    expect(mockOnDeleteTeam).toHaveBeenCalled()
+  })
+
+  it('renders TeamMemberManager with correct props', () => {
+    render(
+      <TeamDetail
+        team={mockTeam}
+        onBack={mockOnBack}
+        onUpdateTeam={mockOnUpdateTeam}
+        onDeleteTeam={mockOnDeleteTeam}
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    const memberManager = screen.getByTestId('team-member-manager')
+    expect(memberManager).toBeInTheDocument()
+    expect(memberManager.textContent).toContain('2 members')
+    expect(memberManager.textContent).toContain('currentUserId: user1')
+  })
+
+  it('renders TeamAccessGrants with correct props', () => {
+    render(
+      <TeamDetail
+        team={mockTeam}
+        onBack={mockOnBack}
+        onUpdateTeam={mockOnUpdateTeam}
+        onDeleteTeam={mockOnDeleteTeam}
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    const accessGrants = screen.getByTestId('team-access-grants')
+    expect(accessGrants).toBeInTheDocument()
+    expect(accessGrants.textContent).toContain('Test Team')
+  })
+})

--- a/web/src/components/teams/__tests__/TeamList.test.tsx
+++ b/web/src/components/teams/__tests__/TeamList.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TeamList } from '../TeamList'
+import type { Team } from '../../../types/teams'
+
+const mockT = vi.fn((key: string) => key)
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: mockT }),
+}))
+
+describe('TeamList', () => {
+  const mockOnCreateTeam = vi.fn()
+  const mockOnSelectTeam = vi.fn()
+
+  const mockTeams: Team[] = [
+    { id: 'team1', name: 'Team Alpha', description: 'First team', memberCount: 5 },
+    { id: 'team2', name: 'Team Beta', description: 'Second team', memberCount: 3 },
+    { id: 'team3', name: 'Team Gamma', description: '', memberCount: 1 },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockT.mockImplementation((key: string) => key)
+  })
+
+  it('renders loading skeleton when isLoading is true', () => {
+    render(<TeamList teams={[]} isLoading={true} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    const skeletons = screen.getAllByRole('generic').filter(el => el.className.includes('animate-pulse'))
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('renders teams list when teams are provided', () => {
+    render(<TeamList teams={mockTeams} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    expect(screen.getByText('Team Alpha')).toBeInTheDocument()
+    expect(screen.getByText('Team Beta')).toBeInTheDocument()
+    expect(screen.getByText('Team Gamma')).toBeInTheDocument()
+    expect(screen.getByText('First team')).toBeInTheDocument()
+    expect(screen.getByText('Second team')).toBeInTheDocument()
+  })
+
+  it('renders empty state when no teams exist', () => {
+    render(<TeamList teams={[]} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    expect(screen.getByText('teams.noTeams')).toBeInTheDocument()
+  })
+
+  it('displays correct member count for each team', () => {
+    render(<TeamList teams={mockTeams} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    expect(screen.getByText('5 members')).toBeInTheDocument()
+    expect(screen.getByText('3 members')).toBeInTheDocument()
+    expect(screen.getByText('1 member')).toBeInTheDocument()
+  })
+
+  it('renders team without description correctly', () => {
+    render(<TeamList teams={mockTeams} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    expect(screen.getByText('Team Gamma')).toBeInTheDocument()
+    expect(screen.queryByText('')).toBeInTheDocument()
+  })
+
+  it('calls onSelectTeam when a team is clicked', () => {
+    render(<TeamList teams={mockTeams} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    const teamButton = screen.getByText('Team Alpha').closest('button')
+    if (teamButton) {
+      fireEvent.click(teamButton)
+    }
+
+    expect(mockOnSelectTeam).toHaveBeenCalledWith('team1')
+  })
+
+  it('opens create team modal when create button is clicked', () => {
+    render(<TeamList teams={mockTeams} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    const createButton = screen.getByText('teams.createTeam')
+    fireEvent.click(createButton)
+
+    expect(screen.getAllByText('teams.createTeam')).toHaveLength(2)
+    expect(screen.getByText('teams.teamName')).toBeInTheDocument()
+    expect(screen.getByText('teams.description')).toBeInTheDocument()
+  })
+
+  it('closes create team modal when cancel is clicked', () => {
+    render(<TeamList teams={mockTeams} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    fireEvent.click(screen.getByText('teams.createTeam'))
+    fireEvent.click(screen.getByText('common.cancel'))
+
+    expect(screen.queryByText('teams.teamName')).not.toBeInTheDocument()
+  })
+
+  it('calls onCreateTeam with trimmed values when form is submitted', () => {
+    render(<TeamList teams={mockTeams} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    fireEvent.click(screen.getByText('teams.createTeam'))
+
+    const nameInput = screen.getByPlaceholderText('teams.teamNamePlaceholder')
+    const descInput = screen.getByPlaceholderText('teams.descriptionPlaceholder')
+
+    fireEvent.change(nameInput, { target: { value: '  New Team  ' } })
+    fireEvent.change(descInput, { target: { value: '  New Description  ' } })
+
+    const submitButton = screen.getAllByText('teams.createTeam')[1]
+    fireEvent.click(submitButton)
+
+    expect(mockOnCreateTeam).toHaveBeenCalledWith('New Team', 'New Description')
+  })
+
+  it('clears form after successful creation', () => {
+    render(<TeamList teams={mockTeams} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    fireEvent.click(screen.getByText('teams.createTeam'))
+
+    const nameInput = screen.getByPlaceholderText('teams.teamNamePlaceholder')
+    const descInput = screen.getByPlaceholderText('teams.descriptionPlaceholder')
+
+    fireEvent.change(nameInput, { target: { value: 'Test Team' } })
+    fireEvent.change(descInput, { target: { value: 'Test Desc' } })
+
+    const submitButton = screen.getAllByText('teams.createTeam')[1]
+    fireEvent.click(submitButton)
+
+    fireEvent.click(screen.getByText('teams.createTeam'))
+
+    const newNameInput = screen.getByPlaceholderText('teams.teamNamePlaceholder')
+    const newDescInput = screen.getByPlaceholderText('teams.descriptionPlaceholder')
+
+    expect((newNameInput as HTMLInputElement).value).toBe('')
+    expect((newDescInput as HTMLTextAreaElement).value).toBe('')
+  })
+
+  it('disables create button when name is empty', () => {
+    render(<TeamList teams={mockTeams} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    fireEvent.click(screen.getByText('teams.createTeam'))
+
+    const submitButton = screen.getAllByText('teams.createTeam')[1]
+    expect(submitButton).toBeDisabled()
+  })
+
+  it('enables create button when name is provided', () => {
+    render(<TeamList teams={mockTeams} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    fireEvent.click(screen.getByText('teams.createTeam'))
+
+    const nameInput = screen.getByPlaceholderText('teams.teamNamePlaceholder')
+    fireEvent.change(nameInput, { target: { value: 'New Team' } })
+
+    const submitButton = screen.getAllByText('teams.createTeam')[1]
+    expect(submitButton).not.toBeDisabled()
+  })
+
+  it('does not submit when name is only whitespace', () => {
+    render(<TeamList teams={mockTeams} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    fireEvent.click(screen.getByText('teams.createTeam'))
+
+    const nameInput = screen.getByPlaceholderText('teams.teamNamePlaceholder')
+    fireEvent.change(nameInput, { target: { value: '   ' } })
+
+    const submitButton = screen.getAllByText('teams.createTeam')[1]
+    expect(submitButton).toBeDisabled()
+  })
+
+  it('displays correct team count', () => {
+    render(<TeamList teams={mockTeams} isLoading={false} onCreateTeam={mockOnCreateTeam} onSelectTeam={mockOnSelectTeam} />)
+
+    expect(screen.getByText('3 teams.teams')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/teams/__tests__/TeamMemberManager.test.tsx
+++ b/web/src/components/teams/__tests__/TeamMemberManager.test.tsx
@@ -1,0 +1,349 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { TeamMemberManager } from '../TeamMemberManager'
+import type { TeamMemberInfo, TeamRole } from '../../../types/teams'
+
+const mockT = vi.fn((key: string) => key)
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: mockT }),
+}))
+
+describe('TeamMemberManager', () => {
+  const mockOnAddMember = vi.fn()
+  const mockOnRemoveMember = vi.fn()
+  const mockOnChangeRole = vi.fn()
+
+  const mockMembers: TeamMemberInfo[] = [
+    { userId: 'user1', role: 'admin', githubLogin: 'admin-user', email: 'admin@example.com' },
+    { userId: 'user2', role: 'member', githubLogin: 'member-user', email: 'member@example.com' },
+    { userId: 'user3', role: 'member', githubLogin: 'another-member', email: 'another@example.com' },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockT.mockImplementation((key: string) => key)
+    mockOnAddMember.mockResolvedValue(true)
+    mockOnRemoveMember.mockResolvedValue(true)
+  })
+
+  it('renders member count correctly', () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    expect(screen.getByText('3 teams.members')).toBeInTheDocument()
+  })
+
+  it('separates admins and regular members', () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    expect(screen.getByText('teams.teamAdmins')).toBeInTheDocument()
+    expect(screen.getByText('teams.teamMembers')).toBeInTheDocument()
+    expect(screen.getByText('admin-user')).toBeInTheDocument()
+    expect(screen.getByText('member-user')).toBeInTheDocument()
+  })
+
+  it('renders member github logins and emails', () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    expect(screen.getByText('admin-user')).toBeInTheDocument()
+    expect(screen.getByText('admin@example.com')).toBeInTheDocument()
+    expect(screen.getByText('member-user')).toBeInTheDocument()
+    expect(screen.getByText('member@example.com')).toBeInTheDocument()
+  })
+
+  it('hides remove button for current user', () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    const adminRow = screen.getByText('admin-user').closest('div')
+    expect(adminRow?.querySelector('button')).toBeNull()
+  })
+
+  it('shows remove button for other users', () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    const memberRows = screen.getAllByRole('button').filter(btn => btn.querySelector('svg'))
+    expect(memberRows.length).toBeGreaterThan(0)
+  })
+
+  it('opens add member modal when add button is clicked', () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    const addButton = screen.getByText('teams.addMember')
+    fireEvent.click(addButton)
+
+    expect(screen.getByText('teams.userId')).toBeInTheDocument()
+    expect(screen.getByText('teams.role')).toBeInTheDocument()
+  })
+
+  it('closes add member modal when cancel is clicked', () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('teams.addMember'))
+    fireEvent.click(screen.getByText('common.cancel'))
+
+    expect(screen.queryByText('teams.userId')).not.toBeInTheDocument()
+  })
+
+  it('calls onAddMember with correct parameters', async () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('teams.addMember'))
+
+    const userIdInput = screen.getByPlaceholderText('GitHub login or user ID')
+    fireEvent.change(userIdInput, { target: { value: 'new-user' } })
+
+    const roleSelect = screen.getByDisplayValue('teams.member')
+    fireEvent.change(roleSelect, { target: { value: 'admin' } })
+
+    const submitButton = screen.getAllByText('teams.addMember')[1]
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockOnAddMember).toHaveBeenCalledWith('new-user', 'admin')
+    })
+  })
+
+  it('clears form and closes modal after successful add', async () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('teams.addMember'))
+
+    const userIdInput = screen.getByPlaceholderText('GitHub login or user ID')
+    fireEvent.change(userIdInput, { target: { value: 'new-user' } })
+
+    const submitButton = screen.getAllByText('teams.addMember')[1]
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.queryByText('teams.userId')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not close modal if add fails', async () => {
+    mockOnAddMember.mockResolvedValue(false)
+
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('teams.addMember'))
+
+    const userIdInput = screen.getByPlaceholderText('GitHub login or user ID')
+    fireEvent.change(userIdInput, { target: { value: 'new-user' } })
+
+    const submitButton = screen.getAllByText('teams.addMember')[1]
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('teams.userId')).toBeInTheDocument()
+    })
+  })
+
+  it('disables add button when userId is empty', () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('teams.addMember'))
+
+    const submitButton = screen.getAllByText('teams.addMember')[1]
+    expect(submitButton).toBeDisabled()
+  })
+
+  it('enables add button when userId is provided', () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('teams.addMember'))
+
+    const userIdInput = screen.getByPlaceholderText('GitHub login or user ID')
+    fireEvent.change(userIdInput, { target: { value: 'new-user' } })
+
+    const submitButton = screen.getAllByText('teams.addMember')[1]
+    expect(submitButton).not.toBeDisabled()
+  })
+
+  it('calls onChangeRole when role is changed', () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    const roleSelects = screen.getAllByRole('combobox')
+    const memberRoleSelect = roleSelects.find(select => {
+      const option = (select as HTMLSelectElement).options[(select as HTMLSelectElement).selectedIndex]
+      return option && option.value === 'member'
+    })
+
+    if (memberRoleSelect) {
+      fireEvent.change(memberRoleSelect, { target: { value: 'admin' } })
+      expect(mockOnChangeRole).toHaveBeenCalled()
+    }
+  })
+
+  it('opens remove confirmation dialog when remove button is clicked', () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    const removeButtons = screen.getAllByRole('button').filter(btn => {
+      const svg = btn.querySelector('svg')
+      return svg !== null
+    })
+
+    if (removeButtons.length > 0) {
+      fireEvent.click(removeButtons[0])
+      expect(screen.getByText('teams.removeMemberTitle')).toBeInTheDocument()
+      expect(screen.getByText('teams.removeMemberMessage')).toBeInTheDocument()
+    }
+  })
+
+  it('calls onRemoveMember when remove is confirmed', async () => {
+    render(
+      <TeamMemberManager
+        members={mockMembers}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    const removeButtons = screen.getAllByRole('button').filter(btn => {
+      const svg = btn.querySelector('svg')
+      return svg !== null
+    })
+
+    if (removeButtons.length > 0) {
+      fireEvent.click(removeButtons[0])
+      const confirmButton = screen.getByText('teams.removeMember')
+      fireEvent.click(confirmButton)
+
+      await waitFor(() => {
+        expect(mockOnRemoveMember).toHaveBeenCalled()
+      })
+    }
+  })
+
+  it('renders members without email correctly', () => {
+    const membersWithoutEmail: TeamMemberInfo[] = [
+      { userId: 'user1', role: 'admin', githubLogin: 'admin-user' },
+    ]
+
+    render(
+      <TeamMemberManager
+        members={membersWithoutEmail}
+        currentUserId="user1"
+        onAddMember={mockOnAddMember}
+        onRemoveMember={mockOnRemoveMember}
+        onChangeRole={mockOnChangeRole}
+      />,
+    )
+
+    expect(screen.getByText('admin-user')).toBeInTheDocument()
+    expect(screen.queryByText('@')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #19696

Adds unit tests for all 4 components in `web/src/components/teams/` which had 0% test coverage:
- TeamAccessGrants.tsx (10 tests)
- TeamDetail.tsx (10 tests)
- TeamList.tsx (14 tests)
- TeamMemberManager.tsx (17 tests)

Total: 51 tests covering props handling, conditional rendering, event handlers, callbacks, and edge cases.