### PR TITLE
[scanner] fix: resolve InstallCTAFlow hooks violation and click interception

### DIFF
--- a/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
+++ b/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
@@ -34,14 +34,6 @@ export function InstallCTAFlow({ cardType, title }: InstallCTAFlowProps) {
   const { status: agentStatus } = useLocalAgent()
   const isAgentConnected = agentStatus === 'connected'
   const { isDemoMode } = useDemoMode()
-
-  // Hide the CTA when demo mode is off
-  if (!isDemoMode) {
-    return null
-  }
-
-  const installInfo = CARD_INSTALL_MAP[cardType]
-
   const { isOpen: showClusterSelect, open: openClusterSelect, close: closeClusterSelect } = useModalState()
   const [showInstallGuide, setShowInstallGuide] = useState<{
     mission: { mission?: { title?: string; description?: string; steps?: { title?: string; description?: string }[] } }
@@ -52,6 +44,13 @@ export function InstallCTAFlow({ cardType, title }: InstallCTAFlowProps) {
   } | null>(null)
   const [isPreparingInstall, setIsPreparingInstall] = useState(false)
   const [installError, setInstallError] = useState<string | null>(null)
+
+  // Hide the CTA when demo mode is off
+  if (!isDemoMode) {
+    return null
+  }
+
+  const installInfo = CARD_INSTALL_MAP[cardType]
 
   const installProjectName = installInfo?.project ?? t('cards:installFlow.componentsFallback', 'components')
   const installCtaLabel = isPreparingInstall
@@ -88,7 +87,7 @@ export function InstallCTAFlow({ cardType, title }: InstallCTAFlowProps) {
   return (
     <>
       {/* Install CTA button */}
-      <div className="mt-auto border-t border-yellow-500/10 pt-2">
+      <div className="border-t border-yellow-500/10 pt-2">
         <button
           onClick={(e) => { e.stopPropagation(); void handleClick() }}
           disabled={isPreparingInstall}


### PR DESCRIPTION
Fixes #20246, Fixes #20247

## Problem

PR #20240 introduced two bugs in `InstallCTAFlow.tsx`:

1. **Hooks violation (#20246)**: An early return `if (!isDemoMode) return null` was placed before `useModalState()` and 4x `useState()` calls, violating React's rules-of-hooks. This caused every open PR's `build-gate` to fail lint.

2. **Click interception (#20247)**: The CTA container used `mt-auto` which caused it to expand and intercept pointer events on sibling layout buttons during Playwright E2E tests.

## Fix

- Move all hook calls (`useModalState`, `useState` × 4) before the early return
- Remove `mt-auto` from the CTA container div

Both are minimal, safe rearrangements with no logic changes.