### PR TITLE
[scanner] fix: resolve refresh icon animation consistency issues

### DIFF
--- a/web/src/components/marketplace/Marketplace.tsx
+++ b/web/src/components/marketplace/Marketplace.tsx
@@ -872,9 +872,10 @@ export function Marketplace() {
           <p className="text-xs text-muted-foreground/70 mb-4">{error}</p>
           <button
             onClick={refresh}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors"
+            disabled={isLoading}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors disabled:opacity-50"
           >
-            <RefreshCw className="w-3 h-3" />
+            <RefreshCw className={`w-3 h-3 ${isLoading ? 'animate-spin' : ''}`} />
             Try again
           </button>
         </div>


### PR DESCRIPTION
Fixes #19705

## Changes

- Add `animate-spin` class to RefreshCw icon in Marketplace error retry button
- Tie animation to `isLoading` state for proper loading feedback
- Add disabled state to prevent multiple clicks during loading

## Investigation

Analyzed the reported files and found that most were false positives (action buttons, reload buttons, or icon imports that don't need spin animation). The confirmed issue was in `Marketplace.tsx` where the error state retry button had `isLoading` available but wasn't using it for the animation.

## Testing

CI will validate the changes.