### PR TITLE
[scanner] fix: remove invalid eslint-disable for non-existent rule

### DIFF
--- a/web/src/components/ui/VirtualizedList.tsx
+++ b/web/src/components/ui/VirtualizedList.tsx
@@ -43,7 +43,6 @@ export function VirtualizedList<T>({
   }, [scrollRef])
 
   // TanStack Virtual manages its own measurement lifecycle; React Compiler skips memoizing this hook safely.
-  // eslint-disable-next-line react-hooks/incompatible-library
   const virtualizer = useVirtualizer({
     count: items.length,
     getScrollElement: () => scrollElementRef.current,


### PR DESCRIPTION
Fixes #20118

Removes the only invalid `eslint-disable` comment in the codebase: `react-hooks/incompatible-library` in VirtualizedList.tsx (rule doesn't exist in eslint.config.js).

All other `eslint-disable` comments reference valid rules and are left intact.

Supersedes #20134 and #20111 which incorrectly removed valid disable comments.