### PR TITLE
[scanner] fix: exclude secret-scan false positives for port numbers

### DIFF
--- a/scripts/secret-scan-test.sh
+++ b/scripts/secret-scan-test.sh
@@ -109,6 +109,7 @@ useDefault = true
   description = "Ignore test fixtures, examples, vendor, and CI docs"
 
 # PCI vendor IDs (15b3=Mellanox, 10de=NVIDIA) flagged as generic-api-key
+# Port numbers and URL paths in comments flagged as generic-api-key
 [[rules]]
   id = "generic-api-key"
   description = "Generic API Key"
@@ -116,6 +117,11 @@ useDefault = true
     regexTarget = "match"
     regexes = [
       '''pci-[0-9a-f]{4}''',
+      '''8080/v1/continuousQueries''',
+    ]
+    fingerprints = [
+      '''Makefile:generic-api-key:17''',
+      '''pkg/api/handlers/mcp/drasi_proxy.go:generic-api-key:188''',
     ]
 TOML
 


### PR DESCRIPTION
Fixes #19783

Adds gitleaks exclusions for false-positive 'Generic API Key' findings that flag port numbers (8080) and URL paths as secrets.

**Changes:**
- Added regex and fingerprint allowlist entries to gitleaks config in `scripts/secret-scan-test.sh`
- Excludes Makefile:17 (port number in GA4 config comment)
- Excludes pkg/api/handlers/mcp/drasi_proxy.go:188 (URL path in Kubernetes proxy comment)