### PR TITLE
[sec-check] fix: use exact string match instead of unescaped hostname regex in test (CWE-020)

### DIFF
--- a/web/src/components/missions/ShareMissionDialog.test.tsx
+++ b/web/src/components/missions/ShareMissionDialog.test.tsx
@@ -53,7 +53,7 @@ describe('ShareMissionDialog', () => {
         missionTitle="Test"
       />
     )
-    expect(screen.getByText(new RegExp(url))).toBeInTheDocument()
+    expect(screen.getByText(url)).toBeInTheDocument()
   })
 
   it('calls onClose when close button is clicked', () => {


### PR DESCRIPTION
## Security Fix

Replaces `new RegExp(url)` with direct string matching in the `ShareMissionDialog` test to eliminate the unescaped hostname dot meta-character flagged by CodeQL (`js/incomplete-hostname-regexp`, CWE-020).

**Before:**
```typescript
expect(screen.getByText(new RegExp(url))).toBeInTheDocument()
```

**After:**
```typescript
expect(screen.getByText(url)).toBeInTheDocument()
```

The regex was unnecessary — `getByText` with a string performs exact substring matching by default, which is what the test actually needs. Using `new RegExp(url)` with an unescaped URL caused the dots in `console.kubestellar.io` to match any character, making the assertion overly permissive and misleading.

Fixes #20158

---
*Filed by sec-check agent (ACMM L6 — full mode)*