### PR TITLE
[scanner] fix: add health indicators to DashboardGrid

### DIFF
--- a/web/src/components/ui/DashboardGrid.tsx
+++ b/web/src/components/ui/DashboardGrid.tsx
@@ -1,10 +1,25 @@
 import { cn } from '@/lib/cn'
+import { CheckCircle, AlertTriangle, AlertCircle, WifiOff } from 'lucide-react'
 import type { ReactNode } from 'react'
+
+export type HealthStatus = 'healthy' | 'degraded' | 'critical' | 'offline'
+
+interface HealthIndicator {
+  status: HealthStatus
+  message?: string
+  clusterConnectivity?: {
+    total: number
+    connected: number
+    offline: number
+  }
+}
 
 interface DashboardGridProps {
   children: ReactNode
   className?: string
   cols?: 1 | 2 | 3 | 4 | 12
+  health?: HealthIndicator
+  showHealthIndicator?: boolean
 }
 
 const COLS_MAP = {
@@ -15,20 +30,96 @@ const COLS_MAP = {
   12: 'grid-cols-12',
 } as const
 
+const HEALTH_STATUS_CONFIGS = {
+  healthy: {
+    color: 'text-green-400',
+    bgColor: 'bg-green-500/10',
+    borderColor: 'border-green-500/30',
+    icon: CheckCircle,
+    label: 'Healthy',
+  },
+  degraded: {
+    color: 'text-yellow-400',
+    bgColor: 'bg-yellow-500/10',
+    borderColor: 'border-yellow-500/30',
+    icon: AlertTriangle,
+    label: 'Degraded',
+  },
+  critical: {
+    color: 'text-red-400',
+    bgColor: 'bg-red-500/10',
+    borderColor: 'border-red-500/30',
+    icon: AlertCircle,
+    label: 'Critical',
+  },
+  offline: {
+    color: 'text-red-400',
+    bgColor: 'bg-red-500/10',
+    borderColor: 'border-red-500/30',
+    icon: WifiOff,
+    label: 'Offline',
+  },
+} as const
+
 export function DashboardGrid({
   children,
   className,
   cols = 2,
+  health,
+  showHealthIndicator = true,
 }: DashboardGridProps) {
+  const showHealth = health && showHealthIndicator && health.status !== 'healthy'
+  const config = health ? HEALTH_STATUS_CONFIGS[health.status] : null
+  const Icon = config?.icon
+
   return (
-    <div
-      className={cn(
-        'grid gap-4',
-        COLS_MAP[cols],
-        className
+    <div className="space-y-3">
+      {showHealth && config && Icon && (
+        <div className="flex items-center justify-between gap-3">
+          <div
+            className={cn(
+              'inline-flex items-center gap-2 rounded border px-2 py-1 text-xs font-medium',
+              config.bgColor,
+              config.color,
+              config.borderColor
+            )}
+            role="status"
+            aria-label={`Dashboard health: ${config.label}`}
+          >
+            <Icon className="h-3 w-3" aria-hidden="true" />
+            <span>{health.message || config.label}</span>
+          </div>
+
+          {health.clusterConnectivity && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span>
+                Clusters: {health.clusterConnectivity.connected}/{health.clusterConnectivity.total}
+              </span>
+              {health.clusterConnectivity.offline > 0 && (
+                <span
+                  className={cn(
+                    'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs font-medium',
+                    'bg-red-500/10 text-red-400 border border-red-500/30'
+                  )}
+                >
+                  <WifiOff className="h-2 w-2" />
+                  {health.clusterConnectivity.offline} offline
+                </span>
+              )}
+            </div>
+          )}
+        </div>
       )}
-    >
-      {children}
+
+      <div
+        className={cn(
+          'grid gap-4',
+          COLS_MAP[cols],
+          className
+        )}
+      >
+        {children}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Fixes #20232

## Changes
- Added health/status indicator system to DashboardGrid component
- Shows cluster connectivity status (connected/total/offline counts)
- Added visual alerts for unhealthy resources with color-coded badges
- Supports healthy/degraded/critical/offline states following existing ClusterStatusBadge patterns
- Optional `health` prop maintains backward compatibility with existing usage

## Implementation
- Added `HealthStatus` type and `HealthIndicator` interface
- Implemented health status badge with icon, color, and message
- Added cluster connectivity display showing online/offline counts
- Used existing color/styling patterns from ClusterStatusBadge and DashboardHealthIndicator
- Health indicator only shows when status is not healthy