### PR TITLE
[scanner] fix: correct resolved notification emoji (✦ not ❆)

### DIFF
--- a/pkg/stellar/solver/solver.go
+++ b/pkg/stellar/solver/solver.go
@@ -315,7 +315,7 @@ func terminate(
 	notifSeverity := "info"
 	switch status {
 	case "resolved":
-		notifTitle = "\u2746 Stellar resolved an issue"
+		notifTitle = "\u2726 Stellar resolved an issue"
 	case "escalated":
 		notifTitle = "\u26a0 Stellar escalated to you"
 		notifSeverity = "warning"


### PR DESCRIPTION
The `terminate` function in `solver.go` used `\u2746` (❆) for the resolved notification title, but the tests correctly expect `\u2726` (✦). This mismatch breaks `go test ./...` on main.

Fixes the following test failures:
- TestTerminateResolved
- TestTerminateAllStatusTypes/resolved_status