### PR TITLE
[scanner] fix: mission-page unit-test regressions

### DIFF
--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -9508,126 +9508,126 @@
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 92,
+    "line": 85,
     "column": 3,
     "message": "'REFRESH_INTERVAL_MS' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 93,
+    "line": 86,
     "column": 3,
     "message": "'CLUSTER_POLL_INTERVAL_MS' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 94,
+    "line": 87,
     "column": 3,
     "message": "'GPU_POLL_INTERVAL_MS' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 95,
+    "line": 88,
     "column": 3,
     "message": "'CACHE_TTL_MS' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 96,
+    "line": 89,
     "column": 3,
     "message": "'MIN_REFRESH_INDICATOR_MS' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 97,
+    "line": 90,
     "column": 3,
     "message": "'getLocalAgentURL' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 99,
+    "line": 92,
     "column": 3,
     "message": "'getEffectiveInterval' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 102,
+    "line": 95,
     "column": 3,
     "message": "'shouldMarkOffline' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 103,
+    "line": 96,
     "column": 3,
     "message": "'recordClusterFailure' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 105,
+    "line": 98,
     "column": 3,
     "message": "'clusterDisplayName' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 106,
+    "line": 99,
     "column": 3,
     "message": "'fetchWithRetry' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 115,
+    "line": 108,
     "column": 3,
     "message": "'notifyClusterSubscribers' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 116,
+    "line": 109,
     "column": 3,
     "message": "'notifyClusterSubscribersDebounced' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 119,
+    "line": 112,
     "column": 3,
     "message": "'setInitialFetchStarted' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 122,
+    "line": 115,
     "column": 3,
     "message": "'initialFetchStarted' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 123,
+    "line": 116,
     "column": 3,
     "message": "'healthCheckFailures' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 128,
+    "line": 121,
     "column": 3,
     "message": "'clusterCacheRef' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 129,
+    "line": 122,
     "column": 3,
     "message": "'subscribeClusterCache' is defined but never used. Allowed unused vars must match /^_/u."
   },

--- a/web/src/components/missions/MissionLandingPage.test.tsx
+++ b/web/src/components/missions/MissionLandingPage.test.tsx
@@ -12,6 +12,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn(),
+  useParams: () => ({}),
 }))
 
 vi.mock('../../hooks/useDemoMode', () => ({


### PR DESCRIPTION
Fixes #20856

The `MissionLandingPage.test.tsx` mocked `react-router-dom` with only `useNavigate`, but `MissionLandingPage` also calls `useParams()`. Without the mock, vitest throws `TypeError: useParams is not a function`, causing the render to fail.

Fix: add `useParams: () => ({})` to the existing `react-router-dom` mock, matching the pattern used in other test files in the same directory.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>