### PR TITLE
feat: add cached EPP status hook

### DIFF
--- a/web/src/hooks/useCachedEPPStatus.test.ts
+++ b/web/src/hooks/useCachedEPPStatus.test.ts
@@ -1,0 +1,147 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LLMdServer } from './useLLMd'
+
+const { mockFetchLLMdServers, mockUseCache } = vi.hoisted(() => ({
+  mockFetchLLMdServers: vi.fn(),
+  mockUseCache: vi.fn(),
+}))
+
+vi.mock('./useCachedLLMd', () => ({
+  fetchLLMdServers: mockFetchLLMdServers,
+}))
+
+vi.mock('../lib/cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/cache')>()
+  return {
+    ...actual,
+    useCache: (options: unknown) => mockUseCache(options),
+    createCachedHook: (config: Record<string, unknown>) => {
+      return () => {
+        const result = mockUseCache(config)
+        return {
+          data: result.data,
+          isLoading: result.isLoading,
+          isRefreshing: result.isRefreshing,
+          isDemoFallback: result.isDemoFallback && !result.isLoading,
+          error: result.error,
+          isFailed: result.isFailed,
+          consecutiveFailures: result.consecutiveFailures,
+          lastRefresh: result.lastRefresh,
+          refetch: result.refetch,
+          retryFetch: result.retryFetch,
+        }
+      }
+    },
+  }
+})
+
+import {
+  fetchEPPStatus,
+  getDemoEPPStatus,
+  summarizeEPPStatus,
+  useCachedEPPStatus,
+} from './useCachedEPPStatus'
+
+const runningEPP: LLMdServer = {
+  id: 'cluster-a-llm-d-llama-epp',
+  name: 'llama-epp',
+  namespace: 'llm-d',
+  cluster: 'cluster-a',
+  model: 'llama',
+  type: 'llm-d',
+  componentType: 'epp',
+  status: 'running',
+  replicas: 2,
+  readyReplicas: 2,
+}
+
+const scalingEPP: LLMdServer = {
+  ...runningEPP,
+  id: 'cluster-a-llm-d-granite-epp',
+  name: 'granite-epp',
+  model: 'granite',
+  status: 'scaling',
+  readyReplicas: 1,
+}
+
+const modelServer: LLMdServer = {
+  ...runningEPP,
+  id: 'cluster-a-llm-d-llama-model',
+  name: 'llama-model',
+  componentType: 'model',
+}
+
+const BASE_STATUS = {
+  data: getDemoEPPStatus(),
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: 111111111,
+  refetch: vi.fn(),
+  retryFetch: vi.fn(),
+}
+
+describe('useCachedEPPStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue(BASE_STATUS)
+  })
+
+  it('summarizes healthy EPPs', () => {
+    expect(summarizeEPPStatus([runningEPP])).toEqual({
+      health: 'healthy',
+      totalEPPs: 1,
+      readyEPPs: 1,
+      degradedEPPs: 0,
+      unavailableEPPs: 0,
+    })
+  })
+
+  it('marks mixed EPP status as degraded', () => {
+    expect(summarizeEPPStatus([runningEPP, scalingEPP])).toMatchObject({
+      health: 'degraded',
+      totalEPPs: 2,
+      readyEPPs: 1,
+      degradedEPPs: 1,
+    })
+  })
+
+  it('marks an empty EPP list as unavailable', () => {
+    expect(summarizeEPPStatus([])).toMatchObject({
+      health: 'unavailable',
+      totalEPPs: 0,
+    })
+  })
+
+  it('filters EPP components from llm-d servers', async () => {
+    mockFetchLLMdServers.mockResolvedValue([runningEPP, modelServer])
+
+    const status = await fetchEPPStatus(['cluster-a'])
+
+    expect(mockFetchLLMdServers).toHaveBeenCalledWith(['cluster-a'])
+    expect(status.epps).toEqual([runningEPP])
+    expect(status.summary).toMatchObject({
+      health: 'healthy',
+      totalEPPs: 1,
+    })
+  })
+
+  it('provides demo EPP data', () => {
+    const demo = getDemoEPPStatus()
+
+    expect(demo.epps.every((epp) => epp.componentType === 'epp')).toBe(true)
+    expect(demo.summary.totalEPPs).toBe(demo.epps.length)
+  })
+
+  it('returns cached data with EPP convenience fields', () => {
+    const { result } = renderHook(() => useCachedEPPStatus())
+
+    expect(result.current.epps).toEqual(BASE_STATUS.data.epps)
+    expect(result.current.summary).toEqual(BASE_STATUS.data.summary)
+    expect(result.current.isDemoFallback).toBe(false)
+  })
+})

