### PR TITLE
[scanner] fix: revert bundle splitting that broke 253 tests

### DIFF
--- a/web/e2e/compliance/i18n-compliance.spec.ts
+++ b/web/e2e/compliance/i18n-compliance.spec.ts
@@ -119,7 +119,7 @@ function safeGetByPath(obj: Record<string, unknown>, dotPath: string): unknown {
  */
 function escapeMdCell(text: string): string {
   return text
-    .replace(/\\/g, '\\\')
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/`/g, '\\`')
     .replace(/</g, '&lt;')

--- a/web/e2e/compliance/security-compliance.spec.ts
+++ b/web/e2e/compliance/security-compliance.spec.ts
@@ -416,7 +416,7 @@ test('security compliance — frontend security audit', async ({ page }, testInf
     try {
       const url = new URL(r.url)
       return url.searchParams.has('token') || url.searchParams.has('access_token')
-    } catch (error) { console.error('Error:', error) return false  }
+    } catch (error) { console.error('Error:', error); return false; }
   })
 
   if (tokenInUrl.length === 0) {

--- a/web/e2e/console-errors/console-error-scan.spec.ts
+++ b/web/e2e/console-errors/console-error-scan.spec.ts
@@ -165,7 +165,7 @@ function getOutputDir(): string {
  */
 function escapeMdCell(text: string): string {
   return text
-    .replace(/\\/g, '\\\')
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/`/g, '\\`')
     .replace(/</g, '&lt;')

--- a/web/e2e/mission-control-stress.spec.ts
+++ b/web/e2e/mission-control-stress.spec.ts
@@ -1178,7 +1178,7 @@ and Prometheus monitoring to track memory usage over time.
             overlay: state.overlay,
             title: state.title,
           }
-        } catch (error) { console.error('Error:', error) return null  }
+        } catch (error) { console.error('Error:', error); return null; }
       }, MC_STORAGE_KEY)
 
       expect(recovered).not.toBeNull()

--- a/web/e2e/mission-journey.spec.ts
+++ b/web/e2e/mission-journey.spec.ts
@@ -395,7 +395,7 @@ async function getMissionStatus(page: Page, missionId?: string): Promise<string 
       if (!Array.isArray(missions)) return null
       const mission = id ? missions.find((m: { id: string }) => m.id === id) : missions[0]
       return mission?.status || null
-    } catch (error) { console.error('Error:', error) return null  }
+    } catch (error) { console.error('Error:', error); return null; }
   }, { id: missionId || null, key: MISSIONS_STORAGE_KEY })
 }
 

--- a/web/e2e/mission-journey.spec.ts
+++ b/web/e2e/mission-journey.spec.ts
@@ -406,7 +406,7 @@ async function getMissionCount(page: Page): Promise<number> {
     try {
       const missions = JSON.parse(raw)
       return Array.isArray(missions) ? missions.length : 0
-    } catch (error) { console.error('Error:', error) return 0  }
+    } catch (error) { console.error('Error:', error); return 0; }
   }, MISSIONS_STORAGE_KEY)
 }
 
@@ -420,7 +420,7 @@ async function getActiveMissions(page: Page): Promise<Array<{ id: string; status
       return missions
         .filter((m: { status: string }) => !['completed', 'failed', 'cancelled', 'saved'].includes(m.status))
         .map((m: { id: string; status: string; title: string }) => ({ id: m.id, status: m.status, title: m.title }))
-    } catch (error) { console.error('Error:', error) return []  }
+    } catch (error) { console.error('Error:', error); return []; }
   }, MISSIONS_STORAGE_KEY)
 }
 

--- a/web/e2e/perf/all-cards-ttfi.spec.ts
+++ b/web/e2e/perf/all-cards-ttfi.spec.ts
@@ -308,7 +308,7 @@ async function getManifestForBatch(page: Page, batch: number, batchSize: number)
       bodyPreview: (document.body.textContent || '').slice(0, 300),
       hasLoginForm: !!document.querySelector('input[type="password"]'),
      }))
