### PR TITLE
🐛 Add target and rel attributes to external link in widget template

### DIFF
--- a/web/src/lib/widgets/codeGenerator.templates.ts
+++ b/web/src/lib/widgets/codeGenerator.templates.ts
@@ -315,7 +315,7 @@ ${wrapOpen}
                               ))}
                             </div>
                           )}
-                          {r.htmlUrl && <div style={{borderTop: '1px solid #334155', paddingTop: 3, marginTop: 2}}><a href={r.htmlUrl + '#logs'} onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}#logs"\`); }} style={{color: '#60a5fa', fontSize: '9px'}}>View Logs</a></div>}
+                          {r.htmlUrl && <div style={{borderTop: '1px solid #334155', paddingTop: 3, marginTop: 2}}><a href={r.htmlUrl + '#logs'} target="_blank" rel="noopener noreferrer" onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}#logs"\`); }} style={{color: '#60a5fa', fontSize: '9px'}}>View Logs</a></div>}
                         </span>
                         <span style={{
                           width: 7, height: 7, borderRadius: '50%', display: 'inline-block', cursor: 'pointer',


### PR DESCRIPTION
Fixes #20294

## Summary

Widget code generator template was missing `target="_blank"` and `rel="noopener noreferrer"` on GitHub workflow log links.

## Changes

- Added security attributes to external link in `web/src/lib/widgets/codeGenerator.templates.ts`
- Link now opens in new tab with proper security isolation

## Note on Issue Findings

The issue reported two categories of findings:

1. **External links without target/rel attributes** — The only instance found was in generated widget code (line 318 of `codeGenerator.templates.ts`). The test file mock mentioned in the scanner report (`LayoutBanners.test.tsx:18`) is intentionally stripped for testing purposes and is not production code.

2. **Drill-down views possibly missing back navigation** — This is a feature request spanning 10+ components and should be scoped separately as it's not a bug fix.

All production UI code already has proper external link attributes. This PR fixes the one legitimate finding in widget template generation.