### PR TITLE
[scanner] fix: repair test failures from coverage suite run #3947

### DIFF
--- a/web/netlify/functions/_shared/__tests__/fetchWithTimeout.test.ts
+++ b/web/netlify/functions/_shared/__tests__/fetchWithTimeout.test.ts
@@ -78,7 +78,9 @@ describe("fetchWithTimeout", () => {
       vi.clearAllMocks();
       vi.unstubAllGlobals();
       
-      const mockFetch = vi.fn().mockResolvedValueOnce(new Response("test", { status: statusCode }));
+      // Status 204 (No Content) should not have a body
+      const responseBody = statusCode === 204 ? null : "test";
+      const mockFetch = vi.fn().mockResolvedValueOnce(new Response(responseBody, { status: statusCode }));
       vi.stubGlobal("fetch", mockFetch);
 
       const result = await fetchWithTimeout("http://example.com", { timeoutMs: 5000 });

--- a/web/src/components/cards/linkerd_status/linkerd_status.test.tsx
+++ b/web/src/components/cards/linkerd_status/linkerd_status.test.tsx
@@ -30,11 +30,16 @@ vi.mock('../../ui/Skeleton', () => ({
 function setup(overrides?: Record<string, unknown>) {
   mockUseCachedLinkerd.mockReturnValue({
     data: {
-      health: 'healthy',
-      meshedPods: 0,
-      totalPods: 0,
-      successRate: 0,
-      rps: 0,
+      summary: {
+        totalMeshedPods: 0,
+        totalPods: 0,
+      },
+      stats: {
+        avgSuccessRatePct: 0,
+        avgRequestsPerSecond: 0,
+        avgP99LatencyMs: 0,
+      },
+      deployments: [],
     },
     isLoading: false,
     isRefreshing: false,

--- a/web/src/components/cards/rook_status/rook_status.test.tsx
+++ b/web/src/components/cards/rook_status/rook_status.test.tsx
@@ -42,11 +42,15 @@ function setup(overrides?: Record<string, unknown>) {
     },
     isLoading: false,
     isRefreshing: false,
+    isDemoData: false,
     isDemoFallback: false,
     isFailed: false,
     consecutiveFailures: 0,
     lastRefresh: Date.now(),
     refetch: vi.fn(),
+    showSkeleton: false,
+    showEmptyState: false,
+    error: null,
     ...overrides,
   })
   mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })

--- a/web/src/components/missions/MissionViews.test.tsx
+++ b/web/src/components/missions/MissionViews.test.tsx
@@ -101,8 +101,9 @@ describe('ResolutionKnowledgePanel', () => {
     const { ResolutionKnowledgePanel } = await import('./ResolutionKnowledgePanel')
     const { container } = render(
       <ResolutionKnowledgePanel
-        query=""
-        onSelectSuggestion={vi.fn()}
+        relatedResolutions={[]}
+        onApplyResolution={vi.fn()}
+        onSaveNewResolution={vi.fn()}
       />
     )
     expect(container).toBeTruthy()
@@ -139,16 +140,30 @@ describe('KagentAgentPicker', () => {
 describe('MissionContentViewer', () => {
   it('renders without errors', async () => {
     const { MissionContentViewer } = await import('./MissionContentViewer')
-    const mockMission = {
-      title: 'Test Mission',
-      description: 'Test',
-      type: 'custom' as const,
-      steps: [],
-      version: '1.0.0',
+    const mockProps = {
+      searchPanel: {
+        searchQuery: '',
+        setSearchQuery: vi.fn(),
+        isOpen: false,
+        setIsOpen: vi.fn(),
+      },
+      filePanel: {
+        selectedPath: null,
+        setSelectedPath: vi.fn(),
+        isOpen: false,
+        setIsOpen: vi.fn(),
+      },
+      content: {
+        directoryEntries: [],
+        isScanning: false,
+        scanResult: null,
+        handleScanComplete: vi.fn(),
+        handleScanDismiss: vi.fn(),
+      },
     }
     const { container } = render(
       <MissionContentViewer
-        mission={mockMission}
+        {...mockProps}
       />
     )
     expect(container).toBeTruthy()

--- a/web/src/components/missions/browser.components.test.tsx
+++ b/web/src/components/missions/browser.components.test.tsx
@@ -74,12 +74,28 @@ describe('RecommendationCard', () => {
 })
 
 describe('TreeNodeItem', () => {
+  const mockNode = {
+    id: 'test-1',
+    name: 'Test Node',
+    path: '/test',
+    type: 'directory' as const,
+    source: 'community' as const,
+  }
+  const defaultProps = {
+    expandedNodes: new Set<string>(),
+    selectedPath: null,
+    nodeRefs: { current: new Map<string, HTMLButtonElement>() },
+  }
+
   it('renders without errors', async () => {
     const { TreeNodeItem } = await import('./browser/TreeNodeItem')
     const { container } = render(
       <TreeNodeItem
-        label="Test Node"
-        onClick={vi.fn()}
+        node={mockNode}
+        depth={0}
+        {...defaultProps}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
       />
     )
     expect(container).toBeTruthy()
@@ -89,8 +105,11 @@ describe('TreeNodeItem', () => {
     const { TreeNodeItem } = await import('./browser/TreeNodeItem')
     render(
       <TreeNodeItem
-        label="Root Node"
-        onClick={vi.fn()}
+        node={{ ...mockNode, name: 'Root Node' }}
+        depth={0}
+        {...defaultProps}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
       />
     )
     expect(screen.getByText('Root Node')).toBeInTheDocument()

--- a/web/src/components/missions/browser/__tests__/TreeNodeItem.test.tsx
+++ b/web/src/components/missions/browser/__tests__/TreeNodeItem.test.tsx
@@ -68,7 +68,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockFileNode}
         depth={0}
-        ...defaultProps
+        {...defaultProps}
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -85,7 +85,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockDirectoryNode}
         depth={0}
-        ...defaultProps
+        {...defaultProps}
         onToggle={onToggle}
         onSelect={vi.fn()}
       />
@@ -106,7 +106,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockFileNode}
         depth={0}
-        ...defaultProps
+        {...defaultProps}
         onToggle={vi.fn()}
         onSelect={onSelect}
       />
@@ -124,7 +124,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockLoadingNode}
         depth={0}
-        ...defaultProps
+        {...defaultProps}
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -140,7 +140,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockFileNode}
         depth={0}
-        ...defaultProps
+        {...defaultProps}
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -150,7 +150,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockFileNode}
         depth={2}
-        ...defaultProps
+        {...defaultProps}
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -165,7 +165,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockGitHubNode}
         depth={0}
-        ...defaultProps
+        {...defaultProps}
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -179,7 +179,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockDirectoryNode}
         depth={0}
-        ...defaultProps
+        {...defaultProps}
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -195,7 +195,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockDirectoryNode}
         depth={0}
-        ...defaultProps
+        {...defaultProps}
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -205,7 +205,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockDirectoryNode}
         depth={0}
-        ...defaultProps, expandedNodes: new Set([mockDirectoryNode.id])
+        {...{ ...defaultProps, expandedNodes: new Set([mockDirectoryNode.id]) }}
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />

--- a/web/src/components/missions/browser/__tests__/TreeNodeItem.test.tsx
+++ b/web/src/components/missions/browser/__tests__/TreeNodeItem.test.tsx
@@ -42,13 +42,19 @@ const mockLoadingNode: TreeNode = {
   loading: true,
 }
 
+const defaultProps = {
+  expandedNodes: new Set<string>(),
+  selectedPath: null,
+  nodeRefs: { current: new Map<string, HTMLButtonElement>() },
+}
+
 describe('TreeNodeItem', () => {
   it('renders directory node with name', () => {
     render(
       <TreeNodeItem
         node={mockDirectoryNode}
         depth={0}
-        isExpanded={false}
+        {...defaultProps}
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -62,7 +68,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockFileNode}
         depth={0}
-        isExpanded={false}
+        ...defaultProps
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -79,7 +85,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockDirectoryNode}
         depth={0}
-        isExpanded={false}
+        ...defaultProps
         onToggle={onToggle}
         onSelect={vi.fn()}
       />
@@ -100,7 +106,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockFileNode}
         depth={0}
-        isExpanded={false}
+        ...defaultProps
         onToggle={vi.fn()}
         onSelect={onSelect}
       />
@@ -118,7 +124,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockLoadingNode}
         depth={0}
-        isExpanded={false}
+        ...defaultProps
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -134,7 +140,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockFileNode}
         depth={0}
-        isExpanded={false}
+        ...defaultProps
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -144,7 +150,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockFileNode}
         depth={2}
-        isExpanded={false}
+        ...defaultProps
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -159,7 +165,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockGitHubNode}
         depth={0}
-        isExpanded={false}
+        ...defaultProps
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -173,7 +179,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockDirectoryNode}
         depth={0}
-        isExpanded={false}
+        ...defaultProps
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -189,7 +195,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockDirectoryNode}
         depth={0}
-        isExpanded={false}
+        ...defaultProps
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />
@@ -199,7 +205,7 @@ describe('TreeNodeItem', () => {
       <TreeNodeItem
         node={mockDirectoryNode}
         depth={0}
-        isExpanded={true}
+        ...defaultProps, expandedNodes: new Set([mockDirectoryNode.id])
         onToggle={vi.fn()}
         onSelect={vi.fn()}
       />

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -61,23 +61,16 @@ if (isBrowserEnvironment) {
       agentFetch: vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => global.fetch(url, init)),
     }
   })
-}
 
-// Cleanup after each test.
-// NOTE: vi.unstubAllGlobals() is intentionally NOT called here. Each test file
-// runs in its own vitest worker so global stubs cannot leak between files.
-// Calling unstubAllGlobals() here would remove file-level stubs (e.g.
-// vi.stubGlobal('fetch', mockFetch)) after the first test in a file, breaking
-// all subsequent tests that rely on that stub.
-afterEach(() => {
-  if (isBrowserEnvironment) {
-    cleanup()
-    window.localStorage.clear()
-    window.sessionStorage?.clear()
-  }
-  vi.unstubAllEnvs()
-  vi.clearAllMocks()
-})
+  // Mock useDemoMode hook to return proper object shape
+  vi.mock('../hooks/useDemoMode', () => ({
+    useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+    getDemoMode: () => true,
+    isDemoModeForced: false,
+    canToggleDemoMode: () => true,
+    isNetlifyDeployment: false,
+  }))
+}
 
 const TOKEN_STORAGE_ALIASES = ['token', 'kc_token', 'kc-token', 'kc-auth-token'] as const
 
@@ -158,3 +151,19 @@ if (isBrowserEnvironment) {
     },
   })
 }
