### PR TITLE
[scanner] fix: add animate-spin to refresh icons in missions, feedback, compliance & history

### DIFF
--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -6,6 +6,7 @@ import {
   Users, ShieldAlert, CheckCircle2, XCircle, AlertTriangle,
   Loader2, RefreshCw, Filter, UserCheck, UserX,
 } from 'lucide-react'
+import { cn } from '../../lib/cn'
 import { authFetch } from '../../lib/api'
 import { DashboardHeader } from '../shared/DashboardHeader'
 import { RotatingTip } from '../ui/RotatingTip'
@@ -95,7 +96,7 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
   if (error) return (
     <div className="flex flex-col items-center justify-center h-64 gap-3">
       <p className="text-red-400 font-medium">{error}</p>
-      <button onClick={fetchData} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-1 p-3 min-h-11 min-w-11"><RefreshCw className="w-4 h-4" /> Retry</button>
+      <button onClick={fetchData} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-1 p-3 min-h-11 min-w-11"><RefreshCw className={cn('w-4 h-4', loading && 'animate-spin')} /> Retry</button>
     </div>
   )
 

--- a/web/src/components/feedback/FeatureRequestList.tsx
+++ b/web/src/components/feedback/FeatureRequestList.tsx
@@ -11,6 +11,7 @@ import {
   Clock,
   RefreshCw,
 } from 'lucide-react'
+import { cn } from '../../lib/cn'
 import {
   useFeatureRequests,
   STATUS_LABELS,
@@ -216,7 +217,7 @@ export function FeatureRequestList() {
           className="p-1 rounded hover:bg-secondary/50 text-muted-foreground"
           title={t('common.refresh')}
         >
-          <RefreshCw className="w-4 h-4" />
+          <RefreshCw className={cn('w-4 h-4', isLoading && 'animate-spin')} />
         </button>
       </div>
 

--- a/web/src/components/missions/MissionBrowserRecommendedTab.tsx
+++ b/web/src/components/missions/MissionBrowserRecommendedTab.tsx
@@ -10,6 +10,7 @@
  */
 
 import { Loader2, Sparkles, RefreshCw, ExternalLink } from 'lucide-react'
+import { cn } from '../../lib/cn'
 import { emitFixerGitHubLink } from '../../lib/analytics'
 import { useTranslation } from 'react-i18next'
 import { CollapsibleSection } from '../ui/CollapsibleSection'
@@ -179,7 +180,7 @@ export function MissionBrowserRecommendedTab({
                 className="p-0.5 rounded hover:bg-secondary/80 text-muted-foreground hover:text-foreground transition-colors"
                 title={tWithFallback('missions.recommended.refreshRecommendations', 'Refresh recommendations')}
               >
-                <RefreshCw className="w-3 h-3" />
+                <RefreshCw className={cn('w-3 h-3', loadingRecommendations && 'animate-spin')} />
               </button>
             </span>
           }

--- a/web/src/components/missions/SaveResolutionDialog.tsx
+++ b/web/src/components/missions/SaveResolutionDialog.tsx
@@ -590,7 +590,7 @@ export function SaveResolutionDialog({
               disabled={isBusy}
               className="flex items-center gap-1 px-2 py-1 text-xs bg-yellow-500/20 hover:bg-yellow-500/30 text-yellow-500 rounded transition-colors disabled:opacity-50"
             >
-              <RefreshCw className="w-3 h-3" />
+              <RefreshCw className={cn('w-3 h-3', isBusy && 'animate-spin')} />
               {t('common.retry')}
             </button>
           </div>


### PR DESCRIPTION
Fixes #20224

Adds conditional animate-spin class to refresh icons in missions, feedback, compliance, and history components so they provide loading feedback when data is being fetched.

Part of #20220