### PR TITLE
[scanner] fix: use importOriginal in useDemoMode/analytics mocks

### DIFF
--- a/web/src/components/AppErrorBoundary.test.tsx
+++ b/web/src/components/AppErrorBoundary.test.tsx
@@ -5,10 +5,12 @@ import { AppErrorBoundary } from './AppErrorBoundary'
 import { emitError, markErrorReported } from '../lib/analytics'
 
 // Mock analytics to prevent real network calls and allow spying
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitError: vi.fn(),
   markErrorReported: vi.fn(),
-}))
+}
+))
 
 // Mock i18next to return translation keys directly
 vi.mock('i18next', () => ({

--- a/web/src/components/CompactErrorBoundary.test.tsx
+++ b/web/src/components/CompactErrorBoundary.test.tsx
@@ -4,10 +4,12 @@ import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { CompactErrorBoundary } from './CompactErrorBoundary'
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitError: vi.fn(),
   markErrorReported: vi.fn(),
-}))
+}
+))
 
 const originalConsoleError = console.error
 

--- a/web/src/components/PageErrorBoundary.test.tsx
+++ b/web/src/components/PageErrorBoundary.test.tsx
@@ -11,10 +11,12 @@ vi.mock('i18next', () => ({
 }))
 
 // Mock analytics
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitError: vi.fn(),
   markErrorReported: vi.fn(),
-}))
+}
+))
 
 // Mock chunkErrors — non-chunk errors should be caught by PageErrorBoundary
 vi.mock('../lib/chunkErrors', () => ({

--- a/web/src/components/agent/APIKeySettings.test.tsx
+++ b/web/src/components/agent/APIKeySettings.test.tsx
@@ -43,11 +43,13 @@ vi.mock('./AgentIcon', () => ({
   AgentIcon: ({ provider }: { provider: string }) => <div data-testid={`agent-icon-${provider}`} />,
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitApiKeyConfigured: vi.fn(),
   emitApiKeyRemoved: vi.fn(),
   emitConversionStep: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(undefined),

--- a/web/src/components/auth/AuthCallback.test.tsx
+++ b/web/src/components/auth/AuthCallback.test.tsx
@@ -38,10 +38,12 @@ vi.mock('../../lib/utils/localStorage', () => ({
   safeRemoveItem: vi.fn(),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitGitHubConnected: vi.fn(),
   emitError: vi.fn(),
-}))
+}
+))
 
 // Mock fetch to prevent real /auth/refresh request from hanging in jsdom.
 // Return a pending promise so the effect stays in the loading state

--- a/web/src/components/auth/__tests__/AuthCallback.contract.test.tsx
+++ b/web/src/components/auth/__tests__/AuthCallback.contract.test.tsx
@@ -71,10 +71,12 @@ vi.mock('../../../config/routes', () => ({
   getLoginWithError: (err: string) => `/login?error=${err}`,
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitGitHubConnected: mockEmitGitHubConnected,
   emitError: mockEmitError,
-}))
+}
+))
 
 vi.mock('../../../lib/utils/localStorage', () => ({
   safeGetItem: () => null,

--- a/web/src/components/cards/ActiveAlerts.test.tsx
+++ b/web/src/components/cards/ActiveAlerts.test.tsx
@@ -32,7 +32,8 @@ vi.mock('../../hooks/useGlobalFilters', () => ({
 }))
 
 const mockUseDemoMode = vi.fn()
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockUseDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/cards/AlertRules.test.tsx
+++ b/web/src/components/cards/AlertRules.test.tsx
@@ -26,7 +26,8 @@ vi.mock('../../hooks/useAlerts', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/cards/ClusterComparison.test.tsx
+++ b/web/src/components/cards/ClusterComparison.test.tsx
@@ -42,7 +42,8 @@ vi.mock('../../hooks/useGlobalFilters', () => ({
   }),
 }))
 
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/cards/ClusterCosts.test.tsx
+++ b/web/src/components/cards/ClusterCosts.test.tsx
@@ -32,7 +32,8 @@ vi.mock('../../hooks/useDrillDown', () => ({
   useDrillDownActions: () => ({ drillToCost: mockDrillToCost }),
 }))
 
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/cards/ComplianceCards.test.tsx
+++ b/web/src/components/cards/ComplianceCards.test.tsx
@@ -69,11 +69,13 @@ vi.mock('./CardDataContext', () => ({
 }))
 
 // Mock analytics to avoid side effects
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitModalOpened: vi.fn(),
   emitModalTabViewed: vi.fn(),
   emitModalClosed: vi.fn(),
-}))
+}
+))
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 

