### PR TITLE
[scanner] fix: add useCachedKagentStatus hook and kagent agent list/status card

### DIFF
--- a/web/src/components/cards/KagentAgentListCard.tsx
+++ b/web/src/components/cards/KagentAgentListCard.tsx
@@ -1,0 +1,240 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Bot, AlertTriangle, CheckCircle2, Clock, XCircle } from 'lucide-react'
+import { useCachedKagentStatus, HEALTH_THRESHOLD_HEALTHY, HEALTH_THRESHOLD_WARNING } from '../../hooks/useCachedKagentStatus'
+import { useCardLoadingState } from './CardDataContext'
+import { Skeleton } from '../ui/Skeleton'
+
+interface KagentAgentListCardProps {
+  config?: {
+    cluster?: string
+  }
+}
+
+const FAILURE_THRESHOLD = 3
+const SKELETON_AGENT_COUNT = 4
+
+// Status icon component
+function StatusIcon({ status }: { status: string }) {
+  if (status === 'Ready') {
+    return <CheckCircle2 className="w-3.5 h-3.5 text-green-400" />
+  }
+  if (status === 'Pending' || status === 'Accepted') {
+    return <Clock className="w-3.5 h-3.5 text-yellow-400" />
+  }
+  if (status === 'Failed') {
+    return <XCircle className="w-3.5 h-3.5 text-red-400" />
+  }
+  return <Bot className="w-3.5 h-3.5 text-muted-foreground" />
+}
+
+// Health badge component
+function HealthBadge({ percentage }: { percentage: number }) {
+  const color =
+    percentage >= HEALTH_THRESHOLD_HEALTHY
+      ? 'bg-green-500/15 text-green-400 border-green-500/20'
+      : percentage >= HEALTH_THRESHOLD_WARNING
+        ? 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20'
+        : 'bg-red-500/15 text-red-400 border-red-500/20'
+
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded border ${color}`}>
+      {percentage}% healthy
+    </span>
+  )
+}
+
+// Metric tile component
+function MetricTile({
+  icon: Icon,
+  label,
+  value,
+  accent,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  value: number
+  accent: string
+}) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-muted/30 border border-border/50">
+      <div className={`p-1.5 rounded-md ${accent}`}>
+        <Icon className="w-3.5 h-3.5" />
+      </div>
+      <div className="min-w-0">
+        <div className="text-lg font-semibold leading-tight">{value}</div>
+        <div className="text-xs text-muted-foreground truncate">{label}</div>
+      </div>
+    </div>
+  )
+}
+
+export function KagentAgentListCard({ config }: KagentAgentListCardProps) {
+  const { t } = useTranslation('cards')
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoFallback,
+    consecutiveFailures,
+  } = useCachedKagentStatus()
+
+  const hasAnyData = data.totalAgents > 0
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    hasAnyData,
+    isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
+    consecutiveFailures,
+    isDemoData: isDemoFallback,
+  })
+
+  // Filter clusters if config specifies one
+  const filteredClusters = useMemo(() => {
+    if (config?.cluster) {
+      return data.clusters.filter(c => c.cluster === config.cluster)
+    }
+    return data.clusters
+  }, [data.clusters, config?.cluster])
+
+  // Compute aggregated stats
+  const stats = useMemo(() => {
+    const totalAgents = filteredClusters.reduce((sum, c) => sum + c.totalAgents, 0)
+    const readyAgents = filteredClusters.reduce((sum, c) => sum + c.readyAgents, 0)
+    const pendingAgents = filteredClusters.reduce((sum, c) => sum + c.pendingAgents, 0)
+    const failedAgents = filteredClusters.reduce((sum, c) => sum + c.failedAgents, 0)
+    const health = totalAgents > 0 ? Math.round((readyAgents / totalAgents) * 100) : 0
+
+    return { totalAgents, readyAgents, pendingAgents, failedAgents, health }
+  }, [filteredClusters])
+
+  if (showSkeleton) {
+    return (
+      <div className="space-y-3 p-1">
+        <div className="grid grid-cols-3 gap-2">
+          {Array.from({ length: 3 }, (_, index) => (
+            <Skeleton key={index} className="h-16 rounded-lg" />
+          ))}
+        </div>
+        <Skeleton className="h-24 rounded-lg" />
+        <div className="space-y-1">
+          {Array.from({ length: SKELETON_AGENT_COUNT }, (_, index) => (
+            <Skeleton key={index} className="h-12 rounded-lg" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <Bot className="w-10 h-10 text-muted-foreground/30 mb-3" />
+        <div className="text-sm font-medium text-muted-foreground">{t('kagent.noAgents')}</div>
+        <div className="text-xs text-muted-foreground mt-1 max-w-[200px]">
+          {t('kagent.noAgentsDescription')}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3 p-1">
+      {/* Summary metrics */}
+      <div className="grid grid-cols-3 gap-2">
+        <MetricTile
+          icon={Bot}
+          label={t('kagent.totalAgents') || 'Total Agents'}
+          value={stats.totalAgents}
+          accent="bg-blue-500/20 text-blue-400"
+        />
+        <MetricTile
+          icon={CheckCircle2}
+          label={t('kagent.ready') || 'Ready'}
+          value={stats.readyAgents}
+          accent="bg-green-500/20 text-green-400"
+        />
+        <MetricTile
+          icon={AlertTriangle}
+          label={t('kagent.issues') || 'Issues'}
+          value={stats.pendingAgents + stats.failedAgents}
+          accent="bg-yellow-500/20 text-yellow-400"
+        />
+      </div>
+
+      {/* Overall health */}
+      <div className="px-1 flex items-center justify-between">
+        <div className="text-xs uppercase tracking-wider text-muted-foreground">
+          {t('kagent.overallHealth') || 'Overall Health'}
+        </div>
+        <HealthBadge percentage={stats.health} />
+      </div>
+
+      {/* Cluster breakdown */}
+      <div className="px-1">
+        <div className="text-xs uppercase tracking-wider text-muted-foreground mb-1.5">
+          {t('kagent.agentsByCluster') || 'Agents by Cluster'}
+        </div>
+        <div className="space-y-1">
+          {filteredClusters.map(cluster => (
+            <div
+              key={cluster.cluster}
+              className="px-2 py-1.5 rounded-lg bg-muted/20 border border-border/40"
+            >
+              <div className="flex items-center justify-between mb-1">
+                <div className="text-sm font-medium text-foreground">{cluster.cluster}</div>
+                <HealthBadge percentage={cluster.healthPercentage} />
+              </div>
+              <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                <span className="flex items-center gap-1">
+                  <CheckCircle2 className="w-3 h-3 text-green-400" />
+                  {cluster.readyAgents} ready
+                </span>
+                {cluster.pendingAgents > 0 && (
+                  <span className="flex items-center gap-1">
+                    <Clock className="w-3 h-3 text-yellow-400" />
+                    {cluster.pendingAgents} pending
+                  </span>
+                )}
+                {cluster.failedAgents > 0 && (
+                  <span className="flex items-center gap-1">
+                    <XCircle className="w-3 h-3 text-red-400" />
+                    {cluster.failedAgents} failed
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Agent list */}
+      <div className="px-1">
+        <div className="text-xs uppercase tracking-wider text-muted-foreground mb-1.5">
+          {t('kagent.recentAgents') || 'Recent Agents'}
+        </div>
+        <div className="space-y-1">
+          {filteredClusters.flatMap(cluster =>
+            cluster.agents.slice(0, 3).map(agent => (
+              <div
+                key={`${agent.cluster}-${agent.namespace}-${agent.name}`}
+                className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-secondary/50 transition-colors"
+              >
+                <StatusIcon status={agent.status} />
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium truncate">{agent.name}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {agent.cluster} / {agent.namespace}
+                  </div>
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {agent.readyReplicas}/{agent.replicas}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -182,6 +182,7 @@ export const CARD_TITLES: Record<string, string> = {
   // Kagent CRD Dashboard
   kagent_status: 'Kagent Status',
   kagent_agent_fleet: 'Kagent Agent Fleet',
+  kagent_agent_list: 'Kagent Agent List',
   kagent_tool_registry: 'Kagent Tool Registry',
   kagent_model_providers: 'Kagent Model Providers',
   kagent_agent_discovery: 'Kagent Agent Discovery',
@@ -533,6 +534,7 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   // Kagent CRD Dashboard
   kagent_status: 'Overview of kagent agents, tools, and models.',
   kagent_agent_fleet: 'All kagent agents across clusters.',
+  kagent_agent_list: 'Agent status monitoring with health metrics.',
   kagent_tool_registry: 'ToolServer and RemoteMCPServer resources.',
   kagent_model_providers: 'ModelConfig and ModelProviderConfig resources.',
   kagent_agent_discovery: 'Agent A2A config, tools, and skills.',

--- a/web/src/components/cards/cardRegistry.aiml.ts
+++ b/web/src/components/cards/cardRegistry.aiml.ts
@@ -17,6 +17,7 @@ const KVCacheMonitor = safeLazy(() => _llmdBundle, 'KVCacheMonitor')
 const _kagentBundle = import('./kagent').catch(() => undefined as never)
 const KagentAgentDiscovery = safeLazy(() => _kagentBundle, 'KagentAgentDiscovery')
 const KagentAgentFleet = safeLazy(() => _kagentBundle, 'KagentAgentFleet')
+const KagentAgentListCard = safeLazy(() => import('./KagentAgentListCard'), 'KagentAgentListCard')
 const KagentModelProviders = safeLazy(() => _kagentBundle, 'KagentModelProviders')
 const KagentSecurity = safeLazy(() => _kagentBundle, 'KagentSecurity')
 const KagentStatusCard = safeLazy(() => import('./KagentStatusCard'), 'KagentStatusCard')
@@ -59,7 +60,7 @@ const ThroughputComparison = safeLazy(() => _llmdBundle, 'ThroughputComparison')
  * Cards:
  * acmm_feedback_loops, acmm_level, acmm_recommendations, benchmark_hero, console_ai_health_check,
  * console_ai_issues, console_ai_kubeconfig_audit, console_ai_offline_detection, epp_health,
- * epp_routing, hardware_leaderboard, kagent_agent_discovery, kagent_agent_fleet,
+ * epp_routing, hardware_leaderboard, kagent_agent_discovery, kagent_agent_fleet, kagent_agent_list,
  * kagent_model_providers, kagent_security, kagent_status, kagent_tool_registry, kagent_topology,
  * kagenti_agent_discovery, kagenti_agent_fleet, kagenti_build_pipeline, kagenti_security,
  * kagenti_security_posture, kagenti_status, kagenti_tool_registry, kagenti_topology, kvcache_monitor,
@@ -91,6 +92,7 @@ const components: Record<string, CardComponent> = {
   hardware_leaderboard: HardwareLeaderboard,
   kagent_agent_discovery: KagentAgentDiscovery,
   kagent_agent_fleet: KagentAgentFleet,
+  kagent_agent_list: KagentAgentListCard,
   kagent_model_providers: KagentModelProviders,
   kagent_security: KagentSecurity,
   kagent_status: KagentStatusCard,
@@ -133,6 +135,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     'epp_health',
     'kagent_agent_discovery',
     'kagent_agent_fleet',
+    'kagent_agent_list',
     'kagent_model_providers',
     'kagent_security',
     'kagent_status',
@@ -154,6 +157,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     'epp_health',
     'kagent_agent_discovery',
     'kagent_agent_fleet',
+    'kagent_agent_list',
     'kagent_model_providers',
     'kagent_security',
     'kagent_status',
@@ -186,6 +190,7 @@ export const aimlCardRegistry: CardRegistryDomain = {
     hardware_leaderboard: () => import('./llmd'),
     kagent_agent_discovery: () => import('./kagent'),
     kagent_agent_fleet: () => import('./kagent'),
+    kagent_agent_list: () => import('./KagentAgentListCard'),
     kagent_model_providers: () => import('./kagent'),
     kagent_security: () => import('./kagent'),
     kagent_status: () => import('./KagentStatusCard'),

--- a/web/src/hooks/useCachedKagentStatus.ts
+++ b/web/src/hooks/useCachedKagentStatus.ts
@@ -1,0 +1,277 @@
+/**
+ * useCachedKagentStatus — Hook for kagent monitoring status.
+ *
+ * Uses the createCachedHook factory for zero-boilerplate caching.
+ * Returns CachedHookResult<KagentStatusData> with agent status and metrics.
+ *
+ * Data source: GET /api/kagent/status — returns cluster-level kagent
+ * agent status, readiness, and activity metrics.
+ */
+
+import { createCachedHook } from '../lib/cache'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY_KAGENT_STATUS = 'kagent_status'
+
+/** Thresholds for health status classification */
+export const HEALTH_THRESHOLD_HEALTHY = 90
+export const HEALTH_THRESHOLD_WARNING = 70
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface KagentAgentStatus {
+  name: string
+  namespace: string
+  cluster: string
+  status: 'Ready' | 'Pending' | 'Failed' | 'Accepted'
+  agentType: 'Declarative' | 'BYO'
+  runtime: string
+  replicas: number
+  readyReplicas: number
+  modelConfigRef: string
+  toolCount: number
+  a2aEnabled: boolean
+  lastHeartbeat?: string
+  uptime?: string
+}
+
+export interface ClusterKagentStatus {
+  cluster: string
+  totalAgents: number
+  readyAgents: number
+  pendingAgents: number
+  failedAgents: number
+  healthPercentage: number
+  agents: KagentAgentStatus[]
+}
+
+export interface KagentStatusData {
+  clusters: ClusterKagentStatus[]
+  totalAgents: number
+  totalReady: number
+  overallHealth: number
+}
+
+// ---------------------------------------------------------------------------
+// Demo data
+// ---------------------------------------------------------------------------
+
+const DEMO_DATA: KagentStatusData = {
+  clusters: [
+    {
+      cluster: 'prod-east',
+      totalAgents: 4,
+      readyAgents: 3,
+      pendingAgents: 0,
+      failedAgents: 1,
+      healthPercentage: 75,
+      agents: [
+        {
+          name: 'k8s-assistant',
+          namespace: 'kagent-system',
+          cluster: 'prod-east',
+          status: 'Ready',
+          agentType: 'Declarative',
+          runtime: 'python',
+          replicas: 2,
+          readyReplicas: 2,
+          modelConfigRef: 'claude-sonnet',
+          toolCount: 4,
+          a2aEnabled: true,
+          lastHeartbeat: '2025-03-24T15:30:00Z',
+          uptime: '68d 5h 30m',
+        },
+        {
+          name: 'code-reviewer',
+          namespace: 'kagent-system',
+          cluster: 'prod-east',
+          status: 'Ready',
+          agentType: 'Declarative',
+          runtime: 'python',
+          replicas: 1,
+          readyReplicas: 1,
+          modelConfigRef: 'gpt-4o',
+          toolCount: 2,
+          a2aEnabled: true,
+          lastHeartbeat: '2025-03-24T15:29:00Z',
+          uptime: '63d 7h 30m',
+        },
+        {
+          name: 'log-parser',
+          namespace: 'kagent-ops',
+          cluster: 'prod-east',
+          status: 'Ready',
+          agentType: 'BYO',
+          runtime: 'go',
+          replicas: 1,
+          readyReplicas: 1,
+          modelConfigRef: 'ollama-llama',
+          toolCount: 1,
+          a2aEnabled: false,
+          lastHeartbeat: '2025-03-24T15:28:00Z',
+          uptime: '71d 2h 30m',
+        },
+        {
+          name: 'security-scanner',
+          namespace: 'kagent-system',
+          cluster: 'prod-east',
+          status: 'Failed',
+          agentType: 'Declarative',
+          runtime: 'python',
+          replicas: 2,
+          readyReplicas: 0,
+          modelConfigRef: 'claude-sonnet',
+          toolCount: 6,
+          a2aEnabled: true,
+          lastHeartbeat: '2025-03-24T14:00:00Z',
+          uptime: '0d 0h 0m',
+        },
+      ],
+    },
+    {
+      cluster: 'prod-west',
+      totalAgents: 3,
+      readyAgents: 3,
+      pendingAgents: 0,
+      failedAgents: 0,
+      healthPercentage: 100,
+      agents: [
+        {
+          name: 'incident-bot',
+          namespace: 'kagent-system',
+          cluster: 'prod-west',
+          status: 'Ready',
+          agentType: 'Declarative',
+          runtime: 'go',
+          replicas: 3,
+          readyReplicas: 3,
+          modelConfigRef: 'claude-sonnet',
+          toolCount: 5,
+          a2aEnabled: false,
+          lastHeartbeat: '2025-03-24T15:30:00Z',
+          uptime: '73d 1h 30m',
+        },
+        {
+          name: 'helm-deployer',
+          namespace: 'kagent-system',
+          cluster: 'prod-west',
+          status: 'Accepted',
+          agentType: 'BYO',
+          runtime: '',
+          replicas: 1,
+          readyReplicas: 1,
+          modelConfigRef: 'gemini-pro',
+          toolCount: 3,
+          a2aEnabled: true,
+          lastHeartbeat: '2025-03-24T15:29:00Z',
+          uptime: '61d 9h 30m',
+        },
+        {
+          name: 'drift-detector',
+          namespace: 'kagent-ops',
+          cluster: 'prod-west',
+          status: 'Ready',
+          agentType: 'Declarative',
+          runtime: 'python',
+          replicas: 1,
+          readyReplicas: 1,
+          modelConfigRef: 'claude-sonnet',
+          toolCount: 3,
+          a2aEnabled: true,
+          lastHeartbeat: '2025-03-24T15:30:00Z',
+          uptime: '69d 0h 30m',
+        },
+      ],
+    },
+    {
+      cluster: 'staging',
+      totalAgents: 2,
+      readyAgents: 1,
+      pendingAgents: 1,
+      failedAgents: 0,
+      healthPercentage: 50,
+      agents: [
+        {
+          name: 'security-scanner',
+          namespace: 'kagent-system',
+          cluster: 'staging',
+          status: 'Ready',
+          agentType: 'Declarative',
+          runtime: 'python',
+          replicas: 2,
+          readyReplicas: 2,
+          modelConfigRef: 'claude-sonnet',
+          toolCount: 6,
+          a2aEnabled: true,
+          lastHeartbeat: '2025-03-24T15:30:00Z',
+          uptime: '65d 4h 30m',
+        },
+        {
+          name: 'cost-analyzer',
+          namespace: 'kagent-ops',
+          cluster: 'staging',
+          status: 'Pending',
+          agentType: 'Declarative',
+          runtime: 'python',
+          replicas: 1,
+          readyReplicas: 0,
+          modelConfigRef: 'gpt-4o-mini',
+          toolCount: 2,
+          a2aEnabled: false,
+          lastHeartbeat: '2025-03-24T15:25:00Z',
+          uptime: '0d 0h 5m',
+        },
+      ],
+    },
+  ],
+  totalAgents: 9,
+  totalReady: 7,
+  overallHealth: 78,
+}
+
+/** Initial empty payload while the first fetch resolves. */
+const INITIAL_DATA: KagentStatusData = {
+  clusters: [],
+  totalAgents: 0,
+  totalReady: 0,
+  overallHealth: 0,
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchKagentStatus(): Promise<KagentStatusData> {
+  const resp = await fetch('/api/kagent/status', {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
+
+  if (!resp.ok) throw new Error(`kagent status HTTP ${resp.status}`)
+
+  const body: KagentStatusData = await resp.json()
+  return {
+    clusters: Array.isArray(body?.clusters) ? body.clusters : [],
+    totalAgents: body?.totalAgents || 0,
+    totalReady: body?.totalReady || 0,
+    overallHealth: body?.overallHealth || 0,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook (factory)
+// ---------------------------------------------------------------------------
+
+export const useCachedKagentStatus = createCachedHook<KagentStatusData>({
+  key: CACHE_KEY_KAGENT_STATUS,
+  category: 'clusters',
+  initialData: INITIAL_DATA,
+  demoData: DEMO_DATA,
+  fetcher: fetchKagentStatus,
+})

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -1564,7 +1564,15 @@
     "providerCount_other": "{{count}} providers",
     "emptyTitle": "No Kagent CRDs Found",
     "emptyDescription": "Install kagent to deploy AI agents on your clusters",
-    "byo": "BYO"
+    "byo": "BYO",
+    "noAgents": "No Agents Found",
+    "noAgentsDescription": "No kagent agents are currently deployed in your clusters",
+    "totalAgents": "Total Agents",
+    "ready": "Ready",
+    "issues": "Issues",
+    "overallHealth": "Overall Health",
+    "agentsByCluster": "Agents by Cluster",
+    "recentAgents": "Recent Agents"
   },
   "prow": {
     "jobName": "Job Name",


### PR DESCRIPTION
Fixes #19912, Fixes #19914

This PR implements:

## 1. useCachedKagentStatus hook (#19912)
- New cached hook for kagent monitoring status
- Includes comprehensive demo data for agent status and health metrics
- Follows the `createCachedHook` pattern used throughout the codebase
- Provides cluster-level status aggregation with health percentages
- Returns agent details including status, replicas, runtime, and heartbeat info

## 2. KagentAgentListCard component (#19914)
- Dashboard card for displaying kagent agent list and status
- Shows overall health metrics with summary tiles
- Displays cluster breakdown with per-cluster health badges
- Lists recent agents with status indicators
- Includes loading states, empty states, and demo fallback

## Files Changed:
- `web/src/hooks/useCachedKagentStatus.ts` - New hook with demo data (277 lines)
- `web/src/components/cards/KagentAgentListCard.tsx` - New dashboard card (240 lines)
- `web/src/components/cards/cardRegistry.aiml.ts` - Register new card in AIML registry
- `web/src/components/cards/cardMetadata.ts` - Add card title and description

## Testing:
Both components include demo data for easy testing and will gracefully fall back to demo mode when the backend API is unavailable.