### PR TITLE
[scanner] fix: restore real tests replaced by stubs in #20868

### DIFF
--- a/web/src/components/dashboard/customizer/sections/__tests__/AISuggestionsSection.test.tsx
+++ b/web/src/components/dashboard/customizer/sections/__tests__/AISuggestionsSection.test.tsx
@@ -43,6 +43,7 @@ describe('AISuggestionsSection', () => {
   })
 
   afterEach(() => {
+    vi.clearAllTimers()
     vi.useRealTimers()
     vi.clearAllMocks()
   })

--- a/web/src/components/layout/__tests__/NavigationShell.test.tsx
+++ b/web/src/components/layout/__tests__/NavigationShell.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { NavigationShell } from '../NavigationShell'
+import type { UpdateProgress } from '../../../types/updates'
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
@@ -26,7 +27,7 @@ vi.mock('../../PageErrorBoundary', () => ({
 }))
 
 vi.mock('../../updates/UpdateProgressBanner', () => ({
-  UpdateProgressBanner: ({ progress }: { progress: any }) => 
+  UpdateProgressBanner: ({ progress }: { progress: UpdateProgress | null }) => 
     progress ? <div data-testid="update-banner">Update Progress</div> : null,
 }))
 

--- a/web/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/web/src/components/layout/__tests__/Sidebar.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { Sidebar } from '../Sidebar'
+import type { SidebarShellProps } from '../SidebarShell'
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
@@ -45,7 +46,7 @@ vi.mock('../../../hooks/useDashboardContext', () => ({
 }))
 
 vi.mock('../SidebarShell', () => ({
-  SidebarShell: ({ navSections, features, onAddCard }: any) => (
+  SidebarShell: ({ navSections, features, onAddCard }: SidebarShellProps) => (
     <div data-testid="sidebar-shell">
       <div data-testid="nav-sections">{JSON.stringify(navSections)}</div>
       <div data-testid="features">{JSON.stringify(features)}</div>

--- a/web/src/components/missions/__tests__/useMissionRecommendations.test.ts
+++ b/web/src/components/missions/__tests__/useMissionRecommendations.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../../lib/missions/matcher', () => ({
 }))
 
 import { useMissionRecommendations } from '../useMissionRecommendations'
+import type { ClusterContext } from '../../../lib/missions/clusterContext'
 
 const FIXER: MissionExport = {
   id: 'fix-1',
@@ -160,7 +161,7 @@ describe('useMissionRecommendations', () => {
   it('passes clusterContext to matchMissionsToCluster', () => {
     mockMissionCache.fixes = [FIXER]
     mockGetCachedRecommendations.mockReturnValue(null)
-    const cluster = { name: 'prod-cluster' } as any
+    const cluster = { name: 'prod-cluster', resources: [], issues: [], labels: {} } as ClusterContext
     renderHook(() => useMissionRecommendations(true, cluster))
     expect(mockMatchMissionsToCluster).toHaveBeenCalledWith([FIXER], cluster)
   })
@@ -177,7 +178,7 @@ describe('useMissionRecommendations', () => {
   it('hasCluster=true when clusterContext is provided', () => {
     mockMissionCache.fixes = [FIXER]
     mockMatchMissionsToCluster.mockReturnValue([MATCH])
-    const cluster = { name: 'test-cluster' } as any
+    const cluster = { name: 'test-cluster', resources: [], issues: [], labels: {} } as ClusterContext
     const { result } = renderHook(() => useMissionRecommendations(true, cluster))
     expect(result.current.hasCluster).toBe(true)
   })

--- a/web/src/components/namespaces/__tests__/NamespaceAccessPanel.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceAccessPanel.test.tsx
@@ -75,6 +75,8 @@ describe('NamespaceAccessPanel', () => {
   })
 
   afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 


### PR DESCRIPTION
Fixes #20869

PR #20868 corrupted 5 test files by committing them as base64-encoded blobs instead of valid TypeScript. This PR restores those files with the correct, non-corrupted content — applying the legitimate fixes that #20868 intended but failed to deliver:

| File | Fix |
|---|---|
| `AISuggestionsSection.test.tsx` | Add `vi.clearAllTimers()` to `afterEach` (timer leak prevention) |
| `NamespaceAccessPanel.test.tsx` | Add `vi.clearAllTimers()` + `vi.useRealTimers()` to `afterEach` |
| `NavigationShell.test.tsx` | Replace `progress: any` → `progress: UpdateProgress \| null` |
| `Sidebar.test.tsx` | Replace `: any` → `: SidebarShellProps` |
| `useMissionRecommendations.test.ts` | Replace `as any` → `as ClusterContext` with required fields |

All 5 files are valid TypeScript with real test coverage intact.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>