### PR TITLE
[ci-maintainer] fix: switch coverage-hourly to --pool=threads to prevent OOM shard crashes

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -64,8 +64,9 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=6144'
         run: |
           npx vitest run --coverage --coverage.reportOnFailure \
-            --reporter=default --reporter=json \
+            --reporter=verbose --reporter=json \
             --outputFile.json=test-results.json \
+            --pool=threads \
             --shard=${{ matrix.shard }}/${{ env.TOTAL_SHARDS }} || true
 
           # Extract failed test names for the issue body


### PR DESCRIPTION
## CI Fix

The Coverage Suite has been failing with all 12 shards crashing in 4-6 minutes (before writing `test-results.json`) across 9+ consecutive runs.

**Root cause:** Vitest's default `forks` pool spawns an isolated fork process per test file. Each fork loads the full module graph independently. With many test files per shard and `NODE_OPTIONS='--max-old-space-size=6144'`, concurrent forks can collectively exhaust the 7 GB GitHub Actions runner, causing OOM crashes with no output.

**Fix:** Switch to `--pool=threads` (worker threads instead of fork processes). Threads share a single Node.js heap per shard, eliminating the cumulative OOM pressure. Also change `--reporter=default` → `--reporter=verbose` to surface error messages in future failures.

This is a **workflow-only change** — no test source code modified. The pre-merge gate is unaffected.

Fixes #20404

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*