### PR TITLE
[scanner] fix: extract hardcoded user-facing strings

### DIFF
--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -187,9 +187,9 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
             <Filter className="w-4 h-4 text-muted-foreground" />
             <div className="w-44">
               <Select value={filterApproval} onChange={e => setFilterApproval(e.target.value)} selectSize="sm">
-                <option value="all">All statuses</option>
-                <option value="approved">Approved</option>
-                <option value="unapproved">Unapproved</option>
+                <option value="all">{i18next.t('common:statusFilters.allStatuses', 'All statuses')}</option>
+                <option value="approved">{i18next.t('common:statusFilters.approved', 'Approved')}</option>
+                <option value="unapproved">{i18next.t('common:statusFilters.unapproved', 'Unapproved')}</option>
                 <option value="emergency">Emergency</option>
                 <option value="pending">Pending</option>
               </Select>

--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, memo, useRef } from 'react'
+import i18next from 'i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { changeControlDashboardConfig } from '../../config/dashboards/change-control'
 import {

--- a/web/src/components/compliance/NISTDashboard.tsx
+++ b/web/src/components/compliance/NISTDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, memo, useRef } from 'react'
+import i18next from 'i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { nistDashboardConfig } from '../../config/dashboards/nist'
 import {

--- a/web/src/components/compliance/NISTDashboard.tsx
+++ b/web/src/components/compliance/NISTDashboard.tsx
@@ -194,7 +194,7 @@ export const NISTDashboardContent = memo(function NISTDashboardContent() {
             <button
               onClick={() => setFamilyFilter('all')}
               className={`px-3 py-1 rounded text-xs ${familyFilter === 'all' ? 'bg-blue-500 text-foreground' : 'bg-muted text-muted-foreground'}`}
-            >All</button>
+            >{i18next.t('common:severityFilters.all', 'All')}</button>
             {families.map(f => (
               <button
                 key={f.id}

--- a/web/src/components/compliance/RBACAuditDashboard.tsx
+++ b/web/src/components/compliance/RBACAuditDashboard.tsx
@@ -231,11 +231,11 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
               value={severityFilter}
               onChange={e => setSeverityFilter(e.target.value)}
             >
-              <option value="all">All Severities</option>
-              <option value="critical">Critical</option>
-              <option value="high">High</option>
-              <option value="medium">Medium</option>
-              <option value="low">Low</option>
+              <option value="all">{i18next.t('common:severityFilters.allSeverities', 'All Severities')}</option>
+              <option value="critical">{i18next.t('common:severityFilters.critical', 'Critical')}</option>
+              <option value="high">{i18next.t('common:severityFilters.high', 'High')}</option>
+              <option value="medium">{i18next.t('common:severityFilters.medium', 'Medium')}</option>
+              <option value="low">{i18next.t('common:severityFilters.low', 'Low')}</option>
             </Select>
           </div>
         )}

--- a/web/src/components/compliance/RBACAuditDashboard.tsx
+++ b/web/src/components/compliance/RBACAuditDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, memo, useRef } from 'react'
+import i18next from 'i18next'
 import { useTranslation } from 'react-i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { rbacAuditDashboardConfig } from '../../config/dashboards/rbac-audit'

--- a/web/src/components/compliance/RiskMatrixDashboard.tsx
+++ b/web/src/components/compliance/RiskMatrixDashboard.tsx
@@ -270,7 +270,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
                 <button
                   onClick={() => setSelectedCell(null)}
                   className="text-xs text-gray-400 hover:text-white"
-                >Clear selection</button>
+                >{i18next.t('common:clearSelection', 'Clear selection')}</button>
               </div>
               {selectedRisks.length === 0 ? (
                 <p className="text-gray-500 text-sm">No risks in this zone</p>

--- a/web/src/components/compliance/RiskMatrixDashboard.tsx
+++ b/web/src/components/compliance/RiskMatrixDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, memo, useCallback, useRef } from 'react'
+import i18next from 'i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { riskMatrixDashboardConfig } from '../../config/dashboards/risk-matrix'
 import {

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -140,11 +140,11 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
             <Filter className="w-4 h-4 text-muted-foreground" />
             <div className="w-40">
               <Select value={filterSeverity} onChange={e => setFilterSeverity(e.target.value)} selectSize="sm">
-                <option value="all">All severities</option>
-                <option value="critical">Critical</option>
-                <option value="high">High</option>
-                <option value="medium">Medium</option>
-                <option value="low">Low</option>
+                <option value="all">{i18next.t('common:severityFilters.all', 'All severities')}</option>
+                <option value="critical">{i18next.t('common:severityFilters.critical', 'Critical')}</option>
+                <option value="high">{i18next.t('common:severityFilters.high', 'High')}</option>
+                <option value="medium">{i18next.t('common:severityFilters.medium', 'Medium')}</option>
+                <option value="low">{i18next.t('common:severityFilters.low', 'Low')}</option>
               </Select>
             </div>
           </div>

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, memo } from 'react'
+import i18next from 'i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { sodDashboardConfig } from '../../config/dashboards/segregation-of-duties'
 import {

--- a/web/src/components/missions/StandaloneOrbitDialog.tsx
+++ b/web/src/components/missions/StandaloneOrbitDialog.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useCallback } from 'react'
+import i18next from 'i18next'
 import { useTranslation } from 'react-i18next'
 import { Satellite, Orbit, X, ChevronDown, ChevronUp, Loader2 } from 'lucide-react'
 import { cn } from '../../lib/cn'

--- a/web/src/components/missions/StandaloneOrbitDialog.tsx
+++ b/web/src/components/missions/StandaloneOrbitDialog.tsx
@@ -92,7 +92,7 @@ function ClusterScopeSection({ clusterName, value, onChange }: ClusterScopeSecti
         className="flex items-center gap-1.5 text-[10px] text-muted-foreground hover:text-foreground transition-colors py-0.5"
       >
         {expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
-        <span>Scope</span>
+        <span>{i18next.t('common:scope', 'Scope')}</span>
         {activeCount > 0 && (
           <span className="bg-purple-500/20 text-purple-400 px-1 rounded-full">
             {activeCount}

--- a/web/src/components/ui/CollapsibleSection.stories.tsx
+++ b/web/src/components/ui/CollapsibleSection.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import i18next from 'i18next'
 import { CollapsibleSection } from './CollapsibleSection'
 import { StatusBadge } from './StatusBadge'
 
@@ -21,7 +22,7 @@ export const Default: Story = {
     defaultOpen: true,
     children: (
       <div className="p-3 bg-secondary/30 rounded-lg text-sm text-foreground">
-        <p>This is the content of the collapsible section.</p>
+        <p>{i18next.t('common:stories.collapsibleContent', 'This is the content of the collapsible section.')}</p>
         <p className="mt-2 text-muted-foreground">It can contain any React nodes.</p>
       </div>
     ),
@@ -34,7 +35,7 @@ export const Collapsed: Story = {
     defaultOpen: false,
     children: (
       <div className="p-3 bg-secondary/30 rounded-lg text-sm text-foreground">
-        <p>This content is hidden by default.</p>
+        <p>{i18next.t('common:stories.hiddenByDefault', 'This content is hidden by default.')}</p>
       </div>
     ),
   },
@@ -48,9 +49,9 @@ export const WithBadge: Story = {
     children: (
       <div className="p-3 bg-secondary/30 rounded-lg text-sm text-foreground">
         <ul className="space-y-1 text-muted-foreground">
-          <li>Pod Security Standards: Pass</li>
-          <li>Network Policies: Pass</li>
-          <li>Resource Limits: Pass</li>
+          <li>{i18next.t('common:stories.podSecurityPass', 'Pod Security Standards: Pass')}</li>
+          <li>{i18next.t('common:stories.networkPoliciesPass', 'Network Policies: Pass')}</li>
+          <li>{i18next.t('common:stories.resourceLimitsPass', 'Resource Limits: Pass')}</li>
         </ul>
       </div>
     ),
@@ -67,7 +68,7 @@ export const WithWarningBadge: Story = {
         <ul className="space-y-1 text-muted-foreground">
           <li>CVE-2024-1234: Medium severity</li>
           <li>CVE-2024-5678: Low severity</li>
-          <li>Deprecated API usage detected</li>
+          <li>{i18next.t('common:stories.deprecatedAPIUsage', 'Deprecated API usage detected')}</li>
         </ul>
       </div>
     ),

--- a/web/src/components/ui/StatusBadge.stories.tsx
+++ b/web/src/components/ui/StatusBadge.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { CheckCircle, AlertTriangle, XCircle, Info, Clock, Zap } from 'lucide-react'
+import i18next from 'i18next'
 import { StatusBadge } from './StatusBadge'
 import { TEST_STRINGS } from '@/lib/test-strings'
 
@@ -97,9 +98,9 @@ export const AllSizes: Story = {
   args: { color: 'blue' },
   render: () => (
     <div className="flex flex-wrap gap-2 items-center">
-      <StatusBadge color="blue" size="xs">Extra Small</StatusBadge>
-      <StatusBadge color="blue" size="sm">Small</StatusBadge>
-      <StatusBadge color="blue" size="md">Medium</StatusBadge>
+      <StatusBadge color="blue" size="xs">{i18next.t('common:sizes.extraSmall', 'Extra Small')}</StatusBadge>
+      <StatusBadge color="blue" size="sm">{i18next.t('common:sizes.small', 'Small')}</StatusBadge>
+      <StatusBadge color="blue" size="md">{i18next.t('common:sizes.medium', 'Medium')}</StatusBadge>
     </div>
   ),
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -5525,5 +5525,33 @@
     "deploy": "Deploy",
     "marketplace": "Marketplace",
     "cost": "Cost"
-  }
+  },
+  "sizes": {
+    "extraSmall": "Extra Small",
+    "small": "Small",
+    "medium": "Medium"
+  },
+  "stories": {
+    "collapsibleContent": "This is the content of the collapsible section.",
+    "hiddenByDefault": "This content is hidden by default.",
+    "podSecurityPass": "Pod Security Standards: Pass",
+    "networkPoliciesPass": "Network Policies: Pass",
+    "resourceLimitsPass": "Resource Limits: Pass",
+    "deprecatedAPIUsage": "Deprecated API usage detected"
+  },
+  "scope": "Scope",
+  "severityFilters": {
+    "allSeverities": "All Severities",
+    "critical": "Critical",
+    "high": "High",
+    "medium": "Medium",
+    "low": "Low",
+    "all": "All severities"
+  },
+  "statusFilters": {
+    "allStatuses": "All statuses",
+    "approved": "Approved",
+    "unapproved": "Unapproved"
+  },
+  "clearSelection": "Clear selection"
 }


### PR DESCRIPTION
Fixes #20032

## Changes

Extracted 25 hardcoded user-facing strings to i18n translations for better localization support:

### Files Modified
- **web/src/locales/en/common.json**: Added new translation keys for sizes, stories, scope, severity/status filters, and actions
- **web/src/components/ui/StatusBadge.stories.tsx**: Converted size labels to use `i18next.t()`
- **web/src/components/ui/CollapsibleSection.stories.tsx**: Converted story content strings to use `i18next.t()`
- **web/src/components/missions/StandaloneOrbitDialog.tsx**: Converted "Scope" label to use `i18next.t()`
- **web/src/components/compliance/RBACAuditDashboard.tsx**: Converted severity filter options to use `i18next.t()`
- **web/src/components/compliance/NISTDashboard.tsx**: Converted "All" button text to use `i18next.t()`
- **web/src/components/compliance/SegregationOfDuties.tsx**: Converted severity filter options to use `i18next.t()`
- **web/src/components/compliance/RiskMatrixDashboard.tsx**: Converted "Clear selection" button to use `i18next.t()`
- **web/src/components/compliance/ChangeControlAudit.tsx**: Converted status filter options to use `i18next.t()`

### Translation Keys Added
- `common:sizes.*` - Size labels (extraSmall, small, medium)
- `common:stories.*` - Storybook content strings
- `common:scope` - Scope label
- `common:severityFilters.*` - Severity filter options
- `common:statusFilters.*` - Status filter options
- `common:clearSelection` - Clear selection action

All strings now use the established i18n pattern `i18next.t('common:key', 'fallback')` for consistent internationalization support.