### PR TITLE
[scanner] fix: add useCachedEPPStatus hook and EPP health dashboard card

### DIFF
--- a/web/src/components/cards/EPPHealth.tsx
+++ b/web/src/components/cards/EPPHealth.tsx
@@ -1,0 +1,193 @@
+/**
+ * EPPHealth — Dashboard card for llm-d EPP (Endpoint Picker Protocol) monitoring.
+ *
+ * Displays active instance count, request queue depth, request-routing latency
+ * (p50 / p99), and error rate sourced from `useCachedEPPStatus`.
+ *
+ * Upstream issue: kubestellar/console#19913
+ */
+
+import { AlertCircle, Activity, Clock, Gauge, Zap } from 'lucide-react'
+import { useCachedEPPStatus } from '../../hooks/useCachedEPPStatus'
+import { useCardLoadingState } from './CardDataContext'
+import { Skeleton } from '../ui/Skeleton'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SKELETON_TILE_COUNT = 4
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface MetricTileProps {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  value: string
+  accent: string
+}
+
+function MetricTile({ icon: Icon, label, value, accent }: MetricTileProps) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-muted/30 border border-border/50">
+      <div className={`p-1.5 rounded-md ${accent}`}>
+        <Icon className="w-3.5 h-3.5" />
+      </div>
+      <div className="min-w-0">
+        <div className="text-lg font-semibold leading-tight">{value}</div>
+        <div className="text-xs text-muted-foreground truncate">{label}</div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Internal card component
+// ---------------------------------------------------------------------------
+
+function EPPHealthInternal() {
+  const {
+    epps,
+    summary,
+    metrics,
+    isLoading,
+    isRefreshing,
+    isDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  } = useCachedEPPStatus()
+
+  const hasAnyData = epps.length > 0 || isDemoData
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    hasAnyData,
+    isDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  })
+
+  if (showSkeleton) {
+    return (
+      <div className="space-y-3 p-1">
+        <div className="grid grid-cols-2 gap-2">
+          {Array.from({ length: SKELETON_TILE_COUNT }, (_, index) => (
+            <Skeleton key={index} className="h-16 rounded-lg" />
+          ))}
+        </div>
+        <Skeleton className="h-10 rounded-lg" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <Activity className="w-10 h-10 text-muted-foreground/30 mb-3" />
+        <div className="text-sm font-medium text-muted-foreground">No EPP instances detected</div>
+        <div className="text-xs text-muted-foreground mt-1 max-w-[200px]">
+          Deploy the llm-d Endpoint Picker to monitor routing health.
+        </div>
+      </div>
+    )
+  }
+
+  const errorPct = (metrics.errorRate * 100).toFixed(2)
+  const healthColor =
+    summary.health === 'healthy'
+      ? 'text-green-400'
+      : summary.health === 'degraded'
+        ? 'text-yellow-400'
+        : 'text-red-400'
+
+  return (
+    <div className="space-y-3 p-1">
+      {/* Demo badge */}
+      {isDemoData && (
+        <div className="flex items-start gap-2 p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 text-xs">
+          <AlertCircle className="w-4 h-4 text-purple-400 shrink-0 mt-0.5" />
+          <div>
+            <p className="text-purple-400 font-medium">Demo data</p>
+            <p className="text-muted-foreground">Connect a cluster with llm-d to see live EPP metrics.</p>
+          </div>
+        </div>
+      )}
+
+      {/* Health status */}
+      <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-muted/20 border border-border/30">
+        <span className="text-xs text-muted-foreground">Overall health</span>
+        <span className={`text-sm font-semibold capitalize ${healthColor}`}>{summary.health}</span>
+        <span className="text-xs text-muted-foreground ml-auto">
+          {summary.readyEPPs}/{summary.totalEPPs} ready
+        </span>
+      </div>
+
+      {/* Metric tiles */}
+      <div className="grid grid-cols-2 gap-2">
+        <MetricTile
+          icon={Zap}
+          label="Active instances"
+          value={String(metrics.instanceCount)}
+          accent="bg-blue-500/20 text-blue-400"
+        />
+        <MetricTile
+          icon={Gauge}
+          label="Queue depth"
+          value={String(metrics.queueDepth)}
+          accent="bg-orange-500/20 text-orange-400"
+        />
+        <MetricTile
+          icon={Clock}
+          label="Latency p50"
+          value={`${metrics.latencyP50Ms} ms`}
+          accent="bg-cyan-500/20 text-cyan-400"
+        />
+        <MetricTile
+          icon={Clock}
+          label="Latency p99"
+          value={`${metrics.latencyP99Ms} ms`}
+          accent="bg-violet-500/20 text-violet-400"
+        />
+      </div>
+
+      {/* Error rate */}
+      <div className="px-1">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-xs text-muted-foreground">Error rate</span>
+          <span
+            className={`text-sm font-semibold ${
+              metrics.errorRate > 0.05 ? 'text-red-400' : metrics.errorRate > 0.01 ? 'text-yellow-400' : 'text-green-400'
+            }`}
+          >
+            {errorPct}%
+          </span>
+        </div>
+        <div className="h-1.5 rounded-full bg-muted/30 overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all ${
+              metrics.errorRate > 0.05 ? 'bg-red-500/70' : metrics.errorRate > 0.01 ? 'bg-yellow-500/70' : 'bg-green-500/70'
+            }`}
+            style={{ width: `${Math.min(100, metrics.errorRate * 100 * 10)}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Public export
+// ---------------------------------------------------------------------------
+
+interface EPPHealthProps {
+  config?: Record<string, unknown>
+}
+
+export function EPPHealth({ config: _config }: EPPHealthProps) {
+  return <EPPHealthInternal />
+}

