### PR TITLE
[scanner] fix: teams unit-test regressions

### DIFF
--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -7317,28 +7317,28 @@
   {
     "file": "src/components/teams/TeamAccessGrants.tsx",
     "rule": "no-restricted-syntax",
-    "line": 172,
+    "line": 173,
     "column": 19,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/teams/TeamAccessGrants.tsx",
     "rule": "no-restricted-syntax",
-    "line": 183,
+    "line": 185,
     "column": 19,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/teams/TeamAccessGrants.tsx",
     "rule": "no-restricted-syntax",
-    "line": 196,
+    "line": 198,
     "column": 19,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/teams/TeamAccessGrants.tsx",
     "rule": "no-restricted-syntax",
-    "line": 210,
+    "line": 213,
     "column": 17,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },

--- a/web/src/components/teams/TeamAccessGrants.tsx
+++ b/web/src/components/teams/TeamAccessGrants.tsx
@@ -155,8 +155,9 @@ export function TeamAccessGrants({ teamName, grants, onGrantChanged }: TeamAcces
             )}
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">{t('teams.scope')}</label>
+                <label htmlFor="grant-scope-select" className="block text-sm font-medium text-muted-foreground mb-1">{t('teams.scope')}</label>
                 <select
+                  id="grant-scope-select"
                   value={scope}
                   onChange={e => setScope(e.target.value as 'namespace' | 'cluster')}
                   className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-white"
@@ -167,9 +168,10 @@ export function TeamAccessGrants({ teamName, grants, onGrantChanged }: TeamAcces
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">{t('teams.cluster')}</label>
+                <label htmlFor="grant-cluster-select" className="block text-sm font-medium text-muted-foreground mb-1">{t('teams.cluster')}</label>
                 <div className="flex items-center gap-2">
                   <select
+                    id="grant-cluster-select"
                     value={selectedCluster}
                     onChange={e => setSelectedCluster(e.target.value)}
                     className="flex-1 px-3 py-2 rounded-lg bg-secondary border border-border text-white"
@@ -192,8 +194,9 @@ export function TeamAccessGrants({ teamName, grants, onGrantChanged }: TeamAcces
 
               {scope === 'namespace' && !applyToAll && (
                 <div>
-                  <label className="block text-sm font-medium text-muted-foreground mb-1">{t('teams.namespace')}</label>
+                  <label htmlFor="grant-namespace-select" className="block text-sm font-medium text-muted-foreground mb-1">{t('teams.namespace')}</label>
                   <select
+                    id="grant-namespace-select"
                     value={selectedNamespace}
                     onChange={e => setSelectedNamespace(e.target.value)}
                     disabled={!selectedCluster}
@@ -206,8 +209,9 @@ export function TeamAccessGrants({ teamName, grants, onGrantChanged }: TeamAcces
               )}
 
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">{t('common.role')}</label>
+                <label htmlFor="grant-role-select" className="block text-sm font-medium text-muted-foreground mb-1">{t('common.role')}</label>
                 <select
+                  id="grant-role-select"
                   value={role}
                   onChange={e => setRole(e.target.value)}
                   className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-white"

--- a/web/src/components/teams/TeamDetail.tsx
+++ b/web/src/components/teams/TeamDetail.tsx
@@ -29,8 +29,9 @@ export function TeamDetail({ team, onBack, onUpdateTeam: _onUpdateTeam, onDelete
   return (
     <div>
       <div className="flex items-center gap-2 mb-4">
-        <button onClick={onBack} className="p-1 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors">
+        <button onClick={onBack} className="flex items-center gap-1 px-2 py-1 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors text-sm">
           <ArrowLeft className="w-4 h-4" />
+          {t('common.back')}
         </button>
         <div className="flex-1">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
Fixes #20855

## Changes

### `web/src/components/teams/TeamDetail.tsx`
- Add `{t('common.back')}` text to the back button alongside the `ArrowLeft` icon, so the test assertion `screen.getByText('Back')` can find it. The `'common.back'` translation key was already present in the test mock.

### `web/src/components/teams/TeamAccessGrants.tsx`
- Add `htmlFor`/`id` pairs to all label-select elements in the grant access modal (`grant-scope-select`, `grant-cluster-select`, `grant-namespace-select`, `grant-role-select`), so `getByRole('combobox', { name: /teams.cluster/i })` resolves the correct element via ARIA accessible-name computation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>