### PR TITLE
[ci-maintainer] fix: install js-yaml dependency in scanner-merge-guardrails.yml

### DIFF
--- a/.github/workflows/scanner-merge-guardrails.yml
+++ b/.github/workflows/scanner-merge-guardrails.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install script dependencies
+        run: npm install --no-save js-yaml
         
       - name: Check Scanner Merge Eligibility
         id: check


### PR DESCRIPTION
## CI Fix

Adds `npm install --no-save js-yaml` before the `Check Scanner Merge Eligibility` step in `scanner-merge-guardrails.yml`.

**Problem:** After fixing the invalid `actions/checkout` pin (PR #20357), the `enforce-guardrails` job now reaches the `actions/github-script` step but immediately fails with:

```
Unhandled error: Error: Cannot find module 'js-yaml'
Require stack:
- /home/runner/work/_actions/actions/github-script/3a2844b7e9c422d3c10d287c895573f...
```

`js-yaml` is not a built-in Node.js module and is not bundled with `actions/github-script` v9. The script uses `require('js-yaml')` to parse `.github/scanner-config.yml`, making this fix necessary for the guardrail to function at all.

**Evidence:** Check run 85258895608 (PR #20349 SHA `ee6a98fc`) and 85258895742 (PR #20360 SHA `b51890b5`) both fail with this error.

**Fix:** Add an explicit `npm install --no-save js-yaml` step immediately after checkout. This installs `js-yaml` into the runner's working directory where `require()` can find it, without modifying `package.json`.

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*