### PR TITLE
[scanner] fix: bump gh-aw from v0.80.9 to v0.81.6

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -15,9 +15,9 @@
       "version": "v9.0.0",
       "sha": "3a2844b7e9c422d3c10d287c895573f7108da1b3"
     },
-    "github/gh-aw-actions/setup@v0.80.9": {
+    "github/gh-aw-actions/setup@v0.81.6": {
       "repo": "github/gh-aw-actions/setup",
-      "version": "v0.80.9",
+      "version": "v0.81.6",
       "sha": "8c7d04ebf1ece56cd381446125da3e0f6896294a"
     },
     "github/gh-aw/actions/setup@v0.75.2": {


### PR DESCRIPTION
Fixes #19964

Bumps gh-aw from v0.80.9 to v0.81.6 as reported by the dependency monitoring workflow.