### PR TITLE
[scanner] fix: add useCachedKagentStatus hook and kagent agent list/status card

### DIFF
--- a/web/src/components/cards/KagentStatus.tsx
+++ b/web/src/components/cards/KagentStatus.tsx
@@ -1,0 +1,262 @@
+import { useMemo } from 'react'
+import { AlertCircle, Bot, Server } from 'lucide-react'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
+import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
+import { Skeleton } from '../ui/Skeleton'
+import { useCardLoadingState } from './CardDataContext'
+import { useTranslation } from 'react-i18next'
+import { useCachedKagentStatus } from '../../hooks/useCachedKagentStatus'
+import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
+import type { KagentStatusData } from '../../lib/demo/kagent'
+
+type SortByOption = 'agentName' | 'namespace' | 'status'
+
+const STATUS_ORDER: Record<string, number> = { error: 0, stopped: 1, running: 2 }
+
+const SORT_COMPARATORS = {
+  agentName: commonComparators.string<KagentStatusData>('agentName'),
+  namespace: commonComparators.string<KagentStatusData>('namespace'),
+  status: (a: KagentStatusData, b: KagentStatusData) =>
+    (STATUS_ORDER[a.status] ?? 3) - (STATUS_ORDER[b.status] ?? 3),
+}
+
+const SORT_OPTIONS_KEYS = [
+  { value: 'agentName' as const, labelKey: 'common:common.name' as const },
+  { value: 'status' as const, labelKey: 'common:common.status' as const },
+  { value: 'namespace' as const, labelKey: 'common:common.namespace' as const },
+]
+
+interface KagentStatusProps {
+  config?: Record<string, unknown>
+}
+
+function StatusBadge({ status }: { status: KagentStatusData['status'] }) {
+  const colors =
+    status === 'running'
+      ? 'bg-green-500/20 text-green-400'
+      : status === 'stopped'
+      ? 'bg-yellow-500/20 text-yellow-400'
+      : 'bg-red-500/20 text-red-400'
+  return <span className={`px-1.5 py-0.5 rounded text-2xs ${colors}`}>{status}</span>
+}
+
+function formatHeartbeat(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const seconds = Math.floor(diff / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ago`
+}
+
+function KagentStatusInternal({ config: _config }: KagentStatusProps) {
+  const { t } = useTranslation(['cards', 'common'])
+  const SORT_OPTIONS = SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) }))
+
+  const {
+    data: allAgents,
+    isLoading,
+    isRefreshing,
+    isDemoData,
+    isFailed,
+    consecutiveFailures,
+    refetch,
+  } = useCachedKagentStatus()
+
+  const hasData = (allAgents ?? []).length > 0
+
+  useCardLoadingState({
+    isLoading: isLoading && !hasData,
+    isRefreshing,
+    hasAnyData: hasData,
+    isDemoData,
+    isFailed,
+    consecutiveFailures,
+  })
+
+  const stats = useMemo(() => {
+    const agents = allAgents ?? []
+    return {
+      total: agents.length,
+      running: agents.filter(a => a.status === 'running').length,
+      stopped: agents.filter(a => a.status === 'stopped').length,
+      error: agents.filter(a => a.status === 'error').length,
+    }
+  }, [allAgents])
+
+  const {
+    items: paginatedAgents,
+    totalItems,
+    currentPage,
+    totalPages,
+    itemsPerPage,
+    goToPage,
+    needsPagination,
+    setItemsPerPage,
+    filters: { search: localSearch, setSearch: setLocalSearch },
+    sorting: { sortBy, setSortBy, sortDirection, setSortDirection },
+    containerRef,
+    containerStyle,
+  } = useCardData<KagentStatusData, SortByOption>(allAgents ?? [], {
+    filter: {
+      searchFields: ['agentName', 'namespace', 'status', 'providerName'],
+      storageKey: 'kagent-agent-status',
+    },
+    sort: {
+      defaultField: 'status',
+      defaultDirection: 'asc',
+      comparators: SORT_COMPARATORS,
+    },
+    defaultLimit: 5,
+  })
+
+  if (isLoading) {
+    return (
+      <div className="h-full flex flex-col min-h-card">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
+          <Skeleton variant="text" width={120} height={20} />
+          <Skeleton variant="rounded" width={80} height={28} />
+        </div>
+        <div className="space-y-2">
+          <Skeleton variant="rounded" height={60} />
+          <Skeleton variant="rounded" height={60} />
+          <Skeleton variant="rounded" height={60} />
+        </div>
+      </div>
+    )
+  }
+
+  if (isFailed) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card p-6">
+        <AlertCircle className="w-12 h-12 text-red-400 mb-4" />
+        <p className="text-sm text-muted-foreground mb-4">
+          {t('kagentAgentStatus.loadFailed', 'Failed to load kagent agent status')}
+        </p>
+        <button
+          onClick={() => refetch()}
+          className="px-4 py-2 rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground text-sm"
+        >
+          {t('common:common.retry')}
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card">
+      {/* Header with controls */}
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 shrink-0">
+        <div className="flex items-center gap-2">
+          <Bot className="w-4 h-4 text-muted-foreground" />
+          <span className="text-sm font-medium text-muted-foreground">
+            {t('kagentAgentStatus.nAgents', { count: totalItems, defaultValue: '{{count}} agents' })}
+          </span>
+        </div>
+        <CardControlsRow
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => setSortBy(v as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+        />
+      </div>
+
+      {/* Demo badge */}
+      {isDemoData && (
+        <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-blue-500/10 border border-blue-500/20 text-xs">
+          <AlertCircle className="w-4 h-4 text-blue-400 shrink-0 mt-0.5" />
+          <p className="text-blue-400 font-medium">
+            {t(
+              'kagentAgentStatus.demoNotice',
+              'Showing demo data — connect a cluster with kagent installed to see live agents',
+            )}
+          </p>
+        </div>
+      )}
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-2 mb-3">
+        <div className="p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-center">
+          <p className="text-2xs text-green-400">{t('kagentAgentStatus.running', 'Running')}</p>
+          <p className="text-lg font-bold text-foreground">{stats.running}</p>
+        </div>
+        <div className="p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
+          <p className="text-2xs text-yellow-400">{t('kagentAgentStatus.stopped', 'Stopped')}</p>
+          <p className="text-lg font-bold text-foreground">{stats.stopped}</p>
+        </div>
+        <div className="p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-center">
+          <p className="text-2xs text-red-400">{t('kagentAgentStatus.error', 'Error')}</p>
+          <p className="text-lg font-bold text-foreground">{stats.error}</p>
+        </div>
+      </div>
+
+      {/* Search */}
+      <CardSearchInput
+        value={localSearch}
+        onChange={setLocalSearch}
+        placeholder={t('kagentAgentStatus.searchAgents', 'Search agents...')}
+        className="mb-3"
+      />
+
+      {/* Agent list */}
+      <div ref={containerRef} className="flex-1 overflow-y-auto space-y-2" style={containerStyle}>
+        {paginatedAgents.map((agent, idx) => (
+          <div
+            key={`${agent.agentName}-${agent.namespace}-${idx}`}
+            className="p-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-y-1 mb-1">
+              <div className="flex items-center gap-2">
+                <Bot className="w-3.5 h-3.5 text-muted-foreground/60" />
+                <span className="text-sm font-medium text-foreground truncate">{agent.agentName}</span>
+                <StatusBadge status={agent.status} />
+              </div>
+              <span className="text-xs text-muted-foreground">
+                {t('kagentAgentStatus.missions', {
+                  count: agent.activeMissions,
+                  defaultValue: '{{count}} missions',
+                })}
+              </span>
+            </div>
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <Server className="w-3 h-3" />
+                <span>{agent.namespace}</span>
+                {agent.providerName && (
+                  <span className="px-1.5 py-0.5 rounded bg-secondary text-2xs">{agent.providerName}</span>
+                )}
+              </div>
+              {agent.lastHeartbeatAt && (
+                <span className="text-2xs">{formatHeartbeat(agent.lastHeartbeatAt)}</span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Pagination */}
+      <CardPaginationFooter
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 10}
+        onPageChange={goToPage}
+        needsPagination={needsPagination && itemsPerPage !== 'unlimited'}
+      />
+    </div>
+  )
+}
+
+export function KagentStatus(props: KagentStatusProps) {
+  return (
+    <DynamicCardErrorBoundary cardId="KagentStatus">
+      <KagentStatusInternal {...props} />
+    </DynamicCardErrorBoundary>
+  )
+}

--- a/web/src/components/cards/cardRegistry.aiml.ts
+++ b/web/src/components/cards/cardRegistry.aiml.ts
@@ -19,6 +19,7 @@ const KagentAgentFleet = safeLazy(() => _kagentBundle, 'KagentAgentFleet')
 const KagentModelProviders = safeLazy(() => _kagentBundle, 'KagentModelProviders')
 const KagentSecurity = safeLazy(() => _kagentBundle, 'KagentSecurity')
 const KagentStatusCard = safeLazy(() => import('./KagentStatusCard'), 'KagentStatusCard')
+const KagentStatusComponent = safeLazy(() => import('./KagentStatus'), 'KagentStatus')
 const KagentToolRegistry = safeLazy(() => _kagentBundle, 'KagentToolRegistry')
 const KagentTopology = safeLazy(() => _kagentBundle, 'KagentTopology')
 const _kagentiBundle = import('./kagenti').catch(() => undefined as never)
@@ -57,14 +58,14 @@ const ThroughputComparison = safeLazy(() => _llmdBundle, 'ThroughputComparison')
  * Cards:
  * acmm_feedback_loops, acmm_level, acmm_recommendations, benchmark_hero, console_ai_health_check,
  * console_ai_issues, console_ai_kubeconfig_audit, console_ai_offline_detection, epp_routing,
- * hardware_leaderboard, kagent_agent_discovery, kagent_agent_fleet, kagent_model_providers,
- * kagent_security, kagent_status, kagent_tool_registry, kagent_topology, kagenti_agent_discovery,
- * kagenti_agent_fleet, kagenti_build_pipeline, kagenti_security, kagenti_security_posture,
- * kagenti_status, kagenti_tool_registry, kagenti_topology, kvcache_monitor, latency_breakdown,
- * llm_inference, llm_models, llmd_ai_insights, llmd_configurator, llmd_flow, llmd_stack_monitor,
- * ml_jobs, ml_notebooks, nightly_e2e_status, pareto_frontier, pd_disaggregation,
- * performance_timeline, provider_health, prow_history, prow_jobs, prow_status,
- * resource_utilization, throughput_comparison
+ * hardware_leaderboard, kagent_agent_discovery, kagent_agent_fleet, kagent_agent_status,
+ * kagent_model_providers, kagent_security, kagent_status, kagent_tool_registry, kagent_topology,
+ * kagenti_agent_discovery, kagenti_agent_fleet, kagenti_build_pipeline, kagenti_security,
+ * kagenti_security_posture, kagenti_status, kagenti_tool_registry, kagenti_topology,
+ * kvcache_monitor, latency_breakdown, llm_inference, llm_models, llmd_ai_insights,
+ * llmd_configurator, llmd_flow, llmd_stack_monitor, ml_jobs, ml_notebooks, nightly_e2e_status,
+ * pareto_frontier, pd_disaggregation, performance_timeline, provider_health, prow_history,
+ * prow_jobs, prow_status, resource_utilization, throughput_comparison
  */
 export interface CardRegistryDomain {
   components: Record<string, CardComponent>
@@ -87,6 +88,7 @@ const components: Record<string, CardComponent> = {
   hardware_leaderboard: HardwareLeaderboard,
   kagent_agent_discovery: KagentAgentDiscovery,
   kagent_agent_fleet: KagentAgentFleet,
+  kagent_agent_status: KagentStatusComponent,
   kagent_model_providers: KagentModelProviders,
   kagent_security: KagentSecurity,
   kagent_status: KagentStatusCard,
@@ -127,6 +129,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
   demoDataCards: new Set([
     'kagent_agent_discovery',
     'kagent_agent_fleet',
+    'kagent_agent_status',
     'kagent_model_providers',
     'kagent_security',
     'kagent_status',
@@ -147,6 +150,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
   liveDataCards: new Set([
     'kagent_agent_discovery',
     'kagent_agent_fleet',
+    'kagent_agent_status',
     'kagent_model_providers',
     'kagent_security',
     'kagent_status',
@@ -177,6 +181,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     hardware_leaderboard: () => import('./llmd'),
     kagent_agent_discovery: () => import('./kagent'),
     kagent_agent_fleet: () => import('./kagent'),
+    kagent_agent_status: () => import('./KagentStatus'),
     kagent_model_providers: () => import('./kagent'),
     kagent_security: () => import('./kagent'),
     kagent_status: () => import('./KagentStatusCard'),
@@ -221,6 +226,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     hardware_leaderboard: 12,
     kagent_agent_discovery: 4,
     kagent_agent_fleet: 8,
+    kagent_agent_status: 4,
     kagent_model_providers: 4,
     kagent_security: 4,
     kagent_status: 4,

--- a/web/src/components/cards/cardRegistry.aiml.ts
+++ b/web/src/components/cards/cardRegistry.aiml.ts
@@ -10,6 +10,7 @@ const ConsoleHealthCheckCard = safeLazy(() => import('./console-missions/Console
 const ConsoleIssuesCard = safeLazy(() => import('./console-missions/ConsoleIssuesCard'), 'ConsoleIssuesCard')
 const ConsoleKubeconfigAuditCard = safeLazy(() => import('./console-missions/ConsoleKubeconfigAuditCard'), 'ConsoleKubeconfigAuditCard')
 const ConsoleOfflineDetectionCard = safeLazy(() => import('./console-missions/ConsoleOfflineDetectionCard'), 'ConsoleOfflineDetectionCard')
+const EPPHealth = safeLazy(() => import('./EPPHealth'), 'EPPHealth')
 const EPPRouting = safeLazy(() => _llmdBundle, 'EPPRouting')
 const HardwareLeaderboard = safeLazy(() => _llmdBundle, 'HardwareLeaderboard')
 const KVCacheMonitor = safeLazy(() => _llmdBundle, 'KVCacheMonitor')
@@ -57,15 +58,15 @@ const ThroughputComparison = safeLazy(() => _llmdBundle, 'ThroughputComparison')
  * AI/ML workload and agent cards.
  * Cards:
  * acmm_feedback_loops, acmm_level, acmm_recommendations, benchmark_hero, console_ai_health_check,
- * console_ai_issues, console_ai_kubeconfig_audit, console_ai_offline_detection, epp_routing,
- * hardware_leaderboard, kagent_agent_discovery, kagent_agent_fleet, kagent_agent_status,
+ * console_ai_issues, console_ai_kubeconfig_audit, console_ai_offline_detection, epp_health,
+ * epp_routing, hardware_leaderboard, kagent_agent_discovery, kagent_agent_fleet, kagent_agent_status,
  * kagent_model_providers, kagent_security, kagent_status, kagent_tool_registry, kagent_topology,
  * kagenti_agent_discovery, kagenti_agent_fleet, kagenti_build_pipeline, kagenti_security,
- * kagenti_security_posture, kagenti_status, kagenti_tool_registry, kagenti_topology,
- * kvcache_monitor, latency_breakdown, llm_inference, llm_models, llmd_ai_insights,
- * llmd_configurator, llmd_flow, llmd_stack_monitor, ml_jobs, ml_notebooks, nightly_e2e_status,
- * pareto_frontier, pd_disaggregation, performance_timeline, provider_health, prow_history,
- * prow_jobs, prow_status, resource_utilization, throughput_comparison
+ * kagenti_security_posture, kagenti_status, kagenti_tool_registry, kagenti_topology, kvcache_monitor,
+ * latency_breakdown, llm_inference, llm_models, llmd_ai_insights, llmd_configurator, llmd_flow,
+ * llmd_stack_monitor, ml_jobs, ml_notebooks, nightly_e2e_status, pareto_frontier, pd_disaggregation,
+ * performance_timeline, provider_health, prow_history, prow_jobs, prow_status,
+ * resource_utilization, throughput_comparison
  */
 export interface CardRegistryDomain {
   components: Record<string, CardComponent>
@@ -84,6 +85,7 @@ const components: Record<string, CardComponent> = {
   console_ai_issues: ConsoleIssuesCard,
   console_ai_kubeconfig_audit: ConsoleKubeconfigAuditCard,
   console_ai_offline_detection: ConsoleOfflineDetectionCard,
+  epp_health: EPPHealth,
   epp_routing: EPPRouting,
   hardware_leaderboard: HardwareLeaderboard,
   kagent_agent_discovery: KagentAgentDiscovery,
@@ -127,6 +129,7 @@ const components: Record<string, CardComponent> = {
 export const aimlCardRegistry: CardRegistryDomain = {
   components,
   demoDataCards: new Set([
+    'epp_health',
     'kagent_agent_discovery',
     'kagent_agent_fleet',
     'kagent_agent_status',
@@ -148,6 +151,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     'ml_notebooks',
   ]),
   liveDataCards: new Set([
+    'epp_health',
     'kagent_agent_discovery',
     'kagent_agent_fleet',
     'kagent_agent_status',
@@ -177,6 +181,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     console_ai_issues: () => import('./console-missions/ConsoleIssuesCard'),
     console_ai_kubeconfig_audit: () => import('./console-missions/ConsoleKubeconfigAuditCard'),
     console_ai_offline_detection: () => import('./console-missions/ConsoleOfflineDetectionCard'),
+    epp_health: () => import('./EPPHealth'),
     epp_routing: () => import('./llmd'),
     hardware_leaderboard: () => import('./llmd'),
     kagent_agent_discovery: () => import('./kagent'),
@@ -222,6 +227,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     console_ai_issues: 6,
     console_ai_kubeconfig_audit: 6,
     console_ai_offline_detection: 6,
+    epp_health: 4,
     epp_routing: 6,
     hardware_leaderboard: 12,
     kagent_agent_discovery: 4,

--- a/web/src/hooks/useCachedKagentStatus.ts
+++ b/web/src/hooks/useCachedKagentStatus.ts
@@ -1,0 +1,64 @@
+/**
+ * useCachedKagentStatus — Hook for kagent agent status monitoring card.
+ *
+ * Follows the useCached* caching contract:
+ *   - Returns: data, isLoading, isRefreshing, isDemoData, isFailed,
+ *     consecutiveFailures, lastRefresh, refetch.
+ *   - isDemoData is suppressed while isLoading is true (so CardWrapper shows
+ *     a skeleton instead of flashing demo data).
+ *
+ * Falls back to demo data when the live endpoint is unavailable.
+ * Reference implementation: useCachedContainerd.ts
+ */
+
+import { createCachedHook, type CachedHookResult } from '../lib/cache'
+import {
+  KAGENT_DEMO_DATA,
+  generateKagentStatus,
+  type KagentStatusData,
+} from '../lib/demo/kagent'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY_KAGENT_STATUS = 'kagent_agent_status'
+
+const INITIAL_DATA: KagentStatusData[] = []
+
+// ---------------------------------------------------------------------------
+// Fetcher (placeholder — replace with real endpoint when available)
+// ---------------------------------------------------------------------------
+
+async function fetchKagentStatus(): Promise<KagentStatusData[]> {
+  throw new Error('kagent status endpoint not configured')
+}
+
+// ---------------------------------------------------------------------------
+// Hook return type
+// ---------------------------------------------------------------------------
+
+export type UseCachedKagentStatusResult = CachedHookResult<KagentStatusData[]> & {
+  isDemoData: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+const useCachedKagentStatusBase = createCachedHook<KagentStatusData[]>({
+  key: CACHE_KEY_KAGENT_STATUS,
+  initialData: INITIAL_DATA,
+  demoData: KAGENT_DEMO_DATA,
+  getDemoData: generateKagentStatus,
+  fetcher: fetchKagentStatus,
+})
+
+export function useCachedKagentStatus(): UseCachedKagentStatusResult {
+  const result = useCachedKagentStatusBase()
+
+  return {
+    ...result,
+    isDemoData: result.isDemoFallback,
+  }
+}

--- a/web/src/lib/demo/kagent.ts
+++ b/web/src/lib/demo/kagent.ts
@@ -1,0 +1,69 @@
+/**
+ * Kagent Status — Demo Data & Type Definitions
+ *
+ * Models kagent agent status data for the kagent monitoring card.
+ * Shown when no cluster is connected or in demo mode.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type KagentAgentStatus = 'running' | 'stopped' | 'error'
+
+export interface KagentStatusData {
+  agentName: string
+  namespace: string
+  status: KagentAgentStatus
+  activeMissions: number
+  lastHeartbeatAt: string
+  providerName: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo rows — realistic but synthetic
+// ---------------------------------------------------------------------------
+
+const DEMO_AGENTS: KagentStatusData[] = [
+  {
+    agentName: 'policy-agent',
+    namespace: 'kagent-system',
+    status: 'running',
+    activeMissions: 3,
+    lastHeartbeatAt: new Date(Date.now() - 15_000).toISOString(),
+    providerName: 'openai',
+  },
+  {
+    agentName: 'diagnostics-agent',
+    namespace: 'kagent-system',
+    status: 'running',
+    activeMissions: 1,
+    lastHeartbeatAt: new Date(Date.now() - 42_000).toISOString(),
+    providerName: 'anthropic',
+  },
+  {
+    agentName: 'remediation-agent',
+    namespace: 'kagent-ops',
+    status: 'stopped',
+    activeMissions: 0,
+    lastHeartbeatAt: new Date(Date.now() - 300_000).toISOString(),
+    providerName: 'openai',
+  },
+  {
+    agentName: 'audit-agent',
+    namespace: 'kagent-ops',
+    status: 'error',
+    activeMissions: 0,
+    lastHeartbeatAt: new Date(Date.now() - 900_000).toISOString(),
+    providerName: 'azure-openai',
+  },
+]
+
+export function generateKagentStatus(): KagentStatusData[] {
+  return DEMO_AGENTS.map(agent => ({
+    ...agent,
+    lastHeartbeatAt: new Date(Date.now() - Math.floor(Math.random() * 600_000)).toISOString(),
+  }))
+}
+
+export const KAGENT_DEMO_DATA: KagentStatusData[] = DEMO_AGENTS


### PR DESCRIPTION
Fixes #19912, Fixes #19914

Adds the `useCachedKagentStatus` hook with demo data for kagent monitoring, and the kagent agent list/status dashboard card component that uses it.

## Changes

### `web/src/lib/demo/kagent.ts` (new)
- `KagentStatusData` interface with `agentName`, `namespace`, `status` (running/stopped/error), `activeMissions`, `lastHeartbeatAt`, `providerName`
- `generateKagentStatus()` factory using `Math.random()` for fresh timestamps per render
- `KAGENT_DEMO_DATA` static demo data array with 4 realistic synthetic agents

### `web/src/hooks/useCachedKagentStatus.ts` (new)
- `useCachedKagentStatus` hook using `createCachedHook<KagentStatusData[]>`
- Falls back to demo data when live endpoint unavailable
- Returns `CachedHookResult<KagentStatusData[]> & { isDemoData: boolean }`
- Follows `useCachedContainerd.ts` pattern

### `web/src/components/cards/KagentStatus.tsx` (new)
- `KagentStatusInternal` component using `useCachedKagentStatus`
- Displays agent list with: name, namespace, status badge, active missions, last heartbeat
- Shows demo data notice badge when `isDemoData` is true
- Uses `useCardLoadingState`, `useCardData`, `CardControlsRow`, `DynamicCardErrorBoundary`
- Skeleton loading and error states

### `web/src/components/cards/cardRegistry.aiml.ts` (modified)
- Registers `KagentStatus` card as `kagent_agent_status` in the aiml domain registry