### PR TITLE
[scanner] fix: resolve canary setup and auth boundary failures

### DIFF
--- a/deploy/helm/kubestellar-console/templates/pre-upgrade-pvc-migration.yaml
+++ b/deploy/helm/kubestellar-console/templates/pre-upgrade-pvc-migration.yaml
@@ -55,11 +55,11 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 1
+  backoffLimit: 3
   # Hard deadline prevents a stuck hook from consuming Helm's --timeout budget.
-  # The migration script uses kubectl delete --timeout=120s per PVC; 180s gives
-  # enough headroom for two PVCs while leaving Helm's 10m window intact.
-  activeDeadlineSeconds: 180
+  # The migration script uses kubectl delete --timeout=120s per PVC; 360s gives
+  # enough headroom for two PVCs and retries while leaving Helm's 10m window intact.
+  activeDeadlineSeconds: 360
   template:
     metadata:
       labels:

--- a/web/e2e/visual-login/helpers/liveSiteAssertions.ts
+++ b/web/e2e/visual-login/helpers/liveSiteAssertions.ts
@@ -251,10 +251,13 @@ async function seedSignedLiveCookieSession(page: Page, baseUrl: string) {
   const githubLogin = process.env.CONSOLE_LIVE_TEST_GITHUB_LOGIN || 'console-live-canary'
   const userId = process.env.CONSOLE_LIVE_TEST_USER_ID || 'console-live-test-user'
   const role = process.env.CONSOLE_LIVE_TEST_USER_ROLE || 'admin'
+  const cookieDomain = url.hostname === '127.0.0.1' || url.hostname === 'localhost' 
+    ? undefined 
+    : url.hostname
   await page.context().addCookies([{
     name: 'kc_auth',
     value: jwt,
-    domain: url.hostname,
+    domain: cookieDomain,
     path: '/',
     httpOnly: true,
     secure: url.protocol === 'https:',


### PR DESCRIPTION
Fixes #20593
Fixes #20594

## Changes

**PVC Migration Job (#20593)**
- Increase `backoffLimit` from 1 to 3 (allows more retries for transient K8s failures)
- Increase `activeDeadlineSeconds` from 180 to 360 (accommodates 2 PVCs × 120s delete timeout + retry overhead)

**Auth Cookie Domain (#20594)**
- Fix cookie domain for localhost/127.0.0.1 canary testing
- Set `domain: undefined` for localhost URLs (required for cookie to send on port-specific URLs like `127.0.0.1:18080`)
- Production URLs (https) still use explicit domain

## Root Cause

**#20593**: Job hit 180s deadline while deleting 2 PVCs (main + backup). Each PVC delete waits up to 120s. With backoffLimit=1, a single transient failure caused total job failure.

**#20594**: Cookie set with `domain: '127.0.0.1'` won't send to `127.0.0.1:18080` (browser treats port as different domain). Private canary check expects 401 on unauthenticated `/api/me`, but test was setting invalid cookie, so got 401 instead of expected 200 after auth.

## Testing

CI will validate build/lint. Canary workflows will validate fixes on next deploy.