### PR TITLE
feat: add llm-d Monitoring dashboard with EPP and endpoint health cards

### DIFF
--- a/web/src/config/cards/__tests__/epp-health.test.ts
+++ b/web/src/config/cards/__tests__/epp-health.test.ts
@@ -1,0 +1,4 @@
+import * as moduleExports from '../epp-health'
+import { registerCardConfigTest } from './card-config-test-helpers'
+
+registerCardConfigTest('epp-health', moduleExports)

--- a/web/src/config/cards/__tests__/epp-routing.test.ts
+++ b/web/src/config/cards/__tests__/epp-routing.test.ts
@@ -1,0 +1,4 @@
+import * as moduleExports from '../epp-routing'
+import { registerCardConfigTest } from './card-config-test-helpers'
+
+registerCardConfigTest('epp-routing', moduleExports)

--- a/web/src/config/cards/__tests__/kvcache-monitor.test.ts
+++ b/web/src/config/cards/__tests__/kvcache-monitor.test.ts
@@ -1,0 +1,4 @@
+import * as moduleExports from '../kvcache-monitor'
+import { registerCardConfigTest } from './card-config-test-helpers'
+
+registerCardConfigTest('kvcache-monitor', moduleExports)

--- a/web/src/config/cards/__tests__/model-endpoint-health.test.ts
+++ b/web/src/config/cards/__tests__/model-endpoint-health.test.ts
@@ -1,0 +1,4 @@
+import * as moduleExports from '../model-endpoint-health'
+import { registerCardConfigTest } from './card-config-test-helpers'
+
+registerCardConfigTest('model-endpoint-health', moduleExports)

