### PR TITLE
✨ feat: kustomize install with curated starter overlay (no Helm required)

### DIFF
--- a/deploy/kustomize/README.md
+++ b/deploy/kustomize/README.md
@@ -1,0 +1,87 @@
+# KubeStellar Console — Kustomize Install
+
+Install the console on any Kubernetes cluster with `kubectl` alone — no Helm
+required. Manifests mirror the Helm chart defaults
+(`deploy/helm/kubestellar-console/`).
+
+## Quick start (3 commands)
+
+```bash
+# 1. Namespace
+kubectl create namespace kubestellar-console
+
+# 2. JWT secret (required — the console refuses to start without one)
+kubectl -n kubestellar-console create secret generic kubestellar-console-jwt \
+  --from-literal=jwt-secret="$(openssl rand -base64 48)"
+
+# 3. Install the starter experience
+kubectl apply -k 'https://github.com/kubestellar/console/deploy/kustomize/overlays/starter?ref=main'
+```
+
+Then open it:
+
+```bash
+kubectl -n kubestellar-console port-forward svc/kubestellar-console 8080:8080
+# → http://localhost:8080
+```
+
+## Variants
+
+| Path | What you get |
+|------|--------------|
+| `base` | Full console, all dashboards, no exposure (use port-forward or add your own Ingress) |
+| `overlays/starter` | **Recommended.** Curated sidebar with three core dashboards (Dashboard, Workloads, Nodes), onboarding questionnaire skipped |
+| `overlays/openshift` | Starter experience plus an edge-terminated OpenShift Route |
+
+## Customizing
+
+Create your own overlay and point `resources` at the base or starter overlay:
+
+```yaml
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/kubestellar/console/deploy/kustomize/overlays/starter?ref=main
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kubestellar-console
+      spec:
+        template:
+          spec:
+            containers:
+              - name: kubestellar-console
+                env:
+                  - name: ENABLED_DASHBOARDS
+                    value: dashboard,workloads,nodes,storage,gpu
+```
+
+Useful environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `ENABLED_DASHBOARDS` | Comma-separated dashboard IDs shown in the sidebar (empty = all). IDs: `web/src/hooks/useSidebarConfig.ts` |
+| `SKIP_ONBOARDING` | `"true"` skips the first-run questionnaire |
+| `APP_NAME`, `LOGO_URL`, `THEME_COLOR` | Rebrand the console for your distribution |
+| `CLAUDE_API_KEY` | Enable AI features |
+
+## Version pinning
+
+The image tag is pinned in `base/kustomization.yaml` (`images:` block) and
+tracks the Helm chart `appVersion`. Override in your overlay:
+
+```yaml
+images:
+  - name: ghcr.io/kubestellar/console
+    newTag: 0.3.29
+```
+
+## Uninstall
+
+```bash
+kubectl delete -k 'https://github.com/kubestellar/console/deploy/kustomize/overlays/starter?ref=main'
+kubectl delete namespace kubestellar-console
+```

--- a/deploy/kustomize/README.md
+++ b/deploy/kustomize/README.md
@@ -68,15 +68,36 @@ Useful environment variables:
 | `APP_NAME`, `LOGO_URL`, `THEME_COLOR` | Rebrand the console for your distribution |
 | `CLAUDE_API_KEY` | Enable AI features |
 
-## Version pinning
+## Exposing on a real hostname
 
-The image tag is pinned in `base/kustomization.yaml` (`images:` block) and
-tracks the Helm chart `appVersion`. Override in your overlay:
+The default (`localhost:8080` via port-forward) needs no configuration.
+When you expose the console on a Route or Ingress hostname, set
+`FRONTEND_URL` so auth redirects return to the right place:
+
+```bash
+kubectl -n kubestellar-console set env deployment/kubestellar-console \
+  FRONTEND_URL=https://console.example.com
+```
+
+(Or patch the env var in your overlay next to `ENABLED_DASHBOARDS`.)
+
+## Staying current / version pinning
+
+The base tracks the **`latest`** release channel. Every nightly and weekly
+release pushes the moving image tags `latest`, `nightly`, and `weekly` plus
+an immutable `vX.Y.Z[-nightly.DATE]` tag, so a fresh install (or pod
+restart — `:latest` implies `imagePullPolicy: Always`) always gets the
+newest console with no manifest changes. The in-app self-upgrade
+(`SELF_UPGRADE_ENABLED=true`) can also roll the deployment forward from
+the UI.
+
+To follow a different channel or pin an exact version for reproducible
+installs, override the tag in your overlay:
 
 ```yaml
 images:
   - name: ghcr.io/kubestellar/console
-    newTag: 0.3.29
+    newTag: weekly   # or nightly, or an immutable tag like v0.3.34-nightly.20260709
 ```
 
 ## Uninstall

