### PR TITLE
[scanner] fix: repair LLMd card tests and Netlify function tests

### DIFF
--- a/web/netlify/functions/_shared/__tests__/fetchWithTimeout.test.ts
+++ b/web/netlify/functions/_shared/__tests__/fetchWithTimeout.test.ts
@@ -2,14 +2,23 @@
  * Unit tests for fetchWithTimeout.ts (#16109).
  * Tests timeout enforcement and signal propagation.
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchWithTimeout } from "../fetchWithTimeout";
 
 describe("fetchWithTimeout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   it("should return response on successful fetch", async () => {
     const mockResponse = new Response("success", { status: 200 });
     const mockFetch = vi.fn().mockResolvedValueOnce(mockResponse);
-    global.fetch = mockFetch;
+    vi.stubGlobal("fetch", mockFetch);
 
     const result = await fetchWithTimeout("http://example.com", { timeoutMs: 5000 });
 
@@ -21,7 +30,7 @@ describe("fetchWithTimeout", () => {
       expect(options.signal).toBeDefined();
       return Promise.resolve(new Response("success", { status: 200 }));
     });
-    global.fetch = mockFetch;
+    vi.stubGlobal("fetch", mockFetch);
 
     await fetchWithTimeout("http://example.com");
 
@@ -33,7 +42,7 @@ describe("fetchWithTimeout", () => {
       expect(options.signal).toBeDefined();
       return Promise.resolve(new Response("success", { status: 200 }));
     });
-    global.fetch = mockFetch;
+    vi.stubGlobal("fetch", mockFetch);
 
     await fetchWithTimeout("http://example.com", { timeoutMs: 3000 });
 
@@ -42,7 +51,7 @@ describe("fetchWithTimeout", () => {
 
   it("should pass through fetch options", async () => {
     const mockFetch = vi.fn().mockResolvedValue(new Response("success", { status: 200 }));
-    global.fetch = mockFetch;
+    vi.stubGlobal("fetch", mockFetch);
 
     await fetchWithTimeout("http://example.com", {
       timeoutMs: 5000,
@@ -67,7 +76,7 @@ describe("fetchWithTimeout", () => {
 
     for (const statusCode of testCases) {
       const mockFetch = vi.fn().mockResolvedValueOnce(new Response("test", { status: statusCode }));
-      global.fetch = mockFetch;
+      vi.stubGlobal("fetch", mockFetch);
 
       const result = await fetchWithTimeout("http://example.com", { timeoutMs: 5000 });
       expect(result.status).toBe(statusCode);
@@ -76,7 +85,7 @@ describe("fetchWithTimeout", () => {
 
   it("should propagate fetch errors", async () => {
     const mockFetch = vi.fn().mockRejectedValueOnce(new Error("Network error"));
-    global.fetch = mockFetch;
+    vi.stubGlobal("fetch", mockFetch);
 
     await expect(fetchWithTimeout("http://example.com", { timeoutMs: 5000 }))
       .rejects.toThrow("Network error");
@@ -85,7 +94,7 @@ describe("fetchWithTimeout", () => {
   it("should handle timeout abort errors", async () => {
     const timeoutError = new DOMException("The operation was aborted.", "AbortError");
     const mockFetch = vi.fn().mockRejectedValueOnce(timeoutError);
-    global.fetch = mockFetch;
+    vi.stubGlobal("fetch", mockFetch);
 
     await expect(fetchWithTimeout("http://example.com", { timeoutMs: 100 }))
       .rejects.toThrow();
@@ -94,7 +103,7 @@ describe("fetchWithTimeout", () => {
   it("should handle empty options", async () => {
     const mockResponse = new Response("success", { status: 200 });
     const mockFetch = vi.fn().mockResolvedValueOnce(mockResponse);
-    global.fetch = mockFetch;
+    vi.stubGlobal("fetch", mockFetch);
 
     const result = await fetchWithTimeout("http://example.com");
 
@@ -108,7 +117,7 @@ describe("fetchWithTimeout", () => {
       expect(options.signal).toBeDefined();
       return Promise.resolve(new Response("success", { status: 200 }));
     });
-    global.fetch = mockFetch;
+    vi.stubGlobal("fetch", mockFetch);
 
     await fetchWithTimeout("http://example.com", {
       timeoutMs: 5000,

--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitorChart.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitorChart.test.tsx
@@ -9,6 +9,25 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => mockUseDemoMode(),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),

--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitorDetailPanel.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitorDetailPanel.test.tsx
@@ -1,6 +1,33 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render } from '@testing-library/react'
 
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => mockUseDemoMode(),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),

--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitorHeader.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitorHeader.test.tsx
@@ -1,6 +1,33 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render } from '@testing-library/react'
 
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => mockUseDemoMode(),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),

--- a/web/src/components/cards/llmd/__tests__/LLMdConfigurator.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/LLMdConfigurator.test.tsx
@@ -9,6 +9,25 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => mockUseDemoMode(),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),

--- a/web/src/components/cards/llmd/__tests__/NightlyE2EDetailPanel.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/NightlyE2EDetailPanel.test.tsx
@@ -1,6 +1,33 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render } from '@testing-library/react'
 
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => mockUseDemoMode(),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),

--- a/web/src/components/cards/llmd/__tests__/NightlyE2EGuideRow.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/NightlyE2EGuideRow.test.tsx
@@ -1,6 +1,33 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render } from '@testing-library/react'
 
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => mockUseDemoMode(),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),


### PR DESCRIPTION
Partially fixes #19800

Fixes failing tests for LLMd card components (KVCacheMonitor*, NightlyE2E*, LLMdConfigurator) and Netlify shared function tests (analytics-dashboard, core-utils, fetchWithTimeout, rate-limit).

## Root Cause

Missing standard mock setup and test lifecycle hooks.

**LLMd card tests** were missing:
- `useDemoMode` hook mock
- `analytics` module mock  
- `useTokenUsage` hook mock

These mocks are required by CardDataContext and other shared infrastructure.

**Netlify fetchWithTimeout test** was missing:
- beforeEach/afterEach lifecycle hooks
- Proper `vi.stubGlobal` instead of direct `global.fetch` mutation

This caused mock isolation failures in vitest sharded mode (12 parallel workers).

## Changes

- Added standard mock setup to all 6 LLMd test files
- Added proper test lifecycle hooks to fetchWithTimeout.test.ts
- Changed global.fetch mutation to vi.stubGlobal for proper cleanup

All changes follow the pattern established in PR #19768, #19755, #19741.