### PR TITLE
[scanner] fix: repair 270 test failures from Coverage Suite run #3958

### DIFF
--- a/web/src/components/cards/NodeConditions.test.tsx
+++ b/web/src/components/cards/NodeConditions.test.tsx
@@ -35,7 +35,7 @@ vi.mock('../../hooks/useCachedData', () => ({
   useCachedNodes: () => mockCachedNodes(),
 }))
 
-const mockIsDemoMode = vi.fn(() => ({ isDemoMode: false }))
+const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../hooks/useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
@@ -110,7 +110,7 @@ const defaultNodesReturn = {
 function setup() {
   mockCachedNodes.mockReturnValue(defaultNodesReturn)
   mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
-  mockIsDemoMode.mockReturnValue({ isDemoMode: false })
+  mockIsDemoMode.mockReturnValue(false)
   mockExecute.mockResolvedValue(undefined)
 }
 

--- a/web/src/components/cards/StorageOverview.test.tsx
+++ b/web/src/components/cards/StorageOverview.test.tsx
@@ -46,7 +46,7 @@ vi.mock('../../hooks/useGlobalFilters', () => ({
   useGlobalFilters: () => mockUseGlobalFilters(),
 }))
 
-const mockIsDemoMode = vi.fn(() => ({ isDemoMode: false }))
+const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../hooks/useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
@@ -159,7 +159,7 @@ function setup() {
   mockUseGlobalFilters.mockReturnValue(defaultGlobalFilters)
   mockUseChartFilters.mockReturnValue(defaultChartFilters)
   mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
-  mockIsDemoMode.mockReturnValue({ isDemoMode: false })
+  mockIsDemoMode.mockReturnValue(false)
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/cards/__tests__/FleetComplianceHeatmap.test.tsx
+++ b/web/src/components/cards/__tests__/FleetComplianceHeatmap.test.tsx
@@ -89,7 +89,7 @@ describe('FleetComplianceHeatmap', () => {
   })
 
   it('renders correct background for Kubescape score thresholds', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'cluster-green' }, { name: 'cluster-amber' }, { name: 'cluster-red' }] })
     
     mockUseKubescape.mockReturnValue({
@@ -114,7 +114,7 @@ describe('FleetComplianceHeatmap', () => {
   })
 
   it('renders correct background for Kyverno violation boundaries', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'cluster-green' }, { name: 'cluster-amber' }, { name: 'cluster-red' }] })
     
     mockUseKyverno.mockReturnValue({
@@ -139,7 +139,7 @@ describe('FleetComplianceHeatmap', () => {
   })
 
   it('renders correct background for Trivy crit+high boundaries', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'cluster-green' }, { name: 'cluster-amber' }, { name: 'cluster-red' }] })
     
     mockUseTrivy.mockReturnValue({
@@ -164,7 +164,7 @@ describe('FleetComplianceHeatmap', () => {
   })
 
   it('handles empty data by rendering clusters from fallback', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'cluster-1' }] })
     // All tools not installed
     

