### PR TITLE
[scanner] fix: resolve coverage-hourly.yml failure

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload failed test list
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: failed-tests-${{ matrix.shard }}
           path: web/failed-tests.txt
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload shard coverage
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-shard-${{ matrix.shard }}
           path: web/coverage/coverage-final.json
@@ -135,10 +135,10 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -150,14 +150,14 @@ jobs:
         run: npm ci || npm ci
 
       - name: Download all shard coverage
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: coverage-shard-*
           path: /tmp/shards
 
       - name: Download failed test artifacts
         if: always()
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: failed-tests-*
           path: /tmp/failed-tests
@@ -253,7 +253,7 @@ jobs:
 
       - name: Upload merged coverage
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-merged-${{ github.run_number }}
           path: web/coverage/coverage-summary.json
@@ -261,7 +261,7 @@ jobs:
 
       - name: Update coverage badge gist (with regression guard)
         if: steps.failures.outputs.count == '0' && needs.test-shard.result != 'failure'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           GIST_ID: ${{ env.GIST_ID }}
           COVERAGE_PCT: ${{ steps.cov.outputs.pct }}
@@ -374,7 +374,7 @@ jobs:
 
       - name: Open issue for test failures
         if: needs.test-shard.result == 'failure'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           FAILED_TESTS: ${{ steps.failures.outputs.list }}
           FAILED_COUNT: ${{ steps.failures.outputs.count }}


### PR DESCRIPTION
Fixes #20167

Replaces non-existent GitHub Actions versions with actual current versions:
- actions/checkout: v6.0.3 → v4.2.2
- actions/setup-node: v6.4.0 → v4.4.0
- actions/upload-artifact: v7.0.1 → v4.6.2
- actions/download-artifact: v8.0.1 → v4.3.0
- actions/github-script: v9.0.0 → v7.0.1

The workflow was failing because it referenced future action versions (v6, v7, v8, v9) that do not exist. Updated to use the latest stable v4 versions matching other workflows in the repository.