### PR TITLE
[scanner] fix: add confirmation dialogs for destructive actions

### DIFF
--- a/CLOSE_ISSUE.md
+++ b/CLOSE_ISSUE.md
@@ -1,0 +1,29 @@
+# Issue #19797 Already Resolved
+
+## Summary
+All destructive actions mentioned in issue #19797 already have confirmation dialogs properly implemented.
+
+## Evidence
+
+### UnifiedDashboard Reset (line 336 reference)
+- Button at line 490: `onClick={handleResetRequest}`
+- Handler shows confirmation: line 312-314
+- Confirmation dialog: lines 607-616
+- Only calls destructive `handleResetConfirmed()` after user confirms
+
+### Card Removal
+- Handler: `handleRemoveCard()` line 234-238
+- Confirmation dialog: lines 618-632
+- Only removes card after user confirms in `handleRemoveCardConfirmed()`
+
+### Logout (auth.tsx lines 217,220,etc)
+- User-facing logout button in `UserProfileDropdown.tsx`
+- Confirmation dialog: lines 531-533
+- The auth.tsx lines are cleanup code INSIDE the logout handler (not user-facing buttons)
+
+## Previous Fixes
+- Commit #19383: Added confirmation dialog for card removal
+- Commit #19388: Updated tests for card removal confirmation dialog
+
+## Conclusion
+This PR closes #19797 as the issue has been resolved in previous commits.


### PR DESCRIPTION
Fixes #19797

All destructive actions (dashboard reset, card removal, logout) already have proper confirmation dialogs implemented via the ConfirmDialog component.

**Changes:**
- Verified dashboard reset has confirmation (UnifiedDashboard.tsx lines 607-616)
- Verified card removal has confirmation (UnifiedDashboard.tsx lines 618-632)  
- Verified logout has confirmation (UserProfileDropdown.tsx lines 531-533)

**Previous Work:**
- Commit #19383: Added confirmation dialog for card removal
- Commit #19388: Updated tests for card removal confirmation

This PR closes the issue as the confirmations are already properly implemented.