### PR TITLE
[scanner] fix: navigation and routing improvements

### DIFF
--- a/web/src/components/drilldown/RemediationConsole.test.tsx
+++ b/web/src/components/drilldown/RemediationConsole.test.tsx
@@ -1,10 +1,63 @@
 import React from 'react'
-import { describe, it, expect } from 'vitest'
-import * as RemediationConsoleModule from './RemediationConsole'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { RemediationConsole } from './RemediationConsole'
+
+vi.mock('../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ addTokens: vi.fn() }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  authFetch: vi.fn(),
+}))
+
+vi.mock('../../lib/clipboard', () => ({
+  copyToClipboard: vi.fn(),
+}))
+
+vi.mock('../../lib/download', () => ({
+  downloadText: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+const BASE_PROPS = {
+  isOpen: true,
+  onClose: vi.fn(),
+  resourceType: 'pod' as const,
+  resourceName: 'my-pod',
+  namespace: 'default',
+  cluster: 'prod-cluster',
+  issues: ['CrashLoopBackOff'],
+}
 
 describe('RemediationConsole Component', () => {
   it('exports RemediationConsole component', () => {
-    expect(RemediationConsoleModule.RemediationConsole).toBeDefined()
-    expect(typeof RemediationConsoleModule.RemediationConsole).toBe('function')
+    expect(RemediationConsole).toBeDefined()
+    expect(typeof RemediationConsole).toBe('function')
+  })
+
+  it('renders the modal when isOpen is true', () => {
+    render(<RemediationConsole {...BASE_PROPS} />)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('does not render when isOpen is false', () => {
+    render(<RemediationConsole {...BASE_PROPS} isOpen={false} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('calls onClose when the close button is clicked', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    render(<RemediationConsole {...BASE_PROPS} onClose={onClose} />)
+    const closeBtn = screen.getByRole('button', { name: /close/i })
+    await user.click(closeBtn)
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/src/components/drilldown/views/OperatorDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/OperatorDrillDown.test.tsx
@@ -1,10 +1,97 @@
 import React from 'react'
-import { describe, it, expect } from 'vitest'
-import * as OperatorDrillDownModule from './OperatorDrillDown'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { OperatorDrillDown } from './OperatorDrillDown'
+
+const mockPop = vi.fn()
+const mockClose = vi.fn()
+const mockDrillToNamespace = vi.fn()
+const mockDrillToCluster = vi.fn()
+const mockDrillToCRD = vi.fn()
+
+vi.mock('../../../hooks/useLocalAgent', () => ({
+  useLocalAgent: () => ({ isConnected: false }),
+}))
+
+vi.mock('../../../hooks/useDrillDownWebSocket', () => ({
+  useDrillDownWebSocket: () => ({ runKubectl: vi.fn() }),
+}))
+
+vi.mock('../../../hooks/useDrillDown', () => ({
+  useDrillDown: () => ({
+    state: { stack: ['root', 'operator'] },
+    pop: mockPop,
+    close: mockClose,
+  }),
+  useDrillDownActions: () => ({
+    drillToNamespace: mockDrillToNamespace,
+    drillToCluster: mockDrillToCluster,
+    drillToCRD: mockDrillToCRD,
+  }),
+}))
+
+vi.mock('../../../hooks/useMissions', () => ({
+  useMissions: () => ({ startMission: vi.fn() }),
+}))
+
+vi.mock('../../modals', () => ({
+  AIActionBar: () => null,
+  AIActionButton: () => null,
+  useModalAI: () => ({
+    defaultAIActions: [],
+    handleAIAction: vi.fn(),
+    isAgentConnected: false,
+  }),
+}))
+
+vi.mock('../../ui/ClusterBadge', () => ({
+  ClusterBadge: ({ cluster }: { cluster: string }) => <span>{cluster}</span>,
+}))
+
+vi.mock('../../ui/ConsoleAIIcon', () => ({
+  ConsoleAIIcon: () => <span>AI</span>,
+}))
+
+vi.mock('../../../lib/utils/sanitizeUrl', () => ({
+  sanitizeUrl: (url: string) => url,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+const OPERATOR_DATA = {
+  cluster: 'prod-cluster',
+  namespace: 'operators',
+  operator: 'cert-manager',
+  phase: 'Succeeded',
+}
 
 describe('OperatorDrillDown Component', () => {
   it('exports OperatorDrillDown component', () => {
-    expect(OperatorDrillDownModule.OperatorDrillDown).toBeDefined()
-    expect(typeof OperatorDrillDownModule.OperatorDrillDown).toBe('function')
+    expect(OperatorDrillDown).toBeDefined()
+    expect(typeof OperatorDrillDown).toBe('function')
+  })
+
+  it('renders operator name in the header', () => {
+    render(<OperatorDrillDown data={OPERATOR_DATA} />)
+    expect(screen.getByText('cert-manager')).toBeInTheDocument()
+  })
+
+  it('shows back button when drill-down stack has multiple entries', () => {
+    render(<OperatorDrillDown data={OPERATOR_DATA} />)
+    const backBtn = screen.getByRole('button', { name: 'drilldown.goBack' })
+    expect(backBtn).toBeInTheDocument()
+  })
+
+  it('calls pop when back button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<OperatorDrillDown data={OPERATOR_DATA} />)
+    const backBtn = screen.getByRole('button', { name: 'drilldown.goBack' })
+    await user.click(backBtn)
+    expect(mockPop).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Fixes #20870

Expands test coverage for navigation in drill-down views flagged by Auto-QA:

- **RemediationConsole.test.tsx**: adds tests for modal render, hidden-when-closed, and close-button callback
- **OperatorDrillDown.test.tsx**: adds tests for operator name render, back-button presence when stack depth > 1, and `pop()` invocation on click

No production code changes — all existing navigation behaviour is already correctly implemented.