### PR TITLE
[ci-maintainer] fix: revert beforeEach stub-clear to afterAll (Coverage Suite regression)

### DIFF
--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, vi } from 'vitest'
+import { afterAll, afterEach, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
@@ -205,15 +205,13 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-// Clear stubs when transitioning to a new test file.
-// In vitest, setupFiles afterAll runs once per worker (not per file), so stubs
-// from FileA leak into FileB. This beforeEach tracks file transitions and clears
-// stubs only when a new file starts, fixing cross-file contamination without
-// requiring changes to individual test files.
-let lastFile = ''
-beforeEach(({ task }) => {
-  if (task.file.name !== lastFile) {
-    vi.unstubAllGlobals()
-    lastFile = task.file.name
-  }
+// Clear global stubs after every test file.
+// In vitest 4.x with pool:'forks'/isolate:false and maxWorkers:1 (CI), all test
+// files in a shard share one worker process, so vi.stubGlobal() calls in one
+// file's beforeAll leak into subsequent files.
+// afterAll in setupFiles runs once per worker (end of shard), not once per file,
+// so this only partially mitigates contamination — see issue #20256 for the
+// full architectural fix (pool:'forks', isolate:true).
+afterAll(() => {
+  vi.unstubAllGlobals()
 })


### PR DESCRIPTION
## CI Fix

### Problem
PR #20253 added a `beforeEach` in `web/src/test/setup.ts` to detect file transitions and call `vi.unstubAllGlobals()`. This caused Coverage Suite failures to jump from **253 → 477** (224 additional failures).

### Root Cause
In Vitest 4.x with `maxWorkers: 1`, the `setupFiles.beforeEach` fires **after** the new test file's `beforeAll` has already run:

```
testFile.beforeAll()        // stubs set via vi.stubGlobal()
setupFiles.beforeEach()     // vi.unstubAllGlobals() fires HERE — destroys those stubs
testFile.beforeEach()
test body                   // stub is gone → test fails
```

Any file that calls `vi.stubGlobal()` in `beforeAll` is broken by this ordering.

### Fix
Replace the broken `beforeEach` block with `afterAll(() => vi.unstubAllGlobals())`. The `afterAll` in setupFiles runs once per shard worker (end of run), which safely clears stubs without interfering with any file's setup hooks.

This restores the 253-failure baseline from before PR #20253.

### Follow-up
Issue #20256 tracks the architectural fix (`isolate: true` in vite.config.ts) to eliminate the remaining 253 failures by giving each test file its own isolated subprocess.

Fixes #20255

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*