### PR TITLE
[scanner] fix: scope implement-fix.lock.yml permissions to minimum required

### DIFF
--- a/.github/workflows/implement-fix.lock.yml
+++ b/.github/workflows/implement-fix.lock.yml
@@ -63,10 +63,7 @@ on:
         description: Issue number to work on
         required: true
 
-permissions:
-  issues: write
-  pull-requests: write
-  contents: write
+permissions: {}
 
 concurrency:
   group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}"


### PR DESCRIPTION
Fixes #19926

Removes overly broad top-level permissions from implement-fix.lock.yml:
- Removed `issues: write`
- Removed `pull-requests: write` 
- Removed `contents: write`

These permissions were inherited only by the pre_activation job, which doesn't need write access—it only checks team membership. All other jobs that require specific permissions have their own explicit scoped permissions defined.

This follows the principle of least privilege established in other workflows like claude.yml.