### PR TITLE
[scanner] fix: add error states to dashboard/monitor card components

### DIFF
--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next'
 import { Check, X, Filter, ChevronDown, ChevronRight, Flag, Sparkles, Lock, Unlock, Eye, RefreshCw } from 'lucide-react'
 import { useCardLoadingState } from './CardDataContext'
 import { CardSkeleton } from '../../lib/cards/CardComponents'
+import { Button } from '../ui/Button'
 import { useACMM } from '../acmm/ACMMProvider'
 import { useMissions } from '../../hooks/useMissions'
 import { ALL_CRITERIA, SOURCES_BY_ID } from '../../lib/acmm/sources'
@@ -249,11 +250,20 @@ export function ACMMFeedbackLoops() {
 
   if (showEmptyState) {
     return (
-      <div className="h-full flex items-center justify-center p-4">
+      <div className="h-full flex flex-col items-center justify-center p-4 gap-2">
         <div className="text-center text-muted-foreground">
           <p className="text-sm font-medium">{t('cards:acmmFeedbackLoops.loadFailed', 'Failed to load criteria')}</p>
           <p className="text-xs mt-1">{t('cards:acmmFeedbackLoops.tryRefresh', 'Please refresh the page or try again later.')}</p>
         </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => scan.refetch()}
+          className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1"
+        >
+          <RefreshCw className="w-3 h-3" />
+          {t('common.retry', 'Retry')}
+        </Button>
       </div>
     )
   }

--- a/web/src/components/cards/GPUInventoryHistory.tsx
+++ b/web/src/components/cards/GPUInventoryHistory.tsx
@@ -2,7 +2,7 @@
 import { useMemo, useState, useRef, useEffect, useCallback } from 'react'
 import {
   Cpu, TrendingUp, TrendingDown, Minus, Clock, Server,
-  BarChart3, Table2, ChevronDown, ArrowUpDown,
+  BarChart3, Table2, ChevronDown, ArrowUpDown, RefreshCw,
 } from 'lucide-react'
 import { useMetricsHistory } from '../../hooks/useMetricsHistory'
 import type { MetricsSnapshot } from '../../types/predictions'
@@ -11,6 +11,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { CardClusterFilter } from '../../lib/cards/CardComponents'
 import { Skeleton, SkeletonStats } from '../ui/Skeleton'
+import { Button } from '../ui/Button'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../lib/cn'
@@ -36,7 +37,9 @@ export function GPUInventoryHistory() {
     isRefreshing,
     isDemoFallback,
     isFailed,
-    consecutiveFailures } = useCachedGPUNodes()
+    consecutiveFailures,
+    refetch,
+  } = useCachedGPUNodes()
   const { isDemoMode } = useDemoMode()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
 
@@ -453,11 +456,20 @@ export function GPUInventoryHistory() {
 
   if (showEmptyState) {
     return (
-      <div className="h-full flex items-center justify-center p-4">
+      <div className="h-full flex flex-col items-center justify-center p-4 gap-2">
         <div className="text-center text-muted-foreground">
           <p className="text-sm font-medium">{t('cards:gpuInventoryHistory.loadFailed', 'Failed to load GPU inventory')}</p>
           <p className="text-xs mt-1">{t('cards:gpuInventoryHistory.tryRefresh', 'Please refresh the page to try again.')}</p>
         </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => refetch()}
+          className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1"
+        >
+          <RefreshCw className="w-3 h-3" />
+          {t('common.retry', 'Retry')}
+        </Button>
       </div>
     )
   }

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback } from 'react'
-import { Plus, AlertTriangle } from 'lucide-react'
+import { Plus, AlertTriangle, RefreshCw } from 'lucide-react'
 import { useModalState } from '../../lib/modals'
 import {
   useClusters,
@@ -13,6 +13,7 @@ import { useCachedNamespaces } from '../../hooks/useCachedData'
 import { Skeleton } from '../ui/Skeleton'
 import { StatusBadge } from '../ui/StatusBadge'
 import { CardEmptyState } from '../ui/CardEmptyState'
+import { Button } from '../ui/Button'
 import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 import { CardControlsRow } from '../../lib/cards/CardComponents'
 import { useCardData, type SortDirection } from '../../lib/cards/cardHooks'
@@ -252,9 +253,20 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
 
   if (showEmptyState) {
     return (
-      <CardEmptyState icon={<AlertTriangle className="w-6 h-6 text-red-400" />}>
-        <p className="text-sm text-red-400">{t('common.fetchFailed', 'Failed to fetch data')}</p>
-      </CardEmptyState>
+      <div className="flex flex-col items-center justify-center h-full gap-2">
+        <CardEmptyState icon={<AlertTriangle className="w-6 h-6 text-red-400" />}>
+          <p className="text-sm text-red-400">{t('common.fetchFailed', 'Failed to fetch data')}</p>
+        </CardEmptyState>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => refetchQuotas()}
+          className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1"
+        >
+          <RefreshCw className="w-3 h-3" />
+          {t('common.retry', 'Retry')}
+        </Button>
+      </div>
     )
   }
 

