### PR TITLE
[scanner] fix: resolve 238 test failures from Coverage Suite run #3919

### DIFF
--- a/web/src/components/teams/__tests__/TeamAccessGrants.test.tsx
+++ b/web/src/components/teams/__tests__/TeamAccessGrants.test.tsx
@@ -42,7 +42,7 @@ describe('TeamAccessGrants', () => {
   })
 
   afterAll(() => {
-    vi.restoreAllMocks()
+    vi.clearAllMocks()
   })
 
   it('renders grants list when grants are provided', () => {

--- a/web/src/components/teams/__tests__/TeamDetail.test.tsx
+++ b/web/src/components/teams/__tests__/TeamDetail.test.tsx
@@ -56,7 +56,7 @@ describe('TeamDetail', () => {
   })
 
   afterAll(() => {
-    vi.restoreAllMocks()
+    vi.clearAllMocks()
   })
 
   it('renders team name and description', () => {

--- a/web/src/components/teams/__tests__/TeamList.test.tsx
+++ b/web/src/components/teams/__tests__/TeamList.test.tsx
@@ -26,7 +26,7 @@ describe('TeamList', () => {
   })
 
   afterAll(() => {
-    vi.restoreAllMocks()
+    vi.clearAllMocks()
   })
 
   it('renders loading skeleton when isLoading is true', () => {

--- a/web/src/components/teams/__tests__/TeamMemberManager.test.tsx
+++ b/web/src/components/teams/__tests__/TeamMemberManager.test.tsx
@@ -29,7 +29,7 @@ describe('TeamMemberManager', () => {
   })
 
   afterAll(() => {
-    vi.restoreAllMocks()
+    vi.clearAllMocks()
   })
 
   it('renders member count correctly', () => {


### PR DESCRIPTION
Fixes #19721

Resolves 238 unit test failures introduced by PR #19704.

## Root Cause
PR #19704 added `vi.restoreAllMocks()` in `afterAll()` hooks in team test files. This restored global mocks (particularly `react-i18next`) that other test files depended on, causing widespread test failures.

## Solution
Changed `vi.restoreAllMocks()` to `vi.clearAllMocks()` in all four team test files:
- `TeamAccessGrants.test.tsx`
- `TeamDetail.test.tsx`
- `TeamList.test.tsx`
- `TeamMemberManager.test.tsx`

This clears mock call history without removing mock implementations, preventing mock pollution while maintaining test isolation.