--- a/deploy/kustomize/base/clusterrole.yaml
+++ b/deploy/kustomize/base/clusterrole.yaml
@@ -1,0 +1,146 @@
+# Read-mostly cluster access for the in-cluster console backend.
+# Kept in sync with deploy/helm/kubestellar-console/templates/clusterrole.yaml
+# (rendered with default values).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubestellar-console
+rules:
+  # Core v1 - read-only (secrets explicitly excluded)
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - pods
+      - pods/log
+      - services
+      - events
+      - configmaps
+      - serviceaccounts
+      - persistentvolumeclaims
+      - persistentvolumes
+      - limitranges
+    verbs: ["get", "list", "watch"]
+
+  # Namespaces — read-only
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs: ["get", "list", "watch"]
+
+  # ResourceQuotas — full CRUD for GPU reservation enforcement
+  - apiGroups: [""]
+    resources:
+      - resourcequotas
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Apps v1 - read-only
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+      - daemonsets
+    verbs: ["get", "list", "watch"]
+
+  # Batch v1 - read-only
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+
+  # Networking v1 - read-only
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs: ["get", "list", "watch"]
+
+  # Autoscaling v2 - read-only
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+
+  # RBAC v1 - read-only (for RBAC analysis features)
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+      - roles
+      - clusterroles
+      - rolebindings
+      - clusterrolebindings
+    verbs: ["get", "list", "watch"]
+
+  # Authorization - permission checks
+  - apiGroups: ["authorization.k8s.io"]
+    resources:
+      - selfsubjectaccessreviews
+    verbs: ["create"]
+
+  # Policy v1 - read-only
+  - apiGroups: ["policy"]
+    resources:
+      - poddisruptionbudgets
+    verbs: ["get", "list", "watch"]
+
+  # API Extensions - read-only (CRD discovery)
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources:
+      - customresourcedefinitions
+    verbs: ["get", "list", "watch"]
+
+  # Admission registration - read-only
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs: ["get", "list", "watch"]
+
+  # NVIDIA GPU Operator - read-only
+  - apiGroups: ["nvidia.com"]
+    resources:
+      - clusterpolicies
+    verbs: ["get", "list", "watch"]
+
+  # Mellanox Network Operator - read-only
+  - apiGroups: ["mellanox.com"]
+    resources:
+      - nicclusterpolicies
+    verbs: ["get", "list", "watch"]
+
+  # Kagenti - read-only
+  - apiGroups: ["agent.kagenti.dev"]
+    resources:
+      - agents
+      - agentbuilds
+      - agentcards
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["mcp.kagenti.com"]
+    resources:
+      - mcpservers
+    verbs: ["get", "list", "watch"]
+
+  # Console CRDs - full CRUD
+  - apiGroups: ["console.kubestellar.io"]
+    resources:
+      - managedworkloads
+      - managedworkloads/status
+      - clustergroups
+      - clustergroups/status
+      - workloaddeployments
+      - workloaddeployments/status
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Gateway API - read-only
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources:
+      - gateways
+      - httproutes
+    verbs: ["get", "list", "watch"]
+
+  # Multi-cluster services - read-only
+  - apiGroups: ["multicluster.x-k8s.io"]
+    resources:
+      - serviceexports
+      - serviceimports
+    verbs: ["get", "list", "watch"]

--- a/deploy/kustomize/base/clusterrolebinding.yaml
+++ b/deploy/kustomize/base/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubestellar-console
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubestellar-console
+subjects:
+  - kind: ServiceAccount
+    name: kubestellar-console
+    namespace: kubestellar-console

