### PR TITLE
[ci-maintainer] fix: add web/harness/** to Coverage Suite path trigger

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
     paths:
       - 'web/src/**'
+      - 'web/harness/**'
       - 'web/netlify/functions/**'
       - 'web/package.json'
       - 'web/package-lock.json'


### PR DESCRIPTION
## CI Fix

Adds `web/harness/**` to the path trigger in `coverage-hourly.yml`.

**Problem:** The Coverage Suite only re-triggers on `web/src/**`, `web/netlify/functions/**`, and a few config files. Changes to `web/harness/` (test utilities, evidence sanitizers, mock helpers) do NOT trigger the suite. This means a bug fix in harness code can merge to main without Coverage Suite re-running to verify the fix.

**Evidence:** PR #20337 (merged July 5) fixed a regex bug in `web/harness/evidence/sanitizeEvidence.ts` that caused 232 Coverage Suite test failures. Because the fix only touched `web/harness/`, no new Coverage Suite run was triggered on the fix commit (`f9161ae9`). The suite continued to report failure on the pre-fix SHA.

**Fix:** Add `- 'web/harness/**'` to the paths list so harness changes re-trigger the suite.

Fixes #20348

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*