### PR TITLE
🐛 fix: revert coverage include to fix 175 test failures

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -344,7 +344,13 @@ export default defineConfig(({ mode }) => ({
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html'],
       include: [
-        'src/**/*.{ts,tsx}',
+        'src/hooks/**',
+        'src/lib/**',
+        'src/contexts/**',
+        'src/components/charts/**',
+        'src/components/dashboard/customizer/**',
+        'src/components/dashboard/shared/cardCatalog.ts',
+        'src/components/dashboard/shared/CardPreview.tsx',
       ],
       exclude: [
         'node_modules/',


### PR DESCRIPTION
Fixes #19996

PR #19995 broadened the coverage include from specific directories to `src/**/*.{ts,tsx}`, which caused 175 test failures due to v8 instrumentation affecting module loading and mocking in previously un-instrumented component tests.

This fix reverts the include pattern to the original specific directories:
- `src/hooks/**`
- `src/lib/**`
- `src/contexts/**`
- `src/components/charts/**`
- `src/components/dashboard/customizer/**`
- `src/components/dashboard/shared/cardCatalog.ts`
- `src/components/dashboard/shared/CardPreview.tsx`

This restores test stability while keeping all other coverage improvements from #19995.