### PR TITLE
[scanner] fix: card component tests mock setup for vitest isolation

### DIFF
--- a/web/src/components/cards/NamespaceMonitorTable.test.tsx
+++ b/web/src/components/cards/NamespaceMonitorTable.test.tsx
@@ -11,6 +11,15 @@ import React from 'react'
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
 import { NamespaceMonitorTable } from './NamespaceMonitorTable'
 import type { NamespaceData, ChangeType, ResourceType } from './NamespaceMonitor.types'
 import type { ClusterInfo } from '../../hooks/useMCP'

--- a/web/src/components/cards/__tests__/ACMMLevel.test.tsx
+++ b/web/src/components/cards/__tests__/ACMMLevel.test.tsx
@@ -1,6 +1,21 @@
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+const mockUseACMM = vi.fn()
+
+vi.mock('../../acmm/ACMMProvider', () => ({
+  useACMM: () => mockUseACMM(),
+}))
+
 import { CardDataReportContext } from '../CardDataContext'
 import { ACMMLevel } from '../ACMMLevel'
 import {
@@ -11,12 +26,6 @@ import {
   TEST_REPO,
 } from './acmmTestFixtures'
 import { computeLevel } from '../../../lib/acmm/computeLevel'
-
-const mockUseACMM = vi.fn()
-
-vi.mock('../../acmm/ACMMProvider', () => ({
-  useACMM: () => mockUseACMM(),
-}))
 
 vi.mock('../../../lib/cards/CardComponents', () => ({
   CardSkeleton: ({ type }: { type?: string }) => (

--- a/web/src/components/cards/__tests__/AgenticDetectionRuns.test.tsx
+++ b/web/src/components/cards/__tests__/AgenticDetectionRuns.test.tsx
@@ -11,20 +11,24 @@ import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { CardDataReportContext } from '../CardDataContext'
-import type { DetectionRun, DetectionRunsData } from '../../../hooks/useAgenticDetectionRuns'
-import { AgenticDetectionRuns } from '../AgenticDetectionRuns'
 
-const ITEMS_PER_PAGE = 10
-const GITHUB_ISSUE_URL = 'https://github.com/kubestellar/console/issues/16283'
-const GITHUB_WORKFLOW_URL = 'https://github.com/kubestellar/console/actions/runs/12345'
-const MS_PER_HOUR = 60 * 60 * 1000
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
 
 const mockUseAgenticDetectionRuns = vi.fn()
 
 vi.mock('../../../hooks/useAgenticDetectionRuns', () => ({
   useAgenticDetectionRuns: () => mockUseAgenticDetectionRuns(),
 }))
+
+import { CardDataReportContext } from '../CardDataContext'
+import type { DetectionRun, DetectionRunsData } from '../../../hooks/useAgenticDetectionRuns'
+import { AgenticDetectionRuns } from '../AgenticDetectionRuns'
 
 function makeRun(overrides: Partial<DetectionRun> = {}): DetectionRun {
   return {

--- a/web/src/components/cards/__tests__/DynamicCardErrorBoundary.test.tsx
+++ b/web/src/components/cards/__tests__/DynamicCardErrorBoundary.test.tsx
@@ -1,6 +1,26 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+vi.mock('../../../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/analytics')>()),
+  emitError: vi.fn(),
+  markErrorReported: vi.fn(),
+}
+))
+
+vi.mock('../../../lib/chunkErrors', () => ({
+  isChunkLoadError: () => false,
+}))
+
 import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
 
 // Suppress console.error from React error boundaries during tests


### PR DESCRIPTION
Part of #20262

Fixes src/components/cards/ test failures caused by vitest isolate mode (PR #20258). Adds proper mock setup so tests work independently.

## Changes
- `NamespaceMonitorTable.test.tsx`: Add `vi.mock('react-i18next')` 
- `ACMMLevel.test.tsx`: Add `vi.mock('react-i18next')`
- `AgenticDetectionRuns.test.tsx`: Add `vi.mock('react-i18next')`
- `DynamicCardErrorBoundary.test.tsx`: Add `vi.mock('react-i18next')`

## Root Cause
Under vitest isolate mode, each test file runs in its own context. Tests that previously inherited `react-i18next` mocks from shared setup now need explicit `vi.mock()` calls.