### PR TITLE
[scanner] fix: repair test failures from coverage suite run #3948

### DIFF
--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -61,15 +61,6 @@ if (isBrowserEnvironment) {
       agentFetch: vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => global.fetch(url, init)),
     }
   })
-
-  // Mock useDemoMode hook to return proper object shape
-  vi.mock('../hooks/useDemoMode', () => ({
-    useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
-    getDemoMode: () => true,
-    isDemoModeForced: false,
-    canToggleDemoMode: () => true,
-    isNetlifyDeployment: false,
-  }))
 }
 
 const TOKEN_STORAGE_ALIASES = ['token', 'kc_token', 'kc-token', 'kc-auth-token'] as const


### PR DESCRIPTION
Fixes #19828

Repairs 112 test failures introduced in coverage suite run #3948.

## Root Cause
PR #19826 accidentally added duplicate `useDemoMode` mock in both:
- `web/src/test/setup.ts` (global vitest setup)
- `web/src/test/utils/setupMocks.ts` (imported by individual tests)

This caused mock conflicts across all tests that import `setupMocks.ts`.

## Solution
Removed the duplicate mock from `setup.ts`. The mock belongs in `setupMocks.ts` where it can be selectively imported by tests that need it.