### PR TITLE
[quality] add unit tests for RBAC models, API client, and auth JWT helpers

### DIFF
--- a/pkg/models/rbac_test.go
+++ b/pkg/models/rbac_test.go
@@ -1,0 +1,464 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestK8sUser_JSONSerialization(t *testing.T) {
+	t.Run("full user with namespace", func(t *testing.T) {
+		user := K8sUser{
+			Kind:      K8sSubjectServiceAccount,
+			Name:      "my-sa",
+			Namespace: "kube-system",
+			Cluster:   "prod-cluster",
+		}
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+		require.Equal(t, "ServiceAccount", m["kind"])
+		require.Equal(t, "my-sa", m["name"])
+		require.Equal(t, "kube-system", m["namespace"])
+		require.Equal(t, "prod-cluster", m["cluster"])
+	})
+
+	t.Run("omitempty namespace absent for User kind", func(t *testing.T) {
+		user := K8sUser{
+			Kind:    K8sSubjectUser,
+			Name:    "alice",
+			Cluster: "dev",
+		}
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+		require.NotContains(t, string(data), `"namespace"`)
+	})
+
+	t.Run("round-trip preserves values", func(t *testing.T) {
+		original := K8sUser{
+			Kind:      K8sSubjectGroup,
+			Name:      "developers",
+			Namespace: "",
+			Cluster:   "staging",
+		}
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded K8sUser
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Equal(t, original.Kind, decoded.Kind)
+		require.Equal(t, original.Name, decoded.Name)
+		require.Equal(t, original.Cluster, decoded.Cluster)
+	})
+}
+
+func TestOpenShiftUser_JSONSerialization(t *testing.T) {
+	t.Run("full user with CreatedAt", func(t *testing.T) {
+		now := time.Now().UTC().Truncate(time.Second)
+		user := OpenShiftUser{
+			Name:       "admin",
+			FullName:   "Admin User",
+			Identities: []string{"github:12345"},
+			Groups:     []string{"cluster-admins"},
+			Cluster:    "ocp-prod",
+			CreatedAt:  &now,
+		}
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var decoded OpenShiftUser
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Equal(t, user.Name, decoded.Name)
+		require.Equal(t, user.FullName, decoded.FullName)
+		require.Equal(t, user.Identities, decoded.Identities)
+		require.Equal(t, user.Groups, decoded.Groups)
+		require.NotNil(t, decoded.CreatedAt)
+		require.True(t, now.Equal(*decoded.CreatedAt))
+	})
+
+	t.Run("nil CreatedAt omitted from JSON", func(t *testing.T) {
+		user := OpenShiftUser{
+			Name:    "viewer",
+			Cluster: "ocp-dev",
+		}
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+		require.NotContains(t, string(data), `"createdAt"`)
+	})
+
+	t.Run("empty optional fields omitted", func(t *testing.T) {
+		user := OpenShiftUser{
+			Name:    "minimal",
+			Cluster: "test",
+		}
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+		require.NotContains(t, string(data), `"fullName"`)
+		require.NotContains(t, string(data), `"identities"`)
+		require.NotContains(t, string(data), `"groups"`)
+	})
+}
+
+func TestK8sRole_JSONSerialization(t *testing.T) {
+	t.Run("ClusterRole serialization", func(t *testing.T) {
+		role := K8sRole{
+			Name:        "cluster-admin",
+			Namespace:   "",
+			Cluster:     "prod",
+			IsCluster:   true,
+			RuleCount:   42,
+			Description: "Full cluster admin",
+		}
+		data, err := json.Marshal(role)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+		require.Equal(t, true, m["isCluster"])
+		require.Equal(t, float64(42), m["ruleCount"])
+		require.NotContains(t, string(data), `"namespace":`)
+	})
+
+	t.Run("namespaced Role", func(t *testing.T) {
+		role := K8sRole{
+			Name:      "pod-reader",
+			Namespace: "default",
+			Cluster:   "dev",
+			IsCluster: false,
+			RuleCount: 3,
+		}
+		data, err := json.Marshal(role)
+		require.NoError(t, err)
+		require.Contains(t, string(data), `"namespace":"default"`)
+		require.Contains(t, string(data), `"isCluster":false`)
+	})
+}
+
+func TestK8sRoleBinding_JSONSerialization(t *testing.T) {
+	binding := K8sRoleBinding{
+		Name:      "admin-binding",
+		Namespace: "production",
+		Cluster:   "prod-cluster",
+		IsCluster: false,
+		RoleName:  "admin",
+		RoleKind:  "ClusterRole",
+		Subjects: []struct {
+			Kind      K8sSubjectKind `json:"kind"`
+			Name      string         `json:"name"`
+			Namespace string         `json:"namespace,omitempty"`
+		}{
+			{Kind: K8sSubjectUser, Name: "alice"},
+			{Kind: K8sSubjectServiceAccount, Name: "deployer", Namespace: "ci"},
+		},
+	}
+	data, err := json.Marshal(binding)
+	require.NoError(t, err)
+
+	var decoded K8sRoleBinding
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, binding.Name, decoded.Name)
+	require.Equal(t, binding.RoleName, decoded.RoleName)
+	require.Len(t, decoded.Subjects, 2)
+	require.Equal(t, K8sSubjectUser, decoded.Subjects[0].Kind)
+	require.Equal(t, "ci", decoded.Subjects[1].Namespace)
+}
+
+func TestK8sServiceAccount_JSONSerialization(t *testing.T) {
+	t.Run("full service account", func(t *testing.T) {
+		now := time.Now().UTC().Truncate(time.Second)
+		sa := K8sServiceAccount{
+			Name:      "my-app",
+			Namespace: "default",
+			Cluster:   "prod",
+			Secrets:   []string{"my-app-token-abc"},
+			Roles:     []string{"pod-reader", "log-viewer"},
+			CreatedAt: &now,
+		}
+		data, err := json.Marshal(sa)
+		require.NoError(t, err)
+
+		var decoded K8sServiceAccount
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Equal(t, sa.Name, decoded.Name)
+		require.Equal(t, sa.Secrets, decoded.Secrets)
+		require.Equal(t, sa.Roles, decoded.Roles)
+		require.NotNil(t, decoded.CreatedAt)
+		require.True(t, now.Equal(*decoded.CreatedAt))
+	})
+
+	t.Run("nil CreatedAt omitted", func(t *testing.T) {
+		sa := K8sServiceAccount{
+			Name:      "minimal-sa",
+			Namespace: "kube-system",
+			Cluster:   "dev",
+		}
+		data, err := json.Marshal(sa)
+		require.NoError(t, err)
+		require.NotContains(t, string(data), `"createdAt"`)
+		require.NotContains(t, string(data), `"secrets"`)
+		require.NotContains(t, string(data), `"roles"`)
+	})
+}
+
+func TestClusterPermissions_JSONSerialization(t *testing.T) {
+	perms := ClusterPermissions{
+		Cluster:        "prod",
+		IsClusterAdmin: true,
+		CanCreateSA:    true,
+		CanManageRBAC:  true,
+		CanViewSecrets: false,
+	}
+	data, err := json.Marshal(perms)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m))
+	require.Equal(t, "prod", m["cluster"])
+	require.Equal(t, true, m["isClusterAdmin"])
+	require.Equal(t, true, m["canCreateServiceAccounts"])
+	require.Equal(t, true, m["canManageRBAC"])
+	require.Equal(t, false, m["canViewSecrets"])
+}
+
+func TestUpdateUserRoleRequest_JSONDeserialization(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected UserRole
+	}{
+		{"admin role", `{"role":"admin"}`, UserRoleAdmin},
+		{"editor role", `{"role":"editor"}`, UserRoleEditor},
+		{"viewer role", `{"role":"viewer"}`, UserRoleViewer},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req UpdateUserRoleRequest
+			require.NoError(t, json.Unmarshal([]byte(tt.input), &req))
+			require.Equal(t, tt.expected, req.Role)
+		})
+	}
+}
+
+func TestCreateServiceAccountRequest_JSONDeserialization(t *testing.T) {
+	input := `{"name":"deploy-bot","namespace":"ci-cd","cluster":"prod"}`
+	var req CreateServiceAccountRequest
+	require.NoError(t, json.Unmarshal([]byte(input), &req))
+	require.Equal(t, "deploy-bot", req.Name)
+	require.Equal(t, "ci-cd", req.Namespace)
+	require.Equal(t, "prod", req.Cluster)
+}
+
+func TestCreateRoleBindingRequest_JSONDeserialization(t *testing.T) {
+	input := `{
+		"name":"viewer-binding",
+		"namespace":"production",
+		"cluster":"main",
+		"isCluster":false,
+		"roleName":"view",
+		"roleKind":"ClusterRole",
+		"subjectKind":"User",
+		"subjectName":"bob",
+		"subjectNamespace":""
+	}`
+	var req CreateRoleBindingRequest
+	require.NoError(t, json.Unmarshal([]byte(input), &req))
+	require.Equal(t, "viewer-binding", req.Name)
+	require.Equal(t, "production", req.Namespace)
+	require.Equal(t, false, req.IsCluster)
+	require.Equal(t, K8sSubjectUser, req.SubjectKind)
+	require.Equal(t, "bob", req.SubjectName)
+}
+
+func TestAuditLogEntry_JSONSerialization(t *testing.T) {
+	id := uuid.New()
+	userID := uuid.New()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	entry := AuditLogEntry{
+		ID:         id,
+		UserID:     userID,
+		Action:     "create_user",
+		TargetType: "console_user",
+		TargetID:   "user-123",
+		Details:    "Created user via admin panel",
+		CreatedAt:  now,
+	}
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	var decoded AuditLogEntry
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, id, decoded.ID)
+	require.Equal(t, userID, decoded.UserID)
+	require.Equal(t, "create_user", decoded.Action)
+	require.Equal(t, "console_user", decoded.TargetType)
+	require.Equal(t, "Created user via admin panel", decoded.Details)
+	require.True(t, now.Equal(decoded.CreatedAt))
+}
+
+func TestCanIRequest_JSONDeserialization(t *testing.T) {
+	t.Run("full request", func(t *testing.T) {
+		input := `{
+			"cluster":"prod",
+			"verb":"create",
+			"resource":"pods",
+			"namespace":"default",
+			"group":"",
+			"subresource":"log",
+			"name":"my-pod"
+		}`
+		var req CanIRequest
+		require.NoError(t, json.Unmarshal([]byte(input), &req))
+		require.Equal(t, "prod", req.Cluster)
+		require.Equal(t, "create", req.Verb)
+		require.Equal(t, "pods", req.Resource)
+		require.Equal(t, "default", req.Namespace)
+		require.Equal(t, "log", req.Subresource)
+		require.Equal(t, "my-pod", req.Name)
+	})
+
+	t.Run("minimal request omits optional fields", func(t *testing.T) {
+		req := CanIRequest{
+			Cluster:  "dev",
+			Verb:     "list",
+			Resource: "namespaces",
+		}
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+		require.NotContains(t, string(data), `"namespace":`)
+		require.NotContains(t, string(data), `"subresource":`)
+		require.NotContains(t, string(data), `"name":`)
+	})
+}
+
+func TestCanIResponse_JSONSerialization(t *testing.T) {
+	t.Run("allowed", func(t *testing.T) {
+		resp := CanIResponse{Allowed: true, Reason: "RBAC: allowed by ClusterRoleBinding"}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+		require.Contains(t, string(data), `"allowed":true`)
+		require.Contains(t, string(data), `"reason"`)
+	})
+
+	t.Run("denied with omitted reason", func(t *testing.T) {
+		resp := CanIResponse{Allowed: false}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+		require.Contains(t, string(data), `"allowed":false`)
+		require.NotContains(t, string(data), `"reason"`)
+	})
+}
+
+func TestUserManagementSummary_JSONSerialization(t *testing.T) {
+	summary := UserManagementSummary{}
+	summary.ConsoleUsers.Total = 10
+	summary.ConsoleUsers.Admins = 2
+	summary.ConsoleUsers.Editors = 3
+	summary.ConsoleUsers.Viewers = 5
+	summary.K8sServiceAccounts.Total = 25
+	summary.K8sServiceAccounts.Clusters = []string{"prod", "staging"}
+	summary.CurrentUserPermissions = []ClusterPermissions{
+		{Cluster: "prod", IsClusterAdmin: true, CanCreateSA: true, CanManageRBAC: true, CanViewSecrets: true},
+	}
+
+	data, err := json.Marshal(summary)
+	require.NoError(t, err)
+
+	var decoded UserManagementSummary
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, 10, decoded.ConsoleUsers.Total)
+	require.Equal(t, 2, decoded.ConsoleUsers.Admins)
+	require.Equal(t, []string{"prod", "staging"}, decoded.K8sServiceAccounts.Clusters)
+	require.Len(t, decoded.CurrentUserPermissions, 1)
+	require.True(t, decoded.CurrentUserPermissions[0].IsClusterAdmin)
+}
+
+func TestNamespaceDetails_JSONSerialization(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	ns := NamespaceDetails{
+		Name:    "production",
+		Cluster: "prod",
+		Status:  "Active",
+		Labels:  map[string]string{"env": "prod", "team": "platform"},
+		CreatedAt: now,
+	}
+	data, err := json.Marshal(ns)
+	require.NoError(t, err)
+
+	var decoded NamespaceDetails
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, "production", decoded.Name)
+	require.Equal(t, "Active", decoded.Status)
+	require.Equal(t, "prod", decoded.Labels["env"])
+	require.True(t, now.Equal(decoded.CreatedAt))
+}
+
+func TestCreateNamespaceRequest_JSONDeserialization(t *testing.T) {
+	input := `{"cluster":"prod","name":"my-namespace","labels":{"env":"staging"}}`
+	var req CreateNamespaceRequest
+	require.NoError(t, json.Unmarshal([]byte(input), &req))
+	require.Equal(t, "prod", req.Cluster)
+	require.Equal(t, "my-namespace", req.Name)
+	require.Equal(t, "staging", req.Labels["env"])
+}
+
+func TestGrantNamespaceAccessRequest_JSONDeserialization(t *testing.T) {
+	input := `{
+		"cluster":"prod",
+		"subjectKind":"ServiceAccount",
+		"subjectName":"deploy-bot",
+		"subjectNamespace":"ci",
+		"role":"edit"
+	}`
+	var req GrantNamespaceAccessRequest
+	require.NoError(t, json.Unmarshal([]byte(input), &req))
+	require.Equal(t, "ServiceAccount", req.SubjectKind)
+	require.Equal(t, "deploy-bot", req.SubjectName)
+	require.Equal(t, "ci", req.SubjectNS)
+	require.Equal(t, "edit", req.Role)
+}
+
+func TestPermissionsSummaryResponse_JSONSerialization(t *testing.T) {
+	resp := PermissionsSummaryResponse{
+		Clusters: map[string]ClusterPermissionsSummary{
+			"prod": {
+				IsClusterAdmin:       true,
+				CanListNodes:         true,
+				CanListNamespaces:    true,
+				CanCreateNamespaces:  false,
+				CanManageRBAC:        true,
+				CanViewSecrets:       false,
+				AccessibleNamespaces: []string{"default", "kube-system"},
+			},
+		},
+	}
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var decoded PermissionsSummaryResponse
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Contains(t, decoded.Clusters, "prod")
+	require.True(t, decoded.Clusters["prod"].IsClusterAdmin)
+	require.Equal(t, []string{"default", "kube-system"}, decoded.Clusters["prod"].AccessibleNamespaces)
+}
+
+func TestConsoleUserWithRole_JSONSerialization(t *testing.T) {
+	user := ConsoleUserWithRole{
+		Role: UserRoleEditor,
+	}
+	user.GitHubLogin = "testuser"
+	user.GitHubID = "999"
+
+	data, err := json.Marshal(user)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m))
+	require.Equal(t, "editor", m["role"])
+	require.Equal(t, "testuser", m["github_login"])
+}

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  UnauthenticatedError,
+  UnauthorizedError,
+  RateLimitError,
+  BackendUnavailableError,
+  safeJson,
+  isBackendUnavailable,
+  checkBackendAvailability,
+  checkOAuthConfigured,
+} from './api'
+
+describe('api.ts error classes', () => {
+  describe('UnauthenticatedError', () => {
+    it('has correct name and message', () => {
+      const err = new UnauthenticatedError()
+      expect(err.name).toBe('UnauthenticatedError')
+      expect(err.message).toBe('No authentication token available')
+      expect(err).toBeInstanceOf(Error)
+    })
+  })
+
+  describe('UnauthorizedError', () => {
+    it('has correct name and message', () => {
+      const err = new UnauthorizedError()
+      expect(err.name).toBe('UnauthorizedError')
+      expect(err.message).toBe('Token is invalid or expired')
+      expect(err).toBeInstanceOf(Error)
+    })
+  })
+
+  describe('RateLimitError', () => {
+    it('has correct name, message, and retryAfter', () => {
+      const err = new RateLimitError(120)
+      expect(err.name).toBe('RateLimitError')
+      expect(err.message).toBe('Rate limited. Try again in 120 seconds.')
+      expect(err.retryAfter).toBe(120)
+      expect(err).toBeInstanceOf(Error)
+    })
+
+    it('stores retryAfter value', () => {
+      const err = new RateLimitError(30)
+      expect(err.retryAfter).toBe(30)
+    })
+  })
+
+  describe('BackendUnavailableError', () => {
+    it('has correct name and message', () => {
+      const err = new BackendUnavailableError()
+      expect(err.name).toBe('BackendUnavailableError')
+      expect(err.message).toBe('Backend API is currently unavailable')
+      expect(err).toBeInstanceOf(Error)
+    })
+  })
+})
+
+describe('safeJson', () => {
+  it('parses JSON response with correct content-type', async () => {
+    const data = { foo: 'bar', count: 42 }
+    const response = new Response(JSON.stringify(data), {
+      headers: { 'content-type': 'application/json' },
+    })
+    const result = await safeJson<typeof data>(response)
+    expect(result).toEqual(data)
+  })
+
+  it('throws when content-type is text/html', async () => {
+    const response = new Response('<html></html>', {
+      headers: { 'content-type': 'text/html' },
+    })
+    await expect(safeJson(response)).rejects.toThrow(
+      'Expected JSON response but received text/html'
+    )
+  })
+
+  it('throws when content-type is missing', async () => {
+    const response = new Response('not json', {
+      headers: {},
+    })
+    await expect(safeJson(response)).rejects.toThrow(
+      'Expected JSON response but received unknown content-type'
+    )
+  })
+
+  it('accepts application/json with charset', async () => {
+    const data = { msg: 'hello' }
+    const response = new Response(JSON.stringify(data), {
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    })
+    const result = await safeJson<typeof data>(response)
+    expect(result).toEqual(data)
+  })
+})
+
+describe('isBackendUnavailable', () => {
+  it('returns false on initial load (unknown state)', () => {
+    // On fresh module load, backendAvailable is null (unknown)
+    // The function should return false to allow first request
+    expect(isBackendUnavailable()).toBe(false)
+  })
+})
+
+describe('checkBackendAvailability', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns true when /health responds successfully', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response('{"status":"ok"}', { status: 200 })
+    )
+    vi.stubGlobal('fetch', mockFetch)
+
+    const result = await checkBackendAvailability(true)
+    expect(result).toBe(true)
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/health',
+      expect.objectContaining({ method: 'GET' })
+    )
+  })
+
+  it('returns false when fetch throws (network error)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')))
+
+    const result = await checkBackendAvailability(true)
+    expect(result).toBe(false)
+  })
+
+  it('returns false when /health responds with 500', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('error', { status: 500 })
+    ))
+
+    const result = await checkBackendAvailability(true)
+    expect(result).toBe(false)
+  })
+
+  it('returns true when /health responds with 4xx (backend is up)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('not found', { status: 404 })
+    ))
+
+    const result = await checkBackendAvailability(true)
+    expect(result).toBe(true)
+  })
+})
+
+describe('checkOAuthConfigured', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns backendUp=true, oauthConfigured=true when health says configured', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ oauth_configured: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ))
+
+    const result = await checkOAuthConfigured()
+    expect(result.backendUp).toBe(true)
+    expect(result.oauthConfigured).toBe(true)
+  })
+
+  it('returns backendUp=true, oauthConfigured=false when not configured', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ oauth_configured: false }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ))
+
+    const result = await checkOAuthConfigured()
+    expect(result.backendUp).toBe(true)
+    expect(result.oauthConfigured).toBe(false)
+  })
+
+  it('returns backendUp=false when fetch fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')))
+
+    const result = await checkOAuthConfigured()
+    expect(result.backendUp).toBe(false)
+    expect(result.oauthConfigured).toBe(false)
+  })
+
+  it('returns backendUp=false when /health returns non-OK', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('', { status: 503 })
+    ))
+
+    const result = await checkOAuthConfigured()
+    expect(result.backendUp).toBe(false)
+    expect(result.oauthConfigured).toBe(false)
+  })
+})

