### PR TITLE
🐛 fix: add Host header to test requests for fasthttp 1.72.0 compatibility

### DIFF
--- a/pkg/api/handlers/auth/auth_test.go
+++ b/pkg/api/handlers/auth/auth_test.go
@@ -53,6 +53,7 @@ func TestDevModeLogin(t *testing.T) {
 		mockStore.On("UpdateLastLogin", mock.Anything).Return(nil).Once()
 
 		req, _ := http.NewRequest("GET", "/auth/dev", nil)
+		req.Host = "localhost"
 		resp, err := app.Test(req, 5000)
 
 		assert.NoError(t, err)
@@ -77,6 +78,7 @@ func TestDevModeLogin(t *testing.T) {
 		mockStore.On("UpdateLastLogin", existingUser.ID).Return(nil).Once()
 
 		req, _ := http.NewRequest("GET", "/auth/dev", nil)
+		req.Host = "localhost"
 		resp, err := app.Test(req, 5000)
 
 		assert.NoError(t, err)
@@ -188,6 +190,7 @@ func TestRefreshToken(t *testing.T) {
 		token, _ := handler.generateJWT(user)
 
 		req, _ := http.NewRequest("POST", "/auth/refresh", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp, _ := app.Test(req, 5000)
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
@@ -328,6 +331,7 @@ func TestGitHubLogin_Redirects(t *testing.T) {
 	app.Get("/auth/github", handler.GitHubLogin)
 
 	req, _ := http.NewRequest("GET", "/auth/github", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 
 	assert.NoError(t, err)
@@ -362,6 +366,7 @@ func TestGitHubCallback_MissingCode(t *testing.T) {
 	app.Get("/auth/callback", handler.GitHubCallback)
 
 	req, _ := http.NewRequest("GET", "/auth/callback", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	if err != nil || resp == nil {
 		t.Fatalf("app.Test failed: %v", err)
@@ -378,6 +383,7 @@ func TestGitHubCallback_InvalidState(t *testing.T) {
 
 	// Provide code but no state
 	req, _ := http.NewRequest("GET", "/auth/callback?code=123", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	if err != nil || resp == nil {
 		t.Fatalf("app.Test failed: %v", err)
@@ -394,6 +400,7 @@ func TestGitHubCallback_GitHubError(t *testing.T) {
 
 	t.Run("Access denied by user", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/auth/callback?error=access_denied&error_description=The+user+denied+access", nil)
+		req.Host = "localhost"
 		resp, err := app.Test(req, 5000)
 		if err != nil || resp == nil {
 			t.Fatalf("app.Test failed: %v", err)
@@ -407,6 +414,7 @@ func TestGitHubCallback_GitHubError(t *testing.T) {
 
 	t.Run("Generic GitHub error", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/auth/callback?error=application_suspended&error_description=App+is+suspended", nil)
+		req.Host = "localhost"
 		resp, err := app.Test(req, 5000)
 		if err != nil || resp == nil {
 			t.Fatalf("app.Test failed: %v", err)
@@ -483,6 +491,8 @@ func TestGitHubCallback_RecoversFromValidCookieOnStateFailure(t *testing.T) {
 
 	t.Run("missing cookie + invalid state redirects to error page", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/auth/callback?code=123&state=bogus", nil)
+
+		req.Host = "localhost"
 
 		resp, err := app.Test(req, 5000)
 		assert.NoError(t, err)
@@ -779,6 +789,7 @@ func TestLogout_RequiresCSRFHeader(t *testing.T) {
 	// Without the CSRF header: 403.
 	req, err := http.NewRequest("POST", "/auth/logout", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -814,6 +825,7 @@ func TestLogout_ExpiredTokenIdempotent(t *testing.T) {
 
 	req, err := http.NewRequest("POST", "/auth/logout", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Authorization", "Bearer "+signed)
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
 	resp, err := app.Test(req, 5000)
@@ -836,6 +848,7 @@ func TestCookieSameSiteStrict(t *testing.T) {
 	mockStore.On("UpdateLastLogin", mock.Anything).Return(nil).Once()
 
 	req, _ := http.NewRequest("GET", "/auth/dev", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 

--- a/pkg/api/handlers/baa_test.go
+++ b/pkg/api/handlers/baa_test.go
@@ -21,6 +21,7 @@ func setupBAAApp() *fiber.App {
 func TestBAAAgreements(t *testing.T) {
 	app := setupBAAApp()
 	req, _ := http.NewRequest("GET", "/api/compliance/baa/agreements", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
@@ -41,6 +42,7 @@ func TestBAAAgreements(t *testing.T) {
 func TestBAAAlerts(t *testing.T) {
 	app := setupBAAApp()
 	req, _ := http.NewRequest("GET", "/api/compliance/baa/alerts", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
@@ -61,6 +63,7 @@ func TestBAAAlerts(t *testing.T) {
 func TestBAASummary(t *testing.T) {
 	app := setupBAAApp()
 	req, _ := http.NewRequest("GET", "/api/compliance/baa/summary", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)

--- a/pkg/api/handlers/card_proxy_test.go
+++ b/pkg/api/handlers/card_proxy_test.go
@@ -122,6 +122,7 @@ func TestCardProxyAuthorization_ViewerForbidden(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/card-proxy?url=https://example.com", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, -1)
 	require.NoError(t, err)
@@ -149,6 +150,7 @@ func TestCardProxyAuthorization_EditorAllowed(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/card-proxy", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, -1)
 	require.NoError(t, err)
@@ -169,6 +171,7 @@ func TestCardProxyAuthorization_NilStoreSkipsCheck(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/card-proxy", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, -1)
 	require.NoError(t, err)

--- a/pkg/api/handlers/compliance/gxp_test.go
+++ b/pkg/api/handlers/compliance/gxp_test.go
@@ -21,6 +21,7 @@ func setupGxPApp() *fiber.App {
 func TestGxPConfig(t *testing.T) {
 	app := setupGxPApp()
 	req, _ := http.NewRequest("GET", "/api/compliance/gxp/config", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
@@ -41,6 +42,7 @@ func TestGxPConfig(t *testing.T) {
 func TestGxPRecords(t *testing.T) {
 	app := setupGxPApp()
 	req, _ := http.NewRequest("GET", "/api/compliance/gxp/records", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
@@ -61,6 +63,7 @@ func TestGxPRecords(t *testing.T) {
 func TestGxPChainVerify(t *testing.T) {
 	app := setupGxPApp()
 	req, _ := http.NewRequest("GET", "/api/compliance/gxp/chain/verify", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
@@ -81,6 +84,7 @@ func TestGxPChainVerify(t *testing.T) {
 func TestGxPSummary(t *testing.T) {
 	app := setupGxPApp()
 	req, _ := http.NewRequest("GET", "/api/compliance/gxp/summary", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)

--- a/pkg/api/handlers/dashboard_test.go
+++ b/pkg/api/handlers/dashboard_test.go
@@ -52,6 +52,7 @@ func TestListDashboards_Empty(t *testing.T) {
 	// MockStore.GetUserDashboards returns nil, nil by default — valid empty list
 	req, err := http.NewRequest("GET", "/api/dashboards", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -68,6 +69,7 @@ func TestCreateDashboard_Success(t *testing.T) {
 	body := `{"name":"Test Dashboard","is_default":false}`
 	req, err := http.NewRequest("POST", "/api/dashboards", strings.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -89,6 +91,7 @@ func TestCreateDashboard_DefaultName(t *testing.T) {
 	body := `{}`
 	req, err := http.NewRequest("POST", "/api/dashboards", strings.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -108,6 +111,7 @@ func TestCreateDashboard_InvalidBody(t *testing.T) {
 
 	req, err := http.NewRequest("POST", "/api/dashboards", strings.NewReader("not-json"))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -124,6 +128,7 @@ func TestGetDashboard_InvalidID(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/dashboards/not-a-uuid", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -139,6 +144,7 @@ func TestGetDashboard_NotFound(t *testing.T) {
 	dashID := uuid.New()
 	req, err := http.NewRequest("GET", "/api/dashboards/"+dashID.String(), nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -154,6 +160,7 @@ func TestDeleteDashboard_InvalidID(t *testing.T) {
 
 	req, err := http.NewRequest("DELETE", "/api/dashboards/bad-id", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -168,6 +175,7 @@ func TestDeleteDashboard_NotFound(t *testing.T) {
 	dashID := uuid.New()
 	req, err := http.NewRequest("DELETE", "/api/dashboards/"+dashID.String(), nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -183,6 +191,7 @@ func TestImportDashboard_InvalidBody(t *testing.T) {
 
 	req, err := http.NewRequest("POST", "/api/dashboards/import", strings.NewReader("not-json"))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -198,6 +207,7 @@ func TestImportDashboard_UnsupportedFormat(t *testing.T) {
 	body := `{"format":"unknown-format","name":"Bad Import","cards":[]}`
 	req, err := http.NewRequest("POST", "/api/dashboards/import", strings.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -213,6 +223,7 @@ func TestImportDashboard_Success(t *testing.T) {
 	body := `{"format":"kc-dashboard-v1","name":"Imported","cards":[]}`
 	req, err := http.NewRequest("POST", "/api/dashboards/import", strings.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -246,6 +257,7 @@ func TestImportDashboard_ExceedsCardLimit(t *testing.T) {
 
 	req, err := http.NewRequest("POST", "/api/dashboards/import", strings.NewReader(sb.String()))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -269,6 +281,7 @@ func TestImportDashboard_ExceedsUserLimit(t *testing.T) {
 	body := `{"format":"kc-dashboard-v1","name":"ShouldFail","cards":[]}`
 	req, err := http.NewRequest("POST", "/api/dashboards/import", strings.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)

--- a/pkg/api/handlers/feedback/crud_validation_test.go
+++ b/pkg/api/handlers/feedback/crud_validation_test.go
@@ -25,6 +25,7 @@ func postCreateRequest(t *testing.T, body string) (int, string) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests", strings.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -49,6 +50,7 @@ func postCreateRequestWithToken(t *testing.T, body string) (int, string) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests", strings.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)

--- a/pkg/api/handlers/feedback/github_webhook_test.go
+++ b/pkg/api/handlers/feedback/github_webhook_test.go
@@ -26,6 +26,7 @@ func TestWebhook_NoSecretConfigured_Returns503(t *testing.T) {
 	payload := requireMarshalJSON(t, map[string]interface{}{"action": "opened"})
 	req, err := http.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Event", "issues")
 	req.Header.Set("X-Hub-Signature-256", "sha256=anything")
@@ -50,6 +51,7 @@ func TestWebhook_OversizedPayload_Returns413(t *testing.T) {
 	sig := signWebhookPayload(oversized, testWebhookSecret)
 	req, err := http.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(oversized))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Event", "issues")
 	req.Header.Set("X-Hub-Signature-256", sig)
@@ -84,6 +86,7 @@ func TestWebhook_EmptySignatureHeader_Returns401(t *testing.T) {
 	// No signature header at all
 	req, err := http.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Event", "issues")
 
@@ -101,6 +104,7 @@ func TestWebhook_ShortSignatureHeader_Returns401(t *testing.T) {
 	payload := requireMarshalJSON(t, map[string]interface{}{"action": "opened"})
 	req, err := http.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Event", "issues")
 	req.Header.Set("X-Hub-Signature-256", "short")

--- a/pkg/api/handlers/feedback/requests_crud_test.go
+++ b/pkg/api/handlers/feedback/requests_crud_test.go
@@ -21,6 +21,7 @@ func TestCloseRequest_Unauthorized(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+uuid.New().String()+"/close", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -36,6 +37,7 @@ func TestCloseRequest_InvalidRequestID(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/invalid-id/close", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -56,6 +58,7 @@ func TestCloseRequest_NotFound(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -80,6 +83,7 @@ func TestCloseRequest_AccessDenied(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -104,6 +108,7 @@ func TestCloseRequest_StoreError(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -120,6 +125,7 @@ func TestCreateFeatureRequest_Unauthorized(t *testing.T) {
 	payload := `{"title":"Test Feature Request Title","description":"This is a test description with enough words","requestType":"feature"}`
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -136,6 +142,7 @@ func TestCreateFeatureRequest_InvalidJSON(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests", strings.NewReader(`invalid json`))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)

--- a/pkg/api/handlers/feedback/requests_github_test.go
+++ b/pkg/api/handlers/feedback/requests_github_test.go
@@ -151,6 +151,7 @@ func TestExtractClientAuth_FromCookie(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/test", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Cookie", clientAuthCookieName+"=cookie-token")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -170,6 +171,7 @@ func TestExtractClientAuth_FromHeader(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/test", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("X-KC-Client-Auth", "header-token")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -189,6 +191,7 @@ func TestExtractClientAuth_CookiePrecedence(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/test", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Cookie", clientAuthCookieName+"=cookie-token")
 	req.Header.Set("X-KC-Client-Auth", "header-token")
 

--- a/pkg/api/handlers/feedback/requests_list_test.go
+++ b/pkg/api/handlers/feedback/requests_list_test.go
@@ -19,6 +19,7 @@ func TestListFeatureRequests_Unauthorized(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/requests", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -34,6 +35,7 @@ func TestListFeatureRequests_InvalidPageParams(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/requests?limit=-1", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -61,6 +63,7 @@ func TestListFeatureRequests_FiltersUntriagedRequests(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/requests", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -77,6 +80,7 @@ func TestListAllFeatureRequests_Unauthorized(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/requests/all", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -97,6 +101,7 @@ func TestListAllFeatureRequests_CountOnly(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/requests/all?count_only=true", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	// Note: This may fail if GitHub token is required, which is acceptable
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -122,6 +127,7 @@ func TestParsePageParams_Defaults(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/test", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)

--- a/pkg/api/handlers/feedback/requests_notifications_test.go
+++ b/pkg/api/handlers/feedback/requests_notifications_test.go
@@ -22,6 +22,7 @@ func TestGetNotifications_Unauthorized(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -43,6 +44,7 @@ func TestGetNotifications_DefaultLimit(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -66,6 +68,7 @@ func TestGetNotifications_CustomLimit(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications?limit=25", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -89,6 +92,7 @@ func TestGetNotifications_LimitCappedAt100(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications?limit=200", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -112,6 +116,7 @@ func TestGetNotifications_ZeroLimitUsesDefault(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications?limit=0", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -129,6 +134,7 @@ func TestGetUnreadCount_Unauthorized(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications/unread", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -150,6 +156,7 @@ func TestGetUnreadCount_StoreError(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications/unread", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -165,6 +172,7 @@ func TestMarkNotificationRead_Unauthorized(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/notifications/"+uuid.New().String()+"/read", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -180,6 +188,7 @@ func TestMarkNotificationRead_InvalidID(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/notifications/invalid-id/read", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -217,6 +226,7 @@ func TestMarkNotificationRead_NotFound(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/notifications/"+notificationID.String()+"/read", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -232,6 +242,7 @@ func TestMarkAllNotificationsRead_Unauthorized(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/notifications/read-all", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -251,6 +262,7 @@ func TestMarkAllNotificationsRead_StoreError(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/notifications/read-all", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)

--- a/pkg/api/handlers/missions/handler_test.go
+++ b/pkg/api/handlers/missions/handler_test.go
@@ -47,6 +47,7 @@ func TestMissions_BrowseConsoleKB_Success(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/browse?path=missions", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -74,6 +75,7 @@ func TestMissions_BrowseConsoleKB_NoPath(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/browse", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -97,6 +99,7 @@ func TestMissions_ValidateMission_ValidMission(t *testing.T) {
 	payload := `{"mission":{"apiVersion":"kc-mission-v1","kind":"Mission","metadata":{"name":"test-mission"},"spec":{"description":"A test mission"}},"path":"fixes/demo/install.json"}`
 	req, err := http.NewRequest("POST", "/api/missions/validate", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -125,6 +128,7 @@ func TestMissions_ValidateMission_QualityFailure(t *testing.T) {
 	payload := `{"mission":{"apiVersion":"kc-mission-v1","kind":"Mission","metadata":{"name":"test-mission"},"spec":{"description":"A test mission"}},"path":"fixes/demo/install.json"}`
 	req, err := http.NewRequest("POST", "/api/missions/validate", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -153,6 +157,7 @@ func TestMissions_ValidateMission_MissionNotInIndex(t *testing.T) {
 	payload := `{"mission":{"apiVersion":"kc-mission-v1","kind":"Mission","metadata":{"name":"test-mission"},"spec":{"description":"A test mission"}},"path":"fixes/demo/install.json"}`
 	req, err := http.NewRequest("POST", "/api/missions/validate", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -172,6 +177,7 @@ func TestMissions_ValidateMission_InvalidMission(t *testing.T) {
 	payload := `{"mission":{"apiVersion":"wrong","spec":{}},"path":"fixes/demo/install.json"}`
 	req, err := http.NewRequest("POST", "/api/missions/validate", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -191,6 +197,7 @@ func TestMissions_ValidateMission_EmptyBody(t *testing.T) {
 
 	req, err := http.NewRequest("POST", "/api/missions/validate", strings.NewReader(""))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -213,6 +220,7 @@ func TestMissions_ValidateMission_TooLarge(t *testing.T) {
 	largePayload := strings.Repeat("x", missionsMaxBodyBytes+1)
 	req, err := http.NewRequest("POST", "/api/missions/validate", strings.NewReader(largePayload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -250,6 +258,7 @@ func TestMissions_ShareToSlack_Success(t *testing.T) {
 	payload := `{"webhookUrl":"https://hooks.slack.com/services/T00/B00/xxx","text":"Hello from mission"}`
 	req, err := http.NewRequest("POST", "/api/missions/share/slack", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -267,6 +276,7 @@ func TestMissions_ShareToSlack_InvalidWebhook(t *testing.T) {
 	payload := `{"webhookUrl":"https://evil.com/webhook","text":"Hello"}`
 	req, err := http.NewRequest("POST", "/api/missions/share/slack", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -282,6 +292,7 @@ func TestMissions_ShareToGitHub_NoToken(t *testing.T) {
 	payload := `{"repo":"kubestellar/console-kb","filePath":"missions/test.yaml","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`
 	req, err := http.NewRequest("POST", "/api/missions/share/github", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -302,6 +313,7 @@ func TestMissions_ShareToGitHub_RepoNotAllowed(t *testing.T) {
 	payload := `{"repo":"kubestellar/private-repo","filePath":"missions/test.yaml","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`
 	req, err := http.NewRequest("POST", "/api/missions/share/github", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Token", "ghp_test123")
 	resp, err := app.Test(req, 5000)
@@ -392,6 +404,7 @@ func TestMissions_ShareToGitHub_Success(t *testing.T) {
 	payload := `{"repo":"kubestellar/console-kb","filePath":"missions/test.yaml","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`
 	req, err := http.NewRequest("POST", "/api/missions/share/github", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Token", "ghp_test123")
 	resp, err := app.Test(req, 5000)
@@ -428,6 +441,7 @@ func TestMissions_GetMissionFile_Success(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/file?path=missions/example.yaml", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -449,6 +463,7 @@ func TestMissions_GetMissionFile_NotFound(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/file?path=missions/nonexistent.yaml", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -637,6 +652,7 @@ func TestMissions_BrowseConsoleKB_EmbeddedFallback(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/browse?path=subdir", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -667,6 +683,7 @@ func TestMissions_GetMissionFile_EmbeddedFallback(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/file?path=subdir/nested.txt", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -885,6 +902,7 @@ func TestGetKBScores_Success(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -915,6 +933,7 @@ func TestGetKBScores_EmptyResultsEncoding(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -936,6 +955,7 @@ func TestGetKBScores_UpstreamError(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -997,6 +1017,7 @@ func TestGetKBScores_EmbeddedFallback(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -1024,6 +1045,7 @@ func TestGetMissionScore_Success(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/coredns/coredns-123", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -1047,6 +1069,7 @@ func TestGetMissionScore_NotFound(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/coredns/coredns-999", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -1065,6 +1088,7 @@ func TestGetMissionScore_NoScore(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/kubernetes/kubernetes-456", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -1087,6 +1111,7 @@ func TestGetMissionScore_ExactIDMatch(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/coredns/coredns-12", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode,
@@ -1124,6 +1149,7 @@ func TestGetMissionScore_UpstreamError(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/"+project+"/"+missionID, nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -1142,6 +1168,7 @@ func TestGetKBGaps_NoStore_ReturnsDisabled(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/gaps", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -1174,6 +1201,7 @@ func TestGetKBGaps_WithStore_ReturnsGaps(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/gaps?limit=5", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -1202,6 +1230,7 @@ func TestGetKBGaps_RequiresAdmin(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/gaps", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)

--- a/pkg/api/handlers/missions/scores_test.go
+++ b/pkg/api/handlers/missions/scores_test.go
@@ -30,6 +30,7 @@ func TestMissions_GetKBScores_Success(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -71,6 +72,7 @@ func TestMissions_GetKBScores_Pagination(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores?limit=2&offset=1", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -94,6 +96,7 @@ func TestMissions_GetKBScores_DemoMode(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("X-Demo-Mode", "true")
 
 	resp, err := app.Test(req, 5000)
@@ -136,6 +139,7 @@ func TestMissions_GetMissionScore_Success(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/demo/test-123", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -168,6 +172,7 @@ func TestMissions_GetMissionScore_NotFound(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/demo/nonexistent", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -195,6 +200,7 @@ func TestMissions_GetMissionScore_NoScore(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/demo/test-123", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)

--- a/pkg/api/handlers/onboarding_test.go
+++ b/pkg/api/handlers/onboarding_test.go
@@ -40,6 +40,7 @@ func TestGetQuestions_ReturnsNonEmpty(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/onboarding/questions", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -66,6 +67,7 @@ func TestSaveResponses_Success(t *testing.T) {
 	payload := `[{"question_key":"role","answer":"SRE"},{"question_key":"focus_layer","answer":"Application"}]`
 	req, err := http.NewRequest("POST", "/api/onboarding/responses", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -89,6 +91,7 @@ func TestSaveResponses_InvalidBody(t *testing.T) {
 
 	req, err := http.NewRequest("POST", "/api/onboarding/responses", strings.NewReader("not-json"))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -107,6 +110,7 @@ func TestCompleteOnboarding_Success(t *testing.T) {
 	// CreateCard, SetUserOnboarded — all succeed silently with default behavior.
 	req, err := http.NewRequest("POST", "/api/onboarding/complete", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)

--- a/pkg/api/handlers/rewards/persistence_test.go
+++ b/pkg/api/handlers/rewards/persistence_test.go
@@ -63,6 +63,7 @@ func TestRewardsHandler_GetReturnsZeroForNewUser(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/rewards/me", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -124,6 +125,7 @@ func TestRewardsHandler_PutRejectsOutOfRangeValues(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPut, "/api/rewards/me", bytes.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
 	require.NoError(t, err)
@@ -142,6 +144,7 @@ func TestRewardsHandler_PostCoinsIncrementsCorrectly(t *testing.T) {
 		require.NoError(t, err)
 		req, err := http.NewRequest(http.MethodPost, "/api/rewards/coins", bytes.NewReader(payload))
 		require.NoError(t, err)
+	req.Host = "localhost"
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := app.Test(req, testRewardsFiberTimeoutMs)
 		require.NoError(t, err)
@@ -164,6 +167,7 @@ func TestRewardsHandler_PostCoinsNegativeDoesNotDriveBelowZero(t *testing.T) {
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodPost, "/api/rewards/coins", bytes.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
 	require.NoError(t, err)
@@ -179,6 +183,7 @@ func TestRewardsHandler_PostCoinsRejectsZeroDelta(t *testing.T) {
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodPost, "/api/rewards/coins", bytes.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
 	require.NoError(t, err)
@@ -193,6 +198,7 @@ func TestRewardsHandler_PostCoinsRejectsOversizedDelta(t *testing.T) {
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodPost, "/api/rewards/coins", bytes.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
 	require.NoError(t, err)
@@ -204,6 +210,7 @@ func TestRewardsHandler_DailyBonusFirstClaimSucceeds(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/rewards/daily-bonus", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
 	require.NoError(t, err)

--- a/pkg/api/handlers/stellar/actions_test.go
+++ b/pkg/api/handlers/stellar/actions_test.go
@@ -79,6 +79,7 @@ func TestStellarActionExecute_RBAC(t *testing.T) {
 
 			req, err := http.NewRequest(http.MethodPost, "/api/stellar/actions/execute", http.NoBody)
 			require.NoError(t, err)
+	req.Host = "localhost"
 			req.Header.Set("Content-Type", "application/json")
 
 			resp, err := app.Test(req, stellarActionExecuteFiberTimeoutMs)
@@ -111,6 +112,7 @@ func TestStellarActionExecute_DestructiveActionsRequireApprovalFlow(t *testing.T
 
 			req, err := http.NewRequest(http.MethodPost, "/api/stellar/actions/execute", bytes.NewReader(body))
 			require.NoError(t, err)
+	req.Host = "localhost"
 			req.Header.Set("Content-Type", "application/json")
 
 			resp, err := app.Test(req, stellarActionExecuteFiberTimeoutMs)

--- a/pkg/api/handlers/stellar/mocked_handlers_test.go
+++ b/pkg/api/handlers/stellar/mocked_handlers_test.go
@@ -125,6 +125,7 @@ func TestStellarCreateTask_DefaultsWithMockedStore(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/tasks", bytes.NewReader([]byte(`{"title":"Investigate failed rollout"}`)))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
@@ -146,6 +147,7 @@ func TestStellarCreateTask_InvalidDueAtReturnsBadRequest(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/tasks", bytes.NewReader([]byte(`{"title":"Investigate failed rollout","dueAt":"not-rfc3339"}`)))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
@@ -163,6 +165,7 @@ func TestStellarUpdateTaskStatus_ReturnsStatusWhenReloadFails(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPatch, "/api/stellar/tasks/task-7/status", bytes.NewReader([]byte(`{"status":"DONE"}`)))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
@@ -187,6 +190,7 @@ func TestStellarSearchMemory_DefaultLimitWithMockedStore(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/memory/search", bytes.NewReader([]byte(`{"query":"oomkilled"}`)))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
@@ -217,6 +221,7 @@ func TestStellarCreateProvider_UsesMockedUpsert(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/providers", bytes.NewReader([]byte(`{"provider":"ollama","displayName":"Local Ollama","baseUrl":"http://127.0.0.1:11434","model":"llama3"}`)))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)

--- a/pkg/api/handlers/stellar/notifications_test.go
+++ b/pkg/api/handlers/stellar/notifications_test.go
@@ -58,6 +58,7 @@ func TestListNotifications_EmptyResult(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/notifications", http.NoBody)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
 	require.NoError(t, err)
@@ -99,6 +100,7 @@ func TestListNotifications_ReturnsCreatedNotifications(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/notifications", http.NoBody)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
 	require.NoError(t, err)
@@ -144,6 +146,7 @@ func TestListNotifications_UnreadOnlyFilter(t *testing.T) {
 	// Query for unread only
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/notifications?unread=true", http.NoBody)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
 	require.NoError(t, err)
@@ -176,6 +179,7 @@ func TestMarkNotificationRead_Success(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/read", http.NoBody)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
 	require.NoError(t, err)
@@ -196,6 +200,7 @@ func TestMarkNotificationRead_MissingID(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/%20/read", http.NoBody)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
 	require.NoError(t, err)
@@ -233,6 +238,7 @@ func TestMarkNotificationInvestigating_Success(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/investigating", bytes.NewReader(bodyBytes))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -253,6 +259,7 @@ func TestMarkNotificationInvestigating_InvalidJSON(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/some-id/investigating", bytes.NewReader([]byte("invalid-json")))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -287,6 +294,7 @@ func TestResolveNotification_Success(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/resolve", bytes.NewReader(bodyBytes))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -328,6 +336,7 @@ func TestDismissNotification_Success(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/dismiss", bytes.NewReader(bodyBytes))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -355,6 +364,7 @@ func TestUpdateNotificationState_NotificationNotFound(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/nonexistent-id/resolve", bytes.NewReader(bodyBytes))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -394,6 +404,7 @@ func TestUpdateNotificationState_FillsAffectedResource(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/resolve", bytes.NewReader(bodyBytes))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -625,6 +636,7 @@ func TestUpdateNotificationState_WrongUser(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/resolve", bytes.NewReader(bodyBytes))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)

--- a/pkg/api/handlers/stellar/observations_test.go
+++ b/pkg/api/handlers/stellar/observations_test.go
@@ -82,6 +82,7 @@ func TestStellarStream_ReturnsUnauthorizedWithoutUser(t *testing.T) {
 	app.Get("/api/stellar/stream", h.Stream)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/stream", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 2000)
 	require.NoError(t, err)
@@ -199,6 +200,7 @@ func TestStellarListObservations_EmptyReturnsEmptyList(t *testing.T) {
 	app, _ := newStellarTestApp(t)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/observations", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, stellarTestFiberTimeoutMs)
 	require.NoError(t, err)
@@ -218,6 +220,7 @@ func TestStellarListObservations_AppliesLimitParam(t *testing.T) {
 	app, _ := newStellarTestApp(t)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/observations?limit=7", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, stellarTestFiberTimeoutMs)
 	require.NoError(t, err)
@@ -248,6 +251,7 @@ func TestStellarIngestEvent_RequiresAuth(t *testing.T) {
 
 	body := `{"cluster":"c1","namespace":"ns","name":"pod-a","type":"Warning","reason":"CrashLoop","message":"back-off"}`
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/events", strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -284,6 +288,7 @@ func TestStellarIngestEvent_MissingFieldsReturnsBadRequest(t *testing.T) {
 	// Missing required fields: cluster is empty.
 	body := `{"cluster":"","namespace":"ns","name":"pod","type":"Warning","reason":"x","message":"y"}`
 	req, err2 := http.NewRequest(http.MethodPost, "/api/stellar/events", bytes.NewReader([]byte(body)))
+	req.Host = "localhost"
 	require.NoError(t, err2)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err2 := editorApp.Test(req, 2000)
@@ -325,6 +330,7 @@ func TestStellarIngestEvent_AcceptsValidEvent(t *testing.T) {
 	}
 	raw, _ := json.Marshal(payload)
 	req, err2 := http.NewRequest(http.MethodPost, "/api/stellar/events", bytes.NewReader(raw))
+	req.Host = "localhost"
 	require.NoError(t, err2)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/api/handlers/stellar/test.go
+++ b/pkg/api/handlers/stellar/test.go
@@ -99,6 +99,7 @@ func TestStellarPreferencesRoundTrip(t *testing.T) {
 	app, _ := newStellarTestApp(t)
 
 	getReq, err := http.NewRequest(http.MethodGet, "/api/stellar/preferences", nil)
+	getReq.Host = "localhost"
 	require.NoError(t, err)
 	getResp, err := app.Test(getReq, stellarTestFiberTimeoutMs)
 	require.NoError(t, err)
@@ -117,6 +118,7 @@ func TestStellarPreferencesRoundTrip(t *testing.T) {
 	}
 	raw, _ := json.Marshal(updateBody)
 	putReq, err := http.NewRequest(http.MethodPut, "/api/stellar/preferences", bytes.NewReader(raw))
+	putReq.Host = "localhost"
 	require.NoError(t, err)
 	putReq.Header.Set("Content-Type", "application/json")
 	putResp, err := app.Test(putReq, stellarTestFiberTimeoutMs)
@@ -139,6 +141,7 @@ func TestStellarMissionAndActionFlow(t *testing.T) {
 	}
 	rawMission, _ := json.Marshal(createMissionBody)
 	createMissionReq, err := http.NewRequest(http.MethodPost, "/api/stellar/missions", bytes.NewReader(rawMission))
+	createMissionReq.Host = "localhost"
 	require.NoError(t, err)
 	createMissionReq.Header.Set("Content-Type", "application/json")
 	createMissionResp, err := app.Test(createMissionReq, stellarTestFiberTimeoutMs)
@@ -159,6 +162,7 @@ func TestStellarMissionAndActionFlow(t *testing.T) {
 	}
 	rawAction, _ := json.Marshal(createActionBody)
 	createActionReq, err := http.NewRequest(http.MethodPost, "/api/stellar/actions", bytes.NewReader(rawAction))
+	createActionReq.Host = "localhost"
 	require.NoError(t, err)
 	createActionReq.Header.Set("Content-Type", "application/json")
 	createActionResp, err := app.Test(createActionReq, stellarTestFiberTimeoutMs)
@@ -171,6 +175,7 @@ func TestStellarMissionAndActionFlow(t *testing.T) {
 	require.NotEmpty(t, actionID)
 
 	approveReq, err := http.NewRequest(http.MethodPost, "/api/stellar/actions/"+actionID+"/approve", bytes.NewReader([]byte(`{}`)))
+	approveReq.Host = "localhost"
 	require.NoError(t, err)
 	approveReq.Header.Set("Content-Type", "application/json")
 	approveResp, err := app.Test(approveReq, stellarTestFiberTimeoutMs)
@@ -186,6 +191,7 @@ func TestStellarAskStateDigestAndNotifications(t *testing.T) {
 	}
 	rawAsk, _ := json.Marshal(askBody)
 	askReq, err := http.NewRequest(http.MethodPost, "/api/stellar/ask", bytes.NewReader(rawAsk))
+	askReq.Host = "localhost"
 	require.NoError(t, err)
 	askReq.Header.Set("Content-Type", "application/json")
 	askResp, err := app.Test(askReq, stellarTestFiberTimeoutMs)
@@ -193,18 +199,21 @@ func TestStellarAskStateDigestAndNotifications(t *testing.T) {
 	require.Equal(t, http.StatusOK, askResp.StatusCode)
 
 	stateReq, err := http.NewRequest(http.MethodGet, "/api/stellar/state", nil)
+	stateReq.Host = "localhost"
 	require.NoError(t, err)
 	stateResp, err := app.Test(stateReq, stellarTestFiberTimeoutMs)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, stateResp.StatusCode)
 
 	digestReq, err := http.NewRequest(http.MethodGet, "/api/stellar/digest", nil)
+	digestReq.Host = "localhost"
 	require.NoError(t, err)
 	digestResp, err := app.Test(digestReq, stellarTestFiberTimeoutMs)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, digestResp.StatusCode)
 
 	notifReq, err := http.NewRequest(http.MethodGet, "/api/stellar/notifications", nil)
+	notifReq.Host = "localhost"
 	require.NoError(t, err)
 	notifResp, err := app.Test(notifReq, stellarTestFiberTimeoutMs)
 	require.NoError(t, err)
@@ -217,6 +226,7 @@ func TestStellarAskStateDigestAndNotifications(t *testing.T) {
 		id, _ := item["id"].(string)
 		if id != "" {
 			readReq, reqErr := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+id+"/read", nil)
+			readReq.Host = "localhost"
 			require.NoError(t, reqErr)
 			readResp, readErr := app.Test(readReq, stellarTestFiberTimeoutMs)
 			require.NoError(t, readErr)
@@ -273,7 +283,7 @@ func TestStellarNotificationStateTransitions(t *testing.T) {
 		UserID:    userID,
 		Type:      "event",
 		Severity:  "critical",
-		Title:     "CrashLoopBackOff — default/api-7c9d",
+		Title:     "CrashLoopBackOff \u2014 default/api-7c9d",
 		Body:      "timeout after 30s waiting for DB pool",
 		Cluster:   "prod-a",
 		Namespace: "default",
@@ -281,7 +291,8 @@ func TestStellarNotificationStateTransitions(t *testing.T) {
 	}
 	require.NoError(t, sqlStore.CreateStellarNotification(context.Background(), notification))
 
-	investigateReq, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+notification.ID+"/investigate", bytes.NewReader([]byte(`{"investigationSummary":"pulling logs"}`)))
+	investigateReq, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+notification.ID+"/investigate", bytes.NewReader([]byte(`{"investigationSummary":"pulling logs"}` )))
+	investigateReq.Host = "localhost"
 	require.NoError(t, err)
 	investigateReq.Header.Set("Content-Type", "application/json")
 	investigateResp, err := app.Test(investigateReq, stellarTestFiberTimeoutMs)
@@ -294,7 +305,8 @@ func TestStellarNotificationStateTransitions(t *testing.T) {
 	assert.Equal(t, "pulling logs", investigating.InvestigationSummary)
 	assert.False(t, investigating.Read)
 
-	resolveReq, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+notification.ID+"/resolve", bytes.NewReader([]byte(`{"resolutionNote":"restarted deployment"}`)))
+	resolveReq, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+notification.ID+"/resolve", bytes.NewReader([]byte(`{"resolutionNote":"restarted deployment"}` )))
+	resolveReq.Host = "localhost"
 	require.NoError(t, err)
 	resolveReq.Header.Set("Content-Type", "application/json")
 	resolveResp, err := app.Test(resolveReq, stellarTestFiberTimeoutMs)
@@ -312,7 +324,7 @@ func TestStellarNotificationStateTransitions(t *testing.T) {
 		UserID:    userID,
 		Type:      "event",
 		Severity:  "warning",
-		Title:     "FailedScheduling — default/api",
+		Title:     "FailedScheduling \u2014 default/api",
 		Body:      "insufficient cpu",
 		Cluster:   "prod-a",
 		Namespace: "default",
@@ -320,7 +332,8 @@ func TestStellarNotificationStateTransitions(t *testing.T) {
 	}
 	require.NoError(t, sqlStore.CreateStellarNotification(context.Background(), notification2))
 
-	dismissReq, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+notification2.ID+"/dismiss", bytes.NewReader([]byte(`{"dismissalReason":"duplicate event"}`)))
+	dismissReq, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+notification2.ID+"/dismiss", bytes.NewReader([]byte(`{"dismissalReason":"duplicate event"}` )))
+	dismissReq.Host = "localhost"
 	require.NoError(t, err)
 	dismissReq.Header.Set("Content-Type", "application/json")
 	dismissResp, err := app.Test(dismissReq, stellarTestFiberTimeoutMs)
@@ -346,6 +359,7 @@ func TestStellarResolveWatchReturnsJSON(t *testing.T) {
 	}
 	rawCreate, _ := json.Marshal(createBody)
 	createReq, err := http.NewRequest(http.MethodPost, "/api/stellar/watches", bytes.NewReader(rawCreate))
+	createReq.Host = "localhost"
 	require.NoError(t, err)
 	createReq.Header.Set("Content-Type", "application/json")
 	createResp, err := app.Test(createReq, stellarTestFiberTimeoutMs)
@@ -359,6 +373,7 @@ func TestStellarResolveWatchReturnsJSON(t *testing.T) {
 	require.NotEmpty(t, watchID)
 
 	resolveReq, err := http.NewRequest(http.MethodPost, "/api/stellar/watches/"+watchID+"/resolve", bytes.NewReader([]byte(`{}`)))
+	resolveReq.Host = "localhost"
 	require.NoError(t, err)
 	resolveReq.Header.Set("Content-Type", "application/json")
 	resolveResp, err := app.Test(resolveReq, stellarTestFiberTimeoutMs)

--- a/pkg/api/handlers/teams_test.go
+++ b/pkg/api/handlers/teams_test.go
@@ -116,6 +116,7 @@ func performTeamRequest(t *testing.T, app *fiber.App, method, path, body string)
 
 	req, err := http.NewRequest(method, path, strings.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/pkg/api/handlers/token_usage_test.go
+++ b/pkg/api/handlers/token_usage_test.go
@@ -58,6 +58,7 @@ func TestTokenUsageHandler_GetReturnsZeroForNewUser(t *testing.T) {
 	app, _, _, _ := newTokenUsageTestApp(t)
 
 	req, _ := http.NewRequest(http.MethodGet, "/api/token-usage/me", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -86,6 +87,7 @@ func TestTokenUsageHandler_PutThenGetRoundTrip(t *testing.T) {
 	raw, _ := json.Marshal(body)
 	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/me", bytes.NewReader(raw))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
@@ -119,6 +121,7 @@ func TestTokenUsageHandler_DeltaIncrementsAtomically(t *testing.T) {
 		})
 		req, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
 		require.NoError(t, err)
+	req.Host = "localhost"
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 		require.NoError(t, err)
@@ -182,6 +185,7 @@ func TestTokenUsageHandler_GetResetsStaleDayTotals(t *testing.T) {
 	})
 	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/me", bytes.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
@@ -213,6 +217,7 @@ func TestTokenUsageHandler_DeltaRejectsNegative(t *testing.T) {
 	})
 	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
@@ -230,6 +235,7 @@ func TestTokenUsageHandler_DeltaRejectsOverLimit(t *testing.T) {
 	})
 	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
@@ -251,6 +257,7 @@ func TestTokenUsageHandler_PutRejectsTooManyCategories(t *testing.T) {
 	})
 	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/me", bytes.NewReader(body))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)

--- a/pkg/api/handlers/user_test.go
+++ b/pkg/api/handlers/user_test.go
@@ -50,6 +50,7 @@ func TestGetCurrentUser_Success(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/user", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -72,6 +73,7 @@ func TestGetCurrentUser_NotFound(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/user", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
@@ -96,6 +98,7 @@ func TestUpdateCurrentUser_Success(t *testing.T) {
 	payload := `{"email":"new@example.com","slackId":"U12345"}`
 	req, err := http.NewRequest("PUT", "/api/user", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -119,6 +122,7 @@ func TestUpdateCurrentUser_NotFound(t *testing.T) {
 	payload := `{"email":"new@example.com"}`
 	req, err := http.NewRequest("PUT", "/api/user", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -135,6 +139,7 @@ func TestUpdateCurrentUser_InvalidBody(t *testing.T) {
 	// calls are expected.
 	req, err := http.NewRequest("PUT", "/api/user", strings.NewReader("not-json"))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -161,6 +166,7 @@ func TestUpdateCurrentUser_InvalidEmail(t *testing.T) {
 	payload := `{"email":"not-an-email"}`
 	req, err := http.NewRequest("PUT", "/api/user", strings.NewReader(payload))
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)

--- a/pkg/api/handlers/websocket_ratelimit_test.go
+++ b/pkg/api/handlers/websocket_ratelimit_test.go
@@ -47,6 +47,7 @@ func TestWebSocketRateLimit(t *testing.T) {
 	// Test: Normal WebSocket upgrade request should succeed
 	req, err := http.NewRequest(http.MethodGet, "/ws", nil)
 	require.NoError(t, err)
+	req.Host = "localhost"
 	req.Header.Set("Upgrade", "websocket")
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")

--- a/pkg/api/handlers/workloads/cluster_groups_test.go
+++ b/pkg/api/handlers/workloads/cluster_groups_test.go
@@ -183,6 +183,7 @@ func TestListClusterGroups_IncludesBuiltIn(t *testing.T) {
 	clusterGroupsMu.Unlock()
 
 	req, _ := http.NewRequest("GET", "/api/cluster-groups", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -212,6 +213,7 @@ func TestCreateClusterGroup_Success(t *testing.T) {
 
 	payload := `{"name":"new-group","kind":"static","clusters":["test-cluster"]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -231,6 +233,7 @@ func TestCreateClusterGroup_MissingName(t *testing.T) {
 
 	payload := `{"name":"","kind":"static","clusters":["c1"]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -245,6 +248,7 @@ func TestCreateClusterGroup_ReservedName(t *testing.T) {
 
 	payload := `{"name":"all-healthy-clusters","kind":"static","clusters":["c1"]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -259,6 +263,7 @@ func TestCreateClusterGroup_StaticNoClusters(t *testing.T) {
 
 	payload := `{"name":"empty-group","kind":"static","clusters":[]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -274,6 +279,7 @@ func TestCreateClusterGroup_DynamicNoClusters(t *testing.T) {
 	// Dynamic groups are allowed with no clusters
 	payload := `{"name":"dyn-group","kind":"dynamic","clusters":[]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -287,6 +293,7 @@ func TestCreateClusterGroup_InvalidBody(t *testing.T) {
 	env.App.Post("/api/cluster-groups", h.CreateClusterGroup)
 
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader("not json"))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -310,6 +317,7 @@ func TestUpdateClusterGroup_Success(t *testing.T) {
 
 	payload := `{"kind":"static","clusters":["c1","c2"]}`
 	req, _ := http.NewRequest("PUT", "/api/cluster-groups/existing", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -329,6 +337,7 @@ func TestUpdateClusterGroup_BuiltInReject(t *testing.T) {
 
 	payload := `{"kind":"static","clusters":["c1"]}`
 	req, _ := http.NewRequest("PUT", "/api/cluster-groups/all-healthy-clusters", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -342,6 +351,7 @@ func TestUpdateClusterGroup_InvalidBody(t *testing.T) {
 	env.App.Put("/api/cluster-groups/:name", h.UpdateClusterGroup)
 
 	req, _ := http.NewRequest("PUT", "/api/cluster-groups/test", strings.NewReader("bad json"))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -363,6 +373,7 @@ func TestDeleteClusterGroup_Success(t *testing.T) {
 	clusterGroupsMu.Unlock()
 
 	req, _ := http.NewRequest("DELETE", "/api/cluster-groups/del-me", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusMultiStatus, resp.StatusCode)
@@ -379,6 +390,7 @@ func TestDeleteClusterGroup_BuiltInReject(t *testing.T) {
 	env.App.Delete("/api/cluster-groups/:name", h.DeleteClusterGroup)
 
 	req, _ := http.NewRequest("DELETE", "/api/cluster-groups/all-healthy-clusters", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
 	assert.Equal(t, 400, resp.StatusCode)
@@ -397,6 +409,7 @@ func TestSyncClusterGroups_Success(t *testing.T) {
 
 	payload := `[{"name":"g1","kind":"static","clusters":["c1"]},{"name":"g2","kind":"dynamic","clusters":[]}]`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups/sync", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -416,6 +429,7 @@ func TestSyncClusterGroups_FiltersReservedName(t *testing.T) {
 	// Include the reserved name — it should be filtered out
 	payload := `[{"name":"all-healthy-clusters","kind":"dynamic","clusters":[]},{"name":"real-group","kind":"static","clusters":["c1"]}]`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups/sync", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -433,6 +447,7 @@ func TestSyncClusterGroups_InvalidJSONClusterGroups(t *testing.T) {
 	env.App.Post("/api/cluster-groups/sync", h.SyncClusterGroups)
 
 	req, _ := http.NewRequest("POST", "/api/cluster-groups/sync", strings.NewReader("not json"))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -452,6 +467,7 @@ func TestSyncClusterGroups_BodyTooLarge(t *testing.T) {
 		bigPayload = strings.Repeat("x", 1<<20+1)
 	}
 	req, err := http.NewRequest("POST", "/api/cluster-groups/sync", strings.NewReader(bigPayload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
@@ -491,6 +507,7 @@ func TestClusterGroupsConcurrentAccess(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 			req, _ := http.NewRequest("GET", "/api/cluster-groups", nil)
+			req.Host = "localhost"
 			env.App.Test(req, -1)
 		}(i)
 		go func(idx int) {

--- a/pkg/api/handlers/workloads/cluster_query_test.go
+++ b/pkg/api/handlers/workloads/cluster_query_test.go
@@ -52,6 +52,7 @@ func TestGenerateClusterQuery_PromptTooLong(t *testing.T) {
 			data, _ := json.Marshal(payload)
 
 			req, err := http.NewRequest("POST", "/api/cluster-groups/ai-query", bytes.NewReader(data))
+			req.Host = "localhost"
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 
@@ -80,6 +81,7 @@ func TestGenerateClusterQuery_EmptyPrompt(t *testing.T) {
 	data, _ := json.Marshal(payload)
 
 	req, err := http.NewRequest("POST", "/api/cluster-groups/ai-query", bytes.NewReader(data))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -305,6 +307,7 @@ func TestGenerateClusterQuery_AIRateLimiter(t *testing.T) {
 	makeRequest := func() *http.Response {
 		payload, _ := json.Marshal(map[string]string{"prompt": "list healthy clusters"})
 		req, err := http.NewRequest(http.MethodPost, "/api/cluster-groups/ai-query", bytes.NewReader(payload))
+		req.Host = "localhost"
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := env.App.Test(req, 5000)
@@ -372,6 +375,7 @@ func TestGenerateClusterQuery_AIRateLimiter_IndependentPerIP(t *testing.T) {
 	makeRequest := func() *http.Response {
 		payload, _ := json.Marshal(map[string]string{"prompt": "list healthy clusters"})
 		req, err := http.NewRequest(http.MethodPost, "/api/cluster-groups/ai-query", bytes.NewReader(payload))
+		req.Host = "localhost"
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := env.App.Test(req, 5000)

--- a/pkg/api/handlers/workloads/handler_test.go
+++ b/pkg/api/handlers/workloads/handler_test.go
@@ -63,6 +63,7 @@ func TestListWorkloads(t *testing.T) {
 	injectDynamicClusterWithObjects(env, "test-cluster", scheme, []runtime.Object{deployment})
 
 	req, err := http.NewRequest("GET", "/api/workloads?cluster=test-cluster", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
@@ -107,6 +108,7 @@ func TestGetWorkload(t *testing.T) {
 
 	// 1. Success Case
 	req, err := http.NewRequest("GET", "/api/workloads/test-cluster/default/my-app", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
@@ -121,6 +123,7 @@ func TestGetWorkload(t *testing.T) {
 
 	// 2. Not Found
 	reqNotFound, err := http.NewRequest("GET", "/api/workloads/test-cluster/default/missing", nil)
+	reqNotFound.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, reqNotFound)
 	respNotFound, errNotFound := env.App.Test(reqNotFound, 5000)
@@ -151,6 +154,7 @@ func TestGetDeployStatus(t *testing.T) {
 	injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{deploy})
 
 	req, err := http.NewRequest("GET", "/api/workloads/deploy-status/c1/default/status-app", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
@@ -194,14 +198,15 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	env.App.Put("/api/cluster-groups/:name", handler.UpdateClusterGroup)
 	env.App.Delete("/api/cluster-groups/:name", handler.DeleteClusterGroup)
 
-	createPayload := map[string]interface{}{
+	createpayload := map[string]interface{}{
 		"name":     "group1",
 		"kind":     "static",
 		"clusters": []string{"c1", "c2"},
 		"color":    "blue",
 	}
-	data, _ := json.Marshal(createPayload)
+	data, _ := json.Marshal(createpayload)
 	req, err := http.NewRequest("POST", "/api/cluster-groups", bytes.NewReader(data))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	req.Header.Set("Content-Type", "application/json")
@@ -212,6 +217,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	assert.Equal(t, 201, resp.StatusCode)
 
 	req, err = http.NewRequest("GET", "/api/cluster-groups", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err = env.App.Test(req)
@@ -228,14 +234,15 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	assert.Equal(t, "all-healthy-clusters", listResp["groups"][0]["name"])
 	assert.Equal(t, "group1", listResp["groups"][1]["name"])
 
-	updatePayload := map[string]interface{}{
+	updatepayload := map[string]interface{}{
 		"name":     "group1",
 		"kind":     "static",
 		"clusters": []string{"c1"},
 		"color":    "red",
 	}
-	data, _ = json.Marshal(updatePayload)
+	data, _ = json.Marshal(updatepayload)
 	req, err = http.NewRequest("PUT", "/api/cluster-groups/group1", bytes.NewReader(data))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	req.Header.Set("Content-Type", "application/json")
@@ -246,6 +253,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 
 	req, err = http.NewRequest("DELETE", "/api/cluster-groups/group1", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err = env.App.Test(req)
@@ -254,6 +262,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 
 	req, err = http.NewRequest("GET", "/api/cluster-groups", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err = env.App.Test(req)
@@ -315,6 +324,7 @@ func TestEvaluateClusterQuery(t *testing.T) {
 
 	data, _ := json.Marshal(query)
 	req, err := http.NewRequest("POST", "/api/cluster-groups/evaluate", bytes.NewReader(data))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	req.Header.Set("Content-Type", "application/json")
@@ -373,6 +383,7 @@ func TestGenerateClusterQuery(t *testing.T) {
 	data, _ := json.Marshal(payload)
 
 	req, err := http.NewRequest("POST", "/api/cluster-groups/generate", bytes.NewReader(data))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	req.Header.Set("Content-Type", "application/json")
@@ -422,6 +433,7 @@ func TestResolveDependencies(t *testing.T) {
 	injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{deploy, svc})
 
 	req, err := http.NewRequest("GET", "/api/workloads/resolve-deps/c1/default/app", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
@@ -468,6 +480,7 @@ func TestMonitorWorkload(t *testing.T) {
 	injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{deploy})
 
 	req, err := http.NewRequest("GET", "/api/workloads/monitor/c1/default/monitored-app", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
@@ -517,6 +530,7 @@ func TestGetDeployLogs(t *testing.T) {
 		injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{pod, deploy}, pod)
 
 		req, err := http.NewRequest("GET", "/api/workloads/logs/c1/default/log-app", nil)
+		req.Host = "localhost"
 		require.NoError(t, err)
 		require.NotNil(t, req)
 		resp, err := env.App.Test(req, 5000)
@@ -532,6 +546,7 @@ func TestGetDeployLogs(t *testing.T) {
 		injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{pod}, pod)
 
 		req, err := http.NewRequest("GET", "/api/workloads/logs/c1/default/missing-app", nil)
+		req.Host = "localhost"
 		require.NoError(t, err)
 		require.NotNil(t, req)
 		resp, err := env.App.Test(req, 5000)
@@ -547,6 +562,7 @@ func TestGetDeployLogs(t *testing.T) {
 	t.Run("MissingCluster_Returns500", func(t *testing.T) {
 		// When the cluster context does not exist, GetClient fails and handler returns 500.
 		req, err := http.NewRequest("GET", "/api/workloads/logs/nonexistent-cluster/default/app", nil)
+		req.Host = "localhost"
 		require.NoError(t, err)
 		require.NotNil(t, req)
 		resp, err := env.App.Test(req, 5000)


### PR DESCRIPTION
Fixes #19909

fasthttp 1.72.0 now requires a `Host` header in all HTTP requests. This adds `req.Host = "localhost"` to every `http.NewRequest` call that goes through Fiber's `app.Test()` in the affected test packages.

## Failing Tests Fixed
- `pkg/api/handlers/stellar` — 6 tests (stream, observations, ingest-event)
- `pkg/api/handlers/workloads` — ~37 tests (cluster_groups, workloads, deploy_logs, cluster_query)

## Root Cause
Fiber uses fasthttp internally. When `app.Test(req, ...)` is called with a Go `*http.Request` that has an empty `Host` field and a relative URL (e.g. `/api/stellar/observations`), Go cannot derive a Host from the URL, so the raw HTTP bytes sent to fasthttp contain no `Host` header. fasthttp 1.72.0 now enforces the HTTP/1.1 requirement that a `Host` header must be present.

## Fix
Added `req.Host = "localhost"` immediately after each `http.NewRequest(...)` call in test files. The `sseGet` helper (which uses a real HTTP client with a full URL) was left unchanged — Go's HTTP client automatically includes the `Host` header from the URL in that case.