### PR TITLE
[scanner] fix: add unit tests for pkg/agent to improve coverage

### DIFF
--- a/pkg/agent/config_compat_test.go
+++ b/pkg/agent/config_compat_test.go
@@ -1,0 +1,98 @@
+package agent
+
+import "testing"
+
+func TestGetConfigManager_NotNil(t *testing.T) {
+	cm := GetConfigManager()
+	if cm == nil {
+		t.Fatal("GetConfigManager() should return non-nil *ConfigManager")
+	}
+}
+
+func TestGetEnvKeyForProvider_KnownProviders(t *testing.T) {
+	cases := []struct {
+		provider string
+		wantKey  string
+	}{
+		{"claude", "ANTHROPIC_API_KEY"},
+		{"openai", "OPENAI_API_KEY"},
+		{"gemini", "GOOGLE_API_KEY"},
+		{"groq", "GROQ_API_KEY"},
+		{"ollama", "OLLAMA_API_KEY"},
+		{"lm-studio", "LM_STUDIO_API_KEY"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			got := getEnvKeyForProvider(tc.provider)
+			if got != tc.wantKey {
+				t.Errorf("getEnvKeyForProvider(%q) = %q, want %q", tc.provider, got, tc.wantKey)
+			}
+		})
+	}
+}
+
+func TestGetBaseURLEnvKeyForProvider_KnownProviders(t *testing.T) {
+	cases := []struct {
+		provider string
+		wantKey  string
+	}{
+		{"ollama", "OLLAMA_URL"},
+		{"llamacpp", "LLAMACPP_URL"},
+		{"vllm", "VLLM_URL"},
+		{"lm-studio", "LM_STUDIO_URL"},
+		{"openai", "OPENAI_BASE_URL"},
+		{"groq", "GROQ_BASE_URL"},
+		{"claude", "ANTHROPIC_BASE_URL"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			got := getBaseURLEnvKeyForProvider(tc.provider)
+			if got != tc.wantKey {
+				t.Errorf("getBaseURLEnvKeyForProvider(%q) = %q, want %q", tc.provider, got, tc.wantKey)
+			}
+		})
+	}
+}
+
+func TestGetModelEnvKeyForProvider_KnownProviders(t *testing.T) {
+	cases := []struct {
+		provider string
+		wantKey  string
+	}{
+		{"claude", "CLAUDE_MODEL"},
+		{"openai", "OPENAI_MODEL"},
+		{"gemini", "GEMINI_MODEL"},
+		{"ollama", "OLLAMA_MODEL"},
+		{"groq", "GROQ_MODEL"},
+		{"lm-studio", "LM_STUDIO_MODEL"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			got := getModelEnvKeyForProvider(tc.provider)
+			if got != tc.wantKey {
+				t.Errorf("getModelEnvKeyForProvider(%q) = %q, want %q", tc.provider, got, tc.wantKey)
+			}
+		})
+	}
+}
+
+func TestGetEnvKeyForProvider_UnknownReturnsEmpty(t *testing.T) {
+	got := getEnvKeyForProvider("unknown-provider-xyz-12345")
+	if got != "" {
+		t.Errorf("getEnvKeyForProvider(unknown) = %q, want empty string", got)
+	}
+}
+
+func TestGetBaseURLEnvKeyForProvider_UnknownReturnsEmpty(t *testing.T) {
+	got := getBaseURLEnvKeyForProvider("unknown-provider-xyz-12345")
+	if got != "" {
+		t.Errorf("getBaseURLEnvKeyForProvider(unknown) = %q, want empty string", got)
+	}
+}
+
+func TestIsolateConfigManager_ReturnsNonNil(t *testing.T) {
+	cm := isolateConfigManager(t)
+	if cm == nil {
+		t.Fatal("isolateConfigManager(t) should return non-nil *ConfigManager")
+	}
+}