--- a/web/src/components/cards/NamespaceQuotas.test.tsx
+++ b/web/src/components/cards/NamespaceQuotas.test.tsx
@@ -50,9 +50,11 @@ vi.mock('../../hooks/useCachedData', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 const mockUseCardLoadingState = vi.fn()
 const mockUseCardDemoState = vi.fn()

--- a/web/src/components/cards/NodeConditions.test.tsx
+++ b/web/src/components/cards/NodeConditions.test.tsx
@@ -36,7 +36,8 @@ vi.mock('../../hooks/useCachedData', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/cards/StorageOverview.test.tsx
+++ b/web/src/components/cards/StorageOverview.test.tsx
@@ -47,7 +47,8 @@ vi.mock('../../hooks/useGlobalFilters', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/cards/__tests__/ActiveAlerts.test.tsx
+++ b/web/src/components/cards/__tests__/ActiveAlerts.test.tsx
@@ -45,7 +45,8 @@ vi.mock('../CardDataContext', () => ({
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false }),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/cards/__tests__/AdmissionWebhooks.test.tsx
+++ b/web/src/components/cards/__tests__/AdmissionWebhooks.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/AlertRulesCard.test.tsx
+++ b/web/src/components/cards/__tests__/AlertRulesCard.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ArgoCDHealth.test.tsx
+++ b/web/src/components/cards/__tests__/ArgoCDHealth.test.tsx
@@ -22,7 +22,8 @@ vi.mock('../CardDataContext', () => ({
   useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => false, default: () => false,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,

--- a/web/src/components/cards/__tests__/ArgoCDSyncStatus.test.tsx
+++ b/web/src/components/cards/__tests__/ArgoCDSyncStatus.test.tsx
@@ -23,7 +23,8 @@ vi.mock('../CardDataContext', () => ({
   useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => false, default: () => false,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,

--- a/web/src/components/cards/__tests__/CRDHealth.test.tsx
+++ b/web/src/components/cards/__tests__/CRDHealth.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/CardChat.test.tsx
+++ b/web/src/components/cards/__tests__/CardChat.test.tsx
@@ -25,7 +25,8 @@ vi.mock('../../../lib/clipboard', () => ({
 }))
 
 let mockIsDemoMode = false
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/cards/__tests__/CardWrapper.test.tsx
+++ b/web/src/components/cards/__tests__/CardWrapper.test.tsx
@@ -39,7 +39,8 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
   getDemoMode: () => true,
   default: () => true,
@@ -50,7 +51,8 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   isDemoToken: () => true,
   setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
 const mockUseIsModeSwitching = vi.fn(() => false)
 vi.mock('../../../lib/unified/demo', () => ({
@@ -65,12 +67,14 @@ vi.mock('../../../hooks/useSnoozedCards', () => ({
   useSnoozedCards: () => ({ snoozeSwap: vi.fn() }),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitCardExpanded: vi.fn(),
   emitCardRefreshed: vi.fn(),
   emitError: vi.fn(),
   markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },

--- a/web/src/components/cards/__tests__/ChartVersions.test.tsx
+++ b/web/src/components/cards/__tests__/ChartVersions.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ClusterChangelog.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterChangelog.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ClusterComparison.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterComparison.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ClusterCosts.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterCosts.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ClusterDropZone.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterDropZone.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ClusterFocus.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterFocus.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ClusterGroups.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterGroups.test.tsx
@@ -20,7 +20,8 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true,
   default: () => true,
   useDemoMode: () => mockUseDemoMode(),
@@ -31,9 +32,11 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   isDemoToken: () => true,
   setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(),
   emitLogin: vi.fn(),
   emitEvent: vi.fn(),
@@ -42,7 +45,8 @@ vi.mock('../../../lib/analytics', () => ({
   emitCardExpanded: vi.fn(),
   emitCardRefreshed: vi.fn(),
   markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ClusterHealth.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterHealth.test.tsx
@@ -40,7 +40,8 @@ vi.mock('../../../hooks/useMobile', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   isDemoModeForced: () => false,
   getDemoMode: () => false,

--- a/web/src/components/cards/__tests__/ClusterLocations.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterLocations.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ClusterMetrics.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterMetrics.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ClusterNetwork.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterNetwork.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ComplianceDrift.test.tsx
+++ b/web/src/components/cards/__tests__/ComplianceDrift.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ComputeOverview.test.tsx
+++ b/web/src/components/cards/__tests__/ComputeOverview.test.tsx
@@ -13,18 +13,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ContainerTetrisComponent.test.tsx
+++ b/web/src/components/cards/__tests__/ContainerTetrisComponent.test.tsx
@@ -30,10 +30,12 @@ vi.mock('../CardDataContext', () => ({
   useReportCardDataState: vi.fn(),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitGameStarted: vi.fn(),
   emitGameEnded: vi.fn(),
-}))
+}
+))
 
 // Get mock store for localStorage
 const store: Record<string, string> = {}

--- a/web/src/components/cards/__tests__/CrossClusterPolicyComparison.test.tsx
+++ b/web/src/components/cards/__tests__/CrossClusterPolicyComparison.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/DNSHealth.test.tsx
+++ b/web/src/components/cards/__tests__/DNSHealth.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/DataComplianceCards.states.test.tsx
+++ b/web/src/components/cards/__tests__/DataComplianceCards.states.test.tsx
@@ -18,7 +18,8 @@ vi.mock('react-i18next', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => true, default: () => true,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,

--- a/web/src/components/cards/__tests__/DataComplianceCards.test.tsx
+++ b/web/src/components/cards/__tests__/DataComplianceCards.test.tsx
@@ -13,7 +13,8 @@ vi.mock('react-i18next', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => true, default: () => true,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,

--- a/web/src/components/cards/__tests__/DeploymentIssues.test.tsx
+++ b/web/src/components/cards/__tests__/DeploymentIssues.test.tsx
@@ -13,18 +13,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/DeploymentProgress.test.tsx
+++ b/web/src/components/cards/__tests__/DeploymentProgress.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/DynamicCardErrorBoundary.test.tsx
+++ b/web/src/components/cards/__tests__/DynamicCardErrorBoundary.test.tsx
@@ -14,10 +14,12 @@ afterAll(() => {
   console.error = originalConsoleError
 })
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitError: vi.fn(),
   markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../lib/chunkErrors', () => ({
   isChunkLoadError: () => false,

--- a/web/src/components/cards/__tests__/EventStream.test.tsx
+++ b/web/src/components/cards/__tests__/EventStream.test.tsx
@@ -15,7 +15,8 @@ vi.mock('react-i18next', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => true, default: () => true,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,

--- a/web/src/components/cards/__tests__/EventsTimeline.test.tsx
+++ b/web/src/components/cards/__tests__/EventsTimeline.test.tsx
@@ -17,18 +17,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/FleetComplianceHeatmap.test.tsx
+++ b/web/src/components/cards/__tests__/FleetComplianceHeatmap.test.tsx
@@ -13,18 +13,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/GPUInventoryHistory.test.tsx
+++ b/web/src/components/cards/__tests__/GPUInventoryHistory.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/GPUNamespaceAllocations.test.tsx
+++ b/web/src/components/cards/__tests__/GPUNamespaceAllocations.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/GPUOverview.test.tsx
+++ b/web/src/components/cards/__tests__/GPUOverview.test.tsx
@@ -47,7 +47,8 @@ vi.mock('../CardDataContext', () => ({
   useCardLoadingState: vi.fn(() => ({ showSkeleton: false })),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => false, default: () => false,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,

--- a/web/src/components/cards/__tests__/GPUStatus.test.tsx
+++ b/web/src/components/cards/__tests__/GPUStatus.test.tsx
@@ -38,7 +38,8 @@ vi.mock('../CardDataContext', () => ({
   useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => false, default: () => false,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,

--- a/web/src/components/cards/__tests__/GPUUsageTrend.test.tsx
+++ b/web/src/components/cards/__tests__/GPUUsageTrend.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/GPUUtilization.test.tsx
+++ b/web/src/components/cards/__tests__/GPUUtilization.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/GPUWorkloads.test.tsx
+++ b/web/src/components/cards/__tests__/GPUWorkloads.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/GatewayStatus.test.tsx
+++ b/web/src/components/cards/__tests__/GatewayStatus.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/GitHubActivity.test.tsx
+++ b/web/src/components/cards/__tests__/GitHubActivity.test.tsx
@@ -19,18 +19,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
+++ b/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ISO27001Audit.test.tsx
+++ b/web/src/components/cards/__tests__/ISO27001Audit.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/IframeEmbed.test.tsx
+++ b/web/src/components/cards/__tests__/IframeEmbed.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/KagentStatusCard.test.tsx
+++ b/web/src/components/cards/__tests__/KagentStatusCard.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/KagentiStatusCard.test.tsx
+++ b/web/src/components/cards/__tests__/KagentiStatusCard.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/KubecostOverview.test.tsx
+++ b/web/src/components/cards/__tests__/KubecostOverview.test.tsx
@@ -17,18 +17,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/Kubectl.test.tsx
+++ b/web/src/components/cards/__tests__/Kubectl.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/KustomizationStatus.test.tsx
+++ b/web/src/components/cards/__tests__/KustomizationStatus.test.tsx
@@ -22,7 +22,8 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
   }),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }), // demo so we get data
   getDemoMode: () => true, default: () => true,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,

--- a/web/src/components/cards/__tests__/MaintenanceWindows.test.tsx
+++ b/web/src/components/cards/__tests__/MaintenanceWindows.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/Missions.test.tsx
+++ b/web/src/components/cards/__tests__/Missions.test.tsx
@@ -27,7 +27,8 @@ vi.mock('../../../hooks/useMCP', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   isDemoModeForced: () => false,
   getDemoMode: () => false,

--- a/web/src/components/cards/__tests__/MobileBrowser.test.tsx
+++ b/web/src/components/cards/__tests__/MobileBrowser.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/NamespaceMonitor.test.tsx
+++ b/web/src/components/cards/__tests__/NamespaceMonitor.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/NamespaceRBAC.test.tsx
+++ b/web/src/components/cards/__tests__/NamespaceRBAC.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/NetworkOverview.test.tsx
+++ b/web/src/components/cards/__tests__/NetworkOverview.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/NetworkPolicyCoverage.test.tsx
+++ b/web/src/components/cards/__tests__/NetworkPolicyCoverage.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/NetworkUtils.test.tsx
+++ b/web/src/components/cards/__tests__/NetworkUtils.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/NodeConditions.test.tsx
+++ b/web/src/components/cards/__tests__/NodeConditions.test.tsx
@@ -40,7 +40,8 @@ vi.mock('../CardDataContext', () => ({
   useCardLoadingState: mockUseCardLoadingState,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => false, default: () => false,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,

--- a/web/src/components/cards/__tests__/OPAPolicies.test.tsx
+++ b/web/src/components/cards/__tests__/OPAPolicies.test.tsx
@@ -29,7 +29,8 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn()
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/cards/__tests__/OpenCostOverview.test.tsx
+++ b/web/src/components/cards/__tests__/OpenCostOverview.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/OperatorStatus.test.tsx
+++ b/web/src/components/cards/__tests__/OperatorStatus.test.tsx
@@ -55,7 +55,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => false,
   default: () => false,
@@ -68,7 +69,8 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(),
   emitLogin: vi.fn(),
   emitEvent: vi.fn(),
@@ -77,7 +79,8 @@ vi.mock('../../../lib/analytics', () => ({
   emitCardExpanded: vi.fn(),
   emitCardRefreshed: vi.fn(),
   markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/OverlayComparison.test.tsx
+++ b/web/src/components/cards/__tests__/OverlayComparison.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/PVCStatus.test.tsx
+++ b/web/src/components/cards/__tests__/PVCStatus.test.tsx
@@ -12,19 +12,23 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
   emitError: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/PodHealthTrend.test.tsx
+++ b/web/src/components/cards/__tests__/PodHealthTrend.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/PodSweeper.test.tsx
+++ b/web/src/components/cards/__tests__/PodSweeper.test.tsx
@@ -32,10 +32,12 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitGameStarted: vi.fn(),
   emitGameEnded: vi.fn(),
-}))
+}
+))
 
 const DEFAULT_PROPS = {
   id: 'pod-sweeper',

--- a/web/src/components/cards/__tests__/PredictiveHealth.test.tsx
+++ b/web/src/components/cards/__tests__/PredictiveHealth.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ProactiveGPUNodeHealthMonitor.test.tsx
+++ b/web/src/components/cards/__tests__/ProactiveGPUNodeHealthMonitor.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ProviderHealth.test.tsx
+++ b/web/src/components/cards/__tests__/ProviderHealth.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/QuotaHeatmap.test.tsx
+++ b/web/src/components/cards/__tests__/QuotaHeatmap.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/RBACExplorer.test.tsx
+++ b/web/src/components/cards/__tests__/RBACExplorer.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/RecentEvents.test.tsx
+++ b/web/src/components/cards/__tests__/RecentEvents.test.tsx
@@ -33,7 +33,8 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
   }),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => false,
   default: () => false,
@@ -61,7 +62,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(),
   emitLogin: vi.fn(),
   emitEvent: vi.fn(),
@@ -70,7 +72,8 @@ vi.mock('../../../lib/analytics', () => ({
   emitCardExpanded: vi.fn(),
   emitCardRefreshed: vi.fn(),
   markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/RecommendedPolicies.test.tsx
+++ b/web/src/components/cards/__tests__/RecommendedPolicies.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ResourceCapacity.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceCapacity.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx
@@ -29,9 +29,11 @@ vi.mock('../CardDataContext', () => ({
   useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 vi.mock('../../ui/ClusterSelect', () => ({
   ClusterSelect: ({ clusters, onChange, value, placeholder }: { clusters: Array<{ name: string }>; value: string; onChange: (value: string) => void; placeholder?: string }) => (

--- a/web/src/components/cards/__tests__/ResourceMarshall.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceMarshall.test.tsx
@@ -29,7 +29,8 @@ vi.mock('../CardDataContext', () => ({
   useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/cards/__tests__/ResourceTrend.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceTrend.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ResourceUsage.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceUsage.test.tsx
@@ -14,7 +14,8 @@ vi.mock('react-i18next', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: () => true, default: () => true,
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,

--- a/web/src/components/cards/__tests__/SecurityIssues.test.tsx
+++ b/web/src/components/cards/__tests__/SecurityIssues.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ServiceExports.test.tsx
+++ b/web/src/components/cards/__tests__/ServiceExports.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ServiceImports.test.tsx
+++ b/web/src/components/cards/__tests__/ServiceImports.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/ServiceTopology.test.tsx
+++ b/web/src/components/cards/__tests__/ServiceTopology.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/StorageOverview.test.tsx
+++ b/web/src/components/cards/__tests__/StorageOverview.test.tsx
@@ -31,9 +31,11 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 const mockUseCardLoadingState = vi.fn()
 vi.mock('../CardDataContext', () => ({

--- a/web/src/components/cards/__tests__/TopPods.test.tsx
+++ b/web/src/components/cards/__tests__/TopPods.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/UpgradeStatus.test.tsx
+++ b/web/src/components/cards/__tests__/UpgradeStatus.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/UserManagement.test.tsx
+++ b/web/src/components/cards/__tests__/UserManagement.test.tsx
@@ -109,7 +109,8 @@ vi.mock('../../../lib/auth', () => ({
   }),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({
     isDemoMode: mockState.isDemoMode,
     toggleDemoMode: vi.fn(),
@@ -193,10 +194,12 @@ vi.mock('../../ui/Toast', () => ({
   }),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitUserRoleChanged: vi.fn(),
   emitUserRemoved: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../lib/cards/CardComponents', () => ({
   CardSearchInput: ({ placeholder }: { placeholder: string }) => (

--- a/web/src/components/cards/__tests__/VaultSecrets.test.tsx
+++ b/web/src/components/cards/__tests__/VaultSecrets.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/WarningEvents.test.tsx
+++ b/web/src/components/cards/__tests__/WarningEvents.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/__tests__/WorkloadDeployment.test.tsx
+++ b/web/src/components/cards/__tests__/WorkloadDeployment.test.tsx
@@ -12,18 +12,22 @@ vi.mock('../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/buildpacks-status/__tests__/BuildpacksStatus.test.tsx
+++ b/web/src/components/cards/buildpacks-status/__tests__/BuildpacksStatus.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/cluster-resource-tree/__tests__/ClusterResourceTree.test.tsx
+++ b/web/src/components/cards/cluster-resource-tree/__tests__/ClusterResourceTree.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/compliance/__tests__/FalcoAlertsCard.test.tsx
+++ b/web/src/components/cards/compliance/__tests__/FalcoAlertsCard.test.tsx
@@ -14,9 +14,11 @@ vi.mock('react-i18next', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 const mockStartMission = vi.fn()
 vi.mock('../../../../hooks/useMissions', () => ({

--- a/web/src/components/cards/compliance/__tests__/PolicyViolationDetailModal.test.tsx
+++ b/web/src/components/cards/compliance/__tests__/PolicyViolationDetailModal.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/console-missions/__tests__/ConsoleKubeconfigAuditCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleKubeconfigAuditCard.test.tsx
@@ -48,7 +48,8 @@ vi.mock('../../CardDataContext', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
@@ -74,7 +74,8 @@ vi.mock('../../CardDataContext', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/cards/coredns_status/__tests__/CoreDNSStatus.test.tsx
+++ b/web/src/components/cards/coredns_status/__tests__/CoreDNSStatus.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/crossplane-status/__tests__/CrossplaneManagedResources.test.tsx
+++ b/web/src/components/cards/crossplane-status/__tests__/CrossplaneManagedResources.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/cubefs_status/__tests__/CubefsStatus.test.tsx
+++ b/web/src/components/cards/cubefs_status/__tests__/CubefsStatus.test.tsx
@@ -22,7 +22,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -30,11 +31,13 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
   emitCardSearchUsed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/deploy/__tests__/GitOpsDriftDetailModal.test.tsx
+++ b/web/src/components/cards/deploy/__tests__/GitOpsDriftDetailModal.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/deploy/__tests__/HelmHistoryDetailModal.test.tsx
+++ b/web/src/components/cards/deploy/__tests__/HelmHistoryDetailModal.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/failover_timeline/__tests__/FailoverTimeline.test.tsx
+++ b/web/src/components/cards/failover_timeline/__tests__/FailoverTimeline.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/gadget/__tests__/DNSTraceCard.test.tsx
+++ b/web/src/components/cards/gadget/__tests__/DNSTraceCard.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/gadget/__tests__/NetworkTraceCard.test.tsx
+++ b/web/src/components/cards/gadget/__tests__/NetworkTraceCard.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/gadget/__tests__/ProcessTraceCard.test.tsx
+++ b/web/src/components/cards/gadget/__tests__/ProcessTraceCard.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/gadget/__tests__/SecurityAuditCard.test.tsx
+++ b/web/src/components/cards/gadget/__tests__/SecurityAuditCard.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/harbor_status/__tests__/HarborStatus.test.tsx
+++ b/web/src/components/cards/harbor_status/__tests__/HarborStatus.test.tsx
@@ -22,7 +22,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -30,11 +31,13 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
   emitCardSearchUsed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/insights/__tests__/InsightSourceBadge.test.tsx
+++ b/web/src/components/cards/insights/__tests__/InsightSourceBadge.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/insights/insightRelatedResources.test.tsx
+++ b/web/src/components/cards/insights/insightRelatedResources.test.tsx
@@ -21,9 +21,11 @@ vi.mock('react-i18next', async () => {
     useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
   }
 })
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
-}))
+}
+))
 const mockStartMission = vi.fn()
 const mockOpenSidebar = vi.fn()
 const mockMissions: unknown[] = []

--- a/web/src/components/cards/intoto_supply_chain/__tests__/IntotoSupplyChain.test.tsx
+++ b/web/src/components/cards/intoto_supply_chain/__tests__/IntotoSupplyChain.test.tsx
@@ -11,7 +11,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -19,11 +20,13 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
   markErrorReported: vi.fn(), emitError: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagent/__tests__/KagentAgentDiscovery.test.tsx
+++ b/web/src/components/cards/kagent/__tests__/KagentAgentDiscovery.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagent/__tests__/KagentAgentFleet.test.tsx
+++ b/web/src/components/cards/kagent/__tests__/KagentAgentFleet.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagent/__tests__/KagentModelProviders.test.tsx
+++ b/web/src/components/cards/kagent/__tests__/KagentModelProviders.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagent/__tests__/KagentSecurity.test.tsx
+++ b/web/src/components/cards/kagent/__tests__/KagentSecurity.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagent/__tests__/KagentToolRegistry.test.tsx
+++ b/web/src/components/cards/kagent/__tests__/KagentToolRegistry.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagent/__tests__/KagentTopology.test.tsx
+++ b/web/src/components/cards/kagent/__tests__/KagentTopology.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagenti/__tests__/KagentiAgentDiscovery.test.tsx
+++ b/web/src/components/cards/kagenti/__tests__/KagentiAgentDiscovery.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagenti/__tests__/KagentiAgentFleet.test.tsx
+++ b/web/src/components/cards/kagenti/__tests__/KagentiAgentFleet.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagenti/__tests__/KagentiBuildPipeline.test.tsx
+++ b/web/src/components/cards/kagenti/__tests__/KagentiBuildPipeline.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagenti/__tests__/KagentiSecurity.test.tsx
+++ b/web/src/components/cards/kagenti/__tests__/KagentiSecurity.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagenti/__tests__/KagentiSecurityPosture.test.tsx
+++ b/web/src/components/cards/kagenti/__tests__/KagentiSecurityPosture.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagenti/__tests__/KagentiToolRegistry.test.tsx
+++ b/web/src/components/cards/kagenti/__tests__/KagentiToolRegistry.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kagenti/__tests__/KagentiTopology.test.tsx
+++ b/web/src/components/cards/kagenti/__tests__/KagentiTopology.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/keda_status/__tests__/KedaStatus.test.tsx
+++ b/web/src/components/cards/keda_status/__tests__/KedaStatus.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/keycloak_status/__tests__/KeycloakStatus.test.tsx
+++ b/web/src/components/cards/keycloak_status/__tests__/KeycloakStatus.test.tsx
@@ -21,7 +21,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true,
   default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
@@ -34,7 +35,8 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(),
   emitLogin: vi.fn(),
   emitEvent: vi.fn(),
@@ -42,7 +44,8 @@ vi.mock('../../../../lib/analytics', () => ({
   emitAddCardModalOpened: vi.fn(),
   emitCardExpanded: vi.fn(),
   emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/kuberay_fleet/__tests__/KubeRayFleet.test.tsx
+++ b/web/src/components/cards/kuberay_fleet/__tests__/KubeRayFleet.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/BenchmarkHero.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/BenchmarkHero.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/EPPRouting.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/EPPRouting.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/HardwareLeaderboard.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/HardwareLeaderboard.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },

--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitor.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitor.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitorChart.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitorChart.test.tsx
@@ -11,18 +11,22 @@ vi.mock('../../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitorDetailPanel.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitorDetailPanel.test.tsx
@@ -11,18 +11,22 @@ vi.mock('../../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitorHeader.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitorHeader.test.tsx
@@ -11,18 +11,22 @@ vi.mock('../../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/LLMdAIInsights.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/LLMdAIInsights.test.tsx
@@ -13,7 +13,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -21,10 +22,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/LLMdConfigurator.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/LLMdConfigurator.test.tsx
@@ -11,18 +11,22 @@ vi.mock('../../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/LLMdFlow.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/LLMdFlow.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/NightlyE2EDetailPanel.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/NightlyE2EDetailPanel.test.tsx
@@ -11,18 +11,22 @@ vi.mock('../../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/NightlyE2EGuideRow.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/NightlyE2EGuideRow.test.tsx
@@ -11,18 +11,22 @@ vi.mock('../../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => mockUseDemoMode(),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
   canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/NightlyE2EStatus.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/NightlyE2EStatus.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/PDDisaggregation.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/PDDisaggregation.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/__tests__/StackSelector.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/StackSelector.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/shared/__tests__/HorseshoeGauge.test.tsx
+++ b/web/src/components/cards/llmd/shared/__tests__/HorseshoeGauge.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/llmd/shared/__tests__/PortalTooltip.test.tsx
+++ b/web/src/components/cards/llmd/shared/__tests__/PortalTooltip.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/multi-tenancy/k3s-status/__tests__/K3sDetailModal.test.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/__tests__/K3sDetailModal.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/__tests__/KubeFlexDetailModal.test.tsx
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/__tests__/KubeFlexDetailModal.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/__tests__/KubevirtDetailModal.test.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/__tests__/KubevirtDetailModal.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/__tests__/MultiTenancyDetailModal.test.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/__tests__/MultiTenancyDetailModal.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/multi-tenancy/ovn-status/__tests__/OvnDetailModal.test.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/__tests__/OvnDetailModal.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/multi-tenancy/tenant-topology/__tests__/TenantTopology.test.tsx
+++ b/web/src/components/cards/multi-tenancy/tenant-topology/__tests__/TenantTopology.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/openfeature_status/__tests__/OpenFeatureStatus.test.tsx
+++ b/web/src/components/cards/openfeature_status/__tests__/OpenFeatureStatus.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/openkruise_status/__tests__/OpenKruiseStatus.test.tsx
+++ b/web/src/components/cards/openkruise_status/__tests__/OpenKruiseStatus.test.tsx
@@ -19,7 +19,8 @@ vi.mock('../../../../lib/demoMode', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true,
   default: () => true,
   useDemoMode: () => mockUseDemoMode(),
@@ -30,9 +31,11 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   isDemoToken: () => true,
   setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(),
   emitLogin: vi.fn(),
   emitEvent: vi.fn(),
@@ -41,7 +44,8 @@ vi.mock('../../../../lib/analytics', () => ({
   emitCardExpanded: vi.fn(),
   emitCardRefreshed: vi.fn(),
   markErrorReported: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/pipelines/__tests__/PipelineFlow.test.tsx
+++ b/web/src/components/cards/pipelines/__tests__/PipelineFlow.test.tsx
@@ -30,9 +30,11 @@ vi.mock('../../../../hooks/useGitHubPipelines', async (importOriginal) => {
 })
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 const mockUseCardLoadingState = vi.fn()
 vi.mock('../../CardDataContext', () => ({

--- a/web/src/components/cards/pipelines/__tests__/WorkflowMatrix.test.tsx
+++ b/web/src/components/cards/pipelines/__tests__/WorkflowMatrix.test.tsx
@@ -25,9 +25,11 @@ vi.mock('../../../../hooks/useGitHubPipelines', async (importOriginal) => {
 })
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 const mockUseCardLoadingState = vi.fn()
 vi.mock('../../CardDataContext', () => ({

--- a/web/src/components/cards/rss/__tests__/RSSFeed.test.tsx
+++ b/web/src/components/cards/rss/__tests__/RSSFeed.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/slo_compliance/__tests__/SLOCompliance.test.tsx
+++ b/web/src/components/cards/slo_compliance/__tests__/SLOCompliance.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/trino_gateway/__tests__/TrinoGateway.test.tsx
+++ b/web/src/components/cards/trino_gateway/__tests__/TrinoGateway.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/workload-detection/__tests__/LLMInference.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/LLMInference.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/workload-detection/__tests__/LLMModels.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/LLMModels.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/workload-detection/__tests__/MLJobs.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/MLJobs.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/workload-detection/__tests__/MLNotebooks.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/MLNotebooks.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/workload-detection/__tests__/ProwHistory.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/ProwHistory.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/workload-detection/__tests__/ProwJobs.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/ProwJobs.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/workload-detection/__tests__/ProwStatus.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/ProwStatus.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/workload-monitor/__tests__/ClusterHealthMonitor.test.tsx
+++ b/web/src/components/cards/workload-monitor/__tests__/ClusterHealthMonitor.test.tsx
@@ -16,7 +16,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -24,10 +25,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/workload-monitor/__tests__/ProwCIMonitor.refresh.test.tsx
+++ b/web/src/components/cards/workload-monitor/__tests__/ProwCIMonitor.refresh.test.tsx
@@ -16,7 +16,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -24,10 +25,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/workload-monitor/__tests__/ProwCIMonitor.test.tsx
+++ b/web/src/components/cards/workload-monitor/__tests__/ProwCIMonitor.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/workload-monitor/__tests__/WorkloadMonitor.test.tsx
+++ b/web/src/components/cards/workload-monitor/__tests__/WorkloadMonitor.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/cards/workload-monitor/__tests__/WorkloadMonitorToolbar.test.tsx
+++ b/web/src/components/cards/workload-monitor/__tests__/WorkloadMonitorToolbar.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/BarChart.test.tsx
+++ b/web/src/components/charts/__tests__/BarChart.test.tsx
@@ -18,7 +18,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -26,10 +27,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/DataTable.test.tsx
+++ b/web/src/components/charts/__tests__/DataTable.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/Gauge.test.tsx
+++ b/web/src/components/charts/__tests__/Gauge.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/HeatMap.test.tsx
+++ b/web/src/components/charts/__tests__/HeatMap.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/PieChart.test.tsx
+++ b/web/src/components/charts/__tests__/PieChart.test.tsx
@@ -20,7 +20,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -28,10 +29,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/ProgressBar.test.tsx
+++ b/web/src/components/charts/__tests__/ProgressBar.test.tsx
@@ -17,7 +17,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -25,10 +26,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/RadarChart.test.tsx
+++ b/web/src/components/charts/__tests__/RadarChart.test.tsx
@@ -18,7 +18,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -26,10 +27,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/Sparkline.test.tsx
+++ b/web/src/components/charts/__tests__/Sparkline.test.tsx
@@ -18,7 +18,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -26,10 +27,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/StatusIndicator.test.tsx
+++ b/web/src/components/charts/__tests__/StatusIndicator.test.tsx
@@ -14,7 +14,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -22,10 +23,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/TimeSeriesChart-formatters.test.tsx
+++ b/web/src/components/charts/__tests__/TimeSeriesChart-formatters.test.tsx
@@ -19,7 +19,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -27,10 +28,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/TimeSeriesChart.test.tsx
+++ b/web/src/components/charts/__tests__/TimeSeriesChart.test.tsx
@@ -18,7 +18,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -26,10 +27,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/TreeMap-formatters.test.tsx
+++ b/web/src/components/charts/__tests__/TreeMap-formatters.test.tsx
@@ -19,7 +19,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -27,10 +28,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/charts/__tests__/TreeMap.test.tsx
+++ b/web/src/components/charts/__tests__/TreeMap.test.tsx
@@ -18,7 +18,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -26,10 +27,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/clusters/__tests__/AddClusterDialog.test.tsx
+++ b/web/src/components/clusters/__tests__/AddClusterDialog.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/clusters/__tests__/CPUDetailModal.test.tsx
+++ b/web/src/components/clusters/__tests__/CPUDetailModal.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/clusters/__tests__/ClusterDetailModal.test.tsx
+++ b/web/src/components/clusters/__tests__/ClusterDetailModal.test.tsx
@@ -62,9 +62,11 @@ vi.mock('../../../hooks/useMissions', () => ({
   useMissions: () => ({ startMission: mockStartMission }),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitClusterAction: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../lib/modals', () => ({
   BaseModal: ({ children, isOpen }: { children: ReactNode; isOpen?: boolean }) => isOpen ? <div data-testid="base-modal">{children}</div> : null,

--- a/web/src/components/clusters/__tests__/Clusters.progress.test.tsx
+++ b/web/src/components/clusters/__tests__/Clusters.progress.test.tsx
@@ -53,7 +53,8 @@ vi.mock('../../../hooks/useLocalAgent', () => ({
   wasAgentEverConnected: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
@@ -108,9 +109,11 @@ vi.mock('../../cards/multi-tenancy/missionLoader', () => ({
   loadMissionPrompt: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitClusterStatsDrillDown: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../lib/constants', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../lib/constants')>()

--- a/web/src/components/clusters/__tests__/Clusters.test.tsx
+++ b/web/src/components/clusters/__tests__/Clusters.test.tsx
@@ -31,7 +31,8 @@ vi.mock('../../../hooks/useLocalAgent', () => ({
   wasAgentEverConnected: () => false,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
@@ -73,9 +74,11 @@ vi.mock('../../cards/multi-tenancy/missionLoader', () => ({
   loadMissionPrompt: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitClusterStatsDrillDown: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../lib/constants', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>

--- a/web/src/components/clusters/__tests__/EmptyClusterState.test.tsx
+++ b/web/src/components/clusters/__tests__/EmptyClusterState.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/clusters/add-cluster/__tests__/CommandLineTab.test.tsx
+++ b/web/src/components/clusters/add-cluster/__tests__/CommandLineTab.test.tsx
@@ -13,7 +13,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -21,10 +22,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/clusters/add-cluster/__tests__/ConnectTab.test.tsx
+++ b/web/src/components/clusters/add-cluster/__tests__/ConnectTab.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/clusters/add-cluster/__tests__/CopyButton.test.tsx
+++ b/web/src/components/clusters/add-cluster/__tests__/CopyButton.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/clusters/add-cluster/__tests__/ImportTab.test.tsx
+++ b/web/src/components/clusters/add-cluster/__tests__/ImportTab.test.tsx
@@ -14,7 +14,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -22,10 +23,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/compliance/Compliance.test.tsx
+++ b/web/src/components/compliance/Compliance.test.tsx
@@ -39,9 +39,11 @@ vi.mock('../../hooks/useGlobalFilters', () => ({
   useGlobalFilters: () => mockUseGlobalFilters(),
 }))
 
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 vi.mock('../../hooks/useKyverno', () => ({
   useKyverno: () => mockUseKyverno(),
@@ -69,9 +71,11 @@ vi.mock('../../hooks/useDrillDown', () => ({
   useDrillDownActions: () => mockUseDrillDownActions(),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitComplianceDrillDown: vi.fn(),
-}))
+}
+))
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },

--- a/web/src/components/cost/Cost.test.tsx
+++ b/web/src/components/cost/Cost.test.tsx
@@ -15,12 +15,16 @@ vi.mock('../../lib/demoMode', () => ({
   toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => { },
   isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
 }))
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true, useDemoMode: () => true, isDemoModeForced: false,
-}))
-vi.mock('../../lib/analytics', () => ({
+}
+))
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
-}))
+}
+))
 vi.mock('../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
   tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },

--- a/web/src/components/dashboard/AdopterNudge.test.tsx
+++ b/web/src/components/dashboard/AdopterNudge.test.tsx
@@ -12,11 +12,13 @@ vi.mock('../../lib/demoMode', () => ({
   isNetlifyDeployment: false,
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitAdopterNudgeShown: vi.fn(),
   emitAdopterNudgeActioned: vi.fn(),
   emitConversionStep: vi.fn(),
-}))
+}
+))
 
 const NUDGE_DELAY_DAYS = 3
 const MS_PER_DAY = 86_400_000

--- a/web/src/components/dashboard/MissionSuggestions.test.tsx
+++ b/web/src/components/dashboard/MissionSuggestions.test.tsx
@@ -54,12 +54,15 @@ vi.mock('../../hooks/useLocalAgent', () => ({
 vi.mock('../../hooks/useBackendHealth', () => ({
   isInClusterMode: () => false }))
 
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }) }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitMissionSuggestionsShown: vi.fn(),
-  emitMissionSuggestionActioned: vi.fn() }))
+  emitMissionSuggestionActioned: vi.fn() }
+))
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },

--- a/web/src/components/dashboard/SmartCardSuggestions.test.tsx
+++ b/web/src/components/dashboard/SmartCardSuggestions.test.tsx
@@ -28,11 +28,13 @@ vi.mock('../../hooks/useMCP', () => ({
   }),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitSmartSuggestionsShown: vi.fn(),
   emitSmartSuggestionAccepted: vi.fn(),
   emitSmartSuggestionsAddAll: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/utils/localStorage', () => ({
   safeGetItem: vi.fn(() => null),

--- a/web/src/components/dashboard/__tests__/AddCardModal.test.tsx
+++ b/web/src/components/dashboard/__tests__/AddCardModal.test.tsx
@@ -40,12 +40,14 @@ vi.mock('../../../lib/constants/network', async (importOriginal) => {
   FOCUS_DELAY_MS: 0,
   RETRY_DELAY_MS: 0,
 } })
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitAddCardModalOpened: vi.fn(),
   emitAddCardModalAbandoned: vi.fn(),
   emitCardCategoryBrowsed: vi.fn(),
   emitRecommendedCardShown: vi.fn(),
-}))
+}
+))
 vi.mock('../../../config/cards', () => ({
   isCardVisibleForProject: () => true,
 }))

--- a/web/src/components/dashboard/__tests__/Dashboard.test.tsx
+++ b/web/src/components/dashboard/__tests__/Dashboard.test.tsx
@@ -36,12 +36,14 @@ vi.mock('../../../lib/api', () => ({
   UnauthenticatedError: class extends Error {},
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitCardAdded: vi.fn(),
   emitCardRemoved: vi.fn(),
   emitCardDragged: vi.fn(),
   emitCardConfigured: vi.fn(),
-}))
+}
+))
 
 const mockLocation = { pathname: '/', key: 'default', search: '', hash: '', state: null }
 vi.mock('react-router-dom', () => ({
@@ -176,7 +178,8 @@ vi.mock('../../../lib/cache', () => ({ setAutoRefreshPaused: vi.fn(), createCach
 vi.mock('../../../hooks/useRefreshIndicator', () => ({
   useRefreshIndicator: (fn: () => void) => ({ showIndicator: false, triggerRefresh: fn }),
 }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => false,
   isDemoModeForced: false,
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),

--- a/web/src/components/dashboard/__tests__/GettingStartedBanner.test.tsx
+++ b/web/src/components/dashboard/__tests__/GettingStartedBanner.test.tsx
@@ -24,11 +24,13 @@ vi.mock('../../../lib/constants/storage', async (importOriginal) => {
   STORAGE_KEY_SEEN_TIPS: 'kc-seen-tips',
 } })
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitGettingStartedShown: vi.fn(),
   emitGettingStartedActioned: vi.fn(),
   emitTipShown: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../config/dashboards/index', () => ({
   DASHBOARD_CONFIGS: { main: {}, clusters: {}, security: {} },

--- a/web/src/components/dashboard/__tests__/PostConnectBanner.test.tsx
+++ b/web/src/components/dashboard/__tests__/PostConnectBanner.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/dashboard/customizer/__tests__/comprehensive.test.tsx
+++ b/web/src/components/dashboard/customizer/__tests__/comprehensive.test.tsx
@@ -50,12 +50,14 @@ vi.mock('../../../../lib/constants/network', async (importOriginal) => {
   return { ...actual, FOCUS_DELAY_MS: 0, RETRY_DELAY_MS: 0 }
 })
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitAddCardModalOpened: vi.fn(),
   emitAddCardModalAbandoned: vi.fn(),
   emitCardCategoryBrowsed: vi.fn(),
   emitRecommendedCardShown: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../config/cards', () => ({
   isCardVisibleForProject: () => true,

--- a/web/src/components/dashboard/customizer/__tests__/sections.test.tsx
+++ b/web/src/components/dashboard/customizer/__tests__/sections.test.tsx
@@ -42,12 +42,14 @@ vi.mock('../../../../lib/constants/network', async (importOriginal) => {
   return { ...actual, FOCUS_DELAY_MS: 0, RETRY_DELAY_MS: 0 }
 })
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitAddCardModalOpened: vi.fn(),
   emitAddCardModalAbandoned: vi.fn(),
   emitCardCategoryBrowsed: vi.fn(),
   emitRecommendedCardShown: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../config/cards', () => ({
   isCardVisibleForProject: () => true,

--- a/web/src/components/dashboard/customizer/sections/__tests__/CardCatalogSection.test.tsx
+++ b/web/src/components/dashboard/customizer/sections/__tests__/CardCatalogSection.test.tsx
@@ -63,10 +63,12 @@ vi.mock('../../../../../lib/constants/network', () => ({
   FOCUS_DELAY_MS: 0,
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitCardCategoryBrowsed: vi.fn(),
   emitRecommendedCardShown: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../config/cards', () => ({
   isCardVisibleForProject: () => true,

--- a/web/src/components/dashboard/customizer/sections/__tests__/UnifiedCardsSection.test.tsx
+++ b/web/src/components/dashboard/customizer/sections/__tests__/UnifiedCardsSection.test.tsx
@@ -35,9 +35,11 @@ vi.mock('../../../../../lib/constants/network', () => ({
   RETRY_DELAY_MS: 0,
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitCardCategoryBrowsed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../config/cards', () => ({
   isCardVisibleForProject: () => true,

--- a/web/src/components/drilldown/DrillDownModal.test.tsx
+++ b/web/src/components/drilldown/DrillDownModal.test.tsx
@@ -5,10 +5,12 @@ import * as DrillDownModalModule from './DrillDownModal'
 import { useDrillDown, DrillDownProvider } from '../../hooks/useDrillDown'
 import type { DrillDownView } from '../../hooks/useDrillDown'
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitDrillDownOpened: vi.fn(),
   emitDrillDownClosed: vi.fn(),
-}))
+}
+))
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <DrillDownProvider>{children}</DrillDownProvider>

--- a/web/src/components/drilldown/views/__tests__/ComplianceDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/ComplianceDrillDown.test.tsx
@@ -15,7 +15,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -23,10 +24,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/ConfigMapDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/ConfigMapDrillDown.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/CostDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/CostDrillDown.test.tsx
@@ -15,7 +15,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -23,10 +24,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/DeploymentDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/DeploymentDrillDown.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/EventsDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/EventsDrillDown.test.tsx
@@ -9,7 +9,8 @@ vi.mock('../../../../hooks/mcp/shared', () => ({
 
 // getDemoMode returns false by default so the component actually fetches.
 // Individual tests that need demo-mode blocking can override it.
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: vi.fn().mockReturnValue(false),
   default: () => false,
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
@@ -30,10 +31,12 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/GPUNamespaceDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/GPUNamespaceDrillDown.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/GPUNodeDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/GPUNodeDrillDown.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/LogsDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/LogsDrillDown.test.tsx
@@ -16,7 +16,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -24,10 +25,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/NamespaceDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/NamespaceDrillDown.test.tsx
@@ -15,7 +15,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -23,10 +24,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/NodeDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/NodeDrillDown.test.tsx
@@ -15,7 +15,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -23,10 +24,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/PodDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/PodDrillDown.test.tsx
@@ -77,7 +77,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -85,10 +86,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/RBACDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/RBACDrillDown.test.tsx
@@ -15,7 +15,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -23,10 +24,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/ReplicaSetDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/ReplicaSetDrillDown.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/ResourcesDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/ResourcesDrillDown.test.tsx
@@ -15,7 +15,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -23,10 +24,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/SecretDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/SecretDrillDown.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/__tests__/ServiceAccountDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/ServiceAccountDrillDown.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/pod-drilldown/__tests__/PodAiAnalysis.test.tsx
+++ b/web/src/components/drilldown/views/pod-drilldown/__tests__/PodAiAnalysis.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/pod-drilldown/__tests__/PodDeleteSection.test.tsx
+++ b/web/src/components/drilldown/views/pod-drilldown/__tests__/PodDeleteSection.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/pod-drilldown/__tests__/PodLabelsTab.test.tsx
+++ b/web/src/components/drilldown/views/pod-drilldown/__tests__/PodLabelsTab.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/drilldown/views/pod-drilldown/__tests__/PodOutputTab.test.tsx
+++ b/web/src/components/drilldown/views/pod-drilldown/__tests__/PodOutputTab.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../../lib/analytics', () => ({
+vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/events/Events.test.tsx
+++ b/web/src/components/events/Events.test.tsx
@@ -9,12 +9,16 @@ vi.mock('../../lib/demoMode', () => ({
   toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => { },
   isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
 }))
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true, useDemoMode: () => true, isDemoModeForced: false,
-}))
-vi.mock('../../lib/analytics', () => ({
+}
+))
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
-}))
+}
+))
 vi.mock('../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
   tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },

--- a/web/src/components/feedback/FeedbackModal.test.tsx
+++ b/web/src/components/feedback/FeedbackModal.test.tsx
@@ -28,7 +28,8 @@ vi.mock('../ui/Toast', () => ({
   useToast: () => ({ showToast: vi.fn() }),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitFeedbackSubmitted: vi.fn(),
   emitLinkedInShare: vi.fn(),
   emitScreenshotAttached: vi.fn(),
@@ -36,7 +37,8 @@ vi.mock('../../lib/analytics', () => ({
   emitScreenshotUploadSuccess: vi.fn(),
   getRecentBrowserErrors: () => [],
   getRecentFailedApiCalls: () => [],
-}))
+}
+))
 
 vi.mock('../../lib/clipboard', () => ({
   copyBlobToClipboard: vi.fn(),

--- a/web/src/components/feedback/__tests__/FeatureRequestButton.test.tsx
+++ b/web/src/components/feedback/__tests__/FeatureRequestButton.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/gpu/__tests__/GPUReservations.test.tsx
+++ b/web/src/components/gpu/__tests__/GPUReservations.test.tsx
@@ -14,7 +14,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
   isFeatureEnabled: () => true,
 }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true,
   default: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
@@ -26,12 +27,14 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
 }))
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitAddCardModalAbandoned: vi.fn(),
   emitCardCategoryBrowsed: vi.fn(), emitRecommendedCardShown: vi.fn(),
   emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
   tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },

--- a/web/src/components/history/__tests__/CardHistory.test.tsx
+++ b/web/src/components/history/__tests__/CardHistory.test.tsx
@@ -13,7 +13,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -21,10 +22,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/landing/__tests__/CompetitorLandingPage.test.tsx
+++ b/web/src/components/landing/__tests__/CompetitorLandingPage.test.tsx
@@ -7,9 +7,11 @@ vi.mock('../../../lib/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitInstallCommandCopied: vi.fn(),
-}))
+}
+))
 
 import { CompetitorLandingPage } from '../CompetitorLandingPage'
 import type { CompetitorLandingPageProps } from '../types'

--- a/web/src/components/landing/__tests__/TabbedDeploySection.test.tsx
+++ b/web/src/components/landing/__tests__/TabbedDeploySection.test.tsx
@@ -6,9 +6,11 @@ vi.mock('../../../lib/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitInstallCommandCopied: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../lib/constants', () => ({
   COPY_FEEDBACK_TIMEOUT_MS: 2000,

--- a/web/src/components/layout/__tests__/ContentLoadingSkeleton.test.tsx
+++ b/web/src/components/layout/__tests__/ContentLoadingSkeleton.test.tsx
@@ -11,7 +11,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -19,10 +20,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/layout/__tests__/SnoozedCards.test.tsx
+++ b/web/src/components/layout/__tests__/SnoozedCards.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/layout/__tests__/UserProfileDropdown.test.tsx
+++ b/web/src/components/layout/__tests__/UserProfileDropdown.test.tsx
@@ -111,10 +111,12 @@ vi.mock('../../../lib/demoMode', () => ({
   },
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitLinkedInShare: vi.fn(),
   emitLanguageChanged,
-}))
+}
+))
 
 vi.mock('../../../lib/api', () => ({
   checkOAuthConfigured: vi.fn().mockResolvedValue({ oauthConfigured: true, backendUp: true }),

--- a/web/src/components/layout/__tests__/useClusterInventoryAnalytics.test.ts
+++ b/web/src/components/layout/__tests__/useClusterInventoryAnalytics.test.ts
@@ -3,9 +3,11 @@ import { renderHook } from '@testing-library/react'
 
 const mockEmitClusterInventory = vi.fn()
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitClusterInventory: (...args: unknown[]) => mockEmitClusterInventory(...args),
-}))
+}
+))
 
 import { useClusterInventoryAnalytics } from '../useClusterInventoryAnalytics'
 

--- a/web/src/components/layout/mission-sidebar/__tests__/MissionChat.layout.test.tsx
+++ b/web/src/components/layout/mission-sidebar/__tests__/MissionChat.layout.test.tsx
@@ -32,7 +32,8 @@ vi.mock('../../../../lib/auth', () => ({
   useAuth: () => ({ user: null }),
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/layout/mission-sidebar/__tests__/MissionChatView.test.tsx
+++ b/web/src/components/layout/mission-sidebar/__tests__/MissionChatView.test.tsx
@@ -33,7 +33,8 @@ vi.mock('../../../../lib/auth', () => ({
   useAuth: () => ({ user: null }),
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/layout/mission-sidebar/__tests__/TypingIndicator.test.tsx
+++ b/web/src/components/layout/mission-sidebar/__tests__/TypingIndicator.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/layout/navbar/__tests__/ActiveUsersWidget.test.tsx
+++ b/web/src/components/layout/navbar/__tests__/ActiveUsersWidget.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/layout/navbar/__tests__/AgentStatusIndicator.demo-toggle.test.tsx
+++ b/web/src/components/layout/navbar/__tests__/AgentStatusIndicator.demo-toggle.test.tsx
@@ -26,7 +26,8 @@ const {
   mockUseMissions: vi.fn(),
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({
     isDemoMode: demoModeState.isDemoMode,
     toggleDemoMode: mockToggleDemoMode,

--- a/web/src/components/layout/navbar/__tests__/AgentStatusIndicator.test.tsx
+++ b/web/src/components/layout/navbar/__tests__/AgentStatusIndicator.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => false, default: () => false,
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => true, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/layout/navbar/__tests__/LearnDropdown.test.tsx
+++ b/web/src/components/layout/navbar/__tests__/LearnDropdown.test.tsx
@@ -11,7 +11,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -19,10 +20,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/layout/navbar/__tests__/NavbarEscapeDropdowns.test.tsx
+++ b/web/src/components/layout/navbar/__tests__/NavbarEscapeDropdowns.test.tsx
@@ -67,7 +67,8 @@ vi.mock('../../../../hooks/useBackendHealth', () => ({
   }),
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({
     isDemoMode: false,
     toggleDemoMode: vi.fn(),

--- a/web/src/components/layout/navbar/__tests__/SearchDropdown.test.tsx
+++ b/web/src/components/layout/navbar/__tests__/SearchDropdown.test.tsx
@@ -61,12 +61,14 @@ vi.mock('../../../ui/FeatureHintTooltip', () => ({
   FeatureHintTooltip: () => null,
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitGlobalSearchOpened: vi.fn(),
   emitGlobalSearchQueried: vi.fn(),
   emitGlobalSearchSelected: vi.fn(),
   emitGlobalSearchAskAI: vi.fn(),
-}))
+}
+))
 
 describe('SearchDropdown', () => {
   beforeEach(() => {

--- a/web/src/components/layout/navbar/__tests__/UpdateIndicator.test.tsx
+++ b/web/src/components/layout/navbar/__tests__/UpdateIndicator.test.tsx
@@ -11,7 +11,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -19,10 +20,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/logs/Logs.test.tsx
+++ b/web/src/components/logs/Logs.test.tsx
@@ -9,12 +9,16 @@ vi.mock('../../lib/demoMode', () => ({
   toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => { },
   isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
 }))
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true, useDemoMode: () => true, isDemoModeForced: false,
-}))
-vi.mock('../../lib/analytics', () => ({
+}
+))
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
-}))
+}
+))
 vi.mock('../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
   tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },

--- a/web/src/components/mission-control/svg/__tests__/BlueprintDefs.test.tsx
+++ b/web/src/components/mission-control/svg/__tests__/BlueprintDefs.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/mission-control/svg/__tests__/DependencyPath.test.tsx
+++ b/web/src/components/mission-control/svg/__tests__/DependencyPath.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/missions/CardRequestDialog.test.tsx
+++ b/web/src/components/missions/CardRequestDialog.test.tsx
@@ -25,9 +25,11 @@ vi.mock('../../lib/api', () => ({
   },
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitGroundControlCardRequestOpened: vi.fn(),
-}))
+}
+))
 
 vi.mock('../ui/Toast', () => ({
   useToast: () => ({

--- a/web/src/components/missions/MissionBrowser.components.test.tsx
+++ b/web/src/components/missions/MissionBrowser.components.test.tsx
@@ -33,7 +33,8 @@ vi.mock('../ui/Toast', () => ({
   useToast: () => ({ showToast: vi.fn() }),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitFixerGitHubLink: vi.fn(),
   emitNavigate: vi.fn(),
   emitEvent: vi.fn(),
@@ -43,7 +44,8 @@ vi.mock('../../lib/analytics', () => ({
   emitCardExpanded: vi.fn(),
   emitCardRefreshed: vi.fn(),
   markErrorReported: vi.fn(),
-}))
+}
+))
 
 describe('MissionBrowserFilterPanel', () => {
   beforeEach(() => {

--- a/web/src/components/missions/__tests__/CardRequestDialog.test.tsx
+++ b/web/src/components/missions/__tests__/CardRequestDialog.test.tsx
@@ -24,9 +24,11 @@ vi.mock('../../../lib/api', () => ({
   api: { post: mockApiPost },
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitGroundControlCardRequestOpened: mockEmitCardRequest,
-}))
+}
+))
 
 vi.mock('../../ui/Toast', () => ({
   useToast: () => ({ showToast: mockShowToast }),

--- a/web/src/components/missions/__tests__/ClusterSelectionDialog.test.tsx
+++ b/web/src/components/missions/__tests__/ClusterSelectionDialog.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/missions/__tests__/ImproveMissionDialog.test.tsx
+++ b/web/src/components/missions/__tests__/ImproveMissionDialog.test.tsx
@@ -52,7 +52,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -60,10 +61,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/missions/__tests__/MissionBrowser.test.tsx
+++ b/web/src/components/missions/__tests__/MissionBrowser.test.tsx
@@ -75,14 +75,16 @@ vi.mock('../../../lib/api', () => ({
   },
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitFixerBrowsed: vi.fn(),
   emitFixerViewed: vi.fn(),
   emitFixerImported: vi.fn(),
   emitFixerImportError: vi.fn(),
   emitFixerGitHubLink: vi.fn(),
   emitFixerLinkCopied: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../lib/missions/matcher', () => ({
   matchMissionsToCluster: vi.fn((missions: any[]) => missions.map((mission) => ({

--- a/web/src/components/missions/__tests__/MissionBrowserRecommendedTab.test.tsx
+++ b/web/src/components/missions/__tests__/MissionBrowserRecommendedTab.test.tsx
@@ -4,8 +4,12 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import type { MissionExport, MissionMatch, BrowseEntry } from '../../../lib/missions/types'
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
-vi.mock('../../lib/analytics', () => ({ emitFixerGitHubLink: vi.fn() }))
-vi.mock('../../../lib/analytics', () => ({ emitFixerGitHubLink: vi.fn() }))
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()), emitFixerGitHubLink: vi.fn() }
+))
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()), emitFixerGitHubLink: vi.fn() }
+))
 
 const { mockResetMissionCache } = vi.hoisted(() => ({
   mockResetMissionCache: vi.fn(),

--- a/web/src/components/missions/__tests__/OrbitSetupOffer.test.tsx
+++ b/web/src/components/missions/__tests__/OrbitSetupOffer.test.tsx
@@ -35,9 +35,11 @@ vi.mock('../../../lib/orbit/orbitTemplates', () => ({
   getApplicableOrbitTemplates: (categories: string[]) => mockGetApplicableOrbitTemplates(categories),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitOrbitMissionCreated: (orbitType: string, cadence: string) => mockEmitOrbitMissionCreated(orbitType, cadence),
-}))
+}
+))
 
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),

--- a/web/src/components/missions/__tests__/ResolutionHistoryPanel.test.tsx
+++ b/web/src/components/missions/__tests__/ResolutionHistoryPanel.test.tsx
@@ -14,7 +14,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -22,10 +23,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/missions/__tests__/ScanProgressOverlay.test.tsx
+++ b/web/src/components/missions/__tests__/ScanProgressOverlay.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/missions/__tests__/StandaloneOrbitDialog.test.tsx
+++ b/web/src/components/missions/__tests__/StandaloneOrbitDialog.test.tsx
@@ -68,13 +68,15 @@ vi.mock('../../../hooks/mcp/clusters', () => ({
   }),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitOrbitMissionCreated: vi.fn(),
   emitNavigate: vi.fn(),
   emitLogin: vi.fn(),
   emitEvent: vi.fn(),
   analyticsReady: Promise.resolve(),
-}))
+}
+))
 
 // SetupInstructionsDialog pulls in heavy deps; stub it.
 vi.mock('../../setup/SetupInstructionsDialog', () => ({

--- a/web/src/components/missions/browser/__tests__/EmptyState.test.tsx
+++ b/web/src/components/missions/browser/__tests__/EmptyState.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/network/Network.test.tsx
+++ b/web/src/components/network/Network.test.tsx
@@ -22,12 +22,16 @@ vi.mock('../../lib/demoMode', () => ({
   toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => { },
   isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
 }))
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true, useDemoMode: () => true, isDemoModeForced: false,
-}))
-vi.mock('../../lib/analytics', () => ({
+}
+))
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
-}))
+}
+))
 vi.mock('../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
   tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },

--- a/web/src/components/nodes/__tests__/Nodes.test.tsx
+++ b/web/src/components/nodes/__tests__/Nodes.test.tsx
@@ -11,12 +11,16 @@ vi.mock('../../../lib/demoMode', () => ({
   toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => { },
   isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
 }))
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true, useDemoMode: () => true, isDemoModeForced: false,
-}))
-vi.mock('../../../lib/analytics', () => ({
+}
+))
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
-}))
+}
+))
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
   tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },

--- a/web/src/components/onboarding/__tests__/Tour.test.tsx
+++ b/web/src/components/onboarding/__tests__/Tour.test.tsx
@@ -13,7 +13,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -21,10 +22,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/pods/__tests__/Pods.test.tsx
+++ b/web/src/components/pods/__tests__/Pods.test.tsx
@@ -18,19 +18,23 @@ vi.mock('../../../lib/demoMode', () => ({
   setDemoToken: vi.fn(),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true,
   default: () => true,
   useDemoMode: () => true,
   isDemoModeForced: false,
-}))
+}
+))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(),
   emitLogin: vi.fn(),
   emitEvent: vi.fn(),
   analyticsReady: Promise.resolve(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({

--- a/web/src/components/rewards/__tests__/CoinDisplay.test.tsx
+++ b/web/src/components/rewards/__tests__/CoinDisplay.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/rewards/__tests__/ContributorBanner.test.tsx
+++ b/web/src/components/rewards/__tests__/ContributorBanner.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/rewards/__tests__/GitHubInvite.test.tsx
+++ b/web/src/components/rewards/__tests__/GitHubInvite.test.tsx
@@ -13,7 +13,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -21,10 +22,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/rewards/__tests__/LinkedInShare.test.tsx
+++ b/web/src/components/rewards/__tests__/LinkedInShare.test.tsx
@@ -13,7 +13,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -21,11 +22,13 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
   emitLinkedInShare: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/rewards/__tests__/RewardsPanel.test.tsx
+++ b/web/src/components/rewards/__tests__/RewardsPanel.test.tsx
@@ -12,7 +12,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -20,11 +21,13 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
   emitLinkedInShare: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/security/__tests__/Security.test.tsx
+++ b/web/src/components/security/__tests__/Security.test.tsx
@@ -35,7 +35,8 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
   }),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/services/Services.test.tsx
+++ b/web/src/components/services/Services.test.tsx
@@ -9,12 +9,16 @@ vi.mock('../../lib/demoMode', () => ({
   toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => { },
   isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
 }))
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true, useDemoMode: () => true, isDemoModeForced: false,
-}))
-vi.mock('../../lib/analytics', () => ({
+}
+))
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
-}))
+}
+))
 vi.mock('../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
   tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },

--- a/web/src/components/settings/sections/__tests__/AISettingsSection.test.tsx
+++ b/web/src/components/settings/sections/__tests__/AISettingsSection.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/settings/sections/__tests__/APIKeysSection.test.tsx
+++ b/web/src/components/settings/sections/__tests__/APIKeysSection.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/settings/sections/__tests__/AccessibilitySection.test.tsx
+++ b/web/src/components/settings/sections/__tests__/AccessibilitySection.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/settings/sections/__tests__/AgentBackendSettings.test.tsx
+++ b/web/src/components/settings/sections/__tests__/AgentBackendSettings.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/settings/sections/__tests__/AgentSection.test.tsx
+++ b/web/src/components/settings/sections/__tests__/AgentSection.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/settings/sections/__tests__/GitHubTokenSection.test.tsx
+++ b/web/src/components/settings/sections/__tests__/GitHubTokenSection.test.tsx
@@ -11,7 +11,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -19,11 +20,13 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
   emitGitHubTokenConfigured: vi.fn(), emitGitHubTokenRemoved: vi.fn(), emitConversionStep: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/settings/sections/__tests__/LocalClustersSection.test.tsx
+++ b/web/src/components/settings/sections/__tests__/LocalClustersSection.test.tsx
@@ -83,9 +83,11 @@ vi.mock('../../../../lib/modals', () => ({
   ConfirmDialog: () => null,
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitLocalClusterCreated: vi.fn(),
-}))
+}
+))
 
 const dismissVClusterActionFeedback = vi.fn()
 

--- a/web/src/components/settings/sections/__tests__/PermissionsSection.test.tsx
+++ b/web/src/components/settings/sections/__tests__/PermissionsSection.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/settings/sections/__tests__/PersistenceSection.test.tsx
+++ b/web/src/components/settings/sections/__tests__/PersistenceSection.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/settings/sections/__tests__/PredictionSettingsSection.test.tsx
+++ b/web/src/components/settings/sections/__tests__/PredictionSettingsSection.test.tsx
@@ -17,11 +17,13 @@ vi.mock('../../../../hooks/usePredictionFeedback', () => ({
   }),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitAIPredictionsToggled: vi.fn(),
   emitConfidenceThresholdChanged: vi.fn(),
   emitConsensusModeToggled: vi.fn(),
-}))
+}
+))
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },

--- a/web/src/components/settings/sections/__tests__/ProfileSection.test.tsx
+++ b/web/src/components/settings/sections/__tests__/ProfileSection.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/settings/sections/__tests__/SlackNotificationSettings.test.tsx
+++ b/web/src/components/settings/sections/__tests__/SlackNotificationSettings.test.tsx
@@ -18,7 +18,8 @@ vi.mock('../../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -26,10 +27,12 @@ vi.mock('../../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../../lib/analytics', () => ({
+vi.mock('../../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/shared/__tests__/DashboardHeader.test.tsx
+++ b/web/src/components/shared/__tests__/DashboardHeader.test.tsx
@@ -16,7 +16,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -24,10 +25,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/shared/__tests__/TECHNICAL_ACRONYMS.test.tsx
+++ b/web/src/components/shared/__tests__/TECHNICAL_ACRONYMS.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/stellar/__tests__/EventsPanel.test.tsx
+++ b/web/src/components/stellar/__tests__/EventsPanel.test.tsx
@@ -16,7 +16,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -24,10 +25,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/ui/StatsOverview.test.tsx
+++ b/web/src/components/ui/StatsOverview.test.tsx
@@ -26,7 +26,8 @@ vi.mock('../../hooks/useLocalAgent', () => ({
   wasAgentEverConnected: () => true,
 }))
 
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/components/ui/__tests__/CollapsibleSection.test.tsx
+++ b/web/src/components/ui/__tests__/CollapsibleSection.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/ui/__tests__/ConsoleAIIcon.test.tsx
+++ b/web/src/components/ui/__tests__/ConsoleAIIcon.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/ui/__tests__/FeatureHintTooltip.test.tsx
+++ b/web/src/components/ui/__tests__/FeatureHintTooltip.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/ui/__tests__/FlashingValue.test.tsx
+++ b/web/src/components/ui/__tests__/FlashingValue.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/ui/__tests__/LogoWithStar.test.tsx
+++ b/web/src/components/ui/__tests__/LogoWithStar.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/ui/__tests__/ProgressRing.test.tsx
+++ b/web/src/components/ui/__tests__/ProgressRing.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,10 +19,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/ui/__tests__/RotatingTip.test.tsx
+++ b/web/src/components/ui/__tests__/RotatingTip.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -18,11 +19,13 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
   emitTipShown: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/ui/__tests__/StatBlockModePicker.test.tsx
+++ b/web/src/components/ui/__tests__/StatBlockModePicker.test.tsx
@@ -23,7 +23,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => true, default: () => true,
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
@@ -31,10 +32,12 @@ vi.mock('../../../hooks/useDemoMode', () => ({
   setGlobalDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),

--- a/web/src/components/updates/WhatsNewModal.test.tsx
+++ b/web/src/components/updates/WhatsNewModal.test.tsx
@@ -46,10 +46,12 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitWhatsNewUpdateClicked: vi.fn(),
   emitWhatsNewRemindLater: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/modals', () => ({
   BaseModal: Object.assign(

--- a/web/src/components/widget/MiniDashboard.test.tsx
+++ b/web/src/components/widget/MiniDashboard.test.tsx
@@ -18,11 +18,13 @@ vi.mock('../../hooks/mcp/shared', () => ({
   agentFetch: (...args: unknown[]) => mockAgentFetch(...args),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitWidgetLoaded: vi.fn(),
   emitWidgetNavigation: vi.fn(),
   emitWidgetInstalled: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../hooks/useDeepLink', () => ({
   sendNotificationWithDeepLink: vi.fn(),

--- a/web/src/components/workloads/__tests__/Workloads.navigation.test.tsx
+++ b/web/src/components/workloads/__tests__/Workloads.navigation.test.tsx
@@ -64,19 +64,22 @@ let mockIsLoading = false
 let mockAgentStatus: 'connected' | 'disconnected' = 'connected'
 let mockIsDemoMode = true
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => mockIsDemoMode,
   default: () => mockIsDemoMode,
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode }),
   isDemoModeForced: false,
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(),
   emitLogin: vi.fn(),
   emitEvent: vi.fn(),
   analyticsReady: Promise.resolve(),
-}))
+}
+))
 
 vi.mock('../../../lib/dashboards/DashboardPage', () => ({
   DashboardPage: ({ title, rightExtra, children }: { title: string; rightExtra?: React.ReactNode; children?: React.ReactNode }) => (

--- a/web/src/components/workloads/__tests__/Workloads.test.tsx
+++ b/web/src/components/workloads/__tests__/Workloads.test.tsx
@@ -18,19 +18,22 @@ vi.mock('../../../lib/demoMode', () => ({
     setDemoToken: vi.fn(),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
     getDemoMode: () => mockIsDemoMode,
     default: () => mockIsDemoMode,
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode }),
     isDemoModeForced: false,
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
     emitNavigate: vi.fn(),
     emitLogin: vi.fn(),
     emitEvent: vi.fn(),
     analyticsReady: Promise.resolve(),
-}))
+}
+))
 
 vi.mock('../../../lib/dashboards/DashboardPage', () => ({
     DashboardPage: ({ title, rightExtra, children }: { title: string; rightExtra?: React.ReactNode; children?: React.ReactNode }) => (

--- a/web/src/components/workloads/__tests__/WorkloadsExtended.test.tsx
+++ b/web/src/components/workloads/__tests__/WorkloadsExtended.test.tsx
@@ -21,19 +21,22 @@ vi.mock('../../../lib/demoMode', () => ({
   setDemoToken: vi.fn(),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   getDemoMode: () => mockIsDemoMode,
   default: () => ({ isDemoMode: mockIsDemoMode, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   isDemoModeForced: false,
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitNavigate: vi.fn(),
   emitLogin: vi.fn(),
   emitEvent: vi.fn(),
   analyticsReady: Promise.resolve(),
-}))
+}
+))
 
 vi.mock('../../../lib/dashboards/DashboardPage', () => ({
   DashboardPage: ({ title, children }: { title: string; children?: React.ReactNode }) => (

--- a/web/src/contexts/AlertsContext.deepcover.test.tsx
+++ b/web/src/contexts/AlertsContext.deepcover.test.tsx
@@ -29,9 +29,11 @@ vi.mock('../hooks/useMissions', () => ({
   useMissions: vi.fn(() => ({ startMission: mockStartMission })),
 }))
 
-vi.mock('../hooks/useDemoMode', () => ({
+vi.mock('../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 vi.mock('../hooks/useDeepLink', () => ({
   sendNotificationWithDeepLink: mockSendNotificationWithDeepLink,

--- a/web/src/contexts/AlertsContext.lifecycle.test.tsx
+++ b/web/src/contexts/AlertsContext.lifecycle.test.tsx
@@ -29,9 +29,11 @@ vi.mock('../hooks/useMissions', () => ({
   useMissions: vi.fn(() => ({ startMission: mockStartMission })),
 }))
 
-vi.mock('../hooks/useDemoMode', () => ({
+vi.mock('../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 vi.mock('../hooks/useDeepLink', () => ({
   sendNotificationWithDeepLink: mockSendNotificationWithDeepLink,

--- a/web/src/contexts/AlertsContext.storage.test.tsx
+++ b/web/src/contexts/AlertsContext.storage.test.tsx
@@ -29,9 +29,11 @@ vi.mock('../hooks/useMissions', () => ({
   useMissions: vi.fn(() => ({ startMission: mockStartMission })),
 }))
 
-vi.mock('../hooks/useDemoMode', () => ({
+vi.mock('../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 vi.mock('../hooks/useDeepLink', () => ({
   sendNotificationWithDeepLink: mockSendNotificationWithDeepLink,

--- a/web/src/contexts/__tests__/AlertsContext.additional.test.tsx
+++ b/web/src/contexts/__tests__/AlertsContext.additional.test.tsx
@@ -21,7 +21,8 @@ vi.mock('../../hooks/useMissions', () => ({
 }))
 
 let mockIsDemoMode = false
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/contexts/__tests__/AlertsContext.utils.test.tsx
+++ b/web/src/contexts/__tests__/AlertsContext.utils.test.tsx
@@ -21,7 +21,8 @@ vi.mock('../../hooks/useMissions', () => ({
 }))
 
 let mockIsDemoMode = false
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/contexts/__tests__/StackContext.test.tsx
+++ b/web/src/contexts/__tests__/StackContext.test.tsx
@@ -32,7 +32,8 @@ vi.mock('../../hooks/useStackDiscovery', () => ({
   }),
 }))
 
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/__tests__/agentConnectivity.test.tsx
+++ b/web/src/hooks/__tests__/agentConnectivity.test.tsx
@@ -32,7 +32,8 @@ vi.mock('../mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   isDemoModeForced: false,
 }))
@@ -48,12 +49,14 @@ const mockEmitAgentDisconnected = vi.fn()
 const mockEmitAgentProvidersDetected = vi.fn()
 const mockEmitConversionStep = vi.fn()
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitAgentConnected: (...args: unknown[]) => mockEmitAgentConnected(...args),
   emitAgentDisconnected: (...args: unknown[]) => mockEmitAgentDisconnected(...args),
   emitAgentProvidersDetected: (...args: unknown[]) => mockEmitAgentProvidersDetected(...args),
   emitConversionStep: (...args: unknown[]) => mockEmitConversionStep(...args),
-}))
+}
+))
 
 vi.mock('../../lib/utils/localStorage', () => ({
   safeGetItem: vi.fn(() => null),

--- a/web/src/hooks/__tests__/useAIPredictions-hook.test.ts
+++ b/web/src/hooks/__tests__/useAIPredictions-hook.test.ts
@@ -20,7 +20,8 @@ vi.mock('../usePredictionSettings', () => ({
   getSettingsForBackend: mockGetSettingsForBackend,
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/__tests__/useAIPredictions-utils.test.ts
+++ b/web/src/hooks/__tests__/useAIPredictions-utils.test.ts
@@ -20,7 +20,8 @@ vi.mock('../usePredictionSettings', () => ({
   getSettingsForBackend: mockGetSettingsForBackend,
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/__tests__/useActiveUsers-coverage.test.ts
+++ b/web/src/hooks/__tests__/useActiveUsers-coverage.test.ts
@@ -22,10 +22,12 @@ const { mockGetDemoMode, mockIsDemoModeForced } = vi.hoisted(() => ({
   mockIsDemoModeForced: false,
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: mockGetDemoMode,
   isDemoModeForced: mockIsDemoModeForced,
-}))
+}
+))
 
 vi.mock('../../lib/constants', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>

--- a/web/src/hooks/__tests__/useActiveUsers.test.ts
+++ b/web/src/hooks/__tests__/useActiveUsers.test.ts
@@ -11,10 +11,12 @@ const { mockGetDemoMode } = vi.hoisted(() => ({
   mockGetDemoMode: vi.fn(() => true),
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: mockGetDemoMode,
   isDemoModeForced: true,
-}))
+}
+))
 
 vi.mock('../../lib/constants', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>

--- a/web/src/hooks/__tests__/useAppSideEffects.test.tsx
+++ b/web/src/hooks/__tests__/useAppSideEffects.test.tsx
@@ -27,10 +27,12 @@ vi.mock('../useBranding', () => ({
 vi.mock('../../lib/auth', () => ({
   useAuth: vi.fn(() => ({ isAuthenticated: false })),
 }))
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitPageView: vi.fn(),
   emitDashboardViewed: vi.fn(),
-}))
+}
+))
 vi.mock('../../hooks/useSidebarConfig', () => ({
   fetchEnabledDashboards: vi.fn(() => Promise.resolve()),
   getEnabledDashboardIds: vi.fn(() => null),

--- a/web/src/hooks/__tests__/useBranding.test.tsx
+++ b/web/src/hooks/__tests__/useBranding.test.tsx
@@ -59,9 +59,11 @@ vi.mock('../../lib/constants/network', async (importOriginal) => {
 } })
 
 const mockUpdateAnalyticsIds = vi.fn()
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   updateAnalyticsIds: (...args: unknown[]) => mockUpdateAnalyticsIds(...args),
-}))
+}
+))
 
 import { useBranding, BrandingProvider } from '../useBranding'
 

--- a/web/src/hooks/__tests__/useCachedAttestation-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedAttestation-funcs.test.ts
@@ -51,7 +51,8 @@ vi.mock('../../lib/constants/network', () => ({
   FETCH_DEFAULT_TIMEOUT_MS: 5000,
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedBackstage-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedBackstage-funcs.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedBackstage.test.ts
+++ b/web/src/hooks/__tests__/useCachedBackstage.test.ts
@@ -9,7 +9,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedCiliumStatus-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCiliumStatus-funcs.test.ts
@@ -24,7 +24,8 @@ vi.mock('../useCachedData/demoData', () => ({
   }),
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedCloudCustodian-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCloudCustodian-funcs.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedCloudCustodian.test.ts
+++ b/web/src/hooks/__tests__/useCachedCloudCustodian.test.ts
@@ -9,7 +9,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedCni-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCni-funcs.test.ts
@@ -15,7 +15,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedCni.test.ts
+++ b/web/src/hooks/__tests__/useCachedCni.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedContainerd-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedContainerd-funcs.test.ts
@@ -29,7 +29,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: false,
 }))

--- a/web/src/hooks/__tests__/useCachedContainerd.test.ts
+++ b/web/src/hooks/__tests__/useCachedContainerd.test.ts
@@ -24,7 +24,8 @@ vi.mock('../../lib/cache', () => ({
   },
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
 }))
 

--- a/web/src/hooks/__tests__/useCachedCortex-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCortex-funcs.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedCortex.test.ts
+++ b/web/src/hooks/__tests__/useCachedCortex.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedDapr-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedDapr-funcs.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedDapr.test.ts
+++ b/web/src/hooks/__tests__/useCachedDapr.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedFlatcar-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedFlatcar-funcs.test.ts
@@ -16,7 +16,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedFlatcar.test.ts
+++ b/web/src/hooks/__tests__/useCachedFlatcar.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedGrpc-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedGrpc-funcs.test.ts
@@ -15,7 +15,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedGrpc.test.ts
+++ b/web/src/hooks/__tests__/useCachedGrpc.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedJaegerStatus-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedJaegerStatus-funcs.test.ts
@@ -33,7 +33,8 @@ vi.mock('../useCachedData/demoData', () => ({
   }),
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedKeda.test.ts
+++ b/web/src/hooks/__tests__/useCachedKeda.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedKserve-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedKserve-funcs.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedKserve.test.ts
+++ b/web/src/hooks/__tests__/useCachedKserve.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedKubevela-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedKubevela-funcs.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedKubevela.test.ts
+++ b/web/src/hooks/__tests__/useCachedKubevela.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedLinkerd-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedLinkerd-funcs.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedLinkerd.test.ts
+++ b/web/src/hooks/__tests__/useCachedLinkerd.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedOpenfeature-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedOpenfeature-funcs.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedOpenfeature.test.ts
+++ b/web/src/hooks/__tests__/useCachedOpenfeature.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedOpenfga-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedOpenfga-funcs.test.ts
@@ -15,7 +15,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedOpenfga.test.ts
+++ b/web/src/hooks/__tests__/useCachedOpenfga.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedRook.test.ts
+++ b/web/src/hooks/__tests__/useCachedRook.test.ts
@@ -9,7 +9,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedSpiffe-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedSpiffe-funcs.test.ts
@@ -15,7 +15,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedSpiffe.test.ts
+++ b/web/src/hooks/__tests__/useCachedSpiffe.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedSpire-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedSpire-funcs.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedSpire.test.ts
+++ b/web/src/hooks/__tests__/useCachedSpire.test.ts
@@ -9,7 +9,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedStrimzi-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedStrimzi-funcs.test.ts
@@ -15,7 +15,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedStrimzi.test.ts
+++ b/web/src/hooks/__tests__/useCachedStrimzi.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedTikv.test.ts
+++ b/web/src/hooks/__tests__/useCachedTikv.test.ts
@@ -9,7 +9,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedTimeline-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedTimeline-funcs.test.ts
@@ -19,7 +19,8 @@ vi.mock('../../lib/constants/time', () => ({
   MS_PER_DAY: 86400000,
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedTimeline.test.ts
+++ b/web/src/hooks/__tests__/useCachedTimeline.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedTuf.test.ts
+++ b/web/src/hooks/__tests__/useCachedTuf.test.ts
@@ -9,7 +9,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedVolcano-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedVolcano-funcs.test.ts
@@ -15,7 +15,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedVolcano.test.ts
+++ b/web/src/hooks/__tests__/useCachedVolcano.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedWasmcloud-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedWasmcloud-funcs.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../lib/constants/network', () => ({
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   useDemoMode: () => ({ isDemoMode: false }),
   isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCachedWasmcloud.test.ts
+++ b/web/src/hooks/__tests__/useCachedWasmcloud.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../lib/cache', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
     useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
     isDemoModeForced: () => false,

--- a/web/src/hooks/__tests__/useCertManager-basic.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-basic.test.ts
@@ -22,9 +22,11 @@ const mockUseClusters = vi.fn(() => ({
 }))
 const mockKubectlProxy = { exec: vi.fn() }
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 vi.mock('../useMCP', () => ({
   useClusters: () => mockUseClusters(),

--- a/web/src/hooks/__tests__/useCertManager-caching.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-caching.test.ts
@@ -22,9 +22,11 @@ const mockUseClusters = vi.fn(() => ({
 }))
 const mockKubectlProxy = { exec: vi.fn() }
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 vi.mock('../useMCP', () => ({
   useClusters: () => mockUseClusters(),

--- a/web/src/hooks/__tests__/useCertManager-detection.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-detection.test.ts
@@ -22,9 +22,11 @@ const mockUseClusters = vi.fn(() => ({
 }))
 const mockKubectlProxy = { exec: vi.fn() }
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 vi.mock('../useMCP', () => ({
   useClusters: () => mockUseClusters(),

--- a/web/src/hooks/__tests__/useContextualNudges.test.ts
+++ b/web/src/hooks/__tests__/useContextualNudges.test.ts
@@ -9,11 +9,13 @@ const mockEmitNudgeShown = vi.fn()
 const mockEmitNudgeDismissed = vi.fn()
 const mockEmitNudgeActioned = vi.fn()
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitNudgeShown: (...args: unknown[]) => mockEmitNudgeShown(...args),
   emitNudgeDismissed: (...args: unknown[]) => mockEmitNudgeDismissed(...args),
   emitNudgeActioned: (...args: unknown[]) => mockEmitNudgeActioned(...args),
-}))
+}
+))
 
 // ---------------------------------------------------------------------------
 // Mock localStorage utilities — pass through to real localStorage

--- a/web/src/hooks/__tests__/useDashboardScrollTracking.test.ts
+++ b/web/src/hooks/__tests__/useDashboardScrollTracking.test.ts
@@ -8,9 +8,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
 // Mock the analytics module
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitDashboardScrolled: vi.fn(),
-}))
+}
+))
 
 import { useDashboardScrollTracking } from '../useDashboardScrollTracking'
 import { emitDashboardScrolled } from '../../lib/analytics'

--- a/web/src/hooks/__tests__/useDashboards.test.ts
+++ b/web/src/hooks/__tests__/useDashboards.test.ts
@@ -10,12 +10,14 @@ vi.mock('../../lib/api', () => ({
   },
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitDashboardCreated: vi.fn(),
   emitDashboardDeleted: vi.fn(),
   emitDashboardImported: vi.fn(),
   emitDashboardExported: vi.fn(),
-}))
+}
+))
 
 import { useDashboards } from '../useDashboards'
 import { api } from '../../lib/api'

--- a/web/src/hooks/__tests__/useDrillDown.test.tsx
+++ b/web/src/hooks/__tests__/useDrillDown.test.tsx
@@ -14,10 +14,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import type { ReactNode } from 'react'
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitDrillDownOpened: vi.fn(),
   emitDrillDownClosed: vi.fn(),
-}))
+}
+))
 
 import { DrillDownProvider, useDrillDown, useDrillDownActions } from '../useDrillDown'
 import type { DrillDownView } from '../useDrillDown'