--- a/deploy/kustomize/base/cronjob-db-backup.yaml
+++ b/deploy/kustomize/base/cronjob-db-backup.yaml
@@ -1,0 +1,84 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kubestellar-console-db-backup
+spec:
+  schedule: "0 */6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: db-backup
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: kubestellar-console
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: db-backup
+              image: ghcr.io/kubestellar/console:0.3.29
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsGroup: 1001
+                runAsNonRoot: true
+                runAsUser: 1001
+                seccompProfile:
+                  type: RuntimeDefault
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+                  DB_PATH="/app/data/console.db"
+                  BACKUP_DIR="/backups"
+                  RETENTION=20
+
+                  mkdir -p "$BACKUP_DIR"
+
+                  # Use SQLite .backup for a consistent, WAL-safe snapshot
+                  if [ -f "$DB_PATH" ]; then
+                    sqlite3 "$DB_PATH" ".backup '$BACKUP_DIR/console-$TIMESTAMP.db'"
+                    echo "Backup created: $BACKUP_DIR/console-$TIMESTAMP.db"
+                  else
+                    echo "ERROR: Database file not found at $DB_PATH"
+                    exit 1
+                  fi
+
+                  # Prune old backups, keep only the most recent $RETENTION
+                  cd "$BACKUP_DIR"
+                  BACKUP_COUNT=$(ls -1 console-*.db 2>/dev/null | wc -l)
+                  if [ "$BACKUP_COUNT" -gt "$RETENTION" ]; then
+                    PRUNE_COUNT=$((BACKUP_COUNT - RETENTION))
+                    ls -1t console-*.db | tail -n "$PRUNE_COUNT" | xargs rm -f
+                    echo "Pruned $PRUNE_COUNT old backup(s), kept $RETENTION"
+                  fi
+              volumeMounts:
+                - name: data
+                  mountPath: /app/data
+                - name: backups
+                  mountPath: /backups
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: kubestellar-console
+            - name: backups
+              persistentVolumeClaim:
+                claimName: kubestellar-console-backups

--- a/deploy/kustomize/base/cronjob-db-backup.yaml
+++ b/deploy/kustomize/base/cronjob-db-backup.yaml
@@ -22,7 +22,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: db-backup
-              image: ghcr.io/kubestellar/console:0.3.29
+              image: ghcr.io/kubestellar/console:latest
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:

--- a/deploy/kustomize/base/deployment.yaml
+++ b/deploy/kustomize/base/deployment.yaml
@@ -1,0 +1,200 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubestellar-console
+spec:
+  replicas: 1
+  progressDeadlineSeconds: 900
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: server
+    spec:
+      serviceAccountName: kubestellar-console
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: db-restore
+          image: ghcr.io/kubestellar/console:0.3.29
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              DB_PATH="/app/data/console.db"
+              BACKUP_DIR="/backups"
+              # Schema-only DBs are <=200KB; anything larger has real data
+              MIN_DATA_SIZE=200000
+
+              # get_file_size: portable file size using stat (GNU/BSD) or wc -c fallback
+              get_file_size() {
+                stat -c%s "$1" 2>/dev/null || stat -f%z "$1" 2>/dev/null || wc -c < "$1" 2>/dev/null | tr -d ' ' || echo "0"
+              }
+
+              if [ -f "$DB_PATH" ]; then
+                DB_SIZE=$(get_file_size "$DB_PATH")
+                if [ "$DB_SIZE" -gt "$MIN_DATA_SIZE" ]; then
+                  echo "Database exists with data (${DB_SIZE} bytes), skipping restore"
+                  exit 0
+                fi
+                echo "Database exists but appears empty (${DB_SIZE} bytes)"
+              else
+                echo "No database file found at $DB_PATH"
+              fi
+
+              # Find the latest backup
+              LATEST=$(ls -1t "$BACKUP_DIR"/console-*.db 2>/dev/null | head -1)
+              if [ -z "$LATEST" ]; then
+                echo "No backups found in $BACKUP_DIR, starting fresh"
+                exit 0
+              fi
+
+              BACKUP_SIZE=$(get_file_size "$LATEST")
+              if [ "$BACKUP_SIZE" -le "$MIN_DATA_SIZE" ]; then
+                echo "Latest backup $LATEST is also empty (${BACKUP_SIZE} bytes), skipping"
+                exit 0
+              fi
+
+              echo "Restoring from backup: $LATEST (${BACKUP_SIZE} bytes)"
+              mkdir -p "$(dirname "$DB_PATH")"
+              cp "$LATEST" "${DB_PATH}.tmp" && mv "${DB_PATH}.tmp" "$DB_PATH"
+              echo "Restore complete"
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+            - name: backups
+              mountPath: /backups
+              readOnly: true
+      containers:
+        - name: kubestellar-console
+          image: ghcr.io/kubestellar/console:0.3.29
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          # Startup probe gives the watchdog reverse proxy time to initialize
+          # before liveness/readiness probes begin. Without this, the pod may
+          # enter CrashLoopBackOff on slow nodes.
+          startupProbe:
+            httpGet:
+              path: /watchdog/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /watchdog/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /watchdog/ready
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          env:
+            - name: PORT
+              value: "8080"
+            - name: BACKEND_PORT
+              value: "8081"
+            - name: DATABASE_PATH
+              value: /app/data/console.db
+            - name: KUBESTELLAR_OPS_PATH
+              value: /usr/local/bin/kubestellar-ops
+            - name: KUBESTELLAR_DEPLOY_PATH
+              value: /usr/local/bin/kubestellar-deploy
+            # Required in production mode. Create before applying:
+            #   kubectl -n kubestellar-console create secret generic \
+            #     kubestellar-console-jwt --from-literal=jwt-secret="$(openssl rand -base64 48)"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: kubestellar-console-jwt
+                  key: jwt-secret
+            # Suppress local kc-agent connections — in-cluster deployments
+            # accessed via port-forward or ingress have no local kc-agent
+            # on the user's machine. (#10267)
+            - name: NO_LOCAL_AGENT
+              value: "true"
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: AI_DEFAULT_MODE
+              value: medium
+            - name: AI_TOKEN_LIMITS_ENABLED
+              value: "true"
+            - name: AI_MONTHLY_TOKEN_LIMIT
+              value: "100000"
+            - name: AI_TOKEN_WARNING_THRESHOLD
+              value: "80"
+            - name: AI_TOKEN_CRITICAL_THRESHOLD
+              value: "95"
+            - name: SELF_UPGRADE_ENABLED
+              value: "true"
+          volumeMounts:
+            - name: kc-config
+              mountPath: /app/.kc
+            - name: tmp
+              mountPath: /tmp
+            - name: data
+              mountPath: /app/data
+      volumes:
+        - name: kc-config
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          persistentVolumeClaim:
+            claimName: kubestellar-console
+        - name: backups
+          persistentVolumeClaim:
+            claimName: kubestellar-console-backups

