### PR TITLE
[scanner] fix: lib and hooks tests mock setup for vitest isolation

### DIFF
--- a/web/src/hooks/__tests__/useDemoMode.test.ts
+++ b/web/src/hooks/__tests__/useDemoMode.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
+// Unmock both demoMode and useDemoMode to test hook integration
+vi.unmock('../../lib/demoMode')
+vi.unmock('../useDemoMode')
+
 // Keys must match the values from lib/constants/storage.ts
 const DEMO_MODE_KEY = 'kc-demo-mode'
 const _TOKEN_KEY = 'token'

--- a/web/src/lib/__tests__/demoMode.test.ts
+++ b/web/src/lib/__tests__/demoMode.test.ts
@@ -1,5 +1,29 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { waitFor } from '@testing-library/react'
+
+// Mock StorageEvent for cross-tab sync tests
+if (typeof global.StorageEvent === 'undefined') {
+  global.StorageEvent = class StorageEvent extends Event {
+    key: string | null
+    newValue: string | null
+    oldValue: string | null
+    url: string
+    storageArea: Storage | null
+    
+    constructor(type: string, init?: StorageEventInit) {
+      super(type, init)
+      this.key = init?.key ?? null
+      this.newValue = init?.newValue ?? null
+      this.oldValue = init?.oldValue ?? null
+      this.url = init?.url ?? ''
+      this.storageArea = init?.storageArea ?? null
+    }
+  } as unknown as typeof StorageEvent
+}
+
+// Unmock demoMode to test the REAL implementation (setup.ts globally mocks it)
+vi.unmock('../demoMode')
+
 import {
   isDemoMode,
   isDemoToken,

--- a/web/src/lib/__tests__/demoModeToggle-regression.test.ts
+++ b/web/src/lib/__tests__/demoModeToggle-regression.test.ts
@@ -14,6 +14,20 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+// Mock CustomEvent for demo mode event dispatch tests
+if (typeof global.CustomEvent === 'undefined') {
+  global.CustomEvent = class CustomEvent<T = unknown> extends Event {
+    detail: T
+    constructor(type: string, init?: CustomEventInit<T>) {
+      super(type, init)
+      this.detail = init?.detail as T
+    }
+  } as unknown as typeof CustomEvent
+}
+
+// Unmock demoMode to test the REAL implementation (setup.ts globally mocks it)
+vi.unmock('../../lib/demoMode')
+
 // ---------------------------------------------------------------------------
 // Constants (mirror source values)
 // ---------------------------------------------------------------------------

--- a/web/src/lib/constants/__tests__/network.test.ts
+++ b/web/src/lib/constants/__tests__/network.test.ts
@@ -220,11 +220,8 @@ describe('getLocalAgentURLs', () => {
 
 describe('suppressLocalAgent', () => {
   it('suppresses agent URLs when called with true', () => {
-    const initialWsUrl = LOCAL_AGENT_WS_URL
-    const initialHttpUrl = LOCAL_AGENT_HTTP_URL
-    
     suppressLocalAgent(true)
-    
+
     expect(LOCAL_AGENT_WS_URL).toBe('ws://localhost:1/disabled')
     expect(LOCAL_AGENT_HTTP_URL).toBe('')
     expect(isLocalAgentSuppressed()).toBe(true)
@@ -233,7 +230,7 @@ describe('suppressLocalAgent', () => {
   it('does not un-suppress once suppressed', () => {
     suppressLocalAgent(true)
     expect(isLocalAgentSuppressed()).toBe(true)
-    
+
     suppressLocalAgent(false)
     expect(isLocalAgentSuppressed()).toBe(true)
   })
@@ -248,7 +245,7 @@ describe('suppressOptionalPollers', () => {
   it('remains suppressed once set', () => {
     suppressOptionalPollers(true)
     expect(areOptionalPollersSuppressed()).toBe(true)
-    
+
     suppressOptionalPollers(false)
     expect(areOptionalPollersSuppressed()).toBe(true)
   })
@@ -259,7 +256,7 @@ describe('getWsBackoffDelay', () => {
     const delay = getWsBackoffDelay(0)
     const expectedMin = WS_RECONNECT_BASE_DELAY_MS
     const expectedMax = WS_RECONNECT_BASE_DELAY_MS + WS_BACKOFF_JITTER_MAX_MS
-    
+
     expect(delay).toBeGreaterThanOrEqual(expectedMin)
     expect(delay).toBeLessThan(expectedMax)
   })
@@ -267,13 +264,13 @@ describe('getWsBackoffDelay', () => {
   it('returns exponential backoff for successive attempts', () => {
     const delay1 = getWsBackoffDelay(1)
     const delay2 = getWsBackoffDelay(2)
-    
+
     const expectedMin1 = WS_RECONNECT_BASE_DELAY_MS * 2
     const expectedMax1 = WS_RECONNECT_BASE_DELAY_MS * 2 + WS_BACKOFF_JITTER_MAX_MS
-    
+
     const expectedMin2 = WS_RECONNECT_BASE_DELAY_MS * 4
     const expectedMax2 = WS_RECONNECT_BASE_DELAY_MS * 4 + WS_BACKOFF_JITTER_MAX_MS
-    
+
     expect(delay1).toBeGreaterThanOrEqual(expectedMin1)
     expect(delay1).toBeLessThan(expectedMax1)
     expect(delay2).toBeGreaterThanOrEqual(expectedMin2)
@@ -284,7 +281,7 @@ describe('getWsBackoffDelay', () => {
     const delay = getWsBackoffDelay(10)
     const expectedMin = WS_RECONNECT_MAX_DELAY_MS
     const expectedMax = WS_RECONNECT_MAX_DELAY_MS + WS_BACKOFF_JITTER_MAX_MS
-    
+
     expect(delay).toBeGreaterThanOrEqual(expectedMin)
     expect(delay).toBeLessThan(expectedMax)
   })
@@ -292,7 +289,7 @@ describe('getWsBackoffDelay', () => {
   it('adds random jitter on each call', () => {
     const delays = Array.from({ length: 5 }, () => getWsBackoffDelay(0))
     const uniqueDelays = new Set(delays)
-    
+
     expect(uniqueDelays.size).toBeGreaterThan(1)
   })
 })

--- a/web/src/lib/constants/__tests__/network.test.ts
+++ b/web/src/lib/constants/__tests__/network.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock process.env before importing the module
+vi.stubEnv('NODE_ENV', 'test')
+
 import {
   LOCAL_AGENT_WS_URL,
   LOCAL_AGENT_HTTP_URL,

--- a/web/src/lib/dynamic-cards/__tests__/compiler.sandbox-hardening.test.ts
+++ b/web/src/lib/dynamic-cards/__tests__/compiler.sandbox-hardening.test.ts
@@ -8,8 +8,28 @@
  * - Prototype chain freezing in deepFreeze
  * - Async createCardComponent (blob URL ES module approach)
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createCardComponent } from '../compiler'
+
+// Mock browser APIs for Node environment
+beforeEach(() => {
+  if (typeof global.Blob === 'undefined') {
+    global.Blob = class Blob {
+      constructor(public parts: BlobPart[], public options?: BlobPropertyBag) {}
+      size = 0
+      type = this.options?.type || ''
+      slice() { return new Blob(this.parts, this.options) }
+      async text() { return this.parts.join('') }
+      async arrayBuffer() { return new ArrayBuffer(0) }
+      stream() { return new ReadableStream() }
+    } as unknown as typeof Blob
+  }
+  
+  if (typeof global.URL.createObjectURL === 'undefined') {
+    global.URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    global.URL.revokeObjectURL = vi.fn()
+  }
+})
 
 // Mock sucrase (transform is not invoked for createCardComponent)
 vi.mock('sucrase', () => ({

--- a/web/src/lib/dynamic-cards/__tests__/compiler.test.ts
+++ b/web/src/lib/dynamic-cards/__tests__/compiler.test.ts
@@ -1,5 +1,25 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { compileCardCode, createCardComponent } from '../compiler'
+
+// Mock browser APIs needed for compiler (Blob, URL.createObjectURL)
+beforeEach(() => {
+  if (typeof global.Blob === 'undefined') {
+    global.Blob = class Blob {
+      constructor(public parts: BlobPart[], public options?: BlobPropertyBag) {}
+      size = 0
+      type = this.options?.type || ''
+      slice() { return new Blob(this.parts, this.options) }
+      async text() { return this.parts.join('') }
+      async arrayBuffer() { return new ArrayBuffer(0) }
+      stream() { return new ReadableStream() }
+    } as unknown as typeof Blob
+  }
+  
+  if (typeof global.URL.createObjectURL === 'undefined') {
+    global.URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    global.URL.revokeObjectURL = vi.fn()
+  }
+})
 
 // Mock sucrase
 vi.mock('sucrase', () => ({


### PR DESCRIPTION
Fixes #20266

Adds proper mock setup to lib and hooks test files so they pass under vitest `isolate: true` mode.

Key changes:
- Unmocked `demoMode` module for tests that need real implementation
- Added `StorageEvent` & `CustomEvent` polyfills for browser event tests
- Added `Blob` & `URL.createObjectURL` mocks for compiler sandbox tests
- Stubbed `NODE_ENV` for environment-dependent tests
- Fixed useStackDiscovery tests that failed to load (missing dependency mocks)

Part of #20262