--- a/pkg/agent/init_test.go
+++ b/pkg/agent/init_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/kubestellar/console/pkg/ai"
+)
+
+// TestInit_WiresAIGetRegistry verifies that pkg/agent/init.go's init()
+// function has assigned the ai.GetRegistry function pointer, which allows
+// components in other packages to reach the agent's provider registry
+// through the ai interface bridge.
+func TestInit_WiresAIGetRegistry(t *testing.T) {
+	if ai.GetRegistry == nil {
+		t.Fatal("ai.GetRegistry should be non-nil after pkg/agent init()")
+	}
+	reg := ai.GetRegistry()
+	if reg == nil {
+		t.Fatal("ai.GetRegistry() should return non-nil Registry")
+	}
+}
+
+// TestInit_WiresAIInitializeProviders verifies that ai.InitializeProviders
+// is wired to the agent package implementation.
+func TestInit_WiresAIInitializeProviders(t *testing.T) {
+	if ai.InitializeProviders == nil {
+		t.Fatal("ai.InitializeProviders should be non-nil after pkg/agent init()")
+	}
+}
+
+// TestInit_WiresAIGetConfigManager verifies that ai.GetConfigManager is
+// non-nil and returns a valid config manager after package initialization.
+func TestInit_WiresAIGetConfigManager(t *testing.T) {
+	if ai.GetConfigManager == nil {
+		t.Fatal("ai.GetConfigManager should be non-nil after pkg/agent init()")
+	}
+	cm := ai.GetConfigManager()
+	if cm == nil {
+		t.Fatal("ai.GetConfigManager() should return non-nil")
+	}
+}
+
+// TestInit_WiresAISetClusterContextProviders verifies that
+// ai.SetClusterContextProviders is non-nil and handles nil arguments without
+// panicking (both bridge and k8sClient may be nil in test environments).
+func TestInit_WiresAISetClusterContextProviders(t *testing.T) {
+	if ai.SetClusterContextProviders == nil {
+		t.Fatal("ai.SetClusterContextProviders should be non-nil after pkg/agent init()")
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("SetClusterContextProviders(nil, nil) panicked: %v", r)
+		}
+	}()
+	ai.SetClusterContextProviders(nil, nil)
+}

--- a/pkg/agent/kagent_compat_test.go
+++ b/pkg/agent/kagent_compat_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import "testing"
+
+func TestAgentGVR_NonEmpty(t *testing.T) {
+	if agentGVR.Resource == "" {
+		t.Error("agentGVR.Resource should not be empty")
+	}
+	if agentGVR.Group == "" {
+		t.Error("agentGVR.Group should not be empty")
+	}
+	if agentGVR.Version == "" {
+		t.Error("agentGVR.Version should not be empty")
+	}
+}
+
+func TestModelConfigGVR_NonEmpty(t *testing.T) {
+	if modelConfigGVR.Resource == "" {
+		t.Error("modelConfigGVR.Resource should not be empty")
+	}
+}
+
+func TestModelProviderConfigGVR_NonEmpty(t *testing.T) {
+	if modelProviderConfigGVR.Resource == "" {
+		t.Error("modelProviderConfigGVR.Resource should not be empty")
+	}
+}
+
+func TestToolServerGVR_NonEmpty(t *testing.T) {
+	if toolServerGVR.Resource == "" {
+		t.Error("toolServerGVR.Resource should not be empty")
+	}
+}
+
+func TestRemoteMCPServerGVR_NonEmpty(t *testing.T) {
+	if remoteMCPServerGVR.Resource == "" {
+		t.Error("remoteMCPServerGVR.Resource should not be empty")
+	}
+}
+
+func TestMemoryGVR_NonEmpty(t *testing.T) {
+	if memoryGVR.Resource == "" {
+		t.Error("memoryGVR.Resource should not be empty")
+	}
+}
+
+func TestKagentHandlers_NotNil(t *testing.T) {
+	s := newTestServer(t)
+	handlers := s.kagentHandlers()
+	if handlers == nil {
+		t.Fatal("kagentHandlers() should return non-nil *kagent.Handlers")
+	}
+}
+
+func TestKagentHandlers_ContextIsServer(t *testing.T) {
+	s := newTestServer(t)
+	handlers := s.kagentHandlers()
+	if handlers.Ctx != s {
+		t.Error("kagentHandlers().Ctx should point to the owning Server")
+	}
+}

