### PR TITLE
[scanner] fix: resolve Build and Deploy KC deploy-pok-prod failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e8939
 WORKDIR /app
 
 # Install runtime dependencies
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk add --no-cache ca-certificates tzdata sqlite
 
 # Copy backend and watcher binaries
 COPY --from=backend-builder /app/console .


### PR DESCRIPTION
Fixes #20446
Fixes #20447

Resolves the workflow failure in the Build and Deploy KC pipeline's deploy-pok-prod job.

## Problem
The `kc-kubestellar-console-db-backup` CronJob pod enters CrashLoopBackOff with exit code 127 (`/bin/sh: sqlite3: not found`) because the runtime container image lacks the sqlite3 CLI binary.

## Solution
Added `sqlite` package to the Alpine runtime dependencies in Dockerfile line 90.

The db-backup CronJob uses `sqlite3` CLI for WAL-safe database backups. The final stage image is based on `alpine:3.22` with minimal packages — this PR adds sqlite3 to the runtime layer.