### PR TITLE
[scanner] fix: resolve Playwright Cross-Browser nightly workflow failure

### DIFF
--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -181,7 +181,7 @@ test.describe('Smoke Tests', () => {
       await settingsLink.click({ force: true })
 
       await expect(page).toHaveURL(/\/settings(?:[?#].*)?$/, { timeout: 10000 })
-      await expect(page.locator('main [data-testid="settings-title"]').first()).toBeVisible({ timeout: 10000 })
+      await expect(page.locator('[data-testid="settings-page"] [data-testid="settings-title"]').first()).toBeVisible({ timeout: 10000 })
 
       // Click the logo button (has aria-label "Go to home dashboard").
       // The navbar renders two such buttons — the logo and the wordmark —


### PR DESCRIPTION
Fixes #19703

The Playwright Cross-Browser (Nightly) workflow failed on mobile and webkit browsers because the settings page test selector was looking for the element inside a hidden desktop nav.

Root cause: The test used selector 'main [data-testid="settings-title"]' which finds the desktop nav title that is hidden on mobile/narrow viewports with 'lg:hidden' CSS class.

Fix: Changed selector to use '[data-testid="settings-page"] [data-testid="settings-title"]' which locates the title within the settings page container, working on all viewport sizes.