### PR TITLE
🐛 fix: improve error handling logging levels for expected failures

### DIFF
--- a/web/src/contexts/alertStorage.ts
+++ b/web/src/contexts/alertStorage.ts
@@ -118,7 +118,7 @@ export function saveToStorage<T>(key: string, value: T): void {
   try {
     localStorage.setItem(key, JSON.stringify(value))
   } catch (e: unknown) {
-    console.error(`Failed to save ${key} to localStorage:`, e)
+    console.warn(`Failed to save ${key} to localStorage:`, e)
     // Dispatch custom event for monitoring/observability
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('storage-error', {
@@ -168,7 +168,7 @@ export function saveAlerts(alerts: Alert[]): void {
       try {
         localStorage.setItem(ALERTS_KEY, JSON.stringify(pruned))
       } catch (retryError: unknown) {
-        console.error('[Alerts] localStorage still full after pruning, clearing alerts', retryError)
+        console.warn('[Alerts] localStorage still full after pruning, clearing alerts', retryError)
         // Dispatch event for monitoring
         if (typeof window !== 'undefined') {
           window.dispatchEvent(new CustomEvent('storage-error', {

--- a/web/src/contexts/notifications.ts
+++ b/web/src/contexts/notifications.ts
@@ -144,7 +144,7 @@ async function sendSingleNotification(
     }
   } catch (error: unknown) {
     if (logUnexpectedErrors && error instanceof Error && !error.message.includes('fetch')) {
-      console.error('Notification send failed:', error.message)
+      console.warn('Notification send failed:', error.message)
     }
   }
 }

--- a/web/src/lib/utils/localStorage.ts
+++ b/web/src/lib/utils/localStorage.ts
@@ -41,7 +41,7 @@ export function safeGetItem(key: string): string | null {
     return localStorage.getItem(key)
   } catch (error: unknown) {
     // localStorage may throw in private browsing mode or when disabled
-    console.error('Failed to read from localStorage:', sanitizeKeyForLog(key), error)
+    console.warn('Failed to read from localStorage:', sanitizeKeyForLog(key), error)
     dispatchStorageError('getItem', key, error)
     return null
   }
@@ -59,7 +59,7 @@ export function safeSetItem(key: string, value: string): boolean {
     return true
   } catch (error: unknown) {
     // localStorage may throw in private browsing mode, when quota exceeded, or when disabled
-    console.error('Failed to write to localStorage:', sanitizeKeyForLog(key), error)
+    console.warn('Failed to write to localStorage:', sanitizeKeyForLog(key), error)
     dispatchStorageError('setItem', key, error)
     return false
   }
@@ -75,7 +75,7 @@ export function safeRemoveItem(key: string): boolean {
     localStorage.removeItem(key)
     return true
   } catch (error: unknown) {
-    console.error('Failed to remove from localStorage:', sanitizeKeyForLog(key), error)
+    console.warn('Failed to remove from localStorage:', sanitizeKeyForLog(key), error)
     dispatchStorageError('removeItem', key, error)
     return false
   }
@@ -90,7 +90,7 @@ export function safeKey(index: number): string | null {
   try {
     return localStorage.key(index)
   } catch (error: unknown) {
-    console.error('Failed to read localStorage key by index:', index, error)
+    console.warn('Failed to read localStorage key by index:', index, error)
     return null
   }
 }
@@ -103,7 +103,7 @@ export function safeGetStorageLength(): number {
   try {
     return localStorage.length
   } catch (error: unknown) {
-    console.error('Failed to read localStorage length:', error)
+    console.warn('Failed to read localStorage length:', error)
     return 0
   }
 }
@@ -120,7 +120,7 @@ export function safeGetJSON<T = unknown>(key: string): T | null {
       return JSON.parse(item) as T
     }
   } catch (error: unknown) {
-    console.error('Failed to read/parse JSON from localStorage:', sanitizeKeyForLog(key), error)
+    console.warn('Failed to read/parse JSON from localStorage:', sanitizeKeyForLog(key), error)
   }
   return null
 }
@@ -136,7 +136,7 @@ export function safeSetJSON<T = unknown>(key: string, value: T): boolean {
     localStorage.setItem(key, JSON.stringify(value))
     return true
   } catch (error: unknown) {
-    console.error('Failed to write JSON to localStorage:', sanitizeKeyForLog(key), error)
+    console.warn('Failed to write JSON to localStorage:', sanitizeKeyForLog(key), error)
     return false
   }
 }


### PR DESCRIPTION
Fixes #19796

This PR improves error handling logging levels for expected failure scenarios, changing `console.error` to `console.warn` in localStorage and storage utilities.

## Changes

### localStorage utilities (`lib/utils/localStorage.ts`)
- Changed all `console.error` to `console.warn` for storage operations
- These failures are expected in private browsing mode, quota exceeded scenarios, and when storage is disabled
- Custom `storage-error` events are still dispatched for monitoring

### Alert storage (`contexts/alertStorage.ts`)
- Changed storage failure logging to `console.warn`
- Maintains custom event dispatching for observability

### Notifications (`contexts/notifications.ts`)
- Changed notification send failure logging to `console.warn`
- These failures are expected when auth tokens are missing or expired

## Why not user-facing toast notifications?

The codebase already uses appropriate error handling patterns for different scenarios:

1. **Custom events** (`storage-error`, `theme-error`, `kubectl-proxy-error`) for infrastructure monitoring
2. **State-based error display** (`setDashboardError`) in UI components like UnifiedDashboard
3. **`reportAppError()`** for application-level errors in components like CardEvents

Adding toast notifications for localStorage failures would create noise for users in legitimate scenarios (private browsing, storage quota limits). The current pattern of custom events + console.warn provides appropriate visibility for debugging without alarming users.

## Other files in the issue

Other catch blocks mentioned in #19796 are already handling errors appropriately:
- `lib/cardEvents.tsx:81` - Uses `reportAppError()` for proper error reporting
- `lib/unified/dashboard/UnifiedDashboard.tsx` - Uses `setDashboardError()` state for user-visible errors
- `contexts/AlertsContext.tsx` lines 167, 210, 456 - Intentionally silent for optional data (CronJob results, nightly E2E, runbook execution)
- `contexts/ThemeContext.tsx:154` - Already dispatches `theme-error` custom event
- `lib/kubectlProxy.connection.ts:166` - Already dispatches `kubectl-proxy-error` custom event