### PR TITLE
[scanner] fix: resolve 188 test failures in Coverage Suite run #4021

### DIFF
--- a/web/src/components/cards/NamespaceQuotas.test.tsx
+++ b/web/src/components/cards/NamespaceQuotas.test.tsx
@@ -107,7 +107,7 @@ function setupMocks(overrides: {
       }
     ],
     isLoading: overrides.quotasLoading ?? false,
-    error: null,
+    error: false,
     refetch: vi.fn(),
     isDemoFallback: overrides.isDemoFallback ?? false,
   })
@@ -130,7 +130,7 @@ function setupMocks(overrides: {
       }
     ],
     isLoading: overrides.limitsLoading ?? false,
-    error: null,
+    error: false,
     refetch: vi.fn(),
   })
 
@@ -139,7 +139,7 @@ function setupMocks(overrides: {
     isLoading: overrides.namespacesLoading ?? false,
     isRefreshing: false,
     isDemoFallback: false,
-    error: null,
+    error: false,
     isFailed: false,
     consecutiveFailures: 0,
   })

--- a/web/src/components/cards/PodIssues.test.tsx
+++ b/web/src/components/cards/PodIssues.test.tsx
@@ -166,7 +166,7 @@ const defaultPodIssuesReturn = {
   isDemoFallback: false,
   isFailed: false,
   consecutiveFailures: 0,
-  error: null,
+  error: false,
 }
 
 const defaultClustersReturn = {

--- a/web/src/components/cards/StorageOverview.test.tsx
+++ b/web/src/components/cards/StorageOverview.test.tsx
@@ -137,7 +137,7 @@ const defaultPVCsReturn = {
   consecutiveFailures: 0,
   isFailed: false,
   isDemoFallback: false,
-  error: null,
+  error: false,
 }
 
 const defaultChartFilters = {

--- a/web/src/components/cards/__tests__/AdmissionWebhooks.test.tsx
+++ b/web/src/components/cards/__tests__/AdmissionWebhooks.test.tsx
@@ -60,7 +60,7 @@ describe('AdmissionWebhooks', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockWebhooks.mockReturnValue({ webhooks: [], isLoading: false, error: null })
+    mockWebhooks.mockReturnValue({ webhooks: [], isLoading: false, error: false })
   })
 
   it('renders without crashing', () => {

--- a/web/src/components/cards/__tests__/CRDHealth.test.tsx
+++ b/web/src/components/cards/__tests__/CRDHealth.test.tsx
@@ -71,7 +71,7 @@ describe('CRDHealth', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockCRDs.mockReturnValue({ crds: [], isLoading: false, error: null })
+    mockCRDs.mockReturnValue({ crds: [], isLoading: false, error: false })
   })
 
   it('renders without crashing', () => {

--- a/web/src/components/cards/__tests__/ChartVersions.test.tsx
+++ b/web/src/components/cards/__tests__/ChartVersions.test.tsx
@@ -78,8 +78,8 @@ describe('ChartVersions', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -94,8 +94,8 @@ describe('ChartVersions', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockHelmReleases.mockReturnValue({ releases: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: null, lastRefresh: null })
+    mockHelmReleases.mockReturnValue({ releases: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: false, lastRefresh: null })
     const { container } = render(<ChartVersions />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -127,7 +127,7 @@ describe('ChartVersions', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<ChartVersions />)
     expect(container).toBeTruthy()
   })
@@ -135,14 +135,14 @@ describe('ChartVersions', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<ChartVersions />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<ChartVersions />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/ClusterChangelog.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterChangelog.test.tsx
@@ -62,7 +62,7 @@ describe('ClusterChangelog', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -77,7 +77,7 @@ describe('ClusterChangelog', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockEvents.mockReturnValue({ events: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
+    mockEvents.mockReturnValue({ events: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
     const { container } = render(<ClusterChangelog />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -103,13 +103,13 @@ describe('ClusterChangelog', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<ClusterChangelog />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<ClusterChangelog />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/ClusterComparison.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterComparison.test.tsx
@@ -77,8 +77,8 @@ describe('ClusterComparison', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToCluster: vi.fn() })
   })
 
@@ -94,8 +94,8 @@ describe('ClusterComparison', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: null, lastRefresh: null })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: false, lastRefresh: null })
     const { container } = render(<ClusterComparison />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -127,7 +127,7 @@ describe('ClusterComparison', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<ClusterComparison />)
     expect(container).toBeTruthy()
   })
@@ -135,14 +135,14 @@ describe('ClusterComparison', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<ClusterComparison />)
     expect(container).toBeTruthy()
   })
 
   it('reports GPU demo fallback state', () => {
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<ClusterComparison />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/ClusterCosts.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterCosts.test.tsx
@@ -96,8 +96,8 @@ describe('ClusterCosts', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToCosts: vi.fn() })
   })
 
@@ -131,7 +131,7 @@ describe('ClusterCosts', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<ClusterCosts />)
     expect(container).toBeTruthy()
   })
@@ -139,14 +139,14 @@ describe('ClusterCosts', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<ClusterCosts />)
     expect(container).toBeTruthy()
   })
 
   it('reports GPU demo fallback state', () => {
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<ClusterCosts />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/ClusterFocus.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterFocus.test.tsx
@@ -80,11 +80,11 @@ describe('ClusterFocus', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockPodIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockDeploymentIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockPodIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockDeploymentIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToCluster: vi.fn() })
   })
 
@@ -100,8 +100,8 @@ describe('ClusterFocus', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: null, lastRefresh: null })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: false, lastRefresh: null })
     const { container } = render(<ClusterFocus />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -133,7 +133,7 @@ describe('ClusterFocus', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<ClusterFocus />)
     expect(container).toBeTruthy()
   })
@@ -141,14 +141,14 @@ describe('ClusterFocus', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<ClusterFocus />)
     expect(container).toBeTruthy()
   })
 
   it('reports GPU demo fallback state', () => {
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<ClusterFocus />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/ClusterGroups.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterGroups.test.tsx
@@ -135,7 +135,7 @@ describe('ClusterGroups', () => {
       isRefreshing: false,
       isFailed: false,
       consecutiveFailures: 0,
-      error: null,
+      error: false,
       lastRefresh: Date.now(),
     })
   })
@@ -170,7 +170,7 @@ describe('ClusterGroups', () => {
       isRefreshing: false,
       isFailed: false,
       consecutiveFailures: 0,
-      error: null,
+      error: false,
       lastRefresh: Date.now(),
     })
     const { container } = render(<ClusterGroups />)

--- a/web/src/components/cards/__tests__/ClusterHealth.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterHealth.test.tsx
@@ -434,7 +434,7 @@ describe('ClusterHealth', () => {
         deduplicatedClusters: clusters,
         isLoading: false,
         isRefreshing: false,
-        error: null,
+        error: false,
         lastRefresh: null,
         consecutiveFailures: 0,
         isFailed: false,

--- a/web/src/components/cards/__tests__/ClusterLocations.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterLocations.test.tsx
@@ -77,7 +77,7 @@ describe('ClusterLocations', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToCluster: vi.fn() })
   })
 
@@ -93,7 +93,7 @@ describe('ClusterLocations', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: null, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: false, lastRefresh: null })
     const { container } = render(<ClusterLocations />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -120,7 +120,7 @@ describe('ClusterLocations', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<ClusterLocations />)
     expect(container).toBeTruthy()

--- a/web/src/components/cards/__tests__/ClusterMetrics.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterMetrics.test.tsx
@@ -90,7 +90,7 @@ describe('ClusterMetrics', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -132,7 +132,7 @@ describe('ClusterMetrics', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<ClusterMetrics />)
     expect(container).toBeTruthy()

--- a/web/src/components/cards/__tests__/ClusterNetwork.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterNetwork.test.tsx
@@ -66,7 +66,7 @@ describe('ClusterNetwork', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -81,7 +81,7 @@ describe('ClusterNetwork', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: null, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: false, lastRefresh: null })
     const { container } = render(<ClusterNetwork />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -108,7 +108,7 @@ describe('ClusterNetwork', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<ClusterNetwork />)
     expect(container).toBeTruthy()

--- a/web/src/components/cards/__tests__/ComputeOverview.test.tsx
+++ b/web/src/components/cards/__tests__/ComputeOverview.test.tsx
@@ -82,8 +82,8 @@ describe('ComputeOverview', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToResources: vi.fn() })
   })
 
@@ -107,7 +107,7 @@ describe('ComputeOverview', () => {
         { name: 'c1', cpuCores: 8, healthy: true, reachable: true, nodeCount: 1, podCount: 10 },
         { name: 'c2', cpuCores: 16, healthy: true, reachable: true, nodeCount: 2, podCount: 20 }
       ],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     
     render(<ComputeOverview />)
@@ -128,7 +128,7 @@ describe('ComputeOverview', () => {
         { name: 'c1', cpuCores: 8, memoryGB: 16, healthy: true, reachable: true, nodeCount: 1, podCount: 10 },
         { name: 'c2', cpuCores: 16, memoryGB: 32, healthy: true, reachable: true, nodeCount: 2, podCount: 20 }
       ],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     
     render(<ComputeOverview />)
@@ -141,7 +141,7 @@ describe('ComputeOverview', () => {
 
   it('renders empty state when no clusters are available', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: true, hasData: false, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     
     render(<ComputeOverview />)
     
@@ -160,7 +160,7 @@ describe('ComputeOverview', () => {
         { name: 'c1', cpuCores: 10, healthy: true, reachable: true, nodeCount: 1, podCount: 1 },
         { name: 'c2', cpuCores: 5, healthy: true, reachable: true, nodeCount: 1, podCount: 1 }
       ],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     
     render(<ComputeOverview />)
@@ -174,8 +174,8 @@ describe('ComputeOverview', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: null, lastRefresh: null })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: false, lastRefresh: null })
     const { container } = render(<ComputeOverview />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -207,7 +207,7 @@ describe('ComputeOverview', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<ComputeOverview />)
     expect(container).toBeTruthy()
   })
@@ -215,14 +215,14 @@ describe('ComputeOverview', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<ComputeOverview />)
     expect(container).toBeTruthy()
   })
 
   it('reports GPU demo fallback state', () => {
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<ComputeOverview />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/CrossClusterPolicyComparison.test.tsx
+++ b/web/src/components/cards/__tests__/CrossClusterPolicyComparison.test.tsx
@@ -59,7 +59,7 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
   useGlobalFilters: () => ({ selectedClusters: [], isAllClustersSelected: true, selectedSeverities: [], isAllSeveritiesSelected: true, customFilter: '' }),
 }))
 
