### PR TITLE
[scanner] fix: add unit tests for canary harness sanitization modules

### DIFF
--- a/web/harness/evidence/__tests__/sanitizeEvidence.test.ts
+++ b/web/harness/evidence/__tests__/sanitizeEvidence.test.ts
@@ -1,0 +1,299 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { sanitizeText, sanitizeJson, safeJsonStringify } from '../sanitizeEvidence'
+
+describe('sanitizeText', () => {
+  describe('private keys', () => {
+    it('redacts RSA private keys', () => {
+      const input = '-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQ...\n-----END RSA PRIVATE KEY-----'
+      const result = sanitizeText(input)
+      expect(result).toBe('[REDACTED_PRIVATE_KEY]')
+    })
+
+    it('redacts EC private keys', () => {
+      const input = '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEI...\n-----END EC PRIVATE KEY-----'
+      const result = sanitizeText(input)
+      expect(result).toBe('[REDACTED_PRIVATE_KEY]')
+    })
+
+    it('redacts private keys in multiline text', () => {
+      const input = `Config:
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkq
+-----END PRIVATE KEY-----
+End`
+      const result = sanitizeText(input)
+      expect(result).toBe('Config:\n[REDACTED_PRIVATE_KEY]\nEnd')
+    })
+  })
+
+  describe('Bearer tokens', () => {
+    it('redacts Bearer tokens', () => {
+      const input = 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
+      const result = sanitizeText(input)
+      expect(result).toBe('Authorization: Bearer [REDACTED]')
+    })
+
+    it('redacts multiple Bearer tokens', () => {
+      const input = 'Bearer abc123 and Bearer xyz789'
+      const result = sanitizeText(input)
+      expect(result).toContain('[REDACTED]')
+      expect(result).not.toContain('abc123')
+      expect(result).not.toContain('xyz789')
+    })
+  })
+
+  describe('JWT tokens', () => {
+    it('redacts JWTs', () => {
+      const input = 'Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+      const result = sanitizeText(input)
+      expect(result).toBe('Token: [REDACTED_JWT]')
+    })
+
+    it('redacts multiple JWTs', () => {
+      const jwt1 = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U'
+      const jwt2 = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5ODc2NTQzMjEwIn0.WlW7rq2jKsIr_fmXrZk8Nt4l_m5J2bH8cR9Y3xZ1abc'
+      const input = `First: ${jwt1}, Second: ${jwt2}`
+      const result = sanitizeText(input)
+      expect(result).not.toContain(jwt1)
+      expect(result).not.toContain(jwt2)
+      expect(result).toContain('[REDACTED_JWT]')
+    })
+  })
+
+  describe('URL parameters', () => {
+    it('redacts access_token in query string', () => {
+      const input = 'https://api.example.com/data?access_token=secret123&foo=bar'
+      const result = sanitizeText(input)
+      expect(result).toContain('access_token=[REDACTED]')
+      expect(result).not.toContain('secret123')
+      expect(result).toContain('foo=bar')
+    })
+
+    it('redacts refresh_token in query string', () => {
+      const input = 'https://api.example.com/auth?refresh_token=refresh_secret'
+      const result = sanitizeText(input)
+      expect(result).toContain('refresh_token=[REDACTED]')
+      expect(result).not.toContain('refresh_secret')
+    })
+
+    it('redacts id_token in query string', () => {
+      const input = 'callback?id_token=id_secret123'
+      const result = sanitizeText(input)
+      expect(result).toContain('id_token=[REDACTED]')
+      expect(result).not.toContain('id_secret123')
+    })
+
+    it('redacts client_secret in query string', () => {
+      const input = 'oauth?client_secret=client123'
+      const result = sanitizeText(input)
+      expect(result).toContain('client_secret=[REDACTED]')
+      expect(result).not.toContain('client123')
+    })
+  })
+
+  describe('HTTP headers', () => {
+    it('redacts Authorization header', () => {
+      const input = 'Authorization: Bearer token123'
+      const result = sanitizeText(input)
+      expect(result).toContain('authorization: [REDACTED]')
+      expect(result).not.toContain('token123')
+    })
+
+    it('redacts Cookie header', () => {
+      const input = 'Cookie: session=abc123; user=test'
+      const result = sanitizeText(input)
+      expect(result).toContain('cookie: [REDACTED]')
+      expect(result).not.toContain('abc123')
+    })
+
+    it('redacts Set-Cookie header', () => {
+      const input = 'Set-Cookie: session=xyz789; HttpOnly'
+      const result = sanitizeText(input)
+      expect(result).toContain('set-cookie: [REDACTED]')
+      expect(result).not.toContain('xyz789')
+    })
+
+    it('redacts x-api-key header', () => {
+      const input = 'x-api-key: apikey123'
+      const result = sanitizeText(input)
+      expect(result).toContain('x-api-key: [REDACTED]')
+      expect(result).not.toContain('apikey123')
+    })
+
+    it('redacts kc-agent-token header', () => {
+      const input = 'kc-agent-token: agent_secret'
+      const result = sanitizeText(input)
+      expect(result).toContain('kc-agent-token: [REDACTED]')
+      expect(result).not.toContain('agent_secret')
+    })
+  })
+
+  describe('kubeconfig data', () => {
+    it('redacts kubeconfig YAML', () => {
+      const input = `apiVersion: v1
+clusters:
+- cluster:
+    server: https://example.com
+  name: test
+users:
+- name: admin
+  user:
+    token: secret123`
+      const result = sanitizeText(input)
+      expect(result).toBe('[REDACTED_KUBECONFIG]')
+    })
+  })
+
+  describe('environment variables', () => {
+    it('redacts sensitive env values when present in text', () => {
+      const originalEnv = process.env.TEST_SECRET
+      process.env.TEST_SECRET = 'my_secret_value_12345'
+      
+      const input = 'Logging: my_secret_value_12345 detected'
+      const result = sanitizeText(input)
+      
+      expect(result).not.toContain('my_secret_value_12345')
+      expect(result).toContain('[REDACTED_ENV_VALUE]')
+      
+      if (originalEnv === undefined) {
+        delete process.env.TEST_SECRET
+      } else {
+        process.env.TEST_SECRET = originalEnv
+      }
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles null input', () => {
+      const result = sanitizeText(null)
+      expect(result).toBe('')
+    })
+
+    it('handles undefined input', () => {
+      const result = sanitizeText(undefined)
+      expect(result).toBe('')
+    })
+
+    it('handles empty string', () => {
+      const result = sanitizeText('')
+      expect(result).toBe('')
+    })
+
+    it('handles text with no secrets', () => {
+      const input = 'This is a normal log message with no secrets.'
+      const result = sanitizeText(input)
+      expect(result).toBe(input)
+    })
+
+    it('preserves non-secret content while redacting secrets', () => {
+      const input = 'User login successful, token: Bearer abc123'
+      const result = sanitizeText(input)
+      expect(result).toContain('User login successful')
+      expect(result).toContain('Bearer [REDACTED]')
+      expect(result).not.toContain('abc123')
+    })
+  })
+})
+
+describe('sanitizeJson', () => {
+  it('redacts string values containing secrets', () => {
+    const input = { message: 'Authorization: Bearer token123' }
+    const result = sanitizeJson(input)
+    expect(result.message).toContain('[REDACTED]')
+    expect(result.message).not.toContain('token123')
+  })
+
+  it('redacts fields with sensitive key names', () => {
+    const input = { username: 'admin', password: 'secret123' }
+    const result = sanitizeJson(input)
+    expect(result.username).toBe('admin')
+    expect(result.password).toBe('[REDACTED]')
+  })
+
+  it('redacts nested objects with sensitive keys', () => {
+    const input = {
+      config: {
+        apiKey: 'key123',
+        endpoint: 'https://example.com',
+      },
+    }
+    const result = sanitizeJson(input)
+    expect(result.config.apiKey).toBe('[REDACTED]')
+    expect(result.config.endpoint).toBe('https://example.com')
+  })
+
+  it('sanitizes arrays', () => {
+    const input = ['normal', 'Bearer token123']
+    const result = sanitizeJson(input)
+    expect(result[0]).toBe('normal')
+    expect(result[1]).toContain('[REDACTED]')
+  })
+
+  it('handles primitives', () => {
+    expect(sanitizeJson(123)).toBe(123)
+    expect(sanitizeJson(true)).toBe(true)
+    expect(sanitizeJson(null)).toBe(null)
+  })
+
+  it('redacts TOKEN in key names', () => {
+    const input = { API_TOKEN: 'token123' }
+    const result = sanitizeJson(input)
+    expect(result.API_TOKEN).toBe('[REDACTED]')
+  })
+
+  it('redacts SECRET in key names', () => {
+    const input = { CLIENT_SECRET: 'secret123' }
+    const result = sanitizeJson(input)
+    expect(result.CLIENT_SECRET).toBe('[REDACTED]')
+  })
+
+  it('redacts CREDENTIAL in key names', () => {
+    const input = { USER_CREDENTIAL: 'cred123' }
+    const result = sanitizeJson(input)
+    expect(result.USER_CREDENTIAL).toBe('[REDACTED]')
+  })
+
+  it('redacts KEY in key names', () => {
+    const input = { API_KEY: 'key123' }
+    const result = sanitizeJson(input)
+    expect(result.API_KEY).toBe('[REDACTED]')
+  })
+
+  it('redacts AUTH in key names', () => {
+    const input = { AUTH_HEADER: 'auth123' }
+    const result = sanitizeJson(input)
+    expect(result.AUTH_HEADER).toBe('[REDACTED]')
+  })
+})
+
+describe('safeJsonStringify', () => {
+  it('stringifies and sanitizes objects', () => {
+    const input = { username: 'admin', password: 'secret123' }
+    const result = safeJsonStringify(input)
+    const parsed = JSON.parse(result)
+    expect(parsed.username).toBe('admin')
+    expect(parsed.password).toBe('[REDACTED]')
+  })
+
+  it('formats JSON with 2-space indentation', () => {
+    const input = { a: 1 }
+    const result = safeJsonStringify(input)
+    expect(result).toContain('  ')
+  })
+
+  it('handles nested structures', () => {
+    const input = {
+      level1: {
+        level2: {
+          token: 'secret123',
+          data: 'normal',
+        },
+      },
+    }
+    const result = safeJsonStringify(input)
+    expect(result).toContain('[REDACTED]')
+    expect(result).not.toContain('secret123')
+    expect(result).toContain('normal')
+  })
+})

--- a/web/harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts
+++ b/web/harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts
@@ -1,0 +1,222 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { redactK8sGroundTruth } from '../redactK8sGroundTruth'
+import type { K8sGroundTruth } from '../k8sTypes'
+
+describe('redactK8sGroundTruth', () => {
+  it('anonymizes context names while preserving count', () => {
+    const input: K8sGroundTruth = {
+      runId: 'test-run-1',
+      contexts: {
+        configured: 3,
+        reachable: 3,
+        names: ['prod-us-east-1', 'staging-eu-west-1', 'dev-local'],
+      },
+      nodes: { total: 0, ready: 0, notReady: 0 },
+      pods: { total: 0, running: 0, pending: 0, failed: 0, crashLoopBackOff: 0 },
+      namespaces: { total: 0, createdByHarness: [] },
+      deployments: { total: 0, available: 0, unavailable: 0 },
+    }
+
+    const result = redactK8sGroundTruth(input)
+
+    expect(result.contexts.names).toHaveLength(3)
+    expect(result.contexts.names[0]).toMatch(/^context-1-/)
+    expect(result.contexts.names[1]).toMatch(/^context-2-/)
+    expect(result.contexts.names[2]).toMatch(/^context-3-/)
+    
+    // Should not contain original names
+    expect(result.contexts.names.join()).not.toContain('prod-us-east-1')
+    expect(result.contexts.names.join()).not.toContain('staging-eu-west-1')
+    expect(result.contexts.names.join()).not.toContain('dev-local')
+  })
+
+  it('handles special characters in context names', () => {
+    const input: K8sGroundTruth = {
+      runId: 'test-run-2',
+      contexts: {
+        configured: 2,
+        reachable: 2,
+        names: ['test@cluster.local', 'arn:aws:eks:region'],
+      },
+      nodes: { total: 0, ready: 0, notReady: 0 },
+      pods: { total: 0, running: 0, pending: 0, failed: 0, crashLoopBackOff: 0 },
+      namespaces: { total: 0, createdByHarness: [] },
+      deployments: { total: 0, available: 0, unavailable: 0 },
+    }
+
+    const result = redactK8sGroundTruth(input)
+
+    expect(result.contexts.names).toHaveLength(2)
+    expect(result.contexts.names[0]).toMatch(/^context-1-/)
+    expect(result.contexts.names[1]).toMatch(/^context-2-/)
+    
+    // Special characters should be removed
+    result.contexts.names.forEach(name => {
+      expect(name).not.toContain('@')
+      expect(name).not.toContain(':')
+    })
+  })
+
+  it('truncates long context names to 12 characters plus prefix', () => {
+    const input: K8sGroundTruth = {
+      runId: 'test-run-3',
+      contexts: {
+        configured: 1,
+        reachable: 1,
+        names: ['very-long-context-name-that-exceeds-limit'],
+      },
+      nodes: { total: 0, ready: 0, notReady: 0 },
+      pods: { total: 0, running: 0, pending: 0, failed: 0, crashLoopBackOff: 0 },
+      namespaces: { total: 0, createdByHarness: [] },
+      deployments: { total: 0, available: 0, unavailable: 0 },
+    }
+
+    const result = redactK8sGroundTruth(input)
+
+    // Format: context-1-{first12chars}
+    expect(result.contexts.names[0]).toMatch(/^context-1-[a-z0-9-]{1,12}$/)
+    expect(result.contexts.names[0].length).toBeLessThanOrEqual('context-1-'.length + 12)
+  })
+
+  it('preserves numeric counters', () => {
+    const input: K8sGroundTruth = {
+      runId: 'test-run-4',
+      contexts: {
+        configured: 3,
+        reachable: 2,
+        names: ['context1', 'context2', 'context3'],
+      },
+      nodes: { total: 10, ready: 8, notReady: 2 },
+      pods: { total: 50, running: 45, pending: 3, failed: 1, crashLoopBackOff: 1 },
+      namespaces: { total: 15, createdByHarness: ['ns1', 'ns2'] },
+      deployments: { total: 20, available: 18, unavailable: 2 },
+    }
+
+    const result = redactK8sGroundTruth(input)
+
+    // All numeric counters should be preserved
+    expect(result.contexts.configured).toBe(3)
+    expect(result.contexts.reachable).toBe(2)
+    expect(result.nodes.total).toBe(10)
+    expect(result.nodes.ready).toBe(8)
+    expect(result.nodes.notReady).toBe(2)
+    expect(result.pods.total).toBe(50)
+    expect(result.pods.running).toBe(45)
+    expect(result.pods.pending).toBe(3)
+    expect(result.pods.failed).toBe(1)
+    expect(result.pods.crashLoopBackOff).toBe(1)
+    expect(result.namespaces.total).toBe(15)
+    expect(result.deployments.total).toBe(20)
+    expect(result.deployments.available).toBe(18)
+    expect(result.deployments.unavailable).toBe(2)
+  })
+
+  it('sanitizes namespace names created by harness', () => {
+    const input: K8sGroundTruth = {
+      runId: 'test-run-5',
+      contexts: {
+        configured: 1,
+        reachable: 1,
+        names: ['test-cluster'],
+      },
+      nodes: { total: 0, ready: 0, notReady: 0 },
+      pods: { total: 0, running: 0, pending: 0, failed: 0, crashLoopBackOff: 0 },
+      namespaces: {
+        total: 3,
+        createdByHarness: ['harness-test-ns-1', 'harness-test-ns-2'],
+      },
+      deployments: { total: 0, available: 0, unavailable: 0 },
+    }
+
+    const result = redactK8sGroundTruth(input)
+
+    // Namespace names should be sanitized (checked for secrets/tokens)
+    expect(result.namespaces.total).toBe(3)
+    expect(result.namespaces.createdByHarness).toHaveLength(2)
+  })
+
+  it('handles empty contexts array', () => {
+    const input: K8sGroundTruth = {
+      runId: 'test-run-6',
+      contexts: {
+        configured: 0,
+        reachable: 0,
+        names: [],
+      },
+      nodes: { total: 0, ready: 0, notReady: 0 },
+      pods: { total: 0, running: 0, pending: 0, failed: 0, crashLoopBackOff: 0 },
+      namespaces: { total: 0, createdByHarness: [] },
+      deployments: { total: 0, available: 0, unavailable: 0 },
+    }
+
+    const result = redactK8sGroundTruth(input)
+
+    expect(result.contexts.names).toEqual([])
+    expect(result.contexts.configured).toBe(0)
+    expect(result.contexts.reachable).toBe(0)
+  })
+
+  it('redacts runId if it contains secrets', () => {
+    const input: K8sGroundTruth = {
+      runId: 'run-token-abc123xyz',
+      contexts: {
+        configured: 1,
+        reachable: 1,
+        names: ['test'],
+      },
+      nodes: { total: 0, ready: 0, notReady: 0 },
+      pods: { total: 0, running: 0, pending: 0, failed: 0, crashLoopBackOff: 0 },
+      namespaces: { total: 0, createdByHarness: [] },
+      deployments: { total: 0, available: 0, unavailable: 0 },
+    }
+
+    const result = redactK8sGroundTruth(input)
+
+    // runId with TOKEN in key should be redacted
+    expect(result.runId).toBe('[REDACTED]')
+  })
+
+  it('applies sanitizeJson to entire structure', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U'
+    const input = {
+      runId: `test-${jwt}`,
+      contexts: {
+        configured: 1,
+        reachable: 1,
+        names: ['test'],
+      },
+      nodes: { total: 0, ready: 0, notReady: 0 },
+      pods: { total: 0, running: 0, pending: 0, failed: 0, crashLoopBackOff: 0 },
+      namespaces: { total: 0, createdByHarness: [] },
+      deployments: { total: 0, available: 0, unavailable: 0 },
+    } as K8sGroundTruth
+
+    const result = redactK8sGroundTruth(input)
+
+    // JWT should be redacted
+    expect(result.runId).not.toContain(jwt)
+    expect(result.runId).toContain('[REDACTED_JWT]')
+  })
+
+  it('handles skipped field', () => {
+    const input: K8sGroundTruth = {
+      runId: 'test-run-7',
+      skipped: 'Test skipped due to missing cluster',
+      contexts: {
+        configured: 0,
+        reachable: 0,
+        names: [],
+      },
+      nodes: { total: 0, ready: 0, notReady: 0 },
+      pods: { total: 0, running: 0, pending: 0, failed: 0, crashLoopBackOff: 0 },
+      namespaces: { total: 0, createdByHarness: [] },
+      deployments: { total: 0, available: 0, unavailable: 0 },
+    }
+
+    const result = redactK8sGroundTruth(input)
+
+    expect(result.skipped).toBe('Test skipped due to missing cluster')
+    expect(result.contexts.names).toEqual([])
+  })
+})


### PR DESCRIPTION
Fixes #20154

Adds high-priority unit tests for security-critical sanitization modules in the canary harness:
- sanitizeEvidence.ts tests
- redactK8sGroundTruth.ts tests

## Test Coverage

### sanitizeEvidence.test.ts
- Private keys (RSA, EC, generic PRIVATE KEY)
- JWT tokens (eyJ... three-part format)
- Bearer tokens
- HTTP headers (Authorization, Cookie, Set-Cookie, x-api-key, kc-agent-token)
- URL query parameters (access_token, refresh_token, id_token, client_secret)
- Kubeconfig YAML blocks
- Environment variable redaction
- Edge cases (null, undefined, empty, no secrets)

### redactK8sGroundTruth.test.ts
- Context name anonymization (preserves count, removes identifiers)
- Special character handling in context names
- Long name truncation (12 char limit)
- Numeric counter preservation
- Namespace sanitization
- JWT/Bearer token redaction in nested data
- runId redaction when sensitive
- Empty/skipped case handling