### PR TITLE
[scanner] fix: resolve color consistency issues across components

### DIFF
--- a/web/src/components/mission-control/fixer-definition-panel/TargetClusterSelector.tsx
+++ b/web/src/components/mission-control/fixer-definition-panel/TargetClusterSelector.tsx
@@ -133,7 +133,7 @@ export function TargetClusterSelector({ selected, onChange }: TargetClusterSelec
                   )}
                   onClick={() => toggleCluster(name)}
                 >
-                  <span className={cn('w-1.5 h-1.5 rounded-full', isHealthy ? 'bg-green-500' : 'bg-yellow-500')} />
+                  <span className={cn('w-1.5 h-1.5 rounded-full', isHealthy ? 'bg-green-400' : 'bg-yellow-400')} />
                   {name}
                   <XIcon className="w-3 h-3 opacity-50 hover:opacity-100" />
                 </button>
@@ -208,7 +208,7 @@ export function TargetClusterSelector({ selected, onChange }: TargetClusterSelec
                 )}
                 onClick={() => toggleCluster(name)}
               >
-                <span className={cn('w-2 h-2 rounded-full shrink-0', isHealthy ? 'bg-green-500' : 'bg-yellow-500')} />
+                <span className={cn('w-2 h-2 rounded-full shrink-0', isHealthy ? 'bg-green-400' : 'bg-yellow-400')} />
                 <span className="truncate">{name}</span>
                 {isSelected && <span className="ml-auto text-primary text-xs">✓</span>}
               </button>

--- a/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
+++ b/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { ShieldAlert, Check, X } from 'lucide-react'
 import { NotificationConfig } from '../../../types/alerts'
 import type { TestResultState } from './NotificationSettingsSection'
+import { cn } from '../../../lib/cn'
 
 interface OpsGenieNotificationSettingsProps {
   config: NotificationConfig
@@ -99,7 +100,7 @@ export function OpsGenieNotificationSettings({
           ) : (
             <X className="w-4 h-4 text-red-400 shrink-0 mt-0.5" />
           )}
-          <p className={`text-sm ${testResult.success ? 'text-green-400' : 'text-red-400'}`}>
+          <p className={cn('text-sm', testResult.success ? 'text-green-400' : 'text-red-400')}>
             {testResult.message}
           </p>
         </div>

--- a/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
+++ b/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { Siren, Check, X } from 'lucide-react'
 import { NotificationConfig } from '../../../types/alerts'
 import type { TestResultState } from './NotificationSettingsSection'
+import { cn } from '../../../lib/cn'
 
 interface PagerDutyNotificationSettingsProps {
   config: NotificationConfig
@@ -99,7 +100,7 @@ export function PagerDutyNotificationSettings({
           ) : (
             <X className="w-4 h-4 text-red-400 shrink-0 mt-0.5" />
           )}
-          <p className={`text-sm ${testResult.success ? 'text-green-400' : 'text-red-400'}`}>
+          <p className={cn('text-sm', testResult.success ? 'text-green-400' : 'text-red-400')}>
             {testResult.message}
           </p>
         </div>

--- a/web/src/components/settings/sections/PersistenceSection.tsx
+++ b/web/src/components/settings/sections/PersistenceSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Database, RefreshCw, Check, X, AlertCircle, Loader2 } from 'lucide-react'
 import { usePersistence, type PersistenceConfig, type ClusterHealth } from '../../../hooks/usePersistence'
 import { useClusters } from '../../../hooks/mcp/clusters'
+import { cn } from '../../../lib/cn'
 
 interface ClusterInfo {
   name: string
@@ -180,7 +181,7 @@ export function PersistenceSection() {
               </button>
             </div>
             {testResult && testResult.cluster === localConfig.primaryCluster && (
-              <p className={`text-xs mt-1 ${testResult.success ? 'text-green-400' : 'text-red-400'}`}>
+              <p className={cn('text-xs mt-1', testResult.success ? 'text-green-400' : 'text-red-400')}>
                 {testResult.success ? t('settings.persistence.connectionSuccess') : t('settings.persistence.connectionFailed')}
               </p>
             )}
@@ -252,7 +253,7 @@ export function PersistenceSection() {
                 </button>
               </div>
               {testResult && testResult.cluster === localConfig.secondaryCluster && (
-                <p className={`text-xs mt-1 ${testResult.success ? 'text-green-400' : 'text-red-400'}`}>
+                <p className={cn('text-xs mt-1', testResult.success ? 'text-green-400' : 'text-red-400')}>
                   {testResult.success ? t('settings.persistence.connectionSuccess') : t('settings.persistence.connectionFailed')}
                 </p>
               )}


### PR DESCRIPTION
Fixes #19820

## Changes

This PR addresses color consistency issues identified in the Auto-QA scan:

### Fixed Issues

1. **TargetClusterSelector.tsx** (lines 136, 211)
   - Changed `bg-green-500` → `bg-green-400` 
   - Changed `bg-yellow-500` → `bg-yellow-400`
   - Ensures consistent color shades for status indicators

2. **PersistenceSection.tsx** (lines 183, 255)
   - Replaced template literal className concatenation with `cn()` utility
   - Added missing `cn` import
   - Standardized conditional className pattern

3. **OpsGenieNotificationSettings.tsx** (line 102)
   - Replaced template literal className concatenation with `cn()` utility
   - Added missing `cn` import

4. **PagerDutyNotificationSettings.tsx** (line 102)
   - Replaced template literal className concatenation with `cn()` utility
   - Added missing `cn` import

### Impact

- More consistent color usage across components
- Cleaner code with `cn()` utility instead of template literals
- Follows established codebase patterns for className merging

Small, focused PR as recommended in issue guidance.