### PR TITLE
[scanner] fix: add demo mode subscription to InstallCTAFlow and related components

### DIFF
--- a/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
+++ b/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
@@ -8,6 +8,7 @@ import { ConfirmMissionPromptDialog } from '../../missions/ConfirmMissionPromptD
 import { useMissions } from '../../../hooks/useMissions'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { useModalState } from '../../../lib/modals'
+import { useDemoMode } from '../../../hooks/useDemoMode'
 
 /** Timeout for fetching KB guide data (ms) */
 const KB_FETCH_TIMEOUT_MS = 10_000
@@ -24,14 +25,20 @@ export interface InstallCTAFlowProps {
  * 3. ConfirmMissionPromptDialog (review/edit prompt)
  * 4. Manual install guide modal (when agent not connected)
  *
- * This component does not fetch card data or own demo-mode state. It is only
- * rendered by cards that are already in a demo/live state decided upstream.
+ * This component subscribes to demo mode state to hide itself when demo mode
+ * is toggled off, ensuring the CTA doesn't persist after switching to live data.
  */
 export function InstallCTAFlow({ cardType, title }: InstallCTAFlowProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { startMission, openSidebar } = useMissions()
   const { status: agentStatus } = useLocalAgent()
   const isAgentConnected = agentStatus === 'connected'
+  const { isDemoMode } = useDemoMode()
+
+  // Hide the CTA when demo mode is off
+  if (!isDemoMode) {
+    return null
+  }
 
   const installInfo = CARD_INSTALL_MAP[cardType]
 


### PR DESCRIPTION
Fixes #20234

Added `useDemoMode()` subscription to `InstallCTAFlow` component to ensure it hides immediately when users toggle out of demo mode.

## Changes

- Added `useDemoMode()` hook import and usage in `InstallCTAFlow.tsx`
- Added early return `if (!isDemoMode) return null` to hide component when demo mode is off
- Updated component documentation to reflect demo mode subscription behavior

## Problem

The InstallCTAFlow component was missing a subscription to demo mode state changes. When users toggled demo mode off, the "Install for live data" button would persist until the parent CardWrapper re-rendered for other reasons, causing UI confusion.

## Solution

By subscribing to demo mode state via `useDemoMode()` hook, the component now reactively hides itself immediately when demo mode is toggled off, providing instant feedback to users.