### PR TITLE
Stabilize Console Live PVC migration

### DIFF
--- a/.github/scripts/console-live-promote-failure-issue.cjs
+++ b/.github/scripts/console-live-promote-failure-issue.cjs
@@ -514,10 +514,17 @@ function rolloutFailureType(text) {
     || /minimum availability|available:\s*0\/1|pod [^\r\n]+ crashloopbackoff/i.test(text)
   )
   if (!hasRolloutSymptom) return ''
+  if (
+    /deploy candidate to console-live|production|live deployment|live_release|live_deployment|promote candidate to production/i.test(text)
+    || /release ["']?kc-live["']? failed|persistentvolumeclaim\/kubestellar-console-live\/kc-live-kubestellar-console/i.test(text)
+    || /\bkc-live-kubestellar-console\b(?!-canary)|live-pod-logs|live-rollback/i.test(text)
+  ) {
+    return 'deployment-rollout'
+  }
   if (/private canary|canary deployment|canary_release|canary_deployment|kc-live-canary|deploy candidate to private canary/i.test(text)) {
     return 'canary-setup'
   }
-  if (/console-live|production|live deployment|live_release|live_deployment|kc-live|deploy candidate to console-live|promote candidate to production/i.test(text)) {
+  if (/\bkc-live\b|console-live/i.test(text)) {
     return 'deployment-rollout'
   }
   return 'canary-setup'

--- a/.github/scripts/console-live-promote-failure-issue.test.cjs
+++ b/.github/scripts/console-live-promote-failure-issue.test.cjs
@@ -320,6 +320,18 @@ test('classifies production rollout failures separately from setup and groundtru
   ].join('\n')), 'deployment-rollout')
 })
 
