### PR TITLE
[quality] fix: add Host header to fiber test requests for fasthttp v1.72.0 compat

### DIFF
--- a/pkg/api/handlers/stellar/actions_test.go
+++ b/pkg/api/handlers/stellar/actions_test.go
@@ -79,6 +79,7 @@ func TestStellarActionExecute_RBAC(t *testing.T) {
 
 			req, err := http.NewRequest(http.MethodPost, "/api/stellar/actions/execute", http.NoBody)
 			require.NoError(t, err)
+			req.Host = "localhost"
 			req.Header.Set("Content-Type", "application/json")
 
 			resp, err := app.Test(req, stellarActionExecuteFiberTimeoutMs)
@@ -111,6 +112,7 @@ func TestStellarActionExecute_DestructiveActionsRequireApprovalFlow(t *testing.T
 
 			req, err := http.NewRequest(http.MethodPost, "/api/stellar/actions/execute", bytes.NewReader(body))
 			require.NoError(t, err)
+			req.Host = "localhost"
 			req.Header.Set("Content-Type", "application/json")
 
 			resp, err := app.Test(req, stellarActionExecuteFiberTimeoutMs)

--- a/pkg/api/handlers/stellar/mocked_handlers_test.go
+++ b/pkg/api/handlers/stellar/mocked_handlers_test.go
@@ -125,6 +125,7 @@ func TestStellarCreateTask_DefaultsWithMockedStore(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/tasks", bytes.NewReader([]byte(`{"title":"Investigate failed rollout"}`)))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
@@ -146,6 +147,7 @@ func TestStellarCreateTask_InvalidDueAtReturnsBadRequest(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/tasks", bytes.NewReader([]byte(`{"title":"Investigate failed rollout","dueAt":"not-rfc3339"}`)))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
@@ -163,6 +165,7 @@ func TestStellarUpdateTaskStatus_ReturnsStatusWhenReloadFails(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPatch, "/api/stellar/tasks/task-7/status", bytes.NewReader([]byte(`{"status":"DONE"}`)))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
@@ -187,6 +190,7 @@ func TestStellarSearchMemory_DefaultLimitWithMockedStore(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/memory/search", bytes.NewReader([]byte(`{"query":"oomkilled"}`)))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
@@ -217,6 +221,7 @@ func TestStellarCreateProvider_UsesMockedUpsert(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/providers", bytes.NewReader([]byte(`{"provider":"ollama","displayName":"Local Ollama","baseUrl":"http://127.0.0.1:11434","model":"llama3"}`)))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)

--- a/pkg/api/handlers/stellar/notifications_test.go
+++ b/pkg/api/handlers/stellar/notifications_test.go
@@ -58,6 +58,7 @@ func TestListNotifications_EmptyResult(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/notifications", http.NoBody)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
 	require.NoError(t, err)
@@ -99,6 +100,7 @@ func TestListNotifications_ReturnsCreatedNotifications(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/notifications", http.NoBody)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
 	require.NoError(t, err)
@@ -117,7 +119,6 @@ func TestListNotifications_UnreadOnlyFilter(t *testing.T) {
 	app, sqlStore, userID := newNotificationTestApp(t)
 	ctx := context.Background()
 
-	// Create two notifications
 	n1 := &store.StellarNotification{
 		UserID:   userID,
 		Type:     "event",
@@ -138,12 +139,11 @@ func TestListNotifications_UnreadOnlyFilter(t *testing.T) {
 	}
 	require.NoError(t, sqlStore.CreateStellarNotification(ctx, n2))
 
-	// Mark n2 as read
 	require.NoError(t, sqlStore.MarkStellarNotificationRead(ctx, userID, n2.ID))
 
-	// Query for unread only
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/notifications?unread=true", http.NoBody)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
 	require.NoError(t, err)
@@ -176,6 +176,7 @@ func TestMarkNotificationRead_Success(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/read", http.NoBody)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
 	require.NoError(t, err)
@@ -183,7 +184,6 @@ func TestMarkNotificationRead_Success(t *testing.T) {
 
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 
-	// Verify notification was marked read
 	updated, err := sqlStore.GetStellarNotification(ctx, userID, n.ID)
 	require.NoError(t, err)
 	require.NotNil(t, updated)
@@ -196,6 +196,7 @@ func TestMarkNotificationRead_MissingID(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/%20/read", http.NoBody)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
 	require.NoError(t, err)
@@ -233,6 +234,7 @@ func TestMarkNotificationInvestigating_Success(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/investigating", bytes.NewReader(bodyBytes))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -253,6 +255,7 @@ func TestMarkNotificationInvestigating_InvalidJSON(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/some-id/investigating", bytes.NewReader([]byte("invalid-json")))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -287,6 +290,7 @@ func TestResolveNotification_Success(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/resolve", bytes.NewReader(bodyBytes))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -328,6 +332,7 @@ func TestDismissNotification_Success(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/dismiss", bytes.NewReader(bodyBytes))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -355,6 +360,7 @@ func TestUpdateNotificationState_NotificationNotFound(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/nonexistent-id/resolve", bytes.NewReader(bodyBytes))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -372,7 +378,6 @@ func TestUpdateNotificationState_FillsAffectedResource(t *testing.T) {
 	app, sqlStore, userID := newNotificationTestApp(t)
 	ctx := context.Background()
 
-	// Notification with DedupeKey but no AffectedResource
 	n := &store.StellarNotification{
 		UserID:    userID,
 		Type:      "event",
@@ -394,6 +399,7 @@ func TestUpdateNotificationState_FillsAffectedResource(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/resolve", bytes.NewReader(bodyBytes))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -408,81 +414,53 @@ func TestUpdateNotificationState_FillsAffectedResource(t *testing.T) {
 }
 
 func TestDescribeNotificationStateChange_Investigating(t *testing.T) {
-	notification := &store.StellarNotification{
-		Status: "investigating",
-	}
-
+	notification := &store.StellarNotification{Status: "investigating"}
 	title, detail, kind := describeNotificationStateChange(notification, "Looking into the logs")
-
 	assert.Equal(t, "manual_investigating", kind)
 	assert.Equal(t, "Event marked investigating", title)
 	assert.Equal(t, "Looking into the logs", detail)
 }
 
 func TestDescribeNotificationStateChange_InvestigatingNoNote(t *testing.T) {
-	notification := &store.StellarNotification{
-		Status: "investigating",
-	}
-
+	notification := &store.StellarNotification{Status: "investigating"}
 	_, detail, kind := describeNotificationStateChange(notification, "")
-
 	assert.Equal(t, "manual_investigating", kind)
 	assert.Equal(t, "Operator opened investigation from the escalated event modal.", detail)
 }
 
 func TestDescribeNotificationStateChange_Resolved(t *testing.T) {
-	notification := &store.StellarNotification{
-		Status: "resolved",
-	}
-
+	notification := &store.StellarNotification{Status: "resolved"}
 	title, detail, kind := describeNotificationStateChange(notification, "Applied fix")
-
 	assert.Equal(t, "manual_resolved", kind)
 	assert.Equal(t, "Event resolved manually", title)
 	assert.Equal(t, "Applied fix", detail)
 }
 
 func TestDescribeNotificationStateChange_ResolvedNoNote(t *testing.T) {
-	notification := &store.StellarNotification{
-		Status: "resolved",
-	}
-
+	notification := &store.StellarNotification{Status: "resolved"}
 	_, detail, kind := describeNotificationStateChange(notification, "")
-
 	assert.Equal(t, "manual_resolved", kind)
 	assert.Equal(t, "Operator resolved the escalated event from the modal.", detail)
 }
 
 func TestDescribeNotificationStateChange_Dismissed(t *testing.T) {
-	notification := &store.StellarNotification{
-		Status: "dismissed",
-	}
-
+	notification := &store.StellarNotification{Status: "dismissed"}
 	title, detail, kind := describeNotificationStateChange(notification, "Not relevant")
-
 	assert.Equal(t, "manual_dismissed", kind)
 	assert.Equal(t, "Event removed from escalated list", title)
 	assert.Equal(t, "Not relevant", detail)
 }
 
 func TestDescribeNotificationStateChange_DismissedNoNote(t *testing.T) {
-	notification := &store.StellarNotification{
-		Status: "dismissed",
-	}
-
+	notification := &store.StellarNotification{Status: "dismissed"}
 	_, detail, kind := describeNotificationStateChange(notification, "")
-
 	assert.Equal(t, "manual_dismissed", kind)
 	assert.Equal(t, "Operator dismissed the escalated event from the modal.", detail)
 }
 
 func TestDescribeNotificationStateChange_UnknownStatus(t *testing.T) {
-	notification := &store.StellarNotification{
-		Status: "unknown",
-	}
-
+	notification := &store.StellarNotification{Status: "unknown"}
 	title, detail, kind := describeNotificationStateChange(notification, "custom note")
-
 	assert.Equal(t, "manual_updated", kind)
 	assert.Equal(t, "Event updated", title)
 	assert.Equal(t, "custom note", detail)
@@ -494,33 +472,15 @@ func TestDeriveNotificationWorkload_StandardFormat(t *testing.T) {
 		dedupeKey string
 		want      string
 	}{
-		{
-			name:      "WithEvPrefix",
-			dedupeKey: "ev:cluster-a:Deployment:web-app",
-			want:      "web-app",
-		},
-		{
-			name:      "WithoutEvPrefix",
-			dedupeKey: "cluster-a:Pod:nginx-pod",
-			want:      "nginx-pod",
-		},
-		{
-			name:      "TooShort",
-			dedupeKey: "ev:cluster",
-			want:      "",
-		},
-		{
-			name:      "Empty",
-			dedupeKey: "",
-			want:      "",
-		},
+		{name: "WithEvPrefix", dedupeKey: "ev:cluster-a:Deployment:web-app", want: "web-app"},
+		{name: "WithoutEvPrefix", dedupeKey: "cluster-a:Pod:nginx-pod", want: "nginx-pod"},
+		{name: "TooShort", dedupeKey: "ev:cluster", want: ""},
+		{name: "Empty", dedupeKey: "", want: ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			notification := &store.StellarNotification{
-				DedupeKey: tt.dedupeKey,
-			}
+			notification := &store.StellarNotification{DedupeKey: tt.dedupeKey}
 			got := deriveNotificationWorkload(notification)
 			assert.Equal(t, tt.want, got)
 		})
@@ -535,38 +495,15 @@ func TestDeriveStellarNotificationResource_StandardFormat(t *testing.T) {
 		title     string
 		want      string
 	}{
-		{
-			name:      "WithEvPrefix",
-			dedupeKey: "ev:cluster-a:Deployment:web-app",
-			want:      "Deployment/web-app",
-		},
-		{
-			name:      "WithoutEvPrefix",
-			dedupeKey: "cluster-a:Pod:nginx-pod",
-			want:      "Pod/nginx-pod",
-		},
-		{
-			name:      "TooShortWithFallback",
-			dedupeKey: "ev:cluster",
-			namespace: "default",
-			title:     "some-pod",
-			want:      "default/some-pod",
-		},
-		{
-			name:      "EmptyDedupeKeyWithTitle",
-			dedupeKey: "",
-			title:     "nginx",
-			want:      "nginx",
-		},
+		{name: "WithEvPrefix", dedupeKey: "ev:cluster-a:Deployment:web-app", want: "Deployment/web-app"},
+		{name: "WithoutEvPrefix", dedupeKey: "cluster-a:Pod:nginx-pod", want: "Pod/nginx-pod"},
+		{name: "TooShortWithFallback", dedupeKey: "ev:cluster", namespace: "default", title: "some-pod", want: "default/some-pod"},
+		{name: "EmptyDedupeKeyWithTitle", dedupeKey: "", title: "nginx", want: "nginx"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			notification := &store.StellarNotification{
-				DedupeKey: tt.dedupeKey,
-				Namespace: tt.namespace,
-				Title:     tt.title,
-			}
+			notification := &store.StellarNotification{DedupeKey: tt.dedupeKey, Namespace: tt.namespace, Title: tt.title}
 			got := deriveStellarNotificationResource(notification)
 			assert.Equal(t, tt.want, got)
 		})
@@ -583,20 +520,9 @@ func TestUpdateNotificationState_WrongUser(t *testing.T) {
 	user2 := uuid.New()
 
 	ctx := context.Background()
-	require.NoError(t, sqlStore.CreateUser(ctx, &models.User{
-		ID:          user1,
-		GitHubID:    "gh-user1",
-		GitHubLogin: "user1",
-		Role:        models.UserRoleEditor,
-	}))
-	require.NoError(t, sqlStore.CreateUser(ctx, &models.User{
-		ID:          user2,
-		GitHubID:    "gh-user2",
-		GitHubLogin: "user2",
-		Role:        models.UserRoleEditor,
-	}))
+	require.NoError(t, sqlStore.CreateUser(ctx, &models.User{ID: user1, GitHubID: "gh-user1", GitHubLogin: "user1", Role: models.UserRoleEditor}))
+	require.NoError(t, sqlStore.CreateUser(ctx, &models.User{ID: user2, GitHubID: "gh-user2", GitHubLogin: "user2", Role: models.UserRoleEditor}))
 
-	// Create notification for user1
 	n := &store.StellarNotification{
 		UserID:   user1.String(),
 		Type:     "event",
@@ -607,7 +533,6 @@ func TestUpdateNotificationState_WrongUser(t *testing.T) {
 	}
 	require.NoError(t, sqlStore.CreateStellarNotification(ctx, n))
 
-	// Setup app for user2
 	app := fiber.New()
 	app.Use(func(c *fiber.Ctx) error {
 		c.Locals("userID", user2)
@@ -617,20 +542,18 @@ func TestUpdateNotificationState_WrongUser(t *testing.T) {
 	handler := NewHandler(sqlStore, nil)
 	app.Post("/api/stellar/notifications/:id/resolve", handler.ResolveNotification)
 
-	body := map[string]string{
-		"resolutionNote": "Trying to resolve someone else's notification",
-	}
+	body := map[string]string{"resolutionNote": "Trying to resolve someone else's notification"}
 	bodyBytes, err := json.Marshal(body)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/resolve", bytes.NewReader(bodyBytes))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	// Should get not found because the notification doesn't belong to user2
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }

--- a/pkg/api/handlers/stellar/observations_test.go
+++ b/pkg/api/handlers/stellar/observations_test.go
@@ -83,6 +83,7 @@ func TestStellarStream_ReturnsUnauthorizedWithoutUser(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/stream", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 2000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
@@ -200,6 +201,7 @@ func TestStellarListObservations_EmptyReturnsEmptyList(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/observations", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, stellarTestFiberTimeoutMs)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -219,6 +221,7 @@ func TestStellarListObservations_AppliesLimitParam(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/observations?limit=7", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, stellarTestFiberTimeoutMs)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -249,6 +252,7 @@ func TestStellarIngestEvent_RequiresAuth(t *testing.T) {
 	body := `{"cluster":"c1","namespace":"ns","name":"pod-a","type":"Warning","reason":"CrashLoop","message":"back-off"}`
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/events", strings.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, 2000)
@@ -285,6 +289,7 @@ func TestStellarIngestEvent_MissingFieldsReturnsBadRequest(t *testing.T) {
 	body := `{"cluster":"","namespace":"ns","name":"pod","type":"Warning","reason":"x","message":"y"}`
 	req, err2 := http.NewRequest(http.MethodPost, "/api/stellar/events", bytes.NewReader([]byte(body)))
 	require.NoError(t, err2)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err2 := editorApp.Test(req, 2000)
 	require.NoError(t, err2)
@@ -326,6 +331,7 @@ func TestStellarIngestEvent_AcceptsValidEvent(t *testing.T) {
 	raw, _ := json.Marshal(payload)
 	req, err2 := http.NewRequest(http.MethodPost, "/api/stellar/events", bytes.NewReader(raw))
 	require.NoError(t, err2)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err2 := adminApp.Test(req, 2000)

--- a/pkg/api/handlers/workloads/cluster_groups_test.go
+++ b/pkg/api/handlers/workloads/cluster_groups_test.go
@@ -32,7 +32,6 @@ func TestLoadPersistedClusterGroups_Success(t *testing.T) {
 
 	h := NewWorkloadHandlers(env.K8sClient, env.Hub, mockStore)
 
-	// Clear in-memory state
 	clusterGroupsMu.Lock()
 	clusterGroups = make(map[string]ClusterGroup)
 	clusterGroupsMu.Unlock()
@@ -50,7 +49,6 @@ func TestLoadPersistedClusterGroups_Success(t *testing.T) {
 
 func TestLoadPersistedClusterGroups_NilStoreClusterGroups(t *testing.T) {
 	h := &WorkloadHandlers{store: nil}
-	// Should not panic
 	h.LoadPersistedClusterGroups()
 }
 
@@ -63,8 +61,6 @@ func TestLoadPersistedClusterGroups_StoreErrorClusterGroups(t *testing.T) {
 	mockStore.On("GetUser", mock.Anything).Return(nil, nil).Maybe()
 
 	h := NewWorkloadHandlers(env.K8sClient, env.Hub, mockStore)
-
-	// Should not panic, just log error
 	h.LoadPersistedClusterGroups()
 }
 
@@ -84,7 +80,6 @@ func TestLoadPersistedClusterGroups_InvalidJSONClusterGroups(t *testing.T) {
 	clusterGroups = make(map[string]ClusterGroup)
 	clusterGroupsMu.Unlock()
 
-	// Should not panic, skip invalid entries
 	h.LoadPersistedClusterGroups()
 
 	clusterGroupsMu.RLock()
@@ -113,7 +108,6 @@ func TestPersistClusterGroup_Success(t *testing.T) {
 func TestPersistClusterGroup_NilStore(t *testing.T) {
 	h := &WorkloadHandlers{store: nil}
 	group := ClusterGroup{Name: "test", Kind: "static"}
-	// Should not panic
 	h.persistClusterGroup(context.Background(), "test", group)
 }
 
@@ -128,7 +122,6 @@ func TestPersistClusterGroup_StoreError(t *testing.T) {
 	h := NewWorkloadHandlers(env.K8sClient, env.Hub, mockStore)
 	group := ClusterGroup{Name: "err-group", Kind: "static"}
 
-	// Should not panic, just log error
 	h.persistClusterGroup(context.Background(), "err-group", group)
 	mockStore.AssertExpectations(t)
 }
@@ -150,7 +143,6 @@ func TestDeletePersistedClusterGroup_Success(t *testing.T) {
 
 func TestDeletePersistedClusterGroup_NilStore(t *testing.T) {
 	h := &WorkloadHandlers{store: nil}
-	// Should not panic
 	h.deletePersistedClusterGroup(context.Background(), "test")
 }
 
@@ -163,7 +155,6 @@ func TestDeletePersistedClusterGroup_StoreError(t *testing.T) {
 	mockStore.On("GetUser", mock.Anything).Return(nil, nil).Maybe()
 
 	h := NewWorkloadHandlers(env.K8sClient, env.Hub, mockStore)
-	// Should not panic
 	h.deletePersistedClusterGroup(context.Background(), "err-group")
 	mockStore.AssertExpectations(t)
 }
@@ -175,7 +166,6 @@ func TestListClusterGroups_IncludesBuiltIn(t *testing.T) {
 	h := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
 	env.App.Get("/api/cluster-groups", h.ListClusterGroups)
 
-	// Clear and add a custom group
 	clusterGroupsMu.Lock()
 	clusterGroups = map[string]ClusterGroup{
 		"custom": {Name: "custom", Kind: "static", Clusters: []string{"c1"}},
@@ -183,6 +173,7 @@ func TestListClusterGroups_IncludesBuiltIn(t *testing.T) {
 	clusterGroupsMu.Unlock()
 
 	req, _ := http.NewRequest("GET", "/api/cluster-groups", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -193,7 +184,6 @@ func TestListClusterGroups_IncludesBuiltIn(t *testing.T) {
 
 	groups := body["groups"]
 	require.GreaterOrEqual(t, len(groups), 2)
-	// First group should be the built-in
 	assert.Equal(t, allHealthyClustersGroupName, groups[0].Name)
 	assert.True(t, groups[0].BuiltIn)
 }
@@ -205,13 +195,13 @@ func TestCreateClusterGroup_Success(t *testing.T) {
 	h := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
 	env.App.Post("/api/cluster-groups", h.CreateClusterGroup)
 
-	// Clear in-memory state
 	clusterGroupsMu.Lock()
 	clusterGroups = make(map[string]ClusterGroup)
 	clusterGroupsMu.Unlock()
 
 	payload := `{"name":"new-group","kind":"static","clusters":["test-cluster"]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -231,6 +221,7 @@ func TestCreateClusterGroup_MissingName(t *testing.T) {
 
 	payload := `{"name":"","kind":"static","clusters":["c1"]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -245,6 +236,7 @@ func TestCreateClusterGroup_ReservedName(t *testing.T) {
 
 	payload := `{"name":"all-healthy-clusters","kind":"static","clusters":["c1"]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -259,6 +251,7 @@ func TestCreateClusterGroup_StaticNoClusters(t *testing.T) {
 
 	payload := `{"name":"empty-group","kind":"static","clusters":[]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -271,9 +264,9 @@ func TestCreateClusterGroup_DynamicNoClusters(t *testing.T) {
 	h := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
 	env.App.Post("/api/cluster-groups", h.CreateClusterGroup)
 
-	// Dynamic groups are allowed with no clusters
 	payload := `{"name":"dyn-group","kind":"dynamic","clusters":[]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -287,6 +280,7 @@ func TestCreateClusterGroup_InvalidBody(t *testing.T) {
 	env.App.Post("/api/cluster-groups", h.CreateClusterGroup)
 
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader("not json"))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -301,7 +295,6 @@ func TestUpdateClusterGroup_Success(t *testing.T) {
 	h := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
 	env.App.Put("/api/cluster-groups/:name", h.UpdateClusterGroup)
 
-	// Seed existing group
 	clusterGroupsMu.Lock()
 	clusterGroups = map[string]ClusterGroup{
 		"existing": {Name: "existing", Kind: "static", Clusters: []string{"c1"}},
@@ -310,6 +303,7 @@ func TestUpdateClusterGroup_Success(t *testing.T) {
 
 	payload := `{"kind":"static","clusters":["c1","c2"]}`
 	req, _ := http.NewRequest("PUT", "/api/cluster-groups/existing", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -329,6 +323,7 @@ func TestUpdateClusterGroup_BuiltInReject(t *testing.T) {
 
 	payload := `{"kind":"static","clusters":["c1"]}`
 	req, _ := http.NewRequest("PUT", "/api/cluster-groups/all-healthy-clusters", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -342,6 +337,7 @@ func TestUpdateClusterGroup_InvalidBody(t *testing.T) {
 	env.App.Put("/api/cluster-groups/:name", h.UpdateClusterGroup)
 
 	req, _ := http.NewRequest("PUT", "/api/cluster-groups/test", strings.NewReader("bad json"))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -363,6 +359,7 @@ func TestDeleteClusterGroup_Success(t *testing.T) {
 	clusterGroupsMu.Unlock()
 
 	req, _ := http.NewRequest("DELETE", "/api/cluster-groups/del-me", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusMultiStatus, resp.StatusCode)
@@ -379,6 +376,7 @@ func TestDeleteClusterGroup_BuiltInReject(t *testing.T) {
 	env.App.Delete("/api/cluster-groups/:name", h.DeleteClusterGroup)
 
 	req, _ := http.NewRequest("DELETE", "/api/cluster-groups/all-healthy-clusters", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
 	assert.Equal(t, 400, resp.StatusCode)
@@ -397,6 +395,7 @@ func TestSyncClusterGroups_Success(t *testing.T) {
 
 	payload := `[{"name":"g1","kind":"static","clusters":["c1"]},{"name":"g2","kind":"dynamic","clusters":[]}]`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups/sync", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -413,9 +412,9 @@ func TestSyncClusterGroups_FiltersReservedName(t *testing.T) {
 	h := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
 	env.App.Post("/api/cluster-groups/sync", h.SyncClusterGroups)
 
-	// Include the reserved name — it should be filtered out
 	payload := `[{"name":"all-healthy-clusters","kind":"dynamic","clusters":[]},{"name":"real-group","kind":"static","clusters":["c1"]}]`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups/sync", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -424,7 +423,7 @@ func TestSyncClusterGroups_FiltersReservedName(t *testing.T) {
 
 	var body map[string]int
 	json.NewDecoder(resp.Body).Decode(&body)
-	assert.Equal(t, 1, body["synced"]) // only "real-group"
+	assert.Equal(t, 1, body["synced"])
 }
 
 func TestSyncClusterGroups_InvalidJSONClusterGroups(t *testing.T) {
@@ -433,6 +432,7 @@ func TestSyncClusterGroups_InvalidJSONClusterGroups(t *testing.T) {
 	env.App.Post("/api/cluster-groups/sync", h.SyncClusterGroups)
 
 	req, _ := http.NewRequest("POST", "/api/cluster-groups/sync", strings.NewReader("not json"))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -445,18 +445,16 @@ func TestSyncClusterGroups_BodyTooLarge(t *testing.T) {
 	h := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
 	env.App.Post("/api/cluster-groups/sync", h.SyncClusterGroups)
 
-	// 1MB + 1 byte
 	bigPayload := "[" + strings.Repeat(`{"name":"x","kind":"static","clusters":["c"]},`, 30000) + `{"name":"last","kind":"static","clusters":["c"]}]`
 	if len(bigPayload) <= 1<<20 {
-		// Ensure it's actually over 1MB
 		bigPayload = strings.Repeat("x", 1<<20+1)
 	}
 	req, err := http.NewRequest("POST", "/api/cluster-groups/sync", strings.NewReader(bigPayload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
-	// Should be 413 or 400 depending on whether Fiber or the handler catches it
 	assert.True(t, resp.StatusCode == 413 || resp.StatusCode == 400)
 }
 
@@ -466,7 +464,6 @@ func TestStopCacheRefresh_Idempotent(t *testing.T) {
 	env := setupTestEnv(t)
 	h := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
 
-	// Calling StopCacheRefresh multiple times should not panic
 	h.StopCacheRefresh()
 	h.StopCacheRefresh()
 	h.StopCacheRefresh()
@@ -485,12 +482,12 @@ func TestClusterGroupsConcurrentAccess(t *testing.T) {
 	clusterGroupsMu.Unlock()
 
 	var wg sync.WaitGroup
-	// Concurrent reads and writes should not race
 	for i := 0; i < 10; i++ {
 		wg.Add(2)
 		go func(idx int) {
 			defer wg.Done()
 			req, _ := http.NewRequest("GET", "/api/cluster-groups", nil)
+			req.Host = "localhost"
 			env.App.Test(req, -1)
 		}(i)
 		go func(idx int) {

--- a/pkg/api/handlers/workloads/handler_test.go
+++ b/pkg/api/handlers/workloads/handler_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newK8sScheme returns a scheme with standard K8s types registered.
 func newK8sScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = k8sscheme.AddToScheme(scheme)
@@ -39,10 +38,7 @@ func TestListWorkloads(t *testing.T) {
 	scheme := newK8sScheme()
 
 	deployment := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Deployment",
-			APIVersion: "apps/v1",
-		},
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-deploy",
 			Namespace: "default",
@@ -53,9 +49,7 @@ func TestListWorkloads(t *testing.T) {
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{Name: "c1", Image: "nginx"}},
-				},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c1", Image: "nginx"}}},
 			},
 		},
 	}
@@ -64,6 +58,7 @@ func TestListWorkloads(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/workloads?cluster=test-cluster", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
 
@@ -108,6 +103,7 @@ func TestGetWorkload(t *testing.T) {
 	// 1. Success Case
 	req, err := http.NewRequest("GET", "/api/workloads/test-cluster/default/my-app", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
@@ -122,6 +118,7 @@ func TestGetWorkload(t *testing.T) {
 	// 2. Not Found
 	reqNotFound, err := http.NewRequest("GET", "/api/workloads/test-cluster/default/missing", nil)
 	require.NoError(t, err)
+	reqNotFound.Host = "localhost"
 	require.NotNil(t, reqNotFound)
 	respNotFound, errNotFound := env.App.Test(reqNotFound, 5000)
 	if errNotFound != nil || respNotFound == nil {
@@ -129,10 +126,6 @@ func TestGetWorkload(t *testing.T) {
 	}
 	assert.Equal(t, 404, respNotFound.StatusCode)
 }
-
-// TestDeployWorkload was removed when /api/workloads/deploy moved to kc-agent
-// (#7993 Phase 1 PR B). Coverage of the underlying deploy logic is provided
-// by pkg/k8s workload tests exercising MultiClusterClient.DeployWorkload.
 
 func TestGetDeployStatus(t *testing.T) {
 	env := setupTestEnv(t)
@@ -152,6 +145,7 @@ func TestGetDeployStatus(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/workloads/deploy-status/c1/default/status-app", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
 
@@ -164,16 +158,6 @@ func TestGetDeployStatus(t *testing.T) {
 	assert.Equal(t, float64(3), status["readyReplicas"])
 }
 
-// TestScaleWorkload was removed when /api/workloads/scale moved to kc-agent
-// (#7993 Phase 1 PR A). The equivalent coverage now lives in the agent
-// package (pkg/agent) which exercises handleScaleHTTP against the shared
-// pkg/k8s MultiClusterClient.ScaleWorkload method.
-
-// TestDeleteWorkload was removed when the DELETE /api/workloads/... route
-// moved to kc-agent (#7993 Phase 1 PR B). Coverage of the underlying delete
-// logic is provided by pkg/k8s workload tests exercising
-// MultiClusterClient.DeleteWorkload.
-
 func TestClusterGroupsCRUD(t *testing.T) {
 	clusterGroupsMu.Lock()
 	clusterGroups = make(map[string]ClusterGroup)
@@ -182,9 +166,6 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	env := setupTestEnv(t)
 	handler := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
 
-	// Inject fake dynamic clients for clusters used in the test so that
-	// LabelClusterNodes / RemoveClusterNodeLabels can resolve them without
-	// a real kubeconfig (fixes CI where ~/.kube/config doesn't exist).
 	nodeGVR := schema.GroupVersionResource{Version: "v1", Resource: "nodes"}
 	injectDynamicCluster(env, "c1", map[schema.GroupVersionResource]string{nodeGVR: "NodeList"})
 	injectDynamicCluster(env, "c2", map[schema.GroupVersionResource]string{nodeGVR: "NodeList"})
@@ -203,6 +184,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	data, _ := json.Marshal(createPayload)
 	req, err := http.NewRequest("POST", "/api/cluster-groups", bytes.NewReader(data))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	require.NotNil(t, req)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -213,6 +195,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 
 	req, err = http.NewRequest("GET", "/api/cluster-groups", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	require.NotNil(t, req)
 	resp, err = env.App.Test(req)
 	require.NoError(t, err)
@@ -222,8 +205,6 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	var listResp map[string][]map[string]interface{}
 	body, _ := io.ReadAll(resp.Body)
 	json.Unmarshal(body, &listResp)
-	// ListClusterGroups prepends the built-in "all-healthy-clusters" group,
-	// so we expect 2 groups total: the built-in one plus "group1".
 	assert.Equal(t, 2, len(listResp["groups"]))
 	assert.Equal(t, "all-healthy-clusters", listResp["groups"][0]["name"])
 	assert.Equal(t, "group1", listResp["groups"][1]["name"])
@@ -237,6 +218,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	data, _ = json.Marshal(updatePayload)
 	req, err = http.NewRequest("PUT", "/api/cluster-groups/group1", bytes.NewReader(data))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	require.NotNil(t, req)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -247,6 +229,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 
 	req, err = http.NewRequest("DELETE", "/api/cluster-groups/group1", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	require.NotNil(t, req)
 	resp, err = env.App.Test(req)
 	require.NoError(t, err)
@@ -255,6 +238,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 
 	req, err = http.NewRequest("GET", "/api/cluster-groups", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	require.NotNil(t, req)
 	resp, err = env.App.Test(req)
 	require.NoError(t, err)
@@ -262,7 +246,6 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	var listRespAfterDelete map[string][]map[string]interface{}
 	bodyAfterDelete, _ := io.ReadAll(resp.Body)
 	json.Unmarshal(bodyAfterDelete, &listRespAfterDelete)
-	// After deleting "group1", only the built-in group should remain.
 	assert.Equal(t, 1, len(listRespAfterDelete["groups"]))
 	assert.Equal(t, "all-healthy-clusters", listRespAfterDelete["groups"][0]["name"])
 }
@@ -273,37 +256,23 @@ func TestEvaluateClusterQuery(t *testing.T) {
 	env.App.Post("/api/cluster-groups/evaluate", handler.EvaluateClusterQuery)
 
 	config := &api.Config{
-		Contexts: map[string]*api.Context{
-			"c1-ctx": {Cluster: "cluster1"},
-		},
-		Clusters: map[string]*api.Cluster{
-			"cluster1": {Server: "https://c1.com"},
-		},
+		Contexts: map[string]*api.Context{"c1-ctx": {Cluster: "cluster1"}},
+		Clusters: map[string]*api.Cluster{"cluster1": {Server: "https://c1.com"}},
 	}
 	env.K8sClient.SetRawConfig(config)
 
 	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "node1",
-			Labels: map[string]string{"region": "us-east"},
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{"region": "us-east"}},
 		Status: corev1.NodeStatus{
-			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
-			Capacity: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("4"),
-				corev1.ResourceMemory: resource.MustParse("16Gi"),
-			},
-			Allocatable: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("4"),
-				corev1.ResourceMemory: resource.MustParse("16Gi"),
-			},
+			Conditions:  []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			Capacity:    corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("16Gi")},
+			Allocatable: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("16Gi")},
 		},
 	}
 
 	c1Client := k8sfake.NewSimpleClientset(node)
 	env.K8sClient.InjectClient("c1-ctx", c1Client)
 
-	// Complex Query with various operators
 	query := map[string]interface{}{
 		"labelSelector": "region=us-east",
 		"filters": []map[string]interface{}{
@@ -316,6 +285,7 @@ func TestEvaluateClusterQuery(t *testing.T) {
 	data, _ := json.Marshal(query)
 	req, err := http.NewRequest("POST", "/api/cluster-groups/evaluate", bytes.NewReader(data))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	require.NotNil(t, req)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -333,7 +303,6 @@ func TestEvaluateClusterQuery(t *testing.T) {
 	assert.Equal(t, "c1-ctx", clusters[0])
 }
 
-// MockAIProvider implements agent.AIProvider for testing.
 type MockAIProvider struct {
 	Response string
 }
@@ -345,11 +314,7 @@ func (m *MockAIProvider) Provider() string                       { return "mock"
 func (m *MockAIProvider) IsAvailable() bool                      { return true }
 func (m *MockAIProvider) Capabilities() agent.ProviderCapability { return agent.CapabilityChat }
 func (m *MockAIProvider) Chat(ctx context.Context, req *agent.ChatRequest) (*agent.ChatResponse, error) {
-	return &agent.ChatResponse{
-		Content: m.Response,
-		Agent:   "mock-ai",
-		Done:    true,
-	}, nil
+	return &agent.ChatResponse{Content: m.Response, Agent: "mock-ai", Done: true}, nil
 }
 func (m *MockAIProvider) StreamChat(ctx context.Context, req *agent.ChatRequest, onChunk func(chunk string)) (*agent.ChatResponse, error) {
 	onChunk(m.Response)
@@ -361,7 +326,6 @@ func TestGenerateClusterQuery(t *testing.T) {
 	handler := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
 	env.App.Post("/api/cluster-groups/generate", handler.GenerateClusterQuery)
 
-	// Register Mock AI
 	registry := agent.GetRegistry()
 	mockAI := &MockAIProvider{
 		Response: `{"suggestedName": "west-cpu-group", "query": {"labelSelector": "region=us-west", "filters": [{"field": "cpuCores", "operator": "gte", "value": "4"}]}}`,
@@ -374,6 +338,7 @@ func TestGenerateClusterQuery(t *testing.T) {
 
 	req, err := http.NewRequest("POST", "/api/cluster-groups/generate", bytes.NewReader(data))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	require.NotNil(t, req)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -414,15 +379,14 @@ func TestResolveDependencies(t *testing.T) {
 	svc := &corev1.Service{
 		TypeMeta:   metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: "app-svc", Namespace: "default"},
-		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{"app": "app"},
-		},
+		Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "app"}},
 	}
 
 	injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{deploy, svc})
 
 	req, err := http.NewRequest("GET", "/api/workloads/resolve-deps/c1/default/app", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
@@ -432,7 +396,6 @@ func TestResolveDependencies(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 	json.Unmarshal(body, &result)
 
-	// Should find Service dependency
 	deps := result["dependencies"].([]interface{})
 	foundSvc := false
 	for _, d := range deps {
@@ -469,6 +432,7 @@ func TestMonitorWorkload(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/workloads/monitor/c1/default/monitored-app", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
@@ -496,9 +460,7 @@ func TestGetDeployLogs(t *testing.T) {
 			Namespace: "default",
 			Labels:    map[string]string{"app": "log-app"},
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{Name: "main"}},
-		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
 	}
 
 	deploy := &appsv1.Deployment{
@@ -510,14 +472,11 @@ func TestGetDeployLogs(t *testing.T) {
 	}
 
 	t.Run("Smoke_WithDeploymentAndPod", func(t *testing.T) {
-		// Smoke test: ensure no panic and handler returns a valid HTTP response.
-		// The fake client does not implement the pod log subresource, so we cannot
-		// assert exact log content. We verify the handler resolves the deployment,
-		// finds matching pods, and returns without crashing.
 		injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{pod, deploy}, pod)
 
 		req, err := http.NewRequest("GET", "/api/workloads/logs/c1/default/log-app", nil)
 		require.NoError(t, err)
+		req.Host = "localhost"
 		require.NotNil(t, req)
 		resp, err := env.App.Test(req, 5000)
 		require.NoError(t, err)
@@ -525,14 +484,11 @@ func TestGetDeployLogs(t *testing.T) {
 	})
 
 	t.Run("Smoke_WithoutDeployment", func(t *testing.T) {
-		// Smoke test: GetDeployLogs always returns 200 with an events payload.
-		// Even when no deployment exists, the handler falls through to listing pods
-		// by label/name prefix and returns an empty events list — it never returns 404.
-		// We verify the handler does not crash and returns a well-formed response.
 		injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{pod}, pod)
 
 		req, err := http.NewRequest("GET", "/api/workloads/logs/c1/default/missing-app", nil)
 		require.NoError(t, err)
+		req.Host = "localhost"
 		require.NotNil(t, req)
 		resp, err := env.App.Test(req, 5000)
 		require.NoError(t, err)
@@ -545,9 +501,9 @@ func TestGetDeployLogs(t *testing.T) {
 	})
 
 	t.Run("MissingCluster_Returns500", func(t *testing.T) {
-		// When the cluster context does not exist, GetClient fails and handler returns 500.
 		req, err := http.NewRequest("GET", "/api/workloads/logs/nonexistent-cluster/default/app", nil)
 		require.NoError(t, err)
+		req.Host = "localhost"
 		require.NotNil(t, req)
 		resp, err := env.App.Test(req, 5000)
 		require.NoError(t, err)


### PR DESCRIPTION
Closing — superseded by #19922, which covers the same workloads + stellar/observations Host header fixes. The additional files this PR covers (actions, mocked_handlers, notifications) will be added to #19922.