-    throw new Error(`TTFI manifest did not load: ${JSON.stringify(debug)}`)
+    throw new Error(`TTFI manifest did not load: ${JSON.stringify(debug)}`, { cause: error })
   }
 
   const manifest = await page.evaluate(() => window.__TTFI_MANIFEST__)

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -129,24 +129,11 @@ export default defineConfig(({ mode }) => ({
             ['cards-cluster', ['/src/components/cards/cluster_health/', '/src/components/cards/cluster_capacity/', '/src/components/cards/cluster_nodes/']],
             ['cards-cost', ['/src/components/cards/cost/', '/src/components/cards/kubecost_status/']],
             ['cards-data', ['/src/components/cards/postgresql_status/', '/src/components/cards/mysql_status/', '/src/components/cards/mongodb_status/']],
-            // Split cards-misc into smaller domain chunks to reduce 2.4M bundle
-            ['cards-service-mesh', ['/src/components/cards/istio_status/', '/src/components/cards/consul_status/']],
-            ['cards-backup', ['/src/components/cards/velero_status/', '/src/components/cards/kasten_status/']],
-            ['cards-build', ['/src/components/cards/tekton_status/', '/src/components/cards/jenkins_status/']],
-            ['cards-policy', ['/src/components/cards/policy/', '/src/components/cards/pod_security/']],
-            ['cards-cert', ['/src/components/cards/cert_manager_status/', '/src/components/cards/vault_status/']],
-            ['cards-edge', ['/src/components/cards/kubeedge_status/', '/src/components/cards/k3s_status/']],
-            ['cards-batch', ['/src/components/cards/job_status/', '/src/components/cards/cronjob_status/']],
-            ['cards-ingress', ['/src/components/cards/nginx_ingress_status/', '/src/components/cards/traefik_status/']],
-            ['cards-virtualization', ['/src/components/cards/kubevirt_status/', '/src/components/cards/kata_status/']],
             ['cards-misc', ['/src/components/cards/']],
-            // Split drilldown views by type to reduce 456KB chunk
-            ['drilldown-terminal', ['/src/components/drilldown/views/PodTerminal', '/src/components/drilldown/views/ShellView']],
-            ['drilldown-logs', ['/src/components/drilldown/views/PodLogs', '/src/components/drilldown/views/LogViewer']],
-            ['drilldown-k8s', ['/src/components/drilldown/views/PodEvents', '/src/components/drilldown/views/NamespaceDetails', '/src/components/drilldown/views/NodeDetails']],
-            ['drilldown-data', ['/src/components/drilldown/views/MetricsViewer', '/src/components/drilldown/views/EventTimeline', '/src/components/drilldown/views/TraceViewer']],
+            // Split drilldown views by type to reduce chunk size
+            ['drilldown-k8s', ['/src/components/drilldown/views/PodLogs', '/src/components/drilldown/views/PodEvents', '/src/components/drilldown/views/PodTerminal', '/src/components/drilldown/views/NamespaceDetails']],
+            ['drilldown-data', ['/src/components/drilldown/views/LogViewer', '/src/components/drilldown/views/MetricsViewer', '/src/components/drilldown/views/EventTimeline']],
             ['drilldown-ui', ['/src/components/drilldown/DrillDownModal', '/src/components/drilldown/DrillDownHeader', '/src/components/drilldown/DrillDownStack']],
-            ['drilldown-views', ['/src/components/drilldown/views/']],
             ['drilldown', ['/src/components/drilldown/']],
             // Dashboard and layout split by concern
             ['dashboard-customizer', ['/src/components/dashboard/customizer/', '/src/components/dashboard/shared/cardCatalog']],
@@ -164,11 +151,10 @@ export default defineConfig(({ mode }) => ({
             ['lib-cache', ['/src/lib/cache/']],
             ['lib-utils', ['/src/lib/utils', '/src/lib/cn.ts', '/src/lib/constants.ts']],
             ['theme-system', ['/src/hooks/useTheme', '/src/hooks/useBranding']],
-            // Split app shell to reduce massive 5.5M app-routes chunk
+            // Split app shell to reduce massive app-routes chunk
             ['app-router', ['/src/components/router/', '/src/lib/router/']],
-            ['app-lazy-routes', ['/src/routes/lazyRoutes.ts']],
-            ['app-routes', ['/src/routes/AppRoutes.tsx']],
-            ['app-shell', ['/src/hooks/usePersistedSettings', '/src/hooks/useAppInit', '/src/App.tsx']],
+            ['app-routes', ['/src/App.tsx']],
+            ['app-shell', ['/src/hooks/usePersistedSettings', '/src/hooks/useAppInit']],
             ['i18n-app', ['/src/lib/i18n.ts', '/src/locales/']],
           ] as const
           for (const [chunkName, needles] of sourceChunkRules) {
@@ -183,23 +169,18 @@ export default defineConfig(({ mode }) => ({
           if (id.includes('/react-router/')) return 'react-router-vendor'
           if (id.includes('/react-reconciler/')) return 'react-reconciler-vendor'
           if (id.includes('/react/')) return 'react-vendor'
-          // three.js ecosystem (split into smaller chunks to reduce 1MB drei-core chunk)
+          // three.js ecosystem (split into smaller chunks to reduce three-core and three-drei)
           if (id.includes('/three-stdlib/')) return 'three-stdlib-vendor'
           if (id.includes('/@react-three/fiber/')) return 'three-fiber-vendor'
-          // Split drei more aggressively to reduce 1012KB drei-core-vendor chunk
-          if (id.includes('/@react-three/drei/') && id.includes('/core/shapes')) return 'drei-shapes-vendor'
-          if (id.includes('/@react-three/drei/') && id.includes('/core/misc')) return 'drei-misc-vendor'
+          // Split drei into sub-chunks to reduce 304KB chunk
           if (id.includes('/@react-three/drei/') && id.includes('/core/')) return 'drei-core-vendor'
           if (id.includes('/@react-three/drei/') && id.includes('/web/')) return 'drei-web-vendor'
-          if (id.includes('/@react-three/drei/') && id.includes('/shaders')) return 'drei-shaders-vendor'
           if (id.includes('/@react-three/drei/')) return 'drei-helpers-vendor'
           if (id.includes('/@react-three/') || id.includes('/zustand/') || id.includes('/stats-gl/')) return 'three-react-vendor'
-          // Split three.js core modules to reduce bundle
+          // Split three.js core modules to reduce 708KB chunk
           if (id.includes('/three/build/three.module.js')) return 'three-core-vendor'
           if (id.includes('/three/src/math/')) return 'three-math-vendor'
           if (id.includes('/three/src/loaders/')) return 'three-loaders-vendor'
-          if (id.includes('/three/src/geometries/')) return 'three-geometries-vendor'
-          if (id.includes('/three/src/materials/')) return 'three-materials-vendor'
           if (id.includes('/three/')) return 'three-extras-vendor'
           // Chart libraries
           if (id.includes('/zrender/')) return 'zrender-vendor'


### PR DESCRIPTION
Fixes #20217, Fixes #20219

Reverts the aggressive bundle chunk splitting from PR #20213 (commit 6ea21f6) which broke 253 unit tests. Also fixes 6 E2E syntax errors introduced by PR #20216's automated quote replacement that broke Playwright tests on main.

### Changes
1. **Revert bundle splitting** — removes chunk splitting config from `vite.config.ts` that caused module resolution failures across the test suite
2. **Fix E2E syntax errors** — repairs corrupted catch blocks (missing semicolons), unterminated string literals, and a missing error cause in 6 spec files

Bundle optimization can be re-attempted with proper test validation.