### PR TITLE
[scanner] fix: migrate network.ts mocks to importOriginal pattern

### DIFF
--- a/web/src/components/dashboard/customizer/sections/__tests__/AISuggestionsSection.test.tsx
+++ b/web/src/components/dashboard/customizer/sections/__tests__/AISuggestionsSection.test.tsx
@@ -20,9 +20,13 @@ vi.mock('../../../shared/cardCatalog', () => ({
 }))
 
 // Mock RETRY_DELAY_MS to 0 so setTimeout resolves near-instantly
-vi.mock('../../../../../lib/constants/network', () => ({
-  RETRY_DELAY_MS: 0,
-}))
+vi.mock('../../../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    RETRY_DELAY_MS: 0,
+  }
+})
 
 import { AISuggestionsSection } from '../AISuggestionsSection'
 

--- a/web/src/components/dashboard/customizer/sections/__tests__/CardCatalogSection.test.tsx
+++ b/web/src/components/dashboard/customizer/sections/__tests__/CardCatalogSection.test.tsx
@@ -59,9 +59,13 @@ vi.mock('../../../../ui/Toast', () => ({
   useToast: () => ({ showToast: mockShowToast }),
 }))
 
-vi.mock('../../../../../lib/constants/network', () => ({
-  FOCUS_DELAY_MS: 0,
-}))
+vi.mock('../../../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FOCUS_DELAY_MS: 0,
+  }
+})
 
 vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),

--- a/web/src/components/dashboard/customizer/sections/__tests__/UnifiedCardsSection.test.tsx
+++ b/web/src/components/dashboard/customizer/sections/__tests__/UnifiedCardsSection.test.tsx
@@ -30,10 +30,14 @@ vi.mock('../../../../ui/Toast', () => ({
   useToast: () => ({ showToast: mockShowToast }),
 }))
 
