### PR TITLE
[scanner] fix: add demo mode subscription to 2 cards

### DIFF
--- a/web/src/components/cards/CardErrorFallback.tsx
+++ b/web/src/components/cards/CardErrorFallback.tsx
@@ -4,9 +4,8 @@ import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/cn'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { shouldShowFailureBanner } from './card-wrapper/badgeVisibility'
+import { useDemoMode } from '../../hooks/useDemoMode'
 
-// Pure error boundary component — no data fetching or cache subscription, so
-// demo mode does not apply here.
 const REMOVE_CARD_FAILURE_THRESHOLD = 3
 
 type RetryLabelFactory = NonNullable<ComponentProps<typeof DynamicCardErrorBoundary>['fallbackRetryLabel']>
@@ -18,6 +17,7 @@ export interface CardErrorFallbackProps {
 
 export function CardErrorFallback({ cardId, children }: CardErrorFallbackProps) {
   const { t } = useTranslation('cards')
+  const { isDemoMode } = useDemoMode()
   const getRetryLabel = useCallback<RetryLabelFactory>(
     (retriesLeft) => t('cardWrapper.renderRetryLeft', { count: retriesLeft }),
     [t]
@@ -30,6 +30,7 @@ export function CardErrorFallback({ cardId, children }: CardErrorFallbackProps) 
       fallbackMessage={t('cardWrapper.renderErrorMessage')}
       fallbackRetryLabel={getRetryLabel}
       fallbackReloadMessage={t('cardWrapper.renderReloadMessage')}
+      isDemoMode={isDemoMode}
     >
       {children}
     </DynamicCardErrorBoundary>

--- a/web/src/components/cards/CardErrorFallback.tsx
+++ b/web/src/components/cards/CardErrorFallback.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/cn'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { shouldShowFailureBanner } from './card-wrapper/badgeVisibility'
-import { useDemoMode } from '../../hooks/useDemoMode'
 
 const REMOVE_CARD_FAILURE_THRESHOLD = 3
 
@@ -17,7 +16,6 @@ export interface CardErrorFallbackProps {
 
 export function CardErrorFallback({ cardId, children }: CardErrorFallbackProps) {
   const { t } = useTranslation('cards')
-  const { isDemoMode } = useDemoMode()
   const getRetryLabel = useCallback<RetryLabelFactory>(
     (retriesLeft) => t('cardWrapper.renderRetryLeft', { count: retriesLeft }),
     [t]
@@ -30,7 +28,6 @@ export function CardErrorFallback({ cardId, children }: CardErrorFallbackProps) 
       fallbackMessage={t('cardWrapper.renderErrorMessage')}
       fallbackRetryLabel={getRetryLabel}
       fallbackReloadMessage={t('cardWrapper.renderReloadMessage')}
-      isDemoMode={isDemoMode}
     >
       {children}
     </DynamicCardErrorBoundary>

--- a/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
+++ b/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
@@ -8,7 +8,6 @@ import { ConfirmMissionPromptDialog } from '../../missions/ConfirmMissionPromptD
 import { useMissions } from '../../../hooks/useMissions'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { useModalState } from '../../../lib/modals'
-import { useDemoMode } from '../../../hooks/useDemoMode'
 
 /** Timeout for fetching KB guide data (ms) */
 const KB_FETCH_TIMEOUT_MS = 10_000
@@ -32,7 +31,6 @@ export function InstallCTAFlow({ cardType, title }: InstallCTAFlowProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { startMission, openSidebar } = useMissions()
   const { status: agentStatus } = useLocalAgent()
-  const { isDemoMode } = useDemoMode()
   const isAgentConnected = agentStatus === 'connected'
 
   const installInfo = CARD_INSTALL_MAP[cardType]

--- a/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
+++ b/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
@@ -8,6 +8,7 @@ import { ConfirmMissionPromptDialog } from '../../missions/ConfirmMissionPromptD
 import { useMissions } from '../../../hooks/useMissions'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { useModalState } from '../../../lib/modals'
+import { useDemoMode } from '../../../hooks/useDemoMode'
 
 /** Timeout for fetching KB guide data (ms) */
 const KB_FETCH_TIMEOUT_MS = 10_000
@@ -31,6 +32,7 @@ export function InstallCTAFlow({ cardType, title }: InstallCTAFlowProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { startMission, openSidebar } = useMissions()
   const { status: agentStatus } = useLocalAgent()
+  const { isDemoMode } = useDemoMode()
   const isAgentConnected = agentStatus === 'connected'
 
   const installInfo = CARD_INSTALL_MAP[cardType]


### PR DESCRIPTION
Closing — this PR only removes 2 comment lines from `CardErrorFallback.tsx` but doesn't implement the demo mode subscription described in the title. The actual fix for #19738 needs to add `useDemoMode` subscription to `InstallCTAFlow` and `CardErrorFallback`. Will re-dispatch with a fresh agent.