--- a/web/src/hooks/useCachedEPPStatus.ts
+++ b/web/src/hooks/useCachedEPPStatus.ts
@@ -1,0 +1,129 @@
+import { createCachedHook, type CachedHookResult, type RefreshCategory } from '../lib/cache'
+import { fetchLLMdServers } from './useCachedLLMd'
+import type { LLMdServer } from './useLLMd'
+
+export type EPPHealth = 'healthy' | 'degraded' | 'unavailable'
+
+export interface EPPStatusSummary {
+  health: EPPHealth
+  totalEPPs: number
+  readyEPPs: number
+  degradedEPPs: number
+  unavailableEPPs: number
+}
+
+export interface EPPStatusData {
+  epps: LLMdServer[]
+  summary: EPPStatusSummary
+  lastCheckTime: string
+}
+
+const DEFAULT_LLMD_CLUSTERS = ['vllm-d', 'platform-eval'] as const
+
+const DEMO_PRIMARY_REPLICAS = 2
+const DEMO_PRIMARY_READY_REPLICAS = 2
+const DEMO_SECONDARY_REPLICAS = 2
+const DEMO_SECONDARY_READY_REPLICAS = 1
+
+const EMPTY_EPP_STATUS: EPPStatusData = {
+  epps: [],
+  summary: {
+    health: 'unavailable',
+    totalEPPs: 0,
+    readyEPPs: 0,
+    degradedEPPs: 0,
+    unavailableEPPs: 0,
+  },
+  lastCheckTime: '',
+}
+
+export function summarizeEPPStatus(epps: LLMdServer[]): EPPStatusSummary {
+  const readyEPPs = epps.filter((epp) => epp.status === 'running').length
+  const degradedEPPs = epps.filter((epp) => epp.status === 'scaling').length
+  const unavailableEPPs = epps.filter((epp) => epp.status === 'stopped' || epp.status === 'error').length
+
+  let health: EPPHealth = 'healthy'
+  if (epps.length === 0) {
+    health = 'unavailable'
+  } else if (degradedEPPs > 0 || unavailableEPPs > 0) {
+    health = 'degraded'
+  }
+
+  return {
+    health,
+    totalEPPs: epps.length,
+    readyEPPs,
+    degradedEPPs,
+    unavailableEPPs,
+  }
+}
+
+export const getDemoEPPStatus = (): EPPStatusData => {
+  const epps: LLMdServer[] = [
+    {
+      id: 'vllm-d-llm-d-llama-epp',
+      name: 'llama-3-epp',
+      namespace: 'llm-d',
+      cluster: 'vllm-d',
+      model: 'llama-3-70b',
+      type: 'llm-d',
+      componentType: 'epp',
+      status: 'running',
+      replicas: DEMO_PRIMARY_REPLICAS,
+      readyReplicas: DEMO_PRIMARY_READY_REPLICAS,
+    },
+    {
+      id: 'platform-eval-llm-d-granite-epp',
+      name: 'granite-epp',
+      namespace: 'llm-d',
+      cluster: 'platform-eval',
+      model: 'granite-13b',
+      type: 'llm-d',
+      componentType: 'epp',
+      status: 'scaling',
+      replicas: DEMO_SECONDARY_REPLICAS,
+      readyReplicas: DEMO_SECONDARY_READY_REPLICAS,
+    },
+  ]
+
+  return {
+    epps,
+    summary: summarizeEPPStatus(epps),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+export async function fetchEPPStatus(
+  clusters: string[] = [...DEFAULT_LLMD_CLUSTERS]
+): Promise<EPPStatusData> {
+  const servers = await fetchLLMdServers(clusters)
+  const epps = servers.filter((server) => server.componentType === 'epp')
+
+  return {
+    epps,
+    summary: summarizeEPPStatus(epps),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+export function useCachedEPPStatus(
+  clusters: string[] = [...DEFAULT_LLMD_CLUSTERS]
+): CachedHookResult<EPPStatusData> & { epps: LLMdServer[]; summary: EPPStatusSummary } {
+  const key = `llmd-epp-status:${clusters.join(',')}`
+
+  const useEPPStatusBase = createCachedHook<EPPStatusData>({
+    key,
+    category: 'gitops' as RefreshCategory,
+    initialData: EMPTY_EPP_STATUS,
+    getDemoData: getDemoEPPStatus,
+    fetcher: () => fetchEPPStatus(clusters),
+  })
+  const result = useEPPStatusBase()
+
+  return {
+    ...result,
+    epps: result.data.epps,
+    summary: result.data.summary,
+    isDemoFallback: result.isDemoFallback && !result.isLoading,
+  }
+}


### PR DESCRIPTION
Refs #18031

---

## Summary of Changes
- Adds the first decomposed llm-d monitoring slice: a cached EPP status hook with demo fallback data.
- Reuses the existing llm-d server discovery path and filters Endpoint Picker Pod components.
- Adds focused coverage for EPP summary states and fetch filtering.

---

## Changes Made
- [x] Added `useCachedEPPStatus` with typed EPP status summary data.
- [x] Added demo EPP status data for future EPP health card work.
- [x] Added unit tests for summary calculation and EPP filtering.
- [x] Kept this PR scoped to the first child task from #18031.

---

## Checklist
- [x] I have reviewed the project's contribution guidelines
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)