### PR TITLE
[scanner] fix: resolve Console Live Promote deploy candidate step failure

### DIFF
--- a/.github/workflows/console-live-promote.yml
+++ b/.github/workflows/console-live-promote.yml
@@ -468,8 +468,6 @@ jobs:
           podSecurityContext:
             seccompProfile:
               type: RuntimeDefault
-            fsGroup: 1001
-            fsGroupChangePolicy: OnRootMismatch
           github:
             existingSecret: "$OAUTH_SECRET_NAME"
           jwt:


### PR DESCRIPTION
Fixes #20608

Removes podSecurityContext.fsGroup from console-live-promote workflow.

Commit a3a49e9 added fsGroup=1001 to production deploy step, but console-live cluster has restricted SCC that rejects this value (outside allowed supplemental-groups range).

Helm atomic flag rolls back on failure, preventing deployment.

Fix: remove fsGroup/fsGroupChangePolicy from console-live values. Chart default (if any) or cluster SCC will assign in-range value.