### PR TITLE
[scanner] fix: resolve Playwright Cross-Browser nightly workflow failure

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -166,7 +166,6 @@ jobs:
             --workers=1 \
             e2e/smoke.spec.ts \
             e2e/responsive-regression.spec.ts \
-            e2e/navbar-responsive.spec.ts \
             e2e/Login.spec.ts \
             e2e/Dashboard.spec.ts
         env:


### PR DESCRIPTION
Fixes #20388

## Problem

Mobile jobs (mobile-safari, mobile-chrome) in Playwright Cross-Browser nightly workflow were failing.

## Root Cause

The mobile job was running `e2e/navbar-responsive.spec.ts`, which explicitly skips ALL tests when `isMobile` is true (line 73):

```typescript
test.skip(isMobile, 'Viewport breakpoint tests are unreliable on mobile device emulation (DPR > 1)')
```

When the workflow ran with `--project=mobile-chrome` or `--project=mobile-safari`, Playwright sets `isMobile=true`, causing all responsive tests to skip, resulting in job failure.

## Fix

Removed `e2e/navbar-responsive.spec.ts` from mobile job test list. The test remains in the cross-browser job where it runs successfully on desktop browsers (Firefox, WebKit).

## Testing

CI will validate this fix. The mobile jobs should now pass with the remaining tests:
- e2e/smoke.spec.ts
- e2e/responsive-regression.spec.ts  
- e2e/Login.spec.ts
- e2e/Dashboard.spec.ts