### PR TITLE
[scanner] fix: increase touch target sizes for mobile accessibility

### DIFF
--- a/web/src/components/cards/llmd/KVCacheMonitorDetailPanel.tsx
+++ b/web/src/components/cards/llmd/KVCacheMonitorDetailPanel.tsx
@@ -56,7 +56,7 @@ export const KVCacheMonitorDetailPanel = memo(function KVCacheMonitorDetailPanel
               <span className="text-sm font-medium text-white">{getDisplayPodName(t, selectedStat.podName, 14)}</span>
               {isDemoData && <StatusBadge color="yellow" size="xs">{t('common:common.demo')}</StatusBadge>}
             </div>
-            <button className="p-1 text-xs text-muted-foreground hover:text-white" onClick={onClose} type="button" aria-label="Close detail panel">
+            <button className="p-3 min-h-11 min-w-11 flex items-center justify-center text-xs text-muted-foreground hover:text-white" onClick={onClose} type="button" aria-label="Close detail panel">
               ✕
             </button>
           </div>


### PR DESCRIPTION
Fixes #20758

## Changes

Increases touch target size on the KVCacheMonitorDetailPanel close button from ~16px (p-1) to 44px minimum (p-3 min-h-11 min-w-11) to meet Apple HIG and WCAG 2.5.5 mobile accessibility guidelines.

- Changed `p-1` to `p-3 min-h-11 min-w-11` with flex centering
- Ensures 44x44px minimum interactive area for touch devices