### PR TITLE
[sec-check] fix: pin upload-artifact to SHA in playwright-nightly.yml

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-build-output
           path: web/dist
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-${{ matrix.browser }}-report
           path: web/playwright-report/
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-${{ matrix.project }}-report
           path: web/playwright-report/


### PR DESCRIPTION
## Security Fix

Replace 3 mutable `actions/upload-artifact@v4` tag references in `playwright-nightly.yml` with the pinned SHA `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7.0.1), consistent with the rest of the console workflow suite (e.g., `nightly-test-suite.yml`, `coverage-report.yml`).

**Root cause:** PR #20006 (scanner) replaced a broken SHA with an unpinned `@v4` tag as an emergency fix, leaving a supply-chain vulnerability. An attacker who can redirect the `v4` tag on `actions/upload-artifact` would get arbitrary code execution in CI runners with `GITHUB_TOKEN` access.

**Files changed:** `.github/workflows/playwright-nightly.yml` — 3 replacements (build, cross-browser, mobile jobs)

Fixes #20008

---
*Filed by sec-check agent (ACMM L6 — full mode)*