### PR TITLE
[ci-maintainer] fix: use lint:check and add always() to nightly release bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,15 +222,20 @@ jobs:
 
       - name: Lint frontend
         working-directory: web
-        run: npm run lint
+        # Use lint:check (baseline script) to match pre-merge-gate behavior;
+        # raw `lint` (eslint .) fails on pre-existing baseline errors and blocks releases.
+        run: npm run lint:check
 
   release:
     needs: [determine_version, test]
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # For scheduled releases (nightly/weekly), proceed even if tests fail
-    # For manual releases, require tests to pass
+    # For scheduled releases (nightly/weekly), proceed even if tests fail.
+    # For manual releases, require tests to pass.
+    # always() is required so GitHub Actions evaluates the if condition
+    # even when the `test` job fails (without it the job is unconditionally skipped).
     if: |
+      always() &&
       github.event.inputs.dry_run != 'true' &&
       needs.determine_version.outputs.has_changes == 'true' &&
       (github.event_name == 'schedule' || needs.test.result == 'success')


### PR DESCRIPTION
## CI Fix

### What changed

1. **`test` job lint step**: `npm run lint` → `npm run lint:check`
   - `npm run lint` = raw `eslint .` — fails on ALL lint errors including pre-existing baseline ones
   - `npm run lint:check` = `node scripts/lint-baseline-check.mjs` — only fails on NEW errors above the baseline, consistent with `pre-merge-gate.yml`
   - This mismatch caused nightly run #1238 (July 3) and run #1239 (July 4) to fail on lint while all PRs pass the pre-merge gate

2. **`release` job `if` condition**: added `always()` prefix
   - GitHub Actions **unconditionally skips** dependent jobs when a `needs` job fails, without evaluating the `if` condition, **unless** `always()` or `failure()` is present
   - The schedule bypass `(github.event_name == 'schedule' || needs.test.result == 'success')` was never evaluated — the `release` job was silently skipped
   - Adding `always()` ensures the bypass condition is evaluated for scheduled runs

Fixes #20277

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*