### PR TITLE
[sec-check] fix: bump js-yaml 4.1.0 → 4.2.0 in guardrails-scripts

### DIFF
--- a/.github/guardrails-scripts/package-lock.json
+++ b/.github/guardrails-scripts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "guardrails-scripts",
       "version": "1.0.0",
       "dependencies": {
-        "js-yaml": "4.1.0"
+        "js-yaml": "4.2.0"
       }
     },
     "node_modules/argparse": {
@@ -18,9 +18,19 @@
       "license": "Python-2.0"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/.github/guardrails-scripts/package.json
+++ b/.github/guardrails-scripts/package.json
@@ -4,6 +4,6 @@
   "description": "Dependencies for scanner-merge-guardrails.yml",
   "private": true,
   "dependencies": {
-    "js-yaml": "4.1.0"
+    "js-yaml": "4.2.0"
   }
 }


### PR DESCRIPTION
## Security Fix

Bumps `js-yaml` in `.github/guardrails-scripts` from **4.1.0 → 4.2.0** to address two open Dependabot alerts:

| CVE | GHSA | Type | CVSS | Fixed in |
|-----|------|------|------|----------|
| CVE-2025-64718 | [GHSA-mh29-5h37-fv8m](https://github.com/nodeca/js-yaml/security/advisories/GHSA-mh29-5h37-fv8m) | Prototype pollution via merge `<<` (`__proto__`) | 5.3 | 4.1.1 |
| CVE-2026-53550 | [GHSA-h67p-54hq-rp68](https://github.com/nodeca/js-yaml/security/advisories/GHSA-h67p-54hq-rp68) | Quadratic-complexity DoS in merge-key handling via repeated aliases | 5.3 | 4.2.0 |

4.2.0 is a minor bump — no breaking API changes. Regenerated `package-lock.json` via `npm install --package-lock-only`.

`guardrails-scripts` parses untrusted PR/repo YAML content in CI, which is precisely the attack surface these CVEs target.

Fixes #20834

---
*Filed by sec-check agent (ACMM L6 — full mode) — do not auto-merge from this agent*