### PR TITLE
[scanner] fix: repair card status render tests

### DIFF
--- a/web/src/components/cards/backstage_status/backstage_status.test.tsx
+++ b/web/src/components/cards/backstage_status/backstage_status.test.tsx
@@ -37,7 +37,7 @@ function setup(overrides?: Record<string, unknown>) {
     },
     isLoading: false,
     isRefreshing: false,
-    isDemoData: false,
+    isDemoFallback: false,
     isFailed: false,
     consecutiveFailures: 0,
     lastRefresh: Date.now(),

--- a/web/src/components/cards/grpc_status/grpc_status.test.tsx
+++ b/web/src/components/cards/grpc_status/grpc_status.test.tsx
@@ -41,7 +41,7 @@ function setup(overrides?: Record<string, unknown>) {
     },
     isLoading: false,
     isRefreshing: false,
-    isDemoData: false,
+    isDemoFallback: false,
     isFailed: false,
     consecutiveFailures: 0,
     lastRefresh: Date.now(),

--- a/web/src/components/cards/linkerd_status/linkerd_status.test.tsx
+++ b/web/src/components/cards/linkerd_status/linkerd_status.test.tsx
@@ -38,7 +38,7 @@ function setup(overrides?: Record<string, unknown>) {
     },
     isLoading: false,
     isRefreshing: false,
-    isDemoData: false,
+    isDemoFallback: false,
     isFailed: false,
     consecutiveFailures: 0,
     lastRefresh: Date.now(),

--- a/web/src/components/cards/rook_status/rook_status.test.tsx
+++ b/web/src/components/cards/rook_status/rook_status.test.tsx
@@ -36,7 +36,7 @@ function setup(overrides?: Record<string, unknown>) {
     },
     isLoading: false,
     isRefreshing: false,
-    isDemoData: false,
+    isDemoFallback: false,
     isFailed: false,
     consecutiveFailures: 0,
     lastRefresh: Date.now(),

--- a/web/src/components/cards/spiffe_status/spiffe_status.test.tsx
+++ b/web/src/components/cards/spiffe_status/spiffe_status.test.tsx
@@ -36,7 +36,7 @@ function setup(overrides?: Record<string, unknown>) {
     },
     isLoading: false,
     isRefreshing: false,
-    isDemoData: false,
+    isDemoFallback: false,
     isFailed: false,
     consecutiveFailures: 0,
     lastRefresh: Date.now(),


### PR DESCRIPTION
Partially fixes #19800

Fixes failing render tests for backstage_status, grpc_status, linkerd_status, rook_status, and spiffe_status cards.

## Root Cause
Test mocks were using `isDemoData` while the actual hooks return `isDemoFallback` from the `CachedHookResult` type. This mismatch caused all tests to fail when components tried to access the `isDemoFallback` field.

## Changes
Updated mock return values in 5 test files to use `isDemoFallback` instead of `isDemoData`:
- `backstage_status.test.tsx`
- `grpc_status.test.tsx`
- `linkerd_status.test.tsx`
- `rook_status.test.tsx`
- `spiffe_status.test.tsx`

## Tests Fixed
✅ 10 test cases across 5 card components now pass:
- BackstageStatus renders skeleton when loading
- BackstageStatus renders without error when data is loaded
- GrpcStatus renders skeleton when loading
- GrpcStatus renders without error when data is loaded
- LinkerdStatus renders skeleton when loading
- LinkerdStatus renders without error when data is loaded
- RookStatus renders skeleton when loading
- RookStatus renders without error when data is loaded
- SpiffeStatus renders skeleton when loading
- SpiffeStatus renders without error when data is loaded

## Impact
This PR fixes 10 of the 154 test failures reported in issue #19800.