### PR TITLE
fix: restore vi.hoisted() to resolve 232 test failures

### DIFF
--- a/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
+++ b/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // Use explicit mock factories so references remain stable after vi.resetModules()
-const mockExecFileSync = vi.fn()
-const mockWriteFileSync = vi.fn()
-const mockMkdirSync = vi.fn()
-const mockMkdtempSync = vi.fn(() => '/tmp/mock-kubeconfig-dir')
-const mockRmSync = vi.fn()
-const mockExistsSync = vi.fn(() => false)
-const mockReadFileSync = vi.fn(() => '')
+const { mockExecFileSync, mockWriteFileSync, mockMkdirSync, mockMkdtempSync, mockRmSync, mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+  mockMkdtempSync: vi.fn(() => '/tmp/mock-kubeconfig-dir'),
+  mockRmSync: vi.fn(),
+  mockExistsSync: vi.fn(() => false),
+  mockReadFileSync: vi.fn(() => ''),
+}))
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,

--- a/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
+++ b/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // Use explicit mock factories so references remain stable after vi.resetModules()
-const mockExecFileSync = vi.fn()
-const mockWriteFileSync = vi.fn()
-const mockMkdirSync = vi.fn()
-const mockMkdtempSync = vi.fn(() => '/tmp/mock-kubeconfig-dir')
-const mockRmSync = vi.fn()
+const { mockExecFileSync, mockWriteFileSync, mockMkdirSync, mockMkdtempSync, mockRmSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+  mockMkdtempSync: vi.fn(() => '/tmp/mock-kubeconfig-dir'),
+  mockRmSync: vi.fn(),
+}))
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,

--- a/web/src/lib/cache/__tests__/cacheStats.test.ts
+++ b/web/src/lib/cache/__tests__/cacheStats.test.ts
@@ -15,7 +15,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // ── Mocks ──────────────────────────────────────────────────────────
 
 const mockPreloadedMetaMap = new Map<string, unknown>()
-const mockClearSessionSnapshots = vi.fn()
+const { mockClearSessionSnapshots } = vi.hoisted(() => ({
+  mockClearSessionSnapshots: vi.fn(),
+}))
 const mockCacheStorageClear = vi.fn().mockResolvedValue(undefined)
 const mockCacheStorageDelete = vi.fn().mockResolvedValue(undefined)
 let mockCacheStorageStats: { keys: string[]; count: number } = { keys: [], count: 0 }

--- a/web/src/lib/utils/__tests__/wsAuth.test.ts
+++ b/web/src/lib/utils/__tests__/wsAuth.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 
-const mockEmitWsAuthMissing = vi.fn()
-const mockGetAgentToken = vi.fn(async () => '')
+const { mockEmitWsAuthMissing, mockGetAgentToken } = vi.hoisted(() => ({
+  mockEmitWsAuthMissing: vi.fn(),
+  mockGetAgentToken: vi.fn(async () => ''),
+}))
 let mockIsLocalAgentSuppressed = false
 
 vi.mock('../../analytics', () => ({


### PR DESCRIPTION
Fixes #20321

## Root Cause

PR #20318 mistakenly reverted the `vi.hoisted()` pattern that was **correctly** fixing Temporal Dead Zone errors in vitest isolate mode. Here's the timeline:

1. **July 4**: PR #20258 enabled `isolate: true` in vitest config
2. **July 4**: PR #20312 added `vi.hoisted()` to fix TDZ errors caused by isolation
3. **July 5**: PR #20318 **REVERTED** #20312 (thought it caused failures, but it was actually fixing them)
4. **July 5**: After #20318 merge → 232 new test failures appeared in Coverage Suite run #4073

## Fix

With `isolate: true`, each test file runs in its own subprocess with a clean global environment. The `vi.mock()` factory functions are hoisted to the top before `const` declarations, causing reference errors when mocks are declared as plain `const`.

This PR restores the `vi.hoisted()` wrapping in the 4 files that were reverted:

- `web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts`
- `web/harness/groundtruth/__tests__/liveFixtureManager.test.ts`
- `web/src/lib/cache/__tests__/cacheStats.test.ts`
- `web/src/lib/utils/__tests__/wsAuth.test.ts`

This re-applies the correct fix from PR #20312 that was working before the accidental revert.

## Verification

Build and e2e tests were passing on main. Only Coverage Suite (vitest unit tests) was failing with 232 failures across 12 shards. This fix restores the proper mock hoisting pattern required by vitest isolate mode.