### PR TITLE
🐛 Revert vi.hoisted() mock pattern causing 231 test failures

### DIFF
--- a/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
+++ b/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
@@ -1,15 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // Use explicit mock factories so references remain stable after vi.resetModules()
-const { mockExecFileSync, mockWriteFileSync, mockMkdirSync, mockMkdtempSync, mockRmSync, mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
-  mockExecFileSync: vi.fn(),
-  mockWriteFileSync: vi.fn(),
-  mockMkdirSync: vi.fn(),
-  mockMkdtempSync: vi.fn(() => '/tmp/mock-kubeconfig-dir'),
-  mockRmSync: vi.fn(),
-  mockExistsSync: vi.fn(() => false),
-  mockReadFileSync: vi.fn(() => ''),
-}))
+const mockExecFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockMkdtempSync = vi.fn(() => '/tmp/mock-kubeconfig-dir')
+const mockRmSync = vi.fn()
+const mockExistsSync = vi.fn(() => false)
+const mockReadFileSync = vi.fn(() => '')
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,

--- a/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
+++ b/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
@@ -1,13 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // Use explicit mock factories so references remain stable after vi.resetModules()
-const { mockExecFileSync, mockWriteFileSync, mockMkdirSync, mockMkdtempSync, mockRmSync } = vi.hoisted(() => ({
-  mockExecFileSync: vi.fn(),
-  mockWriteFileSync: vi.fn(),
-  mockMkdirSync: vi.fn(),
-  mockMkdtempSync: vi.fn(() => '/tmp/mock-kubeconfig-dir'),
-  mockRmSync: vi.fn(),
-}))
+const mockExecFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockMkdtempSync = vi.fn(() => '/tmp/mock-kubeconfig-dir')
+const mockRmSync = vi.fn()
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,

--- a/web/src/lib/cache/__tests__/cacheStats.test.ts
+++ b/web/src/lib/cache/__tests__/cacheStats.test.ts
@@ -15,9 +15,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // ── Mocks ──────────────────────────────────────────────────────────
 
 const mockPreloadedMetaMap = new Map<string, unknown>()
-const { mockClearSessionSnapshots } = vi.hoisted(() => ({
-  mockClearSessionSnapshots: vi.fn(),
-}))
+const mockClearSessionSnapshots = vi.fn()
 const mockCacheStorageClear = vi.fn().mockResolvedValue(undefined)
 const mockCacheStorageDelete = vi.fn().mockResolvedValue(undefined)
 let mockCacheStorageStats: { keys: string[]; count: number } = { keys: [], count: 0 }

--- a/web/src/lib/utils/__tests__/wsAuth.test.ts
+++ b/web/src/lib/utils/__tests__/wsAuth.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 
-const { mockEmitWsAuthMissing, mockGetAgentToken } = vi.hoisted(() => ({
-  mockEmitWsAuthMissing: vi.fn(),
-  mockGetAgentToken: vi.fn(async () => ''),
-}))
+const mockEmitWsAuthMissing = vi.fn()
+const mockGetAgentToken = vi.fn(async () => '')
 let mockIsLocalAgentSuppressed = false
 
 vi.mock('../../analytics', () => ({


### PR DESCRIPTION
Fixes #20316

Reverts the `vi.hoisted()` wrapping introduced in PR #20312. The pattern caused 231 test failures in Coverage Suite run #4070.

## Changed Files
- `web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts`
- `web/harness/groundtruth/__tests__/liveFixtureManager.test.ts`
- `web/src/lib/cache/__tests__/cacheStats.test.ts`
- `web/src/lib/utils/__tests__/wsAuth.test.ts`

## Changes
All mocks reverted from:
```typescript
const { mockFn } = vi.hoisted(() => ({ mockFn: vi.fn() }))
```

Back to:
```typescript
const mockFn = vi.fn()
```

The original `const mock = vi.fn()` pattern works correctly with the current vitest configuration.