--- a/pkg/agent/procgroup_compat_test.go
+++ b/pkg/agent/procgroup_compat_test.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package agent
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestConfigureProcessGroup_DoesNotPanic(t *testing.T) {
+	cmd := exec.Command("true")
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("configureProcessGroup panicked: %v", r)
+		}
+	}()
+	configureProcessGroup(cmd)
+}
+
+func TestConfigureProcessGroup_SetsSysProcAttr(t *testing.T) {
+	cmd := exec.Command("true")
+	configureProcessGroup(cmd)
+	// After configureProcessGroup the SysProcAttr should be set so the
+	// child process runs in its own process group and can be killed cleanly.
+	if cmd.SysProcAttr == nil {
+		t.Error("configureProcessGroup should set SysProcAttr on the command")
+	}
+}

--- a/pkg/agent/provider_prompts_test.go
+++ b/pkg/agent/provider_prompts_test.go
@@ -1,0 +1,35 @@
+package agent
+
+import "testing"
+
+func TestDefaultSystemPrompt_NonEmpty(t *testing.T) {
+	if DefaultSystemPrompt == "" {
+		t.Error("DefaultSystemPrompt should be non-empty")
+	}
+}
+
+func TestChatOnlySystemPrompt_NonEmpty(t *testing.T) {
+	if ChatOnlySystemPrompt == "" {
+		t.Error("ChatOnlySystemPrompt should be non-empty")
+	}
+}
+
+func TestOSCommandHint_NonEmpty(t *testing.T) {
+	hint := OSCommandHint()
+	if hint == "" {
+		t.Error("OSCommandHint() should return a non-empty string")
+	}
+}
+
+func TestOSContext_NonEmpty(t *testing.T) {
+	ctx := OSContext()
+	if ctx == "" {
+		t.Error("OSContext() should return a non-empty string")
+	}
+}
+
+func TestDefaultAndChatOnlyPrompts_AreDifferent(t *testing.T) {
+	if DefaultSystemPrompt == ChatOnlySystemPrompt {
+		t.Error("DefaultSystemPrompt and ChatOnlySystemPrompt should be distinct")
+	}
+}