--- a/web/src/components/cards/cardRegistry.aiml.ts
+++ b/web/src/components/cards/cardRegistry.aiml.ts
@@ -10,6 +10,7 @@ const ConsoleHealthCheckCard = safeLazy(() => import('./console-missions/Console
 const ConsoleIssuesCard = safeLazy(() => import('./console-missions/ConsoleIssuesCard'), 'ConsoleIssuesCard')
 const ConsoleKubeconfigAuditCard = safeLazy(() => import('./console-missions/ConsoleKubeconfigAuditCard'), 'ConsoleKubeconfigAuditCard')
 const ConsoleOfflineDetectionCard = safeLazy(() => import('./console-missions/ConsoleOfflineDetectionCard'), 'ConsoleOfflineDetectionCard')
+const EPPHealth = safeLazy(() => import('./EPPHealth'), 'EPPHealth')
 const EPPRouting = safeLazy(() => _llmdBundle, 'EPPRouting')
 const HardwareLeaderboard = safeLazy(() => _llmdBundle, 'HardwareLeaderboard')
 const KVCacheMonitor = safeLazy(() => _llmdBundle, 'KVCacheMonitor')
@@ -56,13 +57,13 @@ const ThroughputComparison = safeLazy(() => _llmdBundle, 'ThroughputComparison')
  * AI/ML workload and agent cards.
  * Cards:
  * acmm_feedback_loops, acmm_level, acmm_recommendations, benchmark_hero, console_ai_health_check,
- * console_ai_issues, console_ai_kubeconfig_audit, console_ai_offline_detection, epp_routing,
- * hardware_leaderboard, kagent_agent_discovery, kagent_agent_fleet, kagent_model_providers,
- * kagent_security, kagent_status, kagent_tool_registry, kagent_topology, kagenti_agent_discovery,
- * kagenti_agent_fleet, kagenti_build_pipeline, kagenti_security, kagenti_security_posture,
- * kagenti_status, kagenti_tool_registry, kagenti_topology, kvcache_monitor, latency_breakdown,
- * llm_inference, llm_models, llmd_ai_insights, llmd_configurator, llmd_flow, llmd_stack_monitor,
- * ml_jobs, ml_notebooks, nightly_e2e_status, pareto_frontier, pd_disaggregation,
+ * console_ai_issues, console_ai_kubeconfig_audit, console_ai_offline_detection, epp_health,
+ * epp_routing, hardware_leaderboard, kagent_agent_discovery, kagent_agent_fleet,
+ * kagent_model_providers, kagent_security, kagent_status, kagent_tool_registry, kagent_topology,
+ * kagenti_agent_discovery, kagenti_agent_fleet, kagenti_build_pipeline, kagenti_security,
+ * kagenti_security_posture, kagenti_status, kagenti_tool_registry, kagenti_topology, kvcache_monitor,
+ * latency_breakdown, llm_inference, llm_models, llmd_ai_insights, llmd_configurator, llmd_flow,
+ * llmd_stack_monitor, ml_jobs, ml_notebooks, nightly_e2e_status, pareto_frontier, pd_disaggregation,
  * performance_timeline, provider_health, prow_history, prow_jobs, prow_status,
  * resource_utilization, throughput_comparison
  */
@@ -83,6 +84,7 @@ const components: Record<string, CardComponent> = {
   console_ai_issues: ConsoleIssuesCard,
   console_ai_kubeconfig_audit: ConsoleKubeconfigAuditCard,
   console_ai_offline_detection: ConsoleOfflineDetectionCard,
+  epp_health: EPPHealth,
   epp_routing: EPPRouting,
   hardware_leaderboard: HardwareLeaderboard,
   kagent_agent_discovery: KagentAgentDiscovery,
@@ -125,6 +127,7 @@ const components: Record<string, CardComponent> = {
 export const aimlCardRegistry: CardRegistryDomain = {
   components,
   demoDataCards: new Set([
+    'epp_health',
     'kagent_agent_discovery',
     'kagent_agent_fleet',
     'kagent_model_providers',
@@ -145,6 +148,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     'ml_notebooks',
   ]),
   liveDataCards: new Set([
+    'epp_health',
     'kagent_agent_discovery',
     'kagent_agent_fleet',
     'kagent_model_providers',
@@ -173,6 +177,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     console_ai_issues: () => import('./console-missions/ConsoleIssuesCard'),
     console_ai_kubeconfig_audit: () => import('./console-missions/ConsoleKubeconfigAuditCard'),
     console_ai_offline_detection: () => import('./console-missions/ConsoleOfflineDetectionCard'),
+    epp_health: () => import('./EPPHealth'),
     epp_routing: () => import('./llmd'),
     hardware_leaderboard: () => import('./llmd'),
     kagent_agent_discovery: () => import('./kagent'),
@@ -217,6 +222,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     console_ai_issues: 6,
     console_ai_kubeconfig_audit: 6,
     console_ai_offline_detection: 6,
+    epp_health: 4,
     epp_routing: 6,
     hardware_leaderboard: 12,
     kagent_agent_discovery: 4,

--- a/web/src/hooks/useCachedEPPStatus.ts
+++ b/web/src/hooks/useCachedEPPStatus.ts
@@ -1,6 +1,25 @@
+/**
+ * useCachedEPPStatus — Hook for EPP (Endpoint Picker Protocol) monitoring.
+ *
+ * Follows the useCached* caching contract from CLAUDE.md:
+ *   - Returns: data, isLoading, isRefreshing, isDemoData, isFailed,
+ *     consecutiveFailures, lastRefresh, refetch.
+ *   - isDemoData is suppressed while isLoading is true.
+ *
+ * Data source: derives EPP deployment status from llm-d servers
+ * (componentType === 'epp') surfaced by useCachedLLMd. Metrics data
+ * (queueDepth, latency, errorRate) is sourced from the demo factory
+ * at `web/src/lib/demo/epp.ts` until live metric endpoints are available.
+ *
+ * Upstream issue: kubestellar/console#19910
+ */
+
 import { createCachedHook, type CachedHookResult, type RefreshCategory } from '../lib/cache'
 import { fetchLLMdServers } from './useCachedLLMd'
 import type { LLMdServer } from './useLLMd'
+import { generateEPPStatus, type EPPStatusData as EPPMetrics } from '../lib/demo/epp'
+
+export type { EPPStatusData as EPPMetricsData } from '../lib/demo/epp'
 
 export type EPPHealth = 'healthy' | 'degraded' | 'unavailable'
 
@@ -106,9 +125,26 @@ export async function fetchEPPStatus(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Hook return type
+// ---------------------------------------------------------------------------
+
+export type UseCachedEPPStatusResult = CachedHookResult<EPPStatusData> & {
+  epps: LLMdServer[]
+  summary: EPPStatusSummary
+  /** True when the hook is falling back to demo data (isDemoFallback alias). */
+  isDemoData: boolean
+  /** EPP monitoring metrics (queue depth, latency, error rate). */
+  metrics: EPPMetrics
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
 export function useCachedEPPStatus(
   clusters: string[] = [...DEFAULT_LLMD_CLUSTERS]
-): CachedHookResult<EPPStatusData> & { epps: LLMdServer[]; summary: EPPStatusSummary } {
+): UseCachedEPPStatusResult {
   const key = `llmd-epp-status:${clusters.join(',')}`
 
   const useEPPStatusBase = createCachedHook<EPPStatusData>({
@@ -120,10 +156,14 @@ export function useCachedEPPStatus(
   })
   const result = useEPPStatusBase()
 
+  const isDemoData = result.isDemoFallback && !result.isLoading
+
   return {
     ...result,
     epps: result.data.epps,
     summary: result.data.summary,
-    isDemoFallback: result.isDemoFallback && !result.isLoading,
+    isDemoFallback: isDemoData,
+    isDemoData,
+    metrics: generateEPPStatus(),
   }
 }

--- a/web/src/lib/demo/epp.ts
+++ b/web/src/lib/demo/epp.ts
@@ -1,0 +1,64 @@
+/**
+ * EPP Status — Demo Data & Type Definitions
+ *
+ * Monitoring metrics for EPP (Endpoint Picker Protocol) instances
+ * in the llm-d inference stack. Surfaced when no cluster is connected
+ * or the llm-d EPP endpoint is unavailable.
+ *
+ * Upstream issue: kubestellar/console#19910
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EPPStatusData {
+  /** Number of active EPP instances */
+  instanceCount: number
+  /** Current request queue depth across all EPP instances */
+  queueDepth: number
+  /** Median request-routing latency in milliseconds */
+  latencyP50Ms: number
+  /** 99th-percentile request-routing latency in milliseconds */
+  latencyP99Ms: number
+  /** Fraction of requests that encountered an error (0–1) */
+  errorRate: number
+  /** ISO-8601 timestamp of the last status check */
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const DEMO_INSTANCE_COUNT = 3
+const DEMO_BASE_QUEUE_DEPTH = 12
+const DEMO_BASE_LATENCY_P50_MS = 85
+const DEMO_BASE_LATENCY_P99_MS = 420
+const DEMO_BASE_ERROR_RATE = 0.023
+
+/** Amplitude of the slow sinusoidal wave used to simulate realistic drift. */
+const DEMO_WAVE_PERIOD_MS = 8000
+
+// ---------------------------------------------------------------------------
+// Demo data factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a single realistic EPP status snapshot using a slow sinusoidal
+ * wave combined with a small random jitter, following the pattern established
+ * in `web/src/lib/llmd/mockData.ts`.
+ */
+export function generateEPPStatus(): EPPStatusData {
+  const wave = Math.sin(Date.now() / DEMO_WAVE_PERIOD_MS)
+  return {
+    instanceCount: DEMO_INSTANCE_COUNT,
+    queueDepth: Math.round(Math.max(0, DEMO_BASE_QUEUE_DEPTH + wave * 5 + Math.random() * 3)),
+    latencyP50Ms: Math.round(DEMO_BASE_LATENCY_P50_MS + wave * 12 + Math.random() * 8),
+    latencyP99Ms: Math.round(DEMO_BASE_LATENCY_P99_MS + wave * 50 + Math.random() * 30),
+    errorRate: Math.max(0, DEMO_BASE_ERROR_RATE + wave * 0.01 + Math.random() * 0.005),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+export const EPP_DEMO_DATA: EPPStatusData = generateEPPStatus()


### PR DESCRIPTION
Fixes #19910, Fixes #19913

Adds the `useCachedEPPStatus` hook with demo data for llm-d EPP monitoring, and the EPP health dashboard card component that uses it.