### PR TITLE
[ci-maintainer] fix: increase release test job timeout 15→25 min to prevent nightly cancellation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: determine_version
     if: needs.determine_version.outputs.has_changes == 'true'
     outputs:


### PR DESCRIPTION
## CI Fix

The nightly `Release` workflow intermittently fails to produce a release because the `test` job hits its 15-minute timeout before the frontend build can complete.

**Timeline of run #1234 (2026-07-01):**
| Step | Duration |
|------|----------|
| Run Go tests | 10m 27s |
| Install frontend deps (npm ci) | ~11s |
| Build frontend | 4m 21s → **KILLED at 15min timeout** |

Total required: ~17–20 minutes. Budget was only 15 minutes.

**Pattern**: Runs #1228 (2026-06-26), #1230 (2026-06-28), and #1234 (2026-07-01) all cancelled for the same reason — no nightly release was produced on those days.

**Change**: `timeout-minutes: 15 → 25` on the `test` job only. All other timeouts unchanged.

Fixes #20030

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*