--- a/pkg/agent/provider_test.go
+++ b/pkg/agent/provider_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubestellar/console/pkg/ai"
+)
+
+func TestMaxStderrBytes(t *testing.T) {
+	const expected int64 = 1 << 20 // 1 MB
+	if maxStderrBytes != expected {
+		t.Errorf("maxStderrBytes = %d, want %d", maxStderrBytes, expected)
+	}
+}
+
+func TestCapabilityConstants_MatchAIPackage(t *testing.T) {
+	if CapabilityChat != ai.CapabilityChat {
+		t.Errorf("CapabilityChat = %v, want ai.CapabilityChat", CapabilityChat)
+	}
+	if CapabilityToolExec != ai.CapabilityToolExec {
+		t.Errorf("CapabilityToolExec = %v, want ai.CapabilityToolExec", CapabilityToolExec)
+	}
+}
+
+func TestMixedModeConfig_ZeroValue(t *testing.T) {
+	var cfg MixedModeConfig
+	if cfg.Enabled {
+		t.Error("zero-value MixedModeConfig.Enabled should be false")
+	}
+	if cfg.ThinkingAgent != "" {
+		t.Errorf("zero-value ThinkingAgent should be empty, got %q", cfg.ThinkingAgent)
+	}
+	if cfg.ExecutionAgent != "" {
+		t.Errorf("zero-value ExecutionAgent should be empty, got %q", cfg.ExecutionAgent)
+	}
+}
+
+func TestMixedModeConfig_JSONRoundTrip(t *testing.T) {
+	original := MixedModeConfig{
+		ThinkingAgent:  "claude",
+		ExecutionAgent: "bob",
+		Enabled:        true,
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal MixedModeConfig: %v", err)
+	}
+
+	var decoded MixedModeConfig
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal MixedModeConfig: %v", err)
+	}
+
+	if decoded.ThinkingAgent != original.ThinkingAgent {
+		t.Errorf("ThinkingAgent = %q, want %q", decoded.ThinkingAgent, original.ThinkingAgent)
+	}
+	if decoded.ExecutionAgent != original.ExecutionAgent {
+		t.Errorf("ExecutionAgent = %q, want %q", decoded.ExecutionAgent, original.ExecutionAgent)
+	}
+	if decoded.Enabled != original.Enabled {
+		t.Errorf("Enabled = %v, want %v", decoded.Enabled, original.Enabled)
+	}
+}
+
+func TestMixedModeConfig_JSONFieldNames(t *testing.T) {
+	cfg := MixedModeConfig{
+		ThinkingAgent:  "a",
+		ExecutionAgent: "b",
+		Enabled:        true,
+	}
+	data, _ := json.Marshal(cfg)
+	s := string(data)
+
+	for _, want := range []string{`"thinkingAgent"`, `"executionAgent"`, `"enabled"`} {
+		if !contains(s, want) {
+			t.Errorf("JSON field %s not found in %s", want, s)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstr(s, sub))
+}
+
+func containsSubstr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/agent/providers_compat_test.go
+++ b/pkg/agent/providers_compat_test.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProviderKeyConstants_NonEmpty(t *testing.T) {
+	cases := map[string]string{
+		"ProviderKeyOllama":   ProviderKeyOllama,
+		"ProviderKeyLlamaCpp": ProviderKeyLlamaCpp,
+		"ProviderKeyLocalAI":  ProviderKeyLocalAI,
+		"ProviderKeyVLLM":     ProviderKeyVLLM,
+		"ProviderKeyLMStudio": ProviderKeyLMStudio,
+		"ProviderKeyRHAIIS":   ProviderKeyRHAIIS,
+	}
+	for name, val := range cases {
+		if val == "" {
+			t.Errorf("%s should not be empty", name)
+		}
+	}
+}
+
+func TestTruncateString_Behaviors(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"empty string", "", 10, ""},
+		{"shorter than max", "hello", 10, "hello"},
+		{"exactly max", "hello", 5, "hello"},
+		{"longer than max appends ellipsis", "hello world", 5, "hello..."},
+		{"zero max appends ellipsis", "hello", 0, "..."},
+		{"single char within max", "a", 1, "a"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateString(tc.input, tc.maxLen)
+			if got != tc.want {
+				t.Errorf("truncateString(%q, %d) = %q, want %q",
+					tc.input, tc.maxLen, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGroqValidationURL_StartsWithHTTPS(t *testing.T) {
+	url := groqValidationURL()
+	if url == "" {
+		t.Fatal("groqValidationURL() should return non-empty string")
+	}
+	if !strings.HasPrefix(url, "https://") {
+		t.Errorf("groqValidationURL() = %q, want URL starting with https://", url)
+	}
+}
+
+func TestSetAllowLoopbackForTests_DoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("SetAllowLoopbackForTests panicked: %v", r)
+		}
+	}()
+	SetAllowLoopbackForTests(true)
+	SetAllowLoopbackForTests(false)
+	SetAllowLoopbackForTests(true) // restore to test-friendly state
+}
+
+func TestNewRestrictedAIProviderHTTPClient_NonNil(t *testing.T) {
+	const testTimeout = 30 * time.Second
+	client := newRestrictedAIProviderHTTPClient(testTimeout)
+	if client == nil {
+		t.Fatal("newRestrictedAIProviderHTTPClient() should return non-nil client")
+	}
+	if client.Timeout != testTimeout {
+		t.Errorf("client.Timeout = %v, want %v", client.Timeout, testTimeout)
+	}
+	if client.Transport == nil {
+		t.Error("client.Transport must be non-nil for SSRF protection")
+	}
+}
+
+func TestDefaultURLConstants_NonEmpty(t *testing.T) {
+	if defaultOllamaURL == "" {
+		t.Error("defaultOllamaURL should not be empty")
+	}
+	if defaultLMStudioURL == "" {
+		t.Error("defaultLMStudioURL should not be empty")
+	}
+}
+
+func TestKagentiK8sContextKey_NonEmpty(t *testing.T) {
+	if kagentiK8sContextKey == "" {
+		t.Error("kagentiK8sContextKey should not be empty")
+	}
+}

--- a/pkg/agent/server_routes_test.go
+++ b/pkg/agent/server_routes_test.go
@@ -1,0 +1,103 @@
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRegisterRoutes_HealthReturns200 verifies that /health is registered and
+// responds with 200 OK (no auth required for health checks).
+func TestRegisterRoutes_HealthReturns200(t *testing.T) {
+	s := newTestServer(t)
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("/health: want 200, got %d", rec.Code)
+	}
+}
+
+// TestRegisterRoutes_UnknownPath verifies that unregistered paths return 404.
+func TestRegisterRoutes_UnknownPath(t *testing.T) {
+	s := newTestServer(t)
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/this-is-not-a-real-endpoint", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("/this-is-not-a-real-endpoint: want 404, got %d", rec.Code)
+	}
+}
+
+// TestRegisterRoutes_AuthenticatedEndpointsReturn401WithoutToken verifies that
+// auth-protected routes are registered and return 401 (not 404) when the
+// request lacks a valid bearer token.
+func TestRegisterRoutes_AuthenticatedEndpointsReturn401WithoutToken(t *testing.T) {
+	protectedPaths := []string{
+		"/status",
+		"/clusters",
+		"/pods",
+		"/namespaces",
+		"/metrics",
+		"/settings",
+		"/rbac/can-i",
+		"/provider/check",
+	}
+
+	for _, path := range protectedPaths {
+		t.Run(path, func(t *testing.T) {
+			s := newTestServer(t, withToken("secret"))
+			mux := http.NewServeMux()
+			s.registerRoutes(mux)
+
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code == http.StatusNotFound {
+				t.Errorf("%s should be registered (got 404 — route missing from registerRoutes)", path)
+			}
+		})
+	}
+}
+
+// TestRegisterRoutes_OptionsCORSPreflightNoContent checks that the OPTIONS
+// preflight on the catchall "/" handler returns 204 NoContent.
+func TestRegisterRoutes_OptionsCORSPreflightNoContent(t *testing.T) {
+	s := newTestServer(t)
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodOptions, "/some-nonexistent-path", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("OPTIONS catchall: want 204, got %d", rec.Code)
+	}
+}
+
+// TestRegisterRoutes_WSEndpointRegistered verifies that the /ws WebSocket
+// endpoint is registered (returns non-404 for GET).
+func TestRegisterRoutes_WSEndpointRegistered(t *testing.T) {
+	s := newTestServer(t, withToken("tok"))
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	// /ws requires a WebSocket upgrade, so 400/401 is expected — not 404
+	if rec.Code == http.StatusNotFound {
+		t.Error("/ws should be registered (got 404)")
+	}
+}

