### PR TITLE
[scanner] fix: missions dialog crash on open

### DIFF
--- a/web/src/components/missions/ConfirmMissionPromptDialog.tsx
+++ b/web/src/components/missions/ConfirmMissionPromptDialog.tsx
@@ -58,7 +58,7 @@ export function ConfirmMissionPromptDialog({
   // `{pending && <ConfirmMissionPromptDialog ... />}`) so a new instance
   // is created for each pending mission. That means a lazy `useState`
   // initializer is enough — we never need to sync with changing props.
-  const [prompt, setPrompt] = useState<string>(() => initialPrompt)
+  const [prompt, setPrompt] = useState<string>(() => initialPrompt ?? '')
 
   const trimmed = prompt.trim()
   const confirmDisabled = trimmed.length === 0

--- a/web/src/components/missions/ImproveMissionDialog.tsx
+++ b/web/src/components/missions/ImproveMissionDialog.tsx
@@ -98,10 +98,13 @@ export function ImproveMissionDialog({
   ]
 
   const handleSubmit = () => {
+    if (!mission) return
     const url = buildIssueUrl(mission, selectedCategory || 'other', activeSection, details)
     window.open(url, '_blank', 'noopener,noreferrer')
     onClose()
   }
+
+  if (!mission) return null
 
   return (
     <BaseModal isOpen={isOpen} onClose={onClose} size="sm" closeOnBackdrop={false} closeOnEscape={true}>

--- a/web/src/components/missions/MissionContentContext.tsx
+++ b/web/src/components/missions/MissionContentContext.tsx
@@ -113,3 +113,6 @@ export function useMissionContentContext(): MissionContentContextValue {
   }
   return context
 }
+
+/** Alias for backward-compatibility and convenience. */
+export const useMissionContent = useMissionContentContext

--- a/web/src/components/missions/MissionDialogs.test.tsx
+++ b/web/src/components/missions/MissionDialogs.test.tsx
@@ -45,11 +45,12 @@ describe('ConfirmMissionPromptDialog', () => {
     const { ConfirmMissionPromptDialog } = await import('./ConfirmMissionPromptDialog')
     const { container } = render(
       <ConfirmMissionPromptDialog
-        isOpen={true}
-        onClose={vi.fn()}
+        open={true}
+        missionTitle="Confirm"
+        missionDescription="Are you sure?"
+        initialPrompt=""
+        onCancel={vi.fn()}
         onConfirm={vi.fn()}
-        title="Confirm"
-        description="Are you sure?"
       />
     )
     expect(container).toBeTruthy()
@@ -63,8 +64,12 @@ describe('ImproveMissionDialog', () => {
       <ImproveMissionDialog
         isOpen={true}
         onClose={vi.fn()}
-        onSubmit={vi.fn()}
-        missionTitle="Test Mission"
+        mission={{
+          title: 'Test Mission',
+          version: '1.0.0',
+          type: 'install',
+          steps: [],
+        } as import('../../lib/missions/types').MissionExport}
       />
     )
     expect(container).toBeTruthy()


### PR DESCRIPTION
Fixes #20839

## Root causes fixed

1. **Missing `useMissionContent` export** — `MissionContentContext` only exported `useMissionContentContext`; added `useMissionContent` as an alias so existing consumers and tests don't break.

2. **`ConfirmMissionPromptDialog` crash** — `initialPrompt` typed as `string` (required) but rendered without it in tests; `prompt.trim()` crashed on `undefined`. Added `?? ''` fallback in `useState` initializer.

3. **`ImproveMissionDialog` crash** — `mission` prop is required (`MissionExport`) but test passed wrong props (no `mission` object). Added early-return guard and `handleSubmit` guard for `mission === undefined/null`.

4. **`MissionDialogs.test.tsx` wrong props** — fixed `ConfirmMissionPromptDialog` test to use `open`/`missionTitle`/`missionDescription`/`initialPrompt`/`onCancel` (correct API), and `ImproveMissionDialog` test to pass a proper `mission` object instead of `missionTitle`/`onSubmit`.