### PR TITLE
[sec-check] fix: pin semgrep pip install with --require-hashes in nightly-test-suite

### DIFF
--- a/.github/requirements-nightly.txt
+++ b/.github/requirements-nightly.txt
@@ -1,0 +1,143 @@
+Written 46 packages to requirements-nightly.txt
+l transitive dependencies
+# Platform: manylinux2014_x86_64 / Python 3.11
+# Regenerate: pip-compile requirements-nightly.in --generate-hashes --python-version 3.11
+
+attrs==26.1.0 \
+    --hash=sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309
+
+boltons==21.0.0 \
+    --hash=sha256:b9bb7b58b2b420bbe11a6025fdef6d3e5edc9f76a42fb467afe7ca212ef9948b
+
+bracex==3.0 \
+    --hash=sha256:3833e61c2f092d5aa0468fa2e6c6e990a306185abf763b6d122f0158e59c58a5
+
+certifi==2026.6.17 \
+    --hash=sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db
+
+charset-normalizer==3.4.9 \
+    --hash=sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c
+
+click==8.4.2 \
+    --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
+
+click-option-group==0.5.9 \
+    --hash=sha256:ad2599248bd373e2e19bec5407967c3eec1d0d4fc4a5e77b08a0481e75991080
+
+colorama==0.4.6 \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+
+defusedxml==0.7.1 \
+    --hash=sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
+
+deprecated==1.3.1 \
+    --hash=sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f
+
+exceptiongroup==1.2.2 \
+    --hash=sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b
+
+face==26.0.1 \
+    --hash=sha256:ab0a83c37c9789dce658a67a9a80eafaa113c9ec37c5a9d950ff5480542a062d
+
+glom==22.1.0 \
+    --hash=sha256:5339da206bf3532e01a83a35aca202960ea885156986d190574b779598e9e772
+
+googleapis-common-protos==1.75.0 \
+    --hash=sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed
+
+idna==3.18 \
+    --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
+
+importlib-metadata==7.1.0 \
+    --hash=sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570
+
+jsonschema==4.26.0 \
+    --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
+
+jsonschema-specifications==2025.9.1 \
+    --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe
+
+markdown-it-py==4.2.0 \
+    --hash=sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a
+
+mdurl==0.1.2 \
+    --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
+
+opentelemetry-api==1.25.0 \
+    --hash=sha256:757fa1aa020a0f8fa139f8959e53dec2051cc26b832e76fa839a6d76ecefd737
+
+opentelemetry-exporter-otlp-proto-common==1.25.0 \
+    --hash=sha256:15637b7d580c2675f70246563363775b4e6de947871e01d0f4e3881d1848d693
+
+opentelemetry-exporter-otlp-proto-http==1.25.0 \
+    --hash=sha256:2eca686ee11b27acd28198b3ea5e5863a53d1266b91cda47c839d95d5e0541a6
+
+opentelemetry-instrumentation==0.46b0 \
+    --hash=sha256:89cd721b9c18c014ca848ccd11181e6b3fd3f6c7669e35d59c48dc527408c18b
+
+opentelemetry-instrumentation-requests==0.46b0 \
+    --hash=sha256:a8c2472800d8686f3f286cd524b8746b386154092e85a791ba14110d1acc9b81
+
+opentelemetry-proto==1.25.0 \
+    --hash=sha256:f07e3341c78d835d9b86665903b199893befa5e98866f63d22b00d0b7ca4972f
+
+opentelemetry-sdk==1.25.0 \
+    --hash=sha256:d97ff7ec4b351692e9d5a15af570c693b8715ad78b8aafbec5c7100fe966b4c9
+
+opentelemetry-semantic-conventions==0.46b0 \
+    --hash=sha256:6daef4ef9fa51d51855d9f8e0ccd3a1bd59e0e545abe99ac6203804e36ab3e07
+
+opentelemetry-util-http==0.46b0 \
+    --hash=sha256:8dc1949ce63caef08db84ae977fdc1848fe6dc38e6bbaad0ae3e6ecd0d451629
+
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e
+
+peewee==3.19.0 \
+    --hash=sha256:de220b94766e6008c466e00ce4ba5299b9a832117d9eb36d45d0062f3cfd7417
+
+protobuf==4.25.9 \
+    --hash=sha256:438c636de8fb706a0de94a12a268ef1ae8f5ba5ae655a7671fcda5968ba3c9be
+
+pygments==2.20.0 \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+
+referencing==0.37.0 \
+    --hash=sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231
+
+requests==2.34.2 \
+    --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+
+rich==13.5.3 \
+    --hash=sha256:9257b468badc3d347e146a4faa268ff229039d4c2d176ab0cffb4c4fbc73d5d9
+
+rpds-py==2026.6.3 \
+    --hash=sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7
+
+ruamel-yaml==0.19.1 \
+    --hash=sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93
+
+semgrep==1.102.0 \
+    --hash=sha256:4afc25fedae9db030573cab96a162bfc71cc414d00d7040ac179a8c3e88c7bf8
+
+setuptools==83.0.0 \
+    --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3
+
+tomli==2.0.2 \
+    --hash=sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38
+
+typing-extensions==4.16.0 \
+    --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8
+
+urllib3==2.7.0 \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+
+wcmatch==8.5.2 \
+    --hash=sha256:17d3ad3758f9d0b5b4dedc770b65420d4dac62e680229c287bf24c9db856a478
+
+wrapt==1.17.3 \
+    --hash=sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311
+
+zipp==4.1.0 \
+    --hash=sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f
+

