### PR TITLE
[scanner] fix: add user feedback for auto-QA flagged actions (#20894)

### DIFF
--- a/web/src/components/cards/quantum/__tests__/CustomQASMModal.test.tsx
+++ b/web/src/components/cards/quantum/__tests__/CustomQASMModal.test.tsx
@@ -5,6 +5,11 @@ import userEvent from '@testing-library/user-event'
 
 import { CustomQASMModal } from '../CustomQASMModal'
 
+const mockShowToast = vi.fn()
+vi.mock('../../../ui/Toast', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}))
+
 const VALID_QASM = `OPENQASM 2.0;
 include "qelib1.inc";
 qreg q[2];
@@ -235,5 +240,7 @@ describe('CustomQASMModal', () => {
     expect(onSubmit).toHaveBeenCalledWith(VALID_QASM)
     // After submit, content is cleared
     expect(textarea).toHaveValue('')
+    // Success toast should be shown
+    expect(mockShowToast).toHaveBeenCalledWith('QASM circuit submitted successfully', 'success')
   })
 })

--- a/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
+++ b/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
@@ -27,6 +27,7 @@ import { prefetchCardChunks } from '../../../components/cards/cardRegistry'
 import { SHORT_DELAY_MS } from '../../constants/network'
 import { ConfirmDialog, useModalState } from '../../modals'
 import { useTranslation } from 'react-i18next'
+import { useToast } from '../../../components/ui/Toast'
 
 /** Card suggestion type from AddCardModal */
 interface CardSuggestion {
@@ -53,6 +54,7 @@ export function UnifiedDashboard({
   statsData,
   className = '' }: UnifiedDashboardProps) {
   const { t } = useTranslation('common')
+  const { showToast } = useToast()
   // Tab state (for dashboards with tabs) — needed by the cards initializer
   // to route persistence differently in tab-mode dashboards.
   const hasTabs = (config.tabs?.length ?? 0) > 0
@@ -346,6 +348,7 @@ export function UnifiedDashboard({
           setTabCards(seeded)
         }
         setDashboardError(null)
+        showToast(t('dashboard.resetSuccess', 'Dashboard layout reset to defaults'), 'success')
       } catch (error) {
         console.warn('Failed to reset unified dashboard layout', error)
         setDashboardError(t('errors.storagePersistFailed'))


### PR DESCRIPTION
Fixes #20894

## Summary

Addresses the auto-QA findings for missing user feedback on actions:

### Changes

**`web/src/lib/unified/dashboard/UnifiedDashboard.tsx`**
- Import `useToast` from the existing Toast component
- Show a success toast (`'Dashboard layout reset to defaults'`) after `handleResetConfirmed` succeeds — the confirmation dialog was already in place; this adds the post-action feedback

**`web/src/components/cards/quantum/__tests__/CustomQASMModal.test.tsx`**
- Add `vi.mock` for `useToast` with a `mockShowToast` spy
- Assert that `mockShowToast` is called with `('QASM circuit submitted successfully', 'success')` in the submit test — the source component already called `showToast` but the test did not verify it

### Remaining items (for follow-up)

The following flagged locations are internal auth/session cleanup (`localStorage.removeItem` inside the logout flow) and test-setup mocks — not user-facing destructive actions, so no confirmation dialog or toast is appropriate there:
- `lib/auth.tsx:224,227,382,546,547,673` — internal session token/cache cleanup in `logout` and `refreshUser`; `AuthProvider` is the outermost wrapper and sits outside `ToastProvider`, making `useToast` unavailable at that level
- `contexts/__tests__/AlertsContext.additional.test.tsx:829` — test calling `deleteAlert` to exercise the deletion path
- `lib/auth.test.tsx:85,97` — test localStorage mock setup, not production code
