### PR TITLE
🐛 Fix settings page title visibility on mobile browsers

### DIFF
--- a/web/src/components/settings/Settings.tsx
+++ b/web/src/components/settings/Settings.tsx
@@ -421,7 +421,7 @@ export function Settings() {
   return (
     <div
       data-testid="settings-page"
-      className="pt-16 max-w-6xl mx-auto flex gap-6"
+      className="pt-16 max-w-6xl mx-auto flex flex-col lg:flex-row gap-6"
     >
       {/* Settings restored toast */}
       {showRestoredToast && (
@@ -503,7 +503,7 @@ export function Settings() {
       {/* Main Content */}
       <div ref={contentRef} className="flex-1 min-w-0">
         {/* Mobile Header */}
-        <div className="lg:hidden mb-6">
+        <div className="block lg:hidden mb-6">
           <div className="flex items-center justify-between">
             <h1
               data-testid="settings-title"


### PR DESCRIPTION
Fixes #19876

The settings page mobile header was not visible on mobile Safari and Chrome due to flex layout issues on narrow viewports.

## Root Cause
The Playwright Cross-Browser nightly tests were failing on Mobile Safari and Mobile Chrome. Investigation revealed that the `settings-title` element on the Settings page was being reported as hidden on mobile viewports, even though the CSS appeared correct.

The issue was caused by incorrect flex layout on the settings-page container. The `flex` default (row layout) didn't properly handle mobile viewports with the hidden sidebar.

## Fix
- Changed settings-page container from `flex gap-6` to `flex flex-col lg:flex-row gap-6` for proper mobile-first responsive layout (vertical on mobile, horizontal on lg+)
- Added explicit `block lg:hidden` to mobile header to ensure proper display on mobile viewports

This ensures the mobile header (with settings-title) is properly visible and laid out on mobile browsers.

## Testing
The fix should be validated by re-running the Playwright Cross-Browser nightly workflow to ensure both Mobile Safari and Mobile Chrome tests pass.