### PR TITLE
[scanner] fix: increase Helm deploy timeout for volume reattach

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -310,7 +310,7 @@ jobs:
             --set podLabels.team=kubestellar \
             --atomic \
             --wait \
-            --timeout 15m
+            --timeout 30m
 
       - name: Collect diagnostics on deploy failure
         if: failure()
@@ -671,7 +671,7 @@ jobs:
               --atomic \
               --cleanup-on-fail \
               --wait \
-              --timeout 15m
+              --timeout 30m
           }
 
           MAX_ATTEMPTS=2


### PR DESCRIPTION
Fixes #20441

The Build and Deploy KC workflow fails because Helm's `--wait` timeout expires during rolling updates when RWO PVCs need to detach from the old node and reattach to the new node (~7-10s delay). The pods do start successfully after reattach.

This increases the Helm deploy timeout from 15m to 30m in `deploy-vllm-d` and `deploy-pok-prod` jobs to accommodate the volume reattach cycle during zero-downtime rolling updates.