### PR TITLE
[scanner] fix: CI workflow fixes for nightly-llmd-guides and stuck-detection

### DIFF
--- a/.github/workflows/nightly-llmd-guides.yml
+++ b/.github/workflows/nightly-llmd-guides.yml
@@ -21,6 +21,9 @@ on:
           - autoscaler
           - model-mesh
           - custom-metrics
+  push:
+    paths:
+      - '.github/workflows/nightly-llmd-guides.yml'
 
 permissions: read-all
 

--- a/.github/workflows/stuck-detection.yml
+++ b/.github/workflows/stuck-detection.yml
@@ -1,0 +1,63 @@
+name: Stuck Detection Workflow
+
+on:
+  schedule:
+    - cron: "0 * * * *"  # Every hour at :00
+  workflow_dispatch:
+    inputs:
+      force_check:
+        description: 'Force check all items regardless of age'
+        required: false
+        default: 'false'
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  detect-stuck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check for stuck workflow runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Checking for stuck workflow runs..."
+          
+          TIMEOUT_HOURS=6
+          CUTOFF=$(date -u -d "${TIMEOUT_HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ)
+          
+          # Find in_progress runs older than timeout
+          STUCK_RUNS=$(gh api \
+            "repos/${{ github.repository }}/actions/runs" \
+            --jq ".workflow_runs[] | select(.status == \"in_progress\" and .created_at < \"${CUTOFF}\") | {id: .id, name: .name, created_at: .created_at, html_url: .html_url}" \
+            | jq -s '.')
+          
+          STUCK_COUNT=$(echo "$STUCK_RUNS" | jq 'length')
+          
+          if [ "$STUCK_COUNT" -gt 0 ]; then
+            echo "Found ${STUCK_COUNT} stuck workflow run(s):"
+            echo "$STUCK_RUNS" | jq -r '.[] | "- \(.name) (ID: \(.id), created: \(.created_at))"'
+            echo ""
+            echo "::warning::Found ${STUCK_COUNT} workflow runs in 'in_progress' state for more than ${TIMEOUT_HOURS} hours"
+            
+            # Output URLs for manual review
+            echo "Review these runs:"
+            echo "$STUCK_RUNS" | jq -r '.[] | .html_url'
+          else
+            echo "✅ No stuck workflow runs found"
+          fi
+          
+          echo "stuck_count=${STUCK_COUNT}" >> $GITHUB_OUTPUT
+          echo "stuck_runs<<EOF" >> $GITHUB_OUTPUT
+          echo "$STUCK_RUNS" | jq -c '.' >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Stuck Detection Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Timeout threshold:** 6 hours" >> $GITHUB_STEP_SUMMARY
+          echo "**Check time:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Fixes #20014
Fixes #20013

## Changes

### Fix #20014: nightly-llmd-guides.yml phantom failures
Added `push` trigger with `paths` filter matching only `.github/workflows/nightly-llmd-guides.yml`. This prevents GitHub Actions from creating phantom "push" event runs with 0 jobs that show as failures on every commit to main.

### Fix #20013: Missing stuck-detection.yml workflow
Created `stuck-detection.yml` workflow that:
- Runs hourly (`cron: "0 * * * *"`)
- Detects workflow runs stuck in `in_progress` state for >6 hours
- Outputs warnings with run IDs and URLs for manual review
- Includes workflow_dispatch for manual trigger

Both workflows now configured correctly without blocking CI pipeline.