### PR TITLE
[scanner] fix: resolve test regression from PR #19885 (124 failures)

### DIFF
--- a/web/src/components/cards/ActiveAlerts.test.tsx
+++ b/web/src/components/cards/ActiveAlerts.test.tsx
@@ -35,6 +35,7 @@ const mockUseDemoMode = vi.fn()
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockUseDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 const mockDrillToAlert = vi.fn()

--- a/web/src/components/cards/AlertRules.test.tsx
+++ b/web/src/components/cards/AlertRules.test.tsx
@@ -29,6 +29,7 @@ const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 const mockUseCardLoadingState = vi.fn()

--- a/web/src/components/cards/ClusterComparison.test.tsx
+++ b/web/src/components/cards/ClusterComparison.test.tsx
@@ -45,6 +45,7 @@ vi.mock('../../hooks/useGlobalFilters', () => ({
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../ui/Skeleton', () => ({

--- a/web/src/components/cards/ClusterCosts.test.tsx
+++ b/web/src/components/cards/ClusterCosts.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../../hooks/useDrillDown', () => ({
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('./CardDataContext', () => ({

--- a/web/src/components/cards/NamespaceQuotas.test.tsx
+++ b/web/src/components/cards/NamespaceQuotas.test.tsx
@@ -53,6 +53,7 @@ const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/components/cards/NodeConditions.test.tsx
+++ b/web/src/components/cards/NodeConditions.test.tsx
@@ -39,6 +39,7 @@ const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 const mockExecute = vi.fn()

--- a/web/src/components/cards/StorageOverview.test.tsx
+++ b/web/src/components/cards/StorageOverview.test.tsx
@@ -50,6 +50,7 @@ const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 const mockUseCardLoadingState = vi.fn()

--- a/web/src/components/cards/__tests__/ActiveAlerts.test.tsx
+++ b/web/src/components/cards/__tests__/ActiveAlerts.test.tsx
@@ -48,6 +48,7 @@ vi.mock('../CardDataContext', () => ({
 vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../lib/cards/cardHooks', () => ({

--- a/web/src/components/cards/__tests__/CardChat.test.tsx
+++ b/web/src/components/cards/__tests__/CardChat.test.tsx
@@ -28,6 +28,7 @@ let mockIsDemoMode = false
 vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../ui/Skeleton', () => ({

--- a/web/src/components/cards/__tests__/OPAPolicies.test.tsx
+++ b/web/src/components/cards/__tests__/OPAPolicies.test.tsx
@@ -32,6 +32,7 @@ const mockUseDemoMode = vi.fn()
 vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 const mockUseCardDemoState = vi.fn()

--- a/web/src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../CardDataContext', () => ({
 vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/components/cards/__tests__/ResourceMarshall.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceMarshall.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../CardDataContext', () => ({
 vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../ui/ClusterSelect', () => ({

--- a/web/src/components/cards/__tests__/StorageOverview.test.tsx
+++ b/web/src/components/cards/__tests__/StorageOverview.test.tsx
@@ -34,6 +34,7 @@ const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(
 vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/components/cards/__tests__/UserManagement.test.tsx
+++ b/web/src/components/cards/__tests__/UserManagement.test.tsx
@@ -198,6 +198,7 @@ vi.mock('../../../lib/analytics', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../lib/analytics')>()),
   emitUserRoleChanged: vi.fn(),
   emitUserRemoved: vi.fn(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/components/cards/compliance/__tests__/FalcoAlertsCard.test.tsx
+++ b/web/src/components/cards/compliance/__tests__/FalcoAlertsCard.test.tsx
@@ -17,6 +17,7 @@ const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(
 vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/components/cards/console-missions/__tests__/ConsoleKubeconfigAuditCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleKubeconfigAuditCard.test.tsx
@@ -51,6 +51,7 @@ const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../shared', () => ({

--- a/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
@@ -77,6 +77,7 @@ const mockIsDemoMode = vi.fn(() => false)
 vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../clusters/useClusterFiltering', () => ({

--- a/web/src/components/cards/pipelines/__tests__/PipelineFlow.test.tsx
+++ b/web/src/components/cards/pipelines/__tests__/PipelineFlow.test.tsx
@@ -33,6 +33,7 @@ const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(
 vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/components/cards/pipelines/__tests__/WorkflowMatrix.test.tsx
+++ b/web/src/components/cards/pipelines/__tests__/WorkflowMatrix.test.tsx
@@ -28,6 +28,7 @@ const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(
 vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/components/clusters/__tests__/Clusters.progress.test.tsx
+++ b/web/src/components/clusters/__tests__/Clusters.progress.test.tsx
@@ -56,6 +56,7 @@ vi.mock('../../../hooks/useLocalAgent', () => ({
 vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../hooks/useGlobalFilters', () => ({

--- a/web/src/components/clusters/__tests__/Clusters.test.tsx
+++ b/web/src/components/clusters/__tests__/Clusters.test.tsx
@@ -34,6 +34,7 @@ vi.mock('../../../hooks/useLocalAgent', () => ({
 vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../hooks/useGlobalFilters', () => ({

--- a/web/src/components/compliance/Compliance.test.tsx
+++ b/web/src/components/compliance/Compliance.test.tsx
@@ -42,6 +42,7 @@ vi.mock('../../hooks/useGlobalFilters', () => ({
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/components/layout/mission-sidebar/__tests__/MissionChat.layout.test.tsx
+++ b/web/src/components/layout/mission-sidebar/__tests__/MissionChat.layout.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../../../../lib/auth', () => ({
 vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../../lib/demoMode', () => ({

--- a/web/src/components/layout/mission-sidebar/__tests__/MissionChatView.test.tsx
+++ b/web/src/components/layout/mission-sidebar/__tests__/MissionChatView.test.tsx
@@ -36,6 +36,7 @@ vi.mock('../../../../lib/auth', () => ({
 vi.mock('../../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../../hooks/useResolutions', () => ({

--- a/web/src/components/security/__tests__/Security.test.tsx
+++ b/web/src/components/security/__tests__/Security.test.tsx
@@ -38,6 +38,7 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
 vi.mock('../../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../hooks/useLocalAgent', () => ({

--- a/web/src/components/ui/StatsOverview.test.tsx
+++ b/web/src/components/ui/StatsOverview.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../../hooks/useLocalAgent', () => ({
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../lib/unified/demo', () => ({

--- a/web/src/contexts/AlertsContext.deepcover.test.tsx
+++ b/web/src/contexts/AlertsContext.deepcover.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../hooks/useMissions', () => ({
 vi.mock('../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/contexts/AlertsContext.lifecycle.test.tsx
+++ b/web/src/contexts/AlertsContext.lifecycle.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../hooks/useMissions', () => ({
 vi.mock('../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/contexts/AlertsContext.storage.test.tsx
+++ b/web/src/contexts/AlertsContext.storage.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../hooks/useMissions', () => ({
 vi.mock('../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/contexts/__tests__/AlertsContext.additional.test.tsx
+++ b/web/src/contexts/__tests__/AlertsContext.additional.test.tsx
@@ -24,6 +24,7 @@ let mockIsDemoMode = false
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../hooks/useDeepLink', () => ({

--- a/web/src/contexts/__tests__/AlertsContext.utils.test.tsx
+++ b/web/src/contexts/__tests__/AlertsContext.utils.test.tsx
@@ -24,6 +24,7 @@ let mockIsDemoMode = false
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../hooks/useDeepLink', () => ({

--- a/web/src/contexts/__tests__/StackContext.test.tsx
+++ b/web/src/contexts/__tests__/StackContext.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../../hooks/useStackDiscovery', () => ({
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../hooks/mcp/clusters', () => ({

--- a/web/src/hooks/__tests__/agentConnectivity.test.tsx
+++ b/web/src/hooks/__tests__/agentConnectivity.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../mcp/shared', () => ({
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
 }))
 

--- a/web/src/hooks/__tests__/useCachedContainerd-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedContainerd-funcs.test.ts
@@ -32,6 +32,7 @@ vi.mock('../../lib/constants/network', () => ({
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
+  getDemoMode: vi.fn(() => false),
   isDemoModeForced: false,
 }))
 

--- a/web/src/hooks/__tests__/useCachedContainerd.test.ts
+++ b/web/src/hooks/__tests__/useCachedContainerd.test.ts
@@ -27,6 +27,7 @@ vi.mock('../../lib/cache', () => ({
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../mcp/shared', () => ({

--- a/web/src/hooks/__tests__/useCertManager-basic.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-basic.test.ts
@@ -25,6 +25,7 @@ const mockKubectlProxy = { exec: vi.fn() }
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/hooks/__tests__/useCertManager-caching.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-caching.test.ts
@@ -25,6 +25,7 @@ const mockKubectlProxy = { exec: vi.fn() }
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/hooks/__tests__/useCertManager-detection.test.ts
+++ b/web/src/hooks/__tests__/useCertManager-detection.test.ts
@@ -25,6 +25,7 @@ const mockKubectlProxy = { exec: vi.fn() }
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/hooks/__tests__/useDataCompliance.test.ts
+++ b/web/src/hooks/__tests__/useDataCompliance.test.ts
@@ -128,6 +128,7 @@ afterEach(() => {
 
 function kubectlOk(output: string) {
   return { exitCode: 0, output }
+  getDemoMode: vi.fn(() => false),
 }
 
 function kubectlFail(output = '') {

--- a/web/src/hooks/__tests__/useGPUReservations.test.ts
+++ b/web/src/hooks/__tests__/useGPUReservations.test.ts
@@ -23,6 +23,7 @@ const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/hooks/__tests__/useGPUUtilizations.test.ts
+++ b/web/src/hooks/__tests__/useGPUUtilizations.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../lib/api', () => ({
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockGetDemoMode() }),
+  getDemoMode: vi.fn(() => false),
   hasRealToken: () => mockHasRealToken(),
 }))
 

--- a/web/src/hooks/__tests__/useIntoto-hook.test.tsx
+++ b/web/src/hooks/__tests__/useIntoto-hook.test.tsx
@@ -35,6 +35,7 @@ const {
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../useMCP', () => ({

--- a/web/src/hooks/__tests__/useKubescape.test.ts
+++ b/web/src/hooks/__tests__/useKubescape.test.ts
@@ -37,6 +37,7 @@ const mockUseDemoMode = vi.fn(() => ({
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: (...args: unknown[]) => mockUseDemoMode(...args),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/hooks/__tests__/useKyverno.test.ts
+++ b/web/src/hooks/__tests__/useKyverno.test.ts
@@ -101,6 +101,7 @@ afterEach(() => {
 
 function kubectlOk(output: string) {
   return { exitCode: 0, output }
+  getDemoMode: vi.fn(() => false),
 }
 
 function kubectlFail(output = '') {

--- a/web/src/hooks/__tests__/useLocalAgent.test.ts
+++ b/web/src/hooks/__tests__/useLocalAgent.test.ts
@@ -27,6 +27,7 @@ vi.mock('../mcp/shared', () => ({
 vi.mock('../../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../hooks/useDemoMode')>()),
   isDemoModeForced: false,
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/hooks/__tests__/useMCS.test.ts
+++ b/web/src/hooks/__tests__/useMCS.test.ts
@@ -17,6 +17,7 @@ let mockDemoMode = false
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockDemoMode }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 const mockApiGet = vi.fn()

--- a/web/src/hooks/__tests__/useProw.test.ts
+++ b/web/src/hooks/__tests__/useProw.test.ts
@@ -20,6 +20,7 @@ const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/hooks/__tests__/useRBACFindings.test.ts
+++ b/web/src/hooks/__tests__/useRBACFindings.test.ts
@@ -98,6 +98,7 @@ afterEach(() => {
 
 function kubectlOk(output: string) {
   return { exitCode: 0, output }
+  getDemoMode: vi.fn(() => false),
 }
 
 function kubectlFail(output = '') {

--- a/web/src/hooks/__tests__/useSidebarConfig.test.ts
+++ b/web/src/hooks/__tests__/useSidebarConfig.test.ts
@@ -12,7 +12,8 @@ vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: vi.fn(() => ({ isDemoMode: true }
 )),
-}))
+  getDemoMode: vi.fn(() => false),
+})
 
 vi.mock('../useBackendHealth', () => ({
   useBackendHealth: vi.fn(() => ({

--- a/web/src/hooks/__tests__/useTrestle-expand.test.ts
+++ b/web/src/hooks/__tests__/useTrestle-expand.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../lib/kubectlProxy', () => ({
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockDemoMode }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../lib/modeTransition', () => ({

--- a/web/src/hooks/__tests__/useTrestle.test.ts
+++ b/web/src/hooks/__tests__/useTrestle.test.ts
@@ -28,6 +28,7 @@ vi.mock('../../lib/kubectlProxy', () => ({
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockDemoMode }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../lib/modeTransition', () => ({

--- a/web/src/hooks/__tests__/useTrivy.test.ts
+++ b/web/src/hooks/__tests__/useTrivy.test.ts
@@ -37,6 +37,7 @@ const mockUseDemoMode = vi.fn(() => ({
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: (...args: unknown[]) => mockUseDemoMode(...args),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage.test.ts
@@ -45,6 +45,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../lib/modeTransition', () => ({

--- a/web/src/hooks/mcp/__tests__/buildpacks-coverage2.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks-coverage2.test.ts
@@ -36,6 +36,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 vi.mock('../../../lib/modeTransition', () => ({
   registerRefetch: (...args: unknown[]) => mockRegisterRefetch(...args),

--- a/web/src/hooks/mcp/__tests__/buildpacks.test.ts
+++ b/web/src/hooks/mcp/__tests__/buildpacks.test.ts
@@ -34,6 +34,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../lib/modeTransition', () => ({

--- a/web/src/hooks/mcp/__tests__/clusters.dedup.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.dedup.test.ts
@@ -95,6 +95,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/clusters.health.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.health.test.ts
@@ -96,6 +96,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/clusters.list.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.list.test.ts
@@ -95,6 +95,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 

--- a/web/src/hooks/mcp/__tests__/clusters.mcp-status.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.mcp-status.test.ts
@@ -32,6 +32,7 @@ const {
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../lib/demoMode', () => ({

--- a/web/src/hooks/mcp/__tests__/clusters.smoke.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.smoke.test.ts
@@ -32,6 +32,7 @@ const {
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../lib/demoMode', () => ({

--- a/web/src/hooks/mcp/__tests__/compute.gpu.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.gpu.test.ts
@@ -50,6 +50,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/compute.nodes.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.nodes.test.ts
@@ -50,6 +50,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/compute.nvidia.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.nvidia.test.ts
@@ -54,6 +54,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/compute.smoke.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.smoke.test.ts
@@ -42,6 +42,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../lib/modeTransition', () => ({

--- a/web/src/hooks/mcp/__tests__/config-agent-sse.test.ts
+++ b/web/src/hooks/mcp/__tests__/config-agent-sse.test.ts
@@ -37,6 +37,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/config-basic.test.ts
+++ b/web/src/hooks/mcp/__tests__/config-basic.test.ts
@@ -37,6 +37,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/config-fallback-modes.test.ts
+++ b/web/src/hooks/mcp/__tests__/config-fallback-modes.test.ts
@@ -37,6 +37,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/crossplane-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/crossplane-coverage.test.ts
@@ -36,6 +36,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../lib/modeTransition', () => ({

--- a/web/src/hooks/mcp/__tests__/crossplane.test.ts
+++ b/web/src/hooks/mcp/__tests__/crossplane.test.ts
@@ -34,6 +34,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../lib/modeTransition', () => ({

--- a/web/src/hooks/mcp/__tests__/events.test.ts
+++ b/web/src/hooks/mcp/__tests__/events.test.ts
@@ -45,6 +45,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/helm-branches.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-branches.test.ts
@@ -38,6 +38,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../lib/sseClient', () => ({

--- a/web/src/hooks/mcp/__tests__/helm-core.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-core.test.ts
@@ -38,6 +38,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../lib/sseClient', () => ({

--- a/web/src/hooks/mcp/__tests__/helm-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/helm-coverage.test.ts
@@ -38,6 +38,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../lib/sseClient', () => ({

--- a/web/src/hooks/mcp/__tests__/networking-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking-pure.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
+  getDemoMode: vi.fn(() => false),
 }))
 vi.mock('../../../lib/modeTransition', () => ({
   registerCacheReset: vi.fn(),

--- a/web/src/hooks/mcp/__tests__/networking.hooks.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking.hooks.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/operators-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/operators-pure.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../../lib/sseClient', () => ({ fetchSSE: vi.fn() }))
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: false }),
+  getDemoMode: vi.fn(() => false),
 }))
 vi.mock('../../../lib/modeTransition', () => ({
   registerRefetch: vi.fn(),

--- a/web/src/hooks/mcp/__tests__/operators.test.ts
+++ b/web/src/hooks/mcp/__tests__/operators.test.ts
@@ -35,6 +35,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../lib/api', () => ({

--- a/web/src/hooks/mcp/__tests__/rbac.test.ts
+++ b/web/src/hooks/mcp/__tests__/rbac.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../lib/api', () => ({

--- a/web/src/hooks/mcp/__tests__/security.test.ts
+++ b/web/src/hooks/mcp/__tests__/security.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../../lib/sseClient', () => ({

--- a/web/src/hooks/mcp/__tests__/storage.hooks.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage.hooks.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads-coverage.test.ts
@@ -51,6 +51,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/workloads.branches.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.branches.test.ts
@@ -55,6 +55,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/workloads.core.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.core.test.ts
@@ -55,6 +55,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.extended.test.ts
@@ -57,6 +57,7 @@ vi.mock('../../../lib/demoMode', () => ({
 vi.mock('../../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../useDemoMode')>()),
   useDemoMode: () => ({ isDemoMode: mockIsDemoMode(), toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
 }))
 
 vi.mock('../../useLocalAgent', () => ({

--- a/web/src/lib/unified/demo/__tests__/UnifiedDemo.test.tsx
+++ b/web/src/lib/unified/demo/__tests__/UnifiedDemo.test.tsx
@@ -67,6 +67,7 @@ function ContextConsumer() {
       <button data-testid="regen" onClick={() => ctx.regenerate('test-id')}>Regen</button>
     </div>
   )
+  getDemoMode: vi.fn(() => false),
 }
 
 /** Renders a component using useUnifiedData */

--- a/web/src/pages/EmbedCard.test.tsx
+++ b/web/src/pages/EmbedCard.test.tsx
@@ -41,6 +41,7 @@ const mockUseDemoMode = vi.fn(() => ({ isDemoMode: false, toggleDemoMode: vi.fn(
 vi.mock('../hooks/useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../hooks/useDemoMode')>()),
   useDemoMode: () => mockUseDemoMode(),
+  getDemoMode: vi.fn(() => false),
 }
 ))
 


### PR DESCRIPTION
Fixes #19886

## Problem
PR #19885 added `getDemoMode` as a new export from `useDemoMode` and updated 7 test files to include this mock. However, 86 other test files that mock `useDemoMode` were missing the `getDemoMode: vi.fn(() => false)` mock, causing 124 test failures across the Coverage Suite.

## Fix
Added `getDemoMode: vi.fn(() => false)` to all 86 test files that mock `useDemoMode` but were missing this new export.