### PR TITLE
[ci-maintainer] fix: robust report job in nightly-llmd-guides (all guide tests pass)

### DIFF
--- a/.github/workflows/nightly-llmd-guides.yml
+++ b/.github/workflows/nightly-llmd-guides.yml
@@ -246,16 +246,21 @@ jobs:
 
       - name: Find or create tracking issue
         id: issue
+        # continue-on-error: reporting infra failures must not mark passing guide runs as failed
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LABEL="${TRACKING_ISSUE_LABEL}"
           TITLE="${TRACKING_ISSUE_TITLE}"
 
-          # Ensure label exists
+          # Ensure labels exist (|| true already on label create, also create hold)
           gh label create "$LABEL" \
             --description "Nightly llm-d guide E2E results" \
             --color "5319e7" 2>/dev/null || true
+          gh label create "hold" \
+            --description "Hold: do not auto-close" \
+            --color "e4e669" 2>/dev/null || true
 
           # Find existing open issue
           EXISTING=$(gh issue list \
@@ -282,16 +287,19 @@ jobs:
             ISSUE_BODY+="- custom-metrics"$'\n\n'
             ISSUE_BODY+="---"$'\n'
             ISSUE_BODY+="_Results are posted as comments below, newest first._"
-            NEW_ISSUE=$(gh issue create \
+            # Capture URL; grep exits 1 on no match so guard with || true
+            ISSUE_URL=$(gh issue create \
               --title "$TITLE" \
               --label "$LABEL" \
               --label "hold" \
-              --body "$ISSUE_BODY" \
-              | grep -oP '\d+$')
+              --body "$ISSUE_BODY") || true
+            NEW_ISSUE=$(echo "$ISSUE_URL" | grep -oP '\d+$' || true)
             echo "issue_number=$NEW_ISSUE" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Post results to tracking issue
+        # Only run if tracking issue was found/created successfully
+        if: steps.issue.outputs.issue_number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}


### PR DESCRIPTION
## CI Fix

The `Nightly llm-d Guide E2E` workflow has been marking all runs as **failure** for 10+ consecutive runs (runs #58–#67, July 2–4) despite all 8 guide E2E tests passing. The failure is purely in the `report` job's tracking issue infrastructure.

### Root cause

The "Find or create tracking issue" step fails with exit code 1 because:
1. The `hold` label may not exist, causing `gh issue create --label "hold"` to fail
2. With `bash -e`, `gh issue create ... | grep -oP '\d+$'` aborts the script when `grep` exits 1 (no match from failed `gh` command)

The tracking issue "Nightly llm-d Guide E2E Results" has never been successfully created, so the issue creation runs on every scheduled run and fails every time.

### Changes

1. **`continue-on-error: true`** on "Find or create tracking issue" — reporting failures must not mark passing guide runs as failures
2. **Ensure `hold` label exists** before calling `gh issue create --label "hold"` — same pattern used for `nightly-llmd-guides` label
3. **Fix pipeline error handling** — separate `gh issue create` and `grep` with `|| true` guards so `bash -e` doesn't abort on grep exit 1
4. **Guard "Post results" step** with `if: steps.issue.outputs.issue_number != ''` — skips cleanly when tracking issue creation fails

Fixes #20281

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*