+test('classifies live PVC migration failures as production rollout even with canary diagnostics present', () => {
+  assert.equal(classify({}, [
+    'CANARY_RELEASE=kc-live-canary',
+    'Private canary diagnostics were captured earlier in the run',
+    'Deploy candidate to console-live',
+    'Release "kc-live" failed: resource PersistentVolumeClaim/kubestellar-console-live/kc-live-kubestellar-console not ready',
+    'status: Terminating, message: Resource scheduled for deletion',
+    'context deadline exceeded',
+    'job/kc-live-kubestellar-console-pvc-migration BackoffLimitExceeded',
+  ].join('\n')), 'deployment-rollout')
+})
+
 test('classifies signed-session /api/me 401 as auth boundary before browser layout', () => {
   assert.equal(classify({
     browserMatrixFailures: [{

--- a/.github/workflows/console-live-promote.yml
+++ b/.github/workflows/console-live-promote.yml
@@ -58,6 +58,9 @@ env:
   LIVE_CANARY_MIN_ROUTE_DELAY_MS: '15000'
   LIVE_CANARY_PHASE_COOLDOWN_MS: ${{ vars.LIVE_CANARY_PHASE_COOLDOWN_MS || '90000' }}
   LIVE_CANARY_MIN_PHASE_COOLDOWN_MS: '90000'
+  LIVE_PERSISTENCE_ACCESS_MODE: ${{ vars.CONSOLE_LIVE_PERSISTENCE_ACCESS_MODE || 'ReadWriteOnce' }}
+  LIVE_PERSISTENCE_STORAGE_CLASS: ${{ vars.CONSOLE_LIVE_PERSISTENCE_STORAGE_CLASS || '' }}
+  LIVE_BACKUP_ENABLED: ${{ vars.CONSOLE_LIVE_BACKUP_ENABLED || 'false' }}
   CONSOLE_LIVE_TEST_SESSION_COUNT: ${{ vars.CONSOLE_LIVE_TEST_SESSION_COUNT || '80' }}
   CONSOLE_LIVE_ALLOWED_GITHUB_LOGINS: ${{ secrets.CONSOLE_LIVE_ALLOWED_GITHUB_LOGINS || vars.CONSOLE_LIVE_ALLOWED_GITHUB_LOGINS }}
   CONSOLE_LIVE_ADMIN_GITHUB_LOGINS: ${{ secrets.CONSOLE_LIVE_ADMIN_GITHUB_LOGINS || vars.CONSOLE_LIVE_ADMIN_GITHUB_LOGINS }}
@@ -450,6 +453,35 @@ jobs:
         run: |
           set -euo pipefail
           export KUBECONFIG="$DEPLOY_KUBECONFIG"
+
+          target_access_mode="${LIVE_PERSISTENCE_ACCESS_MODE:-ReadWriteOnce}"
+          incompatible_pvcs="$(kubectl -n "$LIVE_NAMESPACE" get pvc -l "app.kubernetes.io/instance=$LIVE_RELEASE" -o json 2>/dev/null \
+            | jq -r --arg mode "$target_access_mode" '.items[] | select((.spec.accessModes // []) | index($mode) | not) | .metadata.name' || true)"
+          if [ -n "$incompatible_pvcs" ]; then
+            echo "::warning::Found console-live PVC(s) incompatible with ${target_access_mode}: $(echo "$incompatible_pvcs" | tr '\n' ' ')"
+            echo "Scaling down $LIVE_DEPLOYMENT before PVC migration..."
+            kubectl -n "$LIVE_NAMESPACE" scale deploy "$LIVE_DEPLOYMENT" --replicas=0 2>/dev/null || true
+            kubectl -n "$LIVE_NAMESPACE" wait pod \
+              -l "app.kubernetes.io/instance=$LIVE_RELEASE,app.kubernetes.io/component!=pvc-migration" \
+              --for=delete --timeout=180s 2>/dev/null || true
+            kubectl -n "$LIVE_NAMESPACE" delete job "${LIVE_DEPLOYMENT}-pvc-migration" --ignore-not-found=true 2>/dev/null || true
+
+            for pvc in $incompatible_pvcs; do
+              echo "::warning::Deleting incompatible PVC '$pvc'; Helm will recreate it as ${target_access_mode}."
+              kubectl -n "$LIVE_NAMESPACE" delete pvc "$pvc" --wait=false 2>/dev/null || true
+              if ! kubectl -n "$LIVE_NAMESPACE" wait --for=delete "pvc/$pvc" --timeout=180s 2>/dev/null; then
+                echo "::warning::PVC '$pvc' is still terminating after scale-down; clearing finalizers."
+                kubectl -n "$LIVE_NAMESPACE" patch pvc "$pvc" --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+                if ! kubectl -n "$LIVE_NAMESPACE" wait --for=delete "pvc/$pvc" --timeout=60s 2>/dev/null; then
+                  echo "::error::PVC '$pvc' could not be deleted; console-live deployment cannot proceed."
+                  exit 1
+                fi
+              fi
+            done
+          else
+            echo "No console-live PVC migration needed for ${target_access_mode}."
+          fi
+
           prod_values="$RUNNER_TEMP/console-live/prod-values.yaml"
           promote_timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           cat > "$prod_values" <<EOF
@@ -468,6 +500,13 @@ jobs:
           serviceAccount:
             create: false
             name: "$LIVE_SERVICE_ACCOUNT"
+          persistence:
+            enabled: true
+            storageClass: "$LIVE_PERSISTENCE_STORAGE_CLASS"
+            accessModes:
+              - "$LIVE_PERSISTENCE_ACCESS_MODE"
+          backup:
+            enabled: $LIVE_BACKUP_ENABLED
           podSecurityContext:
             seccompProfile:
               type: RuntimeDefault
@@ -507,6 +546,8 @@ jobs:
               value: "true"
             - name: SUPPRESS_OPTIONAL_POLLERS
               value: "true"
+            - name: WATCHDOG_RUNTIME_FILE
+              value: /tmp/kc-watcher-runtime.env
           EOF
           helm upgrade --install "$LIVE_RELEASE" ./deploy/helm/kubestellar-console \
             --namespace "$LIVE_NAMESPACE" \

--- a/deploy/helm/kubestellar-console/templates/pre-upgrade-pvc-migration.yaml
+++ b/deploy/helm/kubestellar-console/templates/pre-upgrade-pvc-migration.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.persistence.enabled }}
+{{- $targetAccessMode := "ReadWriteMany" -}}
+{{- if .Values.persistence.accessModes -}}
+{{- $targetAccessMode = index .Values.persistence.accessModes 0 -}}
+{{- end -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -100,7 +104,7 @@ spec:
               NAMESPACE="{{ .Release.Namespace }}"
               MAIN_PVC="{{ include "kubestellar-console.fullname" . }}"
               BACKUP_PVC="{{ include "kubestellar-console.fullname" . }}-backups"
-              TARGET_ACCESS_MODE="ReadWriteMany"
+              TARGET_ACCESS_MODE="{{ $targetAccessMode }}"
 
               echo "=== PVC Access Mode Migration ==="
               echo "Namespace: $NAMESPACE"


### PR DESCRIPTION
### 📌 Fixes

Follow-up to #20538. Addresses the current Console Live rollout failure where the production Helm upgrade tried to migrate OCI block-volume PVCs to `ReadWriteMany`, but the OKE cluster only has block-volume storage classes that bind as `ReadWriteOnce`.

---

### 📝 Summary of Changes

- Make the Console Live workflow deploy persistence with a configurable access mode, defaulting to `ReadWriteOnce` for the current OKE target.
- Keep backup CronJobs disabled by default for Console Live so the test site does not depend on an extra RWO backup PVC.
- Make the pre-upgrade PVC migration hook respect `persistence.accessModes[0]` instead of hardcoding `ReadWriteMany`.
- Delete existing PVCs only when they are incompatible with the configured target access mode.
- Classify production Helm/PVC rollout failures as `deployment-rollout`, even when the same run also contains private canary diagnostics.
- Set `WATCHDOG_RUNTIME_FILE=/tmp/kc-watcher-runtime.env` in the production Console Live deployment values.

---

### Changes Made

- [x] Added Console Live persistence vars: `CONSOLE_LIVE_PERSISTENCE_ACCESS_MODE`, `CONSOLE_LIVE_PERSISTENCE_STORAGE_CLASS`, and `CONSOLE_LIVE_BACKUP_ENABLED`.
- [x] Defaulted Console Live persistence to `ReadWriteOnce`, matching the current OKE storage classes.
- [x] Updated the PVC migration preflight to compare against the configured access mode.
- [x] Updated the Helm migration hook to use the configured access mode.
- [x] Added regression coverage for the actual live PVC failure shape.
- [x] Preserved `canary-setup` classification for real private canary rollout failures.

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo (N/A: no cards added)
- [x] isDemoData is wired correctly (N/A: no card/demo-data changes)
- [x] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

Local checks run:

```text
git diff --check upstream/main...HEAD
node --check .github/scripts/console-live-promote-failure-issue.cjs
node --test .github/scripts/console-live-promote-failure-issue.test.cjs
npx --yes js-yaml .github/workflows/console-live-promote.yml
npx --yes js-yaml .github/workflows/console-live-macos-canary.yml
helm template kc-live deploy/helm/kubestellar-console --set 'persistence.accessModes[0]=ReadWriteOnce' --set backup.enabled=false
```

Manual live repair performed on `ks-console-ci-1`:

```text
helm upgrade --install kc-live deploy/helm/kubestellar-console \
  --namespace kubestellar-console-live \
  --reset-values \
  --no-hooks \
  --atomic \
  --wait
```

Verified after repair:

```text
kc-live image: ghcr.io/kubestellar/console:main
/health: 200
/api/me without auth: 401
/auth/github: redirects to GitHub OAuth
```

---

### 👀 Reviewer Notes

This PR does not change backend rate limits or product UI behavior. It keeps Console Live compatible with the current OKE storage classes and avoids rerunning the hardcoded RWX migration on an RWO-only cluster.