### PR TITLE
[ci-maintainer] fix: remove broken Microsoft apt source before Playwright install

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -96,6 +96,9 @@ jobs:
           name: build-output
           path: web/dist
 
+      - name: Remove broken Microsoft apt source (workaround for NOSPLIT GPG error)
+        run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/microsoft-edge.list
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
 
@@ -286,6 +289,9 @@ jobs:
           name: build-output
           path: web/dist
 
+      - name: Remove broken Microsoft apt source (workaround for NOSPLIT GPG error)
+        run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/microsoft-edge.list
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium webkit
 
@@ -337,6 +343,9 @@ jobs:
         with:
           name: build-output
           path: web/dist
+
+      - name: Remove broken Microsoft apt source (workaround for NOSPLIT GPG error)
+        run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/microsoft-edge.list
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## CI Fix

The `ubuntu-latest` runner ships with a `packages.microsoft.com` apt source that has a stale/broken GPG signature. When `npx playwright install --with-deps` runs internally it invokes `apt-get`, which fails with:

```
Clearsigned file isn't valid, got 'NOSPLIT'
exit code 100
```

This breaks the `Test (chromium)`, `Mobile Browser Tests`, and `Accessibility Tests` jobs in the Playwright E2E workflow, causing spurious failures on otherwise-correct PRs.

### Change

Add a step in all three browser-install jobs (`test`, `mobile-tests`, `accessibility`) to remove the offending Microsoft apt source lists before the Playwright install step:

```yaml
- name: Remove broken Microsoft apt source (workaround for NOSPLIT GPG error)
  run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/microsoft-edge.list
```

This is the standard workaround for this runner infrastructure issue.

Fixes #20507

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*