### PR TITLE
[scanner] fix: remove extra closing braces from test files causing lint parse errors

### DIFF
--- a/web/src/hooks/__tests__/useCachedData-kubectl.test.ts
+++ b/web/src/hooks/__tests__/useCachedData-kubectl.test.ts
@@ -391,4 +391,3 @@ describe('useCachedData', () => {
     })
   })
 })
-})

--- a/web/src/hooks/__tests__/useCertManager-caching.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-caching.test.ts
@@ -617,4 +617,3 @@ describe('useCertManager', () => {
     })
   })
 })
-})

--- a/web/src/hooks/__tests__/useMetricsHistory-advanced.test.ts
+++ b/web/src/hooks/__tests__/useMetricsHistory-advanced.test.ts
@@ -455,4 +455,3 @@ describe('useMetricsHistory', () => {
     })
   })
 })
-})


### PR DESCRIPTION
## Problem

Three test files have an extra closing `})` that causes ESLint parsing errors:

- `useCachedData-kubectl.test.ts:394` — `Parsing error: Declaration or statement expected`
- `useCertManager-caching.test.ts:620` — `Parsing error: Declaration or statement expected`
- `useMetricsHistory-advanced.test.ts:458` — `Parsing error: Declaration or statement expected`

This breaks the `build-gate` lint step on **all PRs**, since these files exist on `main`. The lint summary shows 3 errors among 2833 warnings — these 3 parse errors are the only actual errors.

## Fix

Remove the extra `})` from the end of each file. Each file's `describe()` blocks are properly balanced — the last `})` was a surplus that caused the parser to see an unexpected token after the top-level describe had already closed.

## Files Changed

| File | Lines | Change |
|------|-------|--------|
| `useCachedData-kubectl.test.ts` | 394→393 | Remove extra `})` |
| `useCertManager-caching.test.ts` | 620→619 | Remove extra `})` |
| `useMetricsHistory-advanced.test.ts` | 458→457 | Remove extra `})` |