### PR TITLE
[scanner] fix: resolve keyboard navigation gaps across components

### DIFF
--- a/web/src/components/clusters/components/FilterTabs.tsx
+++ b/web/src/components/clusters/components/FilterTabs.tsx
@@ -52,10 +52,31 @@ export function FilterTabs({
   onCreateClusterWithAI,
 }: FilterTabsProps) {
   const { t } = useTranslation()
+  
+  const filterOptions: FilterType[] = ['all', 'healthy', 'unhealthy', 'unreachable']
+  
+  const handleFilterKeyDown = (e: React.KeyboardEvent, currentFilter: FilterType) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault()
+      const currentIndex = filterOptions.indexOf(currentFilter)
+      const nextIndex = e.key === 'ArrowRight' 
+        ? (currentIndex + 1) % filterOptions.length
+        : (currentIndex - 1 + filterOptions.length) % filterOptions.length
+      onFilterChange(filterOptions[nextIndex])
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      onFilterChange(filterOptions[0])
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      onFilterChange(filterOptions[filterOptions.length - 1])
+    }
+  }
+
   return (
     <div className="flex flex-wrap gap-2 mb-4">
       <button
         onClick={() => onFilterChange('all')}
+        onKeyDown={(e) => handleFilterKeyDown(e, 'all')}
         className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
           filter === 'all'
             ? 'bg-primary text-primary-foreground'
@@ -66,6 +87,7 @@ export function FilterTabs({
       </button>
       <button
         onClick={() => onFilterChange('healthy')}
+        onKeyDown={(e) => handleFilterKeyDown(e, 'healthy')}
         className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
           filter === 'healthy'
             ? 'bg-green-500 text-foreground'
@@ -76,6 +98,7 @@ export function FilterTabs({
       </button>
       <button
         onClick={() => onFilterChange('unhealthy')}
+        onKeyDown={(e) => handleFilterKeyDown(e, 'unhealthy')}
         className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
           filter === 'unhealthy'
             ? 'bg-orange-500 text-foreground'
@@ -86,6 +109,7 @@ export function FilterTabs({
       </button>
       <button
         onClick={() => onFilterChange('unreachable')}
+        onKeyDown={(e) => handleFilterKeyDown(e, 'unreachable')}
         className={`flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
           filter === 'unreachable'
             ? 'bg-yellow-500 text-foreground'
@@ -129,6 +153,23 @@ export function FilterTabs({
               <button
                 key={mode}
                 onClick={() => onLayoutModeChange(mode)}
+                onKeyDown={(e) => {
+                  const modes = LAYOUT_OPTIONS.map((opt) => opt.mode)
+                  const currentIndex = modes.indexOf(mode)
+                  if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+                    e.preventDefault()
+                    const nextIndex = e.key === 'ArrowRight' 
+                      ? (currentIndex + 1) % modes.length
+                      : (currentIndex - 1 + modes.length) % modes.length
+                    onLayoutModeChange(modes[nextIndex])
+                  } else if (e.key === 'Home') {
+                    e.preventDefault()
+                    onLayoutModeChange(modes[0])
+                  } else if (e.key === 'End') {
+                    e.preventDefault()
+                    onLayoutModeChange(modes[modes.length - 1])
+                  }
+                }}
                 className={`p-1.5 rounded-lg transition-colors ${
                   layoutMode === mode
                     ? 'bg-primary text-primary-foreground'

--- a/web/src/components/marketplace/Marketplace.tsx
+++ b/web/src/components/marketplace/Marketplace.tsx
@@ -608,6 +608,48 @@ export function Marketplace() {
   const [sortField, setSortField] = useState<SortField>('name')
   const [sortOrder, setSortOrder] = useState<SortOrder>('asc')
 
+  // Type filter keyboard navigation
+  const typeOptions: (MarketplaceItemType | null)[] = [null, ...Object.keys(TYPE_LABELS) as MarketplaceItemType[]]
+  
+  const handleTypeKeyDown = (e: React.KeyboardEvent, currentType: MarketplaceItemType | null) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault()
+      const currentIndex = typeOptions.indexOf(currentType)
+      const nextIndex = e.key === 'ArrowRight'
+        ? (currentIndex + 1) % typeOptions.length
+        : (currentIndex - 1 + typeOptions.length) % typeOptions.length
+      const nextType = typeOptions[nextIndex]
+      setSelectedType(nextType)
+      setShowHelpWanted(false)
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      setSelectedType(null)
+      setShowHelpWanted(false)
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      setSelectedType(typeOptions[typeOptions.length - 1])
+      setShowHelpWanted(false)
+    }
+  }
+
+  // Tag filter keyboard navigation
+  const handleTagKeyDown = (e: React.KeyboardEvent, currentTag: string | null, tagList: string[]) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault()
+      const currentIndex = currentTag ? tagList.indexOf(currentTag) : -1
+      const nextIndex = e.key === 'ArrowRight'
+        ? (currentIndex + 1) % tagList.length
+        : currentIndex === -1 ? tagList.length - 1 : (currentIndex - 1 + tagList.length) % tagList.length
+      setSelectedTag(tagList[nextIndex])
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      setSelectedTag(tagList[0])
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      setSelectedTag(tagList[tagList.length - 1])
+    }
+  }
+
   const toggleViewMode = (mode: ViewMode) => {
     setViewMode(mode)
     try { localStorage.setItem(VIEW_MODE_KEY, mode) } catch { /* ok */ }
@@ -736,7 +778,11 @@ export function Marketplace() {
 
         {/* Type filter */}
         <div className="flex items-center gap-1.5">
-          <button onClick={() => { setSelectedType(null); setShowHelpWanted(false) }} className={filterBtnClass(!selectedType && !showHelpWanted)}>
+          <button 
+            onClick={() => { setSelectedType(null); setShowHelpWanted(false) }} 
+            onKeyDown={(e) => handleTypeKeyDown(e, null)}
+            className={filterBtnClass(!selectedType && !showHelpWanted)}
+          >
             All
             <span className="text-2xs ml-0.5 opacity-60">{typeCounts.all}</span>
           </button>
@@ -744,6 +790,7 @@ export function Marketplace() {
             <button
               key={type}
               onClick={() => { setSelectedType(selectedType === type ? null : type); setShowHelpWanted(false) }}
+              onKeyDown={(e) => handleTypeKeyDown(e, type)}
               className={filterBtnClass(selectedType === type && !showHelpWanted)}
             >
               <Icon className="w-3 h-3" />
@@ -787,6 +834,7 @@ export function Marketplace() {
               <button
                 key={tag}
                 onClick={() => setSelectedTag(selectedTag === tag ? null : tag)}
+                onKeyDown={(e) => handleTagKeyDown(e, tag, allTags)}
                 className={filterBtnClass(selectedTag === tag)}
               >
                 <Tag className="w-3 h-3" />
@@ -803,6 +851,7 @@ export function Marketplace() {
               <button
                 key={cat}
                 onClick={() => setSelectedTag(selectedTag === cat ? null : cat)}
+                onKeyDown={(e) => handleTagKeyDown(e, cat, cncfCategories)}
                 className={`flex items-center gap-1 px-2 py-1 text-2xs rounded transition-colors ${
                   selectedTag === cat
                     ? 'bg-yellow-500/15 text-yellow-400 font-medium'


### PR DESCRIPTION
Fixes #19822

## Changes

Added keyboard navigation support to filter button groups and interactive UI components:

### FilterTabs Component
- Added arrow key navigation (Left/Right) for filter buttons (All, Healthy, Unhealthy, Offline)
- Added arrow key navigation for layout mode selector buttons
- Added Home/End key support to jump to first/last option

### Marketplace Component
- Added arrow key navigation (Left/Right) for type filter buttons (All, Dashboards, Card Presets, Themes)
- Added arrow key navigation for tag filter buttons
- Added arrow key navigation for CNCF category filter buttons (when in Help Wanted mode)
- Added Home/End key support to jump to first/last option

## Implementation

All keyboard handlers follow the codebase pattern:
- Arrow keys (Left/Right) cycle through options
- Home key jumps to first option
- End key jumps to last option
- Enter/Space already work via native button onClick

## Testing

CI will validate build and lint.