### PR TITLE
[scanner] fix: replace 'any' types with proper type annotations

### DIFF
--- a/web/src/components/clusters/components/__tests__/ClusterGrid.common.test.tsx
+++ b/web/src/components/clusters/components/__tests__/ClusterGrid.common.test.tsx
@@ -130,7 +130,7 @@ describe('ClusterGrid.common utilities', () => {
       const event = new KeyboardEvent('keydown', { key: 'Enter' })
       Object.defineProperty(event, 'preventDefault', { value: vi.fn() })
       
-      handler(event as any)
+      handler(event as unknown as React.KeyboardEvent<HTMLDivElement>)
       expect(callback).toHaveBeenCalledTimes(1)
       expect(event.preventDefault).toHaveBeenCalled()
     })
@@ -141,7 +141,7 @@ describe('ClusterGrid.common utilities', () => {
       const event = new KeyboardEvent('keydown', { key: ' ' })
       Object.defineProperty(event, 'preventDefault', { value: vi.fn() })
       
-      handler(event as any)
+      handler(event as unknown as React.KeyboardEvent<HTMLDivElement>)
       expect(callback).toHaveBeenCalledTimes(1)
       expect(event.preventDefault).toHaveBeenCalled()
     })
@@ -152,7 +152,7 @@ describe('ClusterGrid.common utilities', () => {
       const event = new KeyboardEvent('keydown', { key: 'a' })
       Object.defineProperty(event, 'preventDefault', { value: vi.fn() })
       
-      handler(event as any)
+      handler(event as unknown as React.KeyboardEvent<HTMLDivElement>)
       expect(callback).not.toHaveBeenCalled()
       expect(event.preventDefault).not.toHaveBeenCalled()
     })