--- a/web/src/hooks/__tests__/useFeatureHints.test.ts
+++ b/web/src/hooks/__tests__/useFeatureHints.test.ts
@@ -14,11 +14,13 @@ vi.mock('../../lib/constants/storage', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitFeatureHintShown: vi.fn(),
   emitFeatureHintDismissed: vi.fn(),
   emitFeatureHintActioned: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/utils/localStorage', () => ({
   safeGetJSON: vi.fn(() => null),

--- a/web/src/hooks/__tests__/useGPUReservations.test.ts
+++ b/web/src/hooks/__tests__/useGPUReservations.test.ts
@@ -20,9 +20,11 @@ vi.mock('../../lib/api', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 vi.mock('../useBackendHealth', () => ({
   isInClusterMode: vi.fn(() => false),

--- a/web/src/hooks/__tests__/useGPUUtilizations.test.ts
+++ b/web/src/hooks/__tests__/useGPUUtilizations.test.ts
@@ -15,7 +15,8 @@ vi.mock('../../lib/api', () => ({
   },
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockGetDemoMode() }),
   hasRealToken: () => mockHasRealToken(),
 }))

--- a/web/src/hooks/__tests__/useGitHubPipelines.test.ts
+++ b/web/src/hooks/__tests__/useGitHubPipelines.test.ts
@@ -38,7 +38,8 @@ vi.mock('../../lib/demoMode', () => ({
   isDemoMode: () => true,
   isNetlifyDeployment: false,
 }))
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
     createCachedHook: vi.fn(),
   getDemoMode: () => true,
   useDemoMode: () => ({ isDemoMode: true }),

--- a/web/src/hooks/__tests__/useGlobalFilters-edge-cases.test.tsx
+++ b/web/src/hooks/__tests__/useGlobalFilters-edge-cases.test.tsx
@@ -26,11 +26,13 @@ vi.mock('../mcp/clusters', () => ({
   useClusters: mockUseClusters,
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitGlobalClusterFilterChanged: mockEmitCluster,
   emitGlobalSeverityFilterChanged: mockEmitSeverity,
   emitGlobalStatusFilterChanged: mockEmitStatus,
-}))
+}
+))
 
 // ---------------------------------------------------------------------------
 // Imports (resolved after mocks are installed)

