### PR TITLE
🐛 [scanner] fix: increase Helm deploy timeout for PodInitializing delay

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -310,7 +310,7 @@ jobs:
             --set podLabels.team=kubestellar \
             --atomic \
             --wait \
-            --timeout 30m
+            --timeout 45m
 
       - name: Collect diagnostics on deploy failure
         if: failure()
@@ -671,7 +671,7 @@ jobs:
               --atomic \
               --cleanup-on-fail \
               --wait \
-              --timeout 30m
+              --timeout 45m
           }
 
           MAX_ATTEMPTS=2


### PR DESCRIPTION
Fixes #20451
Fixes #20454

## Problem
Build and Deploy KC workflow fails on every main push because Helm's `--wait` check times out while pods are still in PodInitializing state. The pods eventually become healthy but the job fails prematurely.

## Root Cause
Init containers or volume attachment take longer than expected. Helm `--wait` polls before pod clears PodInitializing.

## Solution
Increase Helm deploy timeout from 30m to 45m for both:
- `deploy-vllm-d` job
- `deploy-pok-prod` job

This accommodates slower init container and volume attachment phases without changing the deployment logic.

## Testing
Workflow will be tested on next main push (run ID > 28850563198).