### PR TITLE
[quality] Add unit tests for RSS card parser and storage utilities

### DIFF
--- a/web/src/components/cards/rss/__tests__/RSSParser.test.ts
+++ b/web/src/components/cards/rss/__tests__/RSSParser.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest'
+import { isValidThumbnail, normalizeRedditLink, parseRSSFeed } from '../RSSParser'
+
+describe('isValidThumbnail', () => {
+  it('returns false for empty string', () => {
+    expect(isValidThumbnail('')).toBe(false)
+  })
+
+  it('returns false for non-http URL', () => {
+    expect(isValidThumbnail('ftp://example.com/img.jpg')).toBe(false)
+    expect(isValidThumbnail('/relative/path.jpg')).toBe(false)
+  })
+
+  it('returns true for valid image URL', () => {
+    expect(isValidThumbnail('https://example.com/article-banner.jpg')).toBe(true)
+  })
+
+  it('rejects placeholder patterns', () => {
+    expect(isValidThumbnail('https://example.com/placeholder.png')).toBe(false)
+    expect(isValidThumbnail('https://example.com/no_image.gif')).toBe(false)
+    expect(isValidThumbnail('https://example.com/blank.gif')).toBe(false)
+    expect(isValidThumbnail('https://example.com/1x1.png')).toBe(false)
+    expect(isValidThumbnail('https://example.com/spacer.gif')).toBe(false)
+  })
+
+  it('rejects social media icon patterns', () => {
+    expect(isValidThumbnail('https://example.com/twitter_icon.png')).toBe(false)
+    expect(isValidThumbnail('https://example.com/facebook_icon.png')).toBe(false)
+    expect(isValidThumbnail('https://example.com/share_icon.svg')).toBe(false)
+  })
+
+  it('rejects logo patterns', () => {
+    expect(isValidThumbnail('https://example.com/logo.png')).toBe(false)
+    expect(isValidThumbnail('https://example.com/logo.gif')).toBe(false)
+  })
+
+  it('rejects feedburner URLs', () => {
+    expect(isValidThumbnail('https://feeds.feedburner.com/img.png')).toBe(false)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isValidThumbnail('https://example.com/PLACEHOLDER.PNG')).toBe(false)
+    expect(isValidThumbnail('https://example.com/NoImage.jpg')).toBe(false)
+  })
+})
+
+describe('normalizeRedditLink', () => {
+  it('replaces old.reddit.com with www.reddit.com', () => {
+    expect(normalizeRedditLink('https://old.reddit.com/r/golang/comments/123'))
+      .toBe('https://www.reddit.com/r/golang/comments/123')
+  })
+
+  it('leaves www.reddit.com unchanged', () => {
+    const url = 'https://www.reddit.com/r/kubernetes'
+    expect(normalizeRedditLink(url)).toBe(url)
+  })
+
+  it('leaves non-reddit URLs unchanged', () => {
+    const url = 'https://example.com/page'
+    expect(normalizeRedditLink(url)).toBe(url)
+  })
+
+  it('replaces multiple occurrences', () => {
+    const url = 'https://old.reddit.com/r/sub?ref=old.reddit.com'
+    expect(normalizeRedditLink(url)).toBe('https://www.reddit.com/r/sub?ref=www.reddit.com')
+  })
+})
+
+describe('parseRSSFeed', () => {
+  it('parses RSS 2.0 items', () => {
+    const xml = `<?xml version="1.0"?>
+    <rss version="2.0">
+      <channel>
+        <item>
+          <title>Test Article</title>
+          <link>https://example.com/article</link>
+          <description>A test description</description>
+          <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+          <author>author@example.com</author>
+        </item>
+      </channel>
+    </rss>`
+
+    const items = parseRSSFeed(xml, 'https://example.com/feed')
+    expect(items).toHaveLength(1)
+    expect(items[0].title).toBe('Test Article')
+    expect(items[0].link).toBe('https://example.com/article')
+    expect(items[0].author).toBe('author@example.com')
+    expect(items[0].pubDate).toBeInstanceOf(Date)
+  })
+
+  it('parses Atom feed entries', () => {
+    const xml = `<?xml version="1.0"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <entry>
+        <title>Atom Entry</title>
+        <link rel="alternate" href="https://example.com/entry"/>
+        <summary>Atom summary</summary>
+        <published>2024-01-01T00:00:00Z</published>
+        <author><name>AtomAuthor</name></author>
+      </entry>
+    </feed>`
+
+    const items = parseRSSFeed(xml, 'https://example.com/atom')
+    expect(items).toHaveLength(1)
+    expect(items[0].title).toBe('Atom Entry')
+    expect(items[0].link).toBe('https://example.com/entry')
+    expect(items[0].author).toBe('AtomAuthor')
+  })
+
+  it('returns empty array for empty feed', () => {
+    const xml = `<?xml version="1.0"?><rss version="2.0"><channel></channel></rss>`
+    expect(parseRSSFeed(xml, 'https://example.com/feed')).toHaveLength(0)
+  })
+
+  it('handles missing optional fields gracefully', () => {
+    const xml = `<?xml version="1.0"?>
+    <rss version="2.0">
+      <channel>
+        <item>
+          <title>Minimal Item</title>
+        </item>
+      </channel>
+    </rss>`
+
+    const items = parseRSSFeed(xml, 'https://example.com/feed')
+    expect(items).toHaveLength(1)
+    expect(items[0].title).toBe('Minimal Item')
+    expect(items[0].link).toBe('')
+    expect(items[0].description).toBe('')
+    expect(items[0].pubDate).toBeUndefined()
+  })
+
+  it('truncates description to 300 chars', () => {
+    const longDesc = 'A'.repeat(500)
+    const xml = `<?xml version="1.0"?>
+    <rss version="2.0">
+      <channel>
+        <item>
+          <title>Long</title>
+          <description>${longDesc}</description>
+        </item>
+      </channel>
+    </rss>`
+
+    const items = parseRSSFeed(xml, 'https://example.com/feed')
+    expect(items[0].description!.length).toBeLessThanOrEqual(300)
+  })
+
+  it('extracts Reddit score and subreddit from reddit feed', () => {
+    const xml = `<?xml version="1.0"?>
+    <rss version="2.0">
+      <channel>
+        <item>
+          <title>Reddit Post</title>
+          <link>https://www.reddit.com/r/kubernetes/comments/abc123</link>
+          <description>submitted by user - 42 points</description>
+        </item>
+      </channel>
+    </rss>`
+
+    const items = parseRSSFeed(xml, 'https://www.reddit.com/r/kubernetes.rss')
+    expect(items[0].score).toBe(42)
+    expect(items[0].subreddit).toBe('kubernetes')
+  })
+
+  it('uses link as item id, falls back to index', () => {
+    const xml = `<?xml version="1.0"?>
+    <rss version="2.0">
+      <channel>
+        <item><title>No Link</title></item>
+      </channel>
+    </rss>`
+
+    const items = parseRSSFeed(xml, 'https://example.com/feed')
+    expect(items[0].id).toBe('item-0')
+  })
+})

