### PR TITLE
[scanner] fix: refresh icon animation consistency (#20826)

### DIFF
--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -17054,7 +17054,7 @@
   {
     "file": "src/lib/dashboards/DashboardComponents.tsx",
     "rule": "no-restricted-syntax",
-    "line": 237,
+    "line": 238,
     "column": 15,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },

--- a/web/src/lib/dashboards/DashboardComponents.tsx
+++ b/web/src/lib/dashboards/DashboardComponents.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { GripVertical, Plus, LayoutGrid, ChevronDown, ChevronRight, RefreshCw, Hourglass, AlertTriangle } from 'lucide-react'
+import { cn } from '@/lib/cn'
 import { getIcon } from '../icons'
 import { DashboardCard } from './types'
 import { CardWrapper } from '../../components/cards/CardWrapper'
@@ -250,7 +251,7 @@ export function DashboardHeader({
               className="p-2 rounded-lg hover:bg-secondary transition-colors disabled:opacity-50"
               title="Refresh data"
             >
-              <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} />
+              <RefreshCw className={cn('w-4 h-4', isFetching && 'animate-spin')} />
             </button>
           )}
           {extra}

--- a/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
+++ b/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { Activity, RefreshCw, Plus, ExternalLink } from 'lucide-react'
+import { cn } from '@/lib/cn'
 import { Button } from '../../../components/ui/Button'
 import { AgentIcon } from '../../../components/agent/AgentIcon'
 import type {
@@ -468,7 +469,7 @@ export function UnifiedDashboard({
               className="p-2"
               title="Refresh"
               icon={<RefreshCw
-                className={`w-4 h-4 text-muted-foreground ${isLoading ? 'animate-spin' : ''}`}
+                className={cn('w-4 h-4 text-muted-foreground', isLoading && 'animate-spin')}
               />}
             />
           )}


### PR DESCRIPTION
Fixes #20826

Replaces #20833 which had CI failures.

Normalize `RefreshCw` conditional `animate-spin` className construction to use `cn()` helper in lib-level dashboard components, matching the canonical pattern already established in `CardToolbar` and other card components.

**Changes:**
- `lib/unified/dashboard/UnifiedDashboard.tsx`: replace template-literal conditional with `cn('w-4 h-4 text-muted-foreground', isLoading && 'animate-spin')`
- `lib/dashboards/DashboardComponents.tsx`: replace template-literal conditional with `cn('w-4 h-4', isFetching && 'animate-spin')`
- `web/.eslint-baseline.json`: update line-number fingerprint for pre-existing `<input>` violation (237→238 after new import shifts lines), preventing spurious `build-gate` CI failure

**Root cause of #20833 CI failure:**
The lint baseline check tracks violations by `file:line:column:rule`. Adding `import { cn }` at line 6 of `DashboardComponents.tsx` shifted all subsequent line numbers by 1, causing the pre-existing `<input>` violation at line 237 to appear as a "new" violation at line 238. Fix: update the baseline to reflect the new line number.