### PR TITLE
[scanner] fix: pin js-yaml@4.1.0 in scanner-merge-guardrails workflow

### DIFF
--- a/.github/workflows/scanner-merge-guardrails.yml
+++ b/.github/workflows/scanner-merge-guardrails.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install script dependencies
-        run: npm install --no-save js-yaml
+        run: npm install --no-save js-yaml@4.1.0
         
       - name: Check Scanner Merge Eligibility
         id: check


### PR DESCRIPTION
## Security Fix\n\nPins `js-yaml` to `4.1.0` in the scanner-merge-guardrails workflow to address the unpinned npm dependency flagged in #20368.\n\nFixes #20368\n\n---\n\n**Status**: Reopened. This PR was previously failing due to the ESLint baseline issue (unrelated). PR #20371 fixes that — once merged, this PR's CI should pass on rebase.