### PR TITLE
[scanner] fix: Console Live macOS Canary workflow failures

### DIFF
--- a/.github/workflows/console-live-macos-canary.yml
+++ b/.github/workflows/console-live-macos-canary.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Install Playwright WebKit
         working-directory: web
-        run: npx playwright install webkit
+        run: npx playwright install --with-deps webkit
 
       - name: Mint signed live test session
         env:


### PR DESCRIPTION
Fixes #20671

## Problem
Console Live macOS Canary workflow failing on all 3 scheduled runs. WebKit browser on macos-14 missing system dependencies.

## Solution
Add `--with-deps` flag to Playwright WebKit install command.

## Changes
- `.github/workflows/console-live-macos-canary.yml` line 97: added `--with-deps`

## Validation  
Pattern used successfully in playwright.yml (line 103) and visual-regression.yml (line 55).