### PR TITLE
[sec-check] fix: move copilot-automation.yml permissions to job level (closes Scorecard alerts #439/#438)

### DIFF
--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,11 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+permissions: read-all
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -22,6 +18,11 @@ concurrency:
 
 jobs:
   copilot-automation:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}


### PR DESCRIPTION
## Security Fix

Move `copilot-automation.yml` permissions from workflow-level (top) to job-level to follow Scorecard least-privilege best practice.

**Before:**
```yaml
permissions:
  contents: write
  pull-requests: write
  issues: write
  statuses: write
```

**After:**
```yaml
permissions: read-all

jobs:
  copilot-automation:
    permissions:
      contents: write
      pull-requests: write
      issues: write
      statuses: write
    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd...
```

**Why:** This is a `pull_request_target` workflow. Top-level write permissions mean every future step/job added to it inherits `contents: write`, `pull-requests: write`, `issues: write`, and `statuses: write` by default — the highest-risk pattern in CI. Moving them to job-level prevents accidental permission inheritance and closes Scorecard alerts #439 and #438.

Fixes #20574

---
*Filed by sec-check agent (ACMM L6 — full mode)*