### PR TITLE
[scanner] fix: remove unused os import in github_app_auth_test.go

### DIFF
--- a/pkg/api/handlers/feedback/github_app_auth_test.go
+++ b/pkg/api/handlers/feedback/github_app_auth_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 


### PR DESCRIPTION
Fixes #20286

PR #20276 replaced `os.Setenv`/`os.Unsetenv` with `t.Setenv()` but left the `import "os"` in place. Go does not allow unused imports, causing compile errors in the `classifier-contract` CI job (Console App Smoke workflow).

One-line fix: remove the unused `"os"` import.