### PR TITLE
[scanner] fix: add unit test coverage for mission-control/ components

### DIFF
--- a/web/src/components/mission-control/AssignmentMatrix.test.tsx
+++ b/web/src/components/mission-control/AssignmentMatrix.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AssignmentMatrix } from './AssignmentMatrix'
+import type { ClusterInfo } from '../../hooks/mcp/types'
+import type { PayloadProject, ClusterAssignment } from './types'
+
+const mockProjects: PayloadProject[] = [
+  {
+    name: 'prometheus',
+    displayName: 'Prometheus',
+    category: 'Observability',
+    maturity: 'graduated',
+    priority: 'required',
+    reason: 'Metrics',
+    dependencies: [],
+  },
+  {
+    name: 'grafana',
+    displayName: 'Grafana',
+    category: 'Observability',
+    maturity: 'graduated',
+    priority: 'recommended',
+    reason: 'Dashboards',
+    dependencies: [],
+  },
+]
+
+const mockClusters: ClusterInfo[] = [
+  {
+    name: 'cluster-1',
+    healthy: true,
+    nodeCount: 3,
+    cpuCores: 12,
+    memoryGB: 32,
+    storageGB: 100,
+  },
+  {
+    name: 'cluster-2',
+    healthy: true,
+    nodeCount: 5,
+    cpuCores: 20,
+    memoryGB: 64,
+    storageGB: 200,
+  },
+]
+
+const mockAssignments: ClusterAssignment[] = [
+  {
+    clusterName: 'cluster-1',
+    projectNames: ['prometheus'],
+    warnings: [],
+  },
+  {
+    clusterName: 'cluster-2',
+    projectNames: [],
+    warnings: [],
+  },
+]
+
+describe('AssignmentMatrix', () => {
+  it('renders project rows', () => {
+    const onToggle = vi.fn()
+
+    render(
+      <AssignmentMatrix
+        projects={mockProjects}
+        clusters={mockClusters}
+        assignments={mockAssignments}
+        onToggle={onToggle}
+      />
+    )
+
+    expect(screen.getByText('Prometheus')).toBeInTheDocument()
+    expect(screen.getByText('Grafana')).toBeInTheDocument()
+  })
+
+  it('renders cluster columns', () => {
+    const onToggle = vi.fn()
+
+    render(
+      <AssignmentMatrix
+        projects={mockProjects}
+        clusters={mockClusters}
+        assignments={mockAssignments}
+        onToggle={onToggle}
+      />
+    )
+
+    expect(screen.getByText(/cluster-1/)).toBeInTheDocument()
+    expect(screen.getByText(/cluster-2/)).toBeInTheDocument()
+  })
+
+  it('shows check mark for assigned projects', () => {
+    const onToggle = vi.fn()
+
+    const { container } = render(
+      <AssignmentMatrix
+        projects={mockProjects}
+        clusters={mockClusters}
+        assignments={mockAssignments}
+        onToggle={onToggle}
+      />
+    )
+
+    const cells = container.querySelectorAll('button')
+    expect(cells.length).toBeGreaterThan(0)
+  })
+
+  it('calls onToggle when cell clicked', () => {
+    const onToggle = vi.fn()
+
+    const { container } = render(
+      <AssignmentMatrix
+        projects={mockProjects}
+        clusters={mockClusters}
+        assignments={mockAssignments}
+        onToggle={onToggle}
+      />
+    )
+
+    const firstCell = container.querySelector('button')
+    if (firstCell) {
+      fireEvent.click(firstCell)
+      expect(onToggle).toHaveBeenCalled()
+    }
+  })
+
+  it('renders empty state when no projects', () => {
+    const onToggle = vi.fn()
+
+    render(
+      <AssignmentMatrix
+        projects={[]}
+        clusters={mockClusters}
+        assignments={[]}
+        onToggle={onToggle}
+      />
+    )
+
+    expect(screen.queryByText('Prometheus')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/mission-control/ClusterAssignmentPanel.test.tsx
+++ b/web/src/components/mission-control/ClusterAssignmentPanel.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ClusterAssignmentPanel } from './ClusterAssignmentPanel'
+import type { ClusterInfo } from '../../hooks/mcp/types'
+import type { PayloadProject, ClusterAssignment } from './types'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const mockClusters: ClusterInfo[] = [
+  {
+    name: 'cluster-1',
+    healthy: true,
+    nodeCount: 3,
+    cpuCores: 12,
+    memoryGB: 32,
+    storageGB: 100,
+  },
+]
+
+const mockProjects: PayloadProject[] = [
+  {
+    name: 'prometheus',
+    displayName: 'Prometheus',
+    category: 'Observability',
+    maturity: 'graduated',
+    priority: 'required',
+    reason: 'Metrics',
+    dependencies: [],
+  },
+]
+
+const mockAssignments: ClusterAssignment[] = [
+  {
+    clusterName: 'cluster-1',
+    projectNames: ['prometheus'],
+    warnings: [],
+  },
+]
+
+describe('ClusterAssignmentPanel', () => {
+  it('renders cluster cards', () => {
+    const onToggleProject = vi.fn()
+
+    render(
+      <ClusterAssignmentPanel
+        clusters={mockClusters}
+        projects={mockProjects}
+        assignments={mockAssignments}
+        onToggleProject={onToggleProject}
+      />
+    )
+
+    expect(screen.getByText(/cluster-1/)).toBeInTheDocument()
+  })
+
+  it('displays available projects', () => {
+    const onToggleProject = vi.fn()
+
+    render(
+      <ClusterAssignmentPanel
+        clusters={mockClusters}
+        projects={mockProjects}
+        assignments={mockAssignments}
+        onToggleProject={onToggleProject}
+      />
+    )
+
+    expect(screen.getByText('prometheus')).toBeInTheDocument()
+  })
+
+  it('handles empty clusters list', () => {
+    const onToggleProject = vi.fn()
+
+    render(
+      <ClusterAssignmentPanel
+        clusters={[]}
+        projects={mockProjects}
+        assignments={[]}
+        onToggleProject={onToggleProject}
+      />
+    )
+
+    expect(screen.getByText(/No clusters/i)).toBeInTheDocument()
+  })
+
+  it('renders cluster readiness information', () => {
+    const onToggleProject = vi.fn()
+
+    render(
+      <ClusterAssignmentPanel
+        clusters={mockClusters}
+        projects={mockProjects}
+        assignments={mockAssignments}
+        onToggleProject={onToggleProject}
+      />
+    )
+
+    expect(screen.getByText(/CPU/)).toBeInTheDocument()
+  })
+})

--- a/web/src/components/mission-control/ClusterReadinessCard.test.tsx
+++ b/web/src/components/mission-control/ClusterReadinessCard.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ClusterReadinessCard } from './ClusterReadinessCard'
+import type { ClusterInfo } from '../../hooks/mcp/types'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const mockCluster: ClusterInfo = {
+  name: 'prod-cluster-1',
+  healthy: true,
+  nodeCount: 5,
+  cpuCores: 20,
+  memoryGB: 64,
+  storageGB: 500,
+  podCount: 150,
+  distribution: 'eks',
+}
+
+describe('ClusterReadinessCard', () => {
+  it('renders cluster name', () => {
+    const onToggleProject = vi.fn()
+
+    render(
+      <ClusterReadinessCard
+        cluster={mockCluster}
+        onToggleProject={onToggleProject}
+        availableProjects={[]}
+      />
+    )
+
+    expect(screen.getByText(/prod-cluster-1/)).toBeInTheDocument()
+  })
+
+  it('shows health indicator when cluster is healthy', () => {
+    const onToggleProject = vi.fn()
+
+    const { container } = render(
+      <ClusterReadinessCard
+        cluster={mockCluster}
+        onToggleProject={onToggleProject}
+        availableProjects={[]}
+      />
+    )
+
+    const healthDot = container.querySelector('[title="Healthy"]')
+    expect(healthDot).toBeInTheDocument()
+  })
+
+  it('displays node count', () => {
+    const onToggleProject = vi.fn()
+
+    const { container } = render(
+      <ClusterReadinessCard
+        cluster={mockCluster}
+        onToggleProject={onToggleProject}
+        availableProjects={[]}
+      />
+    )
+
+    const nodeCount = container.querySelector('[title="5 nodes"]')
+    expect(nodeCount).toBeInTheDocument()
+  })
+
+  it('shows CPU capacity bar', () => {
+    const onToggleProject = vi.fn()
+
+    render(
+      <ClusterReadinessCard
+        cluster={mockCluster}
+        onToggleProject={onToggleProject}
+        availableProjects={[]}
+      />
+    )
+
+    expect(screen.getByText(/CPU/)).toBeInTheDocument()
+  })
+
+  it('renders available projects as checkboxes', () => {
+    const onToggleProject = vi.fn()
+
+    render(
+      <ClusterReadinessCard
+        cluster={mockCluster}
+        onToggleProject={onToggleProject}
+        availableProjects={['prometheus', 'grafana']}
+      />
+    )
+
+    expect(screen.getByText('prometheus')).toBeInTheDocument()
+    expect(screen.getByText('grafana')).toBeInTheDocument()
+  })
+
+  it('displays distribution when present', () => {
+    const onToggleProject = vi.fn()
+
+    render(
+      <ClusterReadinessCard
+        cluster={mockCluster}
+        onToggleProject={onToggleProject}
+        availableProjects={[]}
+      />
+    )
+
+    expect(screen.getByText('eks')).toBeInTheDocument()
+  })
+
+  it('shows recommended border when isRecommended is true', () => {
+    const onToggleProject = vi.fn()
+
+    const { container } = render(
+      <ClusterReadinessCard
+        cluster={mockCluster}
+        onToggleProject={onToggleProject}
+        availableProjects={[]}
+        isRecommended={true}
+      />
+    )
+
+    const card = container.firstChild
+    expect(card).toHaveClass('border-purple-500/50')
+  })
+})

--- a/web/src/components/mission-control/FlightPlanBlueprint.test.tsx
+++ b/web/src/components/mission-control/FlightPlanBlueprint.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FlightPlanBlueprint } from './FlightPlanBlueprint'
+import type { MissionControlState } from './types'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const mockState: MissionControlState = {
+  projects: [
+    {
+      name: 'prometheus',
+      displayName: 'Prometheus',
+      category: 'Observability',
+      maturity: 'graduated',
+      priority: 'required',
+      reason: 'Metrics',
+      dependencies: [],
+    },
+  ],
+  assignments: [
+    {
+      clusterName: 'cluster-1',
+      projectNames: ['prometheus'],
+      warnings: [],
+    },
+  ],
+  phases: [
+    {
+      phase: 1,
+      name: 'Deploy Core',
+      projectNames: ['prometheus'],
+      estimatedSeconds: 300,
+    },
+  ],
+  description: 'Test deployment plan',
+}
+
+describe('FlightPlanBlueprint', () => {
+  it('renders without crashing', () => {
+    const { container } = render(
+      <FlightPlanBlueprint state={mockState} />
+    )
+
+    expect(container.firstChild).toBeInTheDocument()
+  })
+
+  it('displays SVG visualization', () => {
+    const { container } = render(
+      <FlightPlanBlueprint state={mockState} />
+    )
+
+    const svg = container.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('renders project nodes', () => {
+    render(
+      <FlightPlanBlueprint state={mockState} />
+    )
+
+    expect(screen.getByText(/prometheus/i)).toBeInTheDocument()
+  })
+
+  it('handles empty state', () => {
+    const emptyState: MissionControlState = {
+      projects: [],
+      assignments: [],
+      phases: [],
+      description: '',
+    }
+
+    const { container } = render(
+      <FlightPlanBlueprint state={emptyState} />
+    )
+
+    expect(container.firstChild).toBeInTheDocument()
+  })
+})

--- a/web/src/components/mission-control/LaunchSequence.test.tsx
+++ b/web/src/components/mission-control/LaunchSequence.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LaunchSequence } from './LaunchSequence'
+import type { MissionControlState } from './types'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('../../hooks/useMissions', () => ({
+  useMissions: () => ({
+    missions: [],
+    createMission: vi.fn(),
+  }),
+}))
+
+vi.mock('../cards/multi-tenancy/missionLoader', () => ({
+  loadMissionPrompt: vi.fn().mockResolvedValue('mock prompt'),
+}))
+
+const mockState: MissionControlState = {
+  projects: [
+    {
+      name: 'prometheus',
+      displayName: 'Prometheus',
+      category: 'Observability',
+      maturity: 'graduated',
+      priority: 'required',
+      reason: 'Metrics',
+      dependencies: [],
+    },
+  ],
+  assignments: [
+    {
+      clusterName: 'cluster-1',
+      projectNames: ['prometheus'],
+      warnings: [],
+    },
+  ],
+  phases: [
+    {
+      phase: 1,
+      name: 'Deploy Core',
+      projectNames: ['prometheus'],
+      estimatedSeconds: 300,
+    },
+  ],
+  description: 'Test deployment',
+}
+
+describe('LaunchSequence', () => {
+  it('renders mission description', () => {
+    const onComplete = vi.fn()
+    const onCancel = vi.fn()
+
+    render(
+      <LaunchSequence
+        state={mockState}
+        onComplete={onComplete}
+        onCancel={onCancel}
+      />
+    )
+
+    expect(screen.getByText(/Test deployment/)).toBeInTheDocument()
+  })
+
+  it('displays phase information', () => {
+    const onComplete = vi.fn()
+    const onCancel = vi.fn()
+
+    render(
+      <LaunchSequence
+        state={mockState}
+        onComplete={onComplete}
+        onCancel={onCancel}
+      />
+    )
+
+    expect(screen.getByText(/Deploy Core/)).toBeInTheDocument()
+  })
+
+  it('shows cancel button', () => {
+    const onComplete = vi.fn()
+    const onCancel = vi.fn()
+
+    render(
+      <LaunchSequence
+        state={mockState}
+        onComplete={onComplete}
+        onCancel={onCancel}
+      />
+    )
+
+    expect(screen.getByText(/Cancel/)).toBeInTheDocument()
+  })
+
+  it('renders project list', () => {
+    const onComplete = vi.fn()
+    const onCancel = vi.fn()
+
+    render(
+      <LaunchSequence
+        state={mockState}
+        onComplete={onComplete}
+        onCancel={onCancel}
+      />
+    )
+
+    expect(screen.getByText(/prometheus/)).toBeInTheDocument()
+  })
+})

--- a/web/src/components/mission-control/PayloadCard.test.tsx
+++ b/web/src/components/mission-control/PayloadCard.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { PayloadCard } from './PayloadCard'
+import type { PayloadProject } from './types'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const mockProject: PayloadProject = {
+  name: 'prometheus',
+  displayName: 'Prometheus',
+  category: 'Observability',
+  maturity: 'graduated',
+  priority: 'required',
+  reason: 'Metrics collection',
+  dependencies: [],
+}
+
+describe('PayloadCard', () => {
+  it('renders project name and reason', () => {
+    const onRemove = vi.fn()
+    const onUpdatePriority = vi.fn()
+
+    render(
+      <PayloadCard
+        project={mockProject}
+        onRemove={onRemove}
+        onUpdatePriority={onUpdatePriority}
+      />
+    )
+
+    expect(screen.getByText('Prometheus')).toBeInTheDocument()
+    expect(screen.getByText('Metrics collection')).toBeInTheDocument()
+  })
+
+  it('calls onRemove when remove button clicked', () => {
+    const onRemove = vi.fn()
+    const onUpdatePriority = vi.fn()
+
+    const { container } = render(
+      <PayloadCard
+        project={mockProject}
+        onRemove={onRemove}
+        onUpdatePriority={onUpdatePriority}
+      />
+    )
+
+    const removeBtn = container.querySelector('[title="Remove"]')
+    expect(removeBtn).toBeInTheDocument()
+    fireEvent.click(removeBtn!)
+
+    expect(onRemove).toHaveBeenCalledTimes(1)
+  })
+
+  it('displays category badge', () => {
+    const onRemove = vi.fn()
+    const onUpdatePriority = vi.fn()
+
+    render(
+      <PayloadCard
+        project={mockProject}
+        onRemove={onRemove}
+        onUpdatePriority={onUpdatePriority}
+      />
+    )
+
+    expect(screen.getByText('Observability')).toBeInTheDocument()
+  })
+
+  it('shows priority with correct styling', () => {
+    const onRemove = vi.fn()
+    const onUpdatePriority = vi.fn()
+
+    render(
+      <PayloadCard
+        project={mockProject}
+        onRemove={onRemove}
+        onUpdatePriority={onUpdatePriority}
+      />
+    )
+
+    expect(screen.getByText('required')).toBeInTheDocument()
+  })
+
+  it('displays dependencies count when present', () => {
+    const onRemove = vi.fn()
+    const onUpdatePriority = vi.fn()
+    const projectWithDeps: PayloadProject = {
+      ...mockProject,
+      dependencies: ['etcd', 'coredns'],
+    }
+
+    render(
+      <PayloadCard
+        project={projectWithDeps}
+        onRemove={onRemove}
+        onUpdatePriority={onUpdatePriority}
+      />
+    )
+
+    expect(screen.getByText(/\+2 deps/)).toBeInTheDocument()
+  })
+
+  it('shows installed badge when installed prop is true', () => {
+    const onRemove = vi.fn()
+    const onUpdatePriority = vi.fn()
+
+    render(
+      <PayloadCard
+        project={mockProject}
+        onRemove={onRemove}
+        onUpdatePriority={onUpdatePriority}
+        installed={true}
+      />
+    )
+
+    expect(screen.getByText('Installed')).toBeInTheDocument()
+  })
+
+  it('shows needs deploy badge when installed prop is false', () => {
+    const onRemove = vi.fn()
+    const onUpdatePriority = vi.fn()
+
+    render(
+      <PayloadCard
+        project={mockProject}
+        onRemove={onRemove}
+        onUpdatePriority={onUpdatePriority}
+        installed={false}
+      />
+    )
+
+    expect(screen.getByText('Needs deploy')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/mission-control/PayloadGrid.test.tsx
+++ b/web/src/components/mission-control/PayloadGrid.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PayloadGrid } from './PayloadGrid'
+import type { PayloadProject } from './types'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const mockProjects: PayloadProject[] = [
+  {
+    name: 'prometheus',
+    displayName: 'Prometheus',
+    category: 'Observability',
+    maturity: 'graduated',
+    priority: 'required',
+    reason: 'Metrics collection',
+    dependencies: [],
+  },
+  {
+    name: 'grafana',
+    displayName: 'Grafana',
+    category: 'Observability',
+    maturity: 'graduated',
+    priority: 'recommended',
+    reason: 'Dashboards',
+    dependencies: ['prometheus'],
+  },
+]
+
+describe('PayloadGrid', () => {
+  it('renders all projects', () => {
+    const onUpdatePriority = vi.fn()
+    const onRemoveProject = vi.fn()
+
+    render(
+      <PayloadGrid
+        projects={mockProjects}
+        onUpdatePriority={onUpdatePriority}
+        onRemoveProject={onRemoveProject}
+      />
+    )
+
+    expect(screen.getByText('Prometheus')).toBeInTheDocument()
+    expect(screen.getByText('Grafana')).toBeInTheDocument()
+  })
+
+  it('renders empty state when no projects', () => {
+    const onUpdatePriority = vi.fn()
+    const onRemoveProject = vi.fn()
+
+    const { container } = render(
+      <PayloadGrid
+        projects={[]}
+        onUpdatePriority={onUpdatePriority}
+        onRemoveProject={onRemoveProject}
+      />
+    )
+
+    expect(container.textContent).toBeTruthy()
+  })
+
+  it('groups projects by category', () => {
+    const onUpdatePriority = vi.fn()
+    const onRemoveProject = vi.fn()
+
+    render(
+      <PayloadGrid
+        projects={mockProjects}
+        onUpdatePriority={onUpdatePriority}
+        onRemoveProject={onRemoveProject}
+      />
+    )
+
+    expect(screen.getByText('Observability')).toBeInTheDocument()
+  })
+
+  it('renders project count', () => {
+    const onUpdatePriority = vi.fn()
+    const onRemoveProject = vi.fn()
+
+    render(
+      <PayloadGrid
+        projects={mockProjects}
+        onUpdatePriority={onUpdatePriority}
+        onRemoveProject={onRemoveProject}
+      />
+    )
+
+    expect(screen.getByText(/2/)).toBeInTheDocument()
+  })
+})

--- a/web/src/components/mission-control/RequestApprovalModal.test.tsx
+++ b/web/src/components/mission-control/RequestApprovalModal.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { RequestApprovalModal } from './RequestApprovalModal'
+import type { MissionControlState } from './types'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const mockState: MissionControlState = {
+  projects: [
+    {
+      name: 'prometheus',
+      displayName: 'Prometheus',
+      category: 'Observability',
+      maturity: 'graduated',
+      priority: 'required',
+      reason: 'Metrics',
+      dependencies: [],
+    },
+  ],
+  assignments: [
+    {
+      clusterName: 'cluster-1',
+      projectNames: ['prometheus'],
+      warnings: [],
+    },
+  ],
+  phases: [],
+  description: 'Test deployment',
+}
+
+describe('RequestApprovalModal', () => {
+  it('renders modal title', () => {
+    const onClose = vi.fn()
+    const onSubmit = vi.fn()
+
+    render(
+      <RequestApprovalModal
+        isOpen={true}
+        onClose={onClose}
+        onSubmit={onSubmit}
+        state={mockState}
+        installedProjects={new Set()}
+      />
+    )
+
+    expect(screen.getByText(/Request Approval/i)).toBeInTheDocument()
+  })
+
+  it('calls onClose when cancel clicked', () => {
+    const onClose = vi.fn()
+    const onSubmit = vi.fn()
+
+    render(
+      <RequestApprovalModal
+        isOpen={true}
+        onClose={onClose}
+        onSubmit={onSubmit}
+        state={mockState}
+        installedProjects={new Set()}
+      />
+    )
+
+    const cancelBtn = screen.getByText(/Cancel/i)
+    fireEvent.click(cancelBtn)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows preview of approval body', () => {
+    const onClose = vi.fn()
+    const onSubmit = vi.fn()
+
+    render(
+      <RequestApprovalModal
+        isOpen={true}
+        onClose={onClose}
+        onSubmit={onSubmit}
+        state={mockState}
+        installedProjects={new Set()}
+      />
+    )
+
+    expect(screen.getByText(/Test deployment/)).toBeInTheDocument()
+  })
+
+  it('does not render when isOpen is false', () => {
+    const onClose = vi.fn()
+    const onSubmit = vi.fn()
+
+    const { container } = render(
+      <RequestApprovalModal
+        isOpen={false}
+        onClose={onClose}
+        onSubmit={onSubmit}
+        state={mockState}
+        installedProjects={new Set()}
+      />
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #20129

Adds unit test coverage for the mission-control/ directory which previously had 0 test files across 24 source files and 7k+ LOC.

## Changes

Added 8 new test files covering the most critical mission-control components:
- PayloadCard.test.tsx
- ClusterReadinessCard.test.tsx
- AssignmentMatrix.test.tsx
- PayloadGrid.test.tsx
- LaunchSequence.test.tsx
- FlightPlanBlueprint.test.tsx
- ClusterAssignmentPanel.test.tsx
- RequestApprovalModal.test.tsx

All tests follow existing patterns using Vitest + React Testing Library and verify:
- Component rendering
- Prop handling
- Event handlers
- Edge cases