### PR TITLE
[scanner] fix: storage.hooks localStorage cache value mismatch

### DIFF
--- a/web/src/hooks/mcp/__tests__/workloads-pure.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads-pure.test.ts
@@ -9,11 +9,13 @@ const {
   getDemoAllPods,
   loadPodsCacheFromStorage,
   savePodsCacheToStorage,
+  resetPodsCache,
   PODS_CACHE_KEY,
 } = mod.__workloadsTestables
 
 beforeEach(() => {
   localStorage.clear()
+  resetPodsCache()
 })
 
 describe('getDemoPods', () => {

--- a/web/src/hooks/mcp/workloadQueries/index.ts
+++ b/web/src/hooks/mcp/workloadQueries/index.ts
@@ -44,5 +44,7 @@ export const __workloadsTestables = {
   getDemoAllPods,
   loadPodsCacheFromStorage,
   savePodsCacheToStorage,
+  resetPodsCache,
+  resetDeploymentsCache,
   PODS_CACHE_KEY,
 }


### PR DESCRIPTION
Fixes #20693

Ensure localStorage cache reset functions are exported in `__workloadsTestables`. 

Added `resetPodsCache` and `resetDeploymentsCache` to the testables export, and call `resetPodsCache` in beforeEach to clear module-level cache between test runs. This mirrors the fix applied to storage.ts in #20694.

Supersedes closed PR #20701.