### PR TITLE
[scanner] fix: add dark mode variants to light-only color classes

### DIFF
--- a/web/src/components/cards/kagenti/KagentiLifecycleManager.tsx
+++ b/web/src/components/cards/kagenti/KagentiLifecycleManager.tsx
@@ -23,7 +23,7 @@ const AGENT_STATE_COLORS: Record<string, { bg: string; text: string; border: str
   Deploying: { bg: 'bg-blue-500/10', text: 'text-blue-400', border: 'border-blue-500/30' },
   Ready: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/30' },
   Failed: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/30' },
-  Unknown: { bg: 'bg-gray-500/10', text: 'text-gray-400', border: 'border-gray-500/30' },
+  Unknown: { bg: 'bg-gray-500/10 dark:bg-gray-400/10', text: 'text-gray-400 dark:text-gray-300', border: 'border-gray-500/30 dark:border-gray-400/30' },
 }
 
 const BUILD_STATE_COLORS: Record<string, { bg: string; text: string; border: string }> = {
@@ -71,7 +71,7 @@ function LifecycleSummaryBar({
       </div>
       <div className="flex items-center gap-1">
         {states.map((state, idx) => {
-          const colors = colorMap[state] || colorMap.Unknown || { bg: 'bg-gray-500/10', text: 'text-gray-400', border: 'border-gray-500/30' }
+          const colors = colorMap[state] || colorMap.Unknown || { bg: 'bg-gray-500/10 dark:bg-gray-400/10', text: 'text-gray-400 dark:text-gray-300', border: 'border-gray-500/30 dark:border-gray-400/30' }
           const count = counts[state] || 0
           return (
             <div key={state} className="contents">
@@ -249,7 +249,7 @@ function KagentiLifecycleManagerInternal({ config }: KagentiLifecycleManagerProp
           <div className="text-xs font-medium text-muted-foreground px-1">Recent Activity</div>
           {recentEvents.map((event, idx) => {
             const colorMap = event.type === 'agent' ? AGENT_STATE_COLORS : BUILD_STATE_COLORS
-            const colors = colorMap[event.status] || { bg: 'bg-gray-500/10', text: 'text-gray-400', border: 'border-gray-500/30' }
+            const colors = colorMap[event.status] || { bg: 'bg-gray-500/10 dark:bg-gray-400/10', text: 'text-gray-400 dark:text-gray-300', border: 'border-gray-500/30 dark:border-gray-400/30' }
             const Icon = event.type === 'agent' ? Bot : Hammer
             return (
               <div

--- a/web/src/components/feedback/UpdatesTabGitHubContributionsSection.tsx
+++ b/web/src/components/feedback/UpdatesTabGitHubContributionsSection.tsx
@@ -94,7 +94,7 @@ export function GitHubContributionsSection({
               </StatusBadge>
             )}
             {githubRewards.breakdown.other_issues > 0 && (
-              <StatusBadge color="purple" size="xs" rounded="full" className="bg-gray-500/20! text-muted-foreground!" icon={<AlertCircle className="w-2.5 h-2.5" />}>
+              <StatusBadge color="purple" size="xs" rounded="full" className="bg-gray-500/20! dark:bg-gray-400/20! text-muted-foreground!" icon={<AlertCircle className="w-2.5 h-2.5" />}>
                 {githubRewards.breakdown.other_issues} Issues
               </StatusBadge>
             )}

--- a/web/src/pages/UnifiedDashboardTest.tsx
+++ b/web/src/pages/UnifiedDashboardTest.tsx
@@ -84,7 +84,7 @@ export function UnifiedDashboardTest() {
               migrationStatus.status === 'unified' ? 'bg-green-500/20 text-green-400' :
               migrationStatus.status === 'ready' ? 'bg-blue-500/20 text-blue-400' :
               migrationStatus.status === 'excluded' ? 'bg-orange-500/20 text-orange-400' :
-              'bg-gray-500/20 text-muted-foreground'
+              'bg-gray-500/20 dark:bg-gray-400/20 text-muted-foreground'
             }`}>
               {migrationStatus.status}
             </span>


### PR DESCRIPTION
Fixes #20341

Adds dark: variants to 5 light-only color classes in 3 files. Inline color styles (section 2 of the issue) are deferred to a follow-up PR as they require design decisions about CSS variable usage.

Changes:
- UpdatesTabGitHubContributionsSection.tsx: add dark: variant to gray badge
- KagentiLifecycleManager.tsx: add dark: variants to Unknown state color map + fallback color objects (3 locations)
- UnifiedDashboardTest.tsx: add dark: variant to migration status badge