### PR TITLE
[scanner] fix: restore network module exports for component tests

### DIFF
--- a/web/src/components/cards/__tests__/ClusterHealth.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterHealth.test.tsx
@@ -116,7 +116,8 @@ vi.mock('../../ui/Tooltip', () => ({
   ),
 }))
 
-vi.mock('../../../lib/constants/network', () => ({
+vi.mock('../../../lib/constants/network', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/constants/network')>()),
   CARD_LOADING_TIMEOUT_MS: 30000,
   FETCH_DEFAULT_TIMEOUT_MS: 10000,
 }))

--- a/web/src/components/cards/llmd/__tests__/LLMdAIInsights.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/LLMdAIInsights.test.tsx
@@ -34,7 +34,8 @@ vi.mock('../../../../hooks/useTokenUsage', () => ({
   tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
 }))
 
-vi.mock('../../../../lib/constants/network', () => ({
+vi.mock('../../../../lib/constants/network', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../lib/constants/network')>()),
   PROGRESS_SIMULATION_MS: 1,
 }))
 

--- a/web/src/components/missions/__tests__/SaveResolutionDialog.test.tsx
+++ b/web/src/components/missions/__tests__/SaveResolutionDialog.test.tsx
@@ -33,7 +33,8 @@ vi.mock('../../../lib/utils/wsAuth', () => ({
   getWsAuthParams: mockGetWsAuthParams,
 }))
 
-vi.mock('../../../lib/constants', () => ({
+vi.mock('../../../lib/constants', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/constants')>()),
   LOCAL_AGENT_WS_URL: 'ws://localhost:8585/ws',
 }))
 

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -466,3 +466,5 @@ export const LATENCY_ACCEPTABLE_MS = 300
 /** Separator inserted between a port name and its port/protocol string
  * when rendering a named port (e.g. `http: 80/TCP`). */
 export const PORT_NAME_SEPARATOR = ': '
+
+export { isTestEnvironment, getLocalAgentURLs }


### PR DESCRIPTION
Fixes #20066

Resolves the 252 test failures in Coverage Suite run #4014 caused by the network.ts export pattern revert in commit 8ca2056.