--- a/deploy/kustomize/base/deployment.yaml
+++ b/deploy/kustomize/base/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: db-restore
-          image: ghcr.io/kubestellar/console:0.3.29
+          image: ghcr.io/kubestellar/console:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -92,8 +92,8 @@ spec:
               readOnly: true
       containers:
         - name: kubestellar-console
-          image: ghcr.io/kubestellar/console:0.3.29
-          imagePullPolicy: IfNotPresent
+          image: ghcr.io/kubestellar/console:latest
+          imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/deploy/kustomize/base/kustomization.yaml
+++ b/deploy/kustomize/base/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kubestellar-console
+
+labels:
+  - includeSelectors: false
+    includeTemplates: true
+    pairs:
+      app.kubernetes.io/name: kubestellar-console
+      app.kubernetes.io/instance: kubestellar-console
+      app.kubernetes.io/part-of: kubestellar
+      owner: kubestellar
+
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+  - self-upgrade-role.yaml
+  - self-upgrade-rolebinding.yaml
+  - pvc.yaml
+  - pvc-backups.yaml
+  - service.yaml
+  - deployment.yaml
+  - cronjob-db-backup.yaml
+
+# Single place to bump the console version — keep in sync with
+# deploy/helm/kubestellar-console/Chart.yaml appVersion.
+images:
+  - name: ghcr.io/kubestellar/console
+    newTag: 0.3.29

--- a/deploy/kustomize/base/kustomization.yaml
+++ b/deploy/kustomize/base/kustomization.yaml
@@ -25,8 +25,11 @@ resources:
   - deployment.yaml
   - cronjob-db-backup.yaml
 
-# Single place to bump the console version — keep in sync with
-# deploy/helm/kubestellar-console/Chart.yaml appVersion.
+# Release channel. Every nightly/weekly release pushes the moving tags
+# `latest`, `nightly`, and `weekly` plus an immutable version tag
+# (see .github/workflows/release.yml docker-manifest job), so `latest`
+# stays current without any manifest changes here. Pin an immutable
+# vX.Y.Z[-nightly.DATE] tag in your own overlay for reproducible installs.
 images:
   - name: ghcr.io/kubestellar/console
-    newTag: 0.3.29
+    newTag: latest

