### PR TITLE
fix: make a11y-audit comment posting resilient to fork PRs

### DIFF
--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Post PR comment with results
         if: always()
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -97,26 +98,31 @@ jobs:
             const COMMENT_TAG = '<!-- a11y-audit-comment -->';
             body = COMMENT_TAG + '\n' + body;
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const existing = (comments || []).find(c => (c.body || '').includes(COMMENT_TAG));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body,
               });
+
+              const existing = (comments || []).find(c => (c.body || '').includes(COMMENT_TAG));
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              }
+            } catch (err) {
+              // Fork PRs have read-only GITHUB_TOKEN — comment posting is best-effort
+              core.warning(`Could not post a11y comment (expected for fork PRs): ${err.message}`);
             }


### PR DESCRIPTION
## Summary
- Fork PRs receive a read-only `GITHUB_TOKEN`, causing the a11y-audit comment step to fail with 403 (`Resource not accessible by integration`)
- Wraps comment API calls in try/catch so the audit result (pass/fail) is unaffected — comment posting is best-effort
- Adds `continue-on-error: true` as belt-and-suspenders

## Root cause
Triggered by PR #19958 (from fork `DavidDiaz0317`). GitHub restricts `GITHUB_TOKEN` to read-only for `pull_request` events from forks — the `pull-requests: write` permission declared in the workflow is ignored.

## Test plan
- [ ] Verify a11y-audit passes on this PR (no fork, so comment should post)
- [ ] Next fork PR with `.tsx` changes should show the audit passing with a warning instead of failing