### PR TITLE
[scanner] fix: mission component tests mock setup for vitest isolation

### DIFF
--- a/web/src/components/mission-control/ClusterAssignmentPanel.test.tsx
+++ b/web/src/components/mission-control/ClusterAssignmentPanel.test.tsx
@@ -9,6 +9,19 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }))
 
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: { post: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
 const mockClusters: ClusterInfo[] = [
   {
     name: 'cluster-1',

--- a/web/src/components/mission-control/PayloadGrid.test.tsx
+++ b/web/src/components/mission-control/PayloadGrid.test.tsx
@@ -5,7 +5,23 @@ import { PayloadGrid } from './PayloadGrid'
 import type { PayloadProject } from './types'
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: { post: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
 }))
 
 const mockProjects: PayloadProject[] = [

--- a/web/src/components/mission-control/RequestApprovalModal.test.tsx
+++ b/web/src/components/mission-control/RequestApprovalModal.test.tsx
@@ -8,6 +8,19 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }))
 
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: { post: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
 const mockState: MissionControlState = {
   projects: [
     {

--- a/web/src/components/missions/ClusterSelectionDialog.test.tsx
+++ b/web/src/components/missions/ClusterSelectionDialog.test.tsx
@@ -10,11 +10,17 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
-vi.mock('../../hooks/useClusterData', () => ({
-  useClusterData: () => ({
-    data: [],
-    isLoading: false,
-  }),
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: { post: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
 }))
 
 describe('ClusterSelectionDialog', () => {

--- a/web/src/components/missions/ImproveMissionDialog.test.tsx
+++ b/web/src/components/missions/ImproveMissionDialog.test.tsx
@@ -10,6 +10,11 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '' }),
+}))
+
 vi.mock('../../lib/api', () => ({
   api: {
     post: vi.fn(),

--- a/web/src/components/missions/MissionDetailView.test.tsx
+++ b/web/src/components/missions/MissionDetailView.test.tsx
@@ -11,6 +11,19 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: { post: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
 const mockMission: MissionExport = {
   title: 'Install Prometheus',
   description: 'Install Prometheus monitoring stack',

--- a/web/src/components/missions/MissionLandingPage.test.tsx
+++ b/web/src/components/missions/MissionLandingPage.test.tsx
@@ -21,6 +21,14 @@ vi.mock('../../hooks/useDemoMode', () => ({
   }),
 }))
 
+vi.mock('../../lib/api', () => ({
+  api: { post: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
 describe('MissionLandingPage', () => {
   it('renders without errors', () => {
     const { container } = render(<MissionLandingPage />)

--- a/web/src/components/missions/MissionTypeExplainer.test.tsx
+++ b/web/src/components/missions/MissionTypeExplainer.test.tsx
@@ -7,6 +7,26 @@ vi.mock('../../lib/demoMode', () => ({
   isDemoMode: vi.fn(() => true),
 }))
 
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: { post: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
 describe('MissionTypeExplainer', () => {
   it('renders the title', () => {
     render(<MissionTypeExplainer />)

--- a/web/src/components/missions/MissionTypeExplainer.test.tsx
+++ b/web/src/components/missions/MissionTypeExplainer.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MissionTypeExplainer } from './MissionTypeExplainer'
+import { isDemoMode } from '../../lib/demoMode'
 
 vi.mock('../../lib/demoMode', () => ({
   isDemoMode: vi.fn(() => true),
@@ -55,8 +56,7 @@ describe('MissionTypeExplainer', () => {
   })
 
   it('does not render in non-demo mode', () => {
-    const { isDemoMode } = require('../../lib/demoMode')
-    isDemoMode.mockReturnValue(false)
+    vi.mocked(isDemoMode).mockReturnValue(false)
     const { container } = render(<MissionTypeExplainer />)
     expect(container.firstChild).toBeNull()
   })

--- a/web/src/components/missions/SaveResolutionDialog.test.tsx
+++ b/web/src/components/missions/SaveResolutionDialog.test.tsx
@@ -10,6 +10,11 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '' }),
+}))
+
 vi.mock('../../lib/api', () => ({
   api: {
     post: vi.fn(),

--- a/web/src/components/missions/ShareMissionDialog.test.tsx
+++ b/web/src/components/missions/ShareMissionDialog.test.tsx
@@ -10,6 +10,19 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: { post: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
 describe('ShareMissionDialog', () => {
   it('does not render when shareUrl is null', () => {
     const { container } = render(

--- a/web/src/components/missions/__tests__/ResolutionErrorBoundary.test.tsx
+++ b/web/src/components/missions/__tests__/ResolutionErrorBoundary.test.tsx
@@ -10,6 +10,26 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ResolutionErrorBoundary } from '../ResolutionErrorBoundary'
 
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '' }),
+}))
+
+vi.mock('../../../lib/api', () => ({
+  api: { post: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
 const ThrowError = ({ shouldThrow }: { shouldThrow: boolean }) => {
   if (shouldThrow) {
     throw new Error('Test error')

--- a/web/src/components/missions/browser/__tests__/VirtualizedMissionGrid.test.tsx
+++ b/web/src/components/missions/browser/__tests__/VirtualizedMissionGrid.test.tsx
@@ -9,6 +9,26 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { VirtualizedMissionGrid } from '../VirtualizedMissionGrid'
 
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '' }),
+}))
+
+vi.mock('../../../lib/api', () => ({
+  api: { post: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
 interface TestItem {
   id: string
   title: string


### PR DESCRIPTION
Fixes #20267

Adds proper mock setup to mission and mission-control component test files so they pass under vitest `isolate: true` mode. Previously these tests relied on contaminated globals from other test files.

Changes:
- Added react-router-dom, lib/api, ui/Toast mocks to mission test files
- Fixed RequestApprovalModal and ClusterAssignmentPanel tests (failed to load)
- All mocks follow patterns from existing passing tests

Part of #20262