### PR TITLE
[ci-maintainer] fix: grant pull-requests:write to merge-reports job in playwright.yml

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -130,6 +130,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      pull-requests: write # post test-result comment on PR
     defaults:
       run:
         working-directory: web


### PR DESCRIPTION
## CI Fix

Adds `permissions: pull-requests: write` to the `merge-reports` job in `playwright.yml`.

**Problem:** `playwright.yml` declares `permissions: read-all` at the workflow level, giving all jobs read-only access. The `merge-reports` job posts a PR comment summarising test results, but the comment POST to the GitHub Issues/Comments API requires `pull-requests: write` (or `issues: write`). Every run that attempts to post a comment fails with:

```
Unhandled error: HttpError: Resource not accessible by integration
```

This turns every PR with a shard test failure into **two** failed checks instead of one (`Test (chromium, shard N)` + `Merge Test Reports`), making it harder to triage the real failure.

**Fix:** Add a job-level `permissions` block on `merge-reports` that upgrades to `pull-requests: write`. All other jobs retain the read-only default inherited from the workflow level.

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*