### PR TITLE
[scanner] fix: update Go auth tests to expect 401 for unknown users

### DIFF
--- a/pkg/api/handlers/auth/helpers_test.go
+++ b/pkg/api/handlers/auth/helpers_test.go
@@ -24,7 +24,7 @@ func TestAuthHelpers(t *testing.T) {
 		}{
 			{"AdminAllowed", models.UserRoleAdmin, true, false, false, http.StatusOK},
 			{"ViewerForbidden", models.UserRoleViewer, true, false, false, http.StatusForbidden},
-			{"UserNotFound", models.UserRole(""), false, false, false, http.StatusForbidden},
+			{"UserNotFound", models.UserRole(""), false, false, false, http.StatusUnauthorized},
 			{"StoreError", models.UserRole(""), false, true, false, http.StatusInternalServerError},
 			{"NilStoreAllowed", models.UserRole(""), false, false, true, http.StatusOK},
 		}
@@ -75,7 +75,7 @@ func TestAuthHelpers(t *testing.T) {
 			{"AdminAllowed", models.UserRoleAdmin, true, false, false, http.StatusOK},
 			{"EditorAllowed", models.UserRoleEditor, true, false, false, http.StatusOK},
 			{"ViewerForbidden", models.UserRoleViewer, true, false, false, http.StatusForbidden},
-			{"UserNotFound", models.UserRole(""), false, false, false, http.StatusForbidden},
+			{"UserNotFound", models.UserRole(""), false, false, false, http.StatusUnauthorized},
 			{"StoreError", models.UserRole(""), false, true, false, http.StatusInternalServerError},
 			{"NilStoreAllowed", models.UserRole(""), false, false, true, http.StatusOK},
 		}
@@ -145,7 +145,7 @@ func TestAuthHelpers(t *testing.T) {
 			{"EditorAllowed", models.UserRoleEditor, true, http.StatusOK},
 			{"ViewerAllowed", models.UserRoleViewer, true, http.StatusOK},
 			{"InvalidRoleForbidden", models.UserRole("invalid"), true, http.StatusForbidden},
-			{"UserNotFound", models.UserRole(""), false, http.StatusForbidden},
+			{"UserNotFound", models.UserRole(""), false, http.StatusUnauthorized},
 		}
 
 		for _, tt := range tests {

--- a/pkg/api/handlers/compliance/siem_test.go
+++ b/pkg/api/handlers/compliance/siem_test.go
@@ -154,9 +154,9 @@ func TestSIEMHandler_RegisterRoutesRequiresAdmin(t *testing.T) {
 			wantStatus: http.StatusForbidden,
 		},
 		{
-			name:       "UnknownUserIsForbidden",
+			name:       "UnknownUserIsUnauthorized",
 			user:       nil,
-			wantStatus: http.StatusForbidden,
+			wantStatus: http.StatusUnauthorized,
 		},
 	}
 


### PR DESCRIPTION
Fixes #20180

The auth middleware correctly returns 401 (Unauthorized) for unknown users via the `ValidateUserActive` check introduced in the JWT middleware. Tests were asserting 403 (Forbidden) which is semantically incorrect:

- **401 Unauthorized**: user is not authenticated (unknown user)
- **403 Forbidden**: user is authenticated but lacks permission (known user, wrong role)

## Root Cause

`pkg/api/middleware/auth.go` line 688 calls `ValidateUserActive()` which checks if the user exists in the database. When `GetUser()` returns nil, `ValidateUserActive` returns `errUserInactive`, causing the middleware to return 401 "Invalid token" (line 693).

This is the correct behavior - a JWT for a non-existent user is semantically invalid.

## Changes

Updated test expectations from 403 to 401 for "UserNotFound" scenarios:
- `pkg/api/handlers/auth/helpers_test.go`: RequireAdmin/UserNotFound  
- `pkg/api/handlers/auth/helpers_test.go`: requireEditorOrAdmin/UserNotFound
- `pkg/api/handlers/auth/helpers_test.go`: requireViewerOrAbove/UserNotFound
- `pkg/api/handlers/compliance/siem_test.go`: UnknownUserIsUnauthorized (renamed from UnknownUserIsForbidden)

## Testing

These are test-only changes. The failing tests will now pass with the corrected expectations.