### PR TITLE
[scanner] fix: restore corrupted vite.config.ts (unbreaks main build)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,1 +1,407 @@
-$(cat vite-config-updated.ts)
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import istanbul from 'vite-plugin-istanbul'
+import { compression } from 'vite-plugin-compression2'
+import { execSync } from 'child_process'
+import path from 'path'
+
+const isE2ECoverage = process.env.VITE_COVERAGE === 'true'
+
+// Get git version from tags (e.g., v0.3.6-nightly.20260124)
+function getGitVersion(): string {
+  try {
+    // git describe gives: v0.3.6-nightly.20260124-11-g23946568
+    // We extract just the tag part for display
+    const describe = execSync('git describe --tags --always', { encoding: 'utf-8' }).trim()
+    // If it's a clean tag (no commits since), return as-is
+    // If it has commits since tag, extract the base tag
+    const match = describe.match(/^(v[\d.]+(?:-[^-]+)?(?:\.[^-]+)?)/)
+    return match ? match[1] : describe
+  } catch {
+    return '0.0.0'
+  }
+}
+
+// Get git commit hash at build time
+function getGitCommitHash(): string {
+  try {
+    return execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+// https://vite.dev/config/
+export default defineConfig(({ mode }) => ({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      'echarts-for-react/lib/types': path.resolve(__dirname, './src/lib/compat/echarts-for-react/lib/types.ts'),
+      'echarts-for-react': path.resolve(__dirname, './src/lib/compat/echarts-for-react/index.tsx'),
+    },
+  },
+  define: {
+    // Version from git tags, can be overridden by VITE_APP_VERSION for CI/CD
+    __APP_VERSION__: JSON.stringify(process.env.VITE_APP_VERSION || getGitVersion()),
+    __COMMIT_HASH__: JSON.stringify(process.env.VITE_COMMIT_HASH || getGitCommitHash()),
+    __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+    // Dev mode is true in development unless explicitly overridden
+    __DEV_MODE__: process.env.VITE_DEV_MODE !== undefined
+      ? JSON.stringify(process.env.VITE_DEV_MODE === 'true')
+      : JSON.stringify(mode === 'development'),
+    // Strip console/debugger in production (replaces terser drop_console).
+    // Use a no-op arrow function instead of 'undefined' to avoid
+    // `undefined()` crashes in vendor code that calls globalThis.console.*.
+    ...(mode === 'production' ? {
+      'globalThis.console.log': '(()=>{})',
+      'globalThis.console.info': '(()=>{})',
+      'globalThis.console.debug': '(()=>{})',
+      'globalThis.console.trace': '(()=>{})',
+    } : {}),
+  },
+  plugins: [
+    react({
+      // React Compiler disabled — it strips useCallback/useMemo that are
+      // load-bearing for useLayoutEffect dependency stability in CardDataContext,
+      // causing infinite re-render loops (React error #185) in production builds.
+      // Re-enable only after adding 'use no memo' directives to all affected files.
+    }),
+    // Inject build commit hash into the HTML <meta name="app-build-id"> tag
+    // so the stale-HTML detection script can compare against the server.
+    {
+      name: 'inject-build-id',
+      transformIndexHtml(html: string) {
+        return html.replace('__COMMIT_HASH__', process.env.VITE_COMMIT_HASH || getGitCommitHash())
+      },
+    },
+    // Pre-compress assets at build time — avoids chunked encoding on slow networks
+    compression({ algorithms: ['gzip'], exclude: [/\.(br)$/], threshold: 1024 }),
+    compression({ algorithms: ['brotliCompress'], exclude: [/\.(gz)$/], threshold: 1024 }),
+    // Enable Istanbul instrumentation for E2E coverage
+    isE2ECoverage &&
+      istanbul({
+        include: 'src/*',
+        exclude: ['node_modules', 'e2e/**', '**/*.spec.ts', '**/*.test.ts'],
+        extension: ['.js', '.ts', '.tsx', '.jsx'],
+        requireEnv: false,
+        forceBuildInstrument: true,
+      }),
+  ].filter(Boolean),
+  worker: {
+    format: 'es',
+  },
+  optimizeDeps: {
+    exclude: ['@sqlite.org/sqlite-wasm'],
+  },
+  build: {
+    // Vite 8 uses Oxc minifier by default (replaces terser/esbuild).
+    // drop_console equivalent is handled via rolldownOptions.output.
+    rolldownOptions: {
+      output: {
+        manualChunks: (id) => {
+          const sourceChunkRules = [
+            // Specific card registry files first (most specific matches first)
+            ['card-registry', ['/src/components/cards/cardRegistry.ts']],
+            ['card-registry-data', ['/src/config/cards/', '/src/components/cards/cardMetadata.ts', '/src/components/cards/cardDescriptors.registry.ts']],
+            // Split page components into separate chunks by feature area (before general dashboard/layout)
+            ['pages-admin', ['/src/components/cluster-admin/', '/src/components/settings/', '/src/components/namespaces/']],
+            ['pages-workloads', ['/src/components/workloads/', '/src/components/pods/', '/src/components/deployments/', '/src/components/compute/', '/src/components/nodes/']],
+            ['pages-network', ['/src/components/services/', '/src/components/network/', '/src/components/storage/']],
+            ['pages-security', ['/src/components/security/', '/src/components/compliance/', '/src/components/data-compliance/']],
+            ['pages-platform', ['/src/components/gitops/', '/src/components/cicd/', '/src/components/operators/', '/src/components/helm/']],
+            ['pages-aiml', ['/src/components/aiml/', '/src/components/aiagents/', '/src/components/llmd-benchmarks/']],
+            ['pages-misc', ['/src/components/alerts/', '/src/components/cost/', '/src/components/events/', '/src/components/logs/', '/src/components/deploy/', '/src/components/gpu/', '/src/components/arcade/', '/src/components/marketplace/', '/src/components/clusters/']],
+            // Split card components into domain-specific chunks (after card-registry rules, before dashboard)
+            ['cards-gpu', ['/src/components/cards/GPU', '/src/components/cards/ProactiveGPUNodeHealthMonitor']],
+            ['cards-gitops', ['/src/components/cards/ArgoCD', '/src/components/cards/GitOpsDrift', '/src/components/cards/flux_status/', '/src/components/cards/deploy/', '/src/components/cards/deploy-bundle', '/src/components/cards/cardRegistry.gitops']],
+            ['cards-observability', ['/src/components/cards/otel_status/', '/src/components/cards/jaeger_status/', '/src/components/cards/cortex_status/', '/src/components/cards/thanos_status/', '/src/components/cards/fluentd_status/', '/src/components/cards/longhorn_status/', '/src/components/cards/rook_status/', '/src/components/cards/cardRegistry.observability']],
+            ['cards-security', ['/src/components/cards/kyverno/', '/src/components/cards/opa/', '/src/components/cards/trivy/', '/src/components/cards/kubescape/', '/src/components/cards/spiffe_status/', '/src/components/cards/spire_status/', '/src/components/cards/keycloak_status/', '/src/components/cards/compliance/', '/src/components/cards/intoto_supply_chain/', '/src/components/cards/cardRegistry.security', '/src/components/cards/cardRegistry.compliance']],
+            ['cards-aiml', ['/src/components/cards/llmd/', '/src/components/cards/kuberay_fleet/', '/src/components/cards/kserve_status/', '/src/components/cards/kagent/', '/src/components/cards/kagenti/', '/src/components/cards/cardRegistry.ai']],
+            ['cards-quantum', ['/src/components/cards/quantum/', '/src/components/cards/cardRegistry.quantum']],
+            ['cards-networking', ['/src/components/cards/cilium_status/', '/src/components/cards/linkerd_status/', '/src/components/cards/envoy_status/', '/src/components/cards/contour_status/', '/src/components/cards/cni_status/', '/src/components/cards/coredns_status/', '/src/components/cards/nats_status/', '/src/components/cards/grpc_status/']],
+            ['cards-platform', ['/src/components/cards/crossplane-status/', '/src/components/cards/knative_status/', '/src/components/cards/keda_status/', '/src/components/cards/dapr_status/', '/src/components/cards/kubevela_status/', '/src/components/cards/harbor_status/', '/src/components/cards/strimzi_status/', '/src/components/cards/volcano_status/', '/src/components/cards/openkruise_status/', '/src/components/cards/cardRegistry.platform']],
+            // Split remaining cards into smaller groups to avoid oversized cards-misc
+            ['cards-workloads', ['/src/components/cards/workload-detection/', '/src/components/cards/workload-monitor/']],
+            ['cards-storage', ['/src/components/cards/vitess_status/', '/src/components/cards/minio_status/', '/src/components/cards/etcd_status/']],
+            ['cards-messaging', ['/src/components/cards/kafka_status/', '/src/components/cards/rabbitmq_status/', '/src/components/cards/redis_status/']],
+            // Split cards-misc further to reduce bundle size
+            ['cards-monitoring', ['/src/components/cards/prometheus_status/', '/src/components/cards/grafana_status/', '/src/components/cards/alertmanager_status/']],
+            ['cards-cluster', ['/src/components/cards/cluster_health/', '/src/components/cards/cluster_capacity/', '/src/components/cards/cluster_nodes/']],
+            ['cards-cost', ['/src/components/cards/cost/', '/src/components/cards/kubecost_status/']],
+            ['cards-data', ['/src/components/cards/postgresql_status/', '/src/components/cards/mysql_status/', '/src/components/cards/mongodb_status/']],
+            ['cards-misc', ['/src/components/cards/']],
+            // Split drilldown views by type to reduce chunk size
+            ['drilldown-k8s', ['/src/components/drilldown/views/PodLogs', '/src/components/drilldown/views/PodEvents', '/src/components/drilldown/views/PodTerminal', '/src/components/drilldown/views/NamespaceDetails']],
+            ['drilldown-data', ['/src/components/drilldown/views/LogViewer', '/src/components/drilldown/views/MetricsViewer', '/src/components/drilldown/views/EventTimeline']],
+            ['drilldown-ui', ['/src/components/drilldown/DrillDownModal', '/src/components/drilldown/DrillDownHeader', '/src/components/drilldown/DrillDownStack']],
+            ['drilldown', ['/src/components/drilldown/']],
+            // Dashboard and layout split by concern
+            ['dashboard-customizer', ['/src/components/dashboard/customizer/', '/src/components/dashboard/shared/cardCatalog']],
+            ['dashboard-grid', ['/src/components/dashboard/CardGrid', '/src/components/dashboard/DashboardGrid']],
+            ['dashboard-core', ['/src/components/dashboard/', '/src/lib/dashboards/', '/src/lib/unified/dashboard/']],
+            ['layout-header', ['/src/components/layout/Header', '/src/components/layout/TopBar', '/src/components/layout/UserMenu']],
+            ['layout-sidebar', ['/src/components/layout/Sidebar', '/src/components/layout/Navigation', '/src/components/layout/MobileMenu']],
+            ['layout-shell', ['/src/components/layout/']],
+            ['auth-core', ['/src/lib/auth']],
+            // Split contexts and providers into smaller groups
+            ['contexts-dashboard', ['/src/contexts/DashboardProvider', '/src/contexts/DrillDownProvider', '/src/contexts/AlertsProvider']],
+            ['contexts-global', ['/src/contexts/GlobalFiltersProvider', '/src/contexts/ThemeProvider', '/src/contexts/AuthProvider']],
+            ['contexts-providers', ['/src/contexts/', '/src/hooks/useDrillDown', '/src/hooks/useRewards', '/src/hooks/useMissions', '/src/hooks/useGlobalFilters']],
+            ['hooks-data', ['/src/hooks/useCached', '/src/hooks/useCache', '/src/hooks/useCluster', '/src/hooks/useDashboard']],
+            ['lib-cache', ['/src/lib/cache/']],
+            ['lib-utils', ['/src/lib/utils', '/src/lib/cn.ts', '/src/lib/constants.ts']],
+            ['theme-system', ['/src/hooks/useTheme', '/src/hooks/useBranding']],
+            // Split app shell to reduce massive app-routes chunk
+            ['app-router', ['/src/components/router/', '/src/lib/router/']],
+            ['app-routes', ['/src/App.tsx']],
+            ['app-shell', ['/src/hooks/usePersistedSettings', '/src/hooks/useAppInit']],
+            ['i18n-app', ['/src/lib/i18n.ts', '/src/locales/']],
+          ] as const
+          for (const [chunkName, needles] of sourceChunkRules) {
+            if (needles.some(needle => id.includes(needle))) return chunkName
+          }
+          if (!id.includes('node_modules')) return
+          // React core (split scheduler separately to reduce main react bundle)
+          if (id.includes('/scheduler/')) return 'react-scheduler-vendor'
+          if (id.includes('/react-dom/client')) return 'react-dom-client-vendor'
+          if (id.includes('/react-dom/')) return 'react-dom-vendor'
+          if (id.includes('/react-router-dom/')) return 'react-router-dom-vendor'
+          if (id.includes('/react-router/')) return 'react-router-vendor'
+          if (id.includes('/react-reconciler/')) return 'react-reconciler-vendor'
+          if (id.includes('/react/')) return 'react-vendor'
+          // three.js ecosystem (split into smaller chunks to reduce three-core and three-drei)
+          if (id.includes('/three-stdlib/')) return 'three-stdlib-vendor'
+          if (id.includes('/@react-three/fiber/')) return 'three-fiber-vendor'
+          // Split drei into sub-chunks to reduce 304KB chunk
+          if (id.includes('/@react-three/drei/') && id.includes('/core/')) return 'drei-core-vendor'
+          if (id.includes('/@react-three/drei/') && id.includes('/web/')) return 'drei-web-vendor'
+          if (id.includes('/@react-three/drei/')) return 'drei-helpers-vendor'
+          if (id.includes('/@react-three/') || id.includes('/zustand/') || id.includes('/stats-gl/')) return 'three-react-vendor'
+          // Split three.js core modules to reduce 708KB chunk
+          if (id.includes('/three/build/three.module.js')) return 'three-core-vendor'
+          if (id.includes('/three/src/math/')) return 'three-math-vendor'
+          if (id.includes('/three/src/loaders/')) return 'three-loaders-vendor'
+          if (id.includes('/three/')) return 'three-extras-vendor'
+          // Chart libraries
+          if (id.includes('/zrender/')) return 'zrender-vendor'
+          if (id.includes('/echarts-for-react/')) return 'echarts-react-vendor'
+          if (id.includes('/echarts/')) return 'echarts-vendor'
+          if (id.includes('/framer-motion/')) return 'motion-vendor'
+          // Terminal (split addons from core to reduce xterm-core 336KB chunk)
+          if (id.includes('/@xterm/addon-fit/')) return 'xterm-addon-fit-vendor'
+          if (id.includes('/@xterm/addon-web-links/')) return 'xterm-addon-links-vendor'
+          if (id.includes('/@xterm/addon-')) return 'xterm-addon-vendor'
+          if (id.includes('/@xterm/xterm/')) return 'xterm-core-vendor'
+          if (id.includes('/@xterm/')) return 'xterm-vendor'
+          // UI libraries
+          if (id.includes('/lucide-react/')) return 'lucide-vendor'
+          if (id.includes('/@dnd-kit/core/')) return 'dnd-core-vendor'
+          if (id.includes('/@dnd-kit/sortable/')) return 'dnd-sortable-vendor'
+          if (id.includes('/@dnd-kit/')) return 'dnd-vendor'
+          if (
+            id.includes('/react-markdown/') ||
+            id.includes('/remark-') ||
+            id.includes('/rehype-') ||
+            id.includes('/micromark') ||
+            id.includes('/mdast-') ||
+            id.includes('/hast-') ||
+            id.includes('/unist-') ||
+            id.includes('/unified/') ||
+            id.includes('/bail/') ||
+            id.includes('/is-plain-obj/') ||
+            id.includes('/trough/') ||
+            id.includes('/vfile') ||
+            id.includes('/property-information') ||
+            id.includes('/zwitch') ||
+            id.includes('/stringify-entities') ||
+            id.includes('/ccount') ||
+            id.includes('/character-entities') ||
+            id.includes('/comma-separated-tokens') ||
+            id.includes('/space-separated-tokens') ||
+            id.includes('/decode-named-character-reference') ||
+            id.includes('/devlop') ||
+            id.includes('/estree-')
+          ) return 'markdown-vendor'
+          if (id.includes('/sucrase/')) return 'sucrase-vendor'
+          if (id.includes('/@codemirror/legacy-modes/')) return 'codemirror-modes-vendor'
+          if (id.includes('/@uiw/react-codemirror/')) return 'codemirror-react-vendor'
+          if (id.includes('/@codemirror/') || id.includes('/codemirror/') || id.includes('/@lezer/')) return 'codemirror-core-vendor'
+          if (id.includes('/i18next-browser-languagedetector/')) return 'i18n-detector-vendor'
+          if (id.includes('/i18next') || id.includes('/react-i18next/')) return 'i18n-vendor'
+          if (id.includes('/js-yaml/')) return 'yaml-vendor'
+          if (id.includes('/dompurify/')) return 'sanitize-vendor'
+          if (id.includes('/zod/')) return 'schema-vendor'
+          if (id.includes('/@tanstack/react-virtual/')) return 'virtual-vendor'
+          // Split date/time libraries
+          if (id.includes('/date-fns/')) return 'date-vendor'
+          if (id.includes('/dayjs/')) return 'dayjs-vendor'
+          // Split utility libraries to reduce generic vendor chunk
+          if (id.includes('/lodash/') || id.includes('/lodash-es/')) return 'lodash-vendor'
+          if (id.includes('/axios/')) return 'axios-vendor'
+          if (id.includes('/clsx/') || id.includes('/classnames/')) return 'classnames-vendor'
+          if (id.includes('/uuid/')) return 'uuid-vendor'
+          // Split state management
+          if (id.includes('/jotai/')) return 'jotai-vendor'
+          if (id.includes('/immer/')) return 'immer-vendor'
+          // Split async utilities
+          if (id.includes('/p-limit/') || id.includes('/p-queue/')) return 'async-vendor'
+          return 'vendor'
+        },
+      },
+    },
+    // Warn when any chunk exceeds 300 KB after minification, matching the
+    // Auto-QA performance threshold so CI catches regressions early.
+    chunkSizeWarningLimit: 300,
+  },
+  server: {
+    port: 5174,
+    strictPort: true, // Fail if port 5174 is already in use
+    warmup: {
+      // Pre-transform route and card modules on server start so navigation
+      // doesn't pay the cold module-transform penalty.
+      clientFiles: [
+        // Route components (most-used routes first)
+        './src/components/cluster-admin/ClusterAdmin.tsx',
+        './src/components/dashboard/Dashboard.tsx',
+        './src/components/dashboard/CustomDashboard.tsx',
+        './src/components/clusters/Clusters.tsx',
+        './src/components/events/Events.tsx',
+        './src/components/workloads/Workloads.tsx',
+        './src/components/compute/Compute.tsx',
+        './src/components/nodes/Nodes.tsx',
+        './src/components/deployments/Deployments.tsx',
+        './src/components/pods/Pods.tsx',
+        './src/components/services/Services.tsx',
+        './src/components/storage/Storage.tsx',
+        './src/components/network/Network.tsx',
+        './src/components/security/Security.tsx',
+        './src/components/gitops/GitOps.tsx',
+        './src/components/alerts/Alerts.tsx',
+        './src/components/cost/Cost.tsx',
+        './src/components/compliance/Compliance.tsx',
+        './src/components/operators/Operators.tsx',
+        './src/components/helm/HelmReleases.tsx',
+        './src/components/gpu/GPUReservations.tsx',
+        './src/components/data-compliance/DataCompliance.tsx',
+        './src/components/logs/Logs.tsx',
+        './src/components/deploy/Deploy.tsx',
+        './src/components/aiml/AIML.tsx',
+        './src/components/aiagents/AIAgents.tsx',
+        './src/components/cicd/CICD.tsx',
+        './src/components/arcade/Arcade.tsx',
+        './src/components/marketplace/Marketplace.tsx',
+        './src/components/llmd-benchmarks/LLMdBenchmarks.tsx',
+        './src/components/settings/Settings.tsx',
+        './src/components/namespaces/NamespaceManager.tsx',
+        // Card registries and bundles
+        './src/components/cards/cardRegistry.ts',
+        './src/components/cards/deploy-bundle.ts',
+        './src/components/cards/llmd/index.ts',
+        './src/components/cards/workload-detection/index.ts',
+        './src/components/cards/workload-monitor/index.ts',
+        './src/components/cards/kagenti/index.ts',
+        './src/App.tsx',
+      ],
+    },
+    proxy: (() => {
+      // When the watchdog runs with TLS on port 8080, the backend listens
+      // on BACKEND_LISTEN_PORT (default 8081) in plain HTTP. Proxy directly
+      // to the backend to avoid "Client sent an HTTP request to an HTTPS server".
+      const backendPort = process.env.BACKEND_LISTEN_PORT || '8081'
+      const target = `http://localhost:${backendPort}`
+      const wsTarget = `ws://localhost:${backendPort}`
+      const opts = { target, changeOrigin: true }
+      return {
+        '/api': { ...opts },
+        '/health': { ...opts },
+        '/auth/github': { ...opts },
+        '/auth/github/callback': { ...opts },
+        '/auth/manifest/setup': { ...opts },
+        '/auth/manifest/callback': { ...opts },
+        '/auth/refresh': { ...opts },
+        '/api/m': { ...opts },
+        '/ws': { target: wsTarget, ws: true },
+      }
+    })(),
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    css: true,
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'netlify/functions/__tests__/*.{test,spec}.{ts,tsx}', 'netlify/edge-functions/__tests__/*.{test,spec}.{ts,tsx}'],
+    exclude: ['node_modules', 'e2e/**/*'],
+    // Retry flaky tests up to 2 times in CI to reduce false-positive workflow failures (#11872)
+    retry: process.env.CI ? 2 : 0,
+    teardownTimeout: process.env.CI ? 120_000 : 10_000, // CI: increased from 60s to 120s for worker cleanup stability (#10436)
+    // CI runners (2-core, 7GB) OOM with 600+ test files at full concurrency
+    maxWorkers: process.env.CI ? 1 : undefined,
+    minWorkers: process.env.CI ? 1 : undefined,
+    // poolOptions.forks removed — deprecated in Vitest 4 (#5860).
+    // maxWorkers/minWorkers above handle fork limits; teardownTimeout
+    // above handles worker termination timeout.
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'json-summary', 'html'],
+      include: [
+        'src/hooks/**',
+        'src/lib/**',
+        'src/contexts/**',
+        'src/components/charts/**',
+        'src/components/dashboard/customizer/**',
+        'src/components/dashboard/shared/cardCatalog.ts',
+        'src/components/dashboard/shared/CardPreview.tsx',
+      ],
+      exclude: [
+        'node_modules/',
+        'e2e/',
+        'src/test/',
+        '**/*.test.{ts,tsx}',
+        '**/*.spec.{ts,tsx}',
+        '**/*.d.ts',
+        '**/*.md',
+        '**/demo*Data*.{ts,tsx}',
+        '**/icons.{ts,tsx}',
+        // Barrel re-export files: V8 cannot count ESM re-export bindings as
+        // executable lines. These files contain only `export { } from` or
+        // `export * from` statements with no executable logic — excluding them
+        // prevents structurally-uncoverable lines from dragging down the metric.
+        'src/lib/analytics.ts',
+        'src/hooks/useMCP.ts',
+        'src/hooks/useCachedKeda.ts',
+        // lib/demo barrel re-exports: each of these is a thin `export { } from`
+        // wrapper pointing at the card-level demoData. V8 cannot mark ESM
+        // re-export bindings as covered even when tests import them — same issue
+        // as src/lib/analytics.ts. Exclude to prevent 0% drag.
+        'src/lib/demo/chaos_mesh.ts',
+        'src/lib/demo/dapr.ts',
+        'src/lib/demo/envoy.ts',
+        'src/lib/demo/grpc.ts',
+        'src/lib/demo/keda.ts',
+        'src/lib/demo/kubevela.ts',
+        'src/lib/demo/linkerd.ts',
+        'src/lib/demo/openfeature.ts',
+        'src/lib/demo/openfga.ts',
+        'src/lib/demo/spiffe.ts',
+        'src/lib/demo/strimzi.ts',
+        'src/lib/demo/volcano.ts',
+        'src/lib/demo/wasmcloud.ts',
+        // Type-only files: pure TypeScript interfaces/types compile to no JS bytecode.
+        'src/lib/cache/workerMessages.ts',
+        'src/hooks/mcp/types.ts',
+        // Dead code: not imported by any production module (app uses useMissions.tsx).
+        'src/hooks/useMissions.provider.tsx',
+      ],
+      // Per-directory coverage thresholds prevent silent regression in
+      // chronically under-tested directories. Ratchet these up as tests are added.
+      // NOTE: Disabled — thresholds are incompatible with sharded vitest runs
+      // (each shard only covers a subset of files, so per-directory thresholds
+      // always fail in shards that don't include matching tests). Re-enable once
+      // coverage is merged before threshold evaluation.
+      // thresholds: {
+      //   '**/hooks/**': { lines: 20, functions: 20, branches: 20, statements: 20 },
+      //   '**/services/**': { lines: 60, functions: 60, branches: 60, statements: 60 },
+      // },
+    },
+  },
+}))


### PR DESCRIPTION
## P0 Fix — Main Build Broken

The latest commit on `main` (`44606f56`) accidentally replaced `web/vite.config.ts` with the literal string `$(cat vite-config-updated.ts)` instead of the actual file content. This caused a Vite parse error during Docker build, breaking all CI.

### Root Cause
A shell expansion (`$(cat ...)`) was committed as literal text instead of being evaluated, corrupting the vite config.

### Fix
Restores `web/vite.config.ts` to its correct state (matching sha `97195a09` from the previous working commit).

Fixes #19730
Fixes #19731