### PR TITLE
[scanner] fix: resolve Build and Deploy KC persistent deploy failures

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -309,8 +309,7 @@ jobs:
             --set securityContext.runAsGroup=null \
             --set podLabels.team=kubestellar \
             --atomic \
-            --wait \
-            --timeout 45m
+            --timeout 10m
 
       - name: Collect diagnostics on deploy failure
         if: failure()
@@ -670,8 +669,7 @@ jobs:
               --set podLabels.team=kubestellar \
               --atomic \
               --cleanup-on-fail \
-              --wait \
-              --timeout 45m
+              --timeout 10m
           }
 
           MAX_ATTEMPTS=2


### PR DESCRIPTION
Fixes #20458
Fixes #20459

## Root Cause
The `helm upgrade --wait` flag blocks on ALL resources (Jobs, CronJobs, Helm hooks), not just Deployments. Health checks show the app is healthy (200 OK), but the deploy fails BEFORE the health check monitoring step because Helm waits for non-deployment resources that may be stale or failing.

## Fix
- Removed `--wait` flag from `helm upgrade` in both `deploy-vllm-d` and `deploy-pok-prod` jobs
- Kept `--atomic` for automatic rollback on failure
- Reduced timeout from 45m to 10m (no longer waiting for Jobs/CronJobs)
- Rely on existing `kubectl rollout status deployment/...` step that only checks Deployment readiness

## Testing
The fix allows the deploy to complete successfully when the Deployment pods are healthy, without being blocked by unrelated CronJobs or old failed Jobs.