### PR TITLE
[scanner] fix: add vitest test step to pre-merge gate

### DIFF
--- a/.github/workflows/pre-merge-gate.yml
+++ b/.github/workflows/pre-merge-gate.yml
@@ -40,3 +40,9 @@ jobs:
       - name: Frontend lint
         working-directory: web
         run: npm run lint:check
+
+      - name: Frontend test (gate subset)
+        working-directory: web
+        run: npx vitest run --exclude 'harness/**' --exclude 'src/components/missions/**' --exclude 'src/components/mission-control/**' --exclude 'src/lib/__tests__/demoMode*' --exclude 'src/lib/dynamic-cards/**' --exclude 'src/hooks/__tests__/useDemoMode*' --exclude 'src/hooks/__tests__/useStackDiscovery*' --exclude 'src/hooks/mcp/**' --exclude 'src/contexts/__tests__/**' --exclude 'src/components/teams/**' --exclude 'src/config/cards/**' --exclude 'src/components/cards/grpc_status/**' --exclude 'src/components/cards/linkerd_status/**' --exclude 'src/components/cards/rook_status/**' --exclude 'src/components/cards/spiffe_status/**' --exclude 'src/components/cards/quantum/**' --exclude 'src/components/cards/llmd/**' --exclude 'src/lib/constants/__tests__/**'
+        env:
+          CI: true


### PR DESCRIPTION
Fixes #20263

Adds a vitest run step to the pre-merge gate workflow. Excludes the 253 currently-failing test files (tracked in #20262 child issues #20264-#20268) to avoid blocking all PRs. As child issues are resolved, the exclusion list should be narrowed until the gate runs the full suite.

## Changes
- `.github/workflows/pre-merge-gate.yml`: Added frontend test step with exclusions

## Excluded test directories
- `harness/**` — test infrastructure failures
- `src/components/missions/**` — mission component tests
- `src/components/mission-control/**` — mission control tests
- `src/lib/__tests__/demoMode*` — demo mode tests
- `src/lib/dynamic-cards/**` — dynamic card tests
- `src/hooks/__tests__/useDemoMode*` — demo mode hook tests
- `src/hooks/__tests__/useStackDiscovery*` — stack discovery tests
- `src/hooks/mcp/**` — MCP hook tests
- `src/contexts/__tests__/**` — context tests
- `src/components/teams/**` — teams component tests
- `src/config/cards/**` — card config tests
- `src/components/cards/grpc_status/**` — gRPC status card tests
- `src/components/cards/linkerd_status/**` — Linkerd status card tests
- `src/components/cards/rook_status/**` — Rook status card tests
- `src/components/cards/spiffe_status/**` — SPIFFE status card tests
- `src/components/cards/quantum/**` — quantum card tests
- `src/components/cards/llmd/**` — LLMD card tests
- `src/lib/constants/__tests__/**` — constants tests

These exclusions ensure passing tests run in CI to catch regressions while avoiding blocking PRs on known failures.