### PR TITLE
[scanner] fix: remaining auto-qa timer cleanup improvements (#20867)

### DIFF
--- a/web/src/components/namespaces/__tests__/CreateNamespaceModal.test.tsx
+++ b/web/src/components/namespaces/__tests__/CreateNamespaceModal.test.tsx
@@ -13,7 +13,6 @@ import userEvent from '@testing-library/user-event'
 import { CreateNamespaceModal } from '../CreateNamespaceModal'
 
 const DISCARD_CONFIRM_TIMEOUT_MS = 2000
-const MOCK_LATENCY_MS = 200
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -244,9 +243,9 @@ describe('CreateNamespaceModal', () => {
 
   it('disables create button while creation is in progress', async () => {
     const user = userEvent.setup()
-    mockAgentFetch.mockImplementationOnce(
-      () => new Promise(resolve => setTimeout(() => resolve(new Response(JSON.stringify({}), { status: 200 })), MOCK_LATENCY_MS))
-    )
+    // Never-resolving promise keeps the button disabled for the duration of the
+    // assertion without creating a dangling real timer.
+    mockAgentFetch.mockImplementationOnce(() => new Promise(() => {}))
 
     render(
       <CreateNamespaceModal

--- a/web/src/hooks/__tests__/useVersionCheck.provider.test.tsx
+++ b/web/src/hooks/__tests__/useVersionCheck.provider.test.tsx
@@ -56,6 +56,8 @@ describe('cache behaviour', () => {
         localStorage.clear()
         vi.clearAllMocks()
         vi.stubGlobal('fetch', vi.fn())
+        // Capture the hook's internal setInterval so afterEach can clear it.
+        vi.useFakeTimers({ shouldAdvanceTime: true })
     })
 
     afterEach(() => {
@@ -161,6 +163,8 @@ describe('VersionCheckProvider', () => {
         localStorage.clear()
         vi.clearAllMocks()
         vi.stubGlobal('fetch', vi.fn())
+        // Capture the hook's internal setInterval so afterEach can clear it.
+        vi.useFakeTimers({ shouldAdvanceTime: true })
     })
 
     afterEach(() => {

--- a/web/src/hooks/useMissions-agent-selection.test.tsx
+++ b/web/src/hooks/useMissions-agent-selection.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { MissionProvider, useMissions } from './useMissions'
@@ -197,11 +197,13 @@ beforeEach(() => {
   // after 3 s. Tests complete before that fires, but mocking fetch avoids
   // unhandled-rejection warnings from the HTTP fallback path.
   globalThis.fetch = vi.fn().mockResolvedValue({ ok: true })
+  vi.useFakeTimers()
 })
 
 afterEach(() => {
   vi.clearAllTimers()
   vi.useRealTimers()
+  vi.restoreAllMocks()
 })
 
 describe('agent selection: persisted "none" auto-selects available agent', () => {
@@ -285,9 +287,9 @@ describe('mission reconnection edge cases', () => {
     act(() => { result.current.connectToAgent() })
     await act(async () => { MockWebSocket.lastInstance?.simulateOpen() })
 
-    // Wait for reconnect delay
+    // Advance fake timers past the reconnect delay
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 600))
+      await vi.advanceTimersByTimeAsync(600)
     })
 
     const chatCalls = (MockWebSocket.lastInstance?.send.mock.calls ?? []).filter(
@@ -324,8 +326,9 @@ describe('mission reconnection edge cases', () => {
     act(() => { result.current.connectToAgent() })
     await act(async () => { MockWebSocket.lastInstance?.simulateOpen() })
 
+    // Advance fake timers past the reconnect delay
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 600))
+      await vi.advanceTimersByTimeAsync(600)
     })
 
     const chatCalls = (MockWebSocket.lastInstance?.send.mock.calls ?? []).filter(


### PR DESCRIPTION
Part of #20867 (remaining files not covered by #20868)

Fixes the three test files flagged in #20867 that PR #20868 did not touch:

### Changes

**`CreateNamespaceModal.test.tsx`**
- Replace `setTimeout`-based mock (which left a dangling real timer) with a never-resolving promise — keeps the button-disabled assertion intact without creating a timer leak
- Remove the now-unused `MOCK_LATENCY_MS` constant

**`useMissions-agent-selection.test.tsx`**
- Add `vi.useFakeTimers()` to global `beforeEach` so the hook's internal timers are captured by fake-timer infrastructure
- Add `vi.restoreAllMocks()` to `afterEach` (was missing)
- Replace `new Promise(resolve => setTimeout(resolve, 600))` in two reconnect tests with `vi.advanceTimersByTimeAsync(600)` — equivalent behaviour, proper cleanup

**`useVersionCheck.provider.test.tsx`**
- Add `vi.useFakeTimers({ shouldAdvanceTime: true })` to `beforeEach` in both `cache behaviour` and `VersionCheckProvider` describe blocks
- `shouldAdvanceTime: true` lets `waitFor` polling work while still capturing the hook's `setInterval` for proper `afterEach` cleanup

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>