### PR TITLE
[quality] fix: add Host header to pkg/api + middleware test requests for fasthttp 1.72.0

### DIFF
--- a/pkg/api/middleware/auth_test.go
+++ b/pkg/api/middleware/auth_test.go
@@ -27,6 +27,7 @@ func TestJWTAuth(t *testing.T) {
 	t.Run("Valid Token", func(t *testing.T) {
 		token, _ := generateTestToken("test-secret", time.Now().Add(time.Hour))
 		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+token)
 
 		resp, err := app.Test(req, 5000)
@@ -36,12 +37,14 @@ func TestJWTAuth(t *testing.T) {
 
 	t.Run("Missing Header", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Host = "localhost"
 		resp, _ := app.Test(req, 5000)
 		assert.Equal(t, 401, resp.StatusCode)
 	})
 
 	t.Run("Invalid Format", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "InvalidFormat")
 		resp, _ := app.Test(req, 5000)
 		assert.Equal(t, 401, resp.StatusCode)
@@ -50,6 +53,7 @@ func TestJWTAuth(t *testing.T) {
 	t.Run("Invalid Signature", func(t *testing.T) {
 		token, _ := generateTestToken("WRONG-SECRET", time.Now().Add(time.Hour))
 		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp, _ := app.Test(req, 5000)
 		assert.Equal(t, 401, resp.StatusCode)
@@ -58,6 +62,7 @@ func TestJWTAuth(t *testing.T) {
 	t.Run("Expired Token", func(t *testing.T) {
 		token, _ := generateTestToken("test-secret", time.Now().Add(-1*time.Hour))
 		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp, _ := app.Test(req, 5000)
 		assert.Equal(t, 401, resp.StatusCode)
@@ -75,12 +80,14 @@ func TestJWTAuth(t *testing.T) {
 		})
 
 		req := httptest.NewRequest("GET", "/api/mcp/clusters?source=ubersicht-widget", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer widget-agent-token")
 		resp, err := widgetApp.Test(req, 5000)
 		assert.NoError(t, err)
 		assert.Equal(t, 200, resp.StatusCode)
 
 		restrictedReq := httptest.NewRequest("GET", "/api/mcp/secrets?source=ubersicht-widget", nil)
+		restrictedReq.Host = "localhost"
 		restrictedReq.Header.Set("Authorization", "Bearer widget-agent-token")
 		restrictedResp, err := widgetApp.Test(restrictedReq, 5000)
 		assert.NoError(t, err)
@@ -100,11 +107,13 @@ func TestJWTAuth(t *testing.T) {
 		})
 
 		getReq := httptest.NewRequest("GET", "/api/github-pipelines?source=ubersicht-widget&view=pulse", nil)
+		getReq.Host = "localhost"
 		getResp, err := widgetApp.Test(getReq, 5000)
 		assert.NoError(t, err)
 		assert.Equal(t, 401, getResp.StatusCode, "GET /api/github-pipelines must require auth after #16917")
 
 		mutateReq := httptest.NewRequest("POST", "/api/github-pipelines?source=ubersicht-widget&view=mutate", nil)
+		mutateReq.Host = "localhost"
 		mutateResp, err := widgetApp.Test(mutateReq, 5000)
 		assert.NoError(t, err)
 		assert.Equal(t, 401, mutateResp.StatusCode)
@@ -118,6 +127,7 @@ func TestJWTAuth(t *testing.T) {
 		// to be logged by proxies and load balancers.
 		token, _ := generateTestToken("test-secret", time.Now().Add(time.Hour))
 		req := httptest.NewRequest("GET", "/protected/stream?_token="+token, nil)
+		req.Host = "localhost"
 
 		// Setup stream route specifically
 		app.Get("/protected/stream", handler, func(c *fiber.Ctx) error {
@@ -154,6 +164,7 @@ func TestJWTAuth(t *testing.T) {
 		// for authentication.
 		leakedToken, _ := generateTestToken("test-secret", time.Now().Add(time.Hour))
 		req := httptest.NewRequest("GET", "/events/stream?cluster=prod&_token="+leakedToken, nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp, err := stripTestApp.Test(req, 5000)
 		assert.NoError(t, err)
@@ -191,6 +202,7 @@ func TestJWTAuth(t *testing.T) {
 		// must be scrubbed.
 		leakedToken, _ := generateTestToken("test-secret", time.Now().Add(time.Hour))
 		req := httptest.NewRequest("GET", "/events/stream?cluster=prod&_token="+leakedToken, nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+token)
 
 		resp, err := bothTestApp.Test(req, 5000)
@@ -220,6 +232,7 @@ func TestJWTAuth(t *testing.T) {
 
 		leakedToken, _ := generateTestToken("test-secret", time.Now().Add(time.Hour))
 		req := httptest.NewRequest("GET", "/api/resource?_token="+leakedToken, nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+token)
 
 		resp, err := nonStreamApp.Test(req, 5000)
@@ -290,6 +303,7 @@ func TestJWTAuth_TokenRefreshHeader(t *testing.T) {
 		require.NoError(t, err)
 
 		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp, err := app.Test(req, 5000)
 		require.NoError(t, err)
@@ -304,6 +318,7 @@ func TestJWTAuth_TokenRefreshHeader(t *testing.T) {
 		require.NoError(t, err)
 
 		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp, err := app.Test(req, 5000)
 		require.NoError(t, err)
@@ -333,6 +348,7 @@ func TestGetContextHelpers(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("GET", "/me", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	if err != nil || resp == nil {
 		t.Fatalf("app.Test failed: %v", err)
@@ -395,6 +411,7 @@ func TestJWTAuth_StaleHeaderFallsBackToCookie(t *testing.T) {
 		validCookieToken, _ := generateTestToken(secret, time.Now().Add(time.Hour))
 
 		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+staleHeaderToken)
 		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: validCookieToken})
 
@@ -408,6 +425,7 @@ func TestJWTAuth_StaleHeaderFallsBackToCookie(t *testing.T) {
 		staleHeaderToken, _ := generateTestToken("WRONG-SECRET", time.Now().Add(time.Hour))
 
 		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+staleHeaderToken)
 
 		resp, err := app.Test(req, 5000)
@@ -422,6 +440,7 @@ func TestJWTAuth_StaleHeaderFallsBackToCookie(t *testing.T) {
 		staleCookieToken, _ := generateTestToken("ALSO-WRONG", time.Now().Add(time.Hour))
 
 		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+staleHeaderToken)
 		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: staleCookieToken})
 
@@ -438,6 +457,7 @@ func TestJWTAuth_StaleHeaderFallsBackToCookie(t *testing.T) {
 		brokenCookieToken, _ := generateTestToken("WRONG-SECRET", time.Now().Add(time.Hour))
 
 		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+validHeaderToken)
 		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: brokenCookieToken})
 
@@ -483,6 +503,7 @@ func TestJWTAuth_MalformedHeaderFallsBackToCookie(t *testing.T) {
 		t.Run(tc.name+" with valid cookie succeeds", func(t *testing.T) {
 			validCookieToken, _ := generateTestToken(secret, time.Now().Add(time.Hour))
 			req := httptest.NewRequest("GET", "/protected", nil)
+			req.Host = "localhost"
 			req.Header.Set("Authorization", tc.value)
 			req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: validCookieToken})
 
@@ -494,6 +515,7 @@ func TestJWTAuth_MalformedHeaderFallsBackToCookie(t *testing.T) {
 
 		t.Run(tc.name+" with no cookie still 401", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/protected", nil)
+			req.Host = "localhost"
 			req.Header.Set("Authorization", tc.value)
 
 			resp, err := app.Test(req, 5000)
@@ -573,6 +595,7 @@ func TestRevocationFailClosed(t *testing.T) {
 	signed, _ := tok.SignedString([]byte(secret))
 
 	req := httptest.NewRequest("GET", "/protected", nil)
+	req.Host = "localhost"
 	req.Header.Set("Authorization", "Bearer "+signed)
 	resp, err := app.Test(req, 5000)
 	assert.NoError(t, err)
@@ -659,6 +682,7 @@ func TestRevocationQueryTokenRejectedOnUnknownPath(t *testing.T) {
 
 	token, _ := generateTestToken(secret, time.Now().Add(time.Hour))
 	req := httptest.NewRequest("GET", "/api/random/stream?_token="+token, nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req, 5000)
 	assert.NoError(t, err)
 	assert.Equal(t, 401, resp.StatusCode,
@@ -673,6 +697,7 @@ func TestWebSocketUpgrade(t *testing.T) {
 
 	t.Run("Valid Upgrade", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ws", nil)
+		req.Host = "localhost"
 		req.Header.Set("Upgrade", "websocket")
 		resp, err := app.Test(req)
 		assert.NoError(t, err)
@@ -681,6 +706,7 @@ func TestWebSocketUpgrade(t *testing.T) {
 
 	t.Run("Missing Upgrade", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ws", nil)
+		req.Host = "localhost"
 		resp, err := app.Test(req)
 		assert.NoError(t, err)
 		assert.Equal(t, 426, resp.StatusCode) // fiber.ErrUpgradeRequired
@@ -744,6 +770,7 @@ func TestGetContextHelpers_Empty(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("GET", "/empty", nil)
+	req.Host = "localhost"
 	resp, err := app.Test(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -1017,6 +1044,7 @@ func TestJWTAuth_UserValidation(t *testing.T) {
 		InitUserValidation(store)
 
 		req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+makeToken(models.UserRoleViewer))
 		resp, err := app.Test(req, 5000)
 		require.NoError(t, err)
@@ -1029,6 +1057,7 @@ func TestJWTAuth_UserValidation(t *testing.T) {
 		InitUserValidation(store)
 
 		req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+makeToken(models.UserRoleAdmin))
 		resp, err := app.Test(req, 5000)
 		require.NoError(t, err)
@@ -1043,6 +1072,7 @@ func TestJWTAuth_UserValidation(t *testing.T) {
 
 		for i := 0; i < 2; i++ {
 			req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+			req.Host = "localhost"
 			req.Header.Set("Authorization", "Bearer "+token)
 			resp, err := app.Test(req, 5000)
 			require.NoError(t, err)
@@ -1056,6 +1086,7 @@ func TestJWTAuth_UserValidation(t *testing.T) {
 		InitUserValidation(store)
 
 		req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+		req.Host = "localhost"
 		req.Header.Set("Authorization", "Bearer "+makeToken(models.UserRoleViewer))
 		resp, err := app.Test(req, 5000)
 		require.NoError(t, err)

--- a/pkg/api/middleware/auth_ws_revoke_test.go
+++ b/pkg/api/middleware/auth_ws_revoke_test.go
@@ -23,6 +23,7 @@ func TestValidateWebSocketOrigin_NoOrigin(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("GET", "/ws", nil)
+	req.Host = "localhost"
 	// No Origin header — non-browser client should be allowed unconditionally.
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -36,6 +37,7 @@ func TestValidateWebSocketOrigin_DevMode(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("GET", "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "https://attacker.example.com")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -50,6 +52,7 @@ func TestValidateWebSocketOrigin_Rejected(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("GET", "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "https://attacker.example.com")
 	req.Host = "console.kubestellar.io"
 	resp, err := app.Test(req, 5000)
@@ -65,6 +68,7 @@ func TestValidateWebSocketOrigin_MatchesHost(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("GET", "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "http://console.kubestellar.io")
 	req.Host = "console.kubestellar.io"
 	resp, err := app.Test(req, 5000)
@@ -83,6 +87,7 @@ func TestValidateWebSocketOrigin_EnvAllowList(t *testing.T) {
 
 	t.Run("allowed origin", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ws", nil)
+		req.Host = "localhost"
 		req.Header.Set("Origin", "https://allowed.example.com")
 		resp, err := app.Test(req, 5000)
 		require.NoError(t, err)
@@ -91,6 +96,7 @@ func TestValidateWebSocketOrigin_EnvAllowList(t *testing.T) {
 
 	t.Run("second allowed origin", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ws", nil)
+		req.Host = "localhost"
 		req.Header.Set("Origin", "https://also-allowed.dev")
 		resp, err := app.Test(req, 5000)
 		require.NoError(t, err)
@@ -99,6 +105,7 @@ func TestValidateWebSocketOrigin_EnvAllowList(t *testing.T) {
 
 	t.Run("unlisted origin", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ws", nil)
+		req.Host = "localhost"
 		req.Header.Set("Origin", "https://evil.example.com")
 		resp, err := app.Test(req, 5000)
 		require.NoError(t, err)
@@ -116,6 +123,7 @@ func TestIsWSOriginAllowed_CaseInsensitive(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("GET", "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "https://console.example.com")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -132,6 +140,7 @@ func TestIsWSOriginAllowed_TrailingSlash(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("GET", "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "https://console.example.com")
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -146,6 +155,7 @@ func TestIsWSOriginAllowed_HTTPSFromXForwardedProto(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("GET", "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "https://console.kubestellar.io")
 	req.Host = "console.kubestellar.io"
 	req.Header.Set("X-Forwarded-Proto", "https")

--- a/pkg/api/middleware/csrf_test.go
+++ b/pkg/api/middleware/csrf_test.go
@@ -38,6 +38,7 @@ func TestCSRF_SafeMethodsPassThrough(t *testing.T) {
 	for _, method := range safeMethods {
 		t.Run(method, func(t *testing.T) {
 			req := httptest.NewRequest(method, "/any-path", nil)
+			req.Host = "localhost"
 			// No CSRF header — should still pass for safe methods
 			resp, err := app.Test(req)
 			if err != nil {
@@ -64,6 +65,7 @@ func TestCSRF_UnsafeMethodsRejectedWithoutHeader(t *testing.T) {
 	for _, method := range unsafeMethods {
 		t.Run(method, func(t *testing.T) {
 			req := httptest.NewRequest(method, "/any-path", nil)
+			req.Host = "localhost"
 			resp, err := app.Test(req)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -80,6 +82,7 @@ func TestCSRF_UnsafeMethodsRejectedWithWrongValue(t *testing.T) {
 	app := newTestApp()
 
 	req := httptest.NewRequest(http.MethodPost, "/any-path", nil)
+	req.Host = "localhost"
 	req.Header.Set(middleware.CSRFHeaderName, "BadValue")
 	resp, err := app.Test(req)
 	if err != nil {
@@ -104,6 +107,7 @@ func TestCSRF_UnsafeMethodsPassWithCorrectHeader(t *testing.T) {
 	for _, method := range unsafeMethods {
 		t.Run(method, func(t *testing.T) {
 			req := httptest.NewRequest(method, "/any-path", nil)
+			req.Host = "localhost"
 			req.Header.Set(middleware.CSRFHeaderName, middleware.CSRFHeaderValue)
 			resp, err := app.Test(req)
 			if err != nil {

--- a/pkg/api/middleware/ratelimit_test.go
+++ b/pkg/api/middleware/ratelimit_test.go
@@ -227,6 +227,7 @@ func TestCompositeKey(t *testing.T) {
 
 	t.Run("IP only", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/test", nil)
+		req.Host = "localhost"
 		req.Header.Set("X-Forwarded-For", "1.1.1.1")
 		resp, err := app.Test(req)
 		if err != nil {
@@ -250,6 +251,7 @@ func TestCompositeKey(t *testing.T) {
 		})
 
 		req := httptest.NewRequest("GET", "/test", nil)
+		req.Host = "localhost"
 		req.Header.Set("X-Forwarded-For", "2.2.2.2")
 		resp, err := appWithAuth.Test(req)
 		if err != nil {

--- a/pkg/api/middleware/websocket_origin_test.go
+++ b/pkg/api/middleware/websocket_origin_test.go
@@ -21,6 +21,7 @@ func TestValidateWebSocketOrigin_NoOriginHeader(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Host = "localhost"
 	// No Origin header — non-browser client
 	resp, err := app.Test(req, -1)
 	assert.NoError(t, err)
@@ -35,6 +36,7 @@ func TestValidateWebSocketOrigin_DevModeAllowsAll(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "http://evil.example.com")
 	resp, err := app.Test(req, -1)
 	assert.NoError(t, err)
@@ -49,6 +51,7 @@ func TestValidateWebSocketOrigin_MatchingHostAllowed(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "http://localhost:5174")
 	req.Host = "localhost:5174"
 	resp, err := app.Test(req, -1)
@@ -64,6 +67,7 @@ func TestValidateWebSocketOrigin_MismatchedHostRejected(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "http://evil.example.com")
 	req.Host = "localhost:5174"
 	resp, err := app.Test(req, -1)
@@ -79,6 +83,7 @@ func TestValidateWebSocketOrigin_TrailingSlashNormalized(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "http://localhost:8080/")
 	req.Host = "localhost:8080"
 	resp, err := app.Test(req, -1)
@@ -97,6 +102,7 @@ func TestValidateWebSocketOrigin_EnvOverride(t *testing.T) {
 
 	// Allowed origin
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "https://console.kubestellar.io")
 	req.Host = "api.kubestellar.io"
 	resp, err := app.Test(req, -1)
@@ -105,6 +111,7 @@ func TestValidateWebSocketOrigin_EnvOverride(t *testing.T) {
 
 	// Second allowed origin
 	req2 := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req2.Host = "localhost"
 	req2.Header.Set("Origin", "https://staging.kubestellar.io")
 	req2.Host = "api.kubestellar.io"
 	resp2, err := app.Test(req2, -1)
@@ -122,6 +129,7 @@ func TestValidateWebSocketOrigin_EnvRejectsUnlisted(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "https://evil.example.com")
 	req.Host = "api.kubestellar.io"
 	resp, err := app.Test(req, -1)
@@ -139,6 +147,7 @@ func TestValidateWebSocketOrigin_EnvCaseInsensitive(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "https://console.kubestellar.io")
 	req.Host = "api.kubestellar.io"
 	resp, err := app.Test(req, -1)
@@ -156,6 +165,7 @@ func TestValidateWebSocketOrigin_EnvWithTrailingSlash(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "https://console.kubestellar.io")
 	req.Host = "api.kubestellar.io"
 	resp, err := app.Test(req, -1)
@@ -175,6 +185,7 @@ func TestIsWSOriginAllowed_XForwardedProtoHTTPS(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Host = "localhost"
 	req.Header.Set("Origin", "https://myapp.example.com")
 	req.Header.Set("X-Forwarded-Proto", "https")
 	req.Host = "myapp.example.com"

--- a/pkg/api/middleware_setup_test.go
+++ b/pkg/api/middleware_setup_test.go
@@ -55,6 +55,7 @@ func newCSPTestServerWithConfig(t *testing.T, kcAgentURL string, serverCfg Serve
 func cspHeader(t *testing.T, s *Server) string {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "localhost"
 	resp, err := s.app.Test(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -161,6 +162,7 @@ func TestCSP_CustomKCAgentURL_HTTPSInjectsWSS(t *testing.T) {
 func TestCSP_XFrameOptions_DenyOnRegularPaths(t *testing.T) {
 	s := newCSPTestServer(t, defaultKCAgentBaseURL)
 	req := httptest.NewRequest(http.MethodGet, "/some/page", nil)
+	req.Host = "localhost"
 	resp, err := s.app.Test(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -174,6 +176,7 @@ func TestCSP_XFrameOptions_DenyOnRegularPaths(t *testing.T) {
 func TestCSP_XFrameOptions_AllowedOnEmbedPaths(t *testing.T) {
 	s := newCSPTestServer(t, defaultKCAgentBaseURL)
 	req := httptest.NewRequest(http.MethodGet, "/embed/ci-status", nil)
+	req.Host = "localhost"
 	resp, err := s.app.Test(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()

--- a/pkg/api/routes_api_core_test.go
+++ b/pkg/api/routes_api_core_test.go
@@ -40,6 +40,7 @@ func TestAgentAutoUpdateProxyRequiresAdmin(t *testing.T) {
 			})
 
 			req := httptest.NewRequest(http.MethodPost, "/api/agent/auto-update/status", nil)
+			req.Host = "localhost"
 			resp, err := app.Test(req)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantStatus, resp.StatusCode)

--- a/pkg/api/routes_auth_test.go
+++ b/pkg/api/routes_auth_test.go
@@ -201,6 +201,7 @@ func TestSetupAuthRoutes_RegistersAllAuthRoutes(t *testing.T) {
 	for _, route := range authRoutes {
 		t.Run(route.method+" "+route.path, func(t *testing.T) {
 			req := httptest.NewRequest(route.method, route.path, nil)
+			req.Host = "localhost"
 			resp, err := s.app.Test(req, -1)
 			require.NoError(t, err)
 			defer resp.Body.Close()

--- a/pkg/api/routes_feedback_test.go
+++ b/pkg/api/routes_feedback_test.go
@@ -50,6 +50,7 @@ func TestFeedbackRoutes_SubmitFeedbackRequiresAuthentication(t *testing.T) {
 	requestID := uuid.New()
 
 	req := httptest.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/feedback", strings.NewReader(`{"feedback_type":"positive"}`))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -79,6 +80,7 @@ func TestFeedbackRoutes_SubmitFeedbackCreatesFeedback(t *testing.T) {
 	app := newFeedbackRouteTestApp(t, userID, store)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/feedback/requests/"+requestID.String()+"/feedback", strings.NewReader(`{"feedback_type":"positive","comment":"Looks good"}`))
+	req.Host = "localhost"
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)

--- a/pkg/api/routes_health_test.go
+++ b/pkg/api/routes_health_test.go
@@ -66,6 +66,7 @@ func TestHealthRoutes_StatusEndpoints(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req.Host = "localhost"
 			resp, err := server.app.Test(req)
 			require.NoError(t, err)
 			defer resp.Body.Close()
@@ -111,6 +112,7 @@ func TestHealthRoutes_VersionEndpoint(t *testing.T) {
 	server := newHealthTestServer(t, Config{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
+	req.Host = "localhost"
 	resp, err := server.app.Test(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()

--- a/pkg/api/routes_registration_test.go
+++ b/pkg/api/routes_registration_test.go
@@ -128,6 +128,7 @@ func TestSetupRoutes_ProtectedEndpointsKeepAuthAndCSRFGuards(t *testing.T) {
 
 	t.Run("refresh requires csrf before jwt auth", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(`{}`))
+		req.Host = "localhost"
 		req.Header.Set("Content-Type", "application/json")
 
 		resp, err := server.app.Test(req)
@@ -139,6 +140,7 @@ func TestSetupRoutes_ProtectedEndpointsKeepAuthAndCSRFGuards(t *testing.T) {
 
 	t.Run("refresh with csrf still requires jwt", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(`{}`))
+		req.Host = "localhost"
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("X-Requested-With", "XMLHttpRequest")
 
@@ -151,6 +153,7 @@ func TestSetupRoutes_ProtectedEndpointsKeepAuthAndCSRFGuards(t *testing.T) {
 
 	t.Run("api me remains authenticated", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+		req.Host = "localhost"
 
 		resp, err := server.app.Test(req)
 		require.NoError(t, err)
@@ -167,6 +170,7 @@ func TestSetupRoutes_ProtectedEndpointsKeepAuthAndCSRFGuards(t *testing.T) {
 		}, nil).Maybe()
 
 		req := httptest.NewRequest(http.MethodPost, "/api/github/token", strings.NewReader(`{"token":"ghp_test"}`))
+		req.Host = "localhost"
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("X-Requested-With", "XMLHttpRequest")
 		req.Header.Set("Authorization", "Bearer "+signedRouteTestToken(t, viewerID, models.UserRoleViewer))


### PR DESCRIPTION
## Test Improvement

Adds `req.Host = "localhost"` after every `httptest.NewRequest()`/`http.NewRequest()` call in **11 test files** across `pkg/api/` (top-level) and `pkg/api/middleware/` that were missed by #19925.

### Root Cause

PR #19925 fixed 44 files in `pkg/api/handlers/` and `pkg/api/audit/`, but the `go test ./...` CI job still fails because these additional packages also use Fiber's `app.Test(req)` which routes through fasthttp 1.72.0 (requires Host header).

### Files Fixed

**pkg/api/ (top-level):**
- `routes_health_test.go`
- `routes_api_core_test.go`
- `routes_registration_test.go`
- `routes_auth_test.go`
- `routes_feedback_test.go`
- `middleware_setup_test.go`

**pkg/api/middleware/:**
- `csrf_test.go`
- `websocket_origin_test.go`
- `auth_ws_revoke_test.go`
- `auth_test.go`
- `ratelimit_test.go`

### Relationship to #19925

This PR supplements #19925. Together they provide the complete fix for all test files that use `app.Test()`. Both PRs should be merged to fully resolve the go-test failure on main.

Fixes #19909

---
*Filed by quality agent (ACMM L4/L6 — full mode)*