### PR TITLE
[scanner] fix: resolve Playwright cross-browser nightly test failures

### DIFF
--- a/web/e2e/navbar-responsive.spec.ts
+++ b/web/e2e/navbar-responsive.spec.ts
@@ -161,16 +161,16 @@ test.describe('Navbar responsive layout', () => {
     await expect(searchWrapper).toBeVisible()
   })
 
-  test('desktop item group is visible at md+ (768px)', async ({ page, isMobile }) => {
+  test('desktop item group is visible at lg+ (1024px)', async ({ page, isMobile }) => {
     test.skip(isMobile, 'Viewport breakpoint tests are unreliable on mobile device emulation (DPR > 1)')
-    // Use 800px — safely above the 768px md: boundary. Exact-boundary tests
-    // are fragile because browsers may compute 768 CSS px as <768 when rounding.
-    await page.setViewportSize({ width: 800, height: 720 })
+    // Use 1100px — safely above the 1024px lg: boundary. Exact-boundary tests
+    // are fragile because browsers may compute 1024 CSS px as <1024 when rounding.
+    await page.setViewportSize({ width: 1100, height: 720 })
     await setupPage(page)
 
     const nav = page.locator('nav[data-tour="navbar"]')
-    // ClusterFilterPanel/AgentStatus group uses hidden md:flex
-    const desktopGroup = nav.locator('.hidden.md\\:flex').first()
+    // ClusterFilterPanel/AgentStatus group uses hidden lg:flex (changed from md:flex in #19585)
+    const desktopGroup = nav.locator('.hidden.lg\\:flex').first()
     await expect(desktopGroup).toBeVisible()
   })
 

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -176,8 +176,14 @@ test.describe('Smoke Tests', () => {
       }
 
       const settingsLink = page.locator('[data-testid="sidebar-primary-nav"] a[href="/settings"], [data-testid="sidebar"] a[href="/settings"]').first()
-      // WebKit/mobile browsers need more time for sidebar elements to hydrate
-      await expect(settingsLink).toBeVisible({ timeout: 20000 })
+      // WebKit/mobile browsers need more time for sidebar elements to hydrate.
+      // Wait for both the element to exist AND become actionable (no visibility:hidden).
+      // The sidebar slide-in animation can leave elements in a "found but hidden" state.
+      await page.waitForLoadState('networkidle').catch(() => {})
+      await expect(settingsLink).toBeVisible({ timeout: 30000 })
+      // Extra stability wait for webkit/safari where elements can be "visible" but
+      // still mid-transition. Wait for DOM to fully settle after animation.
+      await page.waitForTimeout(500)
       await settingsLink.click({ force: true })
 
       await expect(page).toHaveURL(/\/settings(?:[?#].*)?$/, { timeout: 10000 })


### PR DESCRIPTION
Fixes #19831

Fix two test failures in Playwright Cross-Browser (Nightly) workflow that affected all 4 browsers (mobile-safari, mobile-chrome, firefox, webkit):

## Root Causes

1. **navbar-responsive.spec.ts failure** (Firefox/WebKit):
   - Test selector `.hidden.md:flex` no longer exists
   - Navbar breakpoint changed from `md:` (768px) to `lg:` (1024px) in commit 8c3a874
   - Caused "element(s) not found" error

2. **smoke.spec.ts failure** (mobile-safari/mobile-chrome):
   - Sidebar link was found but had `visibility: hidden`
   - Sidebar slide-in animation leaves elements in "found but hidden" state
   - Test didn't wait for animation to complete before checking visibility

## Changes

1. **navbar-responsive.spec.ts**:
   - Changed selector from `.hidden.md\\:flex` to `.hidden.lg\\:flex`
   - Updated viewport width from 800px to 1100px (above lg: 1024px breakpoint)
   - Updated test name and comments to reflect lg+ (1024px) instead of md+ (768px)

2. **smoke.spec.ts**:
   - Added `waitForLoadState('networkidle')` before visibility check
   - Increased timeout from 20s to 30s for slow mobile browsers
   - Added 500ms settle time after visibility check for WebKit/Safari animation
   - Updated comment to explain the sidebar animation issue

These changes align tests with the current navbar structure and account for cross-browser animation timing differences.