### PR TITLE
[ci-maintainer] fix: replace permissions: read-all with explicit write scopes in 5 reusable-calling workflows

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -4,7 +4,8 @@ on:
   issues:
     types: [labeled]
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  issues: write
 jobs:
   label:
     permissions:

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,7 +12,10 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions: read-all
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   ai-fix:

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -4,7 +4,8 @@ on:
   issue_comment:
     types: [created]
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  issues: write
 jobs:
   assignment-helper:
     permissions:

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions: read-all
+permissions:
+  statuses: write
+  pull-requests: read
 
 jobs:
   copilot-dco:

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [closed]
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  pull-requests: write
 jobs:
   feedback:
     permissions:


### PR DESCRIPTION
## CI Fix

5 workflows call reusable workflows (`uses:`) while holding a `permissions: read-all` token. GitHub rejects these calls at startup with `startup_failure` because the caller's read-only token cannot grant the write permissions the callee needs.

**Confirmed failure:** `Feedback Wanted` — run #28638848082 (2026-07-03T04:40Z)

### Changes

| Workflow | Old | New |
|----------|-----|-----|
| `feedback.yml` | `read-all` | `pull-requests: write` |
| `assignment-helper.yml` | `read-all` | `issues: write` |
| `add-help-wanted.yml` | `read-all` | `issues: write` |
| `copilot-dco.yml` | `read-all` | `statuses: write, pull-requests: read` |
| `ai-fix.yml` | `read-all` | `contents: write, issues: write, pull-requests: write` |

`label-helper.yml` (inline job) and `scorecard.yml` are NOT changed — inline jobs are unaffected and scorecard is currently passing.

Fixes #20190

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*