--- a/web/src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx
@@ -77,7 +77,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
   })
 
   it('when isDemoMode is false and cluster is live, namespace dropdown stays unselected until a cluster is chosen', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockUseCachedNamespaces.mockReturnValue({
       namespaces: ['prod-ns', 'staging-ns'],
       isLoading: false,
@@ -94,7 +94,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
   })
 
   it('when isDemoMode is true, auto-selection prefers "production" namespace if available', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     mockUseCachedNamespaces.mockReturnValue({
       namespaces: ['default', 'production', 'staging'],
       isLoading: false,
@@ -113,7 +113,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
   })
 
   it('when isDemoMode is false, auto-selection logic does NOT run', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockUseCachedNamespaces.mockReturnValue({
       namespaces: ['default', 'production', 'staging'],
       isLoading: false,
@@ -129,7 +129,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
   })
 
   it('isDemoData flag is true when demoMode is true', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     mockUseCachedNamespaces.mockReturnValue({
       namespaces: ['default'],
       isLoading: false,
@@ -149,7 +149,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
   })
 
   it('isDemoData flag is true when isDemoFallback is true', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockUseCachedNamespaces.mockReturnValue({
       namespaces: ['default'],
       isLoading: false,
@@ -169,7 +169,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
   })
 
   it('namespace dropdown renders empty state when useCachedNamespaces returns empty array in live mode', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockUseCachedNamespaces.mockReturnValue({
       namespaces: [],
       isLoading: false,
@@ -186,7 +186,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
 
   it('verifies isDemoData combines demoMode OR isDemoFallback (line 73)', () => {
     // Test case 1: demoMode true, isDemoFallback false
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     mockUseCachedNamespaces.mockReturnValue({
       namespaces: [],
       isLoading: false,
@@ -206,7 +206,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
     vi.clearAllMocks()
 
     // Test case 2: demoMode false, isDemoFallback true
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockUseCachedNamespaces.mockReturnValue({
       namespaces: [],
       isLoading: false,
@@ -226,7 +226,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
     vi.clearAllMocks()
 
     // Test case 3: both false
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockUseCachedNamespaces.mockReturnValue({
       namespaces: [],
       isLoading: false,

--- a/web/src/components/cards/__tests__/StorageOverview.test.tsx
+++ b/web/src/components/cards/__tests__/StorageOverview.test.tsx
@@ -132,7 +132,7 @@ function setup(): void {
   mockUseClusters.mockReturnValue(defaultClustersReturn)
   mockUseCachedPVCs.mockReturnValue(defaultPVCsReturn)
   mockUseGlobalFilters.mockReturnValue(defaultGlobalFilters)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockUseChartFilters.mockReturnValue(defaultChartFilters)
   mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
 }

--- a/web/src/components/cards/pipelines/__tests__/PipelineFlow.test.tsx
+++ b/web/src/components/cards/pipelines/__tests__/PipelineFlow.test.tsx
@@ -131,7 +131,7 @@ describe('PipelineFlow', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockUseCardLoadingState.mockReturnValue({})
     mockRunMutation.mockResolvedValue({ ok: true })
     setupFlow(DEMO_FLOW)
@@ -170,7 +170,7 @@ describe('PipelineFlow', () => {
 
   describe('demo data path', () => {
     it('passes isDemoData=true to useCardLoadingState in demo mode', () => {
-      mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+      mockUseDemoMode.mockReturnValue(true)
       render(<PipelineFlow />)
       expect(mockUseCardLoadingState).toHaveBeenCalledWith(
         expect.objectContaining({ isDemoData: true, hasAnyData: true }),

--- a/web/src/components/cards/pipelines/__tests__/WorkflowMatrix.test.tsx
+++ b/web/src/components/cards/pipelines/__tests__/WorkflowMatrix.test.tsx
@@ -96,7 +96,7 @@ function setupMatrix(data: MatrixPayload | null, opts: { isLoading?: boolean; er
 describe('WorkflowMatrix', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockUseCardLoadingState.mockReturnValue({})
     setupMatrix(DEMO_MATRIX)
   })
@@ -160,7 +160,7 @@ describe('WorkflowMatrix', () => {
 
   describe('demo data path', () => {
     it('passes isDemoData=true to useCardLoadingState in demo mode', () => {
-      mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+      mockUseDemoMode.mockReturnValue(true)
       render(<WorkflowMatrix />)
       expect(mockUseCardLoadingState).toHaveBeenCalledWith(
         expect.objectContaining({ isDemoData: true, hasAnyData: true }),

--- a/web/src/contexts/AlertsContext.deepcover.test.tsx
+++ b/web/src/contexts/AlertsContext.deepcover.test.tsx
@@ -91,7 +91,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   // Re-initialize hoisted mocks after restoreAllMocks clears their implementations
   mockStartMission.mockReturnValue('mock-mission-id')
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockSendNotificationWithDeepLink.mockImplementation(() => {})
   // Re-stub globals after restoreAllMocks clears them
   vi.stubGlobal('Notification', { permission: 'granted', requestPermission: vi.fn() })

--- a/web/src/contexts/AlertsContext.lifecycle.test.tsx
+++ b/web/src/contexts/AlertsContext.lifecycle.test.tsx
@@ -91,7 +91,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   // Re-initialize hoisted mocks after restoreAllMocks clears their implementations
   mockStartMission.mockReturnValue('mock-mission-id')
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockSendNotificationWithDeepLink.mockImplementation(() => {})
   // Re-stub globals after restoreAllMocks clears them
   vi.stubGlobal('Notification', { permission: 'granted', requestPermission: vi.fn() })
@@ -766,7 +766,7 @@ describe('Notification permission', () => {
 describe('demo mode alert cleanup', () => {
   it('removes demo-generated alerts when demo mode is turned off', () => {
     // Start with demo mode on
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const alerts = [
       makeAlert({ id: 'demo-alert', status: 'firing', isDemo: true }),
@@ -781,7 +781,7 @@ describe('demo mode alert cleanup', () => {
     expect(result.current.alerts.length).toBe(3)
 
     // Turn off demo mode
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     rerender()
 
     // Demo alerts should be removed

--- a/web/src/contexts/AlertsContext.storage.test.tsx
+++ b/web/src/contexts/AlertsContext.storage.test.tsx
@@ -91,7 +91,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   // Re-initialize hoisted mocks after restoreAllMocks clears their implementations
   mockStartMission.mockReturnValue('mock-mission-id')
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockSendNotificationWithDeepLink.mockImplementation(() => {})
   // Re-stub globals after restoreAllMocks clears them
   vi.stubGlobal('Notification', { permission: 'granted', requestPermission: vi.fn() })

--- a/web/src/hooks/__tests__/useCertManager-basic.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-basic.test.ts
@@ -14,7 +14,7 @@ import { renderHook, waitFor } from '@testing-library/react'
 // Mocks — declared BEFORE importing the module under test
 // ---------------------------------------------------------------------------
 
-const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false }))
+const mockUseDemoMode = vi.fn(() => false)
 const mockUseClusters = vi.fn(() => ({
   clusters: [],
   deduplicatedClusters: [],
@@ -140,7 +140,7 @@ describe('useCertManager', () => {
     vi.clearAllMocks()
     vi.useFakeTimers({ shouldAdvanceTime: true })
     sessionStorage.clear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -192,7 +192,7 @@ describe('useCertManager', () => {
 
   describe('demo mode', () => {
     it('returns demo certificates when in demo mode', async () => {
-      mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+      mockUseDemoMode.mockReturnValue(true)
 
       const { useCertManager } = await loadModule()
       const { result } = renderHook(() => useCertManager())
@@ -209,7 +209,7 @@ describe('useCertManager', () => {
     })
 
     it('returns demo issuers when in demo mode', async () => {
-      mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+      mockUseDemoMode.mockReturnValue(true)
 
       const { useCertManager } = await loadModule()
       const { result } = renderHook(() => useCertManager())
@@ -225,7 +225,7 @@ describe('useCertManager', () => {
     })
 
     it('demo data includes expected certificate statuses', async () => {
-      mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+      mockUseDemoMode.mockReturnValue(true)
 
       const { useCertManager } = await loadModule()
       const { result } = renderHook(() => useCertManager())

--- a/web/src/hooks/__tests__/useCertManager-caching.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-caching.test.ts
@@ -14,7 +14,7 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 // Mocks — declared BEFORE importing the module under test
 // ---------------------------------------------------------------------------
 
-const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false }))
+const mockUseDemoMode = vi.fn(() => false)
 const mockUseClusters = vi.fn(() => ({
   clusters: [],
   deduplicatedClusters: [],
@@ -140,7 +140,7 @@ describe('useCertManager', () => {
     vi.clearAllMocks()
     vi.useFakeTimers({ shouldAdvanceTime: true })
     sessionStorage.clear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {

--- a/web/src/hooks/__tests__/useCertManager-detection.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-detection.test.ts
@@ -14,7 +14,7 @@ import { renderHook, waitFor } from '@testing-library/react'
 // Mocks — declared BEFORE importing the module under test
 // ---------------------------------------------------------------------------
 
-const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false }))
+const mockUseDemoMode = vi.fn(() => false)
 const mockUseClusters = vi.fn(() => ({
   clusters: [],
   deduplicatedClusters: [],
@@ -140,7 +140,7 @@ describe('useCertManager', () => {
     vi.clearAllMocks()
     vi.useFakeTimers({ shouldAdvanceTime: true })
     sessionStorage.clear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {

--- a/web/src/hooks/__tests__/useGPUReservations.test.ts
+++ b/web/src/hooks/__tests__/useGPUReservations.test.ts
@@ -19,7 +19,7 @@ vi.mock('../../lib/api', () => ({
   },
 }))
 
-const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false }))
+const mockUseDemoMode = vi.fn(() => false)
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => mockUseDemoMode(),
 }))
@@ -70,7 +70,7 @@ describe('useGPUReservations', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers({ shouldAdvanceTime: true })
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockGet.mockResolvedValue({ data: [] })
     mockPost.mockResolvedValue({ data: MOCK_RESERVATION })
     mockPut.mockResolvedValue({ data: MOCK_RESERVATION })
@@ -175,7 +175,7 @@ describe('useGPUReservations', () => {
   // ---------- Demo Mode ----------
 
   it('falls back to demo data when API fails in demo mode', async () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     mockGet.mockRejectedValue(new Error('fail'))
 
     const { result } = renderHook(() => useGPUReservations())
@@ -186,7 +186,7 @@ describe('useGPUReservations', () => {
   })
 
   it('uses demo data when API returns empty in demo mode', async () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     mockGet.mockResolvedValue({ data: [] })
 
     const { result } = renderHook(() => useGPUReservations())
@@ -197,7 +197,7 @@ describe('useGPUReservations', () => {
   })
 
   it('uses live data in demo mode when API returns non-empty', async () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     mockGet.mockResolvedValue({ data: [MOCK_RESERVATION] })
 
     const { result } = renderHook(() => useGPUReservations())

--- a/web/src/hooks/__tests__/useProw.test.ts
+++ b/web/src/hooks/__tests__/useProw.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../lib/constants/network', async (importOriginal) => {
   return { ...actual, KUBECTL_EXTENDED_TIMEOUT_MS: 30000 }
 })
 
-const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false }))
+const mockUseDemoMode = vi.fn(() => false)
 vi.mock('../useDemoMode', () => ({
   useDemoMode: () => mockUseDemoMode(),
 }))
@@ -84,7 +84,7 @@ describe('useProwJobs', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers({ shouldAdvanceTime: true })
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockExec.mockResolvedValue(buildKubectlResponse([]))
   })
 
@@ -311,7 +311,7 @@ describe('useProwJobs', () => {
   // ---------- Demo Mode ----------
 
   it('returns demo data in demo mode without calling kubectlProxy', async () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useProwJobs())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -345,7 +345,7 @@ describe('useProwJobs', () => {
     expect(result.current.jobs[0].id).toBe('live-job')
 
     // Toggle to demo mode
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     rerender()
 
     await waitFor(() => {

--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
@@ -96,7 +96,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'tk')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsNetlifyDeployment.value = false
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockSubscribePolling.mockReturnValue(vi.fn())

--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage2.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage2.test.ts
@@ -62,7 +62,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'tk')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsNetlifyDeployment.value = false
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockSubscribePolling.mockReturnValue(vi.fn())

--- a/web/src/hooks/mcp/__tests__/buildpacks.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks.test.ts
@@ -75,7 +75,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsNetlifyDeployment.value = false
   mockRegisterRefetch.mockReturnValue(vi.fn())
 })
@@ -116,7 +116,7 @@ describe('useBuildpackImages', () => {
 
   it('returns demo images when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     // Use a cluster param to bypass the module-level cache from prior tests
     const { result } = renderHook(() => useBuildpackImages('demo-cluster'))

--- a/web/src/hooks/mcp/__tests__/clusters.dedup.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.dedup.test.ts
@@ -8,7 +8,7 @@ import type { ClusterInfo, ClusterHealth } from '../types'
 // ---------------------------------------------------------------------------
 const mockFullFetchClusters = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 const mockConnectSharedWebSocket = vi.hoisted(() => vi.fn())
-const mockUseDemoMode = vi.hoisted(() => vi.fn().mockReturnValue({ isDemoMode: false }))
+const mockUseDemoMode = vi.hoisted(() => vi.fn().mockReturnValue(false))
 const mockIsDemoMode = vi.hoisted(() => vi.fn(() => false))
 const mockApiGet = vi.hoisted(() => vi.fn())
 const mockTriggerAggressiveDetection = vi.hoisted(() =>

--- a/web/src/hooks/mcp/__tests__/clusters.health.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.health.test.ts
@@ -8,7 +8,7 @@ import type { ClusterInfo, ClusterHealth, MCPStatus } from '../types'
 // ---------------------------------------------------------------------------
 const mockFullFetchClusters = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 const mockConnectSharedWebSocket = vi.hoisted(() => vi.fn())
-const mockUseDemoMode = vi.hoisted(() => vi.fn().mockReturnValue({ isDemoMode: false }))
+const mockUseDemoMode = vi.hoisted(() => vi.fn().mockReturnValue(false))
 const mockIsDemoMode = vi.hoisted(() => vi.fn(() => false))
 const mockApiGet = vi.hoisted(() => vi.fn())
 const mockAgentFetch = vi.hoisted(() => vi.fn())

--- a/web/src/hooks/mcp/__tests__/clusters.list.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.list.test.ts
@@ -8,7 +8,7 @@ import { STORAGE_KEY_TOKEN } from '../../../lib/constants'
 // ---------------------------------------------------------------------------
 const mockFullFetchClusters = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 const mockConnectSharedWebSocket = vi.hoisted(() => vi.fn())
-const mockUseDemoMode = vi.hoisted(() => vi.fn().mockReturnValue({ isDemoMode: false }))
+const mockUseDemoMode = vi.hoisted(() => vi.fn().mockReturnValue(false))
 const mockIsDemoMode = vi.hoisted(() => vi.fn(() => false))
 const mockApiGet = vi.hoisted(() => vi.fn())
 const mockTriggerAggressiveDetection = vi.hoisted(() =>
@@ -164,7 +164,7 @@ describe('useClusters', () => {
     resetSharedState()
     mockFullFetchClusters.mockClear()
     mockConnectSharedWebSocket.mockClear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -231,11 +231,11 @@ describe('useClusters', () => {
   })
 
   it('re-fetches when demo mode changes', async () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     const { rerender } = renderHook(() => useClusters())
     mockFullFetchClusters.mockClear() // ignore initial fetch
 
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     await act(async () => {
       rerender()
     })
@@ -263,7 +263,7 @@ describe('Shared cache / pub-sub', () => {
     resetSharedState()
     mockFullFetchClusters.mockClear()
     mockConnectSharedWebSocket.mockClear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -330,7 +330,7 @@ describe('Shared WebSocket singleton', () => {
     resetSharedState()
     mockFullFetchClusters.mockClear()
     mockConnectSharedWebSocket.mockClear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -389,7 +389,7 @@ describe('useClusters — deduplication integration', () => {
     resetSharedState()
     mockFullFetchClusters.mockClear()
     mockConnectSharedWebSocket.mockClear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -442,7 +442,7 @@ describe('useClusters — demo mode transitions', () => {
     mockFullFetchClusters.mockClear()
     mockConnectSharedWebSocket.mockClear()
     mockTriggerAggressiveDetection.mockClear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -451,13 +451,13 @@ describe('useClusters — demo mode transitions', () => {
 
   it('triggers aggressive detection when switching FROM demo to live mode', async () => {
     // Start in demo mode
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const { rerender } = renderHook(() => useClusters())
     mockFullFetchClusters.mockClear()
     mockTriggerAggressiveDetection.mockClear()
 
     // Switch to live mode
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     await act(async () => { rerender() })
 
     expect(mockTriggerAggressiveDetection).toHaveBeenCalledTimes(1)
@@ -467,13 +467,13 @@ describe('useClusters — demo mode transitions', () => {
 
   it('calls fullFetchClusters directly when switching TO demo mode', async () => {
     // Start in live mode
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     const { rerender } = renderHook(() => useClusters())
     mockFullFetchClusters.mockClear()
     mockTriggerAggressiveDetection.mockClear()
 
     // Switch to demo mode
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     await act(async () => { rerender() })
 
     // Should NOT trigger aggressive detection for demo mode
@@ -482,12 +482,12 @@ describe('useClusters — demo mode transitions', () => {
   })
 
   it('does not re-fetch if demo mode value stays the same across rerenders', async () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     const { rerender } = renderHook(() => useClusters())
     mockFullFetchClusters.mockClear()
 
     // Rerender with same demo mode value
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     await act(async () => { rerender() })
 
     // Should not trigger a re-fetch since isDemoMode didn't change
@@ -500,7 +500,7 @@ describe('useClusters — refetch', () => {
     vi.useRealTimers()
     resetSharedState()
     mockFullFetchClusters.mockClear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -537,7 +537,7 @@ describe('useClusters — cache state fields', () => {
     vi.useRealTimers()
     resetSharedState()
     mockFullFetchClusters.mockClear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -610,7 +610,7 @@ describe('useClusters — deduplication and metric sharing', () => {
     resetSharedState()
     mockFullFetchClusters.mockClear()
     mockConnectSharedWebSocket.mockClear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -696,12 +696,12 @@ describe('useClusters — demo mode transition', () => {
   })
 
   it('calls triggerAggressiveDetection when switching FROM demo to live', async () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const { rerender } = renderHook(() => useClusters())
     mockFullFetchClusters.mockClear()
     mockTriggerAggressiveDetection.mockClear()
 
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     await act(async () => {
       rerender()
     })
@@ -710,11 +710,11 @@ describe('useClusters — demo mode transition', () => {
   })
 
   it('calls fullFetchClusters directly when switching TO demo mode', async () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     const { rerender } = renderHook(() => useClusters())
     mockFullFetchClusters.mockClear()
 
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     await act(async () => {
       rerender()
     })
@@ -728,7 +728,7 @@ describe('useClusters — refetch callback', () => {
     vi.useRealTimers()
     resetSharedState()
     mockFullFetchClusters.mockClear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -759,7 +759,7 @@ describe('useClusters — deduplicatedClusters', () => {
     vi.useRealTimers()
     resetSharedState()
     mockFullFetchClusters.mockClear()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {

--- a/web/src/hooks/mcp/__tests__/compute.gpu.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.gpu.test.ts
@@ -117,7 +117,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsAgentUnavailable.mockReturnValue(true)
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockClusterCacheRef.clusters = []
@@ -292,7 +292,7 @@ describe('useGPUNodes', () => {
 
   it('uses demo GPU nodes when demo mode is enabled and no cached data exists', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     // SSE fails — should fall back to demo data in catch block
     mockFetchSSE.mockRejectedValue(new Error('SSE failed'))
 
@@ -772,7 +772,7 @@ describe('useGPUNodes — deduplication edge cases', () => {
     gpuNodeCache.lastRefresh = null
     gpuNodeCache.lastUpdated = null
     mockIsDemoMode.mockReturnValue(false)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     mockFetchSSE.mockResolvedValue([])
   })
 
@@ -1069,7 +1069,7 @@ describe('fetchGPUNodes — error recovery from localStorage', () => {
 
   it('falls back to demo data when memory cache is empty and demo mode is on', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     gpuNodeCache.nodes = []
     gpuNodeCache.lastUpdated = null

--- a/web/src/hooks/mcp/__tests__/compute.nodes.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.nodes.test.ts
@@ -116,7 +116,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsAgentUnavailable.mockReturnValue(true)
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockClusterCacheRef.clusters = []
@@ -239,7 +239,7 @@ describe('useNodes', () => {
 
   it('returns demo nodes when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useNodes())
 
@@ -413,7 +413,7 @@ describe('useNodes — empty cluster handling', () => {
 describe('useNodes — additional branches', () => {
   it('returns demo nodes filtered by cluster', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useNodes('vllm-d'))
 

--- a/web/src/hooks/mcp/__tests__/compute.nvidia.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.nvidia.test.ts
@@ -125,7 +125,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsAgentUnavailable.mockReturnValue(true)
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockClusterCacheRef.clusters = []

--- a/web/src/hooks/mcp/__tests__/config-agent-sse.test.ts
+++ b/web/src/hooks/mcp/__tests__/config-agent-sse.test.ts
@@ -97,7 +97,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsAgentUnavailable.mockReturnValue(true)
   mockRegisterRefetch.mockReturnValue(vi.fn())
   // Default: SSE returns empty list (succeeds so REST is not reached by default)

--- a/web/src/hooks/mcp/__tests__/config-basic.test.ts
+++ b/web/src/hooks/mcp/__tests__/config-basic.test.ts
@@ -97,7 +97,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsAgentUnavailable.mockReturnValue(true)
   mockRegisterRefetch.mockReturnValue(vi.fn())
   // Default: SSE returns empty list (succeeds so REST is not reached by default)
@@ -195,7 +195,7 @@ describe('useConfigMaps', () => {
 
   it('returns demo config maps when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useConfigMaps())
 
@@ -289,7 +289,7 @@ describe('useSecrets', () => {
 
   it('returns demo secrets when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useSecrets())
 
@@ -368,7 +368,7 @@ describe('useServiceAccounts', () => {
 
   it('returns demo service accounts when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useServiceAccounts())
 

--- a/web/src/hooks/mcp/__tests__/config-fallback-modes.test.ts
+++ b/web/src/hooks/mcp/__tests__/config-fallback-modes.test.ts
@@ -97,7 +97,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsAgentUnavailable.mockReturnValue(true)
   mockRegisterRefetch.mockReturnValue(vi.fn())
   // Default: SSE returns empty list (succeeds so REST is not reached by default)
@@ -285,7 +285,7 @@ describe('useServiceAccounts — REST fallback', () => {
 describe('useConfigMaps — demo mode filtering', () => {
   beforeEach(() => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
   })
 
   it('filters demo configmaps by cluster', async () => {
@@ -334,7 +334,7 @@ describe('useConfigMaps — demo mode filtering', () => {
 describe('useSecrets — demo mode filtering', () => {
   beforeEach(() => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
   })
 
   it('filters demo secrets by cluster', async () => {
@@ -377,7 +377,7 @@ describe('useSecrets — demo mode filtering', () => {
 describe('useServiceAccounts — demo mode filtering', () => {
   beforeEach(() => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
   })
 
   it('filters demo service accounts by cluster', async () => {

--- a/web/src/hooks/mcp/__tests__/crossplane-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/crossplane-coverage.test.ts
@@ -122,7 +122,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   localStorage.clear()
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsNetlifyDeployment.value = false
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockSubscribePolling.mockReturnValue(vi.fn())
@@ -379,7 +379,7 @@ describe('crossplane-coverage: consecutive failure tracking', () => {
 describe('crossplane-coverage: demo mode data processing', () => {
   it('returns demo resources with expected structure', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useCrossplaneManagedResources('demo-struct'))
 
@@ -398,7 +398,7 @@ describe('crossplane-coverage: demo mode data processing', () => {
 
   it('saves demo data to localStorage when no cluster filter', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useCrossplaneManagedResources())
 
@@ -412,7 +412,7 @@ describe('crossplane-coverage: demo mode data processing', () => {
   it('does not save demo data to localStorage when cluster filter provided', async () => {
     localStorage.clear()
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useCrossplaneManagedResources('demo-filtered'))
 
@@ -426,7 +426,7 @@ describe('crossplane-coverage: demo mode data processing', () => {
 
   it('sets lastRefresh on demo mode fetch', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useCrossplaneManagedResources('demo-ts'))
 
@@ -616,7 +616,7 @@ describe('crossplane-coverage: demoMode toggle re-fetches', () => {
 
     // Toggle demo mode
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     rerender()
 
     await waitFor(() => expect(result.current.isDemoData).toBe(true))

--- a/web/src/hooks/mcp/__tests__/crossplane.test.ts
+++ b/web/src/hooks/mcp/__tests__/crossplane.test.ts
@@ -68,7 +68,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   localStorage.clear()
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsNetlifyDeployment.value = false
   mockRegisterRefetch.mockReturnValue(vi.fn())
 })
@@ -114,7 +114,7 @@ describe('useCrossplaneManagedResources', () => {
 
   it('returns demo resources when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     // Use a cluster param to bypass the module-level cache from prior tests
     const { result } = renderHook(() => useCrossplaneManagedResources('demo-cluster'))

--- a/web/src/hooks/mcp/__tests__/events.test.ts
+++ b/web/src/hooks/mcp/__tests__/events.test.ts
@@ -101,7 +101,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsAgentUnavailable.mockReturnValue(true)
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockFetchSSE.mockResolvedValue([])
@@ -244,7 +244,7 @@ describe('useEvents', () => {
 
   it('returns demo events when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useEvents())
 
@@ -411,7 +411,7 @@ describe('useEvents', () => {
 
   it('demo mode filters events by cluster when specified', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useEvents('gke-staging'))
 
@@ -422,7 +422,7 @@ describe('useEvents', () => {
 
   it('demo mode filters events by namespace when specified', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useEvents(undefined, 'production'))
 
@@ -433,7 +433,7 @@ describe('useEvents', () => {
 
   it('demo mode respects the limit parameter', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const DEMO_LIMIT = 2
 
     const { result } = renderHook(() => useEvents(undefined, undefined, DEMO_LIMIT))
@@ -663,7 +663,7 @@ describe('useWarningEvents', () => {
 
   it('returns only Warning events in demo mode', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useWarningEvents())
 
@@ -688,7 +688,7 @@ describe('useWarningEvents', () => {
 
   it('demo mode filters warning events by cluster', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useWarningEvents('vllm-gpu-cluster'))
 
@@ -699,7 +699,7 @@ describe('useWarningEvents', () => {
 
   it('demo mode filters warning events by namespace', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useWarningEvents(undefined, 'production'))
 

--- a/web/src/hooks/mcp/__tests__/helm-branches.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-branches.test.ts
@@ -135,7 +135,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsNetlifyDeployment.value = false
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockSubscribePolling.mockReturnValue(vi.fn())
@@ -225,7 +225,7 @@ describe('useHelmReleases — additional branches', () => {
   it('demo mode refetch with silent does not show refresh indicator', async () => {
     vi.useFakeTimers()
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useHelmReleases())
 

--- a/web/src/hooks/mcp/__tests__/helm-core.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-core.test.ts
@@ -135,7 +135,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsNetlifyDeployment.value = false
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockSubscribePolling.mockReturnValue(vi.fn())
@@ -174,7 +174,7 @@ describe('useHelmReleases', () => {
 
   it('returns demo releases when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useHelmReleases())
 
@@ -348,7 +348,7 @@ describe('useHelmReleases', () => {
 
   it('demo releases each have required HelmRelease fields', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useHelmReleases())
 
@@ -473,7 +473,7 @@ describe('useHelmHistory', () => {
 
   it('returns demo history when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useHelmHistory('c1', 'prometheus', 'monitoring'))
 
@@ -605,7 +605,7 @@ describe('useHelmHistory', () => {
 
   it('demo history entries each have required HelmHistoryEntry fields', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useHelmHistory('c1', 'prometheus', 'monitoring'))
     await waitFor(() => expect(result.current.history.length).toBeGreaterThan(0))
@@ -727,7 +727,7 @@ describe('useHelmValues', () => {
 
   it('returns demo values when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useHelmValues('c1', 'prometheus', 'monitoring'))
 
@@ -881,7 +881,7 @@ describe('useHelmValues', () => {
 
   it('demo values contain expected structure', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const cluster = uniqueCluster('val-demo-struct')
     const { result } = renderHook(() => useHelmValues(cluster, 'prometheus', 'monitoring'))

--- a/web/src/hooks/mcp/__tests__/helm-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-coverage.test.ts
@@ -129,7 +129,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsNetlifyDeployment.value = false
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockSubscribePolling.mockReturnValue(vi.fn())
@@ -359,7 +359,7 @@ describe('useHelmReleases — cache validity and background refresh', () => {
 describe('useHelmReleases — demo mode edge cases', () => {
   it('does not update module cache when demo mode + cluster param', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const cluster = uniqueCluster('demo-cluster')
     const { result } = renderHook(() => useHelmReleases(cluster))
@@ -370,7 +370,7 @@ describe('useHelmReleases — demo mode edge cases', () => {
 
   it('updates module cache when demo mode without cluster param', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useHelmReleases())
 
@@ -532,7 +532,7 @@ describe('useHelmValues — useEffect doFetch path', () => {
 
   it('doFetch returns demo values when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const cluster = uniqueCluster('val-dofetch-demo')
     const { result } = renderHook(() => useHelmValues(cluster, 'my-rel', 'default'))
@@ -631,7 +631,7 @@ describe('useHelmValues — demo mode toggle', () => {
   it('skips demo mode re-fetch on initial mount', async () => {
     const cluster = uniqueCluster('val-no-refetch-init')
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useHelmValues(cluster, 'my-rel', 'default'))
 

--- a/web/src/hooks/mcp/__tests__/networking.hooks.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking.hooks.test.ts
@@ -102,7 +102,7 @@ describe('networking hooks - useServices', () => {
     localStorage.clear()
     mockIsAgentUnavailable.mockReturnValue(false)
     mockIsDemoMode.mockReturnValue(false)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -267,7 +267,7 @@ describe('networking hooks - useServices', () => {
   // Test 7: Demo mode fallback
   it('returns demo data when demo mode is enabled', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useServices('cluster-a'))
 
@@ -356,7 +356,7 @@ describe('networking hooks - useIngresses', () => {
     localStorage.clear()
     mockIsAgentUnavailable.mockReturnValue(false)
     mockIsDemoMode.mockReturnValue(false)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   // Test 1: Loading → Success state transition
@@ -394,7 +394,7 @@ describe('networking hooks - useIngresses', () => {
   // Test 2: Demo mode returns demo ingresses
   it('returns demo data in demo mode', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useIngresses())
 

--- a/web/src/hooks/mcp/__tests__/operators.test.ts
+++ b/web/src/hooks/mcp/__tests__/operators.test.ts
@@ -79,7 +79,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockSubscribeClusterCache.mockReturnValue(vi.fn())
   mockFetchSSE.mockResolvedValue([])
@@ -117,7 +117,7 @@ describe('useOperators', () => {
 
   it('returns demo operators when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useOperators())
 
@@ -196,7 +196,7 @@ describe('useOperatorSubscriptions', () => {
 
   it('returns demo subscriptions when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useOperatorSubscriptions())
 
@@ -316,7 +316,7 @@ describe('useOperators – cluster filter', () => {
 
   it('demo mode returns operators scoped to the given cluster', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useOperators('prod-east'))
 
@@ -353,7 +353,7 @@ describe('useOperators – empty/missing data handling', () => {
 
   it('handles demo mode with no clusters in cache', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     mockClusterCacheRef.clusters = []
 
     const { result } = renderHook(() => useOperators())
@@ -561,7 +561,7 @@ describe('useOperatorSubscriptions – cluster filter', () => {
 
   it('demo mode returns subscriptions scoped to the given cluster', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useOperatorSubscriptions('prod-east'))
 
@@ -597,7 +597,7 @@ describe('useOperatorSubscriptions – empty/missing data handling', () => {
 
   it('handles demo mode with no clusters in cache', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     mockClusterCacheRef.clusters = []
 
     const { result } = renderHook(() => useOperatorSubscriptions())
@@ -683,7 +683,7 @@ describe('useOperatorSubscriptions – REST fills missing cluster field', () => 
 describe('useOperatorSubscriptions – demo data with multiple clusters', () => {
   it('returns subscriptions for all cached clusters when no filter', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     mockClusterCacheRef.clusters = [
       { name: 'cluster-a', context: 'cluster-a' },
       { name: 'cluster-b', context: 'cluster-b' },
@@ -701,7 +701,7 @@ describe('useOperatorSubscriptions – demo data with multiple clusters', () => 
 describe('useOperators – demo data with multiple clusters', () => {
   it('returns operators for all cached clusters when no filter', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     mockClusterCacheRef.clusters = [
       { name: 'cluster-a', context: 'cluster-a' },
       { name: 'cluster-b', context: 'cluster-b' },

--- a/web/src/hooks/mcp/__tests__/rbac.test.ts
+++ b/web/src/hooks/mcp/__tests__/rbac.test.ts
@@ -60,7 +60,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockRegisterRefetch.mockReturnValue(vi.fn())
 })
 
@@ -96,7 +96,7 @@ describe('useK8sRoles', () => {
 
   it('returns demo roles when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sRoles('eks-prod-us-east-1'))
 
@@ -137,7 +137,7 @@ describe('useK8sRoles', () => {
 
   it('filters demo roles by cluster to only matching cluster', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sRoles('eks-prod-us-east-1'))
 
@@ -152,7 +152,7 @@ describe('useK8sRoles', () => {
 
   it('returns all demo roles across clusters when cluster is undefined', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sRoles())
 
@@ -167,7 +167,7 @@ describe('useK8sRoles', () => {
 
   it('distinguishes cluster-scoped vs namespace-scoped roles in demo data', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sRoles('eks-prod-us-east-1'))
 
@@ -289,7 +289,7 @@ describe('useK8sRoles', () => {
 
   it('uses "all" placeholder in refetch key when cluster/namespace are omitted', () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     renderHook(() => useK8sRoles())
 
@@ -317,7 +317,7 @@ describe('useK8sRoles', () => {
 
   it('every demo role has a positive ruleCount', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sRoles())
 
@@ -329,7 +329,7 @@ describe('useK8sRoles', () => {
 
   it('demo cluster filter returns empty for unknown cluster name', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sRoles('nonexistent-cluster'))
 
@@ -365,7 +365,7 @@ describe('useK8sRoleBindings', () => {
 
   it('returns demo bindings when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sRoleBindings('eks-prod-us-east-1'))
 
@@ -405,7 +405,7 @@ describe('useK8sRoleBindings', () => {
 
   it('filters demo bindings by cluster only', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sRoleBindings('gke-staging'))
 
@@ -419,7 +419,7 @@ describe('useK8sRoleBindings', () => {
 
   it('namespace filter includes cluster-scoped bindings (isCluster=true)', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() =>
       useK8sRoleBindings('eks-prod-us-east-1', 'default'),
@@ -438,7 +438,7 @@ describe('useK8sRoleBindings', () => {
 
   it('demo bindings contain all three subject kinds: User, Group, ServiceAccount', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sRoleBindings())
 
@@ -456,7 +456,7 @@ describe('useK8sRoleBindings', () => {
 
   it('demo bindings reference both Role and ClusterRole roleKind', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sRoleBindings())
 
@@ -536,7 +536,7 @@ describe('useK8sRoleBindings', () => {
 
   it('uses "all" placeholders when cluster/namespace are omitted', () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     renderHook(() => useK8sRoleBindings())
 
@@ -548,7 +548,7 @@ describe('useK8sRoleBindings', () => {
 
   it('ServiceAccount subjects carry a namespace field in demo data', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sRoleBindings('gke-staging'))
 
@@ -614,7 +614,7 @@ describe('useK8sServiceAccounts', () => {
 
   it('returns demo service accounts when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sServiceAccounts('eks-prod-us-east-1'))
 
@@ -645,7 +645,7 @@ describe('useK8sServiceAccounts', () => {
 
   it('filters by namespace when provided in demo mode', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sServiceAccounts('eks-prod-us-east-1', 'monitoring'))
 
@@ -658,7 +658,7 @@ describe('useK8sServiceAccounts', () => {
 
   it('filters demo SAs by cluster only when no namespace given', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sServiceAccounts('gke-staging'))
 
@@ -673,7 +673,7 @@ describe('useK8sServiceAccounts', () => {
 
   it('filters demo SAs by both cluster and namespace simultaneously', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() =>
       useK8sServiceAccounts('eks-prod-us-east-1', 'default'),
@@ -691,7 +691,7 @@ describe('useK8sServiceAccounts', () => {
 
   it('demo SAs include secrets arrays', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sServiceAccounts())
 
@@ -704,7 +704,7 @@ describe('useK8sServiceAccounts', () => {
 
   it('some demo SAs have roles while others do not', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sServiceAccounts())
 
@@ -791,7 +791,7 @@ describe('useK8sServiceAccounts', () => {
 
   it('uses "all" placeholder in refetch key when params are omitted', () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     renderHook(() => useK8sServiceAccounts())
 
@@ -825,7 +825,7 @@ describe('useK8sServiceAccounts', () => {
 
   it('demo cluster filter returns empty for unknown cluster name', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useK8sServiceAccounts('nonexistent-cluster'))
 

--- a/web/src/hooks/mcp/__tests__/security.test.ts
+++ b/web/src/hooks/mcp/__tests__/security.test.ts
@@ -105,7 +105,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockRegisterRefetch.mockReturnValue(vi.fn())
   mockSubscribePolling.mockReturnValue(vi.fn())
   mockFetchSSE.mockResolvedValue([])
@@ -144,7 +144,7 @@ describe('useSecurityIssues', () => {
 
   it('returns demo security issues when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useSecurityIssues())
 
@@ -194,7 +194,7 @@ describe('useSecurityIssues', () => {
 
   it('returns lastRefresh timestamp', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useSecurityIssues())
 
@@ -207,7 +207,7 @@ describe('useSecurityIssues', () => {
 
   it('demo issues include all expected severity levels', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useSecurityIssues())
 
@@ -220,7 +220,7 @@ describe('useSecurityIssues', () => {
 
   it('demo issues all have required fields (name, namespace, cluster, issue, severity)', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useSecurityIssues())
 
@@ -336,7 +336,7 @@ describe('useSecurityIssues', () => {
 
   it('skips SSE when demo mode is enabled, never calls fetchSSE', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     mockFetchSSE.mockResolvedValue([])
 
     const { result } = renderHook(() => useSecurityIssues())
@@ -395,7 +395,7 @@ describe('useGitOpsDrifts', () => {
 
   it('returns demo drifts when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useGitOpsDrifts())
 
@@ -449,7 +449,7 @@ describe('useGitOpsDrifts', () => {
 
   it('demo drifts include all three drift types (modified, added, deleted-check)', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useGitOpsDrifts())
 
@@ -462,7 +462,7 @@ describe('useGitOpsDrifts', () => {
 
   it('demo drifts all have required fields (resource, namespace, cluster, kind, driftType, severity)', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useGitOpsDrifts())
 
@@ -692,7 +692,7 @@ describe('useGitOpsDrifts', () => {
 
   it('demo drifts include severity for each entry', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useGitOpsDrifts())
 

--- a/web/src/hooks/mcp/__tests__/storage.hooks.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage.hooks.test.ts
@@ -102,7 +102,7 @@ describe('storage hooks - usePVCs', () => {
     localStorage.clear()
     mockIsAgentUnavailable.mockReturnValue(false)
     mockIsDemoMode.mockReturnValue(false)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -258,7 +258,7 @@ describe('storage hooks - usePVCs', () => {
   // Test 7: Demo mode fallback
   it('returns demo data when demo mode is enabled', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => usePVCs())
 

--- a/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
@@ -145,7 +145,7 @@ beforeEach(() => {
   __resetInfrastructureCaches()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsAgentUnavailable.mockReturnValue(true)
   mockIsBackendUnavailable.mockReturnValue(false)
   mockRegisterRefetch.mockReturnValue(vi.fn())
@@ -500,7 +500,7 @@ describe('useDeploymentIssues — uncovered branches', () => {
   it('silent demo mode does not set isRefreshing', async () => {
     vi.useFakeTimers()
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useDeploymentIssues())
 

--- a/web/src/hooks/mcp/__tests__/workloads.branches.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.branches.test.ts
@@ -133,7 +133,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsAgentUnavailable.mockReturnValue(true)
   mockIsBackendUnavailable.mockReturnValue(false)
   mockRegisterRefetch.mockReturnValue(vi.fn())
@@ -187,7 +187,7 @@ describe('usePods — additional branches', () => {
 
   it('filters demo pods by cluster', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => usePods('prod-east', undefined, 'restarts', 100))
 
@@ -198,7 +198,7 @@ describe('usePods — additional branches', () => {
 
   it('filters demo pods by namespace', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => usePods(undefined, 'production', 'restarts', 100))
 
@@ -220,7 +220,7 @@ describe('usePods — additional branches', () => {
   it('isRefreshing shows briefly in non-silent demo mode fetch', async () => {
     vi.useFakeTimers()
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => usePods())
 
@@ -255,7 +255,7 @@ describe('usePods — additional branches', () => {
 describe('useAllPods — additional branches', () => {
   it('filters by namespace in demo mode', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useAllPods(undefined, 'ml'))
 
@@ -266,7 +266,7 @@ describe('useAllPods — additional branches', () => {
 
   it('bypasses demo mode when forceLive=true', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const livePods = [
       { name: 'live-pod', namespace: 'prod', cluster: 'c1', status: 'Running', ready: '1/1', restarts: 0, age: '1h' },
     ]
@@ -295,7 +295,7 @@ describe('useAllPods — additional branches', () => {
 describe('usePodIssues — additional branches', () => {
   it('filters demo issues by cluster and namespace simultaneously', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => usePodIssues('prod-east', 'production'))
 
@@ -341,7 +341,7 @@ describe('usePodIssues — additional branches', () => {
 describe('useDeploymentIssues — additional branches', () => {
   it('filters demo deployment issues by cluster', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useDeploymentIssues('prod-east'))
 
@@ -352,7 +352,7 @@ describe('useDeploymentIssues — additional branches', () => {
 
   it('filters demo deployment issues by namespace', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useDeploymentIssues(undefined, 'batch'))
 

--- a/web/src/hooks/mcp/__tests__/workloads.core.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.core.test.ts
@@ -144,7 +144,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsAgentUnavailable.mockReturnValue(true)
   mockIsBackendUnavailable.mockReturnValue(false)
   mockRegisterRefetch.mockReturnValue(vi.fn())
@@ -185,7 +185,7 @@ describe('usePods', () => {
 
   it('returns demo pods when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => usePods())
 
@@ -196,7 +196,7 @@ describe('usePods', () => {
 
   it('sorts pods by restarts descending by default', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => usePods(undefined, undefined, 'restarts', 100))
 
@@ -209,7 +209,7 @@ describe('usePods', () => {
 
   it('sorts pods by name when sortBy=name', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => usePods(undefined, undefined, 'name', 100))
 
@@ -221,7 +221,7 @@ describe('usePods', () => {
 
   it('limits the number of returned pods', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const LIMIT = 3
     const { result } = renderHook(() => usePods(undefined, undefined, 'restarts', LIMIT))
@@ -276,7 +276,7 @@ describe('usePods', () => {
 
   it('returns lastRefresh timestamp after fetch', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => usePods())
 
@@ -316,7 +316,7 @@ describe('useAllPods', () => {
 
   it('returns demo pods when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useAllPods())
 
@@ -326,7 +326,7 @@ describe('useAllPods', () => {
 
   it('filters by cluster when provided in demo mode', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useAllPods('vllm-d'))
 
@@ -410,7 +410,7 @@ describe('usePodIssues', () => {
 
   it('returns demo pod issues when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => usePodIssues())
 
@@ -468,7 +468,7 @@ describe('useDeploymentIssues', () => {
 
   it('returns demo deployment issues when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useDeploymentIssues())
 
@@ -504,7 +504,7 @@ describe('useDeployments', () => {
 
   it('returns demo deployments when demo mode is active', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useDeployments())
 

--- a/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
@@ -145,7 +145,7 @@ beforeEach(() => {
   localStorage.clear()
   localStorage.setItem('token', 'test-token')
   mockIsDemoMode.mockReturnValue(false)
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockIsAgentUnavailable.mockReturnValue(true)
   mockIsBackendUnavailable.mockReturnValue(false)
   mockRegisterRefetch.mockReturnValue(vi.fn())
@@ -166,7 +166,7 @@ afterEach(() => {
 describe('useDeployments (extended)', () => {
   it('filters demo deployments by cluster', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useDeployments('prod-east'))
 
@@ -177,7 +177,7 @@ describe('useDeployments (extended)', () => {
 
   it('filters demo deployments by namespace', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useDeployments(undefined, 'batch'))
 
@@ -323,7 +323,7 @@ describe('usePodIssues (extended)', () => {
 
   it('filters demo pod issues by namespace', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => usePodIssues(undefined, 'production'))
 
@@ -372,7 +372,7 @@ describe('usePodIssues (extended)', () => {
 describe('useDeploymentIssues (extended)', () => {
   it('filters demo deployment issues by cluster', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useDeploymentIssues('prod-east'))
 
@@ -680,7 +680,7 @@ describe('useHPAs (extended)', () => {
 describe('useAllPods (extended)', () => {
   it('filters demo pods by namespace', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => useAllPods(undefined, 'ml'))
 
@@ -691,7 +691,7 @@ describe('useAllPods (extended)', () => {
 
   it('bypasses demo mode when forceLive=true', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     mockFetchSSE.mockResolvedValue([
       { name: 'live-pod', namespace: 'live', cluster: 'c1', status: 'Running', ready: '1/1', restarts: 0, age: '1d' },
     ])
@@ -730,7 +730,7 @@ describe('useAllPods (extended)', () => {
 describe('usePods (extended)', () => {
   it('filters demo pods by namespace', async () => {
     mockIsDemoMode.mockReturnValue(true)
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
 
     const { result } = renderHook(() => usePods(undefined, 'production', 'restarts', 100))
 

--- a/web/src/lib/unified/__tests__/registerHooks-coverage.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-coverage.test.ts
@@ -78,7 +78,7 @@ const {
   mockUseK8sRoleBindings: vi.fn().mockReturnValue({ bindings: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUseServiceExports: vi.fn().mockReturnValue({ exports: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUseServiceImports: vi.fn().mockReturnValue({ imports: [], isLoading: false, error: null, refetch: vi.fn() }),
-  mockUseDemoMode: vi.fn().mockReturnValue({ isDemoMode: false }),
+  mockUseDemoMode: vi.fn().mockReturnValue(false),
 }))
 
 vi.mock('../../../hooks/useDemoMode', () => ({
@@ -166,7 +166,7 @@ function getHook(name: string): HookFn {
 beforeEach(() => {
   vi.clearAllMocks()
   vi.useFakeTimers()
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
 })
 
 afterEach(() => {
@@ -267,7 +267,7 @@ describe('useUnifiedServiceAccounts via renderHook', () => {
 
 describe('useDemoDataHook lifecycle (demo mode OFF)', () => {
   beforeEach(() => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   const demoHooks = [
@@ -298,7 +298,7 @@ describe('useDemoDataHook lifecycle (demo mode OFF)', () => {
 
 describe('useDemoDataHook lifecycle (demo mode ON)', () => {
   beforeEach(() => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
   })
 
   it('starts loading then resolves with demo data', async () => {
@@ -334,7 +334,7 @@ describe('useDemoDataHook lifecycle (demo mode ON)', () => {
 
 describe('Batch 4 demo hooks (demo mode OFF)', () => {
   beforeEach(() => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   const batch4Hooks = [
@@ -365,7 +365,7 @@ describe('Batch 4 demo hooks (demo mode OFF)', () => {
 
 describe('Batch 4 demo hooks (demo mode ON)', () => {
   beforeEach(() => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
   })
 
   it('useArgoCDApplications returns demo data after timer', async () => {
@@ -403,7 +403,7 @@ describe('Batch 4 demo hooks (demo mode ON)', () => {
 
 describe('Batch 5 demo hooks (demo mode OFF)', () => {
   beforeEach(() => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   const batch5Hooks = [
@@ -446,7 +446,7 @@ describe('Batch 5 demo hooks (demo mode OFF)', () => {
 
 describe('Batch 5 demo hooks (demo mode ON)', () => {
   beforeEach(() => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
   })
 
   it('useArgoCDHealth returns demo data after timer', async () => {
@@ -491,7 +491,7 @@ describe('Batch 5 demo hooks (demo mode ON)', () => {
 
 describe('Batch 6 demo hooks (demo mode OFF)', () => {
   beforeEach(() => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   const batch6Hooks = [
@@ -514,7 +514,7 @@ describe('Batch 6 demo hooks (demo mode OFF)', () => {
 
 describe('Batch 6 demo hooks (demo mode ON)', () => {
   beforeEach(() => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
   })
 
   it('useGithubActivity returns demo data after timer', async () => {
@@ -545,7 +545,7 @@ describe('Batch 6 demo hooks (demo mode ON)', () => {
 
 describe('useDemoDataHook timer cleanup', () => {
   it('cleans up timer on unmount during loading', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const hook = getHook('useActiveAlerts')
     const { result, unmount } = renderHook(() => hook())
     expect(result.current.isLoading).toBe(true)
@@ -558,7 +558,7 @@ describe('useDemoDataHook timer cleanup', () => {
   })
 
   it('transitions from demo-on to demo-off', async () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const hook = getHook('useTopPods')
     const { result, rerender } = renderHook(() => hook())
 
@@ -567,7 +567,7 @@ describe('useDemoDataHook timer cleanup', () => {
     expect((result.current.data as unknown[]).length).toBeGreaterThan(0)
 
     // Switch to non-demo mode
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     rerender()
 
     expect(result.current.data).toEqual([])

--- a/web/src/lib/unified/__tests__/registerHooks-deep.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-deep.test.ts
@@ -14,7 +14,7 @@ import { useEffect, useState } from 'react'
 // ── Hoisted mocks ──────────────────────────────────────────────────
 
 const { mockUseDemoMode } = vi.hoisted(() => ({
-  mockUseDemoMode: vi.fn().mockReturnValue({ isDemoMode: false }),
+  mockUseDemoMode: vi.fn().mockReturnValue(false),
 }))
 
 vi.mock('../../../hooks/useDemoMode', () => ({
@@ -82,7 +82,7 @@ import { registerUnifiedHooks } from '../registerHooks'
 beforeEach(() => {
   vi.clearAllMocks()
   vi.useFakeTimers()
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
 })
 
 afterEach(() => {
@@ -118,7 +118,7 @@ describe('useDemoDataHook deep branches', () => {
   }
 
   it('returns empty data and isLoading=false in non-demo mode', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     const demoData = [{ id: 1, value: 'test' }]
     const { result } = renderHook(() => useDemoDataHookSimulation(demoData))
 
@@ -130,7 +130,7 @@ describe('useDemoDataHook deep branches', () => {
   })
 
   it('returns empty data while loading in demo mode', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const demoData = [{ id: 1 }]
     const { result } = renderHook(() => useDemoDataHookSimulation(demoData))
 
@@ -140,7 +140,7 @@ describe('useDemoDataHook deep branches', () => {
   })
 
   it('returns demo data after timer fires in demo mode', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const demoData = [{ id: 1, metric: 42 }]
     const { result } = renderHook(() => useDemoDataHookSimulation(demoData))
 
@@ -151,7 +151,7 @@ describe('useDemoDataHook deep branches', () => {
   })
 
   it('cleans up timer on unmount before it fires', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const { unmount } = renderHook(() => useDemoDataHookSimulation([{ id: 1 }]))
 
     // Unmount before timer fires
@@ -161,7 +161,7 @@ describe('useDemoDataHook deep branches', () => {
   })
 
   it('transitions from demo to non-demo mode', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const demoData = [{ id: 1 }]
     const { result, rerender } = renderHook(() => useDemoDataHookSimulation(demoData))
 
@@ -169,14 +169,14 @@ describe('useDemoDataHook deep branches', () => {
     expect(result.current.data).toEqual(demoData)
 
     // Switch to non-demo
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     rerender()
     act(() => { vi.advanceTimersByTime(0) })
     expect(result.current.data).toEqual([])
   })
 
   it('refetch function is a no-op', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const { result } = renderHook(() => useDemoDataHookSimulation([]))
     expect(() => result.current.refetch()).not.toThrow()
   })

--- a/web/src/lib/unified/__tests__/registerHooks-expand.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-expand.test.ts
@@ -22,7 +22,7 @@ import { useEffect, useState } from 'react'
 // ── Hoisted mocks ──────────────────────────────────────────────────
 
 const { mockUseDemoMode, mockUseCachedEvents } = vi.hoisted(() => ({
-  mockUseDemoMode: vi.fn().mockReturnValue({ isDemoMode: false }),
+  mockUseDemoMode: vi.fn().mockReturnValue(false),
   mockUseCachedEvents: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),
 }))
 
@@ -88,7 +88,7 @@ import { registerUnifiedHooks } from '../registerHooks'
 beforeEach(() => {
   vi.clearAllMocks()
   vi.useFakeTimers()
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
   mockUseCachedEvents.mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() })
 })
 
@@ -125,7 +125,7 @@ describe('useDemoDataHook mode transitions', () => {
   }
 
   it('transitions from non-demo to demo: loading then data', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     const demoData = [{ x: 1 }, { x: 2 }]
     const { result, rerender } = renderHook(() => useSimulatedDemoDataHook(demoData))
 
@@ -134,7 +134,7 @@ describe('useDemoDataHook mode transitions', () => {
     expect(result.current.isLoading).toBe(false)
 
     // Switch to demo mode
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     rerender()
 
     // Should be loading
@@ -148,14 +148,14 @@ describe('useDemoDataHook mode transitions', () => {
   })
 
   it('handles rapid mode toggling (timer cleanup)', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const { result, rerender } = renderHook(() => useSimulatedDemoDataHook([{ v: 1 }]))
 
     // Start loading in demo mode
     expect(result.current.isLoading).toBe(true)
 
     // Switch away before timer fires
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     rerender()
     act(() => { vi.advanceTimersByTime(0) })
 
@@ -169,7 +169,7 @@ describe('useDemoDataHook mode transitions', () => {
   })
 
   it('returns empty array for empty demo data in demo mode', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const { result } = renderHook(() => useSimulatedDemoDataHook([]))
     act(() => { vi.advanceTimersByTime(15) })
     expect(result.current.data).toEqual([])

--- a/web/src/lib/unified/__tests__/registerHooks-hooks.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-hooks.test.ts
@@ -54,7 +54,7 @@ const {
 } = vi.hoisted(() => {
   const registry = new Map<string, (params?: Record<string, unknown>) => unknown>()
   return {
-    mockUseDemoMode: vi.fn().mockReturnValue({ isDemoMode: false }),
+    mockUseDemoMode: vi.fn().mockReturnValue(false),
     mockUseCachedPodIssues: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),
     mockUseCachedEvents: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),
     mockUseCachedDeployments: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),
@@ -180,7 +180,7 @@ function getHook(name: string) {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
 })
 
 afterEach(() => {
@@ -474,7 +474,7 @@ describe('useNamespaceEvents via renderHook', () => {
 
 describe('useDemoDataHook via registered demo hooks', () => {
   it('returns empty data when not in demo mode', () => {
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     const hook = getHook('useSecurityIssues')
     const { result } = renderHook(() => hook())
     expect(result.current.data).toEqual([])
@@ -484,7 +484,7 @@ describe('useDemoDataHook via registered demo hooks', () => {
 
   it('shows loading then demo data when in demo mode', () => {
     vi.useFakeTimers()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const hook = getHook('useSecurityIssues')
     const { result } = renderHook(() => hook())
 
@@ -503,7 +503,7 @@ describe('useDemoDataHook via registered demo hooks', () => {
 
   it('cleans up timer on unmount during loading', () => {
     vi.useFakeTimers()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     const hook = getHook('useActiveAlerts')
     const { unmount } = renderHook(() => hook())
 
@@ -517,7 +517,7 @@ describe('useDemoDataHook via registered demo hooks', () => {
 
   it('transitions from non-demo to demo mode', () => {
     vi.useFakeTimers()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
     const hook = getHook('useTopPods')
     const { result, rerender } = renderHook(() => hook())
 
@@ -526,7 +526,7 @@ describe('useDemoDataHook via registered demo hooks', () => {
     expect(result.current.data).toEqual([])
 
     // Switch to demo mode
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    mockUseDemoMode.mockReturnValue(true)
     rerender()
 
     // Should be loading

--- a/web/src/lib/unified/__tests__/registerHooks-wrappers.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-wrappers.test.ts
@@ -78,7 +78,7 @@ const {
   mockUseK8sRoleBindings: vi.fn().mockReturnValue({ bindings: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUseServiceExports: vi.fn().mockReturnValue({ exports: [], isLoading: false, error: null, refetch: vi.fn() }),
   mockUseServiceImports: vi.fn().mockReturnValue({ imports: [], isLoading: false, error: null, refetch: vi.fn() }),
-  mockUseDemoMode: vi.fn().mockReturnValue({ isDemoMode: false }),
+  mockUseDemoMode: vi.fn().mockReturnValue(false),
 }))
 
 vi.mock('../../../hooks/useDemoMode', () => ({
@@ -171,7 +171,7 @@ vi.spyOn({ registerDataHook: originalRegister }, 'registerDataHook')
 beforeEach(() => {
   vi.clearAllMocks()
   vi.useFakeTimers()
-  mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockUseDemoMode.mockReturnValue(false)
 })
 
 afterEach(() => {

--- a/web/src/pages/EmbedCard.test.tsx
+++ b/web/src/pages/EmbedCard.test.tsx
@@ -37,7 +37,7 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
-const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false }))
+const mockUseDemoMode = vi.fn(() => false)
 vi.mock('../hooks/useDemoMode', () => ({
   useDemoMode: () => mockUseDemoMode(),
 }))
@@ -102,7 +102,7 @@ function renderEmbed({ cardType = '', searchQuery = '' }: RenderEmbedOptions = {
 describe('EmbedCard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+    mockUseDemoMode.mockReturnValue(false)
   })
 
   // ---- Scenario 1: Valid card query parameters ----
@@ -219,7 +219,7 @@ describe('EmbedCard', () => {
 
   describe('demo mode in embed context', () => {
     it('displays the demo badge when isDemoMode is active', () => {
-      mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+      mockUseDemoMode.mockReturnValue(true)
       renderEmbed({ cardType: 'nightly-release-pulse' })
 
       expect(screen.getByTestId('demo-badge')).toBeInTheDocument()
@@ -227,7 +227,7 @@ describe('EmbedCard', () => {
     })
 
     it('does not display demo badge when isDemoMode is disabled', () => {
-      mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+      mockUseDemoMode.mockReturnValue(false)
       renderEmbed({ cardType: 'nightly-release-pulse' })
 
       expect(screen.queryByTestId('demo-badge')).not.toBeInTheDocument()


### PR DESCRIPTION
Fixes #19861

Repairs 270 test failures introduced by PR #19855's mock wiring changes.

## Root Cause

PR #19855 attempted to restore dynamic useDemoMode mock wiring but introduced a bug: mock variables were defined to return objects like `{ isDemoMode: false }` instead of plain booleans. This caused nested object structures when the mock factory called `mockIsDemoMode()`, resulting in:

```tsx
{ isDemoMode: { isDemoMode: false } }
```

instead of the expected:

```tsx
{ isDemoMode: false }
```

## Fix

Changed the mock variable declarations from:
```tsx
const mockIsDemoMode = vi.fn(() => ({ isDemoMode: false }))
```

to:
```tsx
const mockIsDemoMode = vi.fn(() => false)
```

And updated all `.mockReturnValue()` calls from:
```tsx
mockIsDemoMode.mockReturnValue({ isDemoMode: false })
```

to:
```tsx
mockIsDemoMode.mockReturnValue(false)
```

Applied across 48 test files.