### PR TITLE
[scanner] fix: restrict token permissions in copilot-dco.yml

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# Least-privilege: read-all at workflow level; each job declares only the
+# Least-privilege: deny all at workflow level; each job declares only the
 # permissions it needs. See Scorecard TokenPermissionsID alerts #1328, #902.
-permissions: read-all
+permissions: {}
 
 jobs:
   copilot-dco:


### PR DESCRIPTION
Fixes #20747

Adds restrictive top-level permissions block to copilot-dco.yml per Scorecard alert #1328.