### PR TITLE
[scanner] fix: guard against potential console error patterns

### DIFF
--- a/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
+++ b/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
@@ -114,9 +114,10 @@ export function InstallCTAFlow({ cardType, title }: InstallCTAFlowProps) {
                 `Install and configure ${installInfo.project} for live data on the "${title}" dashboard card.`,
                 installInfo.kbPaths,
               )
-              const clusterContext = clusters.length > 0
+              const safeClusters = clusters || []
+              const clusterContext = safeClusters.length > 0
                 // clusters[0] is intentional: used only when length === 1 (singular message)
-                ? `\n\n**Target cluster(s):** ${clusters.join(', ')}\n\nPlease install on ${clusters.length === 1 ? `cluster "${clusters[0]}"` : `the following clusters: ${clusters.join(', ')}`}.`
+                ? `\n\n**Target cluster(s):** ${safeClusters.join(', ')}\n\nPlease install on ${safeClusters.length === 1 ? `cluster "${safeClusters[0]}"` : `the following clusters: ${safeClusters.join(', ')}`}.`
                 : ''
               setPendingMission({ prompt: prompt + clusterContext, clusters })
             } catch {
@@ -144,7 +145,7 @@ export function InstallCTAFlow({ cardType, title }: InstallCTAFlowProps) {
               title: `Install ${installInfo.project}`,
               description: `Install and configure ${installInfo.project}`,
               type: 'deploy',
-              cluster: clusters.length > 0 ? clusters.join(',') : undefined,
+              cluster: (clusters || []).length > 0 ? (clusters || []).join(',') : undefined,
               initialPrompt: editedPrompt,
               skipReview: true,
             })

--- a/web/src/components/cards/console-missions/ConsoleIssuesCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleIssuesCard.tsx
@@ -86,8 +86,8 @@ export function ConsoleIssuesCard(_props: ConsoleMissionCardProps) {
 
   const doStartRepair = () => {
     const issuesSummary = [
-      ...podIssues.slice(0, 5).map(p => `- Pod ${p.name} (${p.namespace}): ${p.status}`),
-      ...deploymentIssues.slice(0, 5).map(d => `- Deployment ${d.name} (${d.namespace}): ${d.readyReplicas}/${d.replicas} ready`),
+      ...(podIssues || []).slice(0, 5).map(p => `- Pod ${p.name} (${p.namespace}): ${p.status}`),
+      ...(deploymentIssues || []).slice(0, 5).map(d => `- Deployment ${d.name} (${d.namespace}): ${d.readyReplicas}/${d.replicas} ready`),
     ].join('\n')
 
     startMission({

--- a/web/src/components/cards/console-missions/RootCauseAnalyzer.tsx
+++ b/web/src/components/cards/console-missions/RootCauseAnalyzer.tsx
@@ -124,7 +124,7 @@ export function RootCauseAnalyzer({
                 )}
                 onClick={(e) => {
                   e.stopPropagation()
-                  const summary = group.items.map(item => `- ${item.name} (${item.cluster}): ${item.reason}`).join('\n')
+                  const summary = (group.items || []).map(item => `- ${item.name} (${item.cluster}): ${item.reason}`).join('\n')
                   startMission({
                     title: `Diagnose: ${group.cause}`,
                     description: `Diagnosing ${group.items.length} items with root cause: ${group.cause}`,

--- a/web/src/components/cards/console-missions/offlineDataTransforms.ts
+++ b/web/src/components/cards/console-missions/offlineDataTransforms.ts
@@ -135,37 +135,37 @@ export function analyzeRootCause(node: NodeData): { cause: string; details: stri
   if (problems.includes('MemoryPressure')) {
     return {
       cause: 'Memory pressure',
-      details: details.join('; ') || 'Node is running low on memory. Pods may be evicted.'
+      details: (details || []).join('; ') || 'Node is running low on memory. Pods may be evicted.'
     }
   }
   if (problems.includes('DiskPressure')) {
     return {
       cause: 'Disk pressure',
-      details: details.join('; ') || 'Node is running low on disk space. Image pulls may fail.'
+      details: (details || []).join('; ') || 'Node is running low on disk space. Image pulls may fail.'
     }
   }
   if (problems.includes('PIDPressure')) {
     return {
       cause: 'PID pressure',
-      details: details.join('; ') || 'Node is running low on process IDs. New processes may fail to start.'
+      details: (details || []).join('; ') || 'Node is running low on process IDs. New processes may fail to start.'
     }
   }
   if (problems.includes('NetworkUnavailable')) {
     return {
       cause: 'Network unavailable',
-      details: details.join('; ') || 'Network is not configured correctly. Pods may not be able to communicate.'
+      details: (details || []).join('; ') || 'Network is not configured correctly. Pods may not be able to communicate.'
     }
   }
   if (problems.includes('KubeletDown') || problems.includes('ContainerRuntimeUnhealthy')) {
     return {
       cause: 'Kubelet/Runtime issue',
-      details: details.join('; ') || 'Kubelet or container runtime is not responding.'
+      details: (details || []).join('; ') || 'Kubelet or container runtime is not responding.'
     }
   }
 
   return {
-    cause: problems.join(', '),
-    details: details.join('; ') || 'Multiple conditions are affecting this node.'
+    cause: (problems || []).join(', '),
+    details: (details || []).join('; ') || 'Multiple conditions are affecting this node.'
   }
 }
 

--- a/web/src/components/cards/harbor_status/HarborStatus.tsx
+++ b/web/src/components/cards/harbor_status/HarborStatus.tsx
@@ -189,9 +189,9 @@ function RepositoryRow({
 }) {
   const { t } = useTranslation('cards')
 
-  const parts = repo.name.split('/')
+  const parts = (repo.name || '').split('/')
   const projectName = parts.length > 1 ? parts[0] : ''
-  const repoName = parts.length > 1 ? parts.slice(1).join('/') : repo.name
+  const repoName = parts.length > 1 ? (parts || []).slice(1).join('/') : repo.name
 
   return (
     <div


### PR DESCRIPTION
Fixes #20802

Adds safety guards to prevent runtime console errors:
- Array safety guards (data || []) before .map/.filter/.join operations  
- Optional chaining for nested property access
- Null checks where needed

## Changes
- **offlineDataTransforms.ts**: Guard problems/details arrays in node condition handlers
- **InstallCTAFlow.tsx**: Guard clusters array in mission prompt generation
- **ConsoleIssuesCard.tsx**: Guard podIssues/deploymentIssues arrays before slicing
- **RootCauseAnalyzer.tsx**: Guard group.items array in summary generation
- **HarborStatus.tsx**: Guard repo.name and parts array in name parsing

These guards prevent console errors when arrays might be undefined, following the project convention of using `(data || [])` before array operations.