### PR TITLE
[scanner] fix: add unit test coverage for missions/ components

### DIFF
--- a/web/src/components/missions/ClusterSelectionDialog.test.tsx
+++ b/web/src/components/missions/ClusterSelectionDialog.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ClusterSelectionDialog } from './ClusterSelectionDialog'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../hooks/useClusterData', () => ({
+  useClusterData: () => ({
+    data: [],
+    isLoading: false,
+  }),
+}))
+
+describe('ClusterSelectionDialog', () => {
+  it('does not render when isOpen is false', () => {
+    const { container } = render(
+      <ClusterSelectionDialog
+        isOpen={false}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders dialog when isOpen is true', () => {
+    render(
+      <ClusterSelectionDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('calls onSelect when cluster is selected', () => {
+    const onSelect = vi.fn()
+    render(
+      <ClusterSelectionDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        onSelect={onSelect}
+      />
+    )
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('calls onClose when dialog is closed', () => {
+    const onClose = vi.fn()
+    render(
+      <ClusterSelectionDialog
+        isOpen={true}
+        onClose={onClose}
+        onSelect={vi.fn()}
+      />
+    )
+    const closeButtons = screen.getAllByRole('button')
+    const closeButton = closeButtons.find(btn => 
+      btn.querySelector('svg') || btn.getAttribute('aria-label')?.includes('close')
+    )
+    closeButton?.click()
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/web/src/components/missions/ImproveMissionDialog.test.tsx
+++ b/web/src/components/missions/ImproveMissionDialog.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ImproveMissionDialog } from './ImproveMissionDialog'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    post: vi.fn(),
+  },
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+  }),
+}))
+
+describe('ImproveMissionDialog', () => {
+  it('does not render when mission is null', () => {
+    const { container } = render(
+      <ImproveMissionDialog
+        mission={null}
+        onClose={vi.fn()}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders dialog when mission is provided', () => {
+    const mission = {
+      title: 'Test Mission',
+      description: 'Test description',
+      type: 'install' as const,
+      category: 'Testing',
+      tags: ['test'],
+      steps: [],
+      version: '1.0.0',
+    }
+    render(
+      <ImproveMissionDialog
+        mission={mission}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('displays mission title in dialog', () => {
+    const mission = {
+      title: 'Install Prometheus',
+      description: 'Test description',
+      type: 'install' as const,
+      category: 'Monitoring',
+      tags: [],
+      steps: [],
+      version: '1.0.0',
+    }
+    render(
+      <ImproveMissionDialog
+        mission={mission}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/Install Prometheus/)).toBeInTheDocument()
+  })
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn()
+    const mission = {
+      title: 'Test',
+      description: 'Test',
+      type: 'install' as const,
+      category: 'Test',
+      tags: [],
+      steps: [],
+      version: '1.0.0',
+    }
+    render(
+      <ImproveMissionDialog
+        mission={mission}
+        onClose={onClose}
+      />
+    )
+    const closeButtons = screen.getAllByRole('button')
+    const closeButton = closeButtons.find(btn => 
+      btn.querySelector('svg') || btn.getAttribute('aria-label')?.includes('close')
+    )
+    closeButton?.click()
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/web/src/components/missions/MissionBrowserFilterPanel.test.tsx
+++ b/web/src/components/missions/MissionBrowserFilterPanel.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MissionBrowserFilterPanel } from './MissionBrowserFilterPanel'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const mockFacetCounts = {
+  clusterMatched: 10,
+  community: 50,
+  missionClass: new Map([['installer', 20], ['fixer', 15]]),
+  maturity: new Map([['stable', 25], ['beta', 10]]),
+  difficulty: new Map([['beginner', 15], ['intermediate', 20]]),
+  topTags: [
+    { tag: 'kubernetes', count: 30 },
+    { tag: 'monitoring', count: 20 },
+  ],
+}
+
+describe('MissionBrowserFilterPanel', () => {
+  it('renders without errors', () => {
+    const { container } = render(
+      <MissionBrowserFilterPanel
+        activeFilterCount={0}
+        onClearAllFilters={vi.fn()}
+        minMatchPercent={0}
+        onMinMatchPercentChange={vi.fn()}
+        matchSourceFilter="all"
+        onMatchSourceFilterChange={vi.fn()}
+        categoryFilter=""
+        onCategoryFilterChange={vi.fn()}
+        missionClassFilter=""
+        onMissionClassFilterChange={vi.fn()}
+        maturityFilter=""
+        onMaturityFilterChange={vi.fn()}
+        difficultyFilter=""
+        onDifficultyFilterChange={vi.fn()}
+        cncfFilter=""
+        onCncfFilterChange={vi.fn()}
+        selectedTags={new Set()}
+        onTagToggle={vi.fn()}
+        onClearTags={vi.fn()}
+        facetCounts={mockFacetCounts}
+        recommendationsTotal={100}
+        filteredRecommendationsCount={50}
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+
+  it('displays active filter count when filters are applied', () => {
+    render(
+      <MissionBrowserFilterPanel
+        activeFilterCount={3}
+        onClearAllFilters={vi.fn()}
+        minMatchPercent={50}
+        onMinMatchPercentChange={vi.fn()}
+        matchSourceFilter="cluster"
+        onMatchSourceFilterChange={vi.fn()}
+        categoryFilter="Monitoring"
+        onCategoryFilterChange={vi.fn()}
+        missionClassFilter="installer"
+        onMissionClassFilterChange={vi.fn()}
+        maturityFilter="stable"
+        onMaturityFilterChange={vi.fn()}
+        difficultyFilter="beginner"
+        onDifficultyFilterChange={vi.fn()}
+        cncfFilter=""
+        onCncfFilterChange={vi.fn()}
+        selectedTags={new Set()}
+        onTagToggle={vi.fn()}
+        onClearTags={vi.fn()}
+        facetCounts={mockFacetCounts}
+        recommendationsTotal={100}
+        filteredRecommendationsCount={25}
+      />
+    )
+    expect(screen.getByText(/3/)).toBeInTheDocument()
+  })
+
+  it('calls onClearAllFilters when clear button is clicked', () => {
+    const onClearAllFilters = vi.fn()
+    render(
+      <MissionBrowserFilterPanel
+        activeFilterCount={2}
+        onClearAllFilters={onClearAllFilters}
+        minMatchPercent={0}
+        onMinMatchPercentChange={vi.fn()}
+        matchSourceFilter="all"
+        onMatchSourceFilterChange={vi.fn()}
+        categoryFilter=""
+        onCategoryFilterChange={vi.fn()}
+        missionClassFilter=""
+        onMissionClassFilterChange={vi.fn()}
+        maturityFilter=""
+        onMaturityFilterChange={vi.fn()}
+        difficultyFilter=""
+        onDifficultyFilterChange={vi.fn()}
+        cncfFilter=""
+        onCncfFilterChange={vi.fn()}
+        selectedTags={new Set()}
+        onTagToggle={vi.fn()}
+        onClearTags={vi.fn()}
+        facetCounts={mockFacetCounts}
+        recommendationsTotal={100}
+        filteredRecommendationsCount={50}
+      />
+    )
+    const clearButton = screen.getAllByRole('button').find(btn => btn.textContent?.includes('missions.browser.clearFilters'))
+    clearButton?.click()
+    expect(onClearAllFilters).toHaveBeenCalled()
+  })
+})

--- a/web/src/components/missions/MissionBrowserSidebar.test.tsx
+++ b/web/src/components/missions/MissionBrowserSidebar.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { MissionBrowserSidebar } from './MissionBrowserSidebar'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+describe('MissionBrowserSidebar', () => {
+  it('renders without errors', () => {
+    const { container } = render(
+      <MissionBrowserSidebar
+        onNavigate={vi.fn()}
+        selectedPath=""
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+
+  it('accepts selectedPath prop', () => {
+    const { container } = render(
+      <MissionBrowserSidebar
+        onNavigate={vi.fn()}
+        selectedPath="/missions/install"
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+
+  it('calls onNavigate when navigation occurs', () => {
+    const onNavigate = vi.fn()
+    render(
+      <MissionBrowserSidebar
+        onNavigate={onNavigate}
+        selectedPath=""
+      />
+    )
+    expect(onNavigate).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/missions/MissionContentViewer.test.tsx
+++ b/web/src/components/missions/MissionContentViewer.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { MissionContentProvider } from './MissionContentContext'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+  }),
+}))
+
+describe('MissionContentProvider', () => {
+  it('renders children without errors', () => {
+    const { container } = render(
+      <MissionContentProvider>
+        <div data-testid="child">Test Content</div>
+      </MissionContentProvider>
+    )
+    expect(container.querySelector('[data-testid="child"]')).toBeInTheDocument()
+  })
+
+  it('provides mission content context', () => {
+    const TestConsumer = () => {
+      return <div>Context Consumer</div>
+    }
+
+    const { container } = render(
+      <MissionContentProvider>
+        <TestConsumer />
+      </MissionContentProvider>
+    )
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/missions/MissionDetailView.test.tsx
+++ b/web/src/components/missions/MissionDetailView.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MissionDetailView } from './MissionDetailView'
+import type { MissionExport } from '../../lib/missions/types'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const mockMission: MissionExport = {
+  title: 'Install Prometheus',
+  description: 'Install Prometheus monitoring stack',
+  type: 'install',
+  category: 'Monitoring',
+  tags: ['prometheus', 'monitoring'],
+  steps: [
+    { type: 'command', command: 'helm repo add prometheus-community https://prometheus-community.github.io/helm-charts' },
+    { type: 'command', command: 'helm install prometheus prometheus-community/prometheus' },
+  ],
+  version: '1.0.0',
+}
+
+describe('MissionDetailView', () => {
+  it('renders mission title', () => {
+    render(
+      <MissionDetailView
+        mission={mockMission}
+        rawContent={null}
+        showRaw={false}
+        onToggleRaw={vi.fn()}
+        onImport={vi.fn()}
+        onBack={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Install Prometheus')).toBeInTheDocument()
+  })
+
+  it('renders mission description', () => {
+    render(
+      <MissionDetailView
+        mission={mockMission}
+        rawContent={null}
+        showRaw={false}
+        onToggleRaw={vi.fn()}
+        onImport={vi.fn()}
+        onBack={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Install Prometheus monitoring stack')).toBeInTheDocument()
+  })
+
+  it('renders loading skeleton when loading prop is true', () => {
+    const { container } = render(
+      <MissionDetailView
+        mission={mockMission}
+        rawContent={null}
+        showRaw={false}
+        onToggleRaw={vi.fn()}
+        onImport={vi.fn()}
+        onBack={vi.fn()}
+        loading={true}
+      />
+    )
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument()
+  })
+
+  it('renders error message when error prop is provided', () => {
+    render(
+      <MissionDetailView
+        mission={mockMission}
+        rawContent={null}
+        showRaw={false}
+        onToggleRaw={vi.fn()}
+        onImport={vi.fn()}
+        onBack={vi.fn()}
+        error="Failed to load mission"
+      />
+    )
+    expect(screen.getByText(/Failed to load mission/)).toBeInTheDocument()
+  })
+
+  it('hides back button when hideBackButton is true', () => {
+    render(
+      <MissionDetailView
+        mission={mockMission}
+        rawContent={null}
+        showRaw={false}
+        onToggleRaw={vi.fn()}
+        onImport={vi.fn()}
+        onBack={vi.fn()}
+        hideBackButton={true}
+      />
+    )
+    expect(screen.queryByRole('button', { name: /back/i })).not.toBeInTheDocument()
+  })
+
+  it('uses custom import label when provided', () => {
+    render(
+      <MissionDetailView
+        mission={mockMission}
+        rawContent={null}
+        showRaw={false}
+        onToggleRaw={vi.fn()}
+        onImport={vi.fn()}
+        onBack={vi.fn()}
+        importLabel="Run Mission"
+      />
+    )
+    expect(screen.getByText('Run Mission')).toBeInTheDocument()
+  })
+
+  it('displays match score when provided', () => {
+    render(
+      <MissionDetailView
+        mission={mockMission}
+        rawContent={null}
+        showRaw={false}
+        onToggleRaw={vi.fn()}
+        onImport={vi.fn()}
+        onBack={vi.fn()}
+        matchScore={0.85}
+      />
+    )
+    expect(screen.getByText(/85%/)).toBeInTheDocument()
+  })
+})

--- a/web/src/components/missions/MissionLandingPage.test.tsx
+++ b/web/src/components/missions/MissionLandingPage.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { MissionLandingPage } from './MissionLandingPage'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('../../hooks/useDemoMode', () => ({
+  useDemoMode: () => ({
+    isDemoMode: false,
+    setDemoMode: vi.fn(),
+  }),
+}))
+
+describe('MissionLandingPage', () => {
+  it('renders without errors', () => {
+    const { container } = render(<MissionLandingPage />)
+    expect(container).toBeTruthy()
+  })
+
+  it('displays landing page content', () => {
+    const { container } = render(<MissionLandingPage />)
+    expect(container.textContent).toBeTruthy()
+  })
+})

--- a/web/src/components/missions/ResolutionHistoryPanel.test.tsx
+++ b/web/src/components/missions/ResolutionHistoryPanel.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { ResolutionHistoryPanel } from './ResolutionHistoryPanel'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}))
+
+describe('ResolutionHistoryPanel', () => {
+  it('renders without errors', () => {
+    const { container } = render(
+      <ResolutionHistoryPanel
+        onSelectResolution={vi.fn()}
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+
+  it('accepts onSelectResolution callback', () => {
+    const onSelectResolution = vi.fn()
+    render(
+      <ResolutionHistoryPanel
+        onSelectResolution={onSelectResolution}
+      />
+    )
+    expect(onSelectResolution).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/missions/SaveResolutionDialog.test.tsx
+++ b/web/src/components/missions/SaveResolutionDialog.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SaveResolutionDialog } from './SaveResolutionDialog'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    post: vi.fn(),
+  },
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+  }),
+}))
+
+describe('SaveResolutionDialog', () => {
+  it('does not render when isOpen is false', () => {
+    const { container } = render(
+      <SaveResolutionDialog
+        isOpen={false}
+        onClose={vi.fn()}
+        resolution=""
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders dialog when isOpen is true', () => {
+    render(
+      <SaveResolutionDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        resolution="kubectl rollout restart deployment/my-app"
+      />
+    )
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('displays resolution content in dialog', () => {
+    const resolution = 'kubectl delete pod my-pod'
+    render(
+      <SaveResolutionDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        resolution={resolution}
+      />
+    )
+    expect(screen.getByText(new RegExp(resolution))).toBeInTheDocument()
+  })
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn()
+    render(
+      <SaveResolutionDialog
+        isOpen={true}
+        onClose={onClose}
+        resolution="test resolution"
+      />
+    )
+    const closeButtons = screen.getAllByRole('button')
+    const closeButton = closeButtons.find(btn => 
+      btn.querySelector('svg') || btn.getAttribute('aria-label')?.includes('close')
+    )
+    closeButton?.click()
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/web/src/components/missions/ShareMissionDialog.test.tsx
+++ b/web/src/components/missions/ShareMissionDialog.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ShareMissionDialog } from './ShareMissionDialog'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+describe('ShareMissionDialog', () => {
+  it('does not render when shareUrl is null', () => {
+    const { container } = render(
+      <ShareMissionDialog
+        shareUrl={null}
+        onClose={vi.fn()}
+        missionTitle="Test Mission"
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders dialog when shareUrl is provided', () => {
+    render(
+      <ShareMissionDialog
+        shareUrl="https://console.kubestellar.io/missions/install-prometheus"
+        onClose={vi.fn()}
+        missionTitle="Install Prometheus"
+      />
+    )
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('displays mission title in dialog', () => {
+    render(
+      <ShareMissionDialog
+        shareUrl="https://example.com/mission/123"
+        onClose={vi.fn()}
+        missionTitle="Deploy Application"
+      />
+    )
+    expect(screen.getByText(/Deploy Application/)).toBeInTheDocument()
+  })
+
+  it('displays shareable URL', () => {
+    const url = 'https://console.kubestellar.io/missions/test'
+    render(
+      <ShareMissionDialog
+        shareUrl={url}
+        onClose={vi.fn()}
+        missionTitle="Test"
+      />
+    )
+    expect(screen.getByText(new RegExp(url))).toBeInTheDocument()
+  })
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn()
+    render(
+      <ShareMissionDialog
+        shareUrl="https://example.com/mission"
+        onClose={onClose}
+        missionTitle="Mission"
+      />
+    )
+    const closeButtons = screen.getAllByRole('button')
+    const closeButton = closeButtons.find(btn => 
+      btn.querySelector('svg') || btn.getAttribute('aria-label')?.includes('close')
+    )
+    closeButton?.click()
+    expect(onClose).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Fixes #20131

Adds unit test coverage for the missions/ component directory which previously had 0 test files across 44 source files.

Test files cover:
- MissionDetailView (754 LOC)
- MissionContentViewer/Context (613 LOC)
- MissionBrowserFilterPanel (334 LOC)
- MissionBrowserSidebar
- SaveResolutionDialog
- ShareMissionDialog
- ResolutionHistoryPanel
- ClusterSelectionDialog
- ImproveMissionDialog
- MissionLandingPage