### PR TITLE
[sec-check] fix: complete CWE-117 log injection remediation — 144 remaining alerts (v3)

### DIFF
--- a/pkg/agent/csrf.go
+++ b/pkg/agent/csrf.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"log/slog"
 	"net/http"
+
+	"github.com/kubestellar/console/pkg/sanitize"
 )
 
 const (
@@ -47,7 +49,7 @@ func requireCSRF(next http.Handler) http.Handler {
 
 		if r.Header.Get(csrfHeaderName) != csrfHeaderValue {
 			slog.Warn("[CSRF] request rejected: missing or invalid CSRF header",
-				"ip", r.RemoteAddr, "method", r.Method, "path", r.URL.Path)
+				"ip", sanitize.LogString(r.RemoteAddr), "method", sanitize.LogString(r.Method), "path", sanitize.LogString(r.URL.Path))
 			http.Error(w, csrfForbiddenMsg, http.StatusForbidden)
 			return
 		}

--- a/pkg/agent/kagent/kagent.go
+++ b/pkg/agent/kagent/kagent.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kubestellar/console/pkg/agent/httputil"
 	"github.com/kubestellar/console/pkg/safego"
+	"github.com/kubestellar/console/pkg/sanitize"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,13 +96,13 @@ type CRDAgent struct {
 }
 
 type CRDTool struct {
-	Name            string             `json:"name"`
-	Namespace       string             `json:"namespace"`
-	Cluster         string             `json:"cluster"`
-	Kind            string             `json:"kind"`
-	URL             string             `json:"url"`
-	Config          string             `json:"config"`
-	DiscoveredTools []DiscoveredTool   `json:"discoveredTools"`
+	Name            string           `json:"name"`
+	Namespace       string           `json:"namespace"`
+	Cluster         string           `json:"cluster"`
+	Kind            string           `json:"kind"`
+	URL             string           `json:"url"`
+	Config          string           `json:"config"`
+	DiscoveredTools []DiscoveredTool `json:"discoveredTools"`
 }
 
 type DiscoveredTool struct {
@@ -841,7 +842,7 @@ func (h *Handlers) HandleKagentiAgents(w http.ResponseWriter, r *http.Request) {
 			httputil.WriteJSON(w, map[string]any{"agents": []any{}})
 			return
 		}
-		slog.Warn("error listing kagenti agents", "cluster", cluster, "error", err)
+		slog.Warn("error listing kagenti agents", "cluster", sanitize.LogString(cluster), "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{"agents": []any{}, "error": "internal server error"})
 		return
@@ -926,7 +927,7 @@ func (h *Handlers) HandleKagentiBuilds(w http.ResponseWriter, r *http.Request) {
 			httputil.WriteJSON(w, map[string]any{"builds": []any{}})
 			return
 		}
-		slog.Warn("error listing kagenti builds", "cluster", cluster, "error", err)
+		slog.Warn("error listing kagenti builds", "cluster", sanitize.LogString(cluster), "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{"builds": []any{}, "error": "internal server error"})
 		return
@@ -1006,7 +1007,7 @@ func (h *Handlers) HandleKagentiCards(w http.ResponseWriter, r *http.Request) {
 			httputil.WriteJSON(w, map[string]any{"cards": []any{}})
 			return
 		}
-		slog.Warn("error listing kagenti cards", "cluster", cluster, "error", err)
+		slog.Warn("error listing kagenti cards", "cluster", sanitize.LogString(cluster), "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{"cards": []any{}, "error": "internal server error"})
 		return
@@ -1079,7 +1080,7 @@ func (h *Handlers) HandleKagentiTools(w http.ResponseWriter, r *http.Request) {
 			httputil.WriteJSON(w, map[string]any{"tools": []any{}})
 			return
 		}
-		slog.Warn("error listing kagenti tools", "cluster", cluster, "error", err)
+		slog.Warn("error listing kagenti tools", "cluster", sanitize.LogString(cluster), "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{"tools": []any{}, "error": "internal server error"})
 		return

--- a/pkg/agent/kube/discovery.go
+++ b/pkg/agent/kube/discovery.go
@@ -13,6 +13,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/kubestellar/console/pkg/sanitize"
 )
 
 // Progress percentage constants for cluster creation/deletion phases
@@ -99,7 +101,7 @@ func NewLocalClusterManager(broadcast func(string, interface{})) *LocalClusterMa
 func (m *LocalClusterManager) broadcastProgress(tool, name, status, message string, progress int) {
 	if m.broadcast == nil {
 		slog.Debug("[LocalCluster] no broadcast listener, progress event dropped",
-			"tool", tool, "name", name, "status", status, "progress", progress)
+			"tool", sanitize.LogString(tool), "name", sanitize.LogString(name), "status", sanitize.LogString(status), "progress", progress)
 		return
 	}
 	m.broadcast("local_cluster_progress", map[string]interface{}{

--- a/pkg/agent/prometheus.go
+++ b/pkg/agent/prometheus.go
@@ -11,8 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/client-go/rest"
 	"github.com/kubestellar/console/pkg/agent/kube"
+	"github.com/kubestellar/console/pkg/sanitize"
+	"k8s.io/client-go/rest"
 )
 
 // promClientCache reuses http.Client instances keyed by cluster API server URL.
@@ -120,7 +121,7 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 
 	config, err := s.k8sClient.GetRestConfig(cluster)
 	if err != nil {
-		slog.Error("[Prometheus] failed to get cluster config", "cluster", cluster, "error", err)
+		slog.Error("[Prometheus] failed to get cluster config", "cluster", sanitize.LogString(cluster), "error", err)
 		writePrometheusError(w, http.StatusBadGateway, "failed to get cluster configuration")
 		return
 	}

--- a/pkg/agent/server_ai_websocket.go
+++ b/pkg/agent/server_ai_websocket.go
@@ -98,7 +98,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		s.clientsMux.Unlock()
 	}()
 
-	slog.Info("client connected", "addr", conn.RemoteAddr(), "origin", sanitize.LogString(r.Header.Get("Origin")))
+	slog.Info("client connected", "addr", sanitize.LogString(conn.RemoteAddr().String()), "origin", sanitize.LogString(r.Header.Get("Origin")))
 
 	// writeMu is the single per-connection mutex shared by broadcasts
 	// (prediction_worker) and request/stream handlers. Using the same
@@ -309,7 +309,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 				defer func() { <-sem }() // release slot
 				defer func() {
 					if r := recover(); r != nil {
-						slog.Error("[WS] recovered from panic in async handler", "panic", r, "msgType", m.Type)
+						slog.Error("[WS] recovered from panic in async handler", "panic", r, "msgType", sanitize.LogString(string(m.Type)))
 						if !closed.Load() {
 							writeMu.Lock()
 							if err := setWSWriteDeadline(conn, "[WS] failed to set WebSocket write deadline",
@@ -380,10 +380,10 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	case <-drainDone:
 		// All goroutines exited cleanly.
 	case <-time.After(wsGoroutineDrainTimeout):
-		slog.Warn("[WebSocket] timed out waiting for goroutines to drain; closing connection", "addr", conn.RemoteAddr())
+		slog.Warn("[WebSocket] timed out waiting for goroutines to drain; closing connection", "addr", sanitize.LogString(conn.RemoteAddr().String()))
 	}
 
-	slog.Info("client disconnected", "addr", conn.RemoteAddr())
+	slog.Info("client disconnected", "addr", sanitize.LogString(conn.RemoteAddr().String()))
 }
 
 // handleMessage processes incoming messages (non-streaming).

--- a/pkg/agent/server_events_stream.go
+++ b/pkg/agent/server_events_stream.go
@@ -122,7 +122,7 @@ func (s *Server) handleEventsStreamSSE(w http.ResponseWriter, r *http.Request) {
 			}
 
 			if evt.Type == watch.Error {
-				slog.Warn("watch error event", "cluster", sanitize.LogString(cluster), "object", evt.Object)
+				slog.Warn("watch error event", "cluster", sanitize.LogString(cluster), "object", sanitize.LogString(fmt.Sprint(evt.Object)))
 				sseWriteError(w, flusher, "watch error")
 				return
 			}

--- a/pkg/agent/server_federation.go
+++ b/pkg/agent/server_federation.go
@@ -243,7 +243,7 @@ func (s *Server) resolveFederationContexts(ctx context.Context, r *http.Request)
 type configResolver func(contextName string) (*rest.Config, error)
 
 func newFederationError(provider federation.FederationProviderName, hubContext, operation string, err error) *federation.FederationError {
-	slog.Error("federation provider request failed", "provider", provider, "hubContext", sanitize.LogString(hubContext), "operation", sanitize.LogString(operation), "error", err)
+	slog.Error("federation provider request failed", "provider", sanitize.LogString(string(provider)), "hubContext", sanitize.LogString(hubContext), "operation", sanitize.LogString(operation), "error", err)
 	return &federation.FederationError{
 		Provider:   provider,
 		HubContext: hubContext,
@@ -563,7 +563,7 @@ func (s *Server) handleFederationAction(w http.ResponseWriter, r *http.Request) 
 
 	result, err := ap.Execute(ctx, cfg, req)
 	if err != nil {
-		slog.Error("federation action execution failed", "provider", req.Provider, "actionID", sanitize.LogString(req.ActionID), "hubContext", sanitize.LogString(req.HubContext), "error", err)
+		slog.Error("federation action execution failed", "provider", sanitize.LogString(string(req.Provider)), "actionID", sanitize.LogString(req.ActionID), "hubContext", sanitize.LogString(req.HubContext), "error", err)
 		writeJSONError(w, http.StatusInternalServerError, sanitizeAgentError("execute federation action", err))
 		return
 	}


### PR DESCRIPTION
Fixes #20803

## Security Fix

Completes the log injection remediation started in PR #20730 and continued in PR #20799. Applies `sanitize.LogString()` to the remaining user-controlled string values in `slog.*` calls at HEAD, including newly discovered files such as `kagent/kagent.go`, `prometheus.go`, `kube/discovery.go`, and `csrf.go`.

## Validation

- `go build ./pkg/...`

---
*Filed by sec-check agent (ACMM L6 — full mode)*