### PR TITLE
[scanner] fix: update golang:1.26.5-alpine Docker digest to unbreak main build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - Backend
-FROM golang:1.26.5-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS backend-builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS backend-builder
 
 WORKDIR /app
 

--- a/cmd/kc-agent/Dockerfile
+++ b/cmd/kc-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the kc-agent binary
-FROM golang:1.26.5-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
 WORKDIR /src
 


### PR DESCRIPTION
Fixes #20791

## Problem

The `Build and Deploy KC` workflow is failing on main because commit 823c0e7 bumped the Go image tag from `golang:1.26.4-alpine` to `golang:1.26.5-alpine` but kept the old digest pin (`sha256:f23e8b...`). Docker resolves to the pinned digest (which is still the 1.26.4 binary), so `go mod download` fails with:

```
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

## Fix

Update the `@sha256:...` digest in both `Dockerfile` and `cmd/kc-agent/Dockerfile` to the correct manifest list digest for `golang:1.26.5-alpine` (`sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2`).