### PR TITLE
[scanner] fix: harness/groundtruth unit-test regressions (v2)

### DIFF
--- a/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
+++ b/web/harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts
@@ -16,14 +16,17 @@ vi.mock('node:child_process', () => ({
   default: { execFileSync: mockExecFileSync },
 }))
 
-vi.mock('node:fs', () => ({
-  writeFileSync: mockWriteFileSync,
-  mkdirSync: mockMkdirSync,
-  mkdtempSync: mockMkdtempSync,
-  rmSync: mockRmSync,
-  existsSync: mockExistsSync,
-  readFileSync: mockReadFileSync,
-}))
+vi.mock('node:fs', () => {
+  const mocked = {
+    writeFileSync: mockWriteFileSync,
+    mkdirSync: mockMkdirSync,
+    mkdtempSync: mockMkdtempSync,
+    rmSync: mockRmSync,
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+  }
+  return { ...mocked, default: mocked }
+})
 
 describe('collectK8sGroundTruth', () => {
   const originalEnv = process.env

--- a/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
+++ b/web/harness/groundtruth/__tests__/liveFixtureManager.test.ts
@@ -9,21 +9,19 @@ const { mockExecFileSync, mockWriteFileSync, mockMkdirSync, mockMkdtempSync, moc
   mockRmSync: vi.fn(),
 }))
 
-vi.mock('node:child_process', async () => {
-  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process')
-  const mocked = { ...actual, execFileSync: mockExecFileSync }
-  return { ...mocked, default: mocked }
-})
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+  default: { execFileSync: mockExecFileSync },
+}))
 
-vi.mock('node:fs', async () => {
-  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
-  return {
-    ...actual,
+vi.mock('node:fs', () => {
+  const mocked = {
     writeFileSync: mockWriteFileSync,
     mkdirSync: mockMkdirSync,
     mkdtempSync: mockMkdtempSync,
     rmSync: mockRmSync,
   }
+  return { ...mocked, default: mocked }
 })
 
 describe('liveFixtureManager', () => {


### PR DESCRIPTION
Fixes #20853 (supersedes #20858 which had merge conflicts)

## What

Fix two Vitest 4 mock-interop regressions in the groundtruth harness unit tests.

### `collectK8sGroundTruth.test.ts`

The `vi.mock("node:fs", ...)` factory returned only named exports with no `default` key. In Vitest 4 ESM mode `import fs from "node:fs"` resolves to `undefined` when the factory omits `default`, causing every `fs.*` call in the production code to throw at test time.

**Fix:** wrap the named mocks in a `mocked` object and return `{ ...mocked, default: mocked }`.

### `liveFixtureManager.test.ts`

Both mock factories used `async () => { const actual = await vi.importActual(...) }` which has two bugs:
1. The async factory for `node:child_process` can silently fall back to the real `execFileSync` after `vi.resetModules()` in Vitest 4, causing real `kubectl` to be spawned in CI.
2. The async factory for `node:fs` spread `vi.importActual` — which includes the real `default` (the actual `fs` object) — without overriding it, so `import fs from "node:fs"` in the production code resolved to actual `node:fs`, bypassing all mocked `fs` methods and causing report-writing assertions to fail.

**Fix:** replace both async factories with synchronous factories that match the `collectK8sGroundTruth.test.ts` pattern and include explicit `default: mocked`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>