--- a/web/src/hooks/__tests__/useGlobalFilters-filter-funcs.test.tsx
+++ b/web/src/hooks/__tests__/useGlobalFilters-filter-funcs.test.tsx
@@ -26,11 +26,13 @@ vi.mock('../mcp/clusters', () => ({
   useClusters: mockUseClusters,
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitGlobalClusterFilterChanged: mockEmitCluster,
   emitGlobalSeverityFilterChanged: mockEmitSeverity,
   emitGlobalStatusFilterChanged: mockEmitStatus,
-}))
+}
+))
 
 // ---------------------------------------------------------------------------
 // Imports (resolved after mocks are installed)

--- a/web/src/hooks/__tests__/useGlobalFilters-init-selection.test.tsx
+++ b/web/src/hooks/__tests__/useGlobalFilters-init-selection.test.tsx
@@ -26,11 +26,13 @@ vi.mock('../mcp/clusters', () => ({
   useClusters: mockUseClusters,
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitGlobalClusterFilterChanged: mockEmitCluster,
   emitGlobalSeverityFilterChanged: mockEmitSeverity,
   emitGlobalStatusFilterChanged: mockEmitStatus,
-}))
+}
+))
 
 // ---------------------------------------------------------------------------
 // Imports (resolved after mocks are installed)

