### PR TITLE
[scanner] fix: stabilize flaky onboarding tour skip test

### DIFF
--- a/web/e2e/user-flows/onboarding-tour.spec.ts
+++ b/web/e2e/user-flows/onboarding-tour.spec.ts
@@ -134,6 +134,12 @@ test.describe('Onboarding Tour', () => {
       return
     }
 
+    // Wait for any modal/overlay backdrop to disappear before clicking
+    const overlay = page.locator('.fixed.inset-0, [class*="backdrop"], [class*="overlay"]').first()
+    await overlay.waitFor({ state: 'hidden', timeout: 2000 }).catch(() => {
+      // Overlay might not exist or already hidden - safe to proceed
+    })
+
     await skipBtn.first().click()
 
     const tooltip = page.locator('[class*="tour"], [class*="joyride"], [class*="onboarding"]')


### PR DESCRIPTION
Fixes #20243

## Problem

The onboarding tour "Tour Skip dismisses tour" Playwright test is flaky in CI shard 4. The skip button click times out (75s) because a modal overlay div (`<div class="fixed inset-0 bg-black/60 backdrop-blur-xs z-modal ...">`) intercepts pointer events, causing 111+ retry cycles before timeout.

## Fix

Add explicit wait for overlay/backdrop dismissal before clicking the skip button. The `.catch()` handles the case where no overlay exists (test proceeds normally). This ensures the click reaches the intended element without racing against backdrop animations.