### PR TITLE
[scanner] fix: disable accidental backdrop-close on form modals

### DIFF
--- a/web/src/components/dashboard/customizer/DashboardCustomizer.tsx
+++ b/web/src/components/dashboard/customizer/DashboardCustomizer.tsx
@@ -134,7 +134,7 @@ export function DashboardCustomizer({
 
   return (
     <>
-    <BaseModal isOpen={isOpen} onClose={onClose} size="xl" className="max-w-[75vw]! h-[75vh]!">
+    <BaseModal isOpen={isOpen} onClose={onClose} size="xl" className="max-w-[75vw]! h-[75vh]!" closeOnBackdrop={false}>
       <BaseModal.Header
         title={t('dashboard.studio.title', 'Console Studio')}
         description={t('dashboard.studio.subtitle', 'Your console is built from dashboards containing cards and stat blocks that show real-time cluster data. Browse cards, apply collections, or create custom visualizations.')}

--- a/web/src/components/missions/SubmitToKBDialog.tsx
+++ b/web/src/components/missions/SubmitToKBDialog.tsx
@@ -302,7 +302,7 @@ export function SubmitToKBDialog({ resolution, isOpen, onClose }: SubmitToKBDial
   }
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="md" closeOnBackdrop={!isSubmitPending} closeOnEscape={!isSubmitPending}>
+    <BaseModal isOpen={isOpen} onClose={onClose} size="md" closeOnBackdrop={false} closeOnEscape={!isSubmitPending}>
       <BaseModal.Header title={t('missions.submitToKB.title')} icon={BookUp} onClose={isSubmitPending ? undefined : onClose} />
 
       <BaseModal.Content noPadding>


### PR DESCRIPTION
Fixes #19834

Disables backdrop-click-to-close on modals that contain forms or user input, preventing accidental data loss. Also ensures Escape key handling in EnterpriseLayout modal.

Components updated:
- DashboardCustomizer (Console Studio) - contains CardCatalogSection, AISuggestionsSection, TemplateGallerySection with form selections and user state
- SubmitToKBDialog - contains mission type, CNCF project, and filename form inputs

The other components listed in the issue either:
- Don't contain BaseModal (LocalClustersSection, AiGenerationPanel, InlineAIAssist, SidebarShell, SearchDropdown, MissionBrowserTopBar are sections/top bars)
- Already have closeOnBackdrop={false} (CardFactoryModal, StatBlockFactoryModal)
- Use ApiKeyPromptModal which already handles backdrop safety

Escape key handling works by default in BaseModal unless explicitly disabled with closeOnEscape={false}, so EnterpriseLayout's modal (which uses DashboardCustomizer) already supports it.