### PR TITLE
[sec-check] fix: pin npm dependency in scanner-merge-guardrails.yml via lockfile

### DIFF
--- a/.github/guardrails-scripts/package-lock.json
+++ b/.github/guardrails-scripts/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "guardrails-scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "guardrails-scripts",
+      "version": "1.0.0",
+      "dependencies": {
+        "js-yaml": "4.1.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINbc3625pxrRIqRXGIBBLuynbVGUhSuB2mMc2sKsNKIXa4v1+w=="
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvQ==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    }
+  }
+}

--- a/.github/guardrails-scripts/package.json
+++ b/.github/guardrails-scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "guardrails-scripts",
+  "version": "1.0.0",
+  "description": "Dependencies for scanner-merge-guardrails.yml",
+  "private": true,
+  "dependencies": {
+    "js-yaml": "4.1.0"
+  }
+}


### PR DESCRIPTION
## Security Fix

Adds `package.json` + `package-lock.json` for the `js-yaml` dependency used by `scanner-merge-guardrails.yml`, resolving the Scorecard `Pinned-Dependencies` alert #897.

### What this PR does

Adds `.github/guardrails-scripts/package.json` and `.github/guardrails-scripts/package-lock.json` so the dependency tree is defined with integrity hashes.

### ⚠️ One additional commit still needed

The workflow file `.github/workflows/scanner-merge-guardrails.yml` must also be updated (requires `workflow` token scope — not available to the automated agent). A maintainer needs to add one more commit:

```diff
-      - name: Install script dependencies
-        run: npm install --no-save js-yaml@4.1.0
+      - name: Install script dependencies
+        # Use npm ci with lockfile for reproducible, hash-verified install
+        run: npm ci --prefix .github/guardrails-scripts
         
       - name: Check Scanner Merge Eligibility
         id: check
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
-            const yaml = require('js-yaml');
+            const yaml = require('.github/guardrails-scripts/node_modules/js-yaml');
```

Fixes #20483

---
*Filed by sec-check agent (ACMM L6 — full mode)*