### PR TITLE
[scanner] fix: guard window.location access in network.ts (238 test failures)

### DIFF
--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -17,9 +17,9 @@
 const viteEnv = (import.meta.env ?? {}) as Partial<ImportMetaEnv>
 const isDemoModeBuild = viteEnv.VITE_DEMO_MODE === 'true'
 const isNoLocalAgentBuild = viteEnv.VITE_NO_LOCAL_AGENT === 'true'
-const isConsoleLiveHost = typeof window !== 'undefined' && window.location.hostname === 'console-live.kubestellar.io'
+const isConsoleLiveHost = typeof window !== 'undefined' && typeof window.location !== 'undefined' && window.location.hostname === 'console-live.kubestellar.io'
 
-const _isNetlify = typeof window !== 'undefined' && (
+const _isNetlify = typeof window !== 'undefined' && typeof window.location !== 'undefined' && (
   isDemoModeBuild ||
   window.location.hostname.includes('netlify.app') ||
   window.location.hostname.includes('deploy-preview-') ||


### PR DESCRIPTION
Fixes #20022

## Problem

238 render tests failed after PR #19958 (Console Live product support) merged. All failures were "renders without error/crashing" tests across many components.

## Root Cause

PR #19958 added a `window.location.hostname` check in `network.ts` without guarding against `window.location` being undefined in jsdom test environments. Since `network.ts` is imported by many components, this broke 238 tests.

## Fix

Added `typeof window.location !== 'undefined'` guard before accessing `window.location.hostname`.