### PR TITLE
[scanner] fix: use file-tracking beforeEach for cross-file stub isolation

### DIFF
--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,4 +1,4 @@
-import { afterEach, afterAll, vi } from 'vitest'
+import { afterEach, beforeEach, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
@@ -205,12 +205,15 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-// Cleanup after all tests in the file.
-// NOTE: vi.unstubAllGlobals() runs once per file (not per test) to prevent
-// cross-file stub leaks in sharded mode while preserving within-file stubs.
-// In sharded runs, multiple test files share the same worker. Without cleanup,
-// test file A's stubbed fetch can leak into test file B. Moving to afterAll
-// fixes the leak while allowing tests within a file to set stubs at file scope.
-afterAll(() => {
-  vi.unstubAllGlobals()
+// Clear stubs when transitioning to a new test file.
+// In vitest, setupFiles afterAll runs once per worker (not per file), so stubs
+// from FileA leak into FileB. This beforeEach tracks file transitions and clears
+// stubs only when a new file starts, fixing cross-file contamination without
+// requiring changes to individual test files.
+let lastFile = ''
+beforeEach(({ task }) => {
+  if (task.file.name !== lastFile) {
+    vi.unstubAllGlobals()
+    lastFile = task.file.name
+  }
 })


### PR DESCRIPTION
Fixes #20249, Fixes #20250

## Problem

PR #20244 moved `vi.unstubAllGlobals()` from `afterEach` to `afterAll` in `web/src/test/setup.ts`. This fixed 215 within-file failures but left 253 cross-file stub leaks. In vitest, `setupFiles` `afterAll` hooks run once per worker — not per file — so stubs from FileA still contaminate FileB/FileC.

## Fix

Replace the `afterAll` unstub with a `beforeEach` that tracks file transitions:
- Calls `vi.unstubAllGlobals()` only when the first test of a NEW file starts
- Zero changes needed to individual test files
- Preserves within-file stub behavior (stubs stay active throughout a file's tests)