### PR TITLE
[ci-maintainer] fix: restore write permissions in label-helper and hive-interactive workflows

### DIFF
--- a/.github/workflows/hive-interactive.yml
+++ b/.github/workflows/hive-interactive.yml
@@ -8,7 +8,10 @@ on:
   issue_comment:
     types: [created]
 
-permissions: read-all
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   post-directions:

--- a/.github/workflows/hive-trust-gate.yml
+++ b/.github/workflows/hive-trust-gate.yml
@@ -35,7 +35,9 @@ on:
         description: Why the actor passed or failed the gate
         value: ${{ jobs.evaluate.outputs.trust-reason }}
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read
+  issues: write
 jobs:
   evaluate:
     permissions:

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -4,11 +4,12 @@ on:
   issue_comment:
     types: [created]
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   label-helper:
-    permissions:
-      issues: write
-      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned 2026-06-29 from main
     secrets: inherit


### PR DESCRIPTION
## CI Fix

Three workflow files were changed in commit `64f59614f09b34a1e060ced7b73496df3ee9556d` to use `permissions: read-all` at the workflow level while still specifying `write` access at the job level. GitHub Actions does not allow job-level permissions to exceed the workflow-level grant — `read-all` locks every permission to read-only, so attempting to set `issues: write` or `pull-requests: write` at the job level causes a `startup_failure` before any jobs run.

This PR reverts to the pre-commit permissions model: explicit `write` permissions at the workflow level with no need for job-level escalation.

**Affected workflows:**
- `label-helper.yml` — `startup_failure` on every `issue_comment` event since 2026-07-02T19:13Z
- `hive-interactive.yml` — `startup_failure` on every event since 2026-07-02T19:13Z
- `hive-trust-gate.yml` — same root cause (called by `hive-interactive.yml`)

Fixes #20139

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*