### PR TITLE
[scanner] fix: improve network.ts quality

### DIFF
--- a/web/src/lib/constants/__tests__/network.test.ts
+++ b/web/src/lib/constants/__tests__/network.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
   LOCAL_AGENT_WS_URL,
   LOCAL_AGENT_HTTP_URL,
@@ -24,6 +24,14 @@ import {
   MAX_MESSAGE_SIZE_CHARS,
   suppressLocalAgent,
   isLocalAgentSuppressed,
+  suppressOptionalPollers,
+  areOptionalPollersSuppressed,
+  getWsBackoffDelay,
+  WS_RECONNECT_BASE_DELAY_MS,
+  WS_RECONNECT_MAX_DELAY_MS,
+  WS_BACKOFF_JITTER_MAX_MS,
+  isTestEnvironment,
+  getLocalAgentURLs,
 } from '../network'
 
 const network = {
@@ -114,5 +122,173 @@ describe('network constants', () => {
     for (const [_key, value] of numericKeys) {
       expect(value).toBeGreaterThan(0)
     }
+  })
+})
+
+describe('isTestEnvironment (via module init)', () => {
+  it('returns true in vitest context', () => {
+    expect(isTestEnvironment()).toBe(true)
+    expect(process.env.NODE_ENV).toBe('test')
+  })
+})
+
+describe('getLocalAgentURLs', () => {
+  it('returns default URLs when given empty string', () => {
+    const result = getLocalAgentURLs('')
+    expect(result.httpURL).toBe('http://127.0.0.1:8585')
+    expect(result.wsURL).toBe('ws://127.0.0.1:8585/ws')
+  })
+
+  it('returns default URLs when given undefined', () => {
+    const result = getLocalAgentURLs()
+    expect(result.httpURL).toBe('http://127.0.0.1:8585')
+    expect(result.wsURL).toBe('ws://127.0.0.1:8585/ws')
+  })
+
+  it('returns default URLs when given whitespace', () => {
+    const result = getLocalAgentURLs('   ')
+    expect(result.httpURL).toBe('http://127.0.0.1:8585')
+    expect(result.wsURL).toBe('ws://127.0.0.1:8585/ws')
+  })
+
+  it('strips trailing slash from custom URL', () => {
+    const result = getLocalAgentURLs('http://custom:9090/')
+    expect(result.httpURL).toBe('http://custom:9090')
+    expect(result.wsURL).toBe('ws://custom:9090/ws')
+  })
+
+  it('strips multiple trailing slashes', () => {
+    const result = getLocalAgentURLs('http://custom:9090///')
+    expect(result.httpURL).toBe('http://custom:9090')
+    expect(result.wsURL).toBe('ws://custom:9090/ws')
+  })
+
+  it('converts http to ws protocol', () => {
+    const result = getLocalAgentURLs('http://custom:9090')
+    expect(result.httpURL).toBe('http://custom:9090')
+    expect(result.wsURL).toBe('ws://custom:9090/ws')
+  })
+
+  it('converts https to wss protocol', () => {
+    const result = getLocalAgentURLs('https://custom:9090')
+    expect(result.httpURL).toBe('https://custom:9090')
+    expect(result.wsURL).toBe('wss://custom:9090/ws')
+  })
+
+  it('handles custom URL with path', () => {
+    const result = getLocalAgentURLs('http://custom:9090/api')
+    expect(result.httpURL).toBe('http://custom:9090/api')
+    expect(result.wsURL).toBe('ws://custom:9090/api/ws')
+  })
+
+  it('handles custom URL with path and trailing slash', () => {
+    const result = getLocalAgentURLs('http://custom:9090/api/')
+    expect(result.httpURL).toBe('http://custom:9090/api')
+    expect(result.wsURL).toBe('ws://custom:9090/api/ws')
+  })
+
+  it('strips query params from WebSocket URL', () => {
+    const result = getLocalAgentURLs('http://custom:9090?foo=bar')
+    expect(result.httpURL).toBe('http://custom:9090')
+    expect(result.wsURL).toBe('ws://custom:9090/ws')
+    expect(result.wsURL).not.toContain('?foo=bar')
+  })
+
+  it('strips hash from WebSocket URL', () => {
+    const result = getLocalAgentURLs('http://custom:9090#fragment')
+    expect(result.httpURL).toBe('http://custom:9090')
+    expect(result.wsURL).toBe('ws://custom:9090/ws')
+    expect(result.wsURL).not.toContain('#fragment')
+  })
+
+  it('falls back to defaults when given invalid URL', () => {
+    const result = getLocalAgentURLs('not-a-url')
+    expect(result.httpURL).toBe('http://127.0.0.1:8585')
+    expect(result.wsURL).toBe('ws://127.0.0.1:8585/ws')
+  })
+
+  it('falls back to defaults when given malformed URL', () => {
+    const result = getLocalAgentURLs('http://:invalid')
+    expect(result.httpURL).toBe('http://127.0.0.1:8585')
+    expect(result.wsURL).toBe('ws://127.0.0.1:8585/ws')
+  })
+})
+
+describe('suppressLocalAgent', () => {
+  it('suppresses agent URLs when called with true', () => {
+    const initialWsUrl = LOCAL_AGENT_WS_URL
+    const initialHttpUrl = LOCAL_AGENT_HTTP_URL
+    
+    suppressLocalAgent(true)
+    
+    expect(LOCAL_AGENT_WS_URL).toBe('ws://localhost:1/disabled')
+    expect(LOCAL_AGENT_HTTP_URL).toBe('')
+    expect(isLocalAgentSuppressed()).toBe(true)
+  })
+
+  it('does not un-suppress once suppressed', () => {
+    suppressLocalAgent(true)
+    expect(isLocalAgentSuppressed()).toBe(true)
+    
+    suppressLocalAgent(false)
+    expect(isLocalAgentSuppressed()).toBe(true)
+  })
+})
+
+describe('suppressOptionalPollers', () => {
+  it('suppresses optional pollers when called with true', () => {
+    suppressOptionalPollers(true)
+    expect(areOptionalPollersSuppressed()).toBe(true)
+  })
+
+  it('remains suppressed once set', () => {
+    suppressOptionalPollers(true)
+    expect(areOptionalPollersSuppressed()).toBe(true)
+    
+    suppressOptionalPollers(false)
+    expect(areOptionalPollersSuppressed()).toBe(true)
+  })
+})
+
+describe('getWsBackoffDelay', () => {
+  it('returns base delay plus jitter for attempt 0', () => {
+    const delay = getWsBackoffDelay(0)
+    const expectedMin = WS_RECONNECT_BASE_DELAY_MS
+    const expectedMax = WS_RECONNECT_BASE_DELAY_MS + WS_BACKOFF_JITTER_MAX_MS
+    
+    expect(delay).toBeGreaterThanOrEqual(expectedMin)
+    expect(delay).toBeLessThan(expectedMax)
+  })
+
+  it('returns exponential backoff for successive attempts', () => {
+    const delay1 = getWsBackoffDelay(1)
+    const delay2 = getWsBackoffDelay(2)
+    
+    const expectedMin1 = WS_RECONNECT_BASE_DELAY_MS * 2
+    const expectedMax1 = WS_RECONNECT_BASE_DELAY_MS * 2 + WS_BACKOFF_JITTER_MAX_MS
+    
+    const expectedMin2 = WS_RECONNECT_BASE_DELAY_MS * 4
+    const expectedMax2 = WS_RECONNECT_BASE_DELAY_MS * 4 + WS_BACKOFF_JITTER_MAX_MS
+    
+    expect(delay1).toBeGreaterThanOrEqual(expectedMin1)
+    expect(delay1).toBeLessThan(expectedMax1)
+    expect(delay2).toBeGreaterThanOrEqual(expectedMin2)
+    expect(delay2).toBeLessThan(expectedMax2)
+  })
+
+  it('caps delay at WS_RECONNECT_MAX_DELAY_MS plus jitter', () => {
+    const delay = getWsBackoffDelay(10)
+    const expectedMin = WS_RECONNECT_MAX_DELAY_MS
+    const expectedMax = WS_RECONNECT_MAX_DELAY_MS + WS_BACKOFF_JITTER_MAX_MS
+    
+    expect(delay).toBeGreaterThanOrEqual(expectedMin)
+    expect(delay).toBeLessThan(expectedMax)
+  })
+
+  it('adds random jitter on each call', () => {
+    const delays = Array.from({ length: 5 }, () => getWsBackoffDelay(0))
+    const uniqueDelays = new Set(delays)
+    
+    expect(uniqueDelays.size).toBeGreaterThan(1)
   })
 })

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -15,7 +15,7 @@
  * On Netlify, agent URLs are disabled — there is no local kc-agent.
  * Duplicated from demoMode.ts to avoid circular imports (demoMode → constants → network).
  */
