### PR TITLE
fix: remove stray getDemoMode lines causing 5 lint parse errors on main

### DIFF
--- a/web/src/hooks/__tests__/useDataCompliance.test.ts
+++ b/web/src/hooks/__tests__/useDataCompliance.test.ts
@@ -128,7 +128,6 @@ afterEach(() => {
 
 function kubectlOk(output: string) {
   return { exitCode: 0, output }
-  getDemoMode: vi.fn(() => false),
 }
 
 function kubectlFail(output = '') {

--- a/web/src/hooks/__tests__/useKyverno.test.ts
+++ b/web/src/hooks/__tests__/useKyverno.test.ts
@@ -101,7 +101,6 @@ afterEach(() => {
 
 function kubectlOk(output: string) {
   return { exitCode: 0, output }
-  getDemoMode: vi.fn(() => false),
 }
 
 function kubectlFail(output = '') {

--- a/web/src/hooks/__tests__/useRBACFindings.test.ts
+++ b/web/src/hooks/__tests__/useRBACFindings.test.ts
@@ -98,7 +98,6 @@ afterEach(() => {
 
 function kubectlOk(output: string) {
   return { exitCode: 0, output }
-  getDemoMode: vi.fn(() => false),
 }
 
 function kubectlFail(output = '') {

--- a/web/src/hooks/__tests__/useSidebarConfig.test.ts
+++ b/web/src/hooks/__tests__/useSidebarConfig.test.ts
@@ -12,7 +12,7 @@ vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
   useDemoMode: vi.fn(() => ({ isDemoMode: true })),
   getDemoMode: vi.fn(() => false),
-})
+}))
 
 vi.mock('../useBackendHealth', () => ({
   useBackendHealth: vi.fn(() => ({

--- a/web/src/hooks/__tests__/useSidebarConfig.test.ts
+++ b/web/src/hooks/__tests__/useSidebarConfig.test.ts
@@ -10,8 +10,7 @@ vi.mock('../mcp/shared', () => ({
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),
-  useDemoMode: vi.fn(() => ({ isDemoMode: true }
-)),
+  useDemoMode: vi.fn(() => ({ isDemoMode: true })),
   getDemoMode: vi.fn(() => false),
 })
 

--- a/web/src/lib/unified/demo/__tests__/UnifiedDemo.test.tsx
+++ b/web/src/lib/unified/demo/__tests__/UnifiedDemo.test.tsx
@@ -67,7 +67,6 @@ function ContextConsumer() {
       <button data-testid="regen" onClick={() => ctx.regenerate('test-id')}>Regen</button>
     </div>
   )
-  getDemoMode: vi.fn(() => false),
 }
 
 /** Renders a component using useUnifiedData */


### PR DESCRIPTION
## Summary

- Remove stray `getDemoMode: vi.fn(() => false),` lines from 4 test files where they were placed after `return` statements (unreachable code causing parse errors)
- Fix awkward line break in `useSidebarConfig.test.ts` mock that confused the parser

## Files fixed

- `web/src/hooks/__tests__/useDataCompliance.test.ts` — removed stray line after `return`
- `web/src/hooks/__tests__/useKyverno.test.ts` — same
- `web/src/hooks/__tests__/useRBACFindings.test.ts` — same
- `web/src/hooks/__tests__/useSidebarConfig.test.ts` — fixed line break in mock
- `web/src/lib/unified/demo/__tests__/UnifiedDemo.test.tsx` — removed stray line after JSX return

## Root cause

These stray lines were likely inserted by a bulk automated edit that added `getDemoMode` mocks but placed them outside their intended `vi.mock()` blocks. The 5 parse errors cause `build-gate` to fail on every PR branch, blocking all hold/quality PRs.

## Test plan

- [ ] `build-gate` passes (lint should drop from 5 errors to 0)