### PR TITLE
[sec-check] fix: sanitize.LogString() for c.IP(), agent, namespace, tool in 3 handlers (CWE-117)

### DIFF
--- a/pkg/api/handlers/card_proxy.go
+++ b/pkg/api/handlers/card_proxy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/ssrf"
 	"github.com/kubestellar/console/pkg/safego"
+	"github.com/kubestellar/console/pkg/sanitize"
 	"github.com/kubestellar/console/pkg/store"
 )
 
@@ -233,7 +234,7 @@ func (h *CardProxyHandler) Proxy(c *fiber.Ctx) error {
 		})
 	}
 
-	slog.Info("[CardProxy] proxied request", "clientIP", c.IP(), "host", host, "status", resp.StatusCode, "bytes", len(body))
+	slog.Info("[CardProxy] proxied request", "clientIP", sanitize.LogString(c.IP()), "host", host, "status", resp.StatusCode, "bytes", len(body))
 
 	h.sanitizeResponse(c, resp)
 

--- a/pkg/api/handlers/kagenti_provider_proxy.go
+++ b/pkg/api/handlers/kagenti_provider_proxy.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/kagentiprovider"
+	"github.com/kubestellar/console/pkg/sanitize"
 	"github.com/kubestellar/console/pkg/store"
 )
 
@@ -133,7 +134,7 @@ func (h *KagentiProviderProxyHandler) Chat(c *fiber.Ctx) error {
 
 	stream, err := h.client.Invoke(c.Context(), req.Namespace, req.Agent, enrichedMessage, req.ContextID, nil)
 	if err != nil {
-		slog.Error("kagenti provider invoke failed", "error", err, "agent", req.Agent, "namespace", req.Namespace)
+		slog.Error("kagenti provider invoke failed", "error", err, "agent", sanitize.LogString(req.Agent), "namespace", sanitize.LogString(req.Namespace))
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": "upstream error"})
 	}
 	// stream is closed inside the stream writer callback.
@@ -317,7 +318,7 @@ func (h *KagentiProviderProxyHandler) CallTool(c *fiber.Ctx) error {
 
 	stream, err := h.client.Invoke(c.Context(), req.Namespace, req.Agent, message, "", nil)
 	if err != nil {
-		slog.Error("kagenti provider tool invocation failed", "error", err, "agent", req.Agent, "namespace", req.Namespace, "tool", req.Tool)
+		slog.Error("kagenti provider tool invocation failed", "error", err, "agent", sanitize.LogString(req.Agent), "namespace", sanitize.LogString(req.Namespace), "tool", sanitize.LogString(req.Tool))
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": "upstream error"})
 	}
 	defer stream.Close()
@@ -530,7 +531,7 @@ func (h *KagentiProviderProxyHandler) handleGetPodList(c *fiber.Ctx, args map[st
 
 	pods, err := h.k8sClient.GetPods(ctx, cluster, namespace)
 	if err != nil {
-		slog.Error("get_pod_list failed", "error", err, "cluster", cluster, "namespace", namespace)
+		slog.Error("get_pod_list failed", "error", err, "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace))
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to fetch pods"})
 	}
 
@@ -567,7 +568,7 @@ func (h *KagentiProviderProxyHandler) handleGetEvents(c *fiber.Ctx, args map[str
 
 	events, err := h.k8sClient.GetEvents(ctx, cluster, namespace, limit)
 	if err != nil {
-		slog.Error("get_events failed", "error", err, "cluster", cluster, "namespace", namespace)
+		slog.Error("get_events failed", "error", err, "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace))
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to fetch events"})
 	}
 

--- a/pkg/api/handlers/manifest.go
+++ b/pkg/api/handlers/manifest.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/kubestellar/console/pkg/client"
+	"github.com/kubestellar/console/pkg/sanitize"
 	"github.com/kubestellar/console/pkg/store"
 )
 
@@ -84,7 +85,7 @@ func (h *ManifestHandler) checkBootstrapAuth(c *fiber.Ctx) error {
 	if h.bootstrapToken != "" {
 		provided := c.Query("token")
 		if subtle.ConstantTimeCompare([]byte(h.bootstrapToken), []byte(provided)) != 1 {
-			slog.Warn("[Manifest] bootstrap access denied — invalid or missing token", "ip", c.IP())
+			slog.Warn("[Manifest] bootstrap access denied — invalid or missing token", "ip", sanitize.LogString(c.IP()))
 			return fiber.NewError(fiber.StatusForbidden, "bootstrap token required")
 		}
 		return nil
@@ -92,7 +93,7 @@ func (h *ManifestHandler) checkBootstrapAuth(c *fiber.Ctx) error {
 
 	// No explicit token configured — restrict to loopback/private IPs.
 	if !isBootstrapAllowedIP(c.IP()) {
-		slog.Warn("[Manifest] bootstrap access denied — non-private IP without token", "ip", c.IP())
+		slog.Warn("[Manifest] bootstrap access denied — non-private IP without token", "ip", sanitize.LogString(c.IP()))
 		return fiber.NewError(fiber.StatusForbidden,
 			"manifest bootstrap is restricted; set CONSOLE_BOOTSTRAP_TOKEN or access from localhost")
 	}


### PR DESCRIPTION
## Security Fix

Wraps user-controlled values with `sanitize.LogString()` in three handler files that were missed in the CWE-117 remediation passes (PRs #20730, #20799, #20807).

### Changes

| File | Values sanitized |
|---|---|
| `pkg/api/handlers/card_proxy.go` | `c.IP()` → `sanitize.LogString(c.IP())` |
| `pkg/api/handlers/manifest.go` | `c.IP()` in two `slog.Warn` calls |
| `pkg/api/handlers/kagenti_provider_proxy.go` | `req.Agent`, `req.Namespace`, `req.Tool`, `cluster`, `namespace` in 4 `slog.Error` calls |

Uses the same `sanitize.LogString()` pattern already applied in `pkg/agent/kagent/kagent.go`.

Fixes #20810

---
*Filed by sec-check agent (ACMM L6 — full mode)*