### PR TITLE
[scanner] fix: resolve 247 test failures from batch 3 file split

### DIFF
--- a/web/src/hooks/__tests__/useArgoCD-additional.test.ts
+++ b/web/src/hooks/__tests__/useArgoCD-additional.test.ts
@@ -39,10 +39,11 @@ vi.mock('../useGlobalFilters', () => ({
 
 // Stateful useCache mock — calls the real fetcher, tracks consecutive failures,
 // and exposes error/isFailed so the ArgoCD hook's fallback logic works correctly.
-vi.mock('../../lib/cache', () => {
+vi.mock('../../lib/cache', async (importOriginal) => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const React = require('react')
   const FAILURE_THRESHOLD = 3
+  const actual = await importOriginal<typeof import('../../lib/cache')>()
 
   const useCacheMock = ({
     fetcher,
@@ -105,6 +106,7 @@ vi.mock('../../lib/cache', () => {
   }
 
   return {
+    ...actual,
     useCache: useCacheMock,
     createCachedHook: ({ fetcher, initialData }: {
       fetcher: () => Promise<unknown>; initialData: unknown; [k: string]: unknown

--- a/web/src/hooks/__tests__/useArgoCD-applications.test.ts
+++ b/web/src/hooks/__tests__/useArgoCD-applications.test.ts
@@ -39,10 +39,11 @@ vi.mock('../useGlobalFilters', () => ({
 
 // Stateful useCache mock — calls the real fetcher, tracks consecutive failures,
 // and exposes error/isFailed so the ArgoCD hook's fallback logic works correctly.
-vi.mock('../../lib/cache', () => {
+vi.mock('../../lib/cache', async (importOriginal) => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const React = require('react')
   const FAILURE_THRESHOLD = 3
+  const actual = await importOriginal<typeof import('../../lib/cache')>()
 
   const useCacheMock = ({
     fetcher,
@@ -105,6 +106,7 @@ vi.mock('../../lib/cache', () => {
   }
 
   return {
+    ...actual,
     useCache: useCacheMock,
     createCachedHook: ({ fetcher, initialData }: {
       fetcher: () => Promise<unknown>; initialData: unknown; [k: string]: unknown

--- a/web/src/hooks/__tests__/useArgoCD-health-sync.test.ts
+++ b/web/src/hooks/__tests__/useArgoCD-health-sync.test.ts
@@ -39,10 +39,11 @@ vi.mock('../useGlobalFilters', () => ({
 
 // Stateful useCache mock — calls the real fetcher, tracks consecutive failures,
 // and exposes error/isFailed so the ArgoCD hook's fallback logic works correctly.
-vi.mock('../../lib/cache', () => {
+vi.mock('../../lib/cache', async (importOriginal) => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const React = require('react')
   const FAILURE_THRESHOLD = 3
+  const actual = await importOriginal<typeof import('../../lib/cache')>()
 
   const useCacheMock = ({
     fetcher,
@@ -105,6 +106,7 @@ vi.mock('../../lib/cache', () => {
   }
 
   return {
+    ...actual,
     useCache: useCacheMock,
     createCachedHook: ({ fetcher, initialData }: {
       fetcher: () => Promise<unknown>; initialData: unknown; [k: string]: unknown

--- a/web/src/hooks/useCachedData-integration.test.ts
+++ b/web/src/hooks/useCachedData-integration.test.ts
@@ -23,30 +23,17 @@ const {
 // Module mocks
 // ---------------------------------------------------------------------------
 
-vi.mock('../lib/cache', () => ({
-  useCache: (...args: unknown[]) => mockUseCache(...args),
-  // createCachedHook is a factory that returns a React hook. Hooks that use it
-  // are re-exported through useCachedData.ts; this stub prevents load failures
-  // when the module is imported in tests that only mock useCache.
-  createCachedHook: (_config: unknown) => () => mockUseCache(_config),
-  CONSECUTIVE_FAILURE_THRESHOLD: 3,
-  REFRESH_RATES: {
-    realtime: 15_000,
-    pods: 30_000,
-    clusters: 60_000,
-    deployments: 60_000,
-    services: 60_000,
-    metrics: 45_000,
-    gpu: 45_000,
-    helm: 120_000,
-    gitops: 120_000,
-    namespaces: 180_000,
-    rbac: 300_000,
-    operators: 300_000,
-    costs: 600_000,
-    default: 120_000,
-  },
-}))
+vi.mock('../lib/cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/cache')>()
+  return {
+    ...actual,
+    useCache: (...args: unknown[]) => mockUseCache(...args),
+    // createCachedHook is a factory that returns a React hook. Hooks that use it
+    // are re-exported through useCachedData.ts; this stub prevents load failures
+    // when the module is imported in tests that only mock useCache.
+    createCachedHook: (_config: unknown) => () => mockUseCache(_config),
+  }
+})
 
 vi.mock('../lib/api', () => ({
   isBackendUnavailable: () => mockIsBackendUnavailable(),

--- a/web/src/hooks/useCachedData-pods-events.test.ts
+++ b/web/src/hooks/useCachedData-pods-events.test.ts
@@ -23,30 +23,17 @@ const {
 // Module mocks
 // ---------------------------------------------------------------------------
 
-vi.mock('../lib/cache', () => ({
-  useCache: (...args: unknown[]) => mockUseCache(...args),
-  // createCachedHook is a factory that returns a React hook. Hooks that use it
-  // are re-exported through useCachedData.ts; this stub prevents load failures
-  // when the module is imported in tests that only mock useCache.
-  createCachedHook: (_config: unknown) => () => mockUseCache(_config),
-  CONSECUTIVE_FAILURE_THRESHOLD: 3,
-  REFRESH_RATES: {
-    realtime: 15_000,
-    pods: 30_000,
-    clusters: 60_000,
-    deployments: 60_000,
-    services: 60_000,
-    metrics: 45_000,
-    gpu: 45_000,
-    helm: 120_000,
-    gitops: 120_000,
-    namespaces: 180_000,
-    rbac: 300_000,
-    operators: 300_000,
-    costs: 600_000,
-    default: 120_000,
-  },
-}))
+vi.mock('../lib/cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/cache')>()
+  return {
+    ...actual,
+    useCache: (...args: unknown[]) => mockUseCache(...args),
+    // createCachedHook is a factory that returns a React hook. Hooks that use it
+    // are re-exported through useCachedData.ts; this stub prevents load failures
+    // when the module is imported in tests that only mock useCache.
+    createCachedHook: (_config: unknown) => () => mockUseCache(_config),
+  }
+})
 
 vi.mock('../lib/api', () => ({
   isBackendUnavailable: () => mockIsBackendUnavailable(),

--- a/web/src/hooks/useCachedData-resources.test.ts
+++ b/web/src/hooks/useCachedData-resources.test.ts
@@ -23,30 +23,17 @@ const {
 // Module mocks
 // ---------------------------------------------------------------------------
 
-vi.mock('../lib/cache', () => ({
-  useCache: (...args: unknown[]) => mockUseCache(...args),
-  // createCachedHook is a factory that returns a React hook. Hooks that use it
-  // are re-exported through useCachedData.ts; this stub prevents load failures
-  // when the module is imported in tests that only mock useCache.
-  createCachedHook: (_config: unknown) => () => mockUseCache(_config),
-  CONSECUTIVE_FAILURE_THRESHOLD: 3,
-  REFRESH_RATES: {
-    realtime: 15_000,
-    pods: 30_000,
-    clusters: 60_000,
-    deployments: 60_000,
-    services: 60_000,
-    metrics: 45_000,
-    gpu: 45_000,
-    helm: 120_000,
-    gitops: 120_000,
-    namespaces: 180_000,
-    rbac: 300_000,
-    operators: 300_000,
-    costs: 600_000,
-    default: 120_000,
-  },
-}))
+vi.mock('../lib/cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/cache')>()
+  return {
+    ...actual,
+    useCache: (...args: unknown[]) => mockUseCache(...args),
+    // createCachedHook is a factory that returns a React hook. Hooks that use it
+    // are re-exported through useCachedData.ts; this stub prevents load failures
+    // when the module is imported in tests that only mock useCache.
+    createCachedHook: (_config: unknown) => () => mockUseCache(_config),
+  }
+})
 
 vi.mock('../lib/api', () => ({
   isBackendUnavailable: () => mockIsBackendUnavailable(),


### PR DESCRIPTION
Fixes #19762

## Root Cause

The split useArgoCD and useCachedData test files used **complete mock replacements** for `lib/cache` that only exported `useCache` and `createCachedHook`. In vitest sharded mode (12 parallel workers), these incomplete mocks leaked across test files, breaking 247 tests that import other exports like `CONSECUTIVE_FAILURE_THRESHOLD` and `REFRESH_RATES`.

PR #19764 attempted to fix this by hardcoding the missing constants, but vitest module resolution still caused conflicts because the mock was a complete replacement rather than a partial override.

## Fix

Changed all 6 problematic test files to use the `async (importOriginal)` pattern that **preserves all actual exports** while only mocking specific functions:

```typescript
vi.mock('lib/cache', async (importOriginal) => {
  const actual = await importOriginal<typeof import('lib/cache')>()
  return {
    ...actual,  // ✅ Preserve all real exports
    useCache: mockUseCache,  // Override only what we need
  }
})
```

This matches the pattern used in working tests like `useCachedThanosStatus.test.ts` and **prevents mock contamination** in parallel test runs.

## Files Changed

- `web/src/hooks/__tests__/useArgoCD-additional.test.ts`
- `web/src/hooks/__tests__/useArgoCD-applications.test.ts`
- `web/src/hooks/__tests__/useArgoCD-health-sync.test.ts`
- `web/src/hooks/useCachedData-integration.test.ts`
- `web/src/hooks/useCachedData-pods-events.test.ts`
- `web/src/hooks/useCachedData-resources.test.ts`

## Testing

Will be validated by CI — the fix addresses the root cause of mock isolation issues in sharded test execution.