### PR TITLE
[scanner] fix: collectK8sGroundTruth kubectl mock returns 0 resources

### DIFF
--- a/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
+++ b/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
@@ -11,26 +11,18 @@ const { mockExecFileSync, mockWriteFileSync, mockMkdirSync, mockMkdtempSync, moc
   mockReadFileSync: vi.fn(() => ''),
 }))
 
-vi.mock('node:child_process', async () => {
-  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process')
-  return {
-    ...actual,
-    execFileSync: mockExecFileSync,
-  }
-})
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}))
 
-vi.mock('node:fs', async () => {
-  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
-  return {
-    ...actual,
-    writeFileSync: mockWriteFileSync,
-    mkdirSync: mockMkdirSync,
-    mkdtempSync: mockMkdtempSync,
-    rmSync: mockRmSync,
-    existsSync: mockExistsSync,
-    readFileSync: mockReadFileSync,
-  }
-})
+vi.mock('node:fs', () => ({
+  writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
+  mkdtempSync: mockMkdtempSync,
+  rmSync: mockRmSync,
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+}))
 
 describe('collectK8sGroundTruth', () => {
   const originalEnv = process.env


### PR DESCRIPTION
Fixes #20676

Removes async `vi.importActual` pattern from `node:child_process` and `node:fs` mocks that was causing mock resolution timing issues.

## Problem
12 test assertions failing in `collectK8sGroundTruth.test.ts` - kubectl mocks returned 0 resources instead of expected counts (2 nodes, 4 pods, 2 deployments, 3 namespaces).

## Root Cause
The async mock factory with spread operator `{ ...actual, execFileSync: mockExecFileSync }` was causing timing issues where hoisted mock functions weren't properly overriding the actual `execFileSync` implementation.

## Fix
Reverts to simple synchronous mock factory pattern from commit 68c8ce058 that previously fixed the same issue.

## Testing
Fix verified by code inspection and git history analysis. CI will validate test pass.