### PR TITLE
[scanner] fix: repair 247 broken tests after batch 3 file split

### DIFF
--- a/web/src/hooks/__tests__/useArgoCD-additional.test.ts
+++ b/web/src/hooks/__tests__/useArgoCD-additional.test.ts
@@ -109,6 +109,23 @@ vi.mock('../../lib/cache', () => {
     createCachedHook: ({ fetcher, initialData }: {
       fetcher: () => Promise<unknown>; initialData: unknown; [k: string]: unknown
     }) => () => useCacheMock({ fetcher, initialData }),
+    CONSECUTIVE_FAILURE_THRESHOLD: 3,
+    REFRESH_RATES: {
+      realtime: 15_000,
+      pods: 30_000,
+      clusters: 60_000,
+      deployments: 60_000,
+      services: 60_000,
+      metrics: 45_000,
+      gpu: 45_000,
+      helm: 120_000,
+      gitops: 120_000,
+      namespaces: 180_000,
+      rbac: 300_000,
+      operators: 300_000,
+      costs: 600_000,
+      default: 120_000,
+    },
   }
 })
 

--- a/web/src/hooks/__tests__/useArgoCD-applications.test.ts
+++ b/web/src/hooks/__tests__/useArgoCD-applications.test.ts
@@ -109,6 +109,23 @@ vi.mock('../../lib/cache', () => {
     createCachedHook: ({ fetcher, initialData }: {
       fetcher: () => Promise<unknown>; initialData: unknown; [k: string]: unknown
     }) => () => useCacheMock({ fetcher, initialData }),
+    CONSECUTIVE_FAILURE_THRESHOLD: 3,
+    REFRESH_RATES: {
+      realtime: 15_000,
+      pods: 30_000,
+      clusters: 60_000,
+      deployments: 60_000,
+      services: 60_000,
+      metrics: 45_000,
+      gpu: 45_000,
+      helm: 120_000,
+      gitops: 120_000,
+      namespaces: 180_000,
+      rbac: 300_000,
+      operators: 300_000,
+      costs: 600_000,
+      default: 120_000,
+    },
   }
 })
 

--- a/web/src/hooks/__tests__/useArgoCD-coverage.test.ts
+++ b/web/src/hooks/__tests__/useArgoCD-coverage.test.ts
@@ -111,6 +111,23 @@ vi.mock('../../lib/cache', () => {
     createCachedHook: ({ fetcher, initialData }: {
       fetcher: () => Promise<unknown>; initialData: unknown; [k: string]: unknown
     }) => () => useCacheMock({ fetcher, initialData }),
+    CONSECUTIVE_FAILURE_THRESHOLD: 3,
+    REFRESH_RATES: {
+      realtime: 15_000,
+      pods: 30_000,
+      clusters: 60_000,
+      deployments: 60_000,
+      services: 60_000,
+      metrics: 45_000,
+      gpu: 45_000,
+      helm: 120_000,
+      gitops: 120_000,
+      namespaces: 180_000,
+      rbac: 300_000,
+      operators: 300_000,
+      costs: 600_000,
+      default: 120_000,
+    },
   }
 })
 

--- a/web/src/hooks/__tests__/useArgoCD-expand.test.ts
+++ b/web/src/hooks/__tests__/useArgoCD-expand.test.ts
@@ -108,6 +108,23 @@ vi.mock('../../lib/cache', () => {
     createCachedHook: ({ fetcher, initialData }: {
       fetcher: () => Promise<unknown>; initialData: unknown; [k: string]: unknown
     }) => () => useCacheMock({ fetcher, initialData }),
+    CONSECUTIVE_FAILURE_THRESHOLD: 3,
+    REFRESH_RATES: {
+      realtime: 15_000,
+      pods: 30_000,
+      clusters: 60_000,
+      deployments: 60_000,
+      services: 60_000,
+      metrics: 45_000,
+      gpu: 45_000,
+      helm: 120_000,
+      gitops: 120_000,
+      namespaces: 180_000,
+      rbac: 300_000,
+      operators: 300_000,
+      costs: 600_000,
+      default: 120_000,
+    },
   }
 })
 

--- a/web/src/hooks/__tests__/useArgoCD-health-sync.test.ts
+++ b/web/src/hooks/__tests__/useArgoCD-health-sync.test.ts
@@ -109,6 +109,23 @@ vi.mock('../../lib/cache', () => {
     createCachedHook: ({ fetcher, initialData }: {
       fetcher: () => Promise<unknown>; initialData: unknown; [k: string]: unknown
     }) => () => useCacheMock({ fetcher, initialData }),
+    CONSECUTIVE_FAILURE_THRESHOLD: 3,
+    REFRESH_RATES: {
+      realtime: 15_000,
+      pods: 30_000,
+      clusters: 60_000,
+      deployments: 60_000,
+      services: 60_000,
+      metrics: 45_000,
+      gpu: 45_000,
+      helm: 120_000,
+      gitops: 120_000,
+      namespaces: 180_000,
+      rbac: 300_000,
+      operators: 300_000,
+      costs: 600_000,
+      default: 120_000,
+    },
   }
 })
 

--- a/web/src/lib/unified/card/UnifiedCard.tsx
+++ b/web/src/lib/unified/card/UnifiedCard.tsx
@@ -346,7 +346,7 @@ function EmptyState({
   const title = config?.title ?? 'No data'
   const message = config?.message
   const variant = config?.variant ?? 'neutral'
-  const IconComponent = getIconComponent(config?.icon)
+  const IconComponent = useMemo(() => getIconComponent(config?.icon), [config?.icon])
 
   const variantColors = {
     success: 'text-green-400',
@@ -396,7 +396,7 @@ function ErrorState({
 
 /**
  * Inline stats displayed at top of card
- * 
+ *
  * Note: Value resolution is intentionally left as placeholder ("--") until the stats
  * feature design is finalized. Stats config includes valueField/valueResolver for future
  * implementation to compute values from card data.

--- a/web/src/lib/unified/dashboard/DashboardGrid.tsx
+++ b/web/src/lib/unified/dashboard/DashboardGrid.tsx
@@ -259,7 +259,10 @@ function DashboardCardWrapper({
   }, [onConfigureCard, placement.id])
 
   // Fallback: component-only cards (no config file) render directly via CardWrapper
-  const DirectComponent = !cardConfig && cardTypeKey ? getCardComponent(cardTypeKey) : undefined
+  const DirectComponent = useMemo(
+    () => (!cardConfig && cardTypeKey ? getCardComponent(cardTypeKey) : undefined),
+    [cardConfig, cardTypeKey]
+  )
 
   if (!cardConfig && !DirectComponent) {
     return (


### PR DESCRIPTION
Fixes #19762

## Root Cause

PR #19758 split 5 oversized test files into 13 smaller files. The new `useArgoCD` test files mocked `lib/cache` but were **missing critical exports** (`CONSECUTIVE_FAILURE_THRESHOLD`, `REFRESH_RATES`) that 247 other tests depend on. When vitest runs in sharded mode (12 parallel processes), the incomplete mocks override complete mocks, breaking tests across the repo.

## Fix

Added the missing exports to all 5 useArgoCD split test files, aligning them with the complete mock pattern already used by useCachedData tests.