### PR TITLE
🐛 fix: update trivy installation in container-scan script

### DIFF
--- a/scripts/container-scan-test.sh
+++ b/scripts/container-scan-test.sh
@@ -60,18 +60,12 @@ if ! command -v trivy &>/dev/null; then
   if command -v brew &>/dev/null; then
     brew install trivy 2>/dev/null
   else
-    # Install trivy binary from GitHub releases
-    TRIVY_VERSION="0.58.2"
-    TRIVY_OS="Linux"
-    TRIVY_ARCH="64bit"
-    TRIVY_TAR="trivy_${TRIVY_VERSION}_${TRIVY_OS}-${TRIVY_ARCH}.tar.gz"
-    TRIVY_URL="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TRIVY_TAR}"
-    
+    # Use official trivy install script for Linux
     INSTALL_DIR="${HOME}/.local/bin"
     mkdir -p "$INSTALL_DIR"
     
-    echo -e "${DIM}Downloading trivy v${TRIVY_VERSION}...${NC}"
-    curl -sfL "$TRIVY_URL" | tar xz -C "$INSTALL_DIR" trivy 2>/dev/null || {
+    echo -e "${DIM}Downloading trivy installer...${NC}"
+    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b "$INSTALL_DIR" 2>/dev/null || {
       echo -e "${RED}ERROR: Cannot install trivy — install manually: brew install trivy${NC}"
       exit 1
     }


### PR DESCRIPTION
Fixes #19784

Replaces the hardcoded Trivy v0.58.2 download with the official aquasecurity install script. The original implementation failed on Linux CI runners due to incorrect binary name formatting and version availability issues.

**Changes:**
- Use `curl | sh` with the official Trivy install script from aquasecurity/trivy
- Dynamically selects the correct platform and architecture
- Falls back to `brew install trivy` on macOS as before
- Maintains all error handling and PATH setup logic