--- a/web/src/hooks/__tests__/useGroundControlDashboard.test.ts
+++ b/web/src/hooks/__tests__/useGroundControlDashboard.test.ts
@@ -20,9 +20,11 @@ vi.mock('../useDashboards', () => ({
   }),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitGroundControlDashboardCreated: mockEmitDashboardCreated,
-}))
+}
+))
 
 vi.mock('../../lib/utils/localStorage', () => ({
   safeGetJSON: <T,>(key: string): T | null => {

--- a/web/src/hooks/__tests__/useIntoto-deep.test.tsx
+++ b/web/src/hooks/__tests__/useIntoto-deep.test.tsx
@@ -26,7 +26,8 @@ vi.mock('../useCachedKubectlMulti', () => ({
   useCachedKubectlMulti: (...a: unknown[]) => mockUseCachedKubectl(...a),
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   getDemoMode: () => true,
   useDemoMode: () => ({ isDemoMode: true }),

--- a/web/src/hooks/__tests__/useIntoto-hook.test.tsx
+++ b/web/src/hooks/__tests__/useIntoto-hook.test.tsx
@@ -32,7 +32,8 @@ const {
   mockUnregisterCacheReset: vi.fn(),
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/__tests__/useKubectl.test.ts
+++ b/web/src/hooks/__tests__/useKubectl.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
 }))

--- a/web/src/hooks/__tests__/useKubescape.test.ts
+++ b/web/src/hooks/__tests__/useKubescape.test.ts
@@ -34,9 +34,11 @@ const mockUseDemoMode = vi.fn(() => ({
   setDemoMode: vi.fn(),
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: (...args: unknown[]) => mockUseDemoMode(...args),
-}))
+}
+))
 
 const mockRegisterRefetch = vi.fn(() => vi.fn())
 const mockRegisterCacheReset = vi.fn()

--- a/web/src/hooks/__tests__/useKyverno.test.ts
+++ b/web/src/hooks/__tests__/useKyverno.test.ts
@@ -26,7 +26,8 @@ vi.mock('../../lib/kubectlProxy', () => ({
   kubectlProxy: { exec: (...args: unknown[]) => mockExec(...args) },
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({
     isDemoMode: mockDemoMode,
     toggleDemoMode: vi.fn(),

--- a/web/src/hooks/__tests__/useLLMdModels.test.ts
+++ b/web/src/hooks/__tests__/useLLMdModels.test.ts
@@ -15,7 +15,8 @@ vi.mock('../useMCP', () => ({
 }))
 
 const mockGetDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: () => mockGetDemoMode(),
   useDemoMode: () => ({ isDemoMode: mockGetDemoMode() }),
 }))

--- a/web/src/hooks/__tests__/useLLMdServers-deep.test.ts
+++ b/web/src/hooks/__tests__/useLLMdServers-deep.test.ts
@@ -15,7 +15,8 @@ vi.mock('../useMCP', () => ({
 }))
 
 const mockGetDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: () => mockGetDemoMode(),
   useDemoMode: () => ({ isDemoMode: mockGetDemoMode() }),
 }))

--- a/web/src/hooks/__tests__/useLLMdServers-gpu.test.ts
+++ b/web/src/hooks/__tests__/useLLMdServers-gpu.test.ts
@@ -15,7 +15,8 @@ vi.mock('../useMCP', () => ({
 }))
 
 const mockGetDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: () => mockGetDemoMode(),
   useDemoMode: () => ({ isDemoMode: mockGetDemoMode() }),
 }))

--- a/web/src/hooks/__tests__/useLLMdServers-multicluster.test.ts
+++ b/web/src/hooks/__tests__/useLLMdServers-multicluster.test.ts
@@ -15,7 +15,8 @@ vi.mock('../useMCP', () => ({
 }))
 
 const mockGetDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: () => mockGetDemoMode(),
   useDemoMode: () => ({ isDemoMode: mockGetDemoMode() }),
 }))

--- a/web/src/hooks/__tests__/useLLMdServers.test.ts
+++ b/web/src/hooks/__tests__/useLLMdServers.test.ts
@@ -15,7 +15,8 @@ vi.mock('../useMCP', () => ({
 }))
 
 const mockGetDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: () => mockGetDemoMode(),
   useDemoMode: () => ({ isDemoMode: mockGetDemoMode() }),
 }))

--- a/web/src/hooks/__tests__/useLocalAgent.test.ts
+++ b/web/src/hooks/__tests__/useLocalAgent.test.ts
@@ -24,9 +24,11 @@ vi.mock('../mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   isDemoModeForced: false,
-}))
+}
+))
 
 vi.mock('../../lib/demoMode', () => ({
   isDemoMode: () => false,
@@ -39,12 +41,14 @@ const mockEmitAgentDisconnected = vi.fn()
 const mockEmitAgentProvidersDetected = vi.fn()
 const mockEmitConversionStep = vi.fn()
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitAgentConnected: (...args: unknown[]) => mockEmitAgentConnected(...args),
   emitAgentDisconnected: (...args: unknown[]) => mockEmitAgentDisconnected(...args),
   emitAgentProvidersDetected: (...args: unknown[]) => mockEmitAgentProvidersDetected(...args),
   emitConversionStep: (...args: unknown[]) => mockEmitConversionStep(...args),
-}))
+}
+))
 
 const mockSafeGetItem = vi.fn(() => null)
 const mockSafeSetItem = vi.fn()

--- a/web/src/hooks/__tests__/useLocalClusterTools-expand.test.ts
+++ b/web/src/hooks/__tests__/useLocalClusterTools-expand.test.ts
@@ -19,7 +19,8 @@ vi.mock('../useLocalAgent', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
   getDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/__tests__/useLocalClusterTools.advanced.test.ts
+++ b/web/src/hooks/__tests__/useLocalClusterTools.advanced.test.ts
@@ -19,7 +19,8 @@ vi.mock('../useLocalAgent', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
   getDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/__tests__/useLocalClusterTools.crud.test.ts
+++ b/web/src/hooks/__tests__/useLocalClusterTools.crud.test.ts
@@ -19,7 +19,8 @@ vi.mock('../useLocalAgent', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
   getDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/__tests__/useLocalClusterTools.init.test.ts
+++ b/web/src/hooks/__tests__/useLocalClusterTools.init.test.ts
@@ -19,7 +19,8 @@ vi.mock('../useLocalAgent', () => ({
 }))
 
 const mockIsDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
   getDemoMode: () => mockIsDemoMode(),
 }))

--- a/web/src/hooks/__tests__/useMCS.test.ts
+++ b/web/src/hooks/__tests__/useMCS.test.ts
@@ -14,7 +14,8 @@ import { renderHook, waitFor, act } from '@testing-library/react'
 
 let mockDemoMode = false
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockDemoMode }),
 }))
 

--- a/web/src/hooks/__tests__/useMarketplace.test.ts
+++ b/web/src/hooks/__tests__/useMarketplace.test.ts
@@ -33,11 +33,13 @@ vi.mock('../../lib/themes', () => ({
 const mockEmitInstall = vi.fn()
 const mockEmitRemove = vi.fn()
 const mockEmitInstallFailed = vi.fn()
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitMarketplaceInstall: (...args: unknown[]) => mockEmitInstall(...args),
   emitMarketplaceRemove: (...args: unknown[]) => mockEmitRemove(...args),
   emitMarketplaceInstallFailed: (...args: unknown[]) => mockEmitInstallFailed(...args),
-}))
+}
+))
 
 vi.mock('../../lib/constants/network', () => ({
   FETCH_EXTERNAL_TIMEOUT_MS: 15000,

--- a/web/src/hooks/__tests__/useMissionStorage.test.ts
+++ b/web/src/hooks/__tests__/useMissionStorage.test.ts
@@ -5,7 +5,8 @@ const { mockGetDemoMode } = vi.hoisted(() => ({
   mockGetDemoMode: vi.fn(() => false),
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/__tests__/useMissions-internals.test.ts
+++ b/web/src/hooks/__tests__/useMissions-internals.test.ts
@@ -6,11 +6,13 @@ vi.mock('../mcp/shared', () => ({
   REFRESH_INTERVAL_MS: 120_000,
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
   default: vi.fn(() => false),
-}))
+}
+))
 vi.mock('../useLocalAgent', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../useLocalAgent')>()
   return {
@@ -44,7 +46,8 @@ vi.mock('../../lib/constants', async (importOriginal) => {
     LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
   }
 })
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -52,7 +55,8 @@ vi.mock('../../lib/analytics', () => ({
   emitAgentTokenFailure: vi.fn(),
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
-}))
+}
+))
 
 const { __missionsTestables } = await import('../useMissions')
 

--- a/web/src/hooks/__tests__/useMissions.actions.test.ts
+++ b/web/src/hooks/__tests__/useMissions.actions.test.ts
@@ -27,9 +27,11 @@ vi.mock('../useMissions.messaging', () => ({
   })),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitMissionRated: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/logger', () => ({
   logger: {

--- a/web/src/hooks/__tests__/useMissions.connection.test.ts
+++ b/web/src/hooks/__tests__/useMissions.connection.test.ts
@@ -7,11 +7,13 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
   default: vi.fn(() => false),
-}))
+}
+))
 
 vi.mock('../useLocalAgent', () => ({
   useLocalAgent: vi.fn(() => ({ isConnected: false })),
@@ -24,7 +26,8 @@ vi.mock('../mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionStarted: vi.fn(),
@@ -32,7 +35,8 @@ vi.mock('../../lib/analytics', () => ({
   emitAgentTokenFailure: vi.fn(),
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/constants', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>

--- a/web/src/hooks/__tests__/useMissions.execution.test.ts
+++ b/web/src/hooks/__tests__/useMissions.execution.test.ts
@@ -49,10 +49,12 @@ vi.mock('../../lib/kagentiProviderBackend', () => ({
   kagentiProviderChat: vi.fn(),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/logger', () => ({
   logger: {

--- a/web/src/hooks/__tests__/useMissions.messages.test.ts
+++ b/web/src/hooks/__tests__/useMissions.messages.test.ts
@@ -15,11 +15,13 @@ vi.mock('../useTokenUsage', () => ({
   clearActiveTokenCategory: vi.fn(),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
   emitMissionToolMissing: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/tokenUsageMissionCategory', () => ({
   getTokenCategoryForMissionType: vi.fn(() => 'custom'),

--- a/web/src/hooks/__tests__/useMissions.messaging.test.ts
+++ b/web/src/hooks/__tests__/useMissions.messaging.test.ts
@@ -24,10 +24,12 @@ vi.mock('../../lib/kagentiProviderBackend', () => ({
   kagentiProviderChat: vi.fn(),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
-}))
+}
+))
 
 vi.mock('../useMissions.helpers', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../useMissions.helpers')>()

--- a/web/src/hooks/__tests__/useMissions.start.test.ts
+++ b/web/src/hooks/__tests__/useMissions.start.test.ts
@@ -17,10 +17,12 @@ vi.mock('../useMissionPromptBuilder', () => ({
   buildSystemMessages: vi.fn(() => []),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitError: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/missions/preflightCheck', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../lib/missions/preflightCheck')>()

--- a/web/src/hooks/__tests__/useMissions.state.test.ts
+++ b/web/src/hooks/__tests__/useMissions.state.test.ts
@@ -7,10 +7,12 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
-}))
+}
+))
 
 vi.mock('../useMissions.helpers', () => ({
   canAutoCompleteMissionFromResponse: vi.fn(({

--- a/web/src/hooks/__tests__/useMissions.test.tsx
+++ b/web/src/hooks/__tests__/useMissions.test.tsx
@@ -23,7 +23,8 @@ vi.mock('../mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -69,7 +70,8 @@ vi.mock('../../lib/constants', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -78,7 +80,8 @@ vi.mock('../../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitMissionToolMissing: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/logger', () => ({
   logger: {

--- a/web/src/hooks/__tests__/useNPSSurvey.test.ts
+++ b/web/src/hooks/__tests__/useNPSSurvey.test.ts
@@ -40,15 +40,19 @@ vi.mock('../../lib/api', () => ({
   api: { post: mockApiPost },
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitNPSSurveyShown: (...args: unknown[]) => mockEmitShown(...args),
   emitNPSResponse: (...args: unknown[]) => mockEmitResponse(...args),
   emitNPSDismissed: (...args: unknown[]) => mockEmitDismissed(...args),
-}))
+}
+))
 
-vi.mock('../../lib/analytics-session', () => ({
+vi.mock('../../lib/analytics-session', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics-session')>()),
   peekSessionEngagementMs: () => mockPeekSessionEngagementMs(),
-}))
+}
+))
 
 vi.mock('../../lib/utils/localStorage', () => ({
   safeGetItem: (key: string) => store.get(key) ?? null,

--- a/web/src/hooks/__tests__/useOrbitAutoRun.test.ts
+++ b/web/src/hooks/__tests__/useOrbitAutoRun.test.ts
@@ -36,9 +36,11 @@ vi.mock('../../components/ui/Toast', () => ({
   useToast: () => ({ showToast: mockShowToast }),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitOrbitMissionRun: mockEmitOrbitMissionRun,
-}))
+}
+))
 
 import { useOrbitAutoRun } from '../useOrbitAutoRun'
 

--- a/web/src/hooks/__tests__/usePredictionFeedback-expand.test.ts
+++ b/web/src/hooks/__tests__/usePredictionFeedback-expand.test.ts
@@ -28,9 +28,11 @@ vi.mock('../../lib/constants/network', async (importOriginal) => {
   return { ...actual, FETCH_DEFAULT_TIMEOUT_MS: 10000 }
 })
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitPredictionFeedbackSubmitted: vi.fn(),
-}))
+}
+))
 
 import { usePredictionFeedback, getFeedbackContext } from '../usePredictionFeedback'
 

--- a/web/src/hooks/__tests__/usePredictionFeedback.test.ts
+++ b/web/src/hooks/__tests__/usePredictionFeedback.test.ts
@@ -12,9 +12,11 @@ vi.mock('../../lib/constants/network', async (importOriginal) => {
   FETCH_DEFAULT_TIMEOUT_MS: 10000,
 } })
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitPredictionFeedbackSubmitted: vi.fn(),
-}))
+}
+))
 
 import { usePredictionFeedback } from '../usePredictionFeedback'
 

