### PR TITLE
[scanner] fix: resolve coverage suite shard failures on main

### DIFF
--- a/web/netlify/functions/acmm-scan/__tests__/fetchers.test.ts
+++ b/web/netlify/functions/acmm-scan/__tests__/fetchers.test.ts
@@ -6,7 +6,6 @@ vi.mock('../helpers', async () => {
     ...actual,
     GITHUB_API: 'https://api.github.com',
     API_TIMEOUT_MS: 15000,
-    WEEKS_OF_HISTORY: 4,
   }
 })
 
@@ -156,7 +155,7 @@ describe('fetchWeeklyActivity', () => {
 
     const result = await fetchWeeklyActivity('kubestellar/console', 'tok')
     expect(Array.isArray(result)).toBe(true)
-    expect(result.length).toBe(4) // WEEKS_OF_HISTORY mocked to 4
+    expect(result.length).toBe(16) // WEEKS_OF_HISTORY is 16
     for (const week of result) {
       expect(week).toHaveProperty('week')
       expect(week).toHaveProperty('aiPrs')
@@ -209,7 +208,7 @@ describe('fetchWeeklyActivity', () => {
 
     const result = await fetchWeeklyActivity('org/repo', 'tok')
     // Should still return the buckets, just with zero counts
-    expect(result.length).toBe(4)
+    expect(result.length).toBe(16)
     for (const w of result) {
       expect(w.aiPrs + w.humanPrs).toBe(0)
     }
@@ -234,7 +233,7 @@ describe('fetchWeeklyActivity', () => {
 
   it('ignores items from weeks outside the tracking window', async () => {
     const oldDate = new Date()
-    oldDate.setDate(oldDate.getDate() - 365) // Way outside 4-week window
+    oldDate.setDate(oldDate.getDate() - 365) // Way outside 16-week window
 
     const items = [
       { created_at: oldDate.toISOString(), user: { login: 'dev' }, labels: [] },

--- a/web/src/components/mission-control/RequestApprovalModal.test.tsx
+++ b/web/src/components/mission-control/RequestApprovalModal.test.tsx
@@ -47,13 +47,11 @@ const mockState: MissionControlState = {
 describe('RequestApprovalModal', () => {
   it('renders modal title', () => {
     const onClose = vi.fn()
-    const onSubmit = vi.fn()
 
     render(
       <RequestApprovalModal
         isOpen={true}
         onClose={onClose}
-        onSubmit={onSubmit}
         state={mockState}
         installedProjects={new Set()}
       />
@@ -64,13 +62,11 @@ describe('RequestApprovalModal', () => {
 
   it('calls onClose when cancel clicked', () => {
     const onClose = vi.fn()
-    const onSubmit = vi.fn()
 
     render(
       <RequestApprovalModal
         isOpen={true}
         onClose={onClose}
-        onSubmit={onSubmit}
         state={mockState}
         installedProjects={new Set()}
       />
@@ -84,13 +80,11 @@ describe('RequestApprovalModal', () => {
 
   it('shows preview of approval body', () => {
     const onClose = vi.fn()
-    const onSubmit = vi.fn()
 
     render(
       <RequestApprovalModal
         isOpen={true}
         onClose={onClose}
-        onSubmit={onSubmit}
         state={mockState}
         installedProjects={new Set()}
       />
@@ -101,13 +95,11 @@ describe('RequestApprovalModal', () => {
 
   it('does not render when isOpen is false', () => {
     const onClose = vi.fn()
-    const onSubmit = vi.fn()
 
     const { container } = render(
       <RequestApprovalModal
         isOpen={false}
         onClose={onClose}
-        onSubmit={onSubmit}
         state={mockState}
         installedProjects={new Set()}
       />

--- a/web/src/components/missions/MissionViews.test.tsx
+++ b/web/src/components/missions/MissionViews.test.tsx
@@ -69,8 +69,11 @@ describe('OrbitStatusTracker', () => {
     const { OrbitStatusTracker } = await import('./OrbitStatusTracker')
     const { container } = render(
       <OrbitStatusTracker
-        orbitId="orbit-123"
-        status="active"
+        history={[]}
+        cadence="daily"
+        lastRunAt={null}
+        onRunNow={vi.fn()}
+        onChangeCadence={vi.fn()}
       />
     )
     expect(container).toBeTruthy()


### PR DESCRIPTION
Fixes #20631

Resolves the issue causing all 12 coverage suite shards to fail on main.

## Changes

Fixed three categories of test failures:

1. **RequestApprovalModal.test.tsx** - Removed invalid `onSubmit` prop that doesn't exist in component interface. The component handles submission internally via `handleSubmit` and doesn't expose an `onSubmit` callback.

2. **MissionViews.test.tsx** - Fixed OrbitStatusTracker test to pass correct props (`history`, `cadence`, `onRunNow`, `onChangeCadence`) instead of wrong props (`orbitId`, `status`).

3. **fetchers.test.ts** - Updated `WEEKS_OF_HISTORY` expectation from 4 to 16 to match actual constant value in `helpers.ts`. The test was attempting to mock the constant but the mock wasn't working, causing assertion failures.

## Root Causes

- RequestApprovalModal test was failing to load due to TypeScript compilation error from passing a non-existent prop
- OrbitStatusTracker test was passing completely wrong props that don't match the component interface
- fetchers test was expecting mocked values that weren't being applied at runtime

All three issues would cause immediate test failures on all shards.