### PR TITLE
[quality] add unit tests for getCookieDomain cookie domain logic

### DIFF
--- a/web/e2e/visual-login/helpers/liveSiteAssertions.ts
+++ b/web/e2e/visual-login/helpers/liveSiteAssertions.ts
@@ -132,6 +132,18 @@ export function normalizeBaseUrl(value: string | undefined): string | undefined 
   return value.replace(/\/+$/, '')
 }
 
+/**
+ * Determine the cookie domain for a given hostname.
+ * Returns undefined for localhost/127.0.0.1 (browser requires no explicit domain
+ * for port-specific URLs), otherwise returns the hostname for explicit domain binding.
+ */
+export function getCookieDomain(hostname: string): string | undefined {
+  if (hostname === '127.0.0.1' || hostname === 'localhost') {
+    return undefined
+  }
+  return hostname
+}
+
 export function liveProductionUrl(): string | undefined {
   return normalizeBaseUrl(
     process.env.LIVE_PRODUCTION_CONSOLE_URL
@@ -251,9 +263,7 @@ async function seedSignedLiveCookieSession(page: Page, baseUrl: string) {
   const githubLogin = process.env.CONSOLE_LIVE_TEST_GITHUB_LOGIN || 'console-live-canary'
   const userId = process.env.CONSOLE_LIVE_TEST_USER_ID || 'console-live-test-user'
   const role = process.env.CONSOLE_LIVE_TEST_USER_ROLE || 'admin'
-  const cookieDomain = url.hostname === '127.0.0.1' || url.hostname === 'localhost' 
-    ? undefined 
-    : url.hostname
+  const cookieDomain = getCookieDomain(url.hostname)
   await page.context().addCookies([{
     name: 'kc_auth',
     value: jwt,

--- a/web/harness/helpers/__tests__/liveSiteAssertions.test.ts
+++ b/web/harness/helpers/__tests__/liveSiteAssertions.test.ts
@@ -17,7 +17,7 @@ vi.mock('../../../e2e/helpers/setup', () => ({
   setupDemoMode: vi.fn(),
 }))
 
-import { normalizeBaseUrl, liveCanaryAuthMode, liveProductionUrl, liveCanaryUrl } from '../../../e2e/visual-login/helpers/liveSiteAssertions'
+import { normalizeBaseUrl, liveCanaryAuthMode, liveProductionUrl, liveCanaryUrl, getCookieDomain } from '../../../e2e/visual-login/helpers/liveSiteAssertions'
 
 describe('normalizeBaseUrl', () => {
   it('returns undefined for empty string', () => {
@@ -209,5 +209,35 @@ describe('liveCanaryUrl', () => {
   it('falls back to PLAYWRIGHT_BASE_URL', () => {
     process.env.PLAYWRIGHT_BASE_URL = 'https://playwright.example.com/'
     expect(liveCanaryUrl()).toBe('https://playwright.example.com')
+  })
+})
+
+describe('getCookieDomain', () => {
+  it('returns undefined for 127.0.0.1', () => {
+    expect(getCookieDomain('127.0.0.1')).toBeUndefined()
+  })
+
+  it('returns undefined for localhost', () => {
+    expect(getCookieDomain('localhost')).toBeUndefined()
+  })
+
+  it('returns the hostname for a production domain', () => {
+    expect(getCookieDomain('console.kubestellar.io')).toBe('console.kubestellar.io')
+  })
+
+  it('returns the hostname for a subdomain', () => {
+    expect(getCookieDomain('staging.console.kubestellar.io')).toBe('staging.console.kubestellar.io')
+  })
+
+  it('returns the hostname for an IP address that is not 127.0.0.1', () => {
+    expect(getCookieDomain('192.168.1.100')).toBe('192.168.1.100')
+  })
+
+  it('returns the hostname for IPv6 loopback (::1 is not special-cased)', () => {
+    expect(getCookieDomain('::1')).toBe('::1')
+  })
+
+  it('does not treat "LOCALHOST" (uppercase) as local', () => {
+    expect(getCookieDomain('LOCALHOST')).toBe('LOCALHOST')
   })
 })


### PR DESCRIPTION
## Test Improvement

Extracts the inline cookie domain determination from `seedSignedLiveCookieSession` into a standalone exported `getCookieDomain()` pure function and adds 7 unit tests covering all branches.

### Changes

**`web/e2e/visual-login/helpers/liveSiteAssertions.ts`**
- Extract `getCookieDomain(hostname: string): string | undefined` as an exported pure function
- Replace inline ternary in `seedSignedLiveCookieSession` with call to `getCookieDomain`

**`web/harness/helpers/__tests__/liveSiteAssertions.test.ts`**
- Add `getCookieDomain` describe block with 7 test cases:
  - `127.0.0.1` → `undefined`
  - `localhost` → `undefined`
  - `console.kubestellar.io` → returns hostname
  - `staging.console.kubestellar.io` → returns hostname
  - `192.168.1.100` → returns hostname
  - `::1` (IPv6 loopback) → returns hostname (not special-cased)
  - `LOCALHOST` (uppercase) → returns hostname (case-sensitive)

### Why

The cookie domain logic (introduced in #20636) is critical for canary auth testing — wrong domain silently breaks authentication cookies. Extracting to a testable pure function ensures regressions are caught immediately.

Fixes #20637

---
*Filed by quality agent (ACMM L4/L6 — full mode)*