### PR TITLE
🐛 fix: resolve nightly test script install failures

### DIFF
--- a/scripts/container-scan-test.sh
+++ b/scripts/container-scan-test.sh
@@ -60,7 +60,27 @@ if ! command -v trivy &>/dev/null; then
   if command -v brew &>/dev/null; then
     brew install trivy 2>/dev/null
   else
-    echo -e "${RED}ERROR: Cannot install trivy — install manually: brew install trivy${NC}"
+    # Install trivy binary from GitHub releases
+    TRIVY_VERSION="0.58.2"
+    TRIVY_OS="Linux"
+    TRIVY_ARCH="64bit"
+    TRIVY_TAR="trivy_${TRIVY_VERSION}_${TRIVY_OS}-${TRIVY_ARCH}.tar.gz"
+    TRIVY_URL="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TRIVY_TAR}"
+    
+    INSTALL_DIR="${HOME}/.local/bin"
+    mkdir -p "$INSTALL_DIR"
+    
+    echo -e "${DIM}Downloading trivy v${TRIVY_VERSION}...${NC}"
+    curl -sfL "$TRIVY_URL" | tar xz -C "$INSTALL_DIR" trivy 2>/dev/null || {
+      echo -e "${RED}ERROR: Cannot install trivy — install manually: brew install trivy${NC}"
+      exit 1
+    }
+    
+    export PATH="$INSTALL_DIR:$PATH"
+  fi
+  
+  if ! command -v trivy &>/dev/null; then
+    echo -e "${RED}ERROR: trivy installation failed — binary not found after install${NC}"
     exit 1
   fi
 fi

--- a/scripts/secret-scan-test.sh
+++ b/scripts/secret-scan-test.sh
@@ -57,7 +57,7 @@ if ! command -v gitleaks &>/dev/null; then
   if command -v brew &>/dev/null; then
     brew install gitleaks
   elif command -v go &>/dev/null; then
-    go install github.com/gitleaks/gitleaks/v8@v8.30.1
+    go install github.com/zricethezav/gitleaks/v8@v8.30.1
     # go install places binaries in GOPATH/bin which may not be on PATH
     export PATH="$(go env GOPATH)/bin:$PATH"
   else


### PR DESCRIPTION
Fixes #19708
Fixes #19709

Resolves gitleaks module path mismatch and trivy install failure in nightly test scripts.

## Changes

### scripts/secret-scan-test.sh
- Fixed gitleaks module path from `github.com/gitleaks/gitleaks/v8` to `github.com/zricethezav/gitleaks/v8`
- The correct module path is declared in the gitleaks repository

### scripts/container-scan-test.sh
- Added binary download fallback for trivy when brew is not available
- Downloads trivy v0.58.2 from GitHub releases to `~/.local/bin`
- Resolves install failures on CI runners without brew