### PR TITLE
[quality] Add unit tests for NamespaceManager sub-components

### DIFF
--- a/web/src/components/namespaces/__tests__/NamespaceAccessPanel.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceAccessPanel.test.tsx
@@ -1,0 +1,321 @@
+import React from 'react'
+/**
+ * NamespaceAccessPanel Tests
+ *
+ * Exercises access entry rendering, admin/non-admin states,
+ * grant access button, revoke confirmation, and error handling.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NamespaceAccessPanel } from '../NamespaceAccessPanel'
+import type { NamespaceDetails } from '../types'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockShowToast = vi.fn()
+const mockApiGet = vi.fn()
+const mockAuthFetch = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback || key,
+  }),
+}))
+
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}))
+
+vi.mock('../../../lib/api', () => ({
+  api: { get: (...args: unknown[]) => mockApiGet(...args) },
+  authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}))
+
+vi.mock('../../../lib/constants', () => ({
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:9090',
+}))
+
+vi.mock('../../ui/ClusterBadge', () => ({
+  ClusterBadge: ({ cluster }: { cluster: string }) => <span data-testid="cluster-badge">{cluster}</span>,
+}))
+
+vi.mock('lucide-react', () => ({
+  Shield: () => <svg data-testid="shield-icon" />,
+  Trash2: () => <svg data-testid="trash-icon" />,
+  UserPlus: () => <svg data-testid="user-plus-icon" />,
+}))
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const testNamespace: NamespaceDetails = {
+  name: 'my-namespace',
+  cluster: 'cluster-1',
+  status: 'Active',
+  createdAt: '2024-01-01T00:00:00Z',
+}
+
+const mockBindings = [
+  {
+    bindingName: 'binding-1',
+    subjectKind: 'User',
+    subjectName: 'alice',
+    roleName: 'admin',
+    roleKind: 'ClusterRole',
+  },
+  {
+    bindingName: 'binding-2',
+    subjectKind: 'ServiceAccount',
+    subjectName: 'deploy-bot',
+    roleName: 'edit',
+    roleKind: 'Role',
+  },
+]
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('NamespaceAccessPanel', () => {
+  const mockOnGrantAccess = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiGet.mockResolvedValue({ data: { bindings: [] } })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns null when namespace is null', () => {
+    const { container } = render(
+      <NamespaceAccessPanel
+        namespace={null}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders namespace name and cluster badge', async () => {
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    expect(screen.getByText('my-namespace')).toBeInTheDocument()
+    expect(screen.getByTestId('cluster-badge')).toHaveTextContent('cluster-1')
+  })
+
+  it('shows admin-required message when not admin', () => {
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={false}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    expect(screen.getByText('Admin access required to view role bindings')).toBeInTheDocument()
+  })
+
+  it('does not show Grant Access button for non-admin', () => {
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={false}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    expect(screen.queryByText('Grant Access')).not.toBeInTheDocument()
+  })
+
+  it('shows Grant Access button for admin', () => {
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    expect(screen.getByText('Grant Access')).toBeInTheDocument()
+  })
+
+  it('calls onGrantAccess when Grant Access button is clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await user.click(screen.getByText('Grant Access'))
+    expect(mockOnGrantAccess).toHaveBeenCalled()
+  })
+
+  it('shows "No role bindings found" when entries are empty', async () => {
+    mockApiGet.mockResolvedValue({ data: { bindings: [] } })
+
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('No role bindings found')).toBeInTheDocument()
+    })
+  })
+
+  it('renders access entries with subject name, kind, and role', async () => {
+    mockApiGet.mockResolvedValue({ data: { bindings: mockBindings } })
+
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+      expect(screen.getByText('User')).toBeInTheDocument()
+      expect(screen.getByText('Role: admin')).toBeInTheDocument()
+      expect(screen.getByText('deploy-bot')).toBeInTheDocument()
+      expect(screen.getByText('ServiceAccount')).toBeInTheDocument()
+      expect(screen.getByText('Role: edit')).toBeInTheDocument()
+    })
+  })
+
+  it('calls api.get with correct URL on mount when admin', async () => {
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mockApiGet).toHaveBeenCalledWith(
+        '/api/namespaces/my-namespace/access?cluster=cluster-1'
+      )
+    })
+  })
+
+  it('does not fetch access when not admin', () => {
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={false}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    expect(mockApiGet).not.toHaveBeenCalled()
+  })
+
+  it('shows toast on fetch error', async () => {
+    mockApiGet.mockRejectedValue(new Error('Network error'))
+
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        'Failed to fetch namespace access',
+        'error'
+      )
+    })
+  })
+
+  it('shows admin-specific message on 403 error', async () => {
+    mockApiGet.mockRejectedValue(new Error('Request failed with status 403'))
+
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        'Admin access required to view namespace details',
+        'error'
+      )
+    })
+  })
+
+  it('revoke button prompts confirm dialog', async () => {
+    mockApiGet.mockResolvedValue({ data: { bindings: mockBindings } })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const user = userEvent.setup()
+
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+    })
+
+    const revokeButtons = screen.getAllByTitle('Revoke access')
+    await user.click(revokeButtons[0])
+
+    expect(confirmSpy).toHaveBeenCalledWith('Revoke access for alice?')
+    confirmSpy.mockRestore()
+  })
+
+  it('calls authFetch DELETE when revoke is confirmed', async () => {
+    mockApiGet.mockResolvedValue({ data: { bindings: mockBindings } })
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mockAuthFetch.mockResolvedValue({ ok: true })
+    const user = userEvent.setup()
+
+    render(
+      <NamespaceAccessPanel
+        namespace={testNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+    })
+
+    const revokeButtons = screen.getAllByTitle('Revoke access')
+    await user.click(revokeButtons[0])
+
+    await waitFor(() => {
+      expect(mockAuthFetch).toHaveBeenCalledWith(
+        expect.stringContaining('http://localhost:9090/rolebindings?'),
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+
+    vi.spyOn(window, 'confirm').mockRestore()
+  })
+})

--- a/web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx
@@ -1,0 +1,236 @@
+import React from 'react'
+/**
+ * NamespaceClusterGroup Tests
+ *
+ * Exercises collapse/expand, status indicators, namespace count,
+ * offline badge, skeleton loading, and system namespace detection.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NamespaceClusterGroup } from '../NamespaceClusterGroup'
+import type { NamespaceDetails } from '../types'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: string | Record<string, unknown>) => {
+      if (typeof opts === 'string') return opts
+      if (opts && typeof opts === 'object' && 'defaultValue' in opts) return opts.defaultValue as string
+      return key
+    },
+  }),
+}))
+
+vi.mock('../../ui/ClusterBadge', () => ({
+  ClusterBadge: ({ cluster }: { cluster: string }) => <span data-testid="cluster-badge">{cluster}</span>,
+}))
+
+vi.mock('../NamespaceCard', () => ({
+  NamespaceCard: ({ namespace, onDelete, isSystem }: { namespace: NamespaceDetails; onDelete?: () => void; isSystem?: boolean }) => (
+    <div data-testid={`ns-card-${namespace.name}`} data-system={isSystem}>
+      {namespace.name}
+      {onDelete && <button data-testid={`delete-${namespace.name}`} onClick={onDelete}>delete</button>}
+    </div>
+  ),
+  NamespaceCardSkeleton: () => <div data-testid="skeleton" />,
+}))
+
+vi.mock('lucide-react', () => ({
+  ChevronDown: () => <svg data-testid="chevron-down" />,
+  ChevronRight: () => <svg data-testid="chevron-right" />,
+  WifiOff: () => <svg data-testid="wifi-off" />,
+  Hourglass: () => <svg data-testid="hourglass" />,
+}))
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const makeNamespace = (name: string, cluster = 'cluster-1'): NamespaceDetails => ({
+  name,
+  cluster,
+  status: 'Active',
+  createdAt: '2024-01-01T00:00:00Z',
+})
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('NamespaceClusterGroup', () => {
+  const defaultProps = {
+    clusterName: 'cluster-1',
+    namespaces: [makeNamespace('app-ns'), makeNamespace('dev-ns')],
+    isCollapsed: false,
+    onToggleCollapse: vi.fn(),
+    isLoading: false,
+    hasData: true,
+    isUnreachable: false,
+    selectedNamespace: null,
+    onSelect: vi.fn(),
+    onDelete: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders cluster name via ClusterBadge', () => {
+    render(<NamespaceClusterGroup {...defaultProps} />)
+    expect(screen.getByTestId('cluster-badge')).toHaveTextContent('cluster-1')
+  })
+
+  it('displays namespace count with correct pluralization', () => {
+    render(<NamespaceClusterGroup {...defaultProps} />)
+    expect(screen.getByText('2 namespaces')).toBeInTheDocument()
+  })
+
+  it('displays singular "namespace" for count of 1', () => {
+    render(
+      <NamespaceClusterGroup
+        {...defaultProps}
+        namespaces={[makeNamespace('only-one')]}
+      />
+    )
+    expect(screen.getByText('1 namespace')).toBeInTheDocument()
+  })
+
+  it('calls onToggleCollapse when header button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<NamespaceClusterGroup {...defaultProps} />)
+
+    const btn = screen.getByRole('button', { name: /Collapse cluster-1/i })
+    await user.click(btn)
+
+    expect(defaultProps.onToggleCollapse).toHaveBeenCalled()
+  })
+
+  it('shows chevron-down when expanded', () => {
+    render(<NamespaceClusterGroup {...defaultProps} isCollapsed={false} />)
+    expect(screen.getByTestId('chevron-down')).toBeInTheDocument()
+  })
+
+  it('shows chevron-right when collapsed', () => {
+    render(<NamespaceClusterGroup {...defaultProps} isCollapsed={true} />)
+    expect(screen.getByTestId('chevron-right')).toBeInTheDocument()
+  })
+
+  it('hides namespace cards when collapsed', () => {
+    render(<NamespaceClusterGroup {...defaultProps} isCollapsed={true} />)
+    expect(screen.queryByTestId('ns-card-app-ns')).not.toBeInTheDocument()
+  })
+
+  it('shows namespace cards when expanded', () => {
+    render(<NamespaceClusterGroup {...defaultProps} isCollapsed={false} />)
+    expect(screen.getByTestId('ns-card-app-ns')).toBeInTheDocument()
+    expect(screen.getByTestId('ns-card-dev-ns')).toBeInTheDocument()
+  })
+
+  it('shows offline icon when cluster is unreachable', () => {
+    render(<NamespaceClusterGroup {...defaultProps} isUnreachable={true} />)
+    expect(screen.getByTestId('wifi-off')).toBeInTheDocument()
+    expect(screen.getByText('offline')).toBeInTheDocument()
+  })
+
+  it('shows loading indicator when loading without data', () => {
+    render(
+      <NamespaceClusterGroup
+        {...defaultProps}
+        isLoading={true}
+        hasData={false}
+        namespaces={[]}
+      />
+    )
+    expect(screen.getByText('loading...')).toBeInTheDocument()
+  })
+
+  it('shows skeleton cards when loading without data and expanded', () => {
+    render(
+      <NamespaceClusterGroup
+        {...defaultProps}
+        isLoading={true}
+        hasData={false}
+        isCollapsed={false}
+        namespaces={[]}
+      />
+    )
+    const skeletons = screen.getAllByTestId('skeleton')
+    expect(skeletons).toHaveLength(3)
+  })
+
+  it('shows access denied message for accessDenied status', () => {
+    render(
+      <NamespaceClusterGroup
+        {...defaultProps}
+        clusterStatus="accessDenied"
+        hasData={false}
+        namespaces={[]}
+      />
+    )
+    expect(screen.getByText('Access denied')).toBeInTheDocument()
+  })
+
+  it('shows unavailable message for unavailable status', () => {
+    render(
+      <NamespaceClusterGroup
+        {...defaultProps}
+        clusterStatus="unavailable"
+        hasData={false}
+        namespaces={[]}
+      />
+    )
+    expect(screen.getByText('Data unavailable')).toBeInTheDocument()
+  })
+
+  it('marks system namespaces (kube-*) correctly', () => {
+    render(
+      <NamespaceClusterGroup
+        {...defaultProps}
+        namespaces={[makeNamespace('kube-system')]}
+      />
+    )
+    const card = screen.getByTestId('ns-card-kube-system')
+    expect(card).toHaveAttribute('data-system', 'true')
+  })
+
+  it('marks "default" namespace as system', () => {
+    render(
+      <NamespaceClusterGroup
+        {...defaultProps}
+        namespaces={[makeNamespace('default')]}
+      />
+    )
+    const card = screen.getByTestId('ns-card-default')
+    expect(card).toHaveAttribute('data-system', 'true')
+  })
+
+  it('marks openshift-* namespaces as system', () => {
+    render(
+      <NamespaceClusterGroup
+        {...defaultProps}
+        namespaces={[makeNamespace('openshift-monitoring')]}
+      />
+    )
+    const card = screen.getByTestId('ns-card-openshift-monitoring')
+    expect(card).toHaveAttribute('data-system', 'true')
+  })
+
+  it('does not provide onDelete for system namespaces', () => {
+    render(
+      <NamespaceClusterGroup
+        {...defaultProps}
+        namespaces={[makeNamespace('kube-system')]}
+      />
+    )
+    expect(screen.queryByTestId('delete-kube-system')).not.toBeInTheDocument()
+  })
+
+  it('provides onDelete for non-system namespaces', () => {
+    render(
+      <NamespaceClusterGroup
+        {...defaultProps}
+        namespaces={[makeNamespace('my-app')]}
+      />
+    )
+    expect(screen.getByTestId('delete-my-app')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/namespaces/__tests__/NamespaceFilterBar.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceFilterBar.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react'
+/**
+ * NamespaceFilterBar Tests
+ *
+ * Exercises search input, group-by toggle buttons, and callback behavior.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NamespaceFilterBar } from '../NamespaceFilterBar'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, fallback?: string) => fallback || key }),
+}))
+
+vi.mock('lucide-react', () => ({
+  Search: () => <svg data-testid="search-icon" />,
+  Layers: () => <svg data-testid="layers-icon" />,
+  Server: () => <svg data-testid="server-icon" />,
+}))
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('NamespaceFilterBar', () => {
+  const mockOnSearchChange = vi.fn()
+  const mockOnGroupByChange = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders search input with current value', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery="test-ns"
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveValue('test-ns')
+  })
+
+  it('calls onSearchChange when typing in input', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'kube-system' } })
+
+    expect(mockOnSearchChange).toHaveBeenCalledWith('kube-system')
+  })
+
+  it('renders both group-by toggle buttons', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    expect(screen.getByTitle('Group by cluster')).toBeInTheDocument()
+    expect(screen.getByTitle('Group by type (user/system)')).toBeInTheDocument()
+  })
+
+  it('applies active styling to cluster button when groupBy is cluster', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const clusterBtn = screen.getByTitle('Group by cluster')
+    expect(clusterBtn.className).toContain('bg-blue-500/20')
+    expect(clusterBtn.className).toContain('text-blue-400')
+  })
+
+  it('applies active styling to type button when groupBy is type', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="type"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const typeBtn = screen.getByTitle('Group by type (user/system)')
+    expect(typeBtn.className).toContain('bg-blue-500/20')
+    expect(typeBtn.className).toContain('text-blue-400')
+  })
+
+  it('calls onGroupByChange with "cluster" when cluster button clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="type"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    await user.click(screen.getByTitle('Group by cluster'))
+    expect(mockOnGroupByChange).toHaveBeenCalledWith('cluster')
+  })
+
+  it('calls onGroupByChange with "type" when type button clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    await user.click(screen.getByTitle('Group by type (user/system)'))
+    expect(mockOnGroupByChange).toHaveBeenCalledWith('type')
+  })
+
+  it('renders search icon', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    expect(screen.getByTestId('search-icon')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/namespaces/__tests__/useNamespaceFetch.test.ts
+++ b/web/src/components/namespaces/__tests__/useNamespaceFetch.test.ts
@@ -1,0 +1,284 @@
+/**
+ * useNamespaceFetch Tests
+ *
+ * Tests pure helper functions (buildFallbackNamespaces, getCachedNamespacesForCluster)
+ * and the hook behavior (loading states, caching, auto-refresh, error handling).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockAuthFetch = vi.fn()
+
+vi.mock('../../../lib/api', () => ({
+  authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}))
+
+vi.mock('../../../lib/constants', () => ({
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:9090',
+}))
+
+vi.mock('../../../lib/constants/network', () => ({
+  NAMESPACE_ABORT_TIMEOUT_MS: 5000,
+  isLocalAgentSuppressed: () => false,
+}))
+
+vi.mock('../../../hooks/mcp/shared', () => ({
+  clusterCacheRef: {
+    clusters: [
+      { name: 'cached-cluster', context: 'cached-ctx', namespaces: ['ns-a', 'ns-b'] },
+    ],
+  },
+}))
+
+// Import after mocks
+import { useNamespaceFetch, namespaceCache } from '../useNamespaceFetch'
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeOkResponse(data: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  }
+}
+
+function makeErrorResponse(status: number) {
+  return {
+    ok: false,
+    status,
+    json: () => Promise.resolve({ error: 'mock error' }),
+  }
+}
+
+// ── Tests: Pure functions ──────────────────────────────────────────────────
+
+describe('useNamespaceFetch - pure helpers', () => {
+  beforeEach(() => {
+    namespaceCache.clear()
+  })
+
+  it('getCachedNamespacesForCluster returns empty when cache is empty and no cluster match', async () => {
+    const { getCachedNamespacesForCluster } = await import('../useNamespaceFetch')
+    const result = getCachedNamespacesForCluster('nonexistent-cluster')
+    expect(result).toEqual([])
+  })
+
+  it('getCachedNamespacesForCluster returns cached data when present', async () => {
+    namespaceCache.set('my-cluster', [
+      { name: 'ns1', cluster: 'my-cluster', status: 'Active', createdAt: '2024-01-01T00:00:00Z' },
+    ])
+    const { getCachedNamespacesForCluster } = await import('../useNamespaceFetch')
+    const result = getCachedNamespacesForCluster('my-cluster')
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('ns1')
+  })
+
+  it('getCachedNamespacesForCluster falls back to clusterCacheRef', async () => {
+    const { getCachedNamespacesForCluster } = await import('../useNamespaceFetch')
+    const result = getCachedNamespacesForCluster('cached-cluster')
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe('ns-a')
+    expect(result[1].name).toBe('ns-b')
+  })
+})
+
+// ── Tests: Hook behavior ───────────────────────────────────────────────────
+
+describe('useNamespaceFetch - hook', () => {
+  const mockShowToast = vi.fn()
+  const mockT = (key: string, opts?: string | Record<string, unknown>) => {
+    if (typeof opts === 'string') return opts
+    if (opts && typeof opts === 'object' && 'defaultValue' in opts) return opts.defaultValue as string
+    return key
+  }
+
+  const defaultParams = {
+    allClusterNames: ['cluster-1'],
+    clusters: [{ name: 'cluster-1', context: 'ctx-1', reachable: true }],
+    deduplicatedClusters: [{ name: 'cluster-1', context: 'ctx-1' }],
+    showToast: mockShowToast,
+    t: mockT as never,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    namespaceCache.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('starts with loading=false and empty namespaces', () => {
+    mockAuthFetch.mockImplementation(() => new Promise(() => {})) // never resolves
+    const { result } = renderHook(() => useNamespaceFetch({
+      ...defaultParams,
+      clusters: [], // no clusters = no fetch
+      allClusterNames: [],
+    }))
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.allNamespaces).toEqual([])
+    expect(result.current.error).toBeNull()
+  })
+
+  it('sets loading=true during fetch', async () => {
+    let resolveRequest: (value: unknown) => void
+    mockAuthFetch.mockImplementation(() => new Promise((resolve) => {
+      resolveRequest = resolve
+    }))
+
+    const { result } = renderHook(() => useNamespaceFetch(defaultParams))
+
+    // After the effect fires
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(result.current.loading).toBe(true)
+
+    // Resolve the fetch
+    await act(async () => {
+      resolveRequest!(makeOkResponse({
+        namespaces: [{ name: 'ns1', status: 'Active' }],
+      }))
+      await vi.advanceTimersByTimeAsync(0)
+    })
+  })
+
+  it('populates namespaces on successful agent fetch', async () => {
+    mockAuthFetch.mockResolvedValue(makeOkResponse({
+      namespaces: [
+        { name: 'production', status: 'Active', createdAt: '2024-06-01T00:00:00Z' },
+        { name: 'staging', status: 'Active' },
+      ],
+    }))
+
+    const { result } = renderHook(() => useNamespaceFetch(defaultParams))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.allNamespaces.length).toBeGreaterThanOrEqual(2)
+    const names = result.current.allNamespaces.map(n => n.name)
+    expect(names).toContain('production')
+    expect(names).toContain('staging')
+  })
+
+  it('sets error on auth failure (403)', async () => {
+    mockAuthFetch.mockResolvedValue(makeErrorResponse(403))
+
+    const { result } = renderHook(() => useNamespaceFetch(defaultParams))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    // Should have some error since all clusters failed with auth
+    expect(result.current.error).toBeTruthy()
+  })
+
+  it('auto-refreshes every 30 seconds', async () => {
+    mockAuthFetch.mockResolvedValue(makeOkResponse({ namespaces: [] }))
+
+    renderHook(() => useNamespaceFetch(defaultParams))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    const callCountAfterInitial = mockAuthFetch.mock.calls.length
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000)
+    })
+
+    expect(mockAuthFetch.mock.calls.length).toBeGreaterThan(callCountAfterInitial)
+  })
+
+  it('skips offline clusters', async () => {
+    mockAuthFetch.mockResolvedValue(makeOkResponse({ namespaces: [] }))
+
+    const params = {
+      ...defaultParams,
+      allClusterNames: ['online-cluster', 'offline-cluster'],
+      clusters: [
+        { name: 'online-cluster', context: 'ctx-online', reachable: true },
+        { name: 'offline-cluster', context: 'ctx-offline', reachable: false },
+      ],
+      deduplicatedClusters: [
+        { name: 'online-cluster', context: 'ctx-online' },
+        { name: 'offline-cluster', context: 'ctx-offline' },
+      ],
+    }
+
+    renderHook(() => useNamespaceFetch(params))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    await waitFor(() => {
+      // Should only fetch for online cluster
+      const calls = mockAuthFetch.mock.calls
+      const urls = calls.map(c => c[0] as string)
+      expect(urls.some(u => u.includes('ctx-offline'))).toBe(false)
+    })
+  })
+
+  it('uses cache on subsequent renders without force', async () => {
+    mockAuthFetch.mockResolvedValue(makeOkResponse({
+      namespaces: [{ name: 'cached-ns', status: 'Active' }],
+    }))
+
+    const { result, rerender } = renderHook(() => useNamespaceFetch(defaultParams))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    const callsAfterFirst = mockAuthFetch.mock.calls.length
+
+    // Re-render with same params — should use cache
+    rerender()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    // No additional fetch calls (only the interval would trigger new ones)
+    expect(mockAuthFetch.mock.calls.length).toBe(callsAfterFirst)
+  })
+
+  it('returns lastUpdated timestamp after fetch completes', async () => {
+    mockAuthFetch.mockResolvedValue(makeOkResponse({ namespaces: [] }))
+
+    const { result } = renderHook(() => useNamespaceFetch(defaultParams))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    await waitFor(() => {
+      expect(result.current.lastUpdated).toBeInstanceOf(Date)
+    })
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds **50 unit tests** across four new test files for the modules extracted in PR #20643, which had zero test coverage.

### New test files

| File | Tests | Coverage |
|------|-------|----------|
| `NamespaceFilterBar.test.tsx` | 8 | Search input, group-by toggle buttons, active styling |
| `NamespaceClusterGroup.test.tsx` | 18 | Collapse/expand, status indicators, system namespace detection, offline badge, skeletons |
| `NamespaceAccessPanel.test.tsx` | 14 | Admin/non-admin states, access entries, grant/revoke callbacks, error handling |
| `useNamespaceFetch.test.ts` | 10 | Pure helper functions, hook loading states, caching, auto-refresh, offline cluster skipping |

### Test approach

- **Presentational components** (FilterBar, ClusterGroup): Render tests verifying correct props flow, conditional rendering, and user interactions
- **Stateful component** (AccessPanel): Tests mock API layer, verify fetch behavior, error toasts, and confirm dialog flow
- **Custom hook** (useNamespaceFetch): Tests pure exported helpers directly + renderHook for loading states, caching, and timer-based refresh

Fixes #20650

---
*Filed by quality agent (ACMM L4/L6 — full mode)*