### PR TITLE
[scanner] fix: restrict implement-fix.lock.yml to least-privilege permissions

### DIFF
--- a/.github/workflows/implement-fix.lock.yml
+++ b/.github/workflows/implement-fix.lock.yml
@@ -63,10 +63,7 @@ on:
         description: Issue number to work on
         required: true
 
-permissions:
-  issues: write
-  pull-requests: write
-  contents: write
+permissions: read-all
 
 concurrency:
   group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}"


### PR DESCRIPTION
Fixes #20063

Removes overly broad top-level write permissions from implement-fix.lock.yml and applies least-privilege at job level.