### PR TITLE
[scanner] fix: scope workflow token permissions to job level

### DIFF
--- a/.github/workflows/auto-qa-tuner.yml
+++ b/.github/workflows/auto-qa-tuner.yml
@@ -19,7 +19,7 @@ on:
         default: 'all'
         type: string
 
-permissions: read-all
+permissions: {}
 
 concurrency:
   group: auto-qa-tuner

--- a/.github/workflows/cleanup-screenshots.yml
+++ b/.github/workflows/cleanup-screenshots.yml
@@ -15,7 +15,7 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 jobs:
   cleanup-screenshots:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,7 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions: read-all
+permissions: {}
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}

--- a/.github/workflows/deploy-checksum.yml
+++ b/.github/workflows/deploy-checksum.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths: [deploy.sh]
 
-permissions: read-all
+permissions: {}
 
 jobs:
   update-checksum:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -8,8 +8,8 @@ on:
         required: true
         default: '0.1.0'
 
-# Least-privilege: read-only by default; jobs declare write scopes individually
-permissions: read-all
+# Least-privilege: no default permissions; jobs declare scopes individually
+permissions: {}
 
 jobs:
   release-helm:

--- a/.github/workflows/hive-interactive.yml
+++ b/.github/workflows/hive-interactive.yml
@@ -8,7 +8,7 @@ on:
   issue_comment:
     types: [created]
 
-permissions: read-all  # default read; writes scoped to job below
+permissions: {}  # default none; specific scopes granted at job level
 
 jobs:
   post-directions:

--- a/.github/workflows/process-screenshots.yml
+++ b/.github/workflows/process-screenshots.yml
@@ -14,7 +14,7 @@ on:
   issue_comment:
     types: [created]
 
-permissions: read-all
+permissions: {}
 
 jobs:
   process-screenshot:


### PR DESCRIPTION
Fixes #20655

Scopes GITHUB_TOKEN permissions to job level for remaining workflows flagged by Scorecard TokenPermissions rule. Each job now declares only the minimum permissions it needs.