### PR TITLE
[scanner] test: add unit tests for NamespaceManager sub-components

### DIFF
--- a/web/src/components/namespaces/__tests__/NamespaceAccessPanel.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceAccessPanel.test.tsx
@@ -1,0 +1,306 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NamespaceAccessPanel } from '../NamespaceAccessPanel'
+import { api, authFetch } from '../../../lib/api'
+import type { NamespaceDetails, NamespaceAccessEntry } from '../types'
+
+/**
+ * NamespaceAccessPanel Component Tests
+ * 
+ * Tests rendering of access entries, revocation callback, admin-only
+ * behavior, loading states, error handling, and "Grant Access" button.
+ */
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock('../../../lib/api', () => ({
+  api: {
+    get: vi.fn(),
+  },
+  authFetch: vi.fn(),
+}))
+
+vi.mock('../../ui/ClusterBadge', () => ({
+  ClusterBadge: ({ cluster }: { cluster: string }) => <div data-testid="cluster-badge">{cluster}</div>,
+}))
+
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+  }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback || key,
+  }),
+}))
+
+// ── Test Data ──────────────────────────────────────────────────────────────
+
+const mockNamespace: NamespaceDetails = {
+  name: 'test-namespace',
+  cluster: 'cluster-1',
+  status: 'Active',
+  createdAt: '2024-01-01T00:00:00Z',
+}
+
+const mockAccessEntries: NamespaceAccessEntry[] = [
+  {
+    bindingName: 'binding-1',
+    roleName: 'admin',
+    subjectName: 'alice',
+    subjectKind: 'User',
+  },
+  {
+    bindingName: 'binding-2',
+    roleName: 'edit',
+    subjectName: 'bob',
+    subjectKind: 'ServiceAccount',
+  },
+]
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('NamespaceAccessPanel', () => {
+  const mockOnGrantAccess = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(window, { partial: true }).confirm = vi.fn(() => true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders nothing when namespace is null', () => {
+    const { container } = render(
+      <NamespaceAccessPanel
+        namespace={null}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders namespace name and cluster badge', () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { bindings: [] } })
+
+    render(
+      <NamespaceAccessPanel
+        namespace={mockNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    expect(screen.getByText('test-namespace')).toBeInTheDocument()
+    expect(screen.getByTestId('cluster-badge')).toHaveTextContent('cluster-1')
+  })
+
+  it('shows admin-required message for non-admin users', () => {
+    render(
+      <NamespaceAccessPanel
+        namespace={mockNamespace}
+        isAdmin={false}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    expect(screen.getByText(/Admin access required to view role bindings/i)).toBeInTheDocument()
+  })
+
+  it('fetches and displays access entries for admin users', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { bindings: mockAccessEntries } })
+
+    render(
+      <NamespaceAccessPanel
+        namespace={mockNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('bob')).toBeInTheDocument()
+    expect(screen.getByText('Role: admin')).toBeInTheDocument()
+    expect(screen.getByText('Role: edit')).toBeInTheDocument()
+  })
+
+  it('shows loading spinner while fetching access', async () => {
+    vi.mocked(api.get).mockImplementation(
+      () => new Promise(resolve => setTimeout(() => resolve({ data: { bindings: [] } }), 100))
+    )
+
+    render(
+      <NamespaceAccessPanel
+        namespace={mockNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    expect(screen.getByRole('generic', { name: /spinner/i }) || document.querySelector('.spinner')).toBeTruthy()
+
+    await waitFor(() => {
+      expect(screen.queryByRole('generic', { name: /spinner/i })).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows "no role bindings" message when entries are empty', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { bindings: [] } })
+
+    render(
+      <NamespaceAccessPanel
+        namespace={mockNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/No role bindings found/i)).toBeInTheDocument()
+    })
+  })
+
+  it('displays subject kind badges', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { bindings: mockAccessEntries } })
+
+    render(
+      <NamespaceAccessPanel
+        namespace={mockNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('User')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('ServiceAccount')).toBeInTheDocument()
+  })
+
+  it('calls onGrantAccess when "Grant Access" button is clicked', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { bindings: [] } })
+
+    render(
+      <NamespaceAccessPanel
+        namespace={mockNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    const grantButton = await screen.findByRole('button', { name: /Grant Access/i })
+    await userEvent.click(grantButton)
+
+    expect(mockOnGrantAccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles revoke access click with confirmation', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { bindings: mockAccessEntries } })
+    vi.mocked(authFetch).mockResolvedValue({ ok: true } as Response)
+
+    render(
+      <NamespaceAccessPanel
+        namespace={mockNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+    })
+
+    const revokeButtons = screen.getAllByTitle(/Revoke access/i)
+    await userEvent.click(revokeButtons[0])
+
+    expect(window.confirm).toHaveBeenCalledWith('Revoke access for alice?')
+    expect(authFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/rolebindings'),
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+
+  it('does not revoke if user cancels confirmation', async () => {
+    vi.mocked(window, { partial: true }).confirm = vi.fn(() => false)
+    vi.mocked(api.get).mockResolvedValue({ data: { bindings: mockAccessEntries } })
+
+    render(
+      <NamespaceAccessPanel
+        namespace={mockNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+    })
+
+    const revokeButtons = screen.getAllByTitle(/Revoke access/i)
+    await userEvent.click(revokeButtons[0])
+
+    expect(authFetch).not.toHaveBeenCalled()
+  })
+
+  it('handles fetch access error gracefully', async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error('403 Forbidden'))
+
+    render(
+      <NamespaceAccessPanel
+        namespace={mockNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/No role bindings found/i)).toBeInTheDocument()
+    })
+  })
+
+  it('refetches access entries after namespace changes', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { bindings: mockAccessEntries } })
+
+    const { rerender } = render(
+      <NamespaceAccessPanel
+        namespace={mockNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+    })
+
+    const newNamespace: NamespaceDetails = {
+      ...mockNamespace,
+      name: 'another-namespace',
+    }
+
+    rerender(
+      <NamespaceAccessPanel
+        namespace={newNamespace}
+        isAdmin={true}
+        onGrantAccess={mockOnGrantAccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx
@@ -1,0 +1,372 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NamespaceClusterGroup } from '../NamespaceClusterGroup'
+import type { NamespaceDetails } from '../types'
+
+/**
+ * NamespaceClusterGroup Component Tests
+ * 
+ * Tests collapsible cluster groups: expand/collapse interactions,
+ * status indicators (loading, offline, access denied, unavailable),
+ * namespace rendering, and skeleton display.
+ */
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock('../../ui/ClusterBadge', () => ({
+  ClusterBadge: ({ cluster }: { cluster: string }) => <div data-testid="cluster-badge">{cluster}</div>,
+}))
+
+vi.mock('../NamespaceCard', () => ({
+  NamespaceCard: ({ namespace, onSelect, onDelete }: {
+    namespace: NamespaceDetails
+    onSelect: () => void
+    onDelete?: () => void
+  }) => (
+    <div data-testid="namespace-card">
+      <span>{namespace.name}</span>
+      <button onClick={onSelect}>Select</button>
+      {onDelete && <button onClick={onDelete}>Delete</button>}
+    </div>
+  ),
+  NamespaceCardSkeleton: () => <div data-testid="namespace-skeleton">Loading...</div>,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue || key,
+  }),
+}))
+
+// ── Test Data ──────────────────────────────────────────────────────────────
+
+const mockNamespaces: NamespaceDetails[] = [
+  { name: 'default', cluster: 'cluster-1', status: 'Active', createdAt: '2024-01-01T00:00:00Z' },
+  { name: 'kube-system', cluster: 'cluster-1', status: 'Active', createdAt: '2024-01-01T00:00:00Z' },
+  { name: 'my-app', cluster: 'cluster-1', status: 'Active', createdAt: '2024-01-01T00:00:00Z' },
+]
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('NamespaceClusterGroup', () => {
+  const mockOnToggleCollapse = vi.fn()
+  const mockOnSelect = vi.fn()
+  const mockOnDelete = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders cluster name and namespace count when expanded', () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={mockNamespaces}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={false}
+        hasData={true}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    expect(screen.getByTestId('cluster-badge')).toHaveTextContent('cluster-1')
+    expect(screen.getByText('3 namespaces')).toBeInTheDocument()
+  })
+
+  it('shows singular "namespace" for count of 1', () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={[mockNamespaces[0]]}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={false}
+        hasData={true}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    expect(screen.getByText('1 namespace')).toBeInTheDocument()
+  })
+
+  it('toggles collapse state when header is clicked', async () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={mockNamespaces}
+        isCollapsed={true}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={false}
+        hasData={true}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    const collapseButton = screen.getByRole('button', { name: /Expand cluster-1/i })
+    await userEvent.click(collapseButton)
+
+    expect(mockOnToggleCollapse).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides namespace cards when collapsed', () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={mockNamespaces}
+        isCollapsed={true}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={false}
+        hasData={true}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    expect(screen.queryByTestId('namespace-card')).not.toBeInTheDocument()
+  })
+
+  it('shows namespace cards when expanded', () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={mockNamespaces}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={false}
+        hasData={true}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    const namespaceCards = screen.getAllByTestId('namespace-card')
+    expect(namespaceCards).toHaveLength(3)
+    expect(screen.getByText('default')).toBeInTheDocument()
+    expect(screen.getByText('kube-system')).toBeInTheDocument()
+    expect(screen.getByText('my-app')).toBeInTheDocument()
+  })
+
+  it('shows offline indicator when cluster is unreachable', () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={[]}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={false}
+        hasData={false}
+        isUnreachable={true}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    expect(screen.getByText('offline')).toBeInTheDocument()
+    expect(screen.getByTitle('Cluster offline')).toBeInTheDocument()
+  })
+
+  it('shows "Access denied" status when cluster denies access', () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={[]}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={false}
+        clusterStatus="accessDenied"
+        hasData={false}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    expect(screen.getByText('Access denied')).toBeInTheDocument()
+  })
+
+  it('shows "Data unavailable" status when cluster is unavailable', () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={[]}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={false}
+        clusterStatus="unavailable"
+        hasData={false}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    expect(screen.getByText('Data unavailable')).toBeInTheDocument()
+  })
+
+  it('shows loading skeletons when loading without data', () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={[]}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={true}
+        hasData={false}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    const skeletons = screen.getAllByTestId('namespace-skeleton')
+    expect(skeletons).toHaveLength(3)
+  })
+
+  it('shows loading indicator in header when loading', () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={[]}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={true}
+        hasData={false}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    expect(screen.getByText('loading...')).toBeInTheDocument()
+  })
+
+  it('shows authorization error message when access is denied', () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={[]}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={false}
+        clusterStatus="accessDenied"
+        hasData={false}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    expect(screen.getByText(/Authorization failed for namespace access/i)).toBeInTheDocument()
+  })
+
+  it('shows unavailable message when data is unavailable', () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={[]}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={false}
+        clusterStatus="unavailable"
+        hasData={false}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    expect(screen.getByText(/Namespace data is unavailable/i)).toBeInTheDocument()
+  })
+
+  it('calls onSelect when namespace card is selected', async () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={mockNamespaces}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={false}
+        hasData={true}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    const selectButtons = screen.getAllByRole('button', { name: 'Select' })
+    await userEvent.click(selectButtons[0])
+
+    expect(mockOnSelect).toHaveBeenCalledWith(mockNamespaces[0])
+  })
+
+  it('calls onDelete when namespace delete button is clicked', async () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={mockNamespaces}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={false}
+        hasData={true}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    const deleteButtons = screen.getAllByRole('button', { name: 'Delete' })
+    await userEvent.click(deleteButtons[0])
+
+    expect(mockOnDelete).toHaveBeenCalledWith(mockNamespaces[0])
+  })
+
+  it('does not show skeletons when loading with existing data', () => {
+    render(
+      <NamespaceClusterGroup
+        clusterName="cluster-1"
+        namespaces={mockNamespaces}
+        isCollapsed={false}
+        onToggleCollapse={mockOnToggleCollapse}
+        isLoading={true}
+        hasData={true}
+        isUnreachable={false}
+        selectedNamespace={null}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />
+    )
+
+    expect(screen.queryByTestId('namespace-skeleton')).not.toBeInTheDocument()
+    expect(screen.getAllByTestId('namespace-card')).toHaveLength(3)
+  })
+})

