### PR TITLE
[scanner] fix: restore missing exports causing 244 test failures

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -337,6 +337,8 @@ export default defineConfig(({ mode }) => ({
     // CI runners (2-core, 7GB) OOM with 600+ test files at full concurrency
     maxWorkers: process.env.CI ? 1 : undefined,
     minWorkers: process.env.CI ? 1 : undefined,
+    // Force cache clear to resolve module resolution after codeGenerator.templates.ts monolithic restore (#19791)
+    cache: false,
     // poolOptions.forks removed — deprecated in Vitest 4 (#5860).
     // maxWorkers/minWorkers above handle fork limits; teardownTimeout
     // above handles worker termination timeout.


### PR DESCRIPTION
~~Fixes #19791~~

**Closing**: The `cache: false` approach is incorrect. The Coverage Suite has been failing for 10+ consecutive runs (at least since run #3918). This is a pre-existing systemic issue, not caused by the latest commit. CI runners are fresh and have no stale cache to clear.

The actual root cause requires downloading CI logs to identify the common failure pattern across 244 tests spanning unrelated areas (netlify functions, card components, layout components, missions).