-vi.mock('../../../../../lib/constants/network', () => ({
-  FOCUS_DELAY_MS: 0,
-  RETRY_DELAY_MS: 0,
-}))
+vi.mock('../../../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FOCUS_DELAY_MS: 0,
+    RETRY_DELAY_MS: 0,
+  }
+})
 
 vi.mock('../../../../../lib/analytics', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../../../lib/analytics')>()),

--- a/web/src/components/feedback/FeedbackModal.test.tsx
+++ b/web/src/components/feedback/FeedbackModal.test.tsx
@@ -85,9 +85,13 @@ vi.mock('../../lib/constants', () => ({
   COPY_FEEDBACK_TIMEOUT_MS: 2000,
 }))
 
-vi.mock('../../lib/constants/network', () => ({
-  FEEDBACK_UPLOAD_TIMEOUT_MS: 30000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FEEDBACK_UPLOAD_TIMEOUT_MS: 30000,
+  }
+})
 
 vi.mock('./FeatureRequestTypes', () => ({
   MAX_VIDEO_SIZE_BYTES: 10 * 1024 * 1024,

--- a/web/src/components/settings/sections/__tests__/SettingsBackupSection.test.tsx
+++ b/web/src/components/settings/sections/__tests__/SettingsBackupSection.test.tsx
@@ -9,9 +9,13 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }))
 
-vi.mock('../../../../lib/constants/network', () => ({
-  TOAST_DISMISS_MS: 1000,
-}))
+vi.mock('../../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    TOAST_DISMISS_MS: 1000,
+  }
+})
 
 describe('SettingsBackupSection', () => {
   beforeEach(() => {

--- a/web/src/hooks/__tests__/useAIPredictions-hook.test.ts
+++ b/web/src/hooks/__tests__/useAIPredictions-hook.test.ts
@@ -56,15 +56,19 @@ vi.mock('../../lib/constants', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10000,
-  AI_PREDICTION_TIMEOUT_MS: 30000,
-  WS_RECONNECT_DELAY_MS: 5000,
-  UI_FEEDBACK_TIMEOUT_MS: 500,
-  RETRY_DELAY_MS: 100,
-  MAX_WS_RECONNECT_ATTEMPTS: 5,
-  getWsBackoffDelay: (attempt: number) => Math.min(1000 * Math.pow(2, attempt), 30000),
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10000,
+    AI_PREDICTION_TIMEOUT_MS: 30000,
+    WS_RECONNECT_DELAY_MS: 5000,
+    UI_FEEDBACK_TIMEOUT_MS: 500,
+    RETRY_DELAY_MS: 100,
+    MAX_WS_RECONNECT_ATTEMPTS: 5,
+    getWsBackoffDelay: (attempt: number) => Math.min(1000 * Math.pow(2, attempt), 30000),
+  }
+})
 
 import { useAIPredictions, getRawAIPredictions, isWSConnected, syncSettingsToBackend } from '../useAIPredictions'
 

--- a/web/src/hooks/__tests__/useAIPredictions-utils.test.ts
+++ b/web/src/hooks/__tests__/useAIPredictions-utils.test.ts
@@ -56,15 +56,19 @@ vi.mock('../../lib/constants', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10000,
-  AI_PREDICTION_TIMEOUT_MS: 30000,
-  WS_RECONNECT_DELAY_MS: 5000,
-  UI_FEEDBACK_TIMEOUT_MS: 500,
-  RETRY_DELAY_MS: 100,
-  MAX_WS_RECONNECT_ATTEMPTS: 5,
-  getWsBackoffDelay: (attempt: number) => Math.min(1000 * Math.pow(2, attempt), 30000),
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10000,
+    AI_PREDICTION_TIMEOUT_MS: 30000,
+    WS_RECONNECT_DELAY_MS: 5000,
+    UI_FEEDBACK_TIMEOUT_MS: 500,
+    RETRY_DELAY_MS: 100,
+    MAX_WS_RECONNECT_ATTEMPTS: 5,
+    getWsBackoffDelay: (attempt: number) => Math.min(1000 * Math.pow(2, attempt), 30000),
+  }
+})
 
 import { useAIPredictions, getRawAIPredictions, isWSConnected, syncSettingsToBackend } from '../useAIPredictions'
 

--- a/web/src/hooks/__tests__/useBonusPoints.test.ts
+++ b/web/src/hooks/__tests__/useBonusPoints.test.ts
@@ -31,9 +31,13 @@ vi.mock('../../lib/constants', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 import { useBonusPoints } from '../useBonusPoints'
 

--- a/web/src/hooks/__tests__/useCRDs.test.ts
+++ b/web/src/hooks/__tests__/useCRDs.test.ts
@@ -51,9 +51,13 @@ vi.mock('../../lib/constants', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+  }
+})
 
 vi.mock('../../lib/authToken', () => ({
   getStoredAuthToken: () => mockGetStoredAuthToken(),

--- a/web/src/hooks/__tests__/useCachedAttestation-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedAttestation-funcs.test.ts
@@ -46,10 +46,14 @@ vi.mock('../../lib/cache', () => ({
     useCache: (...args: unknown[]) => mockUseCache(...args),
 }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedBackstage-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedBackstage-funcs.test.ts
@@ -12,11 +12,15 @@ const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: mockAuthFetch }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedCloudCustodian-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCloudCustodian-funcs.test.ts
@@ -12,11 +12,15 @@ const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: mockAuthFetch }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedCni-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCni-funcs.test.ts
@@ -9,11 +9,15 @@ const mockAuthFetch = vi.fn()
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedContainerd-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedContainerd-funcs.test.ts
@@ -24,10 +24,14 @@ const mockCreateCachedHook = vi.hoisted(() => vi.fn())
 
 vi.mock('../mcp/shared', () => ({ agentFetch: mockAgentFetch }))
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedContainerd.test.ts
+++ b/web/src/hooks/__tests__/useCachedContainerd.test.ts
@@ -34,10 +34,14 @@ vi.mock('../mcp/shared', () => ({
   agentFetch: (...args: unknown[]) => mockAgentFetch(...args),
 }))
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../../lib/constants/time', () => ({
   MS_PER_SECOND: 1000,

--- a/web/src/hooks/__tests__/useCachedCoreWorkloads.test.ts
+++ b/web/src/hooks/__tests__/useCachedCoreWorkloads.test.ts
@@ -55,11 +55,15 @@ vi.mock('../../lib/constants', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  KUBECTL_EXTENDED_TIMEOUT_MS: 30000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    KUBECTL_EXTENDED_TIMEOUT_MS: 30000,
+  }
+})
 
 vi.mock('../../lib/utils/concurrency', () => ({
     createCachedHook: vi.fn(),

--- a/web/src/hooks/__tests__/useCachedCortex-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedCortex-funcs.test.ts
@@ -12,11 +12,15 @@ const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: mockAuthFetch }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedDapr-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedDapr-funcs.test.ts
@@ -12,11 +12,15 @@ const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: mockAuthFetch }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedDragonfly-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedDragonfly-funcs.test.ts
@@ -5,10 +5,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
   mockAuthFetch: vi.fn(),

--- a/web/src/hooks/__tests__/useCachedDragonfly.test.ts
+++ b/web/src/hooks/__tests__/useCachedDragonfly.test.ts
@@ -34,9 +34,13 @@ vi.mock('../../lib/api', () => ({
   authFetch: (...args: unknown[]) => mockAuthFetch(...args),
 }))
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+  }
+})
 
 import { useCachedDragonfly, __testables } from '../useCachedDragonfly'
 

