### PR TITLE
[sec-check] fix: apply sanitize.LogString to unsanitized slog calls — 19 go/log-injection CodeQL alerts

### DIFF
--- a/pkg/agent/server_ops_clusters.go
+++ b/pkg/agent/server_ops_clusters.go
@@ -143,7 +143,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		// SECURITY: Validate cluster name against DNS-1123 to prevent command
 		// injection via crafted names that flow into exec.Command args (#7171).
 		if err := kube.ValidateDNS1123Label("cluster name", req.Name); err != nil {
-			slog.Warn("[LocalClusters] invalid cluster name", "name", req.Name, "error", err)
+			slog.Warn("[LocalClusters] invalid cluster name", "name", sanitize.LogString(req.Name), "error", err)
 			http.Error(w, "invalid cluster name", http.StatusBadRequest)
 			return
 		}
@@ -153,7 +153,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		safego.GoWith("local-cluster-create", func() {
 			defer s.clusterOpsWG.Done()
 			if err := s.localClusters.CreateCluster(req.Tool, req.Name); err != nil {
-				slog.Error("[LocalClusters] failed to create cluster", "cluster", req.Name, "tool", req.Tool, "error", err)
+				slog.Error("[LocalClusters] failed to create cluster", "cluster", sanitize.LogString(req.Name), "tool", sanitize.LogString(req.Tool), "error", err)
 				errMsg := sanitizeClusterError(err)
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 					"tool":     req.Tool,
@@ -169,7 +169,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 					"error": errMsg,
 				})
 			} else {
-				slog.Info("[LocalClusters] created cluster", "cluster", req.Name, "tool", req.Tool)
+				slog.Info("[LocalClusters] created cluster", "cluster", sanitize.LogString(req.Name), "tool", sanitize.LogString(req.Tool))
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 					"tool":     req.Tool,
 					"name":     req.Name,
@@ -295,7 +295,7 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 	}
 	// SECURITY: Validate cluster name against DNS-1123 (#7171).
 	if err := kube.ValidateDNS1123Label("cluster name", req.Name); err != nil {
-		slog.Warn("[LocalClusters] invalid cluster name", "name", req.Name, "error", err)
+		slog.Warn("[LocalClusters] invalid cluster name", "name", sanitize.LogString(req.Name), "error", err)
 		http.Error(w, "invalid cluster name", http.StatusBadRequest)
 		return
 	}
@@ -322,7 +322,7 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 		}
 
 		if err != nil {
-			slog.Error("[LocalClusters] lifecycle action failed", "action", sanitize.LogString(req.Action), "cluster", req.Name, "error", err)
+			slog.Error("[LocalClusters] lifecycle action failed", "action", sanitize.LogString(req.Action), "cluster", sanitize.LogString(req.Name), "error", err)
 			errMsg := sanitizeClusterError(err)
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     req.Tool,
@@ -332,7 +332,7 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 				"progress": 0,
 			})
 		} else {
-			slog.Info("[LocalClusters] lifecycle action completed", "action", sanitize.LogString(req.Action), "cluster", req.Name)
+			slog.Info("[LocalClusters] lifecycle action completed", "action", sanitize.LogString(req.Action), "cluster", sanitize.LogString(req.Name))
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     req.Tool,
 				"name":     req.Name,
@@ -414,7 +414,7 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 
 	// SECURITY: Validate name and namespace against DNS-1123 (#7171).
 	if err := kube.ValidateDNS1123Label("vcluster name", req.Name); err != nil {
-		slog.Warn("[vCluster] invalid vcluster name", "name", req.Name, "error", err)
+		slog.Warn("[vCluster] invalid vcluster name", "name", sanitize.LogString(req.Name), "error", err)
 		http.Error(w, "invalid vcluster name", http.StatusBadRequest)
 		return
 	}
@@ -429,7 +429,7 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 	safego.GoWith("vcluster-create", func() {
 		defer s.clusterOpsWG.Done()
 		if err := s.localClusters.CreateVCluster(req.Name, req.Namespace); err != nil {
-			slog.Error("[vCluster] failed to create vcluster", "name", req.Name, "error", err)
+			slog.Error("[vCluster] failed to create vcluster", "name", sanitize.LogString(req.Name), "error", err)
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     "vcluster",
 				"name":     req.Name,
@@ -438,7 +438,7 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 				"progress": progressFailed,
 			})
 		} else {
-			slog.Info("[vCluster] created vcluster", "name", req.Name, "namespace", sanitize.LogString(req.Namespace))
+			slog.Info("[vCluster] created vcluster", "name", sanitize.LogString(req.Name), "namespace", sanitize.LogString(req.Namespace))
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     "vcluster",
 				"name":     req.Name,
@@ -492,7 +492,7 @@ func (s *Server) handleVClusterConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	// SECURITY: Validate name and namespace against DNS-1123 (#7171).
 	if err := kube.ValidateDNS1123Label("vcluster name", req.Name); err != nil {
-		slog.Warn("[vCluster] invalid vcluster name", "name", req.Name, "error", err)
+		slog.Warn("[vCluster] invalid vcluster name", "name", sanitize.LogString(req.Name), "error", err)
 		http.Error(w, "invalid vcluster name", http.StatusBadRequest)
 		return
 	}
@@ -503,7 +503,7 @@ func (s *Server) handleVClusterConnect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.localClusters.ConnectVCluster(req.Name, req.Namespace); err != nil {
-		slog.Error("[vCluster] failed to connect to vcluster", "name", req.Name, "error", err)
+		slog.Error("[vCluster] failed to connect to vcluster", "name", sanitize.LogString(req.Name), "error", err)
 		s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 			"tool":     "vcluster",
 			"name":     req.Name,
@@ -515,7 +515,7 @@ func (s *Server) handleVClusterConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("[vCluster] connected to vcluster", "name", req.Name, "namespace", sanitize.LogString(req.Namespace))
+	slog.Info("[vCluster] connected to vcluster", "name", sanitize.LogString(req.Name), "namespace", sanitize.LogString(req.Namespace))
 	s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 		"tool":     "vcluster",
 		"name":     req.Name,
@@ -566,7 +566,7 @@ func (s *Server) handleVClusterDisconnect(w http.ResponseWriter, r *http.Request
 	}
 	// SECURITY: Validate name and namespace against DNS-1123 (#7171).
 	if err := kube.ValidateDNS1123Label("vcluster name", req.Name); err != nil {
-		slog.Warn("[vCluster] invalid vcluster name", "name", req.Name, "error", err)
+		slog.Warn("[vCluster] invalid vcluster name", "name", sanitize.LogString(req.Name), "error", err)
 		http.Error(w, "invalid vcluster name", http.StatusBadRequest)
 		return
 	}
@@ -577,7 +577,7 @@ func (s *Server) handleVClusterDisconnect(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := s.localClusters.DisconnectVCluster(req.Name, req.Namespace); err != nil {
-		slog.Error("[vCluster] failed to disconnect from vcluster", "name", req.Name, "error", err)
+		slog.Error("[vCluster] failed to disconnect from vcluster", "name", sanitize.LogString(req.Name), "error", err)
 		s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 			"tool":     "vcluster",
 			"name":     req.Name,
@@ -589,7 +589,7 @@ func (s *Server) handleVClusterDisconnect(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	slog.Info("[vCluster] disconnected from vcluster", "name", req.Name)
+	slog.Info("[vCluster] disconnected from vcluster", "name", sanitize.LogString(req.Name))
 	s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 		"tool":     "vcluster",
 		"name":     req.Name,
@@ -640,7 +640,7 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	// SECURITY: Validate name and namespace against DNS-1123 (#7171).
 	if err := kube.ValidateDNS1123Label("vcluster name", req.Name); err != nil {
-		slog.Warn("[vCluster] invalid vcluster name", "name", req.Name, "error", err)
+		slog.Warn("[vCluster] invalid vcluster name", "name", sanitize.LogString(req.Name), "error", err)
 		http.Error(w, "invalid vcluster name", http.StatusBadRequest)
 		return
 	}
@@ -655,7 +655,7 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 	safego.GoWith("vcluster-delete", func() {
 		defer s.clusterOpsWG.Done()
 		if err := s.localClusters.DeleteVCluster(req.Name, req.Namespace); err != nil {
-			slog.Error("[vCluster] failed to delete vcluster", "name", req.Name, "error", err)
+			slog.Error("[vCluster] failed to delete vcluster", "name", sanitize.LogString(req.Name), "error", err)
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     "vcluster",
 				"name":     req.Name,
@@ -664,7 +664,7 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 				"progress": progressFailed,
 			})
 		} else {
-			slog.Info("[vCluster] deleted vcluster", "name", req.Name, "namespace", sanitize.LogString(req.Namespace))
+			slog.Info("[vCluster] deleted vcluster", "name", sanitize.LogString(req.Name), "namespace", sanitize.LogString(req.Namespace))
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     "vcluster",
 				"name":     req.Name,

--- a/pkg/agent/updater/poller.go
+++ b/pkg/agent/updater/poller.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+
+	"github.com/kubestellar/console/pkg/sanitize"
 )
 
 func (uc *UpdateChecker) run(ctx context.Context) {
@@ -128,7 +130,7 @@ func (uc *UpdateChecker) checkReleaseChannel(channel string) {
 	}
 
 	if latest == nil || latest.TagName == currentVersion {
-		slog.Info("[AutoUpdate] already on latest release", "channel", channel, "version", currentVersion)
+		slog.Info("[AutoUpdate] already on latest release", "channel", channel, "version", sanitize.LogString(currentVersion))
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:   "done",
 			Message:  fmt.Sprintf("Already up to date — running latest %s release", channel),
@@ -137,7 +139,7 @@ func (uc *UpdateChecker) checkReleaseChannel(channel string) {
 		return
 	}
 
-	slog.Info("[AutoUpdate] new release available", "current", currentVersion, "latest", latest.TagName)
+	slog.Info("[AutoUpdate] new release available", "current", sanitize.LogString(currentVersion), "latest", sanitize.LogString(latest.TagName))
 
 	switch installMethod {
 	case "binary":
@@ -146,4 +148,3 @@ func (uc *UpdateChecker) checkReleaseChannel(channel string) {
 		uc.executeDevReleaseUpdate(latest)
 	}
 }
-

--- a/pkg/agent/websocket_deadline.go
+++ b/pkg/agent/websocket_deadline.go
@@ -5,12 +5,14 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+
+	"github.com/kubestellar/console/pkg/sanitize"
 )
 
 func setWSWriteDeadline(conn *websocket.Conn, logMsg string, logArgs ...any) error {
 	if err := conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout)); err != nil {
 		attrs := append([]any{}, logArgs...)
-		attrs = append(attrs, "client", conn.RemoteAddr(), "error", err)
+		attrs = append(attrs, "client", sanitize.LogString(conn.RemoteAddr().String()), "error", err)
 		slog.Error(logMsg, attrs...)
 		return err
 	}
@@ -20,7 +22,7 @@ func setWSWriteDeadline(conn *websocket.Conn, logMsg string, logArgs ...any) err
 func clearWSWriteDeadline(conn *websocket.Conn, logMsg string, logArgs ...any) error {
 	if err := conn.SetWriteDeadline(time.Time{}); err != nil {
 		attrs := append([]any{}, logArgs...)
-		attrs = append(attrs, "client", conn.RemoteAddr(), "error", err)
+		attrs = append(attrs, "client", sanitize.LogString(conn.RemoteAddr().String()), "error", err)
 		slog.Error(logMsg, attrs...)
 		return err
 	}

--- a/pkg/agent/workers/prediction_analysis.go
+++ b/pkg/agent/workers/prediction_analysis.go
@@ -100,7 +100,7 @@ func (w *PredictionWorker) runAnalysis(specificProviders []string) {
 	w.lastRun = time.Now()
 	w.mu.Unlock()
 
-	slog.Info("[PredictionWorker] analysis complete", "predictions", len(filtered), "providers", usedProviders)
+	slog.Info("[PredictionWorker] analysis complete", "predictions", len(filtered), "providers", sanitize.LogStrings(usedProviders))
 
 	// Broadcast to WebSocket clients
 	if w.broadcast != nil {
@@ -502,5 +502,3 @@ func (w *PredictionWorker) mergePredictions(byProvider map[string][]AIPrediction
 
 	return result
 }
-
-

--- a/pkg/agent/workers/workers_insight.go
+++ b/pkg/agent/workers/workers_insight.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kubestellar/console/pkg/agent/kube"
 	"github.com/kubestellar/console/pkg/ai"
+	"github.com/kubestellar/console/pkg/sanitize"
 )
 
 // InsightEnrichmentCacheTTL is how long individual enrichments are cached
@@ -265,7 +266,7 @@ func (w *InsightWorker) callAIProvider(insights []InsightSummary) ([]AIInsightEn
 
 		resp, err := provider.Chat(ctx, req)
 		if err != nil {
-			slog.Error("[InsightWorker] provider failed", "provider", name, "error", err)
+			slog.Error("[InsightWorker] provider failed", "provider", sanitize.LogString(name), "error", err)
 			continue
 		}
 		if resp == nil {
@@ -274,7 +275,7 @@ func (w *InsightWorker) callAIProvider(insights []InsightSummary) ([]AIInsightEn
 
 		enrichments, err := parseEnrichmentResponse(resp.Content, insights)
 		if err != nil {
-			slog.Error("[InsightWorker] failed to parse response", "provider", name, "error", err)
+			slog.Error("[InsightWorker] failed to parse response", "provider", sanitize.LogString(name), "error", err)
 			continue
 		}
 
@@ -333,7 +334,7 @@ func buildInsightEnrichmentPrompt(insights []InsightSummary) string {
 		if len(insight.Metrics) > 0 {
 			metricsJSON, err := json.Marshal(insight.Metrics)
 			if err != nil {
-				slog.Warn("[InsightWorker] failed to marshal metrics, omitting from prompt", "insightID", insight.ID, "error", err)
+				slog.Warn("[InsightWorker] failed to marshal metrics, omitting from prompt", "insightID", sanitize.LogString(insight.ID), "error", err)
 			} else {
 				b.WriteString(fmt.Sprintf("Metrics: %s\n", string(metricsJSON)))
 			}

--- a/pkg/k8s/workload_deploy.go
+++ b/pkg/k8s/workload_deploy.go
@@ -73,7 +73,6 @@ func (m *MultiClusterClient) ResolveWorkloadDependencies(
 	return workloadKind, bundle, nil
 }
 
-
 // DeployWorkload fetches a workload manifest from the source cluster and applies it to target clusters
 func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, namespace, name string, targetClusters []string, replicas int32, opts *DeployOptions) (*v1alpha1.DeployResponse, error) {
 	if opts == nil {
@@ -119,7 +118,7 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 	}
 	if len(bundle.Warnings) > 0 {
 		for _, w := range bundle.Warnings {
-			slog.Info("[deploy] dependency warning", "warning", w)
+			slog.Info("[deploy] dependency warning", "warning", sanitize.LogString(w))
 		}
 	}
 

--- a/pkg/sanitize/prompt.go
+++ b/pkg/sanitize/prompt.go
@@ -76,3 +76,16 @@ func LogString(input string) string {
 	}
 	return logInjectionReplacer.Replace(input)
 }
+
+// LogStrings sanitizes a slice of user-controlled strings for logging.
+// Each element is passed through LogString; the result is joined with commas.
+func LogStrings(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	parts := make([]string, len(values))
+	for i, v := range values {
+		parts[i] = LogString(v)
+	}
+	return strings.Join(parts, ", ")
+}


### PR DESCRIPTION
## Security Fix

Apply `sanitize.LogString()` consistently to user-controlled values in `slog` calls across 7 files, resolving 15 of the 19 open CodeQL `go/log-injection` alerts.

### What changed

| File | Change |
|------|--------|
| `pkg/agent/server_ops_clusters.go` | Wrap `req.Name` and `req.Tool` with `LogString` in all local-cluster and vcluster `slog` calls |
| `pkg/agent/websocket_deadline.go` | Sanitize `conn.RemoteAddr().String()` before adding to log attributes |
| `pkg/agent/workers/workers_insight.go` | Sanitize `insight.ID` and provider `name` in error logs |
| `pkg/agent/workers/prediction_analysis.go` | Use new `sanitize.LogStrings` helper for the `usedProviders` slice |
| `pkg/agent/updater/poller.go` | Sanitize `currentVersion` and `latest.TagName` in release-check logs |
| `pkg/k8s/workload_deploy.go` | Sanitize warning strings from `bundle.Warnings` |
| `pkg/sanitize/prompt.go` | Add `LogStrings([]string) string` helper for sanitizing string slices |

### Remaining alerts (CodeQL false positives)

Alerts in `client_gpu_cronjob.go`, `client_health.go`, and `server_rbac.go` already call `sanitize.LogString()` on all fields. CodeQL does not recognize `sanitize.LogString` as a sanitizer in its model, so those alerts fire as false positives. A follow-up PR will add a custom CodeQL sanitizer configuration (`.github/codeql/go-sanitizers.ql`) to mark the function.

Fixes #20684

---
*Filed by sec-check agent (ACMM L6 — full mode)*