### PR TITLE
[scanner] fix: storage.hooks localStorage cache value mismatches

### DIFF
--- a/web/src/hooks/mcp/__tests__/storage-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage-pure.test.ts
@@ -7,11 +7,13 @@ const {
   getDemoLimitRanges,
   loadPVCsCacheFromStorage,
   savePVCsCacheToStorage,
+  resetPVCsCache,
   PVCS_CACHE_KEY,
 } = mod.__storageTestables
 
 beforeEach(() => {
   localStorage.clear()
+  resetPVCsCache()
 })
 
 describe('getDemoPVCs', () => {

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -793,11 +793,16 @@ if (typeof window !== 'undefined') {
   })
 }
 
+function resetPVCsCache() {
+  pvcsCache = null
+}
+
 export const __storageTestables = {
   getDemoPVCs,
   getDemoResourceQuotas,
   getDemoLimitRanges,
   loadPVCsCacheFromStorage,
   savePVCsCacheToStorage,
+  resetPVCsCache,
   PVCS_CACHE_KEY,
 }


### PR DESCRIPTION
Fixes #20675

Export `resetPVCsCache()` in `__storageTestables` and call it in `beforeEach()` to clear module-level `pvcsCache` between test runs.

**Root cause**: Module-level `pvcsCache` variable persisted across test runs, causing cache key/data mismatches in all 12 tests in `storage-pure.test.ts`.

**Changes**:
- Added `resetPVCsCache()` helper function to reset module state
- Exported it in `__storageTestables` for test access  
- Called `resetPVCsCache()` in test `beforeEach()` hook

Tests now properly isolate cache state between runs.