### PR TITLE
[scanner] fix: omit runAsUser on openshift path (#20824)

### DIFF
--- a/deploy/helm/kubestellar-console/README.md
+++ b/deploy/helm/kubestellar-console/README.md
@@ -452,14 +452,23 @@ The chart default (`runAsUser: 1001`) is correct for Kind/Minikube but
 breaks OpenShift silently — the helm upgrade rolls back with no
 container-level error message.
 
-Fix: null out just the UID/GID numbers so SCC can inject its own values
+Fix: use the bundled `values-openshift.yaml` overlay, which already nulls out
+`runAsUser`, `runAsGroup`, and `fsGroup` so the SCC can inject its own values
 while keeping `runAsNonRoot: true` intact (PodSecurity `restricted` still
 requires it — see [#6353](https://github.com/kubestellar/console/issues/6353)):
 
 ```bash
 helm upgrade kc ./deploy/helm/kubestellar-console -n kubestellar-console \
+  -f deploy/helm/kubestellar-console/values-openshift.yaml
+```
+
+If you are not using the overlay file, you can also null the fields manually:
+
+```bash
+helm upgrade kc ./deploy/helm/kubestellar-console -n kubestellar-console \
   --set securityContext.runAsUser=null \
-  --set securityContext.runAsGroup=null
+  --set securityContext.runAsGroup=null \
+  --set podSecurityContext.fsGroup=null
 ```
 
 ### `container has runAsNonRoot and image has non-numeric user (appuser)`

--- a/deploy/helm/kubestellar-console/values-openshift.yaml
+++ b/deploy/helm/kubestellar-console/values-openshift.yaml
@@ -12,10 +12,22 @@ route:
     insecureEdgeTerminationPolicy: Redirect
 
 # OpenShift SCC requirements
+# OpenShift's restricted-v2 SCC assigns UIDs from the namespace's range
+# (e.g. 1001980000/10000) and rejects any pod that pins runAsUser/runAsGroup
+# outside that range. Setting these to null drops them from the merged values
+# so the SCC can inject a valid UID at admission. runAsNonRoot: true is kept
+# so PodSecurity "restricted" enforcement is still satisfied.
+# fsGroup: null is likewise required — the SCC rejects fsGroups outside the
+# namespace's supplemental-groups range, but assigns an in-range value itself.
 podSecurityContext:
+  fsGroup: null
   runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
+  runAsUser: null
+  runAsGroup: null
   allowPrivilegeEscalation: false
   capabilities:
     drop:


### PR DESCRIPTION
Fixes #20824

## Problem

The `values-openshift.yaml` Helm overlay did not override `securityContext.runAsUser`, `securityContext.runAsGroup`, or `podSecurityContext.fsGroup`. Because Helm performs a deep merge, the defaults from `values.yaml` (`runAsUser: 1001`, `runAsGroup: 1001`, `fsGroup: 1001`) were carried through when deploying with `-f values-openshift.yaml`.

OpenShift's `restricted-v2` SCC assigns UIDs from the namespace's allocated range (e.g. `1001980000/10000`) and rejects pods that pin `runAsUser` outside that range. This caused pods to be rejected at admission with no container-level error message.

## Fix

Set `runAsUser: null`, `runAsGroup: null` in `securityContext` and `fsGroup: null` in `podSecurityContext` inside `values-openshift.yaml`. This mirrors the existing kustomize OpenShift overlay (`deploy/kustomize/overlays/openshift/patch-scc-deployment.yaml`) and the guidance already documented in the README.

Also update the README troubleshooting section to prefer the `values-openshift.yaml` approach over manual `--set` flags.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>