### PR TITLE
[scanner] fix: resolve Playwright mobile browser test failures

### DIFF
--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -175,21 +175,21 @@ test.describe('Smoke Tests', () => {
           await hamburger.evaluate((el) => (el as HTMLElement).click())
           await expect(sidebar).toBeVisible({ timeout: 3000 })
           // Mobile sidebar animation: wait for Settings link to become visible after sidebar opens.
-          // Fixes #20086, #20087 — sidebar container visible but links still hidden mid-animation.
-          await expect(settingsLink).toBeVisible({ timeout: 5000 })
+          // Fixes #20086, #20087, #20388 — sidebar container visible but links still hidden mid-animation.
+          await page.waitForLoadState('networkidle').catch((error) => { console.error('Promise catch:', error) })
+          await expect(settingsLink).toBeVisible({ timeout: 10000 })
+          await page.waitForTimeout(500)
+          await settingsLink.waitFor({ state: 'visible', timeout: 5000 })
+          await settingsLink.click({ force: true })
         }
+      } else {
+        // Desktop: sidebar always visible, just wait for link to be ready.
+        await page.waitForLoadState('networkidle').catch((error) => { console.error('Promise catch:', error) })
+        await expect(settingsLink).toBeVisible({ timeout: 45000 })
+        await page.waitForTimeout(500)
+        await settingsLink.waitFor({ state: 'visible', timeout: 10000 })
+        await settingsLink.click({ force: true })
       }
-
-      // WebKit/mobile browsers need more time for sidebar elements to hydrate.
-      // Wait for both the element to exist AND become actionable (no visibility:hidden).
-      // The sidebar slide-in animation can leave elements in a "found but hidden" state.
-      await page.waitForLoadState('networkidle').catch((error) => { console.error('Promise catch:', error) })
-      await expect(settingsLink).toBeVisible({ timeout: 45000 })
-      // Extra stability wait for webkit/safari where elements can be "visible" but
-      // still mid-transition. Wait for DOM to fully settle after animation.
-      await page.waitForTimeout(500)
-      await settingsLink.waitFor({ state: 'visible', timeout: 10000 })
-      await settingsLink.click({ force: true })
 
       await expect(page).toHaveURL(/\/settings(?:[?#].*)?$/, { timeout: 10000 })
       await expect(page.locator('[data-testid="settings-page"] [data-testid="settings-title"]').first()).toBeVisible({ timeout: 15000 })


### PR DESCRIPTION
Fixes #20388

## Problem
Mobile (mobile-safari, mobile-chrome) jobs failed in Playwright nightly workflow run #28776771004.

Error: `expect(settingsLink).toBeVisible()` timed out after 45s. Settings link was `hidden` despite multiple retries.

## Root Cause
Mobile sidebar auto-closes after interaction. Test code:
1. Opened hamburger menu (inside mobile viewport block)
2. Waited for sidebar visible (3s)
3. Waited for settingsLink visible (5s)
4. **Exited mobile block**
5. **Waited again for settingsLink visible (45s) — FAILED**

By step 5, sidebar had auto-closed → link hidden.

## Fix
Click settingsLink **inside the mobile block** while sidebar is still open. Split desktop/mobile paths:
- **Mobile**: Open hamburger → wait for link → click immediately
- **Desktop**: Sidebar always visible → wait → click

Tested against same viewport (393x852) used by failing jobs.