--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -67,6 +67,11 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.11'
+
       - name: Install test tools
         env:
           GOSEC_VERSION: '2.21.4'
@@ -75,7 +80,6 @@ jobs:
           GITLEAKS_SHA: 'b9b81a09e0873f73c5060271e46e9e638ba10f8bf1ec7a0a6e95dd90c6e2b9c5'
           TRIVY_VERSION: '0.69.3'
           TRIVY_SHA: '3efb9ea57badf80b2ac43aba925dd088b45b1accd2f62fb0fbc23edd3ee2ec1fb'
-          SEMGREP_VERSION: '1.102.0'
         shell: bash {0}
         run: |
           # Non-fatal installs: test scripts handle missing tools gracefully.
@@ -105,8 +109,8 @@ jobs:
             || echo "::warning::trivy install or verification failed"
           echo "::endgroup::"
 
-          echo "::group::semgrep (pip)"
-          pip3 install --break-system-packages "semgrep==${SEMGREP_VERSION}" \
+          echo "::group::semgrep (pip — hashed requirements)"
+          pip install --require-hashes -r .github/requirements-nightly.txt \
             && echo "✓ semgrep installed" \
             || echo "::warning::semgrep install failed"
           echo "::endgroup::"


### PR DESCRIPTION
## Security Fix

Add `.github/requirements-nightly.txt` with SHA-256 hashes for `semgrep==1.102.0` and all 46 transitive dependencies (platform: manylinux2014_x86_64 / Python 3.11).

**Changes:**
- New `.github/requirements-nightly.txt` — 46 packages with `--hash=sha256:` pins
- Add `actions/setup-python@ece7cb06 # v6.3.0` (Python 3.11) step before "Install test tools" so downloaded wheels match the pinned hashes
- Replace `pip3 install --break-system-packages "semgrep==1.102.0"` with `pip install --require-hashes -r .github/requirements-nightly.txt`

**Why:** The previous unverified pip install allowed supply-chain attacks — a compromised PyPI account or MITM could serve a malicious package. With `--require-hashes`, every installed byte is validated against hashes captured at pin time.

Fixes #20533

---
*Filed by sec-check agent (ACMM L6 — full mode)*