### PR TITLE
[scanner] fix: resolve lint baseline violations blocking all PRs

### DIFF
--- a/web/harness/groundtruth/__tests__/normalizeK8sState.test.ts
+++ b/web/harness/groundtruth/__tests__/normalizeK8sState.test.ts
@@ -69,7 +69,6 @@ describe('normalizeK8sState', () => {
   })
 
   it('handles deployment with no status', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const deployments = [{ status: undefined }, {}] as Array<Record<string, unknown>>
     const result = normalizeK8sState({ ...baseInput, deployments })
     // availableReplicas defaults to 0, replicas defaults to 0 — 0 >= 0 is true
@@ -92,7 +91,6 @@ describe('normalizeK8sState', () => {
   })
 
   it('handles nodes with missing status gracefully', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const nodes = [{ status: undefined }, {}] as Array<Record<string, unknown>>
     const result = normalizeK8sState({ ...baseInput, nodes })
     expect(result.nodes).toEqual({ total: 2, ready: 0, notReady: 2 })

--- a/web/harness/scripts/__tests__/compareBrowserMatrix.test.ts
+++ b/web/harness/scripts/__tests__/compareBrowserMatrix.test.ts
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('vitest')
+import { describe, it, expect } from 'vitest'
 
 // Import the module to test internals via function extraction
 // compareBrowserMatrix.cjs uses module-level execution, so we test its helper functions


### PR DESCRIPTION
Fixes #20179
Fixes #20182

Removes 3 new lint violations that were introduced on main and are blocking all PR CI:
- 2 unused eslint-disable directives in normalizeK8sState.test.ts
- 1 forbidden require() import in compareBrowserMatrix.test.ts

**Changes:**
- `harness/groundtruth/__tests__/normalizeK8sState.test.ts` — removed unused `eslint-disable-next-line` comments at lines 72 and 95 (code doesn't actually trigger `@typescript-eslint/no-explicit-any`)
- `harness/scripts/__tests__/compareBrowserMatrix.test.ts` — converted `require('vitest')` to ES `import` statement to comply with `@typescript-eslint/no-require-imports`

**Root Cause:**
The lint baseline check (`npm run lint:check`) now detects these violations on main, causing all PRs to fail CI. This PR restores main to a clean lint state.