### PR TITLE
🐛 fix: revert vi.restoreAllMocks() breaking 265 tests

### DIFF
--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -226,7 +226,6 @@ afterEach(() => {
     window.sessionStorage?.clear()
   }
   vi.unstubAllEnvs()
-  vi.restoreAllMocks() // Restore mocks but preserve global stubs (e.g., localStorage) (#20007)
   vi.clearAllMocks()
 })
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -321,7 +321,7 @@ export default defineConfig(({ mode }) => ({
     isolate: true,
     // CI: use threads pool instead of forks to prevent OOM from subprocess spawn storm (#20007)
     // Threads share memory, no fork overhead. Local dev uses default (forks) for stronger isolation.
-    pool: process.env.CI ? 'threads' : undefined,
+    // pool: process.env.CI ? 'threads' : undefined,  // Reverted: threads share memory, can cause mock cross-contamination
     coverage: {
       provider: 'v8',
       // Disable coverage.all to prevent force-importing source files that trigger


### PR DESCRIPTION
Fixes #20434

## Root Cause

PR #20425 added `vi.restoreAllMocks()` to the global `afterEach` in `web/src/test/setup.ts`. This restores all spy/mock implementations to their original values after every test, which breaks any test that:
- Sets up spies in `beforeAll` expecting them to persist
- Relies on `vi.mock()` factory return values that get cleared

Also reverts the `pool: 'threads'` change since threads share memory and can cause mock cross-contamination between test files.

## Fix

- Remove `vi.restoreAllMocks()` from afterEach (keep `vi.clearAllMocks()` which is safe)
- Revert pool to default (forks) for better isolation