### PR TITLE
[quality] add unit tests for canary harness sanitization and K8s state modules

### DIFF
--- a/web/harness/evidence/__tests__/sanitizeEvidence.test.ts
+++ b/web/harness/evidence/__tests__/sanitizeEvidence.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { sanitizeText, sanitizeJson, safeJsonStringify } from '../sanitizeEvidence'
+
+describe('sanitizeText', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('returns empty string for null/undefined input', () => {
+    expect(sanitizeText(null)).toBe('')
+    expect(sanitizeText(undefined)).toBe('')
+  })
+
+  it('passes through clean text unchanged', () => {
+    expect(sanitizeText('hello world')).toBe('hello world')
+  })
+
+  it('redacts PEM private keys', () => {
+    const pem = '-----BEGIN RSA PRIVATE KEY-----\nMIIEow...base64data...\n-----END RSA PRIVATE KEY-----'
+    expect(sanitizeText(pem)).toBe('[REDACTED_PRIVATE_KEY]')
+  })
+
+  it('redacts EC private keys', () => {
+    const pem = '-----BEGIN EC PRIVATE KEY-----\nMHQCAQ...data...\n-----END EC PRIVATE KEY-----'
+    expect(sanitizeText(pem)).toBe('[REDACTED_PRIVATE_KEY]')
+  })
+
+  it('redacts Bearer tokens', () => {
+    const text = 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig'
+    const result = sanitizeText(text)
+    expect(result).toContain('Bearer [REDACTED]')
+    expect(result).not.toContain('eyJhbGciOiJIUzI1NiJ9')
+  })
+
+  it('redacts token URL parameters', () => {
+    const url = 'https://example.com/callback?access_token=secret123&state=ok'
+    const result = sanitizeText(url)
+    expect(result).toContain('access_token=[REDACTED]')
+    expect(result).not.toContain('secret123')
+    expect(result).toContain('state=ok')
+  })
+
+  it('redacts refresh_token URL parameters', () => {
+    const url = 'https://example.com/api?refresh_token=my-refresh-tok&next=home'
+    const result = sanitizeText(url)
+    expect(result).toContain('refresh_token=[REDACTED]')
+    expect(result).not.toContain('my-refresh-tok')
+  })
+
+  it('redacts client_secret URL parameters', () => {
+    const url = 'https://example.com/oauth?client_secret=supersecret&client_id=public'
+    const result = sanitizeText(url)
+    expect(result).toContain('client_secret=[REDACTED]')
+    expect(result).not.toContain('supersecret')
+  })
+
+  it('redacts authorization headers', () => {
+    const text = 'authorization: Basic dXNlcjpwYXNz'
+    const result = sanitizeText(text)
+    expect(result).toContain('authorization: [REDACTED]')
+    expect(result).not.toContain('dXNlcjpwYXNz')
+  })
+
+  it('redacts cookie headers', () => {
+    const text = 'cookie: session=abc123; token=xyz'
+    const result = sanitizeText(text)
+    expect(result).toContain('cookie: [REDACTED]')
+    expect(result).not.toContain('abc123')
+  })
+
+  it('redacts x-api-key headers', () => {
+    const text = 'x-api-key: my-secret-api-key-value'
+    const result = sanitizeText(text)
+    expect(result).toContain('x-api-key: [REDACTED]')
+    expect(result).not.toContain('my-secret-api-key-value')
+  })
+
+  it('redacts kc-agent-token headers', () => {
+    const text = 'kc-agent-token: agent-secret-12345'
+    const result = sanitizeText(text)
+    expect(result).toContain('kc-agent-token: [REDACTED]')
+    expect(result).not.toContain('agent-secret-12345')
+  })
+
+  it('redacts kubeconfig content', () => {
+    const kubeconfig = 'apiVersion: v1\nclusters:\n- cluster:\n    server: https://10.0.0.1\n  name: kind'
+    const result = sanitizeText(kubeconfig)
+    expect(result).toBe('[REDACTED_KUBECONFIG]')
+  })
+
+  it('redacts JWTs', () => {
+    const jwt = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature_data_here'
+    const result = sanitizeText(`token: ${jwt}`)
+    expect(result).toContain('[REDACTED_JWT]')
+    expect(result).not.toContain('eyJhbGciOiJSUzI1NiJ9')
+  })
+
+  it('redacts sensitive environment variable values', () => {
+    process.env.MY_SECRET_TOKEN = 'super-secret-value-12345'
+    const text = 'The value is super-secret-value-12345 here'
+    const result = sanitizeText(text)
+    expect(result).toContain('[REDACTED_ENV_VALUE]')
+    expect(result).not.toContain('super-secret-value-12345')
+  })
+
+  it('ignores short env values (< 6 chars)', () => {
+    process.env.MY_SECRET_KEY = 'short'
+    const text = 'The value is short here'
+    const result = sanitizeText(text)
+    expect(result).toBe('The value is short here')
+  })
+
+  it('handles multiple sensitive patterns in one string', () => {
+    const text = 'Bearer abc123def456 and cookie: session=xyz'
+    const result = sanitizeText(text)
+    expect(result).toContain('Bearer [REDACTED]')
+    expect(result).toContain('cookie: [REDACTED]')
+  })
+})
+
+describe('sanitizeJson', () => {
+  it('redacts values for sensitive keys', () => {
+    const result = sanitizeJson({ PASSWORD: 'secret', name: 'test' })
+    expect(result).toEqual({ PASSWORD: '[REDACTED]', name: 'test' })
+  })
+
+  it('redacts nested sensitive keys', () => {
+    const result = sanitizeJson({ config: { CLIENT_SECRET: 'abc' } })
+    expect(result).toEqual({ config: { CLIENT_SECRET: '[REDACTED]' } })
+  })
+
+  it('sanitizes string values containing secrets', () => {
+    const result = sanitizeJson({ log: 'Bearer my-token-here' })
+    expect(result.log).toContain('Bearer [REDACTED]')
+  })
+
+  it('sanitizes arrays recursively', () => {
+    const result = sanitizeJson(['Bearer secret-tok', 'normal'])
+    expect(result[0]).toContain('Bearer [REDACTED]')
+    expect(result[1]).toBe('normal')
+  })
+
+  it('passes through primitives', () => {
+    expect(sanitizeJson(42)).toBe(42)
+    expect(sanitizeJson(true)).toBe(true)
+    expect(sanitizeJson(null)).toBe(null)
+  })
+
+  it('handles nested objects deeply', () => {
+    const input = { a: { b: { TOKEN: 'secret', c: 'safe' } } }
+    const result = sanitizeJson(input)
+    expect(result).toEqual({ a: { b: { TOKEN: '[REDACTED]', c: 'safe' } } })
+  })
+})
+
+describe('safeJsonStringify', () => {
+  it('produces sanitized JSON output', () => {
+    const result = safeJsonStringify({ SECRET: 'hidden', name: 'test' })
+    const parsed = JSON.parse(result)
+    expect(parsed.SECRET).toBe('[REDACTED]')
+    expect(parsed.name).toBe('test')
+  })
+
+  it('formats with 2-space indentation', () => {
+    const result = safeJsonStringify({ a: 1 })
+    expect(result).toBe('{\n  "a": 1\n}')
+  })
+})