--- a/web/src/hooks/__tests__/useCachedFlatcar-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedFlatcar-funcs.test.ts
@@ -10,11 +10,15 @@ const mockAuthFetch = vi.fn()
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedGrpc-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedGrpc-funcs.test.ts
@@ -9,11 +9,15 @@ const mockAuthFetch = vi.fn()
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedKeda.test.ts
+++ b/web/src/hooks/__tests__/useCachedKeda.test.ts
@@ -40,10 +40,14 @@ vi.mock('../../lib/constants', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
     LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+  }
+})
 
 import { useCachedKeda } from '../useCachedKeda'
 

--- a/web/src/hooks/__tests__/useCachedKserve-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedKserve-funcs.test.ts
@@ -12,11 +12,15 @@ const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: mockAuthFetch }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedKubevela-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedKubevela-funcs.test.ts
@@ -12,11 +12,15 @@ const { mockAuthFetch, mockUseCache: mockUseCacheHoisted } = vi.hoisted(() => ({
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: mockAuthFetch }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedLinkerd-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedLinkerd-funcs.test.ts
@@ -12,11 +12,15 @@ const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: mockAuthFetch }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedLonghorn-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedLonghorn-funcs.test.ts
@@ -5,10 +5,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
   mockAuthFetch: vi.fn(),

--- a/web/src/hooks/__tests__/useCachedLonghorn.test.ts
+++ b/web/src/hooks/__tests__/useCachedLonghorn.test.ts
@@ -34,9 +34,13 @@ vi.mock('../../lib/api', () => ({
   authFetch: (...args: unknown[]) => mockAuthFetch(...args),
 }))
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+  }
+})
 
 import { useCachedLonghorn, __testables } from '../useCachedLonghorn'
 

--- a/web/src/hooks/__tests__/useCachedNodes.test.ts
+++ b/web/src/hooks/__tests__/useCachedNodes.test.ts
@@ -53,11 +53,15 @@ vi.mock('../useCachedData/demoData', () => ({
   getDemoCoreDNSStatus: () => [],
 }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  KUBECTL_EXTENDED_TIMEOUT_MS: 60000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    KUBECTL_EXTENDED_TIMEOUT_MS: 60000,
+  }
+})
 
 import { useCachedNodes, useCachedCoreDNSStatus, useCachedAllNodes } from '../useCachedNodes'
 import { fetchAPI, getClusterFetcher } from '../../lib/cache/fetcherUtils'

