### PR TITLE
[scanner] fix: remove --pool=threads override in Coverage Suite workflow

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -66,7 +66,6 @@ jobs:
           npx vitest run --coverage --coverage.reportOnFailure \
             --reporter=verbose --reporter=json \
             --outputFile.json=test-results.json \
-            --pool=threads \
             --shard=${{ matrix.shard }}/${{ env.TOTAL_SHARDS }} || true
 
           # Extract failed test names for the issue body


### PR DESCRIPTION
Fixes #20439

## Root Cause

PR #20435 reverted `pool: 'threads'` in `web/vite.config.ts` (line 324) and removed `vi.restoreAllMocks()` from `web/src/test/setup.ts`, but the Coverage Suite workflow still had `--pool=threads` hardcoded on line 69 of `.github/workflows/coverage-hourly.yml`.

This CLI flag overrides the vite.config.ts setting, forcing threads pool mode despite the revert. Threads share memory across test files → mock cross-contamination → 265 test failures.

## Fix

Removed `--pool=threads \` from workflow line 69. Tests now use default pool mode (forks) with `isolate: true`, providing proper test isolation and preventing mock leaks between files.

## Verification

Next Coverage Suite run will use forks pool (one process per test file). Expected outcome: 265 failures resolve.