### PR TITLE
[scanner] fix: remove duplicate i18n mock causing 223 test failures

### DIFF
--- a/web/src/components/rbac/__tests__/CanIChecker.test.tsx
+++ b/web/src/components/rbac/__tests__/CanIChecker.test.tsx
@@ -40,14 +40,6 @@ vi.mock('../../../hooks/useMCP', () => ({
   }),
 }))
 
-vi.mock('react-i18next', () => ({
-  initReactI18next: { type: '3rdParty', init: () => {} },
-  useTranslation: () => ({
-    t: (key: string) => key,
-    i18n: { language: 'en', changeLanguage: vi.fn() },
-  }),
-}))
-
 vi.mock('../../ui/Button', () => ({
   Button: ({ children, onClick, disabled, variant, ...rest }: Record<string, unknown>) => (
     <button


### PR DESCRIPTION
Fixes #20783

## Root Cause

The CanIChecker test file had a duplicate `react-i18next` mock that was simpler than the global mock in `setup.ts`. In vitest with worker pooling, this local mock leaked to other tests in the same worker, causing 223 test failures across multiple test files.

## Fix

Removed the duplicate mock from the CanIChecker test. Tests now use the comprehensive global mock from `setup.ts` consistently.