### PR TITLE
[scanner] fix: revert dark mode changes causing test regressions

### DIFF
--- a/web/src/components/marketplace/MarketplaceThumbnail.tsx
+++ b/web/src/components/marketplace/MarketplaceThumbnail.tsx
@@ -109,7 +109,7 @@ function ProjectLogo({ projectName, iconPath }: { projectName: string; iconPath:
 
   if (failed) {
     return (
-      <div className="w-12 h-12 rounded-xl bg-black/25 dark:bg-black/40 backdrop-blur-xs shadow-xs flex items-center justify-center">
+      <div className="w-12 h-12 rounded-xl bg-black/25 backdrop-blur-xs shadow-xs flex items-center justify-center">
         <svg viewBox="0 0 24 24" className="w-8 h-8 text-white drop-shadow-md" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
           <path d={iconPath} />
         </svg>
@@ -118,7 +118,7 @@ function ProjectLogo({ projectName, iconPath }: { projectName: string; iconPath:
   }
 
   return (
-    <div className="w-12 h-12 rounded-xl bg-card/90 dark:bg-card/70 shadow-xs flex items-center justify-center">
+    <div className="w-12 h-12 rounded-xl bg-card/90 shadow-xs flex items-center justify-center">
       <img
         src={getProjectLogoUrl(projectName)}
         alt={projectName}
@@ -146,15 +146,11 @@ export function MarketplaceThumbnail({ itemId, itemType, className, cncfCategory
     const iconPath = cncfIcon || TYPE_FALLBACKS['card-preset'].icon
     return (
       <div
-        className={`relative h-20 flex items-center justify-center bg-gradient-to-br ${isHelpWanted ? 'opacity-70' : ''} ${className || ''}`}
-        style={{
-          '--tw-gradient-from': cncfGradient[0],
-          '--tw-gradient-to': cncfGradient[1],
-          background: `linear-gradient(135deg, ${cncfGradient[0]}, ${cncfGradient[1]})`,
-        } as React.CSSProperties}
+        className={`relative h-20 flex items-center justify-center ${isHelpWanted ? 'opacity-70' : ''} ${className || ''}`}
+        style={{ background: `linear-gradient(135deg, ${cncfGradient[0]}, ${cncfGradient[1]})` }}
       >
         <ProjectLogo projectName={projectName} iconPath={iconPath} />
-        <span className="absolute bottom-1.5 right-2 text-2xs font-medium text-white/70 dark:text-white/60 bg-black/20 dark:bg-black/30 px-1.5 py-0.5 rounded">
+        <span className="absolute bottom-1.5 right-2 text-2xs font-medium text-white/70 bg-black/20 px-1.5 py-0.5 rounded">
           {cncfCategory}
         </span>
       </div>

--- a/web/src/components/mission-control/ClusterReadinessCard.tsx
+++ b/web/src/components/mission-control/ClusterReadinessCard.tsx
@@ -31,10 +31,10 @@ function CapacityBar({ label, used, total, unit }: {
 }) {
   const pct = total > 0 ? Math.min((used / total) * 100, 100) : 0
   const color =
-    pct >= 90 ? 'bg-red-500 dark:bg-red-600' :
-    pct >= 70 ? 'bg-amber-500 dark:bg-amber-600' :
-    pct >= 50 ? 'bg-yellow-500 dark:bg-yellow-600' :
-    'bg-green-500 dark:bg-green-600'
+    pct >= 90 ? 'bg-red-500' :
+    pct >= 70 ? 'bg-amber-500' :
+    pct >= 50 ? 'bg-yellow-500' :
+    'bg-green-500'
 
   return (
     <div className="space-y-0.5">
@@ -44,7 +44,7 @@ function CapacityBar({ label, used, total, unit }: {
           {used.toFixed(1)}/{total.toFixed(1)} {unit} ({pct.toFixed(0)}%)
         </span>
       </div>
-      <div className="h-1.5 bg-secondary dark:bg-secondary/50 rounded-full overflow-hidden">
+      <div className="h-1.5 bg-secondary rounded-full overflow-hidden">
         <div className={cn('h-full rounded-full transition-all', color)} style={{ width: `${pct}%` }} />
       </div>
     </div>
@@ -88,9 +88,9 @@ export function ClusterReadinessCard({
   return (
     <div
       className={cn(
-        'rounded-xl border bg-card dark:bg-card/80 p-4 transition-all',
-        isRecommended && 'border-purple-500/50 dark:border-purple-400/50 shadow-purple-glow',
-        !isRecommended && 'border-border dark:border-border/50'
+        'rounded-xl border bg-card p-4 transition-all',
+        isRecommended && 'border-purple-500/50 shadow-purple-glow',
+        !isRecommended && 'border-border'
       )}
     >
       {/* Header */}
@@ -104,7 +104,7 @@ export function ClusterReadinessCard({
             <span
               className={cn(
                 'w-2 h-2 rounded-full shrink-0',
-                cluster.healthy ? 'bg-green-500 dark:bg-green-400' : 'bg-red-500 dark:bg-red-400'
+                cluster.healthy ? 'bg-green-500' : 'bg-red-500'
               )}
               title={cluster.healthy ? 'Healthy' : 'Unhealthy'}
             />
@@ -131,9 +131,9 @@ export function ClusterReadinessCard({
           <div
             className={cn(
               'flex items-center justify-center w-10 h-10 rounded-full text-sm font-bold',
-              readiness.overallScore >= 70 ? 'bg-green-500/15 dark:bg-green-500/20 text-green-400' :
-              readiness.overallScore >= 40 ? 'bg-yellow-500/15 dark:bg-yellow-500/20 text-yellow-400' :
-              'bg-red-500/15 dark:bg-red-500/20 text-red-400'
+              readiness.overallScore >= 70 ? 'bg-green-500/15 text-green-400' :
+              readiness.overallScore >= 40 ? 'bg-yellow-500/15 text-yellow-400' :
+              'bg-red-500/15 text-red-400'
             )}
             title={`Readiness score: ${readiness.overallScore}%`}
           >
@@ -172,7 +172,7 @@ export function ClusterReadinessCard({
             const isPositive = /already running|already deployed|already installed|skip install|healthy/.test(lower)
             const isError = /not installed|missing|must install|conflict|error|fail/.test(lower)
             // positive = green (already running), error/action needed = amber, neutral = slate
-            const color = isPositive ? 'text-emerald-400' : isError ? 'text-amber-400 dark:text-amber-300' : 'text-slate-400'
+            const color = isPositive ? 'text-emerald-400' : isError ? 'text-amber-400' : 'text-slate-400'
             const icon = isPositive ? '✓' : isError ? '⚠' : '•'
             return (
               <p key={i} className={cn('text-[10px] flex items-start gap-1', color)}>
@@ -185,7 +185,7 @@ export function ClusterReadinessCard({
       )}
 
       {/* Project assignment checkboxes */}
-      <div className="border-t border-border dark:border-border/50 pt-2 mt-2">
+      <div className="border-t border-border pt-2 mt-2">
         <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">
           Assigned Projects
         </p>
@@ -204,7 +204,7 @@ export function ClusterReadinessCard({
                 key={name}
                 className={cn(
                   'flex items-center gap-2 text-xs px-1.5 py-0.5 rounded',
-                  isInstalled ? 'cursor-default' : 'cursor-pointer hover:bg-secondary/50 dark:hover:bg-secondary/30'
+                  isInstalled ? 'cursor-default' : 'cursor-pointer hover:bg-secondary/50'
                 )}
                 title={isInstalled ? `${name} is already installed on this cluster` : undefined}
               >
@@ -223,7 +223,7 @@ export function ClusterReadinessCard({
                 </span>
                 {isKubara && (
                   <span
-                    className="inline-flex items-center gap-0.5 px-1 py-px rounded text-[8px] font-medium bg-emerald-500/10 dark:bg-emerald-500/20 text-emerald-400 border border-emerald-500/20 dark:border-emerald-500/30"
+                    className="inline-flex items-center gap-0.5 px-1 py-px rounded text-[8px] font-medium bg-emerald-500/10 text-emerald-400 border border-emerald-500/20"
                     title={t('layout.missionSidebar.kubaraBadgeTooltip')}
                   >
                     <CheckCircle className="w-2 h-2" />

--- a/web/src/components/settings/sections/ThemeSection.tsx
+++ b/web/src/components/settings/sections/ThemeSection.tsx
@@ -12,14 +12,6 @@ import type { CSSProperties } from 'react'
 const THEME_SECTION_DIV_STYLE_1: CSSProperties = { isolation: 'isolate' }
 const THEME_SECTION_DIV_STYLE_2: CSSProperties = { transform: 'translateZ(0)' }
 
-// CSS variable helper for theme color previews
-function createColorPreviewStyle(color: string): CSSProperties {
-  return {
-    backgroundColor: color,
-    // Ensure color previews remain visible in both light and dark modes
-    opacity: 1,
-  }
-}
 
 interface ThemeSectionProps {
   themeId: string
@@ -71,7 +63,7 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
   return (
     <div id="theme-settings" className="glass rounded-xl p-6 overflow-visible relative z-30" style={THEME_SECTION_DIV_STYLE_1}>
       <div className="flex items-center gap-3 mb-4">
-        <div className="p-2 rounded-lg bg-secondary dark:bg-secondary/50">
+        <div className="p-2 rounded-lg bg-secondary">
           <Palette className="w-5 h-5 text-muted-foreground" />
         </div>
         <div>
@@ -82,7 +74,7 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
 
       <div className="space-y-4">
         {/* Current Theme Display */}
-        <div className="p-4 rounded-lg bg-secondary/30 dark:bg-secondary/20 border border-border dark:border-border/50">
+        <div className="p-4 rounded-lg bg-secondary/30 border border-border">
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm font-medium text-foreground">{currentTheme.name}</p>
@@ -92,21 +84,21 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
               {currentTheme.dark ? (
                 <Moon className="w-4 h-4 text-muted-foreground" />
               ) : (
-                <Sun className="w-4 h-4 text-yellow-400 dark:text-yellow-300" />
+                <Sun className="w-4 h-4 text-yellow-400" />
               )}
-              {/* Color preview dots - these intentionally show theme colors */}
+              {/* Color preview dots */}
               <div className="flex gap-1">
                 <div
-                  className="w-3 h-3 rounded-full border border-border dark:border-border/50"
-                  style={createColorPreviewStyle(currentTheme.colors.brandPrimary)}
+                  className="w-3 h-3 rounded-full border border-border"
+                  style={{ backgroundColor: currentTheme.colors.brandPrimary }}
                 />
                 <div
-                  className="w-3 h-3 rounded-full border border-border dark:border-border/50"
-                  style={createColorPreviewStyle(currentTheme.colors.brandSecondary)}
+                  className="w-3 h-3 rounded-full border border-border"
+                  style={{ backgroundColor: currentTheme.colors.brandSecondary }}
                 />
                 <div
-                  className="w-3 h-3 rounded-full border border-border dark:border-border/50"
-                  style={createColorPreviewStyle(currentTheme.colors.brandTertiary)}
+                  className="w-3 h-3 rounded-full border border-border"
+                  style={{ backgroundColor: currentTheme.colors.brandTertiary }}
                 />
               </div>
             </div>
@@ -127,17 +119,17 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
             aria-haspopup="listbox"
             aria-expanded={themeDropdownOpen}
             aria-labelledby="theme-dropdown-label"
-            className="w-full flex items-center justify-between px-4 py-3 rounded-lg bg-secondary dark:bg-secondary/50 border border-border dark:border-border/50 text-foreground hover:bg-secondary/80 dark:hover:bg-secondary/40 transition-colors"
+            className="w-full flex items-center justify-between px-4 py-3 rounded-lg bg-secondary border border-border text-foreground hover:bg-secondary/80 transition-colors"
           >
             <div className="flex items-center gap-3">
               <div className="flex gap-1">
                 <div
                   className="w-3 h-3 rounded-full"
-                  style={createColorPreviewStyle(currentTheme.colors.brandPrimary)}
+                  style={{ backgroundColor: currentTheme.colors.brandPrimary }}
                 />
                 <div
                   className="w-3 h-3 rounded-full"
-                  style={createColorPreviewStyle(currentTheme.colors.brandSecondary)}
+                  style={{ backgroundColor: currentTheme.colors.brandSecondary }}
                 />
               </div>
               <span>{currentTheme.name}</span>
@@ -150,10 +142,10 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
 
           {/* Dropdown Menu */}
           {themeDropdownOpen && (
-            <div role="listbox" aria-labelledby="theme-dropdown-label" className="absolute z-dropdown mt-2 w-full max-h-[400px] overflow-y-auto rounded-lg bg-card dark:bg-card/90 border border-border dark:border-border/50 shadow-xl" style={THEME_SECTION_DIV_STYLE_2}>
+            <div role="listbox" aria-labelledby="theme-dropdown-label" className="absolute z-dropdown mt-2 w-full max-h-[400px] overflow-y-auto rounded-lg bg-card border border-border shadow-xl" style={THEME_SECTION_DIV_STYLE_2}>
               {themeGroups.map((group) => (
                 <div key={group.name}>
-                  <div className="px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider bg-secondary/50 dark:bg-secondary/30 sticky top-0">
+                  <div className="px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider bg-secondary/50 sticky top-0">
                     {group.name}
                   </div>
                   {group.themes.map((tid) => {
@@ -175,23 +167,23 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
                             setThemeDropdownOpen(false)
                           }
                         }}
-                        className={`w-full flex items-center justify-between px-4 py-3 hover:bg-secondary/50 dark:hover:bg-secondary/30 transition-colors ${
-                          isSelected ? 'bg-primary/10 dark:bg-primary/20' : ''
+                        className={`w-full flex items-center justify-between px-4 py-3 hover:bg-secondary/50 transition-colors ${
+                          isSelected ? 'bg-primary/10' : ''
                         }`}
                       >
                         <div className="flex items-center gap-3">
                           <div className="flex gap-1">
                             <div
-                              className="w-3 h-3 rounded-full border border-border/50 dark:border-border/30"
-                              style={createColorPreviewStyle(t.colors.brandPrimary)}
+                              className="w-3 h-3 rounded-full border border-border/50"
+                              style={{ backgroundColor: t.colors.brandPrimary }}
                             />
                             <div
-                              className="w-3 h-3 rounded-full border border-border/50 dark:border-border/30"
-                              style={createColorPreviewStyle(t.colors.brandSecondary)}
+                              className="w-3 h-3 rounded-full border border-border/50"
+                              style={{ backgroundColor: t.colors.brandSecondary }}
                             />
                             <div
-                              className="w-3 h-3 rounded-full border border-border/50 dark:border-border/30"
-                              style={createColorPreviewStyle(t.colors.brandTertiary)}
+                              className="w-3 h-3 rounded-full border border-border/50"
+                              style={{ backgroundColor: t.colors.brandTertiary }}
                             />
                           </div>
                           <div className="text-left">
@@ -205,7 +197,7 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
                           {t.dark ? (
                             <Moon className="w-3 h-3 text-muted-foreground" />
                           ) : (
-                            <Sun className="w-3 h-3 text-yellow-400 dark:text-yellow-300" />
+                            <Sun className="w-3 h-3 text-yellow-400" />
                           )}
                           {isSelected && <Check className="w-4 h-4 text-primary" />}
                         </div>
@@ -216,7 +208,7 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
               ))}
               {customThemes.length > 0 && (
                 <div>
-                  <div className="px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider bg-secondary/50 dark:bg-secondary/30 sticky top-0">
+                  <div className="px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider bg-secondary/50 sticky top-0">
                     {t('settings.theme.marketplaceThemes')}
                   </div>
                   {customThemes.map((ct) => {
@@ -236,23 +228,23 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
                             setThemeDropdownOpen(false)
                           }
                         }}
-                        className={`w-full flex items-center justify-between px-4 py-3 hover:bg-secondary/50 dark:hover:bg-secondary/30 transition-colors ${
-                          isSelected ? 'bg-primary/10 dark:bg-primary/20' : ''
+                        className={`w-full flex items-center justify-between px-4 py-3 hover:bg-secondary/50 transition-colors ${
+                          isSelected ? 'bg-primary/10' : ''
                         }`}
                       >
                         <div className="flex items-center gap-3">
                           <div className="flex gap-1">
                             <div
-                              className="w-3 h-3 rounded-full border border-border/50 dark:border-border/30"
-                              style={createColorPreviewStyle(ct.colors?.brandPrimary || '#666')}
+                              className="w-3 h-3 rounded-full border border-border/50"
+                              style={{ backgroundColor: ct.colors?.brandPrimary || '#666' }}
                             />
                             <div
-                              className="w-3 h-3 rounded-full border border-border/50 dark:border-border/30"
-                              style={createColorPreviewStyle(ct.colors?.brandSecondary || '#666')}
+                              className="w-3 h-3 rounded-full border border-border/50"
+                              style={{ backgroundColor: ct.colors?.brandSecondary || '#666' }}
                             />
                             <div
-                              className="w-3 h-3 rounded-full border border-border/50 dark:border-border/30"
-                              style={createColorPreviewStyle(ct.colors?.brandTertiary || '#666')}
+                              className="w-3 h-3 rounded-full border border-border/50"
+                              style={{ backgroundColor: ct.colors?.brandTertiary || '#666' }}
                             />
                           </div>
                           <div className="text-left">
@@ -266,7 +258,7 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
                           {ct.dark ? (
                             <Moon className="w-3 h-3 text-muted-foreground" />
                           ) : (
-                            <Sun className="w-3 h-3 text-yellow-400 dark:text-yellow-300" />
+                            <Sun className="w-3 h-3 text-yellow-400" />
                           )}
                           {isSelected && <Check className="w-4 h-4 text-primary" />}
                         </div>
@@ -294,22 +286,22 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
                   title={t.description}
                   className={`flex flex-col items-center gap-1.5 p-3 rounded-lg border transition-all ${
                     isSelected
-                      ? 'border-primary bg-primary/10 dark:bg-primary/20'
-                      : 'border-border dark:border-border/50 hover:border-primary/50 hover:bg-secondary/30 dark:hover:bg-secondary/20'
+                      ? 'border-primary bg-primary/10'
+                      : 'border-border hover:border-primary/50 hover:bg-secondary/30'
                   }`}
                 >
                   <div className="flex gap-0.5">
                     <div
                       className="w-2.5 h-2.5 rounded-full"
-                      style={createColorPreviewStyle(t.colors.brandPrimary)}
+                      style={{ backgroundColor: t.colors.brandPrimary }}
                     />
                     <div
                       className="w-2.5 h-2.5 rounded-full"
-                      style={createColorPreviewStyle(t.colors.brandSecondary)}
+                      style={{ backgroundColor: t.colors.brandSecondary }}
                     />
                     <div
                       className="w-2.5 h-2.5 rounded-full"
-                      style={createColorPreviewStyle(t.colors.brandTertiary)}
+                      style={{ backgroundColor: t.colors.brandTertiary }}
                     />
                   </div>
                   <span className={`text-xs ${isSelected ? 'text-primary font-medium' : 'text-muted-foreground'}`}>
@@ -332,7 +324,7 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
                   <div
                     key={ct.id}
                     className={`flex items-center justify-between p-3 rounded-lg border transition-all ${
-                      isSelected ? 'border-primary bg-primary/10 dark:bg-primary/20' : 'border-border dark:border-border/50 bg-secondary/20 dark:bg-secondary/10'
+                      isSelected ? 'border-primary bg-primary/10' : 'border-border bg-secondary/20'
                     }`}
                   >
                     <button
@@ -340,9 +332,9 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
                       className="flex items-center gap-3 flex-1 text-left"
                     >
                       <div className="flex gap-1">
-                        <div className="w-3 h-3 rounded-full border border-border/50 dark:border-border/30" style={createColorPreviewStyle(ct.colors?.brandPrimary || '#666')} />
-                        <div className="w-3 h-3 rounded-full border border-border/50 dark:border-border/30" style={createColorPreviewStyle(ct.colors?.brandSecondary || '#666')} />
-                        <div className="w-3 h-3 rounded-full border border-border/50 dark:border-border/30" style={createColorPreviewStyle(ct.colors?.brandTertiary || '#666')} />
+                        <div className="w-3 h-3 rounded-full border border-border/50" style={{ backgroundColor: ct.colors?.brandPrimary || '#666' }} />
+                        <div className="w-3 h-3 rounded-full border border-border/50" style={{ backgroundColor: ct.colors?.brandSecondary || '#666' }} />
+                        <div className="w-3 h-3 rounded-full border border-border/50" style={{ backgroundColor: ct.colors?.brandTertiary || '#666' }} />
                       </div>
                       <div>
                         <p className={`text-sm ${isSelected ? 'text-primary font-medium' : 'text-foreground'}`}>{ct.name}</p>
@@ -353,7 +345,7 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
                     <button
                       onClick={() => setConfirmRemoveId(ct.id)}
                       aria-label={t('common.remove')}
-                      className="p-1.5 text-muted-foreground hover:text-red-400 dark:hover:text-red-300 hover:bg-red-950/50 dark:hover:bg-red-900/30 rounded transition-colors"
+                      className="p-1.5 text-muted-foreground hover:text-red-400 hover:bg-red-950/50 rounded transition-colors"
                       title={t('common.remove')}
                     >
                       <Trash2 className="w-3.5 h-3.5" />
@@ -382,7 +374,7 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
               Gradients
             </StatusBadge>
           )}
-          <span className="px-2 py-1 text-xs rounded bg-secondary dark:bg-secondary/50 text-muted-foreground">
+          <span className="px-2 py-1 text-xs rounded bg-secondary text-muted-foreground">
             Font: {currentTheme.font?.family?.split(',')[0]?.replace(/'/g, '') ?? 'System'}
           </span>
         </div>


### PR DESCRIPTION
Fixes #19835
Fixes #19839

Reverts commit 410a024 (PR #19838) which added `dark:` CSS variants that caused 101+ test failures across cards, missions, and netlify function tests.

The dark mode changes will need to be re-applied with proper test updates in a follow-up PR.