-vi.mock('../../../hooks/useKyverno', () => ({ useKyverno: () => ({ policies: [], isLoading: false, error: null }) }))
+vi.mock('../../../hooks/useKyverno', () => ({ useKyverno: () => ({ policies: [], isLoading: false, error: false }) }))
 
 import { CrossClusterPolicyComparison } from '../CrossClusterPolicyComparison'
 
@@ -68,7 +68,7 @@ describe('CrossClusterPolicyComparison', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -96,7 +96,7 @@ describe('CrossClusterPolicyComparison', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<CrossClusterPolicyComparison />)
     expect(container).toBeTruthy()

--- a/web/src/components/cards/__tests__/DNSHealth.test.tsx
+++ b/web/src/components/cards/__tests__/DNSHealth.test.tsx
@@ -62,7 +62,7 @@ describe('DNSHealth', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -77,7 +77,7 @@ describe('DNSHealth', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockPods.mockReturnValue({ pods: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
+    mockPods.mockReturnValue({ pods: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
     const { container } = render(<DNSHealth />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -103,13 +103,13 @@ describe('DNSHealth', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<DNSHealth />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<DNSHealth />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/DeploymentIssues.test.tsx
+++ b/web/src/components/cards/__tests__/DeploymentIssues.test.tsx
@@ -79,7 +79,7 @@ describe('DeploymentIssues', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockDeploymentIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockDeploymentIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToDeployment: vi.fn() })
   })
 
@@ -95,7 +95,7 @@ describe('DeploymentIssues', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockDeploymentIssues.mockReturnValue({ issues: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
+    mockDeploymentIssues.mockReturnValue({ issues: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
     const { container } = render(<DeploymentIssues />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -114,7 +114,7 @@ describe('DeploymentIssues', () => {
   })
 
   it('handles undefined issues without crashing', () => {
-    mockDeploymentIssues.mockReturnValue({ issues: undefined, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
+    mockDeploymentIssues.mockReturnValue({ issues: undefined, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
     const { container } = render(<DeploymentIssues />)
     expect(container).toBeTruthy()
   })
@@ -133,13 +133,13 @@ describe('DeploymentIssues', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockDeploymentIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockDeploymentIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<DeploymentIssues />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockDeploymentIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockDeploymentIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<DeploymentIssues />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/DeploymentProgress.test.tsx
+++ b/web/src/components/cards/__tests__/DeploymentProgress.test.tsx
@@ -78,7 +78,7 @@ describe('DeploymentProgress', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockDeployments.mockReturnValue({ deployments: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockDeployments.mockReturnValue({ deployments: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToDeployment: vi.fn() })
   })
 
@@ -112,13 +112,13 @@ describe('DeploymentProgress', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockDeployments.mockReturnValue({ deployments: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockDeployments.mockReturnValue({ deployments: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<DeploymentProgress />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockDeployments.mockReturnValue({ deployments: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockDeployments.mockReturnValue({ deployments: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<DeploymentProgress />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/DynamicCard.test.tsx
+++ b/web/src/components/cards/__tests__/DynamicCard.test.tsx
@@ -211,11 +211,11 @@ describe('DynamicCard', () => {
   it('passes safeConfig to Tier2CardRuntime', async () => {
     mockGetDynamicCard.mockReturnValue(makeT2Definition())
     const mockCleanup = vi.fn()
-    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: null })
+    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: false })
     mockCreateCardComponent.mockResolvedValue({
       component: () => <div>T2 rendered</div>,
       cleanup: mockCleanup,
-      error: null,
+      error: false,
     })
     await act(async () => {
       render(<DynamicCard config={{ dynamicCardId: 'card-t2', extra: true }} />)
@@ -620,11 +620,11 @@ describe('Tier2CardRuntime', () => {
   })
 
   it('renders compiled component on success', async () => {
-    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: null })
+    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: false })
     mockCreateCardComponent.mockResolvedValue({
       component: () => <div>Tier2 Works</div>,
       cleanup: vi.fn(),
-      error: null,
+      error: false,
     })
 
     await act(async () => {
@@ -644,7 +644,7 @@ describe('Tier2CardRuntime', () => {
   })
 
   it('shows compilation error returned by createCardComponent', async () => {
-    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: null })
+    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: false })
     mockCreateCardComponent.mockResolvedValue({
       component: null,
       cleanup: undefined,
@@ -673,7 +673,7 @@ describe('Tier2CardRuntime', () => {
     mockCreateCardComponent.mockResolvedValue({
       component: () => <div>Cached</div>,
       cleanup: vi.fn(),
-      error: null,
+      error: false,
     })
 
     await act(async () => {
@@ -684,11 +684,11 @@ describe('Tier2CardRuntime', () => {
   })
 
   it('shows no-component message when component is null after compile', async () => {
-    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: null })
+    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: false })
     mockCreateCardComponent.mockResolvedValue({
       component: null,
       cleanup: undefined,
-      error: null,
+      error: false,
     })
 
     await act(async () => {
@@ -701,11 +701,11 @@ describe('Tier2CardRuntime', () => {
 
   it('calls cleanup on unmount', async () => {
     const cleanup = vi.fn()
-    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: null })
+    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: false })
     mockCreateCardComponent.mockResolvedValue({
       component: () => <div>OK</div>,
       cleanup,
-      error: null,
+      error: false,
     })
 
     let unmount!: () => void
@@ -732,11 +732,11 @@ describe('Tier2CardRuntime', () => {
     const ReceivedConfig = vi.fn(({ config }: { config: Record<string, unknown> }) => (
       <div data-testid="cfg">{JSON.stringify(config)}</div>
     ))
-    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: null })
+    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: false })
     mockCreateCardComponent.mockResolvedValue({
       component: ReceivedConfig,
       cleanup: vi.fn(),
-      error: null,
+      error: false,
     })
 
     await act(async () => {
@@ -751,11 +751,11 @@ describe('Tier2CardRuntime', () => {
     const ReceivedConfig = vi.fn(({ config }: { config: Record<string, unknown> }) => (
       <div data-testid="cfg">{JSON.stringify(config)}</div>
     ))
-    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: null })
+    mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: false })
     mockCreateCardComponent.mockResolvedValue({
       component: ReceivedConfig,
       cleanup: vi.fn(),
-      error: null,
+      error: false,
     })
 
     await act(async () => {
@@ -796,7 +796,7 @@ describe('Tier2CardRuntime', () => {
     })
 
     it('shows error when createCardComponent throws during execution', async () => {
-      mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: null })
+      mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: false })
       mockCreateCardComponent.mockRejectedValue(new RangeError('Maximum call stack size exceeded'))
 
       await act(async () => {
@@ -835,11 +835,11 @@ describe('Tier2CardRuntime', () => {
     })
 
     it('renders "No component produced" when component is null and error is null', async () => {
-      mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: null })
+      mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: false })
       mockCreateCardComponent.mockResolvedValue({
         component: null,
         cleanup: undefined,
-        error: null,
+        error: false,
       })
 
       await act(async () => {
@@ -869,11 +869,11 @@ describe('Tier2CardRuntime', () => {
 
     it('cleans up even when compilation fails', async () => {
       const cleanup = vi.fn()
-      mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: null })
+      mockCompileCardCode.mockResolvedValue({ code: 'compiled', error: false })
       mockCreateCardComponent.mockResolvedValue({
         component: () => <div>OK</div>,
         cleanup,
-        error: null,
+        error: false,
       })
 
       let unmount!: () => void

--- a/web/src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx
+++ b/web/src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx
@@ -127,7 +127,7 @@ describe('EnterpriseComplianceCards', () => {
 
   describe('NISTCard (Pattern B - useCache)', () => {
     it('renders loading state when data is null and no error', () => {
-      (useCache as any).mockReturnValue({ data: null, error: null });
+      (useCache as any).mockReturnValue({ data: null, error: false });
 
       render(
         <MemoryRouter>
@@ -155,7 +155,7 @@ describe('EnterpriseComplianceCards', () => {
     it('renders success state and navigates on click', async () => {
       const user = userEvent.setup();
       const mockData = { overall_score: 72, implemented_controls: 50, partial_controls: 10, planned_controls: 5, total_controls: 65 };
-      (useCache as any).mockReturnValue({ data: mockData, error: null });
+      (useCache as any).mockReturnValue({ data: mockData, error: false });
 
       render(
         <MemoryRouter>

--- a/web/src/components/cards/__tests__/EventsTimeline.test.tsx
+++ b/web/src/components/cards/__tests__/EventsTimeline.test.tsx
@@ -85,8 +85,8 @@ describe('EventsTimeline', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockUseGlobalFilters.mockReturnValue({ selectedClusters: [], isAllClustersSelected: true, clusterInfoMap: {}, selectedSeverities: [], isAllSeveritiesSelected: true, customFilter: '' })
   })
 
@@ -102,8 +102,8 @@ describe('EventsTimeline', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockEvents.mockReturnValue({ events: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: null, lastRefresh: null })
+    mockEvents.mockReturnValue({ events: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: false, lastRefresh: null })
     const { container } = render(<EventsTimeline />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -135,7 +135,7 @@ describe('EventsTimeline', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<EventsTimeline />)
     expect(container).toBeTruthy()
   })
@@ -143,14 +143,14 @@ describe('EventsTimeline', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<EventsTimeline />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<EventsTimeline />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })
@@ -166,7 +166,7 @@ describe('EventsTimeline', () => {
       isDemoFallback: false,
       isFailed: false,
       consecutiveFailures: 0,
-      error: null,
+      error: false,
       lastRefresh: Date.now(),
     })
     mockUseClusters.mockReturnValue({
@@ -174,7 +174,7 @@ describe('EventsTimeline', () => {
       deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
       isLoading: false,
       isRefreshing: false,
-      error: null,
+      error: false,
       lastRefresh: Date.now(),
     })
 
@@ -184,8 +184,8 @@ describe('EventsTimeline', () => {
   })
 
   it('handles undefined hook data without crashing', () => {
-    mockEvents.mockReturnValue({ events: undefined, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
-    mockUseClusters.mockReturnValue({ clusters: undefined, deduplicatedClusters: undefined, isLoading: false, isRefreshing: false, error: null, lastRefresh: null })
+    mockEvents.mockReturnValue({ events: undefined, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: undefined, deduplicatedClusters: undefined, isLoading: false, isRefreshing: false, error: false, lastRefresh: null })
     mockUseGlobalFilters.mockReturnValue({ selectedClusters: undefined, isAllClustersSelected: true, clusterInfoMap: undefined, selectedSeverities: [], isAllSeveritiesSelected: true, customFilter: '' })
     const { container } = render(<EventsTimeline />)
     expect(container).toBeTruthy()
@@ -201,7 +201,7 @@ describe('EventsTimeline', () => {
       isDemoFallback: false,
       isFailed: false,
       consecutiveFailures: 0,
-      error: null,
+      error: false,
       lastRefresh: Date.now(),
     })
     mockUseClusters.mockReturnValue({
@@ -209,7 +209,7 @@ describe('EventsTimeline', () => {
       deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
       isLoading: false,
       isRefreshing: false,
-      error: null,
+      error: false,
       lastRefresh: Date.now(),
     })
     mockUseGlobalFilters.mockReturnValue({ selectedClusters: undefined, isAllClustersSelected: true, clusterInfoMap: undefined, selectedSeverities: [], isAllSeveritiesSelected: true, customFilter: '' })

--- a/web/src/components/cards/__tests__/FleetComplianceHeatmap.test.tsx
+++ b/web/src/components/cards/__tests__/FleetComplianceHeatmap.test.tsx
@@ -81,7 +81,7 @@ describe('FleetComplianceHeatmap', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(), consecutiveFailures: 0 })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(), consecutiveFailures: 0 })
     mockUseKyverno.mockReturnValue({ statuses: {}, isLoading: false, isRefreshing: false, lastRefresh: null, isDemoData: false, installed: false, refetch: vi.fn(), clustersChecked: 0, totalClusters: 0 })
     mockUseTrivy.mockReturnValue({ statuses: {}, isLoading: false, isRefreshing: false, isDemoData: false, installed: false, refetch: vi.fn(), clustersChecked: 0, totalClusters: 0 })
     mockUseKubescape.mockReturnValue({ statuses: {}, isLoading: false, isRefreshing: false, isDemoData: false, installed: false, refetch: vi.fn(), clustersChecked: 0, totalClusters: 0 })
@@ -209,7 +209,7 @@ describe('FleetComplianceHeatmap', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<FleetComplianceHeatmap />)
     expect(container).toBeTruthy()

--- a/web/src/components/cards/__tests__/GPUInventory.test.tsx
+++ b/web/src/components/cards/__tests__/GPUInventory.test.tsx
@@ -23,7 +23,7 @@ vi.mock('../../../hooks/useCachedData', () => ({
     nodes: [],
     isLoading: false,
     isRefreshing: false,
-    error: null,
+    error: false,
     isDemoFallback: false,
     isFailed: false,
     consecutiveFailures: 0,
@@ -117,7 +117,7 @@ describe('GPUInventory', () => {
     vi.clearAllMocks()
     const { useCachedGPUNodes } = await import('../../../hooks/useCachedData')
     vi.mocked(useCachedGPUNodes).mockReturnValue({
-      nodes: [], isLoading: false, isRefreshing: false, error: null, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+      nodes: [], isLoading: false, isRefreshing: false, error: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
     } as never)
   })
 
@@ -125,7 +125,7 @@ describe('GPUInventory', () => {
     it('renders skeletons when isLoading and no nodes', async () => {
       const { useCachedGPUNodes } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGPUNodes).mockReturnValue({
-        nodes: [], isLoading: true, isRefreshing: false, error: null, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+        nodes: [], isLoading: true, isRefreshing: false, error: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
       } as never)
       const { useCardLoadingState } = await import('../CardDataContext')
       vi.mocked(useCardLoadingState).mockReturnValueOnce({ showSkeleton: true, showEmptyState: false } as never)
@@ -147,7 +147,7 @@ describe('GPUInventory', () => {
       const { useCachedGPUNodes } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGPUNodes).mockReturnValue({
         nodes: [makeNode()],
-        isLoading: false, isRefreshing: false, error: null, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+        isLoading: false, isRefreshing: false, error: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
       } as never)
       render(<GPUInventory />)
       expect(screen.getByText('common:common.total')).toBeTruthy()
@@ -162,7 +162,7 @@ describe('GPUInventory', () => {
       const { useCachedGPUNodes } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGPUNodes).mockReturnValue({
         nodes: [makeNode()],
-        isLoading: false, isRefreshing: false, error: null, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+        isLoading: false, isRefreshing: false, error: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
       } as never)
       render(<GPUInventory />)
       expect(screen.getByText(/gpuInventory.gpuCount/)).toBeTruthy()
@@ -174,7 +174,7 @@ describe('GPUInventory', () => {
       const { useCachedGPUNodes } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGPUNodes).mockReturnValue({
         nodes: [makeNode()],
-        isLoading: false, isRefreshing: false, error: null, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+        isLoading: false, isRefreshing: false, error: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
       } as never)
       render(<GPUInventory />)
       expect(screen.getByText('gpu-node-1')).toBeTruthy()
@@ -184,7 +184,7 @@ describe('GPUInventory', () => {
       const { useCachedGPUNodes } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGPUNodes).mockReturnValue({
         nodes: [makeNode()],
-        isLoading: false, isRefreshing: false, error: null, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+        isLoading: false, isRefreshing: false, error: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
       } as never)
       render(<GPUInventory />)
       expect(screen.getByText('cluster-1')).toBeTruthy()
@@ -194,7 +194,7 @@ describe('GPUInventory', () => {
       const { useCachedGPUNodes } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGPUNodes).mockReturnValue({
         nodes: [makeNode()],
-        isLoading: false, isRefreshing: false, error: null, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+        isLoading: false, isRefreshing: false, error: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
       } as never)
       render(<GPUInventory />)
       expect(screen.getByText('NVIDIA A100')).toBeTruthy()
@@ -205,7 +205,7 @@ describe('GPUInventory', () => {
       const { useCachedGPUNodes } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGPUNodes).mockReturnValue({
         nodes: [makeNode()],
-        isLoading: false, isRefreshing: false, error: null, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+        isLoading: false, isRefreshing: false, error: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
       } as never)
       render(<GPUInventory />)
       fireEvent.click(screen.getByText('gpu-node-1'))
@@ -220,7 +220,7 @@ describe('GPUInventory', () => {
       const { useCachedGPUNodes } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGPUNodes).mockReturnValue({
         nodes: [makeNode()],
-        isLoading: false, isRefreshing: false, error: null, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+        isLoading: false, isRefreshing: false, error: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
       } as never)
       render(<GPUInventory />)
       const bar = document.querySelector('.bg-purple-500')
@@ -244,7 +244,7 @@ describe('GPUInventory', () => {
       const { useCachedGPUNodes } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGPUNodes).mockReturnValue({
         nodes: [makeNode()],
-        isLoading: false, isRefreshing: false, error: null, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+        isLoading: false, isRefreshing: false, error: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
       } as never)
       render(<GPUInventory />)
       expect(screen.queryByText('gpuInventory.usingSimulatedData')).toBeNull()
@@ -256,7 +256,7 @@ describe('GPUInventory', () => {
       const { useCachedGPUNodes } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGPUNodes).mockReturnValue({
         nodes: [makeNode()],
-        isLoading: false, isRefreshing: false, error: null, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+        isLoading: false, isRefreshing: false, error: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
       } as never)
       render(<GPUInventory />)
       expect(screen.getByTestId('search')).toBeTruthy()
@@ -266,7 +266,7 @@ describe('GPUInventory', () => {
       const { useCachedGPUNodes } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGPUNodes).mockReturnValue({
         nodes: [makeNode()],
-        isLoading: false, isRefreshing: false, error: null, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+        isLoading: false, isRefreshing: false, error: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
       } as never)
       render(<GPUInventory />)
       expect(screen.getByTestId('cluster-filter')).toBeTruthy()

--- a/web/src/components/cards/__tests__/GPUInventoryHistory.test.tsx
+++ b/web/src/components/cards/__tests__/GPUInventoryHistory.test.tsx
@@ -69,7 +69,7 @@ describe('GPUInventoryHistory', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     mockUseMetricsHistory.mockReturnValue({ history: [], isLoading: false })
   })
 
@@ -103,13 +103,13 @@ describe('GPUInventoryHistory', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<GPUInventoryHistory />)
     expect(container).toBeTruthy()
   })
 
   it('reports GPU demo fallback state', () => {
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<GPUInventoryHistory />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })
@@ -122,7 +122,7 @@ describe('GPUInventoryHistory', () => {
     mockGPUNodes.mockReturnValue({
       nodes: [{ name: 'node-a', cluster: 'cl-1', gpuType: 'H100', gpuAllocated: 2, gpuCount: 8 }],
       isLoading: false, isRefreshing: false, isDemoFallback: false,
-      isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now(),
+      isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now(),
     })
     mockUseMetricsHistory.mockReturnValue({
       history: [

--- a/web/src/components/cards/__tests__/GPUNamespaceAllocations.test.tsx
+++ b/web/src/components/cards/__tests__/GPUNamespaceAllocations.test.tsx
@@ -80,8 +80,8 @@ describe('GPUNamespaceAllocations', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockAllPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockAllPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToNamespace: vi.fn() })
   })
 
@@ -115,13 +115,13 @@ describe('GPUNamespaceAllocations', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<GPUNamespaceAllocations />)
     expect(container).toBeTruthy()
   })
 
   it('reports GPU demo fallback state', () => {
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<GPUNamespaceAllocations />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/GPUUsageTrend.test.tsx
+++ b/web/src/components/cards/__tests__/GPUUsageTrend.test.tsx
@@ -78,7 +78,7 @@ vi.mock('../../../hooks/useMetricsHistory', () => ({
 // (issues #8080, #8081) sees an empty persisted GPU cache in tests
 // and does not rely on real localStorage side effects.
 vi.mock('../../../hooks/mcp/compute', () => ({
-  gpuNodeCache: { nodes: [], lastUpdated: null, isLoading: false, isRefreshing: false, error: null, consecutiveFailures: 0, lastRefresh: null },
+  gpuNodeCache: { nodes: [], lastUpdated: null, isLoading: false, isRefreshing: false, error: false, consecutiveFailures: 0, lastRefresh: null },
 }))
 
 import { GPUUsageTrend } from '../GPUUsageTrend'
@@ -88,8 +88,8 @@ describe('GPUUsageTrend', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockUseMetricsHistory.mockReturnValue({ history: [], captureNow: vi.fn(), clearHistory: vi.fn(), getClusterTrend: () => 'stable', getPodRestartTrend: () => 'stable', snapshotCount: 0 })
   })
 
@@ -123,7 +123,7 @@ describe('GPUUsageTrend', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<GPUUsageTrend />)
     expect(container).toBeTruthy()
   })
@@ -131,14 +131,14 @@ describe('GPUUsageTrend', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<GPUUsageTrend />)
     expect(container).toBeTruthy()
   })
 
   it('reports GPU demo fallback state', () => {
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<GPUUsageTrend />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/GPUUtilization.test.tsx
+++ b/web/src/components/cards/__tests__/GPUUtilization.test.tsx
@@ -71,8 +71,8 @@ describe('GPUUtilization', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -105,7 +105,7 @@ describe('GPUUtilization', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<GPUUtilization />)
     expect(container).toBeTruthy()
   })
@@ -113,14 +113,14 @@ describe('GPUUtilization', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<GPUUtilization />)
     expect(container).toBeTruthy()
   })
 
   it('reports GPU demo fallback state', () => {
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<GPUUtilization />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/GPUWorkloads.test.tsx
+++ b/web/src/components/cards/__tests__/GPUWorkloads.test.tsx
@@ -85,9 +85,9 @@ describe('GPUWorkloads', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockAllPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockAllPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToGPU: vi.fn() })
   })
 
@@ -121,7 +121,7 @@ describe('GPUWorkloads', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<GPUWorkloads />)
     expect(container).toBeTruthy()
   })
@@ -129,14 +129,14 @@ describe('GPUWorkloads', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<GPUWorkloads />)
     expect(container).toBeTruthy()
   })
 
   it('reports GPU demo fallback state', () => {
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<GPUWorkloads />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/GitHubActivity.test.tsx
+++ b/web/src/components/cards/__tests__/GitHubActivity.test.tsx
@@ -113,7 +113,7 @@ describe('GitHubActivity', () => {
       data: buildLoadedCacheData(),
       isLoading: false,
       isRefreshing: false,
-      error: null,
+      error: false,
       isDemoFallback: true,
       refetch: mockRefetch,
     })
@@ -146,7 +146,7 @@ describe('GitHubActivity', () => {
       },
       isLoading: true,
       isRefreshing: false,
-      error: null,
+      error: false,
       isDemoFallback: false,
       refetch: mockRefetch,
     })
@@ -193,7 +193,7 @@ describe('GitHubActivity', () => {
       data: buildLoadedCacheData({ prs: [stalePr, ...demo.prs.slice(1)] }),
       isLoading: false,
       isRefreshing: false,
-      error: null,
+      error: false,
       isDemoFallback: true,
       refetch: mockRefetch,
     })
@@ -220,7 +220,7 @@ describe('GitHubActivity', () => {
       data: buildLoadedCacheData({ prs: [stalePr] }),
       isLoading: false,
       isRefreshing: false,
-      error: null,
+      error: false,
       isDemoFallback: true,
       refetch: mockRefetch,
     })

--- a/web/src/components/cards/__tests__/GitOpsDrift.test.tsx
+++ b/web/src/components/cards/__tests__/GitOpsDrift.test.tsx
@@ -24,7 +24,7 @@ vi.mock('../../../hooks/useCachedData', () => ({
     drifts: [],
     isLoading: false,
     isRefreshing: false,
-    error: null,
+    error: false,
     isFailed: false,
     consecutiveFailures: 0,
     isDemoFallback: false,
@@ -151,7 +151,7 @@ describe('GitOpsDrift', () => {
       const { useCachedGitOpsDrifts } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGitOpsDrifts).mockReturnValue({
         drifts: [makeDrift()],
-        isLoading: false, isRefreshing: false, error: null, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
+        isLoading: false, isRefreshing: false, error: false, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
       } as never)
       render(<GitOpsDrift />)
       expect(screen.getByText('my-deployment')).toBeTruthy()
@@ -162,7 +162,7 @@ describe('GitOpsDrift', () => {
       const { useCachedGitOpsDrifts } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGitOpsDrifts).mockReturnValue({
         drifts: [makeDrift()],
-        isLoading: false, isRefreshing: false, error: null, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
+        isLoading: false, isRefreshing: false, error: false, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
       } as never)
       render(<GitOpsDrift />)
       expect(screen.getByText('cluster-1')).toBeTruthy()
@@ -172,7 +172,7 @@ describe('GitOpsDrift', () => {
       const { useCachedGitOpsDrifts } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGitOpsDrifts).mockReturnValue({
         drifts: [makeDrift({ driftType: 'modified' })],
-        isLoading: false, isRefreshing: false, error: null, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
+        isLoading: false, isRefreshing: false, error: false, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
       } as never)
       render(<GitOpsDrift />)
       expect(screen.getByText('cards:gitOpsDrift.modified')).toBeTruthy()
@@ -182,7 +182,7 @@ describe('GitOpsDrift', () => {
       const { useCachedGitOpsDrifts } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGitOpsDrifts).mockReturnValue({
         drifts: [makeDrift({ severity: 'high' })],
-        isLoading: false, isRefreshing: false, error: null, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
+        isLoading: false, isRefreshing: false, error: false, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
       } as never)
       render(<GitOpsDrift />)
       expect(screen.getByText(/gitOpsDrift.nCritical/)).toBeTruthy()
@@ -192,7 +192,7 @@ describe('GitOpsDrift', () => {
       const { useCachedGitOpsDrifts } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGitOpsDrifts).mockReturnValue({
         drifts: [makeDrift()],
-        isLoading: false, isRefreshing: false, error: null, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
+        isLoading: false, isRefreshing: false, error: false, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
       } as never)
       render(<GitOpsDrift />)
       fireEvent.click(screen.getByText('my-deployment'))
@@ -203,7 +203,7 @@ describe('GitOpsDrift', () => {
       const { useCachedGitOpsDrifts } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGitOpsDrifts).mockReturnValue({
         drifts: [makeDrift({ gitVersion: 'main@abc123' })],
-        isLoading: false, isRefreshing: false, error: null, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
+        isLoading: false, isRefreshing: false, error: false, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
       } as never)
       render(<GitOpsDrift />)
       expect(screen.getByText('main@abc123')).toBeTruthy()
@@ -221,7 +221,7 @@ describe('GitOpsDrift', () => {
       const { useCachedGitOpsDrifts } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedGitOpsDrifts).mockReturnValue({
         drifts: [makeDrift({ severity: 'low', resource: 'low-resource' })],
-        isLoading: false, isRefreshing: false, error: null, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
+        isLoading: false, isRefreshing: false, error: false, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
       } as never)
       render(<GitOpsDrift />)
       expect(screen.queryByText('low-resource')).toBeNull()

--- a/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
+++ b/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
@@ -107,9 +107,9 @@ describe('HelmValuesDiff', () => {
     // summarize them here (the summary keeps drifting out of sync).
     mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
+    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: new Date() })
     mockDrillDown.mockReturnValue({ drillToHelm: vi.fn() })
   })
 
@@ -127,8 +127,8 @@ describe('HelmValuesDiff', () => {
     // #6278: flip BOTH demo flags so the mock state matches what
     // production actually produces (see beforeEach comment).
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
-    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<HelmValuesDiff />)
     expect(container).toBeTruthy()
   })
@@ -147,7 +147,7 @@ describe('HelmValuesDiff', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<HelmValuesDiff />)
     expect(container).toBeTruthy()
   })
@@ -155,14 +155,14 @@ describe('HelmValuesDiff', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: new Date(),
     })
     const { container } = render(<HelmValuesDiff />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<HelmValuesDiff />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })
@@ -172,25 +172,25 @@ describe('HelmValuesDiff', () => {
   describe('freshness indicator wiring (#6265, #6267, #6269)', () => {
     it('reports isRefreshing=true when any source is refreshing', () => {
       // Only values is refreshing — combined isRefreshing must still be true
-      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
+      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: new Date() })
       render(<HelmValuesDiff />)
       const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
       expect(lastCall.isRefreshing).toBe(true)
     })
 
     it('reports isRefreshing=true when clusters source is refreshing', () => {
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: null, lastRefresh: new Date() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: false, lastRefresh: new Date() })
       render(<HelmValuesDiff />)
       const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
       expect(lastCall.isRefreshing).toBe(true)
     })
 
     it('reports isRefreshing=false when all 3 sources are quiet', () => {
-      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
+      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: new Date() })
       render(<HelmValuesDiff />)
       const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
       expect(lastCall.isRefreshing).toBe(false)
@@ -206,9 +206,9 @@ describe('HelmValuesDiff', () => {
       // #6271: useClusters().lastRefresh is `Date | null` per shared.ts;
       // useCachedHelm{Releases,Values}().lastRefresh is numeric epoch.
       // Mocks must match the real types.
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date(NEWEST) })
-      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: MIDDLE })
-      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: OLDEST })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: new Date(NEWEST) })
+      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: MIDDLE })
+      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: OLDEST })
       render(<HelmValuesDiff />)
       const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
       expect(props.lastUpdated).toEqual(new Date(OLDEST))
@@ -216,18 +216,18 @@ describe('HelmValuesDiff', () => {
 
     it('passes null lastUpdated when isDemoData is true (regardless of lastRefresh)', () => {
       // Cache holds a fresh-looking lastRefresh from a prior live session — must be hidden
-      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
+      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: new Date() })
       render(<HelmValuesDiff />)
       const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
       expect(props.lastUpdated).toBeNull()
     })
 
     it('passes isRefreshing=true to RefreshIndicator when values source is refreshing', () => {
-      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
+      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: new Date() })
       render(<HelmValuesDiff />)
       const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
       expect(props.isRefreshing).toBe(true)

--- a/web/src/components/cards/__tests__/ISO27001Audit.test.tsx
+++ b/web/src/components/cards/__tests__/ISO27001Audit.test.tsx
@@ -76,7 +76,7 @@ describe('ISO27001Audit', () => {
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockUseCardDemoState.mockReturnValue({ shouldUseDemoData: false })
-    mockISO27001Audit.mockReturnValue({ findings: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockISO27001Audit.mockReturnValue({ findings: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -91,7 +91,7 @@ describe('ISO27001Audit', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockISO27001Audit.mockReturnValue({ findings: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
+    mockISO27001Audit.mockReturnValue({ findings: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
     const { container } = render(<ISO27001Audit />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -123,13 +123,13 @@ describe('ISO27001Audit', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockISO27001Audit.mockReturnValue({ findings: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockISO27001Audit.mockReturnValue({ findings: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<ISO27001Audit />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockISO27001Audit.mockReturnValue({ findings: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockISO27001Audit.mockReturnValue({ findings: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<ISO27001Audit />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/Kubectl.test.tsx
+++ b/web/src/components/cards/__tests__/Kubectl.test.tsx
@@ -74,7 +74,7 @@ describe('Kubectl', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -102,7 +102,7 @@ describe('Kubectl', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<Kubectl />)
     expect(container).toBeTruthy()
@@ -122,7 +122,7 @@ describe('Kubectl', () => {
       ],
       isLoading: false,
       isRefreshing: false,
-      error: null,
+      error: false,
       lastRefresh: Date.now(),
     })
 

--- a/web/src/components/cards/__tests__/Missions.test.tsx
+++ b/web/src/components/cards/__tests__/Missions.test.tsx
@@ -199,7 +199,7 @@ function setupDefaults({
     isRefreshing,
     isFailed,
     consecutiveFailures,
-    error: null,
+    error: false,
     lastRefresh: null,
   })
   mockUseCardLoadingState.mockReturnValue({})

--- a/web/src/components/cards/__tests__/NamespaceMonitor.test.tsx
+++ b/web/src/components/cards/__tests__/NamespaceMonitor.test.tsx
@@ -90,15 +90,15 @@ describe('NamespaceMonitor', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockNamespaces.mockReturnValue({ namespaces: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockDeployments.mockReturnValue({ deployments: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockPVCs.mockReturnValue({ pvcs: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockConfigMaps.mockReturnValue({ configmaps: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockSecrets.mockReturnValue({ secrets: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockJobs.mockReturnValue({ jobs: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockNamespaces.mockReturnValue({ namespaces: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockDeployments.mockReturnValue({ deployments: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockPVCs.mockReturnValue({ pvcs: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockConfigMaps.mockReturnValue({ configmaps: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockSecrets.mockReturnValue({ secrets: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockJobs.mockReturnValue({ jobs: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToNamespace: vi.fn() })
   })
 
@@ -127,7 +127,7 @@ describe('NamespaceMonitor', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<NamespaceMonitor />)
     expect(container).toBeTruthy()

--- a/web/src/components/cards/__tests__/NamespaceRBAC.test.tsx
+++ b/web/src/components/cards/__tests__/NamespaceRBAC.test.tsx
@@ -93,11 +93,11 @@ describe('NamespaceRBAC', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockNamespaces.mockReturnValue({ namespaces: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockK8sRoles.mockReturnValue({ roles: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockK8sRoleBindings.mockReturnValue({ bindings: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockK8sServiceAccounts.mockReturnValue({ serviceAccounts: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockNamespaces.mockReturnValue({ namespaces: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockK8sRoles.mockReturnValue({ roles: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockK8sRoleBindings.mockReturnValue({ bindings: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockK8sServiceAccounts.mockReturnValue({ serviceAccounts: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToRBAC: vi.fn() })
   })
 
@@ -113,7 +113,7 @@ describe('NamespaceRBAC', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: null, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: false, lastRefresh: null })
     const { container } = render(<NamespaceRBAC />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -140,7 +140,7 @@ describe('NamespaceRBAC', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<NamespaceRBAC />)
     expect(container).toBeTruthy()
@@ -149,7 +149,7 @@ describe('NamespaceRBAC', () => {
 
 
   it('does not auto-select the first cluster when demo data includes multiple clusters', () => {
-    mockNamespaces.mockReturnValue({ namespaces: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockNamespaces.mockReturnValue({ namespaces: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     mockUseClusters.mockReturnValue({
       clusters: [
         { name: 'cluster-a', healthy: true, reachable: true },
@@ -161,7 +161,7 @@ describe('NamespaceRBAC', () => {
       ],
       isLoading: false,
       isRefreshing: false,
-      error: null,
+      error: false,
       lastRefresh: Date.now(),
     })
 

--- a/web/src/components/cards/__tests__/NetworkOverview.test.tsx
+++ b/web/src/components/cards/__tests__/NetworkOverview.test.tsx
@@ -100,8 +100,8 @@ describe('NetworkOverview', () => {
     // summarize them here (the summary keeps drifting out of sync).
     mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
+    mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: new Date() })
     mockDrillDown.mockReturnValue({ drillToNetwork: vi.fn() })
   })
 
@@ -117,8 +117,8 @@ describe('NetworkOverview', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockServices.mockReturnValue({ services: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: null, lastRefresh: null })
+    mockServices.mockReturnValue({ services: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: false, lastRefresh: null })
     const { container } = render(<NetworkOverview />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -134,7 +134,7 @@ describe('NetworkOverview', () => {
     // #6278: flip BOTH demo flags so the mock state matches what
     // production actually produces (see beforeEach comment).
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
-    mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<NetworkOverview />)
     expect(container).toBeTruthy()
   })
@@ -153,7 +153,7 @@ describe('NetworkOverview', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<NetworkOverview />)
     expect(container).toBeTruthy()
   })
@@ -161,14 +161,14 @@ describe('NetworkOverview', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: new Date(),
     })
     const { container } = render(<NetworkOverview />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<NetworkOverview />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })
@@ -179,16 +179,16 @@ describe('NetworkOverview', () => {
   describe('freshness indicator wiring (#6265, #6267, #6269)', () => {
     it('reports clustersRefreshing OR servicesRefreshing to useCardLoadingState', () => {
       // Services not refreshing, clusters refreshing → card state must show isRefreshing=true
-      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: null, lastRefresh: new Date() })
+      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: false, lastRefresh: new Date() })
       render(<NetworkOverview />)
       const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
       expect(lastCall.isRefreshing).toBe(true)
     })
 
     it('reports isRefreshing=false when neither source is refreshing', () => {
-      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
+      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: new Date() })
       render(<NetworkOverview />)
       const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
       expect(lastCall.isRefreshing).toBe(false)
@@ -204,8 +204,8 @@ describe('NetworkOverview', () => {
       // useCachedServices().lastRefresh is numeric epoch — mocks must
       // match the real types, otherwise the source's normalization
       // path isn't actually exercised.
-      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: NEWER })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date(OLDER) })
+      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: NEWER })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: new Date(OLDER) })
       render(<NetworkOverview />)
       const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
       expect(props.lastUpdated).toEqual(new Date(OLDER))
@@ -213,16 +213,16 @@ describe('NetworkOverview', () => {
 
     it('passes null lastUpdated when isDemoFallback is true (regardless of lastRefresh)', () => {
       // Cache holds a stale lastRefresh from a prior live session — must be hidden in demo mode
-      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
+      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: new Date() })
       render(<NetworkOverview />)
       const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
       expect(props.lastUpdated).toBeNull()
     })
 
     it('passes isRefreshing=true to RefreshIndicator when clusters source is refreshing', () => {
-      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: null, lastRefresh: new Date() })
+      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: false, lastRefresh: new Date() })
       render(<NetworkOverview />)
       const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
       expect(props.isRefreshing).toBe(true)

--- a/web/src/components/cards/__tests__/NetworkPolicyCoverage.test.tsx
+++ b/web/src/components/cards/__tests__/NetworkPolicyCoverage.test.tsx
@@ -64,7 +64,7 @@ describe('NetworkPolicyCoverage', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -79,7 +79,7 @@ describe('NetworkPolicyCoverage', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockPods.mockReturnValue({ pods: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
+    mockPods.mockReturnValue({ pods: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
     const { container } = render(<NetworkPolicyCoverage />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -105,13 +105,13 @@ describe('NetworkPolicyCoverage', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<NetworkPolicyCoverage />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<NetworkPolicyCoverage />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/OverlayComparison.test.tsx
+++ b/web/src/components/cards/__tests__/OverlayComparison.test.tsx
@@ -71,7 +71,7 @@ describe('OverlayComparison', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToOverlay: vi.fn() })
   })
 
@@ -100,7 +100,7 @@ describe('OverlayComparison', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<OverlayComparison />)
     expect(container).toBeTruthy()
@@ -120,7 +120,7 @@ describe('OverlayComparison', () => {
       ],
       isLoading: false,
       isRefreshing: false,
-      error: null,
+      error: false,
       lastRefresh: Date.now(),
     })
 

--- a/web/src/components/cards/__tests__/PVCStatus.test.tsx
+++ b/web/src/components/cards/__tests__/PVCStatus.test.tsx
@@ -82,7 +82,7 @@ describe('PVCStatus', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockPVCs.mockReturnValue({ pvcs: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPVCs.mockReturnValue({ pvcs: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -97,7 +97,7 @@ describe('PVCStatus', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockPVCs.mockReturnValue({ pvcs: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
+    mockPVCs.mockReturnValue({ pvcs: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
     const { container } = render(<PVCStatus />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -129,13 +129,13 @@ describe('PVCStatus', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockPVCs.mockReturnValue({ pvcs: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPVCs.mockReturnValue({ pvcs: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<PVCStatus />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockPVCs.mockReturnValue({ pvcs: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPVCs.mockReturnValue({ pvcs: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<PVCStatus />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/PodHealthTrend.test.tsx
+++ b/web/src/components/cards/__tests__/PodHealthTrend.test.tsx
@@ -71,8 +71,8 @@ describe('PodHealthTrend', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockPodIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockPodIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -87,8 +87,8 @@ describe('PodHealthTrend', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockPodIssues.mockReturnValue({ issues: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: null, lastRefresh: null })
+    mockPodIssues.mockReturnValue({ issues: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: false, lastRefresh: null })
     const { container } = render(<PodHealthTrend />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -120,7 +120,7 @@ describe('PodHealthTrend', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockPodIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPodIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<PodHealthTrend />)
     expect(container).toBeTruthy()
   })
@@ -128,14 +128,14 @@ describe('PodHealthTrend', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<PodHealthTrend />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockPodIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPodIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<PodHealthTrend />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/PodIssues.test.tsx
+++ b/web/src/components/cards/__tests__/PodIssues.test.tsx
@@ -224,7 +224,7 @@ describe('PodIssues', () => {
     })
 
     it('shows fallback error message when error is null', () => {
-      setupDefaults({ isFailed: true, error: null, issues: [] })
+      setupDefaults({ isFailed: true, error: false, issues: [] })
       render(<PodIssues />)
       expect(screen.getByText('podIssues.apiUnavailable')).toBeInTheDocument()
     })

--- a/web/src/components/cards/__tests__/PredictiveHealth.test.tsx
+++ b/web/src/components/cards/__tests__/PredictiveHealth.test.tsx
@@ -73,8 +73,8 @@ describe('PredictiveHealth', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -115,8 +115,8 @@ describe('PredictiveHealth', () => {
       { name: 'pod-1', cluster: 'cluster-a', restarts: 0 },
       { name: 'pod-2', cluster: 'cluster-b', restarts: 0 },
     ]
-    mockNodes.mockReturnValue({ nodes: testNodes, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockPods.mockReturnValue({ pods: testPods, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockNodes.mockReturnValue({ nodes: testNodes, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: testPods, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
 
     render(<PredictiveHealth />)
 
@@ -139,8 +139,8 @@ describe('PredictiveHealth', () => {
       { name: 'pod-a', cluster: 'cluster-a', restarts: 0 },
       { name: 'pod-b', cluster: 'cluster-b', restarts: 0 },
     ]
-    mockNodes.mockReturnValue({ nodes: testNodes, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockPods.mockReturnValue({ pods: testPods, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockNodes.mockReturnValue({ nodes: testNodes, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: testPods, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
 
     const { container } = render(<PredictiveHealth />)
 
@@ -159,8 +159,8 @@ describe('PredictiveHealth', () => {
     const testPods = [
       { name: 'pod-a', cluster: 'cluster-a', restarts: 10 },
     ]
-    mockNodes.mockReturnValue({ nodes: testNodes, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockPods.mockReturnValue({ pods: testPods, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockNodes.mockReturnValue({ nodes: testNodes, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: testPods, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
 
     const { container } = render(<PredictiveHealth />)
 

--- a/web/src/components/cards/__tests__/ProactiveGPUNodeHealthMonitor.test.tsx
+++ b/web/src/components/cards/__tests__/ProactiveGPUNodeHealthMonitor.test.tsx
@@ -53,7 +53,7 @@ vi.mock('../CardDataContext', () => ({
 const mockGPUNodeHealth = vi.fn()
 vi.mock('../../../hooks/useCachedData', () => ({
   useCachedGPUNodeHealth: () => mockGPUNodeHealth(),
-  useGPUHealthCronJob: () => ({ status: null, isLoading: false, error: null, actionInProgress: false, install: vi.fn(), uninstall: vi.fn(), refetch: vi.fn() }),
+  useGPUHealthCronJob: () => ({ status: null, isLoading: false, error: false, actionInProgress: false, install: vi.fn(), uninstall: vi.fn(), refetch: vi.fn() }),
 }))
 
 const mockDrillDown = vi.fn()
@@ -68,7 +68,7 @@ describe('ProactiveGPUNodeHealthMonitor', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockGPUNodeHealth.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodeHealth.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToGPU: vi.fn() })
   })
 
@@ -102,13 +102,13 @@ describe('ProactiveGPUNodeHealthMonitor', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockGPUNodeHealth.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodeHealth.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<ProactiveGPUNodeHealthMonitor />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockGPUNodeHealth.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodeHealth.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<ProactiveGPUNodeHealthMonitor />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/QuotaHeatmap.test.tsx
+++ b/web/src/components/cards/__tests__/QuotaHeatmap.test.tsx
@@ -62,7 +62,7 @@ describe('QuotaHeatmap', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -95,13 +95,13 @@ describe('QuotaHeatmap', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<QuotaHeatmap />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<QuotaHeatmap />)
     expect(container || true).toBeTruthy()
   })

--- a/web/src/components/cards/__tests__/RBACExplorer.test.tsx
+++ b/web/src/components/cards/__tests__/RBACExplorer.test.tsx
@@ -60,7 +60,7 @@ describe('RBACExplorer', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockRBAC.mockReturnValue({ findings: [], isLoading: false, error: null })
+    mockRBAC.mockReturnValue({ findings: [], isLoading: false, error: false })
   })
 
   it('renders without crashing', () => {

--- a/web/src/components/cards/__tests__/RecommendedPolicies.test.tsx
+++ b/web/src/components/cards/__tests__/RecommendedPolicies.test.tsx
@@ -76,7 +76,7 @@ describe('RecommendedPolicies', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -104,7 +104,7 @@ describe('RecommendedPolicies', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<RecommendedPolicies />)
     expect(container).toBeTruthy()

--- a/web/src/components/cards/__tests__/ResourceCapacity.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceCapacity.test.tsx
@@ -88,8 +88,8 @@ describe('ResourceCapacity', () => {
       showDemoBadge: true,
     })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToResources: vi.fn() })
   })
 
@@ -105,8 +105,8 @@ describe('ResourceCapacity', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: null, lastRefresh: null })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: false, lastRefresh: null })
     const { container } = render(<ResourceCapacity />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -138,7 +138,7 @@ describe('ResourceCapacity', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<ResourceCapacity />)
     expect(container).toBeTruthy()
   })
@@ -146,14 +146,14 @@ describe('ResourceCapacity', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<ResourceCapacity />)
     expect(container).toBeTruthy()
   })
 
   it('reports GPU demo fallback state', () => {
-    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<ResourceCapacity />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx
@@ -72,7 +72,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
     mockUseResolveDependencies.mockReturnValue({
       data: null,
       isLoading: false,
-      error: null,
+      error: false,
       resolve: vi.fn(),
       reset: vi.fn(),
     })
@@ -86,7 +86,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
       isLoading: false,
       isDemoFallback: false,
       isFailed: false,
-      error: null,
+      error: false,
     })
 
     render(<ResourceMarshall />)
@@ -103,7 +103,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
       isLoading: false,
       isDemoFallback: true,
       isFailed: false,
-      error: null,
+      error: false,
     })
 
     const { rerender } = render(<ResourceMarshall />)
@@ -122,7 +122,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
       isLoading: false,
       isDemoFallback: false,
       isFailed: false,
-      error: null,
+      error: false,
     })
 
     render(<ResourceMarshall />)
@@ -138,7 +138,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
       isLoading: false,
       isDemoFallback: false,
       isFailed: false,
-      error: null,
+      error: false,
     })
 
     render(<ResourceMarshall />)
@@ -158,7 +158,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
       isLoading: false,
       isDemoFallback: true,
       isFailed: false,
-      error: null,
+      error: false,
     })
 
     render(<ResourceMarshall />)
@@ -178,7 +178,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
       isLoading: false,
       isDemoFallback: false,
       isFailed: false,
-      error: null,
+      error: false,
     })
 
     const { container } = render(<ResourceMarshall />)
@@ -195,7 +195,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
       isLoading: false,
       isDemoFallback: false,
       isFailed: false,
-      error: null,
+      error: false,
     })
 
     const { rerender } = render(<ResourceMarshall />)
@@ -215,7 +215,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
       isLoading: false,
       isDemoFallback: true,
       isFailed: false,
-      error: null,
+      error: false,
     })
 
     rerender(<ResourceMarshall />)
@@ -235,7 +235,7 @@ describe('ResourceMarshall Namespace Behavior', () => {
       isLoading: false,
       isDemoFallback: false,
       isFailed: false,
-      error: null,
+      error: false,
     })
 
     rerender(<ResourceMarshall />)

--- a/web/src/components/cards/__tests__/ResourceMarshall.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceMarshall.test.tsx
@@ -70,13 +70,13 @@ describe('ResourceMarshall', () => {
       isLoading: false,
       isDemoFallback: false,
       isFailed: false,
-      error: null,
+      error: false,
     })
     mockUseWorkloads.mockReturnValue({ data: [], isLoading: false })
     mockUseResolveDependencies.mockReturnValue({
       data: null,
       isLoading: false,
-      error: null,
+      error: false,
       resolve: vi.fn(),
       reset: vi.fn(),
     })

--- a/web/src/components/cards/__tests__/ResourceTrend.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceTrend.test.tsx
@@ -66,7 +66,7 @@ describe('ResourceTrend', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -94,7 +94,7 @@ describe('ResourceTrend', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<ResourceTrend />)
     expect(container).toBeTruthy()

--- a/web/src/components/cards/__tests__/SecurityIssues.test.tsx
+++ b/web/src/components/cards/__tests__/SecurityIssues.test.tsx
@@ -81,7 +81,7 @@ describe('SecurityIssues', () => {
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockUseCardDemoState.mockReturnValue({ shouldUseDemoData: false })
-    mockSecurityIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockSecurityIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToPod: vi.fn() })
   })
 
@@ -97,7 +97,7 @@ describe('SecurityIssues', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockSecurityIssues.mockReturnValue({ issues: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
+    mockSecurityIssues.mockReturnValue({ issues: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
     const { container } = render(<SecurityIssues />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -129,13 +129,13 @@ describe('SecurityIssues', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockSecurityIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockSecurityIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<SecurityIssues />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockSecurityIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockSecurityIssues.mockReturnValue({ issues: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<SecurityIssues />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/ServiceExports.test.tsx
+++ b/web/src/components/cards/__tests__/ServiceExports.test.tsx
@@ -71,7 +71,7 @@ describe('ServiceExports', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockServiceExports.mockReturnValue({ exports: [], isLoading: false, isRefreshing: false, isDemoData: false, error: null })
+    mockServiceExports.mockReturnValue({ exports: [], isLoading: false, isRefreshing: false, isDemoData: false, error: false })
   })
 
   it('renders without crashing', () => {
@@ -104,7 +104,7 @@ describe('ServiceExports', () => {
   })
 
   it('passes isRefreshing to useCardLoadingState', () => {
-    mockServiceExports.mockReturnValue({ exports: [], isLoading: false, isRefreshing: true, isDemoData: false, error: null })
+    mockServiceExports.mockReturnValue({ exports: [], isLoading: false, isRefreshing: true, isDemoData: false, error: false })
     render(<ServiceExports />)
     expect(mockUseCardLoadingState).toHaveBeenCalledWith(
       expect.objectContaining({ isRefreshing: true }),

--- a/web/src/components/cards/__tests__/ServiceStatus.test.tsx
+++ b/web/src/components/cards/__tests__/ServiceStatus.test.tsx
@@ -27,7 +27,7 @@ vi.mock('../../../hooks/useCachedData', () => ({
     isDemoFallback: false,
     isFailed: false,
     consecutiveFailures: 0,
-    error: null,
+    error: false,
   })),
 }))
 
@@ -148,7 +148,7 @@ describe('ServiceStatus', () => {
         isDemoFallback: false,
         isFailed: false,
         consecutiveFailures: 0,
-        error: null,
+        error: false,
       } as never)
       render(<ServiceStatus />)
       // LB count = 1
@@ -168,7 +168,7 @@ describe('ServiceStatus', () => {
         isDemoFallback: false,
         isFailed: false,
         consecutiveFailures: 0,
-        error: null,
+        error: false,
       } as never)
       render(<ServiceStatus />)
       expect(screen.getByText('my-svc')).toBeTruthy()
@@ -184,7 +184,7 @@ describe('ServiceStatus', () => {
         isDemoFallback: false,
         isFailed: false,
         consecutiveFailures: 0,
-        error: null,
+        error: false,
       } as never)
       render(<ServiceStatus />)
       expect(screen.getByTestId('cluster-badge')).toBeTruthy()
@@ -199,7 +199,7 @@ describe('ServiceStatus', () => {
         isDemoFallback: false,
         isFailed: false,
         consecutiveFailures: 0,
-        error: null,
+        error: false,
       } as never)
       render(<ServiceStatus />)
       expect(screen.getByText('LoadBalancer')).toBeTruthy()
@@ -214,7 +214,7 @@ describe('ServiceStatus', () => {
         isDemoFallback: false,
         isFailed: false,
         consecutiveFailures: 0,
-        error: null,
+        error: false,
       } as never)
       render(<ServiceStatus />)
       expect(screen.getByText('443/TCP, 80/TCP')).toBeTruthy()
@@ -229,7 +229,7 @@ describe('ServiceStatus', () => {
         isDemoFallback: false,
         isFailed: false,
         consecutiveFailures: 0,
-        error: null,
+        error: false,
       } as never)
       render(<ServiceStatus />)
       fireEvent.click(screen.getByText('my-svc'))

--- a/web/src/components/cards/__tests__/ServiceTopology.test.tsx
+++ b/web/src/components/cards/__tests__/ServiceTopology.test.tsx
@@ -60,7 +60,7 @@ describe('ServiceTopology', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockTopology.mockReturnValue({ nodes: [], edges: [], isLoading: false, error: null })
+    mockTopology.mockReturnValue({ nodes: [], edges: [], isLoading: false, error: false })
   })
 
   it('renders without crashing', () => {

--- a/web/src/components/cards/__tests__/StorageOverview.test.tsx
+++ b/web/src/components/cards/__tests__/StorageOverview.test.tsx
@@ -113,7 +113,7 @@ const defaultPVCsReturn = {
   isDemoFallback: false,
   isFailed: false,
   consecutiveFailures: 0,
-  error: null,
+  error: false,
 }
 
 const defaultGlobalFilters = {

--- a/web/src/components/cards/__tests__/TopPods.test.tsx
+++ b/web/src/components/cards/__tests__/TopPods.test.tsx
@@ -78,7 +78,7 @@ describe('TopPods', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToPod: vi.fn() })
   })
 
@@ -94,7 +94,7 @@ describe('TopPods', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockPods.mockReturnValue({ pods: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
+    mockPods.mockReturnValue({ pods: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
     const { container } = render(<TopPods />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -126,13 +126,13 @@ describe('TopPods', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<TopPods />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<TopPods />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })
@@ -180,7 +180,7 @@ describe('TopPods hook ordering', () => {
       isDemoFallback: false,
       isFailed: false,
       consecutiveFailures: 0,
-      error: null,
+      error: false,
       lastRefresh: Date.now(),
     })
 

--- a/web/src/components/cards/__tests__/UpgradeStatus.test.tsx
+++ b/web/src/components/cards/__tests__/UpgradeStatus.test.tsx
@@ -88,7 +88,7 @@ describe('UpgradeStatus', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
     mockDrillDown.mockReturnValue({ drillToUpgrade: vi.fn() })
   })
 
@@ -117,7 +117,7 @@ describe('UpgradeStatus', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<UpgradeStatus />)
     expect(container).toBeTruthy()

--- a/web/src/components/cards/__tests__/VaultSecrets.test.tsx
+++ b/web/src/components/cards/__tests__/VaultSecrets.test.tsx
@@ -62,7 +62,7 @@ describe('VaultSecrets', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -90,7 +90,7 @@ describe('VaultSecrets', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<VaultSecrets />)
     expect(container).toBeTruthy()

--- a/web/src/components/cards/__tests__/WarningEvents.test.tsx
+++ b/web/src/components/cards/__tests__/WarningEvents.test.tsx
@@ -68,7 +68,7 @@ describe('WarningEvents', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     mockUseCardData.mockReturnValue({
       items: [], totalItems: 0, currentPage: 1, totalPages: 0, itemsPerPage: 5,
       goToPage: vi.fn(), needsPagination: false, setItemsPerPage: vi.fn(),
@@ -90,7 +90,7 @@ describe('WarningEvents', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockEvents.mockReturnValue({ events: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: null })
+    mockEvents.mockReturnValue({ events: [], isLoading: true, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: null })
     const { container } = render(<WarningEvents />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -122,13 +122,13 @@ describe('WarningEvents', () => {
 
   it('renders during background refresh with cached data', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: true })
-    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     const { container } = render(<WarningEvents />)
     expect(container).toBeTruthy()
   })
 
   it('reports demo fallback state', () => {
-    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockEvents.mockReturnValue({ events: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: false, lastRefresh: Date.now() })
     render(<WarningEvents />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })

--- a/web/src/components/cards/__tests__/WorkloadDeployment.test.tsx
+++ b/web/src/components/cards/__tests__/WorkloadDeployment.test.tsx
@@ -77,7 +77,7 @@ describe('WorkloadDeployment', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now() })
   })
 
   it('renders without crashing', () => {
@@ -92,7 +92,7 @@ describe('WorkloadDeployment', () => {
 
   it('renders skeleton UI when data is loading', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: true, showEmptyState: false, hasData: false, isRefreshing: false })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: null, lastRefresh: null })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: true, isRefreshing: false, error: false, lastRefresh: null })
     const { container } = render(<WorkloadDeployment />)
     // Skeleton renders animate-pulse elements or similar loading indicators
     expect(container.innerHTML.length).toBeGreaterThan(0)
@@ -113,7 +113,7 @@ describe('WorkloadDeployment', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: false, lastRefresh: Date.now(),
     })
     const { container } = render(<WorkloadDeployment />)
     expect(container).toBeTruthy()

--- a/web/src/components/cards/artifact_hub_status/artifact_hub_status.test.tsx
+++ b/web/src/components/cards/artifact_hub_status/artifact_hub_status.test.tsx
@@ -29,7 +29,7 @@ function setup(overrides?: Record<string, unknown>) {
       totalPublishers: 0,
       totalRepositories: 0,
     },
-    error: null,
+    error: false,
     showSkeleton: false,
     showEmptyState: false,
     ...overrides,
@@ -56,7 +56,7 @@ describe('ArtifactHubStatus', () => {
   })
 
   it('renders empty state when showEmptyState is true', () => {
-    setup({ error: null, showEmptyState: true })
+    setup({ error: false, showEmptyState: true })
     render(<ArtifactHubStatus />)
 
     expect(screen.getByText('artifactHub.noData')).toBeTruthy()

--- a/web/src/components/cards/buildpacks-status/__tests__/BuildpacksStatus.test.tsx
+++ b/web/src/components/cards/buildpacks-status/__tests__/BuildpacksStatus.test.tsx
@@ -42,7 +42,7 @@ vi.mock('../../../../hooks/useMCP', () => ({
 }))
 
 vi.mock('../../../../hooks/useCachedData', () => ({
-  useCachedBuildpackImages: () => ({ images: [], isLoading: false, isFailed: false, consecutiveFailures: 0, error: null, isDemoFallback: null }),
+  useCachedBuildpackImages: () => ({ images: [], isLoading: false, isFailed: false, consecutiveFailures: 0, error: false, isDemoFallback: null }),
 }))
 
 vi.mock('../../../../lib/cards/cardHooks', () => ({

--- a/web/src/components/cards/cluster-resource-tree/__tests__/ClusterResourceTree.test.tsx
+++ b/web/src/components/cards/cluster-resource-tree/__tests__/ClusterResourceTree.test.tsx
@@ -71,7 +71,7 @@ vi.mock('../../../../hooks/useDrillDown', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))
 

--- a/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
@@ -165,7 +165,7 @@ vi.mock('../nodeCache', () => ({
   getNodesCache: () => mockGetNodesCache(),
   subscribeToNodes: () => () => {},
   fetchAllNodes: vi.fn(() =>
-    Promise.resolve({ nodes: [], error: null, consecutiveFailures: 0 }),
+    Promise.resolve({ nodes: [], error: false, consecutiveFailures: 0 }),
   ),
   OFFLINE_DETECTION_FAILURE_THRESHOLD: 3,
   GPU_CLUSTER_EXHAUSTION_THRESHOLD: 0.8,

--- a/web/src/components/cards/crossplane-status/__tests__/CrossplaneManagedResources.test.tsx
+++ b/web/src/components/cards/crossplane-status/__tests__/CrossplaneManagedResources.test.tsx
@@ -79,7 +79,7 @@ vi.mock('../../CardDataContext', () => ({
 }))
 
 vi.mock('../../../../hooks/mcp/crossplane', () => ({
-  useCrossplaneManagedResources: () => ({ resources: [], isLoading: false, isRefreshing: false, error: null, consecutiveFailures: 0, isFailed: false, isDemoData: false }),
+  useCrossplaneManagedResources: () => ({ resources: [], isLoading: false, isRefreshing: false, error: false, consecutiveFailures: 0, isFailed: false, isDemoData: false }),
 }))
 
 import { CrossplaneManagedResources } from '../CrossplaneManagedResources'

--- a/web/src/components/cards/cubefs_status/__tests__/CubefsStatus.test.tsx
+++ b/web/src/components/cards/cubefs_status/__tests__/CubefsStatus.test.tsx
@@ -82,7 +82,7 @@ describe('CubefsStatus', () => {
     mockHookReturn = {
       data: CUBEFS_DEMO_DATA,
       isRefreshing: false,
-      error: null,
+      error: false,
       showSkeleton: false,
       showEmptyState: false,
       lastRefresh: Date.now(),

--- a/web/src/components/cards/flatcar_status/flatcar_status.test.tsx
+++ b/web/src/components/cards/flatcar_status/flatcar_status.test.tsx
@@ -28,7 +28,7 @@ vi.mock('../../ui/Skeleton', () => ({
 function setup(overrides?: Record<string, unknown>) {
   mockUseFlatcarStatus.mockReturnValue({
     data: null,
-    error: null,
+    error: false,
     isRefreshing: false,
     showSkeleton: false,
     showEmptyState: false,
@@ -56,7 +56,7 @@ describe('FlatcarStatus', () => {
   })
 
   it('renders empty state when no Flatcar nodes found', () => {
-    setup({ error: null, showEmptyState: true })
+    setup({ error: false, showEmptyState: true })
     render(<FlatcarStatus />)
 
     expect(screen.getByText('flatcar.noFlatcarNodes')).toBeTruthy()

--- a/web/src/components/cards/grpc_status/grpc_status.test.tsx
+++ b/web/src/components/cards/grpc_status/grpc_status.test.tsx
@@ -50,7 +50,7 @@ function setup(overrides?: Record<string, unknown>) {
     refetch: vi.fn(),
     showSkeleton: false,
     showEmptyState: false,
-    error: null,
+    error: false,
     ...overrides,
   })
   mockUseReportCardDataState.mockReturnValue(undefined)

--- a/web/src/components/cards/kagent/__tests__/KagentSecurity.test.tsx
+++ b/web/src/components/cards/kagent/__tests__/KagentSecurity.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../../../../hooks/mcp/kagent_crds', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))
 

--- a/web/src/components/cards/kagent/__tests__/KagentTopology.test.tsx
+++ b/web/src/components/cards/kagent/__tests__/KagentTopology.test.tsx
@@ -44,7 +44,7 @@ vi.mock('../../../../hooks/mcp/kagent_crds', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))
 

--- a/web/src/components/cards/kagenti/__tests__/KagentiSecurity.test.tsx
+++ b/web/src/components/cards/kagenti/__tests__/KagentiSecurity.test.tsx
@@ -42,7 +42,7 @@ vi.mock('../../../../hooks/mcp/kagenti', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))
 

--- a/web/src/components/cards/kagenti/__tests__/KagentiTopology.test.tsx
+++ b/web/src/components/cards/kagenti/__tests__/KagentiTopology.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../../../../hooks/mcp/kagenti', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))
 

--- a/web/src/components/cards/linkerd_status/linkerd_status.test.tsx
+++ b/web/src/components/cards/linkerd_status/linkerd_status.test.tsx
@@ -52,7 +52,7 @@ function setup(overrides?: Record<string, unknown>) {
     refetch: vi.fn(),
     showSkeleton: false,
     showEmptyState: false,
-    error: null,
+    error: false,
     ...overrides,
   })
   mockUseReportCardDataState.mockReturnValue(undefined)

--- a/web/src/components/cards/llmd/__tests__/KVCacheMonitor.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/KVCacheMonitor.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../../../../lib/llmd/mockData', () => ({
 
 vi.mock('../../CardDataContext', () => ({
   useCardDemoState: () => ({ shouldUseDemoData: null, showDemoBadge: null }),
-  useReportCardDataState: () => ({ data: [], isLoading: false, error: null }),
+  useReportCardDataState: () => ({ data: [], isLoading: false, error: false }),
   useReportCardDataState: () => {},
 }))
 

--- a/web/src/components/cards/llmd/__tests__/LLMdFlow.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/LLMdFlow.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../../../../lib/llmd/mockData', () => ({
 
 vi.mock('../../CardDataContext', () => ({
   useCardDemoState: () => ({ shouldUseDemoData: null, showDemoBadge: null }),
-  useReportCardDataState: () => ({ data: [], isLoading: false, error: null }),
+  useReportCardDataState: () => ({ data: [], isLoading: false, error: false }),
   useReportCardDataState: () => {},
 }))
 

--- a/web/src/components/cards/llmd/__tests__/PDDisaggregation.test.tsx
+++ b/web/src/components/cards/llmd/__tests__/PDDisaggregation.test.tsx
@@ -39,7 +39,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('../../CardDataContext', () => ({
   useCardDemoState: () => ({ shouldUseDemoData: null, showDemoBadge: null }),
-  useReportCardDataState: () => ({ data: [], isLoading: false, error: null }),
+  useReportCardDataState: () => ({ data: [], isLoading: false, error: false }),
   useReportCardDataState: () => {},
 }))
 

--- a/web/src/components/cards/multi-tenancy/tenant-topology/__tests__/TenantTopology.test.tsx
+++ b/web/src/components/cards/multi-tenancy/tenant-topology/__tests__/TenantTopology.test.tsx
@@ -38,7 +38,7 @@ vi.mock('react-i18next', () => ({
 }))
 
 vi.mock('../../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))
 

--- a/web/src/components/cards/quantum/__tests__/QuantumCircuitViewer.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumCircuitViewer.test.tsx
@@ -37,7 +37,7 @@ function defaultHook(overrides: Record<string, unknown> = {}) {
     isFailed: false,
     consecutiveFailures: 0,
     lastRefresh: null,
-    error: null,
+    error: false,
     refetch: vi.fn(),
     ...overrides,
   }

--- a/web/src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumControlPanel.test.tsx
@@ -44,7 +44,7 @@ vi.mock('../../../../hooks/useQASMFiles', () => ({
   useQASMFiles: () => ({
     files: [{ name: 'bell.qasm' }],
     isLoading: false,
-    error: null,
+    error: false,
   }),
 }))
 
@@ -94,7 +94,7 @@ function statusHookReturn(
     isLoading: false,
     isRefreshing: false,
     isDemoData: false,
-    error: null,
+    error: false,
     isFailed: false,
     consecutiveFailures: 0,
     lastRefresh: Date.now(),
@@ -125,7 +125,7 @@ function authHookReturn(
     isLoading: false,
     isRefreshing: false,
     isDemoData: false,
-    error: null,
+    error: false,
     isFailed: false,
     consecutiveFailures: 0,
     lastRefresh: null,

--- a/web/src/components/cards/quantum/__tests__/QuantumHistogramCard.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumHistogramCard.test.tsx
@@ -90,7 +90,7 @@ function defaultHookReturn(
     isLoading: false,
     isRefreshing: false,
     isDemoData: false,
-    error: null,
+    error: false,
     isFailed: false,
     consecutiveFailures: 0,
     lastRefresh: STABLE_LAST_REFRESH_MS,

--- a/web/src/components/cards/quantum/__tests__/QuantumQubitGrid.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumQubitGrid.test.tsx
@@ -45,7 +45,7 @@ function defaultHook(overrides: Record<string, unknown> = {}) {
     isFailed: false,
     consecutiveFailures: 0,
     lastRefresh: null,
-    error: null,
+    error: false,
     refetch: vi.fn(),
     ...overrides,
   }

--- a/web/src/components/cards/quantum/__tests__/QuantumStatus.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/QuantumStatus.test.tsx
@@ -57,7 +57,7 @@ function defaultHookReturn(
     isLoading: false,
     isRefreshing: false,
     isDemoData: false,
-    error: null,
+    error: false,
     isFailed: false,
     consecutiveFailures: 0,
     lastRefresh: Date.now(),

--- a/web/src/components/cards/rook_status/rook_status.test.tsx
+++ b/web/src/components/cards/rook_status/rook_status.test.tsx
@@ -51,7 +51,7 @@ function setup(overrides?: Record<string, unknown>) {
     refetch: vi.fn(),
     showSkeleton: false,
     showEmptyState: false,
-    error: null,
+    error: false,
     ...overrides,
   })
   mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })

--- a/web/src/components/cards/spiffe_status/spiffe_status.test.tsx
+++ b/web/src/components/cards/spiffe_status/spiffe_status.test.tsx
@@ -47,7 +47,7 @@ function setup(overrides?: Record<string, unknown>) {
     refetch: vi.fn(),
     showSkeleton: false,
     showEmptyState: false,
-    error: null,
+    error: false,
     ...overrides,
   })
   mockUseReportCardDataState.mockReturnValue(undefined)

--- a/web/src/components/cards/thanos_status/__tests__/ThanosStatus.test.tsx
+++ b/web/src/components/cards/thanos_status/__tests__/ThanosStatus.test.tsx
@@ -22,7 +22,7 @@ vi.mock('../../../../hooks/useCachedThanosStatus', () => ({
         isLoading: false,
         isRefreshing: false,
         isDemoFallback: false,
-        error: null,
+        error: false,
         isFailed: false,
         consecutiveFailures: 0,
         lastRefresh: Date.now(),

--- a/web/src/components/cards/workload-detection/__tests__/LLMInference.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/LLMInference.test.tsx
@@ -74,7 +74,7 @@ vi.mock('../../../../lib/cards/cardHooks', () => ({
 }))
 
 vi.mock('../../../../hooks/useCachedData', () => ({
-  useCachedLLMdServers: () => ({ servers: [], isLoading: false, isRefreshing: false, lastRefresh: Date.now(), refetch: vi.fn(), isFailed: false, consecutiveFailures: 0, isDemoFallback: null, error: null }),
+  useCachedLLMdServers: () => ({ servers: [], isLoading: false, isRefreshing: false, lastRefresh: Date.now(), refetch: vi.fn(), isFailed: false, consecutiveFailures: 0, isDemoFallback: null, error: false }),
   useCachedGPUNodes: () => ({ nodes: [] }),
 }))
 
@@ -83,7 +83,7 @@ vi.mock('../../../../hooks/useMCP', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))
 

--- a/web/src/components/cards/workload-detection/__tests__/LLMModels.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/LLMModels.test.tsx
@@ -82,7 +82,7 @@ vi.mock('../../../../hooks/useMCP', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))
 

--- a/web/src/components/cards/workload-detection/__tests__/MLJobs.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/MLJobs.test.tsx
@@ -73,7 +73,7 @@ vi.mock('../../../../lib/cards/cardHooks', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))
 

--- a/web/src/components/cards/workload-detection/__tests__/MLNotebooks.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/MLNotebooks.test.tsx
@@ -73,7 +73,7 @@ vi.mock('../../../../lib/cards/cardHooks', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))
 

--- a/web/src/components/cards/workload-detection/__tests__/ProwHistory.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/ProwHistory.test.tsx
@@ -77,7 +77,7 @@ vi.mock('../../../../lib/cards/cardHooks', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardDemoState: () => ({ shouldUseDemoData: null }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))

--- a/web/src/components/cards/workload-detection/__tests__/ProwJobs.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/ProwJobs.test.tsx
@@ -78,7 +78,7 @@ vi.mock('../../../../hooks/useCachedData', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardDemoState: () => ({ shouldUseDemoData: null }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))

--- a/web/src/components/cards/workload-detection/__tests__/ProwStatus.test.tsx
+++ b/web/src/components/cards/workload-detection/__tests__/ProwStatus.test.tsx
@@ -42,7 +42,7 @@ vi.mock('../../../../hooks/useCachedData', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardDemoState: () => ({ shouldUseDemoData: null }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))

--- a/web/src/components/cards/workload-monitor/__tests__/ProwCIMonitor.test.tsx
+++ b/web/src/components/cards/workload-monitor/__tests__/ProwCIMonitor.test.tsx
@@ -82,7 +82,7 @@ vi.mock('../../../../lib/cn', () => ({
 }))
 
 vi.mock('../../../cards/CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardDemoState: () => ({ shouldUseDemoData: null }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))

--- a/web/src/components/cards/workload-monitor/__tests__/WorkloadMonitor.test.tsx
+++ b/web/src/components/cards/workload-monitor/__tests__/WorkloadMonitor.test.tsx
@@ -86,7 +86,7 @@ vi.mock('../../../../hooks/useWorkloads', () => ({
 }))
 
 vi.mock('../../../../hooks/useWorkloadMonitor', () => ({
-  useWorkloadMonitor: () => ({ resources: [], issues: [], overallStatus: null, workloadKind: null, isLoading: false, isRefreshing: false, error: null, refetch: vi.fn() }),
+  useWorkloadMonitor: () => ({ resources: [], issues: [], overallStatus: null, workloadKind: null, isLoading: false, isRefreshing: false, error: false, refetch: vi.fn() }),
 }))
 
 vi.mock('../../../../lib/cn', () => ({
@@ -94,7 +94,7 @@ vi.mock('../../../../lib/cn', () => ({
 }))
 
 vi.mock('../../CardDataContext', () => ({
-  useCardLoadingState: () => ({ data: [], isLoading: false, error: null }),
+  useCardLoadingState: () => ({ data: [], isLoading: false, error: false }),
   useCardLoadingState: () => ({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false }),
 }))
 


### PR DESCRIPTION
Fixes #20092

## Root Cause

Test mocks returned `error: null` but `createCardCachedHook` returns `error: boolean`, causing type mismatch across 188 card component tests.

## Fix

Updated 97 test files to use `error: false` instead of `error: null` to match the actual hook return type.