### PR TITLE
[scanner] fix: sanitize log inputs to prevent CWE-117 log injection

### DIFF
--- a/pkg/agent/server_ops_clusters.go
+++ b/pkg/agent/server_ops_clusters.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubestellar/console/pkg/agent/kube"
 	"github.com/kubestellar/console/pkg/safego"
+	"github.com/kubestellar/console/pkg/sanitize"
 )
 
 const (
@@ -203,7 +204,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 
 		// SECURITY: Validate cluster name against DNS-1123 (#7171).
 		if err := kube.ValidateDNS1123Label("cluster name", name); err != nil {
-			slog.Warn("[LocalClusters] invalid cluster name", "name", name, "error", err)
+			slog.Warn("[LocalClusters] invalid cluster name", "name", sanitize.LogString(name), "error", err)
 			http.Error(w, "invalid cluster name", http.StatusBadRequest)
 			return
 		}
@@ -213,7 +214,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		safego.GoWith("local-cluster-delete", func() {
 			defer s.clusterOpsWG.Done()
 			if err := s.localClusters.DeleteCluster(tool, name); err != nil {
-				slog.Error("[LocalClusters] failed to delete cluster", "cluster", name, "error", err)
+				slog.Error("[LocalClusters] failed to delete cluster", "cluster", sanitize.LogString(name), "error", err)
 				errMsg := sanitizeClusterError(err)
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 					"tool":     tool,
@@ -229,7 +230,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 					"error": errMsg,
 				})
 			} else {
-				slog.Info("[LocalClusters] deleted cluster", "cluster", name)
+				slog.Info("[LocalClusters] deleted cluster", "cluster", sanitize.LogString(name))
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 					"tool":     tool,
 					"name":     name,
@@ -321,7 +322,7 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 		}
 
 		if err != nil {
-			slog.Error("[LocalClusters] lifecycle action failed", "action", req.Action, "cluster", req.Name, "error", err)
+			slog.Error("[LocalClusters] lifecycle action failed", "action", sanitize.LogString(req.Action), "cluster", req.Name, "error", err)
 			errMsg := sanitizeClusterError(err)
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     req.Tool,
@@ -331,7 +332,7 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 				"progress": 0,
 			})
 		} else {
-			slog.Info("[LocalClusters] lifecycle action completed", "action", req.Action, "cluster", req.Name)
+			slog.Info("[LocalClusters] lifecycle action completed", "action", sanitize.LogString(req.Action), "cluster", req.Name)
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     req.Tool,
 				"name":     req.Name,
@@ -417,8 +418,8 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid vcluster name", http.StatusBadRequest)
 		return
 	}
