### PR TITLE
🚑 fix(deploy): unset podSecurityContext.fsGroup on OpenShift deploys (pok-prod/vllm-d)

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -534,6 +534,16 @@ jobs:
       # runAsNonRoot stays `true` (chart default) so PodSecurity
       # "restricted" still accepts the pod — only the UID/GID numbers
       # need to be null.
+      #
+      # The same applies to podSecurityContext.fsGroup, added by #20590:
+      # the chart default (fsGroup=1001, needed on vanilla k8s so the
+      # kubelet chowns the PVC for appuser) falls outside the namespace's
+      # SCC supplemental-groups range, so restricted-v2 rejects every new
+      # pod with "fsGroup: Invalid value: []int64{1001}: 1001 is not an
+      # allowed group" and the ReplicaSet can never create pods (Helm
+      # rolls back with Deployment stuck at "Updated: 0/1"). Unsetting it
+      # lets the SCC assign an in-range fsGroup, which still triggers the
+      # kubelet chown of the mounted PVC.
       - name: Deploy with Helm
         run: |
           recover_release() {
@@ -579,6 +589,7 @@ jobs:
               --set rbac.namespaceCreationEnabled=true \
               --set securityContext.runAsUser=null \
               --set securityContext.runAsGroup=null \
+              --set podSecurityContext.fsGroup=null \
               --set podLabels.team=kubestellar \
               --atomic \
               --cleanup-on-fail \
@@ -945,7 +956,11 @@ jobs:
       # with Helm step above. Same fix: unset runAsUser/runAsGroup so the
       # SCC admission controller can assign a namespace-appropriate UID.
       # runAsNonRoot stays true so PodSecurity "restricted" still accepts
-      # the pod.
+      # the pod. podSecurityContext.fsGroup (chart default 1001, added by
+      # #20590 for vanilla k8s) must be unset for the same reason:
+      # restricted-v2 rejects out-of-range fsGroups, blocking ReplicaSet
+      # pod creation ("Updated: 0/1" rollbacks); the SCC-assigned fsGroup
+      # still triggers the kubelet chown of the PVC.
       - name: Deploy with Helm
         run: |
           cleanup_stuck_pods() {
@@ -998,6 +1013,7 @@ jobs:
               --set rbac.namespaceCreationEnabled=true \
               --set securityContext.runAsUser=null \
               --set securityContext.runAsGroup=null \
+              --set podSecurityContext.fsGroup=null \
               --set podLabels.team=kubestellar \
               --atomic \
               --cleanup-on-fail \

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -53,6 +53,12 @@ podSecurityContext:
   # 1001) can write to the data directory. Without this, the PVC is
   # owned by root and the container gets "permission denied" on
   # console.db and the kc-watcher runtime file.
+  # NOTE: on OpenShift this MUST be unset (--set
+  # podSecurityContext.fsGroup=null): the restricted-v2 SCC rejects
+  # fsGroups outside the namespace's supplemental-groups range, so no
+  # pods can be created at all. The SCC assigns an in-range fsGroup
+  # instead, which still triggers the kubelet chown. See the Deploy
+  # with Helm steps in .github/workflows/build-deploy.yml.
   fsGroup: 1001
 
 securityContext:


### PR DESCRIPTION
## Problem

`deploy-pok-prod` (and `deploy-vllm-d`) on **Build and Deploy KC** fail because the OpenShift `restricted-v2` SCC rejects every new pod:

```
provider restricted-v2: .spec.securityContext.fsGroup: Invalid value: []int64{1001}: 1001 is not an allowed group
```

`podSecurityContext.fsGroup: 1001` was added to the chart defaults in #20590 so the kubelet chowns the PVC for `appuser` on vanilla k8s — but 1001 is outside the namespace's SCC supplemental-groups range on both OpenShift clusters, so ReplicaSets can't create pods at all and Helm rolls back with `Deployment ... not ready. status: InProgress, message: Updated: 0/1`.

Evidence:
- Run [28953555533](https://github.com/kubestellar/console/actions/runs/28953555533): pvc-migration Job pod SCC-rejected (fixed for the hook Job by #20627)
- Run [28963367228](https://github.com/kubestellar/console/actions/runs/28963367228) (includes #20627): hook passes, but the **main Deployment's new ReplicaSet** (`kc-kubestellar-console-6554b9bc64`) hits the identical fsGroup rejection → `Updated: 0/1` rollback on both attempts

## Fix

Add `--set podSecurityContext.fsGroup=null` to both OpenShift `deploy_helm` invocations — the exact pattern already used for `securityContext.runAsUser/runAsGroup=null` since #6344/#6353. The SCC assigns an in-range fsGroup automatically, which still triggers the kubelet chown of the mounted PVC. Vanilla-k8s installs keep the `fsGroup: 1001` default. Documented the caveat in `values.yaml`.

Verified with `helm template`: with the null override the pod securityContext renders only `seccompProfile` (no fsGroup); container securityContext keeps `runAsNonRoot: true` / `readOnlyRootFilesystem: true`; default render still includes `fsGroup: 1001`.

Cluster state (from run diagnostics): both PVCs Bound to healthy PVs, old pod 1/1 Running — no stale/Released PV cleanup needed; the 'Released PV' error path never fired in these runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)