### PR TITLE
[scanner] fix: move ai-fix.yml permissions to job level

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,16 +12,17 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   ai-fix:
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}


### PR DESCRIPTION
Fixes #19944

Moves write permissions from workflow top-level to job level in ai-fix.yml to comply with least-privilege principle and resolve OpenSSF Scorecard Token-Permissions alert.