### PR TITLE
[scanner] fix: bump Go version to patch GO-2026-5856

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.5'
 
 jobs:
   api-contract:

--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -43,7 +43,7 @@ env:
   COPILOT_ASSIGNMENT_DELAY_S: 120  # Seconds between Copilot assignments to avoid rate limiting
   ISSUE_PREFIX: "[Auto-QA]"
   NODE_VERSION: "22"
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
 
 permissions:
   contents: read

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       # Full suite — must match what release.yml runs or main can still

--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   RESULTS_DIR: test-results/nightly
   NODE_VERSION: '22'
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.5'
 
 jobs:
   test:

--- a/.github/workflows/nil-safety.yml
+++ b/.github/workflows/nil-safety.yml
@@ -22,7 +22,7 @@ on:
         type: boolean
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
 
 permissions: read-all  # default read; writes scoped to job below
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Set up Node.js
@@ -255,7 +255,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Set up Node.js

--- a/.github/workflows/startup-smoke.yml
+++ b/.github/workflows/startup-smoke.yml
@@ -35,7 +35,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.5'
   NODE_VERSION: '22'
 
 jobs:

--- a/.github/workflows/update-guard.yml
+++ b/.github/workflows/update-guard.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
 
 permissions: read-all  # default read; writes scoped to job below
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - Backend
-FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS backend-builder
+FROM golang:1.26.5-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS backend-builder
 
 WORKDIR /app
 

--- a/cmd/kc-agent/Dockerfile
+++ b/cmd/kc-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the kc-agent binary
-FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
+FROM golang:1.26.5-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubestellar/console
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/fasthttp/websocket v1.5.12


### PR DESCRIPTION
Fixes #20709

Bumps the Go version from 1.26.4 to 1.26.5 to address GO-2026-5856 (Encrypted Client Hello privacy leak in crypto/tls).

Updated files:
- go.mod
- Dockerfile
- cmd/kc-agent/Dockerfile
- All GitHub workflow files referencing Go version