### PR TITLE
[ci-maintainer] fix: restrict pre-merge-gate to push events only

### DIFF
--- a/.github/workflows/pre-merge-gate.yml
+++ b/.github/workflows/pre-merge-gate.yml
@@ -3,6 +3,7 @@ name: Pre-Merge Build Gate
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened]
 
 permissions: read-all  # default read; writes scoped to job below
 


### PR DESCRIPTION
## CI Fix

Adds `types: [opened, synchronize, reopened]` to `pre-merge-gate.yml` trigger.

**Problem:** Without this filter, GitHub fires the `pull_request` event on ALL PR activity — label changes, review requests, Copilot review comments, etc. With `concurrency: cancel-in-progress: true`, any such event immediately kills the running `build-gate` job. This causes every PR's `build-gate` check to show `cancelled`, blocking all merges.

**Evidence:** All 4 currently open PRs (#20350, #20349, #20347, #20346) have `build-gate: cancelled`. Recent pre-merge-gate runs: all `cancelled` or `failure`. PRs #20350 and #20346 have zero test failures but cannot merge because `build-gate` is a required check and always gets cancelled.

**Fix:** One-line addition restricts the trigger to commit-push events only (opened, synchronize, reopened). Label/review/Copilot events will no longer cancel in-progress runs.

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*