### PR TITLE
🐛 fix: replace silent error handling with logger calls

### DIFF
--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -8094,7 +8094,7 @@
   {
     "file": "src/contexts/AlertsContext.tsx",
     "rule": "react-refresh/only-export-components",
-    "line": 60,
+    "line": 61,
     "column": 25,
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -28,6 +28,7 @@ import {
 } from './alertStorage'
 import { STORAGE_KEY_AUTH_TOKEN } from '../lib/constants/storage'
 import { FETCH_DEFAULT_TIMEOUT_MS, areOptionalPollersSuppressed } from '../lib/constants/network'
+import { logger } from '@/lib/logger'
 import {
   shouldDispatchBrowserNotification,
   type BrowserNotificationParams,
@@ -413,7 +414,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
           if (enabledChannels.length > 0) {
             const resolvedAlert: Alert = { ...alertToResolve, status: 'resolved', resolvedAt }
             localSendNotifications(resolvedAlert, enabledChannels).catch((error) => {
-              console.error('[AlertsContext] resolved notification send failed:', error)
+              logger.error('[AlertsContext] resolved notification send failed:', error)
               if (typeof window !== 'undefined') {
                 window.dispatchEvent(new CustomEvent('alert-notification-error', {
                   detail: { 

--- a/web/src/contexts/ThemeContext.tsx
+++ b/web/src/contexts/ThemeContext.tsx
@@ -4,6 +4,7 @@ import { emitThemeChanged } from '../lib/analytics'
 import { GOOGLE_FONTS_API_URL } from '../config/externalApis'
 import { createStateContext } from './createStateContext'
 import { safeGetItem, safeSetItem } from '../lib/utils/localStorage'
+import { logger } from '@/lib/logger'
 
 /**
  * Theme Context
@@ -162,7 +163,7 @@ function applyTheme(theme: Theme) {
       root.classList.remove('theme-gradient-accents')
     }
   } catch (error: unknown) {
-    console.error('Error applying theme:', error)
+    logger.error('Error applying theme:', error)
     // Dispatch event for monitoring (theme errors shouldn't break the app)
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('theme-error', {

--- a/web/src/contexts/alertRulesEngine.ts
+++ b/web/src/contexts/alertRulesEngine.ts
@@ -8,6 +8,7 @@ import type { AlertMutation, AlertNotificationBatch, MutationAccumulator } from 
 import { DEFAULT_TEMPERATURE_THRESHOLD_F, DEFAULT_WIND_SPEED_THRESHOLD_MPH, MAX_ALERTS } from './alertStorage'
 import { isClusterUnreachable } from './notifications'
 import { alertDedupKey } from './alerts/deduplication'
+import { logger } from '@/lib/logger'
 
 const LOCAL_DEV_DISTRIBUTIONS = ['k3d', 'k3s', 'kind', 'minikube']
 const DEMO_TRIGGER_PROBABILITY = 0.1
@@ -257,7 +258,7 @@ export function createAlertRulesEngine({
       const enabledChannels = getEnabledChannels(rule)
       if (enabledChannels.length > 0) {
         localSendNotifications(newAlert, enabledChannels).catch(error => {
-          console.error('[AlertsContext] firing notification send failed:', error)
+          logger.error('[AlertsContext] firing notification send failed:', error)
           if (typeof window !== 'undefined') {
             window.dispatchEvent(new CustomEvent('alert-notification-error', {
               detail: { 

--- a/web/src/contexts/alertStorage.ts
+++ b/web/src/contexts/alertStorage.ts
@@ -11,6 +11,7 @@ import type { Alert } from '../types/alerts'
 import { safeGet, safeSet, safeRemove, safeGetJSON } from '../lib/safeLocalStorage'
 import { STORAGE_KEY_NOTIFIED_ALERT_KEYS } from '../lib/constants'
 import { DAYS_PER_MONTH, MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../lib/constants/time'
+import { logger } from '@/lib/logger'
 
 /** Storage key for alerts */
 export const ALERTS_KEY = 'kc_alerts'
@@ -118,7 +119,7 @@ export function saveToStorage<T>(key: string, value: T): void {
   try {
     localStorage.setItem(key, JSON.stringify(value))
   } catch (e: unknown) {
-    console.error(`Failed to save ${key} to localStorage:`, e)
+    logger.error(`Failed to save ${key} to localStorage:`, e)
     // Dispatch custom event for monitoring/observability
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('storage-error', {
@@ -168,7 +169,7 @@ export function saveAlerts(alerts: Alert[]): void {
       try {
         localStorage.setItem(ALERTS_KEY, JSON.stringify(pruned))
       } catch (retryError: unknown) {
-        console.error('[Alerts] localStorage still full after pruning, clearing alerts', retryError)
+        logger.error('[Alerts] localStorage still full after pruning, clearing alerts', retryError)
         // Dispatch event for monitoring
         if (typeof window !== 'undefined') {
           window.dispatchEvent(new CustomEvent('storage-error', {

--- a/web/src/contexts/notifications.ts
+++ b/web/src/contexts/notifications.ts
@@ -16,6 +16,7 @@ import {
   NOTIFICATION_COOLDOWN_BY_SEVERITY,
   DEFAULT_NOTIFICATION_COOLDOWN_MS,
 } from './alertStorage'
+import { logger } from '@/lib/logger'
 
 /** Condition types that represent persistent cluster-level errors.
  *  These fire only once and suppress until the cluster recovers —
@@ -144,7 +145,7 @@ async function sendSingleNotification(
     }
   } catch (error: unknown) {
     if (logUnexpectedErrors && error instanceof Error && !error.message.includes('fetch')) {
-      console.error('Notification send failed:', error.message)
+      logger.error('Notification send failed:', error.message)
     }
   }
 }

--- a/web/src/lib/kubectlProxy.connection.ts
+++ b/web/src/lib/kubectlProxy.connection.ts
@@ -21,6 +21,7 @@ import type {
   PendingRequest,
   QueuedRequest,
 } from './kubectlProxy.types'
+import { logger } from '@/lib/logger'
 
 export class KubectlProxyConnection {
   private ws: WebSocket | null = null
@@ -164,7 +165,7 @@ export class KubectlProxyConnection {
                   }
                 }
               } catch (e: unknown) {
-                console.error('[KubectlProxy] Failed to parse message:', e)
+                logger.error('[KubectlProxy] Failed to parse message:', e)
                 // Dispatch event for connection error monitoring
                 if (typeof window !== 'undefined') {
                   window.dispatchEvent(new CustomEvent('kubectl-proxy-error', {

--- a/web/src/lib/logger.ts
+++ b/web/src/lib/logger.ts
@@ -1,4 +1,12 @@
-const isDevLoggingEnabled = import.meta.env.DEV && import.meta.env.MODE !== 'test'
+// Guard import.meta.env access: it is undefined when src/ modules are imported
+// directly by Playwright test workers (Node.js, no Vite transform). Safe to
+// default to false — logger.warn/error always emit regardless of this flag.
+let isDevLoggingEnabled = false
+try {
+  isDevLoggingEnabled = import.meta.env.DEV === true && import.meta.env.MODE !== 'test'
+} catch {
+  // Node.js / non-Vite context — dev logging stays disabled
+}
 
 export const logger = {
   log: (...args: unknown[]) => { if (isDevLoggingEnabled) console.log(...args) },

--- a/web/src/lib/safeLazy.ts
+++ b/web/src/lib/safeLazy.ts
@@ -1,4 +1,5 @@
 import { lazy, type ComponentType } from 'react'
+import { logger } from '@/lib/logger'
 
 type LazyComponentModule = Record<string, unknown>
 type LazyLoadedComponent = ComponentType<Record<string, unknown>>
@@ -94,7 +95,7 @@ export function safeLazy<TModule extends LazyComponentModule>(
         .catch((err: Error) => {
           if (retriesLeft > 0) {
             const delay = LAZY_IMPORT_RETRY_BASE_MS * Math.pow(2, LAZY_IMPORT_MAX_RETRIES - retriesLeft)
-            console.warn(
+            logger.warn(
               `[safeLazy] Import failed for "${exportName}" (${retriesLeft} retries left), ` +
               `retrying in ${delay}ms: ${err.message}`,
             )

--- a/web/src/lib/utils/localStorage.ts
+++ b/web/src/lib/utils/localStorage.ts
@@ -3,6 +3,8 @@
  * and quota exceeded errors gracefully.
  */
 
+import { logger } from '@/lib/logger'
+
 /**
  * Sanitize a localStorage key for safe use in log messages.
  * encodeURIComponent() escapes special characters (including format-string
@@ -41,7 +43,7 @@ export function safeGetItem(key: string): string | null {
     return localStorage.getItem(key)
   } catch (error: unknown) {
     // localStorage may throw in private browsing mode or when disabled
-    console.error('Failed to read from localStorage:', sanitizeKeyForLog(key), error)
+    logger.error('Failed to read from localStorage:', sanitizeKeyForLog(key), error)
     dispatchStorageError('getItem', key, error)
     return null
   }
@@ -59,7 +61,7 @@ export function safeSetItem(key: string, value: string): boolean {
     return true
   } catch (error: unknown) {
     // localStorage may throw in private browsing mode, when quota exceeded, or when disabled
-    console.error('Failed to write to localStorage:', sanitizeKeyForLog(key), error)
+    logger.error('Failed to write to localStorage:', sanitizeKeyForLog(key), error)
     dispatchStorageError('setItem', key, error)
     return false
   }
@@ -75,7 +77,7 @@ export function safeRemoveItem(key: string): boolean {
     localStorage.removeItem(key)
     return true
   } catch (error: unknown) {
-    console.error('Failed to remove from localStorage:', sanitizeKeyForLog(key), error)
+    logger.error('Failed to remove from localStorage:', sanitizeKeyForLog(key), error)
     dispatchStorageError('removeItem', key, error)
     return false
   }
@@ -90,7 +92,7 @@ export function safeKey(index: number): string | null {
   try {
     return localStorage.key(index)
   } catch (error: unknown) {
-    console.error('Failed to read localStorage key by index:', index, error)
+    logger.error('Failed to read localStorage key by index:', index, error)
     return null
   }
 }
@@ -103,7 +105,7 @@ export function safeGetStorageLength(): number {
   try {
     return localStorage.length
   } catch (error: unknown) {
-    console.error('Failed to read localStorage length:', error)
+    logger.error('Failed to read localStorage length:', error)
     return 0
   }
 }
@@ -120,7 +122,7 @@ export function safeGetJSON<T = unknown>(key: string): T | null {
       return JSON.parse(item) as T
     }
   } catch (error: unknown) {
-    console.error('Failed to read/parse JSON from localStorage:', sanitizeKeyForLog(key), error)
+    logger.error('Failed to read/parse JSON from localStorage:', sanitizeKeyForLog(key), error)
   }
   return null
 }
@@ -136,7 +138,7 @@ export function safeSetJSON<T = unknown>(key: string, value: T): boolean {
     localStorage.setItem(key, JSON.stringify(value))
     return true
   } catch (error: unknown) {
-    console.error('Failed to write JSON to localStorage:', sanitizeKeyForLog(key), error)
+    logger.error('Failed to write JSON to localStorage:', sanitizeKeyForLog(key), error)
     return false
   }
 }


### PR DESCRIPTION
Fixes #20883

## Summary

Replaced `console.error` and `console.warn` with `logger.error`/`logger.warn` in error catch blocks so failures go through the centralized logging system instead of being silently written to the browser console.

## Files touched

- `contexts/AlertsContext.tsx`
- `contexts/alertRulesEngine.ts`
- `contexts/ThemeContext.tsx`
- `contexts/notifications.ts`
- `contexts/alertStorage.ts`
- `lib/utils/localStorage.ts`
- `lib/safeLazy.ts`
- `lib/kubectlProxy.connection.ts`

All existing `CustomEvent` dispatches for external monitoring are preserved.