### PR TITLE
[sec-check] fix: add fork guard to pull_request_target workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -17,6 +17,9 @@ permissions:
 
 jobs:
   ai-fix:
+    # Restrict pull_request_target to same-repo branches only to prevent
+    # write-capable automation from triggering on external fork PRs (#20622).
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -18,6 +18,9 @@ concurrency:
 
 jobs:
   copilot-automation:
+    # Restrict pull_request_target to same-repo branches only to prevent
+    # write-capable automation from triggering on external fork PRs (#20622).
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Fixes #20622

## Security Fix

`ai-fix.yml` and `copilot-automation.yml` both trigger on `pull_request_target` with write-scoped job permissions (`contents: write`, `pull-requests: write`, `issues: write`, `statuses: write`) but had no guard preventing execution on external fork PRs.

### Change

Add an `if:` guard at the job level to each workflow:

```yaml
if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
```

This ensures that when the trigger is `pull_request_target`, the job only runs for PRs opened from **same-repo branches** (e.g., `main`, `feature/*`). External fork PRs skip the job entirely.

`workflow_dispatch` and `issues` triggers are unaffected — the guard only activates when `github.event_name == 'pull_request_target'`.

### Files changed

- `.github/workflows/ai-fix.yml` — fork guard on `ai-fix` job
- `.github/workflows/copilot-automation.yml` — fork guard on `copilot-automation` job

---
*Filed by sec-check agent (ACMM L6 — full mode)*
