### PR TITLE
Stabilize Console Live canary failure reporting

### DIFF
--- a/.github/scripts/console-live-promote-failure-issue.cjs
+++ b/.github/scripts/console-live-promote-failure-issue.cjs
@@ -33,6 +33,8 @@ const LIVE_UI_AREAS = ['web/src/components/**', 'web/src/components/dashboard/**
 const BROWSER_LAYOUT_AREAS = ['web/src/components/layout/**', 'web/src/components/ui/**', 'web/src/components/dashboard/**', 'web/e2e/visual-login/macos-popup/**', 'web/e2e/visual-login/browser-matrix/**']
 const BROWSER_CONTENT_AREAS = ['web/src/pages/**', 'web/src/components/**', 'web/src/hooks/**', 'cmd/console/**']
 const FAILURE_TYPE_METADATA = {
+  'canary-setup': { short: 'private canary setup failed', areas: ['.github/workflows/console-live-promote.yml', 'deploy/helm/kubestellar-console/**', 'cmd/watcher/**', 'pkg/watcher/**'] },
+  'deployment-rollout': { short: 'console-live deployment rollout failed', areas: ['.github/workflows/console-live-promote.yml', 'deploy/helm/kubestellar-console/**', 'cmd/watcher/**', 'pkg/watcher/**'] },
   'live-ui-overlap': { short: 'visible text overlap blocks promotion', areas: LIVE_UI_AREAS },
   'live-ui-forbidden-artifact': { short: 'live UI shows demo or local-only artifact', areas: LIVE_UI_AREAS },
   'live-ui-warning-flood': { short: 'live UI shows warning flood', areas: LIVE_UI_AREAS },
@@ -55,7 +57,7 @@ const FAILURE_TYPE_METADATA = {
   'interactive-surface-broken': { short: 'interactive live UI surface is broken', areas: ['web/src/components/layout/**', 'web/src/components/ui/**', 'web/src/components/search/**', 'web/src/components/dashboard/**'] },
   'fixture-state-mismatch': { short: 'controlled fixture state is missing or mislabeled', areas: ['web/harness/groundtruth/liveFixtureManager.ts', 'web/e2e/visual-login/semantic/live-fixtures.spec.ts', 'web/src/components/**', 'web/src/hooks/**'] },
   'groundtruth-mismatch': { short: 'live UI does not match cluster groundtruth', areas: ['web/src/components/**', 'web/harness/groundtruth/**', 'web/e2e/visual-login/semantic/live-canary-ui.spec.ts'] },
-  'auth-boundary': { short: 'production auth boundary failed', areas: ['web/src/lib/auth.tsx', 'cmd/console/**', 'deploy/helm/kubestellar-console/**', '.github/workflows/console-live-promote.yml'], browserMatrix: true },
+  'auth-boundary': { short: 'production auth boundary failed', areas: ['web/src/lib/auth.tsx', 'cmd/console/**', 'deploy/helm/kubestellar-console/**', '.github/workflows/console-live-promote.yml'] },
 }
 
 function walk(dir) {
@@ -504,6 +506,32 @@ function artifactPathsFromText(logText) {
   )
 }
 
+function rolloutFailureType(text) {
+  const hasRolloutSymptom = (
+    /crashloopbackoff|back-off restarting failed container|deployment [^\r\n]+ not ready|rollout status[^\r\n]+timed out/i.test(text)
+    || /timed out waiting for the condition|context deadline exceeded|upgrade failed|installation failed/i.test(text)
+    || /failed to prepare watcher runtime|read-only file system|create watcher runtime info temp file/i.test(text)
+    || /minimum availability|available:\s*0\/1|pod [^\r\n]+ crashloopbackoff/i.test(text)
+  )
+  if (!hasRolloutSymptom) return ''
+  if (/private canary|canary deployment|canary_release|canary_deployment|kc-live-canary|deploy candidate to private canary/i.test(text)) {
+    return 'canary-setup'
+  }
+  if (/console-live|production|live deployment|live_release|live_deployment|kc-live|deploy candidate to console-live|promote candidate to production/i.test(text)) {
+    return 'deployment-rollout'
+  }
+  return 'canary-setup'
+}
+
+function hasAuthBoundaryFailure(text) {
+  return (
+    /signed live canary (?:cookie|session)[\s\S]{0,500}\/api\/me[\s\S]{0,500}(?:401|received:\s*401|expected:\s*200)/i.test(text)
+    || /\/api\/me[\s\S]{0,300}(?:expected:\s*200[\s\S]{0,120}received:\s*401|received:\s*401[\s\S]{0,120}expected:\s*200)/i.test(text)
+    || /\/api\/me\s*=\s*401|\/api\/me[^\r\n]{0,160}\b401\b/i.test(text)
+    || /production auth boundary failed|auth-boundary|auth boundary/i.test(text)
+  )
+}
+
 function classifyFailure({ failures, evidenceItems, liveUiFailures, logText }) {
   const text = sanitizeText(JSON.stringify({ failures, evidenceItems, liveUiFailures }) + '\n' + logText).toLowerCase()
   const browserMatrixFailures = liveUiFailures.browserMatrixFailures || []
@@ -527,6 +555,9 @@ function classifyFailure({ failures, evidenceItems, liveUiFailures, logText }) {
     || (liveUiFailures.unexpectedRequestFailures || []).length
     || browserMatrixFailures.some(failure => failure.classification === 'live-network-error')
     || /live-network-error|startup-error|infrastructure connection error|unexpected app-origin|4xx|5xx|bad request/.test(text)
+  const rolloutFailure = rolloutFailureType(text)
+  if (rolloutFailure) return rolloutFailure
+  if (hasAuthBoundaryFailure(text)) return 'auth-boundary'
   if ((hasCandidateImageFailure || hasCanaryInfraFailure) && !hasProductEvidence) return 'canary-setup'
   if (hasStructuredCoreRateLimit || networkClassifications.some(item =>
     item.classification === 'live-rate-limit-data-loss' && isCoreResourceEndpoint(item.url)

--- a/.github/scripts/console-live-promote-failure-issue.test.cjs
+++ b/.github/scripts/console-live-promote-failure-issue.test.cjs
@@ -126,6 +126,12 @@ test('only browser failures receive the browser-matrix label', () => {
     'needs-fix',
     'browser-matrix',
   ])
+  assert.deepEqual(_test.labelsForFailureType('auth-boundary'), [
+    'console-live',
+    'live-canary',
+    'test-failure',
+    'needs-fix',
+  ])
 })
 
 test('classifies rate limits as live data loss', () => {
@@ -290,6 +296,44 @@ test('classifies structured browser matrix canary setup failures', () => {
 
 test('keeps canary setup as fallback when no parsed product evidence exists', () => {
   assert.equal(classify({}, 'canary browser matrix port-forward did not become healthy'), 'canary-setup')
+})
+
+test('classifies private canary CrashLoop rollout failures as setup failures', () => {
+  assert.equal(classify({}, [
+    'Deploy candidate to private canary',
+    'Error: UPGRADE FAILED: context deadline exceeded',
+    'Deployment kc-live-canary not ready. Available: 0/1',
+    'pod/kc-live-canary-abc123 CrashLoopBackOff',
+    'failed to prepare watcher runtime',
+    'create watcher runtime info temp file: open data/kc-watcher-runtime-123: read-only file system',
+    'cluster-dashboard-groundtruth-match',
+  ].join('\n')), 'canary-setup')
+})
+
+test('classifies production rollout failures separately from setup and groundtruth', () => {
+  assert.equal(classify({}, [
+    'Deploy candidate to console-live',
+    'helm upgrade --install kc-live ./deploy/helm/kubestellar-console --atomic --wait',
+    'Error: UPGRADE FAILED: timed out waiting for the condition',
+    'deployment kc-live not ready',
+    'groundtruth mismatch summary was not produced because deployment failed',
+  ].join('\n')), 'deployment-rollout')
+})
+
+test('classifies signed-session /api/me 401 as auth boundary before browser layout', () => {
+  assert.equal(classify({
+    browserMatrixFailures: [{
+      classification: 'macos-popup-clipped',
+      browser: 'webkit',
+      route: '/',
+      control: 'user-menu',
+      reason: 'not reached because session setup failed',
+    }],
+  }, [
+    'signed live canary cookie must validate against /api/me',
+    'Expected: 200',
+    'Received: 401',
+  ].join('\n')), 'auth-boundary')
 })
 
 test('prioritizes canary setup over product-looking log noise', () => {

--- a/.github/workflows/console-live-macos-canary.yml
+++ b/.github/workflows/console-live-macos-canary.yml
@@ -143,6 +143,26 @@ jobs:
           MACOS_POPUP_LITMUS_FORCE_FAILURE: ${{ env.MACOS_POPUP_LITMUS_FORCE_FAILURE }}
         run: npm run test:visual:macos-popup
 
+      - name: Capture macOS popup diagnostics
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          diag_dir="$RUNNER_TEMP/console-live-macos/diagnostics"
+          mkdir -p "$diag_dir"
+          {
+            echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "workflow=$GITHUB_WORKFLOW"
+            echo "run_id=$GITHUB_RUN_ID"
+            echo "runner_os=$RUNNER_OS"
+            echo "runner_arch=$RUNNER_ARCH"
+            echo "test_console_url=${LIVE_URL:-unknown}"
+            echo "litmus_force_failure=${MACOS_POPUP_LITMUS_FORCE_FAILURE:-false}"
+            echo
+            echo "## Playwright outputs found"
+            find web/e2e/visual-login/test-results web/test-results -maxdepth 4 -type f 2>/dev/null | sort
+          } > "$diag_dir/macos-popup-summary.log"
+
       - name: Upload console live macOS popup evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -152,5 +172,9 @@ jobs:
             web/test-results/macos-popup-results/results.json
             web/test-results/reports/macos-popup/
             web/test-results/macos-popup/
+            web/e2e/visual-login/test-results/macos-popup-results/results.json
+            web/e2e/visual-login/test-results/reports/macos-popup/
+            web/e2e/visual-login/test-results/macos-popup/
+            ${{ runner.temp }}/console-live-macos/diagnostics/
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/console-live-promote.yml
+++ b/.github/workflows/console-live-promote.yml
@@ -748,6 +748,79 @@ jobs:
         working-directory: web
         run: npm run test:visual:browser-matrix:compare
 
+      - name: Capture console live diagnostics
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          diag_dir="$RUNNER_TEMP/console-live/diagnostics"
+          mkdir -p "$diag_dir"
+
+          redact_file() {
+            file="$1"
+            [ -f "$file" ] || return 0
+            sed -E -i \
+              -e 's/(client[-_ ]?secret|jwt[-_ ]?secret|kubeconfig|token|password|cookie)([[:space:]]*[:=][[:space:]]*)[^[:space:]]+/\1\2[REDACTED]/Ig' \
+              -e 's/(github_pat_|ghp_)[A-Za-z0-9_]+/[REDACTED_GITHUB_TOKEN]/g' \
+              -e 's/eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/[REDACTED_JWT]/g' \
+              "$file" || true
+          }
+
+          {
+            echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "workflow=$GITHUB_WORKFLOW"
+            echo "run_id=$GITHUB_RUN_ID"
+            echo "promote_production=${PROMOTE_PRODUCTION:-unknown}"
+            echo "test_console_url=${TEST_CONSOLE_URL:-unknown}"
+            echo "candidate_image=${{ steps.candidate.outputs.image }}"
+            echo "live_namespace=${LIVE_NAMESPACE:-unknown}"
+            echo "live_release=${LIVE_RELEASE:-unknown}"
+            echo "canary_release=${CANARY_RELEASE:-unknown}"
+          } > "$diag_dir/summary.log"
+
+          if [ -n "${DEPLOY_KUBECONFIG:-}" ] && [ -f "$DEPLOY_KUBECONFIG" ]; then
+            export KUBECONFIG="$DEPLOY_KUBECONFIG"
+            {
+              echo "## kubectl context"
+              kubectl config current-context
+              echo
+              echo "## helm live status"
+              helm status "$LIVE_RELEASE" -n "$LIVE_NAMESPACE"
+              echo
+              echo "## helm canary status"
+              helm status "$CANARY_RELEASE" -n "$LIVE_NAMESPACE"
+              echo
+              echo "## live resources"
+              kubectl -n "$LIVE_NAMESPACE" get deploy,svc,ingress,pods -o wide
+              echo
+              echo "## canary deployment describe"
+              kubectl -n "$LIVE_NAMESPACE" describe deploy "$CANARY_DEPLOYMENT"
+              echo
+              echo "## live deployment describe"
+              kubectl -n "$LIVE_NAMESPACE" describe deploy "$LIVE_DEPLOYMENT"
+              echo
+              echo "## canary pods describe"
+              kubectl -n "$LIVE_NAMESPACE" describe pods -l "app.kubernetes.io/instance=$CANARY_RELEASE"
+              echo
+              echo "## live pods describe"
+              kubectl -n "$LIVE_NAMESPACE" describe pods -l "app.kubernetes.io/instance=$LIVE_RELEASE"
+              echo
+              echo "## recent events"
+              kubectl -n "$LIVE_NAMESPACE" get events --sort-by=.lastTimestamp | tail -120
+            } > "$diag_dir/deployment-diagnostics.log" 2>&1
+
+            kubectl -n "$LIVE_NAMESPACE" logs -l "app.kubernetes.io/instance=$CANARY_RELEASE" --all-containers --tail=200 \
+              > "$diag_dir/canary-pod-logs.log" 2>&1 || true
+            kubectl -n "$LIVE_NAMESPACE" logs -l "app.kubernetes.io/instance=$LIVE_RELEASE" --all-containers --tail=200 \
+              > "$diag_dir/live-pod-logs.log" 2>&1 || true
+          else
+            echo "DEPLOY_KUBECONFIG was not available; Kubernetes diagnostics were skipped." > "$diag_dir/deployment-diagnostics.log"
+          fi
+
+          for file in "$diag_dir"/*.log; do
+            redact_file "$file"
+          done
+
       - name: Upload console live promote evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -764,10 +837,16 @@ jobs:
             web/test-results/visual-login-intensive/
             web/e2e/visual-login/test-results/results.json
             web/e2e/visual-login/test-results/evidence/
+            web/e2e/visual-login/test-results/reports/
+            web/e2e/visual-login/test-results/reports/browser-matrix/
+            web/e2e/visual-login/test-results/reports/browser-matrix.json
+            web/e2e/visual-login/test-results/browser-matrix/
+            web/e2e/visual-login/test-results/browser-matrix-results/
             web/e2e/visual-login/test-results/visual-login-intensive/
             ${{ runner.temp }}/console-live/live-rollback.log
             ${{ runner.temp }}/console-live/live-rate-limit-data-loss.json
             ${{ runner.temp }}/console-live/canary-port-forward.log
+            ${{ runner.temp }}/console-live/diagnostics/
           if-no-files-found: warn
           retention-days: 14
 

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	slog.Info("kc-watcher starting", "version", version, "port", strconv.Itoa(*port), "backend-port", strconv.Itoa(*backendPort))
 
-	runtimeState, cleanupRuntime, err := watcher.PrepareRuntime(watcher.RuntimeInfoFile)
+	runtimeState, cleanupRuntime, err := watcher.PrepareRuntime(watcher.RuntimeInfoFileFromEnv())
 	if err != nil {
 		slog.Error("failed to prepare watcher runtime", "error", err)
 		os.Exit(1)

--- a/pkg/watcher/runtime_info_file_test.go
+++ b/pkg/watcher/runtime_info_file_test.go
@@ -1,0 +1,19 @@
+package watcher
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRuntimeInfoFileFromEnv(t *testing.T) {
+	customPath := filepath.Join(t.TempDir(), "runtime.env")
+	t.Setenv(RuntimeInfoFileEnv, customPath)
+	if got := RuntimeInfoFileFromEnv(); got != customPath {
+		t.Fatalf("RuntimeInfoFileFromEnv() = %q, want %q", got, customPath)
+	}
+
+	t.Setenv(RuntimeInfoFileEnv, "   ")
+	if got := RuntimeInfoFileFromEnv(); got != RuntimeInfoFile {
+		t.Fatalf("RuntimeInfoFileFromEnv() with blank env = %q, want %q", got, RuntimeInfoFile)
+	}
+}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -49,6 +49,7 @@ const (
 	DefaultBackendPort  = 8081
 	DefaultListenPort   = 8080
 	RuntimeInfoFile     = "./data/kc-watcher-runtime.env"
+	RuntimeInfoFileEnv  = "WATCHDOG_RUNTIME_FILE"
 	// GitShortHashLen is the number of hex chars shown for the commit
 	// hash in the fallback footer (matches typical `git rev-parse --short` output).
 	GitShortHashLen = 7
@@ -84,6 +85,14 @@ type RuntimeState struct {
 	Dir       string
 	PidFile   string
 	StageFile string
+}
+
+// RuntimeInfoFileFromEnv returns the configured watcher runtime file path.
+func RuntimeInfoFileFromEnv() string {
+	if runtimeInfoFile := strings.TrimSpace(os.Getenv(RuntimeInfoFileEnv)); runtimeInfoFile != "" {
+		return runtimeInfoFile
+	}
+	return RuntimeInfoFile
 }
 
 // Run starts the watcher reverse proxy. It proxies all traffic to the


### PR DESCRIPTION
### 📌 Fixes

Related to #20529 and #20531.

---

### 📝 Summary of Changes

- Make `kc-watcher` honor `WATCHDOG_RUNTIME_FILE`, falling back to `./data/kc-watcher-runtime.env` only when the env var is unset.
- Improve Console Live failure issue classification so rollout/CrashLoop failures are setup or deployment failures, and signed-session `/api/me = 401` remains `auth-boundary`.
- Upload real Playwright output paths plus sanitized Console Live deployment diagnostics so generated issues include actionable evidence.
- Updated the `console-live` environment secret `CONSOLE_LIVE_TEST_USER_ID` to a UUID-shaped value.

---

### Changes Made

- [x] Fixed watcher runtime-file resolution through `WATCHDOG_RUNTIME_FILE`.
- [x] Added a targeted Go test for the runtime-file env fallback behavior.
- [x] Added `canary-setup` and `deployment-rollout` failure metadata and classification precedence.
- [x] Added regression tests for private canary CrashLoop, production rollout timeout, and signed-session `/api/me = 401` classification.
- [x] Added Console Live diagnostics capture before artifact upload.
- [x] Added actual Playwright output paths for Linux Console Live and macOS WebKit canary artifacts.

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo (N/A: no cards added)
- [x] isDemoData is wired correctly (N/A: no card/demo-data changes)
- [x] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

Local checks run:

```text
git diff --check
go test ./pkg/watcher -run TestRuntimeInfoFileFromEnv
go test ./cmd/watcher -run '^$'
node --check .github/scripts/console-live-promote-failure-issue.cjs
node --test .github/scripts/console-live-promote-failure-issue.test.cjs
Workflow YAML parsed with js-yaml
```

Note: full `go test ./cmd/watcher ./pkg/watcher` was attempted locally, but existing Windows filesystem permission/symlink expectations fail on this machine.

---

### 👀 Reviewer Notes

This PR does not change backend rate limits or live UI behavior. It only fixes watcher runtime-file resolution, Console Live failure classification, artifact evidence paths, and sanitized deployment diagnostics.