### PR TITLE
[scanner] fix: harness tests mock setup for vitest isolation

### DIFF
--- a/web/harness/evidence/__tests__/sanitizeEvidence.test.ts
+++ b/web/harness/evidence/__tests__/sanitizeEvidence.test.ts
@@ -5,6 +5,7 @@ describe('sanitizeText', () => {
   const originalEnv = process.env
 
   beforeEach(() => {
+    vi.resetModules()
     vi.clearAllMocks()
     process.env = { ...originalEnv }
   })

--- a/web/harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts
+++ b/web/harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts
@@ -3,6 +3,7 @@ import { redactK8sGroundTruth } from '../redactK8sGroundTruth'
 import type { K8sGroundTruth } from '../k8sTypes'
 
 beforeEach(() => {
+  vi.resetModules()
   vi.clearAllMocks()
 })
 


### PR DESCRIPTION
Part of #20262, related to #20007

Fixes harness/ test failures caused by vitest isolate mode (PR #20258). Adds proper mock setup so tests work independently.

## Changes
- `harness/evidence/__tests__/sanitizeEvidence.test.ts`: Add `vi.resetModules()` in beforeEach
- `harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts`: Add `vi.resetModules()` in beforeEach

## Root Cause
vitest isolate mode requires fresh module state per test. `vi.resetModules()` clears cached imports so tests don't share global state.