### PR TITLE
[scanner] fix: add useCachedDrasiPipelines hook and Drasi pipeline status card

### DIFF
--- a/web/src/components/cards/DrasiPipelines.tsx
+++ b/web/src/components/cards/DrasiPipelines.tsx
@@ -1,0 +1,309 @@
+/**
+ * DrasiPipelines — Dashboard card showing Drasi reactive pipeline statuses.
+ *
+ * Displays a searchable, sortable list of Drasi pipelines with their
+ * operational status, continuous query count, reaction count, and last
+ * event timestamp. Falls back to demo data when no live endpoint is
+ * available.
+ *
+ * Upstream issue: kubestellar/console#19915
+ */
+
+import { useMemo } from 'react'
+import { AlertCircle, Activity, StopCircle, XCircle } from 'lucide-react'
+import { Skeleton } from '../ui/Skeleton'
+import {
+  CardSearchInput,
+  CardControlsRow,
+  CardPaginationFooter,
+} from '../../lib/cards/CardComponents'
+import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
+import { useCardLoadingState } from './CardDataContext'
+import { useCachedDrasiPipelines } from '../../hooks/useCachedDrasiPipelines'
+import type { DrasiPipelineData } from '../../lib/demo/drasi'
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+type SortByOption = 'name' | 'status' | 'queries' | 'reactions' | 'lastEvent'
+
+const SORT_OPTIONS: ReadonlyArray<{ value: SortByOption; label: string }> = [
+  { value: 'name', label: 'Name' },
+  { value: 'status', label: 'Status' },
+  { value: 'queries', label: 'Queries' },
+  { value: 'reactions', label: 'Reactions' },
+  { value: 'lastEvent', label: 'Last Event' },
+]
+
+const STATUS_ORDER: Record<string, number> = {
+  running: 0,
+  stopped: 1,
+  error: 2,
+}
+
+const PIPELINE_SORT_COMPARATORS: Record<SortByOption, (a: DrasiPipelineData, b: DrasiPipelineData) => number> = {
+  name: commonComparators.string<DrasiPipelineData>('pipelineName'),
+  status: commonComparators.statusOrder<DrasiPipelineData>('status', STATUS_ORDER),
+  queries: commonComparators.number<DrasiPipelineData>('continuousQueriesCount'),
+  reactions: commonComparators.number<DrasiPipelineData>('reactionsCount'),
+  lastEvent: commonComparators.date<DrasiPipelineData>('lastEventAt'),
+}
+
+// ---------------------------------------------------------------------------
+// Status display config
+// ---------------------------------------------------------------------------
+
+const STATUS_CONFIG = {
+  running: {
+    label: 'Running',
+    Icon: Activity,
+    textColor: 'text-green-400',
+    bgColor: 'bg-green-500/10',
+    borderColor: 'border-green-500/20',
+  },
+  stopped: {
+    label: 'Stopped',
+    Icon: StopCircle,
+    textColor: 'text-yellow-400',
+    bgColor: 'bg-yellow-500/10',
+    borderColor: 'border-yellow-500/20',
+  },
+  error: {
+    label: 'Error',
+    Icon: XCircle,
+    textColor: 'text-red-400',
+    bgColor: 'bg-red-500/10',
+    borderColor: 'border-red-500/20',
+  },
+} as const
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(isoString: string): string {
+  const date = new Date(isoString)
+  if (Number.isNaN(date.getTime())) return 'Unknown'
+  const diffMs = Date.now() - date.getTime()
+  if (diffMs < 60_000) return 'Just now'
+  const diffMins = Math.floor(diffMs / 60_000)
+  if (diffMins < 60) return `${diffMins}m ago`
+  const diffHours = Math.floor(diffMins / 60)
+  if (diffHours < 24) return `${diffHours}h ago`
+  const diffDays = Math.floor(diffHours / 24)
+  return `${diffDays}d ago`
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface DrasiPipelinesProps {
+  config?: Record<string, unknown>
+}
+
+export function DrasiPipelines({ config: _config }: DrasiPipelinesProps) {
+  const {
+    data: allPipelines,
+    isLoading,
+    isRefreshing,
+    isDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+    refetch,
+  } = useCachedDrasiPipelines()
+
+  const stats = useMemo(() => {
+    const pipelines = allPipelines || []
+    return {
+      total: pipelines.length,
+      running: pipelines.filter(p => p.status === 'running').length,
+      stopped: pipelines.filter(p => p.status === 'stopped').length,
+      error: pipelines.filter(p => p.status === 'error').length,
+    }
+  }, [allPipelines])
+
+  const hasData = (allPipelines || []).length > 0
+  useCardLoadingState({
+    isLoading: isLoading && !hasData,
+    isRefreshing,
+    hasAnyData: hasData,
+    isDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  })
+
+  const {
+    items: paginatedPipelines,
+    totalItems,
+    currentPage,
+    totalPages,
+    itemsPerPage,
+    goToPage,
+    needsPagination,
+    setItemsPerPage,
+    filters: {
+      search: localSearch,
+      setSearch: setLocalSearch,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+    containerRef,
+    containerStyle,
+  } = useCardData<DrasiPipelineData, SortByOption>(allPipelines || [], {
+    filter: {
+      searchFields: ['pipelineName', 'status'],
+      storageKey: 'drasi-pipelines',
+    },
+    sort: {
+      defaultField: 'name',
+      defaultDirection: 'asc',
+      comparators: PIPELINE_SORT_COMPARATORS,
+    },
+    defaultLimit: 5,
+  })
+
+  if (isLoading && !hasData) {
+    return (
+      <div className="h-full flex flex-col min-h-card">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
+          <Skeleton variant="text" width={120} height={20} />
+          <Skeleton variant="rounded" width={80} height={28} />
+        </div>
+        <div className="space-y-2">
+          <Skeleton variant="rounded" height={60} />
+          <Skeleton variant="rounded" height={60} />
+          <Skeleton variant="rounded" height={60} />
+        </div>
+      </div>
+    )
+  }
+
+  if (isFailed && !hasData) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card p-6">
+        <AlertCircle className="w-12 h-12 text-red-400 mb-4" />
+        <p className="text-sm text-muted-foreground mb-4">Failed to load Drasi pipelines</p>
+        <button
+          onClick={() => refetch()}
+          className="px-4 py-2 rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground text-sm"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card">
+      {/* Header controls */}
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 shrink-0">
+        <span className="text-sm font-medium text-muted-foreground">
+          {totalItems} pipeline{totalItems !== 1 ? 's' : ''}
+        </span>
+        <CardControlsRow
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS.map(o => ({ value: o.value, label: o.label })),
+            onSortChange: (v) => setSortBy(v as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+        />
+      </div>
+
+      {/* Search */}
+      <CardSearchInput
+        value={localSearch}
+        onChange={setLocalSearch}
+        placeholder="Search pipelines..."
+        className="mb-3"
+      />
+
+      {/* Demo data notice */}
+      {isDemoData && (
+        <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-blue-500/10 border border-blue-500/20 text-xs">
+          <AlertCircle className="w-4 h-4 text-blue-400 shrink-0 mt-0.5" />
+          <div>
+            <p className="text-blue-400 font-medium">Demo Data</p>
+            <p className="text-muted-foreground">
+              Showing simulated Drasi pipeline data. Connect a cluster with Drasi installed to see live status.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Stats summary */}
+      <div className="grid grid-cols-3 gap-2 mb-3">
+        <div className="p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-center">
+          <p className="text-2xs text-green-400">Running</p>
+          <p className="text-lg font-bold text-foreground">{stats.running}</p>
+        </div>
+        <div className="p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
+          <p className="text-2xs text-yellow-400">Stopped</p>
+          <p className="text-lg font-bold text-foreground">{stats.stopped}</p>
+        </div>
+        <div className="p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-center">
+          <p className="text-2xs text-red-400">Error</p>
+          <p className="text-lg font-bold text-foreground">{stats.error}</p>
+        </div>
+      </div>
+
+      {/* Pipelines list */}
+      <div ref={containerRef} className="flex-1 overflow-y-auto space-y-2" style={containerStyle}>
+        {paginatedPipelines.map((pipeline) => {
+          const cfg = STATUS_CONFIG[pipeline.status]
+          const { Icon } = cfg
+          return (
+            <div
+              key={pipeline.pipelineName}
+              className="p-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-y-1 mb-1">
+                <div className="flex items-center gap-2">
+                  <Icon className={`w-4 h-4 ${cfg.textColor}`} />
+                  <span className="text-sm font-medium text-foreground truncate">{pipeline.pipelineName}</span>
+                  <span className={`px-1.5 py-0.5 rounded text-2xs ${cfg.bgColor} ${cfg.textColor}`}>
+                    {cfg.label}
+                  </span>
+                </div>
+                <span className="text-2xs text-muted-foreground/60">
+                  {formatRelativeTime(pipeline.lastEventAt)}
+                </span>
+              </div>
+              <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                <span>
+                  {pipeline.continuousQueriesCount}{' '}
+                  {pipeline.continuousQueriesCount === 1 ? 'query' : 'queries'}
+                </span>
+                <span>
+                  {pipeline.reactionsCount}{' '}
+                  {pipeline.reactionsCount === 1 ? 'reaction' : 'reactions'}
+                </span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Pagination */}
+      <CardPaginationFooter
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 10}
+        onPageChange={goToPage}
+        needsPagination={needsPagination && itemsPerPage !== 'unlimited'}
+      />
+    </div>
+  )
+}

--- a/web/src/components/cards/cardRegistry.misc.ts
+++ b/web/src/components/cards/cardRegistry.misc.ts
@@ -23,6 +23,7 @@ const CrossplaneManagedResources = safeLazy(() => import('./crossplane-status/Cr
 const CubefsStatus = safeLazy(() => import('./cubefs_status'), 'CubefsStatus')
 const DeploymentRolloutTracker = safeLazy(() => _insightsBundle, 'DeploymentRolloutTracker')
 const DragonflyStatus = safeLazy(() => import('./dragonfly_status'), 'DragonflyStatus')
+const DrasiPipelines = safeLazy(() => import('./DrasiPipelines'), 'DrasiPipelines')
 const _drasiBundle = import('./drasi').catch(() => undefined as never)
 const DrasiReactiveGraph = safeLazy(() => _drasiBundle, 'DrasiReactiveGraph')
 const DynamicCard = safeLazy(() => import('./DynamicCard'), 'DynamicCard')
@@ -95,8 +96,8 @@ const WasmcloudStatus = safeLazy(() => import('./wasmcloud_status'), 'WasmcloudS
  * chaos_mesh_status, checkers, cloudevents_status, cluster_changelog, cluster_delta_detector,
  * config_drift_heatmap, container_tetris, control_plane_health, crio_status,
  * cross_cluster_event_correlation, crossplane_managed_resources, cubefs_status,
- * deployment_rollout_tracker, dragonfly_status, drasi_reactive_graph, dynamic_card, etcd_status,
- * failover_timeline, flappy_pod, flatcar_status, fluid_status, game_2048, gateway_status,
+ * deployment_rollout_tracker, dragonfly_status, drasi_pipelines, drasi_reactive_graph, dynamic_card,
+ * etcd_status, failover_timeline, flappy_pod, flatcar_status, fluid_status, game_2048, gateway_status,
  * github_activity, iframe_embed, issue_activity_chart, karmada_status, keda_status,
  * knative_status, kserve_status, kube_bert, kube_chess, kube_doom, kube_galaga, kube_kart,
  * kube_kong, kube_man, kube_pong, kube_snake, kubectl, kubedle, kuberay_fleet, kubevela_status,
@@ -136,6 +137,7 @@ const components: Record<string, CardComponent> = {
   cubefs_status: CubefsStatus,
   deployment_rollout_tracker: DeploymentRolloutTracker,
   dragonfly_status: DragonflyStatus,
+  drasi_pipelines: DrasiPipelines,
   drasi_reactive_graph: DrasiReactiveGraph,
   dynamic_card: DynamicCard,
   etcd_status: EtcdStatus,
@@ -207,6 +209,7 @@ export const miscCardRegistry: CardRegistryDomain = {
     'admission_webhooks',
     'crossplane_managed_resources',
     'cubefs_status',
+    'drasi_pipelines',
     'fluid_status',
     'gateway_status',
     'knative_status',
@@ -257,6 +260,7 @@ export const miscCardRegistry: CardRegistryDomain = {
     cubefs_status: () => import('./cubefs_status'),
     deployment_rollout_tracker: () => import('./insights'),
     dragonfly_status: () => import('./dragonfly_status'),
+    drasi_pipelines: () => import('./DrasiPipelines'),
     drasi_reactive_graph: () => import('./drasi'),
     dynamic_card: () => import('./DynamicCard'),
     etcd_status: () => import('./cluster-admin-bundle'),
@@ -340,6 +344,7 @@ export const miscCardRegistry: CardRegistryDomain = {
     crossplane_managed_resources: 4,
     deployment_rollout_tracker: 6,
     dragonfly_status: 6,
+    drasi_pipelines: 6,
     drasi_reactive_graph: 12,
     etcd_status: 4,
     failover_timeline: 8,

--- a/web/src/hooks/useCachedDrasiPipelines.ts
+++ b/web/src/hooks/useCachedDrasiPipelines.ts
@@ -1,0 +1,83 @@
+/**
+ * useCachedDrasiPipelines — Hook for the Drasi pipeline status dashboard card.
+ *
+ * Follows the useCached* caching contract:
+ *   - Returns: data, isLoading, isRefreshing, isDemoData, isFailed,
+ *     consecutiveFailures, lastRefresh, refetch.
+ *   - isDemoData is suppressed while isLoading is true (so CardWrapper shows
+ *     a skeleton instead of flashing demo data).
+ *
+ * Data source: /drasi/pipelines endpoint from the local kc-agent.
+ * Falls back to generated demo data when the live endpoint is unavailable.
+ *
+ * Upstream issue: kubestellar/console#19911
+ */
+
+import { createCachedHook, type CachedHookResult } from '../lib/cache'
+import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../lib/constants/network'
+import { agentFetch } from './mcp/shared'
+import {
+  generateDrasiPipelines,
+  type DrasiPipelineData,
+} from '../lib/demo/drasi'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY_DRASI_PIPELINES = 'drasi_pipelines'
+
+/** Empty initial payload while the first fetch resolves. */
+const INITIAL_DATA: DrasiPipelineData[] = []
+
+// ---------------------------------------------------------------------------
+// Backend response shape (narrow — only the fields we consume)
+// ---------------------------------------------------------------------------
+
+interface BackendDrasiPipelinesResponse {
+  pipelines?: DrasiPipelineData[]
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchDrasiPipelines(): Promise<DrasiPipelineData[]> {
+  const resp = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/drasi/pipelines`, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
+
+  if (!resp.ok) throw new Error(`drasi/pipelines HTTP ${resp.status}`)
+
+  const body: BackendDrasiPipelinesResponse = await resp.json()
+  return Array.isArray(body?.pipelines) ? body.pipelines : []
+}
+
+// ---------------------------------------------------------------------------
+// Hook return type
+// ---------------------------------------------------------------------------
+
+export type UseCachedDrasiPipelinesResult = CachedHookResult<DrasiPipelineData[]> & {
+  isDemoData: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+const useCachedDrasiPipelinesBase = createCachedHook<DrasiPipelineData[]>({
+  key: CACHE_KEY_DRASI_PIPELINES,
+  initialData: INITIAL_DATA,
+  getDemoData: generateDrasiPipelines,
+  fetcher: fetchDrasiPipelines,
+})
+
+export function useCachedDrasiPipelines(): UseCachedDrasiPipelinesResult {
+  const result = useCachedDrasiPipelinesBase()
+
+  return {
+    ...result,
+    isDemoData: result.isDemoFallback,
+  }
+}

--- a/web/src/lib/demo/drasi.ts
+++ b/web/src/lib/demo/drasi.ts
@@ -1,0 +1,79 @@
+/**
+ * Drasi Pipelines — Demo Data & Type Definitions
+ *
+ * Models Drasi reactive pipeline status for the dashboard monitoring card.
+ * Shown when no cluster is connected or in demo mode.
+ *
+ * Upstream issue: kubestellar/console#19911
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DrasiPipelineStatus = 'running' | 'stopped' | 'error'
+
+export interface DrasiPipelineData {
+  /** Human-readable pipeline name */
+  pipelineName: string
+  /** Current operational status */
+  status: DrasiPipelineStatus
+  /** Number of continuous queries in this pipeline */
+  continuousQueriesCount: number
+  /** Number of reactions attached to this pipeline */
+  reactionsCount: number
+  /** ISO timestamp of the last event processed by this pipeline */
+  lastEventAt: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo data factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a realistic set of Drasi pipeline status entries for demo mode.
+ * Timestamps are fresh on every call so the card always shows recent activity.
+ */
+export function generateDrasiPipelines(): DrasiPipelineData[] {
+  const now = Date.now()
+  return [
+    {
+      pipelineName: 'stock-ticker',
+      status: 'running',
+      continuousQueriesCount: 4,
+      reactionsCount: 1,
+      lastEventAt: new Date(now - Math.floor(Math.random() * 60_000)).toISOString(),
+    },
+    {
+      pipelineName: 'fraud-detection',
+      status: 'running',
+      continuousQueriesCount: 3,
+      reactionsCount: 3,
+      lastEventAt: new Date(now - Math.floor(Math.random() * 120_000)).toISOString(),
+    },
+    {
+      pipelineName: 'retail-analytics',
+      status: 'running',
+      continuousQueriesCount: 3,
+      reactionsCount: 3,
+      lastEventAt: new Date(now - Math.floor(Math.random() * 300_000)).toISOString(),
+    },
+    {
+      pipelineName: 'iot-telemetry',
+      status: 'stopped',
+      continuousQueriesCount: 3,
+      reactionsCount: 3,
+      lastEventAt: new Date(now - Math.floor(Math.random() * 3_600_000)).toISOString(),
+    },
+    {
+      pipelineName: 'supply-chain',
+      status: 'error',
+      continuousQueriesCount: 3,
+      reactionsCount: 3,
+      lastEventAt: new Date(now - Math.floor(Math.random() * 600_000)).toISOString(),
+    },
+  ]
+}
+
+/** Static demo data snapshot — use `generateDrasiPipelines()` for fresh timestamps. */
+export const DRASI_PIPELINES_DEMO_DATA: DrasiPipelineData[] = generateDrasiPipelines()


### PR DESCRIPTION
Fixes #19911, Fixes #19915

Adds the `useCachedDrasiPipelines` hook with demo data for Drasi reactive pipeline monitoring, and the Drasi pipeline status dashboard card component that uses it.