### PR TITLE
[ci-maintainer] fix: align all codeql-action steps to v4.36.3 to fix CodeQL version skew

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: go
           # Extended queries catch more issues (auth bypass, injection, etc.)
@@ -50,7 +50,7 @@ jobs:
         uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:go"
 
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: javascript-typescript
           # Extended queries catch XSS, prototype pollution, injection, etc.
@@ -79,6 +79,6 @@ jobs:
         uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
## CI Fix

`CodeQL Security Analysis` has been failing on `main` for 3 consecutive runs. A Dependabot PR bumped `codeql-action/autobuild` to v4.36.3 while `init` and `analyze` remained at v4.36.2.

**Error:**
```
Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

**Fix:** Align `init` and `analyze` to v4.36.3 SHA `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a`. Both the Go and JavaScript/TypeScript jobs are updated (6 lines total).

Fixes #20428

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*