### PR TITLE
feat: add llm-d endpoint health monitoring

### DIFF
--- a/web/src/components/cards/cardIcons.ts
+++ b/web/src/components/cards/cardIcons.ts
@@ -164,6 +164,8 @@ export const CARD_ICONS: Record<string, { icon: ComponentType<{ className?: stri
   // ML/AI workload cards
   llm_inference: { icon: Cpu, color: 'text-purple-400' },
   llm_models: { icon: Database, color: 'text-blue-400' },
+  model_endpoint_health: { icon: Cpu, color: 'text-purple-400' },
+  epp_health: { icon: Activity, color: 'text-green-400' },
   llmd_flow: { icon: Workflow, color: 'text-cyan-400' },
   llmd_ai_insights: { icon: Wand2, color: 'text-purple-400' },
   llmd_configurator: { icon: Settings, color: 'text-blue-400' },

--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -220,6 +220,8 @@ export const CARD_TITLES: Record<string, string> = {
   // ML/AI workload cards
   llm_inference: 'llm-d Inference',
   llm_models: 'llm-d Models',
+  model_endpoint_health: 'Model Endpoint Health',
+  epp_health: 'EPP Health',
   llmd_flow: 'llm-d Request Flow',
   llmd_ai_insights: 'llm-d AI Insights',
   llmd_configurator: 'llm-d Configurator',
@@ -564,6 +566,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   prow_history: 'Historical PROW job runs and success rates.',
   llm_inference: 'llm-d is a Kubernetes-native platform for serving Large Language Models. This card shows inference endpoint health, request throughput, and latency metrics for your LLM deployments.',
   llm_models: 'LLM models deployed via llm-d with version info. See which models are loaded, their parameter sizes, and which pods are serving them.',
+  model_endpoint_health: 'Health summary for llm-d model serving endpoints, including ready, degraded, and replica counts across discovered serving deployments.',
+  epp_health: 'Health summary for llm-d Endpoint Picker Pod deployments, including ready, degraded, unavailable, and replica status.',
   llmd_flow: 'Animated visualization showing how an inference request flows through the llm-d stack: from the load balancer, to the Endpoint Picker Pod (EPP), to prefill and decode pods. Helps you understand the request lifecycle.',
   llmd_ai_insights: 'AI-generated insights about llm-d performance, bottlenecks, and optimization recommendations. Uses your cluster metrics to suggest improvements like adjusting batch sizes or scaling pods.',
   llmd_configurator: 'Configure llm-d deployment parameters interactively: replicas, autoscaling thresholds, model variants, and GPU resource limits. Changes can be applied directly to your cluster.',

--- a/web/src/components/cards/cardRegistry.ai.ts
+++ b/web/src/components/cards/cardRegistry.ai.ts
@@ -25,6 +25,8 @@ const ClusterHealthMonitor = safeLazy(() => _workloadMonitorBundle, 'ClusterHeal
 const _llmdBundle = import('./llmd').catch(() => undefined as never)
 const LLMdFlow = safeLazy(() => _llmdBundle, 'LLMdFlow')
 const KVCacheMonitor = safeLazy(() => _llmdBundle, 'KVCacheMonitor')
+const EPPHealth = safeLazy(() => import('./EPPHealth'), 'EPPHealth')
+const ModelEndpointHealthCard = safeLazy(() => _llmdBundle, 'ModelEndpointHealthCard')
 const EPPRouting = safeLazy(() => _llmdBundle, 'EPPRouting')
 const PDDisaggregation = safeLazy(() => _llmdBundle, 'PDDisaggregation')
 const LLMdAIInsights = safeLazy(() => _llmdBundle, 'LLMdAIInsights')
@@ -71,7 +73,8 @@ export const aiCardRegistry: CardRegistryCategory = {
     llm_models: LLMModels, ml_jobs: MLJobs, ml_notebooks: MLNotebooks, workload_monitor: WorkloadMonitor,
     workload_status: WorkloadMonitor, llmd_stack_monitor: LLMdStackMonitor, prow_ci_monitor: ProwCIMonitor,
     github_ci_monitor: GitHubCIMonitor, cluster_health_monitor: ClusterHealthMonitor, llmd_flow: LLMdFlow,
-    kvcache_monitor: KVCacheMonitor, epp_routing: EPPRouting, pd_disaggregation: PDDisaggregation,
+    kvcache_monitor: KVCacheMonitor, epp_health: EPPHealth, model_endpoint_health: ModelEndpointHealthCard,
+    epp_routing: EPPRouting, pd_disaggregation: PDDisaggregation,
     llmd_ai_insights: LLMdAIInsights, llmd_configurator: LLMdConfigurator, nightly_e2e_status: NightlyE2EStatus,
     benchmark_hero: BenchmarkHero, pareto_frontier: ParetoFrontier, hardware_leaderboard: HardwareLeaderboard,
     latency_breakdown: LatencyBreakdown, throughput_comparison: ThroughputComparison,
@@ -94,6 +97,7 @@ export const aiCardRegistry: CardRegistryCategory = {
     ml_notebooks: () => import('./workload-detection'), workload_monitor: () => import('./workload-monitor'), workload_status: () => import('./workload-monitor'),
     llmd_stack_monitor: () => import('./workload-monitor'), prow_ci_monitor: () => import('./workload-monitor'), github_ci_monitor: () => import('./workload-monitor'),
     cluster_health_monitor: () => import('./workload-monitor'), llmd_flow: () => import('./llmd'), kvcache_monitor: () => import('./llmd'),
+    epp_health: () => import('./EPPHealth'), model_endpoint_health: () => import('./llmd'),
     epp_routing: () => import('./llmd'), pd_disaggregation: () => import('./llmd'), llmd_ai_insights: () => import('./llmd'),
     llmd_configurator: () => import('./llmd'), nightly_e2e_status: () => import('./llmd'), benchmark_hero: () => import('./llmd'),
     pareto_frontier: () => import('./llmd'), hardware_leaderboard: () => import('./llmd'), latency_breakdown: () => import('./llmd'),
@@ -114,13 +118,14 @@ export const aiCardRegistry: CardRegistryCategory = {
     kagenti_status: 4, kagenti_agent_fleet: 8, kagenti_build_pipeline: 4, kagenti_tool_registry: 4, kagenti_agent_discovery: 4,
     kagenti_security: 4, kagenti_security_posture: 4, kagenti_topology: 8, kagent_status: 4, kagent_agent_fleet: 8,
     kagent_tool_registry: 4, kagent_model_providers: 4, kagent_agent_discovery: 4, kagent_security: 4, kagent_topology: 8,
-    llmd_flow: 8, kvcache_monitor: 4, epp_routing: 6, pd_disaggregation: 6, llmd_ai_insights: 6, llmd_configurator: 4,
+    llmd_flow: 8, kvcache_monitor: 4, epp_health: 4, model_endpoint_health: 4, epp_routing: 6,
+    pd_disaggregation: 6, llmd_ai_insights: 6, llmd_configurator: 4,
     nightly_e2e_status: 12, benchmark_hero: 12, pareto_frontier: 12, hardware_leaderboard: 12, latency_breakdown: 12,
     throughput_comparison: 12, performance_timeline: 12, resource_utilization: 12, nightly_release_pulse: 6,
     workflow_matrix: 6, pipeline_flow: 12, recent_failures: 6, agentic_detection_runs: 6,
   },
   demoDataCards: ['ml_jobs', 'ml_notebooks', 'llmd_configurator', 'kagenti_status', 'kagenti_agent_fleet', 'kagenti_build_pipeline', 'kagenti_tool_registry', 'kagenti_agent_discovery', 'kagenti_security', 'kagenti_security_posture', 'kagenti_topology', 'kagent_status', 'kagent_agent_fleet', 'kagent_tool_registry', 'kagent_model_providers', 'kagent_agent_discovery', 'kagent_security', 'kagent_topology'],
-  liveDataCards: ['prow_jobs', 'prow_status', 'prow_history', 'llm_inference', 'llm_models', 'workload_monitor', 'workload_status', 'llmd_stack_monitor', 'prow_ci_monitor', 'github_ci_monitor', 'nightly_release_pulse', 'workflow_matrix', 'pipeline_flow', 'recent_failures', 'agentic_detection_runs', 'cluster_health_monitor', 'nightly_e2e_status', 'kagenti_status', 'kagenti_agent_fleet', 'kagenti_build_pipeline', 'kagenti_tool_registry', 'kagenti_agent_discovery', 'kagenti_security', 'kagenti_topology', 'kagent_status', 'kagent_agent_fleet', 'kagent_tool_registry', 'kagent_model_providers', 'kagent_agent_discovery', 'kagent_security', 'kagent_topology'],
+  liveDataCards: ['prow_jobs', 'prow_status', 'prow_history', 'llm_inference', 'llm_models', 'epp_health', 'model_endpoint_health', 'workload_monitor', 'workload_status', 'llmd_stack_monitor', 'prow_ci_monitor', 'github_ci_monitor', 'nightly_release_pulse', 'workflow_matrix', 'pipeline_flow', 'recent_failures', 'agentic_detection_runs', 'cluster_health_monitor', 'nightly_e2e_status', 'kagenti_status', 'kagenti_agent_fleet', 'kagenti_build_pipeline', 'kagenti_tool_registry', 'kagenti_agent_discovery', 'kagenti_security', 'kagenti_topology', 'kagent_status', 'kagent_agent_fleet', 'kagent_tool_registry', 'kagent_model_providers', 'kagent_agent_discovery', 'kagent_security', 'kagent_topology'],
   demoStartupPreloaders: [
     () => import('./workload-detection/MLJobs'), () => import('./workload-detection/MLNotebooks'), () => import('./llmd'),
     () => import('./KagentiStatusCard'), () => import('./kagenti/KagentiAgentFleet'), () => import('./kagenti/KagentiBuildPipeline'),

--- a/web/src/components/cards/cardRegistry.aiml.ts
+++ b/web/src/components/cards/cardRegistry.aiml.ts
@@ -42,6 +42,7 @@ const LLMdStackMonitor = safeLazy(() => _workloadMonitorBundle, 'LLMdStackMonito
 const LatencyBreakdown = safeLazy(() => _llmdBundle, 'LatencyBreakdown')
 const MLJobs = safeLazy(() => _workloadDetectionBundle, 'MLJobs')
 const MLNotebooks = safeLazy(() => _workloadDetectionBundle, 'MLNotebooks')
+const ModelEndpointHealthCard = safeLazy(() => _llmdBundle, 'ModelEndpointHealthCard')
 const NightlyE2EStatus = safeLazy(() => _llmdBundle, 'NightlyE2EStatus')
 const PDDisaggregation = safeLazy(() => _llmdBundle, 'PDDisaggregation')
 const ParetoFrontier = safeLazy(() => _llmdBundle, 'ParetoFrontier')
@@ -63,8 +64,9 @@ const ThroughputComparison = safeLazy(() => _llmdBundle, 'ThroughputComparison')
  * kagenti_agent_discovery, kagenti_agent_fleet, kagenti_build_pipeline, kagenti_security,
  * kagenti_security_posture, kagenti_status, kagenti_tool_registry, kagenti_topology, kvcache_monitor,
  * latency_breakdown, llm_inference, llm_models, llmd_ai_insights, llmd_configurator, llmd_flow,
- * llmd_stack_monitor, ml_jobs, ml_notebooks, nightly_e2e_status, pareto_frontier, pd_disaggregation,
- * performance_timeline, provider_health, prow_history, prow_jobs, prow_status,
+ * llmd_stack_monitor, ml_jobs, ml_notebooks, model_endpoint_health, nightly_e2e_status,
+ * pareto_frontier, pd_disaggregation, performance_timeline, provider_health, prow_history,
+ * prow_jobs, prow_status,
  * resource_utilization, throughput_comparison
  */
 export interface CardRegistryDomain {
@@ -112,6 +114,7 @@ const components: Record<string, CardComponent> = {
   llmd_stack_monitor: LLMdStackMonitor,
   ml_jobs: MLJobs,
   ml_notebooks: MLNotebooks,
+  model_endpoint_health: ModelEndpointHealthCard,
   nightly_e2e_status: NightlyE2EStatus,
   pareto_frontier: ParetoFrontier,
   pd_disaggregation: PDDisaggregation,
@@ -165,6 +168,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     'kagenti_topology',
     'llm_inference',
     'llm_models',
+    'model_endpoint_health',
     'llmd_stack_monitor',
     'nightly_e2e_status',
     'prow_history',
@@ -205,6 +209,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     llmd_stack_monitor: () => import('./workload-monitor'),
     ml_jobs: () => import('./workload-detection'),
     ml_notebooks: () => import('./workload-detection'),
+    model_endpoint_health: () => import('./llmd'),
     nightly_e2e_status: () => import('./llmd'),
     pareto_frontier: () => import('./llmd'),
     pd_disaggregation: () => import('./llmd'),
@@ -250,6 +255,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     llmd_stack_monitor: 6,
     ml_jobs: 6,
     ml_notebooks: 6,
+    model_endpoint_health: 4,
     nightly_e2e_status: 12,
     pareto_frontier: 12,
     pd_disaggregation: 6,

--- a/web/src/components/cards/llmd/ModelEndpointHealthCard.tsx
+++ b/web/src/components/cards/llmd/ModelEndpointHealthCard.tsx
@@ -1,0 +1,203 @@
+import { useMemo } from 'react'
+import { Activity, AlertTriangle, CheckCircle2, Cpu, RefreshCw, XCircle } from 'lucide-react'
+import { useCachedModelEndpointHealth, type ModelEndpointHealth } from '../../../hooks/useCachedModelEndpointHealth'
+import { useCardLoadingState } from '../CardDataContext'
+import { Skeleton } from '../../ui/Skeleton'
+import { cn } from '../../../lib/cn'
+import type { LLMdServer } from '../../../hooks/useLLMd'
+
+interface ModelEndpointHealthCardProps {
+  config?: {
+    cluster?: string
+    clusters?: string[]
+  }
+}
+
+const VISIBLE_ENDPOINT_LIMIT = 5
+
+const HEALTH_LABEL: Record<ModelEndpointHealth, string> = {
+  healthy: 'Healthy',
+  degraded: 'Degraded',
+  unavailable: 'Unavailable',
+}
+
+const HEALTH_STYLE: Record<ModelEndpointHealth, string> = {
+  healthy: 'bg-green-500/15 text-green-400 border-green-500/25',
+  degraded: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/25',
+  unavailable: 'bg-red-500/15 text-red-400 border-red-500/25',
+}
+
+const HEALTH_ICON = {
+  healthy: CheckCircle2,
+  degraded: AlertTriangle,
+  unavailable: XCircle,
+} satisfies Record<ModelEndpointHealth, typeof CheckCircle2>
+
+const STATUS_DOT: Record<LLMdServer['status'], string> = {
+  running: 'bg-green-400',
+  scaling: 'bg-yellow-400',
+  stopped: 'bg-red-400',
+  error: 'bg-red-400',
+}
+
+function getClusters(config?: ModelEndpointHealthCardProps['config']) {
+  if (config?.clusters?.length) return config.clusters
+  if (config?.cluster) return [config.cluster]
+  return undefined
+}
+
+function formatReplicaCount(endpoint: LLMdServer) {
+  return `${endpoint.readyReplicas ?? 0}/${endpoint.replicas ?? 0}`
+}
+
+function formatGpu(endpoint: LLMdServer) {
+  if (!endpoint.gpu && !endpoint.gpuCount) return endpoint.type
+  return `${endpoint.gpu ?? 'GPU'}${endpoint.gpuCount ? ` x${endpoint.gpuCount}` : ''}`
+}
+
+export function ModelEndpointHealthCard({ config }: ModelEndpointHealthCardProps) {
+  const clusters = getClusters(config)
+  const {
+    data,
+    endpoints,
+    summary,
+    lastRefresh,
+    isLoading,
+    isRefreshing,
+    isDemoFallback,
+    isFailed,
+    consecutiveFailures,
+    refetch,
+  } = useCachedModelEndpointHealth(clusters)
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && endpoints.length === 0,
+    isRefreshing,
+    hasAnyData: endpoints.length > 0,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: isDemoFallback,
+  })
+
+  const HealthIcon = HEALTH_ICON[summary.health]
+  const sortedEndpoints = useMemo(() => {
+    return [...endpoints].sort((a, b) => {
+      const statusOrder: Record<LLMdServer['status'], number> = {
+        error: 0,
+        stopped: 1,
+        scaling: 2,
+        running: 3,
+      }
+      return (statusOrder[a.status] ?? 4) - (statusOrder[b.status] ?? 4) || a.name.localeCompare(b.name)
+    })
+  }, [endpoints])
+  const visibleEndpoints = sortedEndpoints.slice(0, VISIBLE_ENDPOINT_LIMIT)
+  const checkTime = data.lastCheckTime || (lastRefresh ? new Date(lastRefresh).toISOString() : '')
+
+  if (showSkeleton) {
+    return (
+      <div className="space-y-3 p-1">
+        <Skeleton className="h-20 rounded-lg" />
+        <div className="grid grid-cols-3 gap-2">
+          <Skeleton className="h-14 rounded-lg" />
+          <Skeleton className="h-14 rounded-lg" />
+          <Skeleton className="h-14 rounded-lg" />
+        </div>
+        <Skeleton className="h-24 rounded-lg" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <Cpu className="w-10 h-10 text-muted-foreground/30 mb-3" />
+        <div className="text-sm font-medium text-muted-foreground">No model endpoints found</div>
+        <div className="text-xs text-muted-foreground mt-1 max-w-[240px]">
+          Model endpoint health will appear when llm-d serving components are discovered.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3 p-1">
+      <div className={cn('rounded-lg border p-3', HEALTH_STYLE[summary.health])}>
+        <div className="flex items-center gap-2">
+          <HealthIcon className="w-4 h-4 shrink-0" />
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-semibold leading-tight">Model endpoint health</div>
+            <div className="text-xs opacity-80">{HEALTH_LABEL[summary.health]}</div>
+          </div>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            disabled={isRefreshing}
+            className="p-1.5 rounded-md hover:bg-background/20 transition-colors disabled:opacity-60"
+            title="Refresh model endpoint health"
+          >
+            <RefreshCw className={cn('w-3.5 h-3.5', isRefreshing && 'animate-spin')} />
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <div className="rounded-lg bg-muted/30 border border-border/50 px-3 py-2">
+          <div className="text-lg font-semibold leading-tight">{summary.readyEndpoints}</div>
+          <div className="text-xs text-muted-foreground">Ready</div>
+        </div>
+        <div className="rounded-lg bg-muted/30 border border-border/50 px-3 py-2">
+          <div className="text-lg font-semibold leading-tight">{summary.degradedEndpoints}</div>
+          <div className="text-xs text-muted-foreground">Degraded</div>
+        </div>
+        <div className="rounded-lg bg-muted/30 border border-border/50 px-3 py-2">
+          <div className="text-lg font-semibold leading-tight">
+            {summary.totalReadyReplicas}/{summary.totalReplicas}
+          </div>
+          <div className="text-xs text-muted-foreground">Replicas</div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border/50 overflow-hidden">
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-border/50">
+          <Activity className="w-3.5 h-3.5 text-purple-400" />
+          <span className="text-xs font-medium text-muted-foreground">
+            {summary.totalEndpoints} model endpoint{summary.totalEndpoints === 1 ? '' : 's'}
+          </span>
+          {isDemoFallback && (
+            <span className="ml-auto text-2xs px-1.5 py-0.5 rounded bg-yellow-500/15 text-yellow-400">
+              Demo
+            </span>
+          )}
+        </div>
+        <div className="divide-y divide-border/40">
+          {visibleEndpoints.map((endpoint) => (
+            <div key={endpoint.id} className="flex items-center gap-2 px-3 py-2">
+              <div className={cn('w-2 h-2 rounded-full shrink-0', STATUS_DOT[endpoint.status])} />
+              <div className="min-w-0 flex-1">
+                <div className="text-sm text-foreground truncate">{endpoint.name}</div>
+                <div className="text-xs text-muted-foreground truncate">
+                  {endpoint.model} / {endpoint.cluster}
+                </div>
+              </div>
+              <div className="text-right shrink-0">
+                <div className="text-xs text-muted-foreground" title="Ready replicas">
+                  {formatReplicaCount(endpoint)}
+                </div>
+                <div className="text-2xs text-muted-foreground/80">{formatGpu(endpoint)}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {checkTime && (
+        <div className="text-2xs text-muted-foreground px-1">
+          Last checked {new Date(checkTime).toLocaleTimeString()}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ModelEndpointHealthCard

--- a/web/src/components/cards/llmd/__tests__/ModelEndpointHealthCard.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/ModelEndpointHealthCard.test.tsx
@@ -1,0 +1,155 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ModelEndpointSummary } from '../../../../hooks/useCachedModelEndpointHealth'
+import type { LLMdServer } from '../../../../hooks/useLLMd'
+
+const mockRefetch = vi.fn()
+const mockUseCachedModelEndpointHealth = vi.fn()
+const mockUseCardLoadingState = vi.fn()
+
+vi.mock('../../../../hooks/useCachedModelEndpointHealth', () => ({
+  useCachedModelEndpointHealth: (clusters?: string[]) => mockUseCachedModelEndpointHealth(clusters),
+}))
+
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (options: unknown) => mockUseCardLoadingState(options),
+}))
+
+vi.mock('../../../ui/Skeleton', () => ({
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-testid="skeleton" className={className} />
+  ),
+}))
+
+const runningEndpoint: LLMdServer = {
+  id: 'cluster-a-llm-d-llama-model',
+  name: 'llama-model',
+  namespace: 'llm-d',
+  cluster: 'cluster-a',
+  model: 'llama',
+  type: 'vllm',
+  componentType: 'model',
+  status: 'running',
+  replicas: 2,
+  readyReplicas: 2,
+  gpu: 'NVIDIA',
+  gpuCount: 2,
+}
+
+const scalingEndpoint: LLMdServer = {
+  ...runningEndpoint,
+  id: 'cluster-b-llm-d-granite-model',
+  name: 'granite-model',
+  cluster: 'cluster-b',
+  model: 'granite',
+  type: 'tgi',
+  status: 'scaling',
+  replicas: 2,
+  readyReplicas: 1,
+}
+
+const degradedSummary: ModelEndpointSummary = {
+  health: 'degraded',
+  totalEndpoints: 2,
+  readyEndpoints: 1,
+  degradedEndpoints: 1,
+  unavailableEndpoints: 0,
+  totalReadyReplicas: 3,
+  totalReplicas: 4,
+}
+
+function mockModelEndpointHealth(overrides: Record<string, unknown> = {}) {
+  mockUseCachedModelEndpointHealth.mockReturnValue({
+    data: {
+      endpoints: [runningEndpoint, scalingEndpoint],
+      summary: degradedSummary,
+      lastCheckTime: '2026-06-29T12:00:00.000Z',
+    },
+    endpoints: [runningEndpoint, scalingEndpoint],
+    summary: degradedSummary,
+    lastRefresh: 111111111,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    refetch: mockRefetch,
+    ...overrides,
+  })
+}
+
+import { ModelEndpointHealthCard } from '../ModelEndpointHealthCard'
+
+describe('ModelEndpointHealthCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+    mockModelEndpointHealth()
+  })
+
+  it('renders model endpoint health summary and rows', () => {
+    render(<ModelEndpointHealthCard />)
+
+    expect(screen.getByText('Model endpoint health')).toBeInTheDocument()
+    expect(screen.getAllByText('Degraded').length).toBeGreaterThan(0)
+    expect(screen.getByText('llama-model')).toBeInTheDocument()
+    expect(screen.getByText('granite-model')).toBeInTheDocument()
+    expect(screen.getByText('2 model endpoints')).toBeInTheDocument()
+    expect(screen.getByText('3/4')).toBeInTheDocument()
+  })
+
+  it('passes configured clusters to the cached hook', () => {
+    render(<ModelEndpointHealthCard config={{ clusters: ['cluster-a', 'cluster-b'] }} />)
+
+    expect(mockUseCachedModelEndpointHealth).toHaveBeenCalledWith(['cluster-a', 'cluster-b'])
+  })
+
+  it('shows an empty state when no model endpoints are available', () => {
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: true })
+    mockModelEndpointHealth({
+      data: {
+        endpoints: [],
+        summary: {
+          health: 'unavailable',
+          totalEndpoints: 0,
+          readyEndpoints: 0,
+          degradedEndpoints: 0,
+          unavailableEndpoints: 0,
+          totalReadyReplicas: 0,
+          totalReplicas: 0,
+        },
+        lastCheckTime: '2026-06-29T12:00:00.000Z',
+      },
+      endpoints: [],
+      summary: {
+        health: 'unavailable',
+        totalEndpoints: 0,
+        readyEndpoints: 0,
+        degradedEndpoints: 0,
+        unavailableEndpoints: 0,
+        totalReadyReplicas: 0,
+        totalReplicas: 0,
+      },
+    })
+
+    render(<ModelEndpointHealthCard />)
+
+    expect(screen.getByText('No model endpoints found')).toBeInTheDocument()
+  })
+
+  it('shows skeleton content while loading', () => {
+    mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false })
+
+    render(<ModelEndpointHealthCard />)
+
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0)
+  })
+
+  it('refreshes model endpoint status from the header action', () => {
+    render(<ModelEndpointHealthCard />)
+
+    fireEvent.click(screen.getByTitle('Refresh model endpoint health'))
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/components/cards/llmd/index.ts
+++ b/web/src/components/cards/llmd/index.ts
@@ -12,6 +12,8 @@
 export { LLMdFlow } from './LLMdFlow'
 export { KVCacheMonitor } from './KVCacheMonitor'
 export { EPPRouting } from './EPPRouting'
+export { EPPHealthCard } from './EPPHealthCard'
+export { ModelEndpointHealthCard } from './ModelEndpointHealthCard'
 export { PDDisaggregation } from './PDDisaggregation'
 export { LLMdAIInsights } from './LLMdAIInsights'
 export { LLMdConfigurator } from './LLMdConfigurator'

--- a/web/src/config/dashboards/ai-ml.ts
+++ b/web/src/config/dashboards/ai-ml.ts
@@ -23,6 +23,8 @@ export const aiMlDashboardConfig: UnifiedDashboardConfig = {
 
     // Configuration and existing cards
     { id: 'llmd-configurator-1', cardType: 'llmd_configurator', title: 'Configurator', position: { w: 4, h: 4 } },
+    { id: 'epp-health-1', cardType: 'epp_health', title: 'EPP Health', position: { w: 4, h: 3 } },
+    { id: 'model-endpoint-health-1', cardType: 'model_endpoint_health', title: 'Model Endpoint Health', position: { w: 4, h: 3 } },
     { id: 'llm-models-1', cardType: 'llm_models', position: { w: 4, h: 3 } },
     { id: 'llm-inference-1', cardType: 'llm_inference', position: { w: 4, h: 3 } },
     { id: 'llmd-stack-monitor-1', cardType: 'llmd_stack_monitor', position: { w: 4, h: 3 } },

--- a/web/src/hooks/useCachedModelEndpointHealth.test.ts
+++ b/web/src/hooks/useCachedModelEndpointHealth.test.ts
@@ -1,0 +1,154 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LLMdServer } from './useLLMd'
+
+const { mockFetchLLMdServers, mockUseCache } = vi.hoisted(() => ({
+  mockFetchLLMdServers: vi.fn(),
+  mockUseCache: vi.fn(),
+}))
+
+vi.mock('./useCachedLLMd', () => ({
+  fetchLLMdServers: mockFetchLLMdServers,
+}))
+
+vi.mock('../lib/cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/cache')>()
+  return {
+    ...actual,
+    useCache: (options: unknown) => mockUseCache(options),
+    createCachedHook: (config: Record<string, unknown>) => {
+      return () => {
+        const result = mockUseCache(config)
+        return {
+          data: result.data,
+          isLoading: result.isLoading,
+          isRefreshing: result.isRefreshing,
+          isDemoFallback: result.isDemoFallback && !result.isLoading,
+          error: result.error,
+          isFailed: result.isFailed,
+          consecutiveFailures: result.consecutiveFailures,
+          lastRefresh: result.lastRefresh,
+          refetch: result.refetch,
+          retryFetch: result.retryFetch,
+        }
+      }
+    },
+  }
+})
+
+import {
+  fetchModelEndpointHealth,
+  getDemoModelEndpointHealth,
+  summarizeModelEndpointHealth,
+  useCachedModelEndpointHealth,
+} from './useCachedModelEndpointHealth'
+
+const runningEndpoint: LLMdServer = {
+  id: 'cluster-a-llm-d-llama-model',
+  name: 'llama-model',
+  namespace: 'llm-d',
+  cluster: 'cluster-a',
+  model: 'llama',
+  type: 'vllm',
+  componentType: 'model',
+  status: 'running',
+  replicas: 2,
+  readyReplicas: 2,
+}
+
+const scalingEndpoint: LLMdServer = {
+  ...runningEndpoint,
+  id: 'cluster-a-llm-d-granite-model',
+  name: 'granite-model',
+  model: 'granite',
+  status: 'scaling',
+  replicas: 2,
+  readyReplicas: 1,
+}
+
+const eppServer: LLMdServer = {
+  ...runningEndpoint,
+  id: 'cluster-a-llm-d-llama-epp',
+  name: 'llama-epp',
+  componentType: 'epp',
+}
+
+const BASE_STATUS = {
+  data: getDemoModelEndpointHealth(),
+  isLoading: false,
+  isRefreshing: false,
+  isDemoFallback: false,
+  error: null,
+  isFailed: false,
+  consecutiveFailures: 0,
+  lastRefresh: 111111111,
+  refetch: vi.fn(),
+  retryFetch: vi.fn(),
+}
+
+describe('useCachedModelEndpointHealth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCache.mockReturnValue(BASE_STATUS)
+  })
+
+  it('summarizes healthy model endpoints', () => {
+    expect(summarizeModelEndpointHealth([runningEndpoint])).toEqual({
+      health: 'healthy',
+      totalEndpoints: 1,
+      readyEndpoints: 1,
+      degradedEndpoints: 0,
+      unavailableEndpoints: 0,
+      totalReadyReplicas: 2,
+      totalReplicas: 2,
+    })
+  })
+
+  it('marks partial replica readiness as degraded', () => {
+    expect(summarizeModelEndpointHealth([runningEndpoint, scalingEndpoint])).toMatchObject({
+      health: 'degraded',
+      totalEndpoints: 2,
+      readyEndpoints: 1,
+      degradedEndpoints: 1,
+      totalReadyReplicas: 3,
+      totalReplicas: 4,
+    })
+  })
+
+  it('marks an empty endpoint list as unavailable', () => {
+    expect(summarizeModelEndpointHealth([])).toMatchObject({
+      health: 'unavailable',
+      totalEndpoints: 0,
+      totalReadyReplicas: 0,
+      totalReplicas: 0,
+    })
+  })
+
+  it('filters model components from llm-d servers', async () => {
+    mockFetchLLMdServers.mockResolvedValue([runningEndpoint, eppServer])
+
+    const status = await fetchModelEndpointHealth(['cluster-a'])
+
+    expect(mockFetchLLMdServers).toHaveBeenCalledWith(['cluster-a'])
+    expect(status.endpoints).toEqual([runningEndpoint])
+    expect(status.summary).toMatchObject({
+      health: 'healthy',
+      totalEndpoints: 1,
+    })
+  })
+
+  it('provides demo model endpoint data', () => {
+    const demo = getDemoModelEndpointHealth()
+
+    expect(demo.endpoints.every((endpoint) => endpoint.componentType === 'model')).toBe(true)
+    expect(demo.summary.totalEndpoints).toBe(demo.endpoints.length)
+  })
+
+  it('returns cached data with endpoint convenience fields', () => {
+    const { result } = renderHook(() => useCachedModelEndpointHealth())
+
+    expect(result.current.endpoints).toEqual(BASE_STATUS.data.endpoints)
+    expect(result.current.summary).toEqual(BASE_STATUS.data.summary)
+    expect(result.current.isDemoFallback).toBe(false)
+  })
+})

--- a/web/src/hooks/useCachedModelEndpointHealth.ts
+++ b/web/src/hooks/useCachedModelEndpointHealth.ts
@@ -1,0 +1,136 @@
+import { createCachedHook, type CachedHookResult, type RefreshCategory } from '../lib/cache'
+import { fetchLLMdServers } from './useCachedLLMd'
+import type { LLMdServer } from './useLLMd'
+
+export type ModelEndpointHealth = 'healthy' | 'degraded' | 'unavailable'
+
+export interface ModelEndpointSummary {
+  health: ModelEndpointHealth
+  totalEndpoints: number
+  readyEndpoints: number
+  degradedEndpoints: number
+  unavailableEndpoints: number
+  totalReadyReplicas: number
+  totalReplicas: number
+}
+
+export interface ModelEndpointHealthData {
+  endpoints: LLMdServer[]
+  summary: ModelEndpointSummary
+  lastCheckTime: string
+}
+
+const DEFAULT_LLMD_CLUSTERS = ['vllm-d', 'platform-eval'] as const
+
+const EMPTY_MODEL_ENDPOINT_HEALTH: ModelEndpointHealthData = {
+  endpoints: [],
+  summary: {
+    health: 'unavailable',
+    totalEndpoints: 0,
+    readyEndpoints: 0,
+    degradedEndpoints: 0,
+    unavailableEndpoints: 0,
+    totalReadyReplicas: 0,
+    totalReplicas: 0,
+  },
+  lastCheckTime: '',
+}
+
+export function summarizeModelEndpointHealth(endpoints: LLMdServer[]): ModelEndpointSummary {
+  const readyEndpoints = endpoints.filter((endpoint) => endpoint.status === 'running').length
+  const degradedEndpoints = endpoints.filter((endpoint) => endpoint.status === 'scaling').length
+  const unavailableEndpoints = endpoints.filter((endpoint) => endpoint.status === 'stopped' || endpoint.status === 'error').length
+  const totalReadyReplicas = endpoints.reduce((sum, endpoint) => sum + (endpoint.readyReplicas ?? 0), 0)
+  const totalReplicas = endpoints.reduce((sum, endpoint) => sum + (endpoint.replicas ?? 0), 0)
+
+  let health: ModelEndpointHealth = 'healthy'
+  if (endpoints.length === 0 || totalReplicas === 0) {
+    health = 'unavailable'
+  } else if (degradedEndpoints > 0 || unavailableEndpoints > 0 || totalReadyReplicas < totalReplicas) {
+    health = 'degraded'
+  }
+
+  return {
+    health,
+    totalEndpoints: endpoints.length,
+    readyEndpoints,
+    degradedEndpoints,
+    unavailableEndpoints,
+    totalReadyReplicas,
+    totalReplicas,
+  }
+}
+
+export const getDemoModelEndpointHealth = (): ModelEndpointHealthData => {
+  const endpoints: LLMdServer[] = [
+    {
+      id: 'vllm-d-llm-d-llama-model',
+      name: 'vllm-llama-3',
+      namespace: 'llm-d',
+      cluster: 'vllm-d',
+      model: 'llama-3-70b',
+      type: 'vllm',
+      componentType: 'model',
+      status: 'running',
+      replicas: 2,
+      readyReplicas: 2,
+      gpu: 'NVIDIA',
+      gpuCount: 4,
+    },
+    {
+      id: 'platform-eval-llm-d-granite-model',
+      name: 'tgi-granite',
+      namespace: 'llm-d',
+      cluster: 'platform-eval',
+      model: 'granite-13b',
+      type: 'tgi',
+      componentType: 'model',
+      status: 'scaling',
+      replicas: 2,
+      readyReplicas: 1,
+      gpu: 'NVIDIA',
+      gpuCount: 2,
+    },
+  ]
+
+  return {
+    endpoints,
+    summary: summarizeModelEndpointHealth(endpoints),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+export async function fetchModelEndpointHealth(
+  clusters: string[] = [...DEFAULT_LLMD_CLUSTERS]
+): Promise<ModelEndpointHealthData> {
+  const servers = await fetchLLMdServers(clusters)
+  const endpoints = servers.filter((server) => server.componentType === 'model')
+
+  return {
+    endpoints,
+    summary: summarizeModelEndpointHealth(endpoints),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+export function useCachedModelEndpointHealth(
+  clusters: string[] = [...DEFAULT_LLMD_CLUSTERS]
+): CachedHookResult<ModelEndpointHealthData> & { endpoints: LLMdServer[]; summary: ModelEndpointSummary } {
+  const key = `llmd-model-endpoint-health:${clusters.join(',')}`
+
+  const useModelEndpointHealthBase = createCachedHook<ModelEndpointHealthData>({
+    key,
+    category: 'gitops' as RefreshCategory,
+    initialData: EMPTY_MODEL_ENDPOINT_HEALTH,
+    getDemoData: getDemoModelEndpointHealth,
+    fetcher: () => fetchModelEndpointHealth(clusters),
+  })
+  const result = useModelEndpointHealthBase()
+
+  return {
+    ...result,
+    endpoints: result.data.endpoints,
+    summary: result.data.summary,
+    isDemoFallback: result.isDemoFallback && !result.isLoading,
+  }
+}


### PR DESCRIPTION
Refs #18031

---

## Summary of Changes
- Wires the merged EPP health card into the AI/ML card registry and dashboard configuration.
- Adds a cached model endpoint health hook that reuses existing llm-d server discovery and filters model serving components.
- Adds a model endpoint health card showing overall health, ready/degraded counts, replica readiness, endpoint rows, demo labeling, and refresh support.

---

## Changes Made
- [x] Registered `epp_health` and `model_endpoint_health` card types.
- [x] Added both cards to the AI/ML dashboard.
- [x] Exported `EPPHealthCard` and `ModelEndpointHealthCard` from the llm-d card bundle.
- [x] Added `useCachedModelEndpointHealth` with demo data and typed summary fields.
- [x] Added focused hook/card tests plus registry validation.

---

## Validation
- [x] `npm test -- run src/hooks/useCachedModelEndpointHealth.test.ts src/components/cards/llmd/__tests__/ModelEndpointHealthCard.test.tsx src/hooks/useCachedEPPStatus.test.ts src/components/cards/llmd/__tests__/EPPHealthCard.test.tsx`
- [x] `npm test -- run src/components/cards/__tests__/cardRegistry.test.ts src/test/card-factory-validation.test.ts src/lib/cards/__tests__/cardInstallMap.test.ts`
- [x] `npx eslint src/hooks/useCachedModelEndpointHealth.ts src/hooks/useCachedModelEndpointHealth.test.ts src/components/cards/llmd/ModelEndpointHealthCard.tsx src/components/cards/llmd/__tests__/ModelEndpointHealthCard.test.tsx src/components/cards/cardRegistry.aiml.ts src/components/cards/cardRegistry.ai.ts src/components/cards/cardMetadata.ts src/components/cards/cardIcons.ts src/config/dashboards/ai-ml.ts src/components/cards/llmd/index.ts`
- [x] `npm run build`

---

## Follow-up
- Autoscaler dashboard/metrics remains a separate slice of #18031.

---

## Checklist
- [x] I have reviewed the project's contribution guidelines
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)
