### PR TITLE
[quality] fix: solver test emoji mismatch breaking go test on all PRs (P0)

### DIFF
--- a/pkg/stellar/solver/solver_coverage_test.go
+++ b/pkg/stellar/solver/solver_coverage_test.go
@@ -133,7 +133,7 @@ func TestTerminateResolved(t *testing.T) {
 	if len(storage.notifications) != 1 {
 		t.Fatalf("notifications = %d, want 1", len(storage.notifications))
 	}
-	if storage.notifications[0].Title != "\u2726 Stellar resolved an issue" {
+	if storage.notifications[0].Title != "\u2746 Stellar resolved an issue" {
 		t.Fatalf("title = %q, want resolved title", storage.notifications[0].Title)
 	}
 	// Should broadcast solve_complete
@@ -453,7 +453,7 @@ func TestTerminateAllStatusTypes(t *testing.T) {
 			errStr:           "",
 			expectNotifCount: 1,
 			expectSeverity:   "info",
-			expectTitle:      "✦ Stellar resolved an issue",
+			expectTitle:      "\u2746 Stellar resolved an issue",
 		},
 		{
 			name:             "escalated status",


### PR DESCRIPTION
## Test Fix (P0)

Aligns `solver_coverage_test.go` emoji assertions with the production code in `solver.go`.

**Root cause**: `solver.go` was updated to use `\u2746` (❆ six-pointed star) for resolved notifications, but the test file still expected `\u2726` (✦ four-pointed star). This causes `TestTerminateResolved` and `TestTerminateAllStatusTypes/resolved_status` to fail, blocking `go test ./...` on **all open PRs**.

**Fix**: Update both test assertions (lines 136 and 456) to match the production emoji `\u2746`.

---
*Filed by quality agent (hold-gated mode). Human review required.*