--- a/deploy/kustomize/base/namespace.yaml
+++ b/deploy/kustomize/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubestellar-console

--- a/deploy/kustomize/base/pvc-backups.yaml
+++ b/deploy/kustomize/base/pvc-backups.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kubestellar-console-backups
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/kustomize/base/pvc.yaml
+++ b/deploy/kustomize/base/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kubestellar-console
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/kustomize/base/self-upgrade-role.yaml
+++ b/deploy/kustomize/base/self-upgrade-role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubestellar-console-self-upgrade
+rules:
+  # Patch own Deployment image tag to trigger a rolling update
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+    resourceNames:
+      - kubestellar-console
+    verbs: ["get", "list", "patch"]

--- a/deploy/kustomize/base/self-upgrade-rolebinding.yaml
+++ b/deploy/kustomize/base/self-upgrade-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubestellar-console-self-upgrade
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubestellar-console-self-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: kubestellar-console
+    namespace: kubestellar-console

--- a/deploy/kustomize/base/service.yaml
+++ b/deploy/kustomize/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubestellar-console
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/component: server

--- a/deploy/kustomize/base/serviceaccount.yaml
+++ b/deploy/kustomize/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubestellar-console
+automountServiceAccountToken: true

--- a/deploy/kustomize/overlays/openshift/kustomization.yaml
+++ b/deploy/kustomize/overlays/openshift/kustomization.yaml
@@ -1,0 +1,7 @@
+# OpenShift overlay — starter experience plus an edge-terminated Route.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../starter
+  - route.yaml

--- a/deploy/kustomize/overlays/openshift/kustomization.yaml
+++ b/deploy/kustomize/overlays/openshift/kustomization.yaml
@@ -2,6 +2,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# Overlay-added resources (route.yaml) do not inherit the base's
+# namespace transformer — declare it here too or the Route lands in
+# the caller's current kubectl namespace.
+namespace: kubestellar-console
+
 resources:
   - ../starter
   - route.yaml
+
+patches:
+  - path: patch-scc-deployment.yaml
+  - path: patch-scc-cronjob.yaml

--- a/deploy/kustomize/overlays/openshift/patch-scc-cronjob.yaml
+++ b/deploy/kustomize/overlays/openshift/patch-scc-cronjob.yaml
@@ -1,0 +1,15 @@
+# See patch-scc-deployment.yaml — same SCC UID-range constraint.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kubestellar-console-db-backup
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: db-backup
+              securityContext:
+                runAsUser: null
+                runAsGroup: null

--- a/deploy/kustomize/overlays/openshift/patch-scc-deployment.yaml
+++ b/deploy/kustomize/overlays/openshift/patch-scc-deployment.yaml
@@ -1,0 +1,21 @@
+# OpenShift's restricted-v2 SCC requires pod UIDs from the namespace's
+# assigned range (e.g. 1001980000/10000) and rejects the chart-default
+# runAsUser/runAsGroup 1001. Dropping them lets the SCC inject a valid
+# UID at admission (runAsNonRoot still enforced).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubestellar-console
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: db-restore
+          securityContext:
+            runAsUser: null
+            runAsGroup: null
+      containers:
+        - name: kubestellar-console
+          securityContext:
+            runAsUser: null
+            runAsGroup: null

--- a/deploy/kustomize/overlays/openshift/route.yaml
+++ b/deploy/kustomize/overlays/openshift/route.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kubestellar-console
+  annotations:
+    haproxy.router.openshift.io/timeout: 5m
+spec:
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  to:
+    kind: Service
+    name: kubestellar-console
+    weight: 100
+  wildcardPolicy: None

--- a/deploy/kustomize/overlays/starter/kustomization.yaml
+++ b/deploy/kustomize/overlays/starter/kustomization.yaml
@@ -1,0 +1,15 @@
+# Starter overlay — the curated out-of-the-box experience.
+#
+# Trims the sidebar to three core dashboards (Dashboard, Workloads, Nodes)
+# and skips the onboarding questionnaire, so a first-time user lands on a
+# simple, useful view of their cluster instead of the full catalog of
+# 60+ dashboards. Everything else stays one click away: users can add
+# dashboards and cards via the sidebar customizer and the Marketplace.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: patch-starter-env.yaml