--- a/web/src/hooks/__tests__/useCachedOpenfeature-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedOpenfeature-funcs.test.ts
@@ -12,11 +12,15 @@ const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: mockAuthFetch }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedOpenfga-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedOpenfga-funcs.test.ts
@@ -9,11 +9,15 @@ const mockAuthFetch = vi.fn()
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedOtel-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedOtel-funcs.test.ts
@@ -5,10 +5,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
   mockAuthFetch: vi.fn(),

--- a/web/src/hooks/__tests__/useCachedOtel.test.ts
+++ b/web/src/hooks/__tests__/useCachedOtel.test.ts
@@ -34,9 +34,13 @@ vi.mock('../../lib/api', () => ({
   authFetch: (...args: unknown[]) => mockAuthFetch(...args),
 }))
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+  }
+})
 
 import { useCachedOtel, __testables } from '../useCachedOtel'
 

--- a/web/src/hooks/__tests__/useCachedRook-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedRook-funcs.test.ts
@@ -31,10 +31,14 @@ vi.mock('../../lib/cache', () => ({
   createCachedHook: (_config: unknown) => () => mockUseCache(_config),
 }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 import { useCachedRook, __testables } from '../useCachedRook'
 

--- a/web/src/hooks/__tests__/useCachedSpiffe-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedSpiffe-funcs.test.ts
@@ -9,11 +9,15 @@ const mockAuthFetch = vi.fn()
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedSpire-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedSpire-funcs.test.ts
@@ -12,11 +12,15 @@ const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: mockAuthFetch }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedStrimzi-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedStrimzi-funcs.test.ts
@@ -9,11 +9,15 @@ const mockAuthFetch = vi.fn()
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedThanosStatus-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedThanosStatus-funcs.test.ts
@@ -13,9 +13,13 @@ vi.mock('../mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 import { getDemoThanosStatus, fetchThanosStatus } from '../useCachedThanosStatus'
 

--- a/web/src/hooks/__tests__/useCachedTikv-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedTikv-funcs.test.ts
@@ -30,10 +30,14 @@ vi.mock('../../lib/cache', () => ({
   useCache: (...args: unknown[]) => mockUseCache(...args),
   createCachedHook: (_config: unknown) => () => mockUseCache(_config),
 }))
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 import { useCachedTikv, __testables } from '../useCachedTikv'
 

--- a/web/src/hooks/__tests__/useCachedTimeline-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedTimeline-funcs.test.ts
@@ -9,10 +9,14 @@ const mockAuthFetch = vi.fn()
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 vi.mock('../../lib/constants/time', () => ({
     createCachedHook: vi.fn(),

--- a/web/src/hooks/__tests__/useCachedTuf-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedTuf-funcs.test.ts
@@ -28,10 +28,14 @@ vi.mock('../../lib/api', () => ({
 vi.mock('../../lib/cache', () => ({
     createCachedHook: vi.fn(), useCache: (...args: unknown[]) => mockUseCache(...args), createCachedHook: (_config: unknown) => () => mockUseCache(_config) }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 vi.mock('../../lib/constants/time', () => ({
     createCachedHook: vi.fn(),

--- a/web/src/hooks/__tests__/useCachedVitess-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedVitess-funcs.test.ts
@@ -5,10 +5,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
   mockAuthFetch: vi.fn(),

--- a/web/src/hooks/__tests__/useCachedVolcano-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedVolcano-funcs.test.ts
@@ -9,11 +9,15 @@ const mockAuthFetch = vi.fn()
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: (...args: unknown[]) => mockAuthFetch(...args) }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useCachedWasmcloud-funcs.test.ts
+++ b/web/src/hooks/__tests__/useCachedWasmcloud-funcs.test.ts
@@ -12,11 +12,15 @@ const { mockAuthFetch, mockUseCache } = vi.hoisted(() => ({
 vi.mock('../../lib/api', () => ({
     createCachedHook: vi.fn(), authFetch: mockAuthFetch }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 vi.mock('../useDemoMode', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../useDemoMode')>()),

--- a/web/src/hooks/__tests__/useDeployMissions-expand.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions-expand.test.ts
@@ -53,11 +53,15 @@ vi.mock('../../lib/constants', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10000,
-  DEPLOY_ABORT_TIMEOUT_MS: 5000,
-  MCP_HOOK_TIMEOUT_MS: 15_000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10000,
+    DEPLOY_ABORT_TIMEOUT_MS: 5000,
+    MCP_HOOK_TIMEOUT_MS: 15_000,
+  }
+})
 
 vi.mock('../useBackendHealth', () => ({
   isInClusterMode: vi.fn().mockReturnValue(false),

--- a/web/src/hooks/__tests__/useDropdownKeyNav-useQASMFiles-pure.test.ts
+++ b/web/src/hooks/__tests__/useDropdownKeyNav-useQASMFiles-pure.test.ts
@@ -24,9 +24,13 @@ vi.mock('../../lib/demoMode', () => ({
   isNetlifyDeployment: false,
 }))
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 import { __testables as dropdownTestables } from '../useDropdownKeyNav'
 import { __testables as qasmTestables } from '../useQASMFiles'

--- a/web/src/hooks/__tests__/useGadget.test.ts
+++ b/web/src/hooks/__tests__/useGadget.test.ts
@@ -56,10 +56,14 @@ vi.mock('../../lib/api', () => ({
   authFetch: (...args: unknown[]) => mockAuthFetch(...args),
 }))
 
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+  }
+})
 
 // Now import the hooks under test
 import {

--- a/web/src/hooks/__tests__/useGatewayStatus.test.ts
+++ b/web/src/hooks/__tests__/useGatewayStatus.test.ts
@@ -34,9 +34,13 @@ vi.mock('../../lib/constants', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 import { useGatewayStatus } from '../useGatewayStatus'
 

--- a/web/src/hooks/__tests__/useGitHubPipelines.test.ts
+++ b/web/src/hooks/__tests__/useGitHubPipelines.test.ts
@@ -51,10 +51,14 @@ vi.mock('../../lib/constants', async (importOriginal) => {
     STORAGE_KEY_TOKEN: 'token',
   }
 })
-vi.mock('../../lib/constants/network', () => ({
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
     createCachedHook: vi.fn(),
-  FETCH_DEFAULT_TIMEOUT_MS: 30000,
-}))
+    FETCH_DEFAULT_TIMEOUT_MS: 30000,
+  }
+})
 
 import {
   getPipelineRepos,

--- a/web/src/hooks/__tests__/useHelmActions.test.ts
+++ b/web/src/hooks/__tests__/useHelmActions.test.ts
@@ -19,9 +19,13 @@ vi.mock('../mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+  }
+})
 
 // Mock global fetch
 const mockFetch = vi.fn()

--- a/web/src/hooks/__tests__/useLastRoute.test.ts
+++ b/web/src/hooks/__tests__/useLastRoute.test.ts
@@ -27,9 +27,13 @@ vi.mock('../../lib/dashboardVisits', () => ({
   recordDashboardVisit: vi.fn(),
 }))
 
-vi.mock('../../lib/constants/network', () => ({
-  FOCUS_DELAY_MS: 0,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FOCUS_DELAY_MS: 0,
+  }
+})
 
 // ---------- Setup ----------
 

--- a/web/src/hooks/__tests__/useMarketplace.test.ts
+++ b/web/src/hooks/__tests__/useMarketplace.test.ts
@@ -41,9 +41,13 @@ vi.mock('../../lib/analytics', async (importOriginal) => ({
 }
 ))
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_EXTERNAL_TIMEOUT_MS: 15000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_EXTERNAL_TIMEOUT_MS: 15000,
+  }
+})
 
 const mockIsCardTypeRegistered = vi.fn(() => false)
 vi.mock('../../components/cards/cardRegistry', () => ({

--- a/web/src/hooks/__tests__/useMissionSuggestions.test.ts
+++ b/web/src/hooks/__tests__/useMissionSuggestions.test.ts
@@ -35,9 +35,13 @@ vi.mock('../useSnoozedMissions', () => ({
   }),
 }))
 
-vi.mock('../../lib/constants/network', () => ({
-  MISSION_SUGGEST_INTERVAL_MS: 120_000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    MISSION_SUGGEST_INTERVAL_MS: 120_000,
+  }
+})
 
 import { useMissionSuggestions } from '../useMissionSuggestions'
 

--- a/web/src/hooks/__tests__/usePersistence.test.ts
+++ b/web/src/hooks/__tests__/usePersistence.test.ts
@@ -22,10 +22,14 @@ vi.mock('../../lib/auth', () => ({
   useAuth: () => ({ token: mockToken }),
 }))
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
-  POLL_INTERVAL_MS: 60_000_000, // Very large so interval never fires during tests
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+    POLL_INTERVAL_MS: 60_000_000, // Very large so interval never fires during tests
+  }
+})
 
 import { usePersistence, useShouldUsePersistence } from '../usePersistence'
 import type { PersistenceConfig, PersistenceStatus } from '../usePersistence'

--- a/web/src/hooks/__tests__/useQASMFiles.test.ts
+++ b/web/src/hooks/__tests__/useQASMFiles.test.ts
@@ -21,9 +21,13 @@ vi.mock('../../lib/demoMode', () => ({
   isQuantumForcedToDemo: () => mockIsQuantumForcedToDemo(),
 }))
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 // ---------- Setup ----------
 

--- a/web/src/hooks/__tests__/useServiceImportsCard.test.ts
+++ b/web/src/hooks/__tests__/useServiceImportsCard.test.ts
@@ -29,9 +29,13 @@ vi.mock('../../lib/constants', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  }
+})
 
 import { useServiceImportsCard } from '../useServiceImportsCard'
 

--- a/web/src/hooks/__tests__/useWorkloads.test.ts
+++ b/web/src/hooks/__tests__/useWorkloads.test.ts
@@ -36,12 +36,16 @@ vi.mock('../../lib/constants', async (importOriginal) => {
   }
 })
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
-  MCP_HOOK_TIMEOUT_MS: 15_000,
-  POLL_INTERVAL_MS: 30_000,
-  POLL_INTERVAL_SLOW_MS: 60_000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+    MCP_HOOK_TIMEOUT_MS: 15_000,
+    POLL_INTERVAL_MS: 30_000,
+    POLL_INTERVAL_SLOW_MS: 60_000,
+  }
+})
 
 vi.mock('../../lib/utils/concurrency', () => ({
   mapSettledWithConcurrency: vi.fn(),

--- a/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
@@ -42,9 +42,13 @@ vi.mock('../dedup', () => ({
   deduplicateClustersByServer: (clusters: unknown[]) => mockDeduplicateClustersByServer(clusters),
 }))
 
-vi.mock('../../../lib/constants/network', () => ({
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+vi.mock('../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 // ---------------------------------------------------------------------------
 // Import under test (after mocks)

--- a/web/src/hooks/mcp/__tests__/sharedImpl.health-expand.test.ts
+++ b/web/src/hooks/mcp/__tests__/sharedImpl.health-expand.test.ts
@@ -70,13 +70,17 @@ vi.mock('../../../lib/constants', () => ({
   KUBECTL_MAX_TIMEOUT_MS: 30_000,
 }))
 
-vi.mock('../../../lib/constants/network', () => ({
-  MCP_HOOK_TIMEOUT_MS: 10_000,
-  METRICS_SERVER_TIMEOUT_MS: 5_000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:4201',
-  KUBECTL_MAX_TIMEOUT_MS: 30_000,
-  FOCUS_DELAY_MS: 100,
-}))
+vi.mock('../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    MCP_HOOK_TIMEOUT_MS: 10_000,
+    METRICS_SERVER_TIMEOUT_MS: 5_000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:4201',
+    KUBECTL_MAX_TIMEOUT_MS: 30_000,
+    FOCUS_DELAY_MS: 100,
+  }
+})
 
 // ── Setup ─────────────────────────────────────────────────────────────────
 

--- a/web/src/hooks/mcp/__tests__/sharedImpl.health.test.ts
+++ b/web/src/hooks/mcp/__tests__/sharedImpl.health.test.ts
@@ -68,13 +68,17 @@ vi.mock('../../../lib/constants', () => ({
   KUBECTL_MAX_TIMEOUT_MS: 30_000,
 }))
 
-vi.mock('../../../lib/constants/network', () => ({
-  MCP_HOOK_TIMEOUT_MS: 10_000,
-  METRICS_SERVER_TIMEOUT_MS: 5_000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:4201',
-  KUBECTL_MAX_TIMEOUT_MS: 30_000,
-  FOCUS_DELAY_MS: 100,
-}))
+vi.mock('../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    MCP_HOOK_TIMEOUT_MS: 10_000,
+    METRICS_SERVER_TIMEOUT_MS: 5_000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:4201',
+    KUBECTL_MAX_TIMEOUT_MS: 30_000,
+    FOCUS_DELAY_MS: 100,
+  }
+})
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 

--- a/web/src/hooks/mcp/__tests__/useClusterResourceQuery.test.ts
+++ b/web/src/hooks/mcp/__tests__/useClusterResourceQuery.test.ts
@@ -39,10 +39,14 @@ vi.mock('../shared', () => ({
   agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as Parameters<typeof fetch>)),
 }))
 
-vi.mock('../../../lib/constants/network', () => ({
-  MCP_HOOK_TIMEOUT_MS: 5_000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+vi.mock('../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    MCP_HOOK_TIMEOUT_MS: 5_000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
 // ---------------------------------------------------------------------------
 // Import under test (after mocks)

--- a/web/src/hooks/mcp/workloadQueries/__tests__/deployments.test.ts
+++ b/web/src/hooks/mcp/workloadQueries/__tests__/deployments.test.ts
@@ -34,10 +34,14 @@ vi.mock('../../../../lib/demoMode', async (importOriginal) => {
   return { ...actual, isDemoMode: vi.fn(() => false) }
 })
 vi.mock('../../../../lib/kubectlProxy', () => ({ kubectlProxy: vi.fn() }))
-vi.mock('../../../../lib/constants/network', () => ({
-  MCP_HOOK_TIMEOUT_MS: 10_000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+vi.mock('../../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    MCP_HOOK_TIMEOUT_MS: 10_000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 vi.mock('../../../../lib/sseClient', () => ({ fetchSSE: vi.fn() }))
 vi.mock('../../../../lib/cache/fetcherUtils', () => ({
   getClusterModeBaseUrl: vi.fn(() => 'http://localhost:8080'),

--- a/web/src/hooks/mcp/workloadQueries/__tests__/edge-cases.test.ts
+++ b/web/src/hooks/mcp/workloadQueries/__tests__/edge-cases.test.ts
@@ -33,10 +33,14 @@ vi.mock('../../../../lib/demoMode', async () => {
 vi.mock('../../../../lib/api', () => ({ isBackendUnavailable: vi.fn(() => false) }))
 vi.mock('../../../../lib/errorClassifier', () => ({ classifyError: vi.fn(() => 'unknown') }))
 vi.mock('../../../../lib/kubectlProxy', () => ({ kubectlProxy: vi.fn() }))
-vi.mock('../../../../lib/constants/network', () => ({
-  MCP_HOOK_TIMEOUT_MS: 10_000,
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+vi.mock('../../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    MCP_HOOK_TIMEOUT_MS: 10_000,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 vi.mock('../../../../lib/sseClient', () => ({ fetchSSE: vi.fn() }))
 vi.mock('../../../../lib/cache/fetcherUtils', () => ({
   getClusterModeBaseUrl: vi.fn(() => 'http://localhost:8080'),

--- a/web/src/hooks/mcp/workloadQueries/__tests__/infrastructure.test.ts
+++ b/web/src/hooks/mcp/workloadQueries/__tests__/infrastructure.test.ts
@@ -22,11 +22,15 @@ const { mockIsAgentUnavailable, mockIsClusterModeBackend, mockFetchSSE } = vi.ho
 // Module mocks
 // ---------------------------------------------------------------------------
 
-vi.mock('../../../../lib/constants/network', () => ({
-  MCP_HOOK_TIMEOUT_MS: 5000,
-  LOCAL_AGENT_HTTP_URL: '',         // empty → triggers early-exit branch
-  RETRY_DELAY_MS: 0,
-}))
+vi.mock('../../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    MCP_HOOK_TIMEOUT_MS: 5000,
+    LOCAL_AGENT_HTTP_URL: '',         // empty → triggers early-exit branch
+    RETRY_DELAY_MS: 0,
+  }
+})
 
 vi.mock('../../../../lib/sseClient', () => ({
   fetchSSE: (...args: unknown[]) => mockFetchSSE(...args),

--- a/web/src/hooks/useCachedData/__tests__/agentFetchers.test.ts
+++ b/web/src/hooks/useCachedData/__tests__/agentFetchers.test.ts
@@ -42,9 +42,13 @@ vi.mock('../../../lib/constants', async (importOriginal) => {
   return { ...actual, LOCAL_AGENT_HTTP_URL: 'http://localhost:8089' }
 })
 
-vi.mock('../../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
-}))
+vi.mock('../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+  }
+})
 
 vi.mock('../../../lib/cache/fetcherUtils', () => ({
   AGENT_HTTP_TIMEOUT_MS: 5_000,

--- a/web/src/hooks/version/__tests__/useAutoUpdate.test.ts
+++ b/web/src/hooks/version/__tests__/useAutoUpdate.test.ts
@@ -13,9 +13,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 // Mocks — must be declared before importing the module under test
 // ---------------------------------------------------------------------------
 
-vi.mock('../../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
-}))
+vi.mock('../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+  }
+})
 
 const mockAuthFetch = vi.fn()
 vi.mock('../../../lib/api', () => ({

--- a/web/src/hooks/version/__tests__/useReleasesFetch.test.ts
+++ b/web/src/hooks/version/__tests__/useReleasesFetch.test.ts
@@ -17,11 +17,15 @@ vi.mock('../../../lib/constants/time', () => ({
   MS_PER_MINUTE: 60_000,
 }))
 
-vi.mock('../../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
-  FETCH_EXTERNAL_TIMEOUT_MS: 15_000,
-  MCP_HOOK_TIMEOUT_MS: 5_000,
-}))
+vi.mock('../../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+    FETCH_EXTERNAL_TIMEOUT_MS: 15_000,
+    MCP_HOOK_TIMEOUT_MS: 5_000,
+  }
+})
 
 const mockAuthFetch = vi.fn()
 vi.mock('../../../lib/api', () => ({


### PR DESCRIPTION
Fixes #20079

## Changes
- Migrated 67 test files from fragile full-module mocks to importOriginal pattern
- Only specific constants are mocked now, rest pass through from actual module
- Reduces test fragility when network.ts exports change

## Pattern
Before:
```ts
vi.mock('../../lib/constants/network', () => ({
  FETCH_DEFAULT_TIMEOUT_MS: 5000,
}))
```

After:
```ts
vi.mock('../../lib/constants/network', async (importOriginal) => {
  const actual = await importOriginal() as Record<string, unknown>
  return {
    ...actual,
    FETCH_DEFAULT_TIMEOUT_MS: 5000,
  }
})
```

Now when network.ts adds new exports, tests won't break with undefined values.