--- a/web/src/components/cards/QualityDashboard.tsx
+++ b/web/src/components/cards/QualityDashboard.tsx
@@ -9,8 +9,10 @@ import {
   ShieldCheck, 
   Zap,
   TrendingUp,
-  Search
+  Search,
+  RefreshCw
 } from 'lucide-react';
+import { Button } from '../ui/Button';
 
 /**
  * QualityDashboard displays real-time metrics for state integrity and AI bug sweeps.
@@ -29,6 +31,7 @@ const QualityDashboard: React.FC = () => {
     isFailed,
     consecutiveFailures,
     error,
+    refetch,
   } = useCachedQuality();
 
   // Report loading state to CardWrapper for skeleton/refresh behavior.
@@ -55,12 +58,21 @@ const QualityDashboard: React.FC = () => {
 
   if (loadingState.showEmptyState) {
     return (
-      <div className="flex items-center justify-center h-48">
+      <div className="flex flex-col items-center justify-center h-48 gap-2">
         <div className="text-center text-muted-foreground">
           <AlertTriangle className="w-6 h-6 mx-auto mb-2 text-red-400" />
           <p className="text-sm font-medium">{t('quality.fetchFailed', 'Failed to fetch quality data')}</p>
           <p className="text-xs mt-1">{t('quality.tryAgain', 'Please refresh the page or try again later.')}</p>
         </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => refetch()}
+          className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1"
+        >
+          <RefreshCw className="w-3 h-3" />
+          {t('common.retry', 'Retry')}
+        </Button>
       </div>
     );
   }

--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from 'react'
-import { ArrowUp, Rocket, AlertTriangle } from 'lucide-react'
+import { ArrowUp, Rocket, AlertTriangle, RefreshCw } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -47,6 +47,7 @@ export function UpgradeStatus({ config: _config }: UpgradeStatusProps) {
     isRefreshing,
     isFailed,
     consecutiveFailures,
+    refetch,
   } = useClusters()
   const { drillToCluster } = useDrillDownActions()
   const { startMission } = useMissions()
@@ -254,9 +255,20 @@ export function UpgradeStatus({ config: _config }: UpgradeStatusProps) {
 
   if (showEmptyState) {
     return (
-      <CardEmptyState icon={<AlertTriangle className="w-6 h-6 text-red-400" />}>
-        <p className="text-sm text-red-400">{t('common.fetchFailed', 'Failed to fetch upgrade status')}</p>
-      </CardEmptyState>
+      <div className="flex flex-col items-center justify-center h-full gap-2">
+        <CardEmptyState icon={<AlertTriangle className="w-6 h-6 text-red-400" />}>
+          <p className="text-sm text-red-400">{t('common.fetchFailed', 'Failed to fetch upgrade status')}</p>
+        </CardEmptyState>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => refetch()}
+          className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1"
+        >
+          <RefreshCw className="w-3 h-3" />
+          {t('common.retry', 'Retry')}
+        </Button>
+      </div>
     )
   }
 


### PR DESCRIPTION
Fixes #20094

Adds error state handling (error message + retry) to dashboard/monitor card components that were fetching data without error fallbacks:
- GPUInventoryHistory
- QualityDashboard
- NamespaceQuotas
- UpgradeStatus
- ACMMFeedbackLoops

Part of #20068