-	if err := kube.ValidateDNS1123Label("namespace", req.Namespace); err != nil {
-		slog.Warn("[vCluster] invalid namespace", "namespace", req.Namespace, "error", err)
+	if err := kube.ValidateDNS1123Label("namespace", sanitize.LogString(req.Namespace)); err != nil {
+		slog.Warn("[vCluster] invalid namespace", "namespace", sanitize.LogString(req.Namespace), "error", err)
 		http.Error(w, "invalid namespace", http.StatusBadRequest)
 		return
 	}
@@ -437,7 +438,7 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 				"progress": progressFailed,
 			})
 		} else {
-			slog.Info("[vCluster] created vcluster", "name", req.Name, "namespace", req.Namespace)
+			slog.Info("[vCluster] created vcluster", "name", req.Name, "namespace", sanitize.LogString(req.Namespace))
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     "vcluster",
 				"name":     req.Name,
@@ -495,8 +496,8 @@ func (s *Server) handleVClusterConnect(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid vcluster name", http.StatusBadRequest)
 		return
 	}
-	if err := kube.ValidateDNS1123Label("namespace", req.Namespace); err != nil {
-		slog.Warn("[vCluster] invalid namespace", "namespace", req.Namespace, "error", err)
+	if err := kube.ValidateDNS1123Label("namespace", sanitize.LogString(req.Namespace)); err != nil {
+		slog.Warn("[vCluster] invalid namespace", "namespace", sanitize.LogString(req.Namespace), "error", err)
 		http.Error(w, "invalid namespace", http.StatusBadRequest)
 		return
 	}
@@ -514,7 +515,7 @@ func (s *Server) handleVClusterConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("[vCluster] connected to vcluster", "name", req.Name, "namespace", req.Namespace)
+	slog.Info("[vCluster] connected to vcluster", "name", req.Name, "namespace", sanitize.LogString(req.Namespace))
 	s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 		"tool":     "vcluster",
 		"name":     req.Name,
@@ -569,8 +570,8 @@ func (s *Server) handleVClusterDisconnect(w http.ResponseWriter, r *http.Request
 		http.Error(w, "invalid vcluster name", http.StatusBadRequest)
 		return
 	}
-	if err := kube.ValidateDNS1123Label("namespace", req.Namespace); err != nil {
-		slog.Warn("[vCluster] invalid namespace", "namespace", req.Namespace, "error", err)
+	if err := kube.ValidateDNS1123Label("namespace", sanitize.LogString(req.Namespace)); err != nil {
+		slog.Warn("[vCluster] invalid namespace", "namespace", sanitize.LogString(req.Namespace), "error", err)
 		http.Error(w, "invalid namespace", http.StatusBadRequest)
 		return
 	}
@@ -643,8 +644,8 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid vcluster name", http.StatusBadRequest)
 		return
 	}
-	if err := kube.ValidateDNS1123Label("namespace", req.Namespace); err != nil {
-		slog.Warn("[vCluster] invalid namespace", "namespace", req.Namespace, "error", err)
+	if err := kube.ValidateDNS1123Label("namespace", sanitize.LogString(req.Namespace)); err != nil {
+		slog.Warn("[vCluster] invalid namespace", "namespace", sanitize.LogString(req.Namespace), "error", err)
 		http.Error(w, "invalid namespace", http.StatusBadRequest)
 		return
 	}
@@ -663,7 +664,7 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 				"progress": progressFailed,
 			})
 		} else {
-			slog.Info("[vCluster] deleted vcluster", "name", req.Name, "namespace", req.Namespace)
+			slog.Info("[vCluster] deleted vcluster", "name", req.Name, "namespace", sanitize.LogString(req.Namespace))
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     "vcluster",
 				"name":     req.Name,

--- a/pkg/agent/server_rbac.go
+++ b/pkg/agent/server_rbac.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/sanitize"
 )
 
 // rbacAnalysisTimeout is the per-request deadline for cross-cluster
