### PR TITLE
[scanner] fix: groundtruth harness child_process default export

### DIFF
--- a/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
+++ b/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
@@ -13,6 +13,7 @@ const { mockExecFileSync, mockWriteFileSync, mockMkdirSync, mockMkdtempSync, moc
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,
+  default: { execFileSync: mockExecFileSync },
 }))
 
 vi.mock('node:fs', () => ({

--- a/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
+++ b/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
@@ -11,10 +11,8 @@ const { mockExecFileSync, mockWriteFileSync, mockMkdirSync, mockMkdtempSync, moc
 
 vi.mock('node:child_process', async () => {
   const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process')
-  return {
-    ...actual,
-    execFileSync: mockExecFileSync,
-  }
+  const mocked = { ...actual, execFileSync: mockExecFileSync }
+  return { ...mocked, default: mocked }
 })
 
 vi.mock('node:fs', async () => {


### PR DESCRIPTION
Fixes #20836

Add `default` export to the `vi.mock('node:child_process')` factories in both test files so CJS interop works correctly in vitest.

Without a `default` export in the mock factory, vitest cannot resolve the module for code that uses CJS interop patterns, causing ~18 test failures across `collectK8sGroundTruth` and `liveFixtureManager` test suites.

**Files changed:**
- `web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts` — added `default: { execFileSync: mockExecFileSync }` to static factory
- `web/harness/groundtruth/__tests__/liveFixtureManager.test.ts` — collapsed result into `mocked` and returned `{ ...mocked, default: mocked }`