### PR TITLE
🐛 fix: TestAgentTokenEndpoint_Contract flake in pkg/api

### DIFF
--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -163,9 +163,9 @@ func ShutdownTokenRevocation() {
 	}
 }
 
-// resetTokenRevocationForTest clears internal state so tests can re-initialize
+// ResetTokenRevocationForTest clears internal state so tests can re-initialize
 // the revocation layer. NOT for production use.
-func resetTokenRevocationForTest() {
+func ResetTokenRevocationForTest() {
 	ShutdownTokenRevocation()
 	revokedTokens.Lock()
 	revokedTokens.tokens = make(map[string]time.Time)

--- a/pkg/api/middleware/auth_test.go
+++ b/pkg/api/middleware/auth_test.go
@@ -569,8 +569,8 @@ func (assertErr) Error() string { return "revocation store unavailable" }
 // IsRevoked returned false, silently disabling server-side logout whenever
 // the DB hiccuped.
 func TestRevocationFailClosed(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	InitTokenRevocation(failingRevoker{})
 
@@ -606,8 +606,8 @@ func TestRevocationFailClosed(t *testing.T) {
 // TestValidateJWTFailClosedOnRevocationError covers the same fail-closed
 // property on the WebSocket/SSE validation path (ValidateJWT).
 func TestValidateJWTFailClosedOnRevocationError(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	InitTokenRevocation(failingRevoker{})
 
@@ -653,8 +653,8 @@ func (s *userValidationTestStore) GetUser(_ context.Context, id uuid.UUID) (*mod
 // indirectly by ensuring the cancel func is still set after a second call
 // and that ShutdownTokenRevocation does not panic on double-call.
 func TestInitTokenRevocationIdempotent(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	InitTokenRevocation(noopRevoker{})
 	// Second call must be a no-op: sync.Once guarantees the inner body
@@ -671,8 +671,8 @@ func TestInitTokenRevocationIdempotent(t *testing.T) {
 // query-param fallback must be rejected on paths that are not in the
 // explicit allow-list, even if they end in /stream.
 func TestRevocationQueryTokenRejectedOnUnknownPath(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	secret := "test-secret"
 	app := fiber.New()
@@ -714,8 +714,8 @@ func TestWebSocketUpgrade(t *testing.T) {
 }
 
 func TestRevocationHelpers(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	jti := "help-jti"
 	RevokeToken(jti, time.Now().Add(time.Hour))
@@ -745,8 +745,8 @@ func TestValidateJWT_NoID(t *testing.T) {
 }
 
 func TestRevocation_Cleanup(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	// Add an expired token and a fresh one
 	now := time.Now()
@@ -777,8 +777,8 @@ func TestGetContextHelpers_Empty(t *testing.T) {
 }
 
 func TestValidateJWT_Revoked(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	secret := "test-secret"
 	jti := "revoked-jti"
@@ -867,8 +867,8 @@ func TestParseJWT_EdgeCases(t *testing.T) {
 // TestValidateJWT_EdgeCases covers additional edge cases in ValidateJWT
 // for improved coverage (#17774).
 func TestValidateJWT_EdgeCases(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	secret := "test-secret"
 

--- a/pkg/api/middleware/auth_ws_revoke_test.go
+++ b/pkg/api/middleware/auth_ws_revoke_test.go
@@ -167,8 +167,8 @@ func TestIsWSOriginAllowed_HTTPSFromXForwardedProto(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRevoke_EvictsExpiredEntries(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	// Fill the cache past max size with expired entries.
 	now := time.Now()
@@ -187,8 +187,8 @@ func TestRevoke_EvictsExpiredEntries(t *testing.T) {
 }
 
 func TestRevoke_EvictsZeroTimeEntries(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	// Fill with zero-time (backfilled) entries that won't expire naturally.
 	for i := 0; i < revokedTokenCacheMaxSize+10; i++ {
@@ -213,8 +213,8 @@ func TestRevoke_EvictsZeroTimeEntries(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCleanup_EvictsZeroTimeAtHalfMax(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	halfMax := revokedTokenCacheMaxSize / 2
 
@@ -243,8 +243,8 @@ func TestCleanup_EvictsZeroTimeAtHalfMax(t *testing.T) {
 }
 
 func TestCleanup_KeepsZeroTimeBelowHalfMax(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	// Add a small number of zero-time entries (well below half-max).
 	for i := 0; i < 10; i++ {
@@ -265,8 +265,8 @@ func TestCleanup_KeepsZeroTimeBelowHalfMax(t *testing.T) {
 }
 
 func TestCleanup_RemovesExpiredKeepsFresh(t *testing.T) {
-	resetTokenRevocationForTest()
-	t.Cleanup(resetTokenRevocationForTest)
+	ResetTokenRevocationForTest()
+	t.Cleanup(ResetTokenRevocationForTest)
 
 	now := time.Now()
 	// 3 expired, 2 fresh

--- a/pkg/api/routes_api_core_test.go
+++ b/pkg/api/routes_api_core_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/kubestellar/console/pkg/api/handlers"
+	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/notifications"
 	"github.com/kubestellar/console/pkg/store"

--- a/pkg/api/routes_api_core_test.go
+++ b/pkg/api/routes_api_core_test.go
@@ -64,6 +64,16 @@ func newAgentTokenTestServer(t *testing.T, agentToken string) *Server {
 	mockStore.On("ListClusterGroups").Return(map[string][]byte{}, nil).Maybe()
 	mockStore.On("SaveClusterGroup", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockStore.On("DeleteClusterGroup", mock.Anything).Return(nil).Maybe()
+	
+	// Reset token revocation state from any previous tests that called
+	// NewServer() → InitTokenRevocation, then t.Cleanup → ShutdownTokenRevocation.
+	// Without this, the middleware's initOnce prevents re-initialization with
+	// a fresh store, causing JWTAuth to fail closed when it sees store==nil (#20857).
+	middleware.resetTokenRevocationForTest()
+	t.Cleanup(middleware.resetTokenRevocationForTest)
+	middleware.InitTokenRevocation(mockStore)
+	middleware.InitUserValidation(mockStore)
+	
 	server := &Server{
 		app:   fiber.New(fiber.Config{ErrorHandler: customErrorHandler}),
 		store: mockStore,

--- a/pkg/api/routes_api_core_test.go
+++ b/pkg/api/routes_api_core_test.go
@@ -69,8 +69,8 @@ func newAgentTokenTestServer(t *testing.T, agentToken string) *Server {
 	// NewServer() → InitTokenRevocation, then t.Cleanup → ShutdownTokenRevocation.
 	// Without this, the middleware's initOnce prevents re-initialization with
 	// a fresh store, causing JWTAuth to fail closed when it sees store==nil (#20857).
-	middleware.resetTokenRevocationForTest()
-	t.Cleanup(middleware.resetTokenRevocationForTest)
+	middleware.ResetTokenRevocationForTest()
+	t.Cleanup(middleware.ResetTokenRevocationForTest)
 	middleware.InitTokenRevocation(mockStore)
 	middleware.InitUserValidation(mockStore)
 	

--- a/pkg/api/routes_registration_test.go
+++ b/pkg/api/routes_registration_test.go
@@ -31,6 +31,15 @@ func newRouteRegistrationServer(t *testing.T) (*Server, *teststore.MockStore) {
 	mockStore.On("ListClusterGroups").Return(map[string][]byte{}, nil).Maybe()
 	mockStore.On("SaveClusterGroup", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockStore.On("DeleteClusterGroup", mock.Anything).Return(nil).Maybe()
+
+	// Reset global middleware state so this test's mockStore is used for
+	// token revocation and user validation, regardless of what previous tests
+	// left behind (mirrors the pattern in newAgentTokenTestServer).
+	middleware.ResetTokenRevocationForTest()
+	t.Cleanup(middleware.ResetTokenRevocationForTest)
+	middleware.InitTokenRevocation(mockStore)
+	middleware.InitUserValidation(mockStore)
+
 	server := &Server{
 		app: fiber.New(fiber.Config{ErrorHandler: customErrorHandler}),
 		store: mockStore,


### PR DESCRIPTION
Fixes #20857

Fixes flaky test ordering failure in pkg/api causing go test failures on multiple PRs (observed on #20857).

## Root cause

TestNewServer_ExplicitDevModeStartsWithoutOAuth (config_test.go) initializes middleware.TokenRevocation via NewServer, then t.Cleanup shuts it down (closing the store). TestAgentTokenEndpoint_Contract runs later alphabetically and inherits leftover global state: the middleware's initOnce has been used but the store is nil, causing JWTAuth to fail closed when checking token revocation.

## Fix

Call middleware.resetTokenRevocationForTest() in newAgentTokenTestServer to reset initOnce and reinitialize with a fresh mock store, matching the pattern already used in pkg/api/middleware/auth_test.go.

## Testing

The fix ensures that TestAgentTokenEndpoint_Contract can run after TestNewServer_* tests without failing due to stale token revocation state.