--- a/web/src/components/namespaces/__tests__/NamespaceFilterBar.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceFilterBar.test.tsx
@@ -1,0 +1,248 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NamespaceFilterBar } from '../NamespaceFilterBar'
+
+/**
+ * NamespaceFilterBar Component Tests
+ * 
+ * Tests search input functionality, group-by toggle (cluster/type),
+ * callback invocations, and UI state transitions.
+ */
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('NamespaceFilterBar', () => {
+  const mockOnSearchChange = vi.fn()
+  const mockOnGroupByChange = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders search input with placeholder', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const searchInput = screen.getByPlaceholderText('common.searchNamespaces')
+    expect(searchInput).toBeInTheDocument()
+  })
+
+  it('displays current search query value', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery="kube-system"
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const searchInput = screen.getByDisplayValue('kube-system')
+    expect(searchInput).toBeInTheDocument()
+  })
+
+  it('calls onSearchChange when search input changes', async () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const searchInput = screen.getByPlaceholderText('common.searchNamespaces')
+    await userEvent.type(searchInput, 'my-app')
+
+    expect(mockOnSearchChange).toHaveBeenCalledTimes(6) // "m", "y", "-", "a", "p", "p"
+    expect(mockOnSearchChange).toHaveBeenLastCalledWith('my-app')
+  })
+
+  it('renders group-by toggle buttons', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /By Cluster/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /By Type/i })).toBeInTheDocument()
+  })
+
+  it('highlights "By Cluster" button when groupBy is "cluster"', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const clusterButton = screen.getByRole('button', { name: /By Cluster/i })
+    expect(clusterButton).toHaveClass('bg-blue-500/20', 'text-blue-400')
+  })
+
+  it('highlights "By Type" button when groupBy is "type"', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="type"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const typeButton = screen.getByRole('button', { name: /By Type/i })
+    expect(typeButton).toHaveClass('bg-blue-500/20', 'text-blue-400')
+  })
+
+  it('calls onGroupByChange with "cluster" when "By Cluster" is clicked', async () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="type"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const clusterButton = screen.getByRole('button', { name: /By Cluster/i })
+    await userEvent.click(clusterButton)
+
+    expect(mockOnGroupByChange).toHaveBeenCalledWith('cluster')
+  })
+
+  it('calls onGroupByChange with "type" when "By Type" is clicked', async () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const typeButton = screen.getByRole('button', { name: /By Type/i })
+    await userEvent.click(typeButton)
+
+    expect(mockOnGroupByChange).toHaveBeenCalledWith('type')
+  })
+
+  it('renders search icon in input', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    // Lucide icons render as <svg>, check for the Search icon's parent container
+    const searchIcon = document.querySelector('.lucide-search') || document.querySelector('svg')
+    expect(searchIcon).toBeInTheDocument()
+  })
+
+  it('renders Server icon for "By Cluster" button', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const clusterButton = screen.getByRole('button', { name: /By Cluster/i })
+    expect(clusterButton.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders Layers icon for "By Type" button', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="type"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const typeButton = screen.getByRole('button', { name: /By Type/i })
+    expect(typeButton.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('applies correct title attributes to buttons', () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const clusterButton = screen.getByRole('button', { name: /By Cluster/i })
+    const typeButton = screen.getByRole('button', { name: /By Type/i })
+
+    expect(clusterButton).toHaveAttribute('title', 'Group by cluster')
+    expect(typeButton).toHaveAttribute('title', 'Group by type (user/system)')
+  })
+
+  it('clears search input when value is emptied', async () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery="test"
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const searchInput = screen.getByDisplayValue('test')
+    await userEvent.clear(searchInput)
+
+    expect(mockOnSearchChange).toHaveBeenCalledWith('')
+  })
+
+  it('does not call onGroupByChange when already selected button is clicked', async () => {
+    render(
+      <NamespaceFilterBar
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+        groupBy="cluster"
+        onGroupByChange={mockOnGroupByChange}
+      />
+    )
+
+    const clusterButton = screen.getByRole('button', { name: /By Cluster/i })
+    await userEvent.click(clusterButton)
+
+    // Still called, but the parent component decides if state should update
+    expect(mockOnGroupByChange).toHaveBeenCalledWith('cluster')
+  })
+})

