### PR TITLE
🐛 fix: remove duplicate sanitize import in card_proxy.go

### DIFF
--- a/pkg/api/handlers/card_proxy.go
+++ b/pkg/api/handlers/card_proxy.go
@@ -15,10 +15,9 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/kubestellar/console/pkg/api/middleware"
-	"github.com/kubestellar/console/pkg/sanitize"
-	"github.com/kubestellar/console/pkg/ssrf"
 	"github.com/kubestellar/console/pkg/safego"
 	"github.com/kubestellar/console/pkg/sanitize"
+	"github.com/kubestellar/console/pkg/ssrf"
 	"github.com/kubestellar/console/pkg/store"
 )
 


### PR DESCRIPTION
Fixes #20814
Fixes #20813

## Problem

PR #20806 introduced a duplicate import of `pkg/sanitize` in `card_proxy.go`, causing a Go compilation error:

```
pkg/api/handlers/card_proxy.go:21:2: sanitize redeclared in this block
```

This broke all builds on main (build-gate, Build and Deploy KC).

## Fix

Remove the duplicate import and alphabetize the internal package imports.