### PR TITLE
[scanner] fix: enable vitest isolate mode to prevent stub cross-contamination

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -316,6 +316,9 @@ export default defineConfig(({ mode }) => ({
     // CI runners (2-core, 7GB) OOM with 600+ test files at full concurrency
     maxWorkers: process.env.CI ? 1 : undefined,
     minWorkers: process.env.CI ? 1 : undefined,
+    // isolate: true ensures each test file runs in its own subprocess with a clean global environment,
+    // preventing vi.stubGlobal() cross-contamination between files (#20256)
+    isolate: true,
     // poolOptions.forks removed — deprecated in Vitest 4 (#5860).
     // maxWorkers/minWorkers above handle fork limits; teardownTimeout
     // above handles worker termination timeout.


### PR DESCRIPTION
Fixes #20256

## Fix

Adds `isolate: true` to the vitest test config in `web/vite.config.ts`.

With Vitest 4.x, `isolate` defaults to `false` for performance, meaning all test files in a shard share one worker process. This causes `vi.stubGlobal()` calls in one file's `beforeAll` to persist into subsequent files, producing 253 test failures.

Setting `isolate: true` with `pool: 'forks'` ensures each test file runs in its own subprocess with a clean global environment, eliminating cross-file stub contamination.

Follows PR #20257 which reverted the broken `beforeEach` approach.