### PR TITLE
[scanner] fix: revert network.ts export pattern to fix 238 test failures

### DIFF
--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -15,7 +15,7 @@
  * On Netlify, agent URLs are disabled — there is no local kc-agent.
  * Duplicated from demoMode.ts to avoid circular imports (demoMode → constants → network).
  */
-export function isTestEnvironment(): boolean {
+function isTestEnvironment(): boolean {
   return typeof process !== 'undefined' && process.env.NODE_ENV === 'test'
 }
 
@@ -101,7 +101,7 @@ function stripTrailingSlash(value: string): string {
   return value.replace(/\/+$/, '')
 }
 
-export function getLocalAgentURLs(agentBaseURL?: string): { httpURL: string; wsURL: string } {
+function getLocalAgentURLs(agentBaseURL?: string): { httpURL: string; wsURL: string } {
   const configuredBaseURL = stripTrailingSlash((agentBaseURL || '').trim())
   if (!configuredBaseURL) {
     return {


### PR DESCRIPTION
Fixes #20049

Reverts the export pattern change from PR #20040 that broke Vitest module hoisting for 238 component tests. Two internal functions (`isTestEnvironment`, `getLocalAgentURLs`) were exported unnecessarily — removing the `export` keyword restores the original module interface and fixes mock hoisting.