### PR TITLE
[scanner] fix: resolve Playwright E2E test failures on main (invalid \\' escapes)

### DIFF
--- a/web/e2e/user-flows/keyboard-navigation.spec.ts
+++ b/web/e2e/user-flows/keyboard-navigation.spec.ts
@@ -78,7 +78,7 @@ test.describe('Keyboard Navigation', () => {
     }
 
     await page.keyboard.press('Enter')
-    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error(\'Promise catch:\', error) })
+    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error('Promise catch:', error) })
 
     // URL may or may not change depending on which link was focused,
     // but the page should not crash
@@ -105,7 +105,7 @@ test.describe('Keyboard Navigation', () => {
       .or(page.getByRole('button', { name: /settings/i }))
       .or(page.locator('[aria-label*="settings" i]'))
 
-    const hasSettings = await settingsBtn.first().isVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasSettings = await settingsBtn.first().isVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasSettings) {
       test.skip()
       return
@@ -113,7 +113,7 @@ test.describe('Keyboard Navigation', () => {
 
     await settingsBtn.first().click()
     const dialog = page.getByRole('dialog')
-    const hasDialog = await dialog.isVisible({ timeout: MODAL_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasDialog = await dialog.isVisible({ timeout: MODAL_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasDialog) {
       test.skip()
       return

--- a/web/e2e/user-flows/mission-exploration.spec.ts
+++ b/web/e2e/user-flows/mission-exploration.spec.ts
@@ -11,12 +11,12 @@ const MISSION_LOAD_TIMEOUT_MS = 5_000
 
 async function ensureMissionBrowserVisible(page: Page): Promise<boolean> {
   const browser = page.getByTestId('mission-browser')
-  if (await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })) {
+  if (await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })) {
     return true
   }
 
   const missionToggle = page.getByTestId('navbar-ai-missions-btn')
-  if (!(await missionToggle.isVisible({ timeout: 3_000 }).catch((error) => { console.error(\'Promise error:\', error); return false }))) {
+  if (!(await missionToggle.isVisible({ timeout: 3_000 }).catch((error) => { console.error('Promise error:', error); return false }))) {
     return false
   }
 
@@ -44,10 +44,10 @@ test.describe('Mission Exploration — "Find and use a mission"', () => {
   test('mission search input is functional', async ({ page }) => {
     await setupDemoAndNavigate(page, '/missions')
     const browser = page.getByTestId('mission-browser')
-    const hasBrowser = await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasBrowser = await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasBrowser) { test.skip(true, 'Mission browser not visible'); return }
     const searchInput = page.getByTestId('mission-search')
-    const hasSearch = await searchInput.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasSearch = await searchInput.isVisible().catch((error) => { console.error('Promise error:', error); return false })
     if (!hasSearch) { test.skip(true, 'Mission search input not visible'); return }
     await searchInput.fill('deploy')
     await page.waitForTimeout(500)
@@ -58,10 +58,10 @@ test.describe('Mission Exploration — "Find and use a mission"', () => {
   test('mission directory tree renders', async ({ page }) => {
     await setupDemoAndNavigate(page, '/missions')
     const browser = page.getByTestId('mission-browser')
-    const hasBrowser = await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasBrowser = await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasBrowser) { test.skip(true, 'Mission browser not visible'); return }
     const tree = page.getByTestId('mission-tree')
-    const hasTree = await tree.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasTree = await tree.isVisible().catch((error) => { console.error('Promise error:', error); return false })
     if (!hasTree) { test.skip(true, 'Mission tree not visible'); return }
     const text = await tree.textContent()
     expect(text?.length).toBeGreaterThan(0)
@@ -70,10 +70,10 @@ test.describe('Mission Exploration — "Find and use a mission"', () => {
   test('mission grid shows missions', async ({ page }) => {
     await setupDemoAndNavigate(page, '/missions')
     const browser = page.getByTestId('mission-browser')
-    const hasBrowser = await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasBrowser = await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasBrowser) { test.skip(true, 'Mission browser not visible'); return }
     const grid = page.getByTestId('mission-grid')
-    const hasGrid = await grid.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasGrid = await grid.isVisible().catch((error) => { console.error('Promise error:', error); return false })
     if (!hasGrid) { test.skip(true, 'Mission grid not visible'); return }
     const text = await grid.textContent()
     expect(text?.length).toBeGreaterThan(0)
@@ -82,14 +82,14 @@ test.describe('Mission Exploration — "Find and use a mission"', () => {
   test('clicking a mission shows detail view', async ({ page }) => {
     await setupDemoAndNavigate(page, '/missions')
     const browser = page.getByTestId('mission-browser')
-    const hasBrowser = await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasBrowser = await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasBrowser) { test.skip(true, 'Mission browser not visible'); return }
     const grid = page.getByTestId('mission-grid')
-    const hasGrid = await grid.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasGrid = await grid.isVisible().catch((error) => { console.error('Promise error:', error); return false })
     if (!hasGrid) { test.skip(true, 'Mission grid not visible'); return }
     // Click the first clickable mission item
     const missionItem = grid.locator('button, a, [role="button"], [class*="cursor-pointer"]').first()
-    const hasMission = await missionItem.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasMission = await missionItem.isVisible().catch((error) => { console.error('Promise error:', error); return false })
     if (!hasMission) { test.skip(true, 'No clickable mission item found'); return }
     await missionItem.click()
     await page.waitForTimeout(500)
@@ -102,14 +102,14 @@ test.describe('Mission Exploration — "Find and use a mission"', () => {
   test('category filter works in mission tree', async ({ page }) => {
     await setupDemoAndNavigate(page, '/missions')
     const browser = page.getByTestId('mission-browser')
-    const hasBrowser = await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasBrowser = await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasBrowser) { test.skip(true, 'Mission browser not visible'); return }
     const tree = page.getByTestId('mission-tree')
-    const hasTree = await tree.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasTree = await tree.isVisible().catch((error) => { console.error('Promise error:', error); return false })
     if (!hasTree) { test.skip(true, 'Mission tree not visible'); return }
     // Click first category in tree to filter
     const treeItem = tree.locator('button, [role="treeitem"], li').first()
-    const hasItem = await treeItem.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasItem = await treeItem.isVisible().catch((error) => { console.error('Promise error:', error); return false })
     if (!hasItem) { test.skip(true, 'No tree item found to click'); return }
     await treeItem.click()
     await page.waitForTimeout(500)
@@ -120,10 +120,10 @@ test.describe('Mission Exploration — "Find and use a mission"', () => {
   test('search clears properly', async ({ page }) => {
     await setupDemoAndNavigate(page, '/missions')
     const browser = page.getByTestId('mission-browser')
-    const hasBrowser = await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasBrowser = await browser.isVisible({ timeout: MISSION_LOAD_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasBrowser) { test.skip(true, 'Mission browser not visible'); return }
     const searchInput = page.getByTestId('mission-search')
-    const hasSearch = await searchInput.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasSearch = await searchInput.isVisible().catch((error) => { console.error('Promise error:', error); return false })
     if (!hasSearch) { test.skip(true, 'Mission search input not visible'); return }
     await searchInput.fill('test-query')
     await page.waitForTimeout(300)

--- a/web/e2e/user-flows/onboarding-tour.spec.ts
+++ b/web/e2e/user-flows/onboarding-tour.spec.ts
@@ -33,14 +33,14 @@ test.describe('Onboarding Tour', () => {
     })
 
     await page.goto('/')
-    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error(\'Promise catch:\', error) })
+    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error('Promise catch:', error) })
 
     // Look for tour prompt, welcome dialog, or onboarding modal
     const tourPrompt = page.getByRole('dialog')
       .or(page.getByTestId('tour-tooltip'))
       .or(page.getByText(/welcome|take a tour|get started/i))
 
-    const hasTour = await tourPrompt.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasTour = await tourPrompt.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasTour) {
       test.info().annotations.push({ type: 'ux-finding', description: 'No tour prompt shown for fresh user — may be disabled or deferred' })
     }
@@ -56,12 +56,12 @@ test.describe('Onboarding Tour', () => {
     })
 
     await page.goto('/')
-    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error(\'Promise catch:\', error) })
+    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error('Promise catch:', error) })
 
     const tooltip = page.getByTestId('tour-tooltip')
       .or(page.locator('[class*="tour"], [class*="joyride"], [class*="onboarding"]'))
 
-    const hasTooltip = await tooltip.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasTooltip = await tooltip.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasTooltip) {
       test.skip()
       return
@@ -82,13 +82,13 @@ test.describe('Onboarding Tour', () => {
     })
 
     await page.goto('/')
-    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error(\'Promise catch:\', error) })
+    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error('Promise catch:', error) })
 
     // Scope the tour tooltip container before looking for Next — a broad
     // getByRole('button', { name: /next/i }) matches pagination/wizard buttons
     // outside the tour and clicking the wrong one navigates away, crashing the test.
     const tourContainer = page.locator('[class*="tour"], [class*="joyride"], [class*="onboarding"]').first()
-    const hasTour = await tourContainer.isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasTour = await tourContainer.isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasTour) {
       test.skip()
       return
@@ -96,7 +96,7 @@ test.describe('Onboarding Tour', () => {
 
     // Only look for Next within the tour tooltip
     const nextBtn = tourContainer.getByRole('button', { name: /next/i })
-    const hasNext = await nextBtn.isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasNext = await nextBtn.isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasNext) {
       test.skip()
       return
@@ -125,10 +125,10 @@ test.describe('Onboarding Tour', () => {
     })
 
     await page.goto('/')
-    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error(\'Promise catch:\', error) })
+    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error('Promise catch:', error) })
 
     const skipBtn = page.getByRole('button', { name: /skip|dismiss|close/i })
-    const hasSkip = await skipBtn.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasSkip = await skipBtn.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasSkip) {
       test.skip()
       return
@@ -150,11 +150,11 @@ test.describe('Onboarding Tour', () => {
     })
 
     await page.goto('/')
-    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error(\'Promise catch:\', error) })
+    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error('Promise catch:', error) })
 
     // Dismiss tour via skip or complete it
     const skipBtn = page.getByRole('button', { name: /skip|dismiss|close|done|finish/i })
-    const hasSkip = await skipBtn.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasSkip = await skipBtn.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (hasSkip) {
       await skipBtn.first().click()
     }
@@ -172,7 +172,7 @@ test.describe('Onboarding Tour', () => {
 
     // setupDemoMode sets demo-user-onboarded=true — verify no tour
     const tooltip = page.locator('[class*="tour"], [class*="joyride"], [class*="onboarding"]')
-    const hasTour = await tooltip.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasTour = await tooltip.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
 
     expect(hasTour, 'Tour should not appear for returning users').toBe(false)
   })
@@ -187,10 +187,10 @@ test.describe('Onboarding Tour', () => {
     })
 
     await page.goto('/')
-    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error(\'Promise catch:\', error) })
+    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error('Promise catch:', error) })
 
     const tooltip = page.locator('[class*="tour"], [class*="joyride"], [class*="onboarding"]')
-    const hasTooltip = await tooltip.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasTooltip = await tooltip.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
 
     if (hasTooltip) {
       await assertNoLayoutOverflow(page)
@@ -208,7 +208,7 @@ test.describe('Onboarding Tour', () => {
 
     // Sidebar should be clickable
     const sidebarLink = page.locator('nav a, [data-testid*="sidebar"] a').first()
-    const hasSidebar = await sidebarLink.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasSidebar = await sidebarLink.isVisible().catch((error) => { console.error('Promise error:', error); return false })
     if (!hasSidebar) { test.skip(true, 'No sidebar link visible to verify usability'); return }
     await expect(sidebarLink).toBeEnabled()
   })

--- a/web/e2e/user-flows/onboarding.spec.ts
+++ b/web/e2e/user-flows/onboarding.spec.ts
@@ -45,7 +45,7 @@ test.describe('Onboarding flow after login', () => {
     }, { tour: TOUR_COMPLETED_KEY, onboarded: ONBOARDED_KEY })
 
     await page.goto('/')
-    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error(\'Promise catch:\', error) })
+    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch((error) => { console.error('Promise catch:', error) })
 
     const body = page.locator('body')
     await expect(body).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
@@ -68,7 +68,7 @@ test.describe('Onboarding flow after login', () => {
     // Tour overlay selectors mirror onboarding-tour.spec.ts so the matcher
     // stays in sync with the Tour component's rendered DOM.
     const tourOverlay = page.locator('[class*="tour"], [class*="joyride"], [class*="onboarding"]')
-    const hasTour = await tourOverlay.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasTour = await tourOverlay.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     expect(hasTour, 'Tour must not render for returning users with tour-completed=true').toBe(false)
   })
 })

--- a/web/e2e/user-flows/settings-configuration.spec.ts
+++ b/web/e2e/user-flows/settings-configuration.spec.ts
@@ -34,7 +34,7 @@ test.describe('Settings Configuration — "Change my preferences"', () => {
     await page.getByTestId('settings-page').waitFor({ state: 'visible', timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
     // Find theme toggle — could be a button, switch, or select
     const themeToggle = page.locator('button:has-text("Theme"), button:has-text("Dark"), button:has-text("Light"), [aria-label*="theme" i], button:has-text("theme")')
-    const hasToggle = await themeToggle.first().isVisible({ timeout: 3_000 }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasToggle = await themeToggle.first().isVisible({ timeout: 3_000 }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasToggle) { test.skip(true, 'Theme toggle not visible'); return }
     const htmlClassBefore = await page.locator('html').getAttribute('class') ?? ''
     await themeToggle.first().click()
@@ -57,7 +57,7 @@ test.describe('Settings Configuration — "Change my preferences"', () => {
     await page.getByTestId('settings-page').waitFor({ state: 'visible', timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
     // Look for AI-related settings
     const aiSection = page.locator('text=/AI|Intelligence|Smart|Agent/i')
-    const hasAI = await aiSection.first().isVisible({ timeout: 3_000 }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasAI = await aiSection.first().isVisible({ timeout: 3_000 }).catch((error) => { console.error('Promise error:', error); return false })
     test.info().annotations.push({
       type: 'ux-finding',
       description: JSON.stringify({
@@ -75,7 +75,7 @@ test.describe('Settings Configuration — "Change my preferences"', () => {
     await page.getByTestId('settings-page').waitFor({ state: 'visible', timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
     // Toggle something if available
     const toggle = page.locator('button[role="switch"], input[type="checkbox"]').first()
-    const hasToggle = await toggle.isVisible({ timeout: 3_000 }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasToggle = await toggle.isVisible({ timeout: 3_000 }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasToggle) { test.skip(true, 'No toggle switch visible'); return }
     const checkedBefore = await toggle.getAttribute('aria-checked') ?? await toggle.isChecked().catch(() => null)
     await toggle.click()
@@ -99,7 +99,7 @@ test.describe('Settings Configuration — "Change my preferences"', () => {
     await setupDemoAndNavigate(page, '/settings')
     await page.getByTestId('settings-page').waitFor({ state: 'visible', timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
     const closeBtn = page.getByTestId('settings-close-desktop')
-    const hasClose = await closeBtn.isVisible({ timeout: 3_000 }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasClose = await closeBtn.isVisible({ timeout: 3_000 }).catch((error) => { console.error('Promise error:', error); return false })
     if (!hasClose) { test.skip(true, 'Settings close button not visible'); return }
     await closeBtn.click()
     await page.waitForTimeout(500)

--- a/web/e2e/user-flows/sidebar-workflow.spec.ts
+++ b/web/e2e/user-flows/sidebar-workflow.spec.ts
@@ -69,7 +69,7 @@ test.describe('Sidebar Workflow — "Navigate and customize sidebar"', () => {
     const widthBefore = await sidebar.evaluate((el) => el.getBoundingClientRect().width)
 
     const collapseBtn = page.getByTestId('sidebar-collapse-toggle')
-    const hasCollapse = await collapseBtn.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasCollapse = await collapseBtn.isVisible().catch((error) => { console.error('Promise error:', error); return false })
     if (hasCollapse) {
       await collapseBtn.click()
       await page.waitForTimeout(TRANSITION_SETTLE_MS)
@@ -83,7 +83,7 @@ test.describe('Sidebar Workflow — "Navigate and customize sidebar"', () => {
     const sidebar = page.getByTestId('sidebar')
     await expect(sidebar).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
     const collapseBtn = page.getByTestId('sidebar-collapse-toggle')
-    const hasCollapse = await collapseBtn.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasCollapse = await collapseBtn.isVisible().catch((error) => { console.error('Promise error:', error); return false })
     if (hasCollapse) {
       const widthBefore = await sidebar.evaluate((el) => el.getBoundingClientRect().width)
       await collapseBtn.click()
@@ -103,7 +103,7 @@ test.describe('Sidebar Workflow — "Navigate and customize sidebar"', () => {
     await expect(sidebar).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
     // Pin button is next to the collapse toggle
     const pinBtn = page.locator('button[title*="pin" i], button[title*="Pin" i]')
-    const hasPin = await pinBtn.first().isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasPin = await pinBtn.first().isVisible().catch((error) => { console.error('Promise error:', error); return false })
     if (hasPin) {
       await pinBtn.first().click()
       await page.waitForTimeout(TRANSITION_SETTLE_MS)
@@ -115,12 +115,12 @@ test.describe('Sidebar Workflow — "Navigate and customize sidebar"', () => {
   test('add card button is accessible', async ({ page }) => {
     await setupDemoAndNavigate(page, '/')
     const addCard = page.getByTestId('sidebar-add-card')
-    const hasAddCard = await addCard.isVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasAddCard = await addCard.isVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (hasAddCard) {
       await addCard.click()
       // Should open a dialog or modal
       const dialog = page.locator('[role="dialog"]')
-      const hasDialog = await dialog.isVisible({ timeout: 3_000 }).catch((error) => { console.error(\'Promise error:\', error); return false })
+      const hasDialog = await dialog.isVisible({ timeout: 3_000 }).catch((error) => { console.error('Promise error:', error); return false })
       expect(hasDialog).toBeTruthy()
     }
   })
@@ -128,7 +128,7 @@ test.describe('Sidebar Workflow — "Navigate and customize sidebar"', () => {
   test('cluster status section shows counts', async ({ page }) => {
     await setupDemoAndNavigate(page, '/')
     const clusterStatus = page.getByTestId('sidebar-cluster-status')
-    const hasStatus = await clusterStatus.isVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS }).catch((error) => { console.error(\'Promise error:\', error); return false })
+    const hasStatus = await clusterStatus.isVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS }).catch((error) => { console.error('Promise error:', error); return false })
     if (hasStatus) {
       // Should show numeric counts for healthy/unhealthy/offline
       const text = await clusterStatus.textContent()
@@ -141,7 +141,7 @@ test.describe('Sidebar Workflow — "Navigate and customize sidebar"', () => {
     await setupDemoAndNavigate(page, '/')
     // On mobile, sidebar should be hidden by default
     const sidebar = page.getByTestId('sidebar')
-    const isVisible = await sidebar.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+    const isVisible = await sidebar.isVisible().catch((error) => { console.error('Promise error:', error); return false })
     test.info().annotations.push({
       type: 'ux-finding',
       description: JSON.stringify({

--- a/web/e2e/workloads-deep.spec.ts
+++ b/web/e2e/workloads-deep.spec.ts
@@ -89,7 +89,7 @@ test.describe.serial('Workloads Deep Tests (/workloads)', () => {
 
     test('shows stats overview', async ({ page }) => {
       const statsArea = getStatsLabel(page, STAT_NAMESPACES_SUBLABEL)
-      const isVisible = await statsArea.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+      const isVisible = await statsArea.isVisible().catch((error) => { console.error('Promise error:', error); return false })
       if (isVisible) {
         await expect(statsArea).toBeVisible()
       }
@@ -113,7 +113,7 @@ test.describe.serial('Workloads Deep Tests (/workloads)', () => {
   test.describe('Content', () => {
     test('renders workload rows or empty state', async ({ page }) => {
       const hasRows = (await page.getByTestId('workload-row').count()) > 0
-      const hasEmpty = await page.getByTestId('workloads-empty-state').isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+      const hasEmpty = await page.getByTestId('workloads-empty-state').isVisible().catch((error) => { console.error('Promise error:', error); return false })
       expect(hasRows || hasEmpty).toBe(true)
     })
 
@@ -146,7 +146,7 @@ test.describe.serial('Workloads Deep Tests (/workloads)', () => {
   test.describe('Refresh', () => {
     test('refresh button is clickable', async ({ page }) => {
       const refreshBtn = page.getByTestId('dashboard-refresh-button')
-      const isVisible = await refreshBtn.isVisible().catch((error) => { console.error(\'Promise error:\', error); return false })
+      const isVisible = await refreshBtn.isVisible().catch((error) => { console.error('Promise error:', error); return false })
       if (isVisible) {
         await expect(refreshBtn).toBeEnabled()
         await refreshBtn.click()

--- a/web/e2e/workloads-interactions.spec.ts
+++ b/web/e2e/workloads-interactions.spec.ts
@@ -129,7 +129,7 @@ test.describe.serial('Workloads interactions (/workloads)', () => {
       const buttonVisible = await deployBtn
         .waitFor({ state: 'visible', timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
         .then(() => true)
-        .catch((error) => { console.error(\'Promise error:\', error); return false })
+        .catch((error) => { console.error('Promise error:', error); return false })
 
       test.skip(!buttonVisible, 'Empty state deploy button is not shown when workloads exist')
 


### PR DESCRIPTION
## Summary

Fixes #20179 — all 4 chromium shards + mobile + accessibility Playwright E2E tests failing on main since 2026-07-02.

## Root Cause

8 test files introduced by PR #20026 ("Add Console Live canary test harness") contain `\'` (backslash-escaped single quotes) in TypeScript source code **outside of string literals** — inside `.catch()` arrow-function callbacks like:

```ts
.catch((error) => { console.error(\'Promise catch:\', error) })
```

TypeScript's Babel parser interprets the bare `\` as the start of a Unicode escape sequence (`\uXXXX`), then hits `'` which is not a valid hex digit, throwing:

```
SyntaxError: Expecting Unicode escape sequence \uXXXX
```

This crashed every test shard at the compilation stage before any test could run.

## Fix

Replaced all `\'` occurrences with `'` in the 8 affected files:

- `web/e2e/user-flows/keyboard-navigation.spec.ts`
- `web/e2e/user-flows/mission-exploration.spec.ts`
- `web/e2e/user-flows/onboarding-tour.spec.ts`
- `web/e2e/user-flows/onboarding.spec.ts`
- `web/e2e/user-flows/settings-configuration.spec.ts`
- `web/e2e/user-flows/sidebar-workflow.spec.ts`
- `web/e2e/workloads-deep.spec.ts`
- `web/e2e/workloads-interactions.spec.ts`

No logic changes — purely a syntax fix.

Signed-off-by: scanner <scanner@kubestellar.io>