### PR TITLE
[scanner] fix: CanIChecker reset button + empty input test assertions

### DIFF
--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -520,7 +520,7 @@ function CanICheckerContent() {
           >
             {checking ? t('rbac.checking') : t('rbac.checkPermission')}
           </Button>
-          {result && (
+          {(result || error) && (
             <Button
               variant="secondary"
               size="lg"

--- a/web/src/components/rbac/__tests__/CanIChecker.test.tsx
+++ b/web/src/components/rbac/__tests__/CanIChecker.test.tsx
@@ -515,8 +515,8 @@ describe('CanIChecker — Edge Cases', () => {
     const checkBtn = screen.getByTestId('can-i-check')
     await userEvent.click(checkBtn)
 
-    // Should either fall back to default or use empty string
-    expect(mockCheckPermission).toHaveBeenCalled()
+    // Should not call permission check with empty verb
+    expect(mockCheckPermission).not.toHaveBeenCalled()
   })
 
   it('handles empty custom resource input', async () => {
@@ -531,7 +531,7 @@ describe('CanIChecker — Edge Cases', () => {
     const checkBtn = screen.getByTestId('can-i-check')
     await userEvent.click(checkBtn)
 
-    expect(mockCheckPermission).toHaveBeenCalled()
+    expect(mockCheckPermission).not.toHaveBeenCalled()
   })
 
   it('handles wildcard resources', async () => {


### PR DESCRIPTION
## Fix

Two bugs in CanIChecker that cause build-gate failure on **all open PRs**:

1. **Component** (`CanIChecker.tsx`): Reset button only rendered when `result` was set, not on error state. Users couldn't reset after an API error.
   - Fix: `{result && (` → `{(result || error) && (`

2. **Test** (`CanIChecker.test.tsx`): Edge-case tests for empty custom verb/resource inputs expected `mockCheckPermission` to be called, but the component correctly returns early (line 207) when inputs are empty.
   - Fix: `.toHaveBeenCalled()` → `.not.toHaveBeenCalled()`

### Impact

This unblocks **13 CI-failing PRs** that all inherit this test failure from main.

Signed-off-by: Scanner Bot <scanner@kubestellar.io>