+
+// Cleanup after each test.
+// NOTE: vi.unstubAllGlobals() is intentionally NOT called here. Each test file
+// runs in its own vitest worker so global stubs cannot leak between files.
+// Calling unstubAllGlobals() here would remove file-level stubs (e.g.
+// vi.stubGlobal('fetch', mockFetch)) after the first test in a file, breaking
+// all subsequent tests that rely on that stub.
+afterEach(() => {
+  if (isBrowserEnvironment) {
+    cleanup()
+    window.localStorage.clear()
+    window.sessionStorage?.clear()
+  }
+  vi.unstubAllEnvs()
+  vi.clearAllMocks()
+})

--- a/web/src/test/utils/setupMocks.ts
+++ b/web/src/test/utils/setupMocks.ts
@@ -17,8 +17,8 @@ vi.mock('../../lib/demoMode', () => ({
 
 vi.mock('../../hooks/useDemoMode', () => ({
   getDemoMode: () => true,
-  default: () => true,
-  useDemoMode: () => true,
+  default: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   isDemoModeForced: false,
 }));
 


### PR DESCRIPTION
Fixes #19823

Fix 115 test failures by correcting mocks and test data structures:

- Fix `useDemoMode` mock to return object `{ isDemoMode, toggleDemoMode, setDemoMode }` instead of boolean
- Fix Response constructor for status 204 to have null body (No Content requires no body)
- Reorder localStorage mock setup before afterEach to prevent 'clear is not a function' error
- Fix `linkerd_status` test to provide correct data shape with `summary.totalMeshedPods/totalPods`
- Add missing `isDemoData`, `showSkeleton`, `showEmptyState`, `error` fields to status card mocks
- Fix `TreeNodeItem` test props to use `expandedNodes` Set, `selectedPath`, `nodeRefs` instead of `isExpanded`
- Fix `ResolutionKnowledgePanel` test to use `relatedResolutions` instead of `query` prop
- Fix `MissionContentViewer` test to provide `searchPanel`, `filePanel`, `content` with `directoryEntries`

These changes address cascading test failures caused by hook interface changes and component refactoring that updated expected prop shapes.