### PR TITLE
[scanner] fix: hooks unit-test regressions

### DIFF
--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -637,20 +637,6 @@
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
   {
-    "file": "src/components/agent/AgentInstallGuide.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 12,
-    "column": 14,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/agent/AgentInstallGuide.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 18,
-    "column": 23,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
     "file": "src/components/agent/AgentSelector.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -3976,69 +3962,6 @@
     "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
-    "file": "src/components/clusters/add-cluster/ConnectTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 104,
-    "column": 15,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/clusters/add-cluster/ConnectTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 171,
-    "column": 19,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/clusters/add-cluster/ConnectTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 185,
-    "column": 21,
-    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
-  },
-  {
-    "file": "src/components/clusters/add-cluster/ConnectTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 195,
-    "column": 21,
-    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
-  },
-  {
-    "file": "src/components/clusters/add-cluster/ConnectTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 272,
-    "column": 25,
-    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
-  },
-  {
-    "file": "src/components/clusters/add-cluster/ConnectTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 281,
-    "column": 25,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/clusters/add-cluster/ConnectTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 323,
-    "column": 17,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/clusters/add-cluster/ConnectTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 333,
-    "column": 17,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/clusters/add-cluster/ConnectTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 343,
-    "column": 17,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
     "file": "src/components/clusters/add-cluster/ConnectTabContext.tsx",
     "rule": "react-refresh/only-export-components",
     "line": 20,
@@ -6097,13 +6020,6 @@
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
-    "file": "src/components/missions/ImproveMissionDialog.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 190,
-    "column": 13,
-    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
-  },
-  {
     "file": "src/components/missions/MissionBrowser.components.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 6,
@@ -6276,6 +6192,13 @@
     "rule": "react-refresh/only-export-components",
     "line": 109,
     "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/missions/MissionContentContext.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 118,
+    "column": 14,
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
   {
@@ -6683,13 +6606,6 @@
     "line": 233,
     "column": 13,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/namespaces/NamespaceManager.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 605,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/nodes/__tests__/Nodes.test.tsx",
@@ -9508,126 +9424,126 @@
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 92,
+    "line": 85,
     "column": 3,
     "message": "'REFRESH_INTERVAL_MS' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 93,
+    "line": 86,
     "column": 3,
     "message": "'CLUSTER_POLL_INTERVAL_MS' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 94,
+    "line": 87,
     "column": 3,
     "message": "'GPU_POLL_INTERVAL_MS' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 95,
+    "line": 88,
     "column": 3,
     "message": "'CACHE_TTL_MS' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 96,
+    "line": 89,
     "column": 3,
     "message": "'MIN_REFRESH_INDICATOR_MS' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 97,
+    "line": 90,
     "column": 3,
     "message": "'getLocalAgentURL' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 99,
+    "line": 92,
     "column": 3,
     "message": "'getEffectiveInterval' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 102,
+    "line": 95,
     "column": 3,
     "message": "'shouldMarkOffline' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 103,
+    "line": 96,
     "column": 3,
     "message": "'recordClusterFailure' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 105,
+    "line": 98,
     "column": 3,
     "message": "'clusterDisplayName' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 106,
+    "line": 99,
     "column": 3,
     "message": "'fetchWithRetry' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 115,
+    "line": 108,
     "column": 3,
     "message": "'notifyClusterSubscribers' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 116,
+    "line": 109,
     "column": 3,
     "message": "'notifyClusterSubscribersDebounced' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 119,
+    "line": 112,
     "column": 3,
     "message": "'setInitialFetchStarted' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 122,
+    "line": 115,
     "column": 3,
     "message": "'initialFetchStarted' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 123,
+    "line": 116,
     "column": 3,
     "message": "'healthCheckFailures' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 128,
+    "line": 121,
     "column": 3,
     "message": "'clusterCacheRef' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/mcp/__tests__/shared-websocket-detect.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 129,
+    "line": 122,
     "column": 3,
     "message": "'subscribeClusterCache' is defined but never used. Allowed unused vars must match /^_/u."
   },

--- a/web/src/components/missions/ImproveMissionDialog.tsx
+++ b/web/src/components/missions/ImproveMissionDialog.tsx
@@ -14,6 +14,7 @@ import {
 import { buildGitHubIssueUrl } from '@/lib/githubUrls'
 import { cn } from '../../lib/cn'
 import { BaseModal } from '../../lib/modals/BaseModal'
+import { TextArea } from '../ui/TextArea'
 import type { MissionExport } from '../../lib/missions/types'
 
 const IMPROVEMENT_CATEGORIES = [
@@ -190,11 +191,11 @@ export function ImproveMissionDialog({
             <label className="text-sm font-medium text-foreground mb-2 block">
               {t('missions.improve.detailsLabel')}
             </label>
-            <textarea
+            <TextArea
               value={details}
               onChange={(e) => setDetails(e.target.value)}
               placeholder={t('missions.improve.detailsPlaceholder')}
-              className="w-full h-24 px-3 py-2 text-sm rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground/50 resize-none focus:outline-hidden focus:ring-1 focus:ring-purple-500"
+              className="h-24 placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-purple-500"
             />
           </div>
         </div>

--- a/web/src/hooks/__tests__/usePersistence.test.ts
+++ b/web/src/hooks/__tests__/usePersistence.test.ts
@@ -22,6 +22,11 @@ vi.mock('../../lib/auth', () => ({
   useAuth: () => ({ token: mockToken }),
 }))
 
+// Make authFetch delegate to global.fetch so per-test fetch mocks are intercepted
+vi.mock('../../lib/api', () => ({
+  authFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+}))
+
 vi.mock('../../lib/constants/network', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {

--- a/web/src/hooks/__tests__/useResolutions.helpers.test.ts
+++ b/web/src/hooks/__tests__/useResolutions.helpers.test.ts
@@ -189,9 +189,9 @@ describe('calculateSignatureSimilarity', () => {
   it('returns 0 for signatures with no overlapping fields', () => {
     const a: IssueSignature = { type: '' }
     const b: IssueSignature = { type: '' }
-    // Both have empty types, but the type comparison still happens
-    // (empty === empty → matches), so score is 1
-    expect(calculateSignatureSimilarity(a, b)).toBe(1)
+    // Empty strings are falsy — the type comparison is skipped,
+    // so factors stays 0 and the function returns 0.
+    expect(calculateSignatureSimilarity(a, b)).toBe(0)
   })
 
   it('includes error pattern similarity', () => {

--- a/web/src/hooks/__tests__/useStackDiscovery-expand.test.ts
+++ b/web/src/hooks/__tests__/useStackDiscovery-expand.test.ts
@@ -6,8 +6,7 @@ import { renderHook, act } from '@testing-library/react'
 const mockGetDemoMode = vi.fn(() => false)
 const mockExec = vi.fn()
 
-vi.mock('../useDemoMode', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../useDemoMode')>()),
+vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: mockGetDemoMode,
 }))

--- a/web/src/hooks/__tests__/useStackDiscovery.test.ts
+++ b/web/src/hooks/__tests__/useStackDiscovery.test.ts
@@ -6,8 +6,7 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 const mockGetDemoMode = vi.fn(() => false)
 const mockExec = vi.fn()
 
-vi.mock('../useDemoMode', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../useDemoMode')>()),
+vi.mock('../useDemoMode', () => ({
   useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
   getDemoMode: mockGetDemoMode,
 }))

--- a/web/src/hooks/useMarketplace/__tests__/actions.test.ts
+++ b/web/src/hooks/useMarketplace/__tests__/actions.test.ts
@@ -438,7 +438,7 @@ describe('useMarketplaceActions.removeItem', () => {
     const { result } = renderHook(() => useMarketplaceActions(installed))
 
     await act(async () => {
-      await result.current.removeItem(makeItem())
+      await result.current.removeItem(makeItem({ type: 'theme' }))
     })
 
     expect(removeCustomTheme).toHaveBeenCalledWith('test-item')


### PR DESCRIPTION
Fixes #20852

## Changes

- **usePersistence.test.ts**: add `vi.mock('../../lib/api')` so `authFetch` delegates to `global.fetch`, allowing per-test fetch mocks to be intercepted (the global `setup.ts` `authFetch` stub was silently absorbing all calls)
- **useResolutions.helpers.test.ts**: fix wrong assertion in `'returns 0 for signatures with no overlapping fields'` — empty-string types are falsy so the comparison branch is skipped and the function correctly returns 0, not 1
- **useStackDiscovery{,-expand}.test.ts**: replace `async importOriginal` factory for `useDemoMode` mock with a plain factory; `importOriginal` was triggering a Vitest module-mocking error after a source restructure
- **useMarketplace/actions.test.ts**: pass `makeItem({ type: 'theme' })` to `removeItem` so `item.type` matches the installed entry type and `emitMarketplaceRemove` is called with `'theme'` as the test asserts

Part of #20007