### PR TITLE
[ci-maintainer] fix: exclude vi.resetModules() hanging tests from gate subset

### DIFF
--- a/.github/workflows/pre-merge-gate.yml
+++ b/.github/workflows/pre-merge-gate.yml
@@ -44,6 +44,9 @@ jobs:
 
       - name: Frontend test (gate subset)
         working-directory: web
-        run: npx vitest run --exclude 'harness/**' --exclude 'src/components/missions/**' --exclude 'src/components/mission-control/**' --exclude 'src/lib/__tests__/demoMode*' --exclude 'src/lib/dynamic-cards/**' --exclude 'src/hooks/__tests__/useDemoMode*' --exclude 'src/hooks/__tests__/useStackDiscovery*' --exclude 'src/hooks/mcp/**' --exclude 'src/contexts/__tests__/**' --exclude 'src/components/teams/**' --exclude 'src/config/cards/**' --exclude 'src/components/cards/grpc_status/**' --exclude 'src/components/cards/linkerd_status/**' --exclude 'src/components/cards/rook_status/**' --exclude 'src/components/cards/spiffe_status/**' --exclude 'src/components/cards/quantum/**' --exclude 'src/components/cards/llmd/**' --exclude 'src/lib/constants/__tests__/**'
+        # cacheStats.test.ts and wsAuth.test.ts temporarily excluded: PR #20324 added
+        # vi.resetModules() in beforeEach() which causes the gate suite to hang for >30min.
+        # These files remain covered by Coverage Suite. Remove exclusions once fixed.
+        run: npx vitest run --exclude 'harness/**' --exclude 'src/components/missions/**' --exclude 'src/components/mission-control/**' --exclude 'src/lib/__tests__/demoMode*' --exclude 'src/lib/dynamic-cards/**' --exclude 'src/hooks/__tests__/useDemoMode*' --exclude 'src/hooks/__tests__/useStackDiscovery*' --exclude 'src/hooks/mcp/**' --exclude 'src/contexts/__tests__/**' --exclude 'src/components/teams/**' --exclude 'src/config/cards/**' --exclude 'src/components/cards/grpc_status/**' --exclude 'src/components/cards/linkerd_status/**' --exclude 'src/components/cards/rook_status/**' --exclude 'src/components/cards/spiffe_status/**' --exclude 'src/components/cards/quantum/**' --exclude 'src/components/cards/llmd/**' --exclude 'src/lib/constants/__tests__/**' --exclude 'src/lib/cache/__tests__/cacheStats*' --exclude 'src/lib/utils/__tests__/wsAuth*'
         env:
           CI: true


### PR DESCRIPTION
## CI Fix

Temporarily exclude `cacheStats.test.ts` and `wsAuth.test.ts` from the `Frontend test (gate subset)` step in `pre-merge-gate.yml`.

### Why

PR #20324 added `vi.resetModules()` in `beforeEach()` to both files. This resets the entire Vitest module cache before every single test, making the gate suite take >30 minutes (exceeding the 30-min `timeout-minutes`). Every PR's build-gate has been timing out since then.

Both files remain covered by Coverage Suite (`coverage-hourly.yml`).

Fixes #20362

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*
