### PR TITLE
[quality] Fix card-config deep schema test to accept componentName alias

### DIFF
--- a/web/src/config/cards/__tests__/card-config-deep-schema.test.ts
+++ b/web/src/config/cards/__tests__/card-config-deep-schema.test.ts
@@ -151,9 +151,10 @@ describe('card config deep schema validation', () => {
     it('custom content has component name', () => {
       const c = getCardConfig(cardType)!
       if (c.content.type === 'custom') {
-        const content = c.content as { type: 'custom'; component?: string }
-        expect(typeof content.component).toBe('string')
-        expect(content.component!.length).toBeGreaterThan(0)
+        const content = c.content as { type: 'custom'; component?: string; componentName?: string }
+        const name = content.component || content.componentName
+        expect(typeof name).toBe('string')
+        expect(name!.length).toBeGreaterThan(0)
       }
     })
 


### PR DESCRIPTION
## Test Improvement

Fixes the `custom content has component name` assertion in `card-config-deep-schema.test.ts` which was failing for all newer card configs that use `componentName` instead of `component`.

The `UnifiedCardConfig` type (line 255-257 of `types.ts`) defines both:
- `componentName?: string` — primary field
- `component?: string` — alias for componentName

The test only checked `content.component`, missing cards that use the canonical `componentName` field. This caused mass failures across `cilium_status`, `gpu_overview`, `cascade_impact_map`, `cluster_delta_detector`, `config_drift_heatmap`, `resource_imbalance_detector`, `right_size_advisor`, `restart_correlation_matrix`, and many others.

**Fix:** Check for either `component` OR `componentName` (matching the type's documented alias pattern).

Fixes #20552

---
*Filed by quality agent (ACMM L4/L6 — full mode)*