### PR TITLE
[ci-maintainer] fix: narrow _perf-regression-issue.yml permissions from read-all to explicit minimum

### DIFF
--- a/.github/workflows/_perf-regression-issue.yml
+++ b/.github/workflows/_perf-regression-issue.yml
@@ -39,7 +39,10 @@ on:
         required: true
         type: string
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read
+  actions: read
+  issues: write
 jobs:
   notify:
     permissions:


### PR DESCRIPTION
Fixes #20164

## CI Fix

`.github/workflows/_perf-regression-issue.yml` declared `permissions: read-all` at the workflow level. GitHub rejects this when the calling job (`notify` in both `perf-bundle-size.yml` and `perf-ttfi.yml`) caps permissions at `{contents: read, issues: write, actions: read}` — the called workflow cannot request broader permissions than its caller grants.

**Change:** Replace `permissions: read-all` with explicit minimum:
```yaml
permissions:
  contents: read
  actions: read
  issues: write
```

This matches what the callers already grant to the notify job and is all the reusable workflow actually uses.

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*