### PR TITLE
[scanner] fix: resolve Playwright Cross-Browser workflow failure

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@6f51ac03aab6b92d7509f6564e66e51f8d5de11d # v4.5.0
         with:
           name: nightly-build-output
           path: web/dist
@@ -74,7 +74,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: nightly-build-output
           path: web/dist
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@6f51ac03aab6b92d7509f6564e66e51f8d5de11d # v4.5.0
         with:
           name: nightly-${{ matrix.browser }}-report
           path: web/playwright-report/
@@ -147,7 +147,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: nightly-build-output
           path: web/dist
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@6f51ac03aab6b92d7509f6564e66e51f8d5de11d # v4.5.0
         with:
           name: nightly-${{ matrix.project }}-report
           path: web/playwright-report/


### PR DESCRIPTION
Fixes #19965

**Root Cause:** Version mismatch between `upload-artifact@v7` and `download-artifact@v8` — these versions use incompatible artifact storage backends in GitHub Actions.

**Solution:** Downgraded both actions to v4 (stable, compatible versions):
- `upload-artifact@v7.0.1` → `v4.5.0`
- `download-artifact@v8.0.1` → `v4.1.8`

**Files Changed:**
- `.github/workflows/playwright-nightly.yml` (5 action version updates)