--- a/web/src/config/cards/epp-health.ts
+++ b/web/src/config/cards/epp-health.ts
@@ -1,0 +1,20 @@
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const eppHealthConfig: UnifiedCardConfig = {
+  type: 'epp_health',
+  title: 'EPP Health',
+  category: 'ai-ml',
+  description: 'Endpoint Picker Policy health and replica status across clusters',
+  projects: ['kubestellar'],
+  icon: 'Activity',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useCachedEPPStatus' },
+  content: { type: 'custom', component: 'EPPHealthCard' },
+  emptyState: { icon: 'Activity', title: 'No EPPs', message: 'No Endpoint Picker Policies detected', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default eppHealthConfig

--- a/web/src/config/cards/epp-routing.ts
+++ b/web/src/config/cards/epp-routing.ts
@@ -1,0 +1,20 @@
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const eppRoutingConfig: UnifiedCardConfig = {
+  type: 'epp_routing',
+  title: 'EPP Routing',
+  category: 'ai-ml',
+  description: 'Endpoint Picker Policy routing configuration, metrics, and request distribution',
+  projects: ['kubestellar'],
+  icon: 'Network',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useEPPRoutingData' },
+  content: { type: 'custom', component: 'EPPRouting' },
+  emptyState: { icon: 'Network', title: 'No Routing', message: 'No EPP routing configuration detected', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default eppRoutingConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -125,9 +125,13 @@ import { kustomizationStatusConfig } from './kustomization-status'
 import { keycloakStatusConfig } from './keycloak-status'
 import { kyvernoPoliciesConfig } from './kyverno-policies'
 import { limitRangeStatusConfig } from './limit-range-status'
+import { eppHealthConfig } from './epp-health'
+import { eppRoutingConfig } from './epp-routing'
+import { kvcacheMonitorConfig } from './kvcache-monitor'
 import { llmInferenceConfig } from './llm-inference'
 import { llmModelsConfig } from './llm-models'
 import { llmdStackMonitorConfig } from './llmd-stack-monitor'
+import { modelEndpointHealthConfig } from './model-endpoint-health'
 import { matchGameConfig } from './match-game'
 import { mlJobsConfig } from './ml-jobs'
 import { mlNotebooksConfig } from './ml-notebooks'
@@ -265,6 +269,8 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   deployment_progress: deploymentProgressConfig,
   deployment_status: deploymentStatusConfig,
   dynamic_card: dynamicCardConfig,
+  epp_health: eppHealthConfig,
+  epp_routing: eppRoutingConfig,
   event_stream: eventStreamConfig,
   event_summary: eventSummaryConfig,
   events_timeline: eventsTimelineConfig,
@@ -336,6 +342,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   kubevirt_status: kubevirtStatusConfig,
   kustomization_status: kustomizationStatusConfig,
   keycloak_status: keycloakStatusConfig,
+  kvcache_monitor: kvcacheMonitorConfig,
   kyverno_policies: kyvernoPoliciesConfig,
   limit_range_status: limitRangeStatusConfig,
   llm_inference: llmInferenceConfig,
@@ -345,6 +352,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   ml_jobs: mlJobsConfig,
   ml_notebooks: mlNotebooksConfig,
   mobile_browser: mobileBrowserConfig,
+  model_endpoint_health: modelEndpointHealthConfig,
   namespace_events: namespaceEventsConfig,
   namespace_monitor: namespaceMonitorConfig,
   namespace_overview: namespaceOverviewConfig,
@@ -453,6 +461,9 @@ export const CARD_PROJECT_TAGS: Record<string, string[]> = {
   throughput_comparison: ['kubestellar'],
   performance_timeline: ['kubestellar'],
   resource_utilization: ['kubestellar'],
+  // LLM-d monitoring cards
+  epp_health: ['kubestellar'],
+  model_endpoint_health: ['kubestellar'],
   // LLM-d architecture cards (component-only)
   llmd_flow: ['kubestellar'],
   kvcache_monitor: ['kubestellar'],
@@ -570,6 +581,8 @@ export {
   deploymentStatusConfig,
   chaosMeshStatusConfig,
   dynamicCardConfig,
+  eppHealthConfig,
+  eppRoutingConfig,
   eventStreamConfig,
   eventSummaryConfig,
   eventsTimelineConfig,
@@ -618,6 +631,7 @@ export {
   kubeVelaStatusConfig,
   kubevirtStatusConfig,
   kustomizationStatusConfig,
+  kvcacheMonitorConfig,
   kyvernoPoliciesConfig,
   limitRangeStatusConfig,
   llmInferenceConfig,
@@ -627,6 +641,7 @@ export {
   mlJobsConfig,
   mlNotebooksConfig,
   mobileBrowserConfig,
+  modelEndpointHealthConfig,
   namespaceEventsConfig,
   namespaceMonitorConfig,
   namespaceOverviewConfig,

--- a/web/src/config/cards/kvcache-monitor.ts
+++ b/web/src/config/cards/kvcache-monitor.ts
@@ -1,0 +1,20 @@
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kvcacheMonitorConfig: UnifiedCardConfig = {
+  type: 'kvcache_monitor',
+  title: 'KV Cache Monitor',
+  category: 'ai-ml',
+  description: 'KV cache utilization and eviction metrics for LLM inference optimization',
+  projects: ['kubestellar'],
+  icon: 'Database',
+  iconColor: 'text-amber-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useKVCacheMonitor' },
+  content: { type: 'custom', component: 'KVCacheMonitor' },
+  emptyState: { icon: 'Database', title: 'No Cache Data', message: 'No KV cache metrics available', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default kvcacheMonitorConfig

--- a/web/src/config/cards/model-endpoint-health.ts
+++ b/web/src/config/cards/model-endpoint-health.ts
@@ -1,0 +1,20 @@
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const modelEndpointHealthConfig: UnifiedCardConfig = {
+  type: 'model_endpoint_health',
+  title: 'Model Endpoint Health',
+  category: 'ai-ml',
+  description: 'LLM model serving endpoint health, replica counts, and GPU allocation',
+  projects: ['kubestellar'],
+  icon: 'Cpu',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useCachedModelEndpointHealth' },
+  content: { type: 'custom', component: 'ModelEndpointHealthCard' },
+  emptyState: { icon: 'Cpu', title: 'No Endpoints', message: 'No model serving endpoints detected', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default modelEndpointHealthConfig

--- a/web/src/config/dashboards/__tests__/llmd-monitoring.test.ts
+++ b/web/src/config/dashboards/__tests__/llmd-monitoring.test.ts
@@ -1,0 +1,4 @@
+import * as moduleExports from '../llmd-monitoring'
+import { registerDashboardConfigTest } from './dashboard-config-test-helpers'
+
+registerDashboardConfigTest('llm-d-monitoring', moduleExports)

--- a/web/src/config/dashboards/index.ts
+++ b/web/src/config/dashboards/index.ts
@@ -51,6 +51,7 @@ import { arcadeDashboardConfig } from './arcade'
 import { deployDashboardConfig } from './deploy'
 import { aiAgentsDashboardConfig } from './ai-agents'
 import { llmdBenchmarksDashboardConfig } from './llmd-benchmarks'
+import { llmdMonitoringDashboardConfig } from './llmd-monitoring'
 import { clusterAdminDashboardConfig } from './cluster-admin'
 import { insightsDashboardConfig } from './insights'
 import { multiTenancyDashboardConfig } from './multi-tenancy'
@@ -114,6 +115,7 @@ export const DASHBOARD_CONFIGS: DashboardConfigRegistry = {
   deploy: deployDashboardConfig,
   'ai-agents': aiAgentsDashboardConfig,
   'llm-d-benchmarks': llmdBenchmarksDashboardConfig,
+  'llm-d-monitoring': llmdMonitoringDashboardConfig,
   'cluster-admin': clusterAdminDashboardConfig,
   insights: insightsDashboardConfig,
   'multi-tenancy': multiTenancyDashboardConfig,
@@ -248,6 +250,7 @@ export {
   deployDashboardConfig,
   aiAgentsDashboardConfig,
   llmdBenchmarksDashboardConfig,
+  llmdMonitoringDashboardConfig,
   clusterAdminDashboardConfig,
   insightsDashboardConfig,
   multiTenancyDashboardConfig,

--- a/web/src/config/dashboards/llmd-monitoring.ts
+++ b/web/src/config/dashboards/llmd-monitoring.ts
@@ -1,0 +1,30 @@
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+const AUTO_REFRESH_INTERVAL_MS = 30000
+
+export const llmdMonitoringDashboardConfig: UnifiedDashboardConfig = {
+  id: 'llm-d-monitoring',
+  name: 'llm-d Monitoring',
+  subtitle: 'EPP health, model endpoint status, and autoscaler overview',
+  route: '/llm-d-monitoring',
+  projects: ['kubestellar'],
+  statsType: 'ai-ml',
+  cards: [
+    { id: 'mon-epp-health-1', cardType: 'epp_health', title: 'EPP Health', position: { w: 6, h: 3 } },
+    { id: 'mon-endpoint-health-1', cardType: 'model_endpoint_health', title: 'Model Endpoint Health', position: { w: 6, h: 3 } },
+    { id: 'mon-stack-1', cardType: 'llmd_stack_monitor', title: 'llm-d Stack Overview', position: { w: 12, h: 4 } },
+    { id: 'mon-epp-routing-1', cardType: 'epp_routing', title: 'EPP Routing', position: { w: 6, h: 4 } },
+    { id: 'mon-kvcache-1', cardType: 'kvcache_monitor', title: 'KV Cache Monitor', position: { w: 6, h: 4 } },
+    { id: 'mon-flow-1', cardType: 'llmd_flow', title: 'Request Flow', position: { w: 6, h: 5 } },
+    { id: 'mon-ai-insights-1', cardType: 'llmd_ai_insights', title: 'AI Insights', position: { w: 6, h: 5 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: AUTO_REFRESH_INTERVAL_MS,
+  },
+  storageKey: 'llmd-monitoring-dashboard-cards',
+}
+
+export default llmdMonitoringDashboardConfig


### PR DESCRIPTION
## Summary

Fixes #18031

Adds a dedicated **llm-d Monitoring** dashboard (`/llm-d-monitoring`) that brings together all operational health views for the llm-d stack:

- **EPP Health** — Endpoint Picker Policy health and replica status across clusters
- **Model Endpoint Health** — LLM model serving endpoint health, replica counts, and GPU allocation
- **llm-d Stack Overview** — Full stack monitor (existing component, now surfaced in the monitoring dashboard)
- **EPP Routing** — Routing configuration, metrics, and request distribution
- **KV Cache Monitor** — Cache utilization and eviction metrics
- **Request Flow** — Visual request flow through the stack
- **AI Insights** — AI-powered operational insights

### New files
- `web/src/config/cards/epp-health.ts` — Card config for EPP health
- `web/src/config/cards/model-endpoint-health.ts` — Card config for model endpoint health
- `web/src/config/cards/epp-routing.ts` — Card config for EPP routing
- `web/src/config/cards/kvcache-monitor.ts` — Card config for KV cache monitor
- `web/src/config/dashboards/llmd-monitoring.ts` — Dashboard config
- Tests for all new configs

### Modified files
- `web/src/config/cards/index.ts` — Register new card configs and project tags
- `web/src/config/dashboards/index.ts` — Register new dashboard

## Test plan
- [ ] Card config tests pass for all 4 new card configs
- [ ] Dashboard config test passes for llmd-monitoring
- [ ] Dashboard renders at `/llm-d-monitoring` with all 7 cards
- [ ] Cards show demo data when no cluster is connected
- [ ] Auto-refresh works at 30s interval