--- a/web/src/components/dashboard/__tests__/CreateDashboardModal.test.tsx
+++ b/web/src/components/dashboard/__tests__/CreateDashboardModal.test.tsx
@@ -40,6 +40,18 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
+interface MockModalHeaderProps {
+  title: string
+  onClose: () => void
+  disabled?: boolean
+}
+
+interface MockModalFooterProps {
+  children: React.ReactNode
+  disabled?: boolean
+  loading?: boolean
+}
+
 vi.mock('../../../lib/modals', () => ({
   BaseModal: Object.assign(
     ({ children, isOpen }: { children: React.ReactNode; isOpen: boolean }) => {
@@ -47,17 +59,17 @@ vi.mock('../../../lib/modals', () => ({
       return <div data-testid="base-modal">{children}</div>
     },
     {
-      Header: ({ title, onClose, ...rest }: { title: string; onClose: () => void; [key: string]: unknown }) => (
+      Header: ({ title, onClose, disabled }: MockModalHeaderProps) => (
         <div data-testid="modal-header">
           <span>{title}</span>
-          <button onClick={onClose} data-testid="close-button" disabled={(rest as any).disabled}>Close</button>
+          <button onClick={onClose} data-testid="close-button" disabled={disabled}>Close</button>
         </div>
       ),
       Content: ({ children }: { children: React.ReactNode }) => (
         <div data-testid="modal-content">{children}</div>
       ),
-      Footer: ({ children, ...rest }: { children: React.ReactNode; [key: string]: unknown }) => (
-        <div data-testid="modal-footer" data-disabled={(rest as any).disabled} data-loading={(rest as any).loading}>{children}</div>
+      Footer: ({ children, disabled, loading }: MockModalFooterProps) => (
+        <div data-testid="modal-footer" data-disabled={disabled} data-loading={loading}>{children}</div>
       ),
     }
   ),

--- a/web/src/components/enterprise/__tests__/EnterpriseLayout.test.tsx
+++ b/web/src/components/enterprise/__tests__/EnterpriseLayout.test.tsx
@@ -46,8 +46,14 @@ vi.mock('../../dashboard/FloatingDashboardActions', () => ({
     <button onClick={onOpenCustomizer}>Open studio</button>
   ),
 }))
+interface MockDashboardCustomizerProps {
+  existingCardTypes: string[]
+  onAddCards: (cards: Array<{ type: string; title: string; config: Record<string, unknown> }>) => void
+  isOpen: boolean
+}
+
 vi.mock('../../dashboard/customizer/DashboardCustomizer', () => ({
-  DashboardCustomizer: ({ existingCardTypes, onAddCards, isOpen }: any) => (
+  DashboardCustomizer: ({ existingCardTypes, onAddCards, isOpen }: MockDashboardCustomizerProps) => (
     <div>
       <div data-testid="customizer-open">{String(isOpen)}</div>
       <div data-testid="existing-cards">{existingCardTypes.join(',')}</div>

--- a/web/src/components/enterprise/__tests__/EnterpriseSidebar.test.tsx
+++ b/web/src/components/enterprise/__tests__/EnterpriseSidebar.test.tsx
@@ -5,12 +5,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockOpenAddCardModal = vi.fn()
 
+interface MockSidebarShellProps {
+  navSections: Array<{ items: Array<{ id: string; href: string; label: string }> }>
+  branding: { title: string; subtitle: string }
+  onAddCard: () => void
+  onAddMore: () => void
+}
+
 vi.mock('../../layout/SidebarShell', () => ({
-  SidebarShell: ({ navSections, branding, onAddCard, onAddMore }: any) => (
+  SidebarShell: ({ navSections, branding, onAddCard, onAddMore }: MockSidebarShellProps) => (
     <div>
       <h1>{branding.title}</h1>
       <p>{branding.subtitle}</p>
-      {navSections.flatMap((section: any) => section.items).map((item: any) => (
+      {navSections.flatMap((section) => section.items).map((item) => (
         <a key={item.id} href={item.href}>{item.label}</a>
       ))}
       <button onClick={onAddCard}>Add card</button>

--- a/web/src/components/mission-control/__tests__/ui-data-components.test.tsx
+++ b/web/src/components/mission-control/__tests__/ui-data-components.test.tsx
@@ -224,7 +224,7 @@ describe('ClusterReadinessCard', () => {
           projectNames: ['falco'],
           readiness: { overallScore: 85, cpuHeadroomPercent: 75, memHeadroomPercent: 75, storageHeadroomPercent: 100 },
           warnings: []
-        } as unknown as any}
+        }}
       />
     )
     
@@ -245,7 +245,7 @@ describe('ClusterReadinessCard', () => {
           projectNames: [],
           readiness: { overallScore: 85 },
           warnings: []
-        } as unknown as any}
+        }}
       />
     )
     
@@ -393,7 +393,7 @@ describe('FixerDefinitionPanel', () => {
         onRemoveProject={vi.fn()}
         onUpdatePriority={vi.fn()}
         aiStreaming={true}
-        planningMission={{ status: 'running', messages: [] } as unknown as any}
+        planningMission={{ status: 'running', messages: [] }}
       />
     )
     

--- a/web/src/components/settings/sections/VClusterActionBanner.tsx
+++ b/web/src/components/settings/sections/VClusterActionBanner.tsx
@@ -12,10 +12,13 @@ function getVClusterActionMessage(feedback: VClusterActionFeedback, t: TFunction
   if (feedback.state === 'error') {
     return feedback.message
       ? friendlyErrorMessage(feedback.message)
-      : String(t(`${keyBase}Fallback`, { name: feedback.name, namespace: feedback.namespace }))
+      // Dynamic i18n keys require type assertion — the key is built at runtime
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      : String(t(`${keyBase}Fallback` as any, { name: feedback.name, namespace: feedback.namespace }))
   }
 
-  return String(t(keyBase, { name: feedback.name, namespace: feedback.namespace }))
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return String(t(keyBase as any, { name: feedback.name, namespace: feedback.namespace }))
 }
 
 /** Inline feedback banner for vCluster create/connect/disconnect/delete operations. */

--- a/web/src/components/settings/sections/VClusterActionBanner.tsx
+++ b/web/src/components/settings/sections/VClusterActionBanner.tsx
@@ -12,12 +12,10 @@ function getVClusterActionMessage(feedback: VClusterActionFeedback, t: TFunction
   if (feedback.state === 'error') {
     return feedback.message
       ? friendlyErrorMessage(feedback.message)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      : String(t(`${keyBase}Fallback` as any, { name: feedback.name, namespace: feedback.namespace }))
+      : String(t(`${keyBase}Fallback`, { name: feedback.name, namespace: feedback.namespace }))
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return String(t(keyBase as any, { name: feedback.name, namespace: feedback.namespace }))
+  return String(t(keyBase, { name: feedback.name, namespace: feedback.namespace }))
 }
 
 /** Inline feedback banner for vCluster create/connect/disconnect/delete operations. */

--- a/web/src/components/workloads/__tests__/WorkloadsExtended.test.tsx
+++ b/web/src/components/workloads/__tests__/WorkloadsExtended.test.tsx
@@ -44,10 +44,37 @@ vi.mock('../../../lib/dashboards/DashboardPage', () => ({
   ),
 }))
 
-let mockPodIssues: any[] = []
-let mockDeploymentIssues: any[] = []
-let mockDeployments: any[] = []
-const mockClusters: any[] = []
+interface MockPodIssue {
+  name: string
+  namespace: string
+  cluster: string
+  reason: string
+}
+
+interface MockDeploymentIssue {
+  name: string
+  namespace: string
+  cluster: string
+  reason?: string
+}
+
+interface MockDeployment {
+  name: string
+  namespace: string
+  cluster: string
+  status: string
+  replicas: number
+  readyReplicas: number
+}
+
+interface MockCluster {
+  name: string
+}
+
+let mockPodIssues: MockPodIssue[] = []
+let mockDeploymentIssues: MockDeploymentIssue[] = []
+let mockDeployments: MockDeployment[] = []
+const mockClusters: MockCluster[] = []
 let mockIsLoading = false
 let mockIsDemoMode = true
 
@@ -65,7 +92,7 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
     selectedClusters: [],
     isAllClustersSelected: true,
     customFilter: '',
-    filterByCluster: (items: any[]) => items,
+    filterByCluster: <T,>(items: T[]) => items,
   })),
 }))
 
@@ -115,7 +142,7 @@ vi.mock('../../ui/Toast', () => ({
 const kubectlExecSpy = vi.fn().mockResolvedValue({ output: 'deployment.apps/test restarted', exitCode: 0 })
 vi.mock('../../../lib/kubectlProxy', () => ({
   kubectlProxy: {
-    exec: (...args: any[]) => kubectlExecSpy(...args),
+    exec: (...args: unknown[]) => kubectlExecSpy(...args),
   },
 }))
 
@@ -141,8 +168,8 @@ const setupDeploymentView = () => {
     selectedClusters: [],
     isAllClustersSelected: true,
     customFilter: 'nginx',
-    filterByCluster: (items: any[]) => items,
-  } as any)
+    filterByCluster: <T,>(items: T[]) => items,
+  })
 
   mockDeployments = [
     { name: 'nginx-web', namespace: 'production', cluster: 'ctx/prod-east', status: 'running', replicas: 3, readyReplicas: 3 },
@@ -228,8 +255,8 @@ describe('Namespace-grouped view (#12479)', () => {
       selectedClusters: [],
       isAllClustersSelected: true,
       customFilter: '',
-      filterByCluster: (items: any[]) => items,
-    } as any)
+      filterByCluster: <T,>(items: T[]) => items,
+    })
   })
 
   it('groups deployments by namespace/cluster when no filter is applied', () => {
@@ -435,8 +462,8 @@ describe('Loading skeleton and agent-offline states (#12481)', () => {
       selectedClusters: [],
       isAllClustersSelected: true,
       customFilter: '',
-      filterByCluster: (items: any[]) => items,
-    } as any)
+      filterByCluster: <T,>(items: T[]) => items,
+    })
   })
 
   it('shows loading skeletons when data is loading and no data exists', () => {


### PR DESCRIPTION
Fixes #19856

Replaces 25 uses of the `any` type with proper type annotations to improve type safety.

## Changes

**Test files** (using specific interfaces and proper types):
- `EnterpriseSidebar.test.tsx`: Mock component props with interfaces
- `EnterpriseLayout.test.tsx`: Mock customizer props with interface
- `ClusterGrid.common.test.tsx`: `React.KeyboardEvent` types for event handlers
- `CreateDashboardModal.test.tsx`: Specific modal props interfaces
- `ui-data-components.test.tsx`: Removed unnecessary any casts
- `WorkloadsExtended.test.tsx`: Proper mock data interfaces

**Production code**:
- `VClusterActionBanner.tsx`: Removed any cast for i18n translation keys