### PR TITLE
[ci-maintainer] fix: repair YAML syntax in nightly-llmd-guides.yml

### DIFF
--- a/.github/workflows/nightly-llmd-guides.yml
+++ b/.github/workflows/nightly-llmd-guides.yml
@@ -228,26 +228,24 @@ jobs:
           if [ -n "$EXISTING" ]; then
             echo "issue_number=$EXISTING" >> "$GITHUB_OUTPUT"
           else
+            ISSUE_BODY="## llm-d Guide E2E Tracking"$'\n\n'
+            ISSUE_BODY+="This issue tracks nightly E2E results for the 8 llm-d guides on OpenShift."$'\n\n'
+            ISSUE_BODY+="### Guides"$'\n'
+            ISSUE_BODY+="- workload-variant-autoscaler"$'\n'
+            ISSUE_BODY+="- basic-inference"$'\n'
+            ISSUE_BODY+="- multi-model"$'\n'
+            ISSUE_BODY+="- gateway"$'\n'
+            ISSUE_BODY+="- epp-config"$'\n'
+            ISSUE_BODY+="- autoscaler"$'\n'
+            ISSUE_BODY+="- model-mesh"$'\n'
+            ISSUE_BODY+="- custom-metrics"$'\n\n'
+            ISSUE_BODY+="---"$'\n'
+            ISSUE_BODY+="_Results are posted as comments below, newest first._"
             NEW_ISSUE=$(gh issue create \
               --title "$TITLE" \
               --label "$LABEL" \
               --label "hold" \
-              --body "## llm-d Guide E2E Tracking
-
-This issue tracks nightly E2E results for the 8 llm-d guides on OpenShift.
-
-### Guides
-- workload-variant-autoscaler
-- basic-inference
-- multi-model
-- gateway
-- epp-config
-- autoscaler
-- model-mesh
-- custom-metrics
-
----
-_Results are posted as comments below, newest first._" \
+              --body "$ISSUE_BODY" \
               | grep -oP '\d+$')
             echo "issue_number=$NEW_ISSUE" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## CI Fix — YAML syntax error in nightly-llmd-guides.yml

### Problem

The `Find or create tracking issue` step had a multiline `--body "..."` argument with text at column 0 inside a `run: |` block. YAML literal block scalars terminate when content drops below the block's indentation level (10 spaces here). Lines like `This issue tracks...`, `### Guides`, `- workload-variant-autoscaler`, etc. at column 0 broke YAML parsing before GitHub Actions could start any jobs — causing `created_at == updated_at` (instant pre-job failure).

### Fix

Convert the multiline inline body string to explicit bash variable assignment using `$'\n'` newlines, with all content at ≥10 spaces indentation so YAML parses correctly.

**Before (YAML invalid):**
```yaml
            --body "## llm-d Guide E2E Tracking

This issue tracks nightly E2E results...
...
EOF" \
```

**After (YAML valid):**
```yaml
            ISSUE_BODY="## llm-d Guide E2E Tracking"$'\n\n'
            ISSUE_BODY+="This issue tracks nightly E2E results..."$'\n'
            ...
            --body "$ISSUE_BODY" \
```

**Verification:** `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nightly-llmd-guides.yml'))"` — YAML valid, 2 jobs, 3+4 steps.

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*