### PR TITLE
[scanner] fix: restore shared test mocks broken by vitest isolation change

### DIFF
--- a/web/harness/evidence/__tests__/sanitizeEvidence.test.ts
+++ b/web/harness/evidence/__tests__/sanitizeEvidence.test.ts
@@ -5,7 +5,6 @@ describe('sanitizeText', () => {
   const originalEnv = process.env
 
   beforeEach(() => {
-    vi.resetModules()
     vi.clearAllMocks()
     process.env = { ...originalEnv }
   })

--- a/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
+++ b/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
@@ -1,12 +1,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import * as childProcess from 'node:child_process'
-import * as fs from 'node:fs'
 
-vi.mock('node:child_process')
-vi.mock('node:fs')
+// Use explicit mock factories so references remain stable after vi.resetModules()
+const mockExecFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockMkdtempSync = vi.fn(() => '/tmp/mock-kubeconfig-dir')
+const mockRmSync = vi.fn()
+const mockExistsSync = vi.fn(() => false)
+const mockReadFileSync = vi.fn(() => '')
 
-const mockedExecFileSync = vi.mocked(childProcess.execFileSync)
-const mockedFs = vi.mocked(fs)
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}))
+
+vi.mock('node:fs', () => ({
+  writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
+  mkdtempSync: mockMkdtempSync,
+  rmSync: mockRmSync,
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+}))
 
 describe('collectK8sGroundTruth', () => {
   const originalEnv = process.env
@@ -14,11 +28,11 @@ describe('collectK8sGroundTruth', () => {
   beforeEach(() => {
     vi.resetModules()
     process.env = { ...originalEnv }
-    mockedExecFileSync.mockReset()
-    mockedFs.writeFileSync.mockImplementation(() => undefined)
-    mockedFs.mkdirSync.mockImplementation(() => '' as unknown as string)
-    mockedFs.mkdtempSync.mockReturnValue('/tmp/mock-kubeconfig-dir')
-    mockedFs.rmSync.mockImplementation(() => undefined)
+    mockExecFileSync.mockReset()
+    mockWriteFileSync.mockImplementation(() => undefined)
+    mockMkdirSync.mockImplementation(() => '' as unknown as string)
+    mockMkdtempSync.mockReturnValue('/tmp/mock-kubeconfig-dir')
+    mockRmSync.mockImplementation(() => undefined)
   })
 
   afterEach(() => {
@@ -44,7 +58,7 @@ describe('collectK8sGroundTruth', () => {
 
     it('returns skipped result when kubectl is unavailable', async () => {
       process.env.LIVE_CLUSTER_TESTS = 'true'
-      mockedExecFileSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error('kubectl not found')
       })
       const { collectK8sGroundTruth } = await loadModule()
@@ -65,7 +79,7 @@ describe('collectK8sGroundTruth', () => {
     it('uses KUBECONFIG_PATH directly when set', async () => {
       process.env.LIVE_CLUSTER_TESTS = 'true'
       process.env.KUBECONFIG_PATH = '/custom/kubeconfig'
-      mockedExecFileSync.mockImplementation((_cmd, args) => {
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
         if (Array.isArray(args) && args.includes('--client=true')) return 'Client Version: v1.28.0'
         if (Array.isArray(args) && args.includes('get-contexts')) return 'ctx-1\nctx-2'
         if (Array.isArray(args) && args.includes('namespaces') && args.includes('--request-timeout=10s')) return ''
@@ -73,8 +87,8 @@ describe('collectK8sGroundTruth', () => {
       })
       const { collectK8sGroundTruth } = await loadModule()
       collectK8sGroundTruth('test')
-      const kubeconfigCalls = mockedExecFileSync.mock.calls.filter(
-        call => Array.isArray(call[1]) && call[1].includes('--kubeconfig'),
+      const kubeconfigCalls = mockExecFileSync.mock.calls.filter(
+        (call: unknown[]) => Array.isArray(call[1]) && call[1].includes('--kubeconfig'),
       )
       for (const call of kubeconfigCalls) {
         expect(call[1]).toContain('/custom/kubeconfig')
@@ -85,14 +99,14 @@ describe('collectK8sGroundTruth', () => {
       process.env.LIVE_CLUSTER_TESTS = 'true'
       delete process.env.KUBECONFIG_PATH
       process.env.KUBECONFIG_B64 = Buffer.from('apiVersion: v1\nkind: Config').toString('base64')
-      mockedExecFileSync.mockImplementation((_cmd, args) => {
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
         if (Array.isArray(args) && args.includes('--client=true')) return 'Client Version: v1.28.0'
         if (Array.isArray(args) && args.includes('get-contexts')) return ''
         return JSON.stringify({ items: [] })
       })
       const { collectK8sGroundTruth } = await loadModule()
       collectK8sGroundTruth('test')
-      expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
         '/tmp/mock-kubeconfig-dir/config',
         'apiVersion: v1\nkind: Config',
         { mode: 0o600 },
@@ -105,7 +119,7 @@ describe('collectK8sGroundTruth', () => {
       process.env.LIVE_CLUSTER_TESTS = 'true'
       process.env.KUBECONFIG_PATH = '/mock/kc'
       process.env.LIVE_CLUSTER_CONTEXTS = 'ctx-a, ctx-c'
-      mockedExecFileSync.mockImplementation((_cmd, args) => {
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
         if (Array.isArray(args) && args.includes('--client=true')) return ''
         if (Array.isArray(args) && args.includes('get-contexts')) return 'ctx-a\nctx-b\nctx-c\nctx-d'
         if (Array.isArray(args) && args.includes('--request-timeout=10s')) return ''
@@ -124,7 +138,7 @@ describe('collectK8sGroundTruth', () => {
       process.env.KUBECONFIG_PATH = '/mock/kc'
       delete process.env.LIVE_CLUSTER_CONTEXTS
       let callCount = 0
-      mockedExecFileSync.mockImplementation((_cmd, args) => {
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
         if (Array.isArray(args) && args.includes('--client=true')) return ''
         if (Array.isArray(args) && args.includes('get-contexts')) return 'ctx-a\nctx-b'
         if (Array.isArray(args) && args.includes('--request-timeout=10s')) {
@@ -146,7 +160,7 @@ describe('collectK8sGroundTruth', () => {
       process.env.LIVE_CLUSTER_TESTS = 'true'
       process.env.KUBECONFIG_PATH = '/mock/kc'
       process.env.LIVE_CLUSTER_CONTEXTS = 'ctx-1'
-      mockedExecFileSync.mockImplementation((_cmd, args) => {
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
         if (Array.isArray(args) && args.includes('--client=true')) return ''
         if (Array.isArray(args) && args.includes('get-contexts')) return 'ctx-1'
         if (Array.isArray(args) && args.includes('--request-timeout=10s')) return ''
@@ -203,7 +217,7 @@ describe('collectK8sGroundTruth', () => {
       process.env.LIVE_CLUSTER_TESTS = 'true'
       process.env.KUBECONFIG_PATH = '/mock/kc'
       process.env.LIVE_CLUSTER_CONTEXTS = 'my-secret-cluster'
-      mockedExecFileSync.mockImplementation((_cmd, args) => {
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
         if (Array.isArray(args) && args.includes('--client=true')) return ''
         if (Array.isArray(args) && args.includes('get-contexts')) return 'my-secret-cluster'
         if (Array.isArray(args) && args.includes('--request-timeout=10s')) return ''
@@ -211,8 +225,8 @@ describe('collectK8sGroundTruth', () => {
       })
       const { collectK8sGroundTruth } = await loadModule()
       collectK8sGroundTruth('test')
-      const writeCall = mockedFs.writeFileSync.mock.calls.find(
-        call => typeof call[0] === 'string' && call[0].includes('groundtruth.json'),
+      const writeCall = mockWriteFileSync.mock.calls.find(
+        (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('groundtruth.json'),
       )
       expect(writeCall).toBeDefined()
       const written = JSON.parse(writeCall![1] as string)
@@ -226,7 +240,7 @@ describe('collectK8sGroundTruth', () => {
       delete process.env.KUBECONFIG_PATH
       process.env.KUBECONFIG_B64 = Buffer.from('content').toString('base64')
       let callCount = 0
-      mockedExecFileSync.mockImplementation((_cmd, args) => {
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
         if (Array.isArray(args) && args.includes('--client=true')) return ''
         if (Array.isArray(args) && args.includes('get-contexts')) {
           callCount++
@@ -240,7 +254,7 @@ describe('collectK8sGroundTruth', () => {
       })
       const { collectK8sGroundTruth } = await loadModule()
       collectK8sGroundTruth('test')
-      expect(mockedFs.rmSync).toHaveBeenCalledWith(
+      expect(mockRmSync).toHaveBeenCalledWith(
         '/tmp/mock-kubeconfig-dir',
         { recursive: true, force: true },
       )

--- a/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
+++ b/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
@@ -1,12 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import * as childProcess from 'node:child_process'
-import * as fs from 'node:fs'
 
-vi.mock('node:child_process')
-vi.mock('node:fs')
+// Use explicit mock factories so references remain stable after vi.resetModules()
+const mockExecFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockMkdtempSync = vi.fn(() => '/tmp/mock-kubeconfig-dir')
+const mockRmSync = vi.fn()
 
-const mockedExecFileSync = vi.mocked(childProcess.execFileSync)
-const mockedFs = vi.mocked(fs)
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}))
+
+vi.mock('node:fs', () => ({
+  writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
+  mkdtempSync: mockMkdtempSync,
+  rmSync: mockRmSync,
+}))
 
 describe('liveFixtureManager', () => {
   const originalEnv = process.env
@@ -14,11 +24,11 @@ describe('liveFixtureManager', () => {
   beforeEach(() => {
     vi.resetModules()
     process.env = { ...originalEnv }
-    mockedExecFileSync.mockReset()
-    mockedFs.writeFileSync.mockImplementation(() => undefined)
-    mockedFs.mkdirSync.mockImplementation(() => '' as unknown as string)
-    mockedFs.mkdtempSync.mockReturnValue('/tmp/mock-kubeconfig-dir')
-    mockedFs.rmSync.mockImplementation(() => undefined)
+    mockExecFileSync.mockReset()
+    mockWriteFileSync.mockImplementation(() => undefined)
+    mockMkdirSync.mockImplementation(() => '' as unknown as string)
+    mockMkdtempSync.mockReturnValue('/tmp/mock-kubeconfig-dir')
+    mockRmSync.mockImplementation(() => undefined)
   })
 
   afterEach(() => {
@@ -58,12 +68,12 @@ describe('liveFixtureManager', () => {
       process.env.LIVE_CLUSTER_FIXTURES = 'true'
       process.env.KUBECONFIG_PATH = '/mock/kubeconfig'
       process.env.LIVE_CLUSTER_FIXTURE_CONTEXT = 'test-context'
-      mockedExecFileSync.mockReturnValue('')
+      mockExecFileSync.mockReturnValue('')
       const { applyLiveFixtures } = await loadModule()
       const report = applyLiveFixtures()
       expect(report.enabled).toBe(true)
       expect(report.context).toBe('test-context')
-      expect(mockedExecFileSync).toHaveBeenCalledWith(
+      expect(mockExecFileSync).toHaveBeenCalledWith(
         'kubectl',
         expect.arrayContaining(['--kubeconfig', '/mock/kubeconfig', '--context', 'test-context', 'apply', '-f', '-']),
         expect.objectContaining({ encoding: 'utf8' }),
@@ -75,7 +85,7 @@ describe('liveFixtureManager', () => {
       process.env.KUBECONFIG_PATH = '/mock/kubeconfig'
       delete process.env.LIVE_CLUSTER_FIXTURE_CONTEXT
       process.env.LIVE_CLUSTER_CONTEXTS = 'ctx-a, ctx-b, ctx-c'
-      mockedExecFileSync.mockReturnValue('')
+      mockExecFileSync.mockReturnValue('')
       const { applyLiveFixtures } = await loadModule()
       const report = applyLiveFixtures()
       expect(report.context).toBe('ctx-a')
@@ -95,8 +105,9 @@ describe('liveFixtureManager', () => {
       process.env.LIVE_CLUSTER_FIXTURES = 'true'
       process.env.KUBECONFIG_PATH = '/mock/kubeconfig'
       process.env.LIVE_CLUSTER_FIXTURE_CONTEXT = 'test-ctx'
-      mockedExecFileSync.mockImplementation((_cmd, args: string[]) => {
-        if (args.includes('pods')) {
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+        const a = args as string[]
+        if (a.includes('pods')) {
           return JSON.stringify({
             items: [
               { metadata: { name: 'pod-a' }, status: { phase: 'Running' } },
@@ -104,7 +115,7 @@ describe('liveFixtureManager', () => {
             ],
           })
         }
-        if (args.includes('deployment')) {
+        if (a.includes('deployment')) {
           return JSON.stringify({ status: { availableReplicas: 2, replicas: 2 } })
         }
         return ''
@@ -122,9 +133,10 @@ describe('liveFixtureManager', () => {
       process.env.LIVE_CLUSTER_FIXTURES = 'true'
       process.env.KUBECONFIG_PATH = '/mock/kubeconfig'
       process.env.LIVE_CLUSTER_FIXTURE_CONTEXT = 'ctx'
-      mockedExecFileSync.mockImplementation((_cmd, args: string[]) => {
-        if (args.includes('pods')) return JSON.stringify({ items: [] })
-        if (args.includes('deployment')) return JSON.stringify({ status: { availableReplicas: 0, replicas: 2 } })
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+        const a = args as string[]
+        if (a.includes('pods')) return JSON.stringify({ items: [] })
+        if (a.includes('deployment')) return JSON.stringify({ status: { availableReplicas: 0, replicas: 2 } })
         return ''
       })
       const { collectLiveFixtureState } = await loadModule()
@@ -146,17 +158,18 @@ describe('liveFixtureManager', () => {
       process.env.LIVE_CLUSTER_FIXTURE_CLEANUP = 'false'
       process.env.KUBECONFIG_PATH = '/mock/kubeconfig'
       process.env.LIVE_CLUSTER_FIXTURE_CONTEXT = 'ctx'
-      mockedExecFileSync.mockImplementation((_cmd, args: string[]) => {
-        if (args.includes('pods')) return JSON.stringify({ items: [] })
-        if (args.includes('deployment')) return JSON.stringify({ status: { availableReplicas: 1, replicas: 1 } })
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+        const a = args as string[]
+        if (a.includes('pods')) return JSON.stringify({ items: [] })
+        if (a.includes('deployment')) return JSON.stringify({ status: { availableReplicas: 1, replicas: 1 } })
         return ''
       })
       const { cleanupLiveFixtures } = await loadModule()
       const report = cleanupLiveFixtures()
       expect(report.enabled).toBe(true)
       // Should NOT have called 'delete namespace'
-      const deleteCall = mockedExecFileSync.mock.calls.find(call =>
-        Array.isArray(call[1]) && call[1].includes('delete'),
+      const deleteCall = mockExecFileSync.mock.calls.find((call: unknown[]) =>
+        Array.isArray(call[1]) && (call[1] as string[]).includes('delete'),
       )
       expect(deleteCall).toBeUndefined()
     })
@@ -166,15 +179,15 @@ describe('liveFixtureManager', () => {
       delete process.env.LIVE_CLUSTER_FIXTURE_CLEANUP
       process.env.KUBECONFIG_PATH = '/mock/kubeconfig'
       process.env.LIVE_CLUSTER_FIXTURE_CONTEXT = 'test-ctx'
-      mockedExecFileSync.mockReturnValue('')
+      mockExecFileSync.mockReturnValue('')
       const { cleanupLiveFixtures } = await loadModule()
       const report = cleanupLiveFixtures()
       expect(report.enabled).toBe(true)
-      const deleteCall = mockedExecFileSync.mock.calls.find(call =>
-        Array.isArray(call[1]) && call[1].includes('delete'),
+      const deleteCall = mockExecFileSync.mock.calls.find((call: unknown[]) =>
+        Array.isArray(call[1]) && (call[1] as string[]).includes('delete'),
       )
       expect(deleteCall).toBeDefined()
-      expect(deleteCall?.[1]).toContain('ks-live-ui-fixtures')
+      expect((deleteCall as unknown[])?.[1]).toContain('ks-live-ui-fixtures')
     })
 
     it('uses KUBECONFIG_B64 to write temp kubeconfig', async () => {
@@ -183,10 +196,10 @@ describe('liveFixtureManager', () => {
       delete process.env.LIVE_CLUSTER_FIXTURE_KUBECONFIG_B64
       process.env.KUBECONFIG_B64 = Buffer.from('mock-kubeconfig-content').toString('base64')
       process.env.LIVE_CLUSTER_FIXTURE_CONTEXT = 'ctx'
-      mockedExecFileSync.mockReturnValue('')
+      mockExecFileSync.mockReturnValue('')
       const { cleanupLiveFixtures } = await loadModule()
       cleanupLiveFixtures()
-      expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
         '/tmp/mock-kubeconfig-dir/config',
         'mock-kubeconfig-content',
         { mode: 0o600 },
@@ -199,8 +212,8 @@ describe('liveFixtureManager', () => {
       delete process.env.LIVE_CLUSTER_FIXTURES
       const { applyLiveFixtures } = await loadModule()
       applyLiveFixtures()
-      const writeCall = mockedFs.writeFileSync.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('live-fixtures.json'),
+      const writeCall = mockWriteFileSync.mock.calls.find((call: unknown[]) =>
+        typeof call[0] === 'string' && (call[0] as string).includes('live-fixtures.json'),
       )
       expect(writeCall).toBeDefined()
       const written = JSON.parse(writeCall![1] as string)

--- a/web/harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts
+++ b/web/harness/groundtruth/__tests__/redactK8sGroundTruth.test.ts
@@ -3,7 +3,6 @@ import { redactK8sGroundTruth } from '../redactK8sGroundTruth'
 import type { K8sGroundTruth } from '../k8sTypes'
 
 beforeEach(() => {
-  vi.resetModules()
   vi.clearAllMocks()
 })
 

--- a/web/src/components/cards/__tests__/AgenticDetectionRuns.test.tsx
+++ b/web/src/components/cards/__tests__/AgenticDetectionRuns.test.tsx
@@ -30,6 +30,11 @@ import { CardDataReportContext } from '../CardDataContext'
 import type { DetectionRun, DetectionRunsData } from '../../../hooks/useAgenticDetectionRuns'
 import { AgenticDetectionRuns } from '../AgenticDetectionRuns'
 
+const ITEMS_PER_PAGE = 10
+const GITHUB_ISSUE_URL = 'https://github.com/kubestellar/console/issues/16283'
+const GITHUB_WORKFLOW_URL = 'https://github.com/kubestellar/console/actions/runs/12345'
+const MS_PER_HOUR = 60 * 60 * 1000
+
 function makeRun(overrides: Partial<DetectionRun> = {}): DetectionRun {
   return {
     conclusion: 'success',

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -8,41 +8,40 @@ const isBrowserEnvironment = typeof window !== 'undefined'
 // This prevents "Cannot find module" errors in Netlify function tests that run in node environment
 if (isBrowserEnvironment) {
   // Mock react-i18next globally to prevent i18n.ts from failing when imported
-  // by vite.config.ts or other modules. Uses importOriginal to get the real
-  // initReactI18next object that i18n.ts needs.
-  vi.mock('react-i18next', async () => {
-    const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next')
-    return {
-      ...actual,
-      useTranslation: () => ({
-        t: (key: string, options?: Record<string, unknown>) => {
-          // Preserve specific LaunchSequence strings used in tests
-          if (key === 'missionControl.launchSequence.missionFailed') return 'Mission failed'
-          if (key === 'missionControl.launchSequence.missionCancelled') return 'Mission cancelled'
-          // Support Deploying X projects in Y phase with pluralization
-          if (key.includes('missionControl.launchSequence.deployingProjects')) {
-            const count = typeof options?.count === 'number' ? options!.count as number : 0
-            const phaseCount = typeof options?.phaseCount === 'number' ? options!.phaseCount as number : 0
-            return `Deploying ${count} project${count === 1 ? '' : 's'} in ${phaseCount} phase`
+  // by vite.config.ts or other modules. Uses synchronous factory to avoid timing
+  // issues with isolate:true where async factories may not resolve before imports.
+  vi.mock('react-i18next', () => ({
+    initReactI18next: { type: '3rdParty', init: () => {} },
+    useTranslation: () => ({
+      t: (key: string, options?: Record<string, unknown>) => {
+        // Preserve specific LaunchSequence strings used in tests
+        if (key === 'missionControl.launchSequence.missionFailed') return 'Mission failed'
+        if (key === 'missionControl.launchSequence.missionCancelled') return 'Mission cancelled'
+        // Support Deploying X projects in Y phase with pluralization
+        if (key.includes('missionControl.launchSequence.deployingProjects')) {
+          const count = typeof options?.count === 'number' ? options!.count as number : 0
+          const phaseCount = typeof options?.phaseCount === 'number' ? options!.phaseCount as number : 0
+          return `Deploying ${count} project${count === 1 ? '' : 's'} in ${phaseCount} phase`
+        }
+        // Generic interpolation: replace {{key}} placeholders when options provided
+        if (options && typeof key === 'string') {
+          let s = key
+          for (const [k, v] of Object.entries(options)) {
+            s = s.replace(new RegExp(`{{\\s*${k}\\s*}}`, 'g'), String(v))
           }
-          // Generic interpolation: replace {{key}} placeholders when options provided
-          if (options && typeof key === 'string') {
-            let s = key
-            for (const [k, v] of Object.entries(options)) {
-              s = s.replace(new RegExp(`{{\\s*${k}\\s*}}`, 'g'), String(v))
-            }
-            return s
-          }
-          // Default: return the key as a fallback
-          return key
-        },
-        i18n: { language: 'en', changeLanguage: vi.fn() },
-      }),
-      Trans: ({ children }: { children: React.ReactNode }) => children,
-      // initReactI18next is imported from the actual module above, so tests that import
-      // i18n.ts (via vite.config.ts) don't crash
-    }
-  })
+          return s
+        }
+        // Default: return the key as a fallback
+        return key
+      },
+      i18n: { language: 'en', changeLanguage: vi.fn() },
+    }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
+    I18nextProvider: ({ children }: { children: React.ReactNode }) => children,
+    withTranslation: () => (Component: React.ComponentType) => Component,
+    Translation: ({ children }: { children: (t: (key: string) => string) => React.ReactNode }) =>
+      children((key: string) => key),
+  }))
 
   // Mock lib/demoMode globally to prevent module-level initialization that accesses
   // localStorage and getStoredAuthTokenSync at import time. This ensures tests don't
@@ -97,21 +96,20 @@ if (isBrowserEnvironment) {
 
   // Mock agentFetch wrappers to delegate to global.fetch so test mocks intercept
   // both the legacy shared wrapper and the direct mcp/agentFetch module imports.
-  vi.mock('../hooks/mcp/shared', async () => {
-    const actual = await vi.importActual<typeof import('../hooks/mcp/shared')>('../hooks/mcp/shared')
-    return {
-      ...actual,
-      agentFetch: vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => global.fetch(url, init)),
-    }
-  })
+  // Uses synchronous factory to avoid timing issues with isolate:true.
+  vi.mock('../hooks/mcp/shared', () => ({
+    agentFetch: vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => global.fetch(url, init)),
+    getAgentBaseUrl: vi.fn(() => ''),
+    getAgentWsUrl: vi.fn(() => ''),
+    isAgentAvailable: vi.fn(() => false),
+  }))
 
-  vi.mock('../hooks/mcp/agentFetch', async () => {
-    const actual = await vi.importActual<typeof import('../hooks/mcp/agentFetch')>('../hooks/mcp/agentFetch')
-    return {
-      ...actual,
-      agentFetch: vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => global.fetch(url, init)),
-    }
-  })
+  vi.mock('../hooks/mcp/agentFetch', () => ({
+    agentFetch: vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => global.fetch(url, init)),
+    getAgentBaseUrl: vi.fn(() => ''),
+    getAgentWsUrl: vi.fn(() => ''),
+    isAgentAvailable: vi.fn(() => false),
+  }))
 }
 
 const TOKEN_STORAGE_ALIASES = ['token', 'kc_token', 'kc-token', 'kc-auth-token'] as const


### PR DESCRIPTION
Fixes #20289

## Root Causes

PR #20285 introduced two categories of test failures when combined with the recent `isolate: true` vitest configuration:

### 1. Missing constants in AgenticDetectionRuns.test.tsx (6 tests)
PR #20285 accidentally removed `ITEMS_PER_PAGE`, `GITHUB_ISSUE_URL`, `GITHUB_WORKFLOW_URL`, and `MS_PER_HOUR` constants when rearranging imports for vitest isolation mock hoisting. These are referenced throughout the test file.

### 2. Async mock factories in setup file (190+ tests)
The global test setup file (`src/test/setup.ts`) used `async` mock factories with `vi.importActual()` for `react-i18next`, `mcp/shared`, and `mcp/agentFetch`. Under `isolate: true`, async factories can cause timing issues where mocks aren't fully resolved before test file imports execute, causing widespread "failed to load" and assertion failures.

### 3. Stale auto-mock references in harness tests (25 tests)
`collectK8sGroundTruth.test.ts` and `liveFixtureManager.test.ts` use `vi.mock('node:child_process')` (auto-mock) combined with `vi.resetModules()`. Under isolation, `vi.resetModules()` causes the auto-mock to produce fresh instances on re-import, making the top-level `vi.mocked()` references stale. Tests configure the old mock but the loaded module uses a new one.

## Changes

- **`src/test/setup.ts`**: Convert all async mock factories to synchronous with inline values. Eliminates timing issues with `isolate: true`.
- **`AgenticDetectionRuns.test.tsx`**: Restore the 4 missing test constants.
- **`collectK8sGroundTruth.test.ts`**: Replace auto-mock with explicit factory using stable `vi.fn()` references defined before `vi.mock()`.
- **`liveFixtureManager.test.ts`**: Same pattern — explicit factories with stable references.
- **`sanitizeEvidence.test.ts`**: Remove unnecessary `vi.resetModules()` (module has no deps).
- **`redactK8sGroundTruth.test.ts`**: Remove unnecessary `vi.resetModules()` (static imports only).

## Testing

These changes fix the identified root causes across all failure categories. The setup file change (sync factories) is the highest-impact fix, addressing the majority of the 221 failures by ensuring mocks are available synchronously before any test file imports execute.