### PR TITLE
[scanner] fix: harden workflow permissions for greetings.yml and copilot-dco.yml

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions: read-all
+
 jobs:
   copilot-dco:
+    permissions:
+      statuses: write
+      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned 2026-06-29 from main

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,10 +6,7 @@ on:
   issues:
     types: [opened, reopened]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   greet:
@@ -17,5 +14,8 @@ jobs:
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned 2026-06-29 from main
     secrets: inherit


### PR DESCRIPTION
Fixes #19959
Fixes #19960

Hardens workflow permissions:
- greetings.yml: moves write permissions to job level, sets top-level `permissions: read-all`
- copilot-dco.yml: adds top-level `permissions: read-all` with job-level scoped write permissions