### PR TITLE
🔒 sec: pin js-yaml via committed lockfile in scanner-merge-guardrails

### DIFF
--- a/.github/guardrails-scripts/package-lock.json
+++ b/.github/guardrails-scripts/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "guardrails-scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "guardrails-scripts",
+      "version": "1.0.0",
+      "dependencies": {
+        "js-yaml": "4.1.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    }
+  }
+}

--- a/.github/guardrails-scripts/package.json
+++ b/.github/guardrails-scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "guardrails-scripts",
+  "version": "1.0.0",
+  "description": "Dependencies for scanner-merge-guardrails.yml",
+  "private": true,
+  "dependencies": {
+    "js-yaml": "4.1.0"
+  }
+}

--- a/.github/workflows/scanner-merge-guardrails.yml
+++ b/.github/workflows/scanner-merge-guardrails.yml
@@ -24,7 +24,10 @@ jobs:
       - name: Install script dependencies
         # --ignore-scripts prevents postinstall/preinstall lifecycle hooks from executing
         # arbitrary code during npm install (supply-chain hardening, fixes #20483)
-        run: npm install --no-save --ignore-scripts js-yaml@4.1.0
+        working-directory: .github/guardrails-scripts
+        # Install from the committed lockfile (pinned, hashes verified) rather
+        # than resolving js-yaml at run time (Scorecard Pinned-Dependencies, #20483).
+        run: npm ci --ignore-scripts
         
       - name: Check Scanner Merge Eligibility
         id: check
@@ -32,7 +35,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const yaml = require('js-yaml');
+            const yaml = require('.github/guardrails-scripts/node_modules/js-yaml');
             
             // Load scanner config
             const configPath = '.github/scanner-config.yml';


### PR DESCRIPTION
Resolves the Scorecard **Pinned-Dependencies** alert (#20483) properly.

## What
- Adds `.github/guardrails-scripts/{package.json,package-lock.json}` (js-yaml 4.1.0, lockfileVersion 3, **valid** integrity hashes).
- Rewires the guardrails workflow to `npm ci --ignore-scripts` in that directory and requires js-yaml from its `node_modules` — so the dependency is installed from the committed, hash-verified lockfile instead of resolved at run time.

## Why this supersedes draft #20485
#20485 added the two lockfile files but (a) its committed `package-lock.json` had a **corrupt** js-yaml integrity hash — `npm ci` fails with EINTEGRITY — and (b) it never rewired the workflow, which still ran an unpinned `npm install js-yaml@4.1.0`, leaving the files unreferenced and the Scorecard alert unresolved.

## Verified locally
- `npm ci --ignore-scripts` → exit 0 with the regenerated lockfile.
- `require(...js-yaml)` resolves from the repo root via the explicit path.
- Integrity hash corrected (`…WvRA==`, vs #20485's corrupt `…WvQ==`).

Fixes #20483

🤖 Generated with [Claude Code](https://claude.com/claude-code)