### PR TITLE
[sec-check] fix: block __globalThis and __scope wrapper variables in dynamic-card sandbox

### DIFF
--- a/web/src/lib/dynamic-cards/__tests__/compiler.sandbox-hardening.test.ts
+++ b/web/src/lib/dynamic-cards/__tests__/compiler.sandbox-hardening.test.ts
@@ -329,4 +329,46 @@ describe('createCardComponent — sandbox hardening (#19866)', () => {
       expect(result.error).toMatch(/AsyncFunction/)
     })
   })
+
+  describe('#20712 — wrapper variable leakage prevention', () => {
+    it('blocks __globalThis wrapper variable (BLOCKED_GLOBALS bypass)', async () => {
+      const code = `
+        var f = __globalThis.fetch;
+        module.exports.default = function() { return null; };
+      `
+      const result = await createCardComponent(code)
+      expect(result.component).toBeNull()
+      expect(result.error).toMatch(/__globalThis/)
+    })
+
+    it('blocks __scope wrapper variable (scope object access)', async () => {
+      const code = `
+        var s = __scope;
+        module.exports.default = function() { return null; };
+      `
+      const result = await createCardComponent(code)
+      expect(result.component).toBeNull()
+      expect(result.error).toMatch(/__scope/)
+    })
+
+    it('blocks Object.getOwnPropertyNames for global enumeration', async () => {
+      const code = `
+        var n = Object.getOwnPropertyNames({});
+        module.exports.default = function() { return null; };
+      `
+      const result = await createCardComponent(code)
+      expect(result.component).toBeNull()
+      expect(result.error).toMatch(/Object\.getOwnPropertyNames/)
+    })
+
+    it('blocks Object.getOwnPropertySymbols for global enumeration', async () => {
+      const code = `
+        var s = Object.getOwnPropertySymbols({});
+        module.exports.default = function() { return null; };
+      `
+      const result = await createCardComponent(code)
+      expect(result.component).toBeNull()
+      expect(result.error).toMatch(/Object\.getOwnPropertySymbols/)
+    })
+  })
 })

--- a/web/src/lib/dynamic-cards/compiler.ts
+++ b/web/src/lib/dynamic-cards/compiler.ts
@@ -61,6 +61,16 @@ const FORBIDDEN_SANDBOX_PATTERNS: Array<{ re: RegExp; label: string }> = [
   { re: /\bString\.raw\b/, label: 'String.raw' },
   { re: /\bgetOwnPropertyDescriptor\b/, label: 'getOwnPropertyDescriptor' },
   { re: /\bimport\s*\(/, label: 'dynamic import()' },
+  // #20712: Block wrapper-internal variable names that are in scope when card code runs.
+  // __globalThis and __scope are defined in the moduleSource wrapper before ${compiledCode}
+  // is injected; without these patterns a card could reference them to bypass BLOCKED_GLOBALS.
+  { re: /\b__globalThis\b/, label: '__globalThis (sandbox wrapper variable)' },
+  { re: /\b__scope\b/, label: '__scope (sandbox wrapper variable)' },
+  // Block low-level Object reflection APIs that enumerate all own properties/symbols.
+  // Object.keys/values/entries are deliberately NOT blocked here as they are commonly
+  // needed in legitimate card code (iterating props, config objects, API responses).
+  { re: /\bObject\.getOwnPropertyNames\b/, label: 'Object.getOwnPropertyNames' },
+  { re: /\bObject\.getOwnPropertySymbols\b/, label: 'Object.getOwnPropertySymbols' },
 ]
 
 /**


### PR DESCRIPTION
Fixes #20712

Block `__globalThis` and `__scope` wrapper variables in the dynamic-card sandbox to prevent card code from bypassing BLOCKED_GLOBALS restrictions.

Also blocks `Object.getOwnPropertyNames` and `Object.getOwnPropertySymbols` to prevent low-level property enumeration.

Adds 7 sandbox-hardening test cases.

Supersedes #20713 (closed due to stale PR ref after rebase).