### PR TITLE
[scanner] fix: downgrade go.mod to go 1.26.4 to match Dockerfile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubestellar/console
 
-go 1.26.5
+go 1.26.4
 
 require (
 	github.com/fasthttp/websocket v1.5.12


### PR DESCRIPTION
## P0 — Fix broken main build

`go.mod` was bumped to `go 1.26.5` but the Dockerfile still uses `golang:1.26.4-alpine` with `GOTOOLCHAIN=local`, causing every build to fail:

```
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

This PR downgrades `go.mod` back to `go 1.26.4` to match the Dockerfile's Go version.

**Root cause**: A recent PR bumped the go directive without updating the Dockerfile.

Fixes #20734, Fixes #20735, Fixes #20736, Fixes #20737, Fixes #20738, Fixes #20739, Fixes #20740, Fixes #20741, Fixes #20742, Fixes #20743

Signed-off-by: Scanner Bot &lt;scanner@kubestellar.io&gt;