--- a/pkg/agent/shell_test.go
+++ b/pkg/agent/shell_test.go
@@ -1,0 +1,16 @@
+package agent
+
+import "testing"
+
+func TestErrNoShellFound_IsNotNil(t *testing.T) {
+	if errNoShellFound == nil {
+		t.Fatal("errNoShellFound should not be nil")
+	}
+}
+
+func TestErrNoShellFound_Message(t *testing.T) {
+	const want = "no usable shell found on PATH"
+	if errNoShellFound.Error() != want {
+		t.Errorf("errNoShellFound.Error() = %q, want %q", errNoShellFound.Error(), want)
+	}
+}

--- a/pkg/agent/shell_unix_test.go
+++ b/pkg/agent/shell_unix_test.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package agent
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveShell_ReturnsValidPath(t *testing.T) {
+	path, err := resolveShell()
+	if err != nil {
+		if err == errNoShellFound {
+			t.Skip("no usable shell found on PATH (unusual CI environment)")
+		}
+		t.Errorf("resolveShell() returned unexpected error: %v", err)
+		return
+	}
+	if path == "" {
+		t.Error("resolveShell() returned empty path without error")
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Errorf("resolveShell() returned path %q that does not exist: %v", path, statErr)
+	}
+}
+
+func TestShellFlag_ReturnsDashC(t *testing.T) {
+	got := shellFlag()
+	if got != "-c" {
+		t.Errorf("shellFlag() = %q, want %q", got, "-c")
+	}
+}
+
+func TestIsWindows_ReturnsFalseOnUnix(t *testing.T) {
+	if isWindows() {
+		t.Error("isWindows() should return false on Unix/macOS/Linux")
+	}
+}

