### PR TITLE
[ci-maintainer] fix: override PVC accessMode to RWO in upgrade-smoke Kind install

### DIFF
--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -107,6 +107,8 @@ jobs:
             --set-string 'extraEnv[0].value=true' \
             --set 'extraEnv[1].name=ALLOW_DEV_MODE_IN_CLUSTER' \
             --set-string 'extraEnv[1].value=true' \
+            --set 'persistence.accessModes[0]=ReadWriteOnce' \
+            --set backup.enabled=false \
             --wait --timeout=${{ env.HELM_INSTALL_TIMEOUT }}
 
       - name: Port-forward and verify baseline health


### PR DESCRIPTION
## CI Fix

### Problem

The `In-Place Upgrade Smoke` workflow has been failing 100% since commit `dc2542d7` (PR #20438) changed `persistence.accessModes` to `ReadWriteMany`. Kind's `local-path` provisioner only supports `ReadWriteOnce`, so both PVCs (`data` + `backups`) stay in `Pending` state, causing `helm install --wait --timeout=5m` to time out.

### Fix

Two `--set` overrides added to the `helm install` step in `upgrade-smoke.yml`:

1. `--set 'persistence.accessModes[0]=ReadWriteOnce'` — overrides the chart default (RWX) for the data PVC to RWO, which Kind's local-path provisioner can satisfy
2. `--set backup.enabled=false` — suppresses the backup CronJob and its `backups` PVC, which has `ReadWriteMany` hardcoded in the template (not templatable from values without a chart change)

Production clusters (`vllm-d`, `pok-prod`) use NFS-backed RWX storage and are unaffected — these overrides apply only to the CI Kind environment.

Fixes #20481

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*