### PR TITLE
[ci-maintainer] fix: correct scorecard.yml job permissions to match reusable workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,6 +12,7 @@ jobs:
   analysis:
     permissions:
       security-events: write
-      id-token: write
+      contents: read
+      actions: read
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned 2026-06-29 from main
     secrets: inherit


### PR DESCRIPTION
## CI Fix

`scorecard.yml` has been producing `startup_failure` on every push to `main` since run #9741 because the `analysis` job's `permissions` don't match what the reusable workflow (`kubestellar/infra/.github/workflows/reusable-scorecard.yml`) actually requires.

**Before:**
```yaml
    permissions:
      security-events: write
      id-token: write        # not needed
      # missing: contents: read
      # missing: actions: read
```

**After:**
```yaml
    permissions:
      security-events: write
      contents: read   # required for checkout/analysis
      actions: read    # required for ossf/scorecard-action
```

GitHub raises `startup_failure` when a called reusable workflow's job-level permissions exceed what the caller grants. The `id-token` permission is unnecessary and is removed.

Fixes #20170

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*