--- a/pkg/agent/workers_compat_test.go
+++ b/pkg/agent/workers_compat_test.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInsightEnrichmentCacheTTL_Positive(t *testing.T) {
+	if InsightEnrichmentCacheTTL <= 0 {
+		t.Errorf("InsightEnrichmentCacheTTL = %v, want > 0", InsightEnrichmentCacheTTL)
+	}
+}
+
+func TestInsightEnrichmentTimeout_Positive(t *testing.T) {
+	if InsightEnrichmentTimeout <= 0 {
+		t.Errorf("InsightEnrichmentTimeout = %v, want > 0", InsightEnrichmentTimeout)
+	}
+}
+
+func TestInsightEnrichmentCacheTTL_ReasonableRange(t *testing.T) {
+	const minTTL = 30 * time.Second
+	const maxTTL = 1 * time.Hour
+	if InsightEnrichmentCacheTTL < minTTL || InsightEnrichmentCacheTTL > maxTTL {
+		t.Errorf("InsightEnrichmentCacheTTL = %v, want between %v and %v",
+			InsightEnrichmentCacheTTL, minTTL, maxTTL)
+	}
+}
+
+func TestInsightEnrichmentTimeout_ReasonableRange(t *testing.T) {
+	const minTimeout = 5 * time.Second
+	const maxTimeout = 5 * time.Minute
+	if InsightEnrichmentTimeout < minTimeout || InsightEnrichmentTimeout > maxTimeout {
+		t.Errorf("InsightEnrichmentTimeout = %v, want between %v and %v",
+			InsightEnrichmentTimeout, minTimeout, maxTimeout)
+	}
+}
+
+func TestWorkerConstructorVars_NonNil(t *testing.T) {
+	if NewInsightWorker == nil {
+		t.Error("NewInsightWorker var should not be nil")
+	}
+	if NewDeviceTracker == nil {
+		t.Error("NewDeviceTracker var should not be nil")
+	}
+	if NewMetricsHistory == nil {
+		t.Error("NewMetricsHistory var should not be nil")
+	}
+	if GetMetricsHandler == nil {
+		t.Error("GetMetricsHandler var should not be nil")
+	}
+	if NewPredictionWorker == nil {
+		t.Error("NewPredictionWorker var should not be nil")
+	}
+}
+
+func TestPredictionTypes_ZeroValueUsable(t *testing.T) {
+	var ps PredictionSettings
+	_ = ps
+	var ap AIPrediction
+	_ = ap
+	var ar AIPredictionsResponse
+	_ = ar
+}
+
+func TestInsightTypes_ZeroValueUsable(t *testing.T) {
+	var is InsightSummary
+	_ = is
+	var ie InsightEnrichmentRequest
+	_ = ie
+	var aie AIInsightEnrichment
+	_ = aie
+}
+
+func TestWorkerConst_InsightEnrichmentCacheTTL_MatchesExpected(t *testing.T) {
+	const expectedTTL = 5 * time.Minute
+	if InsightEnrichmentCacheTTL != expectedTTL {
+		t.Errorf("InsightEnrichmentCacheTTL = %v, want %v", InsightEnrichmentCacheTTL, expectedTTL)
+	}
+}


### PR DESCRIPTION
Closing — compilation error (`contains` redeclared in `server_ai_tokens_test.go:140`). Superseded by #19921 which adds clean registry + provider_prompts tests without conflicts.