### PR TITLE
[scanner] fix: card and team component tests mock setup for vitest isolation

### DIFF
--- a/web/src/components/cards/__tests__/CardToolbar.test.tsx
+++ b/web/src/components/cards/__tests__/CardToolbar.test.tsx
@@ -30,6 +30,14 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
+vi.mock('lucide-react', () => ({
+  ChevronDown: () => <span>ChevronDown</span>,
+  ChevronRight: () => <span>ChevronRight</span>,
+  RefreshCw: () => <span>RefreshCw</span>,
+  Maximize2: () => <span>Maximize2</span>,
+  Bug: () => <span>Bug</span>,
+}))
+
 vi.mock('../card-wrapper/CardActionMenu', () => ({
   CardActionMenu: () => <div data-testid="card-action-menu-stub" />,
 }))


### PR DESCRIPTION
Fixes #20264

Adds lucide-react mock to CardToolbar test so icons render correctly under vitest `isolate: true` mode.

Part of #20262