### PR TITLE
[scanner] fix: expand coverage instrumentation to include all applications

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -344,13 +344,7 @@ export default defineConfig(({ mode }) => ({
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html'],
       include: [
-        'src/hooks/**',
-        'src/lib/**',
-        'src/contexts/**',
-        'src/components/charts/**',
-        'src/components/dashboard/customizer/**',
-        'src/components/dashboard/shared/cardCatalog.ts',
-        'src/components/dashboard/shared/CardPreview.tsx',
+        'src/**/*.{ts,tsx}',
       ],
       exclude: [
         'node_modules/',


### PR DESCRIPTION
Fixes #19984, Fixes #19993, Fixes #19991

Expands `coverage.include` in `web/vite.config.ts` from a narrow subset to `src/**/*.{ts,tsx}`, ensuring all application code is properly instrumented for coverage.

Root cause: tests importing pages/routes/services/components failed when those modules weren't included in coverage instrumentation. This resolves the 174 test failures reported in Coverage Suite run #4003 and the total shard collapse reported in #19991.