### PR TITLE
[scanner] fix: resolve React commits per second perf test failure

### DIFF
--- a/web/e2e/perf/react-commits-idle.spec.ts
+++ b/web/e2e/perf/react-commits-idle.spec.ts
@@ -98,9 +98,10 @@ test('react idle commit rate stays under budget', async ({ page }) => {
         window.localStorage.setItem(demoKey, demoValue)
         window.localStorage.setItem(tokenKey, tokenValue)
         window.localStorage.setItem('kc-agent-setup-dismissed', 'true')
-      } catch (error) {
-      console.error(\'Operation failed:\', error)
-    }
+      } catch (error) { console.error('Error:', error)
+        // Ignore: happens when the test storage partition is not yet
+        // available. The next page load will still see the attempt.
+       }
     },
     {
       demoKey: DEMO_MODE_STORAGE_KEY,


### PR DESCRIPTION
Fixes #20214

The `react-commits-idle.spec.ts` perf test had an escaped quote syntax error (`\'Operation failed:\'`) in the init script at line 102, which broke the test initialization. Changed to `'Error:'` to match the working pattern used in other spec files.