### PR TITLE
[scanner] fix: resolve 292 test failures in Coverage Suite

### DIFF
--- a/web/harness/groundtruth/redactK8sGroundTruth.ts
+++ b/web/harness/groundtruth/redactK8sGroundTruth.ts
@@ -6,7 +6,7 @@ export function redactK8sGroundTruth(groundTruth: K8sGroundTruth): K8sGroundTrut
     ...groundTruth,
     contexts: {
       ...groundTruth.contexts,
-      names: groundTruth.contexts.names.map((name, index) => `context-${index + 1}-${name.replace(/[^a-z0-9]/gi, '').slice(0, 12)}`),
+      names: groundTruth.contexts.names.map((name, index) => `context-${index + 1}-${name.replace(/[^a-z0-9-]/gi, '').slice(0, 12)}`),
     },
   })
 }


### PR DESCRIPTION
Fixes #20468

## Root Cause

PR #20466 (commit 317dcea) changed the regex in `web/harness/groundtruth/redactK8sGroundTruth.ts` from `/[^a-z0-9-]/gi` to `/[^a-z0-9]/gi`, accidentally removing the hyphen from the character class.

This caused context names containing hyphens to be stripped differently than tests expected. Tests that validated redacted context names (like `context-1-prod-us-ea`) now received strings with hyphens removed mid-name (like `context-1-produsea`), breaking assertions across 292 test files including:
- `harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts`
- `harness/groundtruth/__tests__/liveFixtureManager.test.ts`
- `src/components/compliance/*.test.tsx`
- Multiple card component tests

## Fix

Restored the hyphen in the regex character class: `/[^a-z0-9-]/gi`. This matches the original behavior and fixes all 292 test failures by ensuring hyphens are preserved in redacted context names.