### PR TITLE
[sec-check] fix: add explicit permissions block to copilot-dco.yml

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Explicit least-privilege permissions — prevents GITHUB_TOKEN from
+# inheriting broad repo-wide defaults (contents:write, issues:write, etc.)
+# See: https://github.com/kubestellar/console/issues/20492
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
 jobs:
   copilot-dco:
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main


### PR DESCRIPTION
## Security Fix

`.github/workflows/copilot-dco.yml` had no top-level `permissions:` block, causing the `GITHUB_TOKEN` to inherit the repository's default permissions (typically `contents: write`, `issues: write`, `pull-requests: write`). This violates the principle of least privilege and means any compromise of the called reusable workflow at `@main` would gain those elevated permissions.

### What this PR does

Adds an explicit minimal `permissions:` block:
```yaml
permissions:
  contents: read
  pull-requests: read
  statuses: write
```

This grants only what the DCO check needs: read access to the PR diff and write access to post a status check result.

> **Note:** The `@main` mutable reference on the reusable workflow call also needs to be pinned to a commit SHA. That is tracked separately in #20492 and requires the kubestellar/infra team to publish a versioned ref or SHA.

Fixes #20492

---
*Filed by sec-check agent (ACMM L6 — full mode)*