--- a/web/harness/groundtruth/__tests__/normalizeK8sState.test.ts
+++ b/web/harness/groundtruth/__tests__/normalizeK8sState.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeK8sState } from '../normalizeK8sState'
+
+describe('normalizeK8sState', () => {
+  const baseInput = {
+    runId: 'test-run-001',
+    contextNames: ['ctx-a', 'ctx-b'],
+    reachableContexts: ['ctx-a'],
+    nodes: [],
+    pods: [],
+    namespaces: [],
+    deployments: [],
+  }
+
+  it('returns correct structure with empty inputs', () => {
+    const result = normalizeK8sState(baseInput)
+    expect(result).toEqual({
+      runId: 'test-run-001',
+      contexts: { configured: 2, reachable: 1, names: ['ctx-a', 'ctx-b'] },
+      nodes: { total: 0, ready: 0, notReady: 0 },
+      pods: { total: 0, running: 0, pending: 0, failed: 0, crashLoopBackOff: 0 },
+      namespaces: { total: 0, createdByHarness: [] },
+      deployments: { total: 0, available: 0, unavailable: 0 },
+    })
+  })
+
+  it('counts ready and not-ready nodes', () => {
+    const nodes = [
+      { status: { conditions: [{ type: 'Ready', status: 'True' }] } },
+      { status: { conditions: [{ type: 'Ready', status: 'False' }] } },
+      { status: { conditions: [{ type: 'MemoryPressure', status: 'True' }] } },
+    ]
+    const result = normalizeK8sState({ ...baseInput, nodes })
+    expect(result.nodes).toEqual({ total: 3, ready: 1, notReady: 2 })
+  })
+
+  it('counts pod phases correctly', () => {
+    const pods = [
+      { status: { phase: 'Running' } },
+      { status: { phase: 'Running' } },
+      { status: { phase: 'Pending' } },
+      { status: { phase: 'Failed' } },
+      { status: { phase: 'Succeeded' } },
+    ]
+    const result = normalizeK8sState({ ...baseInput, pods })
+    expect(result.pods.total).toBe(5)
+    expect(result.pods.running).toBe(2)
+    expect(result.pods.pending).toBe(1)
+    expect(result.pods.failed).toBe(1)
+  })
+
+  it('counts CrashLoopBackOff pods', () => {
+    const pods = [
+      { status: { phase: 'Running', containerStatuses: [{ state: { waiting: { reason: 'CrashLoopBackOff' } } }] } },
+      { status: { phase: 'Running', containerStatuses: [{ state: { running: {} } }] } },
+    ]
+    const result = normalizeK8sState({ ...baseInput, pods })
+    expect(result.pods.crashLoopBackOff).toBe(1)
+  })
+
+  it('counts available and unavailable deployments', () => {
+    const deployments = [
+      { status: { replicas: 3, availableReplicas: 3 } },
+      { status: { replicas: 2, availableReplicas: 1 } },
+      { status: { replicas: 1, availableReplicas: 0 } },
+    ]
+    const result = normalizeK8sState({ ...baseInput, deployments })
+    expect(result.deployments).toEqual({ total: 3, available: 1, unavailable: 2 })
+  })
+
+  it('handles deployment with no status', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const deployments = [{ status: undefined }, {}] as Array<Record<string, unknown>>
+    const result = normalizeK8sState({ ...baseInput, deployments })
+    // availableReplicas defaults to 0, replicas defaults to 0 — 0 >= 0 is true
+    expect(result.deployments.total).toBe(2)
+    expect(result.deployments.available).toBe(2)
+  })
+
+  it('preserves createdNamespaces', () => {
+    const result = normalizeK8sState({
+      ...baseInput,
+      namespaces: [{}, {}, {}],
+      createdNamespaces: ['ns-a', 'ns-b'],
+    })
+    expect(result.namespaces).toEqual({ total: 3, createdByHarness: ['ns-a', 'ns-b'] })
+  })
+
+  it('defaults createdNamespaces to empty array', () => {
+    const result = normalizeK8sState({ ...baseInput, namespaces: [{}] })
+    expect(result.namespaces.createdByHarness).toEqual([])
+  })
+
+  it('handles nodes with missing status gracefully', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const nodes = [{ status: undefined }, {}] as Array<Record<string, unknown>>
+    const result = normalizeK8sState({ ...baseInput, nodes })
+    expect(result.nodes).toEqual({ total: 2, ready: 0, notReady: 2 })
+  })
+})

