### PR TITLE
[scanner] fix: scope workflow token permissions to least privilege

### DIFF
--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -8,7 +8,8 @@ on:
       - 'web/src/lib/a11y/**'
       - 'web/src/lib/accessibility.ts'
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   CI: true

--- a/.github/workflows/accm-history-update.yml
+++ b/.github/workflows/accm-history-update.yml
@@ -22,7 +22,8 @@ on:
     - cron: "30 6 * * *"
   workflow_dispatch:
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read
 
 env:
   # Public gist that holds the computed history. Not a secret.

--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -10,7 +10,8 @@ on:
       - '.github/workflows/api-contract.yml'
   workflow_dispatch: {}
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read
 
 concurrency:
   group: api-contract-${{ github.ref }}

--- a/.github/workflows/auth-login-smoke.yml
+++ b/.github/workflows/auth-login-smoke.yml
@@ -39,7 +39,8 @@ on:
     - cron: "0 * * * *"
   workflow_dispatch:
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read
 concurrency:
   group: auth-login-smoke
   cancel-in-progress: true

--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -45,7 +45,8 @@ env:
   NODE_VERSION: "22"
   GO_VERSION: "1.26.4"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   auto-qa:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -38,7 +38,8 @@ on:
 # Cluster deploys themselves are serialized by per-job concurrency below.
 
 # Least-privilege: read-only by default; jobs declare write scopes individually
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: build-deploy-kc-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/card-standard-nightly.yml
+++ b/.github/workflows/card-standard-nightly.yml
@@ -13,7 +13,8 @@ on:
   workflow_dispatch:
 
 # Least-privilege: read-only by default; jobs declare write scopes individually
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   card-standard:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,8 @@ on:
     #   - "src/**/*.jsx"
 
 # Least-privilege: read-only by default; jobs declare write scopes individually
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   claude-review:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,8 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,8 @@ on:
         type: boolean
 
 # Least-privilege: read-only by default; jobs declare write scopes individually
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read
 
 # Prevent concurrent scheduled releases (allow manual runs to queue)
 concurrency:


### PR DESCRIPTION
## Changes

Replaces `permissions: read-all` with `permissions: { contents: read }` in 10 workflows that previously had overly broad token permissions:

- a11y-audit.yml
- accm-history-update.yml
- api-contract.yml
- auth-login-smoke.yml
- auto-qa.yml
- build-deploy.yml
- card-standard-nightly.yml
- claude-code-review.yml
- codeql.yml
- release.yml

Each job already declares its specific write permissions; the top-level `read-all` grant was unnecessary and violates least-privilege security practices.

## Security Impact

Reduces the attack surface by ensuring workflows only have read access to repository contents by default, with write permissions explicitly granted at the job level where needed.