### PR TITLE
[quality] fix: add Host header to all Fiber test requests for fasthttp 1.72.0

### DIFF
--- a/pkg/api/audit/audit_test.go
+++ b/pkg/api/audit/audit_test.go
@@ -35,6 +35,7 @@ func TestLogEmitsRequiredFields(t *testing.T) {
 	var buf bytes.Buffer
 	captureLog(&buf, func() {
 		req := httptest.NewRequest("POST", "/api/users/target-123/role", nil)
+		req.Host = "localhost"
 		req.Header.Set("X-Forwarded-For", "10.0.0.1")
 		//nolint:errcheck // test-only; response body is irrelevant
 		app.Test(req)
@@ -76,6 +77,7 @@ func TestLogOmitsDetailsWhenEmpty(t *testing.T) {
 	var buf bytes.Buffer
 	captureLog(&buf, func() {
 		req := httptest.NewRequest("DELETE", "/api/users/target-456", nil)
+		req.Host = "localhost"
 		//nolint:errcheck // test-only
 		app.Test(req)
 	})
@@ -104,6 +106,7 @@ func TestLogUnauthorizedAttempt(t *testing.T) {
 	var buf bytes.Buffer
 	captureLog(&buf, func() {
 		req := httptest.NewRequest("GET", "/api/users", nil)
+		req.Host = "localhost"
 		//nolint:errcheck // test-only
 		app.Test(req)
 	})
@@ -151,6 +154,7 @@ func TestLogPersistsAuditEntry(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("PUT", "/api/settings", nil)
+	req.Host = "localhost"
 	req.Header.Set("X-Forwarded-For", "203.0.113.10")
 	_, err := app.Test(req)
 	if err != nil {
@@ -204,6 +208,7 @@ func TestLogStoreFailureLogsError(t *testing.T) {
 	var buf bytes.Buffer
 	captureLog(&buf, func() {
 		req := httptest.NewRequest("POST", "/api/login", nil)
+		req.Host = "localhost"
 		_, err := app.Test(req)
 		if err != nil {
 			t.Fatalf("app.Test() error = %v", err)

--- a/pkg/api/handlers/agentic_detection_runs_test.go
+++ b/pkg/api/handlers/agentic_detection_runs_test.go
@@ -153,6 +153,7 @@ func TestGetDetectionRuns_DemoMode(t *testing.T) {
 	env.App.Get("/api/detection-runs", h.GetDetectionRuns)
 
 	req, err := http.NewRequest("GET", "/api/detection-runs", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("X-Demo-Mode", "true")
 
@@ -178,6 +179,7 @@ func TestGetDetectionRuns_NoToken_FallsBackToDemo(t *testing.T) {
 	env.App.Get("/api/detection-runs", h.GetDetectionRuns)
 
 	req, err := http.NewRequest("GET", "/api/detection-runs", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)

--- a/pkg/api/handlers/auth/auth_test.go
+++ b/pkg/api/handlers/auth/auth_test.go
@@ -53,6 +53,7 @@ func TestDevModeLogin(t *testing.T) {
 		mockStore.On("UpdateLastLogin", mock.Anything).Return(nil).Once()
 
 		req, _ := http.NewRequest("GET", "/auth/dev", nil)
+		req.Host = "localhost"
 		resp, err := app.Test(req, 5000)
 
 		assert.NoError(t, err)
@@ -77,6 +78,7 @@ func TestDevModeLogin(t *testing.T) {
 		mockStore.On("UpdateLastLogin", existingUser.ID).Return(nil).Once()
 
 		req, _ := http.NewRequest("GET", "/auth/dev", nil)
+		req.Host = "localhost"
 		resp, err := app.Test(req, 5000)
 
 		assert.NoError(t, err)
@@ -94,6 +96,7 @@ func TestDevModeLogin(t *testing.T) {
 // want to exercise the CSRF gate should build requests directly.
 func refreshReq(authHeader string) *http.Request {
 	req, err := http.NewRequest("POST", "/auth/refresh", nil)
+	req.Host = "localhost"
 	if err != nil {
 		panic(err)
 	}
@@ -188,6 +191,7 @@ func TestRefreshToken(t *testing.T) {
 		token, _ := handler.generateJWT(user)
 
 		req, _ := http.NewRequest("POST", "/auth/refresh", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp, _ := app.Test(req, 5000)
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
@@ -328,6 +332,7 @@ func TestGitHubLogin_Redirects(t *testing.T) {
 	app.Get("/auth/github", handler.GitHubLogin)
 
 	req, _ := http.NewRequest("GET", "/auth/github", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 
 	assert.NoError(t, err)
@@ -362,6 +367,7 @@ func TestGitHubCallback_MissingCode(t *testing.T) {
 	app.Get("/auth/callback", handler.GitHubCallback)
 
 	req, _ := http.NewRequest("GET", "/auth/callback", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	if err != nil || resp == nil {
 		t.Fatalf("app.Test failed: %v", err)
@@ -378,6 +384,7 @@ func TestGitHubCallback_InvalidState(t *testing.T) {
 
 	// Provide code but no state
 	req, _ := http.NewRequest("GET", "/auth/callback?code=123", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	if err != nil || resp == nil {
 		t.Fatalf("app.Test failed: %v", err)
@@ -394,6 +401,7 @@ func TestGitHubCallback_GitHubError(t *testing.T) {
 
 	t.Run("Access denied by user", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/auth/callback?error=access_denied&error_description=The+user+denied+access", nil)
+		req.Host = "localhost"
 		resp, err := app.Test(req, 5000)
 		if err != nil || resp == nil {
 			t.Fatalf("app.Test failed: %v", err)
@@ -407,6 +415,7 @@ func TestGitHubCallback_GitHubError(t *testing.T) {
 
 	t.Run("Generic GitHub error", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/auth/callback?error=application_suspended&error_description=App+is+suspended", nil)
+		req.Host = "localhost"
 		resp, err := app.Test(req, 5000)
 		if err != nil || resp == nil {
 			t.Fatalf("app.Test failed: %v", err)
@@ -468,6 +477,7 @@ func TestGitHubCallback_RecoversFromValidCookieOnStateFailure(t *testing.T) {
 		assert.NoError(t, err)
 
 		req, _ := http.NewRequest("GET", "/auth/callback?code=123&state=bogus", nil)
+		req.Host = "localhost"
 		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: cookieToken})
 
 		resp, err := app.Test(req, 5000)
@@ -483,6 +493,7 @@ func TestGitHubCallback_RecoversFromValidCookieOnStateFailure(t *testing.T) {
 
 	t.Run("missing cookie + invalid state redirects to error page", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/auth/callback?code=123&state=bogus", nil)
+		req.Host = "localhost"
 
 		resp, err := app.Test(req, 5000)
 		assert.NoError(t, err)
@@ -505,6 +516,7 @@ func TestGitHubCallback_RecoversFromValidCookieOnStateFailure(t *testing.T) {
 		expiredSigned, _ := expiredJWT.SignedString([]byte("test-secret"))
 
 		req, _ := http.NewRequest("GET", "/auth/callback?code=123&state=bogus", nil)
+		req.Host = "localhost"
 		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: expiredSigned})
 
 		resp, err := app.Test(req, 5000)
@@ -530,6 +542,7 @@ func TestGitHubCallback_RecoversFromValidCookieOnStateFailure(t *testing.T) {
 		forgedSigned, _ := forgedJWT.SignedString([]byte("not-the-real-secret"))
 
 		req, _ := http.NewRequest("GET", "/auth/callback?code=123&state=bogus", nil)
+		req.Host = "localhost"
 		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: forgedSigned})
 
 		resp, err := app.Test(req, 5000)
@@ -548,6 +561,7 @@ func TestGitHubCallback_RecoversFromValidCookieOnStateFailure(t *testing.T) {
 		assert.NoError(t, err)
 
 		req, _ := http.NewRequest("GET", "/auth/callback?code=123", nil)
+		req.Host = "localhost"
 		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: cookieToken})
 
 		resp, err := app.Test(req, 5000)
@@ -753,6 +767,7 @@ func TestGitHubCallback_SanitizesErrorDescription(t *testing.T) {
 	// Include CR/LF in the query param; after URL decoding the handler
 	// should strip the control characters before reflecting them.
 	req, _ := http.NewRequest("GET",
+	req.Host = "localhost"
 		"/auth/callback?error=access_denied&error_description=bad%0D%0Ainjected",
 		nil)
 	resp, err := app.Test(req, 5000)
@@ -778,6 +793,7 @@ func TestLogout_RequiresCSRFHeader(t *testing.T) {
 
 	// Without the CSRF header: 403.
 	req, err := http.NewRequest("POST", "/auth/logout", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := app.Test(req, 5000)
@@ -786,6 +802,7 @@ func TestLogout_RequiresCSRFHeader(t *testing.T) {
 
 	// With the CSRF header: 200.
 	req2, err := http.NewRequest("POST", "/auth/logout", nil)
+	req2.Host = "localhost"
 	require.NoError(t, err)
 	req2.Header.Set("Authorization", "Bearer "+token)
 	req2.Header.Set("X-Requested-With", "XMLHttpRequest")
@@ -813,6 +830,7 @@ func TestLogout_ExpiredTokenIdempotent(t *testing.T) {
 	signed, _ := tok.SignedString([]byte("test-secret"))
 
 	req, err := http.NewRequest("POST", "/auth/logout", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer "+signed)
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
@@ -836,6 +854,7 @@ func TestCookieSameSiteStrict(t *testing.T) {
 	mockStore.On("UpdateLastLogin", mock.Anything).Return(nil).Once()
 
 	req, _ := http.NewRequest("GET", "/auth/dev", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 

--- a/pkg/api/handlers/auth/auth_test.go
+++ b/pkg/api/handlers/auth/auth_test.go
@@ -337,7 +337,6 @@ func TestGitHubLogin_Redirects(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
-
 	loc, _ := resp.Location()
 	assert.Contains(t, loc.String(), "github.com/login/oauth/authorize")
 	assert.Contains(t, loc.String(), "client_id=client-id")
@@ -766,10 +765,12 @@ func TestGitHubCallback_SanitizesErrorDescription(t *testing.T) {
 
 	// Include CR/LF in the query param; after URL decoding the handler
 	// should strip the control characters before reflecting them.
-	req, _ := http.NewRequest("GET",
-	req.Host = "localhost"
+	req, _ := http.NewRequest(
+		"GET",
 		"/auth/callback?error=access_denied&error_description=bad%0D%0Ainjected",
-		nil)
+		nil,
+	)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)

--- a/pkg/api/handlers/card_proxy_test.go
+++ b/pkg/api/handlers/card_proxy_test.go
@@ -121,6 +121,7 @@ func TestCardProxyAuthorization_ViewerForbidden(t *testing.T) {
 	app.Get("/api/card-proxy", handler.Proxy)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/card-proxy?url=https://example.com", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, -1)
@@ -148,6 +149,7 @@ func TestCardProxyAuthorization_EditorAllowed(t *testing.T) {
 	app.Get("/api/card-proxy", handler.Proxy)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/card-proxy", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, -1)
@@ -168,6 +170,7 @@ func TestCardProxyAuthorization_NilStoreSkipsCheck(t *testing.T) {
 	app.Get("/api/card-proxy", handler.Proxy)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/card-proxy", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, -1)

--- a/pkg/api/handlers/cards_test.go
+++ b/pkg/api/handlers/cards_test.go
@@ -55,6 +55,7 @@ func TestGetCardTypes_ReturnsNonEmpty(t *testing.T) {
 	app.Get("/api/cards/types", handler.GetCardTypes)
 
 	req, err := http.NewRequest("GET", "/api/cards/types", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -75,6 +76,7 @@ func TestListCards_InvalidDashboardID(t *testing.T) {
 	app.Get("/api/dashboards/:id/cards", handler.ListCards)
 
 	req, err := http.NewRequest("GET", "/api/dashboards/not-a-uuid/cards", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -90,6 +92,7 @@ func TestListCards_DashboardNotFound(t *testing.T) {
 	// MockStore.GetDashboard returns nil — triggers "Access denied" (nil dashboard check)
 	dashID := uuid.New()
 	req, err := http.NewRequest("GET", "/api/dashboards/"+dashID.String()+"/cards", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -106,6 +109,7 @@ func TestCreateCard_InvalidDashboardID(t *testing.T) {
 
 	body := `{"card_type":"cluster_health","position":{"x":0,"y":0,"w":4,"h":3}}`
 	req, err := http.NewRequest("POST", "/api/dashboards/bad-id/cards", strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -123,6 +127,7 @@ func TestUpdateCard_InvalidCardID(t *testing.T) {
 
 	body := `{"position":{"x":1,"y":1,"w":4,"h":3}}`
 	req, err := http.NewRequest("PUT", "/api/cards/bad-id", strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -142,6 +147,7 @@ func TestUpdateCard_NotFound(t *testing.T) {
 
 	body := `{"position":{"x":1,"y":1,"w":4,"h":3}}`
 	req, err := http.NewRequest("PUT", "/api/cards/"+cardID.String(), strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -158,6 +164,7 @@ func TestDeleteCard_InvalidID(t *testing.T) {
 	app.Delete("/api/cards/:id", handler.DeleteCard)
 
 	req, err := http.NewRequest("DELETE", "/api/cards/bad-id", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -174,6 +181,7 @@ func TestDeleteCard_NotFound(t *testing.T) {
 	mockStore.On("GetCard", cardID).Return(nil, nil)
 
 	req, err := http.NewRequest("DELETE", "/api/cards/"+cardID.String(), nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -238,6 +246,7 @@ func TestRecordFocus_BadBody_Returns400(t *testing.T) {
 	app.Post("/api/cards/:id/focus", handler.RecordFocus)
 
 	req, err := http.NewRequest("POST", "/api/cards/"+cardID.String()+"/focus",
+	req.Host = "localhost"
 		strings.NewReader("{invalid json"))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -255,6 +264,7 @@ func TestGetHistory_ReturnsOK(t *testing.T) {
 	app.Get("/api/cards/history", handler.GetHistory)
 
 	req, err := http.NewRequest("GET", "/api/cards/history", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -417,6 +427,7 @@ func TestMoveCard_RejectsWhenTargetAtLimit(t *testing.T) {
 
 	body := `{"target_dashboard_id":"` + targetDashID.String() + `"}`
 	req, err := http.NewRequest("POST", "/api/cards/"+cardID.String()+"/move", strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -435,6 +446,7 @@ func TestCreateCard_ViewerForbidden(t *testing.T) {
 
 	body := `{"card_type":"cluster_health","position":{"x":0,"y":0,"w":4,"h":3}}`
 	req, err := http.NewRequest("POST", "/api/dashboards/"+dashID.String()+"/cards",
+	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -452,6 +464,7 @@ func TestUpdateCard_ViewerForbidden(t *testing.T) {
 
 	body := `{"position":{"x":1,"y":1,"w":4,"h":3}}`
 	req, err := http.NewRequest("PUT", "/api/cards/"+cardID.String(), strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -467,6 +480,7 @@ func TestDeleteCard_ViewerForbidden(t *testing.T) {
 	app, _, _ := newCardMutationApp(t, models.UserRoleViewer, dashID, cardID)
 
 	req, err := http.NewRequest("DELETE", "/api/cards/"+cardID.String(), nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -483,6 +497,7 @@ func TestCreateCard_AdminAllowed(t *testing.T) {
 
 	body := `{"card_type":"cluster_health","config":{"cluster":"prod"},"position":{"x":0,"y":0,"w":4,"h":3}}`
 	req, err := http.NewRequest("POST", "/api/dashboards/"+dashID.String()+"/cards",
+	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -504,6 +519,7 @@ func TestUpdateCard_AdminAllowedWithConfig(t *testing.T) {
 
 	body := `{"card_type":"pod_issues","config":{"ns":"default"},"position":{"x":1,"y":1,"w":4,"h":3}}`
 	req, err := http.NewRequest("PUT", "/api/cards/"+cardID.String(), strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -526,6 +542,7 @@ func TestCreateCard_LimitReached_Returns429(t *testing.T) {
 
 	body := `{"card_type":"cluster_health","position":{"x":0,"y":0,"w":4,"h":3}}`
 	req, err := http.NewRequest("POST", "/api/dashboards/"+dashID.String()+"/cards",
+	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -545,6 +562,7 @@ func TestCreateCard_UnknownCardType_Returns400(t *testing.T) {
 
 	body := `{"card_type":"not_a_real_card","position":{"x":0,"y":0,"w":4,"h":3}}`
 	req, err := http.NewRequest("POST", "/api/dashboards/"+dashID.String()+"/cards",
+	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -562,6 +580,7 @@ func TestUpdateCard_UnknownCardType_Returns400(t *testing.T) {
 
 	body := `{"card_type":"not_a_real_card"}`
 	req, err := http.NewRequest("PUT", "/api/cards/"+cardID.String(), strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -613,6 +632,7 @@ func TestCreateCard_UserStoreError_Returns500(t *testing.T) {
 
 	body := `{"card_type":"cluster_health","position":{"x":0,"y":0,"w":4,"h":3}}`
 	req, err := http.NewRequest("POST", "/api/dashboards/"+dashID.String()+"/cards",
+	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/api/handlers/cards_test.go
+++ b/pkg/api/handlers/cards_test.go
@@ -55,7 +55,6 @@ func TestGetCardTypes_ReturnsNonEmpty(t *testing.T) {
 	app.Get("/api/cards/types", handler.GetCardTypes)
 
 	req, err := http.NewRequest("GET", "/api/cards/types", nil)
-	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -76,7 +75,6 @@ func TestListCards_InvalidDashboardID(t *testing.T) {
 	app.Get("/api/dashboards/:id/cards", handler.ListCards)
 
 	req, err := http.NewRequest("GET", "/api/dashboards/not-a-uuid/cards", nil)
-	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -92,7 +90,6 @@ func TestListCards_DashboardNotFound(t *testing.T) {
 	// MockStore.GetDashboard returns nil — triggers "Access denied" (nil dashboard check)
 	dashID := uuid.New()
 	req, err := http.NewRequest("GET", "/api/dashboards/"+dashID.String()+"/cards", nil)
-	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -109,7 +106,6 @@ func TestCreateCard_InvalidDashboardID(t *testing.T) {
 
 	body := `{"card_type":"cluster_health","position":{"x":0,"y":0,"w":4,"h":3}}`
 	req, err := http.NewRequest("POST", "/api/dashboards/bad-id/cards", strings.NewReader(body))
-	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -127,7 +123,6 @@ func TestUpdateCard_InvalidCardID(t *testing.T) {
 
 	body := `{"position":{"x":1,"y":1,"w":4,"h":3}}`
 	req, err := http.NewRequest("PUT", "/api/cards/bad-id", strings.NewReader(body))
-	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -147,7 +142,6 @@ func TestUpdateCard_NotFound(t *testing.T) {
 
 	body := `{"position":{"x":1,"y":1,"w":4,"h":3}}`
 	req, err := http.NewRequest("PUT", "/api/cards/"+cardID.String(), strings.NewReader(body))
-	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -164,7 +158,6 @@ func TestDeleteCard_InvalidID(t *testing.T) {
 	app.Delete("/api/cards/:id", handler.DeleteCard)
 
 	req, err := http.NewRequest("DELETE", "/api/cards/bad-id", nil)
-	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -181,7 +174,6 @@ func TestDeleteCard_NotFound(t *testing.T) {
 	mockStore.On("GetCard", cardID).Return(nil, nil)
 
 	req, err := http.NewRequest("DELETE", "/api/cards/"+cardID.String(), nil)
-	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -246,7 +238,6 @@ func TestRecordFocus_BadBody_Returns400(t *testing.T) {
 	app.Post("/api/cards/:id/focus", handler.RecordFocus)
 
 	req, err := http.NewRequest("POST", "/api/cards/"+cardID.String()+"/focus",
-	req.Host = "localhost"
 		strings.NewReader("{invalid json"))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -264,7 +255,6 @@ func TestGetHistory_ReturnsOK(t *testing.T) {
 	app.Get("/api/cards/history", handler.GetHistory)
 
 	req, err := http.NewRequest("GET", "/api/cards/history", nil)
-	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -427,7 +417,6 @@ func TestMoveCard_RejectsWhenTargetAtLimit(t *testing.T) {
 
 	body := `{"target_dashboard_id":"` + targetDashID.String() + `"}`
 	req, err := http.NewRequest("POST", "/api/cards/"+cardID.String()+"/move", strings.NewReader(body))
-	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -446,7 +435,6 @@ func TestCreateCard_ViewerForbidden(t *testing.T) {
 
 	body := `{"card_type":"cluster_health","position":{"x":0,"y":0,"w":4,"h":3}}`
 	req, err := http.NewRequest("POST", "/api/dashboards/"+dashID.String()+"/cards",
-	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -464,7 +452,6 @@ func TestUpdateCard_ViewerForbidden(t *testing.T) {
 
 	body := `{"position":{"x":1,"y":1,"w":4,"h":3}}`
 	req, err := http.NewRequest("PUT", "/api/cards/"+cardID.String(), strings.NewReader(body))
-	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -480,7 +467,6 @@ func TestDeleteCard_ViewerForbidden(t *testing.T) {
 	app, _, _ := newCardMutationApp(t, models.UserRoleViewer, dashID, cardID)
 
 	req, err := http.NewRequest("DELETE", "/api/cards/"+cardID.String(), nil)
-	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -497,7 +483,6 @@ func TestCreateCard_AdminAllowed(t *testing.T) {
 
 	body := `{"card_type":"cluster_health","config":{"cluster":"prod"},"position":{"x":0,"y":0,"w":4,"h":3}}`
 	req, err := http.NewRequest("POST", "/api/dashboards/"+dashID.String()+"/cards",
-	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -519,7 +504,6 @@ func TestUpdateCard_AdminAllowedWithConfig(t *testing.T) {
 
 	body := `{"card_type":"pod_issues","config":{"ns":"default"},"position":{"x":1,"y":1,"w":4,"h":3}}`
 	req, err := http.NewRequest("PUT", "/api/cards/"+cardID.String(), strings.NewReader(body))
-	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -542,7 +526,6 @@ func TestCreateCard_LimitReached_Returns429(t *testing.T) {
 
 	body := `{"card_type":"cluster_health","position":{"x":0,"y":0,"w":4,"h":3}}`
 	req, err := http.NewRequest("POST", "/api/dashboards/"+dashID.String()+"/cards",
-	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -562,7 +545,6 @@ func TestCreateCard_UnknownCardType_Returns400(t *testing.T) {
 
 	body := `{"card_type":"not_a_real_card","position":{"x":0,"y":0,"w":4,"h":3}}`
 	req, err := http.NewRequest("POST", "/api/dashboards/"+dashID.String()+"/cards",
-	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -580,7 +562,6 @@ func TestUpdateCard_UnknownCardType_Returns400(t *testing.T) {
 
 	body := `{"card_type":"not_a_real_card"}`
 	req, err := http.NewRequest("PUT", "/api/cards/"+cardID.String(), strings.NewReader(body))
-	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -632,7 +613,6 @@ func TestCreateCard_UserStoreError_Returns500(t *testing.T) {
 
 	body := `{"card_type":"cluster_health","position":{"x":0,"y":0,"w":4,"h":3}}`
 	req, err := http.NewRequest("POST", "/api/dashboards/"+dashID.String()+"/cards",
-	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/api/handlers/compliance/acmm_scan_test.go
+++ b/pkg/api/handlers/compliance/acmm_scan_test.go
@@ -16,6 +16,7 @@ func TestACMMScanHandler_Demo(t *testing.T) {
 	env.App.Get("/api/acmm/scan", ACMMScanHandler)
 
 	req, err := http.NewRequest("GET", "/api/acmm/scan?repo=kubestellar/console", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("X-Demo-Mode", "true")
 
@@ -38,6 +39,7 @@ func TestACMMScanHandler_InvalidRepo(t *testing.T) {
 	env.App.Get("/api/acmm/scan", ACMMScanHandler)
 
 	req, err := http.NewRequest("GET", "/api/acmm/scan?repo=invalid-repo", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)

--- a/pkg/api/handlers/compliance/compliance_frameworks_test.go
+++ b/pkg/api/handlers/compliance/compliance_frameworks_test.go
@@ -25,6 +25,7 @@ func TestListFrameworks(t *testing.T) {
 	app, _ := setupComplianceFrameworksTest()
 
 	req, err := http.NewRequest("GET", "/api/compliance/frameworks/", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	assert.NoError(t, err)
@@ -42,6 +43,7 @@ func TestGetFramework(t *testing.T) {
 	app, _ := setupComplianceFrameworksTest()
 
 	req, err := http.NewRequest("GET", "/api/compliance/frameworks/pci-dss-4.0", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	assert.NoError(t, err)
@@ -58,6 +60,7 @@ func TestGetFrameworkNotFound(t *testing.T) {
 	app, _ := setupComplianceFrameworksTest()
 
 	req, err := http.NewRequest("GET", "/api/compliance/frameworks/nonexistent", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	assert.NoError(t, err)
@@ -69,6 +72,7 @@ func TestEvaluateFrameworkDemo(t *testing.T) {
 
 	body := `{"cluster":"demo-cluster"}`
 	req, err := http.NewRequest("POST", "/api/compliance/frameworks/pci-dss-4.0/evaluate",
+	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -88,6 +92,7 @@ func TestEvaluateFrameworkNotFound(t *testing.T) {
 
 	body := `{"cluster":"c"}`
 	req, err := http.NewRequest("POST", "/api/compliance/frameworks/nonexistent/evaluate",
+	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -101,6 +106,7 @@ func TestEvaluateFrameworkMissingCluster(t *testing.T) {
 
 	body := `{}`
 	req, err := http.NewRequest("POST", "/api/compliance/frameworks/pci-dss-4.0/evaluate",
+	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -113,6 +119,7 @@ func TestEvaluateFrameworkBadBody(t *testing.T) {
 	app, _ := setupComplianceFrameworksTest()
 
 	req, err := http.NewRequest("POST", "/api/compliance/frameworks/pci-dss-4.0/evaluate",
+	req.Host = "localhost"
 		strings.NewReader("not json"))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -171,6 +178,7 @@ func TestEvaluateLiveCluster(t *testing.T) {
 
 	body := `{"cluster":"live-cluster"}`
 	req, err := http.NewRequest("POST", "/api/compliance/frameworks/pci-dss-4.0/evaluate",
+	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -230,6 +238,7 @@ func TestEvaluateFrameworkLiveError(t *testing.T) {
 
 	body := `{"cluster":"bad-cluster"}`
 	req, err := http.NewRequest("POST", "/api/compliance/frameworks/pci-dss-4.0/evaluate",
+	req.Host = "localhost"
 		strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/api/handlers/compliance/compliance_frameworks_test.go
+++ b/pkg/api/handlers/compliance/compliance_frameworks_test.go
@@ -72,8 +72,8 @@ func TestEvaluateFrameworkDemo(t *testing.T) {
 
 	body := `{"cluster":"demo-cluster"}`
 	req, err := http.NewRequest("POST", "/api/compliance/frameworks/pci-dss-4.0/evaluate",
-	req.Host = "localhost"
 		strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -92,8 +92,8 @@ func TestEvaluateFrameworkNotFound(t *testing.T) {
 
 	body := `{"cluster":"c"}`
 	req, err := http.NewRequest("POST", "/api/compliance/frameworks/nonexistent/evaluate",
-	req.Host = "localhost"
 		strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -106,8 +106,8 @@ func TestEvaluateFrameworkMissingCluster(t *testing.T) {
 
 	body := `{}`
 	req, err := http.NewRequest("POST", "/api/compliance/frameworks/pci-dss-4.0/evaluate",
-	req.Host = "localhost"
 		strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -119,8 +119,8 @@ func TestEvaluateFrameworkBadBody(t *testing.T) {
 	app, _ := setupComplianceFrameworksTest()
 
 	req, err := http.NewRequest("POST", "/api/compliance/frameworks/pci-dss-4.0/evaluate",
-	req.Host = "localhost"
 		strings.NewReader("not json"))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -178,8 +178,8 @@ func TestEvaluateLiveCluster(t *testing.T) {
 
 	body := `{"cluster":"live-cluster"}`
 	req, err := http.NewRequest("POST", "/api/compliance/frameworks/pci-dss-4.0/evaluate",
-	req.Host = "localhost"
 		strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 10000)
@@ -238,8 +238,8 @@ func TestEvaluateFrameworkLiveError(t *testing.T) {
 
 	body := `{"cluster":"bad-cluster"}`
 	req, err := http.NewRequest("POST", "/api/compliance/frameworks/pci-dss-4.0/evaluate",
-	req.Host = "localhost"
 		strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 10000)

--- a/pkg/api/handlers/crds_test.go
+++ b/pkg/api/handlers/crds_test.go
@@ -52,6 +52,7 @@ func TestCRDListCRDs_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/crds", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -72,6 +73,7 @@ func TestCRDListCRDs_NoClient(t *testing.T) {
 	env.App.Get("/api/crds", handler.ListCRDs)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/crds", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)

--- a/pkg/api/handlers/dashboard_test.go
+++ b/pkg/api/handlers/dashboard_test.go
@@ -51,6 +51,7 @@ func TestListDashboards_Empty(t *testing.T) {
 
 	// MockStore.GetUserDashboards returns nil, nil by default — valid empty list
 	req, err := http.NewRequest("GET", "/api/dashboards", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -67,6 +68,7 @@ func TestCreateDashboard_Success(t *testing.T) {
 
 	body := `{"name":"Test Dashboard","is_default":false}`
 	req, err := http.NewRequest("POST", "/api/dashboards", strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -88,6 +90,7 @@ func TestCreateDashboard_DefaultName(t *testing.T) {
 	// Empty name should default to "New Dashboard"
 	body := `{}`
 	req, err := http.NewRequest("POST", "/api/dashboards", strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -107,6 +110,7 @@ func TestCreateDashboard_InvalidBody(t *testing.T) {
 	app.Post("/api/dashboards", handler.CreateDashboard)
 
 	req, err := http.NewRequest("POST", "/api/dashboards", strings.NewReader("not-json"))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -123,6 +127,7 @@ func TestGetDashboard_InvalidID(t *testing.T) {
 	app.Get("/api/dashboards/:id", handler.GetDashboard)
 
 	req, err := http.NewRequest("GET", "/api/dashboards/not-a-uuid", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -138,6 +143,7 @@ func TestGetDashboard_NotFound(t *testing.T) {
 	// MockStore.GetDashboard returns nil, nil — triggers "not found"
 	dashID := uuid.New()
 	req, err := http.NewRequest("GET", "/api/dashboards/"+dashID.String(), nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -153,6 +159,7 @@ func TestDeleteDashboard_InvalidID(t *testing.T) {
 	app.Delete("/api/dashboards/:id", handler.DeleteDashboard)
 
 	req, err := http.NewRequest("DELETE", "/api/dashboards/bad-id", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -167,6 +174,7 @@ func TestDeleteDashboard_NotFound(t *testing.T) {
 
 	dashID := uuid.New()
 	req, err := http.NewRequest("DELETE", "/api/dashboards/"+dashID.String(), nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -182,6 +190,7 @@ func TestImportDashboard_InvalidBody(t *testing.T) {
 	app.Post("/api/dashboards/import", handler.ImportDashboard)
 
 	req, err := http.NewRequest("POST", "/api/dashboards/import", strings.NewReader("not-json"))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -197,6 +206,7 @@ func TestImportDashboard_UnsupportedFormat(t *testing.T) {
 
 	body := `{"format":"unknown-format","name":"Bad Import","cards":[]}`
 	req, err := http.NewRequest("POST", "/api/dashboards/import", strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -212,6 +222,7 @@ func TestImportDashboard_Success(t *testing.T) {
 
 	body := `{"format":"kc-dashboard-v1","name":"Imported","cards":[]}`
 	req, err := http.NewRequest("POST", "/api/dashboards/import", strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -245,6 +256,7 @@ func TestImportDashboard_ExceedsCardLimit(t *testing.T) {
 	sb.WriteString(`]}`)
 
 	req, err := http.NewRequest("POST", "/api/dashboards/import", strings.NewReader(sb.String()))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -268,6 +280,7 @@ func TestImportDashboard_ExceedsUserLimit(t *testing.T) {
 
 	body := `{"format":"kc-dashboard-v1","name":"ShouldFail","cards":[]}`
 	req, err := http.NewRequest("POST", "/api/dashboards/import", strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/api/handlers/events_test.go
+++ b/pkg/api/handlers/events_test.go
@@ -61,6 +61,7 @@ func TestEventRecordEvent_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/events", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -86,6 +87,7 @@ func TestEventRecordEvent_InvalidBody(t *testing.T) {
 	env.App.Post("/api/events", handler.RecordEvent)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/events", bytes.NewBufferString("{"))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -110,6 +112,7 @@ func TestEventRecordEvent_InvalidCardID(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/events", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -132,6 +135,7 @@ func TestEventRecordEvent_StoreError(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/events", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -146,6 +150,7 @@ func TestEventGetEvents_Success(t *testing.T) {
 	env.App.Get("/api/events", handler.GetEvents)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/events", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -168,6 +173,7 @@ func TestEventGetEvents_QueryParams(t *testing.T) {
 	env.App.Get("/api/events", handler.GetEvents)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/events?since=1h&limit=50&offset=10", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -193,6 +199,7 @@ func TestEventGetEvents_LimitClamped(t *testing.T) {
 	env.App.Get("/api/events", handler.GetEvents)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/events?limit=999999", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -215,6 +222,7 @@ func TestEventGetEvents_StoreError(t *testing.T) {
 	env.App.Get("/api/events", handler.GetEvents)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/events", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)

--- a/pkg/api/handlers/feedback/crud_validation_test.go
+++ b/pkg/api/handlers/feedback/crud_validation_test.go
@@ -24,6 +24,7 @@ func postCreateRequest(t *testing.T, body string) (int, string) {
 	app.Post("/api/feedback/requests", handler.CreateFeatureRequest)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests", strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -48,6 +49,7 @@ func postCreateRequestWithToken(t *testing.T, body string) (int, string) {
 	app.Post("/api/feedback/requests", handler.CreateFeatureRequest)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests", strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/api/handlers/feedback/github_webhook_test.go
+++ b/pkg/api/handlers/feedback/github_webhook_test.go
@@ -25,6 +25,7 @@ func TestWebhook_NoSecretConfigured_Returns503(t *testing.T) {
 
 	payload := requireMarshalJSON(t, map[string]interface{}{"action": "opened"})
 	req, err := http.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Event", "issues")
@@ -49,6 +50,7 @@ func TestWebhook_OversizedPayload_Returns413(t *testing.T) {
 
 	sig := signWebhookPayload(oversized, testWebhookSecret)
 	req, err := http.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(oversized))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Event", "issues")
@@ -83,6 +85,7 @@ func TestWebhook_EmptySignatureHeader_Returns401(t *testing.T) {
 
 	// No signature header at all
 	req, err := http.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Event", "issues")
@@ -100,6 +103,7 @@ func TestWebhook_ShortSignatureHeader_Returns401(t *testing.T) {
 
 	payload := requireMarshalJSON(t, map[string]interface{}{"action": "opened"})
 	req, err := http.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Event", "issues")

--- a/pkg/api/handlers/feedback/requests_crud_test.go
+++ b/pkg/api/handlers/feedback/requests_crud_test.go
@@ -20,6 +20,7 @@ func TestCloseRequest_Unauthorized(t *testing.T) {
 	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+uuid.New().String()+"/close", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -35,6 +36,7 @@ func TestCloseRequest_InvalidRequestID(t *testing.T) {
 	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/invalid-id/close", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -55,6 +57,7 @@ func TestCloseRequest_NotFound(t *testing.T) {
 	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -79,6 +82,7 @@ func TestCloseRequest_AccessDenied(t *testing.T) {
 	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -103,6 +107,7 @@ func TestCloseRequest_StoreError(t *testing.T) {
 	app.Post("/api/feedback/requests/:id/close", handler.CloseRequest)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/close", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -119,6 +124,7 @@ func TestCreateFeatureRequest_Unauthorized(t *testing.T) {
 
 	payload := `{"title":"Test Feature Request Title","description":"This is a test description with enough words","requestType":"feature"}`
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -135,6 +141,7 @@ func TestCreateFeatureRequest_InvalidJSON(t *testing.T) {
 	app.Post("/api/feedback/requests", handler.CreateFeatureRequest)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/requests", strings.NewReader(`invalid json`))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/api/handlers/feedback/requests_github_test.go
+++ b/pkg/api/handlers/feedback/requests_github_test.go
@@ -150,6 +150,7 @@ func TestExtractClientAuth_FromCookie(t *testing.T) {
 	})
 
 	req, err := http.NewRequest(http.MethodGet, "/test", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Cookie", clientAuthCookieName+"=cookie-token")
 
@@ -169,6 +170,7 @@ func TestExtractClientAuth_FromHeader(t *testing.T) {
 	})
 
 	req, err := http.NewRequest(http.MethodGet, "/test", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("X-KC-Client-Auth", "header-token")
 
@@ -188,6 +190,7 @@ func TestExtractClientAuth_CookiePrecedence(t *testing.T) {
 	})
 
 	req, err := http.NewRequest(http.MethodGet, "/test", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Cookie", clientAuthCookieName+"=cookie-token")
 	req.Header.Set("X-KC-Client-Auth", "header-token")

--- a/pkg/api/handlers/feedback/requests_list_test.go
+++ b/pkg/api/handlers/feedback/requests_list_test.go
@@ -18,6 +18,7 @@ func TestListFeatureRequests_Unauthorized(t *testing.T) {
 	app.Get("/api/feedback/requests", handler.ListFeatureRequests)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/requests", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -33,6 +34,7 @@ func TestListFeatureRequests_InvalidPageParams(t *testing.T) {
 	app.Get("/api/feedback/requests", handler.ListFeatureRequests)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/requests?limit=-1", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -60,6 +62,7 @@ func TestListFeatureRequests_FiltersUntriagedRequests(t *testing.T) {
 	app.Get("/api/feedback/requests", handler.ListFeatureRequests)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/requests", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -76,6 +79,7 @@ func TestListAllFeatureRequests_Unauthorized(t *testing.T) {
 	app.Get("/api/feedback/requests/all", handler.ListAllFeatureRequests)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/requests/all", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -96,6 +100,7 @@ func TestListAllFeatureRequests_CountOnly(t *testing.T) {
 	app.Get("/api/feedback/requests/all", handler.ListAllFeatureRequests)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/requests/all?count_only=true", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	// Note: This may fail if GitHub token is required, which is acceptable
@@ -121,6 +126,7 @@ func TestParsePageParams_Defaults(t *testing.T) {
 	})
 
 	req, err := http.NewRequest(http.MethodGet, "/test", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)

--- a/pkg/api/handlers/feedback/requests_notifications_test.go
+++ b/pkg/api/handlers/feedback/requests_notifications_test.go
@@ -21,6 +21,7 @@ func TestGetNotifications_Unauthorized(t *testing.T) {
 	app.Get("/api/feedback/notifications", handler.GetNotifications)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -42,6 +43,7 @@ func TestGetNotifications_DefaultLimit(t *testing.T) {
 	app.Get("/api/feedback/notifications", handler.GetNotifications)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -65,6 +67,7 @@ func TestGetNotifications_CustomLimit(t *testing.T) {
 	app.Get("/api/feedback/notifications", handler.GetNotifications)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications?limit=25", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -88,6 +91,7 @@ func TestGetNotifications_LimitCappedAt100(t *testing.T) {
 	app.Get("/api/feedback/notifications", handler.GetNotifications)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications?limit=200", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -111,6 +115,7 @@ func TestGetNotifications_ZeroLimitUsesDefault(t *testing.T) {
 	app.Get("/api/feedback/notifications", handler.GetNotifications)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications?limit=0", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -128,6 +133,7 @@ func TestGetUnreadCount_Unauthorized(t *testing.T) {
 	app.Get("/api/feedback/notifications/unread", handler.GetUnreadCount)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications/unread", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -149,6 +155,7 @@ func TestGetUnreadCount_StoreError(t *testing.T) {
 	app.Get("/api/feedback/notifications/unread", handler.GetUnreadCount)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/feedback/notifications/unread", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -164,6 +171,7 @@ func TestMarkNotificationRead_Unauthorized(t *testing.T) {
 	app.Post("/api/feedback/notifications/:id/read", handler.MarkNotificationRead)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/notifications/"+uuid.New().String()+"/read", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -179,6 +187,7 @@ func TestMarkNotificationRead_InvalidID(t *testing.T) {
 	app.Post("/api/feedback/notifications/:id/read", handler.MarkNotificationRead)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/notifications/invalid-id/read", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -216,6 +225,7 @@ func TestMarkNotificationRead_NotFound(t *testing.T) {
 	app.Post("/api/feedback/notifications/:id/read", handler.MarkNotificationRead)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/notifications/"+notificationID.String()+"/read", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -231,6 +241,7 @@ func TestMarkAllNotificationsRead_Unauthorized(t *testing.T) {
 	app.Post("/api/feedback/notifications/read-all", handler.MarkAllNotificationsRead)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/notifications/read-all", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -250,6 +261,7 @@ func TestMarkAllNotificationsRead_StoreError(t *testing.T) {
 	app.Post("/api/feedback/notifications/read-all", handler.MarkAllNotificationsRead)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/feedback/notifications/read-all", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)

--- a/pkg/api/handlers/gateway_test.go
+++ b/pkg/api/handlers/gateway_test.go
@@ -65,6 +65,7 @@ func TestListGateways(t *testing.T) {
 
 	// Case 1: List all (success)
 	req, _ := http.NewRequest("GET", "/api/gateway/gateways", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -78,6 +79,7 @@ func TestListGateways(t *testing.T) {
 
 	// Case 2: List specific cluster (success)
 	req2, _ := http.NewRequest("GET", "/api/gateway/gateways?cluster=test-cluster", nil)
+	req2.Host = "localhost"
 	resp2, err := env.App.Test(req2, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp2.StatusCode)
@@ -93,6 +95,7 @@ func TestListGateways(t *testing.T) {
 	})
 
 	req3, _ := http.NewRequest("GET", "/api/gateway/gateways?cluster=test-cluster", nil)
+	req3.Host = "localhost"
 	resp3, err := env.App.Test(req3, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 500, resp3.StatusCode,
@@ -126,12 +129,14 @@ func TestGetGateway(t *testing.T) {
 
 	// Case 1: Found
 	req, _ := http.NewRequest("GET", "/api/gateway/gateways/c1/default/target-gw", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 
 	// Case 2: Not Found (name filter excludes it)
 	req2, _ := http.NewRequest("GET", "/api/gateway/gateways/c1/default/missing", nil)
+	req2.Host = "localhost"
 	resp2, err := env.App.Test(req2, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 404, resp2.StatusCode)
@@ -145,6 +150,7 @@ func TestGetGateway(t *testing.T) {
 		return true, nil, errors.New("list failure")
 	})
 	req3, _ := http.NewRequest("GET", "/api/gateway/gateways/c1/default/target-gw", nil)
+	req3.Host = "localhost"
 	resp3, err := env.App.Test(req3, 5000)
 	require.NoError(t, err)
 	if resp3.StatusCode == 404 {
@@ -179,6 +185,7 @@ func TestListHTTPRoutes(t *testing.T) {
 
 	// Case 1: List all
 	req, _ := http.NewRequest("GET", "/api/gateway/httproutes", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -198,6 +205,7 @@ func TestListHTTPRoutes(t *testing.T) {
 		return true, nil, errors.New("route error")
 	})
 	req2, _ := http.NewRequest("GET", "/api/gateway/httproutes?cluster=test-cluster", nil)
+	req2.Host = "localhost"
 	resp2, err := env.App.Test(req2, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 500, resp2.StatusCode,
@@ -231,12 +239,14 @@ func TestGetHTTPRoute(t *testing.T) {
 
 	// Case 1: Found
 	req, _ := http.NewRequest("GET", "/api/gateway/httproutes/c1/default/target-route", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 
 	// Case 2: 404
 	req2, _ := http.NewRequest("GET", "/api/gateway/httproutes/c1/default/missing", nil)
+	req2.Host = "localhost"
 	resp2, err := env.App.Test(req2, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 404, resp2.StatusCode)
@@ -250,6 +260,7 @@ func TestGetGatewayAPIStatus(t *testing.T) {
 	_ = injectDynamicCluster(env, "test-cluster", gatewayGVRs())
 
 	req, _ := http.NewRequest("GET", "/api/gateway/status", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -279,6 +290,7 @@ func TestListGatewaysMock(t *testing.T) {
 		env.App.Get("/api/gateway/gateways", handler.ListGateways)
 
 		req, _ := http.NewRequest("GET", "/api/gateway/gateways", nil)
+		req.Host = "localhost"
 		resp, err := env.App.Test(req, 5000)
 		require.NoError(t, err)
 		assert.Equal(t, 500, resp.StatusCode)
@@ -294,6 +306,7 @@ func TestListGatewaysMock(t *testing.T) {
 		env.App.Get("/api/gateway/gateways", handler.ListGateways)
 
 		req, _ := http.NewRequest("GET", "/api/gateway/gateways", nil)
+		req.Host = "localhost"
 		resp, err := env.App.Test(req, 5000)
 		require.NoError(t, err)
 		assert.Equal(t, 500, resp.StatusCode)
@@ -306,6 +319,7 @@ func TestListGatewaysMock(t *testing.T) {
 		emptyApp.Get("/api/gateway/gateways", handler.ListGateways)
 
 		req, _ := http.NewRequest("GET", "/api/gateway/gateways", nil)
+		req.Host = "localhost"
 		resp, err := emptyApp.Test(req, 5000)
 		require.NoError(t, err)
 		assert.Equal(t, 200, resp.StatusCode)
@@ -335,6 +349,7 @@ func TestListHTTPRoutesMock(t *testing.T) {
 		env.App.Get("/api/gateway/httproutes", handler.ListHTTPRoutes)
 
 		req, _ := http.NewRequest("GET", "/api/gateway/httproutes", nil)
+		req.Host = "localhost"
 		resp, err := env.App.Test(req, 5000)
 		require.NoError(t, err)
 		assert.Equal(t, 500, resp.StatusCode)
@@ -350,6 +365,7 @@ func TestListHTTPRoutesMock(t *testing.T) {
 		env.App.Get("/api/gateway/httproutes", handler.ListHTTPRoutes)
 
 		req, _ := http.NewRequest("GET", "/api/gateway/httproutes?cluster=test-cluster", nil)
+		req.Host = "localhost"
 		resp, err := env.App.Test(req, 5000)
 		require.NoError(t, err)
 		assert.Equal(t, 500, resp.StatusCode)

--- a/pkg/api/handlers/gitops/argo_test.go
+++ b/pkg/api/handlers/gitops/argo_test.go
@@ -71,6 +71,7 @@ func TestGitOpsArgo_ListArgoApplications(t *testing.T) {
 	env.App.Get("/api/gitops/argocd/applications", handler.ListArgoApplications)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/argocd/applications", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := env.App.Test(req)
 	require.NoError(t, err)
@@ -100,6 +101,7 @@ func TestGitOpsArgo_GetArgoHealthSummary(t *testing.T) {
 	env.App.Get("/api/gitops/argocd/health", handler.GetArgoHealthSummary)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/argocd/health", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := env.App.Test(req)
 	require.NoError(t, err)
@@ -129,6 +131,7 @@ func TestGitOpsArgo_GetArgoSyncSummary(t *testing.T) {
 	env.App.Get("/api/gitops/argocd/sync", handler.GetArgoSyncSummary)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/argocd/sync", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := env.App.Test(req)
 	require.NoError(t, err)
@@ -156,6 +159,7 @@ func TestGitOpsArgo_ListArgoApplicationSets(t *testing.T) {
 	env.App.Get("/api/gitops/argocd/applicationsets", handler.ListArgoApplicationSets)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/argocd/applicationsets", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := env.App.Test(req)
 	require.NoError(t, err)
@@ -184,6 +188,7 @@ func TestGitOpsArgo_GetArgoStatus(t *testing.T) {
 	env.App.Get("/api/gitops/argocd/status", handler.GetArgoStatus)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/argocd/status", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := env.App.Test(req)
 	require.NoError(t, err)
@@ -207,6 +212,7 @@ func TestGitOpsArgo_GetHelmValues_Validation(t *testing.T) {
 
 	// Missing release
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/helm/values", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := env.App.Test(req)
 	require.NoError(t, err)
@@ -214,6 +220,7 @@ func TestGitOpsArgo_GetHelmValues_Validation(t *testing.T) {
 
 	// Invalid cluster name
 	req, err = http.NewRequest(http.MethodGet, "/api/gitops/helm/values?release=my-rel&cluster=bad;name", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err = env.App.Test(req)
 	require.NoError(t, err)

--- a/pkg/api/handlers/gitops/drift_test.go
+++ b/pkg/api/handlers/gitops/drift_test.go
@@ -32,6 +32,7 @@ func TestGitOpsDrift_ListDrifts(t *testing.T) {
 
 	// Test list all
 	httpReq, err := http.NewRequest(http.MethodGet, "/api/gitops/drifts", nil)
+	httpReq.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := env.App.Test(httpReq)
 	require.NoError(t, err)
@@ -47,6 +48,7 @@ func TestGitOpsDrift_ListDrifts(t *testing.T) {
 
 	// Test filter by cluster
 	httpReq, err = http.NewRequest(http.MethodGet, "/api/gitops/drifts?cluster=test-cluster", nil)
+	httpReq.Host = "localhost"
 	require.NoError(t, err)
 	resp, err = env.App.Test(httpReq)
 	require.NoError(t, err)
@@ -55,6 +57,7 @@ func TestGitOpsDrift_ListDrifts(t *testing.T) {
 	assert.Len(t, body.Drifts, 1)
 
 	httpReq, err = http.NewRequest(http.MethodGet, "/api/gitops/drifts?cluster=other-cluster", nil)
+	httpReq.Host = "localhost"
 	require.NoError(t, err)
 	resp, err = env.App.Test(httpReq)
 	require.NoError(t, err)

--- a/pkg/api/handlers/gitops/handler_test.go
+++ b/pkg/api/handlers/gitops/handler_test.go
@@ -49,6 +49,7 @@ func TestGitOps_ListHelmHistory_Validation_MissingRelease(t *testing.T) {
 	app.Get("/api/gitops/helm/history", handler.ListHelmHistory)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/helm/history?namespace=default", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -67,6 +68,7 @@ func TestGitOps_ListHelmHistory_Validation_InvalidClusterName(t *testing.T) {
 	app.Get("/api/gitops/helm/history", handler.ListHelmHistory)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/helm/history?release=my-release&cluster=bad;name", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -84,6 +86,7 @@ func TestGitOps_ListHelmHistory_UsesClusterAndNamespaceFilters(t *testing.T) {
 	app.Get("/api/gitops/helm/history", handler.ListHelmHistory)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/helm/history?cluster=prod-east&namespace=payments&release=orders", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -148,6 +151,7 @@ func TestGitOps_GetHelmValues_RBAC(t *testing.T) {
 	app.Get("/api/gitops/helm/values", handler.GetHelmValues)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/helm/values?release=my-rel", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req)
@@ -162,6 +166,7 @@ func TestGitOps_ListHelmHistory_HelmErrorMapping(t *testing.T) {
 	app.Get("/api/gitops/helm/history", handler.ListHelmHistory)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/helm/history?release=orders", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)

--- a/pkg/api/handlers/gitops/helpers_test.go
+++ b/pkg/api/handlers/gitops/helpers_test.go
@@ -55,6 +55,7 @@ func TestIsDemoMode(t *testing.T) {
 			})
 
 			req, err := http.NewRequest(http.MethodGet, "/test", nil)
+			req.Host = "localhost"
 			require.NoError(t, err)
 			if tt.headerVal != "" {
 				req.Header.Set("X-Demo-Mode", tt.headerVal)

--- a/pkg/api/handlers/gitops/operators_test.go
+++ b/pkg/api/handlers/gitops/operators_test.go
@@ -44,6 +44,7 @@ fi
 	env.App.Get("/api/gitops/operators", handler.ListOperators)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/operators?cluster=test-cluster", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := env.App.Test(req)
 	require.NoError(t, err)
@@ -82,6 +83,7 @@ fi
 	env.App.Get("/api/gitops/subscriptions", handler.ListOperatorSubscriptions)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/subscriptions?cluster=test-cluster", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := env.App.Test(req)
 	require.NoError(t, err)
@@ -103,6 +105,7 @@ func TestGitOpsOperators_ListOperators_Validation(t *testing.T) {
 
 	// Invalid cluster name
 	req, err := http.NewRequest(http.MethodGet, "/api/gitops/operators?cluster=bad;name", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := env.App.Test(req)
 	require.NoError(t, err)
@@ -128,6 +131,7 @@ func TestGitOpsOperators_StreamOperators_Validation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, "/api/gitops/operators/stream?cluster="+tc.cluster, nil)
+			req.Host = "localhost"
 			require.NoError(t, err)
 			resp, err := env.App.Test(req)
 			require.NoError(t, err)
@@ -154,6 +158,7 @@ func TestGitOpsOperators_StreamSubscriptions_Validation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, "/api/gitops/subscriptions/stream?cluster="+tc.cluster, nil)
+			req.Host = "localhost"
 			require.NoError(t, err)
 			resp, err := env.App.Test(req)
 			require.NoError(t, err)
@@ -180,6 +185,7 @@ func TestGitOpsOperators_StreamHelmReleases_Validation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, "/api/gitops/helm/stream?cluster="+tc.cluster, nil)
+			req.Host = "localhost"
 			require.NoError(t, err)
 			resp, err := env.App.Test(req)
 			require.NoError(t, err)

--- a/pkg/api/handlers/gpu_test.go
+++ b/pkg/api/handlers/gpu_test.go
@@ -211,6 +211,7 @@ func TestGPUCreateReservation_OverAllocationReturnsConflict(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/gpu/reservations", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -241,6 +242,7 @@ func TestGPUCreateReservation_SetsDefaultDurationAndUserName(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/gpu/reservations", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -274,6 +276,7 @@ func TestGPUCreateReservation_ProvisioningSuccessReturnsActiveReservation(t *tes
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/gpu/reservations", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -328,6 +331,7 @@ func TestGPUCreateReservation_ProvisioningCleanupOnStoreFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/gpu/reservations", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -352,6 +356,7 @@ func TestGPUListReservations_MineNilReturnsEmptyArray(t *testing.T) {
 	env.App.Get("/api/gpu/reservations", handler.ListReservations)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gpu/reservations?mine=true", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -375,6 +380,7 @@ func TestGPUListReservations_NonAdminOnlyGetsOwnReservations(t *testing.T) {
 	env.App.Get("/api/gpu/reservations", handler.ListReservations)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gpu/reservations", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -401,6 +407,7 @@ func TestGPUGetReservation_NonOwnerIsForbidden(t *testing.T) {
 	env.App.Get("/api/gpu/reservations/:id", handler.GetReservation)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gpu/reservations/"+resID.String(), nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -425,6 +432,7 @@ func TestGPUUpdateReservation_RejectsZeroGPUCount(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPut, "/api/gpu/reservations/"+resID.String(), bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -451,6 +459,7 @@ func TestGPUUpdateReservation_RejectsNegativeGPUCount(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPut, "/api/gpu/reservations/"+resID.String(), bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -476,6 +485,7 @@ func TestGPUUpdateReservation_RejectsNegativeDuration(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPut, "/api/gpu/reservations/"+resID.String(), bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -501,6 +511,7 @@ func TestGPUUpdateReservation_RejectsZeroDuration(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPut, "/api/gpu/reservations/"+resID.String(), bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -524,6 +535,7 @@ func TestGPUBulkUtilizations_ForbiddenForNonOwner(t *testing.T) {
 	env.App.Get("/api/gpu/utilizations", handler.GetBulkUtilizations)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gpu/utilizations?ids="+resID.String(), nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)

--- a/pkg/api/handlers/lima_test.go
+++ b/pkg/api/handlers/lima_test.go
@@ -23,6 +23,7 @@ func TestLimaList_DemoModeReturnsDemoData(t *testing.T) {
 	env.App.Get("/api/lima", handler.ListLima)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/lima", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("X-Demo-Mode", "true")
 
@@ -42,6 +43,7 @@ func TestLimaList_NoClientReturns503DemoFallback(t *testing.T) {
 	env.App.Get("/api/lima", handler.ListLima)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/lima", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -60,6 +62,7 @@ func TestLimaList_ReachableClusterNoLimaReturns200LiveEmpty(t *testing.T) {
 	env.App.Get("/api/lima", handler.ListLima)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/lima", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -88,6 +91,7 @@ func TestLimaList_AllClusterQueriesFailReturns503DemoFallback(t *testing.T) {
 	})
 
 	req, err := http.NewRequest(http.MethodGet, "/api/lima", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -134,6 +138,7 @@ func TestLimaList_LimaNodeDetectedFromLabels(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/lima", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)

--- a/pkg/api/handlers/mcs_test.go
+++ b/pkg/api/handlers/mcs_test.go
@@ -60,6 +60,7 @@ func TestListServiceExports(t *testing.T) {
 
 	// Case 1: List all
 	req, _ := http.NewRequest("GET", "/api/mcs/exports", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -80,6 +81,7 @@ func TestListServiceExports(t *testing.T) {
 		return true, nil, errors.New("export list error")
 	})
 	req2, _ := http.NewRequest("GET", "/api/mcs/exports?cluster=test-cluster", nil)
+	req2.Host = "localhost"
 	resp2, err := env.App.Test(req2, 5000)
 	require.NoError(t, err)
 	assert.NotEqual(t, 200, resp2.StatusCode, "arbitrary cluster errors must not be silently swallowed (#6510)")
@@ -89,6 +91,7 @@ func TestListServiceExports(t *testing.T) {
 		return true, nil, errors.New("the server could not find the requested resource")
 	})
 	req3, _ := http.NewRequest("GET", "/api/mcs/exports?cluster=test-cluster", nil)
+	req3.Host = "localhost"
 	resp3, err := env.App.Test(req3, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp3.StatusCode, "CRD-not-installed should still yield an empty list")
@@ -121,6 +124,7 @@ func TestGetServiceExport(t *testing.T) {
 
 	// Found
 	req, _ := http.NewRequest("GET", "/api/mcs/exports/c1/default/target-svc", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -132,6 +136,7 @@ func TestGetServiceExport(t *testing.T) {
 		return true, nil, errors.New("the server could not find the requested resource")
 	})
 	req2, _ := http.NewRequest("GET", "/api/mcs/exports/c1/default/target-svc", nil)
+	req2.Host = "localhost"
 	resp2, err := env.App.Test(req2, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 404, resp2.StatusCode)
@@ -164,6 +169,7 @@ func TestListServiceImports(t *testing.T) {
 
 	// List all
 	req, _ := http.NewRequest("GET", "/api/mcs/imports", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -198,6 +204,7 @@ func TestListServiceExportsMock(t *testing.T) {
 		env.App.Get("/api/mcs/exports", handler.ListServiceExports)
 
 		req, _ := http.NewRequest("GET", "/api/mcs/exports", nil)
+		req.Host = "localhost"
 		resp, err := env.App.Test(req, 5000)
 		require.NoError(t, err)
 		assert.Equal(t, 500, resp.StatusCode)
@@ -213,6 +220,7 @@ func TestListServiceExportsMock(t *testing.T) {
 		env.App.Get("/api/mcs/exports", handler.ListServiceExports)
 
 		req, _ := http.NewRequest("GET", "/api/mcs/exports", nil)
+		req.Host = "localhost"
 		resp, err := env.App.Test(req, 5000)
 		require.NoError(t, err)
 		assert.Equal(t, 500, resp.StatusCode)
@@ -228,6 +236,7 @@ func TestListServiceExportsMock(t *testing.T) {
 		env.App.Get("/api/mcs/exports", handler.ListServiceExports)
 
 		req, _ := http.NewRequest("GET", "/api/mcs/exports?cluster=test-cluster", nil)
+		req.Host = "localhost"
 		resp, err := env.App.Test(req, 5000)
 		require.NoError(t, err)
 		assert.Equal(t, 500, resp.StatusCode)
@@ -240,6 +249,7 @@ func TestListServiceExportsMock(t *testing.T) {
 		emptyApp.Get("/api/mcs/exports", handler.ListServiceExports)
 
 		req, _ := http.NewRequest("GET", "/api/mcs/exports", nil)
+		req.Host = "localhost"
 		resp, err := emptyApp.Test(req, 5000)
 		require.NoError(t, err)
 		assert.Equal(t, 200, resp.StatusCode)
@@ -269,6 +279,7 @@ func TestListServiceImportsMock(t *testing.T) {
 		env.App.Get("/api/mcs/imports", handler.ListServiceImports)
 
 		req, _ := http.NewRequest("GET", "/api/mcs/imports", nil)
+		req.Host = "localhost"
 		resp, err := env.App.Test(req, 5000)
 		require.NoError(t, err)
 		assert.Equal(t, 500, resp.StatusCode)
@@ -284,6 +295,7 @@ func TestListServiceImportsMock(t *testing.T) {
 		env.App.Get("/api/mcs/imports", handler.ListServiceImports)
 
 		req, _ := http.NewRequest("GET", "/api/mcs/imports?cluster=test-cluster", nil)
+		req.Host = "localhost"
 		resp, err := env.App.Test(req, 5000)
 		require.NoError(t, err)
 		assert.Equal(t, 500, resp.StatusCode)

--- a/pkg/api/handlers/missions/handler_test.go
+++ b/pkg/api/handlers/missions/handler_test.go
@@ -46,6 +46,7 @@ func TestMissions_BrowseConsoleKB_Success(t *testing.T) {
 	handler.githubAPIURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/browse?path=missions", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -73,6 +74,7 @@ func TestMissions_BrowseConsoleKB_NoPath(t *testing.T) {
 	handler.githubAPIURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/browse", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -96,6 +98,7 @@ func TestMissions_ValidateMission_ValidMission(t *testing.T) {
 
 	payload := `{"mission":{"apiVersion":"kc-mission-v1","kind":"Mission","metadata":{"name":"test-mission"},"spec":{"description":"A test mission"}},"path":"fixes/demo/install.json"}`
 	req, err := http.NewRequest("POST", "/api/missions/validate", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -124,6 +127,7 @@ func TestMissions_ValidateMission_QualityFailure(t *testing.T) {
 
 	payload := `{"mission":{"apiVersion":"kc-mission-v1","kind":"Mission","metadata":{"name":"test-mission"},"spec":{"description":"A test mission"}},"path":"fixes/demo/install.json"}`
 	req, err := http.NewRequest("POST", "/api/missions/validate", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -152,6 +156,7 @@ func TestMissions_ValidateMission_MissionNotInIndex(t *testing.T) {
 
 	payload := `{"mission":{"apiVersion":"kc-mission-v1","kind":"Mission","metadata":{"name":"test-mission"},"spec":{"description":"A test mission"}},"path":"fixes/demo/install.json"}`
 	req, err := http.NewRequest("POST", "/api/missions/validate", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -171,6 +176,7 @@ func TestMissions_ValidateMission_InvalidMission(t *testing.T) {
 	// Missing apiVersion, kind, metadata.name
 	payload := `{"mission":{"apiVersion":"wrong","spec":{}},"path":"fixes/demo/install.json"}`
 	req, err := http.NewRequest("POST", "/api/missions/validate", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -190,6 +196,7 @@ func TestMissions_ValidateMission_EmptyBody(t *testing.T) {
 	app, _ := setupMissionsTest()
 
 	req, err := http.NewRequest("POST", "/api/missions/validate", strings.NewReader(""))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -212,6 +219,7 @@ func TestMissions_ValidateMission_TooLarge(t *testing.T) {
 
 	largePayload := strings.Repeat("x", missionsMaxBodyBytes+1)
 	req, err := http.NewRequest("POST", "/api/missions/validate", strings.NewReader(largePayload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -249,6 +257,7 @@ func TestMissions_ShareToSlack_Success(t *testing.T) {
 
 	payload := `{"webhookUrl":"https://hooks.slack.com/services/T00/B00/xxx","text":"Hello from mission"}`
 	req, err := http.NewRequest("POST", "/api/missions/share/slack", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -266,6 +275,7 @@ func TestMissions_ShareToSlack_InvalidWebhook(t *testing.T) {
 
 	payload := `{"webhookUrl":"https://evil.com/webhook","text":"Hello"}`
 	req, err := http.NewRequest("POST", "/api/missions/share/slack", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -281,6 +291,7 @@ func TestMissions_ShareToGitHub_NoToken(t *testing.T) {
 
 	payload := `{"repo":"kubestellar/console-kb","filePath":"missions/test.yaml","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`
 	req, err := http.NewRequest("POST", "/api/missions/share/github", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, 5000)
@@ -301,6 +312,7 @@ func TestMissions_ShareToGitHub_RepoNotAllowed(t *testing.T) {
 	// GitHub API calls.
 	payload := `{"repo":"kubestellar/private-repo","filePath":"missions/test.yaml","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`
 	req, err := http.NewRequest("POST", "/api/missions/share/github", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Token", "ghp_test123")
@@ -391,6 +403,7 @@ func TestMissions_ShareToGitHub_Success(t *testing.T) {
 
 	payload := `{"repo":"kubestellar/console-kb","filePath":"missions/test.yaml","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`
 	req, err := http.NewRequest("POST", "/api/missions/share/github", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Token", "ghp_test123")
@@ -427,6 +440,7 @@ func TestMissions_GetMissionFile_Success(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/file?path=missions/example.yaml", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -448,6 +462,7 @@ func TestMissions_GetMissionFile_NotFound(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/file?path=missions/nonexistent.yaml", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -474,6 +489,7 @@ func TestMissions_BrowseConsoleKB_CacheHit(t *testing.T) {
 
 	// First request — should call GitHub (MISS)
 	req1, err := http.NewRequest("GET", "/api/missions/browse?path=fixes", nil)
+	req1.Host = "localhost"
 	require.NoError(t, err)
 	resp1, err := app.Test(req1, 5000)
 	require.NoError(t, err)
@@ -483,6 +499,7 @@ func TestMissions_BrowseConsoleKB_CacheHit(t *testing.T) {
 
 	// Second request — should serve from cache (HIT), NOT call GitHub again
 	req2, err := http.NewRequest("GET", "/api/missions/browse?path=fixes", nil)
+	req2.Host = "localhost"
 	require.NoError(t, err)
 	resp2, err := app.Test(req2, 5000)
 	require.NoError(t, err)
@@ -513,6 +530,7 @@ func TestMissions_GetMissionFile_CacheHit(t *testing.T) {
 
 	// First request — MISS
 	req1, err := http.NewRequest("GET", "/api/missions/file?path=fixes/index.json", nil)
+	req1.Host = "localhost"
 	require.NoError(t, err)
 	resp1, err := app.Test(req1, 5000)
 	require.NoError(t, err)
@@ -522,6 +540,7 @@ func TestMissions_GetMissionFile_CacheHit(t *testing.T) {
 
 	// Second request — HIT
 	req2, err := http.NewRequest("GET", "/api/missions/file?path=fixes/index.json", nil)
+	req2.Host = "localhost"
 	require.NoError(t, err)
 	resp2, err := app.Test(req2, 5000)
 	require.NoError(t, err)
@@ -555,6 +574,7 @@ func TestMissions_BrowseConsoleKB_RateLimitServesStaleCache(t *testing.T) {
 
 	// First request — populate the cache
 	req1, err := http.NewRequest("GET", "/api/missions/browse?path=stale-test", nil)
+	req1.Host = "localhost"
 	require.NoError(t, err)
 	resp1, err := app.Test(req1, 5000)
 	require.NoError(t, err)
@@ -569,6 +589,7 @@ func TestMissions_BrowseConsoleKB_RateLimitServesStaleCache(t *testing.T) {
 
 	// Second request — GitHub returns 403, should serve stale cache
 	req2, err := http.NewRequest("GET", "/api/missions/browse?path=stale-test", nil)
+	req2.Host = "localhost"
 	require.NoError(t, err)
 	resp2, err := app.Test(req2, 5000)
 	require.NoError(t, err)
@@ -601,6 +622,7 @@ func TestMissions_GetMissionFile_RateLimitServesStaleCache(t *testing.T) {
 
 	// Populate cache
 	req1, err := http.NewRequest("GET", "/api/missions/file?path=test/mission.json", nil)
+	req1.Host = "localhost"
 	require.NoError(t, err)
 	resp1, err := app.Test(req1, 5000)
 	require.NoError(t, err)
@@ -615,6 +637,7 @@ func TestMissions_GetMissionFile_RateLimitServesStaleCache(t *testing.T) {
 
 	// Rate-limited request should serve stale
 	req2, err := http.NewRequest("GET", "/api/missions/file?path=test/mission.json", nil)
+	req2.Host = "localhost"
 	require.NoError(t, err)
 	resp2, err := app.Test(req2, 5000)
 	require.NoError(t, err)
@@ -636,6 +659,7 @@ func TestMissions_BrowseConsoleKB_EmbeddedFallback(t *testing.T) {
 	handler.githubAPIURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/browse?path=subdir", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -666,6 +690,7 @@ func TestMissions_GetMissionFile_EmbeddedFallback(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/file?path=subdir/nested.txt", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -884,6 +909,7 @@ func TestGetKBScores_Success(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -914,6 +940,7 @@ func TestGetKBScores_EmptyResultsEncoding(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -935,6 +962,7 @@ func TestGetKBScores_UpstreamError(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -967,6 +995,7 @@ func TestGetKBScores_StaleCache(t *testing.T) {
 
 	// Populate cache
 	req1, _ := http.NewRequest("GET", "/api/missions/scores", nil)
+	req1.Host = "localhost"
 	resp1, err := app.Test(req1, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp1.StatusCode)
@@ -980,6 +1009,7 @@ func TestGetKBScores_StaleCache(t *testing.T) {
 
 	// Second request: GitHub 403, should fall back to stale cache
 	req2, _ := http.NewRequest("GET", "/api/missions/scores", nil)
+	req2.Host = "localhost"
 	resp2, err := app.Test(req2, 5000)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp2.StatusCode, "should serve stale cache on rate-limit")
@@ -996,6 +1026,7 @@ func TestGetKBScores_EmbeddedFallback(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -1023,6 +1054,7 @@ func TestGetMissionScore_Success(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/coredns/coredns-123", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -1046,6 +1078,7 @@ func TestGetMissionScore_NotFound(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/coredns/coredns-999", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -1064,6 +1097,7 @@ func TestGetMissionScore_NoScore(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/kubernetes/kubernetes-456", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -1086,6 +1120,7 @@ func TestGetMissionScore_ExactIDMatch(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/coredns/coredns-12", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -1123,6 +1158,7 @@ func TestGetMissionScore_UpstreamError(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/"+project+"/"+missionID, nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -1141,6 +1177,7 @@ func TestGetKBGaps_NoStore_ReturnsDisabled(t *testing.T) {
 	app, _ := setupMissionsTest()
 
 	req, err := http.NewRequest("GET", "/api/missions/gaps", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -1173,6 +1210,7 @@ func TestGetKBGaps_WithStore_ReturnsGaps(t *testing.T) {
 	handler.RegisterPublicRoutes(app.Group("/api/missions"))
 
 	req, err := http.NewRequest("GET", "/api/missions/gaps?limit=5", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -1201,6 +1239,7 @@ func TestGetKBGaps_RequiresAdmin(t *testing.T) {
 	handler.RegisterRoutes(app.Group("/api/missions"))
 
 	req, err := http.NewRequest("GET", "/api/missions/gaps", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)

--- a/pkg/api/handlers/missions/scores_test.go
+++ b/pkg/api/handlers/missions/scores_test.go
@@ -29,6 +29,7 @@ func TestMissions_GetKBScores_Success(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -70,6 +71,7 @@ func TestMissions_GetKBScores_Pagination(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores?limit=2&offset=1", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -93,6 +95,7 @@ func TestMissions_GetKBScores_DemoMode(t *testing.T) {
 	app, _ := setupMissionsTest()
 
 	req, err := http.NewRequest("GET", "/api/missions/scores", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("X-Demo-Mode", "true")
 
@@ -135,6 +138,7 @@ func TestMissions_GetMissionScore_Success(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/demo/test-123", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -167,6 +171,7 @@ func TestMissions_GetMissionScore_NotFound(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/demo/nonexistent", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -194,6 +199,7 @@ func TestMissions_GetMissionScore_NoScore(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	req, err := http.NewRequest("GET", "/api/missions/scores/demo/test-123", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)

--- a/pkg/api/handlers/onboarding_test.go
+++ b/pkg/api/handlers/onboarding_test.go
@@ -39,6 +39,7 @@ func TestGetQuestions_ReturnsNonEmpty(t *testing.T) {
 	app.Get("/api/onboarding/questions", handler.GetQuestions)
 
 	req, err := http.NewRequest("GET", "/api/onboarding/questions", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -65,6 +66,7 @@ func TestSaveResponses_Success(t *testing.T) {
 
 	payload := `[{"question_key":"role","answer":"SRE"},{"question_key":"focus_layer","answer":"Application"}]`
 	req, err := http.NewRequest("POST", "/api/onboarding/responses", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -88,6 +90,7 @@ func TestSaveResponses_InvalidBody(t *testing.T) {
 	app.Post("/api/onboarding/responses", handler.SaveResponses)
 
 	req, err := http.NewRequest("POST", "/api/onboarding/responses", strings.NewReader("not-json"))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -106,6 +109,7 @@ func TestCompleteOnboarding_Success(t *testing.T) {
 	// MockStore stubs return nil/nil for GetOnboardingResponses, CreateDashboard,
 	// CreateCard, SetUserOnboarded — all succeed silently with default behavior.
 	req, err := http.NewRequest("POST", "/api/onboarding/complete", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)

--- a/pkg/api/handlers/rbac_test.go
+++ b/pkg/api/handlers/rbac_test.go
@@ -65,6 +65,7 @@ func TestRBACUpdateUserRole_ForbiddenForNonAdmin(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPut, "/api/rbac/users/"+uuid.NewString()+"/role", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -98,6 +99,7 @@ func TestRBACUpdateUserRole_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPut, "/api/rbac/users/"+targetUserID.String()+"/role", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -126,6 +128,7 @@ func TestRBACListConsoleUsers_ForbiddenForNonAdmin(t *testing.T) {
 	env.App.Get("/api/rbac/users", handler.ListConsoleUsers)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/rbac/users", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -155,6 +158,7 @@ func TestRBACListConsoleUsers_Success(t *testing.T) {
 	env.App.Get("/api/rbac/users", handler.ListConsoleUsers)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/rbac/users", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)

--- a/pkg/api/handlers/rewards/handler_test.go
+++ b/pkg/api/handlers/rewards/handler_test.go
@@ -32,6 +32,7 @@ func TestGetGitHubRewards(t *testing.T) {
 	// For now, let's verify it returns 503 if GitHub is unreachable (default behavior with fake token).
 
 	req, err := http.NewRequest("GET", "/api/rewards/github", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)

--- a/pkg/api/handlers/rewards/persistence_test.go
+++ b/pkg/api/handlers/rewards/persistence_test.go
@@ -62,6 +62,7 @@ func TestRewardsHandler_GetReturnsZeroForNewUser(t *testing.T) {
 	app, _, userID := newRewardsTestApp(t)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/rewards/me", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
 	require.NoError(t, err)
@@ -95,6 +96,7 @@ func TestRewardsHandler_PutThenGetRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	putReq, err := http.NewRequest(http.MethodPut, "/api/rewards/me", bytes.NewReader(payload))
+	putReq.Host = "localhost"
 	require.NoError(t, err)
 	putReq.Header.Set("Content-Type", "application/json")
 	putResp, err := app.Test(putReq, testRewardsFiberTimeoutMs)
@@ -104,6 +106,7 @@ func TestRewardsHandler_PutThenGetRoundTrip(t *testing.T) {
 	assert.Equal(t, wantCoins, putBody.Coins)
 
 	getReq, err := http.NewRequest(http.MethodGet, "/api/rewards/me", nil)
+	getReq.Host = "localhost"
 	require.NoError(t, err)
 	getResp, err := app.Test(getReq, testRewardsFiberTimeoutMs)
 	require.NoError(t, err)
@@ -123,6 +126,7 @@ func TestRewardsHandler_PutRejectsOutOfRangeValues(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPut, "/api/rewards/me", bytes.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
@@ -141,6 +145,7 @@ func TestRewardsHandler_PostCoinsIncrementsCorrectly(t *testing.T) {
 		payload, err := json.Marshal(map[string]int{"delta": delta})
 		require.NoError(t, err)
 		req, err := http.NewRequest(http.MethodPost, "/api/rewards/coins", bytes.NewReader(payload))
+		req.Host = "localhost"
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := app.Test(req, testRewardsFiberTimeoutMs)
@@ -163,6 +168,7 @@ func TestRewardsHandler_PostCoinsNegativeDoesNotDriveBelowZero(t *testing.T) {
 	payload, err := json.Marshal(map[string]int{"delta": subtract})
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodPost, "/api/rewards/coins", bytes.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
@@ -178,6 +184,7 @@ func TestRewardsHandler_PostCoinsRejectsZeroDelta(t *testing.T) {
 	payload, err := json.Marshal(map[string]int{"delta": 0})
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodPost, "/api/rewards/coins", bytes.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
@@ -192,6 +199,7 @@ func TestRewardsHandler_PostCoinsRejectsOversizedDelta(t *testing.T) {
 	payload, err := json.Marshal(map[string]int{"delta": maxCoinDeltaPerRequest + 1})
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodPost, "/api/rewards/coins", bytes.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
@@ -203,6 +211,7 @@ func TestRewardsHandler_DailyBonusFirstClaimSucceeds(t *testing.T) {
 	app, _, _ := newRewardsTestApp(t)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/rewards/daily-bonus", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
@@ -219,6 +228,7 @@ func TestRewardsHandler_DailyBonusSecondClaimReturns429(t *testing.T) {
 	app, _, _ := newRewardsTestApp(t)
 
 	req1, err := http.NewRequest(http.MethodPost, "/api/rewards/daily-bonus", nil)
+	req1.Host = "localhost"
 	require.NoError(t, err)
 	resp1, err := app.Test(req1, testRewardsFiberTimeoutMs)
 	require.NoError(t, err)
@@ -226,6 +236,7 @@ func TestRewardsHandler_DailyBonusSecondClaimReturns429(t *testing.T) {
 	resp1.Body.Close()
 
 	req2, err := http.NewRequest(http.MethodPost, "/api/rewards/daily-bonus", nil)
+	req2.Host = "localhost"
 	require.NoError(t, err)
 	resp2, err := app.Test(req2, testRewardsFiberTimeoutMs)
 	require.NoError(t, err)
@@ -249,6 +260,7 @@ func TestRewardsHandler_UnauthenticatedReturns401(t *testing.T) {
 	app.Post("/api/rewards/daily-bonus", h.ClaimDailyBonus)
 
 	getReq, _ := http.NewRequest(http.MethodGet, "/api/rewards/me", nil)
+	getReq.Host = "localhost"
 	resp, err := app.Test(getReq, testRewardsFiberTimeoutMs)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)

--- a/pkg/api/handlers/stellar/actions_test.go
+++ b/pkg/api/handlers/stellar/actions_test.go
@@ -78,6 +78,7 @@ func TestStellarActionExecute_RBAC(t *testing.T) {
 			app := newStellarActionExecuteTestApp(t, tt.role)
 
 			req, err := http.NewRequest(http.MethodPost, "/api/stellar/actions/execute", http.NoBody)
+			req.Host = "localhost"
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 
@@ -110,6 +111,7 @@ func TestStellarActionExecute_DestructiveActionsRequireApprovalFlow(t *testing.T
 			require.NoError(t, err)
 
 			req, err := http.NewRequest(http.MethodPost, "/api/stellar/actions/execute", bytes.NewReader(body))
+			req.Host = "localhost"
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/api/handlers/stellar/mocked_handlers_test.go
+++ b/pkg/api/handlers/stellar/mocked_handlers_test.go
@@ -124,6 +124,7 @@ func TestStellarCreateTask_DefaultsWithMockedStore(t *testing.T) {
 	})).Return("task-123", nil).Once()
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/tasks", bytes.NewReader([]byte(`{"title":"Investigate failed rollout"}`)))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -145,6 +146,7 @@ func TestStellarCreateTask_InvalidDueAtReturnsBadRequest(t *testing.T) {
 	app, mockStore, _ := newMockedStellarHandlerApp(t)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/tasks", bytes.NewReader([]byte(`{"title":"Investigate failed rollout","dueAt":"not-rfc3339"}`)))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -162,6 +164,7 @@ func TestStellarUpdateTaskStatus_ReturnsStatusWhenReloadFails(t *testing.T) {
 	mockStore.On("GetOpenTasks", userID).Return(nil, errors.New("reload failed")).Once()
 
 	req, err := http.NewRequest(http.MethodPatch, "/api/stellar/tasks/task-7/status", bytes.NewReader([]byte(`{"status":"DONE"}`)))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -186,6 +189,7 @@ func TestStellarSearchMemory_DefaultLimitWithMockedStore(t *testing.T) {
 	mockStore.On("SearchStellarMemoryEntries", userID, "oomkilled", 20).Return(expected, nil).Once()
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/memory/search", bytes.NewReader([]byte(`{"query":"oomkilled"}`)))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -216,6 +220,7 @@ func TestStellarCreateProvider_UsesMockedUpsert(t *testing.T) {
 	})).Return(nil).Once()
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/providers", bytes.NewReader([]byte(`{"provider":"ollama","displayName":"Local Ollama","baseUrl":"http://127.0.0.1:11434","model":"llama3"}`)))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/api/handlers/stellar/notifications_test.go
+++ b/pkg/api/handlers/stellar/notifications_test.go
@@ -57,6 +57,7 @@ func TestListNotifications_EmptyResult(t *testing.T) {
 	app, _, _ := newNotificationTestApp(t)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/notifications", http.NoBody)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -98,6 +99,7 @@ func TestListNotifications_ReturnsCreatedNotifications(t *testing.T) {
 	require.NoError(t, sqlStore.CreateStellarNotification(ctx, n2))
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/notifications", http.NoBody)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -143,6 +145,7 @@ func TestListNotifications_UnreadOnlyFilter(t *testing.T) {
 
 	// Query for unread only
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/notifications?unread=true", http.NoBody)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -175,6 +178,7 @@ func TestMarkNotificationRead_Success(t *testing.T) {
 	require.NoError(t, sqlStore.CreateStellarNotification(ctx, n))
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/read", http.NoBody)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -195,6 +199,7 @@ func TestMarkNotificationRead_MissingID(t *testing.T) {
 	app, _, _ := newNotificationTestApp(t)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/%20/read", http.NoBody)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, stellarNotificationTestTimeoutMs)
@@ -232,6 +237,7 @@ func TestMarkNotificationInvestigating_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/investigating", bytes.NewReader(bodyBytes))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -252,6 +258,7 @@ func TestMarkNotificationInvestigating_InvalidJSON(t *testing.T) {
 	app, _, _ := newNotificationTestApp(t)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/some-id/investigating", bytes.NewReader([]byte("invalid-json")))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -286,6 +293,7 @@ func TestResolveNotification_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/resolve", bytes.NewReader(bodyBytes))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -327,6 +335,7 @@ func TestDismissNotification_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/dismiss", bytes.NewReader(bodyBytes))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -354,6 +363,7 @@ func TestUpdateNotificationState_NotificationNotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/nonexistent-id/resolve", bytes.NewReader(bodyBytes))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -393,6 +403,7 @@ func TestUpdateNotificationState_FillsAffectedResource(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/resolve", bytes.NewReader(bodyBytes))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -624,6 +635,7 @@ func TestUpdateNotificationState_WrongUser(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/notifications/"+n.ID+"/resolve", bytes.NewReader(bodyBytes))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/api/handlers/stellar/observations_test.go
+++ b/pkg/api/handlers/stellar/observations_test.go
@@ -82,6 +82,7 @@ func TestStellarStream_ReturnsUnauthorizedWithoutUser(t *testing.T) {
 	app.Get("/api/stellar/stream", h.Stream)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/stream", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, 2000)
 	require.NoError(t, err)
@@ -199,6 +200,7 @@ func TestStellarListObservations_EmptyReturnsEmptyList(t *testing.T) {
 	app, _ := newStellarTestApp(t)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/observations", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, stellarTestFiberTimeoutMs)
 	require.NoError(t, err)
@@ -218,6 +220,7 @@ func TestStellarListObservations_AppliesLimitParam(t *testing.T) {
 	app, _ := newStellarTestApp(t)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/stellar/observations?limit=7", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	resp, err := app.Test(req, stellarTestFiberTimeoutMs)
 	require.NoError(t, err)
@@ -248,6 +251,7 @@ func TestStellarIngestEvent_RequiresAuth(t *testing.T) {
 
 	body := `{"cluster":"c1","namespace":"ns","name":"pod-a","type":"Warning","reason":"CrashLoop","message":"back-off"}`
 	req, err := http.NewRequest(http.MethodPost, "/api/stellar/events", strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -284,6 +288,7 @@ func TestStellarIngestEvent_MissingFieldsReturnsBadRequest(t *testing.T) {
 	// Missing required fields: cluster is empty.
 	body := `{"cluster":"","namespace":"ns","name":"pod","type":"Warning","reason":"x","message":"y"}`
 	req, err2 := http.NewRequest(http.MethodPost, "/api/stellar/events", bytes.NewReader([]byte(body)))
+	req.Host = "localhost"
 	require.NoError(t, err2)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err2 := editorApp.Test(req, 2000)
@@ -325,6 +330,7 @@ func TestStellarIngestEvent_AcceptsValidEvent(t *testing.T) {
 	}
 	raw, _ := json.Marshal(payload)
 	req, err2 := http.NewRequest(http.MethodPost, "/api/stellar/events", bytes.NewReader(raw))
+	req.Host = "localhost"
 	require.NoError(t, err2)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/api/handlers/teams_test.go
+++ b/pkg/api/handlers/teams_test.go
@@ -115,6 +115,7 @@ func performTeamRequest(t *testing.T, app *fiber.App, method, path, body string)
 	t.Helper()
 
 	req, err := http.NewRequest(method, path, strings.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")

--- a/pkg/api/handlers/timeline_test.go
+++ b/pkg/api/handlers/timeline_test.go
@@ -32,6 +32,7 @@ func TestTimelineGetTimeline_Success(t *testing.T) {
 	mockStore.On("QueryTimeline", mock.Anything).Return(expectedEvents, nil)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/timeline?cluster=test-cluster", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -55,6 +56,7 @@ func TestTimelineGetTimeline_Error(t *testing.T) {
 	mockStore.On("QueryTimeline", mock.Anything).Return(nil, assert.AnError)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/timeline", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)

--- a/pkg/api/handlers/token_usage_test.go
+++ b/pkg/api/handlers/token_usage_test.go
@@ -58,6 +58,7 @@ func TestTokenUsageHandler_GetReturnsZeroForNewUser(t *testing.T) {
 	app, _, _, _ := newTokenUsageTestApp(t)
 
 	req, _ := http.NewRequest(http.MethodGet, "/api/token-usage/me", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -85,6 +86,7 @@ func TestTokenUsageHandler_PutThenGetRoundTrip(t *testing.T) {
 	}
 	raw, _ := json.Marshal(body)
 	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/me", bytes.NewReader(raw))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
@@ -98,6 +100,7 @@ func TestTokenUsageHandler_PutThenGetRoundTrip(t *testing.T) {
 
 	// Re-fetch and confirm persistence.
 	getReq, err := http.NewRequest(http.MethodGet, "/api/token-usage/me", nil)
+	getReq.Host = "localhost"
 	require.NoError(t, err)
 	getResp, err := app.Test(getReq, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
@@ -118,6 +121,7 @@ func TestTokenUsageHandler_DeltaIncrementsAtomically(t *testing.T) {
 			AgentSessionID: "session-delta-1",
 		})
 		req, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
+		req.Host = "localhost"
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
@@ -127,6 +131,7 @@ func TestTokenUsageHandler_DeltaIncrementsAtomically(t *testing.T) {
 	}
 
 	getReq, err := http.NewRequest(http.MethodGet, "/api/token-usage/me", nil)
+	getReq.Host = "localhost"
 	require.NoError(t, err)
 	getResp, err := app.Test(getReq, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
@@ -148,6 +153,7 @@ func TestTokenUsageHandler_DeltaSessionChangeSkipsAdd(t *testing.T) {
 		AgentSessionID: "session-A",
 	})
 	req1, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body1))
+	req1.Host = "localhost"
 	require.NoError(t, err)
 	req1.Header.Set("Content-Type", "application/json")
 	resp1, err := app.Test(req1, testTokenUsageFiberTimeoutMs)
@@ -161,6 +167,7 @@ func TestTokenUsageHandler_DeltaSessionChangeSkipsAdd(t *testing.T) {
 		AgentSessionID: "session-B",
 	})
 	req2, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body2))
+	req2.Host = "localhost"
 	require.NoError(t, err)
 	req2.Header.Set("Content-Type", "application/json")
 	resp2, err := app.Test(req2, testTokenUsageFiberTimeoutMs)
@@ -181,6 +188,7 @@ func TestTokenUsageHandler_GetResetsStaleDayTotals(t *testing.T) {
 		LastAgentSessionID: "session-stale",
 	})
 	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/me", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
@@ -194,6 +202,7 @@ func TestTokenUsageHandler_GetResetsStaleDayTotals(t *testing.T) {
 	require.NoError(t, err)
 
 	getReq, err := http.NewRequest(http.MethodGet, "/api/token-usage/me", nil)
+	getReq.Host = "localhost"
 	require.NoError(t, err)
 	getResp, err := app.Test(getReq, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
@@ -212,6 +221,7 @@ func TestTokenUsageHandler_DeltaRejectsNegative(t *testing.T) {
 		AgentSessionID: "session-neg",
 	})
 	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
@@ -229,6 +239,7 @@ func TestTokenUsageHandler_DeltaRejectsOverLimit(t *testing.T) {
 		AgentSessionID: "session-big",
 	})
 	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
@@ -250,6 +261,7 @@ func TestTokenUsageHandler_PutRejectsTooManyCategories(t *testing.T) {
 		LastAgentSessionID: "session-many",
 	})
 	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/me", bytes.NewReader(body))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)

--- a/pkg/api/handlers/topology_test.go
+++ b/pkg/api/handlers/topology_test.go
@@ -52,6 +52,7 @@ func TestTopologyGetTopology_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/topology", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)
@@ -96,6 +97,7 @@ func TestTopologyGetTopology_NoClusters(t *testing.T) {
 	env.App.Get("/api/topology", handler.GetTopology)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/topology", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := env.App.Test(req, 5000)

--- a/pkg/api/handlers/user_test.go
+++ b/pkg/api/handlers/user_test.go
@@ -49,6 +49,7 @@ func TestGetCurrentUser_Success(t *testing.T) {
 	mockStore.On("GetUser", userID).Return(expectedUser, nil).Once()
 
 	req, err := http.NewRequest("GET", "/api/user", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -71,6 +72,7 @@ func TestGetCurrentUser_NotFound(t *testing.T) {
 	mockStore.On("GetUser", userID).Return(nil, nil).Once()
 
 	req, err := http.NewRequest("GET", "/api/user", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 
 	resp, err := app.Test(req, fiberTestTimeout)
@@ -95,6 +97,7 @@ func TestUpdateCurrentUser_Success(t *testing.T) {
 
 	payload := `{"email":"new@example.com","slackId":"U12345"}`
 	req, err := http.NewRequest("PUT", "/api/user", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -118,6 +121,7 @@ func TestUpdateCurrentUser_NotFound(t *testing.T) {
 
 	payload := `{"email":"new@example.com"}`
 	req, err := http.NewRequest("PUT", "/api/user", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -134,6 +138,7 @@ func TestUpdateCurrentUser_InvalidBody(t *testing.T) {
 	// Body parsing happens before the service is invoked, so no store
 	// calls are expected.
 	req, err := http.NewRequest("PUT", "/api/user", strings.NewReader("not-json"))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -160,6 +165,7 @@ func TestUpdateCurrentUser_InvalidEmail(t *testing.T) {
 
 	payload := `{"email":"not-an-email"}`
 	req, err := http.NewRequest("PUT", "/api/user", strings.NewReader(payload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/api/handlers/websocket_ratelimit_test.go
+++ b/pkg/api/handlers/websocket_ratelimit_test.go
@@ -46,6 +46,7 @@ func TestWebSocketRateLimit(t *testing.T) {
 
 	// Test: Normal WebSocket upgrade request should succeed
 	req, err := http.NewRequest(http.MethodGet, "/ws", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Upgrade", "websocket")
 	req.Header.Set("Connection", "Upgrade")

--- a/pkg/api/handlers/workloads/cluster_groups_test.go
+++ b/pkg/api/handlers/workloads/cluster_groups_test.go
@@ -183,6 +183,7 @@ func TestListClusterGroups_IncludesBuiltIn(t *testing.T) {
 	clusterGroupsMu.Unlock()
 
 	req, _ := http.NewRequest("GET", "/api/cluster-groups", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -212,6 +213,7 @@ func TestCreateClusterGroup_Success(t *testing.T) {
 
 	payload := `{"name":"new-group","kind":"static","clusters":["test-cluster"]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -231,6 +233,7 @@ func TestCreateClusterGroup_MissingName(t *testing.T) {
 
 	payload := `{"name":"","kind":"static","clusters":["c1"]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -245,6 +248,7 @@ func TestCreateClusterGroup_ReservedName(t *testing.T) {
 
 	payload := `{"name":"all-healthy-clusters","kind":"static","clusters":["c1"]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -259,6 +263,7 @@ func TestCreateClusterGroup_StaticNoClusters(t *testing.T) {
 
 	payload := `{"name":"empty-group","kind":"static","clusters":[]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -274,6 +279,7 @@ func TestCreateClusterGroup_DynamicNoClusters(t *testing.T) {
 	// Dynamic groups are allowed with no clusters
 	payload := `{"name":"dyn-group","kind":"dynamic","clusters":[]}`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -287,6 +293,7 @@ func TestCreateClusterGroup_InvalidBody(t *testing.T) {
 	env.App.Post("/api/cluster-groups", h.CreateClusterGroup)
 
 	req, _ := http.NewRequest("POST", "/api/cluster-groups", strings.NewReader("not json"))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -310,6 +317,7 @@ func TestUpdateClusterGroup_Success(t *testing.T) {
 
 	payload := `{"kind":"static","clusters":["c1","c2"]}`
 	req, _ := http.NewRequest("PUT", "/api/cluster-groups/existing", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -329,6 +337,7 @@ func TestUpdateClusterGroup_BuiltInReject(t *testing.T) {
 
 	payload := `{"kind":"static","clusters":["c1"]}`
 	req, _ := http.NewRequest("PUT", "/api/cluster-groups/all-healthy-clusters", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -342,6 +351,7 @@ func TestUpdateClusterGroup_InvalidBody(t *testing.T) {
 	env.App.Put("/api/cluster-groups/:name", h.UpdateClusterGroup)
 
 	req, _ := http.NewRequest("PUT", "/api/cluster-groups/test", strings.NewReader("bad json"))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -363,6 +373,7 @@ func TestDeleteClusterGroup_Success(t *testing.T) {
 	clusterGroupsMu.Unlock()
 
 	req, _ := http.NewRequest("DELETE", "/api/cluster-groups/del-me", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusMultiStatus, resp.StatusCode)
@@ -379,6 +390,7 @@ func TestDeleteClusterGroup_BuiltInReject(t *testing.T) {
 	env.App.Delete("/api/cluster-groups/:name", h.DeleteClusterGroup)
 
 	req, _ := http.NewRequest("DELETE", "/api/cluster-groups/all-healthy-clusters", nil)
+	req.Host = "localhost"
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
 	assert.Equal(t, 400, resp.StatusCode)
@@ -397,6 +409,7 @@ func TestSyncClusterGroups_Success(t *testing.T) {
 
 	payload := `[{"name":"g1","kind":"static","clusters":["c1"]},{"name":"g2","kind":"dynamic","clusters":[]}]`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups/sync", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -416,6 +429,7 @@ func TestSyncClusterGroups_FiltersReservedName(t *testing.T) {
 	// Include the reserved name — it should be filtered out
 	payload := `[{"name":"all-healthy-clusters","kind":"dynamic","clusters":[]},{"name":"real-group","kind":"static","clusters":["c1"]}]`
 	req, _ := http.NewRequest("POST", "/api/cluster-groups/sync", strings.NewReader(payload))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -433,6 +447,7 @@ func TestSyncClusterGroups_InvalidJSONClusterGroups(t *testing.T) {
 	env.App.Post("/api/cluster-groups/sync", h.SyncClusterGroups)
 
 	req, _ := http.NewRequest("POST", "/api/cluster-groups/sync", strings.NewReader("not json"))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
 	require.NoError(t, err)
@@ -452,6 +467,7 @@ func TestSyncClusterGroups_BodyTooLarge(t *testing.T) {
 		bigPayload = strings.Repeat("x", 1<<20+1)
 	}
 	req, err := http.NewRequest("POST", "/api/cluster-groups/sync", strings.NewReader(bigPayload))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := env.App.Test(req, -1)
@@ -491,6 +507,7 @@ func TestClusterGroupsConcurrentAccess(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 			req, _ := http.NewRequest("GET", "/api/cluster-groups", nil)
+			req.Host = "localhost"
 			env.App.Test(req, -1)
 		}(i)
 		go func(idx int) {

--- a/pkg/api/handlers/workloads/cluster_query_test.go
+++ b/pkg/api/handlers/workloads/cluster_query_test.go
@@ -52,6 +52,7 @@ func TestGenerateClusterQuery_PromptTooLong(t *testing.T) {
 			data, _ := json.Marshal(payload)
 
 			req, err := http.NewRequest("POST", "/api/cluster-groups/ai-query", bytes.NewReader(data))
+			req.Host = "localhost"
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 
@@ -80,6 +81,7 @@ func TestGenerateClusterQuery_EmptyPrompt(t *testing.T) {
 	data, _ := json.Marshal(payload)
 
 	req, err := http.NewRequest("POST", "/api/cluster-groups/ai-query", bytes.NewReader(data))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -305,6 +307,7 @@ func TestGenerateClusterQuery_AIRateLimiter(t *testing.T) {
 	makeRequest := func() *http.Response {
 		payload, _ := json.Marshal(map[string]string{"prompt": "list healthy clusters"})
 		req, err := http.NewRequest(http.MethodPost, "/api/cluster-groups/ai-query", bytes.NewReader(payload))
+		req.Host = "localhost"
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := env.App.Test(req, 5000)
@@ -372,6 +375,7 @@ func TestGenerateClusterQuery_AIRateLimiter_IndependentPerIP(t *testing.T) {
 	makeRequest := func() *http.Response {
 		payload, _ := json.Marshal(map[string]string{"prompt": "list healthy clusters"})
 		req, err := http.NewRequest(http.MethodPost, "/api/cluster-groups/ai-query", bytes.NewReader(payload))
+		req.Host = "localhost"
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := env.App.Test(req, 5000)

--- a/pkg/api/handlers/workloads/handler_test.go
+++ b/pkg/api/handlers/workloads/handler_test.go
@@ -63,6 +63,7 @@ func TestListWorkloads(t *testing.T) {
 	injectDynamicClusterWithObjects(env, "test-cluster", scheme, []runtime.Object{deployment})
 
 	req, err := http.NewRequest("GET", "/api/workloads?cluster=test-cluster", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
@@ -107,6 +108,7 @@ func TestGetWorkload(t *testing.T) {
 
 	// 1. Success Case
 	req, err := http.NewRequest("GET", "/api/workloads/test-cluster/default/my-app", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
@@ -121,6 +123,7 @@ func TestGetWorkload(t *testing.T) {
 
 	// 2. Not Found
 	reqNotFound, err := http.NewRequest("GET", "/api/workloads/test-cluster/default/missing", nil)
+	reqNotFound.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, reqNotFound)
 	respNotFound, errNotFound := env.App.Test(reqNotFound, 5000)
@@ -151,6 +154,7 @@ func TestGetDeployStatus(t *testing.T) {
 	injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{deploy})
 
 	req, err := http.NewRequest("GET", "/api/workloads/deploy-status/c1/default/status-app", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
@@ -202,6 +206,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	}
 	data, _ := json.Marshal(createPayload)
 	req, err := http.NewRequest("POST", "/api/cluster-groups", bytes.NewReader(data))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	req.Header.Set("Content-Type", "application/json")
@@ -212,6 +217,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	assert.Equal(t, 201, resp.StatusCode)
 
 	req, err = http.NewRequest("GET", "/api/cluster-groups", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err = env.App.Test(req)
@@ -236,6 +242,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	}
 	data, _ = json.Marshal(updatePayload)
 	req, err = http.NewRequest("PUT", "/api/cluster-groups/group1", bytes.NewReader(data))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	req.Header.Set("Content-Type", "application/json")
@@ -246,6 +253,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 
 	req, err = http.NewRequest("DELETE", "/api/cluster-groups/group1", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err = env.App.Test(req)
@@ -254,6 +262,7 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 
 	req, err = http.NewRequest("GET", "/api/cluster-groups", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err = env.App.Test(req)
@@ -315,6 +324,7 @@ func TestEvaluateClusterQuery(t *testing.T) {
 
 	data, _ := json.Marshal(query)
 	req, err := http.NewRequest("POST", "/api/cluster-groups/evaluate", bytes.NewReader(data))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	req.Header.Set("Content-Type", "application/json")
@@ -373,6 +383,7 @@ func TestGenerateClusterQuery(t *testing.T) {
 	data, _ := json.Marshal(payload)
 
 	req, err := http.NewRequest("POST", "/api/cluster-groups/generate", bytes.NewReader(data))
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	req.Header.Set("Content-Type", "application/json")
@@ -422,6 +433,7 @@ func TestResolveDependencies(t *testing.T) {
 	injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{deploy, svc})
 
 	req, err := http.NewRequest("GET", "/api/workloads/resolve-deps/c1/default/app", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
@@ -468,6 +480,7 @@ func TestMonitorWorkload(t *testing.T) {
 	injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{deploy})
 
 	req, err := http.NewRequest("GET", "/api/workloads/monitor/c1/default/monitored-app", nil)
+	req.Host = "localhost"
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	resp, err := env.App.Test(req, 5000)
@@ -517,6 +530,7 @@ func TestGetDeployLogs(t *testing.T) {
 		injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{pod, deploy}, pod)
 
 		req, err := http.NewRequest("GET", "/api/workloads/logs/c1/default/log-app", nil)
+		req.Host = "localhost"
 		require.NoError(t, err)
 		require.NotNil(t, req)
 		resp, err := env.App.Test(req, 5000)
@@ -532,6 +546,7 @@ func TestGetDeployLogs(t *testing.T) {
 		injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{pod}, pod)
 
 		req, err := http.NewRequest("GET", "/api/workloads/logs/c1/default/missing-app", nil)
+		req.Host = "localhost"
 		require.NoError(t, err)
 		require.NotNil(t, req)
 		resp, err := env.App.Test(req, 5000)
@@ -547,6 +562,7 @@ func TestGetDeployLogs(t *testing.T) {
 	t.Run("MissingCluster_Returns500", func(t *testing.T) {
 		// When the cluster context does not exist, GetClient fails and handler returns 500.
 		req, err := http.NewRequest("GET", "/api/workloads/logs/nonexistent-cluster/default/app", nil)
+		req.Host = "localhost"
 		require.NoError(t, err)
 		require.NotNil(t, req)
 		resp, err := env.App.Test(req, 5000)


### PR DESCRIPTION
## Test Improvement

Adds `req.Host = "localhost"` after every `http.NewRequest()` and `httptest.NewRequest()` call in **44 test files** across `pkg/api/handlers/` and `pkg/api/audit/`, fixing **336 test request sites** that fail with fasthttp 1.72.0's new requirement for a Host header.

### Root Cause

The `github.com/valyala/fasthttp` bump from 1.58.0 to 1.72.0 (merged to main) introduced a breaking change: all HTTP requests must include a `Host` header. Previously, a missing Host was silently accepted. This broke **356 tests** across 8 packages on main.

### What Changed

All `http.NewRequest()` calls in Fiber handler test files now set `req.Host = "localhost"` immediately after construction. No production code was modified.

### Affected Packages (8)
- `pkg/api/handlers` (main)
- `pkg/api/handlers/auth`
- `pkg/api/handlers/compliance`
- `pkg/api/handlers/feedback`
- `pkg/api/handlers/gitops`
- `pkg/api/handlers/missions`
- `pkg/api/handlers/rewards`
- `pkg/api/handlers/stellar`
- `pkg/api/handlers/workloads`
- `pkg/api/audit`

### Supersedes
This PR is a comprehensive fix that supersedes the partial fixes in:
- #19922 (fixed only workloads + stellar)
- #19919 (duplicate of #19922)

Fixes #19909

---
*Filed by quality agent (ACMM L4/L6 — full mode)*