### PR TITLE
🌱 Split large bundle chunks to reduce bundle size

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -129,11 +129,24 @@ export default defineConfig(({ mode }) => ({
             ['cards-cluster', ['/src/components/cards/cluster_health/', '/src/components/cards/cluster_capacity/', '/src/components/cards/cluster_nodes/']],
             ['cards-cost', ['/src/components/cards/cost/', '/src/components/cards/kubecost_status/']],
             ['cards-data', ['/src/components/cards/postgresql_status/', '/src/components/cards/mysql_status/', '/src/components/cards/mongodb_status/']],
+            // Split cards-misc into smaller domain chunks to reduce 2.4M bundle
+            ['cards-service-mesh', ['/src/components/cards/istio_status/', '/src/components/cards/consul_status/']],
+            ['cards-backup', ['/src/components/cards/velero_status/', '/src/components/cards/kasten_status/']],
+            ['cards-build', ['/src/components/cards/tekton_status/', '/src/components/cards/jenkins_status/']],
+            ['cards-policy', ['/src/components/cards/policy/', '/src/components/cards/pod_security/']],
+            ['cards-cert', ['/src/components/cards/cert_manager_status/', '/src/components/cards/vault_status/']],
+            ['cards-edge', ['/src/components/cards/kubeedge_status/', '/src/components/cards/k3s_status/']],
+            ['cards-batch', ['/src/components/cards/job_status/', '/src/components/cards/cronjob_status/']],
+            ['cards-ingress', ['/src/components/cards/nginx_ingress_status/', '/src/components/cards/traefik_status/']],
+            ['cards-virtualization', ['/src/components/cards/kubevirt_status/', '/src/components/cards/kata_status/']],
             ['cards-misc', ['/src/components/cards/']],
-            // Split drilldown views by type to reduce chunk size
-            ['drilldown-k8s', ['/src/components/drilldown/views/PodLogs', '/src/components/drilldown/views/PodEvents', '/src/components/drilldown/views/PodTerminal', '/src/components/drilldown/views/NamespaceDetails']],
-            ['drilldown-data', ['/src/components/drilldown/views/LogViewer', '/src/components/drilldown/views/MetricsViewer', '/src/components/drilldown/views/EventTimeline']],
+            // Split drilldown views by type to reduce 456KB chunk
+            ['drilldown-terminal', ['/src/components/drilldown/views/PodTerminal', '/src/components/drilldown/views/ShellView']],
+            ['drilldown-logs', ['/src/components/drilldown/views/PodLogs', '/src/components/drilldown/views/LogViewer']],
+            ['drilldown-k8s', ['/src/components/drilldown/views/PodEvents', '/src/components/drilldown/views/NamespaceDetails', '/src/components/drilldown/views/NodeDetails']],
+            ['drilldown-data', ['/src/components/drilldown/views/MetricsViewer', '/src/components/drilldown/views/EventTimeline', '/src/components/drilldown/views/TraceViewer']],
             ['drilldown-ui', ['/src/components/drilldown/DrillDownModal', '/src/components/drilldown/DrillDownHeader', '/src/components/drilldown/DrillDownStack']],
+            ['drilldown-views', ['/src/components/drilldown/views/']],
             ['drilldown', ['/src/components/drilldown/']],
             // Dashboard and layout split by concern
             ['dashboard-customizer', ['/src/components/dashboard/customizer/', '/src/components/dashboard/shared/cardCatalog']],
@@ -151,10 +164,11 @@ export default defineConfig(({ mode }) => ({
             ['lib-cache', ['/src/lib/cache/']],
             ['lib-utils', ['/src/lib/utils', '/src/lib/cn.ts', '/src/lib/constants.ts']],
             ['theme-system', ['/src/hooks/useTheme', '/src/hooks/useBranding']],
-            // Split app shell to reduce massive app-routes chunk
+            // Split app shell to reduce massive 5.5M app-routes chunk
             ['app-router', ['/src/components/router/', '/src/lib/router/']],
-            ['app-routes', ['/src/App.tsx']],
-            ['app-shell', ['/src/hooks/usePersistedSettings', '/src/hooks/useAppInit']],
+            ['app-lazy-routes', ['/src/routes/lazyRoutes.ts']],
+            ['app-routes', ['/src/routes/AppRoutes.tsx']],
+            ['app-shell', ['/src/hooks/usePersistedSettings', '/src/hooks/useAppInit', '/src/App.tsx']],
             ['i18n-app', ['/src/lib/i18n.ts', '/src/locales/']],
           ] as const
           for (const [chunkName, needles] of sourceChunkRules) {
@@ -169,18 +183,23 @@ export default defineConfig(({ mode }) => ({
           if (id.includes('/react-router/')) return 'react-router-vendor'
           if (id.includes('/react-reconciler/')) return 'react-reconciler-vendor'
           if (id.includes('/react/')) return 'react-vendor'
-          // three.js ecosystem (split into smaller chunks to reduce three-core and three-drei)
+          // three.js ecosystem (split into smaller chunks to reduce 1MB drei-core chunk)
           if (id.includes('/three-stdlib/')) return 'three-stdlib-vendor'
           if (id.includes('/@react-three/fiber/')) return 'three-fiber-vendor'
-          // Split drei into sub-chunks to reduce 304KB chunk
+          // Split drei more aggressively to reduce 1012KB drei-core-vendor chunk
+          if (id.includes('/@react-three/drei/') && id.includes('/core/shapes')) return 'drei-shapes-vendor'
+          if (id.includes('/@react-three/drei/') && id.includes('/core/misc')) return 'drei-misc-vendor'
           if (id.includes('/@react-three/drei/') && id.includes('/core/')) return 'drei-core-vendor'
           if (id.includes('/@react-three/drei/') && id.includes('/web/')) return 'drei-web-vendor'
+          if (id.includes('/@react-three/drei/') && id.includes('/shaders')) return 'drei-shaders-vendor'
           if (id.includes('/@react-three/drei/')) return 'drei-helpers-vendor'
           if (id.includes('/@react-three/') || id.includes('/zustand/') || id.includes('/stats-gl/')) return 'three-react-vendor'
-          // Split three.js core modules to reduce 708KB chunk
+          // Split three.js core modules to reduce bundle
           if (id.includes('/three/build/three.module.js')) return 'three-core-vendor'
           if (id.includes('/three/src/math/')) return 'three-math-vendor'
           if (id.includes('/three/src/loaders/')) return 'three-loaders-vendor'
+          if (id.includes('/three/src/geometries/')) return 'three-geometries-vendor'
+          if (id.includes('/three/src/materials/')) return 'three-materials-vendor'
           if (id.includes('/three/')) return 'three-extras-vendor'
           // Chart libraries
           if (id.includes('/zrender/')) return 'zrender-vendor'


### PR DESCRIPTION
Fixes #20209

## Summary
Reduces bundle chunk sizes by further splitting large chunks in vite.config.ts.

## Changes
- **cards-misc** (was 2.4M): Split into 10 smaller domain-specific chunks (service-mesh, backup, build, policy, cert, edge, batch, ingress, virtualization)
- **drilldown** (was 456KB): Split into 5 focused chunks (terminal, logs, k8s, data, views)  
- **drei-core-vendor** (was 1012KB): More granular three.js splitting (shapes, misc, shaders, geometries, materials)
- **app-routes** (was 5.5M): Separated app-lazy-routes.ts from app-routes chunk to reduce bundling of all route imports

## Impact
Targets all chunks flagged in Auto-QA report that exceed 300KB threshold. CI build will validate actual bundle sizes.

## Testing
CI will validate build passes and bundle sizes meet performance targets.