### PR TITLE
[scanner] fix: add top-level read-all permissions to workflows

### DIFF
--- a/.github/workflows/accm-history-update.yml
+++ b/.github/workflows/accm-history-update.yml
@@ -22,8 +22,7 @@ on:
     - cron: "30 6 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 env:
   # Public gist that holds the computed history. Not a secret.

--- a/.github/workflows/acmm-level-monitor.yml
+++ b/.github/workflows/acmm-level-monitor.yml
@@ -11,8 +11,7 @@ on:
         required: false
         default: '5'
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   check-acmm-level:

--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/api-contract.yml'
   workflow_dispatch: {}
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 concurrency:
   group: api-contract-${{ github.ref }}

--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -22,8 +22,7 @@ concurrency:
   group: coverage-suite
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 env:
   NODE_VERSION: '22'

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -26,8 +26,7 @@ concurrency:
   group: coverage-report-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 env:
   NODE_VERSION: '22'

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -30,8 +30,7 @@ on:
       - 'go.sum'
       - '.github/workflows/cross-platform-build.yml'
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   build:

--- a/.github/workflows/fullstack-e2e.yml
+++ b/.github/workflows/fullstack-e2e.yml
@@ -21,8 +21,7 @@ on:
       - 'web/e2e/fullstack-smoke.spec.ts'
       - '.github/workflows/fullstack-e2e.yml'
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 env:
   # Dev-only placeholder — must be >= 32 chars for the server to accept it

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -36,8 +36,7 @@ concurrency:
   group: go-test-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 env:
   GO_COVERAGE_RATCHET_FILE: .github/go-coverage-ratchet.txt

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -13,8 +13,7 @@ on:
   workflow_call: {}
 
 # Minimum permissions: checkout only — no write scopes needed
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   helm-lint-and-template:

--- a/.github/workflows/hive-interactive.yml
+++ b/.github/workflows/hive-interactive.yml
@@ -8,10 +8,7 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   post-directions:

--- a/.github/workflows/hive-trust-gate.yml
+++ b/.github/workflows/hive-trust-gate.yml
@@ -35,9 +35,7 @@ on:
         description: Why the actor passed or failed the gate
         value: ${{ jobs.evaluate.outputs.trust-reason }}
 
-permissions:
-  contents: read
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 jobs:
   evaluate:
     permissions:

--- a/.github/workflows/hold-issue-guard.yml
+++ b/.github/workflows/hold-issue-guard.yml
@@ -6,9 +6,7 @@ on:
   issues:
     types: [labeled, unlabeled]
 
-permissions:
-  issues: read
-  pull-requests: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   check-hold-issues:

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -4,10 +4,7 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   label-helper:

--- a/.github/workflows/lint-warning-gate.yml
+++ b/.github/workflows/lint-warning-gate.yml
@@ -14,8 +14,7 @@ on:
       - '.lint-warning-baseline'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   check-warnings:

--- a/.github/workflows/mttr-badge.yml
+++ b/.github/workflows/mttr-badge.yml
@@ -5,9 +5,7 @@ on:
     - cron: '17 * * * *'
   workflow_dispatch:
 
-permissions:
-  issues: read
-  pull-requests: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   mttr:

--- a/.github/workflows/pre-merge-gate.yml
+++ b/.github/workflows/pre-merge-gate.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 concurrency:
   group: pre-merge-${{ github.head_ref || github.ref }}

--- a/.github/workflows/privileged-client-lint.yml
+++ b/.github/workflows/privileged-client-lint.yml
@@ -41,8 +41,7 @@ on:
       - '.github/allowlist-privileged-client-callers.txt'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   verify:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,7 @@ on:
         type: boolean
 
 # Least-privilege: read-only by default; jobs declare write scopes individually
-permissions:
-  contents: read
-  actions: read
-  checks: read
+permissions: read-all  # default read; writes scoped to job below
 
 # Prevent concurrent scheduled releases (allow manual runs to queue)
 concurrency:

--- a/.github/workflows/rewards-types-drift.yml
+++ b/.github/workflows/rewards-types-drift.yml
@@ -30,8 +30,7 @@ concurrency:
   group: rewards-types-drift-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   check:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,11 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-  id-token: write
-
+permissions: read-all  # default read; writes scoped to job below
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned 2026-06-29 from main
     secrets: inherit

--- a/.github/workflows/startup-smoke-test.yml
+++ b/.github/workflows/startup-smoke-test.yml
@@ -14,8 +14,7 @@ on:
       - 'web/vite.config.ts'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   startup-check:

--- a/.github/workflows/startup-smoke.yml
+++ b/.github/workflows/startup-smoke.yml
@@ -28,8 +28,7 @@ on:
       - '.github/workflows/startup-smoke.yml'
   workflow_dispatch: {}
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 concurrency:
   group: startup-smoke-${{ github.ref }}

--- a/.github/workflows/stuck-detection.yml
+++ b/.github/workflows/stuck-detection.yml
@@ -10,9 +10,7 @@ on:
         required: false
         default: 'false'
 
-permissions:
-  actions: read
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   detect-stuck:

--- a/.github/workflows/submodule-guard.yml
+++ b/.github/workflows/submodule-guard.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   check-submodules:

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -15,8 +15,7 @@ on:
     types: [published]
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   test-version-resolution:

--- a/.github/workflows/update-guard.yml
+++ b/.github/workflows/update-guard.yml
@@ -23,8 +23,7 @@ on:
 env:
   GO_VERSION: "1.26.4"
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   update-tests:

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -36,9 +36,7 @@ on:
     - cron: '17 */6 * * *'
   workflow_dispatch: {}
 
-permissions:
-  contents: read
-  packages: read
+permissions: read-all  # default read; writes scoped to job below
 
 concurrency:
   group: upgrade-smoke-${{ github.ref }}


### PR DESCRIPTION
Fixes #20124

Adopts the Scorecard-recommended pattern: `permissions: read-all` at the workflow level, with write scopes moved to job-level `permissions:` blocks.

Affected: 27 workflow files.