### PR TITLE
[scanner] fix: resolve 174 test failures from useDemoMode mock regression

### DIFF
--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -75,6 +75,11 @@ if (isBrowserEnvironment) {
       toggleDemoMode: vi.fn(),
       setDemoMode: vi.fn(),
     }),
+    // Re-export all lib/demoMode functions (both current and legacy names)
+    isDemoMode: vi.fn(() => false),
+    setDemoMode: vi.fn(),
+    toggleDemoMode: vi.fn(),
+    subscribeDemoMode: vi.fn(() => () => {}),
     getDemoMode: vi.fn(() => false),
     setGlobalDemoMode: vi.fn(),
     isNetlifyDeployment: false,
@@ -83,6 +88,10 @@ if (isBrowserEnvironment) {
     isDemoToken: vi.fn(async () => false),
     hasRealToken: vi.fn(async () => true),
     setDemoToken: vi.fn(),
+    isQuantumWorkloadAvailable: vi.fn(() => false),
+    setQuantumWorkloadAvailable: vi.fn(),
+    isQuantumForcedToDemo: vi.fn(() => false),
+    activatePublicDemoMode: vi.fn(),
   }))
 
 


### PR DESCRIPTION
Fixes #19981

The previous fix (PR #19979, commit 3c38db5) attempted to resolve test failures from a global useDemoMode mock but introduced 174 new failures. 

## Root Cause
The global mock in `setup.ts` was missing key exports that tests import:
- `isQuantumWorkloadAvailable`
- `setQuantumWorkloadAvailable`
- `isQuantumForcedToDemo`
- `activatePublicDemoMode`
- `subscribeDemoMode`
- `isDemoMode`
- `toggleDemoMode`

## Solution
Added all missing exports to the useDemoMode mock in setup.ts, matching the complete API of lib/demoMode that useDemoMode re-exports.

## Testing
This fix ensures that all 174 failing tests can now properly import the functions they need from the mocked useDemoMode module.