--- a/deploy/kustomize/overlays/starter/patch-starter-env.yaml
+++ b/deploy/kustomize/overlays/starter/patch-starter-env.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubestellar-console
+spec:
+  template:
+    spec:
+      containers:
+        - name: kubestellar-console
+          env:
+            # Sidebar shows only these dashboards, in this order.
+            # Valid IDs: web/src/hooks/useSidebarConfig.ts
+            # (DEFAULT_PRIMARY_NAV + DISCOVERABLE_DASHBOARDS).
+            - name: ENABLED_DASHBOARDS
+              value: dashboard,workloads,nodes
+            # Land straight on the dashboard — no questionnaire.
+            - name: SKIP_ONBOARDING
+              value: "true"


### PR DESCRIPTION
## Summary

Adds \`deploy/kustomize/\` so the console installs on any cluster with **kubectl alone** — no Helm, no values files. Motivated by a Bluefin Server (Project Bluefin homelab) integration request where the OOTB experience must be: *go to this IP, it's KubeStellar, and it isn't overwhelming*.

- **\`base/\`** — full parity with the Helm chart's default-rendered resources (deployment + db-restore init container, service, read-mostly ClusterRole, self-upgrade Role, PVCs, 6-hourly SQLite backup CronJob)
- **\`overlays/starter\`** — the curated out-of-the-box experience: sidebar trimmed to **Dashboard, Workloads, Nodes** via \`ENABLED_DASHBOARDS\`, onboarding questionnaire skipped. Everything else remains one click away (sidebar customizer, Marketplace)
- **\`overlays/openshift\`** — starter + edge-terminated Route + SCC patches

Install is three commands:

```bash
kubectl create namespace kubestellar-console
kubectl -n kubestellar-console create secret generic kubestellar-console-jwt \
  --from-literal=jwt-secret="$(openssl rand -base64 48)"
kubectl apply -k 'https://github.com/kubestellar/console/deploy/kustomize/overlays/starter?ref=main'
```

## Design notes

- **JWT secret is user-created at install time** — the backend exits fatally in production mode without \`JWT_SECRET\`, and kustomize cannot generate random values, so no secret material ships in the repo.
- **Image rides the \`latest\` release channel** (\`images:\` transformer in \`base/kustomization.yaml\`). Every nightly/weekly release pushes \`latest\`/\`nightly\`/\`weekly\` moving tags plus an immutable version tag (release.yml docker-manifest job), so kustomize installs stay current with zero manifest bumps. \`:latest\` implies \`imagePullPolicy: Always\`. Chart.yaml's in-repo \`appVersion\` (0.3.29) was never published as an image tag, so pinning it would have shipped a broken install.
- **Self-upgrade still works** — the backend discovers its Deployment by the \`app.kubernetes.io/name\` label, not \`HELM_RELEASE_NAME\`.
- **OpenShift**: \`restricted-v2\` SCC rejects the chart-default \`runAsUser: 1001\` (must be in the namespace UID range). The overlay drops \`runAsUser\`/\`runAsGroup\` so admission assigns a valid UID. Note the Helm chart's \`--openshift\` path renders the same fixed UID and likely hits the same rejection on clusters without a custom SCC — filed separately.
- **Namespace transformer gotcha**: overlay-added resources don't inherit the base's \`namespace:\`, so the openshift overlay declares it explicitly (the Route otherwise lands in the caller's current kubectl namespace).

## Testing (both variants verified on live clusters)

**OpenShift 4.18 (fmaas vllm-d)** — \`overlays/openshift\` applied from the GitHub URL: all 12 resources created, PVCs bound (CephFS), pod Ready, \`/health\` returns \`enabled_dashboards: [dashboard, workloads, nodes]\`, Route serves the UI, sidebar shows exactly the three starter dashboards with no onboarding wizard (screenshot-verified via Playwright).

**Vanilla Kubernetes (fresh kind cluster)** — \`overlays/starter\` applied from the GitHub URL with the exact 3-command flow: pod Ready first try, PVCs bound, \`/health\` correct, \`/auth/github\` → 307 → \`localhost:8080/auth/callback?onboarded=true\` (matches the documented port-forward).

## Follow-ups (separate issues/PRs)

- Frontend routes in-cluster no-OAuth installs to demo mode and never uses the backend's working dev-login (\`web/src/lib/auth.tsx\` gates cookie-restore on \`oauthConfigured\`); live data currently requires the GitHub OAuth wizard.
- \`detectInstallMethod\` reports \`helm\` for any in-cluster install; could detect kustomize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)