### PR TITLE
[scanner] fix: add fallback for undefined tags in savedMissionToExport

### DIFF
--- a/web/src/components/layout/mission-sidebar/missionSidebarHelpers.ts
+++ b/web/src/components/layout/mission-sidebar/missionSidebarHelpers.ts
@@ -126,7 +126,7 @@ export function savedMissionToExport(m: Mission): MissionExport {
     title: m.importedFrom?.title || m.title,
     description: m.importedFrom?.description || m.description,
     type: m.type,
-    tags: m.importedFrom?.tags,
+    tags: m.importedFrom?.tags || [],
     missionClass: m.importedFrom?.missionClass as MissionExport['missionClass'],
     cncfProject: m.importedFrom?.cncfProject,
     steps: (m.importedFrom?.steps || []).map(s => ({


### PR DESCRIPTION
Fixes #19805, Fixes #19806

## Summary

The `tags` property in `savedMissionToExport` used `m.importedFrom?.tags` which evaluates to `undefined` when `importedFrom` is null/undefined, but `MissionExport.tags` requires `string[]`.

Added `|| []` fallback, matching the existing pattern already used for `steps` on the next line.

## Root Cause

PR #19803/#19804 merged changes that exposed this pre-existing type mismatch. The TypeScript compiler now correctly reports:
```
error TS2322: Type 'string[] | undefined' is not assignable to type 'string[]'.
```

## Fix

```diff
-    tags: m.importedFrom?.tags,
+    tags: m.importedFrom?.tags || [],
```

Signed-off-by: Andy Anderson <andy@clubanderson.com>