### PR TITLE
[ci-maintainer] fix: remove duplicate test functions causing go vet failure on all platforms

### DIFF
--- a/pkg/k8s/events_test.go
+++ b/pkg/k8s/events_test.go
@@ -99,24 +99,3 @@ func TestSortEventsByLastSeenDesc(t *testing.T) {
 			events[3].Reason, events[4].Reason)
 	}
 }
-
-func TestSortEventsByLastSeenDesc_MixedTimezones(t *testing.T) {
-	// Lexicographic comparison would get this wrong: the -04:00 string sorts
-	// before "Z" but is actually the more recent instant.
-	events := []Event{
-		{Reason: "Z-formatted", LastSeen: "2024-06-01T12:00:00Z"},
-		{Reason: "Offset-formatted", LastSeen: "2024-06-01T09:00:00-04:00"}, // = 13:00 UTC
-	}
-
-	SortEventsByLastSeenDesc(events)
-
-	if events[0].Reason != "Offset-formatted" {
-		t.Errorf("time-typed sort must rank 13:00 UTC before 12:00 UTC; got %q first",
-			events[0].Reason)
-	}
-}
-
-func TestSortEventsByLastSeenDesc_EmptySlice(t *testing.T) {
-	var events []Event
-	SortEventsByLastSeenDesc(events) // must not panic
-}

--- a/pkg/k8s/rbac_k8s_test.go
+++ b/pkg/k8s/rbac_k8s_test.go
@@ -72,22 +72,7 @@ func TestParseOpenShiftUser_MissingOptionalFields(t *testing.T) {
 	}
 }
 
-func TestParseOpenShiftUser_InvalidTimestamp(t *testing.T) {
-	obj := unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"name":              "charlie",
-				"creationTimestamp": "not-a-timestamp",
-			},
-		},
-	}
-
-	got := parseOpenShiftUser(obj, "test")
-
-	if got.CreatedAt != nil {
-		t.Errorf("CreatedAt: expected nil for invalid timestamp, got %v", got.CreatedAt)
-	}
-}
+// TestParseOpenShiftUser_InvalidTimestamp removed — canonical version is in rbac_openshift_test.go
 
 // ---------- buildProbeNamespaces ----------
 
@@ -101,7 +86,6 @@ func TestBuildProbeNamespaces_DefaultsOnly(t *testing.T) {
 		t.Errorf("expected first namespace 'default', got %q", got[0])
 	}
 }
-
 
 func TestBuildProbeNamespaces_EnvVarAdded(t *testing.T) {
 	t.Setenv(probeNamespacesEnvVar, "team-a,team-b")


### PR DESCRIPTION
## CI Fix

`go vet ./...` was failing on all three platforms (ubuntu, macos, windows) in the Cross-Platform Build workflow due to duplicate test function declarations in `pkg/k8s`.

### Fix 1 — `events_test.go`
`pkg/k8s/events_test.go` and `pkg/k8s/client_events_test.go` both declared:
- `TestSortEventsByLastSeenDesc_MixedTimezones`
- `TestSortEventsByLastSeenDesc_EmptySlice`

Removed the two duplicate functions from `events_test.go`. `client_events_test.go` supersedes them with more comprehensive coverage (uses `testify/require`, includes additional edge cases).

### Fix 2 — `rbac_k8s_test.go`
`pkg/k8s/rbac_k8s_test.go` and `pkg/k8s/rbac_openshift_test.go` both declared:
- `TestParseOpenShiftUser_InvalidTimestamp`

Removed the duplicate from `rbac_k8s_test.go`. `rbac_openshift_test.go` is the canonical version.

Fixes #20015

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*