--- a/web/src/lib/auth.test.ts
+++ b/web/src/lib/auth.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { isJWTExpired } from './auth'
+
+/**
+ * Helper to create a JWT-like token with a specific `exp` claim.
+ * Only creates the structure (header.payload.signature) — not cryptographically valid.
+ */
+function makeJWT(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const body = btoa(JSON.stringify(payload))
+  const signature = 'fake-signature'
+  return `${header}.${body}.${signature}`
+}
+
+describe('isJWTExpired', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns true for an expired JWT', () => {
+    // exp in the past (Unix seconds)
+    const expiredToken = makeJWT({ exp: Math.floor(Date.now() / 1000) - 3600 })
+    expect(isJWTExpired(expiredToken)).toBe(true)
+  })
+
+  it('returns false for a JWT that has not expired', () => {
+    // exp 1 hour in the future
+    const validToken = makeJWT({ exp: Math.floor(Date.now() / 1000) + 3600 })
+    expect(isJWTExpired(validToken)).toBe(false)
+  })
+
+  it('returns false for a JWT expiring exactly now (boundary)', () => {
+    // When exp === now (in seconds), Date.now() in ms >= exp * 1000 is true
+    const nowSec = Math.floor(Date.now() / 1000)
+    const token = makeJWT({ exp: nowSec })
+    // At the boundary, the token is considered expired (Date.now() >= expiryMs)
+    expect(isJWTExpired(token)).toBe(true)
+  })
+
+  it('returns false for opaque (non-JWT) tokens', () => {
+    // Opaque tokens should never be treated as expired
+    expect(isJWTExpired('some-opaque-token')).toBe(false)
+    expect(isJWTExpired('demo-token')).toBe(false)
+  })
+
+  it('returns false when token has only two parts', () => {
+    expect(isJWTExpired('header.payload')).toBe(false)
+  })
+
+  it('returns false when payload has no exp field', () => {
+    const noExpToken = makeJWT({ sub: 'user-123', iat: 1700000000 })
+    expect(isJWTExpired(noExpToken)).toBe(false)
+  })
+
+  it('returns false when exp is not a number', () => {
+    const badExpToken = makeJWT({ exp: 'not-a-number' })
+    expect(isJWTExpired(badExpToken)).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isJWTExpired('')).toBe(false)
+  })
+
+  it('returns false for malformed base64 in payload', () => {
+    // Three parts but middle part is not valid base64
+    expect(isJWTExpired('header.!!!invalid!!!.signature')).toBe(false)
+  })
+
+  it('handles base64url encoding (- and _ characters)', () => {
+    // Create a payload with base64url-specific characters
+    const payload = { exp: Math.floor(Date.now() / 1000) + 3600, data: 'test+value/here' }
+    const payloadStr = JSON.stringify(payload)
+    // Manually encode as base64url
+    const base64 = btoa(payloadStr)
+    const base64url = base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+    const header = btoa(JSON.stringify({ alg: 'HS256' })).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+    const token = `${header}.${base64url}.sig`
+    expect(isJWTExpired(token)).toBe(false) // Not expired (future exp)
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds unit test coverage for three files that previously had zero test coverage:

### pkg/models/rbac_test.go (Fixes #20699)
16 test functions covering JSON serialization/deserialization of all RBAC model types:
- K8sUser, OpenShiftUser, K8sRole, K8sRoleBinding, K8sServiceAccount
- ClusterPermissions, UserManagementSummary, AuditLogEntry
- CanIRequest/Response, PermissionsSummaryResponse
- NamespaceDetails, CreateNamespaceRequest, GrantNamespaceAccessRequest
- ConsoleUserWithRole, UpdateUserRoleRequest, CreateServiceAccountRequest

### web/src/lib/api.test.ts (Fixes #20698)
Tests for exported API client functions:
- Error classes: UnauthenticatedError, UnauthorizedError, RateLimitError, BackendUnavailableError
- `safeJson` content-type guard (JSON, HTML, missing, charset variants)
- `isBackendUnavailable` initial state
- `checkBackendAvailability` (success, network error, 5xx, 4xx)
- `checkOAuthConfigured` (configured, not configured, network error, non-OK)

### web/src/lib/auth.test.ts (Fixes #20697)
10 test cases for `isJWTExpired`:
- Expired JWT, valid JWT, boundary (exp === now)
- Opaque/non-JWT tokens, two-part tokens
- Missing exp, non-numeric exp, empty string
- Malformed base64, base64url encoding

Fixes #20699
Fixes #20698
Fixes #20697

---
*Filed by quality agent (ACMM L4/L6 — full mode)*