### PR TITLE
🐛 fix: address more Coverage Suite failures (part 2)

### DIFF
--- a/web/src/components/missions/browser/__tests__/index.test.ts
+++ b/web/src/components/missions/browser/__tests__/index.test.ts
@@ -25,7 +25,8 @@ describe('browser/index exports', () => {
   })
 
   it('exports TreeNodeItem component', () => {
-    expect(typeof browserExports.TreeNodeItem).toBe('function')
+    // React.memo() returns an object with $$typeof, not a function.
+    expect(browserExports.TreeNodeItem).toBeDefined()
   })
 
   it('exports DirectoryListing component', () => {

--- a/web/src/components/namespaces/__tests__/NamespaceAccessPanel.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceAccessPanel.test.tsx
@@ -27,9 +27,10 @@ vi.mock('../../ui/ClusterBadge', () => ({
   ClusterBadge: ({ cluster }: { cluster: string }) => <div data-testid="cluster-badge">{cluster}</div>,
 }))
 
+const mockShowToast = vi.fn()
 vi.mock('../../ui/Toast', () => ({
   useToast: () => ({
-    showToast: vi.fn(),
+    showToast: mockShowToast,
   }),
 }))
 
@@ -152,10 +153,10 @@ describe('NamespaceAccessPanel', () => {
       />
     )
 
-    expect(screen.getByRole('generic', { name: /spinner/i }) || document.querySelector('.spinner')).toBeTruthy()
+    expect(document.querySelector('.spinner')).toBeTruthy()
 
     await waitFor(() => {
-      expect(screen.queryByRole('generic', { name: /spinner/i })).not.toBeInTheDocument()
+      expect(document.querySelector('.spinner')).toBeNull()
     })
   })
 
@@ -303,7 +304,9 @@ describe('NamespaceAccessPanel', () => {
     )
 
     await waitFor(() => {
-      expect(api.get).toHaveBeenCalledTimes(2)
+      expect(api.get).toHaveBeenCalledWith(
+        expect.stringContaining('another-namespace')
+      )
     })
   })
 })

--- a/web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx
@@ -38,7 +38,10 @@ vi.mock('../NamespaceCard', () => ({
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
   useTranslation: () => ({
-    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue || key,
+    t: (key: string, options?: string | { defaultValue?: string }) => {
+      if (typeof options === 'string') return options
+      return options?.defaultValue || key
+    },
   }),
 }))
 
@@ -348,7 +351,9 @@ describe('NamespaceClusterGroup', () => {
     const deleteButtons = screen.getAllByRole('button', { name: 'Delete' })
     await userEvent.click(deleteButtons[0])
 
-    expect(mockOnDelete).toHaveBeenCalledWith(mockNamespaces[0])
+    // mockNamespaces[0] ('default') and [1] ('kube-system') are system namespaces
+    // and don't render Delete buttons; the first Delete belongs to mockNamespaces[2].
+    expect(mockOnDelete).toHaveBeenCalledWith(mockNamespaces[2])
   })
 
   it('does not show skeletons when loading with existing data', () => {

--- a/web/src/components/namespaces/__tests__/useNamespaceFetch.test.ts
+++ b/web/src/components/namespaces/__tests__/useNamespaceFetch.test.ts
@@ -73,7 +73,6 @@ describe('useNamespaceFetch', () => {
     vi.clearAllMocks()
     namespaceCache.clear()
     clusterCacheRef.clusters = []
-    vi.useFakeTimers()
   })
 
   afterEach(() => {
@@ -226,9 +225,11 @@ describe('useNamespaceFetch', () => {
 
     const initialLastUpdated = result.current.lastUpdated
 
+    vi.useFakeTimers()
     await act(async () => {
       vi.advanceTimersByTime(30000) // AUTO_REFRESH_INTERVAL_MS
     })
+    vi.useRealTimers()
 
     await waitFor(() => {
       expect(result.current.lastUpdated).not.toBe(initialLastUpdated)


### PR DESCRIPTION
Fixes #20885

Follow-up to #20890. Addresses ~13 additional test failures from Coverage Suite run #4201 that were not covered by that PR.

**Fixes:**

- `web/src/components/namespaces/__tests__/useNamespaceFetch.test.ts` (8 tests) — `vi.useFakeTimers()` was set globally in `beforeEach`, but most tests use `waitFor()` which cannot progress under fake timers unless timers are advanced. Fake timers are now scoped to the single auto-refresh test that needs them.
- `web/src/components/missions/browser/__tests__/index.test.ts` (1 test) — `TreeNodeItem` is exported via `React.memo(...)`, which returns an object with `$$typeof`; `typeof` returns `object`, not `function`. Assertion changed to `toBeDefined()`.
- `web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx` (2 tests) — local `t()` mock now handles both string and object-form fallbacks (matching how source calls `t(key, defaultString)` and `t(key, { defaultValue })`); delete-button test now asserts the first *non-system* namespace (`mockNamespaces[2]`), since `default` and `kube-system` are treated as system namespaces without Delete buttons.
- `web/src/components/namespaces/__tests__/NamespaceAccessPanel.test.tsx` (2 tests) — `useToast` mock now returns a module-level `showToast` so `fetchAccess` stays memoized across renders; spinner assertion switched from the brittle `getByRole('generic', {name: /spinner/i})` (which throws) to a direct `.spinner` class query; refetch-on-namespace-change now asserts `api.get` was called with the new namespace URL rather than a fragile call count.

**Not addressed here:**

- `harness/groundtruth/__tests__/collectK8sGroundTruth.test.ts > filters contexts by LIVE_CLUSTER_CONTEXTS env var` — no clear-cut minimum-viable fix without touching production logic; left for a follow-up.
- The ~40 remaining hidden failures in the issue body are not enumerated and would require CI log inspection.

Partial progress on #20885.