### PR TITLE
[scanner] fix: resolve CI workflow failures in playwright and canary

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -171,7 +171,8 @@ jobs:
             e2e/smoke.spec.ts \
             e2e/responsive-regression.spec.ts \
             e2e/Login.spec.ts \
-            e2e/Dashboard.spec.ts
+            e2e/Dashboard.spec.ts \
+            e2e/Settings.spec.ts
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:4173
 

--- a/web/e2e/visual-login/helpers/liveSiteAssertions.ts
+++ b/web/e2e/visual-login/helpers/liveSiteAssertions.ts
@@ -258,7 +258,7 @@ async function seedSignedLiveCookieSession(page: Page, baseUrl: string) {
     path: '/',
     httpOnly: true,
     secure: url.protocol === 'https:',
-    sameSite: 'Strict',
+    sameSite: 'Lax',
     expires: Math.floor(Date.now() / 1000) + 1_800,
   }])
   await page.addInitScript((user) => {


### PR DESCRIPTION
Fixes #20607, Fixes #20609

## Changes

- **Mobile test coverage (#20607)**: Added `Settings.spec.ts` to mobile test suite in `playwright-nightly.yml`. The Settings page has mobile-specific responsive behavior (settings-title vs settings-title-mobile selectors) and was previously only tested in cross-browser jobs, causing mobile viewport regressions to go undetected.

- **Live canary cookie auth (#20609)**: Changed sameSite from `Strict` to `Lax` for console-live test session cookies in `liveSiteAssertions.ts`. Strict sameSite policy blocks cookies on top-level navigation, causing `/api/me` validation to fail when the macOS WebKit canary navigates to the live URL.

## Issue #20608

Could not identify a code-level bug for the "Deploy candidate to console-live" failure. The helm deployment command syntax and YAML configuration appear correct. This issue may require investigation of actual CI failure logs to diagnose - it could be infrastructure, resource constraints, or environmental configuration rather than a code defect.

## Testing

These fixes resolve configuration issues in CI workflows. The Settings.spec.ts test already exists and handles mobile viewports correctly. The sameSite change aligns with standard practice for auth cookies that need to work across navigation contexts.