### PR TITLE
[scanner] fix: namespace unit-test regressions

### DIFF
--- a/web/src/components/namespaces/__tests__/NamespaceFilterBar.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceFilterBar.test.tsx
@@ -77,7 +77,7 @@ describe('NamespaceFilterBar', () => {
     await userEvent.type(searchInput, 'my-app')
 
     expect(mockOnSearchChange).toHaveBeenCalledTimes(6) // "m", "y", "-", "a", "p", "p"
-    expect(mockOnSearchChange).toHaveBeenLastCalledWith('my-app')
+    expect(mockOnSearchChange).toHaveBeenLastCalledWith('p')
   })
 
   it('renders group-by toggle buttons', () => {

--- a/web/src/components/namespaces/__tests__/NamespaceFilterBar.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceFilterBar.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { render, screen } from '@testing-library/react'

--- a/web/src/components/namespaces/__tests__/NamespaceManager.auth.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceManager.auth.test.tsx
@@ -16,6 +16,15 @@ vi.mock('../../../hooks/mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
+vi.mock('../../../lib/api', () => ({
+  authFetch: async (url: RequestInfo | URL, init?: RequestInit) => {
+    const token = localStorage.getItem('token')
+    const headers = new Headers(init?.headers)
+    if (token) headers.set('Authorization', `Bearer ${token}`)
+    return globalThis.fetch(url, { ...init, headers })
+  },
+}))
+
 vi.mock('../../../hooks/useMCP', () => ({
   useClusters: () => mockUseClusters(),
 }))
@@ -34,6 +43,10 @@ vi.mock('../../../lib/modals', () => ({
 
 vi.mock('../../../components/ui/Toast', () => ({
   useToast: () => ({ showToast: vi.fn() }),
+}))
+
+vi.mock('../../../lib/auth', () => ({
+  useAuth: () => ({ user: null }),
 }))
 
 vi.mock('react-i18next', () => ({
@@ -93,7 +106,6 @@ describe('NamespaceManager auth and offline handling', () => {
   it('falls back to the backend when the local agent rejects the first namespace request', async () => {
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 'dev-user' }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify([
         {
           name: 'team-a',
@@ -121,9 +133,6 @@ describe('NamespaceManager auth and offline handling', () => {
     expect(agentCallHeaders).toBeInstanceOf(Headers)
     expect((agentCallHeaders as Headers).get('Authorization')).toBe('Bearer jwt-token')
 
-    const authProbeCall = findFetchCall('/api/me')
-    expect(authProbeCall?.[1]).toEqual(expect.objectContaining({ credentials: 'include' }))
-
     const backendCall = findFetchCall('/api/namespaces?cluster=cluster-1')
     expect(backendCall).toBeDefined()
   })
@@ -140,7 +149,6 @@ describe('NamespaceManager auth and offline handling', () => {
     })
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 'dev-user' }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify([
         {
           name: 'team-a',
@@ -157,7 +165,6 @@ describe('NamespaceManager auth and offline handling', () => {
     })
 
     expect(findFetchCall(':8585/namespaces?cluster=cluster-1-context')).toBeDefined()
-    expect(findFetchCall('/api/me')).toBeDefined()
     expect(findFetchCall('/api/namespaces?cluster=cluster-1-context')).toBeDefined()
   })
 

--- a/web/src/components/namespaces/__tests__/NamespaceManager.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceManager.test.tsx
@@ -28,6 +28,10 @@ vi.mock('../../../hooks/mcp/shared', () => ({
   CLUSTER_POLL_INTERVAL_MS: 60_000,
 }))
 
+vi.mock('../../../lib/api', () => ({
+  authFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+}))
+
 vi.mock('../../../hooks/useMCP', () => ({
   useClusters: () => mockUseClusters(),
 }))
@@ -54,6 +58,10 @@ vi.mock('../../../components/ui/Toast', () => ({
   useToast: () => ({
     showToast: vi.fn(),
   }),
+}))
+
+vi.mock('../../../lib/auth', () => ({
+  useAuth: () => ({ user: null }),
 }))
 
 const mockFetch = vi.fn()

--- a/web/src/components/namespaces/__tests__/useNamespaceFetch.test.ts
+++ b/web/src/components/namespaces/__tests__/useNamespaceFetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, waitFor } from '@testing-library/react'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import { useNamespaceFetch, namespaceCache, getCachedNamespacesForCluster } from '../useNamespaceFetch'
 import { authFetch } from '../../../lib/api'
 import { clusterCacheRef } from '../../../hooks/mcp/shared'
@@ -226,7 +226,9 @@ describe('useNamespaceFetch', () => {
 
     const initialLastUpdated = result.current.lastUpdated
 
-    vi.advanceTimersByTime(30000) // AUTO_REFRESH_INTERVAL_MS
+    await act(async () => {
+      vi.advanceTimersByTime(30000) // AUTO_REFRESH_INTERVAL_MS
+    })
 
     await waitFor(() => {
       expect(result.current.lastUpdated).not.toBe(initialLastUpdated)

--- a/web/src/hooks/mcp/__tests__/namespaces.test.ts
+++ b/web/src/hooks/mcp/__tests__/namespaces.test.ts
@@ -50,6 +50,7 @@ vi.mock('../../../lib/api', () => ({
   api: {
     get: (...args: unknown[]) => mockApiGet(...args),
   },
+  authFetch: vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => globalThis.fetch(url, init)),
 }))
 
 vi.mock('../../../lib/kubectlProxy', () => ({


### PR DESCRIPTION
Fixes #20851

## Summary

Fix 5 failing namespace unit-test suites introduced in the NamespaceManager refactor (#20643).

### Changes

- **`hooks/mcp/__tests__/namespaces.test.ts`**: Add `authFetch` to the `lib/api` mock factory — Vitest 4 strict mock validation requires every imported symbol to be exported from the mock.
- **`NamespaceManager.test.tsx`**: Add `vi.mock('../../../lib/api')` (proxying `authFetch` → `globalThis.fetch`) and `vi.mock('../../../lib/auth')` so all imports resolve through the test's `mockFetch` stub without loading heavy module chains.
- **`NamespaceManager.auth.test.tsx`**: Same `lib/api`/`lib/auth` mocks; use an auth-aware `authFetch` stub that reads `localStorage.getItem('token')` to preserve the `Authorization` header assertions. Remove the `/api/me` probe step — the refactored `useNamespaceFetch` hook makes no such call; update the two affected mock sequences from 3 responses → 2.
- **`NamespaceFilterBar.test.tsx`**: Fix `toHaveBeenLastCalledWith('my-app')` → `toHaveBeenLastCalledWith('p')`. The component passes a controlled `value={searchQuery}` prop that is fixed at `""` in the test; `userEvent.type` therefore fires `onChange` with only the current typed character per keystroke, not the accumulated string.
- **`useNamespaceFetch.test.ts`**: Import `act` from `@testing-library/react`; wrap `vi.advanceTimersByTime(30000)` in `await act(async () => { … })` so React state updates triggered by the fake-timer `setInterval` callback are flushed before the subsequent `waitFor` assertion.