--- a/web/src/components/cards/rss/__tests__/storage.test.ts
+++ b/web/src/components/cards/rss/__tests__/storage.test.ts
@@ -157,7 +157,7 @@ describe('cacheFeed', () => {
     const url = 'https://example.com/cache-me'
     const items = [{ id: '1', title: 'Cached', link: 'https://example.com/c' }]
 
-    cacheFeed(url, items as any)
+    cacheFeed(url, items)
 
     const cached = store.get(CACHE_KEY_PREFIX + hashUrl(url)) as { items: unknown[]; timestamp: number }
     expect(cached).toBeDefined()

--- a/web/src/components/cards/rss/__tests__/storage.test.ts
+++ b/web/src/components/cards/rss/__tests__/storage.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { hashUrl, loadSavedFeeds, saveFeeds, getCachedFeed, cacheFeed } from '../storage'
+import { FEEDS_STORAGE_KEY, CACHE_KEY_PREFIX, CACHE_TTL_MS, PRESET_FEEDS } from '../constants'
+
+// Mock localStorage helpers
+vi.mock('../../../../lib/utils/localStorage', () => {
+  const store = new Map<string, unknown>()
+  return {
+    safeGetJSON: <T>(key: string): T | null => (store.get(key) as T) ?? null,
+    safeSetJSON: (key: string, value: unknown) => { store.set(key, value) },
+    __store: store,
+  }
+})
+
+// Access mock store for test assertions
+async function getStore(): Promise<Map<string, unknown>> {
+  const mod = await import('../../../../lib/utils/localStorage') as { __store: Map<string, unknown> }
+  return mod.__store
+}
+
+describe('hashUrl', () => {
+  it('returns a string for any URL', () => {
+    const result = hashUrl('https://example.com/feed.xml')
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+  })
+
+  it('returns consistent hash for same input', () => {
+    const url = 'https://hnrss.org/frontpage'
+    expect(hashUrl(url)).toBe(hashUrl(url))
+  })
+
+  it('returns different hashes for different URLs', () => {
+    expect(hashUrl('https://a.com')).not.toBe(hashUrl('https://b.com'))
+  })
+
+  it('handles empty string', () => {
+    const result = hashUrl('')
+    expect(typeof result).toBe('string')
+    expect(result).toBe('0')
+  })
+
+  it('returns base-36 encoded string', () => {
+    const result = hashUrl('https://kubernetes.io/feed.xml')
+    // base-36 only contains [0-9a-z]
+    expect(result).toMatch(/^[0-9a-z]+$/)
+  })
+})
+
+describe('loadSavedFeeds', () => {
+  beforeEach(async () => {
+    const store = await getStore()
+    store.clear()
+  })
+
+  it('returns first preset feed when nothing saved', () => {
+    const feeds = loadSavedFeeds()
+    expect(feeds).toEqual([PRESET_FEEDS[0]])
+  })
+
+  it('returns saved feeds from storage', async () => {
+    const store = await getStore()
+    const saved = [{ url: 'https://example.com/rss', name: 'Test', icon: '📰' }]
+    store.set(FEEDS_STORAGE_KEY, saved)
+
+    const feeds = loadSavedFeeds()
+    expect(feeds).toEqual(saved)
+  })
+})
+
+describe('saveFeeds', () => {
+  beforeEach(async () => {
+    const store = await getStore()
+    store.clear()
+  })
+
+  it('persists feeds to storage', async () => {
+    const store = await getStore()
+    const feeds = [{ url: 'https://example.com/rss', name: 'Saved', icon: '✅' }]
+    saveFeeds(feeds)
+    expect(store.get(FEEDS_STORAGE_KEY)).toEqual(feeds)
+  })
+})
+
+describe('getCachedFeed', () => {
+  beforeEach(async () => {
+    const store = await getStore()
+    store.clear()
+  })
+
+  it('returns null for uncached URL', () => {
+    expect(getCachedFeed('https://uncached.com/feed')).toBeNull()
+  })
+
+  it('returns cached data when fresh', async () => {
+    const store = await getStore()
+    const url = 'https://example.com/feed'
+    const items = [{ id: '1', title: 'Item 1', link: 'https://example.com/1' }]
+    store.set(CACHE_KEY_PREFIX + hashUrl(url), { items, timestamp: Date.now() })
+
+    const result = getCachedFeed(url)
+    expect(result).not.toBeNull()
+    expect(result!.items).toHaveLength(1)
+    expect(result!.items[0].title).toBe('Item 1')
+    expect(result!.isStale).toBe(false)
+  })
+
+  it('returns null for expired cache when ignoreExpiry is false', async () => {
+    const store = await getStore()
+    const url = 'https://example.com/expired'
+    const items = [{ id: '1', title: 'Old', link: 'https://example.com/old' }]
+    store.set(CACHE_KEY_PREFIX + hashUrl(url), {
+      items,
+      timestamp: Date.now() - CACHE_TTL_MS - 1000,
+    })
+
+    expect(getCachedFeed(url)).toBeNull()
+  })
+
+  it('returns stale data when ignoreExpiry is true', async () => {
+    const store = await getStore()
+    const url = 'https://example.com/stale'
+    const items = [{ id: '1', title: 'Stale', link: 'https://example.com/s' }]
+    store.set(CACHE_KEY_PREFIX + hashUrl(url), {
+      items,
+      timestamp: Date.now() - CACHE_TTL_MS - 1000,
+    })
+
+    const result = getCachedFeed(url, true)
+    expect(result).not.toBeNull()
+    expect(result!.isStale).toBe(true)
+    expect(result!.items[0].title).toBe('Stale')
+  })
+
+  it('converts pubDate strings back to Date objects', async () => {
+    const store = await getStore()
+    const url = 'https://example.com/dates'
+    const dateStr = '2024-01-01T00:00:00Z'
+    store.set(CACHE_KEY_PREFIX + hashUrl(url), {
+      items: [{ id: '1', title: 'D', link: '', pubDate: dateStr }],
+      timestamp: Date.now(),
+    })
+
+    const result = getCachedFeed(url)
+    expect(result!.items[0].pubDate).toBeInstanceOf(Date)
+  })
+})
+
+describe('cacheFeed', () => {
+  beforeEach(async () => {
+    const store = await getStore()
+    store.clear()
+  })
+
+  it('stores items with a timestamp', async () => {
+    const store = await getStore()
+    const url = 'https://example.com/cache-me'
+    const items = [{ id: '1', title: 'Cached', link: 'https://example.com/c' }]
+
+    cacheFeed(url, items as any)
+
+    const cached = store.get(CACHE_KEY_PREFIX + hashUrl(url)) as { items: unknown[]; timestamp: number }
+    expect(cached).toBeDefined()
+    expect(cached.items).toEqual(items)
+    expect(typeof cached.timestamp).toBe('number')
+    expect(cached.timestamp).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds **30 unit tests** for previously untested RSS card logic, addressing the parser and storage coverage gaps identified in #20512.

### `RSSParser.test.ts` (18 tests)

**`isValidThumbnail`** (9 tests):
- Empty string → false
- Non-http URL → false
- Valid image URL → true
- Rejects placeholder patterns (placeholder, no_image, blank.gif, 1x1, spacer.gif)
- Rejects social media icon patterns (twitter_icon, facebook_icon, share_icon)
- Rejects logo patterns (logo.png, logo.gif)
- Rejects feedburner URLs
- Case-insensitive pattern matching

**`normalizeRedditLink`** (4 tests):
- old.reddit.com → www.reddit.com
- Leaves www.reddit.com unchanged
- Leaves non-Reddit URLs unchanged
- Handles multiple occurrences in same string

**`parseRSSFeed`** (5 tests):
- Parses RSS 2.0 format with all fields
- Parses Atom feed entries with alternate links
- Returns empty array for empty channel
- Handles missing optional fields gracefully (no crash)
- Truncates description to 300 characters
- Extracts Reddit score and subreddit from Reddit feeds
- Falls back to index-based ID when link is empty

### `storage.test.ts` (12 tests)

**`hashUrl`** (5 tests):
- Returns non-empty string for any URL
- Consistent hash for same input
- Different hashes for different URLs
- Empty string returns "0"
- Returns base-36 encoded string

**`loadSavedFeeds`** (2 tests):
- Returns first preset when nothing saved
- Returns saved feeds from localStorage

**`saveFeeds`** (1 test):
- Persists to localStorage under correct key

**`getCachedFeed`** (4 tests):
- Returns null for uncached URL
- Returns fresh data with isStale=false
- Returns null for expired cache (ignoreExpiry=false)
- Returns stale data when ignoreExpiry=true
- Converts pubDate strings back to Date objects

**`cacheFeed`** (1 test):
- Stores items with current timestamp

Partially addresses #20512

---
*Filed by quality agent (ACMM L4/L6 — full mode)*