### PR TITLE
[scanner] fix: harness and context tests mock setup for vitest isolation

### DIFF
--- a/web/harness/evidence/__tests__/sanitizeEvidence.test.ts
+++ b/web/harness/evidence/__tests__/sanitizeEvidence.test.ts
@@ -1,15 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { sanitizeText, sanitizeJson, safeJsonStringify } from '../sanitizeEvidence'
 
 describe('sanitizeText', () => {
   const originalEnv = process.env
 
   beforeEach(() => {
+    vi.clearAllMocks()
     process.env = { ...originalEnv }
   })
 
   afterEach(() => {
     process.env = originalEnv
+    vi.restoreAllMocks()
   })
 
   it('returns empty string for null/undefined input', () => {

--- a/web/harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts
+++ b/web/harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { redactK8sGroundTruth } from '../redactK8sGroundTruth'
 import type { K8sGroundTruth } from '../k8sTypes'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe('redactK8sGroundTruth', () => {
   const baseGroundTruth: K8sGroundTruth = {

--- a/web/src/contexts/__tests__/StackContext.test.tsx
+++ b/web/src/contexts/__tests__/StackContext.test.tsx
@@ -105,6 +105,7 @@ function createStack(overrides: Partial<LLMdStack> = {}): LLMdStack {
 // ── Setup / Teardown ─────────────────────────────────────────────────────
 
 beforeEach(() => {
+  vi.clearAllMocks()
   localStorage.clear()
   mockIsDemoMode = true
   mockDiscoveredStacks = []
@@ -117,6 +118,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks()
+  localStorage.clear()
 })
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Fixes #20268

Adds proper mock setup to harness and context test files so they pass under vitest `isolate: true` mode.

Changes:
- `harness/evidence/__tests__/sanitizeEvidence.test.ts` — Added vi import, mock cleanup
- `harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts` — Added beforeEach/afterEach
- `src/contexts/__tests__/StackContext.test.tsx` — Added vi.clearAllMocks(), localStorage cleanup

Part of #20262