@@ -78,7 +79,7 @@ func (s *Server) handleCanIHTTP(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.k8sClient.CheckCanI(ctx, req.Cluster, req)
 	if err != nil {
-		slog.Error("failed to check permissions", "cluster", req.Cluster, "verb", req.Verb, "resource", req.Resource, "error", err)
+		slog.Error("failed to check permissions", "cluster", sanitize.LogString(req.Cluster), "verb", sanitize.LogString(req.Verb), "resource", sanitize.LogString(req.Resource), "error", err)
 		writeJSONError(w, http.StatusInternalServerError, sanitizeAgentError("check permissions", err))
 		return
 	}
@@ -118,7 +119,7 @@ func (s *Server) handleClusterPermissionsHTTP(w http.ResponseWriter, r *http.Req
 	if cluster != "" {
 		perms, err := s.k8sClient.GetClusterPermissions(ctx, cluster)
 		if err != nil {
-			slog.Error("failed to get cluster permissions", "cluster", cluster, "error", err)
+			slog.Error("failed to get cluster permissions", "cluster", sanitize.LogString(cluster), "error", err)
 			writeJSONError(w, http.StatusInternalServerError, sanitizeAgentError("get cluster permissions", err))
 			return
 		}

--- a/pkg/agent/workers/prediction_analysis.go
+++ b/pkg/agent/workers/prediction_analysis.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/kubestellar/console/pkg/ai"
 	"github.com/kubestellar/console/pkg/safego"
+	"github.com/kubestellar/console/pkg/sanitize"
 )
 
 // runAnalysis performs the AI analysis
@@ -65,7 +66,7 @@ func (w *PredictionWorker) runAnalysis(specificProviders []string) {
 
 		predictions, err := w.analyzeWithProvider(ctx, provider, prompt)
 		if err != nil {
-			slog.Error("[PredictionWorker] provider error", "provider", providerName, "error", err)
+			slog.Error("[PredictionWorker] provider error", "provider", sanitize.LogString(providerName), "error", err)
 			continue
 		}
 
@@ -215,7 +216,7 @@ func (w *PredictionWorker) gatherClusterData(ctx context.Context) (*ClusterAnaly
 
 		for _, cluster := range clusters {
 			if !healthyClusterSet[cluster.Name] {
-				slog.Info("[PredictionWorker] skipping offline cluster", "cluster", cluster.Name)
+				slog.Info("[PredictionWorker] skipping offline cluster", "cluster", sanitize.LogString(cluster.Name))
 				continue
 			}
 			cl := cluster
@@ -240,7 +241,7 @@ func (w *PredictionWorker) gatherClusterData(ctx context.Context) (*ClusterAnaly
 				// --- Pod issues ---
 				pods, podErr := w.k8sClient.FindPodIssues(clusterCtx, cl.Context, "")
 				if podErr != nil {
-					slog.Error("[PredictionWorker] error getting pod issues", "cluster", cl.Name, "error", podErr)
+					slog.Error("[PredictionWorker] error getting pod issues", "cluster", sanitize.LogString(cl.Name), "error", podErr)
 				} else {
 					localPods := make([]PodIssueSummary, 0, len(pods))
 					for _, p := range pods {
@@ -260,7 +261,7 @@ func (w *PredictionWorker) gatherClusterData(ctx context.Context) (*ClusterAnaly
 				// --- GPU nodes ---
 				gpus, gpuErr := w.k8sClient.GetGPUNodes(clusterCtx, cl.Context)
 				if gpuErr != nil {
-					slog.Error("[PredictionWorker] error getting GPU nodes", "cluster", cl.Name, "error", gpuErr)
+					slog.Error("[PredictionWorker] error getting GPU nodes", "cluster", sanitize.LogString(cl.Name), "error", gpuErr)
 				} else {
 					localGPU := make([]GPUNodeSummary, 0, len(gpus))
 					for _, g := range gpus {

--- a/pkg/api/handlers/quantum_proxy.go
+++ b/pkg/api/handlers/quantum_proxy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/kubestellar/console/pkg/api/middleware"
+	"github.com/kubestellar/console/pkg/sanitize"
 )
 
 const (
@@ -101,12 +102,12 @@ func (h *QuantumProxyHandler) ProxyRequest(c *fiber.Ctx) error {
 		targetURL += "?" + queryStr
 	}
 
-	slog.Debug("[QuantumProxy] Forwarding request", "from", c.Path(), "to", targetURL)
+	slog.Debug("[QuantumProxy] Forwarding request", "from", sanitize.LogString(c.Path()), "to", sanitize.LogString(targetURL))
 
 	// Create HTTP client request
 	req, err := http.NewRequestWithContext(c.Context(), http.MethodGet, targetURL, nil)
 	if err != nil {
-		slog.Error("[QuantumProxy] Failed to create request", "target", targetURL, "error", err)
+		slog.Error("[QuantumProxy] Failed to create request", "target", sanitize.LogString(targetURL), "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create request")
 	}
 
@@ -121,7 +122,7 @@ func (h *QuantumProxyHandler) ProxyRequest(c *fiber.Ctx) error {
 	// Execute request with shared client (has timeout)
 	resp, err := quantumClient.Do(req)
 	if err != nil {
-		slog.Error("[QuantumProxy] Quantum service unavailable", "target", targetURL, "error", err)
+		slog.Error("[QuantumProxy] Quantum service unavailable", "target", sanitize.LogString(targetURL), "error", err)
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Quantum service unavailable")
 	}
 	defer resp.Body.Close()
@@ -157,11 +158,11 @@ func (h *QuantumProxyHandler) ProxyResultHistogram(c *fiber.Ctx) error {
 	}
 	targetURL := h.quantumServiceURL + "/api/result/histogram?sort=" + url.QueryEscape(sort)
 
-	slog.Debug("[QuantumProxy] Forwarding histogram request", "from", c.Path(), "to", targetURL)
+	slog.Debug("[QuantumProxy] Forwarding histogram request", "from", sanitize.LogString(c.Path()), "to", sanitize.LogString(targetURL))
 
 	req, err := http.NewRequestWithContext(c.Context(), http.MethodGet, targetURL, nil)
 	if err != nil {
-		slog.Error("[QuantumProxy] Failed to create request", "target", targetURL, "error", err)
+		slog.Error("[QuantumProxy] Failed to create request", "target", sanitize.LogString(targetURL), "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create request")
 	}
 
@@ -176,7 +177,7 @@ func (h *QuantumProxyHandler) ProxyResultHistogram(c *fiber.Ctx) error {
 	// Execute request with shared client (has timeout)
 	resp, err := quantumClient.Do(req)
 	if err != nil {
-		slog.Error("[QuantumProxy] Quantum service unavailable", "target", targetURL, "error", err)
+		slog.Error("[QuantumProxy] Quantum service unavailable", "target", sanitize.LogString(targetURL), "error", err)
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Quantum service unavailable")
 	}
 	defer resp.Body.Close()
@@ -262,12 +263,12 @@ func (h *QuantumProxyHandler) ProxyPostRequest(c *fiber.Ctx) error {
 		targetURL += "?" + queryStr
 	}
 
-	slog.Debug("[QuantumProxy] Forwarding POST request", "from", c.Path(), "to", targetURL)
+	slog.Debug("[QuantumProxy] Forwarding POST request", "from", sanitize.LogString(c.Path()), "to", sanitize.LogString(targetURL))
 
 	// Create HTTP client request
 	req, err := http.NewRequestWithContext(c.Context(), http.MethodPost, targetURL, strings.NewReader(string(c.Body())))
 	if err != nil {
-		slog.Error("[QuantumProxy] Failed to create request", "target", targetURL, "error", err)
+		slog.Error("[QuantumProxy] Failed to create request", "target", sanitize.LogString(targetURL), "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create request")
 	}
 
@@ -282,7 +283,7 @@ func (h *QuantumProxyHandler) ProxyPostRequest(c *fiber.Ctx) error {
 	// Execute request with shared client (has timeout)
 	resp, err := quantumClient.Do(req)
 	if err != nil {
-		slog.Error("[QuantumProxy] Quantum service unavailable", "target", targetURL, "error", err)
+		slog.Error("[QuantumProxy] Quantum service unavailable", "target", sanitize.LogString(targetURL), "error", err)
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Quantum service unavailable")
 	}
 	defer resp.Body.Close()

--- a/pkg/k8s/client_config.go
+++ b/pkg/k8s/client_config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/kubestellar/console/pkg/sanitize"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -125,6 +126,6 @@ func (m *MultiClusterClient) RemoveContext(contextName string) error {
 	delete(m.cacheTime, contextName)
 
 	m.rawConfig = config
-	slog.Info("Removed kubeconfig context", "context", contextName)
+	slog.Info("Removed kubeconfig context", "context", sanitize.LogString(contextName))
 	return nil
 }

--- a/pkg/k8s/client_gpu_cronjob.go
+++ b/pkg/k8s/client_gpu_cronjob.go
@@ -1,21 +1,21 @@
 package k8s
 
 import (
-"context"
-"encoding/json"
-"fmt"
-"log/slog"
-"time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
 
-authorizationv1 "k8s.io/api/authorization/v1"
-batchv1 "k8s.io/api/batch/v1"
-corev1 "k8s.io/api/core/v1"
-rbacv1 "k8s.io/api/rbac/v1"
-"k8s.io/apimachinery/pkg/api/errors"
-metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-"k8s.io/client-go/kubernetes"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
-"github.com/kubestellar/console/pkg/sanitize"
+	"github.com/kubestellar/console/pkg/sanitize"
 )
 
 // GetGPUHealthCronJobStatus checks if the GPU health CronJob is installed and returns its status.
@@ -312,7 +312,7 @@ func (m *MultiClusterClient) InstallGPUHealthCronJob(ctx context.Context, contex
 		}
 	}
 
-	slog.Info("[GPUHealthCronJob] installed", "cluster", sanitize.LogString(contextName), "namespace", sanitize.LogString(namespace), "schedule", sanitize.LogString(schedule), "tier", sanitize.LogString(tier), "version", gpuHealthScriptVersion)
+	slog.Info("[GPUHealthCronJob] installed", "cluster", sanitize.LogString(contextName), "namespace", sanitize.LogString(namespace), "schedule", sanitize.LogString(schedule), "tier", tier, "version", gpuHealthScriptVersion)
 	return nil
 }
 
@@ -687,4 +687,3 @@ func (m *MultiClusterClient) canManageCronJobs(ctx context.Context, client kuber
 	}
 	return result.Status.Allowed
 }
-

--- a/pkg/k8s/client_gpu_cronjob.go
+++ b/pkg/k8s/client_gpu_cronjob.go
@@ -14,6 +14,8 @@ rbacv1 "k8s.io/api/rbac/v1"
 "k8s.io/apimachinery/pkg/api/errors"
 metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 "k8s.io/client-go/kubernetes"
+
+"github.com/kubestellar/console/pkg/sanitize"
 )
 
 // GetGPUHealthCronJobStatus checks if the GPU health CronJob is installed and returns its status.
@@ -61,9 +63,9 @@ func (m *MultiClusterClient) GetGPUHealthCronJobStatus(ctx context.Context, cont
 		// Auto-reconcile: update CronJob if version is outdated and user has permissions
 		if status.UpdateAvailable && status.CanInstall {
 			if reconcileErr := m.InstallGPUHealthCronJob(ctx, contextName, ns, cj.Spec.Schedule, status.Tier); reconcileErr != nil {
-				slog.Error("[GPUHealthCronJob] auto-reconcile failed", "cluster", contextName, "error", reconcileErr)
+				slog.Error("[GPUHealthCronJob] auto-reconcile failed", "cluster", sanitize.LogString(contextName), "error", reconcileErr)
 			} else {
-				slog.Info("[GPUHealthCronJob] auto-reconciled to latest version", "cluster", contextName, "version", gpuHealthScriptVersion)
+				slog.Info("[GPUHealthCronJob] auto-reconciled to latest version", "cluster", sanitize.LogString(contextName), "version", gpuHealthScriptVersion)
 				status.Version = gpuHealthScriptVersion
 				status.UpdateAvailable = false
 			}
@@ -310,7 +312,7 @@ func (m *MultiClusterClient) InstallGPUHealthCronJob(ctx context.Context, contex
 		}
 	}
 
-	slog.Info("[GPUHealthCronJob] installed", "cluster", contextName, "namespace", namespace, "schedule", schedule, "tier", tier, "version", gpuHealthScriptVersion)
+	slog.Info("[GPUHealthCronJob] installed", "cluster", sanitize.LogString(contextName), "namespace", sanitize.LogString(namespace), "schedule", sanitize.LogString(schedule), "tier", sanitize.LogString(tier), "version", gpuHealthScriptVersion)
 	return nil
 }
 
@@ -663,7 +665,7 @@ func (m *MultiClusterClient) UninstallGPUHealthCronJob(ctx context.Context, cont
 		slog.Warn("[GPUHealthCronJob] could not delete ServiceAccount", "error", delErr)
 	}
 
-	slog.Info("[GPUHealthCronJob] uninstalled", "cluster", contextName, "namespace", namespace)
+	slog.Info("[GPUHealthCronJob] uninstalled", "cluster", sanitize.LogString(contextName), "namespace", sanitize.LogString(namespace))
 	return nil
 }
 

--- a/pkg/k8s/client_gpu_discovery.go
+++ b/pkg/k8s/client_gpu_discovery.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/kubestellar/console/pkg/sanitize"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -43,7 +44,7 @@ func (m *MultiClusterClient) getGPUNodesWithPods(ctx context.Context, contextNam
 	allPods, allPodsErr := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
 	if allPodsErr != nil {
 		slog.Error("[GPUNodes] failed to list pods for allocation accounting",
-			"cluster", contextName, "error", allPodsErr)
+			"cluster", sanitize.LogString(contextName), "error", allPodsErr)
 	}
 	// Track allocations by node and accelerator type
 	gpuAllocationByNode := make(map[string]int) // GPU allocations

--- a/pkg/k8s/client_health.go
+++ b/pkg/k8s/client_health.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/console/pkg/safego"
+	"github.com/kubestellar/console/pkg/sanitize"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -136,7 +137,7 @@ func (m *MultiClusterClient) GetClusterHealth(ctx context.Context, contextName s
 	client, err := m.GetClient(contextName)
 	if err != nil {
 		errType := classifyError(err.Error())
-		slog.Error("[Health] cluster client error", "cluster", contextName, "error", err)
+		slog.Error("[Health] cluster client error", "cluster", sanitize.LogString(contextName), "error", err)
 		return &ClusterHealth{
 			Cluster:      contextName,
 			Healthy:      false,
@@ -187,7 +188,7 @@ func (m *MultiClusterClient) GetClusterHealth(ctx context.Context, contextName s
 	// Process nodes - determines reachability
 	if nodesErr != nil {
 		errType := classifyError(nodesErr.Error())
-		slog.Error("[Health] failed to list nodes", "cluster", contextName, "error", nodesErr)
+		slog.Error("[Health] failed to list nodes", "cluster", sanitize.LogString(contextName), "error", nodesErr)
 		health.Healthy = false
 		health.Reachable = false
 		health.ErrorType = errType

--- a/pkg/k8s/client_services.go
+++ b/pkg/k8s/client_services.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/kubestellar/console/pkg/sanitize"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -132,7 +133,7 @@ func (m *MultiClusterClient) GetServices(ctx context.Context, contextName, names
 		}
 	} else {
 		slog.Error("[Services] failed to list endpoints for readiness counts",
-			"cluster", contextName, "namespace", namespace, "error", epErr)
+			"cluster", sanitize.LogString(contextName), "namespace", sanitize.LogString(namespace), "error", epErr)
 	}
 
 	var result []Service

--- a/pkg/k8s/workload_deploy.go
+++ b/pkg/k8s/workload_deploy.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/kubestellar/console/pkg/apis/v1alpha1"
 	"github.com/kubestellar/console/pkg/safego"
+	"github.com/kubestellar/console/pkg/sanitize"
 )
 
 // ResolveWorkloadDependencies fetches a workload by name (trying Deployment/StatefulSet/DaemonSet)
@@ -163,7 +164,7 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 			// 4a. Ensure namespace exists on target
 			nsErr := m.ensureNamespace(clusterCtx, targetClient, namespace, opts)
 			if nsErr != nil {
-				slog.Warn("[deploy] namespace ensure failed", "cluster", targetCluster, "error", nsErr)
+				slog.Warn("[deploy] namespace ensure failed", "cluster", sanitize.LogString(targetCluster), "error", nsErr)
 			}
 
 			// 4b. Apply dependencies in order before the workload
@@ -650,7 +651,7 @@ func (m *MultiClusterClient) DeleteWorkload(ctx context.Context, cluster, namesp
 			}
 			return fmt.Errorf("failed to delete %s %s/%s on cluster %s: %w", g.kind, namespace, name, cluster, err)
 		}
-		slog.Info("[delete] deleted workload", "kind", g.kind, "namespace", namespace, "name", name, "cluster", cluster)
+		slog.Info("[delete] deleted workload", "kind", g.kind, "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "cluster", sanitize.LogString(cluster))
 		return nil
 	}
 

--- a/pkg/safego/safego.go
+++ b/pkg/safego/safego.go
@@ -6,6 +6,8 @@ package safego
 import (
 	"log/slog"
 	"runtime/debug"
+
+	"github.com/kubestellar/console/pkg/sanitize"
 )
 
 // Go launches fn in a new goroutine with automatic panic recovery.
@@ -33,7 +35,7 @@ func GoWith(label string, fn func()) {
 		defer func() {
 			if r := recover(); r != nil {
 				slog.Error("goroutine panicked",
-					"label", label,
+					"label", sanitize.LogString(label),
 					"recover", r,
 					"stack", string(debug.Stack()),
 				)

--- a/pkg/sanitize/prompt.go
+++ b/pkg/sanitize/prompt.go
@@ -1,6 +1,7 @@
 // Package sanitize provides string sanitization utilities for prompt
-// injection prevention. These functions neutralize user-controlled input
-// before it is interpolated into LLM prompts.
+// injection prevention and log injection prevention. These functions
+// neutralize user-controlled input before it is interpolated into LLM
+// prompts or structured log statements.
 //
 // Extracted from pkg/agent to break the pkg/api → pkg/agent coupling.
 // Both packages can depend on this leaf package without creating a cycle.
@@ -55,4 +56,23 @@ func PromptStrings(values []string) []string {
 		}
 	}
 	return sanitized
+}
+
+var logInjectionReplacer = strings.NewReplacer(
+	"\n", "⏎",
+	"\r", "⏎",
+)
+
+// LogString sanitizes user-controlled input before logging to prevent
+// log injection attacks (CWE-117). It replaces newline and carriage-return
+// characters with a visible placeholder (⏎) so attackers cannot forge
+// additional log entries or corrupt log aggregation pipelines.
+//
+// Use this for any user-controlled value passed to log.Printf, slog.Info,
+// zerolog, or other structured logging calls.
+func LogString(input string) string {
+	if input == "" {
+		return ""
+	}
+	return logInjectionReplacer.Replace(input)
 }

--- a/pkg/sanitize/prompt_test.go
+++ b/pkg/sanitize/prompt_test.go
@@ -75,3 +75,29 @@ func TestPromptStrings_Nil(t *testing.T) {
 		t.Fatalf("expected nil, got %v", got)
 	}
 }
+
+func TestLogString_RemovesNewlines(t *testing.T) {
+	input := "malicious\nlog entry\rwith\r\ninjection"
+	got := LogString(input)
+	if strings.Contains(got, "\n") || strings.Contains(got, "\r") {
+		t.Fatalf("expected newlines/CR removed, got %q", got)
+	}
+	expected := "malicious⏎log entry⏎with⏎⏎injection"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestLogString_Empty(t *testing.T) {
+	if got := LogString(""); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
+func TestLogString_SafeInput(t *testing.T) {
+	input := "my-cluster-context"
+	got := LogString(input)
+	if got != "my-cluster-context" {
+		t.Fatalf("expected safe input unchanged, got %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #20628, Fixes #20632

Sanitizes user-controlled values in Go slog/log calls to prevent log injection (CWE-117) as flagged by CodeQL.

## Changes
- Added `LogString()` sanitizer to `pkg/sanitize/prompt.go` — replaces `\n`, `\r` with `⏎`
- Wrapped 40+ user-controlled values across 12 backend files with `sanitize.LogString()`
- Added unit tests for the new sanitizer