### PR TITLE
[scanner] fix: resolve vitest mock hoisting TDZ errors (v2)

### DIFF
--- a/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
+++ b/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // Use explicit mock factories so references remain stable after vi.resetModules()
-const mockExecFileSync = vi.fn()
-const mockWriteFileSync = vi.fn()
-const mockMkdirSync = vi.fn()
-const mockMkdtempSync = vi.fn(() => '/tmp/mock-kubeconfig-dir')
-const mockRmSync = vi.fn()
-const mockExistsSync = vi.fn(() => false)
-const mockReadFileSync = vi.fn(() => '')
+const { mockExecFileSync, mockWriteFileSync, mockMkdirSync, mockMkdtempSync, mockRmSync, mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+  mockMkdtempSync: vi.fn(() => '/tmp/mock-kubeconfig-dir'),
+  mockRmSync: vi.fn(),
+  mockExistsSync: vi.fn(() => false),
+  mockReadFileSync: vi.fn(() => ''),
+}))
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,

--- a/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
+++ b/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // Use explicit mock factories so references remain stable after vi.resetModules()
-const mockExecFileSync = vi.fn()
-const mockWriteFileSync = vi.fn()
-const mockMkdirSync = vi.fn()
-const mockMkdtempSync = vi.fn(() => '/tmp/mock-kubeconfig-dir')
-const mockRmSync = vi.fn()
+const { mockExecFileSync, mockWriteFileSync, mockMkdirSync, mockMkdtempSync, mockRmSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+  mockMkdtempSync: vi.fn(() => '/tmp/mock-kubeconfig-dir'),
+  mockRmSync: vi.fn(),
+}))
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,

--- a/web/src/lib/cache/__tests__/cacheStats.test.ts
+++ b/web/src/lib/cache/__tests__/cacheStats.test.ts
@@ -15,7 +15,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // ── Mocks ──────────────────────────────────────────────────────────
 
 const mockPreloadedMetaMap = new Map<string, unknown>()
-const mockClearSessionSnapshots = vi.fn()
+const { mockClearSessionSnapshots } = vi.hoisted(() => ({
+  mockClearSessionSnapshots: vi.fn(),
+}))
 const mockCacheStorageClear = vi.fn().mockResolvedValue(undefined)
 const mockCacheStorageDelete = vi.fn().mockResolvedValue(undefined)
 let mockCacheStorageStats: { keys: string[]; count: number } = { keys: [], count: 0 }

--- a/web/src/lib/utils/__tests__/wsAuth.test.ts
+++ b/web/src/lib/utils/__tests__/wsAuth.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 
-const mockEmitWsAuthMissing = vi.fn()
-const mockGetAgentToken = vi.fn(async () => '')
+const { mockEmitWsAuthMissing, mockGetAgentToken } = vi.hoisted(() => ({
+  mockEmitWsAuthMissing: vi.fn(),
+  mockGetAgentToken: vi.fn(async () => ''),
+}))
 let mockIsLocalAgentSuppressed = false
 
 vi.mock('../../analytics', () => ({


### PR DESCRIPTION
Fixes #20302

Wraps mock variables in `vi.hoisted()` only when they are referenced inside `vi.mock()` factory functions. Previous attempt (#20303) introduced lint violations by over-applying hoisting and adding unnecessary eslint-disable comments.

This approach is surgical — only 4 files had the actual TDZ pattern where `const mock = vi.fn()` was declared before a `vi.mock()` factory that references it:
- `web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts`
- `web/harness/groundtruth/__tests__/liveFixtureManager.test.ts`
- `web/src/lib/cache/__tests__/cacheStats.test.ts`
- `web/src/lib/utils/__tests__/wsAuth.test.ts`

The 215 test failures cascade from these base test utilities.