-function isTestEnvironment(): boolean {
+export function isTestEnvironment(): boolean {
   return typeof process !== 'undefined' && process.env.NODE_ENV === 'test'
 }
 
@@ -101,7 +101,7 @@ function stripTrailingSlash(value: string): string {
   return value.replace(/\/+$/, '')
 }
 
-function getLocalAgentURLs(agentBaseURL?: string): { httpURL: string; wsURL: string } {
+export function getLocalAgentURLs(agentBaseURL?: string): { httpURL: string; wsURL: string } {
   const configuredBaseURL = stripTrailingSlash((agentBaseURL || '').trim())
   if (!configuredBaseURL) {
     return {


### PR DESCRIPTION
Fixes #20033

## Changes

Added comprehensive unit tests for previously untested logic in `network.ts`:

### ✅ `isTestEnvironment()`
- Verifies it returns `true` in Vitest/jsdom context
- Exported for testing

### ✅ `getLocalAgentURLs(agentBaseURL)`
- Empty/undefined/whitespace inputs → defaults
- Trailing slash stripping (single & multiple)
- Protocol conversion: `http` → `ws`, `https` → `wss`
- Path handling with and without trailing slashes
- Query param & hash stripping from WebSocket URLs
- Invalid URL fallback to defaults
- Exported for testing

### ✅ `suppressLocalAgent(true)` / `suppressOptionalPollers(true)`
- Verify runtime mutation of module-level URLs
- Confirm one-way suppression (no un-suppress)
- Already exported

### ✅ `getWsBackoffDelay(attempt)`
- Base delay + jitter for attempt 0
- Exponential growth for successive attempts
- Max cap at `WS_RECONNECT_MAX_DELAY_MS` + jitter
- Random jitter on each call
- Already exported

All tests follow existing patterns from the codebase.