### PR TITLE
[scanner] fix: nightly unit-test regression

### DIFF
--- a/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
+++ b/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
@@ -9,22 +9,23 @@ const { mockExecFileSync, mockWriteFileSync, mockMkdirSync, mockMkdtempSync, moc
   mockRmSync: vi.fn(),
 }))
 
-vi.mock('node:child_process', async () => {
-  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process')
-  const mocked = { ...actual, execFileSync: mockExecFileSync }
-  return { ...mocked, default: mocked }
-})
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+  default: { execFileSync: mockExecFileSync },
+}))
 
-vi.mock('node:fs', async () => {
-  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
-  return {
-    ...actual,
+vi.mock('node:fs', () => ({
+  writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
+  mkdtempSync: mockMkdtempSync,
+  rmSync: mockRmSync,
+  default: {
     writeFileSync: mockWriteFileSync,
     mkdirSync: mockMkdirSync,
     mkdtempSync: mockMkdtempSync,
     rmSync: mockRmSync,
-  }
-})
+  },
+}))
 
 describe('liveFixtureManager', () => {
   const originalEnv = process.env


### PR DESCRIPTION
Fixes #20007

Replace async `vi.importActual` factories in `liveFixtureManager.test.ts` with synchronous mock factories, matching the working pattern already in `collectK8sGroundTruth.test.ts`.

## Root cause

After `vi.resetModules()` + dynamic `import()` in `beforeEach`, Vitest 4 does not reliably re-evaluate async mock factories:

1. **`node:child_process` async factory** — `execFileSync` resolved to the real function and spawned actual `kubectl` in CI, causing `Error: Command failed: kubectl …` failures.
2. **`node:fs` async factory** — spreading `vi.importActual` result included the real module's `default` export, so `fs.writeFileSync()` / `fs.mkdtempSync()` / `fs.rmSync()` bypassed the mocks, causing `AssertionError: expected undefined to be defined` on `mockWriteFileSync`.

## Fix

Replace both async factories with synchronous ones (no `vi.importActual`) matching the working pattern from `collectK8sGroundTruth.test.ts`:

```ts
vi.mock('node:child_process', () => ({
  execFileSync: mockExecFileSync,
  default: { execFileSync: mockExecFileSync },
}))

vi.mock('node:fs', () => ({
  writeFileSync: mockWriteFileSync,
  mkdirSync: mockMkdirSync,
  mkdtempSync: mockMkdtempSync,
  rmSync: mockRmSync,
  default: {
    writeFileSync: mockWriteFileSync,
    mkdirSync: mockMkdirSync,
    mkdtempSync: mockMkdtempSync,
    rmSync: mockRmSync,
  },
}))
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>