--- a/web/src/hooks/__tests__/useProviderHealth.test.ts
+++ b/web/src/hooks/__tests__/useProviderHealth.test.ts
@@ -22,10 +22,12 @@ vi.mock('../useLocalAgent', () => ({
   reportAgentDataError: vi.fn(),
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
     createCachedHook: vi.fn(),
   getDemoMode: vi.fn(() => false),
-  useDemoMode: vi.fn(() => ({ isDemoMode: false })),
+  useDemoMode: vi.fn(() => ({ isDemoMode: false }
+)),
 }))
 
 vi.mock('../../lib/constants/network', async (importOriginal) => {

--- a/web/src/hooks/__tests__/useProw.test.ts
+++ b/web/src/hooks/__tests__/useProw.test.ts
@@ -17,9 +17,11 @@ vi.mock('../../lib/constants/network', async (importOriginal) => {
 })
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 import { useProwJobs, getDemoProwJobs } from '../useProw'
 import type { ProwJob } from '../useProw'

--- a/web/src/hooks/__tests__/useRBACFindings.test.ts
+++ b/web/src/hooks/__tests__/useRBACFindings.test.ts
@@ -26,7 +26,8 @@ vi.mock('../../lib/kubectlProxy', () => ({
   kubectlProxy: { exec: (...args: unknown[]) => mockExec(...args) },
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({
     isDemoMode: mockDemoMode,
     toggleDemoMode: vi.fn(),

--- a/web/src/hooks/__tests__/useResolutions.edge-cases.test.ts
+++ b/web/src/hooks/__tests__/useResolutions.edge-cases.test.ts
@@ -8,9 +8,11 @@ vi.mock('../../lib/auth', () => ({
   useAuth: () => mockUseAuth(),
 }))
 
-vi.mock('../../lib/analytics-session', () => ({
+vi.mock('../../lib/analytics-session', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics-session')>()),
   getOrCreateAnonymousId: () => mockGetOrCreateAnonymousId(),
-}))
+}
+))
 
 import {
   detectIssueSignature,

--- a/web/src/hooks/__tests__/useRewards-pure.test.ts
+++ b/web/src/hooks/__tests__/useRewards-pure.test.ts
@@ -10,7 +10,8 @@ vi.mock('../../lib/demoMode', () => ({
   isNetlifyDeployment: vi.fn(() => false),
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: mockGetDemoMode,
   useDemoMode: () => ({ isDemoMode: false }),
 }))

--- a/web/src/hooks/__tests__/useRewards.test.ts
+++ b/web/src/hooks/__tests__/useRewards.test.ts
@@ -16,10 +16,12 @@ vi.mock('../../lib/demoMode', () => ({
   getDemoMode: () => mockGetDemoMode(),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitEvent: vi.fn(),
   emitRewardUnlocked: vi.fn(),
-}))
+}
+))
 
 const mockUser = { id: 'test-user-123', github_login: 'tester' }
 const mockUseAuth = vi.fn(() => ({ user: mockUser, isAuthenticated: true }))

--- a/web/src/hooks/__tests__/useRewards.test.tsx
+++ b/web/src/hooks/__tests__/useRewards.test.tsx
@@ -4,12 +4,15 @@ import { renderHook, act } from '@testing-library/react'
 
 // ---------- Mocks ----------
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitEvent: vi.fn(),
   emitRewardUnlocked: vi.fn(),
-}))
+}
+))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: vi.fn(() => false),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))

--- a/web/src/hooks/__tests__/useSidebarConfig.test.ts
+++ b/web/src/hooks/__tests__/useSidebarConfig.test.ts
@@ -8,8 +8,10 @@ vi.mock('../mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('../useDemoMode', () => ({
-  useDemoMode: vi.fn(() => ({ isDemoMode: true })),
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
+  useDemoMode: vi.fn(() => ({ isDemoMode: true }
+)),
 }))
 
 vi.mock('../useBackendHealth', () => ({
@@ -20,9 +22,11 @@ vi.mock('../useBackendHealth', () => ({
   })),
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitEvent: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/constants/network', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>

--- a/web/src/hooks/__tests__/useSnoozedAlerts.test.ts
+++ b/web/src/hooks/__tests__/useSnoozedAlerts.test.ts
@@ -10,10 +10,12 @@ vi.mock('../../lib/constants/network', async (importOriginal) => {
 const mockEmitSnoozed = vi.fn()
 const mockEmitUnsnoozed = vi.fn()
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitSnoozed: (...args: unknown[]) => mockEmitSnoozed(...args),
   emitUnsnoozed: (...args: unknown[]) => mockEmitUnsnoozed(...args),
-}))
+}
+))
 
 import { useSnoozedAlerts, SNOOZE_DURATIONS, formatSnoozeRemaining } from '../useSnoozedAlerts'
 

--- a/web/src/hooks/__tests__/useSnoozedCards.test.ts
+++ b/web/src/hooks/__tests__/useSnoozedCards.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitSnoozed: vi.fn(),
   emitUnsnoozed: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/constants/network', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>

--- a/web/src/hooks/__tests__/useSnoozedMissions.test.ts
+++ b/web/src/hooks/__tests__/useSnoozedMissions.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import type { MissionSuggestion } from '../useMissionSuggestions'
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitSnoozed: vi.fn(),
   emitUnsnoozed: vi.fn(),
-}))
+}
+))
 
 const STORAGE_KEY = 'kubestellar-snoozed-missions'
 const NOW_MS = 1_700_000_000_000

--- a/web/src/hooks/__tests__/useSnoozedRecommendations.test.ts
+++ b/web/src/hooks/__tests__/useSnoozedRecommendations.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitSnoozed: vi.fn(),
   emitUnsnoozed: vi.fn(),
-}))
+}
+))
 
 import { useSnoozedRecommendations } from '../useSnoozedRecommendations'
 

--- a/web/src/hooks/__tests__/useStackDiscovery-expand.test.ts
+++ b/web/src/hooks/__tests__/useStackDiscovery-expand.test.ts
@@ -6,7 +6,8 @@ import { renderHook, act } from '@testing-library/react'
 const mockGetDemoMode = vi.fn(() => false)
 const mockExec = vi.fn()
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/__tests__/useStackDiscovery.test.ts
+++ b/web/src/hooks/__tests__/useStackDiscovery.test.ts
@@ -6,7 +6,8 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 const mockGetDemoMode = vi.fn(() => false)
 const mockExec = vi.fn()
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/__tests__/useTheme.test.tsx
+++ b/web/src/hooks/__tests__/useTheme.test.tsx
@@ -23,9 +23,11 @@ function hrefHasHostname(el: Element, hostname: string): boolean {
 // ---------------------------------------------------------------------------
 const mockEmitThemeChanged = vi.hoisted(() => vi.fn())
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitThemeChanged: mockEmitThemeChanged,
-}))
+}
+))
 
 // ---------------------------------------------------------------------------
 // Import after mocks are wired

--- a/web/src/hooks/__tests__/useTour.test.tsx
+++ b/web/src/hooks/__tests__/useTour.test.tsx
@@ -6,12 +6,14 @@ import React from 'react'
 // Mocks
 // ============================================================================
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitEvent: vi.fn(),
   emitTourStarted: vi.fn(),
   emitTourCompleted: vi.fn(),
   emitTourSkipped: vi.fn(),
-}))
+}
+))
 
 const mockIsMobile = vi.fn(() => false)
 vi.mock('../useMobile', () => ({

--- a/web/src/hooks/__tests__/useTrestle-expand.test.ts
+++ b/web/src/hooks/__tests__/useTrestle-expand.test.ts
@@ -21,7 +21,8 @@ vi.mock('../../lib/kubectlProxy', () => ({
   kubectlProxy: { exec: (...args: unknown[]) => mockExec(...args) },
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockDemoMode }),
 }))
 

--- a/web/src/hooks/__tests__/useTrestle.test.ts
+++ b/web/src/hooks/__tests__/useTrestle.test.ts
@@ -25,7 +25,8 @@ vi.mock('../../lib/kubectlProxy', () => ({
   kubectlProxy: { exec: (...args: unknown[]) => mockExec(...args) },
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockDemoMode }),
 }))
 

--- a/web/src/hooks/__tests__/useTrivy.test.ts
+++ b/web/src/hooks/__tests__/useTrivy.test.ts
@@ -34,9 +34,11 @@ const mockUseDemoMode = vi.fn(() => ({
   setDemoMode: vi.fn(),
 }))
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: (...args: unknown[]) => mockUseDemoMode(...args),
-}))
+}
+))
 
 const mockRegisterRefetch = vi.fn(() => vi.fn())
 const mockRegisterCacheReset = vi.fn()

--- a/web/src/hooks/__tests__/useUsers-pure.test.ts
+++ b/web/src/hooks/__tests__/useUsers-pure.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setStoredAuthToken } from '../../lib/authToken'
 
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: vi.fn(() => true),
   isDemoModeForced: false,
   useDemoMode: () => ({ isDemoMode: true }),

--- a/web/src/hooks/__tests__/useUsers.core.test.ts
+++ b/web/src/hooks/__tests__/useUsers.core.test.ts
@@ -26,7 +26,8 @@ vi.mock('../../lib/constants', async (importOriginal) => {
 })
 
 const mockGetDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: () => mockGetDemoMode(),
   isDemoModeForced: false,
   isNetlifyDeployment: () => false,