--- a/web/harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts
+++ b/web/harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { redactK8sGroundTruth } from '../redactK8sGroundTruth'
+import type { K8sGroundTruth } from '../k8sTypes'
+
+describe('redactK8sGroundTruth', () => {
+  const baseGroundTruth: K8sGroundTruth = {
+    runId: 'run-123',
+    contexts: {
+      configured: 2,
+      reachable: 1,
+      names: ['arn:aws:eks:us-east-1:123456789012:cluster/prod', 'gke_project_zone_cluster'],
+    },
+    nodes: { total: 4, ready: 3, notReady: 1 },
+    pods: { total: 20, running: 15, pending: 3, failed: 2, crashLoopBackOff: 1 },
+    namespaces: { total: 10, createdByHarness: ['ns-fixture-1'] },
+    deployments: { total: 5, available: 4, unavailable: 1 },
+  }
+
+  it('anonymizes context names with index-based prefix', () => {
+    const result = redactK8sGroundTruth(baseGroundTruth)
+    expect(result.contexts.names[0]).toMatch(/^context-1-/)
+    expect(result.contexts.names[1]).toMatch(/^context-2-/)
+  })
+
+  it('strips non-alphanumeric characters from context names', () => {
+    const result = redactK8sGroundTruth(baseGroundTruth)
+    // Original has colons, slashes, underscores — all stripped
+    for (const name of result.contexts.names) {
+      const suffix = name.replace(/^context-\d+-/, '')
+      expect(suffix).toMatch(/^[a-z0-9]*$/i)
+    }
+  })
+
+  it('truncates context name suffix to 12 characters', () => {
+    const result = redactK8sGroundTruth(baseGroundTruth)
+    for (const name of result.contexts.names) {
+      const suffix = name.replace(/^context-\d+-/, '')
+      expect(suffix.length).toBeLessThanOrEqual(12)
+    }
+  })
+
+  it('preserves numeric fields unchanged', () => {
+    const result = redactK8sGroundTruth(baseGroundTruth)
+    expect(result.nodes).toEqual(baseGroundTruth.nodes)
+    expect(result.pods).toEqual(baseGroundTruth.pods)
+    expect(result.deployments).toEqual(baseGroundTruth.deployments)
+    expect(result.contexts.configured).toBe(2)
+    expect(result.contexts.reachable).toBe(1)
+  })
+
+  it('sanitizes any sensitive values via sanitizeJson', () => {
+    const withSecret: K8sGroundTruth = {
+      ...baseGroundTruth,
+      runId: 'Bearer some-secret-token-value',
+    }
+    const result = redactK8sGroundTruth(withSecret)
+    expect(result.runId).toContain('Bearer [REDACTED]')
+  })
+
+  it('handles empty context names array', () => {
+    const input: K8sGroundTruth = {
+      ...baseGroundTruth,
+      contexts: { configured: 0, reachable: 0, names: [] },
+    }
+    const result = redactK8sGroundTruth(input)
+    expect(result.contexts.names).toEqual([])
+  })
+})

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -329,7 +329,7 @@ export default defineConfig(({ mode }) => ({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
     css: true,
-    include: ['src/**/*.{test,spec}.{ts,tsx}', 'netlify/functions/**/__tests__/*.{test,spec}.{ts,tsx}', 'netlify/edge-functions/__tests__/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'netlify/functions/**/__tests__/*.{test,spec}.{ts,tsx}', 'netlify/edge-functions/__tests__/*.{test,spec}.{ts,tsx}', 'harness/**/__tests__/*.{test,spec}.{ts,tsx}'],
     exclude: ['node_modules', 'e2e/**/*'],
     // Retry flaky tests up to 2 times in CI to reduce false-positive workflow failures (#11872)
     retry: process.env.CI ? 2 : 0,


### PR DESCRIPTION
## Test Improvement

Adds **38 unit tests** for the previously-untested canary harness utility modules that handle security-critical secret redaction and K8s state normalization.

### `harness/evidence/__tests__/sanitizeEvidence.test.ts` (24 tests)

**`sanitizeText`** (16 tests):
- PEM private key redaction (RSA, EC)
- Bearer token stripping
- URL parameter redaction (access_token, refresh_token, client_secret)
- HTTP header redaction (authorization, cookie, x-api-key, kc-agent-token)
- Kubeconfig content detection and redaction
- JWT pattern matching
- Environment variable value scrubbing
- Multiple-pattern handling in one string
- Null/undefined/clean input edge cases

**`sanitizeJson`** (6 tests):
- Recursive key-based redaction (PASSWORD, TOKEN, etc.)
- String value sanitization within objects
- Array traversal
- Primitive passthrough
- Deep nesting

**`safeJsonStringify`** (2 tests):
- Sanitized output verification
- Formatting (2-space indent)

### `harness/groundtruth/__tests__/normalizeK8sState.test.ts` (9 tests)

- Empty input produces correct zero-state structure
- Node ready/not-ready counting with missing status
- Pod phase classification (Running, Pending, Failed, Succeeded)
- CrashLoopBackOff detection
- Deployment availability logic (including edge: undefined status)
- Namespace counting and createdByHarness preservation

### `harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts` (5 tests)

- Context name anonymization with index prefix
- Non-alphanumeric stripping from context names
- 12-char truncation of suffix
- Numeric field preservation
- Sensitive value sanitization via sanitizeJson passthrough
- Empty context names array edge case

### Config change

- `vite.config.ts`: added `harness/**/__tests__/*.{test,spec}.{ts,tsx}` to test include glob

Fixes #20154

---
*Filed by quality agent (ACMM L4/L6 — full mode)*