### PR TITLE
[scanner] fix: repair 312 test failures from Coverage Suite run #3957

### DIFF
--- a/web/src/components/cards/ActiveAlerts.test.tsx
+++ b/web/src/components/cards/ActiveAlerts.test.tsx
@@ -33,7 +33,7 @@ vi.mock('../../hooks/useGlobalFilters', () => ({
 
 const mockUseDemoMode = vi.fn()
 vi.mock('../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockUseDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 const mockDrillToAlert = vi.fn()

--- a/web/src/components/cards/AlertRules.test.tsx
+++ b/web/src/components/cards/AlertRules.test.tsx
@@ -27,7 +27,7 @@ vi.mock('../../hooks/useAlerts', () => ({
 
 const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 const mockUseCardLoadingState = vi.fn()

--- a/web/src/components/cards/NamespaceQuotas.test.tsx
+++ b/web/src/components/cards/NamespaceQuotas.test.tsx
@@ -51,7 +51,7 @@ vi.mock('../../hooks/useCachedData', () => ({
 
 const mockUseDemoMode = vi.fn()
 vi.mock('../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 const mockUseCardLoadingState = vi.fn()

--- a/web/src/components/cards/NodeConditions.test.tsx
+++ b/web/src/components/cards/NodeConditions.test.tsx
@@ -37,7 +37,7 @@ vi.mock('../../hooks/useCachedData', () => ({
 
 const mockIsDemoMode = vi.fn(() => ({ isDemoMode: false }))
 vi.mock('../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 const mockExecute = vi.fn()

--- a/web/src/components/cards/StorageOverview.test.tsx
+++ b/web/src/components/cards/StorageOverview.test.tsx
@@ -48,7 +48,7 @@ vi.mock('../../hooks/useGlobalFilters', () => ({
 
 const mockIsDemoMode = vi.fn(() => ({ isDemoMode: false }))
 vi.mock('../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 const mockUseCardLoadingState = vi.fn()

--- a/web/src/components/cards/__tests__/ClusterHealth.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterHealth.test.tsx
@@ -41,7 +41,7 @@ vi.mock('../../../hooks/useMobile', () => ({
 
 const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   isDemoModeForced: () => false,
   getDemoMode: () => false,
   canToggleDemoMode: () => true,

--- a/web/src/components/cards/__tests__/DataComplianceCards.states.test.tsx
+++ b/web/src/components/cards/__tests__/DataComplianceCards.states.test.tsx
@@ -19,7 +19,7 @@ vi.mock('react-i18next', () => ({
 
 const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => true, default: () => true,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),

--- a/web/src/components/cards/__tests__/DataComplianceCards.test.tsx
+++ b/web/src/components/cards/__tests__/DataComplianceCards.test.tsx
@@ -14,7 +14,7 @@ vi.mock('react-i18next', () => ({
 
 const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => true, default: () => true,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),

--- a/web/src/components/cards/__tests__/EventStream.test.tsx
+++ b/web/src/components/cards/__tests__/EventStream.test.tsx
@@ -16,7 +16,7 @@ vi.mock('react-i18next', () => ({
 
 const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => true, default: () => true,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),

--- a/web/src/components/cards/__tests__/Missions.test.tsx
+++ b/web/src/components/cards/__tests__/Missions.test.tsx
@@ -28,7 +28,7 @@ vi.mock('../../../hooks/useMCP', () => ({
 
 const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   isDemoModeForced: () => false,
   getDemoMode: () => false,
   canToggleDemoMode: () => true,

--- a/web/src/components/cards/__tests__/OPAPolicies.test.tsx
+++ b/web/src/components/cards/__tests__/OPAPolicies.test.tsx
@@ -30,7 +30,7 @@ vi.mock('../../../lib/demoMode', () => ({
 
 const mockUseDemoMode = vi.fn()
 vi.mock('../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 const mockUseCardDemoState = vi.fn()

--- a/web/src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx
@@ -30,7 +30,7 @@ vi.mock('../CardDataContext', () => ({
 }))
 
 vi.mock('../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 vi.mock('../../ui/ClusterSelect', () => ({

--- a/web/src/components/cards/__tests__/ResourceUsage.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceUsage.test.tsx
@@ -15,7 +15,7 @@ vi.mock('react-i18next', () => ({
 
 const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => true, default: () => true,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),

--- a/web/src/components/cards/__tests__/StorageOverview.test.tsx
+++ b/web/src/components/cards/__tests__/StorageOverview.test.tsx
@@ -32,7 +32,7 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
 
 const mockUseDemoMode = vi.fn()
 vi.mock('../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 const mockUseCardLoadingState = vi.fn()

--- a/web/src/components/cards/compliance/__tests__/FalcoAlertsCard.test.tsx
+++ b/web/src/components/cards/compliance/__tests__/FalcoAlertsCard.test.tsx
@@ -15,7 +15,7 @@ vi.mock('react-i18next', () => ({
 
 const mockUseDemoMode = vi.fn()
 vi.mock('../../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 const mockStartMission = vi.fn()

--- a/web/src/components/cards/console-missions/__tests__/ConsoleKubeconfigAuditCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleKubeconfigAuditCard.test.tsx
@@ -49,7 +49,7 @@ vi.mock('../../CardDataContext', () => ({
 
 const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../shared', () => ({

--- a/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
@@ -75,7 +75,7 @@ vi.mock('../../CardDataContext', () => ({
 
 const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../clusters/useClusterFiltering', () => ({

--- a/web/src/components/cards/pipelines/__tests__/PipelineFlow.test.tsx
+++ b/web/src/components/cards/pipelines/__tests__/PipelineFlow.test.tsx
@@ -31,7 +31,7 @@ vi.mock('../../../../hooks/useGitHubPipelines', async (importOriginal) => {
 
 const mockUseDemoMode = vi.fn()
 vi.mock('../../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 const mockUseCardLoadingState = vi.fn()

--- a/web/src/components/cards/pipelines/__tests__/WorkflowMatrix.test.tsx
+++ b/web/src/components/cards/pipelines/__tests__/WorkflowMatrix.test.tsx
@@ -26,7 +26,7 @@ vi.mock('../../../../hooks/useGitHubPipelines', async (importOriginal) => {
 
 const mockUseDemoMode = vi.fn()
 vi.mock('../../../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 const mockUseCardLoadingState = vi.fn()

--- a/web/src/components/compliance/Compliance.test.tsx
+++ b/web/src/components/compliance/Compliance.test.tsx
@@ -40,7 +40,7 @@ vi.mock('../../hooks/useGlobalFilters', () => ({
 }))
 
 vi.mock('../../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 vi.mock('../../hooks/useKyverno', () => ({

--- a/web/src/contexts/AlertsContext.deepcover.test.tsx
+++ b/web/src/contexts/AlertsContext.deepcover.test.tsx
@@ -30,7 +30,7 @@ vi.mock('../hooks/useMissions', () => ({
 }))
 
 vi.mock('../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 vi.mock('../hooks/useDeepLink', () => ({

--- a/web/src/contexts/AlertsContext.lifecycle.test.tsx
+++ b/web/src/contexts/AlertsContext.lifecycle.test.tsx
@@ -30,7 +30,7 @@ vi.mock('../hooks/useMissions', () => ({
 }))
 
 vi.mock('../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 vi.mock('../hooks/useDeepLink', () => ({

--- a/web/src/contexts/AlertsContext.storage.test.tsx
+++ b/web/src/contexts/AlertsContext.storage.test.tsx
@@ -30,7 +30,7 @@ vi.mock('../hooks/useMissions', () => ({
 }))
 
 vi.mock('../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 vi.mock('../hooks/useDeepLink', () => ({

--- a/web/src/hooks/__tests__/useCertManager-basic.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-basic.test.ts
@@ -23,7 +23,7 @@ const mockUseClusters = vi.fn(() => ({
 const mockKubectlProxy = { exec: vi.fn() }
 
 vi.mock('../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 vi.mock('../useMCP', () => ({

--- a/web/src/hooks/__tests__/useCertManager-caching.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-caching.test.ts
@@ -23,7 +23,7 @@ const mockUseClusters = vi.fn(() => ({
 const mockKubectlProxy = { exec: vi.fn() }
 
 vi.mock('../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 vi.mock('../useMCP', () => ({

--- a/web/src/hooks/__tests__/useCertManager-detection.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-detection.test.ts
@@ -23,7 +23,7 @@ const mockUseClusters = vi.fn(() => ({
 const mockKubectlProxy = { exec: vi.fn() }
 
 vi.mock('../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 vi.mock('../useMCP', () => ({

--- a/web/src/hooks/__tests__/useGPUReservations.test.ts
+++ b/web/src/hooks/__tests__/useGPUReservations.test.ts
@@ -21,7 +21,7 @@ vi.mock('../../lib/api', () => ({
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false }))
 vi.mock('../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 vi.mock('../useBackendHealth', () => ({

--- a/web/src/hooks/__tests__/useIntoto-hook.test.tsx
+++ b/web/src/hooks/__tests__/useIntoto-hook.test.tsx
@@ -33,7 +33,7 @@ const {
 }))
 
 vi.mock('../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../useMCP', () => ({

--- a/web/src/hooks/__tests__/useProw.test.ts
+++ b/web/src/hooks/__tests__/useProw.test.ts
@@ -18,7 +18,7 @@ vi.mock('../../lib/constants/network', async (importOriginal) => {
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false }))
 vi.mock('../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 import { useProwJobs, getDemoProwJobs } from '../useProw'

--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
@@ -43,7 +43,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../../lib/modeTransition', () => ({

--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage2.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage2.test.ts
@@ -34,7 +34,7 @@ vi.mock('../../../lib/demoMode', () => ({
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },
 }))
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 vi.mock('../../../lib/modeTransition', () => ({
   registerRefetch: (...args: unknown[]) => mockRegisterRefetch(...args),

--- a/web/src/hooks/mcp/__tests__/buildpacks.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks.test.ts
@@ -32,7 +32,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../../lib/modeTransition', () => ({

--- a/web/src/hooks/mcp/__tests__/clusters.health.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.health.test.ts
@@ -94,7 +94,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/clusters.list.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.list.test.ts
@@ -93,7 +93,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/compute.gpu.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.gpu.test.ts
@@ -48,7 +48,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/compute.nodes.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.nodes.test.ts
@@ -48,7 +48,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/compute.nvidia.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.nvidia.test.ts
@@ -52,7 +52,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/config-agent-sse.test.ts
+++ b/web/src/hooks/mcp/__tests__/config-agent-sse.test.ts
@@ -35,7 +35,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/config-basic.test.ts
+++ b/web/src/hooks/mcp/__tests__/config-basic.test.ts
@@ -35,7 +35,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/config-fallback-modes.test.ts
+++ b/web/src/hooks/mcp/__tests__/config-fallback-modes.test.ts
@@ -35,7 +35,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/crossplane-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/crossplane-coverage.test.ts
@@ -34,7 +34,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../../lib/modeTransition', () => ({

--- a/web/src/hooks/mcp/__tests__/crossplane.test.ts
+++ b/web/src/hooks/mcp/__tests__/crossplane.test.ts
@@ -32,7 +32,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../../lib/modeTransition', () => ({

--- a/web/src/hooks/mcp/__tests__/events.test.ts
+++ b/web/src/hooks/mcp/__tests__/events.test.ts
@@ -43,7 +43,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/helm-branches.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-branches.test.ts
@@ -36,7 +36,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../../lib/sseClient', () => ({

--- a/web/src/hooks/mcp/__tests__/helm-core.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-core.test.ts
@@ -36,7 +36,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../../lib/sseClient', () => ({

--- a/web/src/hooks/mcp/__tests__/helm-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-coverage.test.ts
@@ -36,7 +36,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../../lib/sseClient', () => ({

--- a/web/src/hooks/mcp/__tests__/networking.hooks.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking.hooks.test.ts
@@ -31,7 +31,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/operators.test.ts
+++ b/web/src/hooks/mcp/__tests__/operators.test.ts
@@ -33,7 +33,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../../lib/api', () => ({

--- a/web/src/hooks/mcp/__tests__/rbac.test.ts
+++ b/web/src/hooks/mcp/__tests__/rbac.test.ts
@@ -22,7 +22,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../../lib/api', () => ({

--- a/web/src/hooks/mcp/__tests__/security.test.ts
+++ b/web/src/hooks/mcp/__tests__/security.test.ts
@@ -31,7 +31,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../../lib/sseClient', () => ({

--- a/web/src/hooks/mcp/__tests__/storage.hooks.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage.hooks.test.ts
@@ -29,7 +29,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
@@ -49,7 +49,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/workloads.branches.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.branches.test.ts
@@ -53,7 +53,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/workloads.core.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.core.test.ts
@@ -53,7 +53,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
@@ -55,7 +55,7 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 vi.mock('../../useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/pages/EmbedCard.test.tsx
+++ b/web/src/pages/EmbedCard.test.tsx
@@ -39,7 +39,7 @@ vi.mock('react-i18next', () => ({
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false }))
 vi.mock('../hooks/useDemoMode', () => ({
-  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => mockUseDemoMode(),
 }))
 
 const mockPipelineFilterProvider = vi.fn()


### PR DESCRIPTION
Fixes #19854

Restores dynamic useDemoMode mock wiring in 56 test files. PR #19850 replaced dynamic mock calls (mockUseDemoMode()/mockIsDemoMode()) with static isDemoMode: false in vi.mock factories, breaking tests that toggle demo mode to true.

## Root cause

PR #19850 changed lines like:
```js
useDemoMode: () => ({ isDemoMode: mockIsDemoMode() })
```
to:
```js
useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
```

This broke tests that called mockIsDemoMode.mockReturnValue(true) to test demo-mode behavior, since the factory now ignores the dynamic variable.

## Fix

Restores the dynamic mock variable into each vi.mock factory while preserving the toggleDemoMode/setDemoMode properties:

- **Boolean pattern** (mockIsDemoMode): isDemoMode: mockIsDemoMode() with toggle/set wrappers
- **Object pattern** (mockUseDemoMode returning full hook object): useDemoMode: () => mockUseDemoMode()

56 test files updated across card components, hooks, contexts, and MCP hook tests.