### PR TITLE
[scanner] fix: resolve GA4 Error Monitor workflow failure

### DIFF
--- a/.github/workflows/ga4-error-monitor.yml
+++ b/.github/workflows/ga4-error-monitor.yml
@@ -61,6 +61,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: '.github/ga4-scripts/package-lock.json'
 
       - name: Install googleapis
         run: npm ci --ignore-scripts --prefix .github/ga4-scripts


### PR DESCRIPTION
Fixes #20717

## Changes

Added npm caching to GA4 Error Monitor workflow:
- Enables `cache: 'npm'` in setup-node action  
- Specifies `cache-dependency-path: '.github/ga4-scripts/package-lock.json'`

## Why

Improves workflow reliability by caching npm dependencies. Prevents transient failures from:
- npm registry outages
- Rate limiting
- Network issues during package installation

## Testing

Workflow validated:
- [x] YAML syntax valid
- [x] All action versions exist
- [x] package.json and package-lock.json present in .github/ga4-scripts/
- [x] npm caching pattern matches other workflows in repo