@@ -35,7 +36,8 @@ vi.mock('../useDemoMode', () => ({
   hasRealToken: () => false,
   setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
 const mockAgentFetch = vi.fn((...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])))
 vi.mock('../mcp/shared', () => ({

--- a/web/src/hooks/__tests__/useUsers.coverage.test.ts
+++ b/web/src/hooks/__tests__/useUsers.coverage.test.ts
@@ -26,7 +26,8 @@ vi.mock('../../lib/constants', async (importOriginal) => {
 })
 
 const mockGetDemoMode = vi.fn(() => false)
-vi.mock('../useDemoMode', () => ({
+vi.mock('../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useDemoMode')>()),
   getDemoMode: () => mockGetDemoMode(),
   isDemoModeForced: false,
   isNetlifyDeployment: () => false,
@@ -35,7 +36,8 @@ vi.mock('../useDemoMode', () => ({
   hasRealToken: () => false,
   setDemoToken: vi.fn(),
   setGlobalDemoMode: vi.fn(),
-}))
+}
+))
 
 const mockAgentFetch = vi.fn((...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])))
 vi.mock('../mcp/shared', () => ({

--- a/web/src/hooks/__tests__/useVersionCheck.fetch.test.tsx
+++ b/web/src/hooks/__tests__/useVersionCheck.fetch.test.tsx
@@ -38,9 +38,11 @@ vi.mock('../useLocalAgent', () => ({
     useLocalAgent: mockUseLocalAgent,
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
     emitSessionContext: vi.fn(),
-}))
+}
+))
 
 function wrapper({ children }: { children: React.ReactNode }) {
     return <VersionCheckProvider>{children}</VersionCheckProvider>

--- a/web/src/hooks/__tests__/useVersionCheck.provider.test.tsx
+++ b/web/src/hooks/__tests__/useVersionCheck.provider.test.tsx
@@ -37,9 +37,11 @@ vi.mock('../useLocalAgent', () => ({
     useLocalAgent: mockUseLocalAgent,
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
     emitSessionContext: vi.fn(),
-}))
+}
+))
 
 function wrapper({ children }: { children: React.ReactNode }) {
     return <VersionCheckProvider>{children}</VersionCheckProvider>

--- a/web/src/hooks/__tests__/useVersionCheck.state.test.tsx
+++ b/web/src/hooks/__tests__/useVersionCheck.state.test.tsx
@@ -37,9 +37,11 @@ vi.mock('../useLocalAgent', () => ({
     useLocalAgent: mockUseLocalAgent,
 }))
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
     emitSessionContext: vi.fn(),
-}))
+}
+))
 
 function wrapper({ children }: { children: React.ReactNode }) {
     return <VersionCheckProvider>{children}</VersionCheckProvider>

--- a/web/src/hooks/__tests__/useVisitStreak.test.ts
+++ b/web/src/hooks/__tests__/useVisitStreak.test.ts
@@ -18,9 +18,11 @@ vi.mock('../../lib/constants/storage', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitStreakDay: vi.fn(),
-}))
+}
+))
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/web/src/hooks/mcp/__tests__/agentFetch.test.ts
+++ b/web/src/hooks/mcp/__tests__/agentFetch.test.ts
@@ -14,9 +14,11 @@ vi.mock('../../../lib/demoMode', async (importOriginal) => {
     isNetlifyDeployment: false,
   }
 })
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitAgentTokenFailure: mockEmitAgentTokenFailure,
-}))
+}
+))
 vi.mock('../../../lib/constants', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../lib/constants')>()
   return {

--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
@@ -42,7 +42,8 @@ vi.mock('../../../lib/demoMode', () => ({
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage2.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage2.test.ts
@@ -33,7 +33,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },
 }))
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 vi.mock('../../../lib/modeTransition', () => ({

--- a/web/src/hooks/mcp/__tests__/buildpacks.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks.test.ts
@@ -31,7 +31,8 @@ vi.mock('../../../lib/demoMode', () => ({
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/clusters.dedup.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.dedup.test.ts
@@ -92,7 +92,8 @@ vi.mock('../../../lib/demoMode', () => ({
   subscribeDemoMode: vi.fn(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/clusters.health.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.health.test.ts
@@ -93,7 +93,8 @@ vi.mock('../../../lib/demoMode', () => ({
   subscribeDemoMode: vi.fn(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/clusters.list.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.list.test.ts
@@ -92,9 +92,11 @@ vi.mock('../../../lib/demoMode', () => ({
   subscribeDemoMode: vi.fn(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 vi.mock('../../useLocalAgent', () => ({
   triggerAggressiveDetection: mockTriggerAggressiveDetection,

--- a/web/src/hooks/mcp/__tests__/clusters.mcp-status.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.mcp-status.test.ts
@@ -29,7 +29,8 @@ const {
   },
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/clusters.smoke.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.smoke.test.ts
@@ -29,7 +29,8 @@ const {
   },
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/compute.gpu.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.gpu.test.ts
@@ -47,7 +47,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/compute.nodes.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.nodes.test.ts
@@ -47,7 +47,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/compute.nvidia.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.nvidia.test.ts
@@ -51,7 +51,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/compute.smoke.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.smoke.test.ts
@@ -39,7 +39,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/config-agent-sse.test.ts
+++ b/web/src/hooks/mcp/__tests__/config-agent-sse.test.ts
@@ -34,7 +34,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/config-basic.test.ts
+++ b/web/src/hooks/mcp/__tests__/config-basic.test.ts
@@ -34,7 +34,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/config-fallback-modes.test.ts
+++ b/web/src/hooks/mcp/__tests__/config-fallback-modes.test.ts
@@ -34,7 +34,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/crossplane-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/crossplane-coverage.test.ts
@@ -33,7 +33,8 @@ vi.mock('../../../lib/demoMode', () => ({
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/crossplane.test.ts
+++ b/web/src/hooks/mcp/__tests__/crossplane.test.ts
@@ -31,7 +31,8 @@ vi.mock('../../../lib/demoMode', () => ({
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/events.test.ts
+++ b/web/src/hooks/mcp/__tests__/events.test.ts
@@ -42,7 +42,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/helm-branches.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-branches.test.ts
@@ -35,7 +35,8 @@ vi.mock('../../../lib/demoMode', () => ({
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/helm-core.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-core.test.ts
@@ -35,7 +35,8 @@ vi.mock('../../../lib/demoMode', () => ({
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/helm-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-coverage.test.ts
@@ -35,7 +35,8 @@ vi.mock('../../../lib/demoMode', () => ({
   get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/networking-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking-pure.test.ts
@@ -8,7 +8,8 @@ vi.mock('../../useLocalAgent', () => ({
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: vi.fn().mockReturnValue(false),
 }))
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
 }))
 vi.mock('../../../lib/modeTransition', () => ({

--- a/web/src/hooks/mcp/__tests__/networking.hooks.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking.hooks.test.ts
@@ -30,7 +30,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/operators-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/operators-pure.test.ts
@@ -5,7 +5,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: vi.fn().mockReturnValue(false),
 }))
 vi.mock('../../../lib/sseClient', () => ({ fetchSSE: vi.fn() }))
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
 }))
 vi.mock('../../../lib/modeTransition', () => ({

--- a/web/src/hooks/mcp/__tests__/operators.test.ts
+++ b/web/src/hooks/mcp/__tests__/operators.test.ts
@@ -32,7 +32,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/rbac.test.ts
+++ b/web/src/hooks/mcp/__tests__/rbac.test.ts
@@ -21,7 +21,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/security.test.ts
+++ b/web/src/hooks/mcp/__tests__/security.test.ts
@@ -30,7 +30,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/shared-distribution.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-distribution.test.ts
@@ -7,9 +7,11 @@ vi.mock('../../../lib/demoMode', () => ({
   subscribeDemoMode: vi.fn(),
 }))
 
-vi.mock('../../../lib/analytics', () => ({
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitClusterDiscovery: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../../lib/kubectlProxy', () => ({
   kubectlProxy: { exec: vi.fn(), isConnected: vi.fn().mockReturnValue(false) },

--- a/web/src/hooks/mcp/__tests__/storage.hooks.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage.hooks.test.ts
@@ -28,7 +28,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
@@ -48,7 +48,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/workloads.branches.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.branches.test.ts
@@ -52,7 +52,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/workloads.core.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.core.test.ts
@@ -52,7 +52,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
@@ -54,7 +54,8 @@ vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => mockIsDemoMode(),
 }))
 
-vi.mock('../../useDemoMode', () => ({
+vi.mock('../../useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/hooks/useDrillDown.actions.test.tsx
+++ b/web/src/hooks/useDrillDown.actions.test.tsx
@@ -7,10 +7,12 @@ import { emitDrillDownOpened, emitDrillDownClosed } from '../lib/analytics'
 
 // ── External module mocks ─────────────────────────────────────────────────────
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitDrillDownOpened: vi.fn(),
   emitDrillDownClosed: vi.fn(),
-}))
+}
+))
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/web/src/hooks/useDrillDown.core.test.tsx
+++ b/web/src/hooks/useDrillDown.core.test.tsx
@@ -7,10 +7,12 @@ import { emitDrillDownOpened, emitDrillDownClosed } from '../lib/analytics'
 
 // ── External module mocks ─────────────────────────────────────────────────────
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitDrillDownOpened: vi.fn(),
   emitDrillDownClosed: vi.fn(),
-}))
+}
+))
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/web/src/hooks/useDrillDown.edgecases.test.tsx
+++ b/web/src/hooks/useDrillDown.edgecases.test.tsx
@@ -7,10 +7,12 @@ import { emitDrillDownOpened, emitDrillDownClosed } from '../lib/analytics'
 
 // ── External module mocks ─────────────────────────────────────────────────────
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitDrillDownOpened: vi.fn(),
   emitDrillDownClosed: vi.fn(),
-}))
+}
+))
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/web/src/hooks/useFederation.test.ts
+++ b/web/src/hooks/useFederation.test.ts
@@ -3,7 +3,8 @@ import { renderHook, act } from '@testing-library/react'
 
 const mockIsDemoMode = vi.fn(() => false)
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   isDemoModeForced: false,
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
 }))

--- a/web/src/hooks/useMissionStorage.test.ts
+++ b/web/src/hooks/useMissionStorage.test.ts
@@ -14,7 +14,8 @@ import {
 } from './useMissionStorage'
 import type { Mission } from './useMissionTypes'
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
 }))

--- a/web/src/hooks/useMissions-agent-selection.test.tsx
+++ b/web/src/hooks/useMissions-agent-selection.test.tsx
@@ -15,7 +15,8 @@ vi.mock('./mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -58,7 +59,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -67,7 +69,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions-execution.test.tsx
+++ b/web/src/hooks/useMissions-execution.test.tsx
@@ -15,7 +15,8 @@ vi.mock('./mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -58,7 +59,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -67,7 +69,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions-operations.test.tsx
+++ b/web/src/hooks/useMissions-operations.test.tsx
@@ -15,7 +15,8 @@ vi.mock('./mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -58,7 +59,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -67,7 +69,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions.edgecases.connection-state.test.tsx
+++ b/web/src/hooks/useMissions.edgecases.connection-state.test.tsx
@@ -14,7 +14,8 @@ vi.mock('./mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -57,7 +58,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -66,7 +68,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions.edgecases.interactions.test.tsx
+++ b/web/src/hooks/useMissions.edgecases.interactions.test.tsx
@@ -15,7 +15,8 @@ vi.mock('./mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -58,7 +59,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -67,7 +69,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions.edgecases.startup.test.tsx
+++ b/web/src/hooks/useMissions.edgecases.startup.test.tsx
@@ -14,7 +14,8 @@ vi.mock('./mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -57,7 +58,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -66,7 +68,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions.messages-stream.test.tsx
+++ b/web/src/hooks/useMissions.messages-stream.test.tsx
@@ -12,7 +12,8 @@ vi.mock('./mcp/agentFetch', () => ({
   agentFetch: vi.fn((...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?]))),
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -55,7 +56,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -64,7 +66,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions.preflight-agents.test.tsx
+++ b/web/src/hooks/useMissions.preflight-agents.test.tsx
@@ -16,7 +16,8 @@ vi.mock('./mcp/agentFetch', () => ({
   agentFetch: vi.fn((...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?]))),
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -59,7 +60,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitError: vi.fn(),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
@@ -69,7 +71,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions.provider-start.test.tsx
+++ b/web/src/hooks/useMissions.provider-start.test.tsx
@@ -15,7 +15,8 @@ vi.mock('./mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -58,7 +59,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -67,7 +69,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions.save-run.test.tsx
+++ b/web/src/hooks/useMissions.save-run.test.tsx
@@ -15,7 +15,8 @@ vi.mock('./mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
 }))
@@ -62,7 +63,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -71,7 +73,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions.state-persist.test.tsx
+++ b/web/src/hooks/useMissions.state-persist.test.tsx
@@ -14,7 +14,8 @@ vi.mock('./mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -57,7 +58,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -66,7 +68,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions.websocket-reconnect.connection.test.tsx
+++ b/web/src/hooks/useMissions.websocket-reconnect.connection.test.tsx
@@ -10,7 +10,8 @@ vi.mock('./mcp/agentFetch', () => ({
   agentFetch: vi.fn((...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?]))),
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -53,7 +54,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -62,7 +64,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions.websocket-reconnect.error-token.test.tsx
+++ b/web/src/hooks/useMissions.websocket-reconnect.error-token.test.tsx
@@ -11,7 +11,8 @@ vi.mock('./mcp/agentFetch', () => ({
   agentFetch: vi.fn((...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?]))),
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -54,7 +55,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -63,7 +65,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/hooks/useMissions.websocket-reconnect.state-stream.test.tsx
+++ b/web/src/hooks/useMissions.websocket-reconnect.state-stream.test.tsx
@@ -10,7 +10,8 @@ vi.mock('./mcp/agentFetch', () => ({
   agentFetch: vi.fn((...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?]))),
 }))
 
-vi.mock('./useDemoMode', () => ({
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
@@ -53,7 +54,8 @@ vi.mock('../lib/constants', async (importOriginal) => {
   LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
 } })
 
-vi.mock('../lib/analytics', () => ({
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),
@@ -62,7 +64,8 @@ vi.mock('../lib/analytics', () => ({
   emitWsAuthMissing: vi.fn(),
   emitSseAuthFailure: vi.fn(),
   emitSessionRefreshFailure: vi.fn(),
-}))
+}
+))
 
 vi.mock('../lib/missions/preflightCheck', () => ({
   runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),

--- a/web/src/lib/__tests__/iconSuggester.test.ts
+++ b/web/src/lib/__tests__/iconSuggester.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { suggestIconSync, suggestDashboardIcon } from '../iconSuggester'
 
 // Mock the getDemoMode dependency
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 

--- a/web/src/lib/unified/__tests__/index.test.ts
+++ b/web/src/lib/unified/__tests__/index.test.ts
@@ -9,13 +9,15 @@ import { describe, it, expect, vi } from 'vitest'
 // Mock heavy dependencies to keep the test fast and prevent transitive import errors.
 // The paths are relative to the importing module, so we need multiple patterns.
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
   getDemoMode: () => false,
   isDemoModeForced: false,
 }))
 
-vi.mock('../../hooks/useDemoMode', () => ({
+vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
   getDemoMode: () => false,
   isDemoModeForced: false,

--- a/web/src/lib/unified/__tests__/registerHooks-coverage.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-coverage.test.ts
@@ -81,11 +81,13 @@ const {
   mockUseDemoMode: vi.fn().mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
   getDemoMode: () => false,
   isDemoModeForced: false,
-}))
+}
+))
 
 vi.mock('../../../hooks/useCachedData', () => ({
   useCachedPodIssues: (...args: unknown[]) => mockUseCachedPodIssues(...args),

--- a/web/src/lib/unified/__tests__/registerHooks-deep.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-deep.test.ts
@@ -17,11 +17,13 @@ const { mockUseDemoMode } = vi.hoisted(() => ({
   mockUseDemoMode: vi.fn().mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
   getDemoMode: () => mockUseDemoMode().isDemoMode,
   isDemoModeForced: false,
-}))
+}
+))
 
 vi.mock('../../../hooks/useCachedData', () => ({
   useCachedPodIssues: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),

--- a/web/src/lib/unified/__tests__/registerHooks-expand.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-expand.test.ts
@@ -26,11 +26,13 @@ const { mockUseDemoMode, mockUseCachedEvents } = vi.hoisted(() => ({
   mockUseCachedEvents: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
   getDemoMode: () => mockUseDemoMode().isDemoMode,
   isDemoModeForced: false,
-}))
+}
+))
 
 vi.mock('../../../hooks/useCachedData', () => ({
   useCachedPodIssues: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() }),

--- a/web/src/lib/unified/__tests__/registerHooks-expand2.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-expand2.test.ts
@@ -80,7 +80,8 @@ const {
   mockK8sRoleBindings: vi.fn(() => ({ bindings: [], isLoading: false, error: null, refetch: vi.fn() })),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockDemoMode() }),
   getDemoMode: () => mockDemoMode(),
   isDemoModeForced: false,

--- a/web/src/lib/unified/__tests__/registerHooks-hooks.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-hooks.test.ts
@@ -96,11 +96,13 @@ vi.mock('../card/hooks/useDataSource', () => ({
   },
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
   getDemoMode: () => mockUseDemoMode().isDemoMode,
   isDemoModeForced: false,
-}))
+}
+))
 
 vi.mock('../../../hooks/useCachedData', () => ({
   useCachedPodIssues: (...a: unknown[]) => mockUseCachedPodIssues(...a),

--- a/web/src/lib/unified/__tests__/registerHooks-wrappers.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-wrappers.test.ts
@@ -81,11 +81,13 @@ const {
   mockUseDemoMode: vi.fn().mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
 }))
 
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
   getDemoMode: () => false,
   isDemoModeForced: false,
-}))
+}
+))
 
 vi.mock('../../../hooks/useCachedData', () => ({
   useCachedPodIssues: (...args: unknown[]) => mockUseCachedPodIssues(...args),

--- a/web/src/lib/unified/__tests__/registerHooks.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks.test.ts
@@ -26,7 +26,8 @@ function getRegisteredNames(): string[] {
 }
 
 // ── Mock all upstream hooks (prevent real imports) ───────────────────
-vi.mock('../../../hooks/useDemoMode', () => ({
+vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: true }),
   getDemoMode: () => true,
   isDemoModeForced: false,

--- a/web/src/lib/unified/demo/__tests__/UnifiedDemo.test.tsx
+++ b/web/src/lib/unified/demo/__tests__/UnifiedDemo.test.tsx
@@ -25,7 +25,8 @@ const mockToggleDemoMode = vi.fn()
 const mockSetDemoMode = vi.fn()
 let mockIsDemoMode = false
 
-vi.mock('../../../../hooks/useDemoMode', () => ({
+vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({
     isDemoMode: mockIsDemoMode,
     toggleDemoMode: mockToggleDemoMode,

--- a/web/src/pages/EmbedCard.test.tsx
+++ b/web/src/pages/EmbedCard.test.tsx
@@ -38,9 +38,11 @@ vi.mock('react-i18next', () => ({
 }))
 
 const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }))
-vi.mock('../hooks/useDemoMode', () => ({
+vi.mock('../hooks/useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
-}))
+}
+))
 
 const mockPipelineFilterProvider = vi.fn()
 vi.mock('../components/cards/pipelines/PipelineFilterContext', () => ({

--- a/web/src/pages/FromHolmesGPT.test.tsx
+++ b/web/src/pages/FromHolmesGPT.test.tsx
@@ -20,9 +20,11 @@ vi.mock('@/lib/clipboard', () => ({
   copyToClipboard: mockCopyToClipboard,
 }))
 
-vi.mock('@/lib/analytics', () => ({
+vi.mock('@/lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/analytics')>()),
   emitInstallCommandCopied: mockEmitInstallCommandCopied,
-}))
+}
+))
 
 vi.mock('@/lib/constants', () => ({
   COPY_FEEDBACK_TIMEOUT_MS,

--- a/web/src/pages/WhiteLabel.test.tsx
+++ b/web/src/pages/WhiteLabel.test.tsx
@@ -17,13 +17,15 @@ vi.mock('@/lib/constants', () => ({
   COPY_FEEDBACK_TIMEOUT_MS,
 }))
 
-vi.mock('@/lib/analytics', () => ({
+vi.mock('@/lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/analytics')>()),
   emitWhiteLabelViewed: vi.fn(),
   emitWhiteLabelActioned: vi.fn(),
   emitWhiteLabelTabSwitch: vi.fn(),
   emitWhiteLabelCommandCopy: vi.fn(),
   emitInstallCommandCopied: vi.fn(),
-}))
+}
+))
 
 import { WhiteLabel } from './WhiteLabel'
 

--- a/web/src/pages/__tests__/FromHeadlamp.test.tsx
+++ b/web/src/pages/__tests__/FromHeadlamp.test.tsx
@@ -25,10 +25,12 @@ const {
   emitFromLensCommandCopy,
 } = analyticsMocks
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   ...analyticsMocks,
   emitInstallCommandCopied: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),

--- a/web/src/pages/__tests__/FromHolmesGPT.test.tsx
+++ b/web/src/pages/__tests__/FromHolmesGPT.test.tsx
@@ -3,11 +3,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitInstallCommandCopied: vi.fn(),
   emitFromHolmesGPTViewed: vi.fn(),
   emitFromHolmesGPTActioned: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),

--- a/web/src/pages/__tests__/FromLens.test.tsx
+++ b/web/src/pages/__tests__/FromLens.test.tsx
@@ -25,10 +25,12 @@ const {
   emitFromHeadlampCommandCopy,
 } = analyticsMocks
 
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   ...analyticsMocks,
   emitInstallCommandCopied: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),

--- a/web/src/pages/__tests__/SemanticColorTokens.test.tsx
+++ b/web/src/pages/__tests__/SemanticColorTokens.test.tsx
@@ -4,14 +4,16 @@ import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
 // Mock analytics to prevent side effects
-vi.mock('../../lib/analytics', () => ({
+vi.mock('../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/analytics')>()),
   emitPageView: vi.fn(),
   emitWhiteLabelViewed: vi.fn(),
   emitWhiteLabelActioned: vi.fn(),
   emitWhiteLabelTabSwitch: vi.fn(),
   emitWhiteLabelCommandCopy: vi.fn(),
   emitInstallCommandCopied: vi.fn(),
-}))
+}
+))
 
 vi.mock('../../lib/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),


### PR DESCRIPTION
Fixes #19870

## Root Cause
`useDemoMode.ts` re-exports utility functions from `lib/demoMode`. Test mocks that replaced the entire module without these re-exports caused vitest to throw `No export defined` errors.

## Fix
Updated all useDemoMode and analytics mocks to use `importOriginal` pattern, preserving real utility exports while overriding only the hook function.

## Changes
- 514 test files updated
- All `vi.mock` calls for `useDemoMode` now use `async (importOriginal)` pattern
- All `vi.mock` calls for `lib/analytics` now use `async (importOriginal)` pattern
- Re-exported utilities are now preserved in mocks