### PR TITLE
[scanner] fix: resolve stale nightly release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,7 @@ jobs:
         id: changes
         run: |
           LATEST_TAG="${{ steps.latest_tag.outputs.latest_tag }}"
+          RELEASE_TYPE="${{ steps.type.outputs.release_type }}"
 
           # Check for any changes since last tag
           if [ "$LATEST_TAG" = "v0.0.0" ]; then
@@ -119,7 +120,12 @@ jobs:
 
           # Check for any changes at all
           TOTAL_CHANGES=$(git rev-list "$LATEST_TAG"..HEAD --count)
-          if [ "$TOTAL_CHANGES" -gt 0 ]; then
+          
+          # Nightly releases always proceed (to keep tag fresh even without code changes)
+          if [ "$RELEASE_TYPE" = "nightly" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Nightly release: always proceeding (commits since last tag: $TOTAL_CHANGES)"
+          elif [ "$TOTAL_CHANGES" -gt 0 ]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
             echo "Total commits since last release: $TOTAL_CHANGES"
           else


### PR DESCRIPTION
Fixes #20042

Nightly releases were skipping when no code changes existed since last tag, causing `v0.3.33-nightly.20260701` to be missing.

**Root cause:** `has_changes` check in `determine_version` job returned `false` when `git rev-list` found 0 commits since last tag, causing `test` and `release` jobs to skip (both have `if: needs.determine_version.outputs.has_changes == 'true'`).

**Fix:** Nightly releases now always proceed regardless of code changes (keeps tags fresh). Weekly/patch/minor/major releases still require changes.

**Changed logic:**
```bash
if [ "$RELEASE_TYPE" = "nightly" ]; then
  echo "has_changes=true" >> $GITHUB_OUTPUT
  echo "Nightly release: always proceeding (commits since last tag: $TOTAL_CHANGES)"
```

Next scheduled run: 2026-07-02T05:00Z will publish `v0.3.33-nightly.20260702`.