### PR TITLE
[ci-maintainer] fix: update invalid actions/checkout pin in scanner-merge-guardrails.yml

### DIFF
--- a/.github/workflows/scanner-merge-guardrails.yml
+++ b/.github/workflows/scanner-merge-guardrails.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd72e0a28fef7ff2e8c5d # v6.4.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         
       - name: Check Scanner Merge Eligibility
         id: check


### PR DESCRIPTION
## CI Fix

Updates the `actions/checkout` pin in `scanner-merge-guardrails.yml` from an invalid commit SHA to the known-good SHA used by `playwright.yml` and `pre-merge-gate.yml`.

**Problem:** `scanner-merge-guardrails.yml` pins `actions/checkout@eef61447b9ff4aafe5dcd72e0a28fef7ff2e8c5d` with comment `# v6.4.0`. This commit SHA does not exist on the `actions/checkout` repository, causing the `enforce-guardrails` check to fail on every scanner/quality PR with:

```
Unable to resolve action `actions/checkout@eef61447b9ff4aafe5dcd72e0a28fef7ff2e8c5d`,
unable to find version `eef61447b9ff4aafe5dcd72e0a28fef7ff2e8c5d`
```

**Evidence:** PR #20349 `enforce-guardrails` check fails (run 28752715520) with the above error on both old SHA and new SHA `eb7fc775`. Check is a consistent blocker on all scanner/quality PRs.

**Fix:** Update to `df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3` — the same pin used by `playwright.yml` and `pre-merge-gate.yml` which are known to work.

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*