### PR TITLE
[scanner] fix: useNamespaces/Teams data.map guard

### DIFF
--- a/web/src/components/namespaces/GrantAccessModal.tsx
+++ b/web/src/components/namespaces/GrantAccessModal.tsx
@@ -57,13 +57,13 @@ export function GrantAccessModal({ namespace, existingAccess, onClose, onGranted
 
   // Filter out subjects that already have access
   const existingSubjectNames = new Set(
-    existingAccess
+    (Array.isArray(existingAccess) ? existingAccess : [])
       .filter(e => e.subjectKind === subjectKind)
       .map(e => e.subjectName)
   )
 
   const subjectSource = subjectKind === 'Team' 
-    ? teams.map(t => t.name) 
+    ? (Array.isArray(teams) ? teams.map(t => t.name) : [])
     : COMMON_SUBJECTS[subjectKind];
 
   const availableSubjects = (subjectSource || []).filter(

--- a/web/src/hooks/mcp/namespaces.ts
+++ b/web/src/hooks/mcp/namespaces.ts
@@ -102,7 +102,7 @@ export function useNamespaces(cluster?: string, forceLive = false) {
 
         if (response.ok) {
           const data = await response.json()
-          const nsData = data.namespaces || []
+          const nsData = Array.isArray(data.namespaces) ? data.namespaces : []
           if (nsData.length > 0) {
             // Extract just the namespace names
             const nsNames = nsData.map((ns: { name?: string; Name?: string }) => ns.name || ns.Name || '').filter(Boolean)
@@ -154,7 +154,7 @@ export function useNamespaces(cluster?: string, forceLive = false) {
       })
       if (resp.ok) {
         const data = await resp.json()
-        const nsNames = (data || []).map((ns: { name?: string; Name?: string }) => ns.name || ns.Name || '').filter(Boolean)
+        const nsNames = (Array.isArray(data) ? data : []).map((ns: { name?: string; Name?: string }) => ns.name || ns.Name || '').filter(Boolean)
         if (nsNames.length > 0) {
           setNamespaces(mergeWithClusterCache(nsNames, cluster))
           setError(null)


### PR DESCRIPTION
Fixes #20838

Guards `data.map(...)` calls in `useNamespaces` and Teams against non-array API responses.

**Root cause:** `(data || []).map(...)` fails when the backend returns a truthy non-array JSON value (e.g. `{error: "..."}` or `{namespaces: [...]}`), because `{} || []` evaluates to the object itself which has no `.map()` method.

**Changes:**
- `namespaces.ts` tier-1: replace `data.namespaces || []` with `Array.isArray(data.namespaces) ? data.namespaces : []`
- `namespaces.ts` tier-3: change `(data || []).map(...)` to `(Array.isArray(data) ? data : []).map(...)`
- `GrantAccessModal.tsx` (Teams): guard `existingAccess.filter/map` chain and `teams.map` with `Array.isArray` checks