### PR TITLE
[quality] add unit tests for stellar executions and MCP GPU handlers

### DIFF
--- a/pkg/api/handlers/mcp/gpu_test.go
+++ b/pkg/api/handlers/mcp/gpu_test.go
@@ -1,0 +1,240 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubestellar/console/pkg/api/handlers"
+	"github.com/kubestellar/console/pkg/k8s"
+)
+
+func newGPUTestApp(k8sClient *k8s.MultiClusterClient) *fiber.App {
+	app := fiber.New()
+	h := &MCPHandlers{k8sClient: k8sClient}
+
+	app.Get("/api/mcp/gpu/nodes", h.GetGPUNodes)
+	app.Get("/api/mcp/gpu/node-health", h.GetGPUNodeHealth)
+	app.Get("/api/mcp/gpu/health-cronjob-status", h.GetGPUHealthCronJobStatus)
+	app.Get("/api/mcp/gpu/health-cronjob-results", h.GetGPUHealthCronJobResults)
+	app.Get("/api/mcp/gpu/nvidia-operators", h.GetNVIDIAOperatorStatus)
+
+	return app
+}
+
+// --- GetGPUNodes tests ---
+
+func TestGetGPUNodes_DemoMode(t *testing.T) {
+	app := newGPUTestApp(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/nodes", nil)
+	req.Header.Set("X-Demo-Mode", "true")
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	_, ok := body["nodes"]
+	assert.True(t, ok, "demo response should have 'nodes' key")
+}
+
+func TestGetGPUNodes_NoK8sClient(t *testing.T) {
+	app := newGPUTestApp(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/nodes", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusServiceUnavailable, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Contains(t, body["error"], "cluster")
+}
+
+func TestGetGPUNodes_InvalidClusterName(t *testing.T) {
+	app := newGPUTestApp(&k8s.MultiClusterClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/nodes?cluster=INVALID%21NAME", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+// --- GetGPUNodeHealth tests ---
+
+func TestGetGPUNodeHealth_DemoMode(t *testing.T) {
+	app := newGPUTestApp(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/node-health", nil)
+	req.Header.Set("X-Demo-Mode", "true")
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	_, ok := body["nodes"]
+	assert.True(t, ok, "demo response should have 'nodes' key")
+}
+
+func TestGetGPUNodeHealth_NoK8sClient(t *testing.T) {
+	app := newGPUTestApp(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/node-health", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestGetGPUNodeHealth_InvalidClusterName(t *testing.T) {
+	app := newGPUTestApp(&k8s.MultiClusterClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/node-health?cluster=BAD%21NAME", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+// --- GetGPUHealthCronJobStatus tests ---
+
+func TestGetGPUHealthCronJobStatus_DemoMode(t *testing.T) {
+	app := newGPUTestApp(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/health-cronjob-status?cluster=test-cluster", nil)
+	req.Header.Set("X-Demo-Mode", "true")
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	_, ok := body["status"]
+	assert.True(t, ok, "demo response should have 'status' key")
+}
+
+func TestGetGPUHealthCronJobStatus_MissingCluster(t *testing.T) {
+	app := newGPUTestApp(&k8s.MultiClusterClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/health-cronjob-status", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Contains(t, body["error"], "cluster")
+}
+
+func TestGetGPUHealthCronJobStatus_InvalidCluster(t *testing.T) {
+	app := newGPUTestApp(&k8s.MultiClusterClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/health-cronjob-status?cluster=BAD%21", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+func TestGetGPUHealthCronJobStatus_NoK8sClient(t *testing.T) {
+	app := newGPUTestApp(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/health-cronjob-status?cluster=test-cluster", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// --- GetGPUHealthCronJobResults tests ---
+
+func TestGetGPUHealthCronJobResults_DemoMode(t *testing.T) {
+	app := newGPUTestApp(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/health-cronjob-results?cluster=test-cluster", nil)
+	req.Header.Set("X-Demo-Mode", "true")
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	_, ok := body["results"]
+	assert.True(t, ok, "demo response should have 'results' key")
+}
+
+func TestGetGPUHealthCronJobResults_MissingCluster(t *testing.T) {
+	app := newGPUTestApp(&k8s.MultiClusterClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/health-cronjob-results", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Contains(t, body["error"], "cluster")
+}
+
+func TestGetGPUHealthCronJobResults_InvalidCluster(t *testing.T) {
+	app := newGPUTestApp(&k8s.MultiClusterClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/health-cronjob-results?cluster=BAD%21", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+func TestGetGPUHealthCronJobResults_NoK8sClient(t *testing.T) {
+	app := newGPUTestApp(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/health-cronjob-results?cluster=test-cluster", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// --- GetNVIDIAOperatorStatus tests ---
+
+func TestGetNVIDIAOperatorStatus_DemoMode(t *testing.T) {
+	app := newGPUTestApp(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/nvidia-operators", nil)
+	req.Header.Set("X-Demo-Mode", "true")
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	_, ok := body["operators"]
+	assert.True(t, ok, "demo response should have 'operators' key")
+}
+
+func TestGetNVIDIAOperatorStatus_NoK8sClient(t *testing.T) {
+	app := newGPUTestApp(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/nvidia-operators", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestGetNVIDIAOperatorStatus_InvalidClusterName(t *testing.T) {
+	app := newGPUTestApp(&k8s.MultiClusterClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/gpu/nvidia-operators?cluster=BAD%21NAME", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+// Verify that the handlers package demo functions are accessible from mcp package
+func TestDemoFunctionsExist(t *testing.T) {
+	assert.NotNil(t, handlers.GetDemoGPUNodes())
+	assert.NotNil(t, handlers.GetDemoGPUNodeHealth())
+	assert.NotNil(t, handlers.GetDemoNVIDIAOperatorStatus())
+}

--- a/pkg/api/handlers/stellar/executions_test.go
+++ b/pkg/api/handlers/stellar/executions_test.go
@@ -1,0 +1,247 @@
+package stellar
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/store"
+)
+
+func newExecutionsTestApp(t *testing.T) (*fiber.App, *store.SQLiteStore, uuid.UUID) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "executions-test-"+uuid.NewString()+".db")
+	sqlStore, err := store.NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqlStore.Close()
+	})
+
+	testUserID := uuid.New()
+	require.NoError(t, sqlStore.CreateUser(context.Background(), &models.User{
+		ID:          testUserID,
+		GitHubLogin: "exec-test-user",
+		Role:        models.UserRoleViewer,
+	}))
+
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("userID", testUserID)
+		return c.Next()
+	})
+
+	handler := NewHandler(sqlStore, nil)
+	app.Get("/api/stellar/executions", handler.ListExecutions)
+	app.Get("/api/stellar/executions/:id", handler.GetExecution)
+
+	return app, sqlStore, testUserID
+}
+
+func TestListExecutions_Empty(t *testing.T) {
+	app, _, _ := newExecutionsTestApp(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/stellar/executions", nil)
+	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	items, ok := body["items"].([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, items)
+	assert.NotNil(t, body["limit"])
+}
+
+func TestListExecutions_WithData(t *testing.T) {
+	app, sqlStore, userID := newExecutionsTestApp(t)
+
+	// Create a mission first
+	mission := &store.StellarMission{
+		UserID: userID.String(),
+		Name:   "test-mission",
+		Goal:   "testing",
+	}
+	require.NoError(t, sqlStore.CreateStellarMission(context.Background(), mission))
+
+	// Create executions
+	exec := &store.StellarExecution{
+		UserID:      userID.String(),
+		MissionID:   mission.ID,
+		TriggerType: "manual",
+		Status:      "completed",
+	}
+	require.NoError(t, sqlStore.CreateStellarExecution(context.Background(), exec))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/stellar/executions", nil)
+	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	items, ok := body["items"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, items, 1)
+}
+
+func TestListExecutions_FilterByMissionID(t *testing.T) {
+	app, sqlStore, userID := newExecutionsTestApp(t)
+
+	mission1 := &store.StellarMission{UserID: userID.String(), Name: "m1", Goal: "g1"}
+	mission2 := &store.StellarMission{UserID: userID.String(), Name: "m2", Goal: "g2"}
+	require.NoError(t, sqlStore.CreateStellarMission(context.Background(), mission1))
+	require.NoError(t, sqlStore.CreateStellarMission(context.Background(), mission2))
+
+	require.NoError(t, sqlStore.CreateStellarExecution(context.Background(), &store.StellarExecution{
+		UserID: userID.String(), MissionID: mission1.ID, TriggerType: "manual", Status: "completed",
+	}))
+	require.NoError(t, sqlStore.CreateStellarExecution(context.Background(), &store.StellarExecution{
+		UserID: userID.String(), MissionID: mission2.ID, TriggerType: "cron", Status: "running",
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/stellar/executions?mission_id="+mission1.ID, nil)
+	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	items := body["items"].([]interface{})
+	assert.Len(t, items, 1)
+}
+
+func TestListExecutions_FilterByStatus(t *testing.T) {
+	app, sqlStore, userID := newExecutionsTestApp(t)
+
+	mission := &store.StellarMission{UserID: userID.String(), Name: "m", Goal: "g"}
+	require.NoError(t, sqlStore.CreateStellarMission(context.Background(), mission))
+
+	require.NoError(t, sqlStore.CreateStellarExecution(context.Background(), &store.StellarExecution{
+		UserID: userID.String(), MissionID: mission.ID, TriggerType: "manual", Status: "completed",
+	}))
+	require.NoError(t, sqlStore.CreateStellarExecution(context.Background(), &store.StellarExecution{
+		UserID: userID.String(), MissionID: mission.ID, TriggerType: "manual", Status: "failed",
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/stellar/executions?status=completed", nil)
+	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	items := body["items"].([]interface{})
+	assert.Len(t, items, 1)
+}
+
+func TestListExecutions_Pagination(t *testing.T) {
+	app, sqlStore, userID := newExecutionsTestApp(t)
+
+	mission := &store.StellarMission{UserID: userID.String(), Name: "m", Goal: "g"}
+	require.NoError(t, sqlStore.CreateStellarMission(context.Background(), mission))
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, sqlStore.CreateStellarExecution(context.Background(), &store.StellarExecution{
+			UserID: userID.String(), MissionID: mission.ID, TriggerType: "manual", Status: "completed",
+		}))
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/stellar/executions?limit=2&offset=0", nil)
+	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	items := body["items"].([]interface{})
+	assert.Len(t, items, 2)
+	assert.Equal(t, float64(2), body["limit"])
+}
+
+func TestListExecutions_Unauthenticated(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "exec-noauth-"+uuid.NewString()+".db")
+	sqlStore, err := store.NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlStore.Close() })
+
+	app := fiber.New()
+	// No userID middleware — simulates unauthenticated request
+	handler := NewHandler(sqlStore, nil)
+	app.Get("/api/stellar/executions", handler.ListExecutions)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/stellar/executions", nil)
+	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestGetExecution_Success(t *testing.T) {
+	app, sqlStore, userID := newExecutionsTestApp(t)
+
+	mission := &store.StellarMission{UserID: userID.String(), Name: "m", Goal: "g"}
+	require.NoError(t, sqlStore.CreateStellarMission(context.Background(), mission))
+
+	exec := &store.StellarExecution{
+		UserID: userID.String(), MissionID: mission.ID, TriggerType: "manual", Status: "completed",
+	}
+	require.NoError(t, sqlStore.CreateStellarExecution(context.Background(), exec))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/stellar/executions/"+exec.ID, nil)
+	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, exec.ID, body["id"])
+}
+
+func TestGetExecution_NotFound(t *testing.T) {
+	app, _, _ := newExecutionsTestApp(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/stellar/executions/nonexistent-id", nil)
+	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+}
+
+func TestGetExecution_WhitespaceID(t *testing.T) {
+	app, _, _ := newExecutionsTestApp(t)
+
+	// URL-encoded space — TrimSpace makes it empty → 400
+	req := httptest.NewRequest(http.MethodGet, "/api/stellar/executions/%20%20", nil)
+	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
+	require.NoError(t, err)
+
+	// Fiber may treat whitespace-only param as no match (404) or the handler
+	// returns 400 after trimming. Either indicates the request is rejected.
+	assert.True(t, resp.StatusCode == fiber.StatusBadRequest || resp.StatusCode == fiber.StatusNotFound,
+		"expected 400 or 404, got %d", resp.StatusCode)
+}
+
+func TestGetExecution_Unauthenticated(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "exec-noauth2-"+uuid.NewString()+".db")
+	sqlStore, err := store.NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlStore.Close() })
+
+	app := fiber.New()
+	handler := NewHandler(sqlStore, nil)
+	app.Get("/api/stellar/executions/:id", handler.GetExecution)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/stellar/executions/some-id", nil)
+	resp, err := app.Test(req, stellarMockedHandlerTestTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+}


### PR DESCRIPTION
## Test Improvement

Adds comprehensive unit tests for two previously untested handler files:

### pkg/api/handlers/stellar/executions_test.go (10 tests)
- **ListExecutions**: empty list, with data, filter by mission_id, filter by status, pagination, unauthenticated
- **GetExecution**: success, not found, whitespace ID rejection, unauthenticated

### pkg/api/handlers/mcp/gpu_test.go (16 tests)
- **GetGPUNodes**: demo mode, no k8s client, invalid cluster name
- **GetGPUNodeHealth**: demo mode, no k8s client, invalid cluster name
- **GetGPUHealthCronJobStatus**: demo mode, missing cluster param, invalid cluster, no k8s client
- **GetGPUHealthCronJobResults**: demo mode, missing cluster param, invalid cluster, no k8s client
- **GetNVIDIAOperatorStatus**: demo mode, no k8s client, invalid cluster name
- **DemoFunctionsExist**: verifies demo data helpers are accessible

Fixes #20764
Fixes #20763

---
*Filed by quality agent (ACMM L4/L6 — full mode)*