### PR TITLE
[scanner] fix: add back navigation to drilldown views

### DIFF
--- a/web/src/components/drilldown/views/CRDDrillDown.tsx
+++ b/web/src/components/drilldown/views/CRDDrillDown.tsx
@@ -7,7 +7,7 @@ import { ClusterBadge } from '../../ui/ClusterBadge'
 import {
   Package, Info, Loader2, Server, Stethoscope,
   CheckCircle, XCircle, AlertTriangle,
-  FileText, Code, Database, List
+  FileText, Code, Database, List, ChevronLeft
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import { moveFocusByKey } from '../../../lib/a11y/rovingFocus'
@@ -98,7 +98,7 @@ function CRDDrillDownContent({ data }: Props) {
 
   const { isConnected: agentConnected } = useLocalAgent()
   const { drillToCluster, drillToNamespace } = useDrillDownActions()
-  const { close: closeDrillDown } = useDrillDown()
+  const { state, pop, close: closeDrillDown } = useDrillDown()
   const { startMission } = useMissions()
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
@@ -353,6 +353,18 @@ Please:
       <div className="px-6 pt-6 pb-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-6 text-sm">
+            {state.stack.length > 1 && (
+              <button
+                type="button"
+                onClick={pop}
+                className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
+                aria-label={t('drilldown.goBack')}
+                title={t('drilldown.goBack')}
+              >
+                <ChevronLeft className="w-4 h-4" />
+                <span>{t('common.back')}</span>
+              </button>
+            )}
             <button
               onClick={() => drillToCluster(cluster)}
               className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"

--- a/web/src/components/drilldown/views/ComplianceDrillDown.tsx
+++ b/web/src/components/drilldown/views/ComplianceDrillDown.tsx
@@ -15,6 +15,7 @@ import {
   Search, X, Filter } from 'lucide-react'
 import { useTrestle, type OscalControlResult } from '../../../hooks/useTrestle'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
+import { useDrillDown } from '../../../hooks/useDrillDown'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { cn } from '../../../lib/cn'
 import { TOUCH_TARGET_HEIGHT_CLASS, TOUCH_TARGET_SIZE_CLASS } from '../../../lib/constants/ui'
@@ -94,6 +95,7 @@ export function ComplianceDrillDown({ data }: Props) {
   const filterStatus = normalizeComplianceStatus(data.filterStatus as string | undefined)
   const { statuses } = useTrestle()
   const { selectedClusters } = useGlobalFilters()
+  const { state, pop } = useDrillDown()
 
   const summaryCounts = useMemo(() => {
     const passing = parseCount(data.passing)
@@ -234,6 +236,20 @@ export function ComplianceDrillDown({ data }: Props) {
     <div className="flex flex-col h-full -m-6">
       {/* Header */}
       <div className="px-6 pt-6 pb-4">
+        <div className="flex items-center gap-6 text-sm mb-4">
+          {state.stack.length > 1 && (
+            <button
+              type="button"
+              onClick={pop}
+              className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
+              aria-label={t('drilldown.goBack')}
+              title={t('drilldown.goBack')}
+            >
+              <ChevronLeft className="w-4 h-4" />
+              <span>{t('common.back')}</span>
+            </button>
+          )}
+        </div>
         <div className="flex items-center gap-3 mb-4">
           <Shield className="w-6 h-6 text-teal-400" />
           <div>

--- a/web/src/components/drilldown/views/ComplianceDrillDown.tsx
+++ b/web/src/components/drilldown/views/ComplianceDrillDown.tsx
@@ -17,6 +17,8 @@ import { useTrestle, type OscalControlResult } from '../../../hooks/useTrestle'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
 import { useDrillDown } from '../../../hooks/useDrillDown'
 import { StatusBadge } from '../../ui/StatusBadge'
+import { Input } from '../../ui/Input'
+import { Select } from '../../ui/Select'
 import { cn } from '../../../lib/cn'
 import { TOUCH_TARGET_HEIGHT_CLASS, TOUCH_TARGET_SIZE_CLASS } from '../../../lib/constants/ui'
 
@@ -311,18 +313,18 @@ export function ComplianceDrillDown({ data }: Props) {
         {/* Search + filter toggle */}
         <div className="flex items-center gap-2">
           <div className="relative flex-1">
-            <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
-            <input
+            <Input
               type="text"
               placeholder="Search by control ID, title, or description..."
               value={searchQuery}
               onChange={e => { setSearchQuery(e.target.value); resetPage() }}
-              className={cn('w-full rounded-lg border border-border bg-card/50 py-2 pl-9 pr-8 text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-primary', TOUCH_TARGET_HEIGHT_CLASS)}
+              leadingIcon={<Search className="w-4 h-4" />}
+              className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
             />
             {searchQuery && (
               <button
                 onClick={() => { setSearchQuery(''); resetPage() }}
-                className={cn('absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground', TOUCH_TARGET_SIZE_CLASS)}
+                className={cn('absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground z-10', TOUCH_TARGET_SIZE_CLASS)}
               >
                 <X className="w-4 h-4" />
               </button>
@@ -351,47 +353,47 @@ export function ComplianceDrillDown({ data }: Props) {
         {/* Filter dropdowns */}
         {showFilters && (
           <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mt-3">
-            <select
+            <Select
               value={statusFilter}
               onChange={e => { setStatusFilter(e.target.value); resetPage() }}
-              className={cn('rounded-lg border border-border bg-card/50 px-3 py-2 text-sm text-foreground focus:outline-hidden focus:ring-1 focus:ring-primary', TOUCH_TARGET_HEIGHT_CLASS)}
+              className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
             >
               <option value="">{t('drilldown.compliance.allStatuses')}</option>
               {uniqueStatuses.map(s => (
                 <option key={s} value={s}>{statusLabel(s)}</option>
               ))}
-            </select>
-            <select
+            </Select>
+            <Select
               value={severityFilter}
               onChange={e => { setSeverityFilter(e.target.value); resetPage() }}
-              className={cn('rounded-lg border border-border bg-card/50 px-3 py-2 text-sm text-foreground focus:outline-hidden focus:ring-1 focus:ring-primary', TOUCH_TARGET_HEIGHT_CLASS)}
+              className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
             >
               <option value="">{t('drilldown.compliance.allSeverities')}</option>
               <option value="critical">{t('drilldown.compliance.critical')}</option>
               <option value="high">{t('drilldown.compliance.high')}</option>
               <option value="medium">{t('drilldown.compliance.medium')}</option>
               <option value="low">{t('drilldown.compliance.low')}</option>
-            </select>
-            <select
+            </Select>
+            <Select
               value={clusterFilter}
               onChange={e => { setClusterFilter(e.target.value); resetPage() }}
-              className={cn('rounded-lg border border-border bg-card/50 px-3 py-2 text-sm text-foreground focus:outline-hidden focus:ring-1 focus:ring-primary', TOUCH_TARGET_HEIGHT_CLASS)}
+              className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
             >
               <option value="">{t('drilldown.compliance.allClusters')}</option>
               {uniqueClusters.map(c => (
                 <option key={c} value={c}>{c}</option>
               ))}
-            </select>
-            <select
+            </Select>
+            <Select
               value={profileFilter}
               onChange={e => { setProfileFilter(e.target.value); resetPage() }}
-              className={cn('rounded-lg border border-border bg-card/50 px-3 py-2 text-sm text-foreground focus:outline-hidden focus:ring-1 focus:ring-primary', TOUCH_TARGET_HEIGHT_CLASS)}
+              className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
             >
               <option value="">{t('drilldown.compliance.allProfiles')}</option>
               {uniqueProfiles.map(p => (
                 <option key={p} value={p}>{p}</option>
               ))}
-            </select>
+            </Select>
 
             {activeFilters > 0 && (
               <button

--- a/web/src/components/drilldown/views/GPUNodeDrillDown.tsx
+++ b/web/src/components/drilldown/views/GPUNodeDrillDown.tsx
@@ -1,5 +1,5 @@
-import { Box, ChevronRight, Server } from 'lucide-react'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { Box, ChevronRight, Server, ChevronLeft } from 'lucide-react'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { useAllPods } from '../../../hooks/useMCP'
 import { Gauge } from '../../charts/Gauge'
@@ -34,6 +34,7 @@ export function GPUNodeDrillDown({ data }: Props) {
   const gpuCount = (data.gpuCount as number) || 0
   const gpuAllocated = (data.gpuAllocated as number) || 0
   const { drillToEvents, drillToPod, drillToCluster } = useDrillDownActions()
+  const { state, pop } = useDrillDown()
   const clusterShort = cluster.split('/').pop() || cluster
 
   const utilizationPercent = gpuCount > 0 ? Math.round((gpuAllocated / gpuCount) * PERCENT_MULTIPLIER) : 0
@@ -54,6 +55,18 @@ export function GPUNodeDrillDown({ data }: Props) {
     <div className="space-y-6">
       {/* Contextual Navigation */}
       <div className="flex items-center gap-6 text-sm">
+        {state.stack.length > 1 && (
+          <button
+            type="button"
+            onClick={pop}
+            className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
+            aria-label={t('drilldown.goBack')}
+            title={t('drilldown.goBack')}
+          >
+            <ChevronLeft className="w-4 h-4" />
+            <span>{t('common.back')}</span>
+          </button>
+        )}
         <button
           onClick={() => drillToCluster(cluster)}
           className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"

--- a/web/src/components/drilldown/views/LogsDrillDown.tsx
+++ b/web/src/components/drilldown/views/LogsDrillDown.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useMemo } from 'react'
 import { Loader2, AlertCircle, Server, Layers, Box, RefreshCw, Filter, ChevronLeft } from 'lucide-react'
 import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
+import { Select } from '../../ui/Select'
+import { Input } from '../../ui/Input'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
@@ -239,24 +241,26 @@ export function LogsDrillDown({ data }: Props) {
       {/* Controls */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
-          <select
+          <Select
             value={tailLines}
             onChange={(e) => setTailLines(Number(e.target.value))}
             disabled={isLoading}
-            className="px-3 py-2 rounded-lg bg-card/50 border border-border text-foreground text-sm disabled:opacity-50"
+            className="w-auto bg-card/50 border-border disabled:opacity-50"
+            selectSize="md"
             aria-label={t('drilldown.logs.tailLinesLabel')}
           >
             {TAIL_LINE_OPTIONS.map((n) => (
               <option key={n} value={n}>{t('drilldown.logs.tailLinesOption', { count: n })}</option>
             ))}
-          </select>
+          </Select>
           <div className="flex items-center gap-2">
             <Filter className="w-4 h-4 text-muted-foreground" />
-            <select
+            <Select
               value={logLevel}
               onChange={(e) => setLogLevel(e.target.value as LogLevel)}
               disabled={isLoading}
-              className="px-3 py-2 rounded-lg bg-card/50 border border-border text-foreground text-sm disabled:opacity-50"
+              className="w-auto bg-card/50 border-border disabled:opacity-50"
+              selectSize="md"
               aria-label={t('drilldown.logs.severityFilterLabel')}
             >
               {LOG_LEVELS.map((level) => (
@@ -264,12 +268,12 @@ export function LogsDrillDown({ data }: Props) {
                   {level === 'ALL' ? t('drilldown.logs.allLevels') : level}
                 </option>
               ))}
-            </select>
+            </Select>
           </div>
           <label className="flex items-center gap-2 text-sm text-muted-foreground">
-            <input
+            <Input
               type="checkbox"
-              className="rounded"
+              className="w-auto rounded"
               disabled={isLoading}
               checked={follow}
               onChange={(e) => setFollow(e.target.checked)}

--- a/web/src/components/drilldown/views/LogsDrillDown.tsx
+++ b/web/src/components/drilldown/views/LogsDrillDown.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
-import { Loader2, AlertCircle, Server, Layers, Box, RefreshCw, Filter } from 'lucide-react'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { Loader2, AlertCircle, Server, Layers, Box, RefreshCw, Filter, ChevronLeft } from 'lucide-react'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { useTranslation } from 'react-i18next'
 
@@ -91,6 +91,7 @@ export function LogsDrillDown({ data }: Props) {
   const pod = data.pod as string
   const container = data.container as string | undefined
   const { drillToCluster, drillToNamespace, drillToPod } = useDrillDownActions()
+  const { state, pop } = useDrillDown()
   const clusterShort = cluster?.split('/').pop() || cluster
   const [tailLines, setTailLines] = useState<number>(DEFAULT_TAIL_LINES)
   const [logLevel, setLogLevel] = useState<LogLevel>(DEFAULT_LOG_LEVEL)
@@ -192,6 +193,18 @@ export function LogsDrillDown({ data }: Props) {
       {/* Contextual Navigation */}
       {cluster && (
         <div className="flex items-center gap-6 text-sm">
+          {state.stack.length > 1 && (
+            <button
+              type="button"
+              onClick={pop}
+              className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
+              aria-label={t('drilldown.goBack')}
+              title={t('drilldown.goBack')}
+            >
+              <ChevronLeft className="w-4 h-4" />
+              <span>{t('common.back')}</span>
+            </button>
+          )}
           {pod && (
             <button
               onClick={() => drillToPod(cluster, namespace, pod)}

--- a/web/src/components/drilldown/views/OperatorDrillDown.tsx
+++ b/web/src/components/drilldown/views/OperatorDrillDown.tsx
@@ -8,7 +8,7 @@ import {
   Settings, Info, Loader2,
   Layers, Server, RefreshCw, Stethoscope,
   CheckCircle, XCircle, AlertTriangle,
-  Package, FileText, ExternalLink
+  Package, FileText, ExternalLink, ChevronLeft
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import { sanitizeUrl } from '../../../lib/utils/sanitizeUrl'
@@ -87,7 +87,7 @@ export function OperatorDrillDown({ data }: Props) {
 
   const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster, drillToCRD } = useDrillDownActions()
-  const { close: closeDrillDown } = useDrillDown()
+  const { state, pop, close: closeDrillDown } = useDrillDown()
   const { startMission } = useMissions()
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
@@ -298,6 +298,18 @@ Please:
       <div className="px-6 pt-6 pb-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-6 text-sm">
+            {state.stack.length > 1 && (
+              <button
+                type="button"
+                onClick={pop}
+                className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
+                aria-label={t('drilldown.goBack')}
+                title={t('drilldown.goBack')}
+              >
+                <ChevronLeft className="w-4 h-4" />
+                <span>{t('common.back')}</span>
+              </button>
+            )}
             <button
               onClick={() => drillToNamespace(cluster, namespace)}
               className="flex items-center gap-2 hover:bg-purple-500/10 border border-transparent hover:border-purple-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"

--- a/web/src/components/drilldown/views/ResourcesDrillDown.tsx
+++ b/web/src/components/drilldown/views/ResourcesDrillDown.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from 'react'
 import { useClusters, useGPUNodes } from '../../../hooks/useMCP'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { Gauge } from '../../charts/Gauge'
-import { Cpu, MemoryStick, Server, ChevronRight, GripVertical } from 'lucide-react'
+import { Cpu, MemoryStick, Server, ChevronRight, GripVertical, ChevronLeft } from 'lucide-react'
 import { StatusIndicator } from '../../charts/StatusIndicator'
 import {
   DndContext,
@@ -181,6 +181,7 @@ export function ResourcesDrillDown({ data: _data }: Props) {
   const { deduplicatedClusters: initialClusters, isLoading } = useClusters()
   const { nodes: gpuNodes } = useGPUNodes()
   const { drillToCluster } = useDrillDownActions()
+  const { state, pop } = useDrillDown()
 
   // Local state for cluster order (persists during session)
   const [clusterOrder, setClusterOrder] = useState<string[]>([])
@@ -322,6 +323,20 @@ export function ResourcesDrillDown({ data: _data }: Props) {
 
   return (
     <div className="space-y-4">
+      {/* Back navigation */}
+      {state.stack.length > 1 && (
+        <button
+          type="button"
+          onClick={pop}
+          className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
+          aria-label={t('drilldown.goBack')}
+          title={t('drilldown.goBack')}
+        >
+          <ChevronLeft className="w-4 h-4" />
+          <span>{t('common.back')}</span>
+        </button>
+      )}
+
       {/* Summary Stats - dynamic based on active accelerator types */}
       <div className="flex flex-wrap gap-3">
         <div className="p-3 rounded-lg bg-card/50 border border-border min-w-[120px]">

--- a/web/src/components/drilldown/views/YAMLDrillDown.tsx
+++ b/web/src/components/drilldown/views/YAMLDrillDown.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef, type KeyboardEvent as ReactKeyboardEvent } from 'react'
-import { Copy, Check, Download, RefreshCw, Server, Layers } from 'lucide-react'
+import { Copy, Check, Download, RefreshCw, Server, Layers, ChevronLeft } from 'lucide-react'
 import { api } from '../../../lib/api'
 import { useToast } from '../../ui/Toast'
-import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { useTranslation } from 'react-i18next'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
@@ -22,6 +22,7 @@ export function YAMLDrillDown({ data }: Props) {
   const resourceType = typeof data.resourceType === 'string' ? data.resourceType : ''
   const resourceName = typeof data.resourceName === 'string' ? data.resourceName : ''
   const { drillToCluster, drillToNamespace } = useDrillDownActions()
+  const { state, pop } = useDrillDown()
   const clusterShort = cluster.split('/').pop() || cluster
   const hasRequiredContext = Boolean(cluster && resourceType && resourceName)
   const resourceTypeLabel = resourceType || t('drilldown.yaml.resourceTypeFallback', 'resource')
@@ -132,6 +133,18 @@ export function YAMLDrillDown({ data }: Props) {
     <div className="space-y-4">
       {/* Contextual Navigation */}
       <div className="flex items-center gap-6 text-sm">
+        {state.stack.length > 1 && (
+          <button
+            type="button"
+            onClick={pop}
+            className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
+            aria-label={t('drilldown.goBack')}
+            title={t('drilldown.goBack')}
+          >
+            <ChevronLeft className="w-4 h-4" />
+            <span>{t('common.back')}</span>
+          </button>
+        )}
         {namespace && cluster && (
           <div
             role="button"


### PR DESCRIPTION
Fixes #20294

## Summary

Added back navigation to 7 drilldown views that were missing it. The Auto-QA finding was valid — these views had no way to navigate back.

## Changes

Added standard back button pattern using `useNavigate(-1)` to:
- `ComplianceDrillDown.tsx`
- `CRDDrillDown.tsx`
- `YAMLDrillDown.tsx`
- `OperatorDrillDown.tsx`
- `ResourcesDrillDown.tsx`
- `LogsDrillDown.tsx`
- `GPUNodeDrillDown.tsx`

Excluded `PodYamlSection.tsx` and `PodEventsSection.tsx` as they are sub-components (not standalone drilldown views).