### PR TITLE
fix: reduce nil-safety dedup to 2 days and reopen recurring nightly regressions

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -292,7 +292,11 @@ jobs:
           gh label create "triage/needed" --color "FBCA04" \
             --description "Needs triage" 2>/dev/null || true
 
-          # Create an issue for each failing suite (skip if one already exists)
+          # Create an issue for each failing suite (skip if one already exists
+          # or was closed within the dedup window)
+          DEDUP_WINDOW_DAYS=2
+          DEDUP_CUTOFF=$(date -u -d "${DEDUP_WINDOW_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+            || date -u -v-${DEDUP_WINDOW_DAYS}d +%Y-%m-%dT%H:%M:%SZ)
           FAILING_SUITES=$(jq -r '.results[] | select(.status == "fail") | .suite' "$RESULT_FILE" 2>/dev/null || true)
           for suite in $FAILING_SUITES; do
             ISSUE_TITLE="Nightly regression: ${suite}"
@@ -306,6 +310,19 @@ jobs:
             if [ -n "$EXISTING" ]; then
               echo "Issue #${EXISTING} already open for ${suite} — adding comment"
               gh issue comment "$EXISTING" --body "Still failing as of $(date -u +%Y-%m-%d). [Run](${RUN_URL})"
+              continue
+            fi
+
+            # Check for recently-closed issue (within dedup window) to avoid
+            # creating duplicate issues for the same recurring regression
+            RECENT_CLOSED=$(gh issue list --state closed \
+              --label "nightly-regression" \
+              --search "in:title \"${ISSUE_TITLE}\" closed:>${DEDUP_CUTOFF}" \
+              --json number --jq '.[0].number // empty')
+
+            if [ -n "$RECENT_CLOSED" ]; then
+              echo "Issue #${RECENT_CLOSED} closed within ${DEDUP_WINDOW_DAYS}d for ${suite} — reopening"
+              gh issue reopen "$RECENT_CLOSED" --comment "Regression recurred on $(date -u +%Y-%m-%d). [Run](${RUN_URL})"
               continue
             fi
 

--- a/.github/workflows/nil-safety.yml
+++ b/.github/workflows/nil-safety.yml
@@ -252,8 +252,10 @@ jobs:
               }),
             ]);
 
-            const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-            const recentlyClosed = closedIssues.filter(i => new Date(i.closed_at) > sevenDaysAgo);
+            const DEDUP_WINDOW_DAYS = 2;
+            const dedup_window_ms = DEDUP_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+            const dedupCutoff = new Date(Date.now() - dedup_window_ms);
+            const recentlyClosed = closedIssues.filter(i => new Date(i.closed_at) > dedupCutoff);
 
             // Normalize title for dedup: strip numbers
             const normalize = (t) => t.replace(/\[Auto-QA\]\s*/, '').replace(/\d+/g, 'N').toLowerCase().trim();


### PR DESCRIPTION
## Summary

- **nil-safety.yml**: Reduce dedup window from 7 days to 2 days. Previously, if a nil-safety issue was closed (fixed), the nightly wouldn't create a new issue for 7 days even if the problem recurred. Now it creates actionable issues within 2 days, letting scanner fix regressions faster.
- **nightly-test-suite.yml**: When a regression recurs within 2 days of being closed, reopen the existing issue instead of creating a duplicate. This prevents the daily churn of open→close→reopen cycles (e.g., `unit-test` had 5+ duplicate issues in the last week).

## Changes

- Replace magic `7 * 24 * 60 * 60 * 1000` with named `DEDUP_WINDOW_DAYS = 2` constant
- Add recently-closed issue check to nightly test suite issue creation
- Reopen recently-closed issues on recurrence instead of creating duplicates