### PR TITLE
[scanner] fix: add error states to status card components

### DIFF
--- a/web/src/components/cards/cloud_custodian_status/index.tsx
+++ b/web/src/components/cards/cloud_custodian_status/index.tsx
@@ -205,6 +205,7 @@ export function CloudCustodianStatus() {
     consecutiveFailures,
     error,
     lastRefresh,
+    refetch,
   } = useCachedCloudCustodian()
 
   // Rule: never show demo data while still loading
@@ -240,9 +241,17 @@ export function CloudCustodianStatus() {
 
   if (showEmptyState) {
     return (
-      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-3">
         <AlertTriangle className="w-6 h-6 text-red-400" />
         <p className="text-sm text-red-400">{t('cloudCustodianStatus.fetchFailed', 'Failed to fetch Cloud Custodian status')}</p>
+        {error && <p className="text-xs text-muted-foreground max-w-xs text-center">{error}</p>}
+        <button
+          onClick={() => refetch()}
+          className="flex items-center gap-2 px-4 py-2 rounded-md bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors text-sm"
+        >
+          <RefreshCw className="w-4 h-4" />
+          {t('common.retry', 'Retry')}
+        </button>
       </div>
     )
   }

--- a/web/src/components/cards/containerd_status/index.tsx
+++ b/web/src/components/cards/containerd_status/index.tsx
@@ -13,7 +13,7 @@
  */
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { AlertTriangle, Box, CheckCircle, PauseCircle, Server, StopCircle } from 'lucide-react'
+import { AlertTriangle, Box, CheckCircle, PauseCircle, RefreshCw, Server, StopCircle } from 'lucide-react'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
 import { useCachedContainerd } from '../../../hooks/useCachedContainerd'
@@ -82,6 +82,7 @@ export function ContainerdStatus() {
     consecutiveFailures,
     error,
     lastRefresh,
+    refetch,
   } = useCachedContainerd()
 
   const hasAnyData = data.containers.length > 0
@@ -112,9 +113,17 @@ export function ContainerdStatus() {
 
   if (showEmptyState) {
     return (
-      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-3">
         <AlertTriangle className="w-6 h-6 text-red-400" />
         <p className="text-sm text-red-400">{t('containerdStatus.fetchFailed', 'Failed to fetch containerd status')}</p>
+        {error && <p className="text-xs text-muted-foreground max-w-xs text-center">{error}</p>}
+        <button
+          onClick={() => refetch()}
+          className="flex items-center gap-2 px-4 py-2 rounded-md bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors text-sm"
+        >
+          <RefreshCw className="w-4 h-4" />
+          {t('common.retry', 'Retry')}
+        </button>
       </div>
     )
   }

--- a/web/src/components/cards/spire_status/index.tsx
+++ b/web/src/components/cards/spire_status/index.tsx
@@ -125,6 +125,7 @@ export function SpireStatus() {
     consecutiveFailures,
     error,
     lastRefresh,
+    refetch,
   } = useCachedSpire()
 
   // Rule: never show demo data while still loading
@@ -160,9 +161,17 @@ export function SpireStatus() {
 
   if (showEmptyState) {
     return (
-      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-3">
         <AlertTriangle className="w-6 h-6 text-red-400" />
         <p className="text-sm text-red-400">{t('spireStatus.fetchFailed', 'Failed to fetch SPIRE status')}</p>
+        {error && <p className="text-xs text-muted-foreground max-w-xs text-center">{error}</p>}
+        <button
+          onClick={() => refetch()}
+          className="flex items-center gap-2 px-4 py-2 rounded-md bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors text-sm"
+        >
+          <RefreshCw className="w-4 h-4" />
+          {t('common.retry', 'Retry')}
+        </button>
       </div>
     )
   }

--- a/web/src/components/cards/tikv_status/index.tsx
+++ b/web/src/components/cards/tikv_status/index.tsx
@@ -87,6 +87,7 @@ export function TikvStatus() {
     consecutiveFailures,
     error,
     lastRefresh,
+    refetch,
   } = useCachedTikv()
 
   // Rule: never show demo data while still loading
@@ -119,7 +120,18 @@ export function TikvStatus() {
   if (showEmptyState) {
     return (
       <div className="h-full flex items-center justify-center p-4">
-        <EmptyState icon={<AlertTriangle className="w-8 h-8 text-red-400" />} title={t('tikvStatus.fetchFailed', 'Failed to fetch TiKV status')} />
+        <div className="flex flex-col items-center gap-3">
+          <AlertTriangle className="w-8 h-8 text-red-400" />
+          <p className="text-sm font-medium text-red-400">{t('tikvStatus.fetchFailed', 'Failed to fetch TiKV status')}</p>
+          {error && <p className="text-xs text-muted-foreground max-w-xs text-center">{error}</p>}
+          <button
+            onClick={() => refetch()}
+            className="flex items-center gap-2 px-4 py-2 rounded-md bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors text-sm"
+          >
+            <RefreshCw className="w-4 h-4" />
+            {t('common.retry', 'Retry')}
+          </button>
+        </div>
       </div>
     )
   }

--- a/web/src/components/cards/tuf_status/index.tsx
+++ b/web/src/components/cards/tuf_status/index.tsx
@@ -152,6 +152,7 @@ export function TufStatus() {
     consecutiveFailures,
     error,
     lastRefresh,
+    refetch,
   } = useCachedTuf()
 
   // Rule: never show demo data while still loading
@@ -187,9 +188,17 @@ export function TufStatus() {
 
   if (showEmptyState) {
     return (
-      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-3">
         <AlertTriangle className="w-6 h-6 text-red-400" />
         <p className="text-sm text-red-400">{t('tufStatus.fetchFailed', 'Failed to fetch TUF status')}</p>
+        {error && <p className="text-xs text-muted-foreground max-w-xs text-center">{error}</p>}
+        <button
+          onClick={() => refetch()}
+          className="flex items-center gap-2 px-4 py-2 rounded-md bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors text-sm"
+        >
+          <RefreshCw className="w-4 h-4" />
+          {t('common.retry', 'Retry')}
+        </button>
       </div>
     )
   }


### PR DESCRIPTION
Fixes #20096

Adds error state handling (error message + retry) to status card components that were fetching data without error fallbacks:
- containerd_status
- cloud_custodian_status
- spire_status
- tuf_status
- tikv_status

Part of #20068