### PR TITLE
[ci-maintainer] fix: increase build-gate timeout from 15 to 30 minutes

### DIFF
--- a/.github/workflows/pre-merge-gate.yml
+++ b/.github/workflows/pre-merge-gate.yml
@@ -15,7 +15,7 @@ jobs:
   build-gate:
     name: build-gate
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 


### PR DESCRIPTION
## CI Fix

Increases the `build-gate` job timeout from 15 minutes to 30 minutes in `pre-merge-gate.yml`.

**Problem:** The build-gate job consistently times out at the 15-minute limit. Every recent run (post-concurrency-fix) shows exactly ~15.3 min duration with `cancelled` conclusion. Step timings from run 28753161480:

| Step | Duration |
|------|----------|
| Frontend build (`npm run build`) | **351s (5.9 min)** |
| Frontend lint | 63s (1.0 min) |
| Frontend test subset (vitest) | killed after 453s at timeout |

The test subset is reliably killed at the 15-min boundary before it can complete or report results. This means `build-gate` always shows `cancelled` even when all code is correct, blocking all PRs.

**Fix:** `timeout-minutes: 15` → `timeout-minutes: 30`. This matches observed run times (7-8 min for build+lint, plus 8-12 min for the vitest subset).

**Context:** The previous concurrency bug (#20351) caused instant cancellations from PR events. That fix is now live. The remaining cancellations are timeouts — a separate issue requiring this fix.

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*