### PR TITLE
[scanner] fix: use console.error for caught exceptions

### DIFF
--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -413,7 +413,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
           if (enabledChannels.length > 0) {
             const resolvedAlert: Alert = { ...alertToResolve, status: 'resolved', resolvedAt }
             localSendNotifications(resolvedAlert, enabledChannels).catch((error) => {
-              console.warn('[AlertsContext] resolved notification send failed:', error)
+              console.error('[AlertsContext] resolved notification send failed:', error)
               if (typeof window !== 'undefined') {
                 window.dispatchEvent(new CustomEvent('alert-notification-error', {
                   detail: { 

--- a/web/src/contexts/ThemeContext.tsx
+++ b/web/src/contexts/ThemeContext.tsx
@@ -162,7 +162,7 @@ function applyTheme(theme: Theme) {
       root.classList.remove('theme-gradient-accents')
     }
   } catch (error: unknown) {
-    console.warn('Error applying theme:', error)
+    console.error('Error applying theme:', error)
     // Dispatch event for monitoring (theme errors shouldn't break the app)
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('theme-error', {

--- a/web/src/contexts/alertRulesEngine.ts
+++ b/web/src/contexts/alertRulesEngine.ts
@@ -257,7 +257,7 @@ export function createAlertRulesEngine({
       const enabledChannels = getEnabledChannels(rule)
       if (enabledChannels.length > 0) {
         localSendNotifications(newAlert, enabledChannels).catch(error => {
-          console.warn('[AlertsContext] firing notification send failed:', error)
+          console.error('[AlertsContext] firing notification send failed:', error)
           if (typeof window !== 'undefined') {
             window.dispatchEvent(new CustomEvent('alert-notification-error', {
               detail: { 

--- a/web/src/contexts/alertStorage.ts
+++ b/web/src/contexts/alertStorage.ts
@@ -118,7 +118,7 @@ export function saveToStorage<T>(key: string, value: T): void {
   try {
     localStorage.setItem(key, JSON.stringify(value))
   } catch (e: unknown) {
-    console.warn(`Failed to save ${key} to localStorage:`, e)
+    console.error(`Failed to save ${key} to localStorage:`, e)
     // Dispatch custom event for monitoring/observability
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('storage-error', {
@@ -168,7 +168,7 @@ export function saveAlerts(alerts: Alert[]): void {
       try {
         localStorage.setItem(ALERTS_KEY, JSON.stringify(pruned))
       } catch (retryError: unknown) {
-        console.warn('[Alerts] localStorage still full after pruning, clearing alerts', retryError)
+        console.error('[Alerts] localStorage still full after pruning, clearing alerts', retryError)
         // Dispatch event for monitoring
         if (typeof window !== 'undefined') {
           window.dispatchEvent(new CustomEvent('storage-error', {

--- a/web/src/lib/kubectlProxy.connection.ts
+++ b/web/src/lib/kubectlProxy.connection.ts
@@ -164,7 +164,7 @@ export class KubectlProxyConnection {
                   }
                 }
               } catch (e: unknown) {
-                console.warn('[KubectlProxy] Failed to parse message:', e)
+                console.error('[KubectlProxy] Failed to parse message:', e)
                 // Dispatch event for connection error monitoring
                 if (typeof window !== 'undefined') {
                   window.dispatchEvent(new CustomEvent('kubectl-proxy-error', {

--- a/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
+++ b/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
@@ -77,7 +77,7 @@ export function UnifiedDashboard({
           }
         }
       } catch (error) {
-        console.warn('Failed to restore unified dashboard cards', error)
+        console.error('Failed to restore unified dashboard cards', error)
         nextState.error = t('errors.storageRestoreFailed')
       }
     }
@@ -95,7 +95,7 @@ export function UnifiedDashboard({
             }
           }
         } catch (error) {
-          console.warn('Failed to restore unified dashboard tab cards', error)
+          console.error('Failed to restore unified dashboard tab cards', error)
           nextState.error = t('errors.storageRestoreFailed')
         }
       }

--- a/web/src/lib/utils/localStorage.ts
+++ b/web/src/lib/utils/localStorage.ts
@@ -41,7 +41,7 @@ export function safeGetItem(key: string): string | null {
     return localStorage.getItem(key)
   } catch (error: unknown) {
     // localStorage may throw in private browsing mode or when disabled
-    console.warn('Failed to read from localStorage:', sanitizeKeyForLog(key), error)
+    console.error('Failed to read from localStorage:', sanitizeKeyForLog(key), error)
     dispatchStorageError('getItem', key, error)
     return null
   }
@@ -59,7 +59,7 @@ export function safeSetItem(key: string, value: string): boolean {
     return true
   } catch (error: unknown) {
     // localStorage may throw in private browsing mode, when quota exceeded, or when disabled
-    console.warn('Failed to write to localStorage:', sanitizeKeyForLog(key), error)
+    console.error('Failed to write to localStorage:', sanitizeKeyForLog(key), error)
     dispatchStorageError('setItem', key, error)
     return false
   }
@@ -75,7 +75,7 @@ export function safeRemoveItem(key: string): boolean {
     localStorage.removeItem(key)
     return true
   } catch (error: unknown) {
-    console.warn('Failed to remove from localStorage:', sanitizeKeyForLog(key), error)
+    console.error('Failed to remove from localStorage:', sanitizeKeyForLog(key), error)
     dispatchStorageError('removeItem', key, error)
     return false
   }
@@ -90,7 +90,7 @@ export function safeKey(index: number): string | null {
   try {
     return localStorage.key(index)
   } catch (error: unknown) {
-    console.warn('Failed to read localStorage key by index:', index, error)
+    console.error('Failed to read localStorage key by index:', index, error)
     return null
   }
 }
@@ -103,7 +103,7 @@ export function safeGetStorageLength(): number {
   try {
     return localStorage.length
   } catch (error: unknown) {
-    console.warn('Failed to read localStorage length:', error)
+    console.error('Failed to read localStorage length:', error)
     return 0
   }
 }
@@ -120,7 +120,7 @@ export function safeGetJSON<T = unknown>(key: string): T | null {
       return JSON.parse(item) as T
     }
   } catch (error: unknown) {
-    console.warn('Failed to read/parse JSON from localStorage:', sanitizeKeyForLog(key), error)
+    console.error('Failed to read/parse JSON from localStorage:', sanitizeKeyForLog(key), error)
   }
   return null
 }
@@ -136,7 +136,7 @@ export function safeSetJSON<T = unknown>(key: string, value: T): boolean {
     localStorage.setItem(key, JSON.stringify(value))
     return true
   } catch (error: unknown) {
-    console.warn('Failed to write JSON to localStorage:', sanitizeKeyForLog(key), error)
+    console.error('Failed to write JSON to localStorage:', sanitizeKeyForLog(key), error)
     return false
   }
 }


### PR DESCRIPTION
Fixes #20779

Changes console.warn to console.error in catch blocks that handle actual exceptions. These are genuine errors that should appear in error monitoring tools, even when the application gracefully degrades.

## Changes

**Contexts:**
- AlertsContext.tsx: notification send failures (resolved alerts)
- alertRulesEngine.ts: notification send failures (firing alerts)
- ThemeContext.tsx: theme application errors
- alertStorage.ts: localStorage quota/write failures (2 locations)

**Library utilities:**
- kubectlProxy.connection.ts: WebSocket message parse failures
- localStorage.ts: localStorage operation failures (7 functions: getItem, setItem, removeItem, key, length, getJSON, setJSON)
- UnifiedDashboard.tsx: dashboard card restoration failures (2 locations: main cards + tab cards)

## Rationale

While these catch blocks handle errors gracefully (no user-facing disruption), they are still genuine exceptions that should be logged at error level for monitoring and debugging. Using console.error ensures they appear in error tracking tools while maintaining the existing graceful degradation behavior.