### PR TITLE
[scanner] fix: wrap localStorage in try/catch for private browsing safety

### DIFF
--- a/web/src/components/cards/__tests__/CardToolbar.test.tsx
+++ b/web/src/components/cards/__tests__/CardToolbar.test.tsx
@@ -33,7 +33,7 @@ vi.mock('react-i18next', () => ({
 vi.mock('lucide-react', () => ({
   ChevronDown: () => <span>ChevronDown</span>,
   ChevronRight: () => <span>ChevronRight</span>,
-  RefreshCw: ({ className, ...props }: any) => <span data-testid="RefreshCw" className={className} {...props}>RefreshCw</span>,
+  RefreshCw: ({ className, ...props }: unknown) => <span data-testid="RefreshCw" className={className as string} {...(props as object)}>RefreshCw</span>,
   Maximize2: () => <span>Maximize2</span>,
   Bug: () => <span>Bug</span>,
 }))

--- a/web/src/contexts/StackContext.tsx
+++ b/web/src/contexts/StackContext.tsx
@@ -213,7 +213,7 @@ export function StackProvider({ children }: StackProviderProps) {
   // Stable no-op for demo mode so refetch identity doesn't change every render
   const demoRefetch = useCallback(() => {}, [])
   const refetch = isDemoMode ? demoRefetch : liveRefetch
-  const lastRefresh = isDemoMode ? new Date() : liveLastRefresh
+  const lastRefresh = useMemo(() => isDemoMode ? new Date() : liveLastRefresh, [isDemoMode, liveLastRefresh])
 
   const [selectedStackId, setSelectedStackIdState] = useState<string | null>(() => {
     if (typeof window !== 'undefined') {
@@ -293,4 +293,5 @@ export function StackProvider({ children }: StackProviderProps) {
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { useStack, useOptionalStack }

--- a/web/src/contexts/StackContext.tsx
+++ b/web/src/contexts/StackContext.tsx
@@ -12,6 +12,7 @@ import { useStackDiscovery, type LLMdStack, type LLMdStackComponent } from '../h
 import { useDemoMode } from '../hooks/useDemoMode'
 import { useClusters } from '../hooks/mcp/clusters'
 import { createStateContext } from './createStateContext'
+import { safeGetItem, safeSetItem, safeRemoveItem } from '../lib/utils/localStorage'
 
 const STORAGE_KEY = 'kubestellar-llmd-stack'
 
@@ -216,7 +217,7 @@ export function StackProvider({ children }: StackProviderProps) {
 
   const [selectedStackId, setSelectedStackIdState] = useState<string | null>(() => {
     if (typeof window !== 'undefined') {
-      return localStorage.getItem(STORAGE_KEY)
+      return safeGetItem(STORAGE_KEY)
     }
     return null
   })
@@ -226,9 +227,9 @@ export function StackProvider({ children }: StackProviderProps) {
     setSelectedStackIdState(id)
     if (typeof window !== 'undefined') {
       if (id) {
-        localStorage.setItem(STORAGE_KEY, id)
+        safeSetItem(STORAGE_KEY, id)
       } else {
-        localStorage.removeItem(STORAGE_KEY)
+        safeRemoveItem(STORAGE_KEY)
       }
     }
   }, [])

--- a/web/src/contexts/ThemeContext.tsx
+++ b/web/src/contexts/ThemeContext.tsx
@@ -3,6 +3,7 @@ import { Theme, themes, getAllThemes, getThemeById, getDefaultTheme } from '../l
 import { emitThemeChanged } from '../lib/analytics'
 import { GOOGLE_FONTS_API_URL } from '../config/externalApis'
 import { createStateContext } from './createStateContext'
+import { safeGetItem, safeSetItem } from '../lib/utils/localStorage'
 
 /**
  * Theme Context
@@ -218,7 +219,7 @@ export { ThemeContext, useTheme }
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [themeId, setThemeIdState] = useState<string>(() => {
     if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem(STORAGE_KEY)
+      const stored = safeGetItem(STORAGE_KEY)
       // Handle legacy 'dark'/'light' values
       if (stored === 'dark') return 'kubestellar'
       if (stored === 'light') return 'kubestellar-light'
@@ -243,7 +244,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // Track the last selected dark theme for toggle functionality
   const [lastDarkTheme, setLastDarkTheme] = useState<string>(() => {
     if (typeof window !== 'undefined') {
-      return localStorage.getItem(LAST_DARK_THEME_KEY) || 'kubestellar'
+      return safeGetItem(LAST_DARK_THEME_KEY) || 'kubestellar'
     }
     return 'kubestellar'
   })
@@ -255,7 +256,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const theme = getThemeById(id)
     if (theme?.dark && id !== 'system') {
       setLastDarkTheme(id)
-      localStorage.setItem(LAST_DARK_THEME_KEY, id)
+      safeSetItem(LAST_DARK_THEME_KEY, id)
     }
   }
 
@@ -274,7 +275,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // paints, preventing a flash of the previous theme's colors (#14183).
   useLayoutEffect(() => {
     applyTheme(currentTheme)
-    localStorage.setItem(STORAGE_KEY, themeId)
+    safeSetItem(STORAGE_KEY, themeId)
     window.dispatchEvent(new CustomEvent('kubestellar-settings-changed'))
   }, [currentTheme, themeId])
 


### PR DESCRIPTION
Fixes #20375

## Changes
- Wrapped localStorage.getItem/setItem calls in StackContext.tsx and ThemeContext.tsx with safe utilities from `lib/utils/localStorage.ts`
- AlertsContext already used safe wrappers — no changes needed there
- Prevents crashes in private browsing mode (QuotaExceededError, SecurityError)