### PR TITLE
[scanner] fix: remove re-export breaking 208 test mocks

### DIFF
--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -466,5 +466,3 @@ export const LATENCY_ACCEPTABLE_MS = 300
 /** Separator inserted between a port name and its port/protocol string
  * when rendering a named port (e.g. `http: 80/TCP`). */
 export const PORT_NAME_SEPARATOR = ': '
-
-export { isTestEnvironment, getLocalAgentURLs }


### PR DESCRIPTION
Fixes #20072

## Root Cause
PR #20067 (ac764b858) added `export { isTestEnvironment, getLocalAgentURLs }` to `web/src/lib/constants/network.ts` which broke 208 test files that mock network.ts without spreading original exports.

## Fix
Remove the re-export. These functions are only used internally/in tests and don't need to be exported from the module.