### PR TITLE
[scanner] fix: address Coverage Suite #4197 test failures

### DIFF
--- a/web/src/components/drilldown/views/OperatorDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/OperatorDrillDown.test.tsx
@@ -78,7 +78,7 @@ describe('OperatorDrillDown Component', () => {
 
   it('renders operator name in the header', () => {
     render(<OperatorDrillDown data={OPERATOR_DATA} />)
-    expect(screen.getByText('cert-manager')).toBeInTheDocument()
+    expect(screen.getAllByText('cert-manager').length).toBeGreaterThan(0)
   })
 
   it('shows back button when drill-down stack has multiple entries', () => {

--- a/web/src/components/mission-control/FlightPlanBlueprint.test.tsx
+++ b/web/src/components/mission-control/FlightPlanBlueprint.test.tsx
@@ -104,7 +104,7 @@ describe('FlightPlanBlueprint', () => {
       />
     )
 
-    expect(screen.getByText(/prometheus/i)).toBeInTheDocument()
+    expect(screen.getByTestId('mission-control-project-prometheus')).toBeInTheDocument()
   })
 
   it('handles empty state', () => {

--- a/web/src/components/mission-control/LaunchSequence.test.tsx
+++ b/web/src/components/mission-control/LaunchSequence.test.tsx
@@ -43,7 +43,13 @@ const mockState: MissionControlState = {
   deployMode: 'phased',
   targetClusters: [],
   aiStreaming: false,
-  launchProgress: [],
+  launchProgress: [
+    {
+      phase: 1,
+      status: 'pending',
+      projects: [{ name: 'prometheus', status: 'pending' }],
+    },
+  ],
   projects: [
     {
       name: 'prometheus',
@@ -76,7 +82,7 @@ const mockState: MissionControlState = {
 }
 
 describe('LaunchSequence', () => {
-  it('renders mission description', () => {
+  it('renders launch progress summary', () => {
     const onUpdateProgress = vi.fn()
     const onComplete = vi.fn()
 
@@ -88,7 +94,7 @@ describe('LaunchSequence', () => {
       />
     )
 
-    expect(screen.getByText(/Test deployment/)).toBeInTheDocument()
+    expect(screen.getByText('missionControl.launchSequence.deployingProjects_one')).toBeInTheDocument()
   })
 
   it('displays phase information', () => {
@@ -106,23 +112,21 @@ describe('LaunchSequence', () => {
     expect(screen.getByText(/Deploy Core/)).toBeInTheDocument()
   })
 
-  it('shows cancel button', () => {
+  it('shows close button when there is nothing to deploy', () => {
     const onUpdateProgress = vi.fn()
     const onComplete = vi.fn()
     const onClose = vi.fn()
 
     render(
       <LaunchSequence
-        state={mockState}
+        state={{ ...mockState, projects: [], assignments: [], phases: [] }}
         onUpdateProgress={onUpdateProgress}
         onComplete={onComplete}
         onClose={onClose}
       />
     )
 
-    // The close/cancel button uses the 'actions.close' i18n key;
-    // the mock returns the key itself as the rendered text.
-    expect(screen.getByText('actions.close')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'actions.close' })).toBeInTheDocument()
   })
 
   it('renders project list', () => {
@@ -137,6 +141,6 @@ describe('LaunchSequence', () => {
       />
     )
 
-    expect(screen.getByText(/prometheus/)).toBeInTheDocument()
+    expect(screen.getByText('Prometheus')).toBeInTheDocument()
   })
 })

--- a/web/src/components/mission-control/PayloadGrid.test.tsx
+++ b/web/src/components/mission-control/PayloadGrid.test.tsx
@@ -89,7 +89,7 @@ describe('PayloadGrid', () => {
       />
     )
 
-    expect(screen.getByText('Observability')).toBeInTheDocument()
+    expect(screen.getAllByText('Observability')).toHaveLength(2)
   })
 
   it('renders project count', () => {

--- a/web/src/components/mission-control/RequestApprovalModal.test.tsx
+++ b/web/src/components/mission-control/RequestApprovalModal.test.tsx
@@ -68,7 +68,7 @@ describe('RequestApprovalModal', () => {
       />
     )
 
-    expect(screen.getByText(/Request Approval/i)).toBeInTheDocument()
+    expect(screen.getByText(/Request Deployment Approval/i)).toBeInTheDocument()
   })
 
   it('calls onClose when cancel clicked', () => {

--- a/web/src/components/missions/ClusterSelectionDialog.test.tsx
+++ b/web/src/components/missions/ClusterSelectionDialog.test.tsx
@@ -23,12 +23,25 @@ vi.mock('../ui/Toast', () => ({
   useToast: () => ({ showToast: vi.fn() }),
 }))
 
+vi.mock('../../hooks/mcp/clusters', () => ({
+  useClusters: () => ({
+    deduplicatedClusters: [
+      { name: 'cluster-1', context: 'cluster-1', reachable: true, healthy: true },
+      { name: 'cluster-2', context: 'cluster-2', reachable: true, healthy: true },
+    ],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
+
 describe('ClusterSelectionDialog', () => {
   it('does not render when isOpen is false', () => {
     const { container } = render(
       <ClusterSelectionDialog
-        isOpen={false}
-        onClose={vi.fn()}
+        open={false}
+        missionTitle="Test Mission"
+        onCancel={vi.fn()}
         onSelect={vi.fn()}
       />
     )
@@ -38,8 +51,9 @@ describe('ClusterSelectionDialog', () => {
   it('renders dialog when isOpen is true', () => {
     render(
       <ClusterSelectionDialog
-        isOpen={true}
-        onClose={vi.fn()}
+        open={true}
+        missionTitle="Test Mission"
+        onCancel={vi.fn()}
         onSelect={vi.fn()}
       />
     )
@@ -50,28 +64,26 @@ describe('ClusterSelectionDialog', () => {
     const onSelect = vi.fn()
     render(
       <ClusterSelectionDialog
-        isOpen={true}
-        onClose={vi.fn()}
+        open={true}
+        missionTitle="Test Mission"
+        onCancel={vi.fn()}
         onSelect={onSelect}
       />
     )
     expect(onSelect).not.toHaveBeenCalled()
   })
 
-  it('calls onClose when dialog is closed', () => {
+  it('calls onCancel when dialog is closed', () => {
     const onClose = vi.fn()
     render(
       <ClusterSelectionDialog
-        isOpen={true}
-        onClose={onClose}
+        open={true}
+        missionTitle="Test Mission"
+        onCancel={onClose}
         onSelect={vi.fn()}
       />
     )
-    const closeButtons = screen.getAllByRole('button')
-    const closeButton = closeButtons.find(btn => 
-      btn.querySelector('svg') || btn.getAttribute('aria-label')?.includes('close')
-    )
-    closeButton?.click()
+    screen.getByRole('button', { name: /close modal/i }).click()
     expect(onClose).toHaveBeenCalled()
   })
 })

--- a/web/src/components/missions/MissionDetailView.test.tsx
+++ b/web/src/components/missions/MissionDetailView.test.tsx
@@ -78,7 +78,7 @@ describe('MissionDetailView', () => {
         loading={true}
       />
     )
-    expect(container.querySelector('.animate-pulse')).toBeInTheDocument()
+    expect(container.querySelector('.animate-shimmer')).toBeInTheDocument()
   })
 
   it('renders error message when error prop is provided', () => {
@@ -135,7 +135,7 @@ describe('MissionDetailView', () => {
         onToggleRaw={vi.fn()}
         onImport={vi.fn()}
         onBack={vi.fn()}
-        matchScore={0.85}
+        matchScore={85}
       />
     )
     expect(screen.getByText(/85%/)).toBeInTheDocument()

--- a/web/src/components/missions/MissionDialogs.test.tsx
+++ b/web/src/components/missions/MissionDialogs.test.tsx
@@ -25,15 +25,58 @@ vi.mock('../ui/Toast', () => ({
   useToast: () => ({ showToast: vi.fn() }),
 }))
 
+vi.mock('../../hooks/mcp/clusters', () => ({
+  useClusters: () => ({ deduplicatedClusters: [], isLoading: false, error: null, refetch: vi.fn() }),
+}))
+
+vi.mock('../../hooks/useResolutions', () => ({
+  useResolutions: () => ({ saveResolution: vi.fn() }),
+  detectIssueSignature: () => ({ type: 'Troubleshooting', resourceKind: 'Pod' }),
+}))
+
+vi.mock('../../lib/utils/wsAuth', () => ({
+  getWsAuthParams: vi.fn().mockRejectedValue(new Error('AI unavailable')),
+}))
+
+vi.mock('../../lib/missions/scanner/index', () => ({
+  fullScan: vi.fn(() => ({ findings: [], filesScanned: 1, errors: [] })),
+}))
+
+const mockMission = {
+  id: 'mission-1',
+  title: 'Test Mission',
+  description: 'Test',
+  type: 'troubleshoot' as const,
+  status: 'completed' as const,
+  cluster: 'cluster-1',
+  messages: [],
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+}
+
+const mockResolution = {
+  id: 'resolution-1',
+  missionId: 'mission-1',
+  userId: 'user-1',
+  title: 'Test Mission',
+  issueSignature: { type: 'Troubleshooting', resourceKind: 'Pod' },
+  resolution: { summary: 'Test', steps: ['Do the thing'] },
+  context: { cluster: 'cluster-1', operators: [] },
+  effectiveness: { timesUsed: 0, timesSuccessful: 0 },
+  visibility: 'private' as const,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+}
+
 describe('ClusterSelectionDialog', () => {
   it('renders without errors', async () => {
     const { ClusterSelectionDialog } = await import('./ClusterSelectionDialog')
     const { container } = render(
       <ClusterSelectionDialog
-        isOpen={true}
-        onClose={vi.fn()}
+        open={true}
+        missionTitle="Test Mission"
         onSelect={vi.fn()}
-        availableClusters={[]}
+        onCancel={vi.fn()}
       />
     )
     expect(container).toBeTruthy()
@@ -83,8 +126,7 @@ describe('SaveResolutionDialog', () => {
       <SaveResolutionDialog
         isOpen={true}
         onClose={vi.fn()}
-        onSave={vi.fn()}
-        initialTitle=""
+        mission={mockMission}
       />
     )
     expect(container).toBeTruthy()
@@ -94,18 +136,11 @@ describe('SaveResolutionDialog', () => {
 describe('ShareMissionDialog', () => {
   it('renders without errors', async () => {
     const { ShareMissionDialog } = await import('./ShareMissionDialog')
-    const mockMission = {
-      title: 'Test Mission',
-      description: 'Test',
-      type: 'custom' as const,
-      steps: [],
-      version: '1.0.0',
-    }
     const { container } = render(
       <ShareMissionDialog
         isOpen={true}
         onClose={vi.fn()}
-        mission={mockMission}
+        resolution={mockResolution}
       />
     )
     expect(container).toBeTruthy()
@@ -129,18 +164,11 @@ describe('StandaloneOrbitDialog', () => {
 describe('SubmitToKBDialog', () => {
   it('renders without errors', async () => {
     const { SubmitToKBDialog } = await import('./SubmitToKBDialog')
-    const mockMission = {
-      title: 'Test Mission',
-      description: 'Test',
-      type: 'custom' as const,
-      steps: [],
-      version: '1.0.0',
-    }
     const { container } = render(
       <SubmitToKBDialog
         isOpen={true}
         onClose={vi.fn()}
-        mission={mockMission}
+        resolution={mockResolution}
       />
     )
     expect(container).toBeTruthy()

--- a/web/src/components/missions/MissionViews.test.tsx
+++ b/web/src/components/missions/MissionViews.test.tsx
@@ -15,6 +15,16 @@ vi.mock('react-i18next', () => ({
 vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn(),
   useLocation: () => ({ pathname: '/' }),
+  useParams: () => ({ missionId: 'test-mission-id' }),
+}))
+
+vi.mock('../../lib/analytics', () => ({
+  emitMissionError: vi.fn(),
+  emitPageView: vi.fn(),
+  emitNavigate: vi.fn(),
+  emitLogin: vi.fn(),
+  emitEvent: vi.fn(),
+  analyticsReady: Promise.resolve(),
 }))
 
 vi.mock('../../lib/api', () => ({
@@ -187,8 +197,11 @@ describe('MissionDetailView', () => {
     const { container } = render(
       <MissionDetailView
         mission={mockMission}
-        onClose={vi.fn()}
+        rawContent={null}
+        showRaw={false}
+        onToggleRaw={vi.fn()}
         onImport={vi.fn()}
+        onBack={vi.fn()}
       />
     )
     expect(container).toBeTruthy()

--- a/web/src/components/missions/SaveResolutionDialog.test.tsx
+++ b/web/src/components/missions/SaveResolutionDialog.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { SaveResolutionDialog } from './SaveResolutionDialog'
+import type { Mission } from '../../hooks/useMissions'
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
@@ -27,13 +28,36 @@ vi.mock('../ui/Toast', () => ({
   }),
 }))
 
+vi.mock('../../hooks/useResolutions', () => ({
+  useResolutions: () => ({ saveResolution: vi.fn() }),
+  detectIssueSignature: () => ({ type: 'Troubleshooting', resourceKind: 'Pod' }),
+}))
+
+vi.mock('../../lib/utils/wsAuth', () => ({
+  getWsAuthParams: vi.fn().mockRejectedValue(new Error('AI unavailable')),
+}))
+
+const mockMission: Mission = {
+  id: 'mission-1',
+  title: 'Debug pod crash',
+  description: 'kubectl delete pod my-pod',
+  type: 'troubleshoot',
+  status: 'completed',
+  cluster: 'cluster-1',
+  messages: [
+    { id: 'm1', role: 'assistant', content: 'kubectl rollout restart deployment/my-app', timestamp: new Date('2026-01-01T00:00:00Z') },
+  ],
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+}
+
 describe('SaveResolutionDialog', () => {
   it('does not render when isOpen is false', () => {
     const { container } = render(
       <SaveResolutionDialog
         isOpen={false}
         onClose={vi.fn()}
-        resolution=""
+        mission={mockMission}
       />
     )
     expect(container.firstChild).toBeNull()
@@ -44,38 +68,37 @@ describe('SaveResolutionDialog', () => {
       <SaveResolutionDialog
         isOpen={true}
         onClose={vi.fn()}
-        resolution="kubectl rollout restart deployment/my-app"
+        mission={mockMission}
       />
     )
     expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 
-  it('displays resolution content in dialog', () => {
+  it('displays mission-derived content in dialog', async () => {
     const resolution = 'kubectl delete pod my-pod'
     render(
       <SaveResolutionDialog
         isOpen={true}
         onClose={vi.fn()}
-        resolution={resolution}
+        mission={{ ...mockMission, title: resolution }}
       />
     )
-    expect(screen.getByText(new RegExp(resolution))).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByDisplayValue(resolution)).toBeInTheDocument()
+    })
   })
 
-  it('calls onClose when close button is clicked', () => {
+  it('calls onClose when close button is clicked', async () => {
     const onClose = vi.fn()
     render(
       <SaveResolutionDialog
         isOpen={true}
         onClose={onClose}
-        resolution="test resolution"
+        mission={mockMission}
       />
     )
-    const closeButtons = screen.getAllByRole('button')
-    const closeButton = closeButtons.find(btn => 
-      btn.querySelector('svg') || btn.getAttribute('aria-label')?.includes('close')
-    )
-    closeButton?.click()
+    const closeButton = await screen.findByRole('button', { name: /close modal/i })
+    closeButton.click()
     expect(onClose).toHaveBeenCalled()
   })
 })

--- a/web/src/components/missions/__tests__/ClusterSelectionDialog.test.tsx
+++ b/web/src/components/missions/__tests__/ClusterSelectionDialog.test.tsx
@@ -43,7 +43,14 @@ import { ClusterSelectionDialog } from '../ClusterSelectionDialog'
 
 describe('ClusterSelectionDialog', () => {
   it('renders without crashing', () => {
-    const { container } = render(<ClusterSelectionDialog {...({} as Record<string, unknown>)} />)
+    const { container } = render(
+      <ClusterSelectionDialog
+        open={true}
+        missionTitle="Test Mission"
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
     expect(container).toBeTruthy()
   })
 })


### PR DESCRIPTION
Fixes #20877

## Summary

Repairs test failures from Coverage Suite run #4197 across the `mission-control` and `missions` test suites. No production code was changed — only test files were updated to match current component APIs.

## Root Causes Fixed

### 1. `ClusterSelectionDialog` props renamed
- `isOpen` → `open`, `onClose` → `onCancel`
- Added required `missionTitle` prop
- Added missing `useClusters` hook mock

### 2. `SaveResolutionDialog` API changed
- Now requires `mission: Mission` instead of `resolution: string` / `onSave` / `initialTitle`
- Added `useResolutions` and `wsAuth` mocks

### 3. `ShareMissionDialog` / `SubmitToKBDialog` API changed
- Both now take `resolution: Resolution` (not `mission: MissionExport`)
- Added `effectiveness` required field to mock `Resolution` object

### 4. `MissionDetailView` rendering fixes
- Loading skeleton uses `.animate-shimmer` not `.animate-pulse`
- `matchScore` rendered as-is (e.g. `85% match`), so pass `85` not `0.85`
- Fixed missing required props: `rawContent`, `showRaw`, `onToggleRaw`, `onBack`

### 5. `LaunchSequence` description not rendered in JSX
- `state.description` is only used in the mission prompt string, not rendered
- Added `launchProgress` entries so phase/project names actually appear in the DOM
- Renamed tests to reflect what is actually asserted

### 6. `PayloadGrid` duplicate category text
- Both cards render their `category`, causing `getByText` to throw on duplicates
- Changed to `getAllByText(...).toHaveLength(2)`

### 7. `RequestApprovalModal` title text
- Actual text is `"Request Deployment Approval"` not `"Request Approval"`

### 8. `FlightPlanBlueprint` project node selector
- `ProjectNode` SVG element has `data-testid`; use `getByTestId` instead of text search

### 9. `MissionLandingPage` missing mocks
- Added `useParams` to react-router-dom mock (required by the component)
- Added analytics mock (`emitPageView`, `emitMissionError`)

### 10. `OperatorDrillDown` duplicate name text
- Name appears in multiple places (h3 and subscription row); use `getAllByText`

## Files Changed (test files only)

- `web/src/components/drilldown/views/OperatorDrillDown.test.tsx`
- `web/src/components/mission-control/FlightPlanBlueprint.test.tsx`
- `web/src/components/mission-control/LaunchSequence.test.tsx`
- `web/src/components/mission-control/PayloadGrid.test.tsx`
- `web/src/components/mission-control/RequestApprovalModal.test.tsx`
- `web/src/components/missions/ClusterSelectionDialog.test.tsx`
- `web/src/components/missions/MissionDetailView.test.tsx`
- `web/src/components/missions/MissionDialogs.test.tsx`
- `web/src/components/missions/MissionViews.test.tsx`
- `web/src/components/missions/SaveResolutionDialog.test.tsx`
- `web/src/components/missions/__tests__/ClusterSelectionDialog.test.tsx`

## Note on Remaining Failures

The 9 harness/groundtruth tests listed in the issue were already fixed by merged PR #20876 and are passing in the current main branch.