### PR TITLE
[scanner] fix: resolve nightly release workflow failure

### DIFF
--- a/pkg/api/handlers/auth_compat_test.go
+++ b/pkg/api/handlers/auth_compat_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestRequireAdmin(t *testing.T) {
-	s := store.OpenTestDB(t)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -80,6 +79,7 @@ func TestRequireAdmin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			s := store.OpenTestDB(t)
 			app := fiber.New()
 			userID := tt.setupUser(t, s)
 
@@ -100,7 +100,6 @@ func TestRequireAdmin(t *testing.T) {
 }
 
 func TestRequireEditorOrAdmin(t *testing.T) {
-	s := store.OpenTestDB(t)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -160,6 +159,7 @@ func TestRequireEditorOrAdmin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			s := store.OpenTestDB(t)
 			app := fiber.New()
 			userID := tt.setupUser(t, s)
 
@@ -180,7 +180,6 @@ func TestRequireEditorOrAdmin(t *testing.T) {
 }
 
 func TestRequireViewerOrAbove(t *testing.T) {
-	s := store.OpenTestDB(t)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -247,6 +246,7 @@ func TestRequireViewerOrAbove(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			s := store.OpenTestDB(t)
 			app := fiber.New()
 			userID := tt.setupUser(t, s)
 
@@ -267,7 +267,6 @@ func TestRequireViewerOrAbove(t *testing.T) {
 }
 
 func TestRequireEditorOrAdminMiddleware(t *testing.T) {
-	s := store.OpenTestDB(t)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -327,6 +326,7 @@ func TestRequireEditorOrAdminMiddleware(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			s := store.OpenTestDB(t)
 			app := fiber.New()
 			userID := tt.setupUser(t, s)
 

--- a/pkg/api/handlers/feedback/github_app_auth_test.go
+++ b/pkg/api/handlers/feedback/github_app_auth_test.go
@@ -66,19 +66,14 @@ func TestNewGitHubAppTokenProvider(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Clear env vars before each test
-			os.Unsetenv("KUBESTELLAR_CONSOLE_APP_ID")
-			os.Unsetenv("KUBESTELLAR_CONSOLE_APP_INSTALLATION_ID")
-			os.Unsetenv("KUBESTELLAR_CONSOLE_APP_PRIVATE_KEY")
+			t.Setenv("KUBESTELLAR_CONSOLE_APP_ID", "")
+			t.Setenv("KUBESTELLAR_CONSOLE_APP_INSTALLATION_ID", "")
+			t.Setenv("KUBESTELLAR_CONSOLE_APP_PRIVATE_KEY", "")
 
 			// Set test env vars
 			for k, v := range tt.envVars {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
-			defer func() {
-				for k := range tt.envVars {
-					os.Unsetenv(k)
-				}
-			}()
 
 			provider := NewGitHubAppTokenProvider()
 
@@ -250,10 +245,9 @@ func TestExpectedAppSlug(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.envValue != "" {
-				os.Setenv("KUBESTELLAR_CONSOLE_APP_SLUG", tt.envValue)
-				defer os.Unsetenv("KUBESTELLAR_CONSOLE_APP_SLUG")
+				t.Setenv("KUBESTELLAR_CONSOLE_APP_SLUG", tt.envValue)
 			} else {
-				os.Unsetenv("KUBESTELLAR_CONSOLE_APP_SLUG")
+				t.Setenv("KUBESTELLAR_CONSOLE_APP_SLUG", "")
 			}
 
 			slug := ExpectedAppSlug()


### PR DESCRIPTION
Fixes #20196, Fixes #20275

## Summary

Fixes test isolation bugs causing nightly release workflow failures.

### Changes

1. **`pkg/api/handlers/auth_compat_test.go`** — Moved `OpenTestDB(t)` inside each subtest. Parallel subtests were sharing a single SQLite `:memory:` DB with `MaxOpenConns(1)`, triggering database lock errors under parallel execution.

2. **`pkg/api/handlers/github_app_auth_test.go`** — Replaced `os.Setenv`/`os.Unsetenv` with `t.Setenv()`. Parallel tests were leaking env var state to each other.