### PR TITLE
[scanner] fix: update actions/upload-artifact in playwright-nightly

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@6f51ac03aab6b92d7509f6564e66e51f8d5de11d # v4.5.0
+        uses: actions/upload-artifact@v4
         with:
           name: nightly-build-output
           path: web/dist
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@6f51ac03aab6b92d7509f6564e66e51f8d5de11d # v4.5.0
+        uses: actions/upload-artifact@v4
         with:
           name: nightly-${{ matrix.browser }}-report
           path: web/playwright-report/
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@6f51ac03aab6b92d7509f6564e66e51f8d5de11d # v4.5.0
+        uses: actions/upload-artifact@v4
         with:
           name: nightly-${{ matrix.project }}-report
           path: web/playwright-report/


### PR DESCRIPTION
Fixes #20005

The workflow referenced `actions/upload-artifact@6f51ac03aab6b92d7509f6564e66e51f8d5de11d` which no longer resolves, causing immediate 'Set up job' failure. Updated to `actions/upload-artifact@v4`.