--- a/web/src/components/namespaces/__tests__/useNamespaceFetch.test.ts
+++ b/web/src/components/namespaces/__tests__/useNamespaceFetch.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useNamespaceFetch, namespaceCache, getCachedNamespacesForCluster } from '../useNamespaceFetch'
+import { authFetch } from '../../../lib/api'
+import { clusterCacheRef } from '../../../hooks/mcp/shared'
+
+/**
+ * useNamespaceFetch Hook Tests
+ * 
+ * Tests namespace fetching logic, caching behavior, progressive loading,
+ * error handling (auth failures, timeouts, network errors), auto-refresh,
+ * and fallback to pod-based namespace extraction.
+ */
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock('../../../lib/api', () => ({
+  authFetch: vi.fn(),
+}))
+
+vi.mock('../../../hooks/mcp/shared', () => ({
+  clusterCacheRef: {
+    clusters: [],
+  },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | { defaultValue?: string }) => {
+      if (typeof fallback === 'object' && fallback.defaultValue) {
+        return fallback.defaultValue
+      }
+      return typeof fallback === 'string' ? fallback : key
+    },
+  }),
+}))
+
+// ── Test Data ──────────────────────────────────────────────────────────────
+
+const mockClusters = [
+  { name: 'cluster-1', context: 'ctx-1', reachable: true },
+  { name: 'cluster-2', context: 'ctx-2', reachable: true },
+]
+
+const mockDeduplicatedClusters = [
+  { name: 'cluster-1', context: 'ctx-1' },
+  { name: 'cluster-2', context: 'ctx-2' },
+]
+
+const mockNamespaces = [
+  { name: 'default', cluster: 'cluster-1', status: 'Active', createdAt: '2024-01-01T00:00:00Z' },
+  { name: 'kube-system', cluster: 'cluster-1', status: 'Active', createdAt: '2024-01-01T00:00:00Z' },
+]
+
+const mockShowToast = vi.fn()
+const mockT = (key: string) => key
+
+// ── Helper Functions ───────────────────────────────────────────────────────
+
+function createMockResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  } as Response)
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('useNamespaceFetch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    namespaceCache.clear()
+    clusterCacheRef.clusters = []
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('fetches namespaces from backend API', async () => {
+    vi.mocked(authFetch).mockImplementation((url) => {
+      if (url.includes('/api/namespaces')) {
+        return createMockResponse(mockNamespaces)
+      }
+      return createMockResponse({ namespaces: [] }, 404)
+    })
+
+    const { result } = renderHook(() =>
+      useNamespaceFetch({
+        allClusterNames: ['cluster-1'],
+        clusters: mockClusters,
+        deduplicatedClusters: mockDeduplicatedClusters,
+        showToast: mockShowToast,
+        t: mockT,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.allNamespaces.length).toBeGreaterThan(0)
+    expect(namespaceCache.has('cluster-1')).toBe(true)
+  })
+
+  it('uses cached namespaces on subsequent calls', async () => {
+    namespaceCache.set('cluster-1', mockNamespaces)
+
+    const { result } = renderHook(() =>
+      useNamespaceFetch({
+        allClusterNames: ['cluster-1'],
+        clusters: mockClusters,
+        deduplicatedClusters: mockDeduplicatedClusters,
+        showToast: mockShowToast,
+        t: mockT,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.allNamespaces.length).toBe(2)
+    })
+
+    expect(authFetch).not.toHaveBeenCalled()
+  })
+
+  it('handles authorization failures (403)', async () => {
+    vi.mocked(authFetch).mockResolvedValue(
+      createMockResponse({ error: 'Forbidden' }, 403)
+    )
+
+    const { result } = renderHook(() =>
+      useNamespaceFetch({
+        allClusterNames: ['cluster-1'],
+        clusters: mockClusters,
+        deduplicatedClusters: mockDeduplicatedClusters,
+        showToast: mockShowToast,
+        t: mockT,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error).toBeTruthy()
+    expect(result.current.clusterStatuses['cluster-1']).toBe('accessDenied')
+  })
+
+  it('handles network failures and marks cluster unavailable', async () => {
+    vi.mocked(authFetch).mockRejectedValue(new Error('Network error'))
+
+    const { result } = renderHook(() =>
+      useNamespaceFetch({
+        allClusterNames: ['cluster-1'],
+        clusters: mockClusters,
+        deduplicatedClusters: mockDeduplicatedClusters,
+        showToast: mockShowToast,
+        t: mockT,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.clusterStatuses['cluster-1']).toBe('unavailable')
+  })
+
+  it('falls back to pod-based namespace extraction on agent failure', async () => {
+    const mockPods = {
+      pods: [
+        { namespace: 'app-1' },
+        { namespace: 'app-2' },
+        { namespace: 'app-1' }, // duplicate
+      ],
+    }
+
+    vi.mocked(authFetch).mockImplementation((url) => {
+      if (url.includes('/api/namespaces')) {
+        return createMockResponse({ error: 'Not found' }, 404)
+      }
+      if (url.includes('/pods')) {
+        return createMockResponse(mockPods)
+      }
+      return createMockResponse({}, 500)
+    })
+
+    const { result } = renderHook(() =>
+      useNamespaceFetch({
+        allClusterNames: ['cluster-1'],
+        clusters: mockClusters,
+        deduplicatedClusters: mockDeduplicatedClusters,
+        showToast: mockShowToast,
+        t: mockT,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.allNamespaces.some(ns => ns.name === 'app-1')).toBe(true)
+    expect(result.current.allNamespaces.some(ns => ns.name === 'app-2')).toBe(true)
+  })
+
+  it('auto-refreshes namespaces at interval', async () => {
+    vi.mocked(authFetch).mockResolvedValue(createMockResponse(mockNamespaces))
+
+    const { result } = renderHook(() =>
+      useNamespaceFetch({
+        allClusterNames: ['cluster-1'],
+        clusters: mockClusters,
+        deduplicatedClusters: mockDeduplicatedClusters,
+        showToast: mockShowToast,
+        t: mockT,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    const initialLastUpdated = result.current.lastUpdated
+
+    vi.advanceTimersByTime(30000) // AUTO_REFRESH_INTERVAL_MS
+
+    await waitFor(() => {
+      expect(result.current.lastUpdated).not.toBe(initialLastUpdated)
+    })
+  })
+
+  it('skips offline clusters during fetch', async () => {
+    const offlineClusters = [
+      { name: 'cluster-1', context: 'ctx-1', reachable: false },
+      { name: 'cluster-2', context: 'ctx-2', reachable: true },
+    ]
+
+    vi.mocked(authFetch).mockResolvedValue(createMockResponse(mockNamespaces))
+
+    const { result } = renderHook(() =>
+      useNamespaceFetch({
+        allClusterNames: ['cluster-1', 'cluster-2'],
+        clusters: offlineClusters,
+        deduplicatedClusters: mockDeduplicatedClusters,
+        showToast: mockShowToast,
+        t: mockT,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    // Should only fetch cluster-2
+    expect(vi.mocked(authFetch).mock.calls.some(call => 
+      call[0].toString().includes('cluster-2')
+    )).toBe(true)
+  })
+
+  it('tracks loading state per cluster', async () => {
+    vi.mocked(authFetch).mockImplementation(() => 
+      new Promise(resolve => setTimeout(() => resolve(createMockResponse(mockNamespaces)), 100))
+    )
+
+    const { result } = renderHook(() =>
+      useNamespaceFetch({
+        allClusterNames: ['cluster-1', 'cluster-2'],
+        clusters: mockClusters,
+        deduplicatedClusters: mockDeduplicatedClusters,
+        showToast: mockShowToast,
+        t: mockT,
+      })
+    )
+
+    expect(result.current.loadingClusters.size).toBeGreaterThan(0)
+
+    await waitFor(() => {
+      expect(result.current.loadingClusters.size).toBe(0)
+    })
+  })
+
+  it('exports getCachedNamespacesForCluster utility', () => {
+    namespaceCache.set('cluster-1', mockNamespaces)
+    const cached = getCachedNamespacesForCluster('cluster-1')
+    expect(cached).toEqual(mockNamespaces)
+  })
+
+  it('falls back to clusterCacheRef when cache is empty', () => {
+    clusterCacheRef.clusters = [
+      { name: 'cluster-1', context: 'ctx-1', namespaces: ['default', 'kube-system'] },
+    ]
+
+    const cached = getCachedNamespacesForCluster('cluster-1')
+    expect(cached.length).toBe(2)
+    expect(cached[0].name).toBe('default')
+  })
+})


### PR DESCRIPTION
Fixes #20650

Adds comprehensive unit tests for all 4 modules extracted from NamespaceManager.tsx in PR #20643:

- **useNamespaceFetch.test.ts** — fetch logic, caching, auth/network errors, auto-refresh, pod fallback
- **NamespaceAccessPanel.test.tsx** — rendering, access entries, revocation, admin behavior
- **NamespaceClusterGroup.test.tsx** — collapse/expand, status indicators, namespace rendering
- **NamespaceFilterBar.test.tsx** — search input, group-by toggle

Stacked on PR #20643 (the refactor PR that introduces these components).