### PR TITLE
[ci-maintainer] fix: set explicit permissions for OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  security-events: write  # required for SARIF upload
+  contents: read
+  actions: read
 jobs:
   analysis:
     permissions:


### PR DESCRIPTION
## CI Fix

`permissions: read-all` at the workflow level grants only **read** access to all scopes. The `analysis` job calls a reusable workflow that requires `security-events: write` — but job-level permissions cannot **exceed** workflow-level permissions. GitHub rejects the call at startup (`startup_failure`) because `security-events: write` is broader than `read`.

### Change

Replace `permissions: read-all` with the three specific permissions the job actually needs:

```yaml
permissions:
  security-events: write  # required for SARIF upload
  contents: read
  actions: read
```

This allows the job-level permissions block to match (not exceed) workflow-level, eliminating the startup failure.

### Evidence

- 5 consecutive `startup_failure` runs: #28627938339, #28630227755, #28630248215, #28632028479, #28632044731
- All on `main` following the commit that added `permissions: read-all`

Fixes #20170

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*