### PR TITLE
[scanner] fix: add loading/error states to non-card components

### DIFF
--- a/web/src/components/InitialInfrastructureGate.test.tsx
+++ b/web/src/components/InitialInfrastructureGate.test.tsx
@@ -52,6 +52,19 @@ describe('InitialInfrastructureGate', () => {
     })
   })
 
+  it('renders loading state before the initial handshake resolves', () => {
+    mockGetState.mockReturnValue(new Promise(() => {}))
+    mockFetchKagentStatus.mockReturnValue(new Promise(() => {}))
+
+    render(
+      <InitialInfrastructureGate>
+        <div>Ready</div>
+      </InitialInfrastructureGate>
+    )
+
+    expect(screen.getByText('Connecting to infrastructure')).toBeInTheDocument()
+  })
+
   it('renders children after the initial handshake succeeds', async () => {
     mockGetState.mockResolvedValue({ generatedAt: 'now' })
     mockFetchKagentStatus.mockResolvedValue({ available: false, reason: 'not installed' })

--- a/web/src/components/agent/APIKeySettings.test.tsx
+++ b/web/src/components/agent/APIKeySettings.test.tsx
@@ -74,6 +74,14 @@ describe('APIKeySettings Component', () => {
     expect(typeof APIKeySettings).toBe('function')
   })
 
+  it('shows a loading spinner while provider data is in flight', () => {
+    vi.mocked(globalThis.fetch).mockReturnValue(new Promise(() => {}) as Promise<Response>)
+
+    const { container } = render(<APIKeySettings isOpen={true} onClose={vi.fn()} />)
+
+    expect(container.querySelector('.animate-spin')).toBeTruthy()
+  })
+
   it('shows the empty state when no providers are available after filtering', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValue({
       ok: true,
@@ -92,6 +100,15 @@ describe('APIKeySettings Component', () => {
     expect(screen.getByText('OPENAI_API_KEY=sk-...')).toBeInTheDocument()
     expect(screen.getByText('GEMINI_API_KEY=...')).toBeInTheDocument()
     expect(screen.queryByText('Custom')).not.toBeInTheDocument()
+  })
+
+  it('shows the connection error state when provider fetch fails', async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValue(new Error('connection refused'))
+
+    render(<APIKeySettings isOpen={true} onClose={vi.fn()} />)
+
+    expect(await screen.findByText('agent.localAgentRequired')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry Connection' })).toBeInTheDocument()
   })
 
   it('retries fetching provider data from the empty state', async () => {

--- a/web/src/components/alerts/Alerts.test.tsx
+++ b/web/src/components/alerts/Alerts.test.tsx
@@ -6,9 +6,11 @@ import { MemoryRouter } from 'react-router-dom'
 
 import '../../test/utils/setupMocks'
 
+let mockClustersLoading = false
+
 vi.mock('../../lib/dashboards/DashboardPage', () => ({
-  DashboardPage: ({ title, subtitle, children }: { title: string; subtitle?: string; children?: React.ReactNode }) => (
-    <div data-testid='dashboard-page' data-title={title} data-subtitle={subtitle}>
+  DashboardPage: ({ title, subtitle, children, isLoading }: { title: string; subtitle?: string; children?: React.ReactNode; isLoading?: boolean }) => (
+    <div data-testid='dashboard-page' data-title={title} data-subtitle={subtitle} data-loading={isLoading ? 'true' : 'false'}>
       <h1>{title}</h1>
       {subtitle && <p>{subtitle}</p>}
       {children}
@@ -26,7 +28,7 @@ vi.mock('../../hooks/useAlerts', () => ({
 
 vi.mock('../../hooks/useMCP', () => ({
   useClusters: () => ({
-    deduplicatedClusters: [], isRefreshing: false, refetch: vi.fn(), error: null,
+    deduplicatedClusters: [], isLoading: mockClustersLoading, isRefreshing: false, refetch: vi.fn(), error: null,
   }),
 }))
 
@@ -71,5 +73,12 @@ describe('Alerts Component', () => {
     renderAlerts()
     const page = screen.getByTestId('dashboard-page')
     expect(page).toHaveAttribute('data-subtitle')
+  })
+
+  it('marks dashboard loading state while cluster data is loading', () => {
+    mockClustersLoading = true
+    renderAlerts()
+    expect(screen.getByTestId('dashboard-page')).toHaveAttribute('data-loading', 'true')
+    mockClustersLoading = false
   })
 })

--- a/web/src/components/alerts/Alerts.tsx
+++ b/web/src/components/alerts/Alerts.tsx
@@ -18,7 +18,7 @@ export function Alerts() {
   const { t } = useTranslation()
   const { stats, evaluateConditions } = useAlerts()
   const { rules } = useAlertRules()
-  const { isRefreshing: dataRefreshing, refetch, error } = useClusters()
+  const { isLoading: dataLoading, isRefreshing: dataRefreshing, refetch, error } = useClusters()
   const { drillToAllAlerts } = useDrillDownActions()
 
   // Local state for last updated time
@@ -94,7 +94,7 @@ export function Alerts() {
       statsType="alerts"
       getStatValue={getStatValue}
       onRefresh={handleRefresh}
-      isLoading={false}
+      isLoading={dataLoading}
       isRefreshing={dataRefreshing}
       lastUpdated={lastUpdated}
       hasData={stats.firing > 0 || enabledRulesCount > 0}

--- a/web/src/components/auth/AuthCallback.tsx
+++ b/web/src/components/auth/AuthCallback.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
+import { Loader2 } from 'lucide-react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../../lib/auth'
 import { getLastRoute } from '../../hooks/useLastRoute'
@@ -181,7 +182,7 @@ export function AuthCallback() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-terminal">
       <div className="text-center">
-        <div className="spinner w-12 h-12 mx-auto mb-4" role="status" />
+        <Loader2 className="w-12 h-12 mx-auto mb-4 animate-spin text-primary" role="status" aria-label={status} />
         <p className="text-muted-foreground">{status}</p>
       </div>
     </div>

--- a/web/src/components/auth/__tests__/AuthCallback.contract.test.tsx
+++ b/web/src/components/auth/__tests__/AuthCallback.contract.test.tsx
@@ -130,6 +130,15 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('AuthCallback /auth/refresh contract (#6590)', () => {
+  it('renders loading state while auth refresh is pending', () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+
+    const { getByRole, getByText } = renderAuthCallback()
+
+    expect(getByRole('status')).toBeInTheDocument()
+    expect(getByText('authCallback.fetchingUserInfo')).toBeInTheDocument()
+  })
+
   it('navigates to home when response has { refreshed: true, onboarded: true }', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/components/compliance/ChangeControlAudit.test.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.test.tsx
@@ -38,6 +38,13 @@ function mockFetchSuccess() {
 describe('ChangeControlAudit', () => {
   beforeEach(() => { vi.restoreAllMocks() })
 
+  it('shows loading state before change-control endpoints resolve', () => {
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {}) as Promise<Response>)
+    render(<ChangeControlAudit />)
+
+    expect(document.querySelector('.animate-spin')).toBeTruthy()
+  })
+
   it('renders header and summary cards', async () => {
     mockFetchSuccess()
     render(<ChangeControlAudit />)

--- a/web/src/components/compliance/DataResidency.test.tsx
+++ b/web/src/components/compliance/DataResidency.test.tsx
@@ -68,6 +68,13 @@ function mockFetchFailure() {
 describe('DataResidency', () => {
   beforeEach(() => { vi.restoreAllMocks() })
 
+  it('shows loading state before residency endpoints resolve', () => {
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {}) as Promise<Response>)
+    render(<DataResidency />)
+
+    expect(document.querySelector('.animate-spin')).toBeTruthy()
+  })
+
   it('renders summary cards with correct values', async () => {
     mockFetchSuccess()
     render(<DataResidency />)

--- a/web/src/components/compliance/SegregationOfDuties.test.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.test.tsx
@@ -39,6 +39,13 @@ function mockFetchSuccess() {
 describe('SegregationOfDuties', () => {
   beforeEach(() => { vi.restoreAllMocks() })
 
+  it('shows loading state before SoD endpoints resolve', () => {
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {}) as Promise<Response>)
+    render(<SegregationOfDuties />)
+
+    expect(document.querySelector('.animate-spin')).toBeTruthy()
+  })
+
   it('renders header and compliance score', async () => {
     mockFetchSuccess()
     render(<SegregationOfDuties />)

--- a/web/src/components/compliance/SigningStatusDashboard.test.tsx
+++ b/web/src/components/compliance/SigningStatusDashboard.test.tsx
@@ -96,6 +96,13 @@ describe('SigningStatusDashboard', () => {
     vi.resetAllMocks()
   })
 
+  it('shows loading state before signing endpoints resolve', () => {
+    mockedAuthFetch.mockReturnValue(new Promise(() => {}) as Promise<Response>)
+    render(<SigningStatusDashboard />)
+
+    expect(screen.getByText('Loading signing status…')).toBeInTheDocument()
+  })
+
   it('renders summary and image tab data after successful fetch', async () => {
     mockSuccessResponses()
     render(<SigningStatusDashboard />)

--- a/web/src/components/compliance/SigstoreDashboard.test.tsx
+++ b/web/src/components/compliance/SigstoreDashboard.test.tsx
@@ -86,6 +86,13 @@ describe('SigstoreDashboard', () => {
     vi.resetAllMocks()
   })
 
+  it('shows loading state before Sigstore data resolves', async () => {
+    mockedAuthFetch.mockReturnValue(new Promise(() => {}) as Promise<Response>)
+    render(<SigstoreDashboardContent />)
+
+    expect(screen.getByText('Loading Sigstore data…')).toBeInTheDocument()
+  })
+
   it('renders signatures tab and summary after successful fetch', async () => {
     mockSuccessResponses()
     render(<SigstoreDashboardContent />)

--- a/web/src/components/drilldown/views/__tests__/CRDDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/CRDDrillDown.test.tsx
@@ -97,6 +97,17 @@ describe('CRDDrillDown interactions', () => {
     })
   })
 
+  it('shows versions loading state while CRD details are still loading', async () => {
+    mockRunKubectl.mockReturnValue(new Promise(() => {}))
+    const { container } = renderWithDrillDown(<CRDDrillDown data={BASE_DATA} />)
+
+    fireEvent.click(screen.getByRole('tab', { name: /Versions \(0\)/ }))
+
+    await waitFor(() => {
+      expect(container.querySelector('.animate-spin')).toBeTruthy()
+    })
+  })
+
   it('renders the versions list when the versions tab is selected', async () => {
     renderWithDrillDown(<CRDDrillDown data={BASE_DATA} />)
 

--- a/web/src/components/drilldown/views/__tests__/NodeDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/NodeDrillDown.test.tsx
@@ -55,7 +55,7 @@ vi.mock('../../../../lib/clipboard', () => ({
   copyToClipboard: vi.fn(),
 }))
 
-let mockNodeLoading = false
+const mockNodeLoading = false
 let mockNodeFailed = false
 
 vi.mock('../../../../hooks/useCachedData', () => ({

--- a/web/src/components/drilldown/views/__tests__/NodeDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/NodeDrillDown.test.tsx
@@ -55,8 +55,11 @@ vi.mock('../../../../lib/clipboard', () => ({
   copyToClipboard: vi.fn(),
 }))
 
+let mockNodeLoading = false
+let mockNodeFailed = false
+
 vi.mock('../../../../hooks/useCachedData', () => ({
-  useCachedNodes: () => ({ nodes: [], isLoading: false, isFailed: false, isDemoFallback: false, isRefreshing: false, consecutiveFailures: 0, lastRefresh: Date.now(), refetch: vi.fn() }),
+  useCachedNodes: () => ({ nodes: [], isLoading: mockNodeLoading, isFailed: mockNodeFailed, isDemoFallback: false, isRefreshing: false, consecutiveFailures: 0, lastRefresh: Date.now(), refetch: vi.fn() }),
 }))
 
 import { NodeDrillDown } from '../NodeDrillDown'
@@ -65,5 +68,13 @@ describe('NodeDrillDown', () => {
   it('renders without crashing', () => {
     const { container } = render(<NodeDrillDown data={{ cluster: 'c1', node: 'node1' }} />)
     expect(container).toBeTruthy()
+  })
+
+  it('shows node data error state when cached node lookup fails', () => {
+    mockNodeFailed = true
+    const { getByText } = render(<NodeDrillDown data={{ cluster: 'c1', node: 'node1' }} />)
+
+    expect(getByText('drilldown.nodeDetail.unableToLoad')).toBeInTheDocument()
+    mockNodeFailed = false
   })
 })

--- a/web/src/components/drilldown/views/pod-drilldown/__tests__/PodAiAnalysis.test.tsx
+++ b/web/src/components/drilldown/views/pod-drilldown/__tests__/PodAiAnalysis.test.tsx
@@ -49,6 +49,21 @@ describe('PodAiAnalysis', () => {
     expect(container).toBeTruthy()
   })
 
+  it('renders retryable error state when AI analysis fails', () => {
+    render(
+      <PodAiAnalysis
+        aiAnalysis={null}
+        aiAnalysisLoading={false}
+        aiAnalysisError="analysis backend offline"
+        fetchAiAnalysis={vi.fn()}
+        handleRepairPod={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('analysis backend offline')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'common.retry' })).toBeInTheDocument()
+  })
+
   it('disables action buttons when backend actions are unavailable', () => {
     render(
       <PodAiAnalysis

--- a/web/src/components/feedback/SubmitTab.tsx
+++ b/web/src/components/feedback/SubmitTab.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from 'react'
 import {
   Bug, Sparkles, ExternalLink,
   Eye, Pencil, Settings, Maximize2,
-  AlertTriangle, Monitor, BookOpen, FileText, Lock,
+  AlertTriangle, Monitor, BookOpen, FileText, Lock, Loader2,
 } from 'lucide-react'
 import { Github } from '@/lib/icons'
 import { cn } from '@/lib/cn'

--- a/web/src/components/feedback/SubmitTab.tsx
+++ b/web/src/components/feedback/SubmitTab.tsx
@@ -564,9 +564,10 @@ export function SubmitForm({
             </summary>
             <div className="mt-3 space-y-2">
               {isCheckingParentIssueAccess ? (
-                <p className="text-2xs text-muted-foreground">
-                  {t('feedback.checkingIssueLinkAccess', 'Checking repository access…')}
-                </p>
+                <div className="flex items-center gap-2 text-2xs text-muted-foreground">
+                  <Loader2 className="w-3 h-3 animate-spin" />
+                  <p>{t('feedback.checkingIssueLinkAccess', 'Checking repository access…')}</p>
+                </div>
               ) : canLinkParentIssue ? (
                 <>
                   <label htmlFor="feedback-parent-issue" className="block text-xs font-medium text-muted-foreground">

--- a/web/src/components/gitops/GitOps.test.tsx
+++ b/web/src/components/gitops/GitOps.test.tsx
@@ -136,6 +136,19 @@ describe('GitOps Component', () => {
     expect(screen.getByText('gitops.integrationTitle')).toBeInTheDocument()
   })
 
+  it('shows checking state while drift detection is running', async () => {
+    mockClusters = [{ name: 'only', context: 'only' }]
+    driftFetchHandler = () => new Promise(() => {})
+    renderGitOps()
+
+    await waitFor(
+      () => {
+        expect(screen.getAllByText('gitops.checking').length).toBeGreaterThan(0)
+      },
+      { timeout: ASYNC_WAIT_TIMEOUT_MS }
+    )
+  })
+
   // #6155 — in demo mode we must NOT be stuck in perpetual "checking".
   it('does not leave cards stuck in checking state in demo mode (#6155)', async () => {
     demoModeFlag = true

--- a/web/src/components/gitops/SyncDialog.test.tsx
+++ b/web/src/components/gitops/SyncDialog.test.tsx
@@ -89,6 +89,16 @@ describe('SyncDialog Component', () => {
     expect(screen.getByText('GitOps Sync: test-app')).toBeInTheDocument()
   })
 
+  it('shows loading state while drift detection is still running', async () => {
+    fetchMock = makeFetchMock(() => new Promise<Response>(() => {}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { container } = render(<SyncDialog {...defaultProps} />)
+
+    expect(await screen.findByText('gitops.detectingDrift')).toBeInTheDocument()
+    expect(container.querySelector('.animate-spin')).toBeTruthy()
+  })
+
   // #6159 — substantive integration test: calls the real fetch endpoint the
   // component actually uses (NOT `api.post`). Updated for #7993 Phase 4:
   // the component now targets kc-agent's /gitops/detect-drift route.

--- a/web/src/components/logs/Logs.test.tsx
+++ b/web/src/components/logs/Logs.test.tsx
@@ -34,16 +34,18 @@ vi.mock('../../lib/dashboards/DashboardPage', () => ({
   ),
 }))
 
+let mockLogsError: string | null = null
+
 vi.mock('../../hooks/useMCP', () => ({
   useClusters: () => ({
-    clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, refetch: vi.fn(),
+    clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: mockLogsError, refetch: vi.fn(),
   }),
 }))
 
 vi.mock('../../hooks/useCachedData', () => ({
   useCachedEvents: () => ({
     // lastRefresh: null → no lastUpdated timestamp available in test environment
-    events: [], isLoading: false, isRefreshing: false, lastRefresh: null, refetch: vi.fn(),
+    events: [], isLoading: false, isRefreshing: false, error: mockLogsError, lastRefresh: null, refetch: vi.fn(),
   }),
 }))
 
@@ -95,5 +97,15 @@ describe('Logs Component', () => {
     renderLogs()
     const page = screen.getByTestId('dashboard-page')
     expect(page.getAttribute('data-subtitle')).toBeTruthy()
+  })
+
+  it('renders retryable error state when log data fails to load', () => {
+    mockLogsError = 'events api offline'
+    renderLogs()
+
+    expect(screen.getByText('logs.errorLoading')).toBeInTheDocument()
+    expect(screen.getByText('events api offline')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'common.retry' })).toBeInTheDocument()
+    mockLogsError = null
   })
 })

--- a/web/src/components/logs/Logs.tsx
+++ b/web/src/components/logs/Logs.tsx
@@ -1,4 +1,6 @@
 import { useRef, useEffect } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedEvents } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
@@ -24,12 +26,14 @@ const DEFAULT_LOGS_CARDS = [
 ]
 
 export function Logs() {
-  const { deduplicatedClusters: clusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, refetch: refetchClusters } = useClusters()
-  const { events, isLoading: eventsLoading, isRefreshing: eventsRefreshing, lastRefresh, refetch: refetchEvents } = useCachedEvents()
+  const { t } = useTranslation()
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, error: clustersError, refetch: refetchClusters } = useClusters()
+  const { events, isLoading: eventsLoading, isRefreshing: eventsRefreshing, error: eventsError, lastRefresh, refetch: refetchEvents } = useCachedEvents()
   const warningEvents = events.filter(e => e.type === 'Warning')
   const lastUpdated = lastRefresh ? new Date(lastRefresh) : null
   const isLoading = clustersLoading || eventsLoading
   const isRefreshing = clustersRefreshing || eventsRefreshing
+  const error = clustersError || eventsError
 
   const { drillToAllEvents, drillToAllClusters } = useDrillDownActions()
   const { selectedClusters: globalSelectedClusters, isAllClustersSelected } = useGlobalFilters()
@@ -129,6 +133,25 @@ export function Logs() {
       emptyState={{
         title: 'Logs & Events Dashboard',
         description: 'Add cards to monitor Kubernetes events, application logs, and system messages across your clusters.' }}
-    />
+    >
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-500/30 bg-red-500/10 p-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <p className="text-sm font-medium text-red-400">{t('logs.errorLoading', 'Could not load logs data')}</p>
+              <p className="text-xs text-muted-foreground mt-1">{error}</p>
+              <button
+                type="button"
+                onClick={handleRefresh}
+                className="mt-3 inline-flex items-center rounded-lg bg-red-500/15 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/25"
+              >
+                {t('common.retry', 'Retry')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </DashboardPage>
   )
 }

--- a/web/src/components/missions/__tests__/MissionBrowser.test.tsx
+++ b/web/src/components/missions/__tests__/MissionBrowser.test.tsx
@@ -385,6 +385,13 @@ describe('MissionBrowser', () => {
     expect(emptyStates.length).toBeGreaterThanOrEqual(1)
   })
 
+  it('shows recommendation loading spinner while cache search is still running', () => {
+    browserMockState.missionCache.fixesDone = false
+    const { container } = render(<MissionBrowser {...defaultProps} />)
+
+    expect(container.querySelector('.animate-spin')).toBeTruthy()
+  })
+
   it('switches recommended missions to list layout when list view is selected', async () => {
     addRecommendedMission()
     render(<MissionBrowser {...defaultProps} />)

--- a/web/src/components/missions/browser.components.test.tsx
+++ b/web/src/components/missions/browser.components.test.tsx
@@ -3,7 +3,9 @@ import React from 'react'
  * Render tests for browser subdirectory components
  */
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+
+const resetMissionCacheSpy = vi.fn()
+import { render, screen, fireEvent } from '@testing-library/react'
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
@@ -12,12 +14,18 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
+vi.mock('./browser/missionCache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./browser/missionCache')>()),
+  resetMissionCache: resetMissionCacheSpy,
+}))
+
 describe('DirectoryListing', () => {
   it('renders without errors', async () => {
     const { DirectoryListing } = await import('./browser/DirectoryListing')
     const { container } = render(
       <DirectoryListing
-        items={[]}
+        entries={[]}
+        viewMode="grid"
         onSelect={vi.fn()}
       />
     )
@@ -47,14 +55,27 @@ describe('EmptyState', () => {
   })
 })
 
+describe('MissionFetchErrorBanner', () => {
+  it('shows retry loading state after retry click', async () => {
+    resetMissionCacheSpy.mockClear()
+    const { MissionFetchErrorBanner } = await import('./browser/EmptyState')
+    const { container } = render(<MissionFetchErrorBanner message="boom" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'missions.browser.emptyState.retry' }))
+
+    expect(resetMissionCacheSpy).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('.animate-spin')).toBeTruthy()
+  })
+})
+
 describe('RecommendationCard', () => {
   it('renders without errors', async () => {
     const { RecommendationCard } = await import('./browser/RecommendationCard')
     const { container } = render(
       <RecommendationCard
-        title="Test Recommendation"
-        description="Test description"
-        onClick={vi.fn()}
+        match={{ mission: { title: 'Test Recommendation', description: 'Test description', type: 'repair', tags: [], metadata: {} }, score: 1, matchPercent: 75, matchReasons: [] }}
+        onSelect={vi.fn()}
+        onImport={vi.fn()}
       />
     )
     expect(container).toBeTruthy()
@@ -64,9 +85,9 @@ describe('RecommendationCard', () => {
     const { RecommendationCard } = await import('./browser/RecommendationCard')
     render(
       <RecommendationCard
-        title="Install Prometheus"
-        description="Monitoring solution"
-        onClick={vi.fn()}
+        match={{ mission: { title: 'Install Prometheus', description: 'Monitoring solution', type: 'deploy', tags: [], metadata: {} }, score: 2, matchPercent: 90, matchReasons: ['Matched'] }}
+        onSelect={vi.fn()}
+        onImport={vi.fn()}
       />
     )
     expect(screen.getByText('Install Prometheus')).toBeInTheDocument()
@@ -122,9 +143,9 @@ describe('VirtualizedMissionGrid', () => {
     const { VirtualizedMissionGrid } = await import('./browser/VirtualizedMissionGrid')
     const { container } = render(
       <VirtualizedMissionGrid
-        missions={[]}
-        onSelect={vi.fn()}
-        onImport={vi.fn()}
+        items={[]}
+        viewMode="grid"
+        renderItem={() => null}
       />
     )
     expect(container).toBeTruthy()

--- a/web/src/components/workloads/Workloads.tsx
+++ b/web/src/components/workloads/Workloads.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react'
-import { ChevronRight, Plus, RefreshCw, Trash2, Terminal } from 'lucide-react'
+import { AlertTriangle, ChevronRight, Plus, RefreshCw, Trash2, Terminal } from 'lucide-react'
 import { useDeploymentIssues, usePodIssues, useClusters, useDeployments } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -75,10 +75,10 @@ function mapImportedWorkload(workload: Workload): DeploymentSummary {
 export function Workloads() {
   const { t } = useTranslation()
   // Data fetching
-  const { issues: podIssues, isLoading: podIssuesLoading, isRefreshing: podIssuesRefreshing, lastUpdated: podLastUpdated, refetch: refetchPodIssues } = usePodIssues()
-  const { issues: deploymentIssues, isLoading: deploymentIssuesLoading, isRefreshing: deploymentIssuesRefreshing, lastUpdated: deploymentLastUpdated, refetch: refetchDeploymentIssues } = useDeploymentIssues()
-  const { deployments: allDeployments, isLoading: deploymentsLoading, isRefreshing: deploymentsRefreshing, lastUpdated: deploymentsLastUpdated, refetch: refetchDeployments } = useDeployments()
-  const { deduplicatedClusters: clusters, isLoading: clustersLoading, lastUpdated: clustersLastUpdated, refetch: refetchClusters } = useClusters()
+  const { issues: podIssues, isLoading: podIssuesLoading, isRefreshing: podIssuesRefreshing, error: podIssuesError, lastUpdated: podLastUpdated, refetch: refetchPodIssues } = usePodIssues()
+  const { issues: deploymentIssues, isLoading: deploymentIssuesLoading, isRefreshing: deploymentIssuesRefreshing, error: deploymentIssuesError, lastUpdated: deploymentLastUpdated, refetch: refetchDeploymentIssues } = useDeploymentIssues()
+  const { deployments: allDeployments, isLoading: deploymentsLoading, isRefreshing: deploymentsRefreshing, error: deploymentsError, lastUpdated: deploymentsLastUpdated, refetch: refetchDeployments } = useDeployments()
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading, error: clustersError, lastUpdated: clustersLastUpdated, refetch: refetchClusters } = useClusters()
 
   // Combine lastUpdated from all sources - use the most recent one
   const lastUpdated = useMemo(() => {
@@ -111,6 +111,7 @@ export function Workloads() {
   // Combined states
   const isLoading = podIssuesLoading || deploymentIssuesLoading || deploymentsLoading || clustersLoading
   const isRefreshing = podIssuesRefreshing || deploymentIssuesRefreshing || deploymentsRefreshing
+  const loadError = podIssuesError || deploymentIssuesError || deploymentsError || clustersError
   // Show skeletons when loading with no data OR when agent is offline and demo mode is OFF OR mode switching
   const isAgentOffline = agentStatus === 'disconnected'
   const forceSkeletonForOffline = !isDemoMode && isAgentOffline && !isInClusterMode() && !isLocalAgentSuppressed() && !wasAgentEverConnected()
@@ -355,6 +356,24 @@ export function Workloads() {
         description: t('workloads.emptyDescription')
       }}
     >
+      {loadError && (
+        <div className="mb-4 rounded-lg border border-red-500/30 bg-red-500/10 p-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <p className="text-sm font-medium text-red-400">{t('workloads.errorLoading', 'Could not load workload data')}</p>
+              <p className="text-xs text-muted-foreground mt-1">{loadError}</p>
+              <button
+                type="button"
+                onClick={handleRefresh}
+                className="mt-3 inline-flex items-center rounded-lg bg-red-500/15 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/25"
+              >
+                {t('common.retry', 'Retry')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       {/* Workloads List */}
       {showSkeletons ? (
         <div data-testid="workloads-loading-state" className="space-y-3">

--- a/web/src/components/workloads/__tests__/Workloads.navigation.test.tsx
+++ b/web/src/components/workloads/__tests__/Workloads.navigation.test.tsx
@@ -61,6 +61,7 @@ let mockDeploymentIssues: MockDeploymentIssue[] = []
 let mockDeployments: MockDeployment[] = []
 let mockClusters: MockCluster[] = []
 let mockIsLoading = false
+let mockHookError: string | null = null
 let mockAgentStatus: 'connected' | 'disconnected' = 'connected'
 let mockIsDemoMode = true
 
@@ -92,10 +93,10 @@ vi.mock('../../../lib/dashboards/DashboardPage', () => ({
 }))
 
 vi.mock('../../../hooks/useMCP', () => ({
-  usePodIssues: () => ({ issues: mockPodIssues, isLoading: mockIsLoading, isRefreshing: false, lastUpdated: null, refetch: vi.fn() }),
-  useDeploymentIssues: () => ({ issues: mockDeploymentIssues, isLoading: mockIsLoading, isRefreshing: false, lastUpdated: null, refetch: vi.fn() }),
-  useDeployments: () => ({ deployments: mockDeployments, isLoading: mockIsLoading, isRefreshing: false, lastUpdated: null, refetch: vi.fn() }),
-  useClusters: () => ({ clusters: mockClusters, deduplicatedClusters: mockClusters, isLoading: mockIsLoading, lastUpdated: null, refetch: vi.fn() }),
+  usePodIssues: () => ({ issues: mockPodIssues, isLoading: mockIsLoading, isRefreshing: false, error: mockHookError, lastUpdated: null, refetch: vi.fn() }),
+  useDeploymentIssues: () => ({ issues: mockDeploymentIssues, isLoading: mockIsLoading, isRefreshing: false, error: mockHookError, lastUpdated: null, refetch: vi.fn() }),
+  useDeployments: () => ({ deployments: mockDeployments, isLoading: mockIsLoading, isRefreshing: false, error: mockHookError, lastUpdated: null, refetch: vi.fn() }),
+  useClusters: () => ({ clusters: mockClusters, deduplicatedClusters: mockClusters, isLoading: mockIsLoading, error: mockHookError, lastUpdated: null, refetch: vi.fn() }),
 }))
 
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
@@ -191,6 +192,7 @@ describe('Workloads Add Workload button', () => {
     mockDeployments = []
     mockClusters = []
     mockIsLoading = false
+    mockHookError = null
     mockAgentStatus = 'connected'
     mockIsDemoMode = true
     showToastSpy.mockClear()
@@ -228,5 +230,14 @@ describe('Workloads Add Workload button', () => {
 
     expect(screen.getByTestId('workload-import-dialog')).toBeTruthy()
     expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('renders workload error state when workload queries fail', () => {
+    mockHookError = 'cluster fetch failed'
+    renderWorkloads()
+
+    expect(screen.getByText('Could not load workload data')).toBeInTheDocument()
+    expect(screen.getByText('cluster fetch failed')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
   })
 })

--- a/web/src/components/workloads/__tests__/Workloads.test.tsx
+++ b/web/src/components/workloads/__tests__/Workloads.test.tsx
@@ -78,14 +78,15 @@ let mockDeploymentIssues: MockDeploymentIssue[] = []
 let mockDeployments: MockDeployment[] = []
 let mockClusters: MockCluster[] = []
 let mockIsLoading = false
+let mockHookError: string | null = null
 let mockAgentStatus: 'connected' | 'disconnected' = 'connected'
 let mockIsDemoMode = true
 
 vi.mock('../../../hooks/useMCP', () => ({
-    usePodIssues: () => ({ issues: mockPodIssues, isLoading: mockIsLoading, isRefreshing: false, lastUpdated: null, refetch: vi.fn() }),
-    useDeploymentIssues: () => ({ issues: mockDeploymentIssues, isLoading: mockIsLoading, isRefreshing: false, lastUpdated: null, refetch: vi.fn() }),
-    useDeployments: () => ({ deployments: mockDeployments, isLoading: mockIsLoading, isRefreshing: false, lastUpdated: null, refetch: vi.fn() }),
-    useClusters: () => ({ clusters: mockClusters, deduplicatedClusters: mockClusters, isLoading: mockIsLoading, lastUpdated: null, refetch: vi.fn() }),
+    usePodIssues: () => ({ issues: mockPodIssues, isLoading: mockIsLoading, isRefreshing: false, error: mockHookError, lastUpdated: null, refetch: vi.fn() }),
+    useDeploymentIssues: () => ({ issues: mockDeploymentIssues, isLoading: mockIsLoading, isRefreshing: false, error: mockHookError, lastUpdated: null, refetch: vi.fn() }),
+    useDeployments: () => ({ deployments: mockDeployments, isLoading: mockIsLoading, isRefreshing: false, error: mockHookError, lastUpdated: null, refetch: vi.fn() }),
+    useClusters: () => ({ clusters: mockClusters, deduplicatedClusters: mockClusters, isLoading: mockIsLoading, error: mockHookError, lastUpdated: null, refetch: vi.fn() }),
 }))
 
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
@@ -205,6 +206,7 @@ describe('Workloads Component', () => {
         mockDeployments = []
         mockClusters = []
         mockIsLoading = false
+        mockHookError = null
         mockAgentStatus = 'connected'
         mockIsDemoMode = true
         showToastSpy.mockClear()
@@ -219,6 +221,14 @@ describe('Workloads Component', () => {
 
     it('renders without crashing', () => {
         expect(() => renderWorkloads()).not.toThrow()
+    })
+
+    it('renders workload error state when queries fail', () => {
+        mockHookError = 'backend unavailable'
+        renderWorkloads()
+
+        expect(screen.getByText('Could not load workload data')).toBeInTheDocument()
+        expect(screen.getByText('backend unavailable')).toBeInTheDocument()
     })
 
     describe('deployment actions', () => {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { Loader2 } from 'lucide-react'
 import App from './App.tsx'
 import './index.css'
 // Initialize i18n before rendering
@@ -22,6 +23,17 @@ import { loadDynamicCards, getAllDynamicCards, loadDynamicStats } from './lib/dy
 import { STORAGE_KEY_SQLITE_MIGRATED } from './lib/constants'
 import { initAnalytics } from './lib/analytics'
 import { prefetchTopDashboards } from './lib/dashboardVisits'
+
+function BootstrapLoadingScreen() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="text-center">
+        <Loader2 className="w-12 h-12 mx-auto mb-4 animate-spin text-primary" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground">Loading console…</p>
+      </div>
+    </div>
+  )
+}
 
 // ── Chunk load error recovery ─────────────────────────────────────────────
 // When a new build is deployed, chunk filenames change (content hashes).
@@ -126,6 +138,11 @@ const enableMocking = async () => {
   }
 }
 
+const rootElement = document.getElementById('root')!
+const root = ReactDOM.createRoot(rootElement)
+
+root.render(<BootstrapLoadingScreen />)
+
 // Render app after mocking is set up (or fails gracefully)
 enableMocking()
   .catch((error) => {
@@ -139,7 +156,7 @@ enableMocking()
     initAnalytics()
 
     // ── Render FIRST — don't block on async work ──────────────────────
-    ReactDOM.createRoot(document.getElementById('root')!).render(
+    root.render(
       <BrowserRouter>
         <App />
       </BrowserRouter>,


### PR DESCRIPTION
Fixes #20069

Part of #20068

Adds proper loading and error state handling to non-card components (pages, panels, etc.) that fetch data without displaying feedback.

## Changes
- Alerts.tsx: wire real loading state
- Logs.tsx: show retryable error banner
- Workloads.tsx: show retryable error banner  
- AuthCallback.tsx: use Loader2 loading UI
- SubmitTab.tsx: show spinner during parent-issue check
- main.tsx: render bootstrap loading screen
- Tests added/updated for loading/error coverage