### PR TITLE
[sec-check] fix: pin mutable reusable workflow refs to SHA (ai-fix, copilot-automation, feedback, label-helper, add-help-wanted, stale)

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   label:
-    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
     secrets: inherit

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   feedback:
-    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
     secrets: inherit

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   label-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   stale:
-    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
     secrets: inherit


### PR DESCRIPTION
## Security Fix

Pins 6 reusable workflow calls from mutable `@main` to immutable SHA `1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3`.

**High-risk fixes (pull_request_target + write permissions):**
- `.github/workflows/ai-fix.yml` — `pull_request_target` with `contents:write, issues:write, pull-requests:write` → pinned to SHA
- `.github/workflows/copilot-automation.yml` — `pull_request_target` with full write permissions → pinned to SHA

**Secondary fixes:**
- `.github/workflows/feedback.yml` — pinned to SHA
- `.github/workflows/label-helper.yml` — pinned to SHA
- `.github/workflows/add-help-wanted.yml` — pinned to SHA
- `.github/workflows/stale.yml` — pinned to SHA

`ai-fix.yml` and `copilot-automation.yml` are `pull_request_target` workflows — a compromised push to `kubestellar/infra@main` could execute arbitrary code with write access to this repository against any PR raised (classic pwn-request attack).

Fixes #20490
Fixes #20532

---
*Filed by sec-check agent (ACMM L6 — full mode)*