### PR TITLE
[scanner] fix: resolve nightly CI test failures

### DIFF
--- a/web/e2e/user-flows/responsive-layouts.spec.ts
+++ b/web/e2e/user-flows/responsive-layouts.spec.ts
@@ -24,6 +24,19 @@ const ROUTES = ['/', '/clusters', '/settings', '/missions', '/deploy'] as const
 
 async function expectRenderedContent(page: Page, route: string, viewportName: string) {
   await page.waitForLoadState('domcontentloaded')
+  // Wait for React app to mount and replace the loading shell
+  await page.locator('#root').waitFor({ state: 'visible', timeout: ROUTE_CONTENT_TIMEOUT_MS })
+  // Wait for actual app content (not just the loading spinner)
+  await page.waitForFunction(
+    () => {
+      const root = document.getElementById('root')
+      if (!root) return false
+      // If loading shell is still visible, app hasn't mounted yet
+      if (root.querySelector('#app-shell')) return false
+      return (document.body.innerText || '').trim().length > 10
+    },
+    { timeout: ROUTE_CONTENT_TIMEOUT_MS }
+  )
   await expect.poll(
     () => page.evaluate(() => (document.body.innerText || '').trim().length),
     {


### PR DESCRIPTION
Fixes #20035  
Fixes #20036

## Summary

Resolves two nightly CI test failures:

1. **#20036 (playwright-nightly.yml)**: Workflow already fixed — added in c505acf with correct action SHAs. Closed issue as resolved.

2. **#20035 (nightly-ux-journeys.yml)**: Tests failing with blank pages due to race condition between test execution and React app mount.

## Changes

### `web/e2e/user-flows/responsive-layouts.spec.ts`

Added explicit waits in `expectRenderedContent()`:
1. Wait for `#root` element visibility
2. Wait for loading shell (`#app-shell`) to be removed
3. Wait for body text length > 10 chars via `waitForFunction`
4. Then assert with `expect.poll` as before

This prevents checking body content before React app fully mounts, which caused systematic "rendered blank (0 chars)" failures across all routes.

## Testing

CI will validate. No local build/lint per repo conventions (CLAUDE.md, AGENTS.md).