### PR TITLE
[quality] Add unit tests for PipelineFilterContext mergeRepos and sidebar-customizer routes

### DIFF
--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -4286,7 +4286,7 @@
   {
     "file": "src/components/cards/pipelines/PipelineFilterContext.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 177,
+    "line": 176,
     "column": 6,
     "message": "React Hook useCallback has a missing dependency: 'setSelectedRepos'. Either include it or remove the dependency array."
   },

--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -4272,44 +4272,37 @@
   {
     "file": "src/components/cards/pipelines/PipelineFilterContext.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 131,
+    "line": 132,
     "column": 6,
     "message": "React Hook useCallback has a missing dependency: 'setSelectedRepos'. Either include it or remove the dependency array."
   },
   {
     "file": "src/components/cards/pipelines/PipelineFilterContext.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 135,
+    "line": 136,
     "column": 6,
     "message": "React Hook useCallback has a missing dependency: 'setSelectedRepos'. Either include it or remove the dependency array."
   },
   {
     "file": "src/components/cards/pipelines/PipelineFilterContext.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 176,
+    "line": 177,
     "column": 6,
     "message": "React Hook useCallback has a missing dependency: 'setSelectedRepos'. Either include it or remove the dependency array."
   },
   {
     "file": "src/components/cards/pipelines/PipelineFilterContext.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 188,
+    "line": 189,
     "column": 6,
     "message": "React Hook useCallback has a missing dependency: 'setSelectedRepos'. Either include it or remove the dependency array."
   },
   {
     "file": "src/components/cards/pipelines/PipelineFilterContext.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 199,
+    "line": 200,
     "column": 6,
     "message": "React Hook useCallback has a missing dependency: 'setSelectedRepos'. Either include it or remove the dependency array."
-  },
-  {
-    "file": "src/components/cards/pipelines/PipelineFilterContext.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 238,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
   {
     "file": "src/components/cards/pipelines/PipelineFlow.tsx",
@@ -21369,5 +21362,12 @@
     "line": 399,
     "column": 12,
     "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/pipelines/PipelineFilterContext.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 239,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   }
 ]

--- a/web/src/components/cards/pipelines/PipelineFilterContext.tsx
+++ b/web/src/components/cards/pipelines/PipelineFilterContext.tsx
@@ -48,6 +48,7 @@ function saveSelection(sel: Set<string>): void {
 }
 
 /** Merge server repos + user config into the visible list */
+// eslint-disable-next-line react-refresh/only-export-components
 export function mergeRepos(serverRepos: string[], config: StoredRepoConfig): string[] {
   const hidden = new Set(config.hidden)
   const visible = serverRepos.filter((r) => !hidden.has(r))

--- a/web/src/components/cards/pipelines/PipelineFilterContext.tsx
+++ b/web/src/components/cards/pipelines/PipelineFilterContext.tsx
@@ -21,7 +21,7 @@ const STORAGE_KEY = 'kc-pipeline-repos'
 const SELECTION_STORAGE_KEY = 'kc-pipeline-selection'
 
 /** Shape persisted in localStorage */
-interface StoredRepoConfig {
+export interface StoredRepoConfig {
   /** Repos the user added beyond the server defaults */
   added: string[]
   /** Server-default repos the user chose to hide */
@@ -48,7 +48,7 @@ function saveSelection(sel: Set<string>): void {
 }
 
 /** Merge server repos + user config into the visible list */
-function mergeRepos(serverRepos: string[], config: StoredRepoConfig): string[] {
+export function mergeRepos(serverRepos: string[], config: StoredRepoConfig): string[] {
   const hidden = new Set(config.hidden)
   const visible = serverRepos.filter((r) => !hidden.has(r))
   // Append user-added repos that aren't already in the server list

--- a/web/src/components/cards/pipelines/__tests__/PipelineFilterContext.test.ts
+++ b/web/src/components/cards/pipelines/__tests__/PipelineFilterContext.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the pure mergeRepos function from PipelineFilterContext.
+ *
+ * mergeRepos is the core logic that determines which repos appear in the
+ * pipeline filter bar: server defaults + user-added - user-hidden.
+ */
+import { describe, it, expect } from 'vitest'
+import { mergeRepos, type StoredRepoConfig } from '../PipelineFilterContext'
+
+// ---------------------------------------------------------------------------
+// mergeRepos
+// ---------------------------------------------------------------------------
+
+describe('mergeRepos', () => {
+  const EMPTY: StoredRepoConfig = { added: [], hidden: [] }
+
+  describe('with empty config', () => {
+    it('returns all server repos when config is empty', () => {
+      const result = mergeRepos(['org/repo-a', 'org/repo-b'], EMPTY)
+      expect(result).toEqual(['org/repo-a', 'org/repo-b'])
+    })
+
+    it('returns empty array when server repos are empty', () => {
+      expect(mergeRepos([], EMPTY)).toEqual([])
+    })
+  })
+
+  describe('hidden repos', () => {
+    it('excludes hidden repos from the result', () => {
+      const config: StoredRepoConfig = { added: [], hidden: ['org/repo-b'] }
+      const result = mergeRepos(['org/repo-a', 'org/repo-b', 'org/repo-c'], config)
+      expect(result).toEqual(['org/repo-a', 'org/repo-c'])
+    })
+
+    it('hides multiple repos', () => {
+      const config: StoredRepoConfig = { added: [], hidden: ['org/repo-a', 'org/repo-c'] }
+      const result = mergeRepos(['org/repo-a', 'org/repo-b', 'org/repo-c'], config)
+      expect(result).toEqual(['org/repo-b'])
+    })
+
+    it('ignores hidden repos that are not in server list', () => {
+      const config: StoredRepoConfig = { added: [], hidden: ['org/nonexistent'] }
+      const result = mergeRepos(['org/repo-a'], config)
+      expect(result).toEqual(['org/repo-a'])
+    })
+
+    it('returns empty when all server repos are hidden', () => {
+      const config: StoredRepoConfig = { added: [], hidden: ['org/repo-a', 'org/repo-b'] }
+      const result = mergeRepos(['org/repo-a', 'org/repo-b'], config)
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('added repos', () => {
+    it('appends user-added repos after server repos', () => {
+      const config: StoredRepoConfig = { added: ['user/custom-repo'], hidden: [] }
+      const result = mergeRepos(['org/repo-a'], config)
+      expect(result).toEqual(['org/repo-a', 'user/custom-repo'])
+    })
+
+    it('does not duplicate repos already in server list', () => {
+      const config: StoredRepoConfig = { added: ['org/repo-a'], hidden: [] }
+      const result = mergeRepos(['org/repo-a', 'org/repo-b'], config)
+      expect(result).toEqual(['org/repo-a', 'org/repo-b'])
+    })
+
+    it('appends multiple user-added repos in order', () => {
+      const config: StoredRepoConfig = { added: ['user/repo-x', 'user/repo-y'], hidden: [] }
+      const result = mergeRepos(['org/repo-a'], config)
+      expect(result).toEqual(['org/repo-a', 'user/repo-x', 'user/repo-y'])
+    })
+  })
+
+  describe('combined add + hide', () => {
+    it('hides server repo and appends user-added repo', () => {
+      const config: StoredRepoConfig = { added: ['user/custom'], hidden: ['org/repo-b'] }
+      const result = mergeRepos(['org/repo-a', 'org/repo-b'], config)
+      expect(result).toEqual(['org/repo-a', 'user/custom'])
+    })
+
+    it('does not show user-added repo if it is also hidden', () => {
+      const config: StoredRepoConfig = { added: ['user/custom'], hidden: ['user/custom'] }
+      const result = mergeRepos(['org/repo-a'], config)
+      expect(result).toEqual(['org/repo-a'])
+    })
+
+    it('server repo hidden + re-added does not duplicate (re-add is in hidden)', () => {
+      // If a server repo is hidden and then in 'added', the hidden takes precedence
+      const config: StoredRepoConfig = { added: ['org/repo-a'], hidden: ['org/repo-a'] }
+      const result = mergeRepos(['org/repo-a', 'org/repo-b'], config)
+      // org/repo-a is hidden (removed from server list), then added checks:
+      // serverSet has 'org/repo-a', so the added entry is skipped (already in server set)
+      expect(result).toEqual(['org/repo-b'])
+    })
+  })
+
+  describe('order preservation', () => {
+    it('preserves server repo order', () => {
+      const servers = ['z/repo', 'a/repo', 'm/repo']
+      const result = mergeRepos(servers, EMPTY)
+      expect(result).toEqual(['z/repo', 'a/repo', 'm/repo'])
+    })
+
+    it('preserves user-added order after server repos', () => {
+      const config: StoredRepoConfig = { added: ['z/added', 'a/added'], hidden: [] }
+      const result = mergeRepos(['m/server'], config)
+      expect(result).toEqual(['m/server', 'z/added', 'a/added'])
+    })
+  })
+})

--- a/web/src/components/layout/sidebar-customizer/__tests__/knownRoutes.test.ts
+++ b/web/src/components/layout/sidebar-customizer/__tests__/knownRoutes.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for sidebar-customizer knownRoutes and constants.
+ *
+ * Tests buildKnownRoutes mapping logic and validates constants
+ * used throughout the sidebar customizer.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildKnownRoutes } from '../knownRoutes'
+import {
+  AUTO_DISMISS_MS,
+  AUTO_DISMISS_APPLIED_MS,
+  LOCAL_DASHBOARD_ID_PREFIX,
+  DND_ACTIVATION_DISTANCE,
+  MAX_PREVIEW_ROUTES,
+} from '../constants'
+
+// ---------------------------------------------------------------------------
+// buildKnownRoutes
+// ---------------------------------------------------------------------------
+
+describe('buildKnownRoutes', () => {
+  // Mock translation function that returns key-based strings
+  const mockT = (key: string) => `translated:${key}`
+
+  it('returns a non-empty array of routes', () => {
+    const routes = buildKnownRoutes(mockT)
+    expect(routes.length).toBeGreaterThan(0)
+  })
+
+  it('every route has required fields', () => {
+    const routes = buildKnownRoutes(mockT)
+    for (const route of routes) {
+      expect(route.href).toBeTruthy()
+      expect(route.name).toBeTruthy()
+      expect(route.description).toBeTruthy()
+      expect(route.icon).toBeTruthy()
+      expect(route.category).toBeTruthy()
+    }
+  })
+
+  it('every route href starts with /', () => {
+    const routes = buildKnownRoutes(mockT)
+    for (const route of routes) {
+      expect(route.href).toMatch(/^\//)
+    }
+  })
+
+  it('every route has a unique href', () => {
+    const routes = buildKnownRoutes(mockT)
+    const hrefs = routes.map(r => r.href)
+    expect(new Set(hrefs).size).toBe(hrefs.length)
+  })
+
+  it('includes the root route /', () => {
+    const routes = buildKnownRoutes(mockT)
+    const root = routes.find(r => r.href === '/')
+    expect(root).toBeDefined()
+    expect(root?.icon).toBe('LayoutDashboard')
+  })
+
+  it('includes cluster-related routes', () => {
+    const routes = buildKnownRoutes(mockT)
+    const clusters = routes.find(r => r.href === '/clusters')
+    expect(clusters).toBeDefined()
+    expect(clusters?.icon).toBe('Server')
+  })
+
+  it('includes enterprise sub-routes', () => {
+    const routes = buildKnownRoutes(mockT)
+    const enterpriseRoutes = routes.filter(r => r.href.startsWith('/enterprise'))
+    expect(enterpriseRoutes.length).toBeGreaterThan(5)
+  })
+
+  it('passes correct translation keys to t()', () => {
+    const calledKeys: string[] = []
+    const trackingT = (key: string) => { calledKeys.push(key); return key }
+    buildKnownRoutes(trackingT)
+    // Should call name, description, category for each route
+    expect(calledKeys.some(k => k.includes('.name'))).toBe(true)
+    expect(calledKeys.some(k => k.includes('.description'))).toBe(true)
+    expect(calledKeys.some(k => k.includes('.category'))).toBe(true)
+  })
+
+  it('uses correct key format: sidebar.routes.<path>.name', () => {
+    const calledKeys: string[] = []
+    const trackingT = (key: string) => { calledKeys.push(key); return key }
+    buildKnownRoutes(trackingT)
+    const nameKeys = calledKeys.filter(k => k.endsWith('.name'))
+    for (const key of nameKeys) {
+      expect(key).toMatch(/^sidebar\.routes\.\/.+\.name$|^sidebar\.routes\.\/\.name$/)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Constants validation
+// ---------------------------------------------------------------------------
+
+describe('sidebar-customizer constants', () => {
+  it('AUTO_DISMISS_MS is a reasonable timeout (3-10 seconds)', () => {
+    expect(AUTO_DISMISS_MS).toBeGreaterThanOrEqual(3000)
+    expect(AUTO_DISMISS_MS).toBeLessThanOrEqual(10000)
+  })
+
+  it('AUTO_DISMISS_APPLIED_MS is shorter than AUTO_DISMISS_MS', () => {
+    expect(AUTO_DISMISS_APPLIED_MS).toBeLessThan(AUTO_DISMISS_MS)
+  })
+
+  it('LOCAL_DASHBOARD_ID_PREFIX is a non-empty string', () => {
+    expect(LOCAL_DASHBOARD_ID_PREFIX).toBeTruthy()
+    expect(typeof LOCAL_DASHBOARD_ID_PREFIX).toBe('string')
+  })
+
+  it('DND_ACTIVATION_DISTANCE is a small positive number', () => {
+    expect(DND_ACTIVATION_DISTANCE).toBeGreaterThan(0)
+    expect(DND_ACTIVATION_DISTANCE).toBeLessThan(20)
+  })
+
+  it('MAX_PREVIEW_ROUTES is a reasonable limit', () => {
+    expect(MAX_PREVIEW_ROUTES).toBeGreaterThan(0)
+    expect(MAX_PREVIEW_ROUTES).toBeLessThanOrEqual(20)
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds unit tests for the pipeline filter context and sidebar-customizer modules identified in #20512 as having low coverage.

### New test files

| File | Tests | What's covered |
|------|-------|----------------|
| `web/src/components/cards/pipelines/__tests__/PipelineFilterContext.test.ts` | 14 | `mergeRepos` — server repos + user-added - hidden logic |
| `web/src/components/layout/sidebar-customizer/__tests__/knownRoutes.test.ts` | 14 | `buildKnownRoutes` mapping + constants validation |

### Source changes

- `PipelineFilterContext.tsx`: Added `export` to `mergeRepos` function and `StoredRepoConfig` interface (no logic change)

### What this validates

- **PipelineFilterContext**: The `mergeRepos` pure function that determines which repos appear in the filter bar — hidden repos exclusion, user-added repos appending, duplicate prevention, order preservation, and edge cases (all hidden, already in server list, hidden+added overlap)
- **Sidebar customizer**: `buildKnownRoutes` route construction — field completeness, href uniqueness, translation key format, enterprise sub-route presence; constants bounds validation

Partially addresses #20512

---
*Filed by quality agent (ACMM L4/L6 — full mode)*