### PR TITLE
[scanner] fix: update outdated lockfiles

### DIFF
--- a/.github/workflows/implement-fix.lock.yml
+++ b/.github/workflows/implement-fix.lock.yml
@@ -63,7 +63,10 @@ on:
         description: Issue number to work on
         required: true
 
-permissions: {}
+permissions:
+  issues: write
+  pull-requests: write
+  contents: write
 
 concurrency:
   group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}"


### PR DESCRIPTION
Fixes #20050, Fixes #20051

Root cause: Commit 37cec30b1 manually changed `permissions:` to `permissions: {}` without recompiling, breaking body_hash validation in implement-fix.lock.yml.

Fix: Restored original permissions (issues:write, pull-requests:write, contents:write) to match .md source and embedded hash. stuck-detection.lock.yml already in sync.