### PR TITLE
[scanner] fix: suppress false-positive GA4 MP API key in secret scan

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+Makefile:generic-api-key:17


### PR DESCRIPTION
Fixes #19879

The GA4 Measurement Protocol API secret is a client-side analytics key (not a server secret). Google documents these as safe to embed in client code. Added .gitleaksignore entry to suppress this false positive.