### PR TITLE
[quality] add unit tests for renameOrCopy and validateTagName in pkg/agent/updater

### DIFF
--- a/pkg/agent/updater/download_test.go
+++ b/pkg/agent/updater/download_test.go
@@ -243,3 +243,58 @@ func TestVerifyChecksumFromReleaseRejectsTamperedBinary(t *testing.T) {
 		t.Fatalf("expected checksum mismatch error, got %v", err)
 	}
 }
+
+func TestRenameOrCopy_SameDevice(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.bin")
+	dst := filepath.Join(dir, "dest.bin")
+
+	content := []byte("binary-content-here")
+	if err := os.WriteFile(src, content, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := renameOrCopy(src, dst); err != nil {
+		t.Fatalf("renameOrCopy() error = %v", err)
+	}
+
+	// Source should no longer exist (rename moves it)
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Error("source file should not exist after rename")
+	}
+
+	// Dest should have correct content
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("dest content = %q, want %q", got, content)
+	}
+}
+
+func TestRenameOrCopy_SourceNotFound(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "nonexistent.bin")
+	dst := filepath.Join(dir, "dest.bin")
+
+	err := renameOrCopy(src, dst)
+	if err == nil {
+		t.Fatal("expected error for non-existent source")
+	}
+}
+
+func TestRenameOrCopy_DestDirNotExist(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.bin")
+	dst := filepath.Join(dir, "nosuchdir", "dest.bin")
+
+	if err := os.WriteFile(src, []byte("data"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := renameOrCopy(src, dst)
+	if err == nil {
+		t.Fatal("expected error for non-existent dest directory")
+	}
+}

--- a/pkg/agent/updater/execute_test.go
+++ b/pkg/agent/updater/execute_test.go
@@ -716,3 +716,31 @@ func TestExecuteBinaryUpdate_DelegatesToFlow(t *testing.T) {
 	// Should not panic
 	uc.executeBinaryUpdate(release)
 }
+
+func TestValidateTagName(t *testing.T) {
+	tests := []struct {
+		tag     string
+		wantErr bool
+	}{
+		{"v1.2.3", false},
+		{"1.2.3", false},
+		{"v0.0.1", false},
+		{"v10.20.30", false},
+		{"v1.2.3-beta", false},
+		{"v1.2.3-rc.1", false},
+		{"latest", true},
+		{"", true},
+		{"v1.2", true},
+		{"abc", true},
+		{"v1", true},
+		{"release-1.0", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			err := validateTagName(tt.tag)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateTagName(%q) error = %v, wantErr %v", tt.tag, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Test Improvement

Adds unit tests for two previously untested functions in `pkg/agent/updater`:

### `renameOrCopy` (download.go:157) — was 0% coverage

| Test | What it covers |
|------|---------------|
| `TestRenameOrCopy_SameDevice` | Successful same-device rename, verifies content moved |
| `TestRenameOrCopy_SourceNotFound` | Error path: non-existent source |
| `TestRenameOrCopy_DestDirNotExist` | Error path: destination directory missing |

### `validateTagName` (execute.go:22) — was 66.7% coverage

Table-driven test with 12 cases covering valid semver tags (`v1.2.3`, `1.2.3`, `v1.2.3-beta`) and invalid inputs (`latest`, empty, `v1.2`, `abc`).

Fixes #20476

---
*Filed by quality agent (ACMM L4/L6 — full mode)*"