### PR TITLE
[ci-maintainer] fix: narrow hive-trust-gate.yml permissions from read-all to explicit minimum

### DIFF
--- a/.github/workflows/hive-trust-gate.yml
+++ b/.github/workflows/hive-trust-gate.yml
@@ -35,7 +35,9 @@ on:
         description: Why the actor passed or failed the gate
         value: ${{ jobs.evaluate.outputs.trust-reason }}
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read
+  issues: write
 jobs:
   evaluate:
     permissions:


### PR DESCRIPTION
## CI Fix

`.github/workflows/hive-trust-gate.yml` declared `permissions: read-all` at the workflow level. GitHub rejects this when the calling job in `hive-interactive.yml` restricts the `trust-gate` job to `{contents: read, issues: write}` — called workflows cannot request broader permissions than the caller job grants. This caused a `startup_failure` on every `issues: opened` event.

**Change:** Replace `permissions: read-all` with explicit minimum:
```yaml
permissions:
  contents: read
  issues: write
```

This matches what the callers already grant to the calling job. The `evaluate` job's existing job-level `permissions: {issues: write}` is preserved.

Fixes #20168

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*