### PR TITLE
[scanner] fix: Console Live Promote workflow consecutive failures

### DIFF
--- a/.github/workflows/console-live-promote.yml
+++ b/.github/workflows/console-live-promote.yml
@@ -465,6 +465,9 @@ jobs:
           clusterName: "$LIVE_CLUSTER_NAME"
           service:
             type: ClusterIP
+          serviceAccount:
+            create: false
+            name: "$LIVE_SERVICE_ACCOUNT"
           podSecurityContext:
             seccompProfile:
               type: RuntimeDefault


### PR DESCRIPTION
Fixes #20672

## Problem

Console Live Promote workflow failed 3 consecutive times at step "Deploy candidate to console-live". Private canary deploy succeeded but live deploy failed.

## Root Cause

Live deploy values missing `serviceAccount` configuration. Helm attempted to create service account without proper RBAC permissions.

## Solution

Added `serviceAccount.create: false` and `serviceAccount.name: "$LIVE_SERVICE_ACCOUNT"` to live deploy values, matching working canary deploy pattern.

## Changes

- `.github/workflows/console